### PR TITLE
fix(slack): allow app_mention events to bypass dedup cache

### DIFF
--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -165,7 +165,13 @@ export function createSlackMessageHandler(params: {
     ) {
       return;
     }
-    if (ctx.markMessageSeen(message.channel, message.ts)) {
+    // Allow app_mention events to bypass dedup. Slack sends both `message` and
+    // `app_mention` for the same @mention with no delivery-order guarantee. If
+    // the `message` event arrives first it is marked seen; without this guard the
+    // subsequent `app_mention` (which carries the authoritative `wasMentioned`
+    // flag) would be silently dropped, causing missed mentions and lost thread
+    // context.  See: https://github.com/openclaw/openclaw/issues/20151
+    if (opts.source !== "app_mention" && ctx.markMessageSeen(message.channel, message.ts)) {
       return;
     }
     trackEvent?.();


### PR DESCRIPTION
## Summary

Exempts `app_mention` events from the dedup cache check in the Slack message handler, fixing ~50% of channel @mentions being silently dropped.

Fixes #34833

## Problem

Slack delivers both `message` and `app_mention` events for the same @mention with no delivery order guarantee. The dedup cache keys on `channelId:ts`, so whichever arrives first wins:

- If `app_mention` arrives first → processes normally, `message` deduped ✅
- If `message` arrives first → dropped by `requireMention` check, but **dedup key is set** → `app_mention` silently deduped ❌

This causes ~50% of channel mentions to be silently ignored, thread context to never establish, and `invalid_thread_ts` errors.

## Fix

One-line change: skip `markMessageSeen` for `app_mention` events.

```ts
if (opts.source !== "app_mention" && ctx.markMessageSeen(message.channel, message.ts)) {
  return;
}
```

Safe because the downstream debouncer already handles dedup via `buildKey`, and `prepareSlackMessage` merges `wasMentioned` across debounced entries.

## Related

- #20151 / #20152 — original report and unmerged PR with the same fix
- `a1ee60549` — separate fix for DM duplicate processing (different code path, different symptom)