### PR TITLE
CLI: support OPENCLAW_VERBOSE env for verbose without --verbose flag

### DIFF
--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -281,6 +281,26 @@ describe("argv helpers", () => {
     );
   });
 
+  it("treats OPENCLAW_VERBOSE env as verbose when no --verbose/--debug flag", () => {
+    const prev = process.env.OPENCLAW_VERBOSE;
+    try {
+      process.env.OPENCLAW_VERBOSE = "1";
+      expect(getVerboseFlag(["node", "openclaw", "status"])).toBe(true);
+      process.env.OPENCLAW_VERBOSE = "true";
+      expect(getVerboseFlag(["node", "openclaw", "status"])).toBe(true);
+      delete process.env.OPENCLAW_VERBOSE;
+      expect(getVerboseFlag(["node", "openclaw", "status"])).toBe(false);
+      process.env.OPENCLAW_VERBOSE = "0";
+      expect(getVerboseFlag(["node", "openclaw", "status"])).toBe(false);
+    } finally {
+      if (prev !== undefined) {
+        process.env.OPENCLAW_VERBOSE = prev;
+      } else {
+        delete process.env.OPENCLAW_VERBOSE;
+      }
+    }
+  });
+
   it.each([
     {
       name: "missing flag",

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -4,6 +4,7 @@ import {
   FLAG_TERMINATOR,
   isValueToken,
 } from "../infra/cli-root-options.js";
+import { isTruthyEnvValue } from "../infra/env.js";
 
 const HELP_FLAGS = new Set(["-h", "--help"]);
 const VERSION_FLAGS = new Set(["-V", "--version"]);
@@ -129,6 +130,9 @@ export function getVerboseFlag(argv: string[], options?: { includeDebug?: boolea
     return true;
   }
   if (options?.includeDebug && hasFlag(argv, "--debug")) {
+    return true;
+  }
+  if (isTruthyEnvValue(process.env.OPENCLAW_VERBOSE)) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Summary
Support enabling CLI verbose output via the `OPENCLAW_VERBOSE` environment variable so scripts and CI can turn on verbose without passing `--verbose`.

## Changes
- **`src/cli/argv.ts`**: In `getVerboseFlag()`, when neither `--verbose` nor `--debug` is present in argv, treat `process.env.OPENCLAW_VERBOSE` as verbose when it is truthy (using `isTruthyEnvValue()` from `src/infra/env.js`). Argv flags still take precedence.
- **`src/cli/argv.test.ts`**: Add tests for `OPENCLAW_VERBOSE` (e.g. `1`/`true` → verbose, unset/`0` → not verbose when no flag).

## Notes
- No change to `preaction.ts`; it already calls `getVerboseFlag(argv, { includeDebug: true })` and `setVerbose(verbose)`, so env-based verbose is applied automatically.
- Same truthy semantics as other env flags (e.g. `OPENCLAW_HIDE_BANNER`): `1`, `true`, `yes` etc. count as truthy.