### PR TITLE
TUI: preserve long hex tokens for copy safety

### DIFF
--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -249,6 +249,13 @@ describe("sanitizeRenderableText", () => {
     expect(sanitized).toBe(input);
   });
 
+  it("preserves long hex tokens for copy safety", () => {
+    const input = "3ec1311e304d0b34d59fd8a4d4add0a8a3f8eba2d85c1a25";
+    const sanitized = sanitizeRenderableText(input);
+
+    expect(sanitized).toBe(input);
+  });
+
   it("wraps rtl lines with directional isolation marks", () => {
     const input = "مرحبا بالعالم";
     const sanitized = sanitizeRenderableText(input);

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -11,6 +11,7 @@ const BINARY_LINE_REPLACEMENT_THRESHOLD = 12;
 const URL_PREFIX_RE = /^(https?:\/\/|file:\/\/)/i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const FILE_LIKE_RE = /^[a-zA-Z0-9._-]+$/;
+const HEX_BODY_RE = /^[a-fA-F0-9]+$/;
 const RTL_SCRIPT_RE = /[\u0590-\u08ff\ufb1d-\ufdff\ufe70-\ufefc]/;
 const BIDI_CONTROL_RE = /[\u202a-\u202e\u2066-\u2069]/;
 const RTL_ISOLATE_START = "\u2067";
@@ -71,6 +72,10 @@ function isCopySensitiveToken(token: string): boolean {
     return true;
   }
   if (token.includes("/") || token.includes("\\")) {
+    return true;
+  }
+  const normalizedHex = token.startsWith("0x") || token.startsWith("0X") ? token.slice(2) : token;
+  if (normalizedHex.length >= 33 && HEX_BODY_RE.test(normalizedHex) && /\d/.test(normalizedHex)) {
     return true;
   }
   return token.includes("_") && FILE_LIKE_RE.test(token);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: TUI long-token sanitization inserted spaces every 32 characters for long unbroken tokens, including long hex strings shown in code blocks.
- Why it matters: copying credentials/tokens from TUI could include injected spaces and break downstream auth/config.
- What changed: treat long hex tokens as copy-sensitive in `sanitizeRenderableText` so they are preserved verbatim.
- What did NOT change (scope boundary): non-copy-sensitive long tokens still wrap at 32 chars for narrow terminal readability.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34956
- Related #0

## User-visible / Behavior Changes

Long hex tokens displayed in TUI output remain contiguous (no inserted spaces), improving copy/paste safety for token-like values.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): TUI message rendering
- Relevant config (redacted): message content includes long hex token in code block/output text

### Steps

1. Render a long hex token (33+ chars) in TUI output.
2. Observe sanitization output used for display.
3. Copy the rendered token.

### Expected

- Hex token should remain contiguous with no inserted spaces.

### Actual

- Before fix, token wrapping inserted spaces every 32 characters for long unbroken tokens.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added regression test:
- `src/tui/tui-formatters.test.ts`
  - `preserves long hex tokens for copy safety`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- src/tui/tui-formatters.test.ts`
  - `pnpm check`
- Edge cases checked:
  - existing long non-copy-sensitive alphabetic tokens still wrap to 32-char segments.
  - existing copy-sensitive path/url/underscore tokens remain preserved.
- What you did **not** verify:
  - manual copy/paste in a live terminal emulator across multiple terminal apps.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/tui/tui-formatters.ts`
  - `src/tui/tui-formatters.test.ts`
- Known bad symptoms reviewers should watch for:
  - long hex-like strings unexpectedly wrapping again in TUI output.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: broad hex detection could preserve some long alphanumeric values that previously wrapped.
  - Mitigation: detection is constrained to hex-only tokens with at least one digit and length >=33; existing wrapping tests remain enforced.
