### PR TITLE
fix(agents): guard thinking-tag promotion against malformed entries

### DIFF
--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractAssistantText,
   formatReasoningMessage,
+  promoteThinkingTagsToBlocks,
   stripDowngradedToolCallText,
 } from "./pi-embedded-utils.js";
 
@@ -471,6 +472,21 @@ File contents here`,
       });
       expect(extractAssistantText(msg), testCase.name).toBe(testCase.expected);
     }
+  });
+});
+
+describe("promoteThinkingTagsToBlocks", () => {
+  it("does not throw on malformed assistant content entries", () => {
+    const message = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        null,
+        { type: "text", text: "<thinking>internal</thinking> done" },
+      ] as unknown as AssistantMessage["content"],
+      timestamp: Date.now(),
+    });
+
+    expect(() => promoteThinkingTagsToBlocks(message)).not.toThrow();
   });
 });
 

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -476,7 +476,7 @@ File contents here`,
 });
 
 describe("promoteThinkingTagsToBlocks", () => {
-  it("does not throw on malformed assistant content entries", () => {
+  it("does not throw on malformed assistant content entries and keeps normalized blocks", () => {
     const message = makeAssistantMessage({
       role: "assistant",
       content: [
@@ -487,6 +487,10 @@ describe("promoteThinkingTagsToBlocks", () => {
     });
 
     expect(() => promoteThinkingTagsToBlocks(message)).not.toThrow();
+    expect(message.content).toEqual([
+      { type: "thinking", thinking: "internal" },
+      { type: "text", text: "done" },
+    ]);
   });
 });
 

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -373,6 +373,8 @@ export function promoteThinkingTagsToBlocks(message: AssistantMessage): void {
   if (!changed) {
     return;
   }
+  // When we promote tagged text into structured blocks, we also normalize the
+  // message payload and drop malformed/non-object entries collected along the way.
   message.content = next;
 }
 

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -333,7 +333,10 @@ export function promoteThinkingTagsToBlocks(message: AssistantMessage): void {
   if (!Array.isArray(message.content)) {
     return;
   }
-  const hasThinkingBlock = message.content.some((block) => block.type === "thinking");
+  const hasThinkingBlock = message.content.some(
+    (block) =>
+      !!block && typeof block === "object" && (block as { type?: unknown }).type === "thinking",
+  );
   if (hasThinkingBlock) {
     return;
   }
@@ -342,6 +345,9 @@ export function promoteThinkingTagsToBlocks(message: AssistantMessage): void {
   let changed = false;
 
   for (const block of message.content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
     if (block.type !== "text") {
       next.push(block);
       continue;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `promoteThinkingTagsToBlocks` crashed when assistant content contained malformed non-object entries (for example `null`).
- Why it matters: malformed streamed/persisted assistant payloads can crash thinking-tag promotion in the subscribe pipeline.
- What changed: added guard checks before dereferencing `block.type` in thinking-tag detection and promotion loop.
- What changed: added a regression test covering malformed assistant content entries.
- What did NOT change (scope boundary): no change to normal thinking-tag parsing behavior for valid content blocks.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35032
- Related #35023

## User-visible / Behavior Changes

- Assistant thinking-tag promotion no longer throws on malformed content entries.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node v22.22.0, pnpm v10.23.0
- Model/provider: N/A
- Integration/channel (if any): assistant stream subscribe path
- Relevant config (redacted): N/A

### Steps

1. Build assistant message content containing `null` plus a text block.
2. Call `promoteThinkingTagsToBlocks(message)`.
3. Observe throw before fix, no throw after fix.

### Expected

- Function handles malformed entries safely.

### Actual

- Before fix: `TypeError: Cannot read properties of null (reading 'type')`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - New malformed-content regression test fails before fix and passes after.
  - Full `pi-embedded-utils` test file passes.
- Edge cases checked:
  - Content list containing non-object entries alongside normal text blocks.
- What you did **not** verify:
  - Live provider streaming sessions.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/agents/pi-embedded-utils.ts`
  - `src/agents/pi-embedded-utils.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected skipped malformed entries in thinking-tag promotion.

## Risks and Mitigations

- Risk:
  - Malformed non-object entries are skipped during promotion.
  - Mitigation:
    - Applies only to invalid payload fragments; valid blocks preserve existing behavior.

## Root Cause

`promoteThinkingTagsToBlocks` used unguarded `block.type` reads in `.some(...)` and loop processing, assuming every `content` entry is an object.

## Exact Verification Commands Run

- `pnpm test src/agents/pi-embedded-utils.test.ts`
- `pnpm check`
