### PR TITLE
fix: Bug: OPENCLAW_SERVICE_VERSION in LaunchAgent plist not updated on `openclaw update` (macOS) (#34901)

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, ConfigFileSnapshot } from "../config/types.openclaw.js";
@@ -559,6 +561,57 @@ describe("update-cli", () => {
 
     await updateCommand({ restart: false });
 
+    expect(runDaemonInstall).not.toHaveBeenCalled();
+    expect(runRestartScript).not.toHaveBeenCalled();
+    expect(runDaemonRestart).not.toHaveBeenCalled();
+  });
+
+  it("updateCommand patches LaunchAgent OPENCLAW_SERVICE_VERSION on macOS when --no-restart is set", async () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      configurable: true,
+    });
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-plist-"));
+    const plistDir = path.join(homeDir, "Library", "LaunchAgents");
+    const plistPath = path.join(plistDir, "ai.openclaw.gateway.plist");
+    await fs.mkdir(plistDir, { recursive: true });
+    await fs.writeFile(
+      plistPath,
+      `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+\t<key>EnvironmentVariables</key>
+\t<dict>
+\t\t<key>OPENCLAW_SERVICE_VERSION</key>
+\t\t<string>2026.3.1</string>
+\t</dict>
+</dict>
+</plist>
+`,
+      "utf8",
+    );
+    pathExists.mockImplementation(async (candidate: string) => candidate === plistPath);
+
+    try {
+      await withEnvAsync({ HOME: homeDir }, async () => {
+        vi.mocked(runGatewayUpdate).mockResolvedValue(
+          makeOkUpdateResult({
+            after: { version: "2026.3.2" },
+          }),
+        );
+
+        await updateCommand({ restart: false });
+      });
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+
+    const updatedPlist = await fs.readFile(plistPath, "utf8");
+    expect(updatedPlist).toContain("<string>2026.3.2</string>");
     expect(runDaemonInstall).not.toHaveBeenCalled();
     expect(runRestartScript).not.toHaveBeenCalled();
     expect(runDaemonRestart).not.toHaveBeenCalled();

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { confirm, isCancel } from "@clack/prompts";
 import {
@@ -11,6 +13,7 @@ import {
   writeConfigFile,
 } from "../../config/config.js";
 import { formatConfigIssueLines } from "../../config/issue-format.js";
+import { resolveGatewayLaunchAgentLabel } from "../../daemon/constants.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import {
   channelToNpmTag,
@@ -115,6 +118,15 @@ function formatCommandFailure(stdout: string, stderr: string): string {
   return detail.split("\n").slice(-3).join("\n");
 }
 
+function escapeXmlText(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
 type UpdateDryRunPreview = {
   dryRun: true;
   root: string;
@@ -199,6 +211,43 @@ async function refreshGatewayServiceEnv(params: {
   }
 
   await runDaemonInstall({ force: true, json: params.jsonMode || undefined });
+}
+
+async function refreshLaunchAgentServiceVersionFromResult(params: {
+  result: UpdateRunResult;
+}): Promise<boolean> {
+  if (process.platform !== "darwin") {
+    return false;
+  }
+
+  const version = params.result.after?.version?.trim();
+  if (!version) {
+    return false;
+  }
+
+  const label =
+    process.env.OPENCLAW_LAUNCHD_LABEL?.trim() ??
+    resolveGatewayLaunchAgentLabel(process.env.OPENCLAW_PROFILE);
+  const home = process.env.HOME?.trim() || os.homedir();
+  const plistPath = path.join(home, "Library", "LaunchAgents", `${label}.plist`);
+
+  if (!(await pathExists(plistPath))) {
+    return false;
+  }
+
+  const content = await fs.readFile(plistPath, "utf8");
+  const replacement = `<key>OPENCLAW_SERVICE_VERSION</key>\n\t\t\t<string>${escapeXmlText(version)}</string>`;
+  const next = content.replace(
+    /<key>OPENCLAW_SERVICE_VERSION<\/key>\s*<string>[\s\S]*?<\/string>/,
+    replacement,
+  );
+
+  if (next === content) {
+    return false;
+  }
+
+  await fs.writeFile(plistPath, next, "utf8");
+  return true;
 }
 
 async function tryInstallShellCompletion(opts: {
@@ -896,6 +945,18 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     configSnapshot,
     opts,
   });
+
+  if (!refreshGatewayServiceEnv) {
+    try {
+      await refreshLaunchAgentServiceVersionFromResult({ result });
+    } catch (err) {
+      if (!opts.json) {
+        defaultRuntime.log(
+          theme.warn(`Failed to refresh LaunchAgent OPENCLAW_SERVICE_VERSION: ${String(err)}`),
+        );
+      }
+    }
+  }
 
   await tryWriteCompletionCache(root, Boolean(opts.json));
   await tryInstallShellCompletion({


### PR DESCRIPTION
Closes #34901

## Summary

- Problem: Bug: OPENCLAW_SERVICE_VERSION in LaunchAgent plist not updated on `openclaw update` (macOS)
- Why it matters: Reported in #34901
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #34901
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/34901