### PR TITLE
fix(whatsapp): propagate accountId through group policy resolution (#17817)

### DIFF
--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -300,7 +300,7 @@ async function resolveImagesForRequest(
   for (const url of urls) {
     const source = parseImageUrlToSource(url);
     if (source.type === "base64") {
-      totalBytes += estimateBase64DecodedBytes(source.data);
+      totalBytes += estimateBase64DecodedBytes(source.data ?? "");
       if (totalBytes > limits.maxTotalImageBytes) {
         throw new Error(
           `Total image payload too large (${totalBytes}; limit ${limits.maxTotalImageBytes})`,

--- a/src/web/auto-reply/monitor/ack-reaction.ts
+++ b/src/web/auto-reply/monitor/ack-reaction.ts
@@ -34,6 +34,7 @@ export function maybeSendAckReaction(params: {
           agentId: params.agentId,
           sessionKey: params.sessionKey,
           conversationId: conversationIdForCheck,
+          accountId: params.accountId,
         })
       : null;
   const shouldSendReaction = () =>

--- a/src/web/auto-reply/monitor/group-activation.test.ts
+++ b/src/web/auto-reply/monitor/group-activation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import type { loadConfig } from "../../../config/config.js";
+import { resolveGroupPolicyFor, resolveGroupRequireMentionFor } from "./group-activation.js";
+
+// Cast to forward-compatible signature for testing multi-account accountId propagation.
+// On unpatched main the functions only accept (cfg, conversationId) — the accountId
+// parameter is missing, so extra args are silently ignored by JS, producing the wrong
+// (channel-level) result. After the fix, the 3rd argument is honoured.
+type PolicyFn = (
+  cfg: ReturnType<typeof loadConfig>,
+  conversationId: string,
+  accountId?: string,
+) => { allowed: boolean; allowlistEnabled: boolean };
+
+type MentionFn = (
+  cfg: ReturnType<typeof loadConfig>,
+  conversationId: string,
+  accountId?: string,
+) => boolean;
+
+const resolveGroupPolicyForFn = resolveGroupPolicyFor as unknown as PolicyFn;
+const resolveGroupRequireMentionForFn = resolveGroupRequireMentionFor as unknown as MentionFn;
+
+const makeStrictAccountCfg = () =>
+  ({
+    channels: {
+      whatsapp: {
+        // Channel-level: permissive open policy
+        groupPolicy: "open",
+        accounts: {
+          work: {
+            // "work" account: strict allowlist-only policy
+            groupPolicy: "allowlist",
+          },
+        },
+      },
+    },
+  }) as unknown as ReturnType<typeof loadConfig>;
+
+describe("resolveGroupPolicyFor multi-account accountId propagation (#17817)", () => {
+  it("uses account-specific allowlist policy when accountId is provided", () => {
+    const cfg = makeStrictAccountCfg();
+    // "work" account has groupPolicy="allowlist" with no groups configured.
+    // An unknown group "999@g.us" must be blocked (not in allowlist).
+    // On unpatched main, accountId is ignored → channel-level "open" → allowed=true → FAILS.
+    // On fixed code, accountId is used → "work" allowlist → allowed=false → PASSES.
+    const policy = resolveGroupPolicyForFn(cfg, "999@g.us", "work");
+    expect(policy.allowlistEnabled).toBe(true);
+    expect(policy.allowed).toBe(false);
+  });
+
+  it("channel-level open policy is used when no accountId is provided", () => {
+    const cfg = makeStrictAccountCfg();
+    // Without accountId, falls back to DEFAULT_ACCOUNT_ID → channel-level "open" policy.
+    const policy = resolveGroupPolicyForFn(cfg, "999@g.us");
+    expect(policy.allowlistEnabled).toBe(false);
+    expect(policy.allowed).toBe(true);
+  });
+});
+
+describe("resolveGroupRequireMentionFor multi-account accountId propagation (#17817)", () => {
+  it("uses account-specific requireMention when accountId is provided", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "open",
+          // No channel-level groups → requireMention defaults to false
+          accounts: {
+            strict: {
+              // "strict" account forces mention requirement
+              groupPolicy: "allowlist",
+              groups: {
+                "999@g.us": { requireMention: true },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as ReturnType<typeof loadConfig>;
+
+    // On unpatched main, accountId is ignored → no channel-level groups → returns false → FAILS.
+    // On fixed code, accountId is used → strict account groups → returns true → PASSES.
+    const requireMention = resolveGroupRequireMentionForFn(cfg, "999@g.us", "strict");
+    expect(requireMention).toBe(true);
+  });
+});

--- a/src/web/auto-reply/monitor/group-activation.ts
+++ b/src/web/auto-reply/monitor/group-activation.ts
@@ -10,7 +10,11 @@ import {
   resolveStorePath,
 } from "../../../config/sessions.js";
 
-export function resolveGroupPolicyFor(cfg: ReturnType<typeof loadConfig>, conversationId: string) {
+export function resolveGroupPolicyFor(
+  cfg: ReturnType<typeof loadConfig>,
+  conversationId: string,
+  accountId?: string,
+) {
   const groupId = resolveGroupSessionKey({
     From: conversationId,
     ChatType: "group",
@@ -25,6 +29,7 @@ export function resolveGroupPolicyFor(cfg: ReturnType<typeof loadConfig>, conver
   return resolveChannelGroupPolicy({
     cfg,
     channel: "whatsapp",
+    accountId,
     groupId: groupId ?? conversationId,
     hasGroupAllowFrom,
   });
@@ -33,6 +38,7 @@ export function resolveGroupPolicyFor(cfg: ReturnType<typeof loadConfig>, conver
 export function resolveGroupRequireMentionFor(
   cfg: ReturnType<typeof loadConfig>,
   conversationId: string,
+  accountId?: string,
 ) {
   const groupId = resolveGroupSessionKey({
     From: conversationId,
@@ -42,6 +48,7 @@ export function resolveGroupRequireMentionFor(
   return resolveChannelGroupRequireMention({
     cfg,
     channel: "whatsapp",
+    accountId,
     groupId: groupId ?? conversationId,
   });
 }
@@ -51,13 +58,18 @@ export function resolveGroupActivationFor(params: {
   agentId: string;
   sessionKey: string;
   conversationId: string;
+  accountId?: string;
 }) {
   const storePath = resolveStorePath(params.cfg.session?.store, {
     agentId: params.agentId,
   });
   const store = loadSessionStore(storePath);
   const entry = store[params.sessionKey];
-  const requireMention = resolveGroupRequireMentionFor(params.cfg, params.conversationId);
+  const requireMention = resolveGroupRequireMentionFor(
+    params.cfg,
+    params.conversationId,
+    params.accountId,
+  );
   const defaultActivation = !requireMention ? "always" : "mention";
   return normalizeGroupActivation(entry?.groupActivation) ?? defaultActivation;
 }

--- a/src/web/auto-reply/monitor/group-gating.ts
+++ b/src/web/auto-reply/monitor/group-gating.ts
@@ -26,6 +26,7 @@ type ApplyGroupGatingParams = {
   groupHistoryKey: string;
   agentId: string;
   sessionKey: string;
+  accountId?: string;
   baseMentionConfig: MentionConfig;
   authDir?: string;
   groupHistories: Map<string, GroupHistoryEntry[]>;
@@ -80,7 +81,7 @@ function skipGroupMessageAndStoreHistory(params: ApplyGroupGatingParams, verbose
 }
 
 export function applyGroupGating(params: ApplyGroupGatingParams) {
-  const groupPolicy = resolveGroupPolicyFor(params.cfg, params.conversationId);
+  const groupPolicy = resolveGroupPolicyFor(params.cfg, params.conversationId, params.accountId);
   if (groupPolicy.allowlistEnabled && !groupPolicy.allowed) {
     params.logVerbose(`Skipping group message ${params.conversationId} (not in allowlist)`);
     return { shouldProcess: false };
@@ -125,6 +126,7 @@ export function applyGroupGating(params: ApplyGroupGatingParams) {
     agentId: params.agentId,
     sessionKey: params.sessionKey,
     conversationId: params.conversationId,
+    accountId: params.accountId,
   });
   const requireMention = activation !== "always";
   const selfJid = params.msg.selfJid?.replace(/:\\d+/, "");

--- a/src/web/auto-reply/monitor/on-message.ts
+++ b/src/web/auto-reply/monitor/on-message.ts
@@ -131,6 +131,7 @@ export function createWebOnMessageHandler(params: {
         groupHistoryKey,
         agentId: route.agentId,
         sessionKey: route.sessionKey,
+        accountId: route.accountId,
         baseMentionConfig: params.baseMentionConfig,
         authDir: params.account.authDir,
         groupHistories: params.groupHistories,


### PR DESCRIPTION
## Problem
In multi-account deployments, the `accountId` passed in WhatsApp bindings is silently ignored during group policy resolution. All group chats fall through to the default account’s policy, making per-account group allowlists and mention-gating settings non-functional.

## Root cause
`src/web/auto-reply/monitor/group-activation.ts` — `resolveGroupPolicyFor` (line 13) and `resolveGroupRequireMentionFor` (line 33) had no `accountId` parameter. Callers in `group-gating.ts` and `on-message.ts` had `accountId` in scope but had no way to pass it through, so `resolveChannelGroupPolicy` and `resolveChannelGroupRequireMention` always resolved against the default account.

## Fix
Added optional `accountId?: string` to `resolveGroupPolicyFor`, `resolveGroupRequireMentionFor`, and `resolveGroupActivationFor`, and threaded the value through from all call sites in `group-gating.ts`, `on-message.ts`, and `ack-reaction.ts`.

## Verification
- **Test:** `src/web/auto-reply/monitor/group-activation.test.ts` — fails on main (account-specific policy ignored), passes on fix
- **Build:** clean compile (`build-output.log`)
- **Test suite:** no regressions (`test-output.log`)
- **Code proof:** old pattern removed, new pattern confirmed (`step6-verify.log`)

Closes #17817