### PR TITLE
fix(agents): guard context pruning against malformed thinking blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.
 - Agents/xAI tool-call argument decoding: decode HTML-entity encoded xAI/Grok tool-call argument values (`&amp;`, `&quot;`, `&lt;`, `&gt;`, numeric entities) before tool execution so commands with shell operators and quotes no longer fail with parse errors. (#35276) Thanks @Sid-Qin.

--- a/src/agents/pi-extensions/context-pruning/pruner.test.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.test.ts
@@ -1,0 +1,61 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import { pruneContextMessages } from "./pruner.js";
+import { DEFAULT_CONTEXT_PRUNING_SETTINGS } from "./settings.js";
+
+const MODEL = { contextWindow: 1_000_000 };
+
+describe("pruneContextMessages", () => {
+  it("does not crash on assistant message with malformed thinking block (missing thinking string)", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        content: [{ type: "thinking" } as never, { type: "text", text: "ok" }],
+      },
+    ];
+    expect(() =>
+      pruneContextMessages({
+        messages,
+        settings: DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        ctx: { model: MODEL },
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not crash on assistant message with null content entries", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        content: [null as never, { type: "text", text: "world" }],
+      },
+    ];
+    expect(() =>
+      pruneContextMessages({
+        messages,
+        settings: DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        ctx: { model: MODEL },
+      }),
+    ).not.toThrow();
+  });
+
+  it("handles well-formed thinking blocks correctly", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "let me think" },
+          { type: "text", text: "here is the answer" },
+        ],
+      },
+    ];
+    const result = pruneContextMessages({
+      messages,
+      settings: DEFAULT_CONTEXT_PRUNING_SETTINGS,
+      ctx: { model: MODEL },
+    });
+    expect(result).toHaveLength(2);
+  });
+});

--- a/src/agents/pi-extensions/context-pruning/pruner.test.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.test.ts
@@ -1,60 +1,111 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import { pruneContextMessages } from "./pruner.js";
 import { DEFAULT_CONTEXT_PRUNING_SETTINGS } from "./settings.js";
 
-const MODEL = { contextWindow: 1_000_000 };
+type AssistantMessage = Extract<AgentMessage, { role: "assistant" }>;
+type AssistantContentBlock = AssistantMessage["content"][number];
+
+const CONTEXT_WINDOW_1M = {
+  model: { contextWindow: 1_000_000 },
+} as unknown as ExtensionContext;
+
+function makeUser(text: string): AgentMessage {
+  return {
+    role: "user",
+    content: text,
+    timestamp: Date.now(),
+  };
+}
+
+function makeAssistant(content: AssistantMessage["content"]): AgentMessage {
+  return {
+    role: "assistant",
+    content,
+    api: "openai-responses",
+    provider: "openai",
+    model: "test-model",
+    usage: {
+      input: 1,
+      output: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 2,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  };
+}
 
 describe("pruneContextMessages", () => {
   it("does not crash on assistant message with malformed thinking block (missing thinking string)", () => {
     const messages: AgentMessage[] = [
-      { role: "user", content: "hello" },
-      {
-        role: "assistant",
-        content: [{ type: "thinking" } as never, { type: "text", text: "ok" }],
-      },
+      makeUser("hello"),
+      makeAssistant([
+        { type: "thinking" } as unknown as AssistantContentBlock,
+        { type: "text", text: "ok" },
+      ]),
     ];
     expect(() =>
       pruneContextMessages({
         messages,
         settings: DEFAULT_CONTEXT_PRUNING_SETTINGS,
-        ctx: { model: MODEL },
+        ctx: CONTEXT_WINDOW_1M,
       }),
     ).not.toThrow();
   });
 
   it("does not crash on assistant message with null content entries", () => {
     const messages: AgentMessage[] = [
-      { role: "user", content: "hello" },
-      {
-        role: "assistant",
-        content: [null as never, { type: "text", text: "world" }],
-      },
+      makeUser("hello"),
+      makeAssistant([null as unknown as AssistantContentBlock, { type: "text", text: "world" }]),
     ];
     expect(() =>
       pruneContextMessages({
         messages,
         settings: DEFAULT_CONTEXT_PRUNING_SETTINGS,
-        ctx: { model: MODEL },
+        ctx: CONTEXT_WINDOW_1M,
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not crash on assistant message with malformed text block (missing text string)", () => {
+    const messages: AgentMessage[] = [
+      makeUser("hello"),
+      makeAssistant([
+        { type: "text" } as unknown as AssistantContentBlock,
+        { type: "thinking", thinking: "still fine" },
+      ]),
+    ];
+    expect(() =>
+      pruneContextMessages({
+        messages,
+        settings: DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        ctx: CONTEXT_WINDOW_1M,
       }),
     ).not.toThrow();
   });
 
   it("handles well-formed thinking blocks correctly", () => {
     const messages: AgentMessage[] = [
-      { role: "user", content: "hello" },
-      {
-        role: "assistant",
-        content: [
-          { type: "thinking", thinking: "let me think" },
-          { type: "text", text: "here is the answer" },
-        ],
-      },
+      makeUser("hello"),
+      makeAssistant([
+        { type: "thinking", thinking: "let me think" },
+        { type: "text", text: "here is the answer" },
+      ]),
     ];
     const result = pruneContextMessages({
       messages,
       settings: DEFAULT_CONTEXT_PRUNING_SETTINGS,
-      ctx: { model: MODEL },
+      ctx: CONTEXT_WINDOW_1M,
     });
     expect(result).toHaveLength(2);
   });

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -121,10 +121,13 @@ function estimateMessageChars(message: AgentMessage): number {
   if (message.role === "assistant") {
     let chars = 0;
     for (const b of message.content) {
-      if (b.type === "text") {
+      if (!b || typeof b !== "object") {
+        continue;
+      }
+      if (b.type === "text" && typeof b.text === "string") {
         chars += b.text.length;
       }
-      if (b.type === "thinking") {
+      if (b.type === "thinking" && typeof b.thinking === "string") {
         chars += b.thinking.length;
       }
       if (b.type === "toolCall") {


### PR DESCRIPTION
## Summary

- **Problem:** Context pruning crashes with "Cannot read properties of undefined (reading 'length')" when an assistant message contains a malformed thinking block (`{ type: "thinking" }` without a `thinking` string) or null content entries.
- **Why it matters:** Malformed content from providers should never crash the pruning pipeline. This causes session-permanent errors since pruning runs on every turn.
- **What changed:** Added `typeof` guards for `b.thinking` and `b.text` in `estimateMessageChars()`, plus object guards to skip null/undefined entries. Added 3 regression tests.
- **What did NOT change:** No changes to pruning logic, thresholds, or message ordering.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35026

## User-visible / Behavior Changes

- Malformed thinking blocks and null content entries no longer crash context pruning; they are treated as zero-length.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22
- Integration/channel: Any

### Steps

1. Build a message list with an assistant message containing `content: [{"type":"thinking"}]` (missing `thinking` string)
2. Run `pruneContextMessages(...)` with pruning enabled

### Expected

- Pruning completes without throwing

### Actual

- Before fix: `TypeError: Cannot read properties of undefined (reading 'length')`
- After fix: Malformed blocks treated as zero-length, pruning continues normally

## Evidence

```typescript
// Before:
if (b.type === "thinking") { chars += b.thinking.length; }

// After:
if (!b || typeof b !== "object") { continue; }
if (b.type === "text" && typeof b.text === "string") { chars += b.text.length; }
if (b.type === "thinking" && typeof b.thinking === "string") { chars += b.thinking.length; }
```

Test results: 3/3 tests pass including malformed thinking block and null entry regression tests.

## Human Verification (required)

- Verified scenarios: Malformed thinking block (no thinking string), null entries, well-formed thinking blocks
- Edge cases checked: Empty content arrays, mixed valid/invalid entries
- What I did **not** verify: Live provider returning malformed thinking blocks

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert changes in `pruner.ts`
- Files/config to restore: `src/agents/pi-extensions/context-pruning/pruner.ts`
- Known bad symptoms: None expected — guards are additive

## Risks and Mitigations

None — guards only affect malformed entries that would previously crash.
