### PR TITLE
fix(web-search): handle malformed Grok output entries without crashing

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -217,6 +217,19 @@ describe("web_search grok response parsing", () => {
     expect(result.text).toBe("direct output text");
     expect(result.annotationCitations).toEqual(["https://example.com/direct"]);
   });
+
+  it("ignores malformed output entries without throwing", () => {
+    const result = extractGrokContent({
+      output: [
+        null,
+        "bad",
+        { type: "message", content: [null, { type: "output_text", text: "ok" }] },
+      ],
+    } as Parameters<typeof extractGrokContent>[0]);
+
+    expect(result.text).toBe("ok");
+    expect(result.annotationCitations).toEqual([]);
+  });
 });
 
 describe("web_search kimi config resolution", () => {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -283,8 +283,15 @@ function extractGrokContent(data: GrokSearchResponse): {
 } {
   // xAI Responses API format: find the message output with text content
   for (const output of data.output ?? []) {
+    if (!output || typeof output !== "object") {
+      continue;
+    }
+
     if (output.type === "message") {
       for (const block of output.content ?? []) {
+        if (!block || typeof block !== "object") {
+          continue;
+        }
         if (block.type === "output_text" && typeof block.text === "string" && block.text) {
           const urls = (block.annotations ?? [])
             .filter((a) => a.type === "url_citation" && typeof a.url === "string")

--- a/src/i18n/registry.test.ts
+++ b/src/i18n/registry.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 import {
   DEFAULT_LOCALE,
   SUPPORTED_LOCALES,
   loadLazyLocaleTranslation,
   resolveNavigatorLocale,
 } from "../../ui/src/i18n/lib/registry.ts";
+import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 
 function getNestedTranslation(map: TranslationMap | null, ...path: string[]): string | undefined {
   let value: string | TranslationMap | undefined = map ?? undefined;


### PR DESCRIPTION
## Summary
- guard `extractGrokContent` against malformed `output` / `content` entries (e.g. `null`, string)
- keep parsing valid `output_text` blocks as before
- add regression test for mixed malformed + valid blocks

## Why
Grok responses can occasionally contain malformed output items. The parser previously assumed object shapes and could throw while scanning. This keeps parsing resilient and returns the first valid text block instead of crashing.

Fixes #35063

## Testing
- `pnpm test src/agents/tools/web-search.test.ts`
