### PR TITLE
perf: add file modification time cache for workspace context reads

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -28,6 +28,14 @@ const log = createSubsystemLogger("compaction-safeguard");
 
 // Track session managers that have already logged the missing-model warning to avoid log spam.
 const missedModelWarningSessions = new WeakSet<object>();
+
+// Cache for workspace context to avoid repeated file reads
+type WorkspaceContextCache = {
+  content: string;
+  mtimeMs: number;
+  path: string;
+};
+let workspaceContextCache: WorkspaceContextCache | null = null;
 const TURN_PREFIX_INSTRUCTIONS =
   "This summary covers the prefix of a split turn. Focus on the original request," +
   " early progress, and any details needed to understand the retained suffix.";
@@ -530,6 +538,20 @@ async function readWorkspaceContextForSummary(): Promise<string> {
   const agentsPath = path.join(workspaceDir, "AGENTS.md");
 
   try {
+    // Check cache first
+    try {
+      const stats = fs.statSync(agentsPath);
+      if (
+        workspaceContextCache &&
+        workspaceContextCache.path === agentsPath &&
+        workspaceContextCache.mtimeMs === stats.mtimeMs
+      ) {
+        return workspaceContextCache.content;
+      }
+    } catch {
+      // File doesn't exist or can't stat, continue to read
+    }
+
     const opened = await openBoundaryFile({
       absolutePath: agentsPath,
       rootPath: workspaceDir,
@@ -558,12 +580,25 @@ async function readWorkspaceContextForSummary(): Promise<string> {
         ? combined.slice(0, MAX_SUMMARY_CONTEXT_CHARS) + "\n...[truncated]..."
         : combined;
 
-    return `\n\n<workspace-critical-rules>\n${safeContent}\n</workspace-critical-rules>`;
+    const result = `\n\n<workspace-critical-rules>\n${safeContent}\n</workspace-critical-rules>`;
+
+    // Update cache
+    try {
+      const stats = fs.statSync(agentsPath);
+      workspaceContextCache = {
+        content: result,
+        mtimeMs: stats.mtimeMs,
+        path: agentsPath,
+      };
+    } catch {
+      // If we can't stat, don't cache
+    }
+
+    return result;
   } catch {
     return "";
   }
 }
-
 export default function compactionSafeguardExtension(api: ExtensionAPI): void {
   api.on("session_before_compact", async (event, ctx) => {
     const { preparation, customInstructions, signal } = event;


### PR DESCRIPTION
## Summary

Add a simple cache mechanism to avoid repeated file reads of AGENTS.md during compaction operations. The cache stores the file content along with its modification time, and only re-reads the file when it has been modified.

## Problem

The `readWorkspaceContextForSummary` function in `compaction-safeguard.ts` is called during every compaction operation to extract critical workspace context (Session Startup and Red Lines sections) from AGENTS.md. In long-running sessions with frequent compactions, this results in redundant file I/O operations even when the file hasn't changed.

## Solution

Implement a file modification time (mtime) based cache:

1. **Cache Structure**: Store the file content, path, and modification timestamp
2. **Cache Check**: Before reading the file, check if the cached version is still valid by comparing mtime
3. **Cache Update**: After successfully reading the file, update the cache with new content and mtime
4. **Graceful Fallback**: If file stat fails, continue without caching

## Changes

- Add `WorkspaceContextCache` type and `workspaceContextCache` variable
- Modify `readWorkspaceContextForSummary` to check cache before reading
- Update cache after successful file read
- Handle stat failures gracefully

## Performance Impact

- **Before**: Every compaction operation reads AGENTS.md from disk
- **After**: File is only read when modified, subsequent compactions use cached content
- **Benefit**: Reduced I/O operations and latency during compaction

## Testing

- Existing tests pass (compaction-safeguard.test.ts)
- Cache behavior is transparent to callers
- No breaking changes to API or behavior

## Related

This optimization complements the existing compaction safeguard mechanism by reducing overhead in the workspace context reading step.