### PR TITLE
fix(subagents): enforce target model lock on spawn override

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
@@ -271,6 +271,62 @@ describe("openclaw-tools: subagents (sessions_spawn model + thinking)", () => {
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
+  it("sessions_spawn allows same-model override for model-locked target agent", async () => {
+    setSessionsSpawnConfigOverride({
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        defaults: { subagents: { model: "anthropic/claude-sonnet-4-5" } },
+        list: [{ id: "research", model: { primary: "google-gemini-cli/gemini-3.1-pro-preview" } }],
+      },
+    });
+    const calls: GatewayCall[] = [];
+    mockPatchAndSingleAgentRun({ calls, runId: "run-model-lock-same" });
+
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "agent:research:main",
+      agentChannel: "discord",
+    });
+
+    const result = await tool.execute("call-model-lock-same", {
+      task: "do thing",
+      model: "google-gemini-cli/gemini-3.1-pro-preview",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      modelApplied: true,
+    });
+    expect(calls.some((call) => call.method === "agent")).toBe(true);
+  });
+
+  it("sessions_spawn allows normalized model override for model-locked target agent", async () => {
+    setSessionsSpawnConfigOverride({
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        defaults: { subagents: { model: "anthropic/claude-sonnet-4-5" } },
+        list: [{ id: "research", model: { primary: "anthropic/claude-opus-4-5" } }],
+      },
+    });
+    const calls: GatewayCall[] = [];
+    mockPatchAndSingleAgentRun({ calls, runId: "run-model-lock-normalized" });
+
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "agent:research:main",
+      agentChannel: "discord",
+    });
+
+    const result = await tool.execute("call-model-lock-normalized", {
+      task: "do thing",
+      model: "opus-4.5",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      modelApplied: true,
+    });
+    expect(calls.some((call) => call.method === "agent")).toBe(true);
+  });
+
   it("sessions_spawn fails when model patch is rejected", async () => {
     const calls: GatewayCall[] = [];
     mockLongRunningSpawnFlow({

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
@@ -245,6 +245,32 @@ describe("openclaw-tools: subagents (sessions_spawn model + thinking)", () => {
     });
   });
 
+  it("sessions_spawn blocks cross-model override for model-locked target agent", async () => {
+    setSessionsSpawnConfigOverride({
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        defaults: { subagents: { model: "anthropic/claude-sonnet-4-5" } },
+        list: [{ id: "research", model: { primary: "google-gemini-cli/gemini-3.1-pro-preview" } }],
+      },
+    });
+
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "agent:research:main",
+      agentChannel: "discord",
+    });
+
+    const result = await tool.execute("call-model-lock", {
+      task: "do thing",
+      model: "anthropic/claude-opus-4-6",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "forbidden",
+    });
+    expect(String((result.details as { error?: string }).error ?? "")).toContain("model-locked");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
   it("sessions_spawn fails when model patch is rejected", async () => {
     const calls: GatewayCall[] = [];
     mockLongRunningSpawnFlow({

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -14,8 +14,13 @@ import {
 } from "../routing/session-key.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { resolveAgentConfig, resolveAgentWorkspaceDir } from "./agent-scope.js";
+import { DEFAULT_PROVIDER } from "./defaults.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
-import { normalizeModelSelection, resolveSubagentSpawnModelSelection } from "./model-selection.js";
+import {
+  normalizeModelSelection,
+  parseModelRef,
+  resolveSubagentSpawnModelSelection,
+} from "./model-selection.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
 import { buildSubagentSystemPrompt } from "./subagent-announce.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
@@ -390,12 +395,21 @@ export async function spawnSubagentDirect(
   const lockedTargetModelSelection =
     normalizeModelSelection(targetAgentConfig?.subagents?.model) ??
     normalizeModelSelection(targetAgentConfig?.model);
-
-  if (
+  const requestedModelRef = requestedModelSelection
+    ? parseModelRef(requestedModelSelection, DEFAULT_PROVIDER)
+    : null;
+  const lockedTargetModelRef = lockedTargetModelSelection
+    ? parseModelRef(lockedTargetModelSelection, DEFAULT_PROVIDER)
+    : null;
+  const hasModelLockConflict =
     requestedModelSelection &&
     lockedTargetModelSelection &&
-    requestedModelSelection !== lockedTargetModelSelection
-  ) {
+    (requestedModelRef && lockedTargetModelRef
+      ? requestedModelRef.provider !== lockedTargetModelRef.provider ||
+        requestedModelRef.model !== lockedTargetModelRef.model
+      : requestedModelSelection !== lockedTargetModelSelection);
+
+  if (hasModelLockConflict) {
     return {
       status: "forbidden",
       error:

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -15,7 +15,7 @@ import {
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { resolveAgentConfig, resolveAgentWorkspaceDir } from "./agent-scope.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
-import { resolveSubagentSpawnModelSelection } from "./model-selection.js";
+import { normalizeModelSelection, resolveSubagentSpawnModelSelection } from "./model-selection.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
 import { buildSubagentSystemPrompt } from "./subagent-announce.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
@@ -386,6 +386,24 @@ export async function spawnSubagentDirect(
   const childDepth = callerDepth + 1;
   const spawnedByKey = requesterInternalKey;
   const targetAgentConfig = resolveAgentConfig(cfg, targetAgentId);
+  const requestedModelSelection = normalizeModelSelection(modelOverride);
+  const lockedTargetModelSelection =
+    normalizeModelSelection(targetAgentConfig?.subagents?.model) ??
+    normalizeModelSelection(targetAgentConfig?.model);
+
+  if (
+    requestedModelSelection &&
+    lockedTargetModelSelection &&
+    requestedModelSelection !== lockedTargetModelSelection
+  ) {
+    return {
+      status: "forbidden",
+      error:
+        `agentId "${targetAgentId}" is model-locked to "${lockedTargetModelSelection}"; ` +
+        `model override "${requestedModelSelection}" is not allowed`,
+    };
+  }
+
   const resolvedModel = resolveSubagentSpawnModelSelection({
     cfg,
     agentId: targetAgentId,

--- a/src/i18n/registry.test.ts
+++ b/src/i18n/registry.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 import {
   DEFAULT_LOCALE,
   SUPPORTED_LOCALES,
   loadLazyLocaleTranslation,
   resolveNavigatorLocale,
 } from "../../ui/src/i18n/lib/registry.ts";
+import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 
 function getNestedTranslation(map: TranslationMap | null, ...path: string[]): string | undefined {
   let value: string | TranslationMap | undefined = map ?? undefined;


### PR DESCRIPTION
## Summary / What changed
- blocked `sessions_spawn` model overrides when the target agent is explicitly model-pinned
- return `forbidden` with a clear error when override and target lock differ
- added regression test to prove cross-model override is rejected for locked targets

## Why
- operators expect strict model lock behavior for specific agents (example: Aliş must stay on Gemini)
- before this patch, callers could pass `model` override and silently bypass lock intent
- this caused production confusion where a locked agent ran on a different provider/model

## Tests
- added: `sessions_spawn blocks cross-model override for model-locked target agent`
- attempted local run:
  - `pnpm -s vitest run src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts`
  - blocked by missing optional dependency in this environment: `@discordjs/voice`
- CI should run full matrix in clean environment

## Real-world validation
- validated logic on live config shape where target agent has explicit model pin and spawn request sends different override
- expected result is now deterministic `forbidden` instead of cross-model reroute

## Issue
- no tracked issue yet

## AI-assisted disclosure
- AI-assisted: yes
- testing level: lightly tested locally (unit run attempted; environment dependency blocked)
