### PR TITLE
fix: normalize Cloudflare cf-aig-authorization Bearer prefix

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -166,6 +166,22 @@ describe("buildInlineProviderModels", () => {
     expect(result[0].headers).toEqual({ "User-Agent": "custom-agent/1.0" });
   });
 
+  it("normalizes Cloudflare auth header Bearer prefix typo in inline models", () => {
+    const providers: Parameters<typeof buildInlineProviderModels>[0] = {
+      cloudflare: {
+        baseUrl: "https://gateway.ai.cloudflare.com/v1/account/gateway/anthropic",
+        api: "anthropic-messages",
+        headers: { "cf-aig-authorization": "Bearer: test-token" },
+        models: [makeModel("claude-sonnet-4-5")],
+      },
+    };
+
+    const result = buildInlineProviderModels(providers);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].headers).toEqual({ "cf-aig-authorization": "Bearer test-token" });
+  });
+
   it("omits headers when neither provider nor model specifies them", () => {
     const providers: Parameters<typeof buildInlineProviderModels>[0] = {
       plain: {
@@ -220,6 +236,27 @@ describe("resolveModel", () => {
     expect(result.error).toBeUndefined();
     expect((result.model as unknown as { headers?: Record<string, string> }).headers).toEqual({
       "X-Custom-Auth": "token-123",
+    });
+  });
+
+  it("normalizes Cloudflare auth header Bearer prefix typo in fallback model", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "cloudflare-ai-gateway": {
+            baseUrl: "https://gateway.ai.cloudflare.com/v1/account/gateway/anthropic",
+            headers: { "cf-aig-authorization": "Bearer: test-token" },
+            models: [makeModel("claude-sonnet-4-5")],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("cloudflare-ai-gateway", "missing-model", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect((result.model as unknown as { headers?: Record<string, string> }).headers).toEqual({
+      "cf-aig-authorization": "Bearer test-token",
     });
   });
 

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -527,6 +527,36 @@ describe("resolveModel", () => {
     });
   });
 
+  it("normalizes Cloudflare auth header in provider override for registry-found models", () => {
+    mockDiscoveredModel({
+      provider: "openai-chat",
+      modelId: "gpt-5-mini",
+      templateModel: buildForwardCompatTemplate({
+        id: "gpt-5-mini",
+        name: "GPT-5 Mini",
+        provider: "openai-chat",
+        api: "openai",
+        baseUrl: "https://gateway.ai.cloudflare.com/v1/test/openai",
+      }),
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          "openai-chat": {
+            headers: { "cf-aig-authorization": "Bearer: test-token" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModel("openai-chat", "gpt-5-mini", "/tmp/agent", cfg);
+    expect(result.error).toBeUndefined();
+    expect((result.model as unknown as { headers?: Record<string, string> }).headers).toEqual({
+      "cf-aig-authorization": "Bearer test-token",
+    });
+  });
+
   it("does not override when no provider config exists", () => {
     mockDiscoveredModel({
       provider: "anthropic",

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -24,6 +24,27 @@ type InlineProviderConfig = {
 
 export { buildModelAliasLines };
 
+function normalizeCloudflareGatewayAuthHeader(
+  headers: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!headers) {
+    return headers;
+  }
+  let mutated = false;
+  const next = { ...headers };
+  for (const [key, value] of Object.entries(next)) {
+    if (key.toLowerCase() !== "cf-aig-authorization") {
+      continue;
+    }
+    const normalized = value.replace(/^\s*Bearer:\s*/i, "Bearer ");
+    if (normalized !== value) {
+      next[key] = normalized;
+      mutated = true;
+    }
+  }
+  return mutated ? next : headers;
+}
+
 export function buildInlineProviderModels(
   providers: Record<string, InlineProviderConfig>,
 ): InlineModelEntry[] {
@@ -37,10 +58,11 @@ export function buildInlineProviderModels(
       provider: trimmed,
       baseUrl: entry?.baseUrl,
       api: model.api ?? entry?.api,
-      headers:
+      headers: normalizeCloudflareGatewayAuthHeader(
         entry?.headers || (model as InlineModelEntry).headers
           ? { ...entry?.headers, ...(model as InlineModelEntry).headers }
           : undefined,
+      ),
     }));
   });
 }
@@ -120,10 +142,11 @@ export function resolveModel(
           configuredModel?.maxTokens ??
           providerCfg?.models?.[0]?.maxTokens ??
           DEFAULT_CONTEXT_TOKENS,
-        headers:
+        headers: normalizeCloudflareGatewayAuthHeader(
           providerCfg?.headers || configuredModel?.headers
             ? { ...providerCfg?.headers, ...configuredModel?.headers }
             : undefined,
+        ),
       } as Model<Api>);
       return { model: fallbackModel, authStorage, modelRegistry };
     }
@@ -140,10 +163,10 @@ export function resolveModel(
       overridden.baseUrl = providerOverride.baseUrl;
     }
     if (providerOverride.headers) {
-      overridden.headers = {
+      overridden.headers = normalizeCloudflareGatewayAuthHeader({
         ...(model as Model<Api> & { headers?: Record<string, string> }).headers,
         ...providerOverride.headers,
-      };
+      });
     }
     return { model: normalizeModelCompat(overridden), authStorage, modelRegistry };
   }


### PR DESCRIPTION
## Summary
- normalize `cf-aig-authorization` values that use `Bearer:` to `Bearer ` during model resolution
- apply normalization for inline provider models, fallback model resolution, and provider overrides
- add unit tests covering both inline and fallback resolution paths

## Testing
- pnpm vitest src/agents/pi-embedded-runner/model.test.ts

Fixes openclaw/openclaw#34788
