### PR TITLE
docs: replace deprecated --to with --target in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ openclaw onboard --install-daemon
 openclaw gateway --port 18789 --verbose
 
 # Send a message
-openclaw message send --to +1234567890 --message "Hello from OpenClaw"
+openclaw message send --target +1234567890 --message "Hello from OpenClaw"
 
 # Talk to the assistant (optionally deliver back to any connected channel: WhatsApp/Telegram/Slack/Discord/Google Chat/Signal/iMessage/BlueBubbles/IRC/Microsoft Teams/Matrix/Feishu/LINE/Mattermost/Nextcloud Talk/Nostr/Synology Chat/Tlon/Twitch/Zalo/Zalo Personal/WebChat)
 openclaw agent --message "Ship checklist" --thinking high


### PR DESCRIPTION
## Summary
- update the README quick-start example to use `openclaw message send --target ...`
- align docs with the current CLI option name

## Testing
- pnpm format

Closes #10458
