### PR TITLE
gateway: avoid false stale-socket restarts for idle iMessage

### DIFF
--- a/changelog/fragments/imessage-health-monitor-idle-threshold.md
+++ b/changelog/fragments/imessage-health-monitor-idle-threshold.md
@@ -1,0 +1,1 @@
+- gateway health monitor: increase iMessage stale-event default threshold to 6 hours (channel-aware) to prevent false-positive restarts during normal idle periods.

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -106,6 +106,20 @@ function createSlackSnapshotManager(
   );
 }
 
+function createIMessageSnapshotManager(
+  account: Partial<ChannelAccountSnapshot>,
+  overrides?: Partial<ChannelManager>,
+): ChannelManager {
+  return createSnapshotManager(
+    {
+      imessage: {
+        default: account,
+      },
+    },
+    overrides,
+  );
+}
+
 async function expectRestartedChannel(
   manager: ChannelManager,
   channel: ChannelId,
@@ -514,6 +528,30 @@ describe("channel-health-monitor", () => {
       expect(manager.stopChannel).toHaveBeenCalledWith("slack", "default");
       expect(manager.startChannel).toHaveBeenCalledWith("slack", "default");
       monitor.stop();
+    });
+
+    it("uses a longer default stale threshold for iMessage idle periods", async () => {
+      const thirtyMinutes = 30 * 60_000;
+      const now = Date.now();
+      const manager = createIMessageSnapshotManager(
+        runningConnectedSlackAccount({
+          lastStartAt: now - thirtyMinutes - 60_000,
+          lastEventAt: now - thirtyMinutes - 30_000,
+        }),
+      );
+      await expectNoRestart(manager);
+    });
+
+    it("still restarts iMessage channels after very long event silence", async () => {
+      const sevenHours = 7 * 60 * 60_000;
+      const now = Date.now();
+      const manager = createIMessageSnapshotManager(
+        runningConnectedSlackAccount({
+          lastStartAt: now - sevenHours - 60_000,
+          lastEventAt: now - sevenHours - 30_000,
+        }),
+      );
+      await expectRestartedChannel(manager, "imessage");
     });
   });
 });

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -542,6 +542,23 @@ describe("channel-health-monitor", () => {
       await expectNoRestart(manager);
     });
 
+    it("respects explicit stale thresholds for iMessage", async () => {
+      const customThreshold = 10 * 60_000;
+      const now = Date.now();
+      const manager = createIMessageSnapshotManager(
+        runningConnectedSlackAccount({
+          lastStartAt: now - customThreshold - 60_000,
+          lastEventAt: now - customThreshold - 30_000,
+        }),
+      );
+      const monitor = await startAndRunCheck(manager, {
+        staleEventThresholdMs: customThreshold,
+      });
+      expect(manager.stopChannel).toHaveBeenCalledWith("imessage", "default");
+      expect(manager.startChannel).toHaveBeenCalledWith("imessage", "default");
+      monitor.stop();
+    });
+
     it("still restarts iMessage channels after very long event silence", async () => {
       const sevenHours = 7 * 60 * 60_000;
       const now = Date.now();

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -14,6 +14,7 @@ const DEFAULT_MONITOR_STARTUP_GRACE_MS = 60_000;
 const DEFAULT_COOLDOWN_CYCLES = 2;
 const DEFAULT_MAX_RESTARTS_PER_HOUR = 10;
 const ONE_HOUR_MS = 60 * 60_000;
+const DEFAULT_IMESSAGE_STALE_EVENT_THRESHOLD_MS = 6 * ONE_HOUR_MS;
 
 /**
  * How long a connected channel can go without receiving any event before
@@ -74,6 +75,16 @@ function resolveTimingPolicy(
   };
 }
 
+function resolveChannelStaleEventThresholdMs(
+  channelId: string,
+  defaultThresholdMs: number,
+): number {
+  if (channelId === "imessage") {
+    return Math.max(defaultThresholdMs, DEFAULT_IMESSAGE_STALE_EVENT_THRESHOLD_MS);
+  }
+  return defaultThresholdMs;
+}
+
 export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): ChannelHealthMonitor {
   const {
     channelManager,
@@ -124,7 +135,10 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           }
           const healthPolicy: ChannelHealthPolicy = {
             now,
-            staleEventThresholdMs: timing.staleEventThresholdMs,
+            staleEventThresholdMs: resolveChannelStaleEventThresholdMs(
+              channelId,
+              timing.staleEventThresholdMs,
+            ),
             channelConnectGraceMs: timing.channelConnectGraceMs,
           };
           const health = evaluateChannelHealth(status, healthPolicy);

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -78,8 +78,9 @@ function resolveTimingPolicy(
 function resolveChannelStaleEventThresholdMs(
   channelId: string,
   defaultThresholdMs: number,
+  hasExplicitOverride: boolean,
 ): number {
-  if (channelId === "imessage") {
+  if (channelId === "imessage" && !hasExplicitOverride) {
     return Math.max(defaultThresholdMs, DEFAULT_IMESSAGE_STALE_EVENT_THRESHOLD_MS);
   }
   return defaultThresholdMs;
@@ -94,6 +95,8 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
     abortSignal,
   } = deps;
   const timing = resolveTimingPolicy(deps);
+  const hasExplicitStaleEventThreshold =
+    deps.timing?.staleEventThresholdMs !== undefined || deps.staleEventThresholdMs !== undefined;
 
   const cooldownMs = cooldownCycles * checkIntervalMs;
   const restartRecords = new Map<string, RestartRecord>();
@@ -138,6 +141,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             staleEventThresholdMs: resolveChannelStaleEventThresholdMs(
               channelId,
               timing.staleEventThresholdMs,
+              hasExplicitStaleEventThreshold,
             ),
             channelConnectGraceMs: timing.channelConnectGraceMs,
           };


### PR DESCRIPTION
## Summary
Reduce false-positive iMessage stale-socket restarts by using a longer default stale-event window for iMessage channels.

## Problem
Issue #35072 reports iMessage providers restarting roughly every 30 minutes during normal idle periods. The monitor currently uses a single default stale-event threshold (30 minutes) across all channels, which is too aggressive for low-traffic iMessage sessions.

## Changes
- `src/gateway/channel-health-monitor.ts`
  - add channel-aware stale-event threshold resolution
  - keep existing global default behavior for other channels
  - use a higher iMessage default stale-event threshold (6 hours)
- `src/gateway/channel-health-monitor.test.ts`
  - add regression test: iMessage is not restarted after ~30 min idle
  - add guard test: iMessage still restarts after very long silence
- changelog fragment added

## Validation
- `corepack pnpm exec vitest run src/gateway/channel-health-monitor.test.ts --reporter=dot`
- Result: 29 tests passed

Fixes #35072.
