### PR TITLE
docs(gateway): add safety notes for gateway install --force

### DIFF
--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -265,7 +265,9 @@ Notes:
 - `openclaw doctor --yes` accepts the default repair prompts.
 - `openclaw doctor --repair` applies recommended fixes without prompts.
 - `openclaw doctor --repair --force` overwrites custom supervisor configs.
-- You can always force a full rewrite via `openclaw gateway install --force`.
+- `openclaw gateway install --force` does a full rewrite and should be treated as last-resort repair.
+- Before using `openclaw gateway install --force`, back up customized startup wrappers (for example `gateway.cmd`) and verify your service manager strategy.
+- On Windows, if you use Task Scheduler for startup, remove/disable any NSSM service first to avoid duplicate gateway processes binding the same port.
 
 ### 16) Gateway runtime + port diagnostics
 

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -359,6 +359,11 @@ openclaw gateway install --force
 openclaw gateway restart
 ```
 
+Important safety notes:
+
+- `openclaw gateway install --force` rewrites service startup metadata. Back up customized startup wrappers first (for example `gateway.cmd`).
+- On Windows, if startup is managed by Task Scheduler, remove/disable any NSSM service before reinstalling to prevent duplicate processes fighting over the same port.
+
 Related:
 
 - [/gateway/pairing](/gateway/pairing)


### PR DESCRIPTION
## Summary
- add explicit risk notes around `openclaw gateway install --force` in doctor and troubleshooting docs
- clarify that `--force` rewrites startup metadata and should be treated as a last-resort repair
- document Windows conflict risk when Task Scheduler and NSSM are both enabled

Closes #23177.

## Testing
- pnpm format
