### PR TITLE
fix(cron): bypass pending-descendant guard for cron completion direct-send

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -741,6 +741,10 @@ async function sendSubagentAnnounceDirectly(params: {
   completionDirectOrigin?: DeliveryContext;
   directOrigin?: DeliveryContext;
   requesterIsSubagent: boolean;
+  /** When true, skip the pendingDescendantRuns coordination guard. Used for
+   * cron-job completions whose standalone delivery must not be blocked by
+   * sibling/descendant run counts. */
+  skipPendingDescendantGuard?: boolean;
   signal?: AbortSignal;
 }): Promise<SubagentAnnounceDeliveryResult> {
   if (params.signal?.aborted) {
@@ -803,7 +807,9 @@ async function sendSubagentAnnounceDirectly(params: {
         }
         // Keep non-bound completion announcements coordinated via requester
         // session routing while sibling or descendant runs are still pending.
-        if (pendingDescendantRuns > 0) {
+        // Cron-job completions are standalone channel sends and must not be
+        // blocked by descendant counts from other sessions in the tree.
+        if (pendingDescendantRuns > 0 && !params.skipPendingDescendantGuard) {
           shouldSendCompletionDirectly = false;
         }
       }
@@ -921,6 +927,7 @@ async function deliverSubagentAnnouncement(params: {
   spawnMode?: SpawnSubagentMode;
   directIdempotencyKey: string;
   currentRunId?: string;
+  skipPendingDescendantGuard?: boolean;
   signal?: AbortSignal;
 }): Promise<SubagentAnnounceDeliveryResult> {
   return await runSubagentAnnounceDispatch({
@@ -951,6 +958,7 @@ async function deliverSubagentAnnouncement(params: {
         directOrigin: params.directOrigin,
         requesterIsSubagent: params.requesterIsSubagent,
         expectsCompletionMessage: params.expectsCompletionMessage,
+        skipPendingDescendantGuard: params.skipPendingDescendantGuard,
         signal: params.signal,
         bestEffortDeliver: params.bestEffortDeliver,
       }),
@@ -1408,6 +1416,9 @@ export async function runSubagentAnnounceFlow(params: {
       spawnMode: params.spawnMode,
       directIdempotencyKey,
       currentRunId: params.childRunId,
+      // Cron completions are standalone channel sends and must not be held back
+      // by sibling descendant run counts from other sessions in the tree.
+      skipPendingDescendantGuard: announceType === "cron job",
       signal: params.signal,
     });
     // Cron delivery state should only be marked as delivered when we have a


### PR DESCRIPTION
## Root cause

`sendSubagentAnnounceDirectly()` in `src/agents/subagent-announce.ts` blocks completion direct-send whenever `pendingDescendantRuns > 0` (unless forced by bound/hook session routing). This guard runs for all announce types, including cron completions (`announceType: "cron job"`, `expectsCompletionMessage: true`).

For isolated cron runs that spawn subagents, the descendant bookkeeping count can be non-zero at completion time — causing the direct channel send to be skipped, falling back to `callGateway(method: "agent", expectFinal: true)` against the requester session. That fallback path can timeout or disconnect, silently dropping the cron completion delivery.

## Fix

Single-file change in `src/agents/subagent-announce.ts`:

- Added `skipPendingDescendantGuard?: boolean` to `sendSubagentAnnounceDirectly` and `deliverSubagentAnnouncement`.
- In `runSubagentAnnounceFlow`, set `skipPendingDescendantGuard: announceType === "cron job"` at the `deliverSubagentAnnouncement` call site.
- In `sendSubagentAnnounceDirectly`, bypass the `pendingDescendantRuns > 0` guard when the flag is true.

Non-cron flows are unaffected. The bound/hook session fast-path is also untouched.

cc @tyler6204
