### PR TITLE
fix: [Bug]: Undo/Redo not functional in webchat text input (macOS — Cmd+Z, Edit menu greyed out) (#34898)

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -404,27 +404,8 @@ private struct ChatComposerTextView: NSViewRepresentable {
     func makeCoordinator() -> Coordinator { Coordinator(self) }
 
     func makeNSView(context: Context) -> NSScrollView {
-        let textView = ChatComposerNSTextView()
+        let textView = ChatComposerTextViewFactory.makeConfiguredTextView()
         textView.delegate = context.coordinator
-        textView.drawsBackground = false
-        textView.isRichText = false
-        textView.isAutomaticQuoteSubstitutionEnabled = false
-        textView.isAutomaticTextReplacementEnabled = false
-        textView.isAutomaticDashSubstitutionEnabled = false
-        textView.isAutomaticSpellingCorrectionEnabled = false
-        textView.font = .systemFont(ofSize: 14, weight: .regular)
-        textView.textContainer?.lineBreakMode = .byWordWrapping
-        textView.textContainer?.lineFragmentPadding = 0
-        textView.textContainerInset = NSSize(width: 2, height: 4)
-        textView.focusRingType = .none
-
-        textView.minSize = .zero
-        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
-        textView.isHorizontallyResizable = false
-        textView.isVerticallyResizable = true
-        textView.autoresizingMask = [.width]
-        textView.textContainer?.containerSize = NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
-        textView.textContainer?.widthTracksTextView = true
 
         textView.string = self.text
         textView.onSend = { [weak textView] in
@@ -477,6 +458,35 @@ private struct ChatComposerTextView: NSViewRepresentable {
             guard view.window?.firstResponder === view else { return }
             self.parent.text = view.string
         }
+    }
+}
+
+enum ChatComposerTextViewFactory {
+    static func makeConfiguredTextView() -> ChatComposerNSTextView {
+        let textView = ChatComposerNSTextView()
+        textView.drawsBackground = false
+        textView.isRichText = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.font = .systemFont(ofSize: 14, weight: .regular)
+        textView.textContainer?.lineBreakMode = .byWordWrapping
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainerInset = NSSize(width: 2, height: 4)
+        textView.focusRingType = .none
+
+        textView.minSize = .zero
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.isHorizontallyResizable = false
+        textView.isVerticallyResizable = true
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.containerSize = NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
+        textView.textContainer?.widthTracksTextView = true
+
+        // Ensure native undo/redo uses NSTextView's undo manager and enables Edit menu items.
+        textView.allowsUndo = true
+        return textView
     }
 }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewTests.swift
@@ -1,0 +1,11 @@
+import Testing
+@testable import OpenClawChatUI
+
+#if os(macOS)
+@Suite struct ChatComposerTextViewTests {
+    @Test func configuredTextViewEnablesUndo() {
+        let textView = ChatComposerTextViewFactory.makeConfiguredTextView()
+        #expect(textView.allowsUndo)
+    }
+}
+#endif


### PR DESCRIPTION
Closes #34898

## Summary

- Problem: [Bug]: Undo/Redo not functional in webchat text input (macOS — Cmd+Z, Edit menu greyed out)
- Why it matters: Reported in #34898
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #34898
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/34898