### PR TITLE
fix: harden malformed toolResult text blocks

### DIFF
--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
@@ -7,7 +7,12 @@ const IMAGE_CHAR_ESTIMATE = 8_000;
 export type MessageCharEstimateCache = WeakMap<AgentMessage, number>;
 
 function isTextBlock(block: unknown): block is { type: "text"; text: string } {
-  return !!block && typeof block === "object" && (block as { type?: unknown }).type === "text";
+  return (
+    !!block &&
+    typeof block === "object" &&
+    (block as { type?: unknown }).type === "text" &&
+    typeof (block as { text?: unknown }).text === "string"
+  );
 }
 
 function isImageBlock(block: unknown): boolean {

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -268,4 +268,28 @@ describe("installToolResultContextGuard", () => {
     expect(oldResult.details).toBeUndefined();
     expect(newResult.details).toBeUndefined();
   });
+
+  it("does not crash on malformed text blocks missing text", async () => {
+    const agent = makeGuardableAgent();
+
+    installToolResultContextGuard({
+      agent,
+      contextWindowTokens: 1_000,
+    });
+
+    const contextForNextCall = [
+      makeUser("u".repeat(2_000)),
+      castAgentMessage({
+        role: "toolResult",
+        toolCallId: "call_bad",
+        toolName: "read",
+        content: [{ type: "text" }],
+        isError: false,
+      }),
+    ];
+
+    await expect(
+      agent.transformContext?.(contextForNextCall, new AbortController().signal),
+    ).resolves.toBeDefined();
+  });
 });

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -169,6 +169,26 @@ describe("installSessionToolResultGuard", () => {
     expect(messages[1]?.toolName).toBe("read");
   });
 
+  it("sanitizes malformed text toolResult blocks before persistence", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+
+    sm.appendMessage(toolCallMessage);
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text" }],
+        isError: false,
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["assistant", "toolResult"]);
+    const persisted = messages[1] as { content?: Array<{ type?: string; text?: string }> };
+    expect(persisted.content?.[0]).toEqual({ type: "text", text: "" });
+  });
+
   it("preserves ordering with multiple tool calls and partial results", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm);

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -40,6 +40,32 @@ function trimNonEmptyString(value: unknown): string | undefined {
   return trimmed || undefined;
 }
 
+function sanitizeToolResultContentBlocks(message: AgentMessage): AgentMessage {
+  if ((message as { role?: unknown }).role !== "toolResult") {
+    return message;
+  }
+  const toolResult = message as Extract<AgentMessage, { role: "toolResult" }>;
+  const content = (toolResult as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return toolResult;
+  }
+
+  let changed = false;
+  const sanitized = content.map((block) => {
+    if (!block || typeof block !== "object" || (block as { type?: unknown }).type !== "text") {
+      return block;
+    }
+    const text = (block as { text?: unknown }).text;
+    if (typeof text === "string") {
+      return block;
+    }
+    changed = true;
+    return { ...(block as Record<string, unknown>), text: "" };
+  });
+
+  return changed ? ({ ...toolResult, content: sanitized } as AgentMessage) : toolResult;
+}
+
 function normalizePersistedToolResultName(
   message: AgentMessage,
   fallbackName?: string,
@@ -187,7 +213,9 @@ export function installSessionToolResultGuard(
       if (id) {
         pendingState.delete(id);
       }
-      const normalizedToolResult = normalizePersistedToolResultName(nextMessage, toolName);
+      const normalizedToolResult = sanitizeToolResultContentBlocks(
+        normalizePersistedToolResultName(nextMessage, toolName),
+      );
       // Apply hard size cap before persistence to prevent oversized tool results
       // from consuming the entire context window on subsequent LLM calls.
       const capped = capToolResultSize(persistMessage(normalizedToolResult));


### PR DESCRIPTION
## Summary
- tighten tool-result text block type guards so malformed { type: "text" } blocks are not treated as valid text blocks
- sanitize malformed toolResult content during persistence by filling missing text with an empty string
- add regression tests for malformed persisted tool results and context-guard handling

## Testing
- pnpm exec vitest src/agents/session-tool-result-guard.test.ts src/agents/pi-embedded-runner/tool-result-context-guard.test.ts

Fixes openclaw/openclaw#34979
