### PR TITLE
fix(models-config): config apiKey wins over stale models.json on merge (#12740)

### DIFF
--- a/src/agents/models-config.config-apikey-wins-on-update.test.ts
+++ b/src/agents/models-config.config-apikey-wins-on-update.test.ts
@@ -1,0 +1,134 @@
+// Test file to verify fix for issue #12740:
+// Config apiKey must win over stale models.json apiKey in merge mode.
+// This test FAILS on unpatched main and PASSES on the fix.
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveOpenClawAgentDir } from "./agent-paths.js";
+import {
+  installModelsConfigTestHooks,
+  withModelsTempHome as withTempHome,
+} from "./models-config.e2e-harness.js";
+import { ensureOpenClawModelsJson } from "./models-config.js";
+import { readGeneratedModelsJson } from "./models-config.test-utils.js";
+
+installModelsConfigTestHooks();
+
+const MODELS_JSON_NAME = "models.json";
+
+async function writeAgentModelsJson(content: unknown): Promise<void> {
+  const agentDir = resolveOpenClawAgentDir();
+  await fs.mkdir(agentDir, { recursive: true });
+  await fs.writeFile(
+    path.join(agentDir, MODELS_JSON_NAME),
+    JSON.stringify(content, null, 2),
+    "utf8",
+  );
+}
+
+describe("models-config merge mode: config apiKey wins on update (#12740)", () => {
+  it("uses updated config apiKey when existing models.json has a stale key", async () => {
+    // Simulates: user had OLD_API_KEY in models.json, then changed it to
+    // NEW_API_KEY via Control UI (config). The merge must use the new config
+    // value — not silently preserve the stale file value, which would make
+    // the config appear locked.
+    await withTempHome(async () => {
+      // Seed models.json with old key (simulates pre-existing state)
+      await writeAgentModelsJson({
+        providers: {
+          custom: {
+            baseUrl: "https://old.example/v1",
+            apiKey: "OLD_API_KEY",
+            api: "openai-responses",
+            models: [
+              {
+                id: "old-model",
+                name: "Old model",
+                api: "openai-responses",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 8192,
+                maxTokens: 2048,
+              },
+            ],
+          },
+        },
+      });
+
+      // Config now has the updated key (simulates user saving new key via Control UI)
+      await ensureOpenClawModelsJson({
+        models: {
+          mode: "merge",
+          providers: {
+            custom: {
+              baseUrl: "https://new.example/v1",
+              apiKey: "NEW_API_KEY",
+              api: "openai-responses",
+              models: [
+                {
+                  id: "new-model",
+                  name: "New model",
+                  api: "openai-responses",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 2048,
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const parsed = await readGeneratedModelsJson<{
+        providers: Record<string, { apiKey?: string; baseUrl?: string }>;
+      }>();
+
+      // The config-provided NEW_API_KEY must win over the stale OLD_API_KEY in models.json.
+      // On unpatched main, this assertion fails because OLD_API_KEY is preserved.
+      expect(parsed.providers.custom?.apiKey).toBe("NEW_API_KEY");
+      expect(parsed.providers.custom?.baseUrl).toBe("https://new.example/v1");
+    });
+  });
+
+  it("still preserves existing models.json apiKey when config does not supply one", async () => {
+    // The original 9c6dc098c fix: when config has no apiKey, preserve from models.json.
+    // This must still work after our change.
+    await withTempHome(async () => {
+      await writeAgentModelsJson({
+        providers: {
+          custom: {
+            baseUrl: "https://agent.example/v1",
+            apiKey: "AGENT_ONLY_KEY",
+            api: "openai-responses",
+            models: [],
+          },
+        },
+      });
+
+      // Config has NO apiKey for this provider (key set directly in models.json)
+      await ensureOpenClawModelsJson({
+        models: {
+          mode: "merge",
+          providers: {
+            custom: {
+              baseUrl: "",
+              api: "openai-responses",
+              models: [],
+            },
+          },
+        },
+      });
+
+      const parsed = await readGeneratedModelsJson<{
+        providers: Record<string, { apiKey?: string }>;
+      }>();
+
+      // When config doesn't provide a key, preserve the existing one.
+      expect(parsed.providers.custom?.apiKey).toBe("AGENT_ONLY_KEY");
+    });
+  });
+});

--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -207,7 +207,11 @@ describe("models-config", () => {
     });
   });
 
-  it("preserves non-empty agent apiKey/baseUrl for matching providers in merge mode", async () => {
+  it("uses config apiKey/baseUrl when config explicitly provides them, even if models.json has existing values", async () => {
+    // When the config explicitly provides apiKey/baseUrl (e.g. user changed them
+    // via Control UI), those values must win over any stale values in models.json.
+    // Pre-fix the merge spread preserved the old models.json value last, silently
+    // clobbering the config update and making the config appear locked.
     await withTempHome(async () => {
       const parsed = await runCustomProviderMergeTest({
         baseUrl: "https://agent.example/v1",
@@ -215,8 +219,8 @@ describe("models-config", () => {
         api: "openai-responses",
         models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
       });
-      expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
-      expect(parsed.providers.custom?.baseUrl).toBe("https://agent.example/v1");
+      expect(parsed.providers.custom?.apiKey).toBe("CONFIG_KEY");
+      expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
     });
   });
 

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -159,10 +159,14 @@ function mergeWithExistingProviderSecrets(params: {
       continue;
     }
     const preserved: Record<string, unknown> = {};
-    if (typeof existing.apiKey === "string" && existing.apiKey) {
+    // Only carry forward the existing secret when the incoming config entry does
+    // not explicitly supply one.  If the user changed their API key via the
+    // Control UI the updated value arrives in `newEntry`; spreading `preserved`
+    // last would silently clobber that change and make the config appear locked.
+    if (typeof existing.apiKey === "string" && existing.apiKey && !newEntry.apiKey) {
       preserved.apiKey = existing.apiKey;
     }
-    if (typeof existing.baseUrl === "string" && existing.baseUrl) {
+    if (typeof existing.baseUrl === "string" && existing.baseUrl && !newEntry.baseUrl) {
       preserved.baseUrl = existing.baseUrl;
     }
     mergedProviders[key] = { ...newEntry, ...preserved };

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -300,7 +300,7 @@ async function resolveImagesForRequest(
   for (const url of urls) {
     const source = parseImageUrlToSource(url);
     if (source.type === "base64") {
-      totalBytes += estimateBase64DecodedBytes(source.data);
+      totalBytes += estimateBase64DecodedBytes(source.data ?? "");
       if (totalBytes > limits.maxTotalImageBytes) {
         throw new Error(
           `Total image payload too large (${totalBytes}; limit ${limits.maxTotalImageBytes})`,


### PR DESCRIPTION
## Problem

When a user updates their API key via the Control UI while an active model fallback sequence is running, the change appears to be silently ignored. The gateway continues using the old key even after the config change is saved. This made the config appear "locked" during active sessions.

## Root cause

`src/agents/models-config.ts` — `mergeWithExistingProviderSecrets` (lines 159–174, pre-fix): The function unconditionally carried forward the existing `apiKey` from `models.json` into `preserved`, then spread `preserved` *after* `newEntry`, causing the old key to always win:

```ts
if (typeof existing.apiKey === "string" && existing.apiKey) {
  preserved.apiKey = existing.apiKey; // clobbered newEntry.apiKey unconditionally
}
mergedProviders[key] = { ...newEntry, ...preserved }; // preserved always wins
```

## Fix

Add `&& !newEntry.apiKey` (and `&& !newEntry.baseUrl`) so the fallback-to-existing secret only fires when the incoming config does **not** supply a value. When the user sets a new key, `newEntry.apiKey` is populated and the old cached value is correctly bypassed.

## Verification
- **Test:** `src/agents/models-config.config-apikey-wins-on-update.test.ts` — fails on main (OLD_API_KEY returned instead of NEW_API_KEY), passes on fix
- **Build:** clean compile (`build-output.log` — BUILD_STATUS: success)
- **Test suite:** pre-existing ELIFECYCLE failures on both main and fix; 0 new failures (`test-output.log`)
- **Code proof:** unguarded `existing.apiKey) {` pattern removed; `!newEntry.apiKey` guard confirmed (`step6-verify.log`)

Closes #12740