### PR TITLE
UI: fix model select showing wrong primary on initial load

### DIFF
--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -411,7 +411,10 @@ export function buildModelOptions(
       <option value="" disabled>No configured models</option>
     `;
   }
-  return options.map((option) => html`<option value=${option.value}>${option.label}</option>`);
+  return options.map(
+    (option) =>
+      html`<option value=${option.value} ?selected=${option.value === current}>${option.label}</option>`,
+  );
 }
 
 type CompiledPattern =


### PR DESCRIPTION
## Summary

Fixes #34857

The `<select>` element for primary model in the Agents Overview tab shows the wrong model on initial page load. This happens because Lit commits `PropertyPart` bindings (`.value` on `<select>`) **before** the element's `ChildPart` (the `<option>` elements). When `.value` is applied, no matching `<option>` exists yet, so the browser silently ignores the assignment and falls back to the first option once children render.

## Changes

- Added `?selected=${option.value === current}` to each `<option>` in `buildModelOptions()` so selection is established during the `ChildPart` render phase when options are already in the DOM

## Test plan

- [x] Existing `agents-utils.test.ts` tests pass (7/7)
- [ ] Manual: Open Control UI → Agents → select agent with configured primary model → verify `<select>` shows the correct primary model on initial load