### PR TITLE
Cron: bypass pending-descendant guard for completion direct sends

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -622,6 +622,46 @@ describe("subagent announce formatting", () => {
     );
   });
 
+  it("keeps cron completion direct delivery even when sibling runs are still active", async () => {
+    sessionStore = {
+      "agent:main:subagent:test": {
+        sessionId: "child-session-cron-direct",
+      },
+      "agent:main:main": {
+        sessionId: "requester-session-cron-direct",
+      },
+    };
+    readLatestAssistantReplyMock.mockResolvedValue("");
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "final answer: cron" }] }],
+    });
+    subagentRegistryMock.countActiveDescendantRuns.mockImplementation((sessionKey: string) =>
+      sessionKey === "agent:main:main" ? 1 : 0,
+    );
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-direct-cron-active-siblings",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
+      announceType: "cron job",
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(agentSpy).not.toHaveBeenCalled();
+    const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    const rawMessage = call?.params?.message;
+    const msg = typeof rawMessage === "string" ? rawMessage : "";
+    expect(call?.params?.channel).toBe("discord");
+    expect(call?.params?.to).toBe("channel:12345");
+    expect(msg).toContain("final answer: cron");
+    expect(msg).not.toContain("There are still 1 active subagent run for this session.");
+  });
+
   it("keeps session-mode completion delivery on the bound destination when sibling runs are active", async () => {
     sessionStore = {
       "agent:main:subagent:test": {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -733,6 +733,7 @@ async function sendSubagentAnnounceDirectly(params: {
   completionMessage?: string;
   internalEvents?: AgentInternalEvent[];
   expectsCompletionMessage: boolean;
+  announceType?: SubagentAnnounceType;
   bestEffortDeliver?: boolean;
   completionRouteMode?: "bound" | "fallback" | "hook";
   spawnMode?: SpawnSubagentMode;
@@ -779,7 +780,8 @@ async function sendSubagentAnnounceDirectly(params: {
         params.spawnMode === "session" &&
         (params.completionRouteMode === "bound" || params.completionRouteMode === "hook");
       let shouldSendCompletionDirectly = true;
-      if (!forceBoundSessionDirectDelivery) {
+      const shouldCoordinatePendingDescendants = params.announceType !== "cron job";
+      if (!forceBoundSessionDirectDelivery && shouldCoordinatePendingDescendants) {
         let pendingDescendantRuns = 0;
         try {
           const { countPendingDescendantRuns, countPendingDescendantRunsExcludingRun } =
@@ -916,6 +918,7 @@ async function deliverSubagentAnnouncement(params: {
   targetRequesterSessionKey: string;
   requesterIsSubagent: boolean;
   expectsCompletionMessage: boolean;
+  announceType?: SubagentAnnounceType;
   bestEffortDeliver?: boolean;
   completionRouteMode?: "bound" | "fallback" | "hook";
   spawnMode?: SpawnSubagentMode;
@@ -951,6 +954,7 @@ async function deliverSubagentAnnouncement(params: {
         directOrigin: params.directOrigin,
         requesterIsSubagent: params.requesterIsSubagent,
         expectsCompletionMessage: params.expectsCompletionMessage,
+        announceType: params.announceType,
         signal: params.signal,
         bestEffortDeliver: params.bestEffortDeliver,
       }),
@@ -1403,6 +1407,7 @@ export async function runSubagentAnnounceFlow(params: {
       targetRequesterSessionKey,
       requesterIsSubagent,
       expectsCompletionMessage: expectsCompletionMessage,
+      announceType,
       bestEffortDeliver: params.bestEffortDeliver,
       completionRouteMode: completionResolution.routeMode,
       spawnMode: params.spawnMode,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Cron announce completion delivery could be blocked by the `pendingDescendantRuns` coordination guard inside `sendSubagentAnnounceDirectly()`.
- Why it matters: isolated cron runs that spawn descendants can fail channel delivery and fall back to requester-session injection, which times out when no live requester session is available.
- What changed: when `announceType` is `cron job`, completion direct-send now bypasses the pending-descendant coordination guard and proceeds with direct `send` delivery to the resolved channel target.
- What did NOT change (scope boundary): non-cron completion announcements still coordinate through the existing pending-descendant guard; queueing/steer behavior and non-completion announce paths are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34966
- Related #0

## User-visible / Behavior Changes

Cron jobs using announce delivery now keep delivering completion messages directly to the configured channel target even when descendant subagent runs are still pending.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): cron isolated-agent announce delivery (Discord-targeted completion path)
- Relevant config (redacted): isolated cron run with `delivery.mode: "announce"`, `expectsCompletionMessage: true`

### Steps

1. Run `runSubagentAnnounceFlow` with `expectsCompletionMessage: true`, `announceType: "cron job"`, and a valid direct channel target.
2. Make descendant/sibling runs appear pending for requester session via registry counts (`countActiveDescendantRuns` > 0).
3. Observe delivery path selection.

### Expected

- Cron completion should send directly to the resolved delivery target, independent of pending descendant coordination.

### Actual

- Before this change, pending descendants could suppress completion direct-send and force fallback to requester-session injection (`agent` path), causing delivery failures/timeouts in isolated cron flows.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added regression in `src/agents/subagent-announce.format.e2e.test.ts`:
- `keeps cron completion direct delivery even when sibling runs are still active`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test:e2e -- src/agents/subagent-announce.format.e2e.test.ts`
  - `pnpm check`
- Edge cases checked:
  - non-cron completion coordination test still routes through `agent` path when sibling runs are active.
  - cron completion path now uses direct `send` with same active-sibling setup.
- What you did **not** verify:
  - live end-to-end delivery against a remote disconnected Codex ACP session.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/agents/subagent-announce.ts`
  - `src/agents/subagent-announce.format.e2e.test.ts`
- Known bad symptoms reviewers should watch for:
  - cron completion delivery unexpectedly falling back to requester-session announce coordination instead of direct channel send.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Cron completion direct sends could arrive while sibling subagent runs are still active for the same requester session.
  - Mitigation: Scope is limited to `announceType: "cron job"`; non-cron coordination behavior remains unchanged and covered by existing tests.
