### PR TITLE
fix: broaden angle-bracket homoglyph normalization for external-content markers

### DIFF
--- a/src/security/external-content.test.ts
+++ b/src/security/external-content.test.ts
@@ -204,6 +204,9 @@ describe("external-content security", () => {
         ["\u27EE", "\u27EF"], // flattened parentheses
         ["\u276C", "\u276D"], // medium angle bracket ornaments
         ["\u276E", "\u276F"], // heavy angle quotation ornaments
+        ["\u2991", "\u2992"], // angle brackets with dot
+        ["\u2993", "\u2994"], // arc less/greater-than brackets
+        ["\u29FC", "\u29FD"], // curved angle brackets
       ];
 
       for (const [left, right] of bracketPairs) {

--- a/src/security/external-content.ts
+++ b/src/security/external-content.ts
@@ -132,6 +132,12 @@ const ANGLE_BRACKET_MAP: Record<number, string> = {
   0x276d: ">", // medium right-pointing angle bracket ornament
   0x276e: "<", // heavy left-pointing angle quotation mark ornament
   0x276f: ">", // heavy right-pointing angle quotation mark ornament
+  0x2991: "<", // left angle bracket with dot
+  0x2992: ">", // right angle bracket with dot
+  0x2993: "<", // left arc less-than bracket
+  0x2994: ">", // right arc greater-than bracket
+  0x29fc: "<", // left-pointing curved angle bracket
+  0x29fd: ">", // right-pointing curved angle bracket
 };
 
 function foldMarkerChar(char: string): string {
@@ -151,7 +157,7 @@ function foldMarkerChar(char: string): string {
 
 function foldMarkerText(input: string): string {
   return input.replace(
-    /[\uFF21-\uFF3A\uFF41-\uFF5A\uFF1C\uFF1E\u2329\u232A\u3008\u3009\u2039\u203A\u27E8\u27E9\uFE64\uFE65\u00AB\u00BB\u300A\u300B\u27EA\u27EB\u27EC\u27ED\u27EE\u27EF\u276C\u276D\u276E\u276F]/g,
+    /[\uFF21-\uFF3A\uFF41-\uFF5A\uFF1C\uFF1E\u2329\u232A\u3008\u3009\u2039\u203A\u27E8\u27E9\uFE64\uFE65\u00AB\u00BB\u300A\u300B\u27EA\u27EB\u27EC\u27ED\u27EE\u27EF\u276C\u276D\u276E\u276F\u2991\u2992\u2993\u2994\u29FC\u29FD]/g,
     (char) => foldMarkerChar(char),
   );
 }


### PR DESCRIPTION
## Summary
Expand marker-folding coverage for additional Unicode angle-bracket variants so spoofed external-content markers are normalized and sanitized consistently.

## Changes
- Add additional bracket pairs to `ANGLE_BRACKET_MAP` in `src/security/external-content.ts`:
  - U+2991/U+2992 (angle bracket with dot)
  - U+2993/U+2994 (arc less/greater-than brackets)
  - U+29FC/U+29FD (curved angle brackets)
- Extend `foldMarkerText` character class to normalize those new code points.
- Extend `src/security/external-content.test.ts` with bracket-pair test coverage for all new pairs.

## Testing
- `pnpm vitest run src/security/external-content.test.ts`
- Result: 35 passed, 0 failed

Fixes openclaw/openclaw#34943
