### PR TITLE
fix(gateway): allow app:// origins in control-ui allowlist checks

### DIFF
--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -100,4 +100,17 @@ describe("checkBrowserOrigin", () => {
     });
     expect(result.ok).toBe(true);
   });
+
+  it("accepts allowlisted custom app protocol origins", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "gateway.tailnet.ts.net",
+      origin: "app://localhost",
+      allowedOrigins: ["app://localhost"],
+      isLocalClient: false,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.matchedBy).toBe("allowlist");
+    }
+  });
 });

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -16,8 +16,10 @@ function parseOrigin(
   }
   try {
     const url = new URL(trimmed);
+    const normalizedOrigin =
+      url.origin === "null" && url.host ? `${url.protocol}//${url.host}` : url.origin;
     return {
-      origin: url.origin.toLowerCase(),
+      origin: normalizedOrigin.toLowerCase(),
       host: url.host.toLowerCase(),
       hostname: url.hostname.toLowerCase(),
     };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Control UI origin checks rejected Electron origins like `app://localhost` even when explicitly listed in `gateway.controlUi.allowedOrigins`.
- Why it matters: ClawControl desktop app connections over remote gateways (for example Tailscale Serve) were blocked unless users used wildcard `"*"` origins.
- What changed: Origin parsing now normalizes custom-scheme URL origins with host components (for example `app://localhost`) instead of treating them as opaque `null` origins.
- What changed: Added regression coverage proving `allowedOrigins: ["app://localhost"]` is accepted.
- What did NOT change (scope boundary): No auth, pairing, host-header fallback, or wildcard origin behavior was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35035
- Related #23352

## User-visible / Behavior Changes

`gateway.controlUi.allowedOrigins` entries like `app://localhost` now work as expected for Control UI/WebSocket origin checks.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.22.0, pnpm v10.23.0
- Model/provider: N/A
- Integration/channel (if any): Gateway Control UI WebSocket handshake path
- Relevant config (redacted): `gateway.controlUi.allowedOrigins=["app://localhost"]`

### Steps

1. Configure gateway with `gateway.controlUi.allowedOrigins=["app://localhost"]`.
2. Attempt a Control UI/WebSocket handshake with `Origin: app://localhost`.
3. Observe origin check result.

### Expected

- Origin check accepts the request by allowlist match.

### Actual

- Before fix: rejected with `origin not allowed` because parsed origin was normalized to `null`.
- After fix: accepted via allowlist.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added regression test that failed before and passes after for `app://localhost` allowlisting.
  - Existing origin-check and browser-hardening auth tests pass unchanged.
- Edge cases checked:
  - Existing wildcard allowlist behavior remains passing.
  - Existing host-header fallback behavior remains passing.
- What you did **not** verify:
  - Live remote gateway handshake against a real ClawControl desktop app.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/gateway/origin-check.ts`
  - `src/gateway/origin-check.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected acceptance/rejection changes for non-HTTP origins in Control UI/WebSocket checks.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Non-standard schemes with host components are now normalized into comparable origin strings.
  - Mitigation:
    - Behavior is constrained to exact allowlist comparison and covered by regression tests.
