### PR TITLE
fix(agents): preserve webchat origin for subagent announces

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -1937,6 +1937,37 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.to).toBe("telegram:123");
   });
 
+  it("does not fall back to stale external channel when requester origin is webchat", async () => {
+    sessionStore = {
+      "agent:main:main": {
+        sessionId: "session-stale-channel",
+        channel: "telegram",
+        to: "telegram:999",
+        lastChannel: "telegram",
+        lastTo: "telegram:999",
+      },
+    };
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-webchat-origin",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      requesterOrigin: { channel: "webchat", to: "conversation:webchat-main" },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      spawnMode: "session",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(call?.params?.deliver).toBe(false);
+    expect(call?.params?.channel).toBeUndefined();
+    expect(call?.params?.to).toBeUndefined();
+  });
+
   it("routes or falls back for ended parent subagent sessions (#18037)", async () => {
     const cases = [
       {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -455,16 +455,13 @@ function resolveAnnounceOrigin(
   const normalizedRequester = normalizeDeliveryContext(requesterOrigin);
   const normalizedEntry = deliveryContextFromSession(entry);
   if (normalizedRequester?.channel && isInternalMessageChannel(normalizedRequester.channel)) {
-    // Ignore internal channel hints (webchat) so a valid persisted route
-    // can still be used for outbound delivery. Non-standard channels that
-    // are not in the deliverable list should NOT be stripped here — doing
-    // so causes the session entry's stale lastChannel (often WhatsApp) to
-    // override the actual requester origin, leading to delivery failures.
+    // Keep explicit internal requester targets so stale persisted routes
+    // do not hijack completion announcements in shared sessions.
+    if (normalizedRequester.to) {
+      return mergeDeliveryContext(normalizedRequester, normalizedEntry);
+    }
     return mergeDeliveryContext(
-      {
-        accountId: normalizedRequester.accountId,
-        threadId: normalizedRequester.threadId,
-      },
+      { accountId: normalizedRequester.accountId, threadId: normalizedRequester.threadId },
       normalizedEntry,
     );
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: subagent announce routing can strip `webchat` requester origin and fall back to stale persisted external route metadata.
- Why it matters: completion announcements from webchat-originated `sessions_spawn` runs can be delivered to Telegram/other external channels instead of staying with the originating web session.
- What changed: `resolveAnnounceOrigin` now preserves explicit internal requester targets (`webchat` + `to`) so stale session route fields cannot override them.
- What did NOT change (scope boundary): no queue-state-machine refactor; no changes to non-internal channel precedence rules.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34993
- Related #25675

## User-visible / Behavior Changes

Subagent completion announcements keep the spawn-time webchat origin context instead of being hijacked by stale external `lastChannel` metadata.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.22.0
- Model/provider: N/A
- Integration/channel (if any): subagent announce routing (webchat + external channel metadata)
- Relevant config (redacted): shared main session with persisted external `lastChannel`/`lastTo`

### Steps

1. Configure session entry with stale external route (`lastChannel=telegram`, `lastTo=telegram:999`) and run subagent announce flow with `requesterOrigin={channel:webchat,to:conversation:webchat-main}`.
2. Before fix, direct announce delivery resolves to external route (`deliver=true` with external channel target).
3. After fix, run `pnpm vitest --config vitest.e2e.config.ts src/agents/subagent-announce.format.e2e.test.ts -t 'stale session lastChannel|webchat'`.

### Expected

- Explicit internal webchat requester origin remains authoritative; no stale external fallback.

### Actual

- Before fix, stale external route could override internal requester origin and drive external delivery.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: new e2e regression for webchat-origin stale-route case; existing stale-route queued test still passes.
- Edge cases checked: explicit internal requester with `to` is preserved; other requester origin precedence logic remains unchanged for non-internal channels.
- What you did **not** verify: full live multi-channel end-to-end run against real Telegram/webchat services.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/subagent-announce.ts`, `src/agents/subagent-announce.format.e2e.test.ts`.
- Known bad symptoms reviewers should watch for: unexpected fallback to external route in webchat-origin announce scenarios.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: preserving internal origin more aggressively could alter legacy fallback behavior when webchat origin lacks meaningful routing data.
  - Mitigation: fix only applies when an explicit internal target (`to`) is present; legacy fallback path remains for internal origins without explicit target.
