### PR TITLE
fix(context-pruning): guard malformed text blocks from crashing prune pass

### DIFF
--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -246,6 +246,21 @@ describe("context-pruning", () => {
     expect(toolText(findToolResult(next, "t1"))).toBe("[cleared]");
   });
 
+  it("ignores malformed text blocks in tool results", () => {
+    const malformedToolResult = {
+      role: "toolResult",
+      toolCallId: "t_bad",
+      toolName: "exec",
+      content: [{ type: "text" }],
+      isError: false,
+      timestamp: Date.now(),
+    } as unknown as AgentMessage;
+
+    const messages: AgentMessage[] = [makeUser("u1"), makeAssistant("a1"), malformedToolResult];
+
+    expect(() => pruneWithAggressiveDefaults(messages)).not.toThrow();
+  });
+
   it("hard-clear removes eligible tool results before cutoff", () => {
     const messages: AgentMessage[] = [
       makeUser("u1"),

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -16,7 +16,7 @@ function asText(text: string): TextContent {
 function collectTextSegments(content: ReadonlyArray<TextContent | ImageContent>): string[] {
   const parts: string[] = [];
   for (const block of content) {
-    if (block.type === "text") {
+    if (block.type === "text" && typeof block.text === "string") {
       parts.push(block.text);
     }
   }
@@ -99,7 +99,7 @@ function hasImageBlocks(content: ReadonlyArray<TextContent | ImageContent>): boo
 function estimateTextAndImageChars(content: ReadonlyArray<TextContent | ImageContent>): number {
   let chars = 0;
   for (const block of content) {
-    if (block.type === "text") {
+    if (block.type === "text" && typeof block.text === "string") {
       chars += block.text.length;
     }
     if (block.type === "image") {
@@ -121,7 +121,7 @@ function estimateMessageChars(message: AgentMessage): number {
   if (message.role === "assistant") {
     let chars = 0;
     for (const b of message.content) {
-      if (b.type === "text") {
+      if (b.type === "text" && typeof b.text === "string") {
         chars += b.text.length;
       }
       if (b.type === "thinking") {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Context pruning crashed when a persisted `toolResult` contained malformed content block `{ "type": "text" }` (missing `text`).
- Why it matters: A single malformed historical block could break context pruning and interrupt subsequent agent turns.
- What changed: Added string guards in context-pruning char estimators/segment collection so malformed text blocks are treated as zero-length.
- What changed: Added regression test covering malformed tool-result text blocks.
- What did NOT change (scope boundary): No routing/channel/tool-execution behavior changes; only defensive handling in context-pruning internals.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35017
- Related #34979

## User-visible / Behavior Changes

- Context pruning no longer crashes on malformed persisted tool-result text blocks.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node v22.22.0, pnpm v10.23.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Build a message list including a `toolResult` with `content: [{ type: "text" }]`.
2. Run `pruneContextMessages(...)` with pruning enabled.
3. Observe the thrown TypeError before fix; rerun after fix.

### Expected

- Malformed block is ignored for char counting; pruning continues without exception.

### Actual

- Before fix: `TypeError: Cannot read properties of undefined (reading 'length')`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - New regression test fails before fix and passes after fix.
  - Targeted pruning test suite passes.
- Edge cases checked:
  - Malformed `toolResult` text blocks in the pruning pipeline.
- What you did **not** verify:
  - Live channel/provider runtime behavior (not touched by this change).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/agents/pi-extensions/context-pruning/pruner.ts`
  - `src/agents/pi-extensions/context-pruning.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected pruning char-count behavior around malformed history entries.

## Risks and Mitigations

- Risk:
  - Treating malformed text blocks as zero-length could hide malformed data from pruning ratios.
  - Mitigation:
    - Scope is defensive-only and aligns with existing sanitizer behavior; regression test locks non-throwing behavior.

## Root Cause

`context-pruning/pruner.ts` assumed every `type: "text"` block had a string `text` field and read `.length` unguarded in multiple paths (`collectTextSegments`, `estimateTextAndImageChars`, assistant estimation). Persisted malformed blocks violate that assumption.

## Exact Verification Commands Run

- `pnpm test src/agents/pi-extensions/context-pruning.test.ts`
- `pnpm check`
