### PR TITLE
fix(session): flush followup queue on /new and /reset commands

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1674,3 +1674,106 @@ describe("initSessionState internal channel routing preservation", () => {
     expect(result.sessionEntry.deliveryContext?.to).toBe("session:webchat-main");
   });
 });
+
+describe("initSessionState clears followup queue on /new", () => {
+  it("flushes pending followup queue when reset is triggered", async () => {
+    const { FOLLOWUP_QUEUES } = await import("./queue/state.js");
+    const storePath = await createStorePath("openclaw-new-clear-queue-");
+    const sessionKey = "agent:main:telegram:dm:queue-test";
+    const existingSessionId = "existing-session-queued";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: Date.now(),
+      },
+    });
+
+    FOLLOWUP_QUEUES.set(sessionKey, {
+      items: [{ prompt: "stale question", enqueuedAt: Date.now(), run: {} as never }],
+      draining: false,
+      lastEnqueuedAt: Date.now(),
+      mode: "collect",
+      debounceMs: 1000,
+      cap: 20,
+      dropPolicy: "summarize",
+      droppedCount: 0,
+      summaryLines: [],
+    });
+
+    expect(FOLLOWUP_QUEUES.has(sessionKey)).toBe(true);
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 999 },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "/new",
+        RawBody: "/new",
+        CommandBody: "/new",
+        From: "queue-test",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "telegram",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+    expect(FOLLOWUP_QUEUES.has(sessionKey)).toBe(false);
+  });
+
+  it("does not clear queue when session expires naturally (no reset trigger)", async () => {
+    const { FOLLOWUP_QUEUES } = await import("./queue/state.js");
+    const storePath = await createStorePath("openclaw-expire-keep-queue-");
+    const sessionKey = "agent:main:telegram:dm:expire-test";
+    const existingSessionId = "existing-session-expire";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: 0,
+      },
+    });
+
+    FOLLOWUP_QUEUES.set(sessionKey, {
+      items: [{ prompt: "pending question", enqueuedAt: Date.now(), run: {} as never }],
+      draining: false,
+      lastEnqueuedAt: Date.now(),
+      mode: "collect",
+      debounceMs: 1000,
+      cap: 20,
+      dropPolicy: "summarize",
+      droppedCount: 0,
+      summaryLines: [],
+    });
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 0 },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "hello",
+        RawBody: "hello",
+        From: "expire-test",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "telegram",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(false);
+    expect(FOLLOWUP_QUEUES.has(sessionKey)).toBe(true);
+
+    FOLLOWUP_QUEUES.delete(sessionKey);
+  });
+});

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -23,6 +23,7 @@ import {
   updateSessionStore,
 } from "../../config/sessions.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
+import { clearSessionQueues } from "./queue/cleanup.js";
 import { archiveSessionTranscripts } from "../../gateway/session-utils.fs.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -388,6 +389,9 @@ export async function initSessionState(params: {
     sessionEntry.inputTokens = undefined;
     sessionEntry.outputTokens = undefined;
     sessionEntry.contextTokens = undefined;
+    if (resetTriggered && sessionKey) {
+      clearSessionQueues([sessionKey, entry?.sessionId]);
+    }
   }
   // Preserve per-session overrides while resetting compaction state on /new.
   sessionStore[sessionKey] = { ...sessionStore[sessionKey], ...sessionEntry };


### PR DESCRIPTION
## Summary

- **Problem:** When `/new` or `/reset` is issued while the agent is busy processing, queued followup messages survive the session reset and are delivered as the first input to the fresh session. This makes the agent appear to hallucinate topics from the previous conversation.
- **Why it matters:** Users see stale messages from prior sessions injected into new sessions with no indication of their origin, causing confusion and wasted debugging time.
- **What changed:** Added `clearSessionQueues` call in `initSessionState` (channel-side session initialization) when a reset trigger (`/new`, `/reset`) fires. This matches the existing behavior in the gateway-side `sessions.reset` handler which already clears queues via `ensureSessionRuntimeCleanup`.
- **What did NOT change:** Queue behavior for non-reset session creation (idle expiry, freshness-based reset) is unchanged. The gateway-side `sessions.reset` path is untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35092

## User-visible / Behavior Changes

- `/new` and `/reset` commands now flush any pending queued messages before creating a new session, preventing stale message leakage across session boundaries.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Telegram, Discord, Slack, WhatsApp (all channel-side paths)

### Steps

1. Send a message to an agent while it is busy processing
2. Message gets queued (visible as `[Queued messages while agent was busy]`)
3. Send `/new` to reset the session
4. Observe whether the queued message leaks into the new session

### Expected

- Queued messages are discarded when `/new` fires

### Actual

- Before fix: Queued messages survive and are delivered to the new session
- After fix: Queued messages are flushed on `/new` or `/reset`

## Evidence

Test output (2 new tests added):
```
✓ initSessionState clears followup queue on /new > flushes pending followup queue when reset is triggered
✓ initSessionState clears followup queue on /new > does not clear queue when session expires naturally
```

## Human Verification (required)

- Verified scenarios: `/new` with pending queue items, idle expiry without queue clearing
- Edge cases checked: Queue keyed by sessionKey and sessionId both cleared; no clearing on non-reset new sessions
- What I did **not** verify: End-to-end with a live Telegram bot (verified via unit tests)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single `clearSessionQueues` call in `session.ts`
- Files/config to restore: `src/auto-reply/reply/session.ts`
- Known bad symptoms: If reverted, queued messages leak across sessions again

## Risks and Mitigations

- Risk: Users who intentionally want queued messages to carry over to a new session would lose them. Mitigation: This matches the documented behavior of `/stop` which also clears the queue, and the gateway-side reset already clears queues. The workaround of sending `/stop` before `/new` was the only way to achieve this before.
