### PR TITLE
fix(agents): recognise OpenAI/Codex `server_error` JSON body as retryable so model fallback triggers on transient 500s

### DIFF
--- a/changelog/fragments/pr-35160.md
+++ b/changelog/fragments/pr-35160.md
@@ -1,0 +1,1 @@
+fix(agents): recognise OpenAI/Codex `server_error` JSON body as retryable so model fallback triggers on transient 500s

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -547,4 +547,21 @@ describe("classifyFailoverReason", () => {
       ),
     ).toBe("timeout");
   });
+
+  it("classifies OpenAI/Codex JSON server_error 500 responses as timeout so fallback triggers", () => {
+    // OpenAI and Codex return {"type":"error","error":{"type":"server_error","code":"server_error",...}}
+    // for transient 500 failures. Without this check, classifyFailoverReason returns null and
+    // the model fallback chain is never triggered. Refs #35160.
+    expect(
+      classifyFailoverReason(
+        '{"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request. Please try again."}}',
+      ),
+    ).toBe("timeout");
+    // Verify that a missing "code":"server_error" field does NOT produce a false positive
+    expect(
+      classifyFailoverReason(
+        '{"type":"error","error":{"type":"server_error","message":"Some other error"}}',
+      ),
+    ).not.toBe("timeout");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -659,7 +659,15 @@ function isJsonApiInternalServerError(raw: string): boolean {
   const value = raw.toLowerCase();
   // Anthropic often wraps transient 500s in JSON payloads like:
   // {"type":"error","error":{"type":"api_error","message":"Internal server error"}}
-  return value.includes('"type":"api_error"') && value.includes("internal server error");
+  if (value.includes('"type":"api_error"') && value.includes("internal server error")) {
+    return true;
+  }
+  // OpenAI/Codex wraps transient 500s in JSON payloads like:
+  // {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred..."}}
+  if (value.includes('"type":"server_error"') && value.includes('"code":"server_error"')) {
+    return true;
+  }
+  return false;
 }
 
 export function parseImageDimensionError(raw: string): {


### PR DESCRIPTION
Fixes #35160

## Problem

When OpenAI or Codex returns a transient 500 error, the model fallback chain does not trigger. The agent surfaces the raw error to the user instead of falling back to configured alternative models.

## Root Cause

`isJsonApiInternalServerError()` in `errors.ts` only matched the **Anthropic-style** JSON error payload:

```json
{"type":"error","error":{"type":"api_error","message":"Internal server error"}}
```

OpenAI and Codex return a **different shape** for transient 500 failures:

```json
{"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request..."}}
```

Neither `"type":"api_error"` nor `"internal server error"` appear in the OpenAI body, so `classifyFailoverReason()` returns `null` → failover never triggers → users see raw 500 errors even when fallback models are configured.

Note: `isTransientHttpError()` (which covers plain HTTP 500 status lines) also does not match because it uses `extractLeadingHttpStatus()` which expects strings starting with a numeric status code, not JSON payloads.

## Fix

Extend `isJsonApiInternalServerError()` with a second branch matching the OpenAI/Codex pattern. Both `"type":"server_error"` **and** `"code":"server_error"` must be present to avoid false positives on other `server_error` subtypes.

```typescript
// OpenAI/Codex wraps transient 500s as:
// {"type":"error","error":{"type":"server_error","code":"server_error","message":"..."}}
if (value.includes(type:server_error) && value.includes(code:server_error)) {
  return true;
}
```

## Tests

Two new assertions in `pi-embedded-helpers.isbillingerrormessage.test.ts`:
- The Codex 500 JSON body is classified as `"timeout"` → fallback triggers  
- A `server_error` body **without** `"code":"server_error"` is **not** falsely matched
