### PR TITLE
feat(hooks): add gateway:ready hook for reliable post-restart actions (fixes #34747)

### DIFF
--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -187,5 +187,22 @@ export async function startGatewaySidecars(params: {
     }, 750);
   }
 
+  // Fire gateway:ready hook after all initialization is complete.
+  // This provides a reliable trigger for post-restart actions like resuming tasks.
+  // Unlike gateway:startup (which fires after channels start), this fires after
+  // all services including ACP, memory backend, and restart sentinel are initialized.
+  if (params.cfg.hooks?.internal?.enabled) {
+    const isRestart = shouldWakeFromRestartSentinel();
+    setTimeout(() => {
+      const hookEvent = createInternalHookEvent("gateway", "ready", "gateway:ready", {
+        cfg: params.cfg,
+        deps: params.deps,
+        workspaceDir: params.defaultWorkspaceDir,
+        isRestart,
+      });
+      void triggerInternalHook(hookEvent);
+    }, 1000);
+  }
+
   return { browserControl, pluginServices };
 }

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -39,6 +39,24 @@ export type GatewayStartupHookEvent = InternalHookEvent & {
   context: GatewayStartupHookContext;
 };
 
+/**
+ * Gateway ready hook context - fired after all channels and services are fully initialized.
+ * This is the reliable hook to use for post-restart actions like resuming tasks.
+ */
+export type GatewayReadyHookContext = {
+  cfg?: OpenClawConfig;
+  deps?: CliDeps;
+  workspaceDir?: string;
+  /** Whether this startup followed a gateway restart */
+  isRestart?: boolean;
+};
+
+export type GatewayReadyHookEvent = InternalHookEvent & {
+  type: "gateway";
+  action: "ready";
+  context: GatewayReadyHookContext;
+};
+
 // ============================================================================
 // Message Hook Events
 // ============================================================================
@@ -389,6 +407,13 @@ export function isGatewayStartupEvent(event: InternalHookEvent): event is Gatewa
     return false;
   }
   return Boolean(getHookContext<GatewayStartupHookContext>(event));
+}
+
+export function isGatewayReadyEvent(event: InternalHookEvent): event is GatewayReadyHookEvent {
+  if (!isHookEventTypeAndAction(event, "gateway", "ready")) {
+    return false;
+  }
+  return Boolean(getHookContext<GatewayReadyHookContext>(event));
 }
 
 export function isMessageReceivedEvent(


### PR DESCRIPTION
## Summary

Add a new `gateway:ready` hook event that fires after all channels and services are fully initialized. Unlike `gateway:startup` (which fires after channels start with a 250ms delay), `gateway:ready` fires after all initialization is complete including ACP, memory backend, and restart sentinel processing.

## Problem

After a gateway restart, the agent does not resume in-flight tasks or send updates. The existing `gateway:startup` hook fires too early (250ms after channels start), causing race conditions when used to trigger resume actions.

## Solution

- Add new `GatewayReadyHookContext` and `GatewayReadyHookEvent` types in `src/hooks/internal-hooks.ts`
- Add `isGatewayReadyEvent()` type guard function
- Trigger `gateway:ready` hook in `src/gateway/server-startup.ts` after all initialization is complete (1000ms delay)
- Include `isRestart` flag to differentiate between fresh startups and restarts

## Usage

Users can now use the reliable `gateway:ready` hook in their internal hooks configuration:

```json
{
  "hooks": {
    "internal": {
      "enabled": true,
      "handlers": {
        "gateway:ready": {
          "code": "if (event.context.isRestart) { // Resume any in-progress tasks }"
        }
      }
    }
  }
}
```

## Changes

- `src/hooks/internal-hooks.ts`: Add GatewayReadyHookContext, GatewayReadyHookEvent, and isGatewayReadyEvent
- `src/gateway/server-startup.ts`: Trigger gateway:ready hook after all initialization

---

*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one)*