### PR TITLE
fix: Browser Tool Bug: targetUrl required Error Blocks Testing (Revised) (#35166)

### DIFF
--- a/src/agents/tools/browser-tool.test.ts
+++ b/src/agents/tools/browser-tool.test.ts
@@ -310,10 +310,41 @@ describe("browser tool url alias support", () => {
     );
   });
 
+  it("falls back to act request when navigate has no url", async () => {
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", {
+      action: "navigate",
+      targetId: "tab-1",
+      request: {
+        kind: "evaluate",
+        fn: "() => document.title",
+      },
+    });
+
+    expect(browserActionsMocks.browserAct).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({
+        kind: "evaluate",
+        fn: "() => document.title",
+        targetId: "tab-1",
+      }),
+      expect.objectContaining({ profile: undefined }),
+    );
+    expect(browserActionsMocks.browserNavigate).not.toHaveBeenCalled();
+  });
+
   it("keeps targetUrl required error label when both params are missing", async () => {
     const tool = createBrowserTool();
 
     await expect(tool.execute?.("call-1", { action: "open" })).rejects.toThrow(
+      "targetUrl required",
+    );
+  });
+
+  it("keeps targetUrl required error label for navigate when url and request are missing", async () => {
+    const tool = createBrowserTool();
+
+    await expect(tool.execute?.("call-1", { action: "navigate" })).rejects.toThrow(
       "targetUrl required",
     );
   });

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -501,8 +501,24 @@ export function createBrowserTool(opts?: {
           });
         }
         case "navigate": {
-          const targetUrl = readTargetUrlParam(params);
+          const targetUrl = readStringParam(params, "targetUrl") ?? readStringParam(params, "url");
           const targetId = readStringParam(params, "targetId");
+          if (!targetUrl) {
+            const request = readActRequestParam(params);
+            if (!request) {
+              throw new Error("targetUrl required");
+            }
+            const requestWithTarget =
+              request.targetId === undefined && targetId
+                ? ({ ...request, targetId } as typeof request)
+                : request;
+            return await executeActAction({
+              request: requestWithTarget,
+              baseUrl,
+              profile,
+              proxyRequest,
+            });
+          }
           if (proxyRequest) {
             const result = await proxyRequest({
               method: "POST",


### PR DESCRIPTION
Closes #35166

## Summary

- Problem: Browser Tool Bug: targetUrl required Error Blocks Testing (Revised)
- Why it matters: Reported in #35166
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35166
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35166