### PR TITLE
fix(agents): avoid node exec cwd/rawCommand approval mismatches

### DIFF
--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -11,7 +11,7 @@ export type RequestExecApprovalDecisionParams = {
   commandArgv?: string[];
   systemRunPlan?: SystemRunApprovalPlan;
   env?: Record<string, string>;
-  cwd: string;
+  cwd?: string;
   nodeId?: string;
   host: "gateway" | "node";
   security: ExecSecurity;
@@ -154,7 +154,7 @@ type HostExecApprovalParams = {
   commandArgv?: string[];
   systemRunPlan?: SystemRunApprovalPlan;
   env?: Record<string, string>;
-  workdir: string;
+  workdir?: string;
   host: "gateway" | "node";
   nodeId?: string;
   security: ExecSecurity;

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -32,7 +32,7 @@ import { listNodes, resolveNodeIdFromList } from "./tools/nodes-utils.js";
 
 export type ExecuteNodeHostCommandParams = {
   command: string;
-  workdir: string;
+  workdir?: string;
   env: Record<string, string>;
   requestedEnv?: Record<string, string>;
   requestedNode?: string;

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -116,6 +116,40 @@ describe("exec approvals", () => {
       .toBe(approvalId);
   });
 
+  it("does not forward implicit local cwd when host=node", async () => {
+    let prepareParams: unknown;
+    let runParams: unknown;
+
+    vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
+      if (method === "node.invoke") {
+        const invoke = params as { command?: string };
+        if (invoke.command === "system.run.prepare") {
+          prepareParams = params;
+          return buildPreparedSystemRunPayload(params);
+        }
+        if (invoke.command === "system.run") {
+          runParams = params;
+          return { payload: { success: true, stdout: "ok" } };
+        }
+      }
+      return { ok: true };
+    });
+
+    const tool = createExecTool({
+      host: "node",
+      ask: "off",
+      security: "full",
+      approvalRunningNoticeMs: 0,
+    });
+
+    const result = await tool.execute("call-node-cwd", { command: "echo ok" });
+    expect(result.details.status).toBe("completed");
+    expect(
+      (prepareParams as { params?: { cwd?: unknown } } | undefined)?.params?.cwd,
+    ).toBeUndefined();
+    expect((runParams as { params?: { cwd?: unknown } } | undefined)?.params?.cwd).toBeUndefined();
+  });
+
   it("skips approval when node allowlist is satisfied", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-bin-"));
     const binDir = path.join(tempDir, "bin");

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -345,19 +345,29 @@ export function createExecTool(
           ].join("\n"),
         );
       }
-      const rawWorkdir = params.workdir?.trim() || defaults?.cwd || process.cwd();
-      let workdir = rawWorkdir;
+      const configuredWorkdir = params.workdir?.trim() || defaults?.cwd;
+      let workdir: string;
+      let nodeWorkdir: string | undefined;
       let containerWorkdir = sandbox?.containerWorkdir;
-      if (sandbox) {
-        const resolved = await resolveSandboxWorkdir({
-          workdir: rawWorkdir,
-          sandbox,
-          warnings,
-        });
-        workdir = resolved.hostWorkdir;
-        containerWorkdir = resolved.containerWorkdir;
+      if (host === "node") {
+        // host=node runs remotely; avoid implicitly forwarding the local gateway cwd
+        // because it is often invalid on the node filesystem.
+        nodeWorkdir = configuredWorkdir ? resolveWorkdir(configuredWorkdir, warnings) : undefined;
+        workdir = nodeWorkdir ?? process.cwd();
       } else {
-        workdir = resolveWorkdir(rawWorkdir, warnings);
+        const rawWorkdir = configuredWorkdir || process.cwd();
+        workdir = rawWorkdir;
+        if (sandbox) {
+          const resolved = await resolveSandboxWorkdir({
+            workdir: rawWorkdir,
+            sandbox,
+            warnings,
+          });
+          workdir = resolved.hostWorkdir;
+          containerWorkdir = resolved.containerWorkdir;
+        } else {
+          workdir = resolveWorkdir(rawWorkdir, warnings);
+        }
       }
 
       const inheritedBaseEnv = coerceEnv(process.env);
@@ -401,7 +411,7 @@ export function createExecTool(
       if (host === "node") {
         return executeNodeHostCommand({
           command: params.command,
-          workdir,
+          workdir: nodeWorkdir,
           env,
           requestedEnv: params.env,
           requestedNode: params.node?.trim(),

--- a/src/agents/openclaw-tools.camera.test.ts
+++ b/src/agents/openclaw-tools.camera.test.ts
@@ -663,6 +663,50 @@ describe("nodes run", () => {
     });
   });
 
+  it("omits rawCommand in prepare for argv shell wrappers", async () => {
+    let prepareParams: unknown;
+    setupSystemRunGateway({
+      onRunInvoke: () => {
+        return { payload: { stdout: "", stderr: "", exitCode: 0, success: true } };
+      },
+    });
+    callGateway.mockImplementation(async ({ method, params: gatewayParams }: GatewayCall) => {
+      if (method === "node.list") {
+        return mockNodeList({ commands: ["system.run"] });
+      }
+      if (method === "node.invoke") {
+        const command = (gatewayParams as { command?: string } | undefined)?.command;
+        if (command === "system.run.prepare") {
+          prepareParams = gatewayParams;
+          return {
+            payload: {
+              cmdText: "Get-Date",
+              plan: {
+                argv: ["powershell", "-Command", "Get-Date"],
+                cwd: null,
+                rawCommand: null,
+                agentId: null,
+                sessionKey: null,
+              },
+            },
+          };
+        }
+        return { payload: { stdout: "", stderr: "", exitCode: 0, success: true } };
+      }
+      return unexpectedGatewayMethod(method);
+    });
+
+    await executeNodes({
+      action: "run",
+      node: NODE_ID,
+      command: ["powershell", "-Command", "Get-Date"],
+    });
+
+    expect(
+      (prepareParams as { params?: { rawCommand?: unknown } } | undefined)?.params?.rawCommand,
+    ).toBeUndefined();
+  });
+
   it("requests approval and retries with allow-once decision", async () => {
     let invokeCalls = 0;
     let approvalId: string | null = null;

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -18,7 +18,6 @@ import {
 import { parseDurationMs } from "../../cli/parse-duration.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { parsePreparedSystemRunPayload } from "../../infra/system-run-approval-context.js";
-import { formatExecCommand } from "../../infra/system-run-command.js";
 import { imageMimeFromFormat } from "../../media/mime.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
@@ -651,7 +650,6 @@ export function createNodesTool(options?: {
                 command: "system.run.prepare",
                 params: {
                   command,
-                  rawCommand: formatExecCommand(command),
                   cwd,
                   agentId,
                   sessionKey,


### PR DESCRIPTION
## Summary
- stop forwarding implicit local gateway cwd when `exec` runs with `host=node`; only pass cwd when explicitly configured
- avoid pre-binding `rawCommand` in `nodes run` prepare calls so argv shell wrappers don't trip `rawCommand does not match command`
- loosen approval request typing to allow optional cwd/workdir for node-host paths
- add regression tests for both failure paths

## Problem
Issue #34658 reports regressions after v2026.3.2:
- `INVALID_REQUEST: rawCommand does not match command`
- `SYSTEM_RUN_DENIED: approval requires an existing canonical cwd`

The node-host flow was implicitly sending the local gateway cwd to remote nodes, and the nodes prepare path eagerly sent `rawCommand` even when argv wrappers can be normalized differently.

## Fix
- In `createExecTool`, treat `host=node` workdir separately from local/gateway workdir resolution.
- Only pass node `workdir` when provided by user/config defaults.
- In nodes `system.run.prepare`, send canonical `command` and omit forced `rawCommand`.
- Keep behavior unchanged for non-node hosts.

## Testing
- `pnpm build`
- `pnpm check`
- `pnpm test`

All passed locally (`812 passed, 1 skipped` test files).

## AI Disclosure
This PR is AI-assisted. Code has been fully tested locally. I understand what this code does.
