### PR TITLE
perf: bound hook transform and media binary caches

### DIFF
--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { applyHookMappings, resolveHookMappings } from "./hooks-mapping.js";
+import { __test, applyHookMappings, resolveHookMappings } from "./hooks-mapping.js";
 
 const baseUrl = new URL("http://127.0.0.1:18789/hooks/gmail");
 
@@ -470,6 +470,51 @@ describe("hooks mapping", () => {
     if (resultB?.ok && resultB.action?.kind === "wake") {
       expect(resultB.action.text).toBe("from-B");
     }
+  });
+
+  it("evicts oldest transform cache entries when over capacity", async () => {
+    __test.transformCache.clear();
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-cap-"));
+    const transformsRoot = path.join(configDir, "hooks", "transforms");
+    fs.mkdirSync(transformsRoot, { recursive: true });
+    const modPath = path.join(transformsRoot, "many-export.mjs");
+    const exportCount = __test.HOOK_TRANSFORM_CACHE_MAX + 2;
+    fs.writeFileSync(
+      modPath,
+      Array.from(
+        { length: exportCount },
+        (_, i) => `export function transform${i}() { return { kind: "wake", text: "from-${i}" }; }`,
+      ).join("\n"),
+    );
+
+    for (let i = 0; i < exportCount; i += 1) {
+      const mapping = resolveHookMappings(
+        {
+          mappings: [
+            {
+              match: { path: `evict-${i}` },
+              action: "agent",
+              messageTemplate: "unused",
+              transform: { module: "many-export.mjs", export: `transform${i}` },
+            },
+          ],
+        },
+        { configDir },
+      );
+      const result = await applyHookMappings(mapping, {
+        payload: {},
+        headers: {},
+        url: new URL(`http://127.0.0.1:18789/hooks/evict-${i}`),
+        path: `evict-${i}`,
+      });
+      expect(result?.ok).toBe(true);
+    }
+
+    expect(__test.transformCache.size).toBe(__test.HOOK_TRANSFORM_CACHE_MAX);
+    expect(__test.transformCache.has(`${modPath}::transform0`)).toBe(false);
+    expect(__test.transformCache.has(`${modPath}::transform1`)).toBe(false);
+    expect(__test.transformCache.has(`${modPath}::transform${exportCount - 1}`)).toBe(true);
+    __test.transformCache.clear();
   });
 
   it("rejects missing message", async () => {

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -79,6 +79,7 @@ const hookPresetMappings: Record<string, HookMappingConfig[]> = {
   ],
 };
 
+const HOOK_TRANSFORM_CACHE_MAX = 128;
 const transformCache = new Map<string, HookTransformFn>();
 
 type HookTransformResult = Partial<{
@@ -325,15 +326,28 @@ function validateAction(action: HookAction): HookMappingResult {
   return { ok: true, action };
 }
 
+function setTransformCache(cacheKey: string, fn: HookTransformFn): void {
+  transformCache.delete(cacheKey);
+  transformCache.set(cacheKey, fn);
+  if (transformCache.size <= HOOK_TRANSFORM_CACHE_MAX) {
+    return;
+  }
+  const oldest = transformCache.keys().next();
+  if (!oldest.done) {
+    transformCache.delete(oldest.value);
+  }
+}
+
 async function loadTransform(transform: HookMappingTransformResolved): Promise<HookTransformFn> {
   const cacheKey = `${transform.modulePath}::${transform.exportName ?? "default"}`;
   const cached = transformCache.get(cacheKey);
   if (cached) {
+    setTransformCache(cacheKey, cached);
     return cached;
   }
   const mod = await importFileModule({ modulePath: transform.modulePath });
   const fn = resolveTransformFn(mod, transform.exportName);
-  transformCache.set(cacheKey, fn);
+  setTransformCache(cacheKey, fn);
   return fn;
 }
 
@@ -524,3 +538,8 @@ function getByPath(input: Record<string, unknown>, pathExpr: string): unknown {
   }
   return current;
 }
+
+export const __test = {
+  transformCache,
+  HOOK_TRANSFORM_CACHE_MAX,
+};

--- a/src/media-understanding/runner.cache-bounds.test.ts
+++ b/src/media-understanding/runner.cache-bounds.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { __test, clearMediaUnderstandingBinaryCacheForTests } from "./runner.js";
+
+describe("media-understanding runner cache bounds", () => {
+  it("evicts oldest entry when bounded cache exceeds max", () => {
+    const cache = new Map<string, number>();
+    __test.setBoundedCache(cache, "a", 1, 2);
+    __test.setBoundedCache(cache, "b", 2, 2);
+    __test.setBoundedCache(cache, "c", 3, 2);
+
+    expect(cache.size).toBe(2);
+    expect(cache.has("a")).toBe(false);
+    expect(cache.has("b")).toBe(true);
+    expect(cache.has("c")).toBe(true);
+  });
+
+  it("refreshes recency when existing key is reinserted", () => {
+    const cache = new Map<string, number>();
+    __test.setBoundedCache(cache, "a", 1, 2);
+    __test.setBoundedCache(cache, "b", 2, 2);
+    __test.setBoundedCache(cache, "a", 1, 2);
+    __test.setBoundedCache(cache, "c", 3, 2);
+
+    expect(cache.size).toBe(2);
+    expect(cache.has("a")).toBe(true);
+    expect(cache.has("b")).toBe(false);
+    expect(cache.has("c")).toBe(true);
+  });
+
+  it("keeps runtime caches clearable for test isolation", () => {
+    __test.binaryCache.set("/tmp/tool-a", Promise.resolve("/tmp/tool-a"));
+    __test.geminiProbeCache.set("gemini", Promise.resolve(true));
+
+    clearMediaUnderstandingBinaryCacheForTests();
+
+    expect(__test.binaryCache.size).toBe(0);
+    expect(__test.geminiProbeCache.size).toBe(0);
+  });
+});

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -103,8 +103,27 @@ export function createMediaAttachmentCache(
   return new MediaAttachmentCache(attachments, options);
 }
 
+const BINARY_CACHE_MAX = 64;
+const GEMINI_PROBE_CACHE_MAX = 16;
 const binaryCache = new Map<string, Promise<string | null>>();
 const geminiProbeCache = new Map<string, Promise<boolean>>();
+
+function setBoundedCache<T>(
+  cache: Map<string, T>,
+  key: string,
+  value: T,
+  maxEntries: number,
+): void {
+  cache.delete(key);
+  cache.set(key, value);
+  if (cache.size <= maxEntries) {
+    return;
+  }
+  const oldest = cache.keys().next();
+  if (!oldest.done) {
+    cache.delete(oldest.value);
+  }
+}
 
 export function clearMediaUnderstandingBinaryCacheForTests(): void {
   binaryCache.clear();
@@ -165,6 +184,7 @@ async function isExecutable(filePath: string): Promise<boolean> {
 async function findBinary(name: string): Promise<string | null> {
   const cached = binaryCache.get(name);
   if (cached) {
+    setBoundedCache(binaryCache, name, cached, BINARY_CACHE_MAX);
     return cached;
   }
   const resolved = (async () => {
@@ -198,7 +218,7 @@ async function findBinary(name: string): Promise<string | null> {
 
     return null;
   })();
-  binaryCache.set(name, resolved);
+  setBoundedCache(binaryCache, name, resolved, BINARY_CACHE_MAX);
   return resolved;
 }
 
@@ -209,6 +229,7 @@ async function hasBinary(name: string): Promise<boolean> {
 async function probeGeminiCli(): Promise<boolean> {
   const cached = geminiProbeCache.get("gemini");
   if (cached) {
+    setBoundedCache(geminiProbeCache, "gemini", cached, GEMINI_PROBE_CACHE_MAX);
     return cached;
   }
   const resolved = (async () => {
@@ -224,7 +245,7 @@ async function probeGeminiCli(): Promise<boolean> {
       return false;
     }
   })();
-  geminiProbeCache.set("gemini", resolved);
+  setBoundedCache(geminiProbeCache, "gemini", resolved, GEMINI_PROBE_CACHE_MAX);
   return resolved;
 }
 
@@ -803,3 +824,11 @@ export async function runCapability(params: {
     decision,
   };
 }
+
+export const __test = {
+  binaryCache,
+  geminiProbeCache,
+  BINARY_CACHE_MAX,
+  GEMINI_PROBE_CACHE_MAX,
+  setBoundedCache,
+};


### PR DESCRIPTION
Summary
- cap gateway hook transform cache with LRU-style eviction
- cap media-understanding binary lookup/probe caches with LRU-style eviction
- add regression tests for cache bounds and recency refresh

Why
Long-lived gateway processes can accumulate distinct cache keys over time. Without bounds, these daemon-lifetime maps may grow indefinitely in high-churn workloads.

Impact
- keeps memory usage predictable for webhook transform resolution and media binary probing
- preserves cache-hit behavior while evicting oldest cold entries
- no user-facing behavior changes

Risk
Low. Changes are limited to cache bookkeeping; miss behavior remains lazy reload/recompute.

Validation
- pnpm vitest run src/gateway/hooks-mapping.test.ts
- pnpm vitest run src/media-understanding