### PR TITLE
Fix: resolve #34833 fix(slack): app_mention events silently dropped b…

### DIFF
--- a/src/slack/monitor/message-handler.test.ts
+++ b/src/slack/monitor/message-handler.test.ts
@@ -97,6 +97,28 @@ describe("createSlackMessageHandler", () => {
     expect(enqueueMock).not.toHaveBeenCalled();
   });
 
+  it("does not dedupe app_mention events via markMessageSeen", async () => {
+    const markMessageSeen = vi.fn(() => true);
+    const { handler, trackEvent } = createHandlerWithTracker({
+      markMessageSeen,
+    });
+
+    await handler(
+      {
+        type: "message",
+        channel: "C1",
+        ts: "123.456",
+        text: "<@B1> hello",
+      } as never,
+      { source: "app_mention", wasMentioned: true },
+    );
+
+    expect(markMessageSeen).not.toHaveBeenCalled();
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(resolveThreadTsMock).toHaveBeenCalledTimes(1);
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+  });
+
   it("tracks accepted non-duplicate messages", async () => {
     const { handler, trackEvent } = createHandlerWithTracker();
 

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -165,7 +165,7 @@ export function createSlackMessageHandler(params: {
     ) {
       return;
     }
-    if (ctx.markMessageSeen(message.channel, message.ts)) {
+    if (opts.source !== "app_mention" && ctx.markMessageSeen(message.channel, message.ts)) {
       return;
     }
     trackEvent?.();


### PR DESCRIPTION
…y dedup cache when message event arrives first

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
