### PR TITLE
docs(providers): refresh claude-max-api-proxy repository links

### DIFF
--- a/docs/providers/claude-max-api-proxy.md
+++ b/docs/providers/claude-max-api-proxy.md
@@ -138,8 +138,8 @@ launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.claude-max-api.plist
 ## Links
 
 - **npm:** [https://www.npmjs.com/package/claude-max-api-proxy](https://www.npmjs.com/package/claude-max-api-proxy)
-- **GitHub:** [https://github.com/atalovesyou/claude-max-api-proxy](https://github.com/atalovesyou/claude-max-api-proxy)
-- **Issues:** [https://github.com/atalovesyou/claude-max-api-proxy/issues](https://github.com/atalovesyou/claude-max-api-proxy/issues)
+- **GitHub:** [https://github.com/wende/claude-max-api-proxy](https://github.com/wende/claude-max-api-proxy)
+- **Issues:** [https://github.com/wende/claude-max-api-proxy/issues](https://github.com/wende/claude-max-api-proxy/issues)
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- update claude-max-api-proxy documentation links to the actively maintained repository
- switch GitHub and issues URLs from `atalovesyou/...` to `wende/...`
- keep npm package instructions unchanged (`claude-max-api-proxy`)

Refs #20260.

## Testing
- pnpm format
