### PR TITLE
perf(gateway): cache Control UI root realpath in request handler

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -1,8 +1,9 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import type { IncomingMessage } from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { CONTROL_UI_BOOTSTRAP_CONFIG_PATH } from "./control-ui-contract.js";
 import { handleControlUiAvatarRequest, handleControlUiHttpRequest } from "./control-ui.js";
 import { makeMockHttpResponse } from "./test-http-response.js";
@@ -100,6 +101,25 @@ describe("handleControlUiHttpRequest", () => {
       await fs.rm(tmp, { recursive: true, force: true });
     }
   }
+
+  it("reuses cached control-ui root realpath across requests", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const realpathSpy = vi.spyOn(fsSync, "realpathSync");
+        try {
+          const first = runControlUiRequest({ url: "/", method: "GET", rootPath: tmp });
+          const second = runControlUiRequest({ url: "/", method: "GET", rootPath: tmp });
+
+          expect(first.handled).toBe(true);
+          expect(second.handled).toBe(true);
+          const rootLookups = realpathSpy.mock.calls.filter((call) => call[0] === tmp);
+          expect(rootLookups).toHaveLength(1);
+        } finally {
+          realpathSpy.mockRestore();
+        }
+      },
+    });
+  });
 
   it("sets security headers for Control UI responses", async () => {
     await withControlUiRoot({

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -95,6 +95,9 @@ const STATIC_ASSET_EXTENSIONS = new Set([
   ".txt",
 ]);
 
+const CONTROL_UI_ROOT_REALPATH_CACHE_MAX = 32;
+const controlUiRootRealpathCache = new Map<string, string>();
+
 export type ControlUiAvatarResolution =
   | { kind: "none"; reason: string }
   | { kind: "local"; filePath: string }
@@ -240,6 +243,29 @@ function isExpectedSafePathError(error: unknown): boolean {
   return code === "ENOENT" || code === "ENOTDIR" || code === "ELOOP";
 }
 
+function resolveControlUiRootRealpath(root: string): string | null {
+  const cached = controlUiRootRealpathCache.get(root);
+  if (cached) {
+    return cached;
+  }
+  try {
+    const resolved = fs.realpathSync(root);
+    controlUiRootRealpathCache.set(root, resolved);
+    if (controlUiRootRealpathCache.size > CONTROL_UI_ROOT_REALPATH_CACHE_MAX) {
+      const oldest = controlUiRootRealpathCache.keys().next();
+      if (!oldest.done) {
+        controlUiRootRealpathCache.delete(oldest.value);
+      }
+    }
+    return resolved;
+  } catch (error) {
+    if (isExpectedSafePathError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 function resolveSafeAvatarFile(filePath: string): { path: string; fd: number } | null {
   const opened = openVerifiedFileSync({
     filePath,
@@ -377,16 +403,7 @@ export function handleControlUiHttpRequest(
     return true;
   }
 
-  const rootReal = (() => {
-    try {
-      return fs.realpathSync(root);
-    } catch (error) {
-      if (isExpectedSafePathError(error)) {
-        return null;
-      }
-      throw error;
-    }
-  })();
+  const rootReal = resolveControlUiRootRealpath(root);
   if (!rootReal) {
     respondControlUiAssetsUnavailable(res);
     return true;


### PR DESCRIPTION
## Summary
- cache resolved Control UI root realpaths in handleControlUiHttpRequest
- cap cache size at 32 entries to avoid unbounded growth
- keep existing missing-path handling semantics (ENOENT/ENOTDIR/ELOOP => assets unavailable)
- add regression test proving repeated requests for the same root do not repeat root realpathSync lookups

## Why
handleControlUiHttpRequest is on the Control UI serving hot path. It previously called fs.realpathSync(root) on every request even though root is typically stable for the process lifetime. This avoids redundant synchronous filesystem work while preserving all existing safety checks.

## Risk
Low. The cache is bounded and only stores successful resolutions. Runtime root-path churn is uncommon for gateway processes, and all existing request/path validation remains unchanged.

## Testing
- pnpm test src/gateway/control-ui.http.test.ts
- pnpm exec oxfmt --check src/gateway/control-ui.ts src/gateway/control-ui.http.test.ts
