### PR TITLE
feat(discord): add autoThreadName and autoThreadArchiveMin config options

### DIFF
--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -359,7 +359,16 @@ export const DiscordGuildChannelSchema = z
     /** Naming strategy for auto-created threads. "message" uses the message text (default), "first-sentence" uses first sentence only. */
     autoThreadName: z.enum(["message", "first-sentence"]).optional(),
     /** Archive duration for auto-created threads in minutes. Discord supports 60, 1440 (1 day), 4320 (3 days), 10080 (1 week). */
-    autoThreadArchiveMin: z.enum(["60", "1440", "4320", "10080"]).optional(),
+    autoThreadArchiveMin: z
+      .union([
+        z.enum(["60", "1440", "4320", "10080"]),
+        z.literal(60),
+        z.literal(1440),
+        z.literal(4320),
+        z.literal(10080),
+      ])
+      .transform((v) => String(v))
+      .optional(),
   })
   .strict();
 

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -356,6 +356,10 @@ export const DiscordGuildChannelSchema = z
     systemPrompt: z.string().optional(),
     includeThreadStarter: z.boolean().optional(),
     autoThread: z.boolean().optional(),
+    /** Naming strategy for auto-created threads. "message" uses the message text (default), "first-sentence" uses first sentence only. */
+    autoThreadName: z.enum(["message", "first-sentence"]).optional(),
+    /** Archive duration for auto-created threads in minutes. Discord supports 60, 1440 (1 day), 4320 (3 days), 10080 (1 week). */
+    autoThreadArchiveMin: z.enum(["60", "1440", "4320", "10080"]).optional(),
   })
   .strict();
 

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -40,7 +40,7 @@ export type DiscordGuildEntryResolved = {
       includeThreadStarter?: boolean;
       autoThread?: boolean;
       autoThreadName?: "message" | "first-sentence";
-      autoThreadArchiveMin?: "60" | "1440" | "4320" | "10080";
+      autoThreadArchiveMin?: "60" | "1440" | "4320" | "10080" | 60 | 1440 | 4320 | 10080;
     }
   >;
 };
@@ -57,7 +57,7 @@ export type DiscordChannelConfigResolved = {
   includeThreadStarter?: boolean;
   autoThread?: boolean;
   autoThreadName?: "message" | "first-sentence";
-  autoThreadArchiveMin?: "60" | "1440" | "4320" | "10080";
+  autoThreadArchiveMin?: "60" | "1440" | "4320" | "10080" | 60 | 1440 | 4320 | 10080;
   matchKey?: string;
   matchSource?: ChannelMatchSource;
 };

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -39,6 +39,8 @@ export type DiscordGuildEntryResolved = {
       systemPrompt?: string;
       includeThreadStarter?: boolean;
       autoThread?: boolean;
+      autoThreadName?: "message" | "first-sentence";
+      autoThreadArchiveMin?: "60" | "1440" | "4320" | "10080";
     }
   >;
 };
@@ -54,6 +56,8 @@ export type DiscordChannelConfigResolved = {
   systemPrompt?: string;
   includeThreadStarter?: boolean;
   autoThread?: boolean;
+  autoThreadName?: "message" | "first-sentence";
+  autoThreadArchiveMin?: "60" | "1440" | "4320" | "10080";
   matchKey?: string;
   matchSource?: ChannelMatchSource;
 };
@@ -400,6 +404,8 @@ function resolveDiscordChannelConfigEntry(
     systemPrompt: entry.systemPrompt,
     includeThreadStarter: entry.includeThreadStarter,
     autoThread: entry.autoThread,
+    autoThreadName: entry.autoThreadName,
+    autoThreadArchiveMin: entry.autoThreadArchiveMin,
   };
   return resolved;
 }

--- a/src/discord/monitor/threading.auto-thread.test.ts
+++ b/src/discord/monitor/threading.auto-thread.test.ts
@@ -1,5 +1,5 @@
 import { ChannelType } from "@buape/carbon";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { maybeCreateDiscordAutoThread, extractFirstSentence } from "./threading.js";
 
 describe("maybeCreateDiscordAutoThread", () => {
@@ -121,5 +121,106 @@ describe("extractFirstSentence", () => {
 
   it("handles whitespace-only string", () => {
     expect(extractFirstSentence("   ")).toBe("");
+  });
+
+  it("skips common abbreviations like Dr., Mr., etc.", () => {
+    expect(extractFirstSentence("Dr. Smith is here. Call him now.")).toBe("Dr. Smith is here.");
+    expect(extractFirstSentence("Mr. Jones and Mrs. Smith went home. They were tired.")).toBe(
+      "Mr. Jones and Mrs. Smith went home.",
+    );
+    expect(
+      extractFirstSentence("The U.S. government announced something. More details later."),
+    ).toBe("The U.S. government announced something.");
+  });
+});
+
+describe("maybeCreateDiscordAutoThread config integration", () => {
+  const postMock = vi.fn();
+  const getMock = vi.fn();
+  const mockClient = {
+    rest: { post: postMock, get: getMock },
+  } as unknown as Parameters<typeof maybeCreateDiscordAutoThread>[0]["client"];
+  const mockMessage = {
+    id: "msg1",
+    timestamp: "123",
+  } as unknown as Parameters<typeof maybeCreateDiscordAutoThread>[0]["message"];
+
+  beforeEach(() => {
+    postMock.mockReset();
+    getMock.mockReset();
+  });
+
+  it("applies first-sentence naming strategy when configured", async () => {
+    postMock.mockResolvedValueOnce({ id: "thread1" });
+    await maybeCreateDiscordAutoThread({
+      client: mockClient,
+      message: mockMessage,
+      messageChannelId: "text1",
+      isGuildMessage: true,
+      channelConfig: { allowed: true, autoThread: true, autoThreadName: "first-sentence" },
+      channelType: ChannelType.GuildText,
+      baseText: "Hello world. This is extra text.",
+      combinedBody: "",
+    });
+    expect(postMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ body: expect.objectContaining({ name: "Hello world." }) }),
+    );
+  });
+
+  it("uses full message text when autoThreadName is 'message'", async () => {
+    postMock.mockResolvedValueOnce({ id: "thread1" });
+    await maybeCreateDiscordAutoThread({
+      client: mockClient,
+      message: mockMessage,
+      messageChannelId: "text1",
+      isGuildMessage: true,
+      channelConfig: { allowed: true, autoThread: true, autoThreadName: "message" },
+      channelType: ChannelType.GuildText,
+      baseText: "Hello world. This is extra text.",
+      combinedBody: "",
+    });
+    expect(postMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.objectContaining({ name: "Hello world. This is extra text." }),
+      }),
+    );
+  });
+
+  it("uses configured autoThreadArchiveMin", async () => {
+    postMock.mockResolvedValueOnce({ id: "thread1" });
+    await maybeCreateDiscordAutoThread({
+      client: mockClient,
+      message: mockMessage,
+      messageChannelId: "text1",
+      isGuildMessage: true,
+      channelConfig: { allowed: true, autoThread: true, autoThreadArchiveMin: "10080" },
+      channelType: ChannelType.GuildText,
+      baseText: "test",
+      combinedBody: "test",
+    });
+    expect(postMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ body: expect.objectContaining({ auto_archive_duration: 10080 }) }),
+    );
+  });
+
+  it("defaults to 60 minute archive when autoThreadArchiveMin not set", async () => {
+    postMock.mockResolvedValueOnce({ id: "thread1" });
+    await maybeCreateDiscordAutoThread({
+      client: mockClient,
+      message: mockMessage,
+      messageChannelId: "text1",
+      isGuildMessage: true,
+      channelConfig: { allowed: true, autoThread: true },
+      channelType: ChannelType.GuildText,
+      baseText: "test",
+      combinedBody: "test",
+    });
+    expect(postMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ body: expect.objectContaining({ auto_archive_duration: 60 }) }),
+    );
   });
 });

--- a/src/discord/monitor/threading.auto-thread.test.ts
+++ b/src/discord/monitor/threading.auto-thread.test.ts
@@ -137,6 +137,16 @@ describe("extractFirstSentence", () => {
     expect(extractFirstSentence('He said "Done." Then left.')).toBe('He said "Done."');
     expect(extractFirstSentence("(That's it.) Moving on.")).toBe("(That's it.)");
   });
+
+  it("handles inline dots in domains and version numbers", () => {
+    expect(extractFirstSentence("Check out example.com for details. It's great.")).toBe(
+      "Check out example.com for details.",
+    );
+    expect(extractFirstSentence("Version 2.0 is here. Download now.")).toBe("Version 2.0 is here.");
+    expect(extractFirstSentence("See docs.openclaw.io for help. Thanks.")).toBe(
+      "See docs.openclaw.io for help.",
+    );
+  });
 });
 
 describe("maybeCreateDiscordAutoThread config integration", () => {

--- a/src/discord/monitor/threading.auto-thread.test.ts
+++ b/src/discord/monitor/threading.auto-thread.test.ts
@@ -1,6 +1,6 @@
 import { ChannelType } from "@buape/carbon";
 import { describe, it, expect, vi } from "vitest";
-import { maybeCreateDiscordAutoThread } from "./threading.js";
+import { maybeCreateDiscordAutoThread, extractFirstSentence } from "./threading.js";
 
 describe("maybeCreateDiscordAutoThread", () => {
   const postMock = vi.fn();
@@ -87,5 +87,39 @@ describe("maybeCreateDiscordAutoThread", () => {
     });
     expect(result).toBe("thread1");
     expect(postMock).toHaveBeenCalled();
+  });
+});
+
+describe("extractFirstSentence", () => {
+  it("extracts first sentence ending with period", () => {
+    expect(extractFirstSentence("Hello world. This is more text.")).toBe("Hello world.");
+  });
+
+  it("extracts first sentence ending with question mark", () => {
+    expect(extractFirstSentence("Is this working? I hope so.")).toBe("Is this working?");
+  });
+
+  it("extracts first sentence ending with exclamation mark", () => {
+    expect(extractFirstSentence("Hello! How are you?")).toBe("Hello!");
+  });
+
+  it("returns full text if no sentence ending found and under 50 chars", () => {
+    expect(extractFirstSentence("Short text without ending")).toBe("Short text without ending");
+  });
+
+  it("truncates at word boundary if no sentence ending and over 50 chars", () => {
+    const longText =
+      "This is a very long piece of text that does not have any sentence ending punctuation";
+    const result = extractFirstSentence(longText);
+    expect(result.length).toBeLessThanOrEqual(50);
+    expect(longText.startsWith(result)).toBe(true);
+  });
+
+  it("handles empty string", () => {
+    expect(extractFirstSentence("")).toBe("");
+  });
+
+  it("handles whitespace-only string", () => {
+    expect(extractFirstSentence("   ")).toBe("");
   });
 });

--- a/src/discord/monitor/threading.auto-thread.test.ts
+++ b/src/discord/monitor/threading.auto-thread.test.ts
@@ -132,6 +132,11 @@ describe("extractFirstSentence", () => {
       extractFirstSentence("The U.S. government announced something. More details later."),
     ).toBe("The U.S. government announced something.");
   });
+
+  it("handles punctuation before closing quotes and parens", () => {
+    expect(extractFirstSentence('He said "Done." Then left.')).toBe('He said "Done."');
+    expect(extractFirstSentence("(That's it.) Moving on.")).toBe("(That's it.)");
+  });
 });
 
 describe("maybeCreateDiscordAutoThread config integration", () => {

--- a/src/discord/monitor/threading.auto-thread.test.ts
+++ b/src/discord/monitor/threading.auto-thread.test.ts
@@ -147,6 +147,13 @@ describe("extractFirstSentence", () => {
       "See docs.openclaw.io for help.",
     );
   });
+
+  it("preserves sentence-final periods in abbreviations", () => {
+    expect(extractFirstSentence("I moved to the U.S. Then I traveled.")).toBe(
+      "I moved to the U.S.",
+    );
+    expect(extractFirstSentence("We bought fruit, etc. Then left.")).toBe("We bought fruit, etc.");
+  });
 });
 
 describe("maybeCreateDiscordAutoThread config integration", () => {

--- a/src/discord/monitor/threading.ts
+++ b/src/discord/monitor/threading.ts
@@ -258,6 +258,11 @@ export function extractFirstSentence(text: string): string {
   // e.g. and i.e.
   sanitized = sanitized.replace(/\b(e)\.(g)\./gi, `$1${placeholder}$2${placeholder}`);
   sanitized = sanitized.replace(/\b(i)\.(e)\./gi, `$1${placeholder}$2${placeholder}`);
+  // Domain-like patterns: protect dots that are between word chars (foo.bar.com)
+  // This catches subdomains and most domain patterns
+  sanitized = sanitized.replace(/(\w)\.(\w)/g, `$1${placeholder}$2`);
+  // Version numbers (2.0, v1.2.3)
+  sanitized = sanitized.replace(/(\d)\.(\d)/g, `$1${placeholder}$2`);
 
   // Now find the first real sentence ending
   const match = sanitized.match(/^[^.!?]*[.!?]["')\]]*(?:\s|$)/);

--- a/src/discord/monitor/threading.ts
+++ b/src/discord/monitor/threading.ts
@@ -260,7 +260,7 @@ export function extractFirstSentence(text: string): string {
   sanitized = sanitized.replace(/\b(i)\.(e)\./gi, `$1${placeholder}$2${placeholder}`);
 
   // Now find the first real sentence ending
-  const match = sanitized.match(/^[^.!?]*[.!?](?:\s|$)/);
+  const match = sanitized.match(/^[^.!?]*[.!?]["')\]]*(?:\s|$)/);
   if (match) {
     // Get the matched portion length and extract from original
     const matchLength = match[0].length;
@@ -448,7 +448,7 @@ export async function maybeCreateDiscordAutoThread(params: {
 
     // Parse archive duration from config, default to 60 minutes
     const archiveDuration = params.channelConfig?.autoThreadArchiveMin
-      ? parseInt(params.channelConfig.autoThreadArchiveMin, 10)
+      ? Number(params.channelConfig.autoThreadArchiveMin)
       : 60;
 
     const created = (await params.client.rest.post(

--- a/src/discord/monitor/threading.ts
+++ b/src/discord/monitor/threading.ts
@@ -233,6 +233,25 @@ export function resolveDiscordReplyTarget(opts: {
   return opts.hasReplied ? undefined : replyToId;
 }
 
+/**
+ * Extract the first sentence from text for thread naming.
+ * Looks for sentence-ending punctuation followed by space or end of string.
+ */
+export function extractFirstSentence(text: string): string {
+  const trimmed = text.trim();
+  // Match first sentence: text up to and including .!? followed by space or end
+  const match = trimmed.match(/^[^.!?]*[.!?](?:\s|$)/);
+  if (match) {
+    return match[0].trim();
+  }
+  // If no sentence ending found, take first ~50 chars at word boundary
+  if (trimmed.length > 50) {
+    const truncated = trimmed.slice(0, 50).replace(/\s+\S*$/, "");
+    return truncated || trimmed.slice(0, 50);
+  }
+  return trimmed;
+}
+
 export function sanitizeDiscordThreadName(rawName: string, fallbackId: string): string {
   const cleanedName = rawName
     .replace(/<@!?\d+>/g, "") // user mentions
@@ -393,16 +412,25 @@ export async function maybeCreateDiscordAutoThread(params: {
     return undefined;
   }
   try {
-    const threadName = sanitizeDiscordThreadName(
-      params.baseText || params.combinedBody || "Thread",
-      params.message.id,
-    );
+    // Apply naming strategy: "first-sentence" extracts first sentence, "message" (default) uses full text
+    const rawText = params.baseText || params.combinedBody || "Thread";
+    const nameSource =
+      params.channelConfig?.autoThreadName === "first-sentence"
+        ? extractFirstSentence(rawText)
+        : rawText;
+    const threadName = sanitizeDiscordThreadName(nameSource, params.message.id);
+
+    // Parse archive duration from config, default to 60 minutes
+    const archiveDuration = params.channelConfig?.autoThreadArchiveMin
+      ? parseInt(params.channelConfig.autoThreadArchiveMin, 10)
+      : 60;
+
     const created = (await params.client.rest.post(
       `${Routes.channelMessage(messageChannelId, params.message.id)}/threads`,
       {
         body: {
           name: threadName,
-          auto_archive_duration: 60,
+          auto_archive_duration: archiveDuration,
         },
       },
     )) as { id?: string };

--- a/src/discord/monitor/threading.ts
+++ b/src/discord/monitor/threading.ts
@@ -235,15 +235,41 @@ export function resolveDiscordReplyTarget(opts: {
 
 /**
  * Extract the first sentence from text for thread naming.
- * Looks for sentence-ending punctuation followed by space or end of string.
+ * Handles common abbreviations (Dr., Mr., Mrs., Ms., Jr., Sr., vs., etc.)
+ * to avoid false sentence boundaries.
  */
 export function extractFirstSentence(text: string): string {
   const trimmed = text.trim();
-  // Match first sentence: text up to and including .!? followed by space or end
-  const match = trimmed.match(/^[^.!?]*[.!?](?:\s|$)/);
-  if (match) {
-    return match[0].trim();
+  if (!trimmed) {
+    return "";
   }
+
+  // Placeholder for protected periods
+  const placeholder = "\x00DOT\x00";
+
+  // Protect common abbreviations by replacing their periods
+  // Single-letter abbreviations with period
+  let sanitized = trimmed.replace(/\b([A-Z])\./g, `$1${placeholder}`);
+  // Common title/name abbreviations
+  sanitized = sanitized.replace(
+    /\b(Mr|Mrs|Ms|Dr|Jr|Sr|vs|etc|Prof|Rev|St|Lt|Gen|Col|Sgt|Capt)\./gi,
+    `$1${placeholder}`,
+  );
+  // e.g. and i.e.
+  sanitized = sanitized.replace(/\b(e)\.(g)\./gi, `$1${placeholder}$2${placeholder}`);
+  sanitized = sanitized.replace(/\b(i)\.(e)\./gi, `$1${placeholder}$2${placeholder}`);
+
+  // Now find the first real sentence ending
+  const match = sanitized.match(/^[^.!?]*[.!?](?:\s|$)/);
+  if (match) {
+    // Get the matched portion length and extract from original
+    const matchLength = match[0].length;
+    // Count placeholders to adjust length
+    const placeholderCount = (match[0].match(new RegExp(placeholder, "g")) || []).length;
+    const originalLength = matchLength - placeholderCount * (placeholder.length - 1);
+    return trimmed.slice(0, originalLength).trim();
+  }
+
   // If no sentence ending found, take first ~50 chars at word boundary
   if (trimmed.length > 50) {
     const truncated = trimmed.slice(0, 50).replace(/\s+\S*$/, "");

--- a/src/discord/monitor/threading.ts
+++ b/src/discord/monitor/threading.ts
@@ -248,18 +248,24 @@ export function extractFirstSentence(text: string): string {
   const placeholder = "\x00DOT\x00";
 
   // Protect common abbreviations by replacing their periods
-  // Single-letter abbreviations with period
-  let sanitized = trimmed.replace(/\b([A-Z])\./g, `$1${placeholder}`);
-  // Common title/name abbreviations
+  let sanitized = trimmed;
+
+  // Title abbreviations (Dr/Mr/Mrs/Prof etc) - ALWAYS protect, they're followed by names
   sanitized = sanitized.replace(
-    /\b(Mr|Mrs|Ms|Dr|Jr|Sr|vs|etc|Prof|Rev|St|Lt|Gen|Col|Sgt|Capt)\./gi,
+    /\b(Mr|Mrs|Ms|Dr|Prof|Rev|Lt|Gen|Col|Sgt|Capt)\./gi,
     `$1${placeholder}`,
   );
-  // e.g. and i.e.
-  sanitized = sanitized.replace(/\b(e)\.(g)\./gi, `$1${placeholder}$2${placeholder}`);
-  sanitized = sanitized.replace(/\b(i)\.(e)\./gi, `$1${placeholder}$2${placeholder}`);
+
+  // Single-letter abbreviations - only protect if NOT followed by space+capital (sentence start)
+  sanitized = sanitized.replace(/\b([A-Z])\.(?!\s+[A-Z])/g, `$1${placeholder}`);
+
+  // Other abbreviations (Jr/Sr/vs/etc) - only protect if NOT sentence-ending
+  sanitized = sanitized.replace(/\b(Jr|Sr|vs|etc)\.(?!\s+[A-Z])/gi, `$1${placeholder}`);
+
+  // e.g. and i.e. (only protect if not sentence-ending)
+  sanitized = sanitized.replace(/\b(e)\.(g)\.(?!\s+[A-Z])/gi, `$1${placeholder}$2${placeholder}`);
+  sanitized = sanitized.replace(/\b(i)\.(e)\.(?!\s+[A-Z])/gi, `$1${placeholder}$2${placeholder}`);
   // Domain-like patterns: protect dots that are between word chars (foo.bar.com)
-  // This catches subdomains and most domain patterns
   sanitized = sanitized.replace(/(\w)\.(\w)/g, `$1${placeholder}$2`);
   // Version numbers (2.0, v1.2.3)
   sanitized = sanitized.replace(/(\d)\.(\d)/g, `$1${placeholder}$2`);


### PR DESCRIPTION
When I opened the original PR for autoThread, I meant to follow up with these quality-of-life configs, but better late than never.

## Summary

Add two new config options for Discord auto-threads:

- **autoThreadName**: `'message'` (default) or `'first-sentence'`
  - `'message'` uses the full message text (current behavior)
  - `'first-sentence'` extracts just the first sentence for cleaner thread names

- **autoThreadArchiveMin**: `'60'`, `'1440'`, `'4320'`, or `'10080'`
  - Sets the auto-archive duration in minutes
  - Default: 60 (1 hour) - same as before
  - 1440 = 1 day, 4320 = 3 days, 10080 = 1 week

## Problem

Auto-threads currently:
1. Use the raw message content as the thread name (often long and ugly, e.g., 'I'd really like better names for all the discord threads that are created. I'd a')
2. Archive after 60 minutes, causing them to disappear from the sidebar quickly

## Example Config

```yaml
channels:
  discord:
    guilds:
      YOUR_GUILD_ID:
        channels:
          CHANNEL_ID:
            autoThread: true
            autoThreadName: first-sentence
            autoThreadArchiveMin: '10080'  # 1 week
```

## Changes

- Added `autoThreadName` and `autoThreadArchiveMin` to `DiscordGuildChannelSchema`
- Added `extractFirstSentence()` helper function
- Updated `maybeCreateDiscordAutoThread()` to use config options
- Added tests for `extractFirstSentence()`

## Testing

All existing tests pass, plus new tests for the first-sentence extraction logic.