### PR TITLE
Agents: treat Venice Grok models as xAI for schema cleanup

### DIFF
--- a/src/agents/schema/clean-for-xai.test.ts
+++ b/src/agents/schema/clean-for-xai.test.ts
@@ -14,6 +14,14 @@ describe("isXaiProvider", () => {
     expect(isXaiProvider("openrouter", "x-ai/grok-4.1-fast")).toBe(true);
   });
 
+  it("matches venice when model id is a grok variant", () => {
+    expect(isXaiProvider("venice", "grok-4.1-fast")).toBe(true);
+  });
+
+  it("does not match venice with non-grok model id", () => {
+    expect(isXaiProvider("venice", "llama-3.3-70b")).toBe(false);
+  });
+
   it("does not match openrouter with non-xai model id", () => {
     expect(isXaiProvider("openrouter", "openai/gpt-4o")).toBe(false);
   });

--- a/src/agents/schema/clean-for-xai.ts
+++ b/src/agents/schema/clean-for-xai.ts
@@ -45,11 +45,16 @@ export function stripXaiUnsupportedKeywords(schema: unknown): unknown {
 
 export function isXaiProvider(modelProvider?: string, modelId?: string): boolean {
   const provider = modelProvider?.toLowerCase() ?? "";
+  const normalizedModelId = modelId?.toLowerCase() ?? "";
   if (provider.includes("xai") || provider.includes("x-ai")) {
     return true;
   }
+  // Venice proxies Grok models with provider "venice" and model ids like "grok-*".
+  if (provider === "venice" && normalizedModelId.startsWith("grok-")) {
+    return true;
+  }
   // OpenRouter proxies to xAI when the model id starts with "x-ai/"
-  if (provider === "openrouter" && modelId?.toLowerCase().startsWith("x-ai/")) {
+  if (provider === "openrouter" && normalizedModelId.startsWith("x-ai/")) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Venice-served Grok models were not detected as xAI targets in tool schema normalization, so unsupported JSON Schema keywords were left intact.
- Why it matters: xAI rejects those keywords, causing `Invalid arguments passed to the model` failures for `venice/grok-*` models.
- What changed: `isXaiProvider()` now treats `provider=venice` + `modelId` starting with `grok-` as xAI-compatible; regression tests were added.
- What did NOT change (scope boundary): no model catalog changes, no provider auth/config changes, no other schema cleaning logic was modified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34955
- Related #32080

## User-visible / Behavior Changes

Venice Grok models (`venice/grok-*`) now receive the same xAI schema cleanup path as direct xAI/OpenRouter xAI models, preventing `Invalid arguments passed to the model` failures caused by unsupported schema keywords.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: Venice (`venice/grok-4.1-fast`)
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.model.primary = "venice/grok-4.1-fast"`

### Steps

1. Configure primary model as `venice/grok-4.1-fast`.
2. Run a tool-capable request path that normalizes tool schemas.
3. Observe that prior to this patch `isXaiProvider("venice", "grok-4.1-fast")` returns `false`, so unsupported keywords are not stripped.

### Expected

- Venice Grok model path should be treated as xAI for schema cleanup and avoid invalid-arguments failures.

### Actual

- Venice Grok path was not recognized as xAI, leaving unsupported keywords in schemas and triggering invalid-arguments errors.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `node --import tsx -e "import { isXaiProvider } from './src/agents/schema/clean-for-xai.ts'; console.log(isXaiProvider('venice','grok-4.1-fast'));"` returned `false` before the change and `true` after.
  - Added tests covering Venice Grok positive match and Venice non-Grok negative match.
- Edge cases checked:
  - OpenRouter `x-ai/*` behavior remains unchanged.
  - Non-Grok Venice model IDs do not match xAI path.
- What you did **not** verify:
  - Live external Venice API calls (not required for this logic-only change).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Agents: apply xAI schema cleanup for Venice Grok models`.
- Files/config to restore: `src/agents/schema/clean-for-xai.ts`, `src/agents/schema/clean-for-xai.test.ts`.
- Known bad symptoms reviewers should watch for: non-xAI providers incorrectly entering xAI schema cleanup (guarded by provider/model checks + tests).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Overmatching Venice models that are not xAI-backed.
  - Mitigation: Match is restricted to model IDs prefixed with `grok-`; explicit negative test added for non-Grok Venice IDs.
