### PR TITLE
fix(discord): open guild slash cmd access when no authorizer configured (#19310)

### DIFF
--- a/src/channels/command-gating.test.ts
+++ b/src/channels/command-gating.test.ts
@@ -73,6 +73,42 @@ describe("resolveCommandAuthorizedFromAuthorizers", () => {
   });
 });
 
+describe("resolveCommandAuthorizedFromAuthorizers — open-access when nothing configured", () => {
+  it("allows guild slash commands when useAccessGroups is enabled, modeWhenAccessGroupsOn is 'configured', and no authorizer is configured", () => {
+    // Scenario: guild slash command, discordConfig.allowFrom is not set (ownerAllowList=null →
+    // configured:false) and no dm.allowFrom leak, no channel/role restrictions.
+    // With modeWhenAccessGroupsOn:"configured", open access should apply when nothing is configured.
+    // Bug: without this parameter, the useAccessGroups=true path always uses some(configured&&allowed)
+    // which returns false when no authorizer is configured, blocking guild users unexpectedly.
+    expect(
+      resolveCommandAuthorizedFromAuthorizers({
+        useAccessGroups: true,
+        modeWhenAccessGroupsOn: "configured",
+        authorizers: [
+          { configured: false, allowed: false }, // ownerAllowList is null (no allowFrom set)
+          { configured: false, allowed: true }, // no member/role restrictions (open)
+        ],
+        modeWhenAccessGroupsOff: "configured",
+      }),
+    ).toBe(true);
+  });
+
+  it("still denies when useAccessGroups is enabled without modeWhenAccessGroupsOn and no authorizer configured (fail-closed)", () => {
+    // Default behavior (no modeWhenAccessGroupsOn) remains fail-closed for channels
+    // like Slack where unknown-channel access should be denied.
+    expect(
+      resolveCommandAuthorizedFromAuthorizers({
+        useAccessGroups: true,
+        authorizers: [
+          { configured: false, allowed: false },
+          { configured: false, allowed: true },
+        ],
+        modeWhenAccessGroupsOff: "configured",
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("resolveControlCommandGate", () => {
   it("blocks control commands when unauthorized", () => {
     const result = resolveControlCommandGate({

--- a/src/channels/command-gating.ts
+++ b/src/channels/command-gating.ts
@@ -9,6 +9,7 @@ export function resolveCommandAuthorizedFromAuthorizers(params: {
   useAccessGroups: boolean;
   authorizers: CommandAuthorizer[];
   modeWhenAccessGroupsOff?: CommandGatingModeWhenAccessGroupsOff;
+  modeWhenAccessGroupsOn?: "configured" | "deny";
 }): boolean {
   const { useAccessGroups, authorizers } = params;
   const mode = params.modeWhenAccessGroupsOff ?? "allow";
@@ -24,6 +25,12 @@ export function resolveCommandAuthorizedFromAuthorizers(params: {
       return true;
     }
     return authorizers.some((entry) => entry.configured && entry.allowed);
+  }
+  if ((params.modeWhenAccessGroupsOn ?? "deny") === "configured") {
+    const anyConfigured = authorizers.some((entry) => entry.configured);
+    if (!anyConfigured) {
+      return true;
+    }
   }
   return authorizers.some((entry) => entry.configured && entry.allowed);
 }

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -1289,7 +1289,7 @@ async function dispatchDiscordCommandInteraction(params: {
     : [];
   const allowNameMatching = isDangerousNameMatchingEnabled(discordConfig);
   const { ownerAllowList, ownerAllowed: ownerOk } = resolveDiscordOwnerAccess({
-    allowFrom: discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? [],
+    allowFrom: discordConfig?.allowFrom,
     sender: {
       id: sender.id,
       name: sender.name,
@@ -1426,6 +1426,7 @@ async function dispatchDiscordCommandInteraction(params: {
       useAccessGroups,
       authorizers,
       modeWhenAccessGroupsOff: "configured",
+      modeWhenAccessGroupsOn: "configured",
     });
     if (!commandAuthorized) {
       await respond("You are not authorized to use this command.", { ephemeral: true });

--- a/src/discord/voice/command.ts
+++ b/src/discord/voice/command.ts
@@ -161,7 +161,7 @@ async function authorizeVoiceCommand(
   });
 
   const { ownerAllowList, ownerAllowed: ownerOk } = resolveDiscordOwnerAccess({
-    allowFrom: params.discordConfig.allowFrom ?? params.discordConfig.dm?.allowFrom ?? [],
+    allowFrom: params.discordConfig.allowFrom,
     sender: {
       id: sender.id,
       name: sender.name,
@@ -181,6 +181,7 @@ async function authorizeVoiceCommand(
     useAccessGroups: params.useAccessGroups,
     authorizers,
     modeWhenAccessGroupsOff: "configured",
+    modeWhenAccessGroupsOn: "configured",
   });
 
   if (!commandAuthorized) {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -300,7 +300,7 @@ async function resolveImagesForRequest(
   for (const url of urls) {
     const source = parseImageUrlToSource(url);
     if (source.type === "base64") {
-      totalBytes += estimateBase64DecodedBytes(source.data);
+      totalBytes += estimateBase64DecodedBytes(source.data ?? "");
       if (totalBytes > limits.maxTotalImageBytes) {
         throw new Error(
           `Total image payload too large (${totalBytes}; limit ${limits.maxTotalImageBytes})`,


### PR DESCRIPTION
## Problem
When `discord.useAccessGroups` is enabled, guild slash commands incorrectly denied access when `dm.allowFrom` was configured but `allowFrom` was not. The DM pairing allowlist leaked into the guild slash command owner authorizer, blocking users with no explicit guild restrictions.

Even without the DM leak, `resolveCommandAuthorizedFromAuthorizers` lacked an "allow when nothing configured" guard for the `useAccessGroups=true` path that already exists for the `useAccessGroups=false` path.

## Root cause
1. `native-command.ts` (guild block): `discordConfig?.allowFrom ?? discordConfig?.dm?.allowFrom ?? []` incorrectly pulled the DM pairing allowlist into guild owner auth.
2. `voice/command.ts`: same DM allowFrom fallback.
3. `command-gating.ts`: `resolveCommandAuthorizedFromAuthorizers` `useAccessGroups=true` path lacked `!anyConfigured → allow` guard.

## Fix
- `command-gating.ts`: added `modeWhenAccessGroupsOn?: "configured" | "deny"` (default `"deny"`). When `"configured"`, applies open-access guard scoped to callers that opt in — Slack/DM callers are unaffected.
- `native-command.ts`: removed `?? discordConfig?.dm?.allowFrom ?? []` fallback; added `modeWhenAccessGroupsOn: "configured"`.
- `voice/command.ts`: same two changes.

## Verification
- **Test:** `src/channels/command-gating.test.ts` — fails on main (unrecognized param → false), passes on fix (open access when nothing configured)
- **Build:** clean compile (`build-output.log`)
- **Test suite:** zero regressions — Slack fail-closed behavior preserved (`test-output.log`)
- **Code proof:** dm fallback removed, new param present in all affected files (`step6-verify.log`)

Closes #19310