### PR TITLE
fix(plugins): cache missing channel registry lookups with bounded size

### DIFF
--- a/src/channels/plugins/registry-loader.test.ts
+++ b/src/channels/plugins/registry-loader.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createMSTeamsTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import {
+  __getChannelRegistryCacheMaxForTest,
+  createChannelRegistryLoader,
+} from "./registry-loader.js";
+import type { ChannelId } from "./types.js";
+
+describe("createChannelRegistryLoader", () => {
+  const emptyRegistry = createTestRegistry([]);
+
+  beforeEach(() => {
+    setActivePluginRegistry(emptyRegistry);
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(emptyRegistry);
+  });
+
+  it("caches missing and undefined-resolved entries", async () => {
+    const registry = createTestRegistry([
+      {
+        pluginId: "msteams",
+        plugin: createMSTeamsTestPlugin(),
+        source: "test",
+      },
+    ]);
+    setActivePluginRegistry(registry);
+
+    const findSpy = vi.spyOn(registry.channels, "find");
+    const loadOutbound = createChannelRegistryLoader((entry) => entry.plugin.outbound);
+
+    await loadOutbound("unknown" as ChannelId);
+    await loadOutbound("unknown" as ChannelId);
+    await loadOutbound("msteams");
+    await loadOutbound("msteams");
+
+    expect(findSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds miss-cache growth and evicts oldest ids", async () => {
+    const registry = createTestRegistry([]);
+    setActivePluginRegistry(registry);
+
+    const findSpy = vi.spyOn(registry.channels, "find");
+    const loadPlugin = createChannelRegistryLoader((entry) => entry.plugin);
+    const max = __getChannelRegistryCacheMaxForTest();
+
+    await loadPlugin("missing-0" as ChannelId);
+    await loadPlugin("missing-0" as ChannelId);
+    for (let i = 1; i <= max; i += 1) {
+      await loadPlugin(`missing-${i}` as ChannelId);
+    }
+    await loadPlugin("missing-0" as ChannelId);
+
+    expect(findSpy).toHaveBeenCalledTimes(max + 2);
+  });
+});

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -6,10 +6,31 @@ type ChannelRegistryValueResolver<TValue> = (
   entry: PluginChannelRegistration,
 ) => TValue | undefined;
 
+const CHANNEL_REGISTRY_CACHE_MAX = 128;
+const CHANNEL_REGISTRY_MISS = Symbol("channel-registry-miss");
+
+function setCacheValue<TValue>(
+  cache: Map<ChannelId, TValue | typeof CHANNEL_REGISTRY_MISS>,
+  id: ChannelId,
+  value: TValue | typeof CHANNEL_REGISTRY_MISS,
+): void {
+  if (cache.has(id)) {
+    cache.set(id, value);
+    return;
+  }
+  if (cache.size >= CHANNEL_REGISTRY_CACHE_MAX) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) {
+      cache.delete(oldest);
+    }
+  }
+  cache.set(id, value);
+}
+
 export function createChannelRegistryLoader<TValue>(
   resolveValue: ChannelRegistryValueResolver<TValue>,
 ): (id: ChannelId) => Promise<TValue | undefined> {
-  const cache = new Map<ChannelId, TValue>();
+  const cache = new Map<ChannelId, TValue | typeof CHANNEL_REGISTRY_MISS>();
   let lastRegistry: PluginRegistry | null = null;
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
@@ -18,18 +39,18 @@ export function createChannelRegistryLoader<TValue>(
       cache.clear();
       lastRegistry = registry;
     }
-    const cached = cache.get(id);
-    if (cached) {
-      return cached;
+    if (cache.has(id)) {
+      const cached = cache.get(id);
+      return cached === CHANNEL_REGISTRY_MISS ? undefined : cached;
     }
+
     const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
-    if (!pluginEntry) {
-      return undefined;
-    }
-    const resolved = resolveValue(pluginEntry);
-    if (resolved) {
-      cache.set(id, resolved);
-    }
+    const resolved = pluginEntry ? resolveValue(pluginEntry) : undefined;
+    setCacheValue(cache, id, resolved === undefined ? CHANNEL_REGISTRY_MISS : resolved);
     return resolved;
   };
+}
+
+export function __getChannelRegistryCacheMaxForTest(): number {
+  return CHANNEL_REGISTRY_CACHE_MAX;
 }


### PR DESCRIPTION
## Summary
- cache missing channel registry lookups and undefined-resolved entries via an explicit miss sentinel
- bound the channel registry loader cache to 128 entries with FIFO eviction
- add unit tests covering miss/undefined caching and cache-size eviction behavior

## Why
`createChannelRegistryLoader` previously only cached truthy values. Repeated lookups for unknown channel ids (or entries resolving to `undefined`, such as no outbound adapter) repeatedly scanned `registry.channels`. This adds avoidable linear work on hot paths.

## Risk
Low. Change is localized to loader internals and covered by new targeted tests plus existing plugin core tests.

## Testing
- `pnpm vitest run src/channels/plugins/registry-loader.test.ts src/channels/plugins/plugins-core.test.ts`
