### PR TITLE
TUI: suppress heartbeat poll noise in chat history

### DIFF
--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -109,7 +109,7 @@ function stripTokenAtEdges(raw: string): { text: string; didStrip: boolean } {
 
 export function stripHeartbeatToken(
   raw?: string,
-  opts: { mode?: StripHeartbeatMode; maxAckChars?: number } = {},
+  opts: { mode?: StripHeartbeatMode; maxAckChars?: number | string } = {},
 ) {
   if (!raw) {
     return { shouldSkip: true, text: "", didStrip: false };

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -280,6 +280,78 @@ describe("tui session actions", () => {
     );
   });
 
+  it("suppresses poll messages that use configured custom heartbeat prompts", async () => {
+    const customPrompt = "custom heartbeat poll prompt";
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: {},
+      sessions: [{ key: "agent:main:main" }],
+    });
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-1",
+      thinkingLevel: "off",
+      verboseLevel: "off",
+      messages: [
+        { role: "user", content: customPrompt },
+        { role: "user", content: "normal user message" },
+      ],
+    });
+
+    const chatLog = {
+      clearAll: vi.fn(),
+      addSystem: vi.fn(),
+      addUser: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      startTool: vi.fn(() => ({ setResult: vi.fn() })),
+    };
+
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: false,
+      sessionInfo: {},
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { loadHistory: loadSessionHistory } = createSessionActions({
+      client: { listSessions, loadHistory } as unknown as GatewayChatClient,
+      chatLog: chatLog as unknown as import("./components/chat-log.js").ChatLog,
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      heartbeatPrompt: customPrompt,
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn(),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus: vi.fn(),
+    });
+
+    await loadSessionHistory();
+
+    expect(chatLog.addUser).toHaveBeenCalledTimes(1);
+    expect(chatLog.addUser).toHaveBeenCalledWith("normal user message");
+  });
+
   it("uses configured heartbeat ack max chars when deciding history suppression", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       ts: Date.now(),
@@ -350,6 +422,6 @@ describe("tui session actions", () => {
     await loadSessionHistory();
 
     expect(chatLog.finalizeAssistant).toHaveBeenCalledTimes(1);
-    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("HEARTBEAT_OK ping");
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("ping");
   });
 });

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -111,4 +111,98 @@ describe("tui session actions", () => {
     expect(updateFooter).toHaveBeenCalledTimes(2);
     expect(requestRender).toHaveBeenCalledTimes(2);
   });
+
+  it("suppresses heartbeat poll and heartbeat ack noise when loading history", async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: {},
+      sessions: [{ key: "agent:main:main" }],
+    });
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-1",
+      thinkingLevel: "off",
+      verboseLevel: "off",
+      messages: [
+        {
+          role: "user",
+          content:
+            "<relevant-memories>\nRead HEARTBEAT.md if it exists (workspace context). Follow it strictly. If nothing needs attention, reply HEARTBEAT_OK.",
+        },
+        {
+          role: "assistant",
+          content: "HEARTBEAT_OK all good",
+        },
+        {
+          role: "assistant",
+          content: "Disk usage crossed 95 percent on /data and needs cleanup now.",
+        },
+        {
+          role: "user",
+          content: "normal user message",
+        },
+      ],
+    });
+
+    const chatLog = {
+      clearAll: vi.fn(),
+      addSystem: vi.fn(),
+      addUser: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      startTool: vi.fn(() => ({ setResult: vi.fn() })),
+    };
+
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: false,
+      sessionInfo: {},
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { loadHistory: loadSessionHistory } = createSessionActions({
+      client: { listSessions, loadHistory } as unknown as GatewayChatClient,
+      chatLog: chatLog as unknown as import("./components/chat-log.js").ChatLog,
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn(),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus: vi.fn(),
+    });
+
+    await loadSessionHistory();
+
+    expect(loadHistory).toHaveBeenCalledWith({
+      sessionKey: "agent:main:main",
+      limit: 200,
+    });
+    expect(chatLog.clearAll).toHaveBeenCalledTimes(1);
+    expect(chatLog.addUser).toHaveBeenCalledTimes(1);
+    expect(chatLog.addUser).toHaveBeenCalledWith("normal user message");
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledTimes(1);
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith(
+      "Disk usage crossed 95 percent on /data and needs cleanup now.",
+    );
+  });
 });

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -205,4 +205,77 @@ describe("tui session actions", () => {
       "Disk usage crossed 95 percent on /data and needs cleanup now.",
     );
   });
+
+  it("uses configured heartbeat ack max chars when deciding history suppression", async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: {},
+      sessions: [{ key: "agent:main:main" }],
+    });
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-1",
+      thinkingLevel: "off",
+      verboseLevel: "off",
+      messages: [
+        {
+          role: "assistant",
+          content: "HEARTBEAT_OK ping",
+        },
+      ],
+    });
+
+    const chatLog = {
+      clearAll: vi.fn(),
+      addSystem: vi.fn(),
+      addUser: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      startTool: vi.fn(() => ({ setResult: vi.fn() })),
+    };
+
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: false,
+      sessionInfo: {},
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { loadHistory: loadSessionHistory } = createSessionActions({
+      client: { listSessions, loadHistory } as unknown as GatewayChatClient,
+      chatLog: chatLog as unknown as import("./components/chat-log.js").ChatLog,
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      heartbeatAckMaxChars: 3,
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn(),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus: vi.fn(),
+    });
+
+    await loadSessionHistory();
+
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledTimes(1);
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("HEARTBEAT_OK ping");
+  });
 });

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
 import type { GatewayChatClient } from "./gateway-chat.js";
 import { createSessionActions } from "./tui-session-actions.js";
 import type { TuiStateAccess } from "./tui-types.js";
@@ -127,8 +128,7 @@ describe("tui session actions", () => {
       messages: [
         {
           role: "user",
-          content:
-            "<relevant-memories>\nRead HEARTBEAT.md if it exists (workspace context). Follow it strictly. If nothing needs attention, reply HEARTBEAT_OK.",
+          content: `<relevant-memories>\n${HEARTBEAT_PROMPT}`,
         },
         {
           role: "assistant",

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -206,6 +206,80 @@ describe("tui session actions", () => {
     );
   });
 
+  it("keeps assistant messages that mention heartbeat prompt text", async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: {},
+      sessions: [{ key: "agent:main:main" }],
+    });
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-1",
+      thinkingLevel: "off",
+      verboseLevel: "off",
+      messages: [
+        {
+          role: "assistant",
+          content: `Recap for debugging only: ${HEARTBEAT_PROMPT}`,
+        },
+      ],
+    });
+
+    const chatLog = {
+      clearAll: vi.fn(),
+      addSystem: vi.fn(),
+      addUser: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      startTool: vi.fn(() => ({ setResult: vi.fn() })),
+    };
+
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: false,
+      sessionInfo: {},
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { loadHistory: loadSessionHistory } = createSessionActions({
+      client: { listSessions, loadHistory } as unknown as GatewayChatClient,
+      chatLog: chatLog as unknown as import("./components/chat-log.js").ChatLog,
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn(),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus: vi.fn(),
+    });
+
+    await loadSessionHistory();
+
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledTimes(1);
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith(
+      `Recap for debugging only: ${HEARTBEAT_PROMPT}`,
+    );
+  });
+
   it("uses configured heartbeat ack max chars when deciding history suppression", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       ts: Date.now(),

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -352,6 +352,81 @@ describe("tui session actions", () => {
     expect(chatLog.addUser).toHaveBeenCalledWith("normal user message");
   });
 
+  it("keeps normal user history messages that merely mention heartbeat markers", async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: {},
+      sessions: [{ key: "agent:main:main" }],
+    });
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-1",
+      thinkingLevel: "off",
+      verboseLevel: "off",
+      messages: [
+        {
+          role: "user",
+          content:
+            "Please search HEARTBEAT_OK in the logs and also inspect <relevant-memories> later.",
+        },
+      ],
+    });
+
+    const chatLog = {
+      clearAll: vi.fn(),
+      addSystem: vi.fn(),
+      addUser: vi.fn(),
+      finalizeAssistant: vi.fn(),
+      startTool: vi.fn(() => ({ setResult: vi.fn() })),
+    };
+
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: false,
+      sessionInfo: {},
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { loadHistory: loadSessionHistory } = createSessionActions({
+      client: { listSessions, loadHistory } as unknown as GatewayChatClient,
+      chatLog: chatLog as unknown as import("./components/chat-log.js").ChatLog,
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn(),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus: vi.fn(),
+    });
+
+    await loadSessionHistory();
+
+    expect(chatLog.addUser).toHaveBeenCalledTimes(1);
+    expect(chatLog.addUser).toHaveBeenCalledWith(
+      "Please search HEARTBEAT_OK in the logs and also inspect <relevant-memories> later.",
+    );
+  });
+
   it("uses configured heartbeat ack max chars when deciding history suppression", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       ts: Date.now(),

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -1,4 +1,5 @@
 import type { TUI } from "@mariozechner/pi-tui";
+import { stripHeartbeatToken } from "../auto-reply/heartbeat.js";
 import type { SessionsPatchResult } from "../gateway/protocol/index.js";
 import {
   normalizeAgentId,
@@ -37,6 +38,38 @@ type SessionInfoEntry = SessionInfo & {
   modelOverride?: string;
   providerOverride?: string;
 };
+
+function isHeartbeatPollHistoryText(text: string): boolean {
+  const lower = text.trim().toLowerCase();
+  if (!lower) {
+    return false;
+  }
+  return (
+    lower.includes("<relevant-memories>") ||
+    lower.includes("read heartbeat.md if it exists (workspace context). follow it strictly.") ||
+    lower.includes("heartbeat poll:")
+  );
+}
+
+function isHeartbeatAckOnlyHistoryText(text: string): boolean {
+  const stripped = stripHeartbeatToken(text, { mode: "heartbeat" });
+  return stripped.didStrip && stripped.shouldSkip;
+}
+
+function shouldSuppressHistoryMessage(message: Record<string, unknown>): boolean {
+  const role = message.role;
+  if (role !== "user" && role !== "assistant") {
+    return false;
+  }
+  const text = extractTextFromMessage(message);
+  if (!text) {
+    return false;
+  }
+  if (isHeartbeatPollHistoryText(text)) {
+    return true;
+  }
+  return role === "assistant" && isHeartbeatAckOnlyHistoryText(text);
+}
 
 export function createSessionActions(context: SessionActionContext) {
   const {
@@ -304,6 +337,9 @@ export function createSessionActions(context: SessionActionContext) {
           continue;
         }
         const message = entry as Record<string, unknown>;
+        if (shouldSuppressHistoryMessage(message)) {
+          continue;
+        }
         if (isCommandMessage(message)) {
           const text = extractTextFromMessage(message);
           if (text) {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -17,6 +17,7 @@ type SessionActionContext = {
   tui: TUI;
   opts: TuiOptions;
   heartbeatAckMaxChars?: number | string;
+  heartbeatPrompt?: string;
   state: TuiStateAccess;
   agentNames: Map<string, string>;
   initialSessionInput: string;
@@ -40,15 +41,16 @@ type SessionInfoEntry = SessionInfo & {
   providerOverride?: string;
 };
 
-function isHeartbeatPollHistoryText(text: string): boolean {
+function isHeartbeatPollHistoryText(text: string, heartbeatPrompt?: string): boolean {
   const lower = text.trim().toLowerCase();
   if (!lower) {
     return false;
   }
-  const heartbeatPrompt = HEARTBEAT_PROMPT.toLowerCase();
+  const resolvedHeartbeatPrompt = heartbeatPrompt?.trim() || HEARTBEAT_PROMPT;
+  const heartbeatPromptLower = resolvedHeartbeatPrompt.toLowerCase();
   return (
     lower.includes("<relevant-memories>") ||
-    lower.includes(heartbeatPrompt) ||
+    lower.includes(heartbeatPromptLower) ||
     lower.includes("heartbeat poll:")
   );
 }
@@ -61,6 +63,7 @@ function isHeartbeatAckOnlyHistoryText(text: string, maxAckChars?: number | stri
 function shouldSuppressHistoryMessage(
   message: Record<string, unknown>,
   heartbeatAckMaxChars?: number | string,
+  heartbeatPrompt?: string,
 ): boolean {
   const role = message.role;
   if (role !== "user" && role !== "assistant") {
@@ -70,13 +73,27 @@ function shouldSuppressHistoryMessage(
   if (!text) {
     return false;
   }
-  if (role === "user" && isHeartbeatPollHistoryText(text)) {
+  if (role === "user" && isHeartbeatPollHistoryText(text, heartbeatPrompt)) {
     return true;
   }
-  if (role === "assistant" && isHeartbeatPollHistoryText(text)) {
+  if (role === "assistant" && isHeartbeatPollHistoryText(text, heartbeatPrompt)) {
     return false;
   }
   return role === "assistant" && isHeartbeatAckOnlyHistoryText(text, heartbeatAckMaxChars);
+}
+
+function normalizeAssistantHistoryText(
+  text: string,
+  heartbeatAckMaxChars?: number | string,
+): string {
+  const stripped = stripHeartbeatToken(text, {
+    mode: "heartbeat",
+    maxAckChars: heartbeatAckMaxChars,
+  });
+  if (stripped.didStrip && !stripped.shouldSkip && stripped.text) {
+    return stripped.text;
+  }
+  return text;
 }
 
 export function createSessionActions(context: SessionActionContext) {
@@ -86,6 +103,7 @@ export function createSessionActions(context: SessionActionContext) {
     tui,
     opts,
     heartbeatAckMaxChars,
+    heartbeatPrompt,
     state,
     agentNames,
     initialSessionInput,
@@ -346,7 +364,7 @@ export function createSessionActions(context: SessionActionContext) {
           continue;
         }
         const message = entry as Record<string, unknown>;
-        if (shouldSuppressHistoryMessage(message, heartbeatAckMaxChars)) {
+        if (shouldSuppressHistoryMessage(message, heartbeatAckMaxChars, heartbeatPrompt)) {
           continue;
         }
         if (isCommandMessage(message)) {
@@ -364,9 +382,10 @@ export function createSessionActions(context: SessionActionContext) {
           continue;
         }
         if (message.role === "assistant") {
-          const text = extractTextFromMessage(message, {
+          const rawText = extractTextFromMessage(message, {
             includeThinking: state.showThinking,
           });
+          const text = rawText ? normalizeAssistantHistoryText(rawText, heartbeatAckMaxChars) : "";
           if (text) {
             chatLog.finalizeAssistant(text);
           }

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -70,8 +70,11 @@ function shouldSuppressHistoryMessage(
   if (!text) {
     return false;
   }
-  if (isHeartbeatPollHistoryText(text)) {
+  if (role === "user" && isHeartbeatPollHistoryText(text)) {
     return true;
+  }
+  if (role === "assistant" && isHeartbeatPollHistoryText(text)) {
+    return false;
   }
   return role === "assistant" && isHeartbeatAckOnlyHistoryText(text, heartbeatAckMaxChars);
 }

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -16,6 +16,7 @@ type SessionActionContext = {
   chatLog: ChatLog;
   tui: TUI;
   opts: TuiOptions;
+  heartbeatAckMaxChars?: number | string;
   state: TuiStateAccess;
   agentNames: Map<string, string>;
   initialSessionInput: string;
@@ -52,12 +53,15 @@ function isHeartbeatPollHistoryText(text: string): boolean {
   );
 }
 
-function isHeartbeatAckOnlyHistoryText(text: string): boolean {
-  const stripped = stripHeartbeatToken(text, { mode: "heartbeat" });
+function isHeartbeatAckOnlyHistoryText(text: string, maxAckChars?: number | string): boolean {
+  const stripped = stripHeartbeatToken(text, { mode: "heartbeat", maxAckChars });
   return stripped.didStrip && stripped.shouldSkip;
 }
 
-function shouldSuppressHistoryMessage(message: Record<string, unknown>): boolean {
+function shouldSuppressHistoryMessage(
+  message: Record<string, unknown>,
+  heartbeatAckMaxChars?: number | string,
+): boolean {
   const role = message.role;
   if (role !== "user" && role !== "assistant") {
     return false;
@@ -69,7 +73,7 @@ function shouldSuppressHistoryMessage(message: Record<string, unknown>): boolean
   if (isHeartbeatPollHistoryText(text)) {
     return true;
   }
-  return role === "assistant" && isHeartbeatAckOnlyHistoryText(text);
+  return role === "assistant" && isHeartbeatAckOnlyHistoryText(text, heartbeatAckMaxChars);
 }
 
 export function createSessionActions(context: SessionActionContext) {
@@ -78,6 +82,7 @@ export function createSessionActions(context: SessionActionContext) {
     chatLog,
     tui,
     opts,
+    heartbeatAckMaxChars,
     state,
     agentNames,
     initialSessionInput,
@@ -338,7 +343,7 @@ export function createSessionActions(context: SessionActionContext) {
           continue;
         }
         const message = entry as Record<string, unknown>;
-        if (shouldSuppressHistoryMessage(message)) {
+        if (shouldSuppressHistoryMessage(message, heartbeatAckMaxChars)) {
           continue;
         }
         if (isCommandMessage(message)) {

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -1,5 +1,5 @@
 import type { TUI } from "@mariozechner/pi-tui";
-import { stripHeartbeatToken } from "../auto-reply/heartbeat.js";
+import { HEARTBEAT_PROMPT, stripHeartbeatToken } from "../auto-reply/heartbeat.js";
 import type { SessionsPatchResult } from "../gateway/protocol/index.js";
 import {
   normalizeAgentId,
@@ -44,9 +44,10 @@ function isHeartbeatPollHistoryText(text: string): boolean {
   if (!lower) {
     return false;
   }
+  const heartbeatPrompt = HEARTBEAT_PROMPT.toLowerCase();
   return (
     lower.includes("<relevant-memories>") ||
-    lower.includes("read heartbeat.md if it exists (workspace context). follow it strictly.") ||
+    lower.includes(heartbeatPrompt) ||
     lower.includes("heartbeat poll:")
   );
 }

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -42,20 +42,24 @@ type SessionInfoEntry = SessionInfo & {
 };
 
 function isHeartbeatPollHistoryText(text: string, heartbeatPrompt?: string): boolean {
-  const lower = text.trim().toLowerCase();
-  if (!lower) {
+  const trimmed = text.trim();
+  if (!trimmed) {
     return false;
   }
-  const resolvedHeartbeatPrompt = heartbeatPrompt?.trim() || HEARTBEAT_PROMPT;
-  const heartbeatPromptLower = resolvedHeartbeatPrompt.toLowerCase();
+  const normalized = trimmed.toLowerCase();
+  const resolvedHeartbeatPrompt = (heartbeatPrompt?.trim() || HEARTBEAT_PROMPT).toLowerCase();
   return (
-    lower.includes("<relevant-memories>") ||
-    lower.includes(heartbeatPromptLower) ||
-    lower.includes("heartbeat poll:")
+    normalized === resolvedHeartbeatPrompt ||
+    normalized === `<relevant-memories>\n${resolvedHeartbeatPrompt}` ||
+    normalized === `heartbeat poll:\n${resolvedHeartbeatPrompt}` ||
+    normalized === `heartbeat poll: ${resolvedHeartbeatPrompt}`
   );
 }
 
 function isHeartbeatAckOnlyHistoryText(text: string, maxAckChars?: number | string): boolean {
+  if (!/^\s*HEARTBEAT_OK\b/i.test(text)) {
+    return false;
+  }
   const stripped = stripHeartbeatToken(text, { mode: "heartbeat", maxAckChars });
   return stripped.didStrip && stripped.shouldSkip;
 }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -757,6 +757,7 @@ export async function runTui(opts: TuiOptions) {
     tui,
     opts,
     heartbeatAckMaxChars: config.agents?.defaults?.heartbeat?.ackMaxChars,
+    heartbeatPrompt: config.agents?.defaults?.heartbeat?.prompt,
     state,
     agentNames,
     initialSessionInput,

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -756,6 +756,7 @@ export async function runTui(opts: TuiOptions) {
     chatLog,
     tui,
     opts,
+    heartbeatAckMaxChars: config.agents?.defaults?.heartbeat?.ackMaxChars,
     state,
     agentNames,
     initialSessionInput,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: heartbeat poll prompts and short heartbeat ACK replies were rendered as normal chat messages in TUI history.
- Why it matters: TUI users see internal heartbeat noise (`<relevant-memories>`, `Read HEARTBEAT.md...`, `HEARTBEAT_OK`) as if it were normal conversation output.
- What changed: added history-level suppression in TUI session loading for likely heartbeat poll prompts and ACK-only heartbeat responses.
- What did NOT change (scope boundary): this does not alter heartbeat execution/delivery behavior; it only affects TUI history rendering.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34964
- Related #0

## User-visible / Behavior Changes

TUI chat history no longer shows heartbeat poll noise and short ACK-only heartbeat outputs; normal user and alert assistant content still appears.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): TUI (`gateway-client`) history rendering
- Relevant config (redacted): heartbeat enabled session with heartbeat poll/ack messages present in session history

### Steps

1. Load TUI session history containing heartbeat poll user text (`<relevant-memories>`, `Read HEARTBEAT.md...`) and heartbeat ACK assistant text (`HEARTBEAT_OK ...`).
2. Observe the rendered chat log entries.
3. Compare with a normal user message and a non-ACK assistant alert message.

### Expected

- Heartbeat poll and ACK-only heartbeat noise should be hidden from TUI chat history.
- Normal user/assistant content should remain visible.

### Actual

- Before fix, heartbeat poll/ACK noise rendered as regular chat content in TUI.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added regression test:
- `src/tui/tui-session-actions.test.ts`
  - `suppresses heartbeat poll and heartbeat ack noise when loading history`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- src/tui/tui-session-actions.test.ts`
  - `pnpm check`
- Edge cases checked:
  - normal user messages still render.
  - non-ACK assistant alert text still renders.
- What you did **not** verify:
  - live manual TUI run against a long-running remote heartbeat-enabled gateway.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/tui/tui-session-actions.ts`
  - `src/tui/tui-session-actions.test.ts`
- Known bad symptoms reviewers should watch for:
  - legitimate non-heartbeat history messages being unexpectedly filtered.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: heuristic filtering could hide a rare user message that intentionally includes heartbeat prompt markers.
  - Mitigation: filters are constrained to heartbeat-specific signatures and ACK-only token stripping; regression test covers normal content retention.
