### PR TITLE
fix(infra): classify SQLite transient errors to prevent crash loops

### DIFF
--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -163,13 +163,20 @@ describe("isTransientNetworkError", () => {
 });
 
 describe("isTransientSqliteError", () => {
-  it.each(["SQLITE_CANTOPEN", "SQLITE_BUSY", "SQLITE_LOCKED", "SQLITE_IOERR"])(
+  it.each(["SQLITE_BUSY", "SQLITE_LOCKED", "SQLITE_IOERR"])(
     "returns true for error with code %s",
     (code) => {
       const error = Object.assign(new Error("database error"), { code });
       expect(isTransientSqliteError(error)).toBe(true);
     },
   );
+
+  it("returns false for SQLITE_CANTOPEN (permanent, not transient)", () => {
+    const error = Object.assign(new Error("unable to open database file"), {
+      code: "SQLITE_CANTOPEN",
+    });
+    expect(isTransientSqliteError(error)).toBe(false);
+  });
 
   it("returns true for SQLite error nested in cause chain", () => {
     const innerCause = Object.assign(new Error("database is locked"), { code: "SQLITE_BUSY" });

--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isAbortError, isTransientNetworkError } from "./unhandled-rejections.js";
+import {
+  isAbortError,
+  isTransientNetworkError,
+  isTransientSqliteError,
+} from "./unhandled-rejections.js";
 
 describe("isAbortError", () => {
   it("returns true for error with name AbortError", () => {
@@ -156,4 +160,38 @@ describe("isTransientNetworkError", () => {
     const error = new AggregateError([new Error("regular error")], "Multiple errors");
     expect(isTransientNetworkError(error)).toBe(false);
   });
+});
+
+describe("isTransientSqliteError", () => {
+  it.each(["SQLITE_CANTOPEN", "SQLITE_BUSY", "SQLITE_LOCKED", "SQLITE_IOERR"])(
+    "returns true for error with code %s",
+    (code) => {
+      const error = Object.assign(new Error("database error"), { code });
+      expect(isTransientSqliteError(error)).toBe(true);
+    },
+  );
+
+  it("returns true for SQLite error nested in cause chain", () => {
+    const innerCause = Object.assign(new Error("database is locked"), { code: "SQLITE_BUSY" });
+    const outerCause = Object.assign(new Error("query failed"), { cause: innerCause });
+    const error = Object.assign(new Error("operation failed"), { cause: outerCause });
+    expect(isTransientSqliteError(error)).toBe(true);
+  });
+
+  it("returns false for regular errors without SQLite codes", () => {
+    expect(isTransientSqliteError(new Error("Something went wrong"))).toBe(false);
+    expect(isTransientSqliteError(new TypeError("Cannot read property"))).toBe(false);
+  });
+
+  it("returns false for errors with non-SQLite codes", () => {
+    const error = Object.assign(new Error("test"), { code: "ECONNRESET" });
+    expect(isTransientSqliteError(error)).toBe(false);
+  });
+
+  it.each([null, undefined, "string error", 42, { message: "plain object" }])(
+    "returns false for non-SQLite input %#",
+    (value) => {
+      expect(isTransientSqliteError(value)).toBe(false);
+    },
+  );
 });

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -52,12 +52,9 @@ const TRANSIENT_NETWORK_MESSAGE_CODE_RE =
   /\b(ECONNRESET|ECONNREFUSED|ENOTFOUND|ETIMEDOUT|ESOCKETTIMEDOUT|ECONNABORTED|EPIPE|EHOSTUNREACH|ENETUNREACH|EAI_AGAIN|UND_ERR_CONNECT_TIMEOUT|UND_ERR_DNS_RESOLVE_FAILED|UND_ERR_CONNECT|UND_ERR_SOCKET|UND_ERR_HEADERS_TIMEOUT|UND_ERR_BODY_TIMEOUT)\b/i;
 
 // SQLite error codes that indicate transient failures (shouldn't crash the gateway)
-const TRANSIENT_SQLITE_CODES = new Set([
-  "SQLITE_CANTOPEN",
-  "SQLITE_BUSY",
-  "SQLITE_LOCKED",
-  "SQLITE_IOERR",
-]);
+// Note: SQLITE_CANTOPEN is intentionally excluded — it usually signals a permanent
+// condition (wrong path, missing directory, insufficient permissions) not a transient one.
+const TRANSIENT_SQLITE_CODES = new Set(["SQLITE_BUSY", "SQLITE_LOCKED", "SQLITE_IOERR"]);
 
 const TRANSIENT_NETWORK_MESSAGE_SNIPPETS = [
   "getaddrinfo",
@@ -67,6 +64,21 @@ const TRANSIENT_NETWORK_MESSAGE_SNIPPETS = [
   "network is unreachable",
   "temporary failure in name resolution",
 ];
+
+/** Shared traversal callback for collectErrorGraphCandidates — walks cause/reason/original/error/data/errors. */
+const defaultErrorGraphTraversal = (current: Record<string, unknown>): Array<unknown> => {
+  const nested: Array<unknown> = [
+    current.cause,
+    current.reason,
+    current.original,
+    current.error,
+    current.data,
+  ];
+  if (Array.isArray(current.errors)) {
+    nested.push(...current.errors);
+  }
+  return nested;
+};
 
 function getErrorCause(err: unknown): unknown {
   if (!err || typeof err !== "object") {
@@ -139,19 +151,7 @@ export function isTransientNetworkError(err: unknown): boolean {
   if (!err) {
     return false;
   }
-  for (const candidate of collectErrorGraphCandidates(err, (current) => {
-    const nested: Array<unknown> = [
-      current.cause,
-      current.reason,
-      current.original,
-      current.error,
-      current.data,
-    ];
-    if (Array.isArray(current.errors)) {
-      nested.push(...current.errors);
-    }
-    return nested;
-  })) {
+  for (const candidate of collectErrorGraphCandidates(err, defaultErrorGraphTraversal)) {
     const code = extractErrorCodeOrErrno(candidate);
     if (code && TRANSIENT_NETWORK_CODES.has(code)) {
       return true;
@@ -196,19 +196,7 @@ export function isTransientSqliteError(err: unknown): boolean {
   if (!err) {
     return false;
   }
-  for (const candidate of collectErrorGraphCandidates(err, (current) => {
-    const nested: Array<unknown> = [
-      current.cause,
-      current.reason,
-      current.original,
-      current.error,
-      current.data,
-    ];
-    if (Array.isArray(current.errors)) {
-      nested.push(...current.errors);
-    }
-    return nested;
-  })) {
+  for (const candidate of collectErrorGraphCandidates(err, defaultErrorGraphTraversal)) {
     const code = extractErrorCodeOrErrno(candidate);
     if (code && TRANSIENT_SQLITE_CODES.has(code)) {
       return true;

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -51,6 +51,14 @@ const TRANSIENT_NETWORK_ERROR_NAMES = new Set([
 const TRANSIENT_NETWORK_MESSAGE_CODE_RE =
   /\b(ECONNRESET|ECONNREFUSED|ENOTFOUND|ETIMEDOUT|ESOCKETTIMEDOUT|ECONNABORTED|EPIPE|EHOSTUNREACH|ENETUNREACH|EAI_AGAIN|UND_ERR_CONNECT_TIMEOUT|UND_ERR_DNS_RESOLVE_FAILED|UND_ERR_CONNECT|UND_ERR_SOCKET|UND_ERR_HEADERS_TIMEOUT|UND_ERR_BODY_TIMEOUT)\b/i;
 
+// SQLite error codes that indicate transient failures (shouldn't crash the gateway)
+const TRANSIENT_SQLITE_CODES = new Set([
+  "SQLITE_CANTOPEN",
+  "SQLITE_BUSY",
+  "SQLITE_LOCKED",
+  "SQLITE_IOERR",
+]);
+
 const TRANSIENT_NETWORK_MESSAGE_SNIPPETS = [
   "getaddrinfo",
   "socket hang up",
@@ -180,6 +188,35 @@ export function isTransientNetworkError(err: unknown): boolean {
   return false;
 }
 
+/**
+ * Checks if an error is a transient SQLite error that shouldn't crash the gateway.
+ * These are typically temporary I/O or locking issues that resolve on retry.
+ */
+export function isTransientSqliteError(err: unknown): boolean {
+  if (!err) {
+    return false;
+  }
+  for (const candidate of collectErrorGraphCandidates(err, (current) => {
+    const nested: Array<unknown> = [
+      current.cause,
+      current.reason,
+      current.original,
+      current.error,
+      current.data,
+    ];
+    if (Array.isArray(current.errors)) {
+      nested.push(...current.errors);
+    }
+    return nested;
+  })) {
+    const code = extractErrorCodeOrErrno(candidate);
+    if (code && TRANSIENT_SQLITE_CODES.has(code)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function registerUnhandledRejectionHandler(handler: UnhandledRejectionHandler): () => void {
   handlers.add(handler);
   return () => {
@@ -233,6 +270,11 @@ export function installUnhandledRejectionHandler(): void {
         "[openclaw] Non-fatal unhandled rejection (continuing):",
         formatUncaughtError(reason),
       );
+      return;
+    }
+
+    if (isTransientSqliteError(reason)) {
+      console.warn("[openclaw] Non-fatal SQLite error (continuing):", formatUncaughtError(reason));
       return;
     }
 


### PR DESCRIPTION
Fixes #34678

Adds SQLITE_CANTOPEN, SQLITE_BUSY, SQLITE_LOCKED, and SQLITE_IOERR to a new transient SQLite error set in the unhandled rejection handler. These errors are now logged as warnings instead of triggering process.exit(1), preventing LaunchAgent crash loops on macOS.

Changes:
- Added TRANSIENT_SQLITE_CODES set with 4 SQLite error codes
- Added isTransientSqliteError() export for SQLite-specific transient detection
- Updated installUnhandledRejectionHandler() to check SQLite errors before the fatal catch-all
- Added test coverage for all 4 codes including cause-chain detection