### PR TITLE
fix: normalize src/i18n/registry.test.ts formatting for pnpm check

### DIFF
--- a/src/i18n/registry.test.ts
+++ b/src/i18n/registry.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 import {
   DEFAULT_LOCALE,
   SUPPORTED_LOCALES,
   loadLazyLocaleTranslation,
   resolveNavigatorLocale,
 } from "../../ui/src/i18n/lib/registry.ts";
+import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 
 function getNestedTranslation(map: TranslationMap | null, ...path: string[]): string | undefined {
   let value: string | TranslationMap | undefined = map ?? undefined;


### PR DESCRIPTION
## Summary
- run `oxfmt` on `src/i18n/registry.test.ts`
- keep behavior unchanged; formatting-only reorder of imports

## Validation
- `corepack pnpm -s exec oxfmt --check src/i18n/registry.test.ts`

Closes #35066.