### PR TITLE
docs(pi): add linger verification for SSH-based installs

### DIFF
--- a/docs/platforms/raspberry-pi.md
+++ b/docs/platforms/raspberry-pi.md
@@ -153,6 +153,23 @@ sudo systemctl status openclaw
 journalctl -u openclaw -f
 ```
 
+## 8.1) SSH logout survival check (systemd user services)
+
+If your setup uses a systemd **user** service (`openclaw-gateway[-<profile>].service`), make sure lingering is enabled so SSH logout does not stop the service.
+
+```bash
+# Check user service status
+systemctl --user status openclaw-gateway --no-pager
+
+# Check lingering state
+loginctl show-user "$USER" --property=Linger
+
+# If Linger=no, enable it
+sudo loginctl enable-linger "$USER"
+```
+
+If you are running a system service (`sudo systemctl ...`), lingering is not required.
+
 ## 9) Access the Dashboard
 
 Since the Pi is headless, use an SSH tunnel:


### PR DESCRIPTION
## Summary
- add an explicit SSH logout survival check to the Raspberry Pi guide for systemd user-service setups
- document `loginctl show-user ... Linger` verification and `loginctl enable-linger` fix path
- clarify that lingering is not needed for system services

## Testing
- pnpm format

Closes #17069
