### PR TITLE
fix(gateway): resolve token from config/env for agent tool calls; honour --ask CLI override

### DIFF
--- a/src/agents/tools/gateway.ts
+++ b/src/agents/tools/gateway.ts
@@ -123,13 +123,13 @@ export function resolveGatewayOptions(opts?: GatewayCallOptions) {
         })
       : undefined;
   const explicitToken = trimToUndefined(opts?.gatewayToken);
-  const token = validatedOverride
-    ? resolveGatewayOverrideToken({
-        cfg,
-        target: validatedOverride.target,
-        explicitToken,
-      })
-    : explicitToken;
+  // Always resolve credentials via config/env fallback so gateway.auth.mode=token
+  // works for agent tool calls, not just CLI/webchat paths. (#35039)
+  const token = resolveGatewayOverrideToken({
+    cfg,
+    target: validatedOverride?.target ?? "local",
+    explicitToken,
+  });
   const timeoutMs =
     typeof opts?.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
       ? Math.max(1, Math.floor(opts.timeoutMs))

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -117,7 +117,10 @@ function resolveNodesRunPolicy(opts: NodesRunOpts, execDefaults: ExecDefaults | 
   }
   return {
     security: minSecurity(configuredSecurity, requestedSecurity ?? configuredSecurity),
-    ask: maxAsk(configuredAsk, requestedAsk ?? configuredAsk),
+    // When --ask is explicitly provided on the CLI, honour it directly so that
+    // `--ask off` can override the config default. maxAsk would always pick the
+    // stricter value, making it impossible to relax the ask policy from the CLI. (#35122)
+    ask: requestedAsk !== undefined && requestedAsk !== null ? requestedAsk : configuredAsk,
   };
 }
 


### PR DESCRIPTION
Two related fixes for exec/gateway auth policy.

## Fix 1 — agent tools fail with `device-required` when `gateway.auth.mode=token` (closes #35039)

`resolveGatewayOptions()` in `src/agents/tools/gateway.ts` only resolved credentials through `resolveGatewayOverrideToken()` when a `gatewayUrl` override was present. On the default loopback path (`validatedOverride = undefined`) the token fell through to `explicitToken` (i.e. `opts?.gatewayToken`), which is `undefined` for normal agent tool calls like `sessions_spawn` / `cron`.

**Fix:** always call `resolveGatewayOverrideToken()` with `target: validatedOverride?.target ?? "local"`. This gives the default-loopback path the same `OPENCLAW_GATEWAY_TOKEN` / config credential resolution that the CLI/webchat path already had.

## Fix 2 — `--ask off` CLI flag cannot override config default (closes #35122)

`resolveNodesRunPolicy()` passed the CLI value through `maxAsk()` which always picks the stricter value — making it impossible for a user to relax `ask` from the command line when the config default is stricter.

**Fix:** when `--ask` is explicitly provided on the CLI, use the requested value directly instead of running it through `maxAsk()`. Config default is used only when no CLI flag was given. Consistent with the convention that CLI args override config.

## Testing
- `pnpm tsgo` — zero type errors
- `pnpm vitest run src/infra/exec-approvals.test.ts src/infra/exec-approvals-allow-always.test.ts` — 52/52 pass
