### PR TITLE
fix: unify gateway credential fallback for agent tools (closes #35039)

### DIFF
--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -67,6 +67,15 @@ export function resolveExplicitGatewayAuth(opts?: ExplicitGatewayAuth): Explicit
   return { token, password };
 }
 
+function resolveGatewayCredential(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
 export function ensureExplicitGatewayAuth(params: {
   urlOverride?: string;
   auth: ExplicitGatewayAuth;
@@ -208,28 +217,22 @@ export async function callGateway<T = Record<string, unknown>>(
   const token =
     explicitAuth.token ||
     (!urlOverride
-      ? isRemoteMode
-        ? typeof remote?.token === "string" && remote.token.trim().length > 0
-          ? remote.token.trim()
-          : undefined
-        : process.env.OPENCLAW_GATEWAY_TOKEN?.trim() ||
-          process.env.CLAWDBOT_GATEWAY_TOKEN?.trim() ||
-          (typeof authToken === "string" && authToken.trim().length > 0
-            ? authToken.trim()
-            : undefined)
+      ? resolveGatewayCredential(
+          isRemoteMode ? remote?.token : undefined,
+          process.env.OPENCLAW_GATEWAY_TOKEN,
+          process.env.CLAWDBOT_GATEWAY_TOKEN,
+          authToken,
+        )
       : undefined);
   const password =
     explicitAuth.password ||
     (!urlOverride
-      ? process.env.OPENCLAW_GATEWAY_PASSWORD?.trim() ||
-        process.env.CLAWDBOT_GATEWAY_PASSWORD?.trim() ||
-        (isRemoteMode
-          ? typeof remote?.password === "string" && remote.password.trim().length > 0
-            ? remote.password.trim()
-            : undefined
-          : typeof authPassword === "string" && authPassword.trim().length > 0
-            ? authPassword.trim()
-            : undefined)
+      ? resolveGatewayCredential(
+          isRemoteMode ? remote?.password : undefined,
+          process.env.OPENCLAW_GATEWAY_PASSWORD,
+          process.env.CLAWDBOT_GATEWAY_PASSWORD,
+          authPassword,
+        )
       : undefined);
 
   const formatCloseError = (code: number, reason: string) => {


### PR DESCRIPTION
Closes #35039

## Problem
When gateway.mode=remote and auth is token-based, agent tool calls could miss shared auth credentials because gateway call resolution only checked gateway.remote.token in this branch. That could drop calls into the device-auth-required flow and time out.

## Fix
Use a shared credential resolver in callGateway() for both token/password and both local/remote paths. In remote mode, it now falls back through env (OPENCLAW_GATEWAY_*, CLAWDBOT_GATEWAY_*) and gateway.auth.* when explicit overrides are absent.
