### PR TITLE
Discord: fix REST API proxy by patching global fetch

### DIFF
--- a/src/discord/monitor/provider.rest-proxy.test.ts
+++ b/src/discord/monitor/provider.rest-proxy.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveDiscordRestFetch } from "./rest-fetch.js";
 
-const { undiciFetchMock, proxyAgentSpy } = vi.hoisted(() => ({
+const { undiciFetchMock, proxyAgentSpy, setGlobalDispatcherSpy } = vi.hoisted(() => ({
   undiciFetchMock: vi.fn(),
   proxyAgentSpy: vi.fn(),
+  setGlobalDispatcherSpy: vi.fn(),
 }));
 
 vi.mock("undici", () => {
@@ -20,7 +21,18 @@ vi.mock("undici", () => {
   return {
     ProxyAgent,
     fetch: undiciFetchMock,
+    setGlobalDispatcher: setGlobalDispatcherSpy,
   };
+});
+
+let originalFetch: typeof fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
 });
 
 describe("resolveDiscordRestFetch", () => {
@@ -32,18 +44,20 @@ describe("resolveDiscordRestFetch", () => {
     } as const;
     undiciFetchMock.mockClear().mockResolvedValue(new Response("ok", { status: 200 }));
     proxyAgentSpy.mockClear();
+    setGlobalDispatcherSpy.mockClear();
     const fetcher = resolveDiscordRestFetch("http://proxy.test:8080", runtime);
 
     await fetcher("https://discord.com/api/v10/oauth2/applications/@me");
 
     expect(proxyAgentSpy).toHaveBeenCalledWith("http://proxy.test:8080");
+    expect(setGlobalDispatcherSpy).toHaveBeenCalled();
     expect(undiciFetchMock).toHaveBeenCalledWith(
       "https://discord.com/api/v10/oauth2/applications/@me",
       expect.objectContaining({
         dispatcher: expect.objectContaining({ proxyUrl: "http://proxy.test:8080" }),
       }),
     );
-    expect(runtime.log).toHaveBeenCalledWith("discord: rest proxy enabled");
+    expect(runtime.log).toHaveBeenCalledWith("discord: rest proxy enabled (global fetch patched)");
     expect(runtime.error).not.toHaveBeenCalled();
   });
 

--- a/src/discord/monitor/rest-fetch.ts
+++ b/src/discord/monitor/rest-fetch.ts
@@ -1,7 +1,9 @@
-import { ProxyAgent, fetch as undiciFetch } from "undici";
+import { ProxyAgent, fetch as undiciFetch, setGlobalDispatcher } from "undici";
 import { danger } from "../../globals.js";
 import { wrapFetchWithAbortSignal } from "../../infra/fetch.js";
 import type { RuntimeEnv } from "../../runtime.js";
+
+let globalProxySet = false;
 
 export function resolveDiscordRestFetch(
   proxyUrl: string | undefined,
@@ -13,12 +15,27 @@ export function resolveDiscordRestFetch(
   }
   try {
     const agent = new ProxyAgent(proxy);
+    if (!globalProxySet) {
+      setGlobalDispatcher(agent);
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = ((
+        input: RequestInfo | URL,
+        init?: RequestInit,
+      ): Promise<Response> => {
+        return originalFetch(input, {
+          ...init,
+          // @ts-expect-error - undici dispatcher option
+          dispatcher: agent,
+        });
+      }) as typeof fetch;
+      globalProxySet = true;
+      runtime.log?.("discord: rest proxy enabled (global fetch patched)");
+    }
     const fetcher = ((input: RequestInfo | URL, init?: RequestInit) =>
       undiciFetch(input as string | URL, {
         ...(init as Record<string, unknown>),
         dispatcher: agent,
       }) as unknown as Promise<Response>) as typeof fetch;
-    runtime.log?.("discord: rest proxy enabled");
     return wrapFetchWithAbortSignal(fetcher);
   } catch (err) {
     runtime.error?.(danger(`discord: invalid rest proxy: ${String(err)}`));


### PR DESCRIPTION
## Summary

- **Problem**: Discord REST API calls (e.g., `client.fetchUser("@me")`, command deployment) fail with "fetch failed" when a proxy URL is configured, because Carbon Client internally uses `globalThis.fetch` directly without the proxy dispatcher.
- **Why it matters**: Users in restricted network environments (e.g., China) cannot use Discord integration even when proxy is correctly configured.
- **What changed**: Modified `resolveDiscordRestFetch` to:
  1. Call `setGlobalDispatcher(agent)` to set undici global dispatcher
  2. Patch `globalThis.fetch` to automatically include the proxy dispatcher
- **What did NOT change**: WebSocket proxy handling (already working via `createWebSocket` override), no changes to config schema or other channels

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Discord REST API calls now correctly use configured proxy URL
- Users behind proxy can successfully deploy Discord commands and fetch bot identity

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` - All Discord REST API calls now route through configured proxy
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A - proxy configuration is user-controlled

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime: Node.js 22+
- Integration/channel: Discord
- Config: `discord.proxy = "http://127.0.0.1:20171"`

### Steps

1. Configure Discord channel with proxy URL
2. Start OpenClaw gateway
3. Observe logs: "discord: failed to deploy native commands: fetch failed"

### Expected

- Discord commands deploy successfully
- Bot identity fetch succeeds

### Actual (before fix)

- `fetch failed` error for all Discord REST API calls

### Actual (after fix)

- Requests go through proxy, return 401 Unauthorized (expected for invalid token in test)

## Evidence

- [x] Failing test/log before + passing after
- Before: `TypeError: fetch failed` when calling Discord API with proxy configured
- After: `401 Unauthorized` (proves proxy is being used, token validation happens server-side)

## Human Verification (required)

- Verified scenarios:
  - Tested with `http://127.0.0.1:20171` proxy - requests route through proxy
  - Tested without proxy - requests go direct (unchanged behavior)
- Edge cases checked: Invalid proxy URL falls back to direct fetch with error log
- What you did **not** verify: Live Discord bot with valid token

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove proxy config or revert commit
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: If global fetch patch causes issues in other modules, may need to scope the patch more narrowly

## Risks and Mitigations

- Risk: Patching `globalThis.fetch` globally may affect other modules using fetch
  - Mitigation: `globalProxySet` flag ensures patch only applied once; undici dispatcher is standard Node.js mechanism
