### PR TITLE
fix(install): disable git credential prompts during npm install (#35118)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -676,7 +676,17 @@ run_npm_global_install() {
     local log="$2"
 
     local -a cmd
-    cmd=(env "SHARP_IGNORE_GLOBAL_LIBVIPS=$SHARP_IGNORE_GLOBAL_LIBVIPS" npm --loglevel "$NPM_LOGLEVEL")
+    # Prevent git/ssh from prompting for credentials during npm install (installer is non-interactive).
+    # This avoids hangs like: "git@github.com's password:" in piped install flows (#35118).
+    cmd=(
+        env
+        "SHARP_IGNORE_GLOBAL_LIBVIPS=$SHARP_IGNORE_GLOBAL_LIBVIPS"
+        "GIT_TERMINAL_PROMPT=0"
+        "GIT_ASKPASS=false"
+        "GIT_SSH_COMMAND=ssh -oBatchMode=yes"
+        npm
+        --loglevel "$NPM_LOGLEVEL"
+    )
     if [[ -n "$NPM_SILENT_FLAG" ]]; then
         cmd+=("$NPM_SILENT_FLAG")
     fi
@@ -778,6 +788,11 @@ print_npm_failure_diagnostics() {
     first_error="$(extract_first_npm_error_line "$log")"
     if [[ -n "$first_error" ]]; then
         echo "  First npm error: ${first_error}"
+    fi
+
+    if grep -q "terminal prompts disabled" "$log" || grep -q "could not read Username for" "$log"; then
+        echo "  Note: git tried to prompt for credentials during npm install (disabled by this installer to avoid hangs)."
+        echo "  Rerun with --verbose to see the full npm output and identify the dependency requiring git."
     fi
 }
 


### PR DESCRIPTION
## Summary

- Problem: The one-line installer (`curl -fsSL https://openclaw.ai/install.sh | bash`) can hang waiting for interactive git credentials (e.g. `git@github.com's password:`) during the `npm install -g openclaw@...` step.
- Why it matters: The installer is typically run non-interactively; a credential prompt blocks installs and provides no actionable error output.
- What changed: The installer now runs `npm install` with git/ssh set to non-interactive mode (`GIT_TERMINAL_PROMPT=0`, `GIT_ASKPASS=false`, `GIT_SSH_COMMAND=ssh -oBatchMode=yes`) so installs fail fast with an actionable log instead of hanging.
- What did NOT change (scope boundary): No change to which packages are installed or the install method selection; this only affects credential prompting behavior during npm installs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35118

## User-visible / Behavior Changes

- The installer no longer blocks on interactive git credential prompts during `npm install`.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `bash -n scripts/install.sh`.
2. In an environment where `npm install -g openclaw@...` triggers a git/ssh credential prompt, run `curl -fsSL https://openclaw.ai/install.sh | bash`.

### Expected

- Installer does not hang waiting for credentials; npm fails fast with logs.

### Actual

- Previously, the installer could hang waiting for interactive credentials.

## Evidence

- [x] Script parses cleanly (`bash -n scripts/install.sh`).

## Human Verification (required)

- Verified scenarios: `bash -n scripts/install.sh`
- Edge cases checked: N/A
- What you did **not** verify: Full installer run on Linux with a reproducer that triggers the credential prompt

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- Revert this commit.

## Risks and Mitigations

None.
