### PR TITLE
fix(security): avoid prototype-chain account path checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Security/audit account handling: avoid prototype-chain account IDs in audit validation by using own-property checks for `accounts`. (#34982) Thanks @HOYALIM.
 - Agents/session usage tracking: preserve accumulated usage metadata on embedded Pi runner error exits so failed turns still update session `totalTokens` from real usage instead of stale prior values. (#34275) thanks @RealKai42.
 - Nodes/system.run approval hardening: use explicit argv-mutation signaling when regenerating prepared `rawCommand`, and cover the `system.run.prepare -> system.run` handoff so direct PATH-based `nodes.run` commands no longer fail with `rawCommand does not match command`. (#33137) thanks @Sid-Qin.
 - Models/custom provider headers: propagate `models.providers.<name>.headers` across inline, fallback, and registry-found model resolution so header-authenticated proxies consistently receive configured request headers. (#27490) thanks @Sid-Qin.

--- a/src/i18n/registry.test.ts
+++ b/src/i18n/registry.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 import {
   DEFAULT_LOCALE,
   SUPPORTED_LOCALES,
   loadLazyLocaleTranslation,
   resolveNavigatorLocale,
 } from "../../ui/src/i18n/lib/registry.ts";
+import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 
 function getNestedTranslation(map: TranslationMap | null, ...path: string[]): string | undefined {
   let value: string | TranslationMap | undefined = map ?? undefined;

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -108,7 +108,7 @@ function hasExplicitProviderAccountConfig(
   if (!accounts || typeof accounts !== "object") {
     return false;
   }
-  return accountId in accounts;
+  return Object.hasOwn(accounts, accountId);
 }
 
 export async function collectChannelSecurityFindings(params: {

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1998,6 +1998,51 @@ description: test skill
     });
   });
 
+  it("does not treat prototype properties as explicit Discord account config paths", async () => {
+    await withChannelSecurityStateDir(async () => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          discord: {
+            enabled: true,
+            token: "t",
+            dangerouslyAllowNameMatching: true,
+            allowFrom: ["Alice#1234"],
+            accounts: {},
+          },
+        },
+      };
+
+      const pluginWithProtoDefaultAccount: ChannelPlugin = {
+        ...discordPlugin,
+        config: {
+          ...discordPlugin.config,
+          listAccountIds: () => [],
+          defaultAccountId: () => "toString",
+        },
+      };
+
+      const res = await runSecurityAudit({
+        config: cfg,
+        includeFilesystem: false,
+        includeChannelSecurity: true,
+        plugins: [pluginWithProtoDefaultAccount],
+      });
+
+      const dangerousMatchingFinding = res.findings.find(
+        (entry) => entry.checkId === "channels.discord.allowFrom.dangerous_name_matching_enabled",
+      );
+      expect(dangerousMatchingFinding).toBeDefined();
+      expect(dangerousMatchingFinding?.title).not.toContain("(account: toString)");
+
+      const nameBasedFinding = res.findings.find(
+        (entry) => entry.checkId === "channels.discord.allowFrom.name_based_entries",
+      );
+      expect(nameBasedFinding).toBeDefined();
+      expect(nameBasedFinding?.detail).toContain("channels.discord.allowFrom:Alice#1234");
+      expect(nameBasedFinding?.detail).not.toContain("channels.discord.accounts.toString");
+    });
+  });
+
   it("audits name-based allowlists on non-default Discord accounts", async () => {
     await withChannelSecurityStateDir(async () => {
       const cfg: OpenClawConfig = {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `hasExplicitProviderAccountConfig` used `accountId in accounts`, which walks the prototype chain.
- Why it matters: inherited keys (e.g. `toString`) could be treated as explicit account config paths and skew security audit labeling.
- What changed: switched to `Object.hasOwn(accounts, accountId)` and added regression coverage for prototype-key account IDs.
- What did NOT change (scope boundary): no auth logic or runtime channel behavior changed; this is audit-path correctness hardening.

AI-assisted: Yes (Codex)
Testing level: Fully tested (project-level + targeted tests)

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34926
- Related #0

## User-visible / Behavior Changes

Security audit findings no longer treat inherited object properties as explicit account paths.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Security audit path (channel account detection)
- Relevant config (redacted): `channels.discord.accounts = {}` with synthetic default account id `"toString"`

### Steps

1. Use a plugin/account resolution path with default account id `"toString"`.
2. Run security audit finding collection.
3. Verify inherited prototype properties are not treated as explicit account config.

### Expected

- Only own keys in `accounts` count as explicit account paths.

### Actual

- Before fix, prototype keys could be misclassified as explicit account path hits.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added regression test:
- `src/security/audit.test.ts`
  - verifies `toString` is not treated as explicit `channels.discord.accounts.toString` path

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run --config vitest.config.ts src/security/audit.test.ts`
  - full project gate: `pnpm build && pnpm check && pnpm test`
- Edge cases checked:
  - inherited property name as account id
  - non-default account labeling behavior retained
- What you did **not** verify:
  - additional non-Discord plugin-specific account label formatting in live runtime

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/security/audit-channel.ts` and related test.
- Known bad symptoms reviewers should watch for: incorrect `(account: ...)` notes from inherited key names.

## Risks and Mitigations

- Risk: None significant; behavior narrows to own-property checks only.
  - Mitigation: explicit regression test added for prototype-key scenario.
