### PR TITLE
fix(feishu): strip reaction suffix from message_id before API calls

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1338,6 +1338,12 @@ export async function handleFeishuMessage(params: {
     const messageCreateTimeMs = event.message.create_time
       ? parseInt(event.message.create_time, 10)
       : undefined;
+    // Strip synthetic reaction suffix (`:reaction:<emoji>:<uuid>`) from message
+    // IDs before using them in API calls. Reaction events generate synthetic IDs
+    // for dedup but the base ID is what Feishu's API expects.
+    const baseMessageId = ctx.messageId.includes(":reaction:")
+      ? ctx.messageId.slice(0, ctx.messageId.indexOf(":reaction:"))
+      : ctx.messageId;
     // Determine reply target based on group session mode:
     // - Topic-mode groups (group_topic / group_topic_sender): reply to the topic
     //   root so the bot stays in the same thread.
@@ -1354,7 +1360,7 @@ export async function handleFeishuMessage(params: {
       isGroup &&
       (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
     const replyTargetMessageId =
-      isTopicSession || configReplyInThread ? (ctx.rootId ?? ctx.messageId) : ctx.messageId;
+      isTopicSession || configReplyInThread ? (ctx.rootId ?? baseMessageId) : baseMessageId;
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
 
     if (broadcastAgents) {


### PR DESCRIPTION
## Summary

Fixes #34528

When a user reacts to a message in Feishu, the monitor creates a synthetic `message_id` with the format `om_xxx:reaction:THUMBSUP:uuid` for dedup purposes. This synthetic ID was being passed directly to Feishu API calls (e.g. `im.message.reply`), causing 400 errors because Feishu only accepts the base `om_xxx` format.

## Changes

- Strip the `:reaction:*` suffix from `ctx.messageId` before using it as `replyTargetMessageId` in `bot.ts`
- The full synthetic ID is preserved for internal tracking (`MessageSid`) and dedup purposes

## Test plan

- [x] Verified the synthetic ID format matches `monitor.account.ts:118` pattern
- [x] Confirmed `replyTargetMessageId` is the only API-facing use of `ctx.messageId`
- [x] The base message ID (`om_xxx`) is correctly extracted for API calls
- [x] Non-reaction messages are unaffected (no `:reaction:` in their IDs)