### PR TITLE
fix: [Bug]: feishu配置长链接失败 (#35202)

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -133,4 +133,24 @@ describe("createFeishuWSClient proxy handling", () => {
     const options = firstWsClientOptions();
     expect(options.agent).toEqual({ proxyUrl: "http://upper-http:8999" });
   });
+
+  it("ignores non-http proxy protocols to avoid invalid ws proxy handshakes", () => {
+    process.env.HTTPS_PROXY = "ws://127.0.0.1:18789/ws";
+
+    createFeishuWSClient(baseAccount);
+
+    expect(httpsProxyAgentCtorMock).not.toHaveBeenCalled();
+    const options = firstWsClientOptions();
+    expect(options?.agent).toBeUndefined();
+  });
+
+  it("ignores malformed proxy values", () => {
+    process.env.HTTPS_PROXY = "://not-a-url";
+
+    createFeishuWSClient(baseAccount);
+
+    expect(httpsProxyAgentCtorMock).not.toHaveBeenCalled();
+    const options = firstWsClientOptions();
+    expect(options?.agent).toBeUndefined();
+  });
 });

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -2,12 +2,31 @@ import * as Lark from "@larksuiteoapi/node-sdk";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import type { FeishuDomain, ResolvedFeishuAccount } from "./types.js";
 
+const SUPPORTED_WS_PROXY_PROTOCOLS = new Set(["http:", "https:"]);
+
+function parseHttpProxyUrl(raw: string | undefined): string | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    if (!SUPPORTED_WS_PROXY_PROTOCOLS.has(parsed.protocol)) {
+      return undefined;
+    }
+    return trimmed;
+  } catch {
+    return undefined;
+  }
+}
+
 function getWsProxyAgent(): HttpsProxyAgent<string> | undefined {
-  const proxyUrl =
+  const proxyUrl = parseHttpProxyUrl(
     process.env.https_proxy ||
-    process.env.HTTPS_PROXY ||
-    process.env.http_proxy ||
-    process.env.HTTP_PROXY;
+      process.env.HTTPS_PROXY ||
+      process.env.http_proxy ||
+      process.env.HTTP_PROXY,
+  );
   if (!proxyUrl) return undefined;
   return new HttpsProxyAgent(proxyUrl);
 }


### PR DESCRIPTION
Closes #35202

## Summary

- Problem: [Bug]: feishu配置长链接失败
- Why it matters: Reported in #35202
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35202
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35202