### PR TITLE
Ollama: use `thinking` field for thinking-capable models

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -104,20 +104,36 @@ describe("buildAssistantMessage", () => {
     expect(result.usage.totalTokens).toBe(15);
   });
 
-  it("falls back to reasoning when content is empty", () => {
+  it("falls back to thinking when content is empty", () => {
     const response = {
       model: "qwen3:32b",
       created_at: "2026-01-01T00:00:00Z",
       message: {
         role: "assistant" as const,
         content: "",
-        reasoning: "Reasoning output",
+        thinking: "Thinking output",
       },
       done: true,
     };
     const result = buildAssistantMessage(response, modelInfo);
     expect(result.stopReason).toBe("stop");
-    expect(result.content).toEqual([{ type: "text", text: "Reasoning output" }]);
+    expect(result.content).toEqual([{ type: "text", text: "Thinking output" }]);
+  });
+
+  it("falls back to legacy reasoning when content and thinking are empty", () => {
+    const response = {
+      model: "qwen3:32b",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content: "",
+        reasoning: "Legacy reasoning output",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, modelInfo);
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toEqual([{ type: "text", text: "Legacy reasoning output" }]);
   });
 
   it("builds response with tool calls", () => {
@@ -397,11 +413,11 @@ describe("createOllamaStreamFn", () => {
     );
   });
 
-  it("accumulates reasoning chunks when content is empty", async () => {
+  it("accumulates thinking chunks when content is empty", async () => {
     await withMockNdjsonFetch(
       [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","reasoning":"reasoned"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","reasoning":" output"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":"thought"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":" output"},"done":false}',
         '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":2}',
       ],
       async () => {
@@ -413,7 +429,28 @@ describe("createOllamaStreamFn", () => {
           throw new Error("Expected done event");
         }
 
-        expect(doneEvent.message.content).toEqual([{ type: "text", text: "reasoned output" }]);
+        expect(doneEvent.message.content).toEqual([{ type: "text", text: "thought output" }]);
+      },
+    );
+  });
+
+  it("falls back to legacy reasoning chunks when thinking is absent", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","reasoning":"legacy"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","reasoning":" reasoning"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":2}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
+        const events = await collectStreamEvents(stream);
+
+        const doneEvent = events.at(-1);
+        if (!doneEvent || doneEvent.type !== "done") {
+          throw new Error("Expected done event");
+        }
+
+        expect(doneEvent.message.content).toEqual([{ type: "text", text: "legacy reasoning" }]);
       },
     );
   });

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -185,6 +185,7 @@ interface OllamaChatResponse {
   message: {
     role: "assistant";
     content: string;
+    thinking?: string;
     reasoning?: string;
     tool_calls?: OllamaToolCall[];
   };
@@ -323,10 +324,11 @@ export function buildAssistantMessage(
 ): AssistantMessage {
   const content: (TextContent | ToolCall)[] = [];
 
-  // Qwen 3 (and potentially other reasoning models) may return their final
-  // answer in a `reasoning` field with an empty `content`. Fall back to
-  // `reasoning` so the response isn't silently dropped.
-  const text = response.message.content || response.message.reasoning || "";
+  // Thinking-capable models (Qwen 3, etc.) may return their final answer in
+  // the `thinking` field with an empty `content`. Fall back to `thinking`
+  // (canonical Ollama field) then legacy `reasoning` so nothing is dropped.
+  const text =
+    response.message.content || response.message.thinking || response.message.reasoning || "";
   if (text) {
     content.push({ type: "text", text });
   }
@@ -474,8 +476,11 @@ export function createOllamaStreamFn(
         for await (const chunk of parseNdjsonStream(reader)) {
           if (chunk.message?.content) {
             accumulatedContent += chunk.message.content;
+          } else if (chunk.message?.thinking) {
+            // Thinking-capable models: content may be empty, output in thinking
+            accumulatedContent += chunk.message.thinking;
           } else if (chunk.message?.reasoning) {
-            // Qwen 3 reasoning mode: content may be empty, output in reasoning
+            // Legacy fallback for older Ollama versions using reasoning field
             accumulatedContent += chunk.message.reasoning;
           }
 


### PR DESCRIPTION
## Summary

Fixes #34722

The Ollama native API stream reader checked `message.reasoning` but the correct field for thinking-capable models (e.g. Qwen 3) is `message.thinking`. This caused thinking content to be silently dropped.

- **Streaming path**: check `chunk.message.thinking` first, fall back to `chunk.message.reasoning` for backward compatibility
- **Non-streaming path**: check `response.message.thinking` first, then `response.message.reasoning`
- **Type definition**: add `thinking?: string` to `OllamaChatResponse` message interface
- **Tests**: updated to use the canonical `thinking` field; added separate tests for the legacy `reasoning` fallback

## Test plan

- [x] All 23 existing + new tests pass (`pnpm test -- src/agents/ollama-stream.test.ts`)
- [x] Lint/format passes (`pnpm check`)
- [ ] Manual verification with a thinking-capable Ollama model (e.g. `qwen3:32b` with thinking enabled)