### PR TITLE
docs(telegram): recommend allowlist for single-user DM policy

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -119,10 +119,7 @@ Token resolution order is account-aware. In practice, config values win over env
     If you upgraded and your config contains `@username` allowlist entries, run `openclaw doctor --fix` to resolve them (best-effort; requires a Telegram bot token).
     If you previously relied on pairing-store allowlist files, `openclaw doctor --fix` can recover entries into `channels.telegram.allowFrom` in allowlist flows (for example when `dmPolicy: "allowlist"` has no explicit IDs yet).
 
-    Single-user recommendation:
-
-    - For one-owner bots, prefer `dmPolicy: "allowlist"` + explicit numeric `allowFrom` IDs.
-    - This keeps access policy explicit in config and avoids relying on prior pairing approvals.
+    For one-owner bots, prefer `dmPolicy: "allowlist"` with explicit numeric `allowFrom` IDs to keep access policy durable in config (instead of depending on previous pairing approvals).
 
     ### Finding your Telegram user ID
 

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -119,6 +119,11 @@ Token resolution order is account-aware. In practice, config values win over env
     If you upgraded and your config contains `@username` allowlist entries, run `openclaw doctor --fix` to resolve them (best-effort; requires a Telegram bot token).
     If you previously relied on pairing-store allowlist files, `openclaw doctor --fix` can recover entries into `channels.telegram.allowFrom` in allowlist flows (for example when `dmPolicy: "allowlist"` has no explicit IDs yet).
 
+    Single-user recommendation:
+
+    - For one-owner bots, prefer `dmPolicy: "allowlist"` + explicit numeric `allowFrom` IDs.
+    - This keeps access policy explicit in config and avoids relying on prior pairing approvals.
+
     ### Finding your Telegram user ID
 
     Safer (no third-party bot):


### PR DESCRIPTION
## Summary
- add a single-user recommendation to prefer `dmPolicy: "allowlist"` with explicit numeric `allowFrom` IDs
- clarify this keeps DM access policy durable and explicit in config

## Testing
- pnpm format

Closes #21604
