### PR TITLE
fix(i18n): format registry locale test imports for pnpm check

### DIFF
--- a/src/i18n/registry.test.ts
+++ b/src/i18n/registry.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 import {
   DEFAULT_LOCALE,
   SUPPORTED_LOCALES,
   loadLazyLocaleTranslation,
   resolveNavigatorLocale,
 } from "../../ui/src/i18n/lib/registry.ts";
+import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 
 function getNestedTranslation(map: TranslationMap | null, ...path: string[]): string | undefined {
   let value: string | TranslationMap | undefined = map ?? undefined;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `pnpm check` failed on clean `main` because `src/i18n/registry.test.ts` was not oxfmt-compliant.
- Why it matters: this blocks required pre-PR validation (`pnpm check`) for unrelated fixes.
- What changed: applied oxfmt formatting to `src/i18n/registry.test.ts` (import ordering).
- What did NOT change (scope boundary): no logic, behavior, runtime, or API changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35066
- Related #35063

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.22.0, pnpm v10.23.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Checkout latest `main` before this fix.
2. Run `pnpm check`.
3. Observe formatting failure in `src/i18n/registry.test.ts`.

### Expected

- `pnpm check` passes on clean tree.

### Actual

- Before fix: `pnpm format:check` fails on `src/i18n/registry.test.ts`.
- After fix: `pnpm check` passes.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm check` failed before fix due formatting drift.
  - `pnpm check` passes after formatting correction.
- Edge cases checked:
  - Diff remains single file, formatting-only.
- What you did **not** verify:
  - No runtime behavior changes to verify (format-only change).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/i18n/registry.test.ts`
- Known bad symptoms reviewers should watch for:
  - None expected (format-only).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

None.
