### PR TITLE
fix(security): use Object.hasOwn to prevent prototype pollution bypass

### DIFF
--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -90,7 +90,7 @@ function hasExplicitProviderAccountConfig(
   if (!accounts || typeof accounts !== "object") {
     return false;
   }
-  return accountId in accounts;
+  return Object.hasOwn(accounts, accountId);
 }
 
 export async function collectChannelSecurityFindings(params: {


### PR DESCRIPTION
Fixes #34926. Replaces `in` operator with `Object.hasOwn()` in `hasExplicitProviderAccountConfig` to prevent prototype chain traversal that could allow specially crafted accountIds like `__proto__` to bypass the check.