### PR TITLE
fix: honor allow-always for bash script commands

### DIFF
--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -439,6 +439,52 @@ describe("resolveAllowAlwaysPatterns", () => {
     expect(persisted).toEqual([expectedHomePath]);
   });
 
+  it("matches script allowlist for dispatch-wrapped shell invocations", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const scriptPath = path.join(scriptsDir, "save_crystal.sh");
+    fs.writeFileSync(scriptPath, "#!/usr/bin/env bash\necho ok\n");
+    fs.chmodSync(scriptPath, 0o755);
+    const env = makePathEnv(dir);
+
+    const second = evaluateShellAllowlist({
+      command: "/usr/bin/env bash scripts/save_crystal.sh",
+      allowlist: [{ pattern: scriptPath }],
+      safeBins: resolveSafeBins(undefined),
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(true);
+  });
+
+  it("matches script allowlist for trusted absolute shell wrappers", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const scriptPath = path.join(scriptsDir, "save_crystal.sh");
+    fs.writeFileSync(scriptPath, "#!/usr/bin/env bash\necho ok\n");
+    fs.chmodSync(scriptPath, 0o755);
+    const env = makePathEnv(dir);
+
+    const second = evaluateShellAllowlist({
+      command: "/bin/bash scripts/save_crystal.sh",
+      allowlist: [{ pattern: scriptPath }],
+      safeBins: resolveSafeBins(undefined),
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(true);
+  });
+
   it("does not allowlist bypass with path-scoped shell wrapper binaries", () => {
     if (process.platform === "win32") {
       return;

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -302,4 +302,52 @@ describe("resolveAllowAlwaysPatterns", () => {
       persistedPattern: echo,
     });
   });
+
+  it("persists shell script path for bash script invocations", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const scriptPath = path.join(scriptsDir, "save_crystal.sh");
+    fs.writeFileSync(scriptPath, "#!/usr/bin/env bash\necho ok\n");
+    fs.chmodSync(scriptPath, 0o755);
+    const env = makePathEnv(dir);
+    const safeBins = resolveSafeBins(undefined);
+
+    const first = evaluateShellAllowlist({
+      command: "bash scripts/save_crystal.sh",
+      allowlist: [],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    const persisted = resolveAllowAlwaysPatterns({
+      segments: first.segments,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(persisted).toEqual([scriptPath]);
+
+    const second = evaluateShellAllowlist({
+      command: "bash scripts/save_crystal.sh",
+      allowlist: [{ pattern: scriptPath }],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(true);
+    expect(
+      requiresExecApproval({
+        ask: "on-miss",
+        security: "allowlist",
+        analysisOk: second.analysisOk,
+        allowlistSatisfied: second.allowlistSatisfied,
+      }),
+    ).toBe(false);
+  });
 });

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -350,4 +350,127 @@ describe("resolveAllowAlwaysPatterns", () => {
       }),
     ).toBe(false);
   });
+
+  it("persists script path when shell wrapper uses -- separator", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const scriptPath = path.join(scriptsDir, "save_crystal.sh");
+    fs.writeFileSync(scriptPath, "#!/usr/bin/env bash\necho ok\n");
+    fs.chmodSync(scriptPath, 0o755);
+    const env = makePathEnv(dir);
+
+    const analysis = evaluateShellAllowlist({
+      command: "bash -- scripts/save_crystal.sh",
+      allowlist: [],
+      safeBins: resolveSafeBins(undefined),
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    const persisted = resolveAllowAlwaysPatterns({
+      segments: analysis.segments,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(persisted).toEqual([scriptPath]);
+  });
+
+  it("does not persist script path when wrapper options appear before script token", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const scriptPath = path.join(scriptsDir, "save_crystal.sh");
+    fs.writeFileSync(scriptPath, "#!/usr/bin/env bash\necho ok\n");
+    fs.chmodSync(scriptPath, 0o755);
+    const env = makePathEnv(dir);
+
+    const analysis = evaluateShellAllowlist({
+      command: "bash -e scripts/save_crystal.sh",
+      allowlist: [],
+      safeBins: resolveSafeBins(undefined),
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    const persisted = resolveAllowAlwaysPatterns({
+      segments: analysis.segments,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(persisted).toEqual([]);
+  });
+
+  it("persists script path when wrapper command uses tilde", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const scriptPath = path.join(scriptsDir, "save_crystal.sh");
+    fs.writeFileSync(scriptPath, "#!/usr/bin/env bash\necho ok\n");
+    fs.chmodSync(scriptPath, 0o755);
+    const env = { ...makePathEnv(dir), HOME: dir };
+
+    const analysis = evaluateShellAllowlist({
+      command: "bash ~/scripts/save_crystal.sh",
+      allowlist: [],
+      safeBins: resolveSafeBins(undefined),
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    const persisted = resolveAllowAlwaysPatterns({
+      segments: analysis.segments,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    const expectedHomePath = path.join(process.env.HOME ?? "~", "scripts", "save_crystal.sh");
+    expect(persisted).toEqual([expectedHomePath]);
+  });
+
+  it("does not allowlist bypass with path-scoped shell wrapper binaries", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const scriptPath = path.join(scriptsDir, "save_crystal.sh");
+    fs.writeFileSync(scriptPath, "#!/usr/bin/env bash\necho ok\n");
+    fs.chmodSync(scriptPath, 0o755);
+    const fakeBash = path.join(dir, "bash");
+    fs.writeFileSync(fakeBash, "#!/usr/bin/env bash\necho fake\n");
+    fs.chmodSync(fakeBash, 0o755);
+    const env = makePathEnv(dir);
+    const safeBins = resolveSafeBins(undefined);
+
+    const second = evaluateShellAllowlist({
+      command: "./bash scripts/save_crystal.sh",
+      allowlist: [{ pattern: scriptPath }],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(false);
+    expect(
+      requiresExecApproval({
+        ask: "on-miss",
+        security: "allowlist",
+        analysisOk: second.analysisOk,
+        allowlistSatisfied: second.allowlistSatisfied,
+      }),
+    ).toBe(true);
+  });
 });

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -462,6 +462,29 @@ describe("resolveAllowAlwaysPatterns", () => {
     expect(second.allowlistSatisfied).toBe(true);
   });
 
+  it("matches script allowlist for nested dispatch wrappers", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const scriptPath = path.join(scriptsDir, "save_crystal.sh");
+    fs.writeFileSync(scriptPath, "#!/usr/bin/env bash\necho ok\n");
+    fs.chmodSync(scriptPath, 0o755);
+    const env = makePathEnv(dir);
+
+    const second = evaluateShellAllowlist({
+      command: "/usr/bin/env /usr/bin/env bash scripts/save_crystal.sh",
+      allowlist: [{ pattern: scriptPath }],
+      safeBins: resolveSafeBins(undefined),
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(true);
+  });
+
   it("matches script allowlist for trusted absolute shell wrappers", () => {
     if (process.platform === "win32") {
       return;
@@ -483,6 +506,29 @@ describe("resolveAllowAlwaysPatterns", () => {
       platform: process.platform,
     });
     expect(second.allowlistSatisfied).toBe(true);
+  });
+
+  it("does not trust traversal-shaped absolute shell wrapper paths", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const scriptPath = path.join(scriptsDir, "save_crystal.sh");
+    fs.writeFileSync(scriptPath, "#!/usr/bin/env bash\necho ok\n");
+    fs.chmodSync(scriptPath, 0o755);
+    const env = makePathEnv(dir);
+
+    const second = evaluateShellAllowlist({
+      command: "/usr/bin/../../tmp/bash scripts/save_crystal.sh",
+      allowlist: [{ pattern: scriptPath }],
+      safeBins: resolveSafeBins(undefined),
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(false);
   });
 
   it("does not allowlist bypass with path-scoped shell wrapper binaries", () => {

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -485,6 +485,29 @@ describe("resolveAllowAlwaysPatterns", () => {
     expect(second.allowlistSatisfied).toBe(true);
   });
 
+  it("matches script allowlist for four-level dispatch wrapper chains", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const scriptPath = path.join(scriptsDir, "save_crystal.sh");
+    fs.writeFileSync(scriptPath, "#!/usr/bin/env bash\necho ok\n");
+    fs.chmodSync(scriptPath, 0o755);
+    const env = makePathEnv(dir);
+
+    const second = evaluateShellAllowlist({
+      command: "/usr/bin/env /usr/bin/env /usr/bin/env /usr/bin/env bash scripts/save_crystal.sh",
+      allowlist: [{ pattern: scriptPath }],
+      safeBins: resolveSafeBins(undefined),
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(true);
+  });
+
   it("matches script allowlist for trusted absolute shell wrappers", () => {
     if (process.platform === "win32") {
       return;

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -216,7 +216,9 @@ function evaluateSegments(
       segment.resolution?.effectiveArgv && segment.resolution.effectiveArgv.length > 0
         ? segment.resolution.effectiveArgv
         : segment.argv;
-    const candidatePath = resolveAllowlistCandidatePath(segment.resolution, params.cwd);
+    const candidatePath =
+      resolveShellWrapperScriptPath(segment, params.cwd) ??
+      resolveAllowlistCandidatePath(segment.resolution, params.cwd);
     const candidateResolution =
       candidatePath && segment.resolution
         ? { ...segment.resolution, resolvedPath: candidatePath }
@@ -327,6 +329,35 @@ function isDispatchWrapperSegment(segment: ExecCommandSegment): boolean {
   return hasSegmentExecutableMatch(segment, isDispatchWrapperExecutable);
 }
 
+function resolveShellWrapperScriptPath(segment: ExecCommandSegment, cwd?: string): string | null {
+  if (!isShellWrapperSegment(segment)) {
+    return null;
+  }
+  if (extractShellWrapperInlineCommand(segment.argv)) {
+    return null;
+  }
+
+  const argv = segment.argv;
+  if (argv.length < 2) {
+    return null;
+  }
+
+  const start = argv[1]?.trim() === "--" ? 2 : 1;
+  const scriptToken = argv[start]?.trim();
+  if (!scriptToken || scriptToken === "-" || scriptToken.startsWith("-")) {
+    return null;
+  }
+
+  const normalized = scriptToken.startsWith("~")
+    ? scriptToken.replace(/^~(?=$|[\\/])/, process.env.HOME ?? "~")
+    : scriptToken;
+  if (path.isAbsolute(normalized)) {
+    return normalized;
+  }
+  const base = cwd && cwd.trim() ? cwd.trim() : process.cwd();
+  return path.resolve(base, normalized);
+}
+
 function collectAllowAlwaysPatterns(params: {
   segment: ExecCommandSegment;
   cwd?: string;
@@ -372,16 +403,20 @@ function collectAllowAlwaysPatterns(params: {
     return;
   }
 
-  const candidatePath = resolveAllowlistCandidatePath(params.segment.resolution, params.cwd);
-  if (!candidatePath) {
-    return;
-  }
   if (!isShellWrapperSegment(params.segment)) {
+    const candidatePath = resolveAllowlistCandidatePath(params.segment.resolution, params.cwd);
+    if (!candidatePath) {
+      return;
+    }
     params.out.add(candidatePath);
     return;
   }
   const inlineCommand = extractShellWrapperInlineCommand(params.segment.argv);
   if (!inlineCommand) {
+    const scriptPath = resolveShellWrapperScriptPath(params.segment, params.cwd);
+    if (scriptPath) {
+      params.out.add(scriptPath);
+    }
     return;
   }
   const nested = analyzeShellCommand({

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -98,6 +98,22 @@ function isPathScopedExecutableToken(token: string): boolean {
   return token.includes("/") || token.includes("\\");
 }
 
+function isTrustedAbsoluteShellWrapperPath(rawExecutable: string, resolvedPath?: string): boolean {
+  const raw = rawExecutable.trim();
+  if (!path.isAbsolute(raw)) {
+    return false;
+  }
+  if (!resolvedPath || resolvedPath !== raw) {
+    return false;
+  }
+  if (!isShellWrapperExecutable(raw)) {
+    return false;
+  }
+  return (
+    raw.startsWith("/bin/") || raw.startsWith("/usr/bin/") || raw.startsWith("/usr/local/bin/")
+  );
+}
+
 export type ExecAllowlistEvaluation = {
   allowlistSatisfied: boolean;
   allowlistMatches: ExecAllowlistEntry[];
@@ -216,18 +232,38 @@ function evaluateSegments(
       segment.resolution?.effectiveArgv && segment.resolution.effectiveArgv.length > 0
         ? segment.resolution.effectiveArgv
         : segment.argv;
-    const shellScriptPath = resolveShellWrapperScriptPath(segment, params.cwd);
+
+    const dispatchUnwrap = unwrapKnownDispatchWrapperInvocation(segment.argv);
+    const allowlistSegment =
+      dispatchUnwrap.kind === "unwrapped" && dispatchUnwrap.argv.length > 0
+        ? {
+            raw: dispatchUnwrap.argv.join(" "),
+            argv: dispatchUnwrap.argv,
+            resolution: resolveCommandResolutionFromArgv(
+              dispatchUnwrap.argv,
+              params.cwd,
+              params.env,
+            ),
+          }
+        : segment;
+
+    const shellScriptPath = resolveShellWrapperScriptPath(allowlistSegment, params.cwd);
+    const rawExecutable = allowlistSegment.resolution?.rawExecutable?.trim() ?? "";
     const canUseShellScriptPath =
       shellScriptPath &&
-      Boolean(segment.resolution?.rawExecutable) &&
-      !isPathScopedExecutableToken(segment.resolution.rawExecutable.trim());
+      rawExecutable.length > 0 &&
+      (!isPathScopedExecutableToken(rawExecutable) ||
+        isTrustedAbsoluteShellWrapperPath(
+          rawExecutable,
+          allowlistSegment.resolution?.resolvedPath,
+        ));
     const candidatePath =
       (canUseShellScriptPath ? shellScriptPath : null) ??
-      resolveAllowlistCandidatePath(segment.resolution, params.cwd);
+      resolveAllowlistCandidatePath(allowlistSegment.resolution, params.cwd);
     const candidateResolution =
-      candidatePath && segment.resolution
-        ? { ...segment.resolution, resolvedPath: candidatePath }
-        : segment.resolution;
+      candidatePath && allowlistSegment.resolution
+        ? { ...allowlistSegment.resolution, resolvedPath: candidatePath }
+        : allowlistSegment.resolution;
     const match = matchAllowlist(params.allowlist, candidateResolution);
     if (match) {
       matches.push(match);

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -100,17 +100,21 @@ function isPathScopedExecutableToken(token: string): boolean {
 
 function isTrustedAbsoluteShellWrapperPath(rawExecutable: string, resolvedPath?: string): boolean {
   const raw = rawExecutable.trim();
-  if (!path.isAbsolute(raw)) {
+  if (!path.isAbsolute(raw) || !resolvedPath) {
     return false;
   }
-  if (!resolvedPath || resolvedPath !== raw) {
+  const normalizedRaw = path.resolve(raw);
+  const normalizedResolved = path.resolve(resolvedPath);
+  if (normalizedResolved !== normalizedRaw) {
     return false;
   }
-  if (!isShellWrapperExecutable(raw)) {
+  if (!isShellWrapperExecutable(normalizedResolved)) {
     return false;
   }
   return (
-    raw.startsWith("/bin/") || raw.startsWith("/usr/bin/") || raw.startsWith("/usr/local/bin/")
+    normalizedResolved.startsWith("/bin/") ||
+    normalizedResolved.startsWith("/usr/bin/") ||
+    normalizedResolved.startsWith("/usr/local/bin/")
   );
 }
 
@@ -233,17 +237,21 @@ function evaluateSegments(
         ? segment.resolution.effectiveArgv
         : segment.argv;
 
-    const dispatchUnwrap = unwrapKnownDispatchWrapperInvocation(segment.argv);
+    let unwrappedArgv = segment.argv;
+    for (let depth = 0; depth < 3; depth += 1) {
+      const dispatchUnwrap = unwrapKnownDispatchWrapperInvocation(unwrappedArgv);
+      if (dispatchUnwrap.kind !== "unwrapped" || dispatchUnwrap.argv.length === 0) {
+        break;
+      }
+      unwrappedArgv = dispatchUnwrap.argv;
+    }
+
     const allowlistSegment =
-      dispatchUnwrap.kind === "unwrapped" && dispatchUnwrap.argv.length > 0
+      unwrappedArgv !== segment.argv
         ? {
-            raw: dispatchUnwrap.argv.join(" "),
-            argv: dispatchUnwrap.argv,
-            resolution: resolveCommandResolutionFromArgv(
-              dispatchUnwrap.argv,
-              params.cwd,
-              params.env,
-            ),
+            raw: unwrappedArgv.join(" "),
+            argv: unwrappedArgv,
+            resolution: resolveCommandResolutionFromArgv(unwrappedArgv, params.cwd, params.env),
           }
         : segment;
 

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -216,8 +216,13 @@ function evaluateSegments(
       segment.resolution?.effectiveArgv && segment.resolution.effectiveArgv.length > 0
         ? segment.resolution.effectiveArgv
         : segment.argv;
+    const shellScriptPath = resolveShellWrapperScriptPath(segment, params.cwd);
+    const canUseShellScriptPath =
+      shellScriptPath &&
+      Boolean(segment.resolution?.rawExecutable) &&
+      !isPathScopedExecutableToken(segment.resolution.rawExecutable.trim());
     const candidatePath =
-      resolveShellWrapperScriptPath(segment, params.cwd) ??
+      (canUseShellScriptPath ? shellScriptPath : null) ??
       resolveAllowlistCandidatePath(segment.resolution, params.cwd);
     const candidateResolution =
       candidatePath && segment.resolution

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -238,7 +238,8 @@ function evaluateSegments(
         : segment.argv;
 
     let unwrappedArgv = segment.argv;
-    for (let depth = 0; depth < 3; depth += 1) {
+    // Keep depth aligned with dispatch unwrapping in command resolution (currently 4).
+    for (let depth = 0; depth < 4; depth += 1) {
       const dispatchUnwrap = unwrapKnownDispatchWrapperInvocation(unwrappedArgv);
       if (dispatchUnwrap.kind !== "unwrapped" || dispatchUnwrap.argv.length === 0) {
         break;


### PR DESCRIPTION
## Summary
- persist script-path allowlist entries for shell-wrapper script invocations like `bash scripts/save_crystal.sh`
- allow allowlist matching against the resolved script path for shell-wrapper script runs
- keep existing inline-command unwrapping behavior and add regression coverage

## Testing
- pnpm exec vitest run src/infra/exec-approvals-allow-always.test.ts

Fixes openclaw/openclaw#35024