### PR TITLE
fix(agents): classify Codex streaming server_error as failover timeout

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -547,4 +547,12 @@ describe("classifyFailoverReason", () => {
       ),
     ).toBe("timeout");
   });
+
+  it("classifies Codex streaming server_error payloads as timeout", () => {
+    expect(
+      classifyFailoverReason(
+        'Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request.","param":null},"sequence_number":2}',
+      ),
+    ).toBe("timeout");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -659,7 +659,12 @@ function isJsonApiInternalServerError(raw: string): boolean {
   const value = raw.toLowerCase();
   // Anthropic often wraps transient 500s in JSON payloads like:
   // {"type":"error","error":{"type":"api_error","message":"Internal server error"}}
-  return value.includes('"type":"api_error"') && value.includes("internal server error");
+  if (value.includes('"type":"api_error"') && value.includes("internal server error")) {
+    return true;
+  }
+  // OpenAI Codex streaming errors can arrive as embedded JSON payloads:
+  // Codex error: {"type":"error","error":{"type":"server_error","code":"server_error",...}}
+  return value.includes('"type":"server_error"') || value.includes('"code":"server_error"');
 }
 
 export function parseImageDimensionError(raw: string): {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Codex streaming `server_error` payloads (for example `Codex error: {"type":"error","error":{"type":"server_error"...}}`) were not classified as failover-eligible, so fallback chains were skipped.
- Why it matters: sessions ended on primary-model error even with configured fallback models, especially affecting unattended runs (cron/bots).
- What changed: expanded JSON internal-server classification to include embedded `server_error` payload markers.
- What changed: added regression test for Codex streaming `server_error` message classification.
- What did NOT change (scope boundary): no fallback ordering changes, no retry loop changes, no provider request-path changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35220
- Related #35160
- Related #35119

## User-visible / Behavior Changes

When Codex streaming returns `server_error` payloads, fallback models are now attempted instead of terminating immediately.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.22.0, pnpm v10.23.0
- Model/provider: `openai-codex` / Codex streaming error-classification path
- Integration/channel (if any): embedded runner fallback classification
- Relevant config (redacted): fallback-enabled model chain

### Steps

1. Feed `classifyFailoverReason` a Codex streaming error string with `"type":"server_error"`.
2. Observe pre-fix vs post-fix classification.
3. Run fallback-related helper tests.

### Expected

- Codex streaming `server_error` text is classified as transient (`timeout`) so fallback path is eligible.

### Actual

- Before fix: `classifyFailoverReason(...)` returned `null` for Codex `server_error` strings.
- After fix: returns `"timeout"`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - New regression test fails before fix and passes after.
  - `failover-error` helper tests still pass.
  - Full repo `pnpm check` passes.
- Edge cases checked:
  - Existing `api_error` + `Internal server error` classification remains passing.
- What you did **not** verify:
  - Live Codex streaming session against external API.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/agents/pi-embedded-helpers/errors.ts`
  - `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- Known bad symptoms reviewers should watch for:
  - Over-classification of unrelated error strings containing `server_error` markers.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Some provider error payloads containing `server_error` may now be treated as transient/failover-eligible.
  - Mitigation:
    - Classification applies only to error text already in stopReason=`error` paths; regression coverage added and existing classifier tests remain green.
