### PR TITLE
fix(cron): coerce string-typed everyMs/anchorMs in legacy stored data

### DIFF
--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   clearCronScheduleCacheForTest,
+  coerceFiniteScheduleNumber,
   computeNextRunAtMs,
   getCronScheduleCacheSizeForTest,
 } from "./schedule.js";
@@ -73,6 +74,26 @@ describe("cron schedule", () => {
 
     // Should return nowMs + everyMs, not nowMs (which would cause infinite loop)
     expect(next).toBe(now + 30_000);
+  });
+
+  it("handles string-typed everyMs and anchorMs from legacy stored data (#34652)", () => {
+    const anchor = Date.parse("2025-12-13T00:00:00.000Z");
+    const now = anchor + 10_000;
+    const next = computeNextRunAtMs(
+      {
+        kind: "every",
+        everyMs: "30000" as unknown as number,
+        anchorMs: `${anchor}` as unknown as number,
+      },
+      now,
+    );
+    expect(next).toBe(anchor + 30_000);
+  });
+
+  it("returns undefined for non-numeric string everyMs", () => {
+    const now = Date.now();
+    const next = computeNextRunAtMs({ kind: "every", everyMs: "abc" as unknown as number }, now);
+    expect(next).toBeUndefined();
   });
 
   it("advances when now matches anchor for every schedule", () => {
@@ -161,5 +182,40 @@ describe("cron schedule", () => {
       const next = computeNextRunAtMs(dailyNoon, completedAtMs);
       expect(next).toBe(noonMs + 86_400_000); // next day
     });
+  });
+});
+
+describe("coerceFiniteScheduleNumber", () => {
+  it("returns the number for a finite number", () => {
+    expect(coerceFiniteScheduleNumber(60000)).toBe(60000);
+  });
+
+  it("returns undefined for NaN", () => {
+    expect(coerceFiniteScheduleNumber(NaN)).toBeUndefined();
+  });
+
+  it("returns undefined for Infinity", () => {
+    expect(coerceFiniteScheduleNumber(Infinity)).toBeUndefined();
+  });
+
+  it("parses a numeric string", () => {
+    expect(coerceFiniteScheduleNumber("60000")).toBe(60000);
+  });
+
+  it("parses a numeric string with whitespace", () => {
+    expect(coerceFiniteScheduleNumber(" 60000 ")).toBe(60000);
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(coerceFiniteScheduleNumber("")).toBeUndefined();
+  });
+
+  it("returns undefined for non-numeric string", () => {
+    expect(coerceFiniteScheduleNumber("abc")).toBeUndefined();
+  });
+
+  it("returns undefined for null/undefined", () => {
+    expect(coerceFiniteScheduleNumber(null)).toBeUndefined();
+    expect(coerceFiniteScheduleNumber(undefined)).toBeUndefined();
   });
 });

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -30,6 +30,25 @@ function resolveCachedCron(expr: string, timezone: string): Cron {
   return next;
 }
 
+/**
+ * Coerce a value to a finite number, handling both numeric and string-typed
+ * values that may appear in legacy persisted cron job data.
+ */
+export function coerceFiniteScheduleNumber(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
 export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): number | undefined {
   if (schedule.kind === "at") {
     // Handle both canonical `at` (string) and legacy `atMs` (number) fields.
@@ -51,8 +70,13 @@ export function computeNextRunAtMs(schedule: CronSchedule, nowMs: number): numbe
   }
 
   if (schedule.kind === "every") {
-    const everyMs = Math.max(1, Math.floor(schedule.everyMs));
-    const anchor = Math.max(0, Math.floor(schedule.anchorMs ?? nowMs));
+    const everyMsRaw = coerceFiniteScheduleNumber(schedule.everyMs);
+    if (everyMsRaw === undefined) {
+      return undefined;
+    }
+    const everyMs = Math.max(1, Math.floor(everyMsRaw));
+    const anchorRaw = coerceFiniteScheduleNumber(schedule.anchorMs);
+    const anchor = Math.max(0, Math.floor(anchorRaw ?? nowMs));
     if (nowMs < anchor) {
       return anchor;
     }

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { parseAbsoluteTimeMs } from "../parse.js";
-import { computeNextRunAtMs } from "../schedule.js";
+import { coerceFiniteScheduleNumber, computeNextRunAtMs } from "../schedule.js";
 import {
   normalizeCronStaggerMs,
   resolveCronStaggerMs,
@@ -88,9 +88,9 @@ function resolveEveryAnchorMs(params: {
   schedule: { everyMs: number; anchorMs?: number };
   fallbackAnchorMs: number;
 }) {
-  const raw = params.schedule.anchorMs;
-  if (isFiniteTimestamp(raw)) {
-    return Math.max(0, Math.floor(raw));
+  const coerced = coerceFiniteScheduleNumber(params.schedule.anchorMs);
+  if (coerced !== undefined) {
+    return Math.max(0, Math.floor(coerced));
   }
   if (isFiniteTimestamp(params.fallbackAnchorMs)) {
     return Math.max(0, Math.floor(params.fallbackAnchorMs));
@@ -201,7 +201,11 @@ export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | und
     return undefined;
   }
   if (job.schedule.kind === "every") {
-    const everyMs = Math.max(1, Math.floor(job.schedule.everyMs));
+    const everyMsRaw = coerceFiniteScheduleNumber(job.schedule.everyMs);
+    if (everyMsRaw === undefined) {
+      return undefined;
+    }
+    const everyMs = Math.max(1, Math.floor(everyMsRaw));
     const lastRunAtMs = job.state.lastRunAtMs;
     if (typeof lastRunAtMs === "number" && Number.isFinite(lastRunAtMs)) {
       const nextFromLastRun = Math.floor(lastRunAtMs) + everyMs;

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -6,6 +6,7 @@ import {
 } from "../legacy-delivery.js";
 import { parseAbsoluteTimeMs } from "../parse.js";
 import { migrateLegacyCronPayload } from "../payload-migration.js";
+import { coerceFiniteScheduleNumber } from "../schedule.js";
 import { normalizeCronStaggerMs, resolveDefaultCronStaggerMs } from "../stagger.js";
 import { loadCronStore, saveCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
@@ -411,15 +412,19 @@ export async function ensureLoaded(
       }
 
       const everyMsRaw = sched.everyMs;
-      const everyMs =
-        typeof everyMsRaw === "number" && Number.isFinite(everyMsRaw)
-          ? Math.floor(everyMsRaw)
-          : null;
+      const everyMsCoerced = coerceFiniteScheduleNumber(everyMsRaw);
+      const everyMs = everyMsCoerced !== undefined ? Math.floor(everyMsCoerced) : null;
+      // Repair string-typed everyMs from legacy stored data.
+      if (everyMs !== null && everyMsRaw !== everyMs) {
+        sched.everyMs = everyMs;
+        mutated = true;
+      }
       if ((kind === "every" || sched.kind === "every") && everyMs !== null) {
         const anchorRaw = sched.anchorMs;
+        const anchorCoerced = coerceFiniteScheduleNumber(anchorRaw);
         const normalizedAnchor =
-          typeof anchorRaw === "number" && Number.isFinite(anchorRaw)
-            ? Math.max(0, Math.floor(anchorRaw))
+          anchorCoerced !== undefined
+            ? Math.max(0, Math.floor(anchorCoerced))
             : typeof raw.createdAtMs === "number" && Number.isFinite(raw.createdAtMs)
               ? Math.max(0, Math.floor(raw.createdAtMs))
               : typeof raw.updatedAtMs === "number" && Number.isFinite(raw.updatedAtMs)


### PR DESCRIPTION
## Summary
- **Root cause**: Legacy persisted cron jobs may store `everyMs` and `anchorMs` as JSON strings (e.g. `"60000"`). `Math.floor("60000")` returns `NaN`, making `nextWakeAtMs` permanently null and preventing jobs from firing.
- Added a single shared `coerceFiniteScheduleNumber(value)` helper in `schedule.ts` that safely handles both number and string inputs.
- Applied it in all 3 code paths that read these fields: `computeNextRunAtMs`, `computeJobNextRunAtMs` / `resolveEveryAnchorMs`, and the store migration.
- Unlike the competing PR, this does **not** duplicate the helper 3 times — it exports once and imports where needed (DRY).
- Focused scope: only fixes the cron bug, no unrelated failover/security changes bundled in.

## Test plan
- [x] `npx vitest run src/cron/schedule.test.ts` — 26 passed (10 new)
- [x] `npx vitest run src/cron/service.jobs.test.ts` — 31 passed
- [x] `npx vitest run src/cron/service.store-migration.test.ts` — 3 passed
- [x] `npx vitest run src/cron/service.every-jobs-fire.test.ts` — 3 passed
- [x] `npx vitest run src/cron/service.issue-regressions.test.ts` — 33 passed
- [x] `npx vitest run src/cron/service.store.migration.test.ts` — 6 passed

Fixes #34652

🤖 Generated with [Claude Code](https://claude.com/claude-code)