### PR TITLE
fix: rebuild control UI during build (closes #34908)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "android:install": "cd apps/android && ./gradlew :app:installDebug",
     "android:run": "cd apps/android && ./gradlew :app:installDebug && adb shell am start -n ai.openclaw.android/.MainActivity",
     "android:test": "cd apps/android && ./gradlew :app:testDebugUnitTest",
-    "build": "pnpm canvas:a2ui:bundle && tsdown && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-compat.ts",
+    "build": "pnpm canvas:a2ui:bundle && tsdown && pnpm ui:build && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-compat.ts",
     "build:plugin-sdk:dts": "tsc -p tsconfig.plugin-sdk.dts.json",
     "canvas:a2ui:bundle": "bash scripts/bundle-a2ui.sh",
     "check": "pnpm format:check && pnpm tsgo && pnpm lint",


### PR DESCRIPTION
Closes #34908

## Problem
Control UI assets were not rebuilt by the main 
> openclaw@2026.2.10 build /root/openclaw/workspace/openclaw-34908
> pnpm canvas:a2ui:bundle && tsdown && pnpm ui:build && pnpm build:plugin-sdk:dts && node --import tsx scripts/write-plugin-sdk-entry-dts.ts && node --import tsx scripts/canvas-a2ui-copy.ts && node --import tsx scripts/copy-hook-metadata.ts && node --import tsx scripts/write-build-info.ts && node --import tsx scripts/write-cli-compat.ts


> openclaw@2026.2.10 canvas:a2ui:bundle /root/openclaw/workspace/openclaw-34908
> bash scripts/bundle-a2ui.sh

 ELIFECYCLE  Command failed with exit code 254.
 WARN   Local package.json exists, but node_modules missing, did you mean to install?
 ELIFECYCLE  Command failed with exit code 254.
 WARN   Local package.json exists, but node_modules missing, did you mean to install? pipeline, so release flows that rely on  could publish stale  bundles with an old version badge.

## Fix
Include 
> openclaw@2026.2.10 ui:build /root/openclaw/workspace/openclaw-34908
> node scripts/ui.js build

Scope: all 35 workspace projects
..                                       | Progress: resolved 1, reused 0, downloaded 0, added 0
..                                       | +891 ++++++++++++++++++++++++++++++++

   ╭──────────────────────────────────────────╮
   │                                          │
   │   Update available! 10.23.0 → 10.30.3.   │
   │   Changelog: https://pnpm.io/v/10.30.3   │
   │     To update, run: pnpm add -g pnpm     │
   │                                          │
   ╰──────────────────────────────────────────╯

..                                       | Progress: resolved 891, reused 692, downloaded 0, added 0
..                                       | Progress: resolved 891, reused 890, downloaded 0, added 692
..                                       | Progress: resolved 891, reused 890, downloaded 0, added 890
..                                       | Progress: resolved 891, reused 890, downloaded 0, added 891, done

dependencies:
+ @noble/ed25519 3.0.0
+ dompurify 3.3.1
+ lit 3.3.2
+ marked 17.0.2
+ vite 7.3.1

devDependencies: skipped

╭ Warning ─────────────────────────────────────────────────────────────────────╮
│                                                                              │
│   Ignored build scripts: core-js.                                            │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed     │
│   to run scripts.                                                            │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯

.. prepare$ command -v git >/dev/null 2>&1 && git config core.hooksPath git-hooks || exit 0
.. prepare: Done
Done in 5.2s using pnpm v10.23.0

> openclaw-control-ui@ build /root/openclaw/workspace/openclaw-34908/ui
> vite build

vite v7.3.1 building client environment for production...
transforming...
✓ 131 modules transformed.
rendering chunks...
computing gzip size...
../dist/control-ui/index.html                   0.69 kB │ gzip:   0.37 kB
../dist/control-ui/assets/index-DWhx-9JL.css   83.87 kB │ gzip:  14.63 kB
../dist/control-ui/assets/index-BVQdeHPi.js   545.63 kB │ gzip: 137.21 kB │ map: 1,496.84 kB
✓ built in 2.05s in the root  script so  is always regenerated together with backend dist artifacts before packaging.