### PR TITLE
fix(discord): reject invalid PDF attachment payloads

### DIFF
--- a/src/discord/monitor/message-utils.test.ts
+++ b/src/discord/monitor/message-utils.test.ts
@@ -423,6 +423,70 @@ describe("resolveMediaList", () => {
     ]);
   });
 
+  it("falls back to URL when downloaded PDF payload is invalid", async () => {
+    const attachment = {
+      id: "att-invalid-pdf",
+      url: "https://cdn.discordapp.com/attachments/1/invalid.pdf",
+      filename: "invalid.pdf",
+      content_type: "application/pdf",
+    };
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("null"),
+      contentType: "application/json",
+    });
+
+    const result = await resolveMediaList(
+      asMessage({
+        attachments: [attachment],
+      }),
+      512,
+    );
+
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
+    expect(saveMediaBuffer).not.toHaveBeenCalled();
+    expect(result).toEqual([
+      {
+        path: attachment.url,
+        contentType: "application/pdf",
+        placeholder: "<media:document>",
+      },
+    ]);
+  });
+
+  it("keeps valid PDF payloads", async () => {
+    const attachment = {
+      id: "att-valid-pdf",
+      url: "https://cdn.discordapp.com/attachments/1/valid.pdf",
+      filename: "valid.pdf",
+      content_type: "application/pdf",
+    };
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("%PDF-1.7\n"),
+      contentType: "application/pdf",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/valid.pdf",
+      contentType: "application/pdf",
+    });
+
+    const result = await resolveMediaList(
+      asMessage({
+        attachments: [attachment],
+      }),
+      512,
+    );
+
+    expect(fetchRemoteMedia).toHaveBeenCalledTimes(1);
+    expect(saveMediaBuffer).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      {
+        path: "/tmp/valid.pdf",
+        contentType: "application/pdf",
+        placeholder: "<media:document>",
+      },
+    ]);
+  });
+
   it("preserves downloaded attachments alongside failed ones", async () => {
     const goodAttachment = {
       id: "att-good",

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -100,6 +100,7 @@ const DISCORD_CHANNEL_INFO_CACHE = new Map<
   { value: DiscordChannelInfo | null; expiresAt: number }
 >();
 const DISCORD_STICKER_ASSET_BASE_URL = "https://media.discordapp.net/stickers";
+const PDF_SIGNATURE = Buffer.from("%PDF-");
 
 export function __resetDiscordChannelInfoCacheForTest() {
   DISCORD_CHANNEL_INFO_CACHE.clear();
@@ -202,6 +203,29 @@ function resolveDiscordSnapshotStickers(snapshot: DiscordSnapshotMessage): APISt
   return normalizeStickerItems(snapshot.stickers ?? snapshot.sticker_items);
 }
 
+function isPdfAttachment(attachment: APIAttachment): boolean {
+  const mime = attachment.content_type?.toLowerCase();
+  if (mime === "application/pdf") {
+    return true;
+  }
+  return attachment.filename?.toLowerCase().endsWith(".pdf") ?? false;
+}
+
+function hasPdfSignature(buffer: Buffer): boolean {
+  return (
+    buffer.length >= PDF_SIGNATURE.length &&
+    buffer.subarray(0, PDF_SIGNATURE.length).equals(PDF_SIGNATURE)
+  );
+}
+
+function assertAttachmentPayloadIntegrity(attachment: APIAttachment, buffer: Buffer): void {
+  // Discord CDN intermittently returns a JSON `null` body for some attachment URLs.
+  // Guard obvious PDF corruption so we fall back to URL metadata instead of saving bad bytes.
+  if (isPdfAttachment(attachment) && !hasPdfSignature(buffer)) {
+    throw new Error("downloaded payload is not a valid PDF");
+  }
+}
+
 export function hasDiscordMessageStickers(message: Message): boolean {
   return resolveDiscordMessageStickers(message).length > 0;
 }
@@ -287,6 +311,7 @@ async function appendResolvedMediaFromAttachments(params: {
         fetchImpl: params.fetchImpl,
         ssrfPolicy: params.ssrfPolicy,
       });
+      assertAttachmentPayloadIntegrity(attachment, fetched.buffer);
       const saved = await saveMediaBuffer(
         fetched.buffer,
         fetched.contentType ?? attachment.content_type,


### PR DESCRIPTION
## Summary
- detect invalid downloaded PDF payloads in Discord attachment ingestion
- when payload fails PDF signature check, fall back to attachment URL metadata instead of saving corrupted bytes
- add regression tests for invalid `null` payload fallback and valid PDF pass-through

## Testing
- pnpm test -- --run src/discord/monitor/message-utils.test.ts
- pnpm exec oxfmt --check src/discord/monitor/message-utils.ts src/discord/monitor/message-utils.test.ts

Fixes #34415
