### PR TITLE
fix: fix(slack): app_mention events silently dropped by dedup cache when message event arrives first (#34833)

### DIFF
--- a/src/slack/monitor/message-handler.test.ts
+++ b/src/slack/monitor/message-handler.test.ts
@@ -97,6 +97,24 @@ describe("createSlackMessageHandler", () => {
     expect(enqueueMock).not.toHaveBeenCalled();
   });
 
+  it("does not dedupe app_mention events through markMessageSeen", async () => {
+    const { handler, trackEvent } = createHandlerWithTracker({ markMessageSeen: () => true });
+
+    await handler(
+      {
+        type: "app_mention",
+        channel: "C1",
+        ts: "123.456",
+        text: "<@U_BOT> hello",
+      } as never,
+      { source: "app_mention", wasMentioned: true },
+    );
+
+    expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(resolveThreadTsMock).toHaveBeenCalledTimes(1);
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+  });
+
   it("tracks accepted non-duplicate messages", async () => {
     const { handler, trackEvent } = createHandlerWithTracker();
 

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -165,7 +165,7 @@ export function createSlackMessageHandler(params: {
     ) {
       return;
     }
-    if (ctx.markMessageSeen(message.channel, message.ts)) {
+    if (opts.source !== "app_mention" && ctx.markMessageSeen(message.channel, message.ts)) {
       return;
     }
     trackEvent?.();


### PR DESCRIPTION
Closes #34833

## Summary

- Problem: fix(slack): app_mention events silently dropped by dedup cache when message event arrives first
- Why it matters: Reported in #34833
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #34833
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/34833