### PR TITLE
fix(gateway): keep hook announce summaries in target session lane

### DIFF
--- a/package.json
+++ b/package.json
@@ -380,7 +380,7 @@
     "sharp": "^0.34.5",
     "sqlite-vec": "0.1.7-alpha.2",
     "strip-ansi": "^7.2.0",
-    "tar": "7.5.9",
+    "tar": "7.5.10",
     "tslog": "^4.10.2",
     "undici": "^7.22.0",
     "ws": "^8.19.0",
@@ -429,7 +429,7 @@
       "qs": "6.14.2",
       "node-domexception": "npm:@nolyfill/domexception@^1.0.28",
       "@sinclair/typebox": "0.34.48",
-      "tar": "7.5.9",
+      "tar": "7.5.10",
       "tough-cookie": "4.1.3"
     },
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   qs: 6.14.2
   node-domexception: npm:@nolyfill/domexception@^1.0.28
   '@sinclair/typebox': 0.34.48
-  tar: 7.5.9
+  tar: 7.5.10
   tough-cookie: 4.1.3
 
 importers:
@@ -179,8 +179,8 @@ importers:
         specifier: ^7.2.0
         version: 7.2.0
       tar:
-        specifier: 7.5.9
-        version: 7.5.9
+        specifier: 7.5.10
+        version: 7.5.10
       tslog:
         specifier: ^4.10.2
         version: 4.10.2
@@ -462,7 +462,7 @@ importers:
     dependencies:
       '@tloncorp/api':
         specifier: git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87
-        version: git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87
+        version: https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87
       '@tloncorp/tlon-skill':
         specifier: 0.1.9
         version: 0.1.9
@@ -2938,8 +2938,8 @@ packages:
     resolution: {integrity: sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA==}
     engines: {node: '>=12.17.0'}
 
-  '@tloncorp/api@git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87':
-    resolution: {commit: 7eede1c1a756977b09f96aa14a92e2b06318ae87, repo: https://github.com/tloncorp/api-beta.git, type: git}
+  '@tloncorp/api@https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87':
+    resolution: {tarball: https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87}
     version: 0.0.2
 
   '@tloncorp/tlon-skill-darwin-arm64@0.1.9':
@@ -5700,10 +5700,9 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
-  tar@7.5.9:
-    resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
+  tar@7.5.10:
+    resolution: {integrity: sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -6962,7 +6961,7 @@ snapshots:
       npmlog: 5.0.1
       rimraf: 3.0.2
       semver: 7.7.4
-      tar: 7.5.9
+      tar: 7.5.10
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -8908,7 +8907,7 @@ snapshots:
 
   '@tinyhttp/content-disposition@2.2.4': {}
 
-  '@tloncorp/api@git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87':
+  '@tloncorp/api@https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87':
     dependencies:
       '@aws-sdk/client-s3': 3.1000.0
       '@aws-sdk/s3-request-presigner': 3.1000.0
@@ -9729,7 +9728,7 @@ snapshots:
       node-api-headers: 1.8.0
       rc: 1.2.8
       semver: 7.7.4
-      tar: 7.5.9
+      tar: 7.5.10
       url-join: 4.0.1
       which: 6.0.1
       yargs: 17.7.2
@@ -11246,7 +11245,7 @@ snapshots:
       sharp: 0.34.5
       sqlite-vec: 0.1.7-alpha.2
       strip-ansi: 7.2.0
-      tar: 7.5.9
+      tar: 7.5.10
       tslog: 4.10.2
       undici: 7.22.0
       ws: 8.19.0
@@ -12191,7 +12190,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  tar@7.5.9:
+  tar@7.5.10:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -342,7 +342,13 @@ export async function runCronIsolatedAgentTurn(params: {
   });
 
   const { formattedTime, timeLine } = resolveCronStyleNow(params.cfg, now);
-  const base = `[cron:${params.job.id} ${params.job.name}] ${params.message}`.trim();
+  const laneTag =
+    typeof params.lane === "string" && params.lane.trim()
+      ? params.lane.trim().toLowerCase()
+      : "cron";
+  const normalizedLaneTag = laneTag.replace(/[^a-z0-9_-]/g, "") || "cron";
+  const base =
+    `[${normalizedLaneTag}:${params.job.id} ${params.job.name}] ${params.message}`.trim();
 
   // SECURITY: Wrap external hook content with security boundaries to prevent prompt injection
   // unless explicitly allowed via a dangerous config override.

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -39,7 +39,6 @@ import {
   normalizeHookHeaders,
   normalizeWakePayload,
   readJsonBody,
-  normalizeHookDispatchSessionKey,
   resolveHookSessionKey,
   resolveHookTargetAgentId,
   resolveHookChannel,
@@ -413,10 +412,7 @@ export function createHooksRequestHandler(
       const targetAgentId = resolveHookTargetAgentId(hooksConfig, normalized.value.agentId);
       const runId = dispatchAgentHook({
         ...normalized.value,
-        sessionKey: normalizeHookDispatchSessionKey({
-          sessionKey: sessionKey.value,
-          targetAgentId,
-        }),
+        sessionKey: sessionKey.value,
         agentId: targetAgentId,
       });
       sendJson(res, 200, { ok: true, runId });
@@ -473,10 +469,7 @@ export function createHooksRequestHandler(
             name: mapped.action.name ?? "Hook",
             agentId: targetAgentId,
             wakeMode: mapped.action.wakeMode,
-            sessionKey: normalizeHookDispatchSessionKey({
-              sessionKey: sessionKey.value,
-              targetAgentId,
-            }),
+            sessionKey: sessionKey.value,
             deliver: resolveHookDeliver(mapped.action.deliver),
             channel,
             to: mapped.action.to,

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -42,6 +42,18 @@ async function postHook(
   });
 }
 
+async function waitForSessionEvent(sessionKey: string, timeoutMs = 2000): Promise<string[]> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const events = peekSystemEvents(sessionKey);
+    if (events.length > 0) {
+      return events;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`timeout waiting for system event in ${sessionKey}`);
+}
+
 function setMainAndHooksAgents(): void {
   testState.agentsConfig = {
     list: [{ id: "main", default: true }, { id: "hooks" }],
@@ -243,6 +255,34 @@ describe("gateway server hooks", () => {
 
       const mappedBadPrefix = await postHook(port, "/hooks/mapped-bad", { subject: "hello" });
       expect(mappedBadPrefix.status).toBe(400);
+    });
+  });
+
+  test("posts hook summaries to the requested session key instead of main", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["agent:"],
+    };
+    setMainAndHooksAgents();
+
+    await withGatewayServer(async ({ port }) => {
+      const targetSessionKey = "agent:main:whatsapp:dm:+15550001111";
+      mockIsolatedRunOkOnce();
+
+      const resAgent = await postHook(port, "/hooks/agent", {
+        message: "Do it",
+        name: "Email",
+        sessionKey: targetSessionKey,
+      });
+      expect(resAgent.status).toBe(200);
+
+      const targetEvents = await waitForSessionEvent(targetSessionKey);
+      expect(targetEvents.some((e) => e.includes("Hook Email: done"))).toBe(true);
+      expect(peekSystemEvents(resolveMainKey()).length).toBe(0);
+
+      drainSystemEvents(targetSessionKey);
     });
   });
 

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -304,14 +304,18 @@ describe("gateway server hooks", () => {
         sessionKey: "agent:hooks:slack:channel:c123",
       });
       expect(resAgent.status).toBe(200);
-      await waitForSystemEvent();
+      const requestedSessionKey = "agent:hooks:slack:channel:c123";
+      const notifyEvents = await waitForSessionEvent(requestedSessionKey);
+      expect(notifyEvents.some((e) => e.includes("Hook Email: done"))).toBe(true);
 
       const routedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
         | { sessionKey?: string; job?: { agentId?: string } }
         | undefined;
       expect(routedCall?.job?.agentId).toBe("hooks");
       expect(routedCall?.sessionKey).toBe("slack:channel:c123");
-      drainSystemEvents(resolveMainKey());
+      expect(peekSystemEvents("slack:channel:c123")).toEqual([]);
+      expect(peekSystemEvents(resolveMainKey())).toEqual([]);
+      drainSystemEvents(requestedSessionKey);
     });
   });
 

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -319,6 +319,39 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("canonicalizes notify lane when request session key uses mixed-case agent prefix", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:", "agent:"],
+    };
+    setMainAndHooksAgents();
+    await withGatewayServer(async ({ port }) => {
+      mockIsolatedRunOkOnce();
+
+      const resAgent = await postHook(port, "/hooks/agent", {
+        message: "Do it",
+        name: "Email",
+        agentId: "hooks",
+        sessionKey: "agent:HOOKS:slack:channel:c123",
+      });
+      expect(resAgent.status).toBe(200);
+
+      const canonicalNotifyKey = "agent:hooks:slack:channel:c123";
+      const notifyEvents = await waitForSessionEvent(canonicalNotifyKey);
+      expect(notifyEvents.some((e) => e.includes("Hook Email: done"))).toBe(true);
+
+      const routedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
+        | { sessionKey?: string; job?: { agentId?: string } }
+        | undefined;
+      expect(routedCall?.job?.agentId).toBe("hooks");
+      expect(routedCall?.sessionKey).toBe("slack:channel:c123");
+      expect(peekSystemEvents("agent:HOOKS:slack:channel:c123")).toEqual([]);
+      drainSystemEvents(canonicalNotifyKey);
+    });
+  });
+
   test("enforces hooks.allowedAgentIds for explicit agent routing", async () => {
     testState.hooksConfig = {
       enabled: true,

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -352,6 +352,39 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("canonicalizes cross-agent notify lane when request session key uses mixed-case agent prefix", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:", "agent:"],
+    };
+    setMainAndHooksAgents();
+    await withGatewayServer(async ({ port }) => {
+      mockIsolatedRunOkOnce();
+
+      const resAgent = await postHook(port, "/hooks/agent", {
+        message: "Do it",
+        name: "Email",
+        agentId: "main",
+        sessionKey: "agent:HOOKS:slack:channel:c123",
+      });
+      expect(resAgent.status).toBe(200);
+
+      const canonicalNotifyKey = "agent:hooks:slack:channel:c123";
+      const notifyEvents = await waitForSessionEvent(canonicalNotifyKey);
+      expect(notifyEvents.some((e) => e.includes("Hook Email: done"))).toBe(true);
+
+      const routedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
+        | { sessionKey?: string; job?: { agentId?: string } }
+        | undefined;
+      expect(routedCall?.job?.agentId).toBe("main");
+      expect(routedCall?.sessionKey).toBe(canonicalNotifyKey);
+      expect(peekSystemEvents("agent:HOOKS:slack:channel:c123")).toEqual([]);
+      drainSystemEvents(canonicalNotifyKey);
+    });
+  });
+
   test("enforces hooks.allowedAgentIds for explicit agent routing", async () => {
     testState.hooksConfig = {
       enabled: true,

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -39,6 +39,7 @@ export function createGatewayHooksRequestHandler(params: {
       targetAgentId: value.agentId,
     });
     const mainSessionKey = resolveMainSessionKeyFromConfig();
+    const notifySessionKey = sessionKey || mainSessionKey;
     const jobId = randomUUID();
     const now = Date.now();
     const job: CronJob = {
@@ -75,14 +76,14 @@ export function createGatewayHooksRequestHandler(params: {
           job,
           message: value.message,
           sessionKey,
-          lane: "cron",
+          lane: "hook",
         });
         const summary = result.summary?.trim() || result.error?.trim() || result.status;
         const prefix =
           result.status === "ok" ? `Hook ${value.name}` : `Hook ${value.name} (${result.status})`;
         if (!result.delivered) {
           enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {
-            sessionKey: mainSessionKey,
+            sessionKey: notifySessionKey,
           });
           if (value.wakeMode === "now") {
             requestHeartbeatNow({ reason: `hook:${jobId}` });
@@ -91,7 +92,7 @@ export function createGatewayHooksRequestHandler(params: {
       } catch (err) {
         logHooks.warn(`hook agent failed: ${String(err)}`);
         enqueueSystemEvent(`Hook ${value.name} (error): ${String(err)}`, {
-          sessionKey: mainSessionKey,
+          sessionKey: notifySessionKey,
         });
         if (value.wakeMode === "now") {
           requestHeartbeatNow({ reason: `hook:${jobId}:error` });

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -7,6 +7,7 @@ import type { CronJob } from "../../cron/types.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import {
   normalizeHookDispatchSessionKey,
   type HookAgentDispatchPayload,
@@ -40,10 +41,20 @@ export function createGatewayHooksRequestHandler(params: {
       targetAgentId: value.agentId,
     });
     const mainSessionKey = resolveMainSessionKeyFromConfig();
-    const notifySessionKey =
-      requestedSessionKey && requestedSessionKey !== sessionKey
-        ? requestedSessionKey
-        : sessionKey || mainSessionKey;
+    let notifySessionKey = sessionKey || mainSessionKey;
+    if (requestedSessionKey && requestedSessionKey !== sessionKey) {
+      const parsedRequested = parseAgentSessionKey(requestedSessionKey);
+      const targetAgentId = value.agentId ? normalizeAgentId(value.agentId) : undefined;
+      if (
+        parsedRequested &&
+        targetAgentId &&
+        normalizeAgentId(parsedRequested.agentId) === targetAgentId
+      ) {
+        notifySessionKey = `agent:${targetAgentId}:${sessionKey}`;
+      } else {
+        notifySessionKey = requestedSessionKey;
+      }
+    }
     const jobId = randomUUID();
     const now = Date.now();
     const job: CronJob = {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -34,12 +34,16 @@ export function createGatewayHooksRequestHandler(params: {
   };
 
   const dispatchAgentHook = (value: HookAgentDispatchPayload) => {
+    const requestedSessionKey = value.sessionKey.trim();
     const sessionKey = normalizeHookDispatchSessionKey({
-      sessionKey: value.sessionKey,
+      sessionKey: requestedSessionKey,
       targetAgentId: value.agentId,
     });
     const mainSessionKey = resolveMainSessionKeyFromConfig();
-    const notifySessionKey = sessionKey || mainSessionKey;
+    const notifySessionKey =
+      requestedSessionKey && requestedSessionKey !== sessionKey
+        ? requestedSessionKey
+        : sessionKey || mainSessionKey;
     const jobId = randomUUID();
     const now = Date.now();
     const job: CronJob = {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -52,7 +52,7 @@ export function createGatewayHooksRequestHandler(params: {
       ) {
         notifySessionKey = `agent:${targetAgentId}:${sessionKey}`;
       } else {
-        notifySessionKey = requestedSessionKey;
+        notifySessionKey = sessionKey || mainSessionKey;
       }
     }
     const jobId = randomUUID();

--- a/src/i18n/registry.test.ts
+++ b/src/i18n/registry.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 import {
   DEFAULT_LOCALE,
   SUPPORTED_LOCALES,
   loadLazyLocaleTranslation,
   resolveNavigatorLocale,
 } from "../../ui/src/i18n/lib/registry.ts";
+import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 
 function getNestedTranslation(map: TranslationMap | null, ...path: string[]): string | undefined {
   let value: string | TranslationMap | undefined = map ?? undefined;


### PR DESCRIPTION
## Summary / What changed
- route `/hooks/agent` fallback summaries and errors to the resolved target session lane instead of leaking to unrelated lanes
- preserve requested lane when duplicate `agent:<id>:` prefixes are normalized for isolated dispatch
- canonicalize preserved `agent:` notify lanes so mixed-case inputs do not enqueue into undrainable queues
- add regression coverage for duplicate-prefix + mixed-case notify-lane paths in gateway hook tests

## Why
- fixes dropped or misrouted hook completion/error summaries in production when lane normalization and agent-prefixed session keys interact
- removes a class of silent delivery failures where events were enqueued under a lane key that later runs never drain

## Tests
- `pnpm exec vitest run --config vitest.config.ts src/gateway/server.hooks.test.ts -t "normalizes duplicate target-agent prefixes before isolated dispatch|canonicalizes notify lane when request session key uses mixed-case agent prefix" src/gateway/hooks.test.ts`
- `pnpm check`

## Real-world validation
- validated in local gateway flow with hook-lane scenarios (duplicate prefix + mixed-case session key) before opening this clean PR branch

## Issue
- Fixes #35083
- Supersedes #35082 (closed by cleanup bot due dirty branch state)
