### PR TITLE
fix: resolve web_fetch fetch failed error

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -527,6 +527,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
+      useEnvProxy: true,
       init: {
         headers: {
           Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",


### PR DESCRIPTION
Closes #32947

Problem: web_fetch always fails with 'fetch failed' even for simple URLs like https://example.com
Fix: web_fetch now uses trusted environment proxy mode (useEnvProxy: true) for outbound fetches, matching web_search behavior. This allows web_fetch to honor configured HTTP(S)_PROXY/NO_PROXY environments and avoids direct undici network path failures on proxy-required hosts while keeping SSRF protections in place.