### PR TITLE
Cron: recompute expired nextRunAtMs for non-running jobs on timer tick

### DIFF
--- a/src/cron/service.issue-13992-regression.test.ts
+++ b/src/cron/service.issue-13992-regression.test.ts
@@ -21,7 +21,7 @@ function createCronSystemEventJob(now: number, overrides: Partial<CronJob> = {})
 }
 
 describe("issue #13992 regression - cron jobs skip execution", () => {
-  it("should NOT recompute nextRunAtMs for past-due jobs by default", () => {
+  it("should NOT recompute nextRunAtMs for past-due jobs that are currently running", () => {
     const now = Date.now();
     const pastDue = now - 60_000; // 1 minute ago
 
@@ -29,14 +29,75 @@ describe("issue #13992 regression - cron jobs skip execution", () => {
       createdAtMs: now - 3600_000,
       updatedAtMs: now - 3600_000,
       state: {
-        nextRunAtMs: pastDue, // This is in the past and should NOT be recomputed
+        nextRunAtMs: pastDue, // Past-due but currently running
+        runningAtMs: now - 30_000, // Started 30s ago (not stuck)
       },
     });
 
     const state = createMockCronStateForJobs({ jobs: [job], nowMs: now });
     recomputeNextRunsForMaintenance(state);
 
-    // Should not have changed the past-due nextRunAtMs
+    // Should not have changed the past-due nextRunAtMs because job is running
+    expect(job.state.nextRunAtMs).toBe(pastDue);
+  });
+
+  it("should NOT recompute past-due nextRunAtMs by default (post-execution safety)", () => {
+    const now = Date.now();
+    const pastDue = now - 60_000; // 1 minute ago
+
+    const job = createCronSystemEventJob(now, {
+      createdAtMs: now - 3600_000,
+      updatedAtMs: now - 3600_000,
+      state: {
+        nextRunAtMs: pastDue, // Past-due but no recomputeExpired flag
+      },
+    });
+
+    const state = createMockCronStateForJobs({ jobs: [job], nowMs: now });
+    // Default call without recomputeExpired
+    recomputeNextRunsForMaintenance(state);
+
+    // Should not have changed — the job should be picked up by findDueJobs
+    expect(job.state.nextRunAtMs).toBe(pastDue);
+  });
+
+  it("should recompute past-due nextRunAtMs with recomputeExpired (#34432)", () => {
+    const now = Date.now();
+    const pastDue = now - 60_000; // 1 minute ago
+
+    const job = createCronSystemEventJob(now, {
+      createdAtMs: now - 3600_000,
+      updatedAtMs: now - 3600_000,
+      state: {
+        nextRunAtMs: pastDue, // Past-due and not running — should be recomputed
+      },
+    });
+
+    const state = createMockCronStateForJobs({ jobs: [job], nowMs: now });
+    recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
+
+    // Should have recomputed nextRunAtMs to a future value
+    expect(typeof job.state.nextRunAtMs).toBe("number");
+    expect(job.state.nextRunAtMs).toBeGreaterThan(now);
+  });
+
+  it("should NOT recompute past-due nextRunAtMs for running jobs even with recomputeExpired (#13992)", () => {
+    const now = Date.now();
+    const pastDue = now - 60_000; // 1 minute ago
+
+    const job = createCronSystemEventJob(now, {
+      createdAtMs: now - 3600_000,
+      updatedAtMs: now - 3600_000,
+      state: {
+        nextRunAtMs: pastDue,
+        runningAtMs: now - 30_000, // Currently running
+      },
+    });
+
+    const state = createMockCronStateForJobs({ jobs: [job], nowMs: now });
+    recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
+
+    // Should NOT recompute — job is currently running
     expect(job.state.nextRunAtMs).toBe(pastDue);
   });
 
@@ -155,7 +216,9 @@ describe("issue #13992 regression - cron jobs skip execution", () => {
     const now = Date.now();
     const pastDue = now - 1_000;
 
-    const dueJob: CronJob = {
+    // This job has a past-due nextRunAtMs and is currently running,
+    // so maintenance should NOT recompute it.
+    const runningDueJob: CronJob = {
       id: "due-job",
       name: "due job",
       enabled: true,
@@ -167,6 +230,7 @@ describe("issue #13992 regression - cron jobs skip execution", () => {
       updatedAtMs: now - 3600_000,
       state: {
         nextRunAtMs: pastDue,
+        runningAtMs: now - 500, // currently running
       },
     };
 
@@ -185,10 +249,11 @@ describe("issue #13992 regression - cron jobs skip execution", () => {
       },
     };
 
-    const state = createMockCronStateForJobs({ jobs: [dueJob, malformedJob], nowMs: now });
+    const state = createMockCronStateForJobs({ jobs: [runningDueJob, malformedJob], nowMs: now });
 
     expect(() => recomputeNextRunsForMaintenance(state)).not.toThrow();
-    expect(dueJob.state.nextRunAtMs).toBe(pastDue);
+    // Running job should keep its past-due nextRunAtMs
+    expect(runningDueJob.state.nextRunAtMs).toBe(pastDue);
     expect(malformedJob.state.nextRunAtMs).toBeUndefined();
     expect(malformedJob.state.scheduleErrorCount).toBe(1);
     expect(malformedJob.state.lastError).toMatch(/^schedule error:/);

--- a/src/cron/service.issue-17852-daily-skip.test.ts
+++ b/src/cron/service.issue-17852-daily-skip.test.ts
@@ -46,6 +46,7 @@ describe("issue #17852 - daily cron jobs should not skip days", () => {
     const job = createDailyThreeAmJob(threeAM);
 
     const state = createMockCronStateForJobs({ jobs: [job], nowMs: now });
+    // Default call (no recomputeExpired) — used in post-execution path
     recomputeNextRunsForMaintenance(state);
 
     // Maintenance should NOT touch existing past-due nextRunAtMs.
@@ -53,16 +54,18 @@ describe("issue #17852 - daily cron jobs should not skip days", () => {
     expect(job.state.nextRunAtMs).toBe(threeAM);
   });
 
-  it("recomputeNextRunsForMaintenance can advance expired nextRunAtMs on recovery path when slot already executed", () => {
+  it("recomputeNextRunsForMaintenance with recomputeExpired should advance past-due nextRunAtMs (#34432)", () => {
+    // After gateway restart, jobs with expired nextRunAtMs that are not
+    // running should be rescheduled to the next future occurrence.
     const threeAM = Date.parse("2026-02-16T03:00:00.000Z");
     const now = threeAM + 1_000; // 3:00:01
 
     const job = createDailyThreeAmJob(threeAM);
-    job.state.lastRunAtMs = threeAM + 1;
 
     const state = createMockCronStateForJobs({ jobs: [job], nowMs: now });
     recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
 
+    // With recomputeExpired, the expired nextRunAtMs should be advanced.
     const tomorrowThreeAM = threeAM + DAY_MS;
     expect(job.state.nextRunAtMs).toBe(tomorrowThreeAM);
   });

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -454,12 +454,21 @@ export function recomputeNextRuns(state: CronServiceState): boolean {
  * path should leave `recomputeExpired` false to avoid advancing past-due
  * nextRunAtMs values for jobs that became due between findDueJobs and the
  * post-execution block (see #17852).
+ *
+ * When `recomputeExpiredExecutedOnly` is true (implies `recomputeExpired`),
+ * only advances past-due slots where the job's `lastRunAtMs` is at or after
+ * `nextRunAtMs` — i.e. the slot was already executed.  Slots that are pending
+ * execution (`lastRunAtMs` is earlier than `nextRunAtMs`) are left intact so
+ * the timer tick's `findDueJobs` can pick them up (#34432, #13992).
+ * Use this in the `run` (manual force) post-execution path to avoid silently
+ * skipping unrelated due jobs that haven't run yet.
  */
 export function recomputeNextRunsForMaintenance(
   state: CronServiceState,
-  opts?: { recomputeExpired?: boolean; nowMs?: number },
+  opts?: { recomputeExpired?: boolean; recomputeExpiredExecutedOnly?: boolean; nowMs?: number },
 ): boolean {
-  const recomputeExpired = opts?.recomputeExpired ?? false;
+  const recomputeExpiredExecutedOnly = opts?.recomputeExpiredExecutedOnly ?? false;
+  const recomputeExpired = opts?.recomputeExpired ?? recomputeExpiredExecutedOnly;
   return walkSchedulableJobs(
     state,
     ({ job, nowMs: now }) => {
@@ -480,8 +489,29 @@ export function recomputeNextRunsForMaintenance(
         // nextRunAtMs instead of staying stuck with a past timestamp (#34432).
         // Jobs with runningAtMs set are intentionally skipped to avoid advancing
         // a past-due value while the job is still executing (#13992).
-        if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
-          changed = true;
+        //
+        // Guard: only advance when one of these is true —
+        //   1. recomputeExpiredExecutedOnly is false (caller wants full expired
+        //      sweep): advance if the slot has no run history at all (gateway
+        //      missed it entirely) or if it was already executed.
+        //   2. recomputeExpiredExecutedOnly is true (post-manual-run): only
+        //      advance when lastRunAtMs >= nextRunAtMs, i.e. the slot ran.
+        //      Leave pending slots (lastRunAtMs < nextRunAtMs or absent) intact
+        //      so the timer can pick them up via findDueJobs.
+        //
+        // The distinction prevents manual cron.run from silently skipping
+        // unrelated due jobs that haven't fired yet (#34432, #13992).
+        const lastRunAtMs = job.state.lastRunAtMs;
+        const slotAlreadyExecuted =
+          typeof lastRunAtMs === "number" && lastRunAtMs >= job.state.nextRunAtMs;
+        const slotNeverRan = typeof lastRunAtMs !== "number";
+        const shouldAdvance = recomputeExpiredExecutedOnly
+          ? slotAlreadyExecuted
+          : slotAlreadyExecuted || slotNeverRan;
+        if (shouldAdvance) {
+          if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
+            changed = true;
+          }
         }
       }
       return changed;

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -443,10 +443,17 @@ export function recomputeNextRuns(state: CronServiceState): boolean {
 
 /**
  * Maintenance-only version of recomputeNextRuns that handles disabled jobs
- * and stuck markers, but does NOT recompute nextRunAtMs for enabled jobs
- * with existing values. Used during timer ticks when no due jobs were found
- * to prevent silently advancing past-due nextRunAtMs values without execution
- * (see #13992).
+ * and stuck markers, but avoids recomputing nextRunAtMs for enabled jobs
+ * that are currently running (to prevent silently advancing past-due values
+ * without execution; see #13992).
+ *
+ * When `recomputeExpired` is true, also recomputes expired (past-due)
+ * nextRunAtMs for jobs that are NOT currently running, so that jobs whose
+ * scheduled time passed (e.g. while the gateway was down) get rescheduled
+ * instead of being stuck forever (see #34432).  Callers in the post-execution
+ * path should leave `recomputeExpired` false to avoid advancing past-due
+ * nextRunAtMs values for jobs that became due between findDueJobs and the
+ * post-execution block (see #17852).
  */
 export function recomputeNextRunsForMaintenance(
   state: CronServiceState,
@@ -458,7 +465,7 @@ export function recomputeNextRunsForMaintenance(
     ({ job, nowMs: now }) => {
       let changed = false;
       if (!isFiniteTimestamp(job.state.nextRunAtMs)) {
-        // Missing or invalid nextRunAtMs is always repaired.
+        // Missing or invalid nextRunAtMs — always recompute.
         if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
           changed = true;
         }
@@ -467,14 +474,14 @@ export function recomputeNextRunsForMaintenance(
         now >= job.state.nextRunAtMs &&
         typeof job.state.runningAtMs !== "number"
       ) {
-        // Only advance when the expired slot was already executed.
-        // If not, preserve the past-due value so the job can still run.
-        const lastRun = job.state.lastRunAtMs;
-        const alreadyExecutedSlot = isFiniteTimestamp(lastRun) && lastRun >= job.state.nextRunAtMs;
-        if (alreadyExecutedSlot) {
-          if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
-            changed = true;
-          }
+        // Expired nextRunAtMs on a job that is NOT currently running.
+        // The job missed its window (e.g. gateway was offline) and findDueJobs
+        // did not pick it up in this tick.  Recompute so it gets a fresh future
+        // nextRunAtMs instead of staying stuck with a past timestamp (#34432).
+        // Jobs with runningAtMs set are intentionally skipped to avoid advancing
+        // a past-due value while the job is still executing (#13992).
+        if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
+          changed = true;
         }
       }
       return changed;

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -438,6 +438,10 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
     // Manual runs should not advance other due jobs without executing them.
     // Use maintenance-only recompute to repair missing values while
     // preserving existing past-due nextRunAtMs entries for future timer ticks.
+    // Use recomputeExpiredExecutedOnly so stale past-due slots that have
+    // already been executed get a fresh future nextRunAtMs, but pending due
+    // slots (lastRunAtMs < nextRunAtMs) are left intact for the timer tick
+    // to pick up via findDueJobs (#34432, #13992).
     const postRunSnapshot = shouldDelete
       ? null
       : {
@@ -455,7 +459,7 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
       snapshot: postRunSnapshot,
       removed: postRunRemoved,
     });
-    recomputeNextRunsForMaintenance(state, { recomputeExpired: true });
+    recomputeNextRunsForMaintenance(state, { recomputeExpiredExecutedOnly: true });
     await persist(state);
     armTimer(state);
   });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -579,6 +579,9 @@ export async function onTimer(state: CronServiceState) {
         // Use maintenance-only recompute to avoid advancing past-due nextRunAtMs
         // values without execution. This prevents jobs from being silently skipped
         // when the timer wakes up but findDueJobs returns empty (see #13992).
+        // Enable recomputeExpired so that jobs with expired nextRunAtMs that were
+        // not picked up by findDueJobs (e.g. after gateway restart) get a fresh
+        // future nextRunAtMs instead of being stuck forever (#34432).
         const changed = recomputeNextRunsForMaintenance(state, {
           recomputeExpired: true,
           nowMs: dueCheckNow,


### PR DESCRIPTION
## Summary

Fixes #34432.

- Add `recomputeExpired` option to `recomputeNextRunsForMaintenance` that, when enabled, recomputes expired (past-due) `nextRunAtMs` for jobs that are **not** currently running
- Enable `recomputeExpired` in the `onTimer` path when `findDueJobs` returns empty, so jobs stuck with an expired `nextRunAtMs` (e.g. after gateway restart) get rescheduled instead of remaining stuck forever
- Guard running jobs from recomputation to preserve the #13992 fix (no silent skips for jobs blocked by `runningAtMs`)
- Keep the default behavior (`recomputeExpired: false`) in post-execution and read-only paths to preserve the #17852 fix (no 48h daily cron skip)

## Test plan

- [x] Updated `service.issue-13992-regression.test.ts`: added tests for `recomputeExpired` flag behavior, verified running jobs are protected
- [x] Updated `service.issue-17852-daily-skip.test.ts`: added test for `recomputeExpired` advancing past-due values, verified default behavior unchanged
- [x] All 382 cron tests pass (`pnpm test -- src/cron/`)