### PR TITLE
Discord: harden v10 api-types imports for CLI startup

### DIFF
--- a/src/agents/tools/discord-actions-moderation-shared.ts
+++ b/src/agents/tools/discord-actions-moderation-shared.ts
@@ -1,4 +1,4 @@
-import { PermissionFlagsBits } from "discord-api-types/v10";
+import { PermissionFlagsBits } from "../../discord/api-types-runtime.js";
 import { readNumberParam, readStringParam } from "./common.js";
 
 export type DiscordModerationAction = "timeout" | "kick" | "ban";

--- a/src/discord/api-types-runtime.ts
+++ b/src/discord/api-types-runtime.ts
@@ -8,6 +8,7 @@ export const ApplicationCommandOptionType = discordApiV10.ApplicationCommandOpti
 export const ButtonStyle = discordApiV10.ButtonStyle;
 export const ChannelType = discordApiV10.ChannelType;
 export const MessageFlags = discordApiV10.MessageFlags;
+export const PollLayoutType = discordApiV10.PollLayoutType;
 export const PermissionFlagsBits = discordApiV10.PermissionFlagsBits;
 export const Routes = discordApiV10.Routes;
 export const StickerFormatType = discordApiV10.StickerFormatType;

--- a/src/discord/api-types-runtime.ts
+++ b/src/discord/api-types-runtime.ts
@@ -7,6 +7,7 @@ const discordApiV10 = require("discord-api-types/v10") as DiscordApiV10;
 export const ApplicationCommandOptionType = discordApiV10.ApplicationCommandOptionType;
 export const ButtonStyle = discordApiV10.ButtonStyle;
 export const ChannelType = discordApiV10.ChannelType;
+export const ComponentType = discordApiV10.ComponentType;
 export const MessageFlags = discordApiV10.MessageFlags;
 export const PollLayoutType = discordApiV10.PollLayoutType;
 export const PermissionFlagsBits = discordApiV10.PermissionFlagsBits;

--- a/src/discord/api-types-runtime.ts
+++ b/src/discord/api-types-runtime.ts
@@ -13,6 +13,7 @@ export const PermissionFlagsBits = discordApiV10.PermissionFlagsBits;
 export const Routes = discordApiV10.Routes;
 export const StickerFormatType = discordApiV10.StickerFormatType;
 export const TextInputStyle = discordApiV10.TextInputStyle;
+export type DiscordButtonStyle = (typeof ButtonStyle)[keyof typeof ButtonStyle];
 
 // Type-only re-export so existing imports can keep using a single module path.
 export type * from "discord-api-types/v10";

--- a/src/discord/api-types-runtime.ts
+++ b/src/discord/api-types-runtime.ts
@@ -1,0 +1,17 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+type DiscordApiV10 = typeof import("discord-api-types/v10");
+const discordApiV10 = require("discord-api-types/v10") as DiscordApiV10;
+
+export const ApplicationCommandOptionType = discordApiV10.ApplicationCommandOptionType;
+export const ButtonStyle = discordApiV10.ButtonStyle;
+export const ChannelType = discordApiV10.ChannelType;
+export const MessageFlags = discordApiV10.MessageFlags;
+export const PermissionFlagsBits = discordApiV10.PermissionFlagsBits;
+export const Routes = discordApiV10.Routes;
+export const StickerFormatType = discordApiV10.StickerFormatType;
+export const TextInputStyle = discordApiV10.TextInputStyle;
+
+// Type-only re-export so existing imports can keep using a single module path.
+export type * from "discord-api-types/v10";

--- a/src/discord/components.test.ts
+++ b/src/discord/components.test.ts
@@ -1,5 +1,5 @@
-import { MessageFlags } from "discord-api-types/v10";
 import { describe, expect, it, beforeEach } from "vitest";
+import { MessageFlags } from "./api-types-runtime.js";
 import {
   clearDiscordComponentEntries,
   registerDiscordComponentEntries,

--- a/src/discord/components.ts
+++ b/src/discord/components.ts
@@ -24,7 +24,12 @@ import {
   type ComponentParserResult,
   type TopLevelComponents,
 } from "@buape/carbon";
-import { ButtonStyle, MessageFlags, TextInputStyle } from "./api-types-runtime.js";
+import {
+  ButtonStyle,
+  MessageFlags,
+  TextInputStyle,
+  type DiscordButtonStyle,
+} from "./api-types-runtime.js";
 
 export const DISCORD_COMPONENT_CUSTOM_ID_KEY = "occomp";
 export const DISCORD_MODAL_CUSTOM_ID_KEY = "ocmodal";
@@ -292,8 +297,6 @@ export function resolveDiscordComponentAttachmentName(value: string): string {
   }
   return attachmentName;
 }
-
-type DiscordButtonStyle = (typeof ButtonStyle)[keyof typeof ButtonStyle];
 
 function mapButtonStyle(style?: DiscordComponentButtonStyle): DiscordButtonStyle {
   switch ((style ?? "primary").toLowerCase()) {

--- a/src/discord/components.ts
+++ b/src/discord/components.ts
@@ -24,7 +24,7 @@ import {
   type ComponentParserResult,
   type TopLevelComponents,
 } from "@buape/carbon";
-import { ButtonStyle, MessageFlags, TextInputStyle } from "discord-api-types/v10";
+import { ButtonStyle, MessageFlags, TextInputStyle } from "./api-types-runtime.js";
 
 export const DISCORD_COMPONENT_CUSTOM_ID_KEY = "occomp";
 export const DISCORD_MODAL_CUSTOM_ID_KEY = "ocmodal";
@@ -293,7 +293,9 @@ export function resolveDiscordComponentAttachmentName(value: string): string {
   return attachmentName;
 }
 
-function mapButtonStyle(style?: DiscordComponentButtonStyle): ButtonStyle {
+type DiscordButtonStyle = (typeof ButtonStyle)[keyof typeof ButtonStyle];
+
+function mapButtonStyle(style?: DiscordComponentButtonStyle): DiscordButtonStyle {
   switch ((style ?? "primary").toLowerCase()) {
     case "secondary":
       return ButtonStyle.Secondary;

--- a/src/discord/draft-stream.ts
+++ b/src/discord/draft-stream.ts
@@ -1,6 +1,6 @@
 import type { RequestClient } from "@buape/carbon";
-import { Routes } from "discord-api-types/v10";
 import { createFinalizableDraftLifecycle } from "../channels/draft-stream-controls.js";
+import { Routes } from "./api-types-runtime.js";
 
 /** Discord messages cap at 2000 characters. */
 const DISCORD_STREAM_MAX_CHARS = 2000;

--- a/src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.e2e.test.ts
+++ b/src/discord/monitor.tool-result.accepts-guild-messages-mentionpatterns-match.e2e.test.ts
@@ -1,8 +1,8 @@
 import type { Client } from "@buape/carbon";
 import { ChannelType, MessageType } from "@buape/carbon";
-import { Routes } from "discord-api-types/v10";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createReplyDispatcherWithTyping } from "../auto-reply/reply/reply-dispatcher.js";
+import { Routes } from "./api-types-runtime.js";
 import {
   dispatchMock,
   readAllowFromStoreMock,

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -15,8 +15,6 @@ import {
   type StringSelectMenuInteraction,
   type UserSelectMenuInteraction,
 } from "@buape/carbon";
-import type { APIStringSelectComponent } from "discord-api-types/v10";
-import { ButtonStyle, ChannelType } from "discord-api-types/v10";
 import { resolveHumanDelayConfig } from "../../agents/identity.js";
 import { resolveChunkMode, resolveTextChunkLimit } from "../../auto-reply/chunk.js";
 import { formatInboundEnvelope, resolveEnvelopeFormatOptions } from "../../auto-reply/envelope.js";
@@ -43,6 +41,8 @@ import {
   readStoreAllowFromForDmPolicy,
   resolvePinnedMainDmOwnerFromAllowlist,
 } from "../../security/dm-policy-shared.js";
+import type { APIStringSelectComponent } from "../api-types-runtime.js";
+import { ButtonStyle, ChannelType } from "../api-types-runtime.js";
 import { resolveDiscordComponentEntry, resolveDiscordModalEntry } from "../components-registry.js";
 import {
   createDiscordFormModal,

--- a/src/discord/monitor/exec-approvals.test.ts
+++ b/src/discord/monitor/exec-approvals.test.ts
@@ -2,10 +2,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { ButtonInteraction, ComponentData } from "@buape/carbon";
-import { Routes } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { clearSessionStoreCacheForTest } from "../../config/sessions.js";
 import type { DiscordExecApprovalConfig } from "../../config/types.discord.js";
+import { Routes } from "../api-types-runtime.js";
 import {
   buildExecApprovalCustomId,
   extractDiscordChannelId,

--- a/src/discord/monitor/exec-approvals.ts
+++ b/src/discord/monitor/exec-approvals.ts
@@ -9,7 +9,6 @@ import {
   type MessagePayloadObject,
   type TopLevelComponents,
 } from "@buape/carbon";
-import { ButtonStyle, Routes } from "discord-api-types/v10";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
 import type { DiscordExecApprovalConfig } from "../../config/types.discord.js";
@@ -30,11 +29,13 @@ import {
   GATEWAY_CLIENT_NAMES,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import { ButtonStyle, Routes } from "../api-types-runtime.js";
 import { createDiscordClient, stripUndefinedFields } from "../send.shared.js";
 import { DiscordUiContainer } from "../ui.js";
 
 const EXEC_APPROVAL_KEY = "execapproval";
 export type { ExecApprovalRequest, ExecApprovalResolved };
+type DiscordButtonStyle = (typeof ButtonStyle)[keyof typeof ButtonStyle];
 
 /** Extract Discord channel ID from a session key like "agent:main:discord:channel:123456789" */
 export function extractDiscordChannelId(sessionKey?: string | null): string | null {
@@ -140,13 +141,13 @@ class ExecApprovalContainer extends DiscordUiContainer {
 class ExecApprovalActionButton extends Button {
   customId: string;
   label: string;
-  style: ButtonStyle;
+  style: DiscordButtonStyle;
 
   constructor(params: {
     approvalId: string;
     action: ExecApprovalDecision;
     label: string;
-    style: ButtonStyle;
+    style: DiscordButtonStyle;
   }) {
     super();
     this.customId = buildExecApprovalCustomId(params.approvalId, params.action);

--- a/src/discord/monitor/exec-approvals.ts
+++ b/src/discord/monitor/exec-approvals.ts
@@ -29,13 +29,12 @@ import {
   GATEWAY_CLIENT_NAMES,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
-import { ButtonStyle, Routes } from "../api-types-runtime.js";
+import { ButtonStyle, Routes, type DiscordButtonStyle } from "../api-types-runtime.js";
 import { createDiscordClient, stripUndefinedFields } from "../send.shared.js";
 import { DiscordUiContainer } from "../ui.js";
 
 const EXEC_APPROVAL_KEY = "execapproval";
 export type { ExecApprovalRequest, ExecApprovalResolved };
-type DiscordButtonStyle = (typeof ButtonStyle)[keyof typeof ButtonStyle];
 
 /** Extract Discord channel ID from a session key like "agent:main:discord:channel:123456789" */
 export function extractDiscordChannelId(sessionKey?: string | null): string | null {

--- a/src/discord/monitor/gateway-plugin.ts
+++ b/src/discord/monitor/gateway-plugin.ts
@@ -1,11 +1,11 @@
 import { GatewayIntents, GatewayPlugin } from "@buape/carbon/gateway";
-import type { APIGatewayBotInfo } from "discord-api-types/v10";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { ProxyAgent, fetch as undiciFetch } from "undici";
 import WebSocket from "ws";
 import type { DiscordAccountConfig } from "../../config/types.js";
 import { danger } from "../../globals.js";
 import type { RuntimeEnv } from "../../runtime.js";
+import type { APIGatewayBotInfo } from "../api-types-runtime.js";
 
 export function resolveDiscordGatewayIntents(
   intentsConfig?: import("../../config/types.discord.js").DiscordIntentsConfig,

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -724,7 +724,7 @@ export class DiscordPresenceListener extends PresenceUpdateListener {
       setPresence(
         this.accountId,
         userId,
-        data as import("discord-api-types/v10").GatewayPresenceUpdate,
+        data as import("../api-types-runtime.js").GatewayPresenceUpdate,
       );
     } catch (err) {
       const logger = this.logger ?? discordEventQueueLog;

--- a/src/discord/monitor/message-utils.test.ts
+++ b/src/discord/monitor/message-utils.test.ts
@@ -1,6 +1,6 @@
 import { ChannelType, type Client, type Message } from "@buape/carbon";
-import { StickerFormatType } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { StickerFormatType } from "../api-types-runtime.js";
 
 const fetchRemoteMedia = vi.fn();
 const saveMediaBuffer = vi.fn();

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -1,10 +1,14 @@
 import type { ChannelType, Client, Message } from "@buape/carbon";
-import { StickerFormatType, type APIAttachment, type APIStickerItem } from "discord-api-types/v10";
 import { buildMediaPayload } from "../../channels/plugins/media-payload.js";
 import { logVerbose } from "../../globals.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { fetchRemoteMedia, type FetchLike } from "../../media/fetch.js";
 import { saveMediaBuffer } from "../../media/store.js";
+import {
+  StickerFormatType,
+  type APIAttachment,
+  type APIStickerItem,
+} from "../api-types-runtime.js";
 
 const DISCORD_CDN_HOSTNAMES = [
   "cdn.discordapp.com",

--- a/src/discord/monitor/model-picker.test.ts
+++ b/src/discord/monitor/model-picker.test.ts
@@ -1,8 +1,8 @@
 import { serializePayload } from "@buape/carbon";
-import { ComponentType } from "discord-api-types/v10";
 import { describe, expect, it, vi } from "vitest";
 import * as modelsCommandModule from "../../auto-reply/reply/commands-models.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { ComponentType } from "../api-types-runtime.js";
 import {
   DISCORD_CUSTOM_ID_MAX_CHARS,
   DISCORD_MODEL_PICKER_MODEL_PAGE_SIZE,

--- a/src/discord/monitor/model-picker.ts
+++ b/src/discord/monitor/model-picker.ts
@@ -9,14 +9,14 @@ import {
   type MessagePayloadObject,
   type TopLevelComponents,
 } from "@buape/carbon";
-import type { APISelectMenuOption } from "discord-api-types/v10";
-import { ButtonStyle } from "discord-api-types/v10";
 import { normalizeProviderId } from "../../agents/model-selection.js";
 import {
   buildModelsProviderData,
   type ModelsProviderData,
 } from "../../auto-reply/reply/commands-models.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { APISelectMenuOption } from "../api-types-runtime.js";
+import { ButtonStyle } from "../api-types-runtime.js";
 
 export const DISCORD_MODEL_PICKER_CUSTOM_ID_KEY = "mdlpk";
 export const DISCORD_CUSTOM_ID_MAX_CHARS = 100;
@@ -35,6 +35,7 @@ export const DISCORD_MODEL_PICKER_PROVIDER_SINGLE_PAGE_MAX =
 export const DISCORD_MODEL_PICKER_MODEL_PAGE_SIZE = DISCORD_COMPONENT_MAX_SELECT_OPTIONS;
 
 const DISCORD_PROVIDER_BUTTON_LABEL_MAX_CHARS = 18;
+type DiscordButtonStyle = (typeof ButtonStyle)[keyof typeof ButtonStyle];
 
 const COMMAND_CONTEXTS = ["model", "models"] as const;
 const PICKER_ACTIONS = [
@@ -90,7 +91,7 @@ export type DiscordModelPickerLayout = "v2" | "classic";
 type DiscordModelPickerButtonOptions = {
   label: string;
   customId: string;
-  style?: ButtonStyle;
+  style?: DiscordButtonStyle;
   disabled?: boolean;
 };
 

--- a/src/discord/monitor/model-picker.ts
+++ b/src/discord/monitor/model-picker.ts
@@ -15,8 +15,11 @@ import {
   type ModelsProviderData,
 } from "../../auto-reply/reply/commands-models.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import type { APISelectMenuOption } from "../api-types-runtime.js";
-import { ButtonStyle } from "../api-types-runtime.js";
+import {
+  ButtonStyle,
+  type APISelectMenuOption,
+  type DiscordButtonStyle,
+} from "../api-types-runtime.js";
 
 export const DISCORD_MODEL_PICKER_CUSTOM_ID_KEY = "mdlpk";
 export const DISCORD_CUSTOM_ID_MAX_CHARS = 100;
@@ -35,7 +38,6 @@ export const DISCORD_MODEL_PICKER_PROVIDER_SINGLE_PAGE_MAX =
 export const DISCORD_MODEL_PICKER_MODEL_PAGE_SIZE = DISCORD_COMPONENT_MAX_SELECT_OPTIONS;
 
 const DISCORD_PROVIDER_BUTTON_LABEL_MAX_CHARS = 18;
-type DiscordButtonStyle = (typeof ButtonStyle)[keyof typeof ButtonStyle];
 
 const COMMAND_CONTEXTS = ["model", "models"] as const;
 const PICKER_ACTIONS = [

--- a/src/discord/monitor/monitor.test.ts
+++ b/src/discord/monitor/monitor.test.ts
@@ -5,11 +5,11 @@ import type {
   StringSelectMenuInteraction,
 } from "@buape/carbon";
 import type { Client } from "@buape/carbon";
-import type { GatewayPresenceUpdate } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { DiscordAccountConfig } from "../../config/types.discord.js";
 import { buildAgentSessionKey } from "../../routing/resolve-route.js";
+import type { GatewayPresenceUpdate } from "../api-types-runtime.js";
 import {
   clearDiscordComponentEntries,
   registerDiscordComponentEntries,

--- a/src/discord/monitor/native-command.model-picker.test.ts
+++ b/src/discord/monitor/native-command.model-picker.test.ts
@@ -1,4 +1,3 @@
-import { ChannelType } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as commandRegistryModule from "../../auto-reply/commands-registry.js";
 import type {
@@ -10,6 +9,7 @@ import * as dispatcherModule from "../../auto-reply/reply/provider-dispatcher.js
 import type { OpenClawConfig } from "../../config/config.js";
 import * as globalsModule from "../../globals.js";
 import * as timeoutModule from "../../utils/with-timeout.js";
+import { ChannelType } from "../api-types-runtime.js";
 import * as modelPickerPreferencesModule from "./model-picker-preferences.js";
 import * as modelPickerModule from "./model-picker.js";
 import { createModelsProviderData as createBaseModelsProviderData } from "./model-picker.test-utils.js";

--- a/src/discord/monitor/native-command.plugin-dispatch.test.ts
+++ b/src/discord/monitor/native-command.plugin-dispatch.test.ts
@@ -1,9 +1,9 @@
-import { ChannelType } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { NativeCommandSpec } from "../../auto-reply/commands-registry.js";
 import * as dispatcherModule from "../../auto-reply/reply/provider-dispatcher.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import * as pluginCommandsModule from "../../plugins/commands.js";
+import { ChannelType } from "../api-types-runtime.js";
 import { createDiscordNativeCommand } from "./native-command.js";
 import { createNoopThreadBindingManager } from "./thread-bindings.js";
 

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -13,7 +13,6 @@ import {
   type ComponentData,
   type StringSelectMenuInteraction,
 } from "@buape/carbon";
-import { ApplicationCommandOptionType, ButtonStyle } from "discord-api-types/v10";
 import { resolveHumanDelayConfig } from "../../agents/identity.js";
 import { resolveChunkMode, resolveTextChunkLimit } from "../../auto-reply/chunk.js";
 import type {
@@ -53,6 +52,7 @@ import { buildUntrustedChannelMetadata } from "../../security/channel-metadata.j
 import { chunkItems } from "../../utils/chunk-items.js";
 import { withTimeout } from "../../utils/with-timeout.js";
 import { loadWebMedia } from "../../web/media.js";
+import { ApplicationCommandOptionType, ButtonStyle } from "../api-types-runtime.js";
 import { chunkDiscordTextWithMode } from "../chunk.js";
 import {
   isDiscordGroupAllowedByPolicy,

--- a/src/discord/monitor/presence-cache.ts
+++ b/src/discord/monitor/presence-cache.ts
@@ -1,4 +1,4 @@
-import type { GatewayPresenceUpdate } from "discord-api-types/v10";
+import type { GatewayPresenceUpdate } from "../api-types-runtime.js";
 
 /**
  * In-memory cache of Discord user presence data.

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -9,7 +9,6 @@ import {
 } from "@buape/carbon";
 import { GatewayCloseCodes, type GatewayPlugin } from "@buape/carbon/gateway";
 import { VoicePlugin } from "@buape/carbon/voice";
-import { Routes } from "discord-api-types/v10";
 import { getAcpSessionManager } from "../../acp/control-plane/manager.js";
 import { isAcpRuntimeError } from "../../acp/runtime/errors.js";
 import { resolveTextChunkLimit } from "../../auto-reply/chunk.js";
@@ -43,6 +42,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getPluginCommandSpecs } from "../../plugins/commands.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../../runtime.js";
 import { resolveDiscordAccount } from "../accounts.js";
+import { Routes } from "../api-types-runtime.js";
 import { fetchDiscordApplicationId } from "../probe.js";
 import { normalizeDiscordToken } from "../token.js";
 import { createDiscordVoiceCommand } from "../voice/command.js";

--- a/src/discord/monitor/thread-bindings.discord-api.test.ts
+++ b/src/discord/monitor/thread-bindings.discord-api.test.ts
@@ -1,5 +1,5 @@
-import { ChannelType } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChannelType } from "../api-types-runtime.js";
 
 const hoisted = vi.hoisted(() => {
   const restGet = vi.fn();

--- a/src/discord/monitor/thread-bindings.discord-api.ts
+++ b/src/discord/monitor/thread-bindings.discord-api.ts
@@ -1,5 +1,5 @@
-import { ChannelType, Routes } from "discord-api-types/v10";
 import { logVerbose } from "../../globals.js";
+import { ChannelType, Routes } from "../api-types-runtime.js";
 import { createDiscordRestClient } from "../client.js";
 import { sendMessageDiscord, sendWebhookMessageDiscord } from "../send.js";
 import { createThreadDiscord } from "../send.messages.js";

--- a/src/discord/monitor/thread-bindings.manager.ts
+++ b/src/discord/monitor/thread-bindings.manager.ts
@@ -1,4 +1,3 @@
-import { Routes } from "discord-api-types/v10";
 import { logVerbose } from "../../globals.js";
 import {
   registerSessionBindingAdapter,
@@ -7,6 +6,7 @@ import {
   type SessionBindingRecord,
 } from "../../infra/outbound/session-binding-service.js";
 import { normalizeAccountId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { Routes } from "../api-types-runtime.js";
 import { createDiscordRestClient } from "../client.js";
 import {
   createThreadForBinding,

--- a/src/discord/monitor/threading.ts
+++ b/src/discord/monitor/threading.ts
@@ -1,10 +1,10 @@
 import { ChannelType, type Client } from "@buape/carbon";
-import { Routes } from "discord-api-types/v10";
 import { createReplyReferencePlanner } from "../../auto-reply/reply/reply-reference.js";
 import type { ReplyToMode } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
 import { buildAgentSessionKey } from "../../routing/resolve-route.js";
 import { truncateUtf16Safe } from "../../utils.js";
+import { Routes } from "../api-types-runtime.js";
 import type { DiscordChannelConfigResolved } from "./allow-list.js";
 import type { DiscordMessageEvent } from "./listeners.js";
 import {

--- a/src/discord/send.channels.ts
+++ b/src/discord/send.channels.ts
@@ -1,5 +1,5 @@
-import type { APIChannel } from "discord-api-types/v10";
-import { Routes } from "discord-api-types/v10";
+import type { APIChannel } from "./api-types-runtime.js";
+import { Routes } from "./api-types-runtime.js";
 import { resolveDiscordRest } from "./send.shared.js";
 import type {
   DiscordChannelCreate,

--- a/src/discord/send.components.test.ts
+++ b/src/discord/send.components.test.ts
@@ -1,5 +1,5 @@
-import { ChannelType } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChannelType } from "./api-types-runtime.js";
 import { registerDiscordComponentEntries } from "./components-registry.js";
 import { sendDiscordComponentMessage } from "./send.components.js";
 import { makeDiscordRest } from "./send.test-harness.js";

--- a/src/discord/send.components.ts
+++ b/src/discord/send.components.ts
@@ -4,11 +4,11 @@ import {
   type MessagePayloadObject,
   type RequestClient,
 } from "@buape/carbon";
-import { ChannelType, Routes } from "discord-api-types/v10";
 import { loadConfig, type OpenClawConfig } from "../config/config.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
 import { loadWebMedia } from "../web/media.js";
 import { resolveDiscordAccount } from "./accounts.js";
+import { ChannelType, Routes } from "./api-types-runtime.js";
 import { registerDiscordComponentEntries } from "./components-registry.js";
 import {
   buildDiscordComponentMessage,

--- a/src/discord/send.creates-thread.test.ts
+++ b/src/discord/send.creates-thread.test.ts
@@ -1,6 +1,6 @@
 import { RateLimitError } from "@buape/carbon";
-import { ChannelType, Routes } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChannelType, Routes } from "./api-types-runtime.js";
 import {
   addRoleDiscord,
   banMemberDiscord,

--- a/src/discord/send.emojis-stickers.ts
+++ b/src/discord/send.emojis-stickers.ts
@@ -1,5 +1,5 @@
-import { Routes } from "discord-api-types/v10";
 import { loadWebMediaRaw } from "../web/media.js";
+import { Routes } from "./api-types-runtime.js";
 import { normalizeEmojiName, resolveDiscordRest } from "./send.shared.js";
 import type { DiscordEmojiUpload, DiscordReactOpts, DiscordStickerUpload } from "./send.types.js";
 import { DISCORD_MAX_EMOJI_BYTES, DISCORD_MAX_STICKER_BYTES } from "./send.types.js";

--- a/src/discord/send.guild.ts
+++ b/src/discord/send.guild.ts
@@ -5,8 +5,8 @@ import type {
   APIRole,
   APIVoiceState,
   RESTPostAPIGuildScheduledEventJSONBody,
-} from "discord-api-types/v10";
-import { Routes } from "discord-api-types/v10";
+} from "./api-types-runtime.js";
+import { Routes } from "./api-types-runtime.js";
 import { resolveDiscordRest } from "./send.shared.js";
 import type {
   DiscordModerationTarget,

--- a/src/discord/send.messages.ts
+++ b/src/discord/send.messages.ts
@@ -1,5 +1,5 @@
-import type { APIChannel, APIMessage } from "discord-api-types/v10";
-import { ChannelType, Routes } from "discord-api-types/v10";
+import type { APIChannel, APIMessage } from "./api-types-runtime.js";
+import { ChannelType, Routes } from "./api-types-runtime.js";
 import { resolveDiscordRest } from "./send.shared.js";
 import type {
   DiscordMessageEdit,
@@ -108,7 +108,7 @@ export async function createThreadDiscord(
   if (!payload.messageId && payload.type !== undefined) {
     body.type = payload.type;
   }
-  let channelType: ChannelType | undefined;
+  let channelType: APIChannel["type"] | undefined;
   if (!payload.messageId) {
     // Only detect channel kind for route-less thread creation.
     // If this lookup fails, keep prior behavior and let Discord validate.

--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -2,7 +2,6 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { serializePayload, type MessagePayloadObject, type RequestClient } from "@buape/carbon";
-import { ChannelType, Routes } from "discord-api-types/v10";
 import { resolveChunkMode } from "../auto-reply/chunk.js";
 import { loadConfig, type OpenClawConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
@@ -16,6 +15,7 @@ import { unlinkIfExists } from "../media/temp-files.js";
 import type { PollInput } from "../polls.js";
 import { loadWebMediaRaw } from "../web/media.js";
 import { resolveDiscordAccount } from "./accounts.js";
+import { ChannelType, Routes } from "./api-types-runtime.js";
 import { rewriteDiscordKnownMentions } from "./mentions.js";
 import {
   buildDiscordMessagePayload,

--- a/src/discord/send.permissions.authz.test.ts
+++ b/src/discord/send.permissions.authz.test.ts
@@ -1,6 +1,6 @@
 import type { RequestClient } from "@buape/carbon";
-import { PermissionFlagsBits, Routes } from "discord-api-types/v10";
 import { describe, expect, it, vi } from "vitest";
+import { PermissionFlagsBits, Routes } from "./api-types-runtime.js";
 import {
   fetchMemberGuildPermissionsDiscord,
   hasAllGuildPermissionsDiscord,

--- a/src/discord/send.permissions.ts
+++ b/src/discord/send.permissions.ts
@@ -1,6 +1,6 @@
 import type { RequestClient } from "@buape/carbon";
-import type { APIChannel, APIGuild, APIGuildMember, APIRole } from "discord-api-types/v10";
-import { ChannelType, PermissionFlagsBits, Routes } from "discord-api-types/v10";
+import type { APIChannel, APIGuild, APIGuildMember, APIRole } from "./api-types-runtime.js";
+import { ChannelType, PermissionFlagsBits, Routes } from "./api-types-runtime.js";
 import { resolveDiscordRest } from "./client.js";
 import type { DiscordPermissionsSummary, DiscordReactOpts } from "./send.types.js";
 

--- a/src/discord/send.reactions.ts
+++ b/src/discord/send.reactions.ts
@@ -1,5 +1,5 @@
-import { Routes } from "discord-api-types/v10";
 import { loadConfig } from "../config/config.js";
+import { Routes } from "./api-types-runtime.js";
 import {
   buildReactionIdentifier,
   createDiscordClient,

--- a/src/discord/send.sends-basic-channel-messages.test.ts
+++ b/src/discord/send.sends-basic-channel-messages.test.ts
@@ -1,5 +1,5 @@
-import { ChannelType, PermissionFlagsBits, Routes } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChannelType, PermissionFlagsBits, Routes } from "./api-types-runtime.js";
 import {
   __resetDiscordDirectoryCacheForTest,
   rememberDiscordDirectoryUser,

--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -6,7 +6,6 @@ import {
   type MessagePayloadObject,
   type TopLevelComponents,
 } from "@buape/carbon";
-import { PollLayoutType } from "discord-api-types/payloads/v10";
 import type { RESTAPIPoll } from "discord-api-types/rest/v10";
 import type { ChunkMode } from "../auto-reply/chunk.js";
 import { loadConfig, type OpenClawConfig } from "../config/config.js";
@@ -15,7 +14,7 @@ import { buildOutboundMediaLoadOptions } from "../media/load-options.js";
 import { normalizePollDurationHours, normalizePollInput, type PollInput } from "../polls.js";
 import { loadWebMedia } from "../web/media.js";
 import { resolveDiscordAccount } from "./accounts.js";
-import { Routes, type APIChannel, type APIEmbed } from "./api-types-runtime.js";
+import { PollLayoutType, Routes, type APIChannel, type APIEmbed } from "./api-types-runtime.js";
 import { chunkDiscordTextWithMode } from "./chunk.js";
 import { createDiscordClient, resolveDiscordRest } from "./client.js";
 import { fetchChannelPermissionsDiscord, isThreadChannelType } from "./send.permissions.js";

--- a/src/discord/send.shared.ts
+++ b/src/discord/send.shared.ts
@@ -8,7 +8,6 @@ import {
 } from "@buape/carbon";
 import { PollLayoutType } from "discord-api-types/payloads/v10";
 import type { RESTAPIPoll } from "discord-api-types/rest/v10";
-import { Routes, type APIChannel, type APIEmbed } from "discord-api-types/v10";
 import type { ChunkMode } from "../auto-reply/chunk.js";
 import { loadConfig, type OpenClawConfig } from "../config/config.js";
 import type { RetryRunner } from "../infra/retry-policy.js";
@@ -16,6 +15,7 @@ import { buildOutboundMediaLoadOptions } from "../media/load-options.js";
 import { normalizePollDurationHours, normalizePollInput, type PollInput } from "../polls.js";
 import { loadWebMedia } from "../web/media.js";
 import { resolveDiscordAccount } from "./accounts.js";
+import { Routes, type APIChannel, type APIEmbed } from "./api-types-runtime.js";
 import { chunkDiscordTextWithMode } from "./chunk.js";
 import { createDiscordClient, resolveDiscordRest } from "./client.js";
 import { fetchChannelPermissionsDiscord, isThreadChannelType } from "./send.permissions.js";

--- a/src/discord/voice/command.ts
+++ b/src/discord/voice/command.ts
@@ -5,15 +5,15 @@ import {
   type CommandInteraction,
   type CommandOptions,
 } from "@buape/carbon";
-import {
-  ApplicationCommandOptionType,
-  ChannelType as DiscordChannelType,
-  type APIApplicationCommandChannelOption,
-} from "discord-api-types/v10";
 import { resolveCommandAuthorizedFromAuthorizers } from "../../channels/command-gating.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { isDangerousNameMatchingEnabled } from "../../config/dangerous-name-matching.js";
 import type { DiscordAccountConfig } from "../../config/types.js";
+import {
+  ApplicationCommandOptionType,
+  ChannelType as DiscordChannelType,
+  type APIApplicationCommandChannelOption,
+} from "../api-types-runtime.js";
 import { formatMention } from "../mentions.js";
 import {
   isDiscordGroupAllowedByPolicy,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: ESM imports of `discord-api-types/v10` require `v10.mjs`; when that file is missing in an install, CLI startup crashes before command execution.
- Why it matters: users on affected installs hit immediate startup failure (`ENOENT .../discord-api-types/v10.mjs`) for basic commands like `openclaw status`.
- What changed: Discord runtime imports now go through a new shim (`src/discord/api-types-runtime.ts`) that loads `discord-api-types/v10` via `createRequire`, forcing the CommonJS `v10.js` path.
- What did NOT change (scope boundary): Discord API semantics, routes, permissions, and runtime behavior are unchanged; this is import-resolution hardening only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34925
- Related #34540

## User-visible / Behavior Changes

OpenClaw no longer depends on `discord-api-types/v10.mjs` being present for Discord runtime module loading; installs with only `v10.js` continue to start and run.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Discord runtime imports
- Relevant config (redacted): N/A

### Steps

1. In a temp module, define `discord-api-types` exports where `./v10` maps `import -> ./v10.mjs` and `require -> ./v10.js`, with `v10.js` present and `v10.mjs` missing.
2. Execute ESM import: `import { Routes } from "discord-api-types/v10"`.
3. Observe module-not-found failure for `v10.mjs`.
4. Execute CJS path via `createRequire(...).require("discord-api-types/v10")`.
5. Observe success via `v10.js`.

### Expected

- OpenClaw Discord runtime loading should survive installs where `v10.mjs` is missing but `v10.js` exists.

### Actual

- Before patch, runtime import path required `v10.mjs` and crashed startup.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Deterministic repro: missing-`v10.mjs` temp package fails for ESM import and succeeds with `createRequire`.
  - Shim import smoke test: `node --import tsx -e "import { Routes } from './src/discord/api-types-runtime.ts'"` succeeds.
  - CLI startup smoke: `pnpm openclaw --help` completes successfully after the shim migration.
- Edge cases checked:
  - Discord monitor/send/voice runtime modules compile and load via focused test suites.
  - Type-only usages preserved through shim type re-export.
- What you did **not** verify:
  - Global npm install behavior on a remote host with the exact broken package state.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Discord: load api-types v10 via require shim`.
- Files/config to restore: `src/discord/api-types-runtime.ts` plus affected Discord imports.
- Known bad symptoms reviewers should watch for: unexpected Discord runtime import/type errors in modules migrated to the shim.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Wrapper could diverge from upstream runtime/type exports over time.
  - Mitigation: shim exports are minimal, typed against `typeof import("discord-api-types/v10")`, and compile-time checks cover Discord call sites.
