### PR TITLE
fix(tui): preserve long hex tokens for copy-safe rendering

### DIFF
--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -249,6 +249,13 @@ describe("sanitizeRenderableText", () => {
     expect(sanitized).toBe(input);
   });
 
+  it("preserves long all-letter hex tokens for copy safety", () => {
+    const input = "deadbeefcafebabe".repeat(3);
+    const sanitized = sanitizeRenderableText(input);
+
+    expect(sanitized).toBe(input);
+  });
+
   it("preserves long hex tokens for copy safety", () => {
     const input = "3ec1311e304d0b34d59fd8a4d4add0a8a3f8eba2d85c1a25";
     const sanitized = sanitizeRenderableText(input);

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -263,6 +263,13 @@ describe("sanitizeRenderableText", () => {
     expect(sanitized).toBe(input);
   });
 
+  it("preserves long all-digit hex tokens for copy safety", () => {
+    const input = "1234567890".repeat(4);
+    const sanitized = sanitizeRenderableText(input);
+
+    expect(sanitized).toBe(input);
+  });
+
   it("wraps rtl lines with directional isolation marks", () => {
     const input = "مرحبا بالعالم";
     const sanitized = sanitizeRenderableText(input);

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -249,6 +249,13 @@ describe("sanitizeRenderableText", () => {
     expect(sanitized).toBe(input);
   });
 
+  it("preserves long hex tokens for copy safety", () => {
+    const input = "3ec1311e304d0b34d59fd8a4d4add0a8a3f8eba2d85c1a25";
+    const sanitized = sanitizeRenderableText(input);
+
+    expect(sanitized).toBe(input);
+  });
+
   it("wraps rtl lines with directional isolation marks", () => {
     const input = "مرحبا بالعالم";
     const sanitized = sanitizeRenderableText(input);

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -11,7 +11,7 @@ const BINARY_LINE_REPLACEMENT_THRESHOLD = 12;
 const URL_PREFIX_RE = /^(https?:\/\/|file:\/\/)/i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const FILE_LIKE_RE = /^[a-zA-Z0-9._-]+$/;
-const LONG_HEX_TOKEN_RE = /^(?!([a-f0-9])\1+$)(?=.*[a-f])[a-f0-9]{33,}$/i;
+const LONG_HEX_TOKEN_RE = /^(?!([a-f0-9])\1+$)[a-f0-9]{33,}$/i;
 const RTL_SCRIPT_RE = /[\u0590-\u08ff\ufb1d-\ufdff\ufe70-\ufefc]/;
 const BIDI_CONTROL_RE = /[\u202a-\u202e\u2066-\u2069]/;
 const RTL_ISOLATE_START = "\u2067";

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -11,6 +11,7 @@ const BINARY_LINE_REPLACEMENT_THRESHOLD = 12;
 const URL_PREFIX_RE = /^(https?:\/\/|file:\/\/)/i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const FILE_LIKE_RE = /^[a-zA-Z0-9._-]+$/;
+const LONG_HEX_TOKEN_RE = /^(?=.*[a-f])(?=.*\d)[a-f0-9]{33,}$/i;
 const RTL_SCRIPT_RE = /[\u0590-\u08ff\ufb1d-\ufdff\ufe70-\ufefc]/;
 const BIDI_CONTROL_RE = /[\u202a-\u202e\u2066-\u2069]/;
 const RTL_ISOLATE_START = "\u2067";
@@ -56,6 +57,9 @@ function chunkToken(token: string, maxChars: number): string[] {
 }
 
 function isCopySensitiveToken(token: string): boolean {
+  if (LONG_HEX_TOKEN_RE.test(token)) {
+    return true;
+  }
   if (URL_PREFIX_RE.test(token)) {
     return true;
   }

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -11,7 +11,7 @@ const BINARY_LINE_REPLACEMENT_THRESHOLD = 12;
 const URL_PREFIX_RE = /^(https?:\/\/|file:\/\/)/i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const FILE_LIKE_RE = /^[a-zA-Z0-9._-]+$/;
-const LONG_HEX_TOKEN_RE = /^(?=.*[a-f])(?=.*\d)[a-f0-9]{33,}$/i;
+const LONG_HEX_TOKEN_RE = /^(?!([a-f0-9])\1+$)(?=.*[a-f])[a-f0-9]{33,}$/i;
 const RTL_SCRIPT_RE = /[\u0590-\u08ff\ufb1d-\ufdff\ufe70-\ufefc]/;
 const BIDI_CONTROL_RE = /[\u202a-\u202e\u2066-\u2069]/;
 const RTL_ISOLATE_START = "\u2067";


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `sanitizeRenderableText()` inserts spaces every 32 chars for long unbroken tokens, which corrupts long hex credentials when users copy from TUI code blocks.
- Why it matters: pasted auth tokens become invalid with a hidden internal space.
- What changed: long hex tokens are now treated as copy-sensitive and preserved verbatim; added regression coverage for a 48-char hex token.
- What did NOT change (scope boundary): no syntax-highlighter behavior was changed; non-hex long-token wrapping behavior remains unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34956
- Related #

## User-visible / Behavior Changes

Long hex strings rendered in TUI output are no longer split with an inserted space, so copied token values remain intact.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - This change only preserves contiguous token rendering for long hex strings to prevent copy corruption; no new token exposure is introduced.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.22.0
- Model/provider: N/A
- Integration/channel (if any): TUI rendering path
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm vitest src/tui/tui-formatters.test.ts -t 'preserves long hex tokens for copy safety'` on `upstream/main` (or before this patch).
2. Observe failure: sanitized output inserts a space after 32 chars in a 48-char hex token.
3. Apply patch and rerun `pnpm vitest src/tui/tui-formatters.test.ts`.

### Expected

- Long hex token remains contiguous when sanitized/rendered.

### Actual

- Before fix: `3ec1311e304d0b34d59fd8a4d4add0a8 a3f8eba2d85c1a25` (extra space inserted).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: exact reported 48-char hex token now preserved; full `src/tui/tui-formatters.test.ts` passes.
- Edge cases checked: existing long-token wrapping tests for non-hex strings (`"a".repeat(140)`, `"b".repeat(90)`) still pass.
- What you did **not** verify: end-to-end interactive terminal copy/paste behavior in a live TUI session.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/tui/tui-formatters.ts`, `src/tui/tui-formatters.test.ts`.
- Known bad symptoms reviewers should watch for: unexpectedly unwrapped non-sensitive long tokens (not observed with current tests).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: regex may classify some non-token long alphanumeric strings as copy-sensitive.
  - Mitigation: regex is constrained to hex characters (`[a-f0-9]`) and excludes single-character repeats via negative lookahead; existing generic long-token wrapping tests still pass.

