### PR TITLE
fix: feat(cli): add --session-key targeting for openclaw agent command (#34837)

### DIFF
--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -71,13 +71,23 @@ describe("registerAgentCommands", () => {
   });
 
   it("runs agent command with deps and verbose enabled for --verbose on", async () => {
-    await runCli(["agent", "--message", "hi", "--verbose", "ON", "--json"]);
+    await runCli([
+      "agent",
+      "--message",
+      "hi",
+      "--session-key",
+      "agent:ops:slack:channel:c0agdlshsva",
+      "--verbose",
+      "ON",
+      "--json",
+    ]);
 
     expect(setVerboseMock).toHaveBeenCalledWith(true);
     expect(createDefaultDepsMock).toHaveBeenCalledTimes(1);
     expect(agentCliCommandMock).toHaveBeenCalledWith(
       expect.objectContaining({
         message: "hi",
+        sessionKey: "agent:ops:slack:channel:c0agdlshsva",
         verbose: "ON",
         json: true,
       }),

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -26,6 +26,7 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
     .requiredOption("-m, --message <text>", "Message body for the agent")
     .option("-t, --to <number>", "Recipient number in E.164 used to derive the session key")
     .option("--session-id <id>", "Use an explicit session id")
+    .option("--session-key <key>", "Use an explicit session key")
     .option("--agent <id>", "Agent id (overrides routing bindings)")
     .option("--thinking <level>", "Thinking level: off | minimal | low | medium | high")
     .option("--verbose <on|off>", "Persist agent verbose level for the session")
@@ -58,6 +59,10 @@ ${formatHelpExamples([
   [
     'openclaw agent --session-id 1234 --message "Summarize inbox" --thinking medium',
     "Target a session with explicit thinking level.",
+  ],
+  [
+    'openclaw agent --session-key "agent:ops:slack:channel:c0agdlshsva" --message "Summarize inbox"',
+    "Target a specific channel-backed session key.",
   ],
   [
     'openclaw agent --to +15555550123 --message "Trace logs" --verbose on --json',

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -15,7 +15,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import * as configModule from "../config/config.js";
 import { callGateway } from "../gateway/call.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { agentCliCommand } from "./agent-via-gateway.js";
+import { agentCliCommand, agentViaGatewayCommand } from "./agent-via-gateway.js";
 import { agentCommand } from "./agent.js";
 
 const runtime: RuntimeEnv = {
@@ -83,6 +83,31 @@ beforeEach(() => {
 });
 
 describe("agentCliCommand", () => {
+  it("accepts --session-key as a standalone session target", async () => {
+    await withTempStore(async () => {
+      mockGatewaySuccessReply();
+
+      await agentCliCommand(
+        { message: "hi", sessionKey: "agent:ops:slack:channel:c0agdlshsva" },
+        runtime,
+      );
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      const request = vi.mocked(callGateway).mock.calls[0]?.[0] as {
+        params?: { sessionKey?: string };
+      };
+      expect(request.params?.sessionKey).toBe("agent:ops:slack:channel:c0agdlshsva");
+    });
+  });
+
+  it("rejects calls without --to, --session-id, --session-key, or --agent", async () => {
+    await withTempStore(async () => {
+      await expect(agentViaGatewayCommand({ message: "hi" }, runtime)).rejects.toThrow(
+        "Pass --to <E.164>, --session-id, --session-key, or --agent to choose a session",
+      );
+    });
+  });
+
   it("uses a timer-safe max gateway timeout when --timeout is 0", async () => {
     await withTempStore(async () => {
       mockGatewaySuccessReply();

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -37,6 +37,7 @@ export type AgentCliOpts = {
   agent?: string;
   to?: string;
   sessionId?: string;
+  sessionKey?: string;
   thinking?: string;
   verbose?: string;
   json?: boolean;
@@ -89,8 +90,10 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
   if (!body) {
     throw new Error("Message (--message) is required");
   }
-  if (!opts.to && !opts.sessionId && !opts.agent) {
-    throw new Error("Pass --to <E.164>, --session-id, or --agent to choose a session");
+  if (!opts.to && !opts.sessionId && !opts.sessionKey && !opts.agent) {
+    throw new Error(
+      "Pass --to <E.164>, --session-id, --session-key, or --agent to choose a session",
+    );
   }
 
   const cfg = loadConfig();
@@ -115,6 +118,7 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
     agentId,
     to: opts.to,
     sessionId: opts.sessionId,
+    sessionKey: opts.sessionKey,
   }).sessionKey;
 
   const channel = normalizeMessageChannel(opts.channel);


### PR DESCRIPTION
Closes #34837

## Summary

- Problem: feat(cli): add --session-key targeting for openclaw agent command
- Why it matters: Reported in #34837
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #34837
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/34837