### PR TITLE
docs(gateway): clarify cron.jobs config boundary

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2877,6 +2877,8 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
 - `runLog.keepLines`: newest lines retained when run-log pruning is triggered. Default: `2000`.
 - `webhookToken`: bearer token used for cron webhook POST delivery (`delivery.mode = "webhook"`), if omitted no auth header is sent.
 - `webhook`: deprecated legacy fallback webhook URL (http/https) used only for stored jobs that still have `notify: true`.
+- This `cron` object configures runtime behavior only. Job records are managed via `openclaw cron add/edit/remove` (or Gateway `cron.*` tools), not via a `cron.jobs` key in `openclaw.json`.
+- Jobs are persisted on the gateway host in `~/.openclaw/cron/jobs.json`.
 
 See [Cron Jobs](/automation/cron-jobs).
 

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -263,6 +263,8 @@ When validation fails:
 
     - `sessionRetention`: prune completed isolated run sessions from `sessions.json` (default `24h`; set `false` to disable).
     - `runLog`: prune `cron/runs/<jobId>.jsonl` by size and retained lines.
+    - `cron` here configures scheduler runtime only. Job definitions are not declared in `openclaw.json`.
+    - `cron.jobs` is not a valid config key. Manage jobs with `openclaw cron add/edit/remove` (or Gateway `cron.*` tools), persisted at `~/.openclaw/cron/jobs.json`.
     - See [Cron jobs](/automation/cron-jobs) for feature overview and CLI examples.
 
   </Accordion>


### PR DESCRIPTION
## Summary
- clarify that `cron` in `openclaw.json` configures runtime behavior only
- explicitly document that `cron.jobs` is not a valid config key
- point users to `openclaw cron add/edit/remove` (or Gateway `cron.*` tools) and the persisted job store path `~/.openclaw/cron/jobs.json`

Closes #27947.

## Testing
- pnpm format
