### PR TITLE
fix: prevent context-guard crash on malformed tool-result text blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -380,7 +380,7 @@
     "sharp": "^0.34.5",
     "sqlite-vec": "0.1.7-alpha.2",
     "strip-ansi": "^7.2.0",
-    "tar": "7.5.9",
+    "tar": "7.5.10",
     "tslog": "^4.10.2",
     "undici": "^7.22.0",
     "ws": "^8.19.0",
@@ -429,7 +429,7 @@
       "qs": "6.14.2",
       "node-domexception": "npm:@nolyfill/domexception@^1.0.28",
       "@sinclair/typebox": "0.34.48",
-      "tar": "7.5.9",
+      "tar": "7.5.10",
       "tough-cookie": "4.1.3"
     },
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   qs: 6.14.2
   node-domexception: npm:@nolyfill/domexception@^1.0.28
   '@sinclair/typebox': 0.34.48
-  tar: 7.5.9
+  tar: 7.5.10
   tough-cookie: 4.1.3
 
 importers:
@@ -179,8 +179,8 @@ importers:
         specifier: ^7.2.0
         version: 7.2.0
       tar:
-        specifier: 7.5.9
-        version: 7.5.9
+        specifier: 7.5.10
+        version: 7.5.10
       tslog:
         specifier: ^4.10.2
         version: 4.10.2
@@ -5700,10 +5700,9 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
-  tar@7.5.9:
-    resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
+  tar@7.5.10:
+    resolution: {integrity: sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -6962,7 +6961,7 @@ snapshots:
       npmlog: 5.0.1
       rimraf: 3.0.2
       semver: 7.7.4
-      tar: 7.5.9
+      tar: 7.5.10
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -9729,7 +9728,7 @@ snapshots:
       node-api-headers: 1.8.0
       rc: 1.2.8
       semver: 7.7.4
-      tar: 7.5.9
+      tar: 7.5.10
       url-join: 4.0.1
       which: 6.0.1
       yargs: 17.7.2
@@ -11246,7 +11245,7 @@ snapshots:
       sharp: 0.34.5
       sqlite-vec: 0.1.7-alpha.2
       strip-ansi: 7.2.0
-      tar: 7.5.9
+      tar: 7.5.10
       tslog: 4.10.2
       undici: 7.22.0
       ws: 8.19.0
@@ -12191,7 +12190,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  tar@7.5.9:
+  tar@7.5.10:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
@@ -7,7 +7,12 @@ const IMAGE_CHAR_ESTIMATE = 8_000;
 export type MessageCharEstimateCache = WeakMap<AgentMessage, number>;
 
 function isTextBlock(block: unknown): block is { type: "text"; text: string } {
-  return !!block && typeof block === "object" && (block as { type?: unknown }).type === "text";
+  return (
+    !!block &&
+    typeof block === "object" &&
+    (block as { type?: unknown }).type === "text" &&
+    typeof (block as { text?: unknown }).text === "string"
+  );
 }
 
 function isImageBlock(block: unknown): boolean {

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -53,6 +53,18 @@ function makeToolResultWithDetails(id: string, text: string, detailText: string)
   });
 }
 
+function makeMalformedToolResult(id: string): AgentMessage {
+  return castAgentMessage({
+    role: "toolResult",
+    toolCallId: id,
+    toolName: "read",
+    // Intentionally malformed: text block omits the "text" field.
+    content: [{ type: "text" }],
+    isError: false,
+    timestamp: Date.now(),
+  });
+}
+
 function getToolResultText(msg: AgentMessage): string {
   const content = (msg as { content?: unknown }).content;
   if (!Array.isArray(content)) {
@@ -267,5 +279,24 @@ describe("installToolResultContextGuard", () => {
     expect(newResultText).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
     expect(oldResult.details).toBeUndefined();
     expect(newResult.details).toBeUndefined();
+  });
+
+  it("does not crash when toolResult text blocks are malformed", async () => {
+    const agent = makeGuardableAgent();
+
+    installToolResultContextGuard({
+      agent,
+      contextWindowTokens: 1_000,
+    });
+
+    const contextForNextCall = [
+      makeUser("u".repeat(2_000)),
+      makeMalformedToolResult("call_bad"),
+      makeToolResult("call_new", "y".repeat(1_000)),
+    ];
+
+    await expect(
+      agent.transformContext?.(contextForNextCall, new AbortController().signal),
+    ).resolves.toBe(contextForNextCall);
   });
 });

--- a/src/i18n/registry.test.ts
+++ b/src/i18n/registry.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 import {
   DEFAULT_LOCALE,
   SUPPORTED_LOCALES,
   loadLazyLocaleTranslation,
   resolveNavigatorLocale,
 } from "../../ui/src/i18n/lib/registry.ts";
+import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 
 function getNestedTranslation(map: TranslationMap | null, ...path: string[]): string | undefined {
   let value: string | TranslationMap | undefined = map ?? undefined;


### PR DESCRIPTION
## Summary
- tighten the tool-result text block guard to require `text` to be a string before treating a block as text
- add a regression test that feeds a malformed toolResult content block (`{ type: "text" }`) through the context guard
- verify the context guard no longer crashes when estimating/truncating context with malformed tool-result blocks

## Testing
- pnpm test -- src/agents/pi-embedded-runner/tool-result-context-guard.test.ts src/agents/pi-embedded-runner/tool-result-truncation.test.ts

Fixes #34979
