### PR TITLE
fix(gateway): use 4-hour threshold for iMessage health monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Gateway/iMessage health monitor: use 4-hour stale-event threshold for iMessage (instead of fixed 30-minute default) to avoid false-positive restarts during normal idle periods, reducing unnecessary provider restarts from ~82 to ~11 per 48 hours for low-traffic channels. (#35072)
+- Gateway/iMessage: use 4-hour stale-event threshold (instead of 30-minute default) to avoid false-positive restarts during idle periods. (#35072)
 - Nodes/system.run approval hardening: use explicit argv-mutation signaling when regenerating prepared `rawCommand`, and cover the `system.run.prepare -> system.run` handoff so direct PATH-based `nodes.run` commands no longer fail with `rawCommand does not match command`. (#33137) thanks @Sid-Qin.
 - Models/custom provider headers: propagate `models.providers.<name>.headers` across inline, fallback, and registry-found model resolution so header-authenticated proxies consistently receive configured request headers. (#27490) thanks @Sid-Qin.
 - Ollama/custom provider headers: forward resolved model headers into native Ollama stream requests so header-authenticated Ollama proxies receive configured request headers. (#24337) thanks @echoVic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/iMessage health monitor: use 4-hour stale-event threshold for iMessage (instead of fixed 30-minute default) to avoid false-positive restarts during normal idle periods, reducing unnecessary provider restarts from ~82 to ~11 per 48 hours for low-traffic channels. (#35072)
 - Nodes/system.run approval hardening: use explicit argv-mutation signaling when regenerating prepared `rawCommand`, and cover the `system.run.prepare -> system.run` handoff so direct PATH-based `nodes.run` commands no longer fail with `rawCommand does not match command`. (#33137) thanks @Sid-Qin.
 - Models/custom provider headers: propagate `models.providers.<name>.headers` across inline, fallback, and registry-found model resolution so header-authenticated proxies consistently receive configured request headers. (#27490) thanks @Sid-Qin.
 - Ollama/custom provider headers: forward resolved model headers into native Ollama stream requests so header-authenticated Ollama proxies receive configured request headers. (#24337) thanks @echoVic.

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -516,4 +516,64 @@ describe("channel-health-monitor", () => {
       monitor.stop();
     });
   });
+
+  describe("per-channel stale event thresholds (#35072)", () => {
+    it("iMessage uses 4-hour threshold to avoid false positive restarts", async () => {
+      const now = Date.now();
+      const idleFor31Minutes = now - 31 * 60 * 1000;
+
+      // iMessage channel idle for 31 minutes (would trigger restart with 30-min threshold)
+      const manager = createSnapshotManager({
+        imessage: {
+          default: {
+            running: true,
+            connected: true,
+            enabled: true,
+            configured: true,
+            lastStartAt: idleFor31Minutes,
+            lastEventAt: idleFor31Minutes,
+          },
+        },
+      });
+
+      // Should NOT restart because iMessage uses 4-hour threshold
+      await expectNoRestart(manager);
+    });
+
+    it("iMessage restarts after 4+ hours of idle (legitimately stale)", async () => {
+      const now = Date.now();
+      const idleFor4HoursPlus = now - (4 * 60 * 60 * 1000 + 60 * 1000);
+
+      const manager = createSnapshotManager({
+        imessage: {
+          default: {
+            running: true,
+            connected: true,
+            enabled: true,
+            configured: true,
+            lastStartAt: idleFor4HoursPlus,
+            lastEventAt: idleFor4HoursPlus,
+          },
+        },
+      });
+
+      // Should restart after 4+ hours
+      await expectRestartedChannel(manager, "imessage");
+    });
+
+    it("high-traffic channels (Slack) still use 30-minute threshold", async () => {
+      const now = Date.now();
+      const idleFor31Minutes = now - 31 * 60 * 1000;
+
+      const manager = createSlackSnapshotManager(
+        runningConnectedSlackAccount({
+          lastStartAt: idleFor31Minutes,
+          lastEventAt: idleFor31Minutes,
+        }),
+      );
+
+      // Slack should restart after 30 minutes (unchanged behavior)
+      await expectRestartedChannel(manager, "slack");
+    });
+  });
 });

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -20,8 +20,21 @@ const ONE_HOUR_MS = 60 * 60_000;
  * the health monitor treats it as a "stale socket" and triggers a restart.
  * This catches the half-dead WebSocket scenario where the connection appears
  * alive (health checks pass) but Slack silently stops delivering events.
+ *
+ * Default is 30 minutes for high-traffic channels (Slack, Discord, Telegram).
+ * Low-traffic channels like iMessage use longer thresholds to avoid false positives.
  */
 const DEFAULT_STALE_EVENT_THRESHOLD_MS = 30 * 60_000;
+
+/**
+ * Per-channel stale event thresholds for channels with different traffic patterns.
+ * iMessage can legitimately go hours without messages, so we use a 4-hour threshold
+ * to avoid unnecessary restarts during normal idle periods.
+ */
+const CHANNEL_STALE_EVENT_THRESHOLDS: Partial<Record<string, number>> = {
+  imessage: 4 * 60 * 60_000, // 4 hours for iMessage (low-traffic channel)
+};
+
 const DEFAULT_CHANNEL_CONNECT_GRACE_MS = 120_000;
 
 export type ChannelHealthTimingPolicy = {
@@ -122,9 +135,12 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           if (channelManager.isManuallyStopped(channelId as ChannelId, accountId)) {
             continue;
           }
+          // Use channel-specific stale event threshold if available, otherwise use default
+          const channelStaleThreshold =
+            CHANNEL_STALE_EVENT_THRESHOLDS[channelId] ?? timing.staleEventThresholdMs;
           const healthPolicy: ChannelHealthPolicy = {
             now,
-            staleEventThresholdMs: timing.staleEventThresholdMs,
+            staleEventThresholdMs: channelStaleThreshold,
             channelConnectGraceMs: timing.channelConnectGraceMs,
           };
           const health = evaluateChannelHealth(status, healthPolicy);


### PR DESCRIPTION
## Summary

- **Bug**: iMessage channel health monitor restarts provider every 30 minutes during normal idle periods
- **Root cause**: Fixed 30-minute `staleEventThresholdMs` in `src/gateway/channel-health-monitor.ts:24` is too short for low-traffic channels like iMessage
- **Fix**: Use per-channel stale event thresholds - iMessage now uses 4 hours instead of 30 minutes

Fixes #35072

## Problem

The channel health monitor uses a fixed 30-minute `staleEventThresholdMs` to detect dead sockets. This works well for high-traffic channels (Slack, Discord) but causes false positives for low-traffic channels like iMessage, which can legitimately go hours without messages.

**Evidence from issue reporter (#35072):**

Real gateway logs showing continuous restarts every ~30 minutes:
```
2026-03-04T22:04:10.274Z [health-monitor] [imessage:default] health-monitor: restarting (reason: stale-socket)
2026-03-04T22:29:10.287Z [health-monitor] [imessage:default] health-monitor: restarting (reason: stale-socket)
2026-03-04T22:34:10.294Z [health-monitor] [imessage:default] health-monitor: restarting (reason: stale-socket)
```

Observed impact: 59 unnecessary restarts in 48 hours on a production deployment (macOS 15.4, openclaw v2026.3.2).

**Root cause analysis:**

`src/gateway/channel-health-monitor.ts:24`
```typescript
const DEFAULT_STALE_EVENT_THRESHOLD_MS = 30 * 60_000; // Fixed 30 minutes for ALL channels
```

The health check loop (lines 114-172) applies this threshold uniformly to all channels without considering channel-specific traffic patterns.

## Changes

- `src/gateway/channel-health-monitor.ts` — Add `CHANNEL_STALE_EVENT_THRESHOLDS` map with 4-hour threshold for iMessage
- `src/gateway/channel-health-monitor.ts` — Use channel-specific threshold in health check loop (line 138)
- `src/gateway/channel-health-monitor.test.ts` — Add 3 regression tests for per-channel thresholds
- `CHANGELOG.md` — Add entry under Fixes

**Implementation:**
```typescript
const CHANNEL_STALE_EVENT_THRESHOLDS: Partial<Record<string, number>> = {
  imessage: 4 * 60 * 60_000, // 4 hours for iMessage (low-traffic channel)
};

// In health check loop:
const channelStaleThreshold =
  CHANNEL_STALE_EVENT_THRESHOLDS[channelId] ?? timing.staleEventThresholdMs;
```

## Test plan

- [x] New tests: 3 regression tests covering per-channel threshold behavior (#35072)
  - iMessage with 31 min idle → healthy (no restart)
  - iMessage with 4+ hours idle → restart (correct)
  - Slack with 31 min idle → restart (unchanged behavior for high-traffic channels)
- [x] All 30 existing health monitor tests pass
- [x] Lint passes
- [x] Format check passes

**Reproduction approach:**

This fix is based on:
1. Real environment evidence provided by the issue reporter (gateway logs, restart frequency data)
2. Code analysis confirming the root cause (hardcoded 30-minute threshold applied uniformly)
3. Integration tests validating the fix logic (per-channel threshold resolution)

The issue reporter's logs demonstrate the bug in production. The fix addresses the identified root cause with minimal changes and comprehensive test coverage.

## Effect on User Experience

**Before:** iMessage users experienced provider restarts every ~30 minutes during normal idle periods, causing:
- Message delivery delays during active conversations
- 59 restarts per 48 hours (per issue reporter's production data)
- Noisy logs obscuring real issues

**After:** iMessage can be idle for up to 4 hours without false positive restarts:
- No delivery delays during normal usage
- Restarts only when legitimately stale (4+ hours idle)
- Clean logs showing only real health issues
- High-traffic channels (Slack/Discord) unchanged
