### PR TITLE
fix: repair Bedrock toolUse/toolResult transcript pairing

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -406,6 +406,54 @@ describe("sanitizeSessionHistory", () => {
     expect(result).toEqual([]);
   });
 
+  it("drops orphaned toolResult entries when switching from openai history to bedrock", async () => {
+    const sessionEntries = [
+      makeModelSnapshotEntry({
+        provider: "openai",
+        modelApi: "openai-responses",
+        modelId: "gpt-5.2",
+      }),
+    ];
+    const sessionManager = makeInMemorySessionManager(sessionEntries);
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "tool_abc123", name: "read", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "tool_abc123",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+      } as unknown as AgentMessage,
+      { role: "user", content: "continue" },
+      {
+        role: "toolResult",
+        toolCallId: "tool_01VihkDRptyLpX1ApUPe7ooU",
+        toolName: "read",
+        content: [{ type: "text", text: "stale result" }],
+      } as unknown as AgentMessage,
+    ] as unknown as AgentMessage[];
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "bedrock-converse-stream",
+      provider: "amazon-bedrock",
+      modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+      sessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result.map((msg) => msg.role)).toEqual(["assistant", "toolResult", "user"]);
+    expect(
+      result.some(
+        (msg) =>
+          msg.role === "toolResult" &&
+          (msg as { toolCallId?: string }).toolCallId === "tool_01VihkDRptyLpX1ApUPe7ooU",
+      ),
+    ).toBe(false);
+  });
+
   it("drops orphaned toolResult entries when switching from openai history to anthropic", async () => {
     const sessionEntries = [
       makeModelSnapshotEntry({

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -39,4 +39,14 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.sanitizeToolCallIds).toBe(false);
     expect(policy.toolCallIdMode).toBeUndefined();
   });
+
+  it("enables tool/result pairing repair for Bedrock Converse", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "amazon-bedrock",
+      modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+      modelApi: "bedrock-converse-stream",
+    });
+    expect(policy.repairToolUseResultPairing).toBe(true);
+    expect(policy.allowSyntheticToolResults).toBe(true);
+  });
 });

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -1,6 +1,6 @@
+import type { ToolCallIdMode } from "./tool-call-id.js";
 import { normalizeProviderId } from "./model-selection.js";
 import { isAntigravityClaude, isGoogleModelApi } from "./pi-embedded-helpers/google.js";
-import type { ToolCallIdMode } from "./tool-call-id.js";
 
 export type TranscriptSanitizeMode = "full" | "images-only";
 
@@ -62,6 +62,13 @@ function isAnthropicApi(modelApi?: string | null, provider?: string | null): boo
   return normalized === "anthropic";
 }
 
+function isBedrockApi(modelApi?: string | null, provider?: string | null): boolean {
+  if (modelApi === "bedrock-converse-stream") {
+    return true;
+  }
+  return normalizeProviderId(provider ?? "") === "amazon-bedrock";
+}
+
 function isMistralModel(params: { provider?: string | null; modelId?: string | null }): boolean {
   const provider = normalizeProviderId(params.provider ?? "");
   if (provider === "mistral") {
@@ -83,6 +90,7 @@ export function resolveTranscriptPolicy(params: {
   const modelId = params.modelId ?? "";
   const isGoogle = isGoogleModelApi(params.modelApi);
   const isAnthropic = isAnthropicApi(params.modelApi, provider);
+  const isBedrock = isBedrockApi(params.modelApi, provider);
   const isOpenAi = isOpenAiProvider(provider) || (!provider && isOpenAiApi(params.modelApi));
   const isMistral = isMistralModel({ provider, modelId });
   const isOpenRouterGemini =
@@ -109,7 +117,7 @@ export function resolveTranscriptPolicy(params: {
     : sanitizeToolCallIds
       ? "strict"
       : undefined;
-  const repairToolUseResultPairing = isGoogle || isAnthropic;
+  const repairToolUseResultPairing = isGoogle || isAnthropic || isBedrock;
   const sanitizeThoughtSignatures = isOpenRouterGemini
     ? { allowBase64Only: true, includeCamelCase: true }
     : undefined;
@@ -127,6 +135,6 @@ export function resolveTranscriptPolicy(params: {
     applyGoogleTurnOrdering: !isOpenAi && isGoogle,
     validateGeminiTurns: !isOpenAi && isGoogle,
     validateAnthropicTurns: !isOpenAi && isAnthropic,
-    allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic),
+    allowSyntheticToolResults: !isOpenAi && (isGoogle || isAnthropic || isBedrock),
   };
 }


### PR DESCRIPTION
## Summary
- treat Bedrock Converse/ConverseStream as a strict tool-pairing provider in transcript policy
- enable pairing repair + synthetic tool results for Bedrock
- add tests for Bedrock policy and stale orphaned toolResult cleanup when switching providers

## Why
Bedrock rejects requests when a user turn contains more `toolResult` blocks than the previous assistant turn's `toolUse` blocks. Stale orphaned tool results could survive sanitation when switching to Bedrock because Bedrock was not included in pairing-repair policy.

## Validation
```bash
./node_modules/.bin/vitest run --config vitest.unit.config.ts \
  src/agents/transcript-policy.test.ts \
  src/agents/pi-embedded-runner.sanitize-session-history.test.ts
```

Passed: 26 tests

Closes #35098
