### PR TITLE
exec approvals: honor allow-always for bash script invocations

### DIFF
--- a/changelog/fragments/bash-script-always-allow-patterns.md
+++ b/changelog/fragments/bash-script-always-allow-patterns.md
@@ -1,0 +1,1 @@
+- exec approvals: `allow-always` now persists and matches shell script paths for wrapper invocations like `bash scripts/foo.sh`, so repeated runs stop prompting while still avoiding broad wrapper-wide allow rules.

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -127,6 +127,57 @@ describe("resolveAllowAlwaysPatterns", () => {
     expect(new Set(patterns)).toEqual(new Set([whoami, ls]));
   });
 
+  it("persists shell script paths for wrapper invocations without inline commands", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const script = path.join(scriptsDir, "save_crystal.sh");
+    fs.writeFileSync(script, "echo ok\n");
+
+    const safeBins = resolveSafeBins(undefined);
+    const env = { PATH: `${dir}${path.delimiter}${process.env.PATH ?? ""}` };
+    const first = evaluateShellAllowlist({
+      command: "bash scripts/save_crystal.sh",
+      allowlist: [],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    const persisted = resolveAllowAlwaysPatterns({
+      segments: first.segments,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(persisted).toEqual([script]);
+
+    const second = evaluateShellAllowlist({
+      command: "bash scripts/save_crystal.sh",
+      allowlist: [{ pattern: script }],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(second.allowlistSatisfied).toBe(true);
+
+    const other = path.join(scriptsDir, "other.sh");
+    fs.writeFileSync(other, "echo other\n");
+    const third = evaluateShellAllowlist({
+      command: "bash scripts/other.sh",
+      allowlist: [{ pattern: script }],
+      safeBins,
+      cwd: dir,
+      env,
+      platform: process.platform,
+    });
+    expect(third.allowlistSatisfied).toBe(false);
+  });
+
   it("does not persist broad shell binaries when no inner command can be derived", () => {
     const patterns = resolveAllowAlwaysPatterns({
       segments: [

--- a/src/infra/exec-approvals-allow-always.test.ts
+++ b/src/infra/exec-approvals-allow-always.test.ts
@@ -178,6 +178,44 @@ describe("resolveAllowAlwaysPatterns", () => {
     expect(third.allowlistSatisfied).toBe(false);
   });
 
+  it("does not treat inline shell commands as persisted script paths", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const script = path.join(scriptsDir, "save_crystal.sh");
+    fs.writeFileSync(script, "echo ok\n");
+    const env = { PATH: `${dir}${path.delimiter}${process.env.PATH ?? ""}` };
+    expectAllowAlwaysBypassBlocked({
+      dir,
+      firstCommand: "bash scripts/save_crystal.sh",
+      secondCommand: "bash -lc 'scripts/save_crystal.sh'",
+      env,
+      persistedPattern: script,
+    });
+  });
+
+  it("does not treat stdin shell mode as a persisted script path", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const dir = makeTempDir();
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    const script = path.join(scriptsDir, "save_crystal.sh");
+    fs.writeFileSync(script, "echo ok\n");
+    const env = { PATH: `${dir}${path.delimiter}${process.env.PATH ?? ""}` };
+    expectAllowAlwaysBypassBlocked({
+      dir,
+      firstCommand: "bash scripts/save_crystal.sh",
+      secondCommand: "bash -s scripts/save_crystal.sh",
+      env,
+      persistedPattern: script,
+    });
+  });
+
   it("does not persist broad shell binaries when no inner command can be derived", () => {
     const patterns = resolveAllowAlwaysPatterns({
       segments: [

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -25,6 +25,7 @@ import {
   unwrapKnownShellMultiplexerInvocation,
   unwrapKnownDispatchWrapperInvocation,
 } from "./exec-wrapper-resolution.js";
+import { expandHomePrefix } from "./home-dir.js";
 
 function hasShellLineContinuation(command: string): boolean {
   return /\\(?:\r\n|\n|\r)/.test(command);
@@ -221,7 +222,19 @@ function evaluateSegments(
       candidatePath && segment.resolution
         ? { ...segment.resolution, resolvedPath: candidatePath }
         : segment.resolution;
-    const match = matchAllowlist(params.allowlist, candidateResolution);
+    const executableMatch = matchAllowlist(params.allowlist, candidateResolution);
+    const shellScriptCandidatePath = resolveShellWrapperScriptCandidatePath({
+      segment,
+      cwd: params.cwd,
+    });
+    const shellScriptMatch = shellScriptCandidatePath
+      ? matchAllowlist(params.allowlist, {
+          rawExecutable: shellScriptCandidatePath,
+          resolvedPath: shellScriptCandidatePath,
+          executableName: path.basename(shellScriptCandidatePath),
+        })
+      : null;
+    const match = executableMatch ?? shellScriptMatch;
     if (match) {
       matches.push(match);
     }
@@ -327,6 +340,69 @@ function isDispatchWrapperSegment(segment: ExecCommandSegment): boolean {
   return hasSegmentExecutableMatch(segment, isDispatchWrapperExecutable);
 }
 
+const SHELL_WRAPPER_OPTIONS_WITH_VALUE = new Set([
+  "-c",
+  "--command",
+  "-o",
+  "-O",
+  "+O",
+  "--rcfile",
+  "--init-file",
+  "--startup-file",
+]);
+
+function resolveShellWrapperScriptCandidatePath(params: {
+  segment: ExecCommandSegment;
+  cwd?: string;
+}): string | undefined {
+  if (!isShellWrapperSegment(params.segment)) {
+    return undefined;
+  }
+
+  const argv = params.segment.argv;
+  if (!Array.isArray(argv) || argv.length < 2) {
+    return undefined;
+  }
+
+  let idx = 1;
+  while (idx < argv.length) {
+    const token = argv[idx]?.trim() ?? "";
+    if (!token) {
+      idx += 1;
+      continue;
+    }
+    if (token === "--") {
+      idx += 1;
+      break;
+    }
+    if (token === "-c" || token === "--command") {
+      return undefined;
+    }
+    if (SHELL_WRAPPER_OPTIONS_WITH_VALUE.has(token)) {
+      idx += 2;
+      continue;
+    }
+    if (token.startsWith("-") || token.startsWith("+")) {
+      idx += 1;
+      continue;
+    }
+    break;
+  }
+
+  const scriptToken = argv[idx]?.trim();
+  if (!scriptToken) {
+    return undefined;
+  }
+
+  if (path.isAbsolute(scriptToken)) {
+    return scriptToken;
+  }
+
+  const expanded = scriptToken.startsWith("~") ? expandHomePrefix(scriptToken) : scriptToken;
+  const base = params.cwd && params.cwd.trim().length > 0 ? params.cwd : process.cwd();
+  return path.resolve(base, expanded);
+}
+
 function collectAllowAlwaysPatterns(params: {
   segment: ExecCommandSegment;
   cwd?: string;
@@ -382,6 +458,13 @@ function collectAllowAlwaysPatterns(params: {
   }
   const inlineCommand = extractShellWrapperInlineCommand(params.segment.argv);
   if (!inlineCommand) {
+    const scriptPath = resolveShellWrapperScriptCandidatePath({
+      segment: params.segment,
+      cwd: params.cwd,
+    });
+    if (scriptPath) {
+      params.out.add(scriptPath);
+    }
     return;
   }
   const nested = analyzeShellCommand({

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -223,10 +223,14 @@ function evaluateSegments(
         ? { ...segment.resolution, resolvedPath: candidatePath }
         : segment.resolution;
     const executableMatch = matchAllowlist(params.allowlist, candidateResolution);
-    const shellScriptCandidatePath = resolveShellWrapperScriptCandidatePath({
-      segment,
-      cwd: params.cwd,
-    });
+    const inlineCommand = extractShellWrapperInlineCommand(segment.argv);
+    const shellScriptCandidatePath =
+      inlineCommand === null
+        ? resolveShellWrapperScriptCandidatePath({
+            segment,
+            cwd: params.cwd,
+          })
+        : undefined;
     const shellScriptMatch = shellScriptCandidatePath
       ? matchAllowlist(params.allowlist, {
           rawExecutable: shellScriptCandidatePath,
@@ -376,6 +380,12 @@ function resolveShellWrapperScriptCandidatePath(params: {
       break;
     }
     if (token === "-c" || token === "--command") {
+      return undefined;
+    }
+    if (/^-[^-]*c[^-]*$/i.test(token)) {
+      return undefined;
+    }
+    if (token === "-s" || /^-[^-]*s[^-]*$/i.test(token)) {
       return undefined;
     }
     if (SHELL_WRAPPER_OPTIONS_WITH_VALUE.has(token)) {


### PR DESCRIPTION
## Summary
Fix `allow-always` not sticking for shell script wrapper commands such as:

- `bash scripts/save_crystal.sh`

Previously, these commands could continue prompting for approval on every run.

## Root cause
`resolveAllowAlwaysPatterns(...)` skipped shell-wrapper segments when there was no inline `-c` payload, so no allowlist pattern was persisted.

## Changes
- `src/infra/exec-approvals-allowlist.ts`
  - add shell-script target inference for wrapper invocations without inline commands
  - persist inferred script path for `allow-always`
  - allow allowlist matching against inferred shell script path (in addition to executable path)
- `src/infra/exec-approvals-allow-always.test.ts`
  - add regression test for `bash scripts/save_crystal.sh`
  - verify same script is auto-allowed after persistence
  - verify a different script is still denied (no broad bypass)
- changelog fragment added

## Validation
- `corepack pnpm exec vitest run src/infra/exec-approvals-allow-always.test.ts --reporter=dot`
- Result: 12 tests passed

Fixes #35024.
