### PR TITLE
fix(exec): honor 'Always allow' for bash script invocations

### DIFF
--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -302,4 +302,160 @@ describe("resolveAllowAlwaysPatterns", () => {
       persistedPattern: echo,
     });
   });
+
+  it("persists script file path when bash invokes a script without -c", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const script = makeExecutable(scriptsDir, "save_crystal.sh");
+
+    const patterns = resolveAllowAlwaysPatterns({
+      segments: [
+        {
+          raw: `bash scripts/save_crystal.sh`,
+          argv: ["bash", "scripts/save_crystal.sh"],
+          resolution: {
+            rawExecutable: "bash",
+            resolvedPath: "/bin/bash",
+            executableName: "bash",
+          },
+        },
+      ],
+      cwd: dir,
+      env: makePathEnv(dir),
+      platform: process.platform,
+    });
+    expect(patterns).toEqual([script]);
+  });
+
+  it("round-trips bash script file: persist then match", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const script = makeExecutable(scriptsDir, "save_crystal.sh");
+    // Include system PATH so that `bash` resolves to the real binary.
+    const env = { PATH: `${dir}${path.delimiter}${process.env.PATH ?? ""}` };
+    const safeBins = resolveSafeBins(undefined);
+
+    // First invocation: derive the persisted pattern.
+    const first = evaluateShellAllowlist({
+      command: "bash scripts/save_crystal.sh",
+      allowlist: [],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    const persisted = resolveAllowAlwaysPatterns({
+      segments: first.segments,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(persisted).toEqual([script]);
+
+    // Second invocation: the same command should now match the allowlist.
+    const second = evaluateShellAllowlist({
+      command: "bash scripts/save_crystal.sh",
+      allowlist: [{ pattern: script }],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(true);
+  });
+
+  it("does not persist script path when bash uses -c", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const whoami = makeExecutable(dir, "whoami");
+    const patterns = resolveAllowAlwaysPatterns({
+      segments: [
+        {
+          raw: "bash -c 'whoami'",
+          argv: ["bash", "-c", "whoami"],
+          resolution: {
+            rawExecutable: "bash",
+            resolvedPath: "/bin/bash",
+            executableName: "bash",
+          },
+        },
+      ],
+      cwd: dir,
+      env: makePathEnv(dir),
+      platform: process.platform,
+    });
+    // Should unwrap to the inner command, not treat as script file.
+    expect(patterns).toEqual([whoami]);
+  });
+
+  it("does not persist anything for bash -s (stdin mode)", () => {
+    const patterns = resolveAllowAlwaysPatterns({
+      segments: [
+        {
+          raw: "bash -s",
+          argv: ["bash", "-s"],
+          resolution: {
+            rawExecutable: "bash",
+            resolvedPath: "/bin/bash",
+            executableName: "bash",
+          },
+        },
+      ],
+      platform: process.platform,
+    });
+    expect(patterns).toEqual([]);
+  });
+
+  it("does not persist anything for bash -s with trailing args", () => {
+    const patterns = resolveAllowAlwaysPatterns({
+      segments: [
+        {
+          raw: "bash -s foo.sh",
+          argv: ["bash", "-s", "foo.sh"],
+          resolution: {
+            rawExecutable: "bash",
+            resolvedPath: "/bin/bash",
+            executableName: "bash",
+          },
+        },
+      ],
+      platform: process.platform,
+    });
+    expect(patterns).toEqual([]);
+  });
+
+  it("skips -o flag value and persists the actual script file", () => {
+    const dir = makeTempDir();
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const script = path.join(scriptsDir, "deploy.sh");
+    fs.writeFileSync(script, "#!/bin/bash\n", { mode: 0o755 });
+    const patterns = resolveAllowAlwaysPatterns({
+      segments: [
+        {
+          raw: "bash -o pipefail scripts/deploy.sh",
+          argv: ["bash", "-o", "pipefail", "scripts/deploy.sh"],
+          resolution: {
+            rawExecutable: "bash",
+            resolvedPath: "/bin/bash",
+            executableName: "bash",
+          },
+        },
+      ],
+      cwd: dir,
+      env: makePathEnv(dir),
+      platform: process.platform,
+    });
+    expect(patterns).toEqual([script]);
+  });
 });

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -20,6 +20,7 @@ import {
 import { isTrustedSafeBinPath } from "./exec-safe-bin-trust.js";
 import {
   extractShellWrapperInlineCommand,
+  extractShellScriptFileArg,
   isDispatchWrapperExecutable,
   isShellWrapperExecutable,
   unwrapKnownShellMultiplexerInvocation,
@@ -221,7 +222,27 @@ function evaluateSegments(
       candidatePath && segment.resolution
         ? { ...segment.resolution, resolvedPath: candidatePath }
         : segment.resolution;
-    const match = matchAllowlist(params.allowlist, candidateResolution);
+    let match = matchAllowlist(params.allowlist, candidateResolution);
+    // When the segment is a shell wrapper invoked with a script file
+    // (e.g. `bash scripts/save_crystal.sh`), also check the script file
+    // path against the allowlist so "always allow" persisted patterns work.
+    if (!match && isShellWrapperSegment(segment)) {
+      const scriptFile = extractShellScriptFileArg(segment.argv);
+      if (scriptFile) {
+        const scriptResolution = resolveCommandResolutionFromArgv(
+          [scriptFile],
+          params.cwd,
+          undefined,
+        );
+        const scriptCandidatePath = resolveAllowlistCandidatePath(scriptResolution, params.cwd);
+        if (scriptResolution && scriptCandidatePath) {
+          match = matchAllowlist(params.allowlist, {
+            ...scriptResolution,
+            resolvedPath: scriptCandidatePath,
+          });
+        }
+      }
+    }
     if (match) {
       matches.push(match);
     }
@@ -382,6 +403,21 @@ function collectAllowAlwaysPatterns(params: {
   }
   const inlineCommand = extractShellWrapperInlineCommand(params.segment.argv);
   if (!inlineCommand) {
+    // No inline command (no -c flag). Check if the shell is invoked with a
+    // script file argument, e.g. `bash scripts/save_crystal.sh`.
+    // In that case, persist the resolved script file path.
+    const scriptFile = extractShellScriptFileArg(params.segment.argv);
+    if (scriptFile) {
+      const scriptResolution = resolveCommandResolutionFromArgv(
+        [scriptFile],
+        params.cwd,
+        params.env,
+      );
+      const scriptPath = resolveAllowlistCandidatePath(scriptResolution, params.cwd);
+      if (scriptPath) {
+        params.out.add(scriptPath);
+      }
+    }
     return;
   }
   const nested = analyzeShellCommand({

--- a/src/infra/exec-wrapper-resolution.ts
+++ b/src/infra/exec-wrapper-resolution.ts
@@ -122,6 +122,80 @@ export function isShellWrapperExecutable(token: string): boolean {
   return SHELL_WRAPPER_CANONICAL.has(normalizeExecutableToken(token));
 }
 
+/**
+ * Extract the script file argument from a POSIX shell invocation like
+ * `bash scripts/save_crystal.sh` or `bash -x scripts/save_crystal.sh`.
+ *
+ * Returns `null` when no script file can be identified (e.g. `bash -c "cmd"`,
+ * `bash -s`, or bare `bash`).
+ */
+export function extractShellScriptFileArg(argv: string[]): string | null {
+  if (argv.length < 2) {
+    return null;
+  }
+  const token0 = argv[0]?.trim();
+  if (!token0) {
+    return null;
+  }
+  const base = normalizeExecutableToken(token0);
+  // Only handle POSIX shell wrappers for script-file extraction.
+  if (!POSIX_SHELL_NAMES.has(base)) {
+    return null;
+  }
+  // Walk argv[1..] skipping known option flags. The first positional argument
+  // that does not start with `-` (and is not consumed by `-c`/`--command`) is
+  // the script file.
+  for (let i = 1; i < argv.length; i++) {
+    const token = argv[i]?.trim();
+    if (!token) {
+      continue;
+    }
+    const lower = token.toLowerCase();
+    // If we hit `-c` / `--command` / `-lc`, this is an inline command invocation,
+    // not a script file invocation.
+    if (POSIX_INLINE_COMMAND_FLAGS.has(lower)) {
+      return null;
+    }
+    // Combined short flags containing 'c' (e.g. `-xc`) are also inline commands.
+    if (/^-[^-]*c[^-]*$/i.test(token)) {
+      return null;
+    }
+    // `-s` means "read from stdin"; remaining args are positional, not a script.
+    if (lower === "-s") {
+      return null;
+    }
+    // Combined short flags containing 's' (e.g. `-ls`) also mean stdin read.
+    if (/^-[^-]*s[^-]*$/i.test(token) && !token.includes("c")) {
+      return null;
+    }
+    // `--` terminates options; next arg (if any) is the script file.
+    if (token === "--") {
+      const next = argv[i + 1]?.trim();
+      return next && next.length > 0 ? next : null;
+    }
+    // Skip option flags (single `-` is stdin, treat as no script file).
+    if (token === "-") {
+      return null;
+    }
+    // Flags that consume the next argument as a value.
+    if (SHELL_FLAGS_WITH_VALUE.has(lower) || lower === "--rcfile" || lower === "--init-file") {
+      i++; // skip the value
+      continue;
+    }
+    if (token.startsWith("-")) {
+      continue;
+    }
+    // First positional argument is the script file.
+    return token;
+  }
+  return null;
+}
+
+const POSIX_SHELL_NAMES: ReadonlySet<string> = new Set(POSIX_SHELL_WRAPPER_NAMES);
+
+/** Shell flags that consume the next argv element as a value (not a script file). */
+const SHELL_FLAGS_WITH_VALUE: ReadonlySet<string> = new Set(["-o", "+o"]);
+
 function normalizeRawCommand(rawCommand?: string | null): string | null {
   const trimmed = rawCommand?.trim() ?? "";
   return trimmed.length > 0 ? trimmed : null;


### PR DESCRIPTION
Closes #35024

## Problem

Bash script commands (`bash scripts/save_crystal.sh`) don't honor "Always allow" in the runtime allowlist. Every invocation re-prompts for approval, unlike binary commands which correctly persist the allowlist entry.

## Root Cause

`collectAllowAlwaysPatterns` detects `bash` as a shell wrapper and calls `extractShellWrapperInlineCommand`, which looks for `-c`. Since `bash scripts/save_crystal.sh` doesn't use `-c`, it returns `null`, and the function returns without persisting any pattern.

On the matching side, `evaluateSegments` only matches the shell binary path (e.g. `/bin/bash`) against the allowlist — never the script file path.

## Fix

1. **New function `extractShellScriptFileArg()`** in `exec-wrapper-resolution.ts`: extracts the first positional (non-flag) argument from a POSIX shell invocation as the script file path. Correctly handles `--`, `-s` (stdin), combined flags, and `-c` (returns null for inline commands).

2. **Persist side** (`collectAllowAlwaysPatterns`): when a shell wrapper has no inline command (`-c`), extract the script file argument, resolve its path, and add it to the persisted patterns.

3. **Match side** (`evaluateSegments`): when a shell wrapper segment doesn't match the allowlist directly, also try resolving and matching the script file argument.

## Tests

4 new tests added to `exec-approvals-allow-always.test.ts`:
- Persists script file path when bash invokes a script without `-c`
- Round-trips: persist pattern → match on re-invocation
- Does not affect `bash -c` inline command behavior
- Does not persist anything for `bash -s` (stdin mode)

All 132 existing exec-approvals tests continue to pass.