### PR TITLE
fix(context-pruning): avoid crashes on malformed text blocks

### DIFF
--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -423,4 +423,23 @@ describe("context-pruning", () => {
     expect(text).toContain("efghij");
     expect(text).toContain("[Tool result trimmed:");
   });
+
+  it("ignores malformed text blocks in tool results during pruning", () => {
+    const malformedToolResult: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "t1",
+      toolName: "exec",
+      content: [
+        { type: "text" } as unknown as ToolResultMessage["content"][number],
+        { type: "text", text: "x".repeat(20_000) },
+      ],
+      isError: false,
+      timestamp: Date.now(),
+    };
+    const messages: AgentMessage[] = [makeUser("u1"), malformedToolResult];
+
+    const next = pruneWithAggressiveDefaults(messages);
+
+    expect(toolText(findToolResult(next, "t1"))).toBe("[cleared]");
+  });
 });

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -16,7 +16,7 @@ function asText(text: string): TextContent {
 function collectTextSegments(content: ReadonlyArray<TextContent | ImageContent>): string[] {
   const parts: string[] = [];
   for (const block of content) {
-    if (block.type === "text") {
+    if (block.type === "text" && typeof block.text === "string") {
       parts.push(block.text);
     }
   }
@@ -99,7 +99,7 @@ function hasImageBlocks(content: ReadonlyArray<TextContent | ImageContent>): boo
 function estimateTextAndImageChars(content: ReadonlyArray<TextContent | ImageContent>): number {
   let chars = 0;
   for (const block of content) {
-    if (block.type === "text") {
+    if (block.type === "text" && typeof block.text === "string") {
       chars += block.text.length;
     }
     if (block.type === "image") {
@@ -121,7 +121,7 @@ function estimateMessageChars(message: AgentMessage): number {
   if (message.role === "assistant") {
     let chars = 0;
     for (const b of message.content) {
-      if (b.type === "text") {
+      if (b.type === "text" && typeof b.text === "string") {
         chars += b.text.length;
       }
       if (b.type === "thinking") {


### PR DESCRIPTION
## Summary
- guard text-length accounting in context pruning so malformed `{ type: "text" }` blocks are treated as empty instead of crashing
- harden soft-trim text collection to ignore malformed text blocks without `text`
- add regression coverage for malformed tool-result text blocks during pruning

Fixes #35017

## Testing
- pnpm test src/agents/pi-extensions/context-pruning.test.ts
