### PR TITLE
docs(subagents): fix minimal bootstrap file list

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -285,6 +285,6 @@ Sub-agents use a dedicated in-process queue lane:
 - Sub-agent announce is **best-effort**. If the gateway restarts, pending "announce back" work is lost.
 - Sub-agents still share the same gateway process resources; treat `maxConcurrent` as a safety valve.
 - `sessions_spawn` is always non-blocking: it returns `{ status: "accepted", runId, childSessionKey }` immediately.
-- Sub-agent context only injects `AGENTS.md` + `TOOLS.md` (no `SOUL.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, or `BOOTSTRAP.md`).
+- Sub-agent context uses a minimal bootstrap allowlist: `AGENTS.md`, `TOOLS.md`, `SOUL.md`, `IDENTITY.md`, and `USER.md` (excludes `HEARTBEAT.md`, `BOOTSTRAP.md`, and memory files).
 - Maximum nesting depth is 5 (`maxSpawnDepth` range: 1–5). Depth 2 is recommended for most use cases.
 - `maxChildrenPerAgent` caps active children per session (default: 5, range: 1–20).


### PR DESCRIPTION
## Summary
- update sub-agent docs to match runtime minimal bootstrap allowlist
- clarify that sub-agents keep `AGENTS.md`, `TOOLS.md`, `SOUL.md`, `IDENTITY.md`, and `USER.md`
- clarify that `HEARTBEAT.md`, `BOOTSTRAP.md`, and memory files are excluded from sub-agent minimal context

Closes #27038.

## Testing
- pnpm format
