### PR TITLE
fix(cron): thread delivery context through wake-now systemEvent jobs

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -218,9 +218,38 @@ export function registerCronAddCommand(cron: Command) {
               ? opts.account.trim()
               : undefined;
 
+          // Check if the user explicitly provided --channel (not just the
+          // default "last") or --to, indicating intent to set delivery context.
+          const hasExplicitDeliveryTarget =
+            (typeof opts.channel === "string" &&
+              opts.channel.trim() &&
+              opts.channel.trim() !== "last") ||
+            (typeof opts.to === "string" && opts.to.trim());
+
           if (accountId && (sessionTarget !== "isolated" || payload.kind !== "agentTurn")) {
-            throw new Error("--account requires an isolated agentTurn job with delivery.");
+            // Allow --account for main+systemEvent+wake-now when --channel/--to
+            // are explicitly set, so delivery context threads through (#34572).
+            if (
+              !(
+                sessionTarget === "main" &&
+                payload.kind === "systemEvent" &&
+                wakeMode === "now" &&
+                hasExplicitDeliveryTarget
+              )
+            ) {
+              throw new Error("--account requires an isolated agentTurn job with delivery.");
+            }
           }
+
+          // Allow delivery config for main+systemEvent+wake-now when explicit
+          // --channel or --to is provided.  This threads delivery context
+          // through to the heartbeat runner so the agent's response routes to
+          // the intended destination (#34572).
+          const hasMainWakeDelivery =
+            sessionTarget === "main" &&
+            payload.kind === "systemEvent" &&
+            wakeMode === "now" &&
+            hasExplicitDeliveryTarget;
 
           const deliveryMode =
             sessionTarget === "isolated" && payload.kind === "agentTurn"
@@ -229,7 +258,9 @@ export function registerCronAddCommand(cron: Command) {
                 : hasNoDeliver
                   ? "none"
                   : "announce"
-              : undefined;
+              : hasMainWakeDelivery
+                ? "none"
+                : undefined;
 
           const nameRaw = typeof opts.name === "string" ? opts.name : "";
           const name = nameRaw.trim();

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -219,12 +219,12 @@ export function registerCronAddCommand(cron: Command) {
               : undefined;
 
           // Check if the user explicitly provided --channel (not just the
-          // default "last") or --to, indicating intent to set delivery context.
+          // default "last").  --to alone is not sufficient because the heartbeat
+          // runner may silently ignore `to` when `target` is "last" (#34572).
           const hasExplicitDeliveryTarget =
-            (typeof opts.channel === "string" &&
-              opts.channel.trim() &&
-              opts.channel.trim() !== "last") ||
-            (typeof opts.to === "string" && opts.to.trim());
+            typeof opts.channel === "string" &&
+            opts.channel.trim() &&
+            opts.channel.trim() !== "last";
 
           if (accountId && (sessionTarget !== "isolated" || payload.kind !== "agentTurn")) {
             // Allow --account for main+systemEvent+wake-now when --channel/--to

--- a/src/cron/service.main-job-delivery-override.test.ts
+++ b/src/cron/service.main-job-delivery-override.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import { setupCronServiceSuite, writeCronStoreSnapshot } from "./service.test-harness.js";
+import type { CronJob } from "./types.js";
+
+const { logger, makeStorePath } = setupCronServiceSuite({
+  prefix: "cron-main-delivery-override",
+});
+
+type RunHeartbeatOnce = NonNullable<
+  ConstructorParameters<typeof CronService>[0]["runHeartbeatOnce"]
+>;
+
+describe("cron main job delivery override (#34572)", () => {
+  function createMainCronJob(params: {
+    now: number;
+    id: string;
+    delivery?: CronJob["delivery"];
+  }): CronJob {
+    return {
+      id: params.id,
+      name: params.id,
+      enabled: true,
+      createdAtMs: params.now - 10_000,
+      updatedAtMs: params.now - 10_000,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "callback result" },
+      delivery: params.delivery,
+      state: { nextRunAtMs: params.now - 1 },
+    };
+  }
+
+  function createCronWithSpies(params: { storePath: string; runHeartbeatOnce: RunHeartbeatOnce }) {
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+    const cron = new CronService({
+      storePath: params.storePath,
+      cronEnabled: true,
+      log: logger,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runHeartbeatOnce: params.runHeartbeatOnce,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+    return { cron, enqueueSystemEvent, requestHeartbeatNow };
+  }
+
+  async function runSingleTick(cron: CronService) {
+    await cron.start();
+    await vi.advanceTimersByTimeAsync(2_000);
+    await vi.advanceTimersByTimeAsync(1_000);
+    cron.stop();
+  }
+
+  it("uses explicit delivery.channel as heartbeat target", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.now();
+
+    const job = createMainCronJob({
+      now,
+      id: "explicit-channel",
+      delivery: { mode: "none", channel: "discord", to: "channel:123" },
+    });
+
+    await writeCronStoreSnapshot({ storePath, jobs: [job] });
+
+    const runHeartbeatOnce = vi.fn<RunHeartbeatOnce>(async () => ({
+      status: "ran" as const,
+      durationMs: 50,
+    }));
+
+    const { cron } = createCronWithSpies({ storePath, runHeartbeatOnce });
+    await runSingleTick(cron);
+
+    expect(runHeartbeatOnce).toHaveBeenCalled();
+    const callArgs = runHeartbeatOnce.mock.calls[0]?.[0];
+    expect(callArgs?.heartbeat?.target).toBe("discord");
+    expect(callArgs?.heartbeat?.to).toBe("channel:123");
+  });
+
+  it("uses explicit delivery.accountId in heartbeat override", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.now();
+
+    const job = createMainCronJob({
+      now,
+      id: "explicit-account",
+      delivery: { mode: "none", channel: "telegram", to: "-1001234567890", accountId: "bot2" },
+    });
+
+    await writeCronStoreSnapshot({ storePath, jobs: [job] });
+
+    const runHeartbeatOnce = vi.fn<RunHeartbeatOnce>(async () => ({
+      status: "ran" as const,
+      durationMs: 50,
+    }));
+
+    const { cron } = createCronWithSpies({ storePath, runHeartbeatOnce });
+    await runSingleTick(cron);
+
+    expect(runHeartbeatOnce).toHaveBeenCalled();
+    const callArgs = runHeartbeatOnce.mock.calls[0]?.[0];
+    expect(callArgs?.heartbeat?.target).toBe("telegram");
+    expect(callArgs?.heartbeat?.to).toBe("-1001234567890");
+    expect(callArgs?.heartbeat?.accountId).toBe("bot2");
+  });
+
+  it("falls back to target=last when no delivery config", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.now();
+
+    const job = createMainCronJob({
+      now,
+      id: "no-delivery",
+    });
+
+    await writeCronStoreSnapshot({ storePath, jobs: [job] });
+
+    const runHeartbeatOnce = vi.fn<RunHeartbeatOnce>(async () => ({
+      status: "ran" as const,
+      durationMs: 50,
+    }));
+
+    const { cron } = createCronWithSpies({ storePath, runHeartbeatOnce });
+    await runSingleTick(cron);
+
+    expect(runHeartbeatOnce).toHaveBeenCalled();
+    const callArgs = runHeartbeatOnce.mock.calls[0]?.[0];
+    expect(callArgs?.heartbeat?.target).toBe("last");
+  });
+
+  it("falls back to target=last when delivery.channel is 'last'", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.now();
+
+    const job = createMainCronJob({
+      now,
+      id: "channel-last",
+      delivery: { mode: "none", channel: "last" },
+    });
+
+    await writeCronStoreSnapshot({ storePath, jobs: [job] });
+
+    const runHeartbeatOnce = vi.fn<RunHeartbeatOnce>(async () => ({
+      status: "ran" as const,
+      durationMs: 50,
+    }));
+
+    const { cron } = createCronWithSpies({ storePath, runHeartbeatOnce });
+    await runSingleTick(cron);
+
+    expect(runHeartbeatOnce).toHaveBeenCalled();
+    const callArgs = runHeartbeatOnce.mock.calls[0]?.[0];
+    expect(callArgs?.heartbeat?.target).toBe("last");
+  });
+});

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -901,6 +901,23 @@ export async function executeJobCore(
       sessionKey: targetMainSessionKey,
       contextKey: `cron:${job.id}`,
     });
+    // Resolve heartbeat delivery target from the job's delivery config.
+    // When --channel/--to are specified on the cron job, use those explicitly
+    // so the agent's response routes to the intended destination (#34572).
+    // Fall back to "last" (the previous default) when no delivery config is set.
+    const heartbeatDeliveryOverride: { target?: string; to?: string; accountId?: string } = {};
+    if (job.delivery?.channel && job.delivery.channel !== "last") {
+      heartbeatDeliveryOverride.target = job.delivery.channel;
+    } else {
+      heartbeatDeliveryOverride.target = "last";
+    }
+    if (job.delivery?.to) {
+      heartbeatDeliveryOverride.to = job.delivery.to;
+    }
+    if (job.delivery?.accountId) {
+      heartbeatDeliveryOverride.accountId = job.delivery.accountId;
+    }
+
     if (job.wakeMode === "now" && state.deps.runHeartbeatOnce) {
       const reason = `cron:${job.id}`;
       const maxWaitMs = state.deps.wakeNowHeartbeatBusyMaxWaitMs ?? 2 * 60_000;
@@ -916,11 +933,9 @@ export async function executeJobCore(
           reason,
           agentId: job.agentId,
           sessionKey: targetMainSessionKey,
-          // Cron-triggered heartbeats should deliver to the last active channel.
-          // Without this override, heartbeat target defaults to "none" (since
-          // e2362d35) and cron main-session responses are silently swallowed.
-          // See: https://github.com/openclaw/openclaw/issues/28508
-          heartbeat: { target: "last" },
+          // Use explicit delivery config from the cron job when available,
+          // otherwise fall back to "last" to avoid silent swallowing (#28508).
+          heartbeat: heartbeatDeliveryOverride,
         });
         if (
           heartbeatResult.status !== "skipped" ||


### PR DESCRIPTION
## What
Threads delivery config (channel/to/accountId) from cron job through to the heartbeat runner for main-session systemEvent jobs with `wakeMode=now`.

## Why
Fixes #34572 — When a cron job uses `--system-event` with `--wake now`, the agent wakes via immediate heartbeat but has no delivery context. Its response goes nowhere because heartbeat target defaults to `"none"`. The isolated session path already solves this with `--channel` and `--to` flags, but the main+wake-now path ignored them.

## How
1. **`timer.ts`**: Before calling `runHeartbeatOnce`, resolve heartbeat delivery target from `job.delivery` config. If `job.delivery.channel` is set (and not `"last"`), use it as the heartbeat target. Pass `to` and `accountId` through as well. Falls back to `target="last"` (existing behavior) when no delivery config is set.

2. **`register.cron-add.ts`**: Allow `--channel`/`--to`/`--account` flags to create a delivery config on main+systemEvent+wake-now jobs. Uses `delivery.mode="none"` (no announce) since the purpose is routing, not announce-style delivery.

### Example usage (proposed in issue)
```bash
openclaw cron add \
  --at "1s" \
  --session-key "agent:main:discord:channel:123" \
  --system-event "[callback] Task complete" \
  --wake now \
  --channel discord \
  --to "channel:123" \
  --delete-after-run
```

## Testing
- [x] `pnpm build && pnpm check` pass
- [x] All 416 cron tests pass (including 34 CLI tests)
- [x] New test file: `service.main-job-delivery-override.test.ts` (4 cases)
  - Explicit channel → used as heartbeat target
  - Explicit accountId → threaded through
  - No delivery config → falls back to `target=last`
  - `delivery.channel=last` → falls back to `target=last`
- [x] AI-assisted (Claude, fully tested)
