### PR TITLE
fix(ci): remove semver build metadata from bun version

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -61,7 +61,7 @@ runs:
       if: inputs.install-bun == 'true'
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: "1.3.9+cf6cdbbba"
+        bun-version: "1.3.9"
 
     - name: Runtime versions
       shell: bash


### PR DESCRIPTION
## Problem

The bun test lane fails on all PRs and `main` with:

```
Downloading a new version of Bun: https://github.com/oven-sh/bun/releases/download/bun-v1.3.9%2Bcf6cdbbba/bun-linux-x64.zip
##[error]Error: Unexpected HTTP response: 404
```

## Root Cause

`.github/actions/setup-node-env/action.yml` sets `bun-version: "1.3.9+cf6cdbbba"`.

`oven-sh/setup-bun@v2` treats this as a strict semver match and constructs tag `bun-v1.3.9+cf6cdbbba`. When building the download URL, `encodeURIComponent()` encodes `+` → `%2B`, producing a URL that 404s because GitHub Release tags don't include build metadata suffixes.

The actual release tag is `bun-v1.3.9`.

## Fix

Strip the build metadata: `"1.3.9+cf6cdbbba"` → `"1.3.9"`.

## Evidence

- Failed on main: run [`22683353738`](https://github.com/openclaw/openclaw/actions/runs/22683353738)
- Failed on PRs: [`22682528426`](https://github.com/openclaw/openclaw/actions/runs/22682528426), [`22682529444`](https://github.com/openclaw/openclaw/actions/runs/22682529444), [`22682530048`](https://github.com/openclaw/openclaw/actions/runs/22682530048)
- `oven-sh/setup-bun` source: [`download-url.ts#L28`](https://github.com/oven-sh/setup-bun/blob/v2/src/download-url.ts#L28) — `validateStrict()` passes, so the version is used verbatim as a tag