### PR TITLE
fix(security): replace `in` with Object.hasOwn in hasExplicitProviderAccountConfig

### DIFF
--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -108,7 +108,7 @@ function hasExplicitProviderAccountConfig(
   if (!accounts || typeof accounts !== "object") {
     return false;
   }
-  return accountId in accounts;
+  return Object.hasOwn(accounts, accountId);
 }
 
 export async function collectChannelSecurityFindings(params: {


### PR DESCRIPTION
## What

Replace the `in` operator with `Object.hasOwn()` in `hasExplicitProviderAccountConfig` to prevent a prototype-pollution bypass.

## Why

The `in` operator checks the full prototype chain, not just own properties. An attacker who can influence the `accountId` value (e.g. via a specially crafted channel sender ID) could supply `__proto__`, `constructor`, `toString`, or any other inherited property name. The check would return `true`, causing the function to treat the account as explicitly configured — potentially suppressing security warnings or granting unintended access classifications.

Fixes #34926

## How

```diff
-  return accountId in accounts;
+  return Object.hasOwn(accounts, accountId);
```

`Object.hasOwn()` only checks own enumerable properties (Node.js 16.9+, all modern environments). It is functionally equivalent to the old check for all legitimate account IDs and explicitly rejects prototype-chain properties.

## Testing

All 90 existing security audit tests pass:

```bash
vitest run src/security/audit.test.ts
```

## Breaking Changes

None. All legitimate account IDs are own properties of the `accounts` config object. The only behavioral change is that crafted prototype-property names no longer produce false positives.