### PR TITLE
fix: [Bug]: [node-llama-cpp] A prebuilt binary was not found, falling back to using no GPU (#35181)

### DIFF
--- a/package.json
+++ b/package.json
@@ -412,6 +412,11 @@
     "@napi-rs/canvas": "^0.1.89",
     "node-llama-cpp": "3.16.2"
   },
+  "peerDependenciesMeta": {
+    "node-llama-cpp": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=22.12.0"
   },

--- a/test/package-json.optional-peer.test.ts
+++ b/test/package-json.optional-peer.test.ts
@@ -1,0 +1,18 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+type RootPackageJson = {
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+};
+
+describe("package.json optional peer deps", () => {
+  it("marks node-llama-cpp as an optional peer dependency", () => {
+    const packageJsonPath = path.resolve(import.meta.dirname, "../package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as RootPackageJson;
+
+    expect(packageJson.peerDependencies?.["node-llama-cpp"]).toBeDefined();
+    expect(packageJson.peerDependenciesMeta?.["node-llama-cpp"]?.optional).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #35181

## Summary

- Problem: [Bug]: [node-llama-cpp] A prebuilt binary was not found, falling back to using no GPU
- Why it matters: Reported in #35181
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35181
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35181