### PR TITLE
Gateway: prevent webchat messages from inheriting external channel routing

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -155,6 +155,7 @@ async function runNonStreamingChatSend(params: {
   sessionKey?: string;
   deliver?: boolean;
   client?: unknown;
+  isWebchatConnect?: boolean;
   expectBroadcast?: boolean;
 }) {
   const sendParams: {
@@ -177,7 +178,7 @@ async function runNonStreamingChatSend(params: {
     >[0]["respond"],
     req: {} as never,
     client: (params.client ?? null) as never,
-    isWebchatConnect: () => false,
+    isWebchatConnect: () => params.isWebchatConnect ?? false,
     context: params.context as GatewayRequestContext,
   });
 
@@ -712,6 +713,47 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       idempotencyKey: "idem-no-deliver-internal-surface",
       sessionKey: "agent:main:discord:direct:1234567890",
       deliver: false,
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        OriginatingChannel: "webchat",
+        OriginatingTo: undefined,
+        AccountId: undefined,
+      }),
+    );
+  });
+
+  it("chat.send does not inherit channel routing for webchat connections on channel-scoped sessions", async () => {
+    createTranscriptFixture("openclaw-chat-send-webchat-no-inherit-channel-route-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "slack",
+        to: "slack:U12345678",
+        accountId: "default",
+      },
+      lastChannel: "slack",
+      lastTo: "slack:U12345678",
+      lastAccountId: "default",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    // Webchat/control-ui connection sending to a channel-scoped session:
+    // OriginatingChannel must remain "webchat" so responses go back to the
+    // web dashboard instead of leaking to the external channel (Slack).
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-webchat-no-inherit-channel-route",
+      sessionKey: "agent:main:slack:direct:U12345678",
+      isWebchatConnect: true,
+      client: {
+        connId: "conn-webchat",
+        connect: { client: { id: "openclaw-control-ui" } },
+      },
       expectBroadcast: false,
     });
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -727,7 +727,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       runIds: res.aborted ? [runId] : [],
     });
   },
-  "chat.send": async ({ params, respond, context, client }) => {
+  "chat.send": async ({ params, respond, context, client, isWebchatConnect }) => {
     if (!validateChatSendParams(params)) {
       respond(
         false,
@@ -890,6 +890,10 @@ export const chatHandlers: GatewayRequestHandlers = {
         !isChannelScopedSession &&
         typeof sessionScopeParts[1] === "string" &&
         sessionChannelHint === routeChannelCandidate;
+      // Messages arriving through the webchat/control-ui chat endpoint should
+      // never inherit prior external route metadata -- the response must go
+      // back to the webchat surface, not to the channel stored on the session.
+      const isWebchatOrigin = Boolean(client?.connect && isWebchatConnect(client.connect));
       const clientMode = client?.connect?.client?.mode;
       const isFromWebchatClient =
         isWebchatClient(client?.connect?.client) || clientMode === GATEWAY_CLIENT_MODES.UI;
@@ -900,6 +904,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       // stale routes across surfaces. Allow configured main sessions from
       // non-Webchat/UI clients (e.g., CLI, backend) to keep the last external route.
       const canInheritDeliverableRoute = Boolean(
+        !isWebchatOrigin &&
         sessionChannelHint &&
         sessionChannelHint !== INTERNAL_MESSAGE_CHANNEL &&
         ((!isChannelAgnosticSessionScope &&


### PR DESCRIPTION
## Summary

Fixes #34647

When a message arrives through the gateway's `chat.send` endpoint (control-ui/webchat), the inbound metadata incorrectly inherits channel routing from the session's stored delivery context. This causes responses to be routed to an external channel (e.g. Slack) instead of back to the web dashboard.

- Add `isWebchatOrigin` check to `canInheritDeliverableRoute` in `chat.send` so webchat/control-ui connections never inherit prior external route metadata
- Add test case verifying that control-ui messages get `OriginatingChannel: "webchat"` even when the session has Slack routing stored

## Test plan

- [x] Existing tests pass (14/14 directive-tags, 19/19 total chat tests)
- [x] New test: `chat.send does not inherit channel routing for webchat connections on channel-scoped sessions`
- [ ] Manual: open control-ui, send message to session with prior Slack routing, verify response stays in web dashboard