### PR TITLE
docs(memory): fix MEMORY.md load-scope wording

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -105,7 +105,8 @@ These are the standard files OpenClaw expects inside the workspace:
 
 - `MEMORY.md` (optional)
   - Curated long-term memory.
-  - Only load in the main, private session (not shared/group contexts).
+  - Loaded in standard sessions.
+  - Omitted from minimal bootstrap contexts (subagent + cron sessions).
 
 See [Memory](/concepts/memory) for the workflow and automatic memory flush.
 

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -23,7 +23,8 @@ The default workspace layout uses two memory layers:
   - Read today + yesterday at session start.
 - `MEMORY.md` (optional)
   - Curated long-term memory.
-  - **Only load in the main, private session** (never in group contexts).
+  - Loaded in standard sessions.
+  - Omitted from minimal bootstrap contexts (subagent + cron sessions).
 
 These files live under the workspace (`agents.defaults.workspace`, default
 `~/.openclaw/workspace`). See [Agent workspace](/concepts/agent-workspace) for the full layout.


### PR DESCRIPTION
## Summary
- update memory docs to reflect actual bootstrap behavior for `MEMORY.md`
- clarify that `MEMORY.md` is included in standard sessions
- clarify that minimal bootstrap contexts (subagent + cron) omit `MEMORY.md`

Closes #24404.

## Testing
- pnpm format
