### PR TITLE
Telegram: allow fallback routing for configured default account

### DIFF
--- a/src/telegram/accounts.ts
+++ b/src/telegram/accounts.ts
@@ -72,20 +72,27 @@ export function resetMissingDefaultWarnFlag(): void {
 }
 
 export function resolveDefaultTelegramAccountId(cfg: OpenClawConfig): string {
+  return resolveDefaultTelegramRoutingAccount(cfg).accountId;
+}
+
+export function resolveDefaultTelegramRoutingAccount(cfg: OpenClawConfig): {
+  accountId: string;
+  explicit: boolean;
+} {
   const boundDefault = resolveDefaultAgentBoundAccountId(cfg, "telegram");
   if (boundDefault) {
-    return boundDefault;
+    return { accountId: boundDefault, explicit: true };
   }
   const preferred = normalizeOptionalAccountId(cfg.channels?.telegram?.defaultAccount);
   if (
     preferred &&
     listTelegramAccountIds(cfg).some((accountId) => normalizeAccountId(accountId) === preferred)
   ) {
-    return preferred;
+    return { accountId: preferred, explicit: true };
   }
   const ids = listTelegramAccountIds(cfg);
   if (ids.includes(DEFAULT_ACCOUNT_ID)) {
-    return DEFAULT_ACCOUNT_ID;
+    return { accountId: DEFAULT_ACCOUNT_ID, explicit: true };
   }
   if (ids.length > 1 && !emittedMissingDefaultWarn) {
     emittedMissingDefaultWarn = true;
@@ -94,7 +101,7 @@ export function resolveDefaultTelegramAccountId(cfg: OpenClawConfig): string {
         `${formatSetExplicitDefaultInstruction("telegram")} to avoid routing surprises in multi-account setups.`,
     );
   }
-  return ids[0] ?? DEFAULT_ACCOUNT_ID;
+  return { accountId: ids[0] ?? DEFAULT_ACCOUNT_ID, explicit: false };
 }
 
 function resolveAccountConfig(

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -44,12 +44,9 @@ import {
   resolveAgentRoute,
   type ResolvedAgentRoute,
 } from "../routing/resolve-route.js";
-import {
-  DEFAULT_ACCOUNT_ID,
-  buildAgentMainSessionKey,
-  resolveThreadSessionKeys,
-} from "../routing/session-key.js";
+import { buildAgentMainSessionKey, resolveThreadSessionKeys } from "../routing/session-key.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../security/dm-policy-shared.js";
+import { resolveDefaultTelegramAccountId } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
   firstDefined,
@@ -245,13 +242,15 @@ export const buildTelegramMessageContext = async ({
       `telegram: per-topic agent override: topic=${resolvedThreadId ?? dmThreadId} agent=${topicAgentId} sessionKey=${overrideSessionKey}`,
     );
   }
-  // Fail closed for named Telegram accounts when route resolution falls back to
-  // default-agent routing. This prevents cross-account DM/session contamination.
-  if (route.accountId !== DEFAULT_ACCOUNT_ID && route.matchedBy === "default") {
+  const defaultTelegramAccountId = resolveDefaultTelegramAccountId(freshCfg);
+  // Fail closed when fallback routing would route a non-default Telegram account.
+  // This keeps cross-account isolation while allowing the configured default account
+  // (which may be a non-"default" id) to route without explicit bindings.
+  if (route.matchedBy === "default" && route.accountId !== defaultTelegramAccountId) {
     logInboundDrop({
       log: logVerbose,
       channel: "telegram",
-      reason: "non-default account requires explicit binding",
+      reason: "non-default telegram account requires explicit binding",
       target: route.accountId,
     });
     return null;

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -44,9 +44,13 @@ import {
   resolveAgentRoute,
   type ResolvedAgentRoute,
 } from "../routing/resolve-route.js";
-import { buildAgentMainSessionKey, resolveThreadSessionKeys } from "../routing/session-key.js";
+import {
+  buildAgentMainSessionKey,
+  DEFAULT_ACCOUNT_ID,
+  resolveThreadSessionKeys,
+} from "../routing/session-key.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../security/dm-policy-shared.js";
-import { resolveDefaultTelegramAccountId } from "./accounts.js";
+import { listTelegramAccountIds, resolveDefaultTelegramRoutingAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
   firstDefined,
@@ -242,11 +246,18 @@ export const buildTelegramMessageContext = async ({
       `telegram: per-topic agent override: topic=${resolvedThreadId ?? dmThreadId} agent=${topicAgentId} sessionKey=${overrideSessionKey}`,
     );
   }
-  const defaultTelegramAccountId = resolveDefaultTelegramAccountId(freshCfg);
+  const defaultTelegramRoutingAccount = resolveDefaultTelegramRoutingAccount(freshCfg);
+  const allowImplicitNamedDefaultRoute =
+    route.accountId === defaultTelegramRoutingAccount.accountId &&
+    (defaultTelegramRoutingAccount.explicit || listTelegramAccountIds(freshCfg).length === 1);
   // Fail closed when fallback routing would route a non-default Telegram account.
-  // This keeps cross-account isolation while allowing the configured default account
-  // (which may be a non-"default" id) to route without explicit bindings.
-  if (route.matchedBy === "default" && route.accountId !== defaultTelegramAccountId) {
+  // Only the literal default account, a deliberately configured default, or a
+  // single-account setup may use bindingless fallback routing.
+  if (
+    route.matchedBy === "default" &&
+    route.accountId !== DEFAULT_ACCOUNT_ID &&
+    !allowImplicitNamedDefaultRoute
+  ) {
     logInboundDrop({
       log: logVerbose,
       channel: "telegram",

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -813,11 +813,50 @@ describe("createTelegramBot", () => {
     expect(payload.SessionKey).toBe("agent:opie:main");
   });
 
-  it("drops non-default account DMs without explicit bindings", async () => {
+  it("routes DMs for configured default telegram account without explicit bindings", async () => {
     loadConfig.mockReturnValue({
       channels: {
         telegram: {
           accounts: {
+            opie: {
+              botToken: "tok-opie",
+              dmPolicy: "open",
+            },
+          },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok", accountId: "opie" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 123, type: "private" },
+        from: { id: 999, username: "testuser" },
+        text: "hello",
+        date: 1736380800,
+        message_id: 42,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = replySpy.mock.calls[0][0];
+    expect(payload.AccountId).toBe("opie");
+  });
+
+  it("drops non-default account DMs without explicit bindings when a different default account is configured", async () => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          defaultAccount: "primary",
+          accounts: {
+            primary: {
+              botToken: "tok-primary",
+              dmPolicy: "open",
+            },
             opie: {
               botToken: "tok-opie",
               dmPolicy: "open",

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -884,6 +884,42 @@ describe("createTelegramBot", () => {
     expect(replySpy).not.toHaveBeenCalled();
   });
 
+  it("drops named-account DMs without explicit bindings when multi-account default is only inferred", async () => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          accounts: {
+            opie: {
+              botToken: "tok-opie",
+              dmPolicy: "open",
+            },
+            work: {
+              botToken: "tok-work",
+              dmPolicy: "open",
+            },
+          },
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok", accountId: "opie" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 123, type: "private" },
+        from: { id: 999, username: "testuser" },
+        text: "hello",
+        date: 1736380800,
+        message_id: 42,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).not.toHaveBeenCalled();
+  });
+
   it("applies group mention overrides and fallback behavior", async () => {
     const cases: Array<{
       config: Record<string, unknown>;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram inbound DMs for named accounts were dropped when route resolution used fallback (`matchedBy: "default"`), even when that account was the configured Telegram default account.
- Why it matters: single-account setups with non-`default` IDs (for example `atlas`) can send outbound but silently lose inbound updates; `lastInboundAt` stays `null`.
- What changed: `buildTelegramMessageContext` now allows fallback routing for the configured Telegram default account ID, and still blocks non-default accounts without explicit bindings.
- What did NOT change (scope boundary): explicit binding behavior, multi-account isolation guard, webhook/polling mechanics, and Telegram transport code are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34941
- Related #33154

## User-visible / Behavior Changes

Telegram inbound DMs now process correctly when the bot account is the configured Telegram default account but its ID is not literally `default`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A (routing-level behavior)
- Integration/channel (if any): Telegram
- Relevant config (redacted): `channels.telegram.accounts.opie` with no explicit binding

### Steps

1. Configure Telegram with a single named account (for example `opie`) and no `bindings` entry.
2. Start the bot with `accountId: "opie"` and receive a DM.
3. Observe current behavior: message is dropped due to non-default-account guard despite fallback route.

### Expected

- If fallback resolves to the configured Telegram default account, inbound DM should route normally.

### Actual

- Inbound DM is dropped when account ID is not literal `default`, even when that account is the effective Telegram default.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Existing behavior reproduced via test: `drops non-default account DMs without explicit bindings`.
  - Updated behavior: fallback routing now succeeds for the configured default account.
  - Guard remains: non-default secondary accounts are still dropped without explicit bindings.
- Edge cases checked:
  - Explicit account binding path still routes as before.
  - Multi-account setup with `defaultAccount` pointing elsewhere still blocks secondary unbound accounts.
- What you did **not** verify:
  - Live Telegram webhook/polling against real bot tokens.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Telegram: allow fallback routing for configured default account`.
- Files/config to restore: `src/telegram/bot-message-context.ts`, `src/telegram/bot.create-telegram-bot.test.ts`.
- Known bad symptoms reviewers should watch for: unbound secondary Telegram accounts routing unexpectedly in multi-account setups (covered by regression test).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Relaxing the guard could allow unintended cross-account routing in multi-account configs.
  - Mitigation: Guard still blocks when fallback account differs from configured Telegram default account; regression test added for this case.
