### PR TITLE
docs(compaction): document WORKFLOW_AUTO post-compaction usage

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -99,6 +99,11 @@ These are the standard files OpenClaw expects inside the workspace:
   - Only created for a brand-new workspace.
   - Delete it after the ritual is complete.
 
+- `WORKFLOW_AUTO.md` (optional)
+  - Post-compaction recovery checklist for your agent.
+  - Keep this as procedural "what to re-read after compaction" guidance.
+  - Reference it from your `AGENTS.md` `Session Startup` section so compaction refresh hints can point the agent to it.
+
 - `memory/YYYY-MM-DD.md`
   - Daily memory log (one file per day).
   - Recommended to read today + yesterday on session start.

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -36,6 +36,18 @@ You’ll see:
 Before compaction, OpenClaw can run a **silent memory flush** turn to store
 durable notes to disk. See [Memory](/concepts/memory) for details and config.
 
+### Post-compaction context refresh
+
+After auto-compaction completes, OpenClaw can enqueue a small system refresh
+message derived from your workspace `AGENTS.md`:
+
+- `## Session Startup`
+- `## Red Lines`
+
+Use `Session Startup` to declare the files your agent should re-read after
+compaction. If you keep a dedicated checklist in `WORKFLOW_AUTO.md`, reference
+it from that section.
+
 ## Manual compaction
 
 Use `/compact` (optionally with instructions) to force a compaction pass:


### PR DESCRIPTION
## Summary
- document optional `WORKFLOW_AUTO.md` in the workspace file map
- explain post-compaction context refresh behavior and where `Session Startup` / `Red Lines` are sourced
- add guidance to reference `WORKFLOW_AUTO.md` from `AGENTS.md` startup sequence

Closes #23176.

## Testing
- pnpm format
