### PR TITLE
doctor: detect duplicate openclaw installations

### DIFF
--- a/src/commands/doctor-duplicate-installs.test.ts
+++ b/src/commands/doctor-duplicate-installs.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  access: vi.fn(),
+  realpath: vi.fn(),
+  execFileAsync: vi.fn(),
+  note: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    access: mocks.access,
+    realpath: mocks.realpath,
+  },
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock("node:util", () => ({
+  promisify: () => mocks.execFileAsync,
+}));
+
+vi.mock("../terminal/note.js", () => ({
+  note: mocks.note,
+}));
+
+import {
+  collectCandidateDirs,
+  findOpenClawInstallations,
+  noteDuplicateInstallations,
+} from "./doctor-duplicate-installs.js";
+
+describe("collectCandidateDirs", () => {
+  it("includes PATH entries", () => {
+    const dirs = collectCandidateDirs({
+      PATH: "/usr/bin:/usr/local/bin",
+      HOME: "/home/test",
+    });
+    expect(dirs).toContain("/usr/bin");
+    expect(dirs).toContain("/usr/local/bin");
+  });
+
+  it("includes well-known npm-global dir", () => {
+    const dirs = collectCandidateDirs({
+      PATH: "/usr/bin",
+      HOME: "/home/test",
+    });
+    expect(dirs).toContain("/home/test/.npm-global/bin");
+  });
+
+  it("includes volta bin dir", () => {
+    const dirs = collectCandidateDirs({
+      PATH: "",
+      HOME: "/home/test",
+    });
+    expect(dirs).toContain("/home/test/.volta/bin");
+  });
+
+  it("deduplicates directories", () => {
+    const dirs = collectCandidateDirs({
+      PATH: "/usr/bin:/usr/bin:/usr/bin",
+      HOME: "/home/test",
+    });
+    const usrBinCount = dirs.filter((d) => d === "/usr/bin").length;
+    expect(usrBinCount).toBe(1);
+  });
+});
+
+describe("findOpenClawInstallations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: no files exist
+    mocks.access.mockRejectedValue(new Error("ENOENT"));
+    mocks.realpath.mockImplementation(async (p: string) => p);
+    mocks.execFileAsync.mockRejectedValue(new Error("not found"));
+  });
+
+  it("returns empty array when no binaries are found", async () => {
+    const result = await findOpenClawInstallations({
+      PATH: "/usr/bin",
+      HOME: "/home/test",
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("finds a single installation", async () => {
+    mocks.access.mockImplementation(async (p: string) => {
+      if (p === "/usr/bin/openclaw") {
+        return undefined;
+      }
+      throw new Error("ENOENT");
+    });
+    mocks.realpath.mockImplementation(async (p: string) => p);
+    mocks.execFileAsync.mockImplementation(async (bin: string) => {
+      if (bin === "/usr/bin/openclaw") {
+        return { stdout: "2026.3.2\n", stderr: "" };
+      }
+      throw new Error("not found");
+    });
+
+    const result = await findOpenClawInstallations({
+      PATH: "/usr/bin",
+      HOME: "/home/test",
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].binPath).toBe("/usr/bin/openclaw");
+    expect(result[0].version).toBe("2026.3.2");
+  });
+
+  it("finds multiple installations at different real paths", async () => {
+    const existing = new Set(["/usr/bin/openclaw", "/home/test/.npm-global/bin/openclaw"]);
+    mocks.access.mockImplementation(async (p: string) => {
+      if (existing.has(p)) {
+        return undefined;
+      }
+      throw new Error("ENOENT");
+    });
+    mocks.realpath.mockImplementation(async (p: string) => p);
+    mocks.execFileAsync.mockImplementation(async (bin: string) => {
+      if (bin === "/usr/bin/openclaw") {
+        return { stdout: "2026.2.25\n", stderr: "" };
+      }
+      if (bin === "/home/test/.npm-global/bin/openclaw") {
+        return { stdout: "2026.3.2\n", stderr: "" };
+      }
+      throw new Error("not found");
+    });
+
+    const result = await findOpenClawInstallations({
+      PATH: "/usr/bin:/home/test/.npm-global/bin",
+      HOME: "/home/test",
+    });
+    expect(result).toHaveLength(2);
+    expect(result.map((i) => i.version)).toContain("2026.2.25");
+    expect(result.map((i) => i.version)).toContain("2026.3.2");
+  });
+
+  it("deduplicates symlinks resolving to same real path", async () => {
+    mocks.access.mockImplementation(async (p: string) => {
+      if (p === "/usr/bin/openclaw" || p === "/usr/local/bin/openclaw") {
+        return undefined;
+      }
+      throw new Error("ENOENT");
+    });
+    // Both resolve to the same real path
+    mocks.realpath.mockImplementation(async () => "/opt/openclaw/bin/openclaw");
+    mocks.execFileAsync.mockResolvedValue({ stdout: "2026.3.2\n", stderr: "" });
+
+    const result = await findOpenClawInstallations({
+      PATH: "/usr/bin:/usr/local/bin",
+      HOME: "/home/test",
+    });
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe("noteDuplicateInstallations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.access.mockRejectedValue(new Error("ENOENT"));
+    mocks.realpath.mockImplementation(async (p: string) => p);
+    mocks.execFileAsync.mockRejectedValue(new Error("not found"));
+  });
+
+  it("does not emit a note when 0 or 1 installations found", async () => {
+    const result = await noteDuplicateInstallations();
+    expect(result.warnings).toHaveLength(0);
+    expect(mocks.note).not.toHaveBeenCalled();
+  });
+
+  it("emits a note when multiple installations found", async () => {
+    const existing = new Set(["/usr/bin/openclaw", "/home/test/.npm-global/bin/openclaw"]);
+    mocks.access.mockImplementation(async (p: string) => {
+      if (existing.has(p)) {
+        return undefined;
+      }
+      throw new Error("ENOENT");
+    });
+    mocks.realpath.mockImplementation(async (p: string) => p);
+    mocks.execFileAsync.mockImplementation(async (bin: string) => {
+      if (bin === "/usr/bin/openclaw") {
+        return { stdout: "2026.2.25\n", stderr: "" };
+      }
+      if (bin === "/home/test/.npm-global/bin/openclaw") {
+        return { stdout: "2026.3.2\n", stderr: "" };
+      }
+      throw new Error("not found");
+    });
+
+    // Ensure PATH includes both directories so they're scanned
+    const origPath = process.env.PATH;
+    process.env.PATH = "/usr/bin:/home/test/.npm-global/bin";
+    const origHome = process.env.HOME;
+    process.env.HOME = "/home/test";
+
+    try {
+      const result = await noteDuplicateInstallations();
+      expect(result.installations).toHaveLength(2);
+      expect(result.warnings.length).toBeGreaterThan(0);
+      expect(mocks.note).toHaveBeenCalledWith(
+        expect.stringContaining("Found 2 openclaw binaries"),
+        "Duplicate installations",
+      );
+    } finally {
+      process.env.PATH = origPath;
+      process.env.HOME = origHome;
+    }
+  });
+});

--- a/src/commands/doctor-duplicate-installs.ts
+++ b/src/commands/doctor-duplicate-installs.ts
@@ -1,0 +1,191 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { note } from "../terminal/note.js";
+
+const execFileAsync = promisify(execFile);
+
+export type OpenClawInstallation = {
+  binPath: string;
+  version: string | null;
+  isCurrent: boolean;
+};
+
+export type DuplicateInstallResult = {
+  installations: OpenClawInstallation[];
+  warnings: string[];
+};
+
+/**
+ * Collect candidate directories that might contain an `openclaw` binary.
+ * Always includes PATH entries plus well-known npm/node global dirs.
+ */
+export function collectCandidateDirs(env: Record<string, string | undefined>): string[] {
+  const home = env.HOME ?? env.USERPROFILE ?? os.homedir();
+  const dirs = new Set<string>();
+
+  // PATH entries
+  const pathVar = env.PATH ?? "";
+  for (const entry of pathVar.split(path.delimiter)) {
+    const trimmed = entry.trim();
+    if (trimmed) {
+      dirs.add(trimmed);
+    }
+  }
+
+  // Well-known global install locations
+  const wellKnown = [
+    "/usr/bin",
+    "/usr/local/bin",
+    "/usr/lib/node_modules/.bin",
+    path.join(home, ".npm-global", "bin"),
+    path.join(home, ".npm-global", "lib", "node_modules", ".bin"),
+    // volta
+    path.join(home, ".volta", "bin"),
+    // nvm typical
+    path.join(home, ".nvm", "current", "bin"),
+    // fnm
+    path.join(home, ".local", "share", "fnm", "current", "bin"),
+    // pnpm global
+    path.join(home, ".local", "share", "pnpm"),
+    // Linuxbrew
+    path.join(home, ".linuxbrew", "bin"),
+    "/home/linuxbrew/.linuxbrew/bin",
+  ];
+
+  for (const dir of wellKnown) {
+    dirs.add(dir);
+  }
+
+  return [...dirs];
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveRealPath(p: string): Promise<string> {
+  try {
+    return await fs.realpath(p);
+  } catch {
+    return p;
+  }
+}
+
+async function probeVersion(binPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(binPath, ["--version"], {
+      timeout: 5000,
+      env: { ...process.env, NODE_NO_WARNINGS: "1" },
+    });
+    const trimmed = stdout.trim();
+    // Version output is typically just the version string or "openclaw vX.Y.Z"
+    const match = trimmed.match(/(\d{4}\.\d+\.\d+(?:[a-zA-Z0-9._-]*))/);
+    return match?.[1] ?? trimmed.split("\n")[0]?.trim() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function findOpenClawInstallations(
+  env: Record<string, string | undefined>,
+): Promise<OpenClawInstallation[]> {
+  const candidateDirs = collectCandidateDirs(env);
+  const binName = process.platform === "win32" ? "openclaw.cmd" : "openclaw";
+  const seen = new Set<string>();
+  const installations: OpenClawInstallation[] = [];
+
+  // Determine the "current" binary — what `process.argv[1]` resolves to.
+  const currentBin = process.argv[1] ? await resolveRealPath(process.argv[1]) : null;
+
+  for (const dir of candidateDirs) {
+    const candidate = path.join(dir, binName);
+    if (!(await fileExists(candidate))) {
+      continue;
+    }
+
+    const realPath = await resolveRealPath(candidate);
+    if (seen.has(realPath)) {
+      continue;
+    }
+    seen.add(realPath);
+
+    const version = await probeVersion(candidate);
+    installations.push({
+      binPath: candidate,
+      version,
+      isCurrent: currentBin !== null && realPath === currentBin,
+    });
+  }
+
+  return installations;
+}
+
+function shortenHome(p: string): string {
+  const home = os.homedir();
+  if (p.startsWith(home + path.sep)) {
+    return "~" + p.slice(home.length);
+  }
+  return p;
+}
+
+function buildRemediationHint(install: OpenClawInstallation): string {
+  const p = install.binPath;
+  if (
+    p.startsWith("/usr/lib/node_modules/") ||
+    p.startsWith("/usr/bin/") ||
+    p.startsWith("/usr/local/")
+  ) {
+    return `sudo npm uninstall -g openclaw`;
+  }
+  if (p.includes(".npm-global")) {
+    return `npm uninstall -g openclaw`;
+  }
+  if (p.includes(".volta")) {
+    return `volta uninstall openclaw`;
+  }
+  return `rm ${shortenHome(p)}`;
+}
+
+export async function noteDuplicateInstallations(): Promise<DuplicateInstallResult> {
+  const installations = await findOpenClawInstallations(
+    process.env as Record<string, string | undefined>,
+  );
+  const warnings: string[] = [];
+
+  if (installations.length <= 1) {
+    return { installations, warnings };
+  }
+
+  const lines: string[] = [];
+  lines.push(`Found ${installations.length} openclaw binaries:`);
+  for (const inst of installations) {
+    const versionStr = inst.version ? `v${inst.version}` : "unknown version";
+    const currentTag = inst.isCurrent ? " ← current" : "";
+    lines.push(`- ${shortenHome(inst.binPath)} (${versionStr})${currentTag}`);
+  }
+
+  lines.push("");
+  lines.push("Multiple installations can cause gateway port conflicts and infinite restart loops.");
+
+  // Suggest removing the non-current ones
+  const stale = installations.filter((i) => !i.isCurrent);
+  if (stale.length > 0) {
+    lines.push("Remove the stale installation(s):");
+    for (const s of stale) {
+      lines.push(`  ${buildRemediationHint(s)}`);
+    }
+  }
+
+  note(lines.join("\n"), "Duplicate installations");
+  warnings.push(...lines);
+
+  return { installations, warnings };
+}

--- a/src/commands/doctor-duplicate-installs.ts
+++ b/src/commands/doctor-duplicate-installs.ts
@@ -105,19 +105,22 @@ export async function findOpenClawInstallations(
   // Determine the "current" binary — what `process.argv[1]` resolves to.
   const currentBin = process.argv[1] ? await resolveRealPath(process.argv[1]) : null;
 
-  for (const dir of candidateDirs) {
-    const candidate = path.join(dir, binName);
-    if (!(await fileExists(candidate))) {
-      continue;
-    }
+  // Probe all candidate dirs in parallel (each probeVersion already has a 5 s timeout).
+  const candidates = candidateDirs.map((dir) => path.join(dir, binName));
+  const probeResults = await Promise.all(
+    candidates.map(async (candidate) => {
+      if (!(await fileExists(candidate))) return null;
+      const realPath = await resolveRealPath(candidate);
+      const version = await probeVersion(candidate);
+      return { candidate, realPath, version };
+    }),
+  );
 
-    const realPath = await resolveRealPath(candidate);
-    if (seen.has(realPath)) {
-      continue;
-    }
+  for (const result of probeResults) {
+    if (!result) continue;
+    const { candidate, realPath, version } = result;
+    if (seen.has(realPath)) continue;
     seen.add(realPath);
-
-    const version = await probeVersion(candidate);
     installations.push({
       binPath: candidate,
       version,
@@ -151,6 +154,17 @@ function buildRemediationHint(install: OpenClawInstallation): string {
   if (p.includes(".volta")) {
     return `volta uninstall openclaw`;
   }
+  // Managed version managers — use their first-class uninstall commands rather than bare rm,
+  // which would leave dangling shims and break the package manager's internal bookkeeping.
+  if (p.includes("pnpm")) {
+    return `pnpm remove -g openclaw`;
+  }
+  if (p.includes(".nvm")) {
+    return `nvm exec node npm uninstall -g openclaw`;
+  }
+  if (p.includes("fnm")) {
+    return `fnm exec -- npm uninstall -g openclaw`;
+  }
   return `rm ${shortenHome(p)}`;
 }
 
@@ -175,13 +189,23 @@ export async function noteDuplicateInstallations(): Promise<DuplicateInstallResu
   lines.push("");
   lines.push("Multiple installations can cause gateway port conflicts and infinite restart loops.");
 
-  // Suggest removing the non-current ones
+  // Suggest removing the non-current ones.
+  // Guard: if no installation is identified as current (process.argv[1] didn't match any
+  // discovered binary), isCurrent will be false for ALL of them. In that case, do NOT
+  // emit removal hints — we can't tell which one is the running binary, so recommending
+  // removal of all of them would be dangerous.
+  const hasCurrent = installations.some((i) => i.isCurrent);
   const stale = installations.filter((i) => !i.isCurrent);
-  if (stale.length > 0) {
+  if (hasCurrent && stale.length > 0) {
     lines.push("Remove the stale installation(s):");
     for (const s of stale) {
       lines.push(`  ${buildRemediationHint(s)}`);
     }
+  } else if (!hasCurrent && stale.length > 0) {
+    lines.push(
+      "Could not identify which installation is currently running. " +
+        "Inspect the list above and manually remove unwanted copies.",
+    );
   }
 
   note(lines.join("\n"), "Duplicate installations");

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -29,6 +29,7 @@ import {
 import { noteBootstrapFileSize } from "./doctor-bootstrap-size.js";
 import { doctorShellCompletion } from "./doctor-completion.js";
 import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
+import { noteDuplicateInstallations } from "./doctor-duplicate-installs.js";
 import { maybeRepairGatewayDaemon } from "./doctor-gateway-daemon-flow.js";
 import { checkGatewayHealth, probeGatewayMemoryStatus } from "./doctor-gateway-health.js";
 import {
@@ -94,6 +95,7 @@ export async function doctorCommand(
 
   await maybeRepairUiProtocolFreshness(runtime, prompter);
   noteSourceInstallIssues(root);
+  await noteDuplicateInstallations();
   noteDeprecatedLegacyEnvVars();
   noteStartupOptimizationHints();
 

--- a/src/i18n/registry.test.ts
+++ b/src/i18n/registry.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 import {
   DEFAULT_LOCALE,
   SUPPORTED_LOCALES,
   loadLazyLocaleTranslation,
   resolveNavigatorLocale,
 } from "../../ui/src/i18n/lib/registry.ts";
+import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 
 function getNestedTranslation(map: TranslationMap | null, ...path: string[]): string | undefined {
   let value: string | TranslationMap | undefined = map ?? undefined;


### PR DESCRIPTION
## Summary

- Adds a new `doctor-duplicate-installs` check that scans PATH entries and well-known install locations (npm global, volta, nvm, fnm, pnpm, Linuxbrew) for multiple `openclaw` binaries
- Deduplicates via realpath to avoid false positives from symlinks
- Probes each binary's version and marks which is currently running
- Emits a clear warning with remediation steps when duplicates are found
- Wired into the doctor flow early (after `noteSourceInstallIssues`, before config repairs)

Closes #35129

## Context

On a production server, two openclaw installations (system-level `/usr/lib/node_modules/openclaw` v2026.2.25 and user-level `~/.npm-global/lib/node_modules/openclaw` v2026.3.2) had competing systemd services fighting over port 18789 with `--force`, each SIGKILL'ing the other in an infinite restart loop (170+ restarts before diagnosis). This check catches that class of issue early.

## Test plan

- [x] Unit tests cover: candidate dir collection, single binary detection, multi-binary detection, symlink deduplication, note emission for duplicates, no-op for single install
- [ ] Manual: install openclaw at two locations, run `openclaw doctor`, verify warning appears with correct paths/versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)