### PR TITLE
config: fall back to .bak when primary config fails validation

### DIFF
--- a/src/config/config.bak-fallback.test.ts
+++ b/src/config/config.bak-fallback.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createConfigIO } from "./io.js";
+
+async function withTempHome(run: (home: string) => Promise<void>): Promise<void> {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bak-fallback-"));
+  try {
+    await run(home);
+  } finally {
+    await fs.rm(home, { recursive: true, force: true });
+  }
+}
+
+describe("config .bak fallback on invalid primary config", () => {
+  it("falls back to .bak when primary config is invalid", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      const configPath = path.join(configDir, "openclaw.json");
+
+      // Write an invalid primary config (bad key that fails validation)
+      await fs.writeFile(configPath, JSON.stringify({ gateway: { port: "not-a-number" } }));
+
+      // Write a valid .bak with a known port
+      await fs.writeFile(`${configPath}.bak`, JSON.stringify({ gateway: { port: 19876 } }));
+
+      const io = createConfigIO({ env: {} as NodeJS.ProcessEnv, homedir: () => home });
+      const cfg = io.loadConfig();
+      expect(cfg.gateway?.port).toBe(19876);
+    });
+  });
+
+  it("throws when both primary and .bak are invalid", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      const configPath = path.join(configDir, "openclaw.json");
+
+      // Both configs are invalid
+      await fs.writeFile(configPath, JSON.stringify({ gateway: { port: "bad" } }));
+      await fs.writeFile(`${configPath}.bak`, JSON.stringify({ gateway: { port: "also-bad" } }));
+
+      const io = createConfigIO({ env: {} as NodeJS.ProcessEnv, homedir: () => home });
+      expect(() => io.loadConfig()).toThrow("Invalid config");
+    });
+  });
+
+  it("throws when primary is invalid and no .bak exists", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      const configPath = path.join(configDir, "openclaw.json");
+
+      await fs.writeFile(configPath, JSON.stringify({ gateway: { port: "bad" } }));
+      // No .bak file
+
+      const io = createConfigIO({ env: {} as NodeJS.ProcessEnv, homedir: () => home });
+      expect(() => io.loadConfig()).toThrow("Invalid config");
+    });
+  });
+
+  it("loads primary config normally when it is valid (no fallback needed)", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      const configPath = path.join(configDir, "openclaw.json");
+
+      await fs.writeFile(configPath, JSON.stringify({ gateway: { port: 12345 } }));
+
+      const io = createConfigIO({ env: {} as NodeJS.ProcessEnv, homedir: () => home });
+      const cfg = io.loadConfig();
+      expect(cfg.gateway?.port).toBe(12345);
+    });
+  });
+});

--- a/src/config/config.bak-fallback.test.ts
+++ b/src/config/config.bak-fallback.test.ts
@@ -32,7 +32,7 @@ describe("config .bak fallback on invalid primary config", () => {
     });
   });
 
-  it("throws when both primary and .bak are invalid", async () => {
+  it("returns empty config when both primary and .bak are invalid", async () => {
     await withTempHome(async (home) => {
       const configDir = path.join(home, ".openclaw");
       await fs.mkdir(configDir, { recursive: true });
@@ -43,11 +43,12 @@ describe("config .bak fallback on invalid primary config", () => {
       await fs.writeFile(`${configPath}.bak`, JSON.stringify({ gateway: { port: "also-bad" } }));
 
       const io = createConfigIO({ env: {} as NodeJS.ProcessEnv, homedir: () => home });
-      expect(() => io.loadConfig()).toThrow("Invalid config");
+      const cfg = io.loadConfig();
+      expect(cfg).toEqual({});
     });
   });
 
-  it("throws when primary is invalid and no .bak exists", async () => {
+  it("returns empty config when primary is invalid and no .bak exists", async () => {
     await withTempHome(async (home) => {
       const configDir = path.join(home, ".openclaw");
       await fs.mkdir(configDir, { recursive: true });
@@ -57,7 +58,8 @@ describe("config .bak fallback on invalid primary config", () => {
       // No .bak file
 
       const io = createConfigIO({ env: {} as NodeJS.ProcessEnv, homedir: () => home });
-      expect(() => io.loadConfig()).toThrow("Invalid config");
+      const cfg = io.loadConfig();
+      expect(cfg).toEqual({});
     });
   });
 

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -742,7 +742,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       if (preValidationDuplicates.length > 0) {
         throw new DuplicateAgentDirError(preValidationDuplicates);
       }
-      const validated = validateConfigObjectWithPlugins(resolvedConfig);
+      let validated = validateConfigObjectWithPlugins(resolvedConfig);
       if (!validated.ok) {
         const details = validated.issues
           .map(
@@ -754,10 +754,37 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           loggedInvalidConfigs.add(configPath);
           deps.logger.error(`Invalid config at ${configPath}:\\n${details}`);
         }
-        const error = new Error(`Invalid config at ${configPath}:\n${details}`);
-        (error as { code?: string; details?: string }).code = "INVALID_CONFIG";
-        (error as { code?: string; details?: string }).details = details;
-        throw error;
+
+        // Fallback: try loading .bak if the primary config is invalid.
+        // The backup-rotation module already maintains .bak files on every
+        // successful write, so a recent valid copy is usually available.
+        const bakPath = `${configPath}.bak`;
+        if (deps.fs.existsSync(bakPath)) {
+          try {
+            const bakRaw = deps.fs.readFileSync(bakPath, "utf-8");
+            const bakParsed = deps.json5.parse(bakRaw);
+            const { resolvedConfigRaw: bakResolved } = resolveConfigForRead(
+              resolveConfigIncludesForRead(bakParsed, bakPath, deps),
+              deps.env,
+            );
+            const bakValidated = validateConfigObjectWithPlugins(bakResolved);
+            if (bakValidated.ok) {
+              deps.logger.warn(
+                `Loaded fallback config from ${bakPath} (primary config was invalid)`,
+              );
+              validated = bakValidated;
+            }
+          } catch {
+            // .bak is also broken — fall through to throw the original error.
+          }
+        }
+
+        if (!validated.ok) {
+          const error = new Error(`Invalid config at ${configPath}:\n${details}`);
+          (error as { code?: string; details?: string }).code = "INVALID_CONFIG";
+          (error as { code?: string; details?: string }).details = details;
+          throw error;
+        }
       }
       if (validated.warnings.length > 0) {
         const details = validated.warnings

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -721,6 +721,8 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
       const raw = deps.fs.readFileSync(configPath, "utf-8");
       const parsed = deps.json5.parse(raw);
+      // Snapshot env before primary resolution so .bak fallback starts clean.
+      const envBeforePrimaryResolve = { ...deps.env };
       const readResolution = resolveConfigForRead(
         resolveConfigIncludesForRead(parsed, configPath, deps),
         deps.env,
@@ -763,19 +765,27 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           try {
             const bakRaw = deps.fs.readFileSync(bakPath, "utf-8");
             const bakParsed = deps.json5.parse(bakRaw);
+            // Start from pre-primary-resolution env so invalid primary config.env
+            // entries don't leak into .bak resolution
+            const bakEnv = { ...envBeforePrimaryResolve };
             const { resolvedConfigRaw: bakResolved } = resolveConfigForRead(
               resolveConfigIncludesForRead(bakParsed, bakPath, deps),
-              deps.env,
+              bakEnv,
             );
+            warnOnConfigMiskeys(bakResolved, deps.logger);
             const bakValidated = validateConfigObjectWithPlugins(bakResolved);
             if (bakValidated.ok) {
+              // Merge env changes only after validation succeeds
+              Object.assign(deps.env, bakEnv);
               deps.logger.warn(
                 `Loaded fallback config from ${bakPath} (primary config was invalid)`,
               );
               validated = bakValidated;
             }
-          } catch {
-            // .bak is also broken — fall through to throw the original error.
+          } catch (bakErr) {
+            deps.logger.warn(
+              `Fallback config at ${bakPath} could not be loaded: ${String(bakErr)}`,
+            );
           }
         }
 

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -775,7 +775,13 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
             warnOnConfigMiskeys(bakResolved, deps.logger);
             const bakValidated = validateConfigObjectWithPlugins(bakResolved);
             if (bakValidated.ok) {
-              // Merge env changes only after validation succeeds
+              // Fully restore env: remove stale keys injected by invalid
+              // primary config before applying the backup's env entries.
+              for (const key of Object.keys(deps.env)) {
+                if (!(key in bakEnv)) {
+                  delete deps.env[key];
+                }
+              }
               Object.assign(deps.env, bakEnv);
               deps.logger.warn(
                 `Loaded fallback config from ${bakPath} (primary config was invalid)`,


### PR DESCRIPTION
When `openclaw.json` contains invalid keys or values, `loadConfig()` now tries loading `openclaw.json.bak` before throwing. The backup-rotation module already maintains `.bak` files on every successful config write, but until now a corrupted primary config would crash the gateway with no automatic recovery path.

AI-assisted: yes (Claude)

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
