### PR TITLE
fix(feishu): reject non-Feishu IDs in send target resolution

### DIFF
--- a/extensions/feishu/src/send-target.test.ts
+++ b/extensions/feishu/src/send-target.test.ts
@@ -57,6 +57,24 @@ describe("resolveFeishuSendTarget", () => {
     expect(result.receiveIdType).toBe("user_id");
   });
 
+  it("rejects Discord IDs that leak from cross-channel shared sessions", () => {
+    expect(() =>
+      resolveFeishuSendTarget({
+        cfg,
+        to: "discord:1089077850088415312",
+      }),
+    ).toThrow("not a recognized Feishu ID format");
+  });
+
+  it("rejects Telegram IDs that leak from cross-channel shared sessions", () => {
+    expect(() =>
+      resolveFeishuSendTarget({
+        cfg,
+        to: "telegram:12345678",
+      }),
+    ).toThrow("not a recognized Feishu ID format");
+  });
+
   it("throws when target account is not configured", () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "default",

--- a/extensions/feishu/src/send-target.ts
+++ b/extensions/feishu/src/send-target.ts
@@ -1,7 +1,7 @@
 import type { ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
-import { resolveReceiveIdType, normalizeFeishuTarget } from "./targets.js";
+import { detectIdType, resolveReceiveIdType, normalizeFeishuTarget } from "./targets.js";
 
 export function resolveFeishuSendTarget(params: {
   cfg: ClawdbotConfig;
@@ -17,6 +17,16 @@ export function resolveFeishuSendTarget(params: {
   const receiveId = normalizeFeishuTarget(target);
   if (!receiveId) {
     throw new Error(`Invalid Feishu target: ${params.to}`);
+  }
+  // Validate the normalized ID has a recognized Feishu format.
+  // In shared-session setups (dmScope: "main"), delivery context may be
+  // contaminated with IDs from other channels (e.g. "discord:..." or
+  // "telegram:..."). Reject early with a clear error instead of letting
+  // invalid IDs reach the Feishu API.
+  if (detectIdType(receiveId) === null) {
+    throw new Error(
+      `Invalid Feishu target "${params.to}": not a recognized Feishu ID format (possible cross-channel routing contamination)`,
+    );
   }
   // Preserve explicit routing prefixes (chat/group/user/dm/open_id) when present.
   // normalizeFeishuTarget strips these prefixes, so infer type from the raw target first.


### PR DESCRIPTION
## Summary

- Problem: When `dmScope` is `"main"` (default), all DM channels share a single session. If a user interacts via Discord, the session's `lastTo` gets updated with a Discord-format ID (e.g. `discord:1089077850088415312`). A subsequent Feishu outbound delivery picks up this stale ID via `resolveSessionDeliveryTarget` and passes it to the Feishu API, which rejects it with `Invalid ids`.
- Why it matters: Multi-channel setups with shared sessions (the default `dmScope: "main"`) silently fail on Feishu outbound delivery when another channel has touched the session. Users see cryptic Feishu API errors instead of a clear explanation.
- What changed: Added `detectIdType()` validation in `resolveFeishuSendTarget()` to reject IDs that don't match any known Feishu format (chat_id `oc_*`, open_id `ou_*`, or alphanumeric user_id). The error message explicitly mentions cross-channel routing contamination.
- What did NOT change (scope boundary): No changes to session routing, `normalizeFeishuTarget`, `resolveReceiveIdType`, or any core delivery infrastructure. The fix is strictly a defensive guard in the Feishu send path.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #34665

## User-visible / Behavior Changes

Previously, a contaminated Discord/Telegram ID reaching the Feishu send path would produce an opaque Feishu API error (`Invalid ids: [discord:...]`). Now it throws a clear error mentioning "not a recognized Feishu ID format (possible cross-channel routing contamination)" before the API call.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: Feishu + Discord (multi-channel)
- Relevant config: `dmScope: "main"` (default), `dmPolicy: "pairing"` (Feishu default)

### Steps

1. Configure an agent with both Feishu and Discord channels, default `dmScope: "main"`
2. Send a DM via Discord — session's `lastTo` is updated to `discord:<snowflake-id>`
3. Trigger an outbound Feishu delivery (e.g. heartbeat or proactive message) that reads the shared session

### Expected

- Clear error: `Invalid Feishu target "discord:...": not a recognized Feishu ID format (possible cross-channel routing contamination)`

### Actual (before fix)

- Opaque Feishu API error: `Invalid ids: [discord:1089077850088415312]`

## Evidence

- [x] Failing test/log before + passing after

Two new test cases in `send-target.test.ts`:
- `rejects Discord IDs that leak from cross-channel shared sessions` — verifies `discord:1089077850088415312` is rejected
- `rejects Telegram IDs that leak from cross-channel shared sessions` — verifies `telegram:12345678` is rejected

All 6 tests pass. All 14 existing `targets.test.ts` tests pass (no regression).

## Human Verification (required)

- Verified scenarios: `discord:*` and `telegram:*` IDs rejected; valid Feishu IDs (`ou_*`, `oc_*`, bare alphanumeric, prefixed `feishu:user:*`, `lark:dm:*`) still accepted
- Edge cases checked: Bare alphanumeric user IDs (`user_123`) pass `USER_ID_REGEX` and are not rejected; empty targets still throw the existing "Invalid Feishu target" error
- What you did **not** verify: End-to-end multi-channel delivery with a live Feishu + Discord setup

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit; the validation is a single `if` guard in `resolveFeishuSendTarget`
- Files/config to restore: `extensions/feishu/src/send-target.ts`
- Known bad symptoms reviewers should watch for: Legitimate Feishu IDs being incorrectly rejected (would show "not a recognized Feishu ID format" error in logs)

## Risks and Mitigations

- Risk: A non-standard Feishu user_id containing special characters (e.g. `:`) might be incorrectly rejected
  - Mitigation: `detectIdType` uses the regex `^[a-zA-Z0-9_-]+$` which matches all documented Feishu ID formats (oc_*, ou_*, alphanumeric user_ids). The Feishu API itself rejects IDs outside this character set.