### PR TITLE
docs: clarify cron.jobs is invalid and jobs are CLI-managed

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2877,6 +2877,7 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
 - `runLog.keepLines`: newest lines retained when run-log pruning is triggered. Default: `2000`.
 - `webhookToken`: bearer token used for cron webhook POST delivery (`delivery.mode = "webhook"`), if omitted no auth header is sent.
 - `webhook`: deprecated legacy fallback webhook URL (http/https) used only for stored jobs that still have `notify: true`.
+- Cron jobs are not declared in `openclaw.json`; `cron.jobs` is not a valid config key. Create/manage jobs with `openclaw cron add|edit|remove` (stored at `~/.openclaw/cron/jobs.json` by default, overridable via `cron.store`).
 
 See [Cron Jobs](/automation/cron-jobs).
 


### PR DESCRIPTION
## Summary
- document that `cron.jobs` is not a valid `openclaw.json` key
- clarify cron jobs are CLI-managed records (`openclaw cron add|edit|remove`)
- point to default storage (`~/.openclaw/cron/jobs.json`) and `cron.store` override

## Testing
- pnpm format

Closes #27947
