### PR TITLE
fix(skills): handle numeric frontmatter names without crashes

### DIFF
--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -88,11 +88,7 @@ describe("loadWorkspaceSkillEntries", () => {
     await fs.mkdir(managedDir, { recursive: true });
     await fs.writeFile(
       path.join(skillsDir, "SKILL.md"),
-      "---
-name: 12306
-description: test
----
-",
+      `---\nname: 12306\ndescription: test\n---\n`,
       "utf-8",
     );
 

--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -79,6 +79,31 @@ async function setupWorkspaceWithDiffsPlugin() {
 }
 
 describe("loadWorkspaceSkillEntries", () => {
+  it("coerces non-string frontmatter names to strings", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const managedDir = path.join(workspaceDir, ".managed");
+    const skillsDir = path.join(workspaceDir, "skills", "train");
+
+    await fs.mkdir(skillsDir, { recursive: true });
+    await fs.mkdir(managedDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillsDir, "SKILL.md"),
+      "---
+name: 12306
+description: test
+---
+",
+      "utf-8",
+    );
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+    });
+
+    expect(entries.map((entry) => entry.skill.name)).toContain("12306");
+  });
+
   it("handles an empty managed skills dir without throwing", async () => {
     const workspaceDir = await createTempWorkspaceDir();
     const managedDir = path.join(workspaceDir, ".managed");

--- a/src/agents/skills/bundled-context.ts
+++ b/src/agents/skills/bundled-context.ts
@@ -31,8 +31,9 @@ export function resolveBundledSkillsContext(
   }
   const result = loadSkillsFromDir({ dir, source: "openclaw-bundled" });
   for (const skill of result.skills) {
-    if (skill.name.trim()) {
-      names.add(skill.name);
+    const name = String(skill.name ?? "").trim();
+    if (name) {
+      names.add(name);
     }
   }
   cachedBundledContext = { dir, names: new Set(names) };

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -205,14 +205,23 @@ function resolveNestedSkillsRoot(
   return { baseDir: dir };
 }
 
+function normalizeLoadedSkillName(skill: Skill): Skill {
+  const name = String(skill.name ?? "").trim();
+  return { ...skill, name };
+}
+
 function unwrapLoadedSkills(loaded: unknown): Skill[] {
   if (Array.isArray(loaded)) {
-    return loaded as Skill[];
+    return loaded
+      .map((skill) => normalizeLoadedSkillName(skill as Skill))
+      .filter((skill) => Boolean(skill.name));
   }
   if (loaded && typeof loaded === "object" && "skills" in loaded) {
     const skills = (loaded as { skills?: unknown }).skills;
     if (Array.isArray(skills)) {
-      return skills as Skill[];
+      return skills
+        .map((skill) => normalizeLoadedSkillName(skill as Skill))
+        .filter((skill) => Boolean(skill.name));
     }
   }
   return [];


### PR DESCRIPTION
## Summary
- coerce loaded skill names to strings during discovery before downstream filtering and command-name sanitization
- ignore skills whose coerced names are empty after trimming
- coerce bundled skill names before adding to the bundled-name context set
- add a regression test covering `name: 12306` frontmatter

## Why
`name: 12306` in YAML is parsed as a number. Some skill paths assume a string and call string methods, which can throw and silently hide the skill from discovery. This change normalizes names at load boundaries to prevent type crashes and keep discovery resilient.

Closes #35252

## Validation
- Added unit test: `src/agents/skills.loadworkspaceskillentries.test.ts` (numeric name is loaded as "12306")
- Local test execution was not run in this environment because project dependencies are not installed (`node_modules` missing).
