### PR TITLE
feat(slack): make assistant thread status text configurable

### DIFF
--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -196,7 +196,7 @@ export type SlackAccountConfig = {
   typingReaction?: string;
   /**
    * Status text shown in Slack Assistant threads while the bot is processing.
-   * Slack automatically prepends the bot name. Default: "is typing…"
+   * Slack automatically prepends the bot name. Default: "is typing..."
    */
   assistantStatus?: string;
 };

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -194,6 +194,11 @@ export type SlackAccountConfig = {
   ackReaction?: string;
   /** Reaction emoji added while processing a reply (e.g. "hourglass_flowing_sand"). Removed when done. Useful as a typing indicator fallback when assistant mode is not enabled. */
   typingReaction?: string;
+  /**
+   * Status text shown in Slack Assistant threads while the bot is processing.
+   * Slack automatically prepends the bot name. Default: "is typing…"
+   */
+  assistantStatus?: string;
 };
 
 export type SlackConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -901,6 +901,7 @@ export const SlackAccountSchema = z
     responsePrefix: z.string().optional(),
     ackReaction: z.string().optional(),
     typingReaction: z.string().optional(),
+    assistantStatus: z.string().optional(),
   })
   .strict()
   .superRefine((value) => {

--- a/src/slack/monitor/context.test.ts
+++ b/src/slack/monitor/context.test.ts
@@ -42,6 +42,7 @@ function createTestContext() {
     },
     textLimit: 4000,
     typingReaction: "",
+    assistantStatus: "is typing...",
     ackReactionScope: "group-mentions",
     mediaMaxBytes: 20 * 1024 * 1024,
     removeAckAfterReply: false,

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -54,6 +54,7 @@ export type SlackMonitorContext = {
   textLimit: number;
   ackReactionScope: string;
   typingReaction: string;
+  assistantStatus: string;
   mediaMaxBytes: number;
   removeAckAfterReply: boolean;
 
@@ -118,6 +119,7 @@ export function createSlackMonitorContext(params: {
   textLimit: number;
   ackReactionScope: string;
   typingReaction: string;
+  assistantStatus: string;
   mediaMaxBytes: number;
   removeAckAfterReply: boolean;
 }): SlackMonitorContext {
@@ -418,6 +420,7 @@ export function createSlackMonitorContext(params: {
     textLimit: params.textLimit,
     ackReactionScope: params.ackReactionScope,
     typingReaction: params.typingReaction,
+    assistantStatus: params.assistantStatus,
     mediaMaxBytes: params.mediaMaxBytes,
     removeAckAfterReply: params.removeAckAfterReply,
     logger,

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -147,7 +147,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       await ctx.setSlackThreadStatus({
         channelId: message.channel,
         threadTs: statusThreadTs,
-        status: "is typing...",
+        status: ctx.assistantStatus,
       });
       if (typingReaction && message.ts) {
         await reactSlackMessage(message.channel, message.ts, typingReaction, {

--- a/src/slack/monitor/message-handler/prepare.test-helpers.ts
+++ b/src/slack/monitor/message-handler/prepare.test-helpers.ts
@@ -47,6 +47,7 @@ export function createInboundSlackTestContext(params: {
     textLimit: 4000,
     ackReactionScope: "group-mentions",
     typingReaction: "",
+    assistantStatus: "is typing...",
     mediaMaxBytes: 1024,
     removeAckAfterReply: false,
   });

--- a/src/slack/monitor/monitor.test.ts
+++ b/src/slack/monitor/monitor.test.ts
@@ -142,6 +142,7 @@ const baseParams = () => ({
   textLimit: 4000,
   ackReactionScope: "group-mentions",
   typingReaction: "",
+  assistantStatus: "is typing...",
   mediaMaxBytes: 1,
   threadHistoryScope: "thread" as const,
   threadInheritParent: false,

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -182,6 +182,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const textLimit = resolveTextChunkLimit(cfg, "slack", account.accountId);
   const ackReactionScope = cfg.messages?.ackReactionScope ?? "group-mentions";
   const typingReaction = slackCfg.typingReaction?.trim() ?? "";
+  const assistantStatus = slackCfg.assistantStatus?.trim() || "is typing...";
   const mediaMaxBytes = (opts.mediaMaxMb ?? slackCfg.mediaMaxMb ?? 20) * 1024 * 1024;
   const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
 
@@ -281,6 +282,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     textLimit,
     ackReactionScope,
     typingReaction,
+    assistantStatus,
     mediaMaxBytes,
     removeAckAfterReply,
   });


### PR DESCRIPTION
## Summary

Closes #34693

Adds a `channels.slack.assistantStatus` config option to customize the status text shown in Slack Assistant threads while the bot is processing a reply. Slack automatically prepends the bot name.

Default behavior is unchanged (`"is typing..."`).

## Example config

```json
{
  "channels": {
    "slack": {
      "assistantStatus": "is thinking..."
    }
  }
}
```

Per-account override also works:

```json
{
  "channels": {
    "slack": {
      "accounts": {
        "mybot": {
          "assistantStatus": "is researching..."
        }
      }
    }
  }
}
```

## Changes

### Config (`src/config/`)
- **types.slack.ts** — Added `assistantStatus?: string` to `SlackAccountConfig`
- **zod-schema.providers-core.ts** — Added zod validation

### Runtime (`src/slack/monitor/`)
- **provider.ts** — Read `assistantStatus` from config with `"is typing..."` fallback
- **context.ts** — Added `assistantStatus` to `SlackMonitorContext` type, params, and return
- **message-handler/dispatch.ts** — Use `ctx.assistantStatus` instead of hardcoded string

### Tests
- Updated mock context fixtures in `context.test.ts`, `monitor.test.ts`, `prepare.test.ts`, and `prepare.test-helpers.ts` with the new required field

## Notes
- The `loadingMessages` array mentioned in the original issue is not implemented here. Slack's `assistant.threads.setStatus` only accepts a single status string. The cycling loading messages would require a separate mechanism (e.g., a timer that rotates through messages) which adds complexity and may warrant a separate PR if desired.