### PR TITLE
docs: clarify launchctl kickstart vs bootstrap usage

### DIFF
--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -196,7 +196,14 @@ openclaw logs --follow
 
 If you’re supervised:
 
-- macOS launchd (app-bundled LaunchAgent): `launchctl kickstart -k gui/$UID/ai.openclaw.gateway` (use `ai.openclaw.<profile>`; legacy `com.openclaw.*` still works)
+- macOS launchd (app-bundled LaunchAgent):
+  - Quick restart for an already-loaded service: `launchctl kickstart -k gui/$UID/ai.openclaw.gateway` (use `ai.openclaw.<profile>`; legacy `com.openclaw.*` still works).
+  - For unloaded jobs (common with `.nop`) or after plist edits/version upgrades, do a full reload:
+    ```bash
+    launchctl bootout gui/$UID/ai.openclaw.gateway
+    launchctl bootstrap gui/$UID "$HOME/Library/LaunchAgents/ai.openclaw.gateway.plist"
+    ```
+  - `kickstart` uses a service label; `bootstrap` uses a plist file path.
 - Linux systemd user service: `systemctl --user restart openclaw-gateway[-<profile>].service`
 - Windows (WSL2): `systemctl --user restart openclaw-gateway[-<profile>].service`
   - `launchctl`/`systemctl` only work if the service is installed; otherwise run `openclaw gateway install`.

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -199,11 +199,14 @@ If you’re supervised:
 - macOS launchd (app-bundled LaunchAgent):
   - Quick restart for an already-loaded service: `launchctl kickstart -k gui/$UID/ai.openclaw.gateway` (use `ai.openclaw.<profile>`; legacy `com.openclaw.*` still works).
   - For unloaded jobs (common with `.nop`) or after plist edits/version upgrades, do a full reload:
+
     ```bash
     launchctl bootout gui/$UID/ai.openclaw.gateway
     launchctl bootstrap gui/$UID "$HOME/Library/LaunchAgents/ai.openclaw.gateway.plist"
     ```
+
   - `kickstart` uses a service label; `bootstrap` uses a plist file path.
+
 - Linux systemd user service: `systemctl --user restart openclaw-gateway[-<profile>].service`
 - Windows (WSL2): `systemctl --user restart openclaw-gateway[-<profile>].service`
   - `launchctl`/`systemctl` only work if the service is installed; otherwise run `openclaw gateway install`.

--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -40,9 +40,16 @@ The app manages a per‑user LaunchAgent labeled `ai.openclaw.gateway`
 ```bash
 launchctl kickstart -k gui/$UID/ai.openclaw.gateway
 launchctl bootout gui/$UID/ai.openclaw.gateway
+launchctl bootstrap gui/$UID "$HOME/Library/LaunchAgents/ai.openclaw.gateway.plist"
 ```
 
 Replace the label with `ai.openclaw.<profile>` when running a named profile.
+
+Usage guidance:
+
+- Use `kickstart -k` only when the service is already loaded and you want a quick restart.
+- Use `bootout + bootstrap` when the service is not loaded (common for `.nop`) or after plist edits/version upgrades.
+- `kickstart` takes a service label (`ai.openclaw.gateway`), while `bootstrap` takes a plist path.
 
 If the LaunchAgent isn’t installed, enable it from the app or run
 `openclaw gateway install`.


### PR DESCRIPTION
## Summary
- clarify when to use launchctl kickstart -k versus bootout + bootstrap on macOS
- document label vs plist-path command semantics to prevent restart confusion
- add explicit bootstrap startup hint in macOS launchd docs

## Testing
- pnpm format

Closes #31623
