### PR TITLE
fix(skills): honor explicit env overrides for sensitive keys

### DIFF
--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -263,6 +263,45 @@ describe("applySkillEnvOverrides", () => {
     });
   });
 
+  it("allows explicit sensitive env overrides from config", async () => {
+    const workspaceDir = await makeWorkspace();
+    const skillDir = path.join(workspaceDir, "skills", "gog-env-skill");
+    await writeSkill({
+      dir: skillDir,
+      name: "gog-env-skill",
+      description: "Needs env",
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, resolveTestSkillDirs(workspaceDir));
+
+    withClearedEnv(["GOG_ACCOUNT", "GOG_KEYRING_PASSWORD"], () => {
+      const restore = applySkillEnvOverrides({
+        skills: entries,
+        config: {
+          skills: {
+            entries: {
+              "gog-env-skill": {
+                env: {
+                  GOG_ACCOUNT: "example@gmail.com",
+                  GOG_KEYRING_PASSWORD: "top-secret",
+                },
+              },
+            },
+          },
+        },
+      });
+
+      try {
+        expect(process.env.GOG_ACCOUNT).toBe("example@gmail.com");
+        expect(process.env.GOG_KEYRING_PASSWORD).toBe("top-secret");
+      } finally {
+        restore();
+        expect(process.env.GOG_ACCOUNT).toBeUndefined();
+        expect(process.env.GOG_KEYRING_PASSWORD).toBeUndefined();
+      }
+    });
+  });
+
   it("applies env overrides from snapshots", async () => {
     const workspaceDir = await makeWorkspace();
     const skillDir = path.join(workspaceDir, "skills", "env-skill");

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -102,6 +102,9 @@ function applySkillConfigEnvOverrides(params: {
       if (!envKey || !envValue || process.env[envKey]) {
         continue;
       }
+      // Explicit per-skill env overrides are user opt-in and should be honored even when
+      // the key name looks sensitive (for example *_PASSWORD keyring helpers).
+      allowedSensitiveKeys.add(envKey);
       pendingOverrides[envKey] = envValue;
     }
   }


### PR DESCRIPTION
## Summary
- treat explicitly configured `skills.entries.<skill>.env` keys as approved sensitive overrides during a run
- keep existing hard-block protection for dangerous host env keys
- add a regression test covering `GOG_ACCOUNT` + `GOG_KEYRING_PASSWORD` injection

## Testing
- pnpm test src/agents/skills.test.ts

Fixes #31583
