### PR TITLE
fix(tools): detect Venice+Grok as xAI provider for schema cleaning

### DIFF
--- a/src/agents/schema/clean-for-xai.test.ts
+++ b/src/agents/schema/clean-for-xai.test.ts
@@ -18,6 +18,26 @@ describe("isXaiProvider", () => {
     expect(isXaiProvider("openrouter", "openai/gpt-4o")).toBe(false);
   });
 
+  it("matches venice with grok model id", () => {
+    expect(isXaiProvider("venice", "grok-4.1-fast")).toBe(true);
+  });
+
+  it("matches venice with grok-41-fast model id (Venice catalog id)", () => {
+    expect(isXaiProvider("venice", "grok-41-fast")).toBe(true);
+  });
+
+  it("matches venice with grok-code-fast-1 model id", () => {
+    expect(isXaiProvider("venice", "grok-code-fast-1")).toBe(true);
+  });
+
+  it("does not match venice with non-grok model id", () => {
+    expect(isXaiProvider("venice", "llama-3.3-70b")).toBe(false);
+  });
+
+  it("does not match venice without model id", () => {
+    expect(isXaiProvider("venice")).toBe(false);
+  });
+
   it("does not match openai provider", () => {
     expect(isXaiProvider("openai")).toBe(false);
   });

--- a/src/agents/schema/clean-for-xai.ts
+++ b/src/agents/schema/clean-for-xai.ts
@@ -52,5 +52,9 @@ export function isXaiProvider(modelProvider?: string, modelId?: string): boolean
   if (provider === "openrouter" && modelId?.toLowerCase().startsWith("x-ai/")) {
     return true;
   }
+  // Venice proxies xAI/Grok models; model IDs start with "grok-"
+  if (provider === "venice" && modelId?.toLowerCase().startsWith("grok-")) {
+    return true;
+  }
   return false;
 }


### PR DESCRIPTION
## Summary

Extends `isXaiProvider()` in `src/agents/schema/clean-for-xai.ts` to also detect **Venice** as an xAI proxy when the model ID starts with `grok-`. Without this, requests to e.g. `venice/grok-4.1-fast` or `venice/grok-41-fast` fail with `Invalid arguments passed to the model` — the same root cause as #32039, just via a different provider.

Closes #34955
Related: #32039, #32080

## Changes

- `src/agents/schema/clean-for-xai.ts` — add Venice+Grok branch to `isXaiProvider()`
- `src/agents/schema/clean-for-xai.test.ts` — 5 new test cases covering Venice detection (grok-4.1-fast, grok-41-fast, grok-code-fast-1, non-grok Venice model, Venice without model ID)

## Test plan

- [x] `pnpm test src/agents/schema/clean-for-xai.test.ts` — 20 tests pass
- [x] Live container test with `venice/grok-4.1-fast` — confirmed working after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)