### PR TITLE
fix(session): archive old transcript on automatic session rollover

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1100,7 +1100,7 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       expect.objectContaining({
         sessionId: existingSessionId,
         storePath,
-        reason: "reset",
+        reason: "stale",
       }),
     );
     archiveSpy.mockRestore();
@@ -1175,7 +1175,7 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       expect.objectContaining({
         sessionId: existingSessionId,
         storePath,
-        reason: "reset",
+        reason: "stale",
       }),
     );
     archiveSpy.mockRestore();

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1135,6 +1135,51 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     expect(result.sessionEntry.verboseLevel).toBeUndefined();
     expect(result.sessionEntry.thinkingLevel).toBeUndefined();
   });
+
+  it("archives the previous transcript when session freshness starts a new session", async () => {
+    const storePath = await createStorePath("openclaw-archive-stale-session-");
+    const sessionKey = "agent:main:telegram:dm:user-stale-archive";
+    const existingSessionId = "existing-stale-session";
+    await seedSessionStoreWithOverrides({
+      storePath,
+      sessionKey,
+      sessionId: existingSessionId,
+      overrides: { updatedAt: 1, verboseLevel: "on" },
+    });
+    const sessionUtils = await import("../../gateway/session-utils.fs.js");
+    const archiveSpy = vi.spyOn(sessionUtils, "archiveSessionTranscripts");
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 0 },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "hello again",
+        RawBody: "hello again",
+        CommandBody: "hello again",
+        From: "user-stale-archive",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "telegram",
+        Surface: "telegram",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(false);
+    expect(archiveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: existingSessionId,
+        storePath,
+        reason: "reset",
+      }),
+    );
+    archiveSpy.mockRestore();
+  });
 });
 
 describe("buildQueuedSystemPrompt", () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -423,7 +423,7 @@ export async function initSessionState(params: {
       storePath,
       sessionFile: archivedSessionEntry.sessionFile,
       agentId,
-      reason: "reset",
+      reason: resetTriggered ? "reset" : "stale",
     });
   }
 

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -242,6 +242,10 @@ export async function initSessionState(params: {
       persistedLabel = entry.label;
     }
   }
+  const archivedSessionEntry =
+    entry && isNewSession && entry.sessionId && entry.sessionId !== sessionId
+      ? { ...entry }
+      : undefined;
 
   const baseEntry = !isNewSession && freshEntry ? entry : undefined;
   // Track the originating channel/to for announce routing (subagent announce-back).
@@ -413,11 +417,11 @@ export async function initSessionState(params: {
   );
 
   // Archive old transcript so it doesn't accumulate on disk (#14869).
-  if (previousSessionEntry?.sessionId) {
+  if (archivedSessionEntry?.sessionId) {
     archiveSessionTranscripts({
-      sessionId: previousSessionEntry.sessionId,
+      sessionId: archivedSessionEntry.sessionId,
       storePath,
-      sessionFile: previousSessionEntry.sessionFile,
+      sessionFile: archivedSessionEntry.sessionFile,
       agentId,
       reason: "reset",
     });

--- a/src/config/sessions/artifacts.ts
+++ b/src/config/sessions/artifacts.ts
@@ -1,4 +1,4 @@
-export type SessionArchiveReason = "bak" | "reset" | "deleted";
+export type SessionArchiveReason = "bak" | "reset" | "stale" | "deleted";
 
 const ARCHIVE_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:\.\d{3})?Z$/;
 const LEGACY_STORE_BACKUP_RE = /^sessions\.json\.bak\.\d+$/;
@@ -19,6 +19,7 @@ export function isSessionArchiveArtifactName(fileName: string): boolean {
   }
   return (
     hasArchiveSuffix(fileName, "deleted") ||
+    hasArchiveSuffix(fileName, "stale") ||
     hasArchiveSuffix(fileName, "reset") ||
     hasArchiveSuffix(fileName, "bak")
   );

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -428,6 +428,11 @@ async function saveSessionStoreUnlocked(
           olderThanMs: maintenance.pruneAfterMs,
           reason: "deleted",
         });
+        await cleanupArchivedSessionTranscripts({
+          directories: targetDirs,
+          olderThanMs: maintenance.pruneAfterMs,
+          reason: "stale",
+        });
         if (maintenance.resetArchiveRetentionMs != null) {
           await cleanupArchivedSessionTranscripts({
             directories: targetDirs,

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -190,7 +190,7 @@ export function archiveSessionTranscripts(opts: {
   storePath: string | undefined;
   sessionFile?: string;
   agentId?: string;
-  reason: "reset" | "deleted";
+  reason: "reset" | "stale" | "deleted";
   /**
    * When true, only archive files resolved under the session store directory.
    * This prevents maintenance operations from mutating paths outside the agent sessions dir.


### PR DESCRIPTION
## Summary

- Problem: when a session rolls over automatically (for example, freshness/idle rollover), OpenClaw remaps the session key to a new `sessionId` but does not archive the previous transcript file.
- Why it matters: this leaves orphaned `.jsonl` transcripts on disk with no active key mapping, matching the reported data-loss symptom from the user perspective.
- What changed: `initSessionState` now archives the previous transcript whenever the session key rolls to a different `sessionId`, not only on explicit `/new` or `/reset`.
- What did NOT change (scope boundary): no changes to model selection logic, cron scheduling behavior, heartbeat dispatch, or session reset policy rules.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35215
- Related #14869

## User-visible / Behavior Changes

When OpenClaw auto-starts a fresh session ID for an existing session key, the previous transcript is now archived as a reset artifact instead of being left as an untracked orphan `.jsonl`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: n/a (unit-level session init behavior)
- Integration/channel (if any): session init path used by messaging channels/heartbeat/cron routing
- Relevant config (redacted): `session.idleMinutes: 0` in test config

### Steps

1. Seed a session store entry for a session key with an existing `sessionId` and stale `updatedAt`.
2. Run `initSessionState` for the same session key with non-reset input (`"hello again"`) and freshness policy forcing rollover.
3. Observe whether `archiveSessionTranscripts(...)` is called for the old `sessionId`.

### Expected

- A new session is created.
- Previous transcript is archived (same archive path used by reset flow).

### Actual

- Before fix: new session is created but archive was not triggered unless `/new` or `/reset` set `resetTriggered=true`.
- After fix: archive is triggered on any session-id rollover for that key.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Existing `/new` archive behavior still passes.
  - New regression test confirms archive call on freshness-based rollover (`resetTriggered=false`).
- Edge cases checked:
  - No archive when session ID is unchanged.
- What you did **not** verify:
  - Live channel E2E replay on production data.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/auto-reply/reply/session.ts`
- Known bad symptoms reviewers should watch for: unexpected archive calls when session ID does not actually rotate.

## Risks and Mitigations

- Risk: broader archive trigger could archive in unintended rollover paths.
  - Mitigation: guard only archives when an existing entry is present and `entry.sessionId !== new sessionId`; regression coverage added.

