### PR TITLE
[Security]: Fix security vulnerability through __proto__

### DIFF
--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -108,7 +108,7 @@ function hasExplicitProviderAccountConfig(
   if (!accounts || typeof accounts !== "object") {
     return false;
   }
-  return accountId in accounts;
+  return Object.hasOwn(accounts, accountId);
 }
 
 export async function collectChannelSecurityFindings(params: {


### PR DESCRIPTION
## Summary

* Problem: The helper function hasExplicitProviderAccountConfig used the in operator to check if an accountId exists in an accounts object. The in operator also traverses the prototype chain, so a specially crafted accountId like "__proto__" would return true even when no such account is actually configured.

* Why it matters: This can cause the security audit to misinterpret the configuration, potentially skipping warnings for real accounts or treating non‑existent accounts as explicitly configured, which could weaken security guarantees.

* What changed: Replaced accountId in accounts with Object.hasOwn(accounts, accountId) to ensure only the object’s own properties are considered.

What did NOT change: No behavior changes for normal account IDs.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34926
- 
## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

Risk without this change: The helper function hasExplicitProviderAccountConfig (in src/security/audit-channel.ts) uses the JavaScript in operator to check whether a given accountId exists in the accounts configuration object. The in operator also traverses the object's prototype chain, meaning that if an attacker can supply a specially crafted accountId (e.g., `__proto__` or `constructor`), the check will erroneously return true even though no such account is actually configured.

## Repro + Verification

Because this is a proactive hardening fix and the exact exploit steps could be misused if published, we deliberately omit a full proof‑of‑concept.

Unforetunately, I don't have a local instance of OpenClaw installed, so I haven't tested this change, but I'm pretty confident from looking at the code that this is correct, but please correct me if I'm mistaken, thanks!

### Environment

- OS: N/A (code change only)
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A