### PR TITLE
Models: avoid Venice discovery in implicit provider bootstrap

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -52,7 +52,11 @@ import {
   TOGETHER_MODEL_CATALOG,
   buildTogetherModelDefinition,
 } from "./together-models.js";
-import { discoverVeniceModels, VENICE_BASE_URL } from "./venice-models.js";
+import {
+  buildVeniceModelDefinition,
+  VENICE_BASE_URL,
+  VENICE_MODEL_CATALOG,
+} from "./venice-models.js";
 
 type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 export type ProviderConfig = NonNullable<ModelsConfig["providers"]>[string];
@@ -756,8 +760,8 @@ export function buildXiaomiProvider(): ProviderConfig {
   };
 }
 
-async function buildVeniceProvider(): Promise<ProviderConfig> {
-  const models = await discoverVeniceModels();
+function buildVeniceProvider(): ProviderConfig {
+  const models = VENICE_MODEL_CATALOG.map(buildVeniceModelDefinition);
   return {
     baseUrl: VENICE_BASE_URL,
     api: "openai-completions",
@@ -969,7 +973,7 @@ export async function resolveImplicitProviders(params: {
     resolveEnvApiKeyVarName("venice") ??
     resolveApiKeyFromProfiles({ provider: "venice", store: authStore });
   if (veniceKey) {
-    providers.venice = { ...(await buildVeniceProvider()), apiKey: veniceKey };
+    providers.venice = { ...buildVeniceProvider(), apiKey: veniceKey };
   }
 
   const qwenProfiles = listProfilesForProvider(authStore, "qwen-portal");

--- a/src/agents/models-config.providers.venice.test.ts
+++ b/src/agents/models-config.providers.venice.test.ts
@@ -1,0 +1,43 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
+import { resolveImplicitProviders } from "./models-config.providers.js";
+import { VENICE_MODEL_CATALOG } from "./venice-models.js";
+
+describe("Venice implicit provider", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses static Venice catalog without runtime discovery fetches", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await withEnvAsync(
+      {
+        NODE_ENV: "development",
+        VITEST: undefined,
+        VENICE_API_KEY: "venice-test-key",
+        OLLAMA_API_KEY: undefined,
+        HUGGINGFACE_API_KEY: undefined,
+        AWS_REGION: undefined,
+        AWS_ACCESS_KEY_ID: undefined,
+        AWS_SECRET_ACCESS_KEY: undefined,
+        AWS_SESSION_TOKEN: undefined,
+      },
+      async () => {
+        const providers = await resolveImplicitProviders({ agentDir });
+        expect(providers?.venice).toBeDefined();
+        expect(providers?.venice?.models).toHaveLength(VENICE_MODEL_CATALOG.length);
+      },
+    );
+
+    const veniceCalls = fetchSpy.mock.calls.filter(([url]) => {
+      const requestUrl = typeof url === "string" ? url : url instanceof URL ? url.href : "";
+      return requestUrl.includes("api.venice.ai/api/v1/models");
+    });
+    expect(veniceCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Implicit Venice provider bootstrap (`resolveImplicitProviders`) performed live Venice model discovery, which can add repeated network timeout/retry latency during startup/runtime provider resolution.
- Why it matters: Users can hit long stalls when Venice discovery times out, including cases where a cached Venice key still exists and model discovery runs during status/config paths.
- What changed: Switched implicit Venice provider construction to use the static Venice catalog (`VENICE_MODEL_CATALOG`) instead of runtime discovery calls.
- What did NOT change (scope boundary): Explicit model/provider config behavior, Venice catalog contents, and `discoverVeniceModels()` itself remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34914
- Related #

## User-visible / Behavior Changes

Implicit Venice provider initialization no longer performs runtime discovery HTTP calls. Startup/provider-resolution paths avoid Venice discovery timeout penalties and use the static Venice catalog immediately.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.1 (local dev)
- Runtime/container: Node.js v22.22.0
- Model/provider: Venice implicit provider path
- Integration/channel (if any): N/A
- Relevant config (redacted):
  - `VENICE_API_KEY` set
  - no explicit `models.providers.venice` required for repro

### Steps

1. Configure environment with `VENICE_API_KEY` and run implicit provider resolution (`resolveImplicitProviders`).
2. Observe pre-fix behavior: Venice implicit provider path can execute live discovery (`https://api.venice.ai/api/v1/models`) with retry/timeout overhead.
3. Apply fix and rerun implicit provider resolution.

### Expected

- Implicit provider bootstrap should return Venice provider models without network discovery overhead.

### Actual

- Before fix, implicit bootstrap could call Venice discovery and incur timeout/retry latency.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added regression test that ensures implicit provider resolution with `VENICE_API_KEY` does not issue Venice discovery HTTP requests.
  - Verified implicit Venice provider is still present and populated with full static catalog.
- Edge cases checked:
  - Existing Venice catalog-backed provider shape remains unchanged (`api`, `baseUrl`, model count).
- What you did **not** verify:
  - Live Venice API behavior in this path (by design this path now avoids runtime discovery).

Verification commands run:

```bash
pnpm test -- src/agents/models-config.providers.venice.test.ts
pnpm test -- src/agents/models-config.providers.nvidia.test.ts src/agents/venice-models.test.ts
pnpm check
```

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `Models: avoid Venice discovery in implicit provider bootstrap`.
- Files/config to restore:
  - `src/agents/models-config.providers.ts`
  - `src/agents/models-config.providers.venice.test.ts`
- Known bad symptoms reviewers should watch for:
  - Implicit Venice provider missing when only API key is present.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Newly launched Venice models from live discovery are not reflected in implicit provider bootstrap until catalog update.
  - Mitigation: Static fallback remains stable and deterministic; explicit discovery code path remains available for future targeted use.
