### PR TITLE
fix: [Bug]: macOS app crashes with fatal access conflict in TalkOverlayController.present() when voice wake is enabled (#34903)

### DIFF
--- a/apps/macos/Sources/OpenClaw/TalkOverlay.swift
+++ b/apps/macos/Sources/OpenClaw/TalkOverlay.swift
@@ -30,11 +30,15 @@ final class TalkOverlayController {
         self.ensureWindow()
         self.hostingView?.rootView = TalkOverlayView(controller: self)
         let target = self.targetFrame()
-        OverlayPanelFactory.present(
-            window: self.window,
-            isVisible: &self.model.isVisible,
-            target: target)
-        { window in
+        guard let window = self.window else { return }
+
+        // Avoid `inout` access to observable state here; reentrant view reads can overlap
+        // with the borrow and trigger a fatal exclusivity conflict at launch.
+        if !self.model.isVisible {
+            self.model.isVisible = true
+            let start = target.offsetBy(dx: 0, dy: -6)
+            OverlayPanelFactory.animatePresent(window: window, from: start, to: target)
+        } else {
             window.setFrame(target, display: true)
             window.orderFrontRegardless()
         }

--- a/apps/macos/Tests/OpenClawIPCTests/LowCoverageViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LowCoverageViewSmokeTests.swift
@@ -66,6 +66,14 @@ struct LowCoverageViewSmokeTests {
         try? await Task.sleep(nanoseconds: 250_000_000)
     }
 
+    @Test func talkOverlayPresentsAndDismisses() async {
+        let controller = TalkOverlayController()
+        controller.present()
+        controller.present()
+        controller.dismiss()
+        try? await Task.sleep(nanoseconds: 250_000_000)
+    }
+
     @Test func visualEffectViewHostsInNSHostingView() {
         let hosting = NSHostingView(rootView: VisualEffectView(material: .sidebar))
         _ = hosting.fittingSize


### PR DESCRIPTION
Closes #34903

## Summary

- Problem: [Bug]: macOS app crashes with fatal access conflict in TalkOverlayController.present() when voice wake is enabled
- Why it matters: Reported in #34903
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #34903
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/34903