### PR TITLE
fix(agents): preserve copilot claude thinking blocks during replay

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -567,17 +567,20 @@ describe("sanitizeSessionHistory", () => {
     ).toBe(false);
   });
 
-  it("drops assistant thinking blocks for github-copilot models", async () => {
+  it("preserves assistant thinking blocks and strips signatures for github-copilot claude models", async () => {
     setNonGoogleModelApi();
 
     const messages = makeThinkingAndTextAssistantMessages("reasoning_text");
 
     const result = await sanitizeGithubCopilotHistory({ messages });
     const assistant = getAssistantMessage(result);
-    expect(assistant.content).toEqual([{ type: "text", text: "hi" }]);
+    expect(assistant.content).toEqual([
+      { type: "thinking", thinking: "internal" },
+      { type: "text", text: "hi" },
+    ]);
   });
 
-  it("preserves assistant turn when all content is thinking blocks (github-copilot)", async () => {
+  it("preserves thinking-only assistant turns for github-copilot claude models", async () => {
     setNonGoogleModelApi();
 
     const messages: AgentMessage[] = [
@@ -594,13 +597,13 @@ describe("sanitizeSessionHistory", () => {
 
     const result = await sanitizeGithubCopilotHistory({ messages });
 
-    // Assistant turn should be preserved (not dropped) to maintain turn alternation
+    // Assistant turn should be preserved with thinking content.
     expect(result).toHaveLength(3);
     const assistant = getAssistantMessage(result);
-    expect(assistant.content).toEqual([{ type: "text", text: "" }]);
+    expect(assistant.content).toEqual([{ type: "thinking", thinking: "some reasoning" }]);
   });
 
-  it("preserves tool_use blocks when dropping thinking blocks (github-copilot)", async () => {
+  it("preserves tool_use blocks while keeping thinking blocks for github-copilot claude", async () => {
     setNonGoogleModelApi();
 
     const messages: AgentMessage[] = [
@@ -620,7 +623,7 @@ describe("sanitizeSessionHistory", () => {
     const types = getAssistantContentTypes(result);
     expect(types).toContain("toolCall");
     expect(types).toContain("text");
-    expect(types).not.toContain("thinking");
+    expect(types).toContain("thinking");
   });
 
   it("does not drop thinking blocks for non-copilot providers", async () => {

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -27,7 +27,7 @@ import type { TranscriptPolicy } from "../transcript-policy.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
 import { makeZeroUsageSnapshot } from "../usage.js";
 import { log } from "./logger.js";
-import { dropThinkingBlocks } from "./thinking.js";
+import { stripThinkingSignatures } from "./thinking.js";
 import { describeUnknownError } from "./utils.js";
 
 const GOOGLE_TURN_ORDERING_CUSTOM_TYPE = "google-turn-ordering-bootstrap";
@@ -440,7 +440,7 @@ export async function sanitizeSessionHistory(params: {
     },
   );
   const droppedThinking = policy.dropThinkingBlocks
-    ? dropThinkingBlocks(sanitizedImages)
+    ? stripThinkingSignatures(sanitizedImages)
     : sanitizedImages;
   const sanitizedToolCalls = sanitizeToolCallInputs(droppedThinking, {
     allowedToolNames: params.allowedToolNames,

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -439,10 +439,10 @@ export async function sanitizeSessionHistory(params: {
       ...resolveImageSanitizationLimits(params.config),
     },
   );
-  const droppedThinking = policy.dropThinkingBlocks
+  const thinkingSignaturesSanitized = policy.stripThinkingSignatures
     ? stripThinkingSignatures(sanitizedImages)
     : sanitizedImages;
-  const sanitizedToolCalls = sanitizeToolCallInputs(droppedThinking, {
+  const sanitizedToolCalls = sanitizeToolCallInputs(thinkingSignaturesSanitized, {
     allowedToolNames: params.allowedToolNames,
   });
   const repairedTools = policy.repairToolUseResultPairing

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -111,7 +111,7 @@ import {
   buildEmbeddedSystemPrompt,
   createSystemPromptOverride,
 } from "../system-prompt.js";
-import { dropThinkingBlocks } from "../thinking.js";
+import { stripThinkingSignatures } from "../thinking.js";
 import { collectAllowedToolNames } from "../tool-name-allowlist.js";
 import { installToolResultContextGuard } from "../tool-result-context-guard.js";
 import { splitSdkTools } from "../tool-split.js";
@@ -1078,9 +1078,9 @@ export async function runEmbeddedAttempt(
         activeSession.agent.streamFn = cacheTrace.wrapStreamFn(activeSession.agent.streamFn);
       }
 
-      // Copilot/Claude can reject persisted `thinking` blocks (e.g. thinkingSignature:"reasoning_text")
-      // on *any* follow-up provider call (including tool continuations). Wrap the stream function
-      // so every outbound request sees sanitized messages.
+      // Copilot/Claude can reject persisted thinking signatures (for example,
+      // thinkingSignature:"reasoning_text") on follow-up provider calls.
+      // Wrap the stream function so every outbound request sees signature-sanitized messages.
       if (transcriptPolicy.dropThinkingBlocks) {
         const inner = activeSession.agent.streamFn;
         activeSession.agent.streamFn = (model, context, options) => {
@@ -1089,7 +1089,9 @@ export async function runEmbeddedAttempt(
           if (!Array.isArray(messages)) {
             return inner(model, context, options);
           }
-          const sanitized = dropThinkingBlocks(messages as unknown as AgentMessage[]) as unknown;
+          const sanitized = stripThinkingSignatures(
+            messages as unknown as AgentMessage[],
+          ) as unknown;
           if (sanitized === messages) {
             return inner(model, context, options);
           }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1081,7 +1081,7 @@ export async function runEmbeddedAttempt(
       // Copilot/Claude can reject persisted thinking signatures (for example,
       // thinkingSignature:"reasoning_text") on follow-up provider calls.
       // Wrap the stream function so every outbound request sees signature-sanitized messages.
-      if (transcriptPolicy.dropThinkingBlocks) {
+      if (transcriptPolicy.stripThinkingSignatures) {
         const inner = activeSession.agent.streamFn;
         activeSession.agent.streamFn = (model, context, options) => {
           const ctx = context as unknown as { messages?: unknown };

--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -1,7 +1,11 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
-import { dropThinkingBlocks, isAssistantMessageWithContent } from "./thinking.js";
+import {
+  dropThinkingBlocks,
+  isAssistantMessageWithContent,
+  stripThinkingSignatures,
+} from "./thinking.js";
 
 describe("isAssistantMessageWithContent", () => {
   it("accepts assistant messages with array content and rejects others", () => {
@@ -57,5 +61,47 @@ describe("dropThinkingBlocks", () => {
     const result = dropThinkingBlocks(messages);
     const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
     expect(assistant.content).toEqual([{ type: "text", text: "" }]);
+  });
+});
+
+describe("stripThinkingSignatures", () => {
+  it("returns the original reference when no thinking signatures are present", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "internal" },
+          { type: "text", text: "final" },
+        ],
+      }),
+    ];
+
+    const result = stripThinkingSignatures(messages);
+    expect(result).toBe(messages);
+  });
+
+  it("preserves thinking blocks while removing signature fields", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "internal",
+            thinkingSignature: "reasoning_text",
+            thought_signature: "msg_abc",
+          },
+          { type: "text", text: "final" },
+        ],
+      }),
+    ];
+
+    const result = stripThinkingSignatures(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(result).not.toBe(messages);
+    expect(assistant.content).toEqual([
+      { type: "thinking", thinking: "internal" },
+      { type: "text", text: "final" },
+    ]);
   });
 });

--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -104,4 +104,25 @@ describe("stripThinkingSignatures", () => {
       { type: "text", text: "final" },
     ]);
   });
+
+  it("removes snake_case and camelCase signature variants", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "internal",
+            thinking_signature: "sig_snake",
+            thoughtSignature: "sig_camel",
+          },
+        ],
+      }),
+    ];
+
+    const result = stripThinkingSignatures(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(result).not.toBe(messages);
+    expect(assistant.content).toEqual([{ type: "thinking", thinking: "internal" }]);
+  });
 });

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -51,3 +51,59 @@ export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
   }
   return touched ? out : messages;
 }
+
+/**
+ * Preserve `thinking` blocks while removing signature fields that can be
+ * rejected by provider validators when replaying persisted history.
+ */
+export function stripThinkingSignatures(messages: AgentMessage[]): AgentMessage[] {
+  let touched = false;
+  const out: AgentMessage[] = [];
+
+  for (const msg of messages) {
+    if (!isAssistantMessageWithContent(msg)) {
+      out.push(msg);
+      continue;
+    }
+
+    let changed = false;
+    const nextContent = msg.content.map((block) => {
+      if (!block || typeof block !== "object") {
+        return block;
+      }
+      if ((block as { type?: unknown }).type !== "thinking") {
+        return block;
+      }
+      const rec = block as unknown as Record<string, unknown>;
+      const hasThinkingSignature = Object.hasOwn(rec, "thinkingSignature");
+      const hasSnakeSignature = Object.hasOwn(rec, "thinking_signature");
+      const hasThoughtSignature = Object.hasOwn(rec, "thought_signature");
+      const hasThoughtSignatureCamel = Object.hasOwn(rec, "thoughtSignature");
+      if (
+        !hasThinkingSignature &&
+        !hasSnakeSignature &&
+        !hasThoughtSignature &&
+        !hasThoughtSignatureCamel
+      ) {
+        return block;
+      }
+
+      const next = { ...rec };
+      delete next.thinkingSignature;
+      delete next.thinking_signature;
+      delete next.thought_signature;
+      delete next.thoughtSignature;
+      touched = true;
+      changed = true;
+      return next as unknown as AssistantContentBlock;
+    });
+
+    if (!changed) {
+      out.push(msg);
+      continue;
+    }
+    out.push({ ...msg, content: nextContent });
+  }
+
+  return touched ? out : messages;
+}

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -98,7 +98,7 @@ export function resolveTranscriptPolicy(params: {
 
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").
-  // Drop these blocks at send-time to keep sessions usable.
+  // Enable thinking-signature sanitization for these sessions.
   const dropThinkingBlocks = isCopilotClaude;
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -14,8 +14,7 @@ export type TranscriptPolicy = {
     allowBase64Only?: boolean;
     includeCamelCase?: boolean;
   };
-  sanitizeThinkingSignatures: boolean;
-  dropThinkingBlocks: boolean;
+  stripThinkingSignatures: boolean;
   applyGoogleTurnOrdering: boolean;
   validateGeminiTurns: boolean;
   validateAnthropicTurns: boolean;
@@ -99,7 +98,7 @@ export function resolveTranscriptPolicy(params: {
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").
   // Enable thinking-signature sanitization for these sessions.
-  const dropThinkingBlocks = isCopilotClaude;
+  const stripThinkingSignatures = isCopilotClaude;
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 
@@ -125,8 +124,7 @@ export function resolveTranscriptPolicy(params: {
     repairToolUseResultPairing,
     preserveSignatures: false,
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
-    sanitizeThinkingSignatures: false,
-    dropThinkingBlocks,
+    stripThinkingSignatures,
     applyGoogleTurnOrdering: !isOpenAi && isGoogle,
     validateGeminiTurns: !isOpenAi && isGoogle,
     validateAnthropicTurns: !isOpenAi && (isAnthropic || isStrictOpenAiCompatible),


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Copilot-Claude transcript sanitization dropped assistant `thinking` blocks during replay, which can make follow-up Anthropic requests fail when thinking mode expects an initial `thinking`/`redacted_thinking` block.
- Why it matters: Sub-agent runs that use tools can fail deterministically on turn 2 after tool return.
- What changed: Replaced drop behavior with signature sanitization (`stripThinkingSignatures`) so `thinking` blocks are preserved while unsafe signature fields are removed.
- What changed: Applied the sanitizer in both session-history replay and streamFn outbound wrapping paths.
- What did NOT change (scope boundary): No model-selection/routing changes; no behavior change for non-Copilot-Claude policies.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35023
- Related #34971

## User-visible / Behavior Changes

- Copilot-Claude sessions retain assistant thinking blocks during history replay, while signature fields are stripped.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node v22.22.0, pnpm v10.23.0
- Model/provider: github-copilot / claude-sonnet-4 (policy path)
- Integration/channel (if any): sub-agent sessions (`sessions_spawn`)
- Relevant config (redacted): Copilot-Claude model path with thinking enabled

### Steps

1. Replay an assistant turn containing `thinking` + `toolCall` via Copilot-Claude transcript sanitation path.
2. Continue to next turn after tool result.
3. Observe whether the assistant thinking block is preserved in outbound replay.

### Expected

- Thinking blocks remain in replayed assistant turns; only signature fields are stripped.

### Actual

- Before fix, thinking blocks were dropped entirely for Copilot-Claude policy.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Updated replay sanitation tests fail before fix and pass after fix.
  - Utility tests for thinking signature stripping pass.
- Edge cases checked:
  - Thinking-only assistant turns remain preserved.
  - Tool-call turns keep `toolCall` + `text` while preserving `thinking`.
- What you did **not** verify:
  - Live remote provider session runs in external environments.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/agents/pi-embedded-runner/thinking.ts`
  - `src/agents/pi-embedded-runner/google.ts`
  - `src/agents/pi-embedded-runner/run/attempt.ts`
- Known bad symptoms reviewers should watch for:
  - Copilot-Claude replay issues with unexpected signature validation errors.

## Risks and Mitigations

- Risk:
  - Some endpoints may still require stricter redaction semantics than signature removal.
  - Mitigation:
    - Change is constrained to Copilot-Claude policy path and backed by regression tests; easy revert path.

## Root Cause

`dropThinkingBlocks` was applied in Copilot-Claude replay paths, removing `thinking` blocks from assistant history. For thinking-enabled flows, this can violate provider replay requirements on subsequent turns.

## Exact Verification Commands Run

- `pnpm test src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/pi-embedded-runner/thinking.test.ts`
- `pnpm check`
