### PR TITLE
Add per-agent sandbox session visibility override feature

### DIFF
--- a/src/agents/openclaw-tools.sessions-visibility.test.ts
+++ b/src/agents/openclaw-tools.sessions-visibility.test.ts
@@ -4,6 +4,9 @@ const callGatewayMock = vi.fn();
 vi.mock("../gateway/call.js", () => ({
   callGateway: (opts: unknown) => callGatewayMock(opts),
 }));
+vi.mock("./tools/sessions-send-tool.a2a.js", () => ({
+  runSessionsSendA2AFlow: vi.fn(),
+}));
 
 let mockConfig: Record<string, unknown> = {
   session: { mainKey: "main", scope: "per-sender" },
@@ -37,14 +40,36 @@ async function loadFreshOpenClawToolsModuleForTest() {
   ({ createOpenClawTools } = await import("./openclaw-tools.js"));
 }
 
-function getSessionsHistoryTool(options?: { sandboxed?: boolean }) {
+function getSessionsHistoryTool(options?: {
+  sandboxed?: boolean;
+  agentSessionKey?: string;
+  requesterAgentIdOverride?: string;
+}) {
   const tool = createOpenClawTools({
-    agentSessionKey: "main",
+    agentSessionKey: options?.agentSessionKey ?? "main",
     sandboxed: options?.sandboxed,
+    requesterAgentIdOverride: options?.requesterAgentIdOverride,
   }).find((candidate) => candidate.name === "sessions_history");
   expect(tool).toBeDefined();
   if (!tool) {
     throw new Error("missing sessions_history tool");
+  }
+  return tool;
+}
+
+function getSessionsSendTool(options?: {
+  sandboxed?: boolean;
+  agentSessionKey?: string;
+  requesterAgentIdOverride?: string;
+}) {
+  const tool = createOpenClawTools({
+    agentSessionKey: options?.agentSessionKey ?? "main",
+    sandboxed: options?.sandboxed,
+    requesterAgentIdOverride: options?.requesterAgentIdOverride,
+  }).find((candidate) => candidate.name === "sessions_send");
+  expect(tool).toBeDefined();
+  if (!tool) {
+    throw new Error("missing sessions_send tool");
   }
   return tool;
 }
@@ -135,5 +160,67 @@ describe("sessions tools visibility", () => {
       sessionKey: "agent:other:main",
     });
     expect(denied.details).toMatchObject({ status: "forbidden" });
+  });
+
+  it("uses requesterAgentIdOverride for sandbox clamp in sessions_history", async () => {
+    mockConfig = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: { sessions: { visibility: "all" }, agentToAgent: { enabled: true, allow: ["*"] } },
+      agents: {
+        defaults: { sandbox: { sessionToolsVisibility: "spawned" } },
+        list: [{ id: "tony", sandbox: { sessionToolsVisibility: "all" } }],
+      },
+    };
+    mockGatewayWithHistory();
+
+    const tool = getSessionsHistoryTool({
+      sandboxed: true,
+      agentSessionKey: "global",
+      requesterAgentIdOverride: "tony",
+    });
+
+    const result = await tool.execute("call5", {
+      sessionKey: "agent:other:main",
+    });
+    expect(result.details).toMatchObject({
+      sessionKey: "agent:other:main",
+    });
+    expect(Array.isArray((result.details as { messages?: unknown }).messages)).toBe(true);
+  });
+
+  it("uses requesterAgentIdOverride for sandbox clamp in sessions_send", async () => {
+    mockConfig = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: { sessions: { visibility: "all" }, agentToAgent: { enabled: true, allow: ["*"] } },
+      agents: {
+        defaults: { sandbox: { sessionToolsVisibility: "spawned" } },
+        list: [{ id: "tony", sandbox: { sessionToolsVisibility: "all" } }],
+      },
+    };
+    callGatewayMock.mockClear();
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const req = opts as { method?: string };
+      if (req.method === "agent") {
+        return { runId: "run-override" };
+      }
+      return {};
+    });
+
+    const tool = getSessionsSendTool({
+      sandboxed: true,
+      agentSessionKey: "global",
+      requesterAgentIdOverride: "tony",
+    });
+
+    const result = await tool.execute("call6", {
+      sessionKey: "agent:other:main",
+      message: "ping",
+      timeoutSeconds: 0,
+    });
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      sessionKey: "agent:other:main",
+      runId: "run-override",
+    });
   });
 });

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -199,12 +199,14 @@ export function createOpenClawTools(
       sandboxed: options?.sandboxed,
       config: resolvedConfig,
       callGateway: openClawToolsDeps.callGateway,
+      requesterAgentIdOverride: options?.requesterAgentIdOverride,
     }),
     createSessionsHistoryTool({
       agentSessionKey: options?.agentSessionKey,
       sandboxed: options?.sandboxed,
       config: resolvedConfig,
       callGateway: openClawToolsDeps.callGateway,
+      requesterAgentIdOverride: options?.requesterAgentIdOverride,
     }),
     createSessionsSendTool({
       agentSessionKey: options?.agentSessionKey,
@@ -212,6 +214,7 @@ export function createOpenClawTools(
       sandboxed: options?.sandboxed,
       config: resolvedConfig,
       callGateway: openClawToolsDeps.callGateway,
+      requesterAgentIdOverride: options?.requesterAgentIdOverride,
     }),
     createSessionsYieldTool({
       sessionId: options?.sessionId,

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -44,11 +44,38 @@ describe("resolveEffectiveSessionToolsVisibility", () => {
     } as unknown as OpenClawConfig;
     expect(resolveEffectiveSessionToolsVisibility({ cfg, sandboxed: true })).toBe("all");
   });
+
+  it("uses per-agent sandbox clamp override when provided", () => {
+    const cfg = {
+      tools: { sessions: { visibility: "all" } },
+      agents: {
+        defaults: { sandbox: { sessionToolsVisibility: "spawned" } },
+        list: [{ id: "tony", sandbox: { sessionToolsVisibility: "all" } }],
+      },
+    } as unknown as OpenClawConfig;
+    expect(
+      resolveEffectiveSessionToolsVisibility({
+        cfg,
+        sandboxed: true,
+        agentId: "tony",
+      }),
+    ).toBe("all");
+  });
 });
 
 describe("sandbox session-tools context", () => {
   it("defaults sandbox visibility clamp to spawned", () => {
     expect(resolveSandboxSessionToolsVisibility({} as unknown as OpenClawConfig)).toBe("spawned");
+  });
+
+  it("prefers per-agent sandbox visibility override over defaults", () => {
+    const cfg = {
+      agents: {
+        defaults: { sandbox: { sessionToolsVisibility: "spawned" } },
+        list: [{ id: "tony", sandbox: { sessionToolsVisibility: "all" } }],
+      },
+    } as unknown as OpenClawConfig;
+    expect(resolveSandboxSessionToolsVisibility(cfg, "tony")).toBe("all");
   });
 
   it("restricts non-subagent sandboxed sessions to spawned visibility", () => {

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -95,6 +95,26 @@ describe("sandbox session-tools context", () => {
     expect(resolveSandboxSessionToolsVisibility(cfg, "tony")).toBe("all");
   });
 
+  it("matches per-agent overrides case-insensitively", () => {
+    const cfg = {
+      agents: {
+        defaults: { sandbox: { sessionToolsVisibility: "spawned" } },
+        list: [{ id: "Tony", sandbox: { sessionToolsVisibility: "all" } }],
+      },
+    } as unknown as OpenClawConfig;
+    expect(resolveSandboxSessionToolsVisibility(cfg, "tony")).toBe("all");
+  });
+
+  it("falls back to default when agentId is not found in agents.list", () => {
+    const cfg = {
+      agents: {
+        defaults: { sandbox: { sessionToolsVisibility: "spawned" } },
+        list: [{ id: "tony", sandbox: { sessionToolsVisibility: "all" } }],
+      },
+    } as unknown as OpenClawConfig;
+    expect(resolveSandboxSessionToolsVisibility(cfg, "unknown-agent")).toBe("spawned");
+  });
+
   it("restricts non-subagent sandboxed sessions to spawned visibility", () => {
     const cfg = {
       tools: { sessions: { visibility: "all" } },

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -61,6 +61,23 @@ describe("resolveEffectiveSessionToolsVisibility", () => {
       }),
     ).toBe("all");
   });
+
+  it("falls back to default sandbox clamp when agentId override is missing", () => {
+    const cfg = {
+      tools: { sessions: { visibility: "all" } },
+      agents: {
+        defaults: { sandbox: { sessionToolsVisibility: "spawned" } },
+        list: [{ id: "tony", sandbox: { sessionToolsVisibility: "all" } }],
+      },
+    } as unknown as OpenClawConfig;
+    expect(
+      resolveEffectiveSessionToolsVisibility({
+        cfg,
+        sandboxed: true,
+        agentId: "ghost",
+      }),
+    ).toBe("tree");
+  });
 });
 
 describe("sandbox session-tools context", () => {

--- a/src/agents/tools/sessions-access.test.ts
+++ b/src/agents/tools/sessions-access.test.ts
@@ -62,7 +62,7 @@ describe("resolveEffectiveSessionToolsVisibility", () => {
     ).toBe("all");
   });
 
-  it("falls back to default sandbox clamp when agentId override is missing", () => {
+  it("falls back to default sandbox clamp when agentId is not found in agents.list", () => {
     const cfg = {
       tools: { sessions: { visibility: "all" } },
       agents: {

--- a/src/agents/tools/sessions-access.ts
+++ b/src/agents/tools/sessions-access.ts
@@ -33,25 +33,37 @@ export function resolveSessionToolsVisibility(cfg: OpenClawConfig): SessionTools
 export function resolveEffectiveSessionToolsVisibility(params: {
   cfg: OpenClawConfig;
   sandboxed: boolean;
+  agentId?: string;
 }): SessionToolsVisibility {
   const visibility = resolveSessionToolsVisibility(params.cfg);
   if (!params.sandboxed) {
     return visibility;
   }
-  const sandboxClamp = params.cfg.agents?.defaults?.sandbox?.sessionToolsVisibility ?? "spawned";
+  const sandboxClamp = resolveSandboxSessionToolsVisibility(params.cfg, params.agentId);
   if (sandboxClamp === "spawned" && visibility !== "tree") {
     return "tree";
   }
   return visibility;
 }
 
-export function resolveSandboxSessionToolsVisibility(cfg: OpenClawConfig): "spawned" | "all" {
+export function resolveSandboxSessionToolsVisibility(
+  cfg: OpenClawConfig,
+  agentId?: string,
+): "spawned" | "all" {
+  if (agentId) {
+    const override = cfg.agents?.list?.find((entry) => entry.id === agentId)?.sandbox
+      ?.sessionToolsVisibility;
+    if (override === "spawned" || override === "all") {
+      return override;
+    }
+  }
   return cfg.agents?.defaults?.sandbox?.sessionToolsVisibility ?? "spawned";
 }
 
 export function resolveSandboxedSessionToolContext(params: {
   cfg: OpenClawConfig;
   agentSessionKey?: string;
+  agentId?: string;
   sandboxed?: boolean;
 }): {
   mainKey: string;
@@ -62,7 +74,12 @@ export function resolveSandboxedSessionToolContext(params: {
   restrictToSpawned: boolean;
 } {
   const { mainKey, alias } = resolveMainSessionAlias(params.cfg);
-  const visibility = resolveSandboxSessionToolsVisibility(params.cfg);
+  const requesterAgentId =
+    params.agentId ??
+    (typeof params.agentSessionKey === "string" && params.agentSessionKey.trim()
+      ? resolveAgentIdFromSessionKey(params.agentSessionKey)
+      : undefined);
+  const visibility = resolveSandboxSessionToolsVisibility(params.cfg, requesterAgentId);
   const requesterInternalKey =
     typeof params.agentSessionKey === "string" && params.agentSessionKey.trim()
       ? resolveInternalSessionKey({

--- a/src/agents/tools/sessions-access.ts
+++ b/src/agents/tools/sessions-access.ts
@@ -1,5 +1,9 @@
 import type { OpenClawConfig } from "../../config/config.js";
-import { isSubagentSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import {
+  isSubagentSessionKey,
+  normalizeAgentId,
+  resolveAgentIdFromSessionKey,
+} from "../../routing/session-key.js";
 import {
   listSpawnedSessionKeys,
   resolveInternalSessionKey,
@@ -51,8 +55,10 @@ export function resolveSandboxSessionToolsVisibility(
   agentId?: string,
 ): "spawned" | "all" {
   if (agentId) {
-    const override = cfg.agents?.list?.find((entry) => entry.id === agentId)?.sandbox
-      ?.sessionToolsVisibility;
+    const normalizedAgentId = normalizeAgentId(agentId);
+    const override = cfg.agents?.list?.find(
+      (entry) => normalizeAgentId(entry.id) === normalizedAgentId,
+    )?.sandbox?.sessionToolsVisibility;
     if (override === "spawned" || override === "all") {
       return override;
     }

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -193,7 +193,6 @@ export function createSessionsHistoryTool(opts?: {
         resolveSandboxedSessionToolContext({
           cfg,
           agentSessionKey: opts?.agentSessionKey,
-          agentId: requesterAgentId,
           sandboxed: opts?.sandboxed,
         });
       const resolvedSession = await resolveSessionReference({

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -173,6 +173,7 @@ export function createSessionsHistoryTool(opts?: {
   sandboxed?: boolean;
   config?: OpenClawConfig;
   callGateway?: GatewayCaller;
+  requesterAgentIdOverride?: string;
 }): AnyAgentTool {
   return {
     label: "Session History",
@@ -186,13 +187,14 @@ export function createSessionsHistoryTool(opts?: {
         required: true,
       });
       const cfg = opts?.config ?? loadConfig();
-      const requesterAgentId = opts?.agentSessionKey
-        ? resolveAgentIdFromSessionKey(opts.agentSessionKey)
-        : undefined;
+      const requesterAgentId =
+        opts?.requesterAgentIdOverride ??
+        (opts?.agentSessionKey ? resolveAgentIdFromSessionKey(opts.agentSessionKey) : undefined);
       const { mainKey, alias, effectiveRequesterKey, restrictToSpawned } =
         resolveSandboxedSessionToolContext({
           cfg,
           agentSessionKey: opts?.agentSessionKey,
+          agentId: opts?.requesterAgentIdOverride,
           sandboxed: opts?.sandboxed,
         });
       const resolvedSession = await resolveSessionReference({

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -1,6 +1,7 @@
 import { Type } from "@sinclair/typebox";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { capArrayByJsonBytes } from "../../gateway/session-utils.fs.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { redactSensitiveText } from "../../logging/redact.js";
@@ -185,10 +186,14 @@ export function createSessionsHistoryTool(opts?: {
         required: true,
       });
       const cfg = opts?.config ?? loadConfig();
+      const requesterAgentId = opts?.agentSessionKey
+        ? resolveAgentIdFromSessionKey(opts.agentSessionKey)
+        : undefined;
       const { mainKey, alias, effectiveRequesterKey, restrictToSpawned } =
         resolveSandboxedSessionToolContext({
           cfg,
           agentSessionKey: opts?.agentSessionKey,
+          agentId: requesterAgentId,
           sandboxed: opts?.sandboxed,
         });
       const resolvedSession = await resolveSessionReference({
@@ -221,6 +226,7 @@ export function createSessionsHistoryTool(opts?: {
       const visibility = resolveEffectiveSessionToolsVisibility({
         cfg,
         sandboxed: opts?.sandboxed === true,
+        agentId: requesterAgentId,
       });
       const visibilityGuard = await createSessionVisibilityGuard({
         action: "history",

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -1,10 +1,10 @@
 import { Type } from "@sinclair/typebox";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
-import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { capArrayByJsonBytes } from "../../gateway/session-utils.fs.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import { redactSensitiveText } from "../../logging/redact.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -53,7 +53,6 @@ export function createSessionsListTool(opts?: {
         resolveSandboxedSessionToolContext({
           cfg,
           agentSessionKey: opts?.agentSessionKey,
-          agentId: requesterAgentId,
           sandboxed: opts?.sandboxed,
         });
       const effectiveRequesterKey = requesterInternalKey ?? alias;

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -46,16 +46,21 @@ export function createSessionsListTool(opts?: {
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
       const cfg = opts?.config ?? loadConfig();
+      const requesterAgentId = opts?.agentSessionKey
+        ? resolveAgentIdFromSessionKey(opts.agentSessionKey)
+        : undefined;
       const { mainKey, alias, requesterInternalKey, restrictToSpawned } =
         resolveSandboxedSessionToolContext({
           cfg,
           agentSessionKey: opts?.agentSessionKey,
+          agentId: requesterAgentId,
           sandboxed: opts?.sandboxed,
         });
       const effectiveRequesterKey = requesterInternalKey ?? alias;
       const visibility = resolveEffectiveSessionToolsVisibility({
         cfg,
         sandboxed: opts?.sandboxed === true,
+        agentId: requesterAgentId,
       });
 
       const kindsRaw = readStringArrayParam(params, "kinds")?.map((value) =>

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -37,6 +37,7 @@ export function createSessionsListTool(opts?: {
   sandboxed?: boolean;
   config?: OpenClawConfig;
   callGateway?: GatewayCaller;
+  requesterAgentIdOverride?: string;
 }): AnyAgentTool {
   return {
     label: "Sessions",
@@ -46,13 +47,14 @@ export function createSessionsListTool(opts?: {
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
       const cfg = opts?.config ?? loadConfig();
-      const requesterAgentId = opts?.agentSessionKey
-        ? resolveAgentIdFromSessionKey(opts.agentSessionKey)
-        : undefined;
+      const requesterAgentId =
+        opts?.requesterAgentIdOverride ??
+        (opts?.agentSessionKey ? resolveAgentIdFromSessionKey(opts.agentSessionKey) : undefined);
       const { mainKey, alias, requesterInternalKey, restrictToSpawned } =
         resolveSandboxedSessionToolContext({
           cfg,
           agentSessionKey: opts?.agentSessionKey,
+          agentId: opts?.requesterAgentIdOverride,
           sandboxed: opts?.sandboxed,
         });
       const effectiveRequesterKey = requesterInternalKey ?? alias;

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -71,6 +71,7 @@ export function createSessionsSendTool(opts?: {
   sandboxed?: boolean;
   config?: OpenClawConfig;
   callGateway?: GatewayCaller;
+  requesterAgentIdOverride?: string;
 }): AnyAgentTool {
   return {
     label: "Session Send",
@@ -84,9 +85,9 @@ export function createSessionsSendTool(opts?: {
       const message = readStringParam(params, "message", { required: true });
       const { cfg, mainKey, alias, effectiveRequesterKey, restrictToSpawned } =
         resolveSessionToolContext(opts);
-      const requesterAgentId = opts?.agentSessionKey
-        ? resolveAgentIdFromSessionKey(opts.agentSessionKey)
-        : undefined;
+      const requesterAgentId =
+        opts?.requesterAgentIdOverride ??
+        (opts?.agentSessionKey ? resolveAgentIdFromSessionKey(opts.agentSessionKey) : undefined);
 
       const a2aPolicy = createAgentToAgentPolicy(cfg);
       const sessionVisibility = resolveEffectiveSessionToolsVisibility({

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -108,12 +108,12 @@ export function createSessionsSendTool(opts?: {
 
       let sessionKey = sessionKeyParam;
       if (!sessionKey && labelParam) {
-        const requesterAgentId = resolveAgentIdFromSessionKey(effectiveRequesterKey);
+        const labelRequesterAgentId = resolveAgentIdFromSessionKey(effectiveRequesterKey);
         const requestedAgentId = labelAgentIdParam
           ? normalizeAgentId(labelAgentIdParam)
           : undefined;
 
-        if (restrictToSpawned && requestedAgentId && requestedAgentId !== requesterAgentId) {
+        if (restrictToSpawned && requestedAgentId && requestedAgentId !== labelRequesterAgentId) {
           return jsonResult({
             runId: crypto.randomUUID(),
             status: "forbidden",
@@ -121,7 +121,11 @@ export function createSessionsSendTool(opts?: {
           });
         }
 
-        if (requesterAgentId && requestedAgentId && requestedAgentId !== requesterAgentId) {
+        if (
+          labelRequesterAgentId &&
+          requestedAgentId &&
+          requestedAgentId !== labelRequesterAgentId
+        ) {
           if (!a2aPolicy.enabled) {
             return jsonResult({
               runId: crypto.randomUUID(),
@@ -130,7 +134,7 @@ export function createSessionsSendTool(opts?: {
                 "Agent-to-agent messaging is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent sends.",
             });
           }
-          if (!a2aPolicy.isAllowed(requesterAgentId, requestedAgentId)) {
+          if (!a2aPolicy.isAllowed(labelRequesterAgentId, requestedAgentId)) {
             return jsonResult({
               runId: crypto.randomUUID(),
               status: "forbidden",

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -109,7 +109,8 @@ export function createSessionsSendTool(opts?: {
 
       let sessionKey = sessionKeyParam;
       if (!sessionKey && labelParam) {
-        const labelRequesterAgentId = resolveAgentIdFromSessionKey(effectiveRequesterKey);
+        const labelRequesterAgentId =
+          requesterAgentId ?? resolveAgentIdFromSessionKey(effectiveRequesterKey);
         const requestedAgentId = labelAgentIdParam
           ? normalizeAgentId(labelAgentIdParam)
           : undefined;

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -84,11 +84,15 @@ export function createSessionsSendTool(opts?: {
       const message = readStringParam(params, "message", { required: true });
       const { cfg, mainKey, alias, effectiveRequesterKey, restrictToSpawned } =
         resolveSessionToolContext(opts);
+      const requesterAgentId = opts?.agentSessionKey
+        ? resolveAgentIdFromSessionKey(opts.agentSessionKey)
+        : undefined;
 
       const a2aPolicy = createAgentToAgentPolicy(cfg);
       const sessionVisibility = resolveEffectiveSessionToolsVisibility({
         cfg,
         sandboxed: opts?.sandboxed === true,
+        agentId: requesterAgentId,
       });
 
       const sessionKeyParam = readStringParam(params, "sessionKey");


### PR DESCRIPTION
## Summary

- Problem: `agents.defaults.sandbox.sessionToolsVisibility` is global — all sandboxed agents share the same visibility clamp with no per-agent override
- Why it matters: Operators running multiple agents (e.g. a local assistant + a K8s orchestrator) cannot grant one agent broader session visibility without exposing all sandboxed agents to the same setting
- What changed: `resolveSandboxSessionToolsVisibility` now accepts an optional `agentId` and checks `agents.list[<id>].sandbox.sessionToolsVisibility` before falling back to `agents.defaults.sandbox.sessionToolsVisibility`. Callers (`sessions_list`, `sessions_history`, `sessions_send`) derive the requester agent id from the session key and pass it through
- What did NOT change: Default behavior is identical — existing configs require zero changes

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration

## User-visible / Behavior Changes

New optional config field per agent list entry:
json
{
  "agents": {
    "list": [
      { "id": "tony", "sandbox": { "sessionToolsVisibility": "all" } }
],
    "defaults": {
      "sandbox": { "sessionToolsVisibility": "spawned" }
    }
  }
}
No behavior change for agents without the field.

## Security Impact (required)

- New permissions/capabilities? Yes — per-agent override allows specific agents broader session visibility
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? Yes — opt-in only, explicit per named agent
- Risk + mitigation: Global default remains `"spawned"`. Operators must explicitly set the override. No change to agents without it.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No — new optional field only
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert: remove `sandbox.sessionToolsVisibility` from agent list entry
- Known bad symptoms: unexpected cross-session visibility → check agent list config

## Evidence
- [x] New unit tests in `sessions-access.test.ts` covering per-agent override, fallback to defaults, and edge cases

## Human Verification (required)

- Verified: per-agent override correct, falls back gracefully when agent not in list, both `"spawned"` and `"all"` values tested
- Not verified: full integration test with live gateway (node blocked in sandbox)

## Risks and Mitigations

- Risk: operator accidentally grants broad visibility to wrong agent
  - Mitigation: explicit opt-in per named agent, global default unchanged