### PR TITLE
fix(telegram): bound sent-message cache growth per chat

### DIFF
--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -87,6 +87,16 @@ describe("sent-message-cache", () => {
     clearSentMessageCache();
     expect(wasSentByBot(123, 1)).toBe(false);
   });
+
+  it("evicts oldest entries when per-chat cache exceeds hard limit", () => {
+    for (let i = 1; i <= 5001; i += 1) {
+      recordSentMessage(123, i);
+    }
+
+    expect(wasSentByBot(123, 1)).toBe(false);
+    expect(wasSentByBot(123, 2)).toBe(true);
+    expect(wasSentByBot(123, 5001)).toBe(true);
+  });
 });
 
 describe("buildInlineKeyboard", () => {

--- a/src/telegram/sent-message-cache.ts
+++ b/src/telegram/sent-message-cache.ts
@@ -4,6 +4,7 @@
  */
 
 const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const MAX_MESSAGES_PER_CHAT = 5000;
 
 type CacheEntry = {
   timestamps: Map<number, number>;
@@ -24,6 +25,16 @@ function cleanupExpired(entry: CacheEntry): void {
   }
 }
 
+function enforceMaxMessages(entry: CacheEntry): void {
+  while (entry.timestamps.size > MAX_MESSAGES_PER_CHAT) {
+    const oldest = entry.timestamps.keys().next().value;
+    if (oldest === undefined) {
+      break;
+    }
+    entry.timestamps.delete(oldest);
+  }
+}
+
 /**
  * Record a message ID as sent by the bot.
  */
@@ -39,6 +50,7 @@ export function recordSentMessage(chatId: number | string, messageId: number): v
   if (entry.timestamps.size > 100) {
     cleanupExpired(entry);
   }
+  enforceMaxMessages(entry);
 }
 
 /**
@@ -52,6 +64,10 @@ export function wasSentByBot(chatId: number | string, messageId: number): boolea
   }
   // Clean up expired entries on read
   cleanupExpired(entry);
+  if (entry.timestamps.size === 0) {
+    sentMessages.delete(key);
+    return false;
+  }
   return entry.timestamps.has(messageId);
 }
 


### PR DESCRIPTION
## Summary
- add a hard per-chat bound (`MAX_MESSAGES_PER_CHAT = 5000`) to the Telegram sent-message cache
- evict oldest message IDs when a chat exceeds the cap
- keep existing TTL cleanup and remove empty per-chat buckets after read cleanup
- add a regression test to verify oldest-first eviction at cap overflow

## Why
The cache was TTL-based only. In high-throughput chats, IDs can accumulate quickly within 24h and raise memory usage before expiration. A hard bound keeps memory predictable without changing the core behavior.

## Risk
Low. Scope is limited to Telegram own-message tracking. The trade-off is that IDs older than the capped window are no longer considered bot-sent for reaction filtering, which is acceptable for this in-memory heuristic.

## Test
- `pnpm vitest src/telegram/send.test.ts`
