### PR TITLE
CLI: support OPENCLAW_VERBOSE env for verbose without --verbose flag

### DIFF
--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -108,6 +108,16 @@ Both resolve from process env at activation time. SecretRef details are document
 | Variable             | Purpose                                                                                                                                                                                      |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `OPENCLAW_LOG_LEVEL` | Override log level for both file and console (e.g. `debug`, `trace`). Takes precedence over `logging.level` and `logging.consoleLevel` in config. Invalid values are ignored with a warning. |
+| `OPENCLAW_VERBOSE`   | Enable verbose console output when set to a truthy value (e.g. `1`, `true`). Same effect as the global CLI flag `--verbose`. Useful in scripts or CI when you cannot pass the flag.          |
+
+### Verbose: CLI vs environment
+
+Verbose output can be enabled in two ways:
+
+- **Command line:** the global option `--verbose` (or `--debug` where supported) turns on verbose for that run.
+- **Environment:** set `OPENCLAW_VERBOSE=1` (or another truthy value such as `true`) so that any CLI invocation uses verbose without passing the flag.
+
+**Precedence:** the command line wins. If you pass `--verbose` or `--debug`, that determines the result. Only when neither flag is present does the CLI check `OPENCLAW_VERBOSE`. So you can set the env var for default behavior and still override per run with `--verbose` or by omitting the flag when you want non-verbose.
 
 ### `OPENCLAW_HOME`
 

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -274,11 +274,21 @@ describe("argv helpers", () => {
   });
 
   it("parses verbose flags", () => {
-    expect(getVerboseFlag(["node", "openclaw", "status", "--verbose"])).toBe(true);
-    expect(getVerboseFlag(["node", "openclaw", "status", "--debug"])).toBe(false);
-    expect(getVerboseFlag(["node", "openclaw", "status", "--debug"], { includeDebug: true })).toBe(
-      true,
-    );
+    const prev = process.env.OPENCLAW_VERBOSE;
+    try {
+      delete process.env.OPENCLAW_VERBOSE;
+      expect(getVerboseFlag(["node", "openclaw", "status", "--verbose"])).toBe(true);
+      expect(getVerboseFlag(["node", "openclaw", "status", "--debug"])).toBe(false);
+      expect(
+        getVerboseFlag(["node", "openclaw", "status", "--debug"], { includeDebug: true }),
+      ).toBe(true);
+    } finally {
+      if (prev !== undefined) {
+        process.env.OPENCLAW_VERBOSE = prev;
+      } else {
+        delete process.env.OPENCLAW_VERBOSE;
+      }
+    }
   });
 
   it("treats OPENCLAW_VERBOSE env as verbose when no --verbose/--debug flag", () => {

--- a/src/cli/argv.test.ts
+++ b/src/cli/argv.test.ts
@@ -281,6 +281,26 @@ describe("argv helpers", () => {
     );
   });
 
+  it("treats OPENCLAW_VERBOSE env as verbose when no --verbose/--debug flag", () => {
+    const prev = process.env.OPENCLAW_VERBOSE;
+    try {
+      process.env.OPENCLAW_VERBOSE = "1";
+      expect(getVerboseFlag(["node", "openclaw", "status"])).toBe(true);
+      process.env.OPENCLAW_VERBOSE = "true";
+      expect(getVerboseFlag(["node", "openclaw", "status"])).toBe(true);
+      delete process.env.OPENCLAW_VERBOSE;
+      expect(getVerboseFlag(["node", "openclaw", "status"])).toBe(false);
+      process.env.OPENCLAW_VERBOSE = "0";
+      expect(getVerboseFlag(["node", "openclaw", "status"])).toBe(false);
+    } finally {
+      if (prev !== undefined) {
+        process.env.OPENCLAW_VERBOSE = prev;
+      } else {
+        delete process.env.OPENCLAW_VERBOSE;
+      }
+    }
+  });
+
   it.each([
     {
       name: "missing flag",

--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -4,6 +4,7 @@ import {
   FLAG_TERMINATOR,
   isValueToken,
 } from "../infra/cli-root-options.js";
+import { isTruthyEnvValue } from "../infra/env.js";
 
 const HELP_FLAGS = new Set(["-h", "--help"]);
 const VERSION_FLAGS = new Set(["-V", "--version"]);
@@ -129,6 +130,9 @@ export function getVerboseFlag(argv: string[], options?: { includeDebug?: boolea
     return true;
   }
   if (options?.includeDebug && hasFlag(argv, "--debug")) {
+    return true;
+  }
+  if (isTruthyEnvValue(process.env.OPENCLAW_VERBOSE)) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Summary

Support enabling CLI verbose output via the `OPENCLAW_VERBOSE` environment variable so scripts and CI can turn on verbose without passing `--verbose`.

## Changes

### Production

- **`src/cli/argv.ts`**: In `getVerboseFlag()`, when neither `--verbose` nor `--debug` is present in argv, treat `process.env.OPENCLAW_VERBOSE` as verbose when it is truthy (using `isTruthyEnvValue()` from `src/infra/env.js`). Argv flags still take precedence.

### Tests

- **`src/cli/argv.test.ts`**:
  - New test: `OPENCLAW_VERBOSE` (e.g. `1`/`true` → verbose, unset/`0` → not verbose when no flag).
  - Existing "parses verbose flags" test: save/restore `process.env.OPENCLAW_VERBOSE` so it does not depend on the environment (avoids failures in CI when `OPENCLAW_VERBOSE` is set).

### Docs

- **`docs/help/environment.md`**: Add `OPENCLAW_VERBOSE` to the Logging table and a "Verbose: CLI vs environment" subsection (both ways to enable, precedence: CLI over env).


## Behavior

- **Ways to enable verbose:** global CLI `--verbose` (or `--debug` where supported), or env `OPENCLAW_VERBOSE=1` (or other truthy value).
- **Precedence:** command line wins; only when no `--verbose`/`--debug` is passed does the CLI check `OPENCLAW_VERBOSE`.
- Same truthy semantics as other env flags (e.g. `OPENCLAW_HIDE_BANNER`): `1`, `true`, `yes` etc. count as truthy.

## Notes

- No change to `preaction.ts`; it already calls `getVerboseFlag(argv, { includeDebug: true })` and `setVerbose(verbose)`, so env-based verbose is applied automatically.
- Useful for CI and scripts where setting the env var is easier than passing the flag on every invocation.