### PR TITLE
perf: optimize toWhatsappJid by avoiding redundant regex replace

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -127,8 +127,8 @@ export function toWhatsappJid(number: string): string {
     return withoutPrefix;
   }
   const e164 = normalizeE164(withoutPrefix);
-  const digits = e164.replace(/\D/g, "");
-  return `${digits}@s.whatsapp.net`;
+  // e164 is always "+digits", so we can slice off the leading "+"
+  return `${e164.slice(1)}@s.whatsapp.net`;
 }
 
 export type JidToE164Options = {


### PR DESCRIPTION
Optimizes toWhatsappJid by eliminating redundant regex operation. normalizeE164 already returns +digits format, so we can use slice(1) instead of replace(/\D/g, '').