### PR TITLE
fix(review): require non-empty behavioral sweep branch fields

### DIFF
--- a/scripts/pr
+++ b/scripts/pr
@@ -704,7 +704,7 @@ review_validate_artifacts() {
   fi
 
   local invalid_behavioral_branch_count
-  invalid_behavioral_branch_count=$(jq '[.behavioralSweep.branches[]? | select((.path|type)!="string" or (.decision|type)!="string" or (.outcome|type)!="string")] | length' .local/review.json)
+  invalid_behavioral_branch_count=$(jq '[.behavioralSweep.branches[]? | select((.path|type)!="string" or (.decision|type)!="string" or (.outcome|type)!="string" or ((.path|gsub("^\\s+|\\s+$";""))|length)==0 or ((.decision|gsub("^\\s+|\\s+$";""))|length)==0 or ((.outcome|gsub("^\\s+|\\s+$";""))|length)==0)] | length' .local/review.json)
   if [ "$invalid_behavioral_branch_count" -gt 0 ]; then
     echo "Invalid behavioral sweep branch entry in .local/review.json: each branch needs string path/decision/outcome"
     exit 1


### PR DESCRIPTION
## Summary
- tighten `scripts/pr` artifact validation for `behavioralSweep.branches`
- require `path`, `decision`, and `outcome` to be non-empty (trimmed) strings

## Why
This closes a validation gap where empty placeholder strings could pass type-only checks.

## Validation
- `bash -n scripts/pr`
- `jq` sanity checks for whitespace-only branch fields
- Codex ACP incremental review verdict: **Approved**