### PR TITLE
CLI: add --session-key flag to openclaw agent

### DIFF
--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -26,6 +26,7 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
     .requiredOption("-m, --message <text>", "Message body for the agent")
     .option("-t, --to <number>", "Recipient number in E.164 used to derive the session key")
     .option("--session-id <id>", "Use an explicit session id")
+    .option("--session-key <key>", "Use an explicit session key")
     .option("--agent <id>", "Agent id (overrides routing bindings)")
     .option("--thinking <level>", "Thinking level: off | minimal | low | medium | high")
     .option("--verbose <on|off>", "Persist agent verbose level for the session")

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -37,6 +37,7 @@ export type AgentCliOpts = {
   agent?: string;
   to?: string;
   sessionId?: string;
+  sessionKey?: string;
   thinking?: string;
   verbose?: string;
   json?: boolean;
@@ -89,8 +90,10 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
   if (!body) {
     throw new Error("Message (--message) is required");
   }
-  if (!opts.to && !opts.sessionId && !opts.agent) {
-    throw new Error("Pass --to <E.164>, --session-id, or --agent to choose a session");
+  if (!opts.to && !opts.sessionId && !opts.sessionKey && !opts.agent) {
+    throw new Error(
+      "Pass --to <E.164>, --session-id, --session-key, or --agent to choose a session",
+    );
   }
 
   const cfg = loadConfig();
@@ -115,6 +118,7 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
     agentId,
     to: opts.to,
     sessionId: opts.sessionId,
+    sessionKey: opts.sessionKey,
   }).sessionKey;
 
   const channel = normalizeMessageChannel(opts.channel);
@@ -181,6 +185,7 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
   const localOpts = {
     ...opts,
     agentId: opts.agent,
+    sessionKey: opts.sessionKey,
     replyAccountId: opts.replyAccount,
   };
   if (opts.local === true) {

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -185,7 +185,6 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
   const localOpts = {
     ...opts,
     agentId: opts.agent,
-    sessionKey: opts.sessionKey,
     replyAccountId: opts.replyAccount,
   };
   if (opts.local === true) {


### PR DESCRIPTION
## Summary

- Add `--session-key <key>` option to `openclaw agent` CLI for explicit session key routing
- Plumb `sessionKey` through `AgentCliOpts`, validation guard, `resolveSessionKeyForRequest()`, and the `--local` fallback path
- Enables external integrations (e.g., agentgram polling scripts) to use custom session keys like `agentgram:<room_id>` for per-room session isolation

## Test plan

- [x] `pnpm tsgo` — no new type errors
- [x] `pnpm test -- src/commands/agent/session.test` — all 8 tests pass
- [ ] Manual: `openclaw agent --session-key "agentgram:test-room" --message "hello" --json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)