### PR TITLE
fix(whatsapp): fix mid-session listener desync and watchdog null-lastMessageAt bug

### DIFF
--- a/src/web/active-listener.ts
+++ b/src/web/active-listener.ts
@@ -1,6 +1,9 @@
 import { formatCliCommand } from "../cli/command-format.js";
+import { getChildLogger } from "../logging.js";
 import type { PollInput } from "../polls.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
+
+const listenerLog = getChildLogger({ module: "web-active-listener" });
 
 export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
@@ -69,6 +72,13 @@ export function setActiveWebListener(
 
   const id = resolveWebAccountId(accountId);
   if (!listener) {
+    if (listeners.has(id)) {
+      // Diagnostic: trace every removal to help surface silent desync cases.
+      listenerLog.warn(
+        { accountId: id, stack: new Error("listener-removal-trace").stack },
+        "[active-listener] listener removed from map",
+      );
+    }
     listeners.delete(id);
   } else {
     listeners.set(id, listener);

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -13,7 +13,7 @@ import { getChildLogger } from "../../logging.js";
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import { resolveWhatsAppAccount } from "../accounts.js";
-import { setActiveWebListener } from "../active-listener.js";
+import { getActiveWebListener, setActiveWebListener } from "../active-listener.js";
 import { monitorWebInbox } from "../inbound.js";
 import {
   computeBackoff,
@@ -215,6 +215,10 @@ export async function monitorWebChannel(
       },
     });
 
+    // Register in the active listener map before emitting connected=true so the two
+    // are never out of sync (a send attempt between the emit and the registration would
+    // otherwise throw "No active WhatsApp Web listener").
+    setActiveWebListener(account.accountId, listener);
     status.connected = true;
     status.lastConnectedAt = Date.now();
     status.lastEventAt = status.lastConnectedAt;
@@ -231,8 +235,6 @@ export async function monitorWebChannel(
     enqueueSystemEvent(`WhatsApp gateway connected${selfE164 ? ` as ${selfE164}` : ""}.`, {
       sessionKey: connectRoute.sessionKey,
     });
-
-    setActiveWebListener(account.accountId, listener);
     unregisterUnhandled = registerUnhandledRejectionHandler((reason) => {
       if (!isLikelyWhatsAppCryptoError(reason)) {
         return false;
@@ -251,7 +253,13 @@ export async function monitorWebChannel(
     });
 
     const closeListener = async () => {
-      setActiveWebListener(account.accountId, null);
+      // Only remove from map if this instance is still the active listener.
+      // During a rapid-restart storm, a newer monitorWebChannel instance may have
+      // already registered its listener; blindly clearing the map entry here would
+      // leave status=connected while the map is empty, causing the mid-session desync.
+      if (getActiveWebListener(account.accountId) === listener) {
+        setActiveWebListener(account.accountId, null);
+      }
       if (unregisterUnhandled) {
         unregisterUnhandled();
         unregisterUnhandled = null;
@@ -300,6 +308,28 @@ export async function monitorWebChannel(
       }, heartbeatSeconds * 1000);
 
       watchdogTimer = setInterval(() => {
+        // Check for listener desync: map entry was removed without a close event.
+        // This can happen when a stale monitorWebChannel instance's closeListener
+        // runs and clears the map even though a newer instance had taken it over,
+        // or when the Baileys socket exits silently without emitting onClose.
+        // Without this check the watchdog was completely inert when lastMessageAt
+        // was null (e.g. no messages received in the current session), so the
+        // desync would go undetected indefinitely.
+        const hasListener = !!getActiveWebListener(account.accountId);
+        if (!hasListener) {
+          if (status.connected) {
+            heartbeatLogger.warn(
+              { connectionId, messagesHandled: handledMessages },
+              "watchdog: listener map empty while status=connected — forcing reconnect",
+            );
+            listener.signalClose?.({
+              status: 499,
+              isLoggedOut: false,
+              error: "watchdog-listener-desync",
+            });
+          }
+          return;
+        }
         if (!lastMessageAt) {
           return;
         }

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -322,6 +322,12 @@ export async function monitorWebChannel(
               { connectionId, messagesHandled: handledMessages },
               "watchdog: listener map empty while status=connected — forcing reconnect",
             );
+            // Mirror the message-timeout path: call closeListener() first so the
+            // heartbeat and watchdog timers are stopped before we signal the socket
+            // to close — otherwise the timers keep firing on a dead connection.
+            void closeListener().catch((err) => {
+              logVerbose(`Close listener failed: ${formatError(err)}`);
+            });
             listener.signalClose?.({
               status: 499,
               isLoggedOut: false,


### PR DESCRIPTION
Fixes #34741

## Root cause

Two cooperating bugs caused the `No active WhatsApp Web listener` desync described in the issue:

### Bug 1 — `closeListener` could clobber a newer instance's map entry

During a rapid-restart storm, a second `monitorWebChannel` call would register its fresh listener in the shared `listeners` map, but the first (stale) instance's `closeListener` would still call `setActiveWebListener(accountId, null)` — unconditionally deleting whatever was in the map. That left `status.connected = true` while `listeners` was empty. Sends then failed with "No active WhatsApp Web listener" indefinitely, with no auto-recovery.

**Fix:** Guard the removal with an identity check — only clear the map entry if _this instance's_ listener is still the current one:

```ts
if (getActiveWebListener(account.accountId) === listener) {
  setActiveWebListener(account.accountId, null);
}
```

### Bug 2 — Watchdog was completely inert when `lastMessageAt` is null

The watchdog's first check was `if (!lastMessageAt) return`, so if no inbound messages had been received in the current session (common on outbound-only deployments or right after a restart), the watchdog never ran any recovery logic. An empty listener map with `status.connected = true` would therefore go undetected until a manual restart.

**Fix:** Check the listener map first, before the `lastMessageAt` guard, and signal a reconnect when the map is empty while `status.connected` is still true.

### Bonus fix — registration-before-emission ordering

`setActiveWebListener` was called _after_ `emitStatus()` on the connect path. A concurrent send attempt in that brief window would throw "No active WhatsApp Web listener" even though the connection was healthy. Fixed by registering the listener in the map before emitting `connected: true`.

### Diagnostic logging

`setActiveWebListener` now emits a `warn`-level log with a stack trace every time a listener is removed from the map, making future silent-removal incidents immediately visible in gateway logs.

## Changes

- `src/web/active-listener.ts` — import logger; warn+stack on every listener removal
- `src/web/auto-reply/monitor.ts`
  - Import `getActiveWebListener`
  - Move `setActiveWebListener(listener)` before `emitStatus()` on connect
  - Guard `closeListener` with identity check
  - Watchdog: detect empty listener map independently of `lastMessageAt`

## Testing

- Existing unit tests in `src/web/outbound.test.ts` and `src/web/auto-reply/web-auto-reply-monitor.test.ts` continue to pass.
- The race can be reproduced locally by running two overlapping `monitorWebChannel` calls against the same `accountId`; with the fix the second instance's listener is preserved when the first instance closes.

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)
