### PR TITLE
perf(telegram): bound sent-message cache growth

### DIFF
--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -5,7 +5,13 @@ import {
   importTelegramSendModule,
   installTelegramSendTestHooks,
 } from "./send.test-harness.js";
-import { clearSentMessageCache, recordSentMessage, wasSentByBot } from "./sent-message-cache.js";
+import {
+  clearSentMessageCache,
+  recordSentMessage,
+  SENT_MESSAGE_CACHE_MAX_CHATS,
+  SENT_MESSAGE_CACHE_MAX_PER_CHAT,
+  wasSentByBot,
+} from "./sent-message-cache.js";
 
 installTelegramSendTestHooks();
 
@@ -86,6 +92,25 @@ describe("sent-message-cache", () => {
 
     clearSentMessageCache();
     expect(wasSentByBot(123, 1)).toBe(false);
+  });
+
+  it("caps tracked message IDs per chat", () => {
+    const chatId = 777;
+    for (let i = 1; i <= SENT_MESSAGE_CACHE_MAX_PER_CHAT + 5; i += 1) {
+      recordSentMessage(chatId, i);
+    }
+
+    expect(wasSentByBot(chatId, 1)).toBe(false);
+    expect(wasSentByBot(chatId, SENT_MESSAGE_CACHE_MAX_PER_CHAT + 5)).toBe(true);
+  });
+
+  it("caps tracked chats globally", () => {
+    for (let i = 1; i <= SENT_MESSAGE_CACHE_MAX_CHATS + 1; i += 1) {
+      recordSentMessage(i, 1);
+    }
+
+    expect(wasSentByBot(1, 1)).toBe(false);
+    expect(wasSentByBot(SENT_MESSAGE_CACHE_MAX_CHATS + 1, 1)).toBe(true);
   });
 });
 

--- a/src/telegram/sent-message-cache.ts
+++ b/src/telegram/sent-message-cache.ts
@@ -3,7 +3,11 @@
  * Used to identify bot's own messages for reaction filtering ("own" mode).
  */
 
+import { pruneMapToMaxSize } from "../infra/map-size.js";
+
 const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+export const SENT_MESSAGE_CACHE_MAX_PER_CHAT = 1_000;
+export const SENT_MESSAGE_CACHE_MAX_CHATS = 2_000;
 
 type CacheEntry = {
   timestamps: Map<number, number>;
@@ -24,6 +28,11 @@ function cleanupExpired(entry: CacheEntry): void {
   }
 }
 
+function touchChatEntry(chatKey: string, entry: CacheEntry): void {
+  sentMessages.delete(chatKey);
+  sentMessages.set(chatKey, entry);
+}
+
 /**
  * Record a message ID as sent by the bot.
  */
@@ -32,13 +41,19 @@ export function recordSentMessage(chatId: number | string, messageId: number): v
   let entry = sentMessages.get(key);
   if (!entry) {
     entry = { timestamps: new Map() };
-    sentMessages.set(key, entry);
   }
+
+  cleanupExpired(entry);
+
+  // Re-insert to refresh insertion order and keep active chats during global pruning.
+  touchChatEntry(key, entry);
+
+  // Re-insert to refresh message insertion order on duplicate message IDs.
+  entry.timestamps.delete(messageId);
   entry.timestamps.set(messageId, Date.now());
-  // Periodic cleanup
-  if (entry.timestamps.size > 100) {
-    cleanupExpired(entry);
-  }
+
+  pruneMapToMaxSize(entry.timestamps, SENT_MESSAGE_CACHE_MAX_PER_CHAT);
+  pruneMapToMaxSize(sentMessages, SENT_MESSAGE_CACHE_MAX_CHATS);
 }
 
 /**
@@ -50,8 +65,12 @@ export function wasSentByBot(chatId: number | string, messageId: number): boolea
   if (!entry) {
     return false;
   }
-  // Clean up expired entries on read
+  // Clean up expired entries on read.
   cleanupExpired(entry);
+  if (entry.timestamps.size === 0) {
+    sentMessages.delete(key);
+    return false;
+  }
   return entry.timestamps.has(messageId);
 }
 


### PR DESCRIPTION
## Summary\n- cap Telegram sent-message cache size per chat and across chats\n- prune oldest entries to keep recent IDs for `own` reaction filtering\n- remove empty chat buckets after TTL cleanup\n- add tests for per-chat and global cap behavior\n\n## Why\n`sent-message-cache` retains 24h of message IDs. In high-volume deployments this could grow without bound and accumulate memory pressure.\n\n## Risk\nLow. Change is scoped to in-memory reaction filtering cache. Under extreme traffic, very old IDs can now be evicted earlier, which is acceptable for `own` mode semantics.