### PR TITLE
fix(discord): respond to unauthorized slash commands instead of silent timeout

### DIFF
--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -387,3 +387,34 @@ export function resolveCommandAuthorization(params: {
     to: to || undefined,
   };
 }
+
+/**
+ * Checks whether a sender is authorized by `commands.allowFrom` for native command dispatch.
+ *
+ * Returns `null` when `commands.allowFrom` is not configured (caller should fall through
+ * to channel-level authorization). Returns `true` / `false` when configured.
+ */
+export function resolveCommandsAllowFromCheck(params: {
+  cfg: OpenClawConfig;
+  providerId?: ChannelId;
+  accountId?: string | null;
+  senderId?: string | null;
+}): boolean | null {
+  const { cfg, providerId, accountId, senderId } = params;
+  const dock = providerId ? getChannelDock(providerId) : undefined;
+  const list = resolveCommandsAllowFromList({ dock, cfg, accountId, providerId });
+  if (list === null) {
+    return null;
+  }
+  if (list.some((entry) => entry.trim() === "*")) {
+    return true;
+  }
+  const candidates = resolveSenderCandidates({
+    dock,
+    providerId,
+    cfg,
+    accountId,
+    senderId,
+  });
+  return candidates.some((candidate) => list.includes(candidate));
+}

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
-import { resolveCommandAuthorization } from "./command-auth.js";
+import { resolveCommandAuthorization, resolveCommandsAllowFromCheck } from "./command-auth.js";
 import { hasControlCommand, hasInlineCommandTokens } from "./command-detection.js";
 import { listChatCommands } from "./commands-registry.js";
 import { parseActivationCommand } from "./group-activation.js";
@@ -489,6 +489,80 @@ describe("resolveCommandAuthorization", () => {
       commandAuthorized: true,
     });
     expect(auth.senderIsOwner).toBe(false);
+  });
+
+  describe("resolveCommandsAllowFromCheck", () => {
+    it("returns null when commands.allowFrom is not configured", () => {
+      const cfg = { channels: { discord: {} } } as OpenClawConfig;
+      const result = resolveCommandsAllowFromCheck({
+        cfg,
+        providerId: "discord",
+        accountId: null,
+        senderId: "123",
+      });
+      expect(result).toBeNull();
+    });
+
+    it("returns true for authorized sender in global list", () => {
+      const cfg = {
+        commands: { allowFrom: { "*": ["123"] } },
+      } as OpenClawConfig;
+      const result = resolveCommandsAllowFromCheck({
+        cfg,
+        providerId: "discord",
+        accountId: null,
+        senderId: "123",
+      });
+      expect(result).toBe(true);
+    });
+
+    it("returns false for unauthorized sender", () => {
+      const cfg = {
+        commands: { allowFrom: { "*": ["123"] } },
+      } as OpenClawConfig;
+      const result = resolveCommandsAllowFromCheck({
+        cfg,
+        providerId: "discord",
+        accountId: null,
+        senderId: "999",
+      });
+      expect(result).toBe(false);
+    });
+
+    it("returns true when wildcard is in list", () => {
+      const cfg = {
+        commands: { allowFrom: { "*": ["*"] } },
+      } as OpenClawConfig;
+      const result = resolveCommandsAllowFromCheck({
+        cfg,
+        providerId: "discord",
+        accountId: null,
+        senderId: "anyone",
+      });
+      expect(result).toBe(true);
+    });
+
+    it("uses provider-specific list over global", () => {
+      const cfg = {
+        commands: { allowFrom: { "*": ["globaluser"], discord: ["456"] } },
+      } as OpenClawConfig;
+      const globalResult = resolveCommandsAllowFromCheck({
+        cfg,
+        providerId: "discord",
+        accountId: null,
+        senderId: "globaluser",
+      });
+      expect(globalResult).toBe(false);
+
+      const discordResult = resolveCommandsAllowFromCheck({
+        cfg,
+        providerId: "discord",
+        accountId: null,
+        senderId: "456",
+      });
+      expect(discordResult).toBe(true);
+    });
+  });
   });
 });
 

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -563,7 +563,6 @@ describe("resolveCommandAuthorization", () => {
       expect(discordResult).toBe(true);
     });
   });
-  });
 });
 
 describe("control command parsing", () => {

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -20,7 +20,7 @@ import {
 } from "../../acp/persistent-bindings.route.js";
 import { resolveHumanDelayConfig } from "../../agents/identity.js";
 import { resolveChunkMode, resolveTextChunkLimit } from "../../auto-reply/chunk.js";
-import { resolveCommandAuthorization } from "../../auto-reply/command-auth.js";
+import { resolveCommandAuthorization, resolveCommandsAllowFromCheck } from "../../auto-reply/command-auth.js";
 import type {
   ChatCommandDefinition,
   CommandArgDefinition,
@@ -1500,6 +1500,20 @@ async function dispatchDiscordCommandInteraction(params: {
   }
   if (isGroupDm && discordConfig?.dm?.groupEnabled === false) {
     await respond("Discord group DMs are disabled.");
+    return;
+  }
+
+  // Check commands.allowFrom authorization (applies to both DM and guild commands).
+  // This must happen early — before the interaction is deferred — so that unauthorized
+  // users receive an immediate response instead of a silent timeout.
+  const commandsAllowFromResult = resolveCommandsAllowFromCheck({
+    cfg,
+    providerId: "discord",
+    accountId,
+    senderId: sender.id,
+  });
+  if (commandsAllowFromResult === false) {
+    await respond("You are not authorized to use this command.", { ephemeral: true });
     return;
   }
 

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -20,7 +20,10 @@ import {
 } from "../../acp/persistent-bindings.route.js";
 import { resolveHumanDelayConfig } from "../../agents/identity.js";
 import { resolveChunkMode, resolveTextChunkLimit } from "../../auto-reply/chunk.js";
-import { resolveCommandAuthorization, resolveCommandsAllowFromCheck } from "../../auto-reply/command-auth.js";
+import {
+  resolveCommandAuthorization,
+  resolveCommandsAllowFromCheck,
+} from "../../auto-reply/command-auth.js";
 import type {
   ChatCommandDefinition,
   CommandArgDefinition,


### PR DESCRIPTION
## Summary

- Problem: When `commands.allowFrom` is configured, unauthorized Discord users invoking native slash commands receive a silent timeout ("The application did not respond") instead of a clear error message. The slash command is deferred (ACK sent) but `commands.allowFrom` is only evaluated later in the text-command pipeline, which returns `{ shouldContinue: false }` without sending a response — so Discord never receives a follow-up.
- Why it matters: Users see a confusing timeout with no indication that they were rejected due to authorization. This affects all Discord deployments using `commands.allowFrom`.
- What changed: Added an early `commands.allowFrom` check in the native slash command dispatcher (`dispatchDiscordCommandInteraction`) that runs **before** the interaction is deferred. Unauthorized users now receive an immediate ephemeral "You are not authorized to use this command." response. Extracted a new `resolveCommandsAllowFromCheck()` helper from the existing authorization logic in `command-auth.ts` to avoid duplicating the allowFrom resolution.
- What did NOT change (scope boundary): The existing text-command authorization path in `command-gates.ts` and the auto-reply pipeline are untouched. Channel-level `allowFrom`, DM policy, and guild/member access checks remain unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Discord channel

## Linked Issue/PR

- Closes #34776

## User-visible / Behavior Changes

- Unauthorized Discord slash command users now receive an immediate ephemeral "You are not authorized to use this command." message instead of a silent timeout.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OS: macOS
- Runtime: Node 22+

### Steps
1. Configure `commands.allowFrom` to restrict command access to specific users
2. Have an unauthorized user invoke a Discord native slash command (e.g., /status)

### Expected
Unauthorized users receive an immediate ephemeral "You are not authorized to use this command." message.

### Actual (before fix)
Users see "The application did not respond" timeout error after several minutes.

## Evidence

- [x] Failing test/log before + passing after

```
 ✓ resolveCommandsAllowFromCheck > returns null when commands.allowFrom is not configured
 ✓ resolveCommandsAllowFromCheck > returns true for authorized sender in global list
 ✓ resolveCommandsAllowFromCheck > returns false for unauthorized sender
 ✓ resolveCommandsAllowFromCheck > returns true when wildcard is in list
 ✓ resolveCommandsAllowFromCheck > uses provider-specific list over global

 Test Files  1 passed (1)
      Tests  29 passed (29)
```

Full suite: 811 passed, 1 pre-existing failure (time-sensitive `ui.presenter-next-run.test.ts`), 0 new failures.

## Human Verification (required)

- Verified scenarios: Local test suite passes (`pnpm build && pnpm check && pnpm test`)
- Edge cases checked: `commands.allowFrom` not configured (returns null, no change to behavior), wildcard entry, provider-specific vs global list
- What you did **not** verify: Live Discord integration testing with real bot credentials

> **Note:** This PR was created with AI assistance (Claude Code). The code changes have been reviewed and understood.

## Compatibility / Migration

- Backward compatible? Yes — when `commands.allowFrom` is not configured, the new check returns `null` and falls through to existing behavior
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: `git revert <commit-hash>` — the existing text-command pipeline still evaluates `commands.allowFrom`, so reverting only removes the early check in the native command path
- Known bad symptoms: If `resolveCommandsAllowFromCheck` incorrectly returns `false` for an authorized user, they would be blocked from using slash commands (but text commands would still work)

## Risks and Mitigations

- Risk: The new check uses the same `resolveCommandsAllowFromList` and `resolveSenderCandidates` functions as the existing authorization, so normalization behavior is identical. No new logic paths.