### PR TITLE
docs(tailscale): document direct serve one-liner for HTTPS Control UI

### DIFF
--- a/docs/gateway/tailscale.md
+++ b/docs/gateway/tailscale.md
@@ -97,6 +97,16 @@ openclaw gateway --tailscale serve
 openclaw gateway --tailscale funnel --auth password
 ```
 
+If the gateway is already running on loopback and you only need a fast HTTPS
+Control UI endpoint, you can also use Tailscale directly:
+
+```bash
+tailscale serve --bg http://127.0.0.1:18789
+```
+
+Then open `https://<magicdns>/` for a secure browser context (no
+`allowInsecureAuth` workaround needed).
+
 ## Notes
 
 - Tailscale Serve/Funnel requires the `tailscale` CLI to be installed and logged in.


### PR DESCRIPTION
## Summary
- add a direct `tailscale serve --bg http://127.0.0.1:18789` one-liner for existing loopback gateways
- explicitly call out that this gives secure HTTPS context for Control UI
- clarify that this avoids insecure-auth workarounds for remote browser access

Closes #14513.

## Testing
- pnpm format
