### PR TITLE
Gateway: handle systemctl is-enabled non-zero exit gracefully

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -79,16 +79,15 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
-  it("throws when systemctl is-enabled fails for non-state errors", async () => {
+  it("returns false when systemctl is-enabled fails with bus error", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
       const err = new Error("Failed to connect to bus") as Error & { code?: number };
       err.code = 1;
       cb(err, "", "Failed to connect to bus");
     });
-    await expect(isSystemdServiceEnabled({ env: {} })).rejects.toThrow(
-      "systemctl is-enabled unavailable: Failed to connect to bus",
-    );
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
   });
 
   it("returns false when systemctl is-enabled exits with code 4 (not-found)", async () => {
@@ -101,6 +100,21 @@ describe("isSystemdServiceEnabled", () => {
       ) as Error & { code?: number };
       err.code = 4;
       cb(err, "not-found\n", "");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
+
+  it("returns false when systemctl is-enabled exits with code 1 and empty stdout", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      // On fresh Ubuntu 24.04 EC2, systemctl --user is-enabled may exit with
+      // code 1 and produce no stdout state keyword at all.
+      const err = new Error(
+        "Command failed: systemctl --user is-enabled openclaw-gateway.service",
+      ) as Error & { code?: number };
+      err.code = 1;
+      cb(err, "", "");
     });
     const result = await isSystemdServiceEnabled({ env: {} });
     expect(result).toBe(false);

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -374,10 +374,19 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
     return true;
   }
   const detail = readSystemctlDetail(res);
-  if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
+  if (isSystemctlMissing(detail)) {
     return false;
   }
-  throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());
+  // `systemctl is-enabled` exits non-zero for disabled / not-found / masked /
+  // static / indirect states.  On some Ubuntu/EC2 setups stdout is empty and
+  // only the generic Node "Command failed: ..." error message appears in the
+  // detail string, so keyword matching alone can miss legitimate not-enabled
+  // responses.  Treat any non-zero exit from an available systemctl binary as
+  // "not enabled" rather than crashing the gateway start flow.
+  if (isSystemdUnitNotEnabled(detail)) {
+    return false;
+  }
+  return false;
 }
 
 export async function readSystemdServiceRuntime(


### PR DESCRIPTION
## Summary

- Fix `openclaw gateway start` crashing on fresh Ubuntu 24.04 EC2 instances where `systemctl --user is-enabled openclaw-gateway.service` exits with code 1 and empty stdout
- Treat any non-zero exit from an available `systemctl` binary as "not enabled" instead of throwing, since `is-enabled` exit codes 1 and 4 both indicate non-enabled states (disabled, not-found, masked, etc.)
- Add test coverage for the empty-stdout edge case and convert the bus-error test from expecting a throw to expecting `false`

Fixes #34791

## Test plan

- [x] `pnpm test -- --run src/daemon/systemd.test.ts` — all 22 tests pass
- [x] `pnpm test -- --run src/cli/daemon-cli/lifecycle-core.test.ts` — all 3 tests pass
- [x] `pnpm check` — no lint/format errors