### PR TITLE
feat(plugins): add appendSystemPrompt to hook results

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -465,6 +465,12 @@ export async function resolvePromptBuildHookResult(params: {
     prependContext: [promptBuildResult?.prependContext, legacyResult?.prependContext]
       .filter((value): value is string => Boolean(value))
       .join("\n\n"),
+    appendSystemPrompt: [
+      promptBuildResult?.appendSystemPrompt,
+      legacyResult?.appendSystemPrompt,
+    ]
+      .filter((value): value is string => Boolean(value))
+      .join("\n\n"),
   };
 }
 
@@ -1410,6 +1416,18 @@ export async function runEmbeddedAttempt(
             applySystemPromptOverrideToSession(activeSession, legacySystemPrompt);
             systemPromptText = legacySystemPrompt;
             log.debug(`hooks: applied systemPrompt override (${legacySystemPrompt.length} chars)`);
+          }
+          const appendSystemPrompt =
+            typeof hookResult?.appendSystemPrompt === "string"
+              ? hookResult.appendSystemPrompt.trim()
+              : "";
+          if (appendSystemPrompt) {
+            const appended = `${systemPromptText}\n\n${appendSystemPrompt}`;
+            applySystemPromptOverrideToSession(activeSession, appended);
+            systemPromptText = appended;
+            log.debug(
+              `hooks: appended to system prompt (${appendSystemPrompt.length} chars)`,
+            );
           }
         }
 

--- a/src/plugins/hooks.phase-hooks.test.ts
+++ b/src/plugins/hooks.phase-hooks.test.ts
@@ -72,4 +72,42 @@ describe("phase hooks merger", () => {
     expect(result?.prependContext).toBe("context A\n\ncontext B");
     expect(result?.systemPrompt).toBe("system A");
   });
+
+  it("before_prompt_build concatenates appendSystemPrompt from multiple plugins", async () => {
+    addTypedHook(
+      registry,
+      "before_prompt_build",
+      "plugin-a",
+      () => ({ appendSystemPrompt: "observation A" }),
+      10,
+    );
+    addTypedHook(
+      registry,
+      "before_prompt_build",
+      "plugin-b",
+      () => ({ appendSystemPrompt: "observation B" }),
+      1,
+    );
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforePromptBuild({ prompt: "test", messages: [] }, {});
+
+    expect(result?.appendSystemPrompt).toBe("observation A\n\nobservation B");
+  });
+
+  it("before_prompt_build preserves appendSystemPrompt when only one plugin provides it", async () => {
+    addTypedHook(
+      registry,
+      "before_prompt_build",
+      "plugin-a",
+      () => ({ prependContext: "some context", appendSystemPrompt: "appended" }),
+      10,
+    );
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runBeforePromptBuild({ prompt: "test", messages: [] }, {});
+
+    expect(result?.appendSystemPrompt).toBe("appended");
+    expect(result?.prependContext).toBe("some context");
+  });
 });

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -144,6 +144,10 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       acc?.prependContext && next.prependContext
         ? `${acc.prependContext}\n\n${next.prependContext}`
         : (next.prependContext ?? acc?.prependContext),
+    appendSystemPrompt:
+      acc?.appendSystemPrompt && next.appendSystemPrompt
+        ? `${acc.appendSystemPrompt}\n\n${next.appendSystemPrompt}`
+        : (next.appendSystemPrompt ?? acc?.appendSystemPrompt),
   });
 
   const mergeSubagentSpawningResult = (

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -369,6 +369,7 @@ export type PluginHookBeforePromptBuildEvent = {
 export type PluginHookBeforePromptBuildResult = {
   systemPrompt?: string;
   prependContext?: string;
+  appendSystemPrompt?: string;
 };
 
 // before_agent_start hook (legacy compatibility: combines both phases)


### PR DESCRIPTION
## Summary

- **Problem:** Plugins that need to inject persistent context into the system prompt have no good option. `systemPrompt` replaces the entire prompt (destructive). `prependContext` duplicates per-message in the transcript (bloating).
- **Why it matters:** Observational memory plugins, context enrichment plugins, and RAG plugins need to append supplementary context alongside SOUL.md/USER.md without replacing or bloating.
- **What changed:** Added `appendSystemPrompt?: string` to `PluginHookBeforePromptBuildResult`. Multiple plugins returning `appendSystemPrompt` are concatenated with `

` (same as `prependContext`). The appended text is applied after the system prompt is finalized (including any `systemPrompt` override from hooks).
- **What did NOT change:** Existing `systemPrompt` and `prependContext` behavior is unchanged. No changes to hook invocation order or priority.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34727

## User-visible / Behavior Changes

- Plugins can now return `appendSystemPrompt` from `before_prompt_build` and `before_agent_start` hooks to non-destructively append context to the system prompt.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22
- Integration/channel: Any

### Steps

1. Create a plugin that returns `{ appendSystemPrompt: "observational context here" }` from `before_prompt_build`
2. Run an agent session

### Expected

- System prompt contains the appended context at the end, after SOUL.md/USER.md/AGENTS.md

### Actual

- Before: No way to append without replacing (`systemPrompt`) or bloating transcript (`prependContext`)
- After: `appendSystemPrompt` appends to system prompt non-destructively

## Evidence

```typescript
// types.ts
export type PluginHookBeforePromptBuildResult = {
  systemPrompt?: string;
  prependContext?: string;
  appendSystemPrompt?: string;  // NEW
};

// hooks.ts merge logic
appendSystemPrompt:
  acc?.appendSystemPrompt && next.appendSystemPrompt
    ? `${acc.appendSystemPrompt}

${next.appendSystemPrompt}`
    : (next.appendSystemPrompt ?? acc?.appendSystemPrompt),

// attempt.ts application
if (appendSystemPrompt) {
  const appended = `${systemPromptText}

${appendSystemPrompt}`;
  applySystemPromptOverrideToSession(activeSession, appended);
  systemPromptText = appended;
}
```

Test results: 4/4 phase hooks tests pass including 2 new appendSystemPrompt merge tests.

## Human Verification (required)

- Verified scenarios: Multiple plugins concatenating appendSystemPrompt, single plugin providing it, combined with prependContext
- Edge cases checked: Empty/undefined appendSystemPrompt, interaction with systemPrompt override
- What I did **not** verify: Live plugin using appendSystemPrompt in production

## Compatibility / Migration

- Backward compatible? `Yes` — new optional field, no existing behavior changed
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert changes in 3 files
- Files/config to restore: `src/plugins/types.ts`, `src/plugins/hooks.ts`, `src/agents/pi-embedded-runner/run/attempt.ts`
- Known bad symptoms: None expected — field is optional and only used when returned by plugins

## Risks and Mitigations

- Risk: Plugin appending very large text to system prompt could cause context overflow. Mitigation: This is the same risk as `prependContext` — plugins are responsible for content size.
