### PR TITLE
fix(ui): use ?selected binding on model options to fix initial render

### DIFF
--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -1,5 +1,7 @@
+import { render } from "lit";
 import { describe, expect, it } from "vitest";
 import {
+  buildModelOptions,
   resolveConfiguredCronModelSuggestions,
   resolveEffectiveModelFallbacks,
   sortLocaleStrings,
@@ -86,6 +88,57 @@ describe("resolveConfiguredCronModelSuggestions", () => {
     expect(resolveConfiguredCronModelSuggestions({ agents: { defaults: { model: "" } } })).toEqual(
       [],
     );
+  });
+});
+
+describe("buildModelOptions", () => {
+  const configForm = {
+    agents: {
+      defaults: {
+        models: {
+          "github-copilot/claude-sonnet-4.6": {},
+          "openai-codex/gpt-5.3-codex": { alias: "codex" },
+          "google/gemini-3-pro-preview": {},
+        },
+      },
+    },
+  };
+
+  function renderIntoSelect(current?: string | null) {
+    const select = document.createElement("select");
+    render(buildModelOptions(configForm, current), select);
+    return select;
+  }
+
+  it("marks exactly one option selected when current matches a configured model", () => {
+    const select = renderIntoSelect("openai-codex/gpt-5.3-codex");
+    const selected = Array.from(select.options).filter((o) => o.selected);
+    expect(selected).toHaveLength(1);
+    expect(selected[0].value).toBe("openai-codex/gpt-5.3-codex");
+  });
+
+  it("marks the prepended Current option selected when current is not in the configured list", () => {
+    const select = renderIntoSelect("unknown/model-x");
+    const selected = Array.from(select.options).filter((o) => o.selected);
+    expect(selected).toHaveLength(1);
+    expect(selected[0].value).toBe("unknown/model-x");
+    expect(selected[0].label).toContain("Current");
+  });
+
+  it("sets no explicit selected attribute when current is undefined", () => {
+    const select = renderIntoSelect(undefined);
+    // Browsers always auto-select the first option; verify no option has an
+    // explicit ?selected binding (hasAttribute vs the DOM .selected property).
+    const explicitlySelected = Array.from(select.options).filter((o) => o.hasAttribute("selected"));
+    expect(explicitlySelected).toHaveLength(0);
+  });
+
+  it("renders all configured models as options", () => {
+    const select = renderIntoSelect("github-copilot/claude-sonnet-4.6");
+    const values = Array.from(select.options).map((o) => o.value);
+    expect(values).toContain("github-copilot/claude-sonnet-4.6");
+    expect(values).toContain("openai-codex/gpt-5.3-codex");
+    expect(values).toContain("google/gemini-3-pro-preview");
   });
 });
 

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -411,7 +411,9 @@ export function buildModelOptions(
       <option value="" disabled>No configured models</option>
     `;
   }
-  return options.map((option) => html`<option value=${option.value}>${option.label}</option>`);
+  return options.map(
+    (option) => html`<option value=${option.value} ?selected=${option.value === current}>${option.label}</option>`,
+  );
 }
 
 type CompiledPattern =


### PR DESCRIPTION
Fixes #34857

## Summary

- `buildModelOptions` now adds `?selected=${option.value === current}` to each `<option>` element
- Removes dependency on `.value` PropertyPart timing for establishing the initial selection

## Root Cause

Lit commits `PropertyPart` bindings (`.value` on `<select>`) before the element's child `ChildPart` (the `<option>` elements). On the initial render when `configForm` first loads, `select.value` is assigned while the select still contains the stale "No configured models" placeholder — the assignment silently fails and the browser falls back to the first option.

Adding `?selected` to each `<option>` moves selection responsibility into the `ChildPart` render phase, where the options are already in the DOM and the correct one gets `selected` set.

## Test plan

- Open Agents → Overview tab on initial page load
- Confirm "Primary model" `<select>` shows the configured primary instead of the first option in the list
- Confirm switching between agents continues to show correct model for each
- Confirm non-default agents show "Inherit default" when no per-agent model is set