### PR TITLE
fix: Grok (xAI) tool_call arguments are HTML-entity encoded, breaking exec tool (#35173)

### DIFF
--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -183,6 +183,86 @@ describe("before_tool_call hook integration", () => {
     });
     expect(consumeAdjustedParamsForToolCall(sharedToolCallId, "run-a")).toBeUndefined();
   });
+
+  it("decodes HTML-entity encoded params for xAI models", async () => {
+    hookRunner.hasHooks.mockReturnValue(false);
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const tool = wrapToolWithBeforeToolCallHook({ name: "exec", execute } as any, {
+      modelProvider: "xai",
+      modelId: "grok-4-1-fast",
+    });
+    const extensionContext = {} as Parameters<typeof tool.execute>[3];
+
+    await tool.execute(
+      "call-xai-1",
+      {
+        command:
+          "source .env &amp;&amp; psql &quot;$DATABASE_URL&quot; -c &quot;SELECT 1 &lt; 2&quot;",
+      },
+      undefined,
+      extensionContext,
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      "call-xai-1",
+      {
+        command: 'source .env && psql "$DATABASE_URL" -c "SELECT 1 < 2"',
+      },
+      undefined,
+      extensionContext,
+    );
+  });
+
+  it("decodes HTML-entity encoded params for xAI models routed through OpenRouter", async () => {
+    hookRunner.hasHooks.mockReturnValue(false);
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const tool = wrapToolWithBeforeToolCallHook({ name: "exec", execute } as any, {
+      modelProvider: "openrouter",
+      modelId: "x-ai/grok-4-1-fast",
+    });
+    const extensionContext = {} as Parameters<typeof tool.execute>[3];
+
+    await tool.execute(
+      "call-xai-or-1",
+      { command: "echo &quot;hi&quot;" },
+      undefined,
+      extensionContext,
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      "call-xai-or-1",
+      { command: 'echo "hi"' },
+      undefined,
+      extensionContext,
+    );
+  });
+
+  it("does not decode HTML entities for non-xAI providers", async () => {
+    hookRunner.hasHooks.mockReturnValue(false);
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const tool = wrapToolWithBeforeToolCallHook({ name: "exec", execute } as any, {
+      modelProvider: "openai",
+      modelId: "gpt-5-mini",
+    });
+    const extensionContext = {} as Parameters<typeof tool.execute>[3];
+
+    await tool.execute(
+      "call-openai-1",
+      { command: "echo &amp;&amp;" },
+      undefined,
+      extensionContext,
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      "call-openai-1",
+      { command: "echo &amp;&amp;" },
+      undefined,
+      extensionContext,
+    );
+  });
 });
 
 describe("before_tool_call hook deduplication (#15502)", () => {

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -3,6 +3,7 @@ import type { SessionState } from "../logging/diagnostic-session-state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { isPlainObject } from "../utils.js";
+import { isXaiProvider } from "./schema/clean-for-xai.js";
 import { normalizeToolName } from "./tool-policy.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -12,6 +13,8 @@ export type HookContext = {
   /** Ephemeral session UUID — regenerated on /new and /reset. */
   sessionId?: string;
   runId?: string;
+  modelProvider?: string;
+  modelId?: string;
   loopDetection?: ToolLoopDetectionConfig;
 };
 
@@ -26,6 +29,39 @@ const MAX_LOOP_WARNING_KEYS = 256;
 let beforeToolCallRuntimePromise: Promise<
   typeof import("./pi-tools.before-tool-call.runtime.js")
 > | null = null;
+
+const HTML_ENTITY_RE = /&(amp|quot|lt|gt|apos|#39|#x27);/i;
+
+function decodeHtmlEntities(value: string): string {
+  if (!HTML_ENTITY_RE.test(value)) {
+    return value;
+  }
+  return value
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&apos;/gi, "'")
+    .replace(/&#39;/gi, "'")
+    .replace(/&#x27;/gi, "'");
+}
+
+function decodeHtmlEntitiesInParams(value: unknown): unknown {
+  if (typeof value === "string") {
+    return decodeHtmlEntities(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => decodeHtmlEntitiesInParams(item));
+  }
+  if (!isPlainObject(value)) {
+    return value;
+  }
+  const decoded: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    decoded[key] = decodeHtmlEntitiesInParams(entry);
+  }
+  return decoded;
+}
 
 function loadBeforeToolCallRuntime() {
   beforeToolCallRuntimePromise ??= import("./pi-tools.before-tool-call.runtime.js");
@@ -95,7 +131,9 @@ export async function runBeforeToolCallHook(args: {
   ctx?: HookContext;
 }): Promise<HookOutcome> {
   const toolName = normalizeToolName(args.toolName || "tool");
-  const params = args.params;
+  const params = isXaiProvider(args.ctx?.modelProvider, args.ctx?.modelId)
+    ? decodeHtmlEntitiesInParams(args.params)
+    : args.params;
 
   if (args.ctx?.sessionKey) {
     const { getDiagnosticSessionState, logToolLoopAction, detectToolCallLoop, recordToolCall } =
@@ -149,7 +187,7 @@ export async function runBeforeToolCallHook(args: {
 
   const hookRunner = getGlobalHookRunner();
   if (!hookRunner?.hasHooks("before_tool_call")) {
-    return { blocked: false, params: args.params };
+    return { blocked: false, params };
   }
 
   try {
@@ -270,6 +308,8 @@ export const __testing = {
   BEFORE_TOOL_CALL_WRAPPED,
   buildAdjustedParamsKey,
   adjustedParamsByToolCallId,
+  decodeHtmlEntities,
+  decodeHtmlEntitiesInParams,
   runBeforeToolCallHook,
   isPlainObject,
 };

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -540,6 +540,8 @@ export function createOpenClawCodingTools(options?: {
       sessionKey: options?.sessionKey,
       sessionId: options?.sessionId,
       runId: options?.runId,
+      modelProvider: options?.modelProvider,
+      modelId: options?.modelId,
       loopDetection: resolveToolLoopDetectionConfig({ cfg: options?.config, agentId }),
     }),
   );


### PR DESCRIPTION
Closes #35173

## Summary

- Problem: Grok (xAI) tool_call arguments are HTML-entity encoded, breaking exec tool
- Why it matters: Reported in #35173
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35173
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35173