### PR TITLE
chore: remove unused dependency @snazzah/davey

### DIFF
--- a/package.json
+++ b/package.json
@@ -348,7 +348,6 @@
     "@sinclair/typebox": "0.34.48",
     "@slack/bolt": "^4.6.0",
     "@slack/web-api": "^7.14.1",
-    "@snazzah/davey": "^0.1.9",
     "@whiskeysockets/baileys": "7.0.0-rc.9",
     "ajv": "^8.18.0",
     "chalk": "^5.6.2",


### PR DESCRIPTION
This PR removes the unused dependency `@snazzah/davey` from package.json, as identified by knip dead code analysis. This reduces the installation footprint and potential security surface area.