### PR TITLE
fix(telegram): avoid duplicate final sends on unmodified preview edits

### DIFF
--- a/src/telegram/lane-delivery.test.ts
+++ b/src/telegram/lane-delivery.test.ts
@@ -146,6 +146,30 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.log).toHaveBeenCalledWith(expect.stringContaining("treating as delivered"));
   });
 
+  it("treats 'message is not modified' preview edit errors as delivered", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    harness.editPreview.mockRejectedValue(
+      new Error(
+        "400: Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message",
+      ),
+    );
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Hello final",
+      payload: { text: "Hello final" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("preview-finalized");
+    expect(harness.editPreview).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+    expect(harness.markDelivered).toHaveBeenCalledTimes(1);
+    expect(harness.log).toHaveBeenCalledWith(
+      expect.stringContaining('edit returned "message is not modified"; treating as delivered'),
+    );
+  });
+
   it("falls back to normal delivery when editing an existing preview fails", async () => {
     const harness = createHarness({ answerMessageId: 999 });
     harness.editPreview.mockRejectedValue(new Error("500: preview edit failed"));

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -2,6 +2,23 @@ import type { ReplyPayload } from "../auto-reply/types.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import type { TelegramDraftStream } from "./draft-stream.js";
 
+const MESSAGE_NOT_MODIFIED_RE =
+  /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
+
+function isMessageNotModifiedError(err: unknown): boolean {
+  const text =
+    typeof err === "string"
+      ? err
+      : err instanceof Error
+        ? err.message
+        : typeof err === "object" && err && "description" in err
+          ? typeof err.description === "string"
+            ? err.description
+            : ""
+          : "";
+  return MESSAGE_NOT_MODIFIED_RE.test(text);
+}
+
 export type LaneName = "answer" | "reasoning";
 
 export type DraftLaneState = {
@@ -216,6 +233,13 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       params.markDelivered();
       return true;
     } catch (err) {
+      if (isMessageNotModifiedError(err)) {
+        params.log(
+          `telegram: ${args.laneName} preview ${args.context} edit returned "message is not modified"; treating as delivered`,
+        );
+        params.markDelivered();
+        return true;
+      }
       if (args.treatEditFailureAsDelivered) {
         params.log(
           `telegram: ${args.laneName} preview ${args.context} edit failed after stop-created flush; treating as delivered (${String(err)})`,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram partial streaming could send duplicate final messages when preview finalize hit `message is not modified` during edit.
- Why it matters: users in `channels.telegram.streaming = "partial"` may receive duplicate replies in v3.2 regression cases.
- What changed: treat Telegram `message is not modified` edit failures as already-delivered preview-finalization, preventing redundant fallback send.
- What did NOT change (scope boundary): no changes to Telegram routing, session-key logic, or block/progress mode defaults.

AI-assisted: Yes (Codex)
Testing level: Fully tested (project-level + targeted tests)

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34790
- Related #34804

## User-visible / Behavior Changes

In Telegram `partial` mode, finalization no longer emits duplicate fallback messages when Telegram returns `message is not modified` on preview edit.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): `channels.telegram.streaming = "partial"`

### Steps

1. Stream a Telegram preview message in partial mode.
2. Finalize with text identical to current preview so edit returns `400 Bad Request: message is not modified`.
3. Ensure finalization is treated as delivered without fallback duplicate send.

### Expected

- No duplicate final message in chat.

### Actual

- Before fix, edit failure could fall through to normal send and duplicate content.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added test:
- `src/telegram/lane-delivery.test.ts`
  - covers `message is not modified` error path and asserts no fallback send

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run --config vitest.config.ts src/telegram/lane-delivery.test.ts src/telegram/bot-message-dispatch.test.ts`
  - full project gate: `pnpm build && pnpm check && pnpm test`
- Edge cases checked:
  - normal preview-edit failure still falls back
  - stop-created preview finalize behavior unchanged
- What you did **not** verify:
  - live Telegram bot session against production API

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/telegram/lane-delivery.ts` and related test.
- Known bad symptoms reviewers should watch for: reappearance of duplicate finals in Telegram partial mode.

## Risks and Mitigations

- Risk: Error-message matching can miss novel Telegram variants.
  - Mitigation: regex handles both canonical text and `MESSAGE_NOT_MODIFIED` marker; fallback behavior remains for unrelated errors.
