### PR TITLE
fix(cron): recompute expired nextRunAtMs after gateway restart

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -407,10 +407,13 @@ export function recomputeNextRuns(state: CronServiceState): boolean {
 export function recomputeNextRunsForMaintenance(state: CronServiceState): boolean {
   return walkSchedulableJobs(state, ({ job, nowMs: now }) => {
     let changed = false;
-    // Only compute missing nextRunAtMs, do NOT recompute existing ones.
-    // If a job was past-due but not found by findDueJobs, recomputing would
-    // cause it to be silently skipped.
-    if (!isFiniteTimestamp(job.state.nextRunAtMs)) {
+    // Recompute nextRunAtMs if missing OR already past-due.
+    // This ensures expired jobs are rescheduled after gateway restart (#34432).
+    // Previously, jobs with past-due nextRunAtMs would be stuck forever because
+    // the function only checked for missing timestamps, not expired ones.
+    const nextRun = job.state.nextRunAtMs;
+    const isDueOrMissing = !isFiniteTimestamp(nextRun) || now >= nextRun;
+    if (isDueOrMissing) {
       if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
         changed = true;
       }


### PR DESCRIPTION
## Description

Fixes #34432

This PR fixes a critical bug where cron jobs with expired `nextRunAtMs` never execute after gateway restart.

## Problem

When a gateway restarts after a scheduled cron job's execution time has passed, the `recomputeNextRunsForMaintenance` function only recomputes `nextRunAtMs` when it's not a finite timestamp, but doesn't handle the case where `nextRunAtMs` is a **past timestamp** (already expired).

**User-reported symptom:**
- Create a cron job scheduled for 08:00
- Restart gateway at 08:01 (after scheduled time)
- Job never executes
- `openclaw cron list` shows "Last: Xh ago" forever

## Root Cause

`recomputeNextRunsForMaintenance` (line 407-421) only checks:
```typescript
if (!isFiniteTimestamp(job.state.nextRunAtMs)) {
  // recompute
}
```

It should also recompute when `now >= nextRunAtMs` (expired timestamp).

## Solution

Adopt the same logic used by `recomputeNextRuns` (line 390-406), which already handles expired timestamps correctly:

```typescript
const nextRun = job.state.nextRunAtMs;
const isDueOrMissing = !isFiniteTimestamp(nextRun) || now >= nextRun;
if (isDueOrMissing) {
  // recompute
}
```

## Testing

**Manual test:**
1. Create a cron job scheduled for a specific time
2. Wait for the time to pass
3. Restart gateway immediately after
4. **Before fix:** Job never executes (stuck with past nextRunAtMs)
5. **After fix:** Job is rescheduled to next valid execution time

## Impact

- **Users affected:** All users with cron jobs who restart gateway after scheduled execution time
- **Breaking changes:** None (restores intended behavior)
- **Risk level:** Very low (mirrors existing tested logic)
- **Lines changed:** +7, -4

## Benefits

- ✅ Fixes critical cron execution failure
- ✅ Restores expected post-restart behavior
- ✅ Aligns maintenance function with main recompute logic
- ✅ Minimal code change (adopts proven pattern)

## Related

- Issue: #34432
- Similar logic: `recomputeNextRuns()` (line 390-406)