### PR TITLE
perf(agents): bound bootstrap snapshot cache with LRU eviction

### DIFF
--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  MAX_BOOTSTRAP_CACHE_ENTRIES,
   clearAllBootstrapSnapshots,
   clearBootstrapSnapshot,
   getOrLoadBootstrapFiles,
@@ -64,6 +65,45 @@ describe("getOrLoadBootstrapFiles", () => {
     expect(r1).toBe(files);
     expect(r2).toBe(files2);
     expect(mockLoad).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts the least recently used session when cache exceeds max entries", async () => {
+    mockLoad.mockImplementation(async (workspaceDir) => [makeFile("AGENTS.md", workspaceDir)]);
+
+    for (let i = 0; i < MAX_BOOTSTRAP_CACHE_ENTRIES; i += 1) {
+      await getOrLoadBootstrapFiles({
+        workspaceDir: `/ws/${i}`,
+        sessionKey: `session-${i}`,
+      });
+    }
+    expect(mockLoad).toHaveBeenCalledTimes(MAX_BOOTSTRAP_CACHE_ENTRIES);
+
+    // Touch session-0 so session-1 becomes the oldest entry.
+    await getOrLoadBootstrapFiles({
+      workspaceDir: "/ws/0",
+      sessionKey: "session-0",
+    });
+    expect(mockLoad).toHaveBeenCalledTimes(MAX_BOOTSTRAP_CACHE_ENTRIES);
+
+    await getOrLoadBootstrapFiles({
+      workspaceDir: "/ws/overflow",
+      sessionKey: "session-overflow",
+    });
+    expect(mockLoad).toHaveBeenCalledTimes(MAX_BOOTSTRAP_CACHE_ENTRIES + 1);
+
+    // session-0 should stay cached after its LRU bump.
+    await getOrLoadBootstrapFiles({
+      workspaceDir: "/ws/0",
+      sessionKey: "session-0",
+    });
+    expect(mockLoad).toHaveBeenCalledTimes(MAX_BOOTSTRAP_CACHE_ENTRIES + 1);
+
+    // session-1 should have been evicted as the oldest untouched entry.
+    await getOrLoadBootstrapFiles({
+      workspaceDir: "/ws/1",
+      sessionKey: "session-1",
+    });
+    expect(mockLoad).toHaveBeenCalledTimes(MAX_BOOTSTRAP_CACHE_ENTRIES + 2);
   });
 });
 

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -1,6 +1,17 @@
 import { loadWorkspaceBootstrapFiles, type WorkspaceBootstrapFile } from "./workspace.js";
 
 const cache = new Map<string, WorkspaceBootstrapFile[]>();
+export const MAX_BOOTSTRAP_CACHE_ENTRIES = 256;
+
+function trimBootstrapCache(): void {
+  while (cache.size > MAX_BOOTSTRAP_CACHE_ENTRIES) {
+    const oldestKey = cache.keys().next().value;
+    if (typeof oldestKey !== "string" || oldestKey.length === 0) {
+      break;
+    }
+    cache.delete(oldestKey);
+  }
+}
 
 export async function getOrLoadBootstrapFiles(params: {
   workspaceDir: string;
@@ -8,11 +19,15 @@ export async function getOrLoadBootstrapFiles(params: {
 }): Promise<WorkspaceBootstrapFile[]> {
   const existing = cache.get(params.sessionKey);
   if (existing) {
+    // Bump recency so frequently-used sessions are least likely to be evicted.
+    cache.delete(params.sessionKey);
+    cache.set(params.sessionKey, existing);
     return existing;
   }
 
   const files = await loadWorkspaceBootstrapFiles(params.workspaceDir);
   cache.set(params.sessionKey, files);
+  trimBootstrapCache();
   return files;
 }
 


### PR DESCRIPTION
## Summary
- add a hard cap (MAX_BOOTSTRAP_CACHE_ENTRIES = 256) for bootstrap snapshot cache entries
- implement simple LRU behavior by bumping recency on cache hits
- trim oldest entries when cache exceeds cap
- add a focused test that verifies eviction order and recency bump behavior

## Why
Long-lived gateways can accumulate per-session bootstrap snapshots indefinitely, causing avoidable memory growth over time.

## Impact
- keeps hot sessions cached
- bounds memory for cold/abandoned sessions
- preserves existing functional behavior (cold entries can be lazily reloaded)

## Risk
Low. The only behavior change is potential cache misses for old cold sessions once the cap is exceeded.

## Testing
- pnpm test src/agents/bootstrap-cache.test.ts
