### PR TITLE
fix(agents): discover Bedrock inference profile IDs alongside foundation models

### DIFF
--- a/package.json
+++ b/package.json
@@ -380,7 +380,7 @@
     "sharp": "^0.34.5",
     "sqlite-vec": "0.1.7-alpha.2",
     "strip-ansi": "^7.2.0",
-    "tar": "7.5.9",
+    "tar": "7.5.10",
     "tslog": "^4.10.2",
     "undici": "^7.22.0",
     "ws": "^8.19.0",
@@ -419,7 +419,8 @@
   "pnpm": {
     "minimumReleaseAge": 2880,
     "overrides": {
-      "hono": "4.11.10",
+      "hono": "4.12.5",
+      "@hono/node-server": "1.19.10",
       "fast-xml-parser": "5.3.8",
       "request": "npm:@cypress/request@3.0.10",
       "request-promise": "npm:@cypress/request-promise@5.0.0",
@@ -428,7 +429,7 @@
       "qs": "6.14.2",
       "node-domexception": "npm:@nolyfill/domexception@^1.0.28",
       "@sinclair/typebox": "0.34.48",
-      "tar": "7.5.9",
+      "tar": "7.5.10",
       "tough-cookie": "4.1.3"
     },
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  hono: 4.11.10
+  hono: 4.12.5
+  '@hono/node-server': 1.19.10
   fast-xml-parser: 5.3.8
   request: npm:@cypress/request@3.0.10
   request-promise: npm:@cypress/request-promise@5.0.0
@@ -14,7 +15,7 @@ overrides:
   qs: 6.14.2
   node-domexception: npm:@nolyfill/domexception@^1.0.28
   '@sinclair/typebox': 0.34.48
-  tar: 7.5.9
+  tar: 7.5.10
   tough-cookie: 4.1.3
 
 importers:
@@ -29,7 +30,7 @@ importers:
         version: 3.1000.0
       '@buape/carbon':
         specifier: 0.0.0-beta-20260216184201
-        version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
+        version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.5)(opusscript@0.1.1)
       '@clack/prompts':
         specifier: ^1.0.1
         version: 1.0.1
@@ -178,8 +179,8 @@ importers:
         specifier: ^7.2.0
         version: 7.2.0
       tar:
-        specifier: 7.5.9
-        version: 7.5.9
+        specifier: 7.5.10
+        version: 7.5.10
       tslog:
         specifier: ^4.10.2
         version: 4.10.2
@@ -342,7 +343,7 @@ importers:
         version: 10.6.1
       openclaw:
         specifier: '>=2026.3.2'
-        version: 2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
+        version: 2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.12.5)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/imessage: {}
 
@@ -403,7 +404,7 @@ importers:
     dependencies:
       openclaw:
         specifier: '>=2026.3.2'
-        version: 2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
+        version: 2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.12.5)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/memory-lancedb:
     dependencies:
@@ -1144,11 +1145,11 @@ packages:
     resolution: {integrity: sha512-f7MAw7YuoEYgJEQ1VyRcLHGuVmCpmXi65GVR8CAtPWPqIZf/HFr4vHzVpOfQMpEQw9Pt5uh07guuLt5HE8ruog==}
     hasBin: true
 
-  '@hono/node-server@1.19.9':
-    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+  '@hono/node-server@1.19.10':
+    resolution: {integrity: sha512-hZ7nOssGqRgyV3FVVQdfi+U4q02uB23bpnYpdvNXkYTRRyWx84b7yf1ans+dnJ/7h41sGL3CeQTfO+ZGxuO+Iw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.11.10
+      hono: 4.12.5
 
   '@huggingface/jinja@0.5.5':
     resolution: {integrity: sha512-xRlzazC+QZwr6z4ixEqYHo9fgwhTZ3xNSdljlKfUFGZSdlvt166DljRELFUfFytlYOYvo3vTisA/AFOuOAzFQQ==}
@@ -4219,8 +4220,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.11.10:
-    resolution: {integrity: sha512-kyWP5PAiMooEvGrA9jcD3IXF7ATu8+o7B3KCbPXid5se52NPqnOpM/r9qeW2heMnOekF4kqR1fXJqCYeCLKrZg==}
+  hono@4.12.5:
+    resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.0.1:
@@ -5699,10 +5700,9 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
-  tar@7.5.9:
-    resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
+  tar@7.5.10:
+    resolution: {integrity: sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -6820,14 +6820,14 @@ snapshots:
 
   '@borewit/text-codec@0.2.1': {}
 
-  '@buape/carbon@0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)':
+  '@buape/carbon@0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.5)(opusscript@0.1.1)':
     dependencies:
       '@types/node': 25.3.3
       discord-api-types: 0.38.37
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260120.0
       '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
-      '@hono/node-server': 1.19.9(hono@4.11.10)
+      '@hono/node-server': 1.19.10(hono@4.12.5)
       '@types/bun': 1.3.9
       '@types/ws': 8.18.1
       ws: 8.19.0
@@ -6961,7 +6961,7 @@ snapshots:
       npmlog: 5.0.1
       rimraf: 3.0.2
       semver: 7.7.4
-      tar: 7.5.9
+      tar: 7.5.10
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -7138,9 +7138,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@hono/node-server@1.19.9(hono@4.11.10)':
+  '@hono/node-server@1.19.10(hono@4.12.5)':
     dependencies:
-      hono: 4.11.10
+      hono: 4.12.5
     optional: true
 
   '@huggingface/jinja@0.5.5': {}
@@ -9728,7 +9728,7 @@ snapshots:
       node-api-headers: 1.8.0
       rc: 1.2.8
       semver: 7.7.4
-      tar: 7.5.9
+      tar: 7.5.10
       url-join: 4.0.1
       which: 6.0.1
       yargs: 17.7.2
@@ -10395,7 +10395,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.11.10:
+  hono@4.12.5:
     optional: true
 
   hookable@6.0.1: {}
@@ -11189,11 +11189,11 @@ snapshots:
       ws: 8.19.0
       zod: 4.3.6
 
-  openclaw@2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3)):
+  openclaw@2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.12.5)(node-llama-cpp@3.16.2(typescript@5.9.3)):
     dependencies:
       '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
       '@aws-sdk/client-bedrock': 3.1000.0
-      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
+      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.5)(opusscript@0.1.1)
       '@clack/prompts': 1.0.1
       '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
       '@grammyjs/runner': 2.0.3(grammy@1.41.0)
@@ -11245,7 +11245,7 @@ snapshots:
       sharp: 0.34.5
       sqlite-vec: 0.1.7-alpha.2
       strip-ansi: 7.2.0
-      tar: 7.5.9
+      tar: 7.5.10
       tslog: 4.10.2
       undici: 7.22.0
       ws: 8.19.0
@@ -12190,7 +12190,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  tar@7.5.9:
+  tar@7.5.10:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/src/agents/bedrock-discovery.test.ts
+++ b/src/agents/bedrock-discovery.test.ts
@@ -329,20 +329,31 @@ describe("bedrock discovery", () => {
     );
   });
 
-  it("does not cache partial discovery results", async () => {
+  it("caches partial discovery results briefly before retrying failed sources", async () => {
     const { discoverBedrockModels } = await loadDiscovery();
+    let nowMs = 1_000_000;
     setupDiscoveryResponses({
       foundationError: new Error("foundation-model discovery failed"),
       inferencePages: [
         { inferenceProfileSummaries: [baseInferenceProfileSummary] },
         { inferenceProfileSummaries: [baseInferenceProfileSummary] },
+        { inferenceProfileSummaries: [baseInferenceProfileSummary] },
       ],
     });
 
-    await discoverBedrockModels({ region: "us-east-1", clientFactory });
-    await discoverBedrockModels({ region: "us-east-1", clientFactory });
+    await discoverBedrockModels({ region: "us-east-1", clientFactory, now: () => nowMs });
+    await discoverBedrockModels({ region: "us-east-1", clientFactory, now: () => nowMs });
 
-    // Each call should re-run both source queries when the previous result was partial.
+    // Partial results are cached for a short TTL to avoid repeated retries/log spam.
+    expect(sendMock).toHaveBeenCalledTimes(2);
+
+    nowMs += 59_000;
+    await discoverBedrockModels({ region: "us-east-1", clientFactory, now: () => nowMs });
+    expect(sendMock).toHaveBeenCalledTimes(2);
+
+    // After short partial-TTL expiry, discovery retries both sources.
+    nowMs += 2_000;
+    await discoverBedrockModels({ region: "us-east-1", clientFactory, now: () => nowMs });
     expect(sendMock).toHaveBeenCalledTimes(4);
   });
 

--- a/src/agents/bedrock-discovery.test.ts
+++ b/src/agents/bedrock-discovery.test.ts
@@ -329,6 +329,23 @@ describe("bedrock discovery", () => {
     );
   });
 
+  it("does not cache partial discovery results", async () => {
+    const { discoverBedrockModels } = await loadDiscovery();
+    setupDiscoveryResponses({
+      foundationError: new Error("foundation-model discovery failed"),
+      inferencePages: [
+        { inferenceProfileSummaries: [baseInferenceProfileSummary] },
+        { inferenceProfileSummaries: [baseInferenceProfileSummary] },
+      ],
+    });
+
+    await discoverBedrockModels({ region: "us-east-1", clientFactory });
+    await discoverBedrockModels({ region: "us-east-1", clientFactory });
+
+    // Each call should re-run both source queries when the previous result was partial.
+    expect(sendMock).toHaveBeenCalledTimes(4);
+  });
+
   it("caches results when refreshInterval is enabled", async () => {
     const { discoverBedrockModels } = await loadDiscovery();
     setupDiscoveryResponses({

--- a/src/agents/bedrock-discovery.test.ts
+++ b/src/agents/bedrock-discovery.test.ts
@@ -1,4 +1,8 @@
-import type { BedrockClient } from "@aws-sdk/client-bedrock";
+import {
+  ListFoundationModelsCommand,
+  ListInferenceProfilesCommand,
+  type BedrockClient,
+} from "@aws-sdk/client-bedrock";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const sendMock = vi.fn();
@@ -14,65 +18,108 @@ const baseActiveAnthropicSummary = {
   modelLifecycle: { status: "ACTIVE" },
 };
 
+const baseInferenceProfileSummary = {
+  inferenceProfileId: "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+  inferenceProfileName: "US Claude 3.5 Sonnet",
+  status: "ACTIVE",
+};
+
+type DiscoveryFoundationResponse = {
+  modelSummaries?: Array<Record<string, unknown>>;
+};
+
+type DiscoveryInferenceResponse = {
+  inferenceProfileSummaries?: Array<Record<string, unknown>>;
+  nextToken?: string;
+};
+
 async function loadDiscovery() {
   const mod = await import("./bedrock-discovery.js");
   mod.resetBedrockDiscoveryCacheForTest();
   return mod;
 }
 
-function mockSingleActiveSummary(overrides: Partial<typeof baseActiveAnthropicSummary> = {}): void {
-  sendMock.mockResolvedValueOnce({
-    modelSummaries: [{ ...baseActiveAnthropicSummary, ...overrides }],
+function setupDiscoveryResponses(params?: {
+  foundation?: DiscoveryFoundationResponse;
+  inferencePages?: DiscoveryInferenceResponse[];
+  foundationError?: Error;
+  inferenceError?: Error;
+}): void {
+  const inferencePages = params?.inferencePages ?? [{ inferenceProfileSummaries: [] }];
+  let inferenceIndex = 0;
+
+  sendMock.mockImplementation(async (command: unknown) => {
+    if (command instanceof ListFoundationModelsCommand) {
+      if (params?.foundationError) {
+        throw params.foundationError;
+      }
+      return params?.foundation ?? ({ modelSummaries: [] } as DiscoveryFoundationResponse);
+    }
+
+    if (command instanceof ListInferenceProfilesCommand) {
+      if (params?.inferenceError) {
+        throw params.inferenceError;
+      }
+      const page = inferencePages[inferenceIndex] ?? ({ inferenceProfileSummaries: [] } as const);
+      inferenceIndex += 1;
+      return page;
+    }
+
+    throw new Error(
+      `Unexpected command type: ${String((command as { constructor?: { name?: string } })?.constructor?.name)}`,
+    );
   });
 }
 
 describe("bedrock discovery", () => {
   beforeEach(() => {
-    sendMock.mockClear();
+    sendMock.mockReset();
   });
 
-  it("filters to active streaming text models and maps modalities", async () => {
+  it("filters to active streaming text foundation models and maps modalities", async () => {
     const { discoverBedrockModels } = await loadDiscovery();
 
-    sendMock.mockResolvedValueOnce({
-      modelSummaries: [
-        {
-          modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
-          modelName: "Claude 3.7 Sonnet",
-          providerName: "anthropic",
-          inputModalities: ["TEXT", "IMAGE"],
-          outputModalities: ["TEXT"],
-          responseStreamingSupported: true,
-          modelLifecycle: { status: "ACTIVE" },
-        },
-        {
-          modelId: "anthropic.claude-3-haiku-20240307-v1:0",
-          modelName: "Claude 3 Haiku",
-          providerName: "anthropic",
-          inputModalities: ["TEXT"],
-          outputModalities: ["TEXT"],
-          responseStreamingSupported: false,
-          modelLifecycle: { status: "ACTIVE" },
-        },
-        {
-          modelId: "meta.llama3-8b-instruct-v1:0",
-          modelName: "Llama 3 8B",
-          providerName: "meta",
-          inputModalities: ["TEXT"],
-          outputModalities: ["TEXT"],
-          responseStreamingSupported: true,
-          modelLifecycle: { status: "INACTIVE" },
-        },
-        {
-          modelId: "amazon.titan-embed-text-v1",
-          modelName: "Titan Embed",
-          providerName: "amazon",
-          inputModalities: ["TEXT"],
-          outputModalities: ["EMBEDDING"],
-          responseStreamingSupported: true,
-          modelLifecycle: { status: "ACTIVE" },
-        },
-      ],
+    setupDiscoveryResponses({
+      foundation: {
+        modelSummaries: [
+          {
+            modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+            modelName: "Claude 3.7 Sonnet",
+            providerName: "anthropic",
+            inputModalities: ["TEXT", "IMAGE"],
+            outputModalities: ["TEXT"],
+            responseStreamingSupported: true,
+            modelLifecycle: { status: "ACTIVE" },
+          },
+          {
+            modelId: "anthropic.claude-3-haiku-20240307-v1:0",
+            modelName: "Claude 3 Haiku",
+            providerName: "anthropic",
+            inputModalities: ["TEXT"],
+            outputModalities: ["TEXT"],
+            responseStreamingSupported: false,
+            modelLifecycle: { status: "ACTIVE" },
+          },
+          {
+            modelId: "meta.llama3-8b-instruct-v1:0",
+            modelName: "Llama 3 8B",
+            providerName: "meta",
+            inputModalities: ["TEXT"],
+            outputModalities: ["TEXT"],
+            responseStreamingSupported: true,
+            modelLifecycle: { status: "INACTIVE" },
+          },
+          {
+            modelId: "amazon.titan-embed-text-v1",
+            modelName: "Titan Embed",
+            providerName: "amazon",
+            inputModalities: ["TEXT"],
+            outputModalities: ["EMBEDDING"],
+            responseStreamingSupported: true,
+            modelLifecycle: { status: "ACTIVE" },
+          },
+        ],
+      },
     });
 
     const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
@@ -87,21 +134,101 @@ describe("bedrock discovery", () => {
     });
   });
 
-  it("applies provider filter", async () => {
+  it("includes active inference profiles with pagination", async () => {
     const { discoverBedrockModels } = await loadDiscovery();
-    mockSingleActiveSummary();
+
+    setupDiscoveryResponses({
+      foundation: { modelSummaries: [] },
+      inferencePages: [
+        {
+          inferenceProfileSummaries: [
+            {
+              inferenceProfileId: "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+              inferenceProfileName: "US Claude 3.5 Sonnet",
+              status: "ACTIVE",
+            },
+            {
+              inferenceProfileId: "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+              inferenceProfileName: "Duplicate profile id",
+              status: "ACTIVE",
+            },
+          ],
+          nextToken: "next-page",
+        },
+        {
+          inferenceProfileSummaries: [
+            {
+              inferenceProfileId: "eu.amazon.nova-lite-v1:0",
+              inferenceProfileName: "EU Nova Thinking Lite",
+              status: "ACTIVE",
+            },
+            {
+              inferenceProfileId: "us.meta.llama-3-2-11b-instruct-v1:0",
+              inferenceProfileName: "US Meta Inactive",
+              status: "INACTIVE",
+            },
+          ],
+        },
+      ],
+    });
+
+    const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
+    expect(models).toHaveLength(2);
+    expect(models.map((entry) => entry.id)).toEqual([
+      "eu.amazon.nova-lite-v1:0",
+      "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+    ]);
+    expect(models[0]).toMatchObject({
+      name: "EU Nova Thinking Lite",
+      reasoning: true,
+      input: ["text"],
+    });
+  });
+
+  it("applies provider filter across foundation models and inference profiles", async () => {
+    const { discoverBedrockModels } = await loadDiscovery();
+    setupDiscoveryResponses({
+      foundation: {
+        modelSummaries: [
+          baseActiveAnthropicSummary,
+          {
+            ...baseActiveAnthropicSummary,
+            modelId: "amazon.nova-micro-v1:0",
+            modelName: "Nova Micro",
+            providerName: "amazon",
+          },
+        ],
+      },
+      inferencePages: [
+        {
+          inferenceProfileSummaries: [
+            baseInferenceProfileSummary,
+            {
+              inferenceProfileId: "us.amazon.nova-pro-v1:0",
+              inferenceProfileName: "US Nova Pro",
+              status: "ACTIVE",
+            },
+          ],
+        },
+      ],
+    });
 
     const models = await discoverBedrockModels({
       region: "us-east-1",
       config: { providerFilter: ["amazon"] },
       clientFactory,
     });
-    expect(models).toHaveLength(0);
+    expect(models.map((entry) => entry.id)).toEqual([
+      "amazon.nova-micro-v1:0",
+      "us.amazon.nova-pro-v1:0",
+    ]);
   });
 
   it("uses configured defaults for context and max tokens", async () => {
     const { discoverBedrockModels } = await loadDiscovery();
-    mockSingleActiveSummary();
+    setupDiscoveryResponses({
+      foundation: { modelSummaries: [baseActiveAnthropicSummary] },
+    });
 
     const models = await discoverBedrockModels({
       region: "us-east-1",
@@ -111,21 +238,47 @@ describe("bedrock discovery", () => {
     expect(models[0]).toMatchObject({ contextWindow: 64000, maxTokens: 8192 });
   });
 
+  it("returns inference profiles when foundation-model discovery fails", async () => {
+    const { discoverBedrockModels } = await loadDiscovery();
+    setupDiscoveryResponses({
+      foundationError: new Error("foundation-model discovery failed"),
+      inferencePages: [{ inferenceProfileSummaries: [baseInferenceProfileSummary] }],
+    });
+
+    const models = await discoverBedrockModels({
+      region: "us-east-1",
+      clientFactory,
+    });
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+      }),
+    ]);
+  });
+
   it("caches results when refreshInterval is enabled", async () => {
     const { discoverBedrockModels } = await loadDiscovery();
-    mockSingleActiveSummary();
+    setupDiscoveryResponses({
+      foundation: { modelSummaries: [baseActiveAnthropicSummary] },
+    });
 
     await discoverBedrockModels({ region: "us-east-1", clientFactory });
     await discoverBedrockModels({ region: "us-east-1", clientFactory });
-    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledTimes(2);
   });
 
   it("skips cache when refreshInterval is 0", async () => {
     const { discoverBedrockModels } = await loadDiscovery();
 
-    sendMock
-      .mockResolvedValueOnce({ modelSummaries: [baseActiveAnthropicSummary] })
-      .mockResolvedValueOnce({ modelSummaries: [baseActiveAnthropicSummary] });
+    setupDiscoveryResponses({
+      foundation: { modelSummaries: [baseActiveAnthropicSummary] },
+      inferencePages: [
+        { inferenceProfileSummaries: [] },
+        { inferenceProfileSummaries: [] },
+        { inferenceProfileSummaries: [] },
+        { inferenceProfileSummaries: [] },
+      ],
+    });
 
     await discoverBedrockModels({
       region: "us-east-1",
@@ -137,6 +290,6 @@ describe("bedrock discovery", () => {
       config: { refreshInterval: 0 },
       clientFactory,
     });
-    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(sendMock).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/agents/bedrock-discovery.test.ts
+++ b/src/agents/bedrock-discovery.test.ts
@@ -5,6 +5,16 @@ import {
 } from "@aws-sdk/client-bedrock";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const loggerMocks = vi.hoisted(() => ({
+  warn: vi.fn(),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    warn: loggerMocks.warn,
+  }),
+}));
+
 const sendMock = vi.fn();
 const clientFactory = () => ({ send: sendMock }) as unknown as BedrockClient;
 
@@ -74,6 +84,7 @@ function setupDiscoveryResponses(params?: {
 describe("bedrock discovery", () => {
   beforeEach(() => {
     sendMock.mockReset();
+    loggerMocks.warn.mockReset();
   });
 
   it("filters to active streaming text foundation models and maps modalities", async () => {
@@ -224,6 +235,44 @@ describe("bedrock discovery", () => {
     ]);
   });
 
+  it("matches provider filters for inference profiles with extended location prefixes", async () => {
+    const { discoverBedrockModels } = await loadDiscovery();
+    setupDiscoveryResponses({
+      foundation: { modelSummaries: [] },
+      inferencePages: [
+        {
+          inferenceProfileSummaries: [
+            {
+              inferenceProfileId: "apac.amazon.nova-lite-v1:0",
+              inferenceProfileName: "APAC Nova Lite",
+              status: "ACTIVE",
+            },
+            {
+              inferenceProfileId: "us-gov.amazon.nova-pro-v1:0",
+              inferenceProfileName: "US Gov Nova Pro",
+              status: "ACTIVE",
+            },
+            {
+              inferenceProfileId: "us-gov.anthropic.claude-3-5-sonnet-20241022-v2:0",
+              inferenceProfileName: "US Gov Claude",
+              status: "ACTIVE",
+            },
+          ],
+        },
+      ],
+    });
+
+    const models = await discoverBedrockModels({
+      region: "us-east-1",
+      config: { providerFilter: ["amazon"] },
+      clientFactory,
+    });
+    expect(models.map((entry) => entry.id)).toEqual([
+      "apac.amazon.nova-lite-v1:0",
+      "us-gov.amazon.nova-pro-v1:0",
+    ]);
+  });
+
   it("uses configured defaults for context and max tokens", async () => {
     const { discoverBedrockModels } = await loadDiscovery();
     setupDiscoveryResponses({
@@ -254,6 +303,30 @@ describe("bedrock discovery", () => {
         id: "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
       }),
     ]);
+  });
+
+  it("logs partial failures when at least one discovery source succeeds", async () => {
+    const { discoverBedrockModels } = await loadDiscovery();
+    const foundationError = new Error("foundation-model discovery failed");
+    setupDiscoveryResponses({
+      foundationError,
+      inferencePages: [{ inferenceProfileSummaries: [baseInferenceProfileSummary] }],
+    });
+
+    const models = await discoverBedrockModels({
+      region: "us-east-1",
+      clientFactory,
+    });
+
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+      }),
+    ]);
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(1);
+    expect(loggerMocks.warn).toHaveBeenCalledWith(
+      `Failed to list foundation models during Bedrock discovery: ${String(foundationError)}`,
+    );
   });
 
   it("caches results when refreshInterval is enabled", async () => {

--- a/src/agents/bedrock-discovery.ts
+++ b/src/agents/bedrock-discovery.ts
@@ -303,6 +303,7 @@ export async function discoverBedrockModels(params: {
 
   const clientFactory = params.clientFactory ?? ((region: string) => new BedrockClient({ region }));
   const client = clientFactory(params.region);
+  let hadPartialFailure = false;
 
   const discoveryPromise = (async () => {
     const defaults = {
@@ -322,6 +323,7 @@ export async function discoverBedrockModels(params: {
         discovered.push(toModelDefinitionFromFoundationModel(summary, defaults));
       }
     } catch (error) {
+      hadPartialFailure = true;
       log.warn(`Failed to list foundation models during Bedrock discovery: ${String(error)}`);
       partialFailures.push(error);
     }
@@ -335,6 +337,7 @@ export async function discoverBedrockModels(params: {
         discovered.push(toModelDefinitionFromInferenceProfile(summary, defaults));
       }
     } catch (error) {
+      hadPartialFailure = true;
       log.warn(`Failed to list inference profiles during Bedrock discovery: ${String(error)}`);
       partialFailures.push(error);
     }
@@ -356,10 +359,14 @@ export async function discoverBedrockModels(params: {
   try {
     const value = await discoveryPromise;
     if (refreshIntervalSeconds > 0) {
-      discoveryCache.set(cacheKey, {
-        expiresAt: now + refreshIntervalSeconds * 1000,
-        value,
-      });
+      if (hadPartialFailure) {
+        discoveryCache.delete(cacheKey);
+      } else {
+        discoveryCache.set(cacheKey, {
+          expiresAt: now + refreshIntervalSeconds * 1000,
+          value,
+        });
+      }
     }
     return value;
   } catch (error) {

--- a/src/agents/bedrock-discovery.ts
+++ b/src/agents/bedrock-discovery.ts
@@ -11,6 +11,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 const log = createSubsystemLogger("bedrock-discovery");
 
 const DEFAULT_REFRESH_INTERVAL_SECONDS = 3600;
+const PARTIAL_FAILURE_CACHE_TTL_SECONDS = 60;
 const DEFAULT_CONTEXT_WINDOW = 32000;
 const DEFAULT_MAX_TOKENS = 4096;
 const DEFAULT_COST = {
@@ -360,7 +361,18 @@ export async function discoverBedrockModels(params: {
     const value = await discoveryPromise;
     if (refreshIntervalSeconds > 0) {
       if (hadPartialFailure) {
-        discoveryCache.delete(cacheKey);
+        const partialTtlSeconds = Math.min(
+          refreshIntervalSeconds,
+          PARTIAL_FAILURE_CACHE_TTL_SECONDS,
+        );
+        if (partialTtlSeconds > 0) {
+          discoveryCache.set(cacheKey, {
+            expiresAt: now + partialTtlSeconds * 1000,
+            value,
+          });
+        } else {
+          discoveryCache.delete(cacheKey);
+        }
       } else {
         discoveryCache.set(cacheKey, {
           expiresAt: now + refreshIntervalSeconds * 1000,

--- a/src/agents/bedrock-discovery.ts
+++ b/src/agents/bedrock-discovery.ts
@@ -1,7 +1,9 @@
 import {
   BedrockClient,
   ListFoundationModelsCommand,
+  ListInferenceProfilesCommand,
   type ListFoundationModelsCommandOutput,
+  type ListInferenceProfilesCommandOutput,
 } from "@aws-sdk/client-bedrock";
 import type { BedrockDiscoveryConfig, ModelDefinitionConfig } from "../config/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -19,6 +21,9 @@ const DEFAULT_COST = {
 };
 
 type BedrockModelSummary = NonNullable<ListFoundationModelsCommandOutput["modelSummaries"]>[number];
+type InferenceProfileSummary = NonNullable<
+  ListInferenceProfilesCommandOutput["inferenceProfileSummaries"]
+>[number];
 
 type BedrockDiscoveryCacheEntry = {
   expiresAt: number;
@@ -28,6 +33,8 @@ type BedrockDiscoveryCacheEntry = {
 
 const discoveryCache = new Map<string, BedrockDiscoveryCacheEntry>();
 let hasLoggedBedrockError = false;
+const INFERENCE_PROFILE_PAGE_SIZE = 100;
+const INFERENCE_PROFILE_REGION_PREFIXES = new Set(["us", "eu", "ap", "sa", "ca", "me", "af"]);
 
 function normalizeProviderFilter(filter?: string[]): string[] {
   if (!filter || filter.length === 0) {
@@ -58,6 +65,11 @@ function isActive(summary: BedrockModelSummary): boolean {
   return typeof status === "string" ? status.toUpperCase() === "ACTIVE" : false;
 }
 
+function isInferenceProfileActive(summary: InferenceProfileSummary): boolean {
+  const status = summary.status;
+  return typeof status === "string" ? status.toUpperCase() === "ACTIVE" : false;
+}
+
 function mapInputModalities(summary: BedrockModelSummary): Array<"text" | "image"> {
   const inputs = summary.inputModalities ?? [];
   const mapped = new Set<"text" | "image">();
@@ -76,8 +88,8 @@ function mapInputModalities(summary: BedrockModelSummary): Array<"text" | "image
   return Array.from(mapped);
 }
 
-function inferReasoningSupport(summary: BedrockModelSummary): boolean {
-  const haystack = `${summary.modelId ?? ""} ${summary.modelName ?? ""}`.toLowerCase();
+function inferReasoningSupport(id: string | undefined, name: string | undefined): boolean {
+  const haystack = `${id ?? ""} ${name ?? ""}`.toLowerCase();
   return haystack.includes("reasoning") || haystack.includes("thinking");
 }
 
@@ -91,7 +103,7 @@ function resolveDefaultMaxTokens(config?: BedrockDiscoveryConfig): number {
   return value > 0 ? value : DEFAULT_MAX_TOKENS;
 }
 
-function matchesProviderFilter(summary: BedrockModelSummary, filter: string[]): boolean {
+function matchesFoundationProviderFilter(summary: BedrockModelSummary, filter: string[]): boolean {
   if (filter.length === 0) {
     return true;
   }
@@ -105,11 +117,41 @@ function matchesProviderFilter(summary: BedrockModelSummary, filter: string[]): 
   return filter.includes(normalized);
 }
 
-function shouldIncludeSummary(summary: BedrockModelSummary, filter: string[]): boolean {
+function extractInferenceProviderId(summary: InferenceProfileSummary): string | undefined {
+  const rawId = summary.inferenceProfileId?.trim().toLowerCase();
+  if (!rawId) {
+    return undefined;
+  }
+  const idTail = rawId.includes("/") ? (rawId.split("/").pop() ?? rawId) : rawId;
+  const parts = idTail.split(".").filter((part) => part.length > 0);
+  if (parts.length === 0) {
+    return undefined;
+  }
+  if (parts.length > 1 && INFERENCE_PROFILE_REGION_PREFIXES.has(parts[0])) {
+    return parts[1];
+  }
+  return parts[0];
+}
+
+function matchesInferenceProviderFilter(
+  summary: InferenceProfileSummary,
+  filter: string[],
+): boolean {
+  if (filter.length === 0) {
+    return true;
+  }
+  const providerId = extractInferenceProviderId(summary);
+  if (!providerId) {
+    return false;
+  }
+  return filter.includes(providerId);
+}
+
+function shouldIncludeFoundationModel(summary: BedrockModelSummary, filter: string[]): boolean {
   if (!summary.modelId?.trim()) {
     return false;
   }
-  if (!matchesProviderFilter(summary, filter)) {
+  if (!matchesFoundationProviderFilter(summary, filter)) {
     return false;
   }
   if (summary.responseStreamingSupported !== true) {
@@ -124,7 +166,23 @@ function shouldIncludeSummary(summary: BedrockModelSummary, filter: string[]): b
   return true;
 }
 
-function toModelDefinition(
+function shouldIncludeInferenceProfile(
+  summary: InferenceProfileSummary,
+  filter: string[],
+): boolean {
+  if (!summary.inferenceProfileId?.trim()) {
+    return false;
+  }
+  if (!matchesInferenceProviderFilter(summary, filter)) {
+    return false;
+  }
+  if (!isInferenceProfileActive(summary)) {
+    return false;
+  }
+  return true;
+}
+
+function toModelDefinitionFromFoundationModel(
   summary: BedrockModelSummary,
   defaults: { contextWindow: number; maxTokens: number },
 ): ModelDefinitionConfig {
@@ -132,12 +190,58 @@ function toModelDefinition(
   return {
     id,
     name: summary.modelName?.trim() || id,
-    reasoning: inferReasoningSupport(summary),
+    reasoning: inferReasoningSupport(summary.modelId, summary.modelName),
     input: mapInputModalities(summary),
     cost: DEFAULT_COST,
     contextWindow: defaults.contextWindow,
     maxTokens: defaults.maxTokens,
   };
+}
+
+function toModelDefinitionFromInferenceProfile(
+  summary: InferenceProfileSummary,
+  defaults: { contextWindow: number; maxTokens: number },
+): ModelDefinitionConfig {
+  const id = summary.inferenceProfileId?.trim() ?? "";
+  return {
+    id,
+    name: summary.inferenceProfileName?.trim() || id,
+    reasoning: inferReasoningSupport(summary.inferenceProfileId, summary.inferenceProfileName),
+    // Inference profile summaries do not expose full modality metadata.
+    input: ["text"],
+    cost: DEFAULT_COST,
+    contextWindow: defaults.contextWindow,
+    maxTokens: defaults.maxTokens,
+  };
+}
+
+async function listInferenceProfileSummaries(
+  client: BedrockClient,
+): Promise<InferenceProfileSummary[]> {
+  const summaries: InferenceProfileSummary[] = [];
+  let nextToken: string | undefined;
+  do {
+    const response = await client.send(
+      new ListInferenceProfilesCommand({
+        maxResults: INFERENCE_PROFILE_PAGE_SIZE,
+        ...(nextToken ? { nextToken } : {}),
+      }),
+    );
+    summaries.push(...(response.inferenceProfileSummaries ?? []));
+    nextToken = response.nextToken;
+  } while (nextToken);
+  return summaries;
+}
+
+function dedupeModelsById(models: ModelDefinitionConfig[]): ModelDefinitionConfig[] {
+  const byId = new Map<string, ModelDefinitionConfig>();
+  for (const model of models) {
+    if (!model.id || byId.has(model.id)) {
+      continue;
+    }
+    byId.set(model.id, model);
+  }
+  return Array.from(byId.values());
 }
 
 export function resetBedrockDiscoveryCacheForTest(): void {
@@ -181,20 +285,43 @@ export async function discoverBedrockModels(params: {
   const client = clientFactory(params.region);
 
   const discoveryPromise = (async () => {
-    const response = await client.send(new ListFoundationModelsCommand({}));
+    const defaults = {
+      contextWindow: defaultContextWindow,
+      maxTokens: defaultMaxTokens,
+    };
+
     const discovered: ModelDefinitionConfig[] = [];
-    for (const summary of response.modelSummaries ?? []) {
-      if (!shouldIncludeSummary(summary, providerFilter)) {
-        continue;
+    const partialFailures: unknown[] = [];
+
+    try {
+      const response = await client.send(new ListFoundationModelsCommand({}));
+      for (const summary of response.modelSummaries ?? []) {
+        if (!shouldIncludeFoundationModel(summary, providerFilter)) {
+          continue;
+        }
+        discovered.push(toModelDefinitionFromFoundationModel(summary, defaults));
       }
-      discovered.push(
-        toModelDefinition(summary, {
-          contextWindow: defaultContextWindow,
-          maxTokens: defaultMaxTokens,
-        }),
-      );
+    } catch (error) {
+      partialFailures.push(error);
     }
-    return discovered.toSorted((a, b) => a.name.localeCompare(b.name));
+
+    try {
+      const inferenceProfiles = await listInferenceProfileSummaries(client);
+      for (const summary of inferenceProfiles) {
+        if (!shouldIncludeInferenceProfile(summary, providerFilter)) {
+          continue;
+        }
+        discovered.push(toModelDefinitionFromInferenceProfile(summary, defaults));
+      }
+    } catch (error) {
+      partialFailures.push(error);
+    }
+
+    if (discovered.length === 0 && partialFailures.length > 0) {
+      throw partialFailures[0];
+    }
+
+    return dedupeModelsById(discovered).toSorted((a, b) => a.name.localeCompare(b.name));
   })();
 
   if (refreshIntervalSeconds > 0) {

--- a/src/agents/bedrock-discovery.ts
+++ b/src/agents/bedrock-discovery.ts
@@ -34,7 +34,20 @@ type BedrockDiscoveryCacheEntry = {
 const discoveryCache = new Map<string, BedrockDiscoveryCacheEntry>();
 let hasLoggedBedrockError = false;
 const INFERENCE_PROFILE_PAGE_SIZE = 100;
-const INFERENCE_PROFILE_REGION_PREFIXES = new Set(["us", "eu", "ap", "sa", "ca", "me", "af"]);
+const INFERENCE_PROFILE_LOCATION_PREFIXES = new Set([
+  "us",
+  "eu",
+  "ap",
+  "sa",
+  "ca",
+  "me",
+  "af",
+  "apac",
+  "latam",
+  "emea",
+  "global",
+]);
+const INFERENCE_PROFILE_REGION_PREFIX_PATTERN = /^[a-z]{2}(?:-[a-z0-9-]+)?$/;
 
 function normalizeProviderFilter(filter?: string[]): string[] {
   if (!filter || filter.length === 0) {
@@ -117,6 +130,13 @@ function matchesFoundationProviderFilter(summary: BedrockModelSummary, filter: s
   return filter.includes(normalized);
 }
 
+function isInferenceProfileLocationPrefix(part: string): boolean {
+  if (INFERENCE_PROFILE_LOCATION_PREFIXES.has(part)) {
+    return true;
+  }
+  return INFERENCE_PROFILE_REGION_PREFIX_PATTERN.test(part);
+}
+
 function extractInferenceProviderId(summary: InferenceProfileSummary): string | undefined {
   const rawId = summary.inferenceProfileId?.trim().toLowerCase();
   if (!rawId) {
@@ -127,7 +147,7 @@ function extractInferenceProviderId(summary: InferenceProfileSummary): string | 
   if (parts.length === 0) {
     return undefined;
   }
-  if (parts.length > 1 && INFERENCE_PROFILE_REGION_PREFIXES.has(parts[0])) {
+  if (parts.length > 1 && isInferenceProfileLocationPrefix(parts[0])) {
     return parts[1];
   }
   return parts[0];
@@ -302,6 +322,7 @@ export async function discoverBedrockModels(params: {
         discovered.push(toModelDefinitionFromFoundationModel(summary, defaults));
       }
     } catch (error) {
+      log.warn(`Failed to list foundation models during Bedrock discovery: ${String(error)}`);
       partialFailures.push(error);
     }
 
@@ -314,6 +335,7 @@ export async function discoverBedrockModels(params: {
         discovered.push(toModelDefinitionFromInferenceProfile(summary, defaults));
       }
     } catch (error) {
+      log.warn(`Failed to list inference profiles during Bedrock discovery: ${String(error)}`);
       partialFailures.push(error);
     }
 


### PR DESCRIPTION
## Summary
- extend Bedrock model discovery to include inference profile IDs via `ListInferenceProfiles` (with pagination)
- keep existing `ListFoundationModels` discovery so current behavior is preserved
- dedupe by discovered id and keep sorting stable
- tolerate partial AWS API failures (use whichever discovery path succeeds)
- add regression coverage for inference-profile pagination, provider filtering across both sources, partial-failure fallback, and cache behavior

## Overlap/Conflict Notes
- overlaps with #5500 in `src/agents/bedrock-discovery.ts` root-cause area (inference-profile discovery)
- this branch keeps foundation-model discovery and adds tests; #5500 currently replaces foundation discovery and has red CI
- proposed single merge target: this PR

## Validation
- `pnpm vitest run src/agents/bedrock-discovery.test.ts`
- `pnpm check`

covers #5290
builds on #5500

Exit plan: happy to move commits to #5500 and close this if maintainers prefer that consolidation path.

Credit note: thanks @heqiqi for the initial inference-profile direction in #5500.
