### PR TITLE
fix(discord): enforce allowFrom on native slash dispatch

### DIFF
--- a/src/discord/monitor/native-command.plugin-dispatch.test.ts
+++ b/src/discord/monitor/native-command.plugin-dispatch.test.ts
@@ -9,8 +9,8 @@ import { createNoopThreadBindingManager } from "./thread-bindings.js";
 
 type MockCommandInteraction = {
   user: { id: string; username: string; globalName: string };
-  channel: { type: ChannelType; id: string };
-  guild: null;
+  channel: { type: ChannelType; id: string; name?: string };
+  guild: { id: string; name: string } | null;
   rawData: { id: string; member: { roles: string[] } };
   options: {
     getString: ReturnType<typeof vi.fn>;
@@ -22,18 +22,25 @@ type MockCommandInteraction = {
   client: object;
 };
 
-function createInteraction(): MockCommandInteraction {
+function createInteraction(params?: {
+  userId?: string;
+  channelType?: ChannelType;
+  channelId?: string;
+  channelName?: string;
+  guild?: { id: string; name: string } | null;
+}): MockCommandInteraction {
   return {
     user: {
-      id: "owner",
+      id: params?.userId ?? "owner",
       username: "tester",
       globalName: "Tester",
     },
     channel: {
-      type: ChannelType.DM,
-      id: "dm-1",
+      type: params?.channelType ?? ChannelType.DM,
+      id: params?.channelId ?? "dm-1",
+      ...(params?.channelName ? { name: params.channelName } : {}),
     },
-    guild: null,
+    guild: params?.guild ?? null,
     rawData: {
       id: "interaction-1",
       member: { roles: [] },
@@ -109,5 +116,54 @@ describe("Discord native plugin command dispatch", () => {
     expect(interaction.reply).toHaveBeenCalledWith(
       expect.objectContaining({ content: "direct plugin output" }),
     );
+  });
+
+  it("rejects unauthorized slash command users when commands.allowFrom is configured", async () => {
+    const cfg = createConfig();
+    cfg.commands = {
+      allowFrom: {
+        discord: ["allowed-user"],
+      },
+    };
+    const commandSpec: NativeCommandSpec = {
+      name: "status",
+      description: "Show status",
+      acceptsArgs: false,
+    };
+    const command = createDiscordNativeCommand({
+      command: commandSpec,
+      cfg,
+      discordConfig: cfg.channels?.discord ?? {},
+      accountId: "default",
+      sessionPrefix: "discord:slash",
+      ephemeralDefault: true,
+      threadBindings: createNoopThreadBindingManager("default"),
+    });
+    const interaction = createInteraction({
+      channelType: ChannelType.GuildText,
+      channelId: "channel-1",
+      channelName: "general",
+      guild: { id: "guild-1", name: "Guild" },
+      userId: "not-allowed",
+    });
+
+    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
+    const dispatchSpy = vi
+      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
+      .mockResolvedValue({} as never);
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    const replies = [...interaction.reply.mock.calls, ...interaction.followUp.mock.calls].map(
+      (call) => call[0] as { content?: string; ephemeral?: boolean },
+    );
+    expect(
+      replies.some(
+        (payload) =>
+          payload.content === "You are not authorized to use this command." &&
+          payload.ephemeral === true,
+      ),
+    ).toBe(true);
   });
 });

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -16,6 +16,7 @@ import {
 import { ApplicationCommandOptionType, ButtonStyle } from "discord-api-types/v10";
 import { resolveHumanDelayConfig } from "../../agents/identity.js";
 import { resolveChunkMode, resolveTextChunkLimit } from "../../auto-reply/chunk.js";
+import { resolveCommandAuthorization } from "../../auto-reply/command-auth.js";
 import type {
   ChatCommandDefinition,
   CommandArgDefinition,
@@ -1433,6 +1434,38 @@ async function dispatchDiscordCommandInteraction(params: {
     return;
   }
 
+  const channelId = rawChannelId || "unknown";
+  const from = isDirectMessage
+    ? `discord:${user.id}`
+    : isGroupDm
+      ? `discord:group:${channelId}`
+      : `discord:channel:${channelId}`;
+  const ownerAllowFrom = resolveDiscordOwnerAllowFrom({
+    channelConfig,
+    guildInfo,
+    sender: { id: sender.id, name: sender.name, tag: sender.tag },
+    allowNameMatching,
+  });
+  const commandAuthorization = resolveCommandAuthorization({
+    ctx: {
+      Provider: "discord",
+      Surface: "discord",
+      AccountId: accountId,
+      From: from,
+      To: `slash:${user.id}`,
+      SenderId: user.id,
+      ChatType: isDirectMessage ? "direct" : isGroupDm ? "group" : "channel",
+      OwnerAllowFrom: ownerAllowFrom,
+    },
+    cfg,
+    commandAuthorized,
+  });
+  if (!commandAuthorization.isAuthorizedSender) {
+    await respond("You are not authorized to use this command.", { ephemeral: true });
+    return;
+  }
+  commandAuthorized = commandAuthorization.isAuthorizedSender;
+
   const menu = resolveCommandArgMenu({
     command,
     args: commandArgs,
@@ -1474,7 +1507,6 @@ async function dispatchDiscordCommandInteraction(params: {
     if (suppressReplies) {
       return;
     }
-    const channelId = rawChannelId || "unknown";
     const pluginReply = await executePluginCommand({
       command: pluginMatch.command,
       args: pluginMatch.args,
@@ -1484,11 +1516,7 @@ async function dispatchDiscordCommandInteraction(params: {
       isAuthorizedSender: commandAuthorized,
       commandBody: prompt,
       config: cfg,
-      from: isDirectMessage
-        ? `discord:${user.id}`
-        : isGroupDm
-          ? `discord:group:${channelId}`
-          : `discord:channel:${channelId}`,
+      from,
       to: `slash:${user.id}`,
       accountId,
     });
@@ -1527,7 +1555,6 @@ async function dispatchDiscordCommandInteraction(params: {
   }
 
   const isGuild = Boolean(interaction.guild);
-  const channelId = rawChannelId || "unknown";
   const interactionId = interaction.rawData.id;
   const route = resolveAgentRoute({
     cfg,
@@ -1552,23 +1579,13 @@ async function dispatchDiscordCommandInteraction(params: {
       }
     : route;
   const conversationLabel = isDirectMessage ? (user.globalName ?? user.username) : channelId;
-  const ownerAllowFrom = resolveDiscordOwnerAllowFrom({
-    channelConfig,
-    guildInfo,
-    sender: { id: sender.id, name: sender.name, tag: sender.tag },
-    allowNameMatching,
-  });
   const ctxPayload = finalizeInboundContext({
     Body: prompt,
     BodyForAgent: prompt,
     RawBody: prompt,
     CommandBody: prompt,
     CommandArgs: commandArgs,
-    From: isDirectMessage
-      ? `discord:${user.id}`
-      : isGroupDm
-        ? `discord:group:${channelId}`
-        : `discord:channel:${channelId}`,
+    From: from,
     To: `slash:${user.id}`,
     SessionKey: boundSessionKey ?? `agent:${effectiveRoute.agentId}:${sessionPrefix}:${user.id}`,
     CommandTargetSessionKey: boundSessionKey ?? effectiveRoute.sessionKey,


### PR DESCRIPTION
## Summary
- enforce `commands.allowFrom` authorization at the start of Discord native slash command dispatch
- return an immediate ephemeral denial message when sender is not authorized
- keep downstream plugin/agent command paths unchanged for authorized users by reusing a single resolved `from` context

## Root cause
Discord native slash command dispatch did not run the shared `resolveCommandAuthorization` gate before plugin/agent dispatch. With `commands.allowFrom.discord` configured, unauthorized users could reach the slash path and end up without a clear denial reply, causing timeout-like behavior.

## Fix
- add early authorization resolution in `src/discord/monitor/native-command.ts`
- fail fast with `"You are not authorized to use this command."` (ephemeral) when denied
- thread the resolved `from` value through plugin execution and inbound context to avoid divergent behavior

## Test plan
- `pnpm build`
- `pnpm check`
- `pnpm test`
- `pnpm test src/discord/monitor/native-command.plugin-dispatch.test.ts`

## Regression test
- added `rejects unauthorized slash command users when commands.allowFrom is configured` in `src/discord/monitor/native-command.plugin-dispatch.test.ts`

Closes #34776

AI disclosure: This PR is AI-assisted. Code has been fully tested locally. I understand what this code does.
