### PR TITLE
docs(start): clarify WSL2 is recommended on Windows

### DIFF
--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -41,6 +41,12 @@ Check your Node version with `node --version` if you are unsure.
 />
       </Tab>
       <Tab title="Windows (PowerShell)">
+        <Note>
+        For best stability and feature compatibility on Windows, we strongly recommend
+        installing OpenClaw inside WSL2. See [Windows (WSL2)](/platforms/windows).
+        The native PowerShell path works, but may have more platform-specific limitations.
+        </Note>
+
         ```powershell
         iwr -useb https://openclaw.ai/install.ps1 | iex
         ```


### PR DESCRIPTION
## Summary
- add a Windows callout in Getting Started that points users to WSL2 as the recommended path
- keep the PowerShell one-liner available, but frame it as a fallback with potential platform-specific limitations
- align wording with existing Install/Windows docs to remove mixed recommendations

Closes #15027.

## Testing
- pnpm format
