### PR TITLE
feat(cli): include commit SHA in -v/--version output

### DIFF
--- a/src/cli/program/help.test.ts
+++ b/src/cli/program/help.test.ts
@@ -39,6 +39,11 @@ vi.mock("./register.subclis.js", () => ({
   getSubCliCommandsWithSubcommands: () => ["gateway"],
 }));
 
+const resolveCommitHashMock = vi.fn(() => "abc1234");
+vi.mock("../../infra/git-commit.js", () => ({
+  resolveCommitHash: (...args: unknown[]) => resolveCommitHashMock(...args),
+}));
+
 const { configureProgramHelp } = await import("./help.js");
 
 const testProgramContext: ProgramContext = {
@@ -108,6 +113,23 @@ describe("configureProgramHelp", () => {
   });
 
   it("prints version and exits immediately when version flags are present", () => {
+    process.argv = ["node", "openclaw", "--version"];
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? ""}`);
+    }) as typeof process.exit);
+
+    const program = makeProgramWithCommands();
+    expect(() => configureProgramHelp(program, testProgramContext)).toThrow("exit:0");
+    expect(logSpy).toHaveBeenCalledWith("9.9.9-test (abc1234)");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("prints version without commit hash when resolveCommitHash returns null", () => {
+    resolveCommitHashMock.mockReturnValueOnce(null);
     process.argv = ["node", "openclaw", "--version"];
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -9,6 +9,7 @@ import { CLI_LOG_LEVEL_VALUES, parseCliLogLevelOption } from "../log-level-optio
 import { getCoreCliCommandsWithSubcommands } from "./command-registry.js";
 import type { ProgramContext } from "./context.js";
 import { getSubCliCommandsWithSubcommands } from "./register.subclis.js";
+import { resolveCommitHash } from "../../infra/git-commit.js";
 
 const CLI_NAME = resolveCliName();
 const CLI_NAME_PATTERN = escapeRegExp(CLI_NAME);
@@ -109,7 +110,11 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     hasFlag(process.argv, "--version") ||
     hasRootVersionAlias(process.argv)
   ) {
-    console.log(ctx.programVersion);
+    const commit = resolveCommitHash();
+    const versionStr = commit
+      ? `${ctx.programVersion} (${commit})`
+      : ctx.programVersion;
+    console.log(versionStr);
     process.exit(0);
   }
 


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw -v` only shows the bare version number (e.g. `2026.3.1`) while the startup banner shows the full version with commit hash (e.g. `OpenClaw 2026.3.1 (b13e19b)`). This inconsistency makes it hard to verify which exact local build is running.
- **Why it matters:** Users diagnosing issues or confirming deployments need the commit SHA to match against git history. Having to start the full gateway just to see the banner is inconvenient.
- **What changed:** The `-V`/`--version` flag handler in `src/cli/program/help.ts` now imports `resolveCommitHash` and appends the short SHA when available, producing output like `2026.3.1 (b13e19b)`.
- **What did NOT change:** The banner output is unchanged. When no commit hash is available (npm install, no git), the output falls back to the bare version number.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34972

## User-visible / Behavior Changes

- `openclaw -v` / `openclaw --version` now outputs `<version> (<commit>)` instead of just `<version>` when a commit hash is available.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: CLI

### Steps

1. Run `openclaw -v` or `openclaw --version`

### Expected

- Output includes commit SHA: `2026.3.1 (b13e19b)`

### Actual

- Before fix: `2026.3.1`
- After fix: `2026.3.1 (b13e19b)`

## Evidence

```
✓ prints version and exits immediately when version flags are present
✓ prints version without commit hash when resolveCommitHash returns null
```

## Human Verification (required)

- Verified scenarios: version flag with commit hash, version flag without commit hash (null)
- Edge cases checked: resolveCommitHash returning null gracefully falls back to bare version
- What I did **not** verify: `-v` alias (tested `--version` via unit test)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the import and version string formatting in `help.ts`
- Files/config to restore: `src/cli/program/help.ts`
- Known bad symptoms: None expected

## Risks and Mitigations

None — purely additive change to CLI output format.
