### PR TITLE
fix(agents): recover tool name from toolCallId when model returns empty name

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 import {
+  extractToolNameFromCallId,
   isOllamaCompatProvider,
   resolveAttemptFsWorkspaceOnly,
   resolveOllamaBaseUrlForRun,
@@ -491,5 +492,151 @@ describe("decodeHtmlEntitiesInObject", () => {
   it("decodes numeric character references", () => {
     expect(decodeHtmlEntitiesInObject("&#39;hello&#39;")).toBe("'hello'");
     expect(decodeHtmlEntitiesInObject("&#x27;world&#x27;")).toBe("'world'");
+  });
+});
+
+describe("extractToolNameFromCallId", () => {
+  const tools = new Set(["read", "write", "exec", "browser", "image", "web_search"]);
+
+  it("extracts tool name from standard format: functions.read:0", () => {
+    expect(extractToolNameFromCallId("functions.read:0", tools)).toBe("read");
+  });
+
+  it("extracts tool name from standard format: functions.write:1", () => {
+    expect(extractToolNameFromCallId("functions.write:1", tools)).toBe("write");
+  });
+
+  it("extracts tool name from standard format: functions.exec:2", () => {
+    expect(extractToolNameFromCallId("functions.exec:2", tools)).toBe("exec");
+  });
+
+  it("extracts tool name from missing-colon format: functions.read1", () => {
+    expect(extractToolNameFromCallId("functions.read1", tools)).toBe("read");
+  });
+
+  it("extracts tool name from no-separator format: functionsread3", () => {
+    expect(extractToolNameFromCallId("functionsread3", tools)).toBe("read");
+  });
+
+  it("extracts tool name from no-separator format: functionswrite4", () => {
+    expect(extractToolNameFromCallId("functionswrite4", tools)).toBe("write");
+  });
+
+  it("extracts tool name from no-separator format: functionsexec5", () => {
+    expect(extractToolNameFromCallId("functionsexec5", tools)).toBe("exec");
+  });
+
+  it("prefers longer tool name matches over shorter ones", () => {
+    expect(extractToolNameFromCallId("functionsweb_search3", tools)).toBe("web_search");
+  });
+
+  it("returns null when no tool name matches", () => {
+    expect(extractToolNameFromCallId("functions.unknown:0", tools)).toBeNull();
+  });
+
+  it("returns null for empty toolCallId", () => {
+    expect(extractToolNameFromCallId("", tools)).toBeNull();
+  });
+
+  it("returns null for empty allowedToolNames", () => {
+    expect(extractToolNameFromCallId("functions.read:0", new Set())).toBeNull();
+  });
+
+  it("is case-insensitive for matching", () => {
+    expect(extractToolNameFromCallId("functions.READ:0", tools)).toBe("read");
+    expect(extractToolNameFromCallId("FUNCTIONS.Read:0", tools)).toBe("read");
+  });
+});
+
+describe("wrapStreamFnTrimToolCallNames - toolCallId name recovery", () => {
+  function createFakeStream(params: { events: unknown[]; resultMessage: unknown }): {
+    result: () => Promise<unknown>;
+    [Symbol.asyncIterator]: () => AsyncIterator<unknown>;
+  } {
+    return {
+      async result() {
+        return params.resultMessage;
+      },
+      [Symbol.asyncIterator]() {
+        return (async function* () {
+          for (const event of params.events) {
+            yield event;
+          }
+        })();
+      },
+    };
+  }
+
+  async function invokeWrappedStream(
+    baseFn: (...args: never[]) => unknown,
+    allowedToolNames?: Set<string>,
+  ) {
+    const wrappedFn = wrapStreamFnTrimToolCallNames(baseFn as never, allowedToolNames);
+    return await wrappedFn({} as never, {} as never, {} as never);
+  }
+
+  it("recovers tool name from toolCallId when name is empty", async () => {
+    const toolCall = { type: "toolCall", name: "", id: "functions.read:0" };
+    const finalMessage = { role: "assistant", content: [toolCall] };
+    const baseFn = vi.fn(() => createFakeStream({ events: [], resultMessage: finalMessage }));
+
+    const stream = await invokeWrappedStream(baseFn, new Set(["read", "write", "exec"]));
+    await stream.result();
+
+    expect(toolCall.name).toBe("read");
+  });
+
+  it("recovers tool name from toolCallId with missing colon", async () => {
+    const toolCall = { type: "toolCall", name: "", id: "functions.read1" };
+    const finalMessage = { role: "assistant", content: [toolCall] };
+    const baseFn = vi.fn(() => createFakeStream({ events: [], resultMessage: finalMessage }));
+
+    const stream = await invokeWrappedStream(baseFn, new Set(["read", "write", "exec"]));
+    await stream.result();
+
+    expect(toolCall.name).toBe("read");
+  });
+
+  it("recovers tool name from toolCallId with no separator", async () => {
+    const toolCall = { type: "toolCall", name: "", id: "functionswrite4" };
+    const finalMessage = { role: "assistant", content: [toolCall] };
+    const baseFn = vi.fn(() => createFakeStream({ events: [], resultMessage: finalMessage }));
+
+    const stream = await invokeWrappedStream(baseFn, new Set(["read", "write", "exec"]));
+    await stream.result();
+
+    expect(toolCall.name).toBe("write");
+  });
+
+  it("does not overwrite valid tool names with toolCallId extraction", async () => {
+    const toolCall = { type: "toolCall", name: "exec", id: "functions.read:0" };
+    const finalMessage = { role: "assistant", content: [toolCall] };
+    const baseFn = vi.fn(() => createFakeStream({ events: [], resultMessage: finalMessage }));
+
+    const stream = await invokeWrappedStream(baseFn, new Set(["read", "write", "exec"]));
+    await stream.result();
+
+    // Should keep the explicit name "exec", not overwrite with "read" from ID
+    expect(toolCall.name).toBe("exec");
+  });
+
+  it("recovers tool name from toolCallId in partial/message events during streaming", async () => {
+    const partialToolCall = { type: "toolCall", name: "", id: "functionsread3" };
+    const event = {
+      type: "toolcall_delta",
+      partial: { role: "assistant", content: [partialToolCall] },
+    };
+    const finalToolCall = { type: "toolCall", name: "", id: "functionswrite4" };
+    const finalMessage = { role: "assistant", content: [finalToolCall] };
+    const baseFn = vi.fn(() => createFakeStream({ events: [event], resultMessage: finalMessage }));
+
+    const stream = await invokeWrappedStream(baseFn, new Set(["read", "write", "exec"]));
+    for await (const _item of stream) {
+      // drain
+    }
+    await stream.result();
+
+    expect(partialToolCall.name).toBe("read");
+    expect(finalToolCall.name).toBe("write");
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -236,6 +236,58 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
     });
 }
 
+/**
+ * Extract a tool name from a tool call ID by matching against known tool names.
+ *
+ * Some providers (e.g. Kimi) encode the tool name inside the tool call ID with
+ * inconsistent formats:
+ *   - `functions.read:0`   (standard: dotSeparator + colonIndex)
+ *   - `functions.read1`    (missing colon)
+ *   - `functionsread3`     (no separator at all)
+ *
+ * We match against the known tool name set to find the longest tool name that
+ * appears inside the ID, preferring longer matches to avoid false positives
+ * (e.g. "exec" matching inside "functionse**exec**ute3").
+ */
+export function extractToolNameFromCallId(
+  toolCallId: string,
+  allowedToolNames: Set<string>,
+): string | null {
+  if (!toolCallId || allowedToolNames.size === 0) {
+    return null;
+  }
+  const lower = toolCallId.toLowerCase();
+
+  // Try the standard `functions.<name>:<index>` format first.
+  const dotPos = lower.indexOf(".");
+  if (dotPos >= 0) {
+    const afterDot = lower.slice(dotPos + 1);
+    // Strip trailing `:N` index or trailing digits
+    const colonPos = afterDot.indexOf(":");
+    const candidate = colonPos >= 0 ? afterDot.slice(0, colonPos) : afterDot.replace(/\d+$/, "");
+    if (candidate) {
+      for (const name of allowedToolNames) {
+        if (name.toLowerCase() === candidate) {
+          return name;
+        }
+      }
+    }
+  }
+
+  // Fallback: find the longest allowed tool name that appears as a substring
+  // of the lowered ID. Longer matches take priority to avoid false positives.
+  let bestMatch: string | null = null;
+  let bestLen = 0;
+  for (const name of allowedToolNames) {
+    const nameLower = name.toLowerCase();
+    if (nameLower.length > bestLen && lower.includes(nameLower)) {
+      bestMatch = name;
+      bestLen = nameLower.length;
+    }
+  }
+  return bestMatch;
+}
+
 function normalizeToolCallNameForDispatch(rawName: string, allowedToolNames?: Set<string>): string {
   const trimmed = rawName.trim();
   if (!trimmed) {
@@ -355,13 +407,37 @@ function trimWhitespaceFromToolCallNamesInMessage(
     if (!block || typeof block !== "object") {
       continue;
     }
-    const typedBlock = block as { type?: unknown; name?: unknown };
-    if (typedBlock.type !== "toolCall" || typeof typedBlock.name !== "string") {
+    const typedBlock = block as { type?: unknown; name?: unknown; id?: unknown };
+    if (typedBlock.type !== "toolCall") {
       continue;
     }
-    const normalized = normalizeToolCallNameForDispatch(typedBlock.name, allowedToolNames);
-    if (normalized !== typedBlock.name) {
-      typedBlock.name = normalized;
+
+    // When the model provides a valid name, normalize it as before.
+    if (typeof typedBlock.name === "string" && typedBlock.name.trim()) {
+      const normalized = normalizeToolCallNameForDispatch(typedBlock.name, allowedToolNames);
+      if (normalized !== typedBlock.name) {
+        typedBlock.name = normalized;
+      }
+      continue;
+    }
+
+    // Recovery: when the name is empty/missing, try to extract it from the
+    // toolCallId. Some providers (e.g. Kimi) encode the tool name inside the
+    // ID with inconsistent formats like `functions.read:0` or `functionsread3`.
+    if (allowedToolNames && allowedToolNames.size > 0 && typeof typedBlock.id === "string") {
+      const recovered = extractToolNameFromCallId(typedBlock.id, allowedToolNames);
+      if (recovered) {
+        typedBlock.name = recovered;
+        continue;
+      }
+    }
+
+    // Fallback: normalize whatever string value is there (may be empty).
+    if (typeof typedBlock.name === "string") {
+      const normalized = normalizeToolCallNameForDispatch(typedBlock.name, allowedToolNames);
+      if (normalized !== typedBlock.name) {
+        typedBlock.name = normalized;
+      }
     }
   }
   normalizeToolCallIdsInMessage(message);


### PR DESCRIPTION
## Summary

Fixes #34294

Some providers (e.g. Kimi) generate tool call responses where the `name` field is empty or missing, but the tool name is encoded inside the `toolCallId` with inconsistent formats:

- `functions.read:0` (standard format)
- `functions.read1` (missing colon separator)
- `functionsread3` (no separator at all)

This causes `Tool <name> not found` errors because the agent-core loop does exact name matching.

## Changes

- Added `extractToolNameFromCallId()` that parses tool names from various toolCallId formats by matching against known tool names, preferring longest matches to avoid false positives
- Modified `trimWhitespaceFromToolCallNamesInMessage()` to attempt name recovery from the toolCallId when the tool name is empty/missing
- Added comprehensive tests covering all toolCallId formats, case insensitivity, and streaming integration

## Test plan

- [x] All 44 existing + new tests pass in `attempt.test.ts`
- [x] Tests cover standard format (`functions.read:0`), missing-colon (`functions.read1`), no-separator (`functionsread3`), case insensitivity, longest-match preference, and streaming event recovery
- [x] Verified that valid tool names are never overwritten by toolCallId extraction