### PR TITLE
fix(cron): create backup before user edits, not during normalization

### DIFF
--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -543,7 +543,7 @@ export async function ensureLoaded(
   }
 
   if (mutated) {
-    await persist(state);
+    await persist(state, { skipBackup: true });
   }
 }
 
@@ -561,11 +561,11 @@ export function warnIfDisabled(state: CronServiceState, action: string) {
   );
 }
 
-export async function persist(state: CronServiceState) {
+export async function persist(state: CronServiceState, opts?: { skipBackup?: boolean }) {
   if (!state.store) {
     return;
   }
-  await saveCronStore(state.deps.storePath, state.store);
+  await saveCronStore(state.deps.storePath, state.store, opts);
   // Update file mtime after save to prevent immediate reload
   state.storeFileMtimeMs = await getFileMtimeMs(state.deps.storePath);
 }

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -52,7 +52,11 @@ export async function loadCronStore(storePath: string): Promise<CronStoreFile> {
   }
 }
 
-export async function saveCronStore(storePath: string, store: CronStoreFile) {
+export async function saveCronStore(
+  storePath: string,
+  store: CronStoreFile,
+  opts?: { skipBackup?: boolean },
+) {
   await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
   const json = JSON.stringify(store, null, 2);
   const cached = serializedStoreCache.get(storePath);
@@ -76,7 +80,7 @@ export async function saveCronStore(storePath: string, store: CronStoreFile) {
   }
   const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
   await fs.promises.writeFile(tmp, json, "utf-8");
-  if (previous !== null) {
+  if (previous !== null && !opts?.skipBackup) {
     try {
       await fs.promises.copyFile(storePath, `${storePath}.bak`);
     } catch {


### PR DESCRIPTION
## Summary

- **Problem:** The cron store backup file (`jobs.json.bak`) becomes identical to `jobs.json` after editing a job, because `saveCronStore` creates a backup on every write — including the normalization pass in `ensureLoaded`. When the actual user edit triggers a second save, the `.bak` already reflects the normalized state, not the pre-edit original.
- **Why it matters:** Users rely on `.bak` to recover their previous job definitions. If the backup is identical to the current file, there is nothing to recover from.
- **What changed:** Added an optional `skipBackup` parameter to `saveCronStore` (in `src/cron/store.ts`) and threaded it through the `persist` helper (in `src/cron/service/store.ts`). The `ensureLoaded` normalization now calls `persist(state, { skipBackup: true })` so the backup is only created on actual user-initiated mutations.
- **What did NOT change:** The backup behavior for user-initiated edits, creates, and deletes is unchanged. The normalization logic itself is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #35195

## User-visible / Behavior Changes

- `jobs.json.bak` now preserves the state of `jobs.json` from before the last user edit, not from before normalization. This is the expected behavior for a rollback/recovery file.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 20+
- Integration/channel: N/A (cron subsystem)

### Steps

1. Have a `jobs.json` with at least one job
2. Restart the gateway (triggers `ensureLoaded` → normalization → backup → save)
3. Edit a job via the API
4. Compare `jobs.json` and `jobs.json.bak`

### Expected

- `jobs.json.bak` should contain the job definitions from before the edit

### Actual

- Before fix: `jobs.json.bak` is identical to `jobs.json` (captured normalization, not pre-edit state)
- After fix: `jobs.json.bak` correctly reflects the pre-edit state

## Evidence

```typescript
// src/cron/store.ts — saveCronStore now accepts skipBackup
export async function saveCronStore(
  storePath: string,
  store: CronStoreFile,
  opts?: { skipBackup?: boolean },
) {
  // ...
  if (previous !== null && !opts?.skipBackup) {
    try {
      await fs.promises.copyFile(storePath, `${storePath}.bak`);
    } catch { /* best-effort */ }
  }
  // ...
}

// src/cron/service/store.ts — ensureLoaded skips backup during normalization
if (mutated) {
  await persist(state, { skipBackup: true });
}
```

All existing cron tests pass:
- `src/cron/store.test.ts` ✓
- `src/cron/service.jobs.test.ts` ✓
- `src/cron/service.store.migration.test.ts` ✓
- `src/cron/normalize.test.ts` ✓
- `src/gateway/server.cron.test.ts` ✓

## Human Verification (required)

- Verified scenarios: normalization-only save skips backup; user-edit save creates backup
- Edge cases checked: first-ever save (no previous file) still skips backup correctly; multiple normalizations don't create spurious backups
- What I did **not** verify: end-to-end with a live gateway instance

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the two changed files; backup behavior returns to always-create
- Files/config to restore: `src/cron/store.ts`, `src/cron/service/store.ts`
- Known bad symptoms: If `skipBackup` is accidentally passed for user edits, backups would stop being created

## Risks and Mitigations

- **Risk:** A future caller of `persist` might forget to omit `skipBackup` for user mutations. **Mitigation:** The default is `false` (always create backup), so only explicit opt-in skips it. The only place that passes `skipBackup: true` is the normalization path in `ensureLoaded`.
