### PR TITLE
fix(context-pruning): guard malformed thinking blocks in estimator

### DIFF
--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -246,6 +246,16 @@ describe("context-pruning", () => {
     expect(toolText(findToolResult(next, "t1"))).toBe("[cleared]");
   });
 
+  it("ignores malformed thinking blocks in assistant messages", () => {
+    const malformedAssistant = makeAssistant("a1") as Extract<AgentMessage, { role: "assistant" }>;
+    malformedAssistant.content = [
+      { type: "thinking" },
+    ] as unknown as typeof malformedAssistant.content;
+    const messages: AgentMessage[] = [makeUser("u1"), malformedAssistant];
+
+    expect(() => pruneWithAggressiveDefaults(messages)).not.toThrow();
+  });
+
   it("hard-clear removes eligible tool results before cutoff", () => {
     const messages: AgentMessage[] = [
       makeUser("u1"),

--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -256,6 +256,14 @@ describe("context-pruning", () => {
     expect(() => pruneWithAggressiveDefaults(messages)).not.toThrow();
   });
 
+  it("ignores malformed text blocks in assistant messages", () => {
+    const malformedAssistant = makeAssistant("a1") as Extract<AgentMessage, { role: "assistant" }>;
+    malformedAssistant.content = [{ type: "text" }] as unknown as typeof malformedAssistant.content;
+    const messages: AgentMessage[] = [makeUser("u1"), malformedAssistant];
+
+    expect(() => pruneWithAggressiveDefaults(messages)).not.toThrow();
+  });
+
   it("hard-clear removes eligible tool results before cutoff", () => {
     const messages: AgentMessage[] = [
       makeUser("u1"),

--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -264,6 +264,26 @@ describe("context-pruning", () => {
     expect(() => pruneWithAggressiveDefaults(messages)).not.toThrow();
   });
 
+  it("ignores malformed text blocks in user messages", () => {
+    const malformedUser = makeUser("u1") as Extract<AgentMessage, { role: "user" }>;
+    malformedUser.content = [{ type: "text" }] as unknown as typeof malformedUser.content;
+    const messages: AgentMessage[] = [malformedUser, makeAssistant("a1")];
+
+    expect(() => pruneWithAggressiveDefaults(messages)).not.toThrow();
+  });
+
+  it("ignores malformed text blocks in tool results", () => {
+    const malformedTool = makeToolResult({
+      toolCallId: "t1",
+      toolName: "exec",
+      text: "ok",
+    });
+    malformedTool.content = [{ type: "text" }] as unknown as typeof malformedTool.content;
+    const messages: AgentMessage[] = [makeUser("u1"), makeAssistant("a1"), malformedTool];
+
+    expect(() => pruneWithAggressiveDefaults(messages)).not.toThrow();
+  });
+
   it("hard-clear removes eligible tool results before cutoff", () => {
     const messages: AgentMessage[] = [
       makeUser("u1"),

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -121,7 +121,7 @@ function estimateMessageChars(message: AgentMessage): number {
   if (message.role === "assistant") {
     let chars = 0;
     for (const b of message.content) {
-      if (b.type === "text") {
+      if (b.type === "text" && typeof b.text === "string") {
         chars += b.text.length;
       }
       if (b.type === "thinking" && typeof b.thinking === "string") {

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -16,7 +16,7 @@ function asText(text: string): TextContent {
 function collectTextSegments(content: ReadonlyArray<TextContent | ImageContent>): string[] {
   const parts: string[] = [];
   for (const block of content) {
-    if (block.type === "text") {
+    if (block.type === "text" && typeof block.text === "string") {
       parts.push(block.text);
     }
   }
@@ -99,7 +99,7 @@ function hasImageBlocks(content: ReadonlyArray<TextContent | ImageContent>): boo
 function estimateTextAndImageChars(content: ReadonlyArray<TextContent | ImageContent>): number {
   let chars = 0;
   for (const block of content) {
-    if (block.type === "text") {
+    if (block.type === "text" && typeof block.text === "string") {
       chars += block.text.length;
     }
     if (block.type === "image") {

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -124,7 +124,7 @@ function estimateMessageChars(message: AgentMessage): number {
       if (b.type === "text") {
         chars += b.text.length;
       }
-      if (b.type === "thinking") {
+      if (b.type === "thinking" && typeof b.thinking === "string") {
         chars += b.thinking.length;
       }
       if (b.type === "toolCall") {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Context pruning crashed when assistant history contained malformed thinking blocks (`{ type: "thinking" }` without a `thinking` string).
- Why it matters: A single malformed persisted block can break pruning and interrupt subsequent runs.
- What changed: Added a string guard for assistant thinking blocks in pruning char estimation.
- What changed: Added regression test that reproduces malformed thinking block input.
- What did NOT change (scope boundary): No routing/provider behavior changes; only defensive char-estimation logic in context pruning.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35026
- Related #35017

## User-visible / Behavior Changes

- Context pruning no longer throws on malformed assistant thinking blocks.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node v22.22.0, pnpm v10.23.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Build messages with an assistant content block `{ type: "thinking" }` (missing `thinking`).
2. Run `pruneContextMessages(...)`.
3. Observe pre-fix throw vs post-fix non-throw behavior.

### Expected

- Malformed thinking block is ignored for char counting.

### Actual

- Before fix: `TypeError: Cannot read properties of undefined (reading 'length')`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - New malformed-thinking regression test fails before fix and passes after.
  - Context pruning test file passes.
- Edge cases checked:
  - Assistant message content with malformed thinking blocks.
- What you did **not** verify:
  - Live provider/channel runs (not touched).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/agents/pi-extensions/context-pruning/pruner.ts`
  - `src/agents/pi-extensions/context-pruning.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected context-pruning char-estimation behavior around malformed assistant blocks.

## Risks and Mitigations

- Risk:
  - Malformed thinking entries contribute 0 chars and may slightly undercount historical context.
  - Mitigation:
    - Defensive behavior is intentional and bounded to malformed payloads only.

## Root Cause

`context-pruning/pruner.ts` assumed `b.thinking` was always a string when `b.type === "thinking"`; malformed persisted blocks violate that assumption and caused unguarded `.length` access.

## Exact Verification Commands Run

- `pnpm test src/agents/pi-extensions/context-pruning.test.ts`
- `pnpm check`
