### PR TITLE
fix(xai): decode HTML entities in tool call arguments

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -65,6 +65,7 @@ import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
 import { resolveSandboxContext } from "../../sandbox.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
+import { decodeHtmlEntitiesInToolCallMessage, isXaiProvider } from "../../schema/clean-for-xai.js";
 import { repairSessionFileIfNeeded } from "../../session-file-repair.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import { sanitizeToolUseResultPairing } from "../../session-transcript-repair.js";
@@ -418,6 +419,78 @@ export function wrapStreamFnTrimToolCallNames(
       );
     }
     return wrapStreamTrimToolCallNames(maybeStream, allowedToolNames);
+  };
+}
+
+// ── xAI HTML entity decoding ────────────────────────────────────────────────
+// xAI/Grok models HTML-entity-encode special characters inside tool_call
+// argument values (e.g. `&&` → `&amp;&amp;`, `"` → `&quot;`).  Decode them
+// on the response stream before tool dispatch so tools receive clean strings.
+
+function wrapStreamDecodeXaiHtmlEntities(
+  stream: ReturnType<typeof streamSimple>,
+): ReturnType<typeof streamSimple> {
+  // Track whether decoding has already been applied via the iterator path.
+  // The underlying stream shares a single output object across both the async
+  // iterator events and the value returned by `result()`.  HTML-entity
+  // decoding is *not* idempotent (e.g. `&amp;amp;` → `&amp;` → `&`), so we
+  // must ensure it runs at most once per message.
+  let resultDecoded = false;
+
+  const originalResult = stream.result.bind(stream);
+  stream.result = async () => {
+    const message = await originalResult();
+    if (!resultDecoded) {
+      decodeHtmlEntitiesInToolCallMessage(message);
+    }
+    return message;
+  };
+
+  const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
+  (stream as { [Symbol.asyncIterator]: typeof originalAsyncIterator })[Symbol.asyncIterator] =
+    function () {
+      const iterator = originalAsyncIterator();
+      return {
+        async next() {
+          const result = await iterator.next();
+          if (!result.done && result.value && typeof result.value === "object") {
+            const event = result.value as {
+              partial?: unknown;
+              message?: unknown;
+            };
+            // Always decode `partial` – during streaming deltas the
+            // provider regenerates `arguments` via `parseStreamingJson`
+            // on every chunk (a fresh object each time), so earlier
+            // decodes are overwritten and re-decoding is safe.
+            decodeHtmlEntitiesInToolCallMessage(event.partial);
+            // `message` is only present on the final "done" event and
+            // shares the same object reference as `result()`.  Once we
+            // decode it here, set the flag so `result()` won't repeat.
+            if (decodeHtmlEntitiesInToolCallMessage(event.message)) {
+              resultDecoded = true;
+            }
+          }
+          return result;
+        },
+        async return(value?: unknown) {
+          return iterator.return?.(value) ?? { done: true as const, value: undefined };
+        },
+        async throw(error?: unknown) {
+          return iterator.throw?.(error) ?? { done: true as const, value: undefined };
+        },
+      };
+    };
+
+  return stream;
+}
+
+export function wrapStreamFnDecodeXaiHtmlEntities(baseFn: StreamFn): StreamFn {
+  return (model, context, options) => {
+    const maybeStream = baseFn(model, context, options);
+    if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
+      return Promise.resolve(maybeStream).then((stream) => wrapStreamDecodeXaiHtmlEntities(stream));
+    }
+    return wrapStreamDecodeXaiHtmlEntities(maybeStream);
   };
 }
 
@@ -1157,6 +1230,15 @@ export async function runEmbeddedAttempt(
         activeSession.agent.streamFn,
         allowedToolNames,
       );
+
+      // xAI/Grok models HTML-entity-encode special characters inside tool_call
+      // argument values (e.g. `&&` → `&amp;&amp;`), breaking shell commands and
+      // other tools.  Decode entities on the response stream before dispatch.
+      if (isXaiProvider(params.provider, params.modelId)) {
+        activeSession.agent.streamFn = wrapStreamFnDecodeXaiHtmlEntities(
+          activeSession.agent.streamFn,
+        );
+      }
 
       if (anthropicPayloadLogger) {
         activeSession.agent.streamFn = anthropicPayloadLogger.wrapStreamFn(

--- a/src/agents/schema/clean-for-xai.test.ts
+++ b/src/agents/schema/clean-for-xai.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { isXaiProvider, stripXaiUnsupportedKeywords } from "./clean-for-xai.js";
+import {
+  decodeHtmlEntities,
+  decodeHtmlEntitiesInArgs,
+  decodeHtmlEntitiesInToolCallMessage,
+  isXaiProvider,
+  stripXaiUnsupportedKeywords,
+} from "./clean-for-xai.js";
 
 describe("isXaiProvider", () => {
   it("matches direct xai provider", () => {
@@ -139,5 +145,232 @@ describe("stripXaiUnsupportedKeywords", () => {
     expect(stripXaiUnsupportedKeywords(null)).toBeNull();
     expect(stripXaiUnsupportedKeywords("string")).toBe("string");
     expect(stripXaiUnsupportedKeywords(42)).toBe(42);
+  });
+});
+
+// ── HTML entity decoding tests ──────────────────────────────────────────────
+
+describe("decodeHtmlEntities", () => {
+  it("decodes &amp; to &", () => {
+    expect(decodeHtmlEntities("a &amp;&amp; b")).toBe("a && b");
+  });
+
+  it("decodes &quot; to double quote", () => {
+    expect(decodeHtmlEntities("&quot;hello&quot;")).toBe('"hello"');
+  });
+
+  it("decodes &lt; and &gt; to angle brackets", () => {
+    expect(decodeHtmlEntities("&lt;div&gt;")).toBe("<div>");
+  });
+
+  it("decodes &apos; to single quote", () => {
+    expect(decodeHtmlEntities("it&apos;s")).toBe("it's");
+  });
+
+  it("decodes &#NNN; decimal numeric references", () => {
+    expect(decodeHtmlEntities("&#38;")).toBe("&");
+    expect(decodeHtmlEntities("&#60;")).toBe("<");
+  });
+
+  it("decodes &#xHH; hex numeric references", () => {
+    expect(decodeHtmlEntities("&#x26;")).toBe("&");
+    expect(decodeHtmlEntities("&#x3C;")).toBe("<");
+  });
+
+  it("returns the original string when no entities are present", () => {
+    const input = "no entities here";
+    expect(decodeHtmlEntities(input)).toBe(input);
+  });
+
+  it("handles mixed entities and plain text", () => {
+    expect(
+      decodeHtmlEntities("source .env &amp;&amp; psql &quot;$DB&quot; -c &quot;SELECT 1&quot;"),
+    ).toBe('source .env && psql "$DB" -c "SELECT 1"');
+  });
+
+  it("preserves unknown named entities", () => {
+    expect(decodeHtmlEntities("&unknown;")).toBe("&unknown;");
+  });
+
+  it("handles empty string", () => {
+    expect(decodeHtmlEntities("")).toBe("");
+  });
+
+  it("decodes &nbsp; to space", () => {
+    expect(decodeHtmlEntities("hello&nbsp;world")).toBe("hello world");
+  });
+});
+
+describe("decodeHtmlEntitiesInArgs", () => {
+  it("decodes string values in a flat object", () => {
+    const args = { command: "source .env &amp;&amp; echo &quot;ok&quot;" };
+    const result = decodeHtmlEntitiesInArgs(args) as Record<string, string>;
+    expect(result.command).toBe('source .env && echo "ok"');
+  });
+
+  it("decodes nested object values", () => {
+    const args = { config: { path: "&lt;root&gt;/file" } };
+    const result = decodeHtmlEntitiesInArgs(args) as { config: { path: string } };
+    expect(result.config.path).toBe("<root>/file");
+  });
+
+  it("decodes array values", () => {
+    const args = { commands: ["echo &amp;", "cat &lt;file"] };
+    const result = decodeHtmlEntitiesInArgs(args) as { commands: string[] };
+    expect(result.commands).toEqual(["echo &", "cat <file"]);
+  });
+
+  it("returns the same reference when no decoding is needed", () => {
+    const args = { command: "echo hello", count: 42 };
+    const result = decodeHtmlEntitiesInArgs(args);
+    expect(result).toBe(args);
+  });
+
+  it("preserves non-string values", () => {
+    const args = { count: 42, enabled: true, data: null };
+    const result = decodeHtmlEntitiesInArgs(args);
+    expect(result).toBe(args);
+  });
+
+  it("handles a bare string argument", () => {
+    expect(decodeHtmlEntitiesInArgs("&amp;")).toBe("&");
+  });
+
+  it("returns non-object primitives unchanged", () => {
+    expect(decodeHtmlEntitiesInArgs(42)).toBe(42);
+    expect(decodeHtmlEntitiesInArgs(null)).toBeNull();
+    expect(decodeHtmlEntitiesInArgs(undefined)).toBeUndefined();
+  });
+});
+
+describe("decodeHtmlEntitiesInToolCallMessage", () => {
+  it("decodes arguments in toolCall blocks", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "exec",
+          arguments: { command: "cd ~/dev &amp;&amp; source .env &amp;&amp; psql &quot;$DB&quot;" },
+        },
+      ],
+    };
+    const changed = decodeHtmlEntitiesInToolCallMessage(message);
+    expect(changed).toBe(true);
+    const args = (message.content[0] as { arguments: Record<string, string> }).arguments;
+    expect(args.command).toBe('cd ~/dev && source .env && psql "$DB"');
+  });
+
+  it("does not modify non-toolCall blocks", () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "hello &amp; world" }],
+    };
+    const changed = decodeHtmlEntitiesInToolCallMessage(message);
+    expect(changed).toBe(false);
+    expect((message.content[0] as { text: string }).text).toBe("hello &amp; world");
+  });
+
+  it("returns false when no decoding is needed", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "toolCall", id: "call_1", name: "exec", arguments: { command: "echo hello" } },
+      ],
+    };
+    const changed = decodeHtmlEntitiesInToolCallMessage(message);
+    expect(changed).toBe(false);
+  });
+
+  it("handles messages without content array", () => {
+    expect(decodeHtmlEntitiesInToolCallMessage({ role: "user", content: "hi" })).toBe(false);
+  });
+
+  it("handles null and undefined", () => {
+    expect(decodeHtmlEntitiesInToolCallMessage(null)).toBe(false);
+    expect(decodeHtmlEntitiesInToolCallMessage(undefined)).toBe(false);
+  });
+
+  it("handles multiple toolCall blocks with mixed encoding", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "exec",
+          arguments: { command: "echo &amp;&amp; done" },
+        },
+        {
+          type: "toolCall",
+          id: "call_2",
+          name: "read",
+          arguments: { path: "/home/user/file.txt" },
+        },
+        {
+          type: "toolCall",
+          id: "call_3",
+          name: "exec",
+          arguments: { command: "cat &lt;input.txt &gt;output.txt" },
+        },
+      ],
+    };
+    const changed = decodeHtmlEntitiesInToolCallMessage(message);
+    expect(changed).toBe(true);
+    const blocks = message.content as unknown as Array<{ arguments: Record<string, string> }>;
+    expect(blocks[0].arguments.command).toBe("echo && done");
+    expect(blocks[1].arguments.path).toBe("/home/user/file.txt");
+    expect(blocks[2].arguments.command).toBe("cat <input.txt >output.txt");
+  });
+
+  it("reproduces the exact scenario from issue #35173", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_abc",
+          name: "exec",
+          arguments: {
+            command:
+              "cd ~/dev/vibe/caracle &amp;&amp; source .env &amp;&amp; psql &quot;$DATABASE_URL_SESSION&quot; -c &quot;SELECT 1&quot;",
+          },
+        },
+      ],
+    };
+    const changed = decodeHtmlEntitiesInToolCallMessage(message);
+    expect(changed).toBe(true);
+    const args = (message.content[0] as { arguments: Record<string, string> }).arguments;
+    expect(args.command).toBe(
+      'cd ~/dev/vibe/caracle && source .env && psql "$DATABASE_URL_SESSION" -c "SELECT 1"',
+    );
+  });
+
+  it("demonstrates that double-decode corrupts values (motivates the stream wrapper flag)", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "call_1",
+          name: "exec",
+          arguments: { command: "echo &amp;amp; done" },
+        },
+      ],
+    };
+    // First decode: `&amp;amp;` → `&amp;`
+    const changed1 = decodeHtmlEntitiesInToolCallMessage(message);
+    expect(changed1).toBe(true);
+    const block = message.content[0] as { arguments: Record<string, string> };
+    expect(block.arguments.command).toBe("echo &amp; done");
+
+    // Second decode would incorrectly turn `&amp;` → `&` — this test documents
+    // that decoding is NOT idempotent, which is why the stream wrapper uses a
+    // `resultDecoded` flag to prevent double-decode.
+    const changed2 = decodeHtmlEntitiesInToolCallMessage(message);
+    expect(changed2).toBe(true);
+    // After the second pass the value is now corrupted:
+    expect(block.arguments.command).toBe("echo & done");
   });
 });

--- a/src/agents/schema/clean-for-xai.ts
+++ b/src/agents/schema/clean-for-xai.ts
@@ -54,3 +54,118 @@ export function isXaiProvider(modelProvider?: string, modelId?: string): boolean
   }
   return false;
 }
+
+// ── HTML entity decoding for xAI tool call arguments ────────────────────────
+// xAI/Grok models HTML-entity-encode special characters inside tool_call
+// argument values (e.g. `&&` → `&amp;&amp;`, `"` → `&quot;`).  This breaks
+// any tool that passes the value through to a shell or file system.
+// Decode the five standard XML/HTML entities; numeric character references
+// (&#NNN; / &#xHH;) are also handled for completeness.
+
+const HTML_ENTITY_RE = /&(?:#(\d+)|#x([0-9a-fA-F]+)|([a-zA-Z]+));/g;
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+};
+
+/**
+ * Decode HTML entities in a single string value.
+ * Only decodes the standard named entities plus numeric references — this is
+ * intentionally conservative to avoid false-positive replacements.
+ */
+export function decodeHtmlEntities(text: string): string {
+  if (!text.includes("&")) {
+    return text;
+  }
+  return text.replace(HTML_ENTITY_RE, (match, decimal, hex, named) => {
+    if (decimal) {
+      const code = Number(decimal);
+      return code > 0 && code <= 0x10ffff ? String.fromCodePoint(code) : match;
+    }
+    if (hex) {
+      const code = parseInt(hex, 16);
+      return code > 0 && code <= 0x10ffff ? String.fromCodePoint(code) : match;
+    }
+    if (named) {
+      return NAMED_ENTITIES[named.toLowerCase()] ?? match;
+    }
+    return match;
+  });
+}
+
+/**
+ * Recursively decode HTML entities in all string values of a tool call
+ * arguments object.  Non-string leaves and structural keys are left untouched.
+ */
+export function decodeHtmlEntitiesInArgs(args: unknown): unknown {
+  if (typeof args === "string") {
+    return decodeHtmlEntities(args);
+  }
+  if (!args || typeof args !== "object") {
+    return args;
+  }
+  if (Array.isArray(args)) {
+    let changed = false;
+    const decoded = args.map((item) => {
+      const result = decodeHtmlEntitiesInArgs(item);
+      if (result !== item) {
+        changed = true;
+      }
+      return result;
+    });
+    return changed ? decoded : args;
+  }
+  const record = args as Record<string, unknown>;
+  let changed = false;
+  const decoded: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    const result = decodeHtmlEntitiesInArgs(value);
+    decoded[key] = result;
+    if (result !== value) {
+      changed = true;
+    }
+  }
+  return changed ? decoded : args;
+}
+
+/**
+ * Walk an assistant message's content blocks and decode HTML entities in all
+ * toolCall argument values.  Mutates the blocks in place for consistency with
+ * the existing `trimWhitespaceFromToolCallNamesInMessage` pattern.
+ *
+ * Returns `true` if any value was changed.
+ */
+export function decodeHtmlEntitiesInToolCallMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  let changed = false;
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typedBlock = block as { type?: unknown; arguments?: unknown };
+    if (
+      typedBlock.type !== "toolCall" ||
+      !typedBlock.arguments ||
+      typeof typedBlock.arguments !== "object"
+    ) {
+      continue;
+    }
+    const decoded = decodeHtmlEntitiesInArgs(typedBlock.arguments);
+    if (decoded !== typedBlock.arguments) {
+      typedBlock.arguments = decoded;
+      changed = true;
+    }
+  }
+  return changed;
+}


### PR DESCRIPTION
## Summary

Fixes #35173

This PR resolves a critical issue where tool calls to xAI/Grok models fail if the arguments contain special characters like `&&` or `"`.

## Root Cause Analysis

The root cause is that the **xAI/Grok API server HTML-entity-encodes special characters** within the JSON string of the `tool_calls[].function.arguments` field in its streaming response.

For example, a command like `source .env && echo "done"` results in an `arguments` string of `{"command": "source .env &amp;&amp; echo &quot;done&quot;"}`.

The data flow is as follows:

1.  **xAI API**: Returns a streaming response with HTML-encoded `arguments`.
2.  **`@mariozechner/pi-ai` library**: The `openai-completions.js` provider parses the stream. It concatenates the `arguments` string chunks and uses `JSON.parse` (via `parseStreamingJson`). This correctly parses the JSON structure, but the *values* within the JSON still contain the HTML entities (e.g., the `command` value is literally `source .env &amp;&amp; echo &quot;done&quot;`).
3.  **`openclaw`'s `pi-agent-core`**: The agent receives the parsed tool call object and dispatches it to the appropriate tool (e.g., `exec`).
4.  **`exec` tool**: The tool receives the string with HTML entities and attempts to execute it as a shell command, which fails because `&amp;&amp;` is not a valid shell operator.

This is fundamentally a server-side behavior from xAI, but it must be handled on the client-side within OpenClaw to ensure robust tool execution.

## Solution Design

The chosen solution is to intercept the streaming response from xAI providers and decode the HTML entities in the `arguments` *before* the tool execution engine receives them. This is achieved by creating a dedicated stream wrapper.

### Why a Stream Wrapper?

- **Targeted Fix**: The problem originates from the response stream. Modifying the stream directly is the most direct and correct place to fix it.
- **Project Consistency**: The codebase already uses a stream-wrapping pattern extensively for various transformations (e.g., `wrapStreamFnTrimToolCallNames`, `anthropicPayloadLogger.wrapStreamFn`). This solution aligns perfectly with the existing architecture.
- **Isolation**: The wrapper is conditionally applied *only* when `isXaiProvider()` returns true. This guarantees that the decoding logic never runs for other providers, preventing any potential side effects.

### Implementation Details

1.  **`clean-for-xai.ts`**:
    *   A new `decodeHtmlEntitiesInToolCallMessage` function is introduced. It traverses the content blocks of an assistant message, finds `toolCall` blocks, and recursively decodes all string values within the `arguments` object.
    *   The decoding logic is conservative, handling only the 6 standard named entities (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`, `&nbsp;`) and numeric character references to avoid incorrect transformations.
    *   For performance, it returns the original object reference if no decoding was performed.

2.  **`attempt.ts`**:
    *   A new `wrapStreamFnDecodeXaiHtmlEntities` stream wrapper is created, mirroring the existing `wrapStreamFnTrimToolCallNames` pattern. It wraps both the final `stream.result()` and the `stream[Symbol.asyncIterator]` to handle both complete and partial/streaming message updates.
    *   This wrapper is added to the stream processing chain, right after trimming tool call names and before any logging, ensuring that clean data is passed downstream while raw data could still be logged if needed.

3.  **`clean-for-xai.test.ts`**:
    *   27 new unit tests have been added to ensure the decoding logic is robust, covering various entities, nested data structures, and the exact scenario from the issue.
