### PR TITLE
fix: normalize ≪ ≫ marker homoglyphs in external content sanitizer

### DIFF
--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
@@ -7,7 +7,12 @@ const IMAGE_CHAR_ESTIMATE = 8_000;
 export type MessageCharEstimateCache = WeakMap<AgentMessage, number>;
 
 function isTextBlock(block: unknown): block is { type: "text"; text: string } {
-  return !!block && typeof block === "object" && (block as { type?: unknown }).type === "text";
+  return (
+    !!block &&
+    typeof block === "object" &&
+    (block as { type?: unknown }).type === "text" &&
+    typeof (block as { text?: unknown }).text === "string"
+  );
 }
 
 function isImageBlock(block: unknown): boolean {

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -268,4 +268,28 @@ describe("installToolResultContextGuard", () => {
     expect(oldResult.details).toBeUndefined();
     expect(newResult.details).toBeUndefined();
   });
+
+  it("does not crash on malformed text blocks missing text", async () => {
+    const agent = makeGuardableAgent();
+
+    installToolResultContextGuard({
+      agent,
+      contextWindowTokens: 1_000,
+    });
+
+    const contextForNextCall = [
+      makeUser("u".repeat(2_000)),
+      castAgentMessage({
+        role: "toolResult",
+        toolCallId: "call_bad",
+        toolName: "read",
+        content: [{ type: "text" }],
+        isError: false,
+      }),
+    ];
+
+    await expect(
+      agent.transformContext?.(contextForNextCall, new AbortController().signal),
+    ).resolves.toBeDefined();
+  });
 });

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -169,6 +169,26 @@ describe("installSessionToolResultGuard", () => {
     expect(messages[1]?.toolName).toBe("read");
   });
 
+  it("sanitizes malformed text toolResult blocks before persistence", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+
+    sm.appendMessage(toolCallMessage);
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text" }],
+        isError: false,
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["assistant", "toolResult"]);
+    const persisted = messages[1] as { content?: Array<{ type?: string; text?: string }> };
+    expect(persisted.content?.[0]).toEqual({ type: "text", text: "" });
+  });
+
   it("preserves ordering with multiple tool calls and partial results", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm);

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -40,6 +40,32 @@ function trimNonEmptyString(value: unknown): string | undefined {
   return trimmed || undefined;
 }
 
+function sanitizeToolResultContentBlocks(message: AgentMessage): AgentMessage {
+  if ((message as { role?: unknown }).role !== "toolResult") {
+    return message;
+  }
+  const toolResult = message as Extract<AgentMessage, { role: "toolResult" }>;
+  const content = (toolResult as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return toolResult;
+  }
+
+  let changed = false;
+  const sanitized = content.map((block) => {
+    if (!block || typeof block !== "object" || (block as { type?: unknown }).type !== "text") {
+      return block;
+    }
+    const text = (block as { text?: unknown }).text;
+    if (typeof text === "string") {
+      return block;
+    }
+    changed = true;
+    return { ...(block as Record<string, unknown>), text: "" };
+  });
+
+  return changed ? ({ ...toolResult, content: sanitized } as AgentMessage) : toolResult;
+}
+
 function normalizePersistedToolResultName(
   message: AgentMessage,
   fallbackName?: string,
@@ -187,7 +213,9 @@ export function installSessionToolResultGuard(
       if (id) {
         pendingState.delete(id);
       }
-      const normalizedToolResult = normalizePersistedToolResultName(nextMessage, toolName);
+      const normalizedToolResult = sanitizeToolResultContentBlocks(
+        normalizePersistedToolResultName(nextMessage, toolName),
+      );
       // Apply hard size cap before persistence to prevent oversized tool results
       // from consuming the entire context window on subsequent LLM calls.
       const capped = capToolResultSize(persistMessage(normalizedToolResult));

--- a/src/security/external-content.test.ts
+++ b/src/security/external-content.test.ts
@@ -204,6 +204,7 @@ describe("external-content security", () => {
         ["\u27EE", "\u27EF"], // flattened parentheses
         ["\u276C", "\u276D"], // medium angle bracket ornaments
         ["\u276E", "\u276F"], // heavy angle quotation ornaments
+        ["\u226A", "\u226B"], // much less-than/greater-than
       ];
 
       for (const [left, right] of bracketPairs) {

--- a/src/security/external-content.ts
+++ b/src/security/external-content.ts
@@ -132,6 +132,8 @@ const ANGLE_BRACKET_MAP: Record<number, string> = {
   0x276d: ">", // medium right-pointing angle bracket ornament
   0x276e: "<", // heavy left-pointing angle quotation mark ornament
   0x276f: ">", // heavy right-pointing angle quotation mark ornament
+  0x226a: "<", // much less-than
+  0x226b: ">", // much greater-than
 };
 
 function foldMarkerChar(char: string): string {
@@ -151,7 +153,7 @@ function foldMarkerChar(char: string): string {
 
 function foldMarkerText(input: string): string {
   return input.replace(
-    /[\uFF21-\uFF3A\uFF41-\uFF5A\uFF1C\uFF1E\u2329\u232A\u3008\u3009\u2039\u203A\u27E8\u27E9\uFE64\uFE65\u00AB\u00BB\u300A\u300B\u27EA\u27EB\u27EC\u27ED\u27EE\u27EF\u276C\u276D\u276E\u276F]/g,
+    /[\uFF21-\uFF3A\uFF41-\uFF5A\uFF1C\uFF1E\u2329\u232A\u3008\u3009\u2039\u203A\u27E8\u27E9\uFE64\uFE65\u00AB\u00BB\u300A\u300B\u27EA\u27EB\u27EC\u27ED\u27EE\u27EF\u276C\u276D\u276E\u276F\u226A\u226B]/g,
     (char) => foldMarkerChar(char),
   );
 }


### PR DESCRIPTION
## Summary
- treat Unicode much-less-than (≪, U+226A) and much-greater-than (≫, U+226B) as angle bracket homoglyphs during marker folding
- extend homoglyph folding regex coverage to include these characters
- add regression test coverage for ≪/≫ marker spoofing

## Testing
- npm run test -- src/security/external-content.test.ts -t "normalizes additional angle bracket homoglyph markers before sanitizing"

Fixes openclaw/openclaw#34943