### PR TITLE
fix(compaction): skip LLM call when session has no real conversation messages

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -648,6 +648,28 @@ export async function compactEmbeddedPiSessionDirect(
             });
         }
 
+        // Pre-flight: skip the compaction LLM call entirely when the session
+        // contains no real conversation messages (user/assistant/toolResult).
+        // When compaction.mode is "safeguard", the extension's session_before_compact
+        // handler would detect this and return { cancel: true }, but only after
+        // session.compact() has already initiated an LLM API round-trip (~33k tokens
+        // on a typical system-prompt-only session). Checking here avoids the
+        // unnecessary token spend — particularly costly on idle cron sessions that
+        // cycle every ~30 minutes with no user content.
+        const messagesToCompact = limited.length > 0 ? limited : session.messages;
+        const hasRealConversationMessages = messagesToCompact.some(
+          (msg) =>
+            msg.role === "user" || msg.role === "assistant" || msg.role === "toolResult",
+        );
+        if (!hasRealConversationMessages) {
+          log.warn(
+            `[compaction-diag] skip runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
+              `diagId=${diagId} trigger=${trigger} reason=no_real_conversation_messages ` +
+              `durationMs=${Date.now() - startedAt}`,
+          );
+          return { ok: true, compacted: false, reason: "no real conversation messages" };
+        }
+
         const diagEnabled = log.isEnabled("debug");
         const preMetrics = diagEnabled ? summarizeCompactionMessages(session.messages) : undefined;
         if (diagEnabled && preMetrics) {


### PR DESCRIPTION
## Summary

Closes #34935

When `compaction.mode: "safeguard"` is configured, OpenClaw was initiating a full LLM API round-trip (~33k tokens) for every session at each compaction interval — including isolated cron sessions that contain zero real conversation messages. The compaction-safeguard extension's `session_before_compact` handler correctly returned `{ cancel: true }` afterward, but the LLM API call had already been billed. On an idle system with multiple cron sessions, this produced ~48 unnecessary API calls per day.

## Root Cause

`compactEmbeddedPiSessionDirect` in `compact.ts` called `session.compact()` unconditionally. The real-message guard lived inside the compaction-safeguard extension (`compaction-safeguard.ts:570`), which only executes inside `session.compact()`'s internal flow — after the LLM round-trip has already been initiated.

## Fix

Add a pre-flight check in `compact.ts` before calling `session.compact()`. The check mirrors the existing guard in the extension: if the session contains no `user`, `assistant`, or `toolResult` messages, return early with `{ ok: true, compacted: false, reason: "no real conversation messages" }`. This short-circuits the compaction path entirely — no `session.compact()` call, no LLM API request.

## Changes

- **`src/agents/pi-embedded-runner/compact.ts`**: Added pre-flight real-message check (+22 lines) before `compactWithSafetyTimeout(() => session.compact(...))`

## Testing

- Existing compaction-safeguard tests: **47 passed** (no regressions)
- Existing config.compaction-settings tests: **3 passed**
- `pnpm protocol:check`: **no diff** (no protocol changes)

## Impact

- Idle cron sessions (no conversation content) will no longer trigger LLM API calls at each compaction interval
- Sessions with real content are unaffected — the check passes through and compaction proceeds normally
- The compaction-safeguard extension's own guard remains as a secondary safety net for any path that bypasses this check