### PR TITLE
fix(agents): treat HTTP 500 as failover-eligible server error

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -14,12 +14,23 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 403 })).toBe("auth");
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
-    // Transient server errors (502/503/504) should trigger failover as timeout.
+    // Transient server errors (500/502/503/504) should trigger failover as timeout.
+    expect(resolveFailoverReasonFromError({ status: 500 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 504 })).toBe("timeout");
     // Anthropic 529 (overloaded) should trigger failover as rate_limit.
     expect(resolveFailoverReasonFromError({ status: 529 })).toBe("rate_limit");
+  });
+
+  it("treats HTTP 500 server_error as failover-eligible timeout", () => {
+    const err = coerceToFailoverError(
+      { status: 500, message: "server_error" },
+      { provider: "openai", model: "codex-mini-latest" },
+    );
+    expect(err?.reason).toBe("timeout");
+    expect(err?.provider).toBe("openai");
+    expect(err?.model).toBe("codex-mini-latest");
   });
 
   it("infers format errors from error messages", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -168,7 +168,7 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 408) {
     return "timeout";
   }
-  if (status === 502 || status === 503 || status === 504) {
+  if (status === 500 || status === 502 || status === 503 || status === 504) {
     return "timeout";
   }
   if (status === 529) {


### PR DESCRIPTION
## Summary

- **Problem:** HTTP 500 (`server_error`) from providers like Codex does not trigger the model fallback chain. Users see raw error messages and must manually switch models.
- **Why it matters:** Provider-side 500 errors are transient failures that should trigger automatic failover, just like 502/503/504. Without this, users experience silent failures on providers like Codex that return 500 for internal server errors.
- **What changed:** Added `status === 500` to the transient server error check in `resolveFailoverReasonFromError()`, alongside existing 502/503/504 handling. Added test coverage for HTTP 500 failover.
- **What did NOT change:** No changes to failover logic, retry behavior, or other status code handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35119

## User-visible / Behavior Changes

- HTTP 500 errors from model providers now trigger automatic fallback to the next model in the fallback chain, instead of surfacing raw error messages.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22
- Integration/channel: Any (Discord, Telegram, etc.)

### Steps

1. Configure a model fallback chain (e.g., `codex-mini-latest` → `gemini-2.5-flash`)
2. Provider returns HTTP 500 `server_error`

### Expected

- Fallback chain triggers, next model is tried automatically

### Actual

- Before fix: Raw error displayed, no fallback
- After fix: Fallback triggers automatically on HTTP 500

## Evidence

```typescript
// Before: only 502/503/504 handled
if (status === 502 || status === 503 || status === 504) { return "timeout"; }

// After: 500 included
if (status === 500 || status === 502 || status === 503 || status === 504) { return "timeout"; }
```

Test results: 18/18 tests pass including new HTTP 500 coverage.

## Human Verification (required)

- Verified scenarios: HTTP 500 now returns "timeout" failover reason, coercion creates proper FailoverError with provider/model metadata
- Edge cases checked: Other status codes (402, 429, 401, 403, 529, 400) unchanged
- What I did **not** verify: Live Codex provider returning 500

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single line change in `failover-error.ts`
- Files/config to restore: `src/agents/failover-error.ts`
- Known bad symptoms: If HTTP 500 should NOT trigger failover for some reason, this would cause unnecessary fallback attempts

## Risks and Mitigations

- Some providers may use HTTP 500 for permanent errors. However, the failover chain will eventually exhaust candidates and surface the error, so worst case is a few extra retries. This matches industry convention (502/503/504 are already treated as transient).
