### PR TITLE
fix(cli): let --ask off override config default in nodes run

### DIFF
--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -117,7 +117,7 @@ function resolveNodesRunPolicy(opts: NodesRunOpts, execDefaults: ExecDefaults | 
   }
   return {
     security: minSecurity(configuredSecurity, requestedSecurity ?? configuredSecurity),
-    ask: maxAsk(configuredAsk, requestedAsk ?? configuredAsk),
+    ask: requestedAsk ?? configuredAsk,
   };
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw nodes run --ask off` cannot override the config default value. `resolveNodesRunPolicy()` uses `maxAsk()` to merge CLI and config values, always picking the stricter mode. So `maxAsk("on-miss", "off")` returns `"on-miss"`, ignoring the explicit CLI override.
- **Why it matters:** Users expect CLI arguments to have higher priority than config file defaults. When `--ask off` doesn't work, users must edit config files to disable approval prompts, which is inconvenient for scripting and automation.
- **What changed:** Changed `resolveNodesRunPolicy()` to use the explicit CLI `--ask` value directly when provided (`requestedAsk ?? configuredAsk`), instead of taking the max with config. The agent-level approval merge in `resolveNodeApprovals()` still uses `maxAsk()`, preserving agent-defined ask policies.
- **What did NOT change:** Security policy merge (`minSecurity`) is unchanged. Agent-level ask merge is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35122

## User-visible / Behavior Changes

- `openclaw nodes run --ask off` now correctly disables the approval prompt, overriding the config default.

## Security Impact (required)

- New permissions/capabilities? `No` — users could already set `ask: "off"` in config
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — security policy merge (`minSecurity`) is unchanged
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22
- Integration/channel: CLI

### Steps

1. Leave `tools.exec.ask` unset in config (defaults to `"on-miss"`)
2. Run: `openclaw nodes run --node <node> --ask off -- <command>`

### Expected

- Command executes directly without approval prompt

### Actual

- Before fix: Still triggers approval flow, errors with "approval expired"
- After fix: Skips approval, executes directly

## Evidence

```typescript
// Before: CLI --ask off is ignored
ask: maxAsk(configuredAsk, requestedAsk ?? configuredAsk),
// maxAsk("on-miss", "off") → "on-miss"

// After: CLI --ask directly overrides config
ask: requestedAsk ?? configuredAsk,
// requestedAsk = "off" → "off"
```

All 41 exec-approvals tests pass. TypeScript compilation clean.

## Human Verification (required)

- Verified scenarios: `--ask off` overriding config default, no `--ask` flag falling back to config
- Edge cases checked: Invalid `--ask` value still throws, agent-level maxAsk still applies
- What I did **not** verify: Live `nodes run` execution with approval flow

## Compatibility / Migration

- Backward compatible? `Yes` — users who don't pass `--ask` see no change
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single line in `register.invoke.ts`
- Files/config to restore: `src/cli/nodes-cli/register.invoke.ts`
- Known bad symptoms: If reverting, `--ask off` will again be ignored

## Risks and Mitigations

- Risk: User overrides `--ask off` when admin intended mandatory approval. Mitigation: Agent-level ask policy (`resolveNodeApprovals`) still uses `maxAsk`, so agent-defined ask=always will still be respected. Only the config-level default is overridable from CLI.
