### PR TITLE
fix: Bug: Session compaction leaks tool call arguments into conversation text (#35244)

### DIFF
--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   estimateMessagesTokens,
   pruneHistoryForContextShare,
+  sanitizeMessagesForCompaction,
   splitMessagesByTokenShare,
 } from "./compaction.js";
 
@@ -275,5 +276,67 @@ describe("pruneHistoryForContextShare", () => {
     // droppedMessages = 1 (assistant) + 2 (orphaned tool_results) = 3
     // droppedMessagesList only has the assistant message
     expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length + 2);
+  });
+});
+
+describe("sanitizeMessagesForCompaction", () => {
+  it("redacts raw tool-call arguments before compaction summarization", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_write",
+            name: "write",
+            arguments: { filePath: "/tmp/feishu_voice_sender.py", content: "print('hi')" },
+          },
+          {
+            type: "toolUse",
+            id: "call_message",
+            name: "message",
+            input: { filePath: "/tmp/feishu_voice_sender.py", target: "user-1" },
+            partialJson: '{"filePath":"/tmp/feishu_voice_sender.py"}',
+          },
+        ],
+        timestamp: 1,
+      } as AgentMessage,
+    ];
+
+    const sanitized = sanitizeMessagesForCompaction(messages);
+    const assistant = sanitized[0] as { content?: unknown[] };
+    const blocks = assistant.content as Array<Record<string, unknown>>;
+
+    expect(blocks[0]?.arguments).toEqual({});
+    expect(blocks[1]?.input).toEqual({});
+    expect(blocks[1]).not.toHaveProperty("partialJson");
+  });
+
+  it("does not mutate original messages when sanitizing tool-call arguments", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_1",
+            name: "message",
+            arguments: { filePath: "/tmp/secret.txt" },
+          },
+        ],
+        timestamp: 1,
+      } as AgentMessage,
+    ];
+
+    const original = (messages[0] as { content: Array<Record<string, unknown>> }).content[0];
+    const sanitized = sanitizeMessagesForCompaction(messages);
+    const sanitizedBlock = ((sanitized[0] as { content: unknown[] }).content[0] ?? {}) as Record<
+      string,
+      unknown
+    >;
+
+    expect(original.arguments).toEqual({ filePath: "/tmp/secret.txt" });
+    expect(sanitizedBlock.arguments).toEqual({});
+    expect(sanitizedBlock).not.toBe(original);
   });
 });

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -31,6 +31,7 @@ const MERGE_SUMMARIES_INSTRUCTIONS = [
 const IDENTIFIER_PRESERVATION_INSTRUCTIONS =
   "Preserve all opaque identifiers exactly as written (no shortening or reconstruction), " +
   "including UUIDs, hashes, IDs, tokens, API keys, hostnames, IPs, ports, URLs, and file names.";
+const TOOL_CALL_CONTENT_BLOCK_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
 
 export type CompactionSummarizationInstructions = {
   identifierPolicy?: AgentCompactionIdentifierPolicy;
@@ -70,9 +71,69 @@ export function buildCompactionSummarizationInstructions(
 }
 
 export function estimateMessagesTokens(messages: AgentMessage[]): number {
-  // SECURITY: toolResult.details can contain untrusted/verbose payloads; never include in LLM-facing compaction.
-  const safe = stripToolResultDetails(messages);
+  const safe = sanitizeMessagesForCompaction(messages);
   return safe.reduce((sum, message) => sum + estimateTokens(message), 0);
+}
+
+function sanitizeAssistantContentBlock(block: unknown): unknown {
+  if (!block || typeof block !== "object") {
+    return block;
+  }
+  const type = (block as { type?: unknown }).type;
+  if (typeof type !== "string" || !TOOL_CALL_CONTENT_BLOCK_TYPES.has(type)) {
+    return block;
+  }
+
+  const blockRecord = block as Record<string, unknown>;
+  const hasArguments = Object.hasOwn(blockRecord, "arguments");
+  const hasInput = Object.hasOwn(blockRecord, "input");
+  const hasPartialJson = Object.hasOwn(blockRecord, "partialJson");
+  if (!hasArguments && !hasInput && !hasPartialJson) {
+    return block;
+  }
+
+  const { arguments: _arguments, input: _input, partialJson: _partialJson, ...rest } = blockRecord;
+  const next: Record<string, unknown> = { ...rest };
+  if (hasArguments) {
+    next.arguments = {};
+  }
+  if (hasInput) {
+    next.input = {};
+  }
+  return next;
+}
+
+function sanitizeCompactionMessage(message: AgentMessage): AgentMessage {
+  if (message.role !== "assistant" || !Array.isArray(message.content)) {
+    return message;
+  }
+  let changed = false;
+  const nextContent = message.content.map((block) => {
+    const nextBlock = sanitizeAssistantContentBlock(block);
+    if (nextBlock !== block) {
+      changed = true;
+    }
+    return nextBlock;
+  });
+  if (!changed) {
+    return message;
+  }
+  return { ...message, content: nextContent } as AgentMessage;
+}
+
+export function sanitizeMessagesForCompaction(messages: AgentMessage[]): AgentMessage[] {
+  // SECURITY: toolResult.details and tool-call argument payloads can contain
+  // untrusted or sensitive data; never include them in LLM-facing compaction.
+  const withoutToolResultDetails = stripToolResultDetails(messages);
+  let changed = withoutToolResultDetails !== messages;
+  const sanitized = withoutToolResultDetails.map((message) => {
+    const nextMessage = sanitizeCompactionMessage(message);
+    if (nextMessage !== message) {
+      changed = true;
+    }
+    return nextMessage;
+  });
+  return changed ? sanitized : messages;
 }
 
 function estimateCompactionMessageTokens(message: AgentMessage): number {
@@ -223,8 +284,8 @@ async function summarizeChunks(params: {
     return params.previousSummary ?? DEFAULT_SUMMARY_FALLBACK;
   }
 
-  // SECURITY: never feed toolResult.details into summarization prompts.
-  const safeMessages = stripToolResultDetails(params.messages);
+  // SECURITY: never feed toolResult.details or raw tool-call args into compaction prompts.
+  const safeMessages = sanitizeMessagesForCompaction(params.messages);
   const chunks = chunkMessagesByMaxTokens(safeMessages, params.maxChunkTokens);
   let summary = params.previousSummary;
   const effectiveInstructions = buildCompactionSummarizationInstructions(


### PR DESCRIPTION
Closes #35244

## Summary

- Problem: Bug: Session compaction leaks tool call arguments into conversation text
- Why it matters: Reported in #35244
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35244
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35244