### PR TITLE
fix: Feature: /steer as shorthand for /queue steer in main session (#34881)

### DIFF
--- a/src/auto-reply/reply.directive.parse.test.ts
+++ b/src/auto-reply/reply.directive.parse.test.ts
@@ -150,6 +150,19 @@ describe("directive parsing", () => {
     expect(res.cleaned).toBe("please now");
   });
 
+  it("treats /steer <message> as queue steer shorthand", () => {
+    const res = extractQueueDirective("/steer check on the download progress");
+    expect(res.hasDirective).toBe(true);
+    expect(res.queueMode).toBe("steer");
+    expect(res.cleaned).toBe("check on the download progress");
+  });
+
+  it("keeps /steer <id> <message> for subagent steering", () => {
+    const res = extractQueueDirective("/steer #2 check timer.ts instead");
+    expect(res.hasDirective).toBe(false);
+    expect(res.cleaned).toBe("/steer #2 check timer.ts instead");
+  });
+
   it("preserves spacing when stripping think directives before paths", () => {
     const res = extractThinkDirective("thats not /think high/tmp/hello");
     expect(res.hasDirective).toBe(true);

--- a/src/auto-reply/reply/commands-subagents.ts
+++ b/src/auto-reply/reply/commands-subagents.ts
@@ -13,9 +13,12 @@ import { handleSubagentsUnfocusAction } from "./commands-subagents/action-unfocu
 import {
   type SubagentsCommandContext,
   extractMessageText,
+  isMainRequesterSession,
+  isSubagentIndexToken,
   resolveHandledPrefix,
   resolveRequesterSessionKey,
   resolveSubagentsAction,
+  COMMAND_STEER,
   stopWithText,
 } from "./commands-subagents/shared.js";
 import type { CommandHandler } from "./commands-types.js";
@@ -52,6 +55,15 @@ export const handleSubagentsCommand: CommandHandler = async (params, allowTextCo
   });
   if (!requesterKey) {
     return stopWithText("⚠️ Missing session key.");
+  }
+  if (
+    action === "steer" &&
+    handledPrefix === COMMAND_STEER &&
+    isMainRequesterSession({ requesterKey, cfg: params.cfg }) &&
+    restTokens.length > 0 &&
+    !isSubagentIndexToken(restTokens[0])
+  ) {
+    return null;
   }
 
   const ctx: SubagentsCommandContext = {

--- a/src/auto-reply/reply/commands-subagents/shared.ts
+++ b/src/auto-reply/reply/commands-subagents/shared.ts
@@ -59,6 +59,7 @@ const SUBAGENT_TASK_PREVIEW_MAX = 110;
 export const STEER_ABORT_SETTLE_TIMEOUT_MS = 5_000;
 
 const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SUBAGENT_INDEX_RE = /^#?\d+$/;
 
 function compactLine(value: string) {
   return value.replace(/\s+/g, " ").trim();
@@ -214,6 +215,27 @@ export function resolveRequesterSessionKey(
   }
   const { mainKey, alias } = resolveMainSessionAlias(params.cfg);
   return resolveInternalSessionKey({ key: raw, alias, mainKey });
+}
+
+export function isMainRequesterSession(params: {
+  requesterKey: string;
+  cfg: SubagentsCommandParams["cfg"];
+}): boolean {
+  const parsed = parseAgentSessionKey(params.requesterKey);
+  const scopeKey = (parsed?.rest ?? params.requesterKey).trim().toLowerCase();
+  if (!scopeKey) {
+    return false;
+  }
+  const { mainKey, alias } = resolveMainSessionAlias(params.cfg);
+  return scopeKey === "main" || scopeKey === mainKey || scopeKey === alias;
+}
+
+export function isSubagentIndexToken(token: string | undefined): boolean {
+  const cleaned = token?.trim() ?? "";
+  if (!cleaned) {
+    return false;
+  }
+  return SUBAGENT_INDEX_RE.test(cleaned);
 }
 
 export function resolveHandledPrefix(normalized: string): string | null {

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -1419,6 +1419,29 @@ describe("handleCommands subagents", () => {
     expect(trackedRuns[0].endedAt).toBeUndefined();
   });
 
+  it("lets /steer <message> pass through in main session for queue shorthand", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildParams("/steer check on the download progress", cfg);
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(true);
+    expect(result.reply).toBeUndefined();
+  });
+
+  it("keeps /steer <message> as subagent steering outside main session", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildParams("/steer check on the download progress", cfg);
+    params.sessionKey = "agent:main:whatsapp:direct:user-123";
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Unknown subagent id: check");
+  });
+
   it("restores announce behavior when /steer replacement dispatch fails", async () => {
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string };

--- a/src/auto-reply/reply/queue/directive.ts
+++ b/src/auto-reply/reply/queue/directive.ts
@@ -3,6 +3,8 @@ import { skipDirectiveArgPrefix, takeDirectiveToken } from "../directive-parsing
 import { normalizeQueueDropPolicy, normalizeQueueMode } from "./normalize.js";
 import type { QueueDropPolicy, QueueMode } from "./types.js";
 
+const SUBAGENT_INDEX_RE = /^#?\d+$/;
+
 function parseQueueDebounce(raw?: string): number | undefined {
   if (!raw) {
     return undefined;
@@ -143,6 +145,22 @@ export function extractQueueDirective(body?: string): {
       hasOptions: false,
     };
   }
+  const steerAliasMatch = /^\s*\/steer(?:(?:\s+)(.+))?$/i.exec(body);
+  if (steerAliasMatch) {
+    const rest = (steerAliasMatch[1] ?? "").trim();
+    const firstToken = rest.split(/\s+/, 1)[0]?.trim() ?? "";
+    if (rest && !SUBAGENT_INDEX_RE.test(firstToken)) {
+      return {
+        cleaned: rest,
+        queueMode: "steer",
+        queueReset: false,
+        rawMode: "steer",
+        hasDirective: true,
+        hasOptions: false,
+      };
+    }
+  }
+
   const re = /(?:^|\s)\/queue(?=$|\s|:)/i;
   const match = re.exec(body);
   if (!match) {


### PR DESCRIPTION
Closes #34881

## Summary

- Problem: Feature: /steer as shorthand for /queue steer in main session
- Why it matters: Reported in #34881
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #34881
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/34881