### PR TITLE
cli(version): include commit SHA in -v/--version output

### DIFF
--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -9,6 +9,7 @@ import { CLI_LOG_LEVEL_VALUES, parseCliLogLevelOption } from "../log-level-optio
 import { getCoreCliCommandsWithSubcommands } from "./command-registry.js";
 import type { ProgramContext } from "./context.js";
 import { getSubCliCommandsWithSubcommands } from "./register.subclis.js";
+import { resolveCommitHash } from "../../infra/git-commit.js";
 
 const CLI_NAME = resolveCliName();
 const CLI_NAME_PATTERN = escapeRegExp(CLI_NAME);
@@ -109,7 +110,11 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     hasFlag(process.argv, "--version") ||
     hasRootVersionAlias(process.argv)
   ) {
-    console.log(ctx.programVersion);
+    const commit = resolveCommitHash({ env: process.env });
+    const version = commit
+      ? `${ctx.programVersion} (${commit})`
+      : ctx.programVersion;
+    console.log(version);
     process.exit(0);
   }
 


### PR DESCRIPTION
## Summary

Include commit SHA in `-v`/`--version` output for local/dev builds, matching the banner format.

## Changes

- `src/cli/program/help.ts`: Add commit SHA to version flag output when available

## Before

```bash
$ openclaw -v
2026.3.1
```

## After

```bash
$ openclaw -v
2026.3.1 (b13e19b)
```

Closes #34972