### PR TITLE
fix: fallback to systemctl in system context

### DIFF
--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -164,11 +164,31 @@ async function execSystemctl(
       code?: unknown;
       message?: unknown;
     };
+    const stdout = typeof e.stdout === "string" ? e.stdout : "";
+    const stderr =
+      typeof e.stderr === "string" ? e.stderr : typeof e.message === "string" ? e.message : "";
+    const code = typeof e.code === "number" ? e.code : 1;
+    const detail = `${stderr} ${stdout}`.toLowerCase();
+    const noUserBus =
+      args.includes("--user") &&
+      (detail.includes("failed to connect to bus") || detail.includes("no medium found"));
+    if (noUserBus) {
+      try {
+        const fallbackArgs = args.filter((arg) => arg !== "--user");
+        const fallback = await execFileAsync("systemctl", fallbackArgs, { encoding: "utf8" });
+        return {
+          stdout: String(fallback.stdout ?? ""),
+          stderr: String(fallback.stderr ?? ""),
+          code: 0,
+        };
+      } catch {
+        // keep original user-scope error for clearer diagnostics
+      }
+    }
     return {
-      stdout: typeof e.stdout === "string" ? e.stdout : "",
-      stderr:
-        typeof e.stderr === "string" ? e.stderr : typeof e.message === "string" ? e.message : "",
-      code: typeof e.code === "number" ? e.code : 1,
+      stdout,
+      stderr,
+      code,
     };
   }
 }


### PR DESCRIPTION
Closes #29051

## Problem
Gateway service management/status code always called `systemctl --user`. In system service contexts without a user bus, this fails with `Failed to connect to bus: No medium found`.

## Fix
When a `systemctl --user ...` call fails due to user-bus unavailability, retry the same command in system scope (without `--user`). Keep the original error if fallback also fails.
