### PR TITLE
fix(exec): persist script path for shell+script "Always allow" so it survives across runs

### DIFF
--- a/changelog/fragments/pr-35024.md
+++ b/changelog/fragments/pr-35024.md
@@ -1,0 +1,1 @@
+fix(exec): persist script path in allowlist for shell+script invocations so "Always allow" survives across runs

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -302,4 +302,166 @@ describe("resolveAllowAlwaysPatterns", () => {
       persistedPattern: echo,
     });
   });
+
+  it("persists the script file path for shell+script invocations (bash scripts/foo.sh)", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    // Create a shell script file
+    const scriptPath = path.join(dir, "scripts", "save_crystal.sh");
+    fs.mkdirSync(path.join(dir, "scripts"), { recursive: true });
+    fs.writeFileSync(scriptPath, "#!/bin/bash\necho ok");
+    fs.chmodSync(scriptPath, 0o755);
+
+    const patterns = resolveAllowAlwaysPatterns({
+      segments: [
+        {
+          raw: "bash scripts/save_crystal.sh",
+          argv: ["bash", "scripts/save_crystal.sh"],
+          resolution: {
+            rawExecutable: "bash",
+            resolvedPath: "/bin/bash",
+            executableName: "bash",
+          },
+        },
+      ],
+      cwd: dir,
+      env: process.env,
+      platform: process.platform,
+    });
+    expect(patterns).toEqual([scriptPath]);
+  });
+
+  it("persists the script path when shell flags precede the script (sh -xe setup.sh)", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptPath = path.join(dir, "setup.sh");
+    fs.writeFileSync(scriptPath, "#!/bin/sh\necho ok");
+    fs.chmodSync(scriptPath, 0o755);
+
+    const patterns = resolveAllowAlwaysPatterns({
+      segments: [
+        {
+          raw: "sh -xe setup.sh",
+          argv: ["sh", "-xe", "setup.sh"],
+          resolution: {
+            rawExecutable: "sh",
+            resolvedPath: "/bin/sh",
+            executableName: "sh",
+          },
+        },
+      ],
+      cwd: dir,
+      env: process.env,
+      platform: process.platform,
+    });
+    expect(patterns).toEqual([scriptPath]);
+  });
+
+  it("does NOT persist script path when shell uses -c inline command (not a script file)", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    makeExecutable(dir, "echo");
+    const env = makePathEnv(dir);
+    const patterns = resolveAllowAlwaysPatterns({
+      segments: [
+        {
+          raw: "bash -c 'echo hello'",
+          argv: ["bash", "-c", "echo hello"],
+          resolution: {
+            rawExecutable: "bash",
+            resolvedPath: "/bin/bash",
+            executableName: "bash",
+          },
+        },
+      ],
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    // Inline -c command: inner executable (echo) is persisted, not the script
+    expect(patterns).not.toContain("/bin/bash");
+  });
+});
+
+describe("evaluateShellAllowlist with shell+script allowlist entries", () => {
+  it("satisfies allowlist when script path matches a stored entry (bash scripts/foo.sh)", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptPath = path.join(dir, "scripts", "save_crystal.sh");
+    fs.mkdirSync(path.join(dir, "scripts"), { recursive: true });
+    fs.writeFileSync(scriptPath, "#!/bin/bash\necho ok");
+    fs.chmodSync(scriptPath, 0o755);
+
+    const safeBins = resolveSafeBins(undefined);
+    const result = evaluateShellAllowlist({
+      command: "bash scripts/save_crystal.sh",
+      allowlist: [{ id: "test-id", pattern: scriptPath }],
+      safeBins,
+      cwd: dir,
+      env: process.env,
+      platform: process.platform,
+    });
+    expect(result.allowlistSatisfied).toBe(true);
+  });
+
+  it("round-trips allow-always for bash+script: persisted pattern satisfies the next run", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptPath = path.join(dir, "scripts", "backup.sh");
+    fs.mkdirSync(path.join(dir, "scripts"), { recursive: true });
+    fs.writeFileSync(scriptPath, "#!/bin/bash\necho ok");
+    fs.chmodSync(scriptPath, 0o755);
+
+    const safeBins = resolveSafeBins(undefined);
+    const command = "bash scripts/backup.sh";
+
+    // First run: no allowlist → not satisfied
+    const first = evaluateShellAllowlist({
+      command,
+      allowlist: [],
+      safeBins,
+      cwd: dir,
+      env: process.env,
+      platform: process.platform,
+    });
+    expect(first.allowlistSatisfied).toBe(false);
+
+    // Simulate "Always allow": persist the patterns
+    const persisted = resolveAllowAlwaysPatterns({
+      segments: first.segments,
+      cwd: dir,
+      env: process.env,
+      platform: process.platform,
+    });
+    expect(persisted).toEqual([scriptPath]);
+
+    // Second run: allowlist contains the script path → satisfied, no re-prompt
+    const second = evaluateShellAllowlist({
+      command,
+      allowlist: persisted.map((p) => ({ id: "saved", pattern: p })),
+      safeBins,
+      cwd: dir,
+      env: process.env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(true);
+    expect(
+      requiresExecApproval({
+        ask: "on-miss",
+        security: "allowlist",
+        analysisOk: second.analysisOk,
+        allowlistSatisfied: second.allowlistSatisfied,
+      }),
+    ).toBe(false);
+  });
 });

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -19,6 +19,7 @@ import {
 } from "./exec-safe-bin-policy.js";
 import { isTrustedSafeBinPath } from "./exec-safe-bin-trust.js";
 import {
+  extractPosixShellScriptArg,
   extractShellWrapperInlineCommand,
   isDispatchWrapperExecutable,
   isShellWrapperExecutable,
@@ -221,7 +222,23 @@ function evaluateSegments(
       candidatePath && segment.resolution
         ? { ...segment.resolution, resolvedPath: candidatePath }
         : segment.resolution;
-    const match = matchAllowlist(params.allowlist, candidateResolution);
+    let match = matchAllowlist(params.allowlist, candidateResolution);
+    // For shell+script invocations (e.g. `bash scripts/foo.sh`), "Always allow"
+    // persists the resolved script path rather than the shell binary.
+    // If the shell executable itself is not in the allowlist, check the script.
+    if (!match) {
+      const scriptArg = extractPosixShellScriptArg(segment.argv);
+      if (scriptArg) {
+        const scriptPath = resolveShellScriptFilePath(scriptArg, params.cwd);
+        if (scriptPath) {
+          match = matchAllowlist(params.allowlist, {
+            rawExecutable: scriptArg,
+            executableName: path.basename(scriptArg),
+            resolvedPath: scriptPath,
+          });
+        }
+      }
+    }
     if (match) {
       matches.push(match);
     }
@@ -327,6 +344,32 @@ function isDispatchWrapperSegment(segment: ExecCommandSegment): boolean {
   return hasSegmentExecutableMatch(segment, isDispatchWrapperExecutable);
 }
 
+/**
+ * Resolves the absolute path for a shell script file argument.
+ * Unlike resolveAllowlistCandidatePath, this also handles bare file names
+ * without a path separator (e.g. `bash foo.sh` runs foo.sh from the cwd).
+ */
+function resolveShellScriptFilePath(
+  scriptArg: string,
+  cwd: string | undefined,
+): string | undefined {
+  const trimmed = scriptArg.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  // Try the standard candidate-path resolution first (handles ~ and paths with separators).
+  const candidate = resolveAllowlistCandidatePath(
+    { rawExecutable: trimmed, executableName: path.basename(trimmed) },
+    cwd,
+  );
+  if (candidate) {
+    return candidate;
+  }
+  // resolveAllowlistCandidatePath skips bare names (no path separator),
+  // but for `bash foo.sh` the script is still relative to the cwd.
+  return path.resolve(cwd ?? process.cwd(), trimmed);
+}
+
 function collectAllowAlwaysPatterns(params: {
   segment: ExecCommandSegment;
   cwd?: string;
@@ -382,6 +425,16 @@ function collectAllowAlwaysPatterns(params: {
   }
   const inlineCommand = extractShellWrapperInlineCommand(params.segment.argv);
   if (!inlineCommand) {
+    // Shell invoked with a script file (e.g. `bash scripts/foo.sh`).
+    // Resolve and persist the script path so "Always allow" survives
+    // across invocations without re-prompting each time.
+    const scriptArg = extractPosixShellScriptArg(params.segment.argv);
+    if (scriptArg) {
+      const scriptPath = resolveShellScriptFilePath(scriptArg, params.cwd);
+      if (scriptPath) {
+        params.out.add(scriptPath);
+      }
+    }
     return;
   }
   const nested = analyzeShellCommand({

--- a/src/infra/exec-wrapper-resolution.ts
+++ b/src/infra/exec-wrapper-resolution.ts
@@ -657,3 +657,53 @@ export function extractShellWrapperCommand(
 ): ShellWrapperCommand {
   return extractShellWrapperCommandInternal(argv, normalizeRawCommand(rawCommand), 0);
 }
+
+/**
+ * For a POSIX shell invocation that directly runs a script file
+ * (e.g. `bash scripts/foo.sh`, `sh -xe setup.sh`), returns the script file
+ * argument ("scripts/foo.sh", "setup.sh"). Returns null when:
+ * - argv[0] is not a POSIX shell (e.g. `ls`)
+ * - the invocation uses an inline -c command (e.g. `bash -c "echo hi"`)
+ * - no positional script argument can be found
+ */
+export function extractPosixShellScriptArg(argv: string[]): string | null {
+  const base0 = normalizeExecutableToken(argv[0]?.trim() ?? "");
+  if (!POSIX_SHELL_WRAPPER_CANONICAL.has(base0)) {
+    return null;
+  }
+  let i = 1;
+  while (i < argv.length) {
+    const token = argv[i].trim();
+    if (!token) {
+      i += 1;
+      continue;
+    }
+    // Explicit end-of-options: the next argument is the script file.
+    if (token === "--") {
+      const next = argv[i + 1]?.trim();
+      return next || null;
+    }
+    const lower = token.toLowerCase();
+    // -c (or combined flag like -xc / -lc) means an inline command follows,
+    // not a script file.
+    if (POSIX_INLINE_COMMAND_FLAGS.has(lower)) {
+      return null;
+    }
+    if (/^-[a-z]*c/i.test(token)) {
+      return null;
+    }
+    // -o / +o take an option-name value; skip both tokens.
+    if (token === "-o" || token === "+o" || token === "-O") {
+      i += 2;
+      continue;
+    }
+    // Any other single-letter option flag (e.g. -e -x -u -n -v): skip.
+    if (/^[-+][a-zA-Z]+$/.test(token)) {
+      i += 1;
+      continue;
+    }
+    // First non-flag token is the script file.
+    return token;
+  }
+  return null;
+}


### PR DESCRIPTION
Fixes #35024

## Problem

When a user clicks **"Always allow"** for a command like `bash scripts/save_crystal.sh`, the runtime allowlist silently drops the entry — causing re-prompting on every single invocation. Binary commands (`ls`, `docker`, etc.) work correctly.

## Root Cause

`collectAllowAlwaysPatterns` recognises POSIX shells (`bash`/`sh`/`zsh`) via `isShellWrapperSegment` and then calls `extractShellWrapperInlineCommand` expecting a `-c` inline-command payload. For script-file invocations there is no `-c` flag, so the function returns `null` and the early-return branch fires **without writing any pattern to the allowlist**.

```
bash scripts/save_crystal.sh
  → isShellWrapperSegment = true  ✓
  → extractShellWrapperInlineCommand = null  (no -c flag)
  → early return, nothing persisted  ← BUG
```

The next invocation finds an empty allowlist → prompts again.

## Fix

1. **`extractPosixShellScriptArg`** (`exec-wrapper-resolution.ts`) — scans argv past option flags to find the first positional script-file argument; returns `null` when a `-c` inline-command flag is present (leaving the existing `-c` unwrap path intact).

2. **`resolveShellScriptFilePath`** helper — resolves the script argument to an absolute path, handling relative paths (`scripts/foo.sh`), bare names (`foo.sh` → cwd-relative), and `~` expansion.

3. **`collectAllowAlwaysPatterns`** — when no inline command is found, calls the new helpers and persists the resolved script path.

4. **`evaluateSegments`** — after a miss on the shell executable path, also probes the allowlist with the resolved script path so stored entries are matched on subsequent invocations.

## Tests

Five new test cases in `exec-approvals-allow-always.test.ts`:
- Persists resolved script path for `bash scripts/save_crystal.sh`
- Persists resolved path when option flags precede the script (`sh -xe setup.sh`)
- Does **not** persist script path when `-c` is used (non-regression)
- Allowlist is satisfied when script path entry matches
- Full **round-trip**: first run → allow-always → persisted pattern → second run auto-approved (no re-prompt)
