### PR TITLE
fix: [Bug]: Cron backup mechanism issue: jobs.json.bak is identical to jobs.json after modification (#35195)

### DIFF
--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -1,3 +1,4 @@
+import fsNode from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -73,6 +74,38 @@ describe("cron store", () => {
 
     await saveCronStore(store.storePath, first);
     await saveCronStore(store.storePath, second);
+
+    const currentRaw = await fs.readFile(store.storePath, "utf-8");
+    const backupRaw = await fs.readFile(`${store.storePath}.bak`, "utf-8");
+    expect(JSON.parse(currentRaw)).toEqual(second);
+    expect(JSON.parse(backupRaw)).toEqual(first);
+  });
+
+  it("writes backup from pre-save snapshot even if store file changes before replace", async () => {
+    const store = await makeStorePath();
+    const first = makeStore("job-1", true);
+    const second = makeStore("job-2", false);
+
+    await saveCronStore(store.storePath, first);
+
+    const originalWriteFile = fsNode.promises.writeFile.bind(fsNode.promises);
+    let injected = false;
+    const writeSpy = vi
+      .spyOn(fsNode.promises, "writeFile")
+      .mockImplementation(async (file, data, options) => {
+        await originalWriteFile(file, data, options);
+        if (!injected && typeof file === "string" && file.endsWith(".tmp")) {
+          injected = true;
+          // Simulate a concurrent overwrite before backup creation.
+          await originalWriteFile(store.storePath, JSON.stringify(second, null, 2), "utf-8");
+        }
+      });
+
+    try {
+      await saveCronStore(store.storePath, second);
+    } finally {
+      writeSpy.mockRestore();
+    }
 
     const currentRaw = await fs.readFile(store.storePath, "utf-8");
     const backupRaw = await fs.readFile(`${store.storePath}.bak`, "utf-8");

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -78,7 +78,7 @@ export async function saveCronStore(storePath: string, store: CronStoreFile) {
   await fs.promises.writeFile(tmp, json, "utf-8");
   if (previous !== null) {
     try {
-      await fs.promises.copyFile(storePath, `${storePath}.bak`);
+      await fs.promises.writeFile(`${storePath}.bak`, previous, "utf-8");
     } catch {
       // best-effort
     }


### PR DESCRIPTION
Closes #35195

## Summary

- Problem: [Bug]: Cron backup mechanism issue: jobs.json.bak is identical to jobs.json after modification
- Why it matters: Reported in #35195
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35195
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35195