### PR TITLE
fix(agents): guard openai ws parser against malformed message parts

### DIFF
--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -594,6 +594,23 @@ describe("buildAssistantMessageFromResponse", () => {
     expect(msg.content).toEqual([]);
     expect(msg.stopReason).toBe("stop");
   });
+
+  it("ignores malformed message content entries", () => {
+    const response = makeResponseObject("resp_8", "Hello");
+    const messageItem = response.output?.find((item) => item.type === "message");
+    if (!messageItem || messageItem.type !== "message") {
+      throw new Error("missing message output item");
+    }
+    messageItem.content = [
+      null as unknown as (typeof messageItem.content)[number],
+      ...messageItem.content,
+    ];
+
+    expect(() => buildAssistantMessageFromResponse(response, modelInfo)).not.toThrow();
+    const msg = buildAssistantMessageFromResponse(response, modelInfo);
+    const textBlock = msg.content.find((c) => c.type === "text") as { text?: string } | undefined;
+    expect(textBlock?.text).toBe("Hello");
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -293,8 +293,16 @@ export function buildAssistantMessageFromResponse(
   for (const item of response.output ?? []) {
     if (item.type === "message") {
       for (const part of item.content ?? []) {
-        if (part.type === "output_text" && part.text) {
-          content.push({ type: "text", text: part.text });
+        if (
+          !part ||
+          typeof part !== "object" ||
+          (part as { type?: unknown }).type !== "output_text"
+        ) {
+          continue;
+        }
+        const text = (part as { text?: unknown }).text;
+        if (typeof text === "string" && text.length > 0) {
+          content.push({ type: "text", text });
         }
       }
     } else if (item.type === "function_call") {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenAI WS response parsing crashed on malformed `message.content` entries (e.g. `null`) due to unguarded `part.type` access.
- Why it matters: malformed provider payload fragments can break WS turn handling instead of safely parsing available content.
- What changed: added shape/type guards in `buildAssistantMessageFromResponse` before reading message content parts.
- What changed: added regression test that injects malformed content entries and verifies parser resilience.
- What did NOT change (scope boundary): no protocol or routing changes; valid payload parsing behavior remains unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35045
- Related #35033

## User-visible / Behavior Changes

- OpenAI WS parser now tolerates malformed message content entries instead of throwing.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node v22.22.0, pnpm v10.23.0
- Model/provider: OpenAI WS response parser path
- Integration/channel (if any): WS streaming
- Relevant config (redacted): N/A

### Steps

1. Construct a response with `output` message content containing `null` and valid `output_text` entries.
2. Call `buildAssistantMessageFromResponse(...)`.
3. Observe throw before fix vs non-throw after fix.

### Expected

- Parser skips malformed entries and keeps valid text/tool blocks.

### Actual

- Before fix: `TypeError: Cannot read properties of null (reading 'type')`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - New malformed-content parser test fails before fix and passes after.
  - Full `openai-ws-stream` unit file passes.
- Edge cases checked:
  - Mixed malformed + valid content entries.
- What you did **not** verify:
  - Live OpenAI WS network sessions.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/agents/openai-ws-stream.ts`
  - `src/agents/openai-ws-stream.test.ts`
- Known bad symptoms reviewers should watch for:
  - Missing text extraction from WS message items when malformed entries are present.

## Risks and Mitigations

- Risk:
  - Malformed entries are ignored rather than surfaced explicitly.
  - Mitigation:
    - Behavior is defensive and preserves valid parts; test coverage added for mixed payloads.

## Root Cause

`buildAssistantMessageFromResponse` iterated untrusted `item.content` and dereferenced `part.type` without checking for object shape.

## Exact Verification Commands Run

- `pnpm test src/agents/openai-ws-stream.test.ts`
- `pnpm check`
