### PR TITLE
fix: bug: agents model selection <select> shows wrong primary model on initial load (#34857)

### DIFF
--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildModelOptions,
   resolveConfiguredCronModelSuggestions,
   resolveEffectiveModelFallbacks,
   sortLocaleStrings,
@@ -96,5 +97,31 @@ describe("sortLocaleStrings", () => {
 
   it("accepts any iterable input, including sets", () => {
     expect(sortLocaleStrings(new Set(["beta", "alpha"]))).toEqual(["alpha", "beta"]);
+  });
+});
+
+describe("buildModelOptions", () => {
+  it("marks the current model option as selected in option bindings", () => {
+    const configForm = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5-mini": { alias: "fast" },
+            "openai/gpt-5.3-codex": { alias: "primary" },
+          },
+        },
+      },
+    } as Record<string, unknown>;
+
+    const options = buildModelOptions(configForm, "openai/gpt-5.3-codex") as Array<{
+      strings: readonly string[];
+      values: readonly unknown[];
+    }>;
+
+    expect(Array.isArray(options)).toBe(true);
+    const selected = options.find((option) => option.values[0] === "openai/gpt-5.3-codex");
+    const unselected = options.find((option) => option.values[0] === "openai/gpt-5-mini");
+    expect(selected?.values[1]).toBe(true);
+    expect(unselected?.values[1]).toBe(false);
   });
 });

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -411,7 +411,10 @@ export function buildModelOptions(
       <option value="" disabled>No configured models</option>
     `;
   }
-  return options.map((option) => html`<option value=${option.value}>${option.label}</option>`);
+  return options.map(
+    (option) =>
+      html`<option value=${option.value} ?selected=${option.value === current}>${option.label}</option>`,
+  );
 }
 
 type CompiledPattern =


### PR DESCRIPTION
Closes #34857

## Summary

- Problem: bug: agents model selection <select> shows wrong primary model on initial load
- Why it matters: Reported in #34857
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #34857
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/34857