### PR TITLE
fix(sessions): keep named agent sessions from auto-resetting (#14459)

### DIFF
--- a/src/commands/agent/session.test.ts
+++ b/src/commands/agent/session.test.ts
@@ -22,7 +22,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
   listAgentIds: mocks.listAgentIds,
 }));
 
-const { resolveSessionKeyForRequest } = await import("./session.js");
+const { resolveSession, resolveSessionKeyForRequest } = await import("./session.js");
 
 describe("resolveSessionKeyForRequest", () => {
   const MAIN_STORE_PATH = "/tmp/main-store.json";
@@ -175,5 +175,52 @@ describe("resolveSessionKeyForRequest", () => {
     expect(storePaths).toHaveLength(2);
     expect(storePaths).toContain(MAIN_STORE_PATH);
     expect(storePaths).toContain(MYBOT_STORE_PATH);
+  });
+});
+
+describe("resolveSession", () => {
+  const MAIN_STORE_PATH = "/tmp/main-store.json";
+  const cfg: OpenClawConfig = {
+    session: { scope: "per-sender", mainKey: "main" },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listAgentIds.mockReturnValue(["main"]);
+    mocks.resolveStorePath.mockReturnValue(MAIN_STORE_PATH);
+  });
+
+  it("reuses sessionId for named agent sessions even when reset policy marks them stale (#14459)", async () => {
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:sip-v3": {
+        sessionId: "544c1a32-da1b-43c0-a4de-e3fb5a1cffb4",
+        updatedAt: 0,
+      },
+    });
+
+    const result = resolveSession({
+      cfg,
+      sessionKey: "agent:main:sip-v3",
+    });
+
+    expect(result.sessionId).toBe("544c1a32-da1b-43c0-a4de-e3fb5a1cffb4");
+    expect(result.isNewSession).toBe(false);
+  });
+
+  it("still applies reset policy to the agent main session", async () => {
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:main": {
+        sessionId: "00000000-0000-4000-8000-000000000000",
+        updatedAt: 0,
+      },
+    });
+
+    const result = resolveSession({
+      cfg,
+      sessionKey: "agent:main:main",
+    });
+
+    expect(result.sessionId).not.toBe("00000000-0000-4000-8000-000000000000");
+    expect(result.isNewSession).toBe(true);
   });
 });

--- a/src/commands/agent/session.ts
+++ b/src/commands/agent/session.ts
@@ -9,6 +9,7 @@ import {
 } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
+  canonicalizeMainSessionAlias,
   evaluateSessionFreshness,
   loadSessionStore,
   resolveAgentIdFromSessionKey,
@@ -136,10 +137,39 @@ export function resolveSession(opts: {
     resetType,
     resetOverride: channelReset,
   });
-  const fresh = sessionEntry
-    ? evaluateSessionFreshness({ updatedAt: sessionEntry.updatedAt, now, policy: resetPolicy })
-        .fresh
-    : false;
+
+  const shouldBypassFreshnessReset =
+    Boolean(sessionEntry) &&
+    resetType === "direct" &&
+    Boolean(sessionKey?.toLowerCase().startsWith("agent:")) &&
+    (() => {
+      const key = sessionKey!.trim().toLowerCase();
+      const agentId = resolveAgentIdFromSessionKey(key);
+      if (!agentId) {
+        return false;
+      }
+      const canonicalized = canonicalizeMainSessionAlias({
+        cfg: opts.cfg,
+        agentId,
+        sessionKey: key,
+      });
+      const agentMainKey = resolveExplicitAgentSessionKey({
+        cfg: opts.cfg,
+        agentId,
+      });
+      // Named agent sessions should resume their existing transcript even when
+      // the default "direct" reset policy would consider them stale (e.g. daily
+      // resets). This keeps sessions_send targets stable across days (#14459).
+      //
+      // Main sessions remain subject to reset policies.
+      return canonicalized === key && agentMainKey !== undefined && canonicalized !== agentMainKey;
+    })();
+
+  const fresh =
+    Boolean(sessionEntry) &&
+    (shouldBypassFreshnessReset ||
+      evaluateSessionFreshness({ updatedAt: sessionEntry!.updatedAt, now, policy: resetPolicy })
+        .fresh);
   const sessionId =
     opts.sessionId?.trim() || (fresh ? sessionEntry?.sessionId : undefined) || crypto.randomUUID();
   const isNewSession = !fresh && !opts.sessionId;


### PR DESCRIPTION
## Summary

- Problem: Explicitly targeted, named agent sessions (e.g. `agent:main:sip-v3`) can be treated as “stale” by the default direct-session reset policy (daily/idle), causing a new `sessionId` to be minted and the existing transcript to be ignored when re-invoked (e.g. via `sessions_send`).
- Why it matters: This breaks continuity for long-running named sessions and makes `sessions_send`/spawn-based workflows appear to “forget” their history even though transcripts exist.
- What changed: `resolveSession` now bypasses freshness resets for named `agent:<id>:<name>` sessions that are not the agent’s main session, so they continue to reuse their stored `sessionId`/transcript across days.
- What did NOT change (scope boundary): Main sessions and non-direct sessions (group/thread) still follow the configured reset policy; this only affects explicitly named, direct agent sessions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #14459

## User-visible / Behavior Changes

- Named agent sessions targeted by key (e.g. `agent:main:project-x`) now reliably resume their existing transcript instead of auto-resetting due to the default direct-session reset policy.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm test src/commands/agent/session.test.ts`.

### Expected

- A stale-but-named session key reuses its stored `sessionId`.
- The agent main session still follows reset policy and can mint a new `sessionId` when stale.

### Actual

- Previously, named sessions could mint a new `sessionId` when stale and appear to lose transcript context.

## Evidence

- [x] Regression tests added/updated (`src/commands/agent/session.test.ts`)

## Human Verification (required)

- Verified scenarios: `pnpm test src/commands/agent/session.test.ts`
- Edge cases checked: Main session still resets; bypass applies only to named direct agent sessions
- What you did **not** verify: Full end-to-end `sessions_send` flow against a live gateway

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- Revert this commit.

## Risks and Mitigations

None.
