### PR TITLE
fix: [Bug]: ACP client interactive mode returns only [end_turn] (no assistant content) on OpenClaw 2026.3.2 (#34863)

### DIFF
--- a/src/acp/translator.events.test.ts
+++ b/src/acp/translator.events.test.ts
@@ -1,0 +1,109 @@
+import type { AgentSideConnection, PromptRequest } from "@agentclientprotocol/sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayClient } from "../gateway/client.js";
+import type { EventFrame } from "../gateway/protocol/index.js";
+import { createInMemorySessionStore } from "./session.js";
+import { AcpGatewayAgent } from "./translator.js";
+
+function chatEvent(payload: Record<string, unknown>): EventFrame {
+  return {
+    event: "chat",
+    payload,
+  } as unknown as EventFrame;
+}
+
+function createPromptRequest(sessionId: string, text: string): PromptRequest {
+  return {
+    sessionId,
+    prompt: [{ type: "text", text }],
+    _meta: {},
+  } as unknown as PromptRequest;
+}
+
+function getAgentMessageChunks(sessionUpdate: ReturnType<typeof vi.fn>): string[] {
+  const chunks: string[] = [];
+  for (const [call] of sessionUpdate.mock.calls) {
+    const params = call as { update?: { sessionUpdate?: string; content?: { text?: string } } };
+    if (params.update?.sessionUpdate !== "agent_message_chunk") {
+      continue;
+    }
+    const text = params.update.content?.text;
+    if (typeof text === "string" && text.length > 0) {
+      chunks.push(text);
+    }
+  }
+  return chunks;
+}
+
+describe("acp translator chat event mapping", () => {
+  it("emits assistant text from final-only chat payloads", async () => {
+    const sessionUpdate = vi.fn(async () => {});
+    const connection = { sessionUpdate } as unknown as AgentSideConnection;
+    const request = vi.fn(async () => ({ ok: true })) as unknown as GatewayClient["request"];
+    const gateway = { request } as GatewayClient;
+    const sessionStore = createInMemorySessionStore();
+    sessionStore.createSession({
+      sessionId: "session-final-only",
+      sessionKey: "agent:main:main",
+      cwd: "/tmp",
+    });
+    const agent = new AcpGatewayAgent(connection, gateway, { sessionStore });
+
+    const promptPromise = agent.prompt(createPromptRequest("session-final-only", "hello"));
+
+    await agent.handleGatewayEvent(
+      chatEvent({
+        state: "final",
+        sessionKey: "agent:main:main",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "hello from final" }],
+        },
+      }),
+    );
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    expect(getAgentMessageChunks(sessionUpdate)).toEqual(["hello from final"]);
+  });
+
+  it("emits only the missing tail when final payload extends prior delta text", async () => {
+    const sessionUpdate = vi.fn(async () => {});
+    const connection = { sessionUpdate } as unknown as AgentSideConnection;
+    const request = vi.fn(async () => ({ ok: true })) as unknown as GatewayClient["request"];
+    const gateway = { request } as GatewayClient;
+    const sessionStore = createInMemorySessionStore();
+    sessionStore.createSession({
+      sessionId: "session-delta-final",
+      sessionKey: "agent:main:main",
+      cwd: "/tmp",
+    });
+    const agent = new AcpGatewayAgent(connection, gateway, { sessionStore });
+
+    const promptPromise = agent.prompt(createPromptRequest("session-delta-final", "hello"));
+
+    await agent.handleGatewayEvent(
+      chatEvent({
+        state: "delta",
+        sessionKey: "agent:main:main",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "hel" }],
+        },
+      }),
+    );
+    await agent.handleGatewayEvent(
+      chatEvent({
+        state: "final",
+        sessionKey: "agent:main:main",
+        stopReason: "max_tokens",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "hello" }],
+        },
+      }),
+    );
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "max_tokens" });
+    expect(getAgentMessageChunks(sessionUpdate)).toEqual(["hel", "lo"]);
+  });
+});

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -423,6 +423,10 @@ export class AcpGatewayAgent implements Agent {
     }
 
     if (state === "final") {
+      // Some clients rely on final-only chat payloads when intermediate deltas are suppressed.
+      if (messageData) {
+        await this.handleDeltaEvent(pending.sessionId, messageData);
+      }
       const rawStopReason = payload.stopReason as string | undefined;
       const stopReason: StopReason = rawStopReason === "max_tokens" ? "max_tokens" : "end_turn";
       this.finishPrompt(pending.sessionId, pending, stopReason);


### PR DESCRIPTION
Closes #34863

## Summary

- Problem: [Bug]: ACP client interactive mode returns only [end_turn] (no assistant content) on OpenClaw 2026.3.2
- Why it matters: Reported in #34863
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #34863
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/34863