### PR TITLE
fix(agents): prevent totalTokens crash when assistant usage is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/probes: keep `/health`, `/healthz`, `/ready`, and `/readyz` reachable when the Control UI is mounted at `/`, preserve plugin-owned route precedence on those paths, and make `/ready` and `/readyz` report channel-backed readiness with startup grace plus `503` on disconnected managed channels, while `/health` and `/healthz` stay shallow liveness probes. (#18446) Thanks @vibecodooor, @mahsumaktas, and @vincentkoc.
 - Feishu/media downloads: drop invalid timeout fields from SDK method calls now that client-level `httpTimeoutMs` applies to requests. (#38267) Thanks @ant1eicher and @thewilloftheshadow.
 - PI embedded runner/Feishu docs: propagate sender identity into embedded attempts so Feishu doc auto-grant restores requester access for embedded-runner executions. (#32915) thanks @cszhouwei.
+- Agents/usage normalization: normalize missing or partial assistant usage snapshots before compaction accounting so `openclaw agent --json` no longer crashes when provider payloads omit `totalTokens` or related usage fields. (#34977) thanks @sp-hk2ldn.
 
 ## 2026.3.2
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -330,6 +330,55 @@ describe("sanitizeSessionHistory", () => {
     expect(assistants[1]?.usage).toBeDefined();
   });
 
+  it("adds a zeroed assistant usage snapshot when usage is missing", async () => {
+    vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
+
+    const messages = castAgentMessages([
+      { role: "user", content: "question" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "answer without usage" }],
+      },
+    ]);
+
+    const result = await sanitizeOpenAIHistory(messages);
+    const assistant = result.find((message) => message.role === "assistant") as
+      | (AgentMessage & { usage?: unknown })
+      | undefined;
+
+    expect(assistant?.usage).toEqual(makeZeroUsageSnapshot());
+  });
+
+  it("normalizes mixed partial assistant usage fields to numeric totals", async () => {
+    vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
+
+    const messages = castAgentMessages([
+      { role: "user", content: "question" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "answer with partial usage" }],
+        usage: {
+          output: 3,
+          cache_read_input_tokens: 9,
+        },
+      },
+    ]);
+
+    const result = await sanitizeOpenAIHistory(messages);
+    const assistant = result.find((message) => message.role === "assistant") as
+      | (AgentMessage & { usage?: unknown })
+      | undefined;
+
+    expect(assistant?.usage).toEqual({
+      ...makeZeroUsageSnapshot(),
+      input: 0,
+      output: 3,
+      cacheRead: 9,
+      cacheWrite: 0,
+      totalTokens: 12,
+    });
+  });
+
   it("drops stale usage when compaction summary appears before kept assistant messages", async () => {
     vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -379,6 +379,83 @@ describe("sanitizeSessionHistory", () => {
     });
   });
 
+  it("preserves existing usage cost while normalizing token fields", async () => {
+    vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
+
+    const messages = castAgentMessages([
+      { role: "user", content: "question" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "answer with partial usage and cost" }],
+        usage: {
+          output: 3,
+          cache_read_input_tokens: 9,
+          cost: {
+            input: 1.25,
+            output: 2.5,
+            cacheRead: 0.25,
+            cacheWrite: 0,
+            total: 4,
+          },
+        },
+      },
+    ]);
+
+    const result = await sanitizeOpenAIHistory(messages);
+    const assistant = result.find((message) => message.role === "assistant") as
+      | (AgentMessage & { usage?: unknown })
+      | undefined;
+
+    expect(assistant?.usage).toEqual({
+      ...makeZeroUsageSnapshot(),
+      input: 0,
+      output: 3,
+      cacheRead: 9,
+      cacheWrite: 0,
+      totalTokens: 12,
+      cost: {
+        input: 1.25,
+        output: 2.5,
+        cacheRead: 0.25,
+        cacheWrite: 0,
+        total: 4,
+      },
+    });
+  });
+
+  it("adds missing usage cost even when token fields already match", async () => {
+    vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
+
+    const messages = castAgentMessages([
+      { role: "user", content: "question" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "answer with complete numeric usage but no cost" }],
+        usage: {
+          input: 1,
+          output: 2,
+          cacheRead: 3,
+          cacheWrite: 4,
+          totalTokens: 10,
+        },
+      },
+    ]);
+
+    const result = await sanitizeOpenAIHistory(messages);
+    const assistant = result.find((message) => message.role === "assistant") as
+      | (AgentMessage & { usage?: unknown })
+      | undefined;
+
+    expect(assistant?.usage).toEqual({
+      ...makeZeroUsageSnapshot(),
+      input: 1,
+      output: 2,
+      cacheRead: 3,
+      cacheWrite: 4,
+      totalTokens: 10,
+    });
+  });
+
   it("drops stale usage when compaction summary appears before kept assistant messages", async () => {
     vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -370,7 +370,6 @@ describe("sanitizeSessionHistory", () => {
       | undefined;
 
     expect(assistant?.usage).toEqual({
-      ...makeZeroUsageSnapshot(),
       input: 0,
       output: 3,
       cacheRead: 9,
@@ -423,7 +422,7 @@ describe("sanitizeSessionHistory", () => {
     });
   });
 
-  it("adds missing usage cost even when token fields already match", async () => {
+  it("preserves unknown cost when token fields already match", async () => {
     vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
 
     const messages = castAgentMessages([
@@ -447,13 +446,13 @@ describe("sanitizeSessionHistory", () => {
       | undefined;
 
     expect(assistant?.usage).toEqual({
-      ...makeZeroUsageSnapshot(),
       input: 1,
       output: 2,
       cacheRead: 3,
       cacheWrite: 4,
       totalTokens: 10,
     });
+    expect((assistant?.usage as { cost?: unknown } | undefined)?.cost).toBeUndefined();
   });
 
   it("drops stale usage when compaction summary appears before kept assistant messages", async () => {

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -217,31 +217,44 @@ function normalizeAssistantUsageSnapshot(usage: unknown) {
   const totalTokens = normalized.total ?? input + output + cacheRead + cacheWrite;
   const cost = normalizeAssistantUsageCost(usage);
   return {
-    ...makeZeroUsageSnapshot(),
-    cost,
     input,
     output,
     cacheRead,
     cacheWrite,
     totalTokens,
+    ...(cost ? { cost } : {}),
   };
 }
 
-function normalizeAssistantUsageCost(usage: unknown): AssistantUsageSnapshot["cost"] {
+function normalizeAssistantUsageCost(usage: unknown): AssistantUsageSnapshot["cost"] | undefined {
   const base = makeZeroUsageSnapshot().cost;
   if (!usage || typeof usage !== "object") {
-    return base;
+    return undefined;
   }
   const rawCost = (usage as { cost?: unknown }).cost;
   if (!rawCost || typeof rawCost !== "object") {
-    return base;
+    return undefined;
   }
   const cost = rawCost as Record<string, unknown>;
-  const input = toFiniteCostNumber(cost.input) ?? base.input;
-  const output = toFiniteCostNumber(cost.output) ?? base.output;
-  const cacheRead = toFiniteCostNumber(cost.cacheRead) ?? base.cacheRead;
-  const cacheWrite = toFiniteCostNumber(cost.cacheWrite) ?? base.cacheWrite;
-  const total = toFiniteCostNumber(cost.total) ?? input + output + cacheRead + cacheWrite;
+  const inputRaw = toFiniteCostNumber(cost.input);
+  const outputRaw = toFiniteCostNumber(cost.output);
+  const cacheReadRaw = toFiniteCostNumber(cost.cacheRead);
+  const cacheWriteRaw = toFiniteCostNumber(cost.cacheWrite);
+  const totalRaw = toFiniteCostNumber(cost.total);
+  if (
+    inputRaw === undefined &&
+    outputRaw === undefined &&
+    cacheReadRaw === undefined &&
+    cacheWriteRaw === undefined &&
+    totalRaw === undefined
+  ) {
+    return undefined;
+  }
+  const input = inputRaw ?? base.input;
+  const output = outputRaw ?? base.output;
+  const cacheRead = cacheReadRaw ?? base.cacheRead;
+  const cacheWrite = cacheWriteRaw ?? base.cacheWrite;
+  const total = totalRaw ?? input + output + cacheRead + cacheWrite;
   return { input, output, cacheRead, cacheWrite, total };
 }
 
@@ -266,21 +279,24 @@ function ensureAssistantUsageSnapshots(messages: AgentMessage[]): AgentMessage[]
       message.usage && typeof message.usage === "object"
         ? (message.usage as { cost?: unknown }).cost
         : undefined;
+    const normalizedCost = normalizedUsage.cost;
     if (
       message.usage &&
       typeof message.usage === "object" &&
-      usageCost &&
-      typeof usageCost === "object" &&
       (message.usage as { input?: unknown }).input === normalizedUsage.input &&
       (message.usage as { output?: unknown }).output === normalizedUsage.output &&
       (message.usage as { cacheRead?: unknown }).cacheRead === normalizedUsage.cacheRead &&
       (message.usage as { cacheWrite?: unknown }).cacheWrite === normalizedUsage.cacheWrite &&
       (message.usage as { totalTokens?: unknown }).totalTokens === normalizedUsage.totalTokens &&
-      (usageCost as { input?: unknown }).input === normalizedUsage.cost.input &&
-      (usageCost as { output?: unknown }).output === normalizedUsage.cost.output &&
-      (usageCost as { cacheRead?: unknown }).cacheRead === normalizedUsage.cost.cacheRead &&
-      (usageCost as { cacheWrite?: unknown }).cacheWrite === normalizedUsage.cost.cacheWrite &&
-      (usageCost as { total?: unknown }).total === normalizedUsage.cost.total
+      ((normalizedCost &&
+        usageCost &&
+        typeof usageCost === "object" &&
+        (usageCost as { input?: unknown }).input === normalizedCost.input &&
+        (usageCost as { output?: unknown }).output === normalizedCost.output &&
+        (usageCost as { cacheRead?: unknown }).cacheRead === normalizedCost.cacheRead &&
+        (usageCost as { cacheWrite?: unknown }).cacheWrite === normalizedCost.cacheWrite &&
+        (usageCost as { total?: unknown }).total === normalizedCost.total) ||
+        (!normalizedCost && usageCost === undefined))
     ) {
       continue;
     }

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -25,7 +25,7 @@ import {
 } from "../session-transcript-repair.js";
 import type { TranscriptPolicy } from "../transcript-policy.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
-import { makeZeroUsageSnapshot } from "../usage.js";
+import { makeZeroUsageSnapshot, normalizeUsage, type UsageLike } from "../usage.js";
 import { log } from "./logger.js";
 import { dropThinkingBlocks } from "./thinking.js";
 import { describeUnknownError } from "./utils.js";
@@ -197,6 +197,60 @@ function stripStaleAssistantUsageBeforeLatestCompaction(messages: AgentMessage[]
     } as unknown as AgentMessage;
     touched = true;
   }
+  return touched ? out : messages;
+}
+
+function normalizeAssistantUsageSnapshot(usage: unknown) {
+  const normalized = normalizeUsage((usage ?? undefined) as UsageLike | undefined);
+  if (!normalized) {
+    return makeZeroUsageSnapshot();
+  }
+  const input = normalized.input ?? 0;
+  const output = normalized.output ?? 0;
+  const cacheRead = normalized.cacheRead ?? 0;
+  const cacheWrite = normalized.cacheWrite ?? 0;
+  const totalTokens = normalized.total ?? input + output + cacheRead + cacheWrite;
+  return {
+    ...makeZeroUsageSnapshot(),
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    totalTokens,
+  };
+}
+
+function ensureAssistantUsageSnapshots(messages: AgentMessage[]): AgentMessage[] {
+  if (messages.length === 0) {
+    return messages;
+  }
+
+  let touched = false;
+  const out = [...messages];
+  for (let i = 0; i < out.length; i += 1) {
+    const message = out[i] as (AgentMessage & { role?: unknown; usage?: unknown }) | undefined;
+    if (!message || message.role !== "assistant") {
+      continue;
+    }
+    const normalizedUsage = normalizeAssistantUsageSnapshot(message.usage);
+    if (
+      message.usage &&
+      typeof message.usage === "object" &&
+      (message.usage as { input?: unknown }).input === normalizedUsage.input &&
+      (message.usage as { output?: unknown }).output === normalizedUsage.output &&
+      (message.usage as { cacheRead?: unknown }).cacheRead === normalizedUsage.cacheRead &&
+      (message.usage as { cacheWrite?: unknown }).cacheWrite === normalizedUsage.cacheWrite &&
+      (message.usage as { totalTokens?: unknown }).totalTokens === normalizedUsage.totalTokens
+    ) {
+      continue;
+    }
+    out[i] = {
+      ...(message as unknown as Record<string, unknown>),
+      usage: normalizedUsage,
+    } as AgentMessage;
+    touched = true;
+  }
+
   return touched ? out : messages;
 }
 
@@ -449,8 +503,9 @@ export async function sanitizeSessionHistory(params: {
     ? sanitizeToolUseResultPairing(sanitizedToolCalls)
     : sanitizedToolCalls;
   const sanitizedToolResults = stripToolResultDetails(repairedTools);
-  const sanitizedCompactionUsage =
-    stripStaleAssistantUsageBeforeLatestCompaction(sanitizedToolResults);
+  const sanitizedCompactionUsage = ensureAssistantUsageSnapshots(
+    stripStaleAssistantUsageBeforeLatestCompaction(sanitizedToolResults),
+  );
 
   const isOpenAIResponsesApi =
     params.modelApi === "openai-responses" || params.modelApi === "openai-codex-responses";

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -25,7 +25,12 @@ import {
 } from "../session-transcript-repair.js";
 import type { TranscriptPolicy } from "../transcript-policy.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
-import { makeZeroUsageSnapshot, normalizeUsage, type UsageLike } from "../usage.js";
+import {
+  makeZeroUsageSnapshot,
+  normalizeUsage,
+  type AssistantUsageSnapshot,
+  type UsageLike,
+} from "../usage.js";
 import { log } from "./logger.js";
 import { dropThinkingBlocks } from "./thinking.js";
 import { describeUnknownError } from "./utils.js";
@@ -210,14 +215,38 @@ function normalizeAssistantUsageSnapshot(usage: unknown) {
   const cacheRead = normalized.cacheRead ?? 0;
   const cacheWrite = normalized.cacheWrite ?? 0;
   const totalTokens = normalized.total ?? input + output + cacheRead + cacheWrite;
+  const cost = normalizeAssistantUsageCost(usage);
   return {
     ...makeZeroUsageSnapshot(),
+    cost,
     input,
     output,
     cacheRead,
     cacheWrite,
     totalTokens,
   };
+}
+
+function normalizeAssistantUsageCost(usage: unknown): AssistantUsageSnapshot["cost"] {
+  const base = makeZeroUsageSnapshot().cost;
+  if (!usage || typeof usage !== "object") {
+    return base;
+  }
+  const rawCost = (usage as { cost?: unknown }).cost;
+  if (!rawCost || typeof rawCost !== "object") {
+    return base;
+  }
+  const cost = rawCost as Record<string, unknown>;
+  const input = toFiniteCostNumber(cost.input) ?? base.input;
+  const output = toFiniteCostNumber(cost.output) ?? base.output;
+  const cacheRead = toFiniteCostNumber(cost.cacheRead) ?? base.cacheRead;
+  const cacheWrite = toFiniteCostNumber(cost.cacheWrite) ?? base.cacheWrite;
+  const total = toFiniteCostNumber(cost.total) ?? input + output + cacheRead + cacheWrite;
+  return { input, output, cacheRead, cacheWrite, total };
+}
+
+function toFiniteCostNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function ensureAssistantUsageSnapshots(messages: AgentMessage[]): AgentMessage[] {
@@ -233,14 +262,25 @@ function ensureAssistantUsageSnapshots(messages: AgentMessage[]): AgentMessage[]
       continue;
     }
     const normalizedUsage = normalizeAssistantUsageSnapshot(message.usage);
+    const usageCost =
+      message.usage && typeof message.usage === "object"
+        ? (message.usage as { cost?: unknown }).cost
+        : undefined;
     if (
       message.usage &&
       typeof message.usage === "object" &&
+      usageCost &&
+      typeof usageCost === "object" &&
       (message.usage as { input?: unknown }).input === normalizedUsage.input &&
       (message.usage as { output?: unknown }).output === normalizedUsage.output &&
       (message.usage as { cacheRead?: unknown }).cacheRead === normalizedUsage.cacheRead &&
       (message.usage as { cacheWrite?: unknown }).cacheWrite === normalizedUsage.cacheWrite &&
-      (message.usage as { totalTokens?: unknown }).totalTokens === normalizedUsage.totalTokens
+      (message.usage as { totalTokens?: unknown }).totalTokens === normalizedUsage.totalTokens &&
+      (usageCost as { input?: unknown }).input === normalizedUsage.cost.input &&
+      (usageCost as { output?: unknown }).output === normalizedUsage.cost.output &&
+      (usageCost as { cacheRead?: unknown }).cacheRead === normalizedUsage.cost.cacheRead &&
+      (usageCost as { cacheWrite?: unknown }).cacheWrite === normalizedUsage.cost.cacheWrite &&
+      (usageCost as { total?: unknown }).total === normalizedUsage.cost.total
     ) {
       continue;
     }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw agent --json` can crash in compaction/token accounting with `TypeError: Cannot read properties of undefined (reading 'totalTokens')` when assistant messages have missing/partial `usage`.
- Why it matters: a missing usage object can brick the run path and prevent valid JSON response output.
- What changed: sanitize session history now normalizes assistant usage snapshots defensively before compaction accounting; missing usage becomes a zero snapshot and partial usage fields are normalized to numeric values with computed totals.
- What changed: added regression tests for missing assistant usage and mixed partial usage fields.
- What did NOT change (scope boundary): no Mission Control/task-board or unrelated routing/status changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30134
- Related #26458

## User-visible / Behavior Changes

`openclaw agent --json` no longer crashes when assistant usage is missing in the compaction/token-accounting path; execution continues and JSON output shape remains intact.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm
- Model/provider: embedded pi runner / compaction path
- Integration/channel (if any): CLI (`openclaw agent --json`)
- Relevant config (redacted): local config had legacy telegram key warning preventing full live run completion

### Steps

1. Run focused tests:
   - `pnpm test src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/usage.test.ts`
2. Run command-path test:
   - `pnpm test src/commands/agent.test.ts -t "prints JSON payload when requested"`
3. Attempt live repro command:
   - `pnpm openclaw agent --agent sherbert --message "ping" --json`

### Expected

- Missing/partial assistant usage does not throw.
- Token calc path remains numeric and null-safe.

### Actual

- Tests passed: 44/44 and 31/31.
- Live command no longer showed `totalTokens` TypeError; run in this environment stopped earlier due local legacy config validation.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Assistant message with no `usage` is normalized to zero snapshot and does not crash path.
  - Assistant message with partial usage fields is normalized to numeric snapshot with computed `totalTokens`.
- Edge cases checked:
  - Existing stale-usage compaction sanitization behavior remains in place.
  - JSON command-path test remains green.
- What you did **not** verify:
  - Full end-to-end live JSON payload in this shell due local legacy config validation gate.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `e5a18e5cf`.
- Files/config to restore:
  - `src/agents/pi-embedded-runner/google.ts`
  - `src/agents/pi-embedded-runner.sanitize-session-history.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected compaction threshold behavior if assistant usage normalization regresses.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Normalizing malformed assistant usage could mask upstream provider payload defects.
  - Mitigation: behavior is intentionally defensive for runtime safety, and tests lock expected normalization semantics.
