### PR TITLE
fix(skills): coerce skill name to string to prevent TypeError

### DIFF
--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -55,7 +55,9 @@ export type SkillStatusReport = {
 };
 
 function resolveSkillKey(entry: SkillEntry): string {
-  return entry.metadata?.skillKey ?? entry.skill.name;
+  // Defensive: skill.name may be a number if YAML parses name: 12306 without quotes
+  const name = entry.metadata?.skillKey ?? entry.skill.name;
+  return typeof name === "string" ? name : String(name);
 }
 
 function selectPreferredInstallSpec(

--- a/src/agents/skills/bundled-context.ts
+++ b/src/agents/skills/bundled-context.ts
@@ -31,8 +31,9 @@ export function resolveBundledSkillsContext(
   }
   const result = loadSkillsFromDir({ dir, source: "openclaw-bundled" });
   for (const skill of result.skills) {
-    if (skill.name.trim()) {
-      names.add(skill.name);
+    const skillName = String(skill.name);
+    if (skillName.trim()) {
+      names.add(skillName);
     }
   }
   cachedBundledContext = { dir, names: new Set(names) };

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -64,7 +64,8 @@ export function isBundledSkillAllowed(entry: SkillEntry, allowlist?: string[]): 
     return true;
   }
   const key = resolveSkillKey(entry.skill, entry);
-  return allowlist.includes(key) || allowlist.includes(entry.skill.name);
+  const skillName = String(entry.skill.name);
+  return allowlist.includes(key) || allowlist.includes(skillName);
 }
 
 export function shouldIncludeSkill(params: {

--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -224,5 +224,7 @@ export function resolveSkillInvocationPolicy(
 }
 
 export function resolveSkillKey(skill: Skill, entry?: SkillEntry): string {
-  return entry?.metadata?.skillKey ?? skill.name;
+  // Defensive: skill.name may be a number if YAML parses name: 12306 without quotes
+  const name = entry?.metadata?.skillKey ?? skill.name;
+  return typeof name === "string" ? name : String(name);
 }

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -76,12 +76,13 @@ function filterSkillEntries(
     const normalized = normalizeSkillFilter(skillFilter) ?? [];
     const label = normalized.length > 0 ? normalized.join(", ") : "(none)";
     skillsLogger.debug(`Applying skill filter: ${label}`);
+    // Defensive: coerce name to string in case YAML parsed it as a number (e.g., name: 12306)
     filtered =
       normalized.length > 0
-        ? filtered.filter((entry) => normalized.includes(entry.skill.name))
+        ? filtered.filter((entry) => normalized.includes(String(entry.skill.name)))
         : [];
     skillsLogger.debug(
-      `After skill filter: ${filtered.map((entry) => entry.skill.name).join(", ") || "(none)"}`,
+      `After skill filter: ${filtered.map((entry) => String(entry.skill.name)).join(", ") || "(none)"}`,
     );
   }
   return filtered;
@@ -452,7 +453,7 @@ export function buildWorkspaceSkillSnapshot(
   return {
     prompt,
     skills: eligible.map((entry) => ({
-      name: entry.skill.name,
+      name: String(entry.skill.name),
       primaryEnv: entry.metadata?.primaryEnv,
       requiredEnv: entry.metadata?.requires?.env?.slice(),
     })),
@@ -622,12 +623,14 @@ export async function syncSkillsToWorkspace(params: {
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : JSON.stringify(error);
-        skillsLogger.warn(`Failed to resolve safe destination for ${entry.skill.name}: ${message}`);
+        skillsLogger.warn(
+          `Failed to resolve safe destination for ${String(entry.skill.name)}: ${message}`,
+        );
         continue;
       }
       if (!dest) {
         skillsLogger.warn(
-          `Failed to resolve safe destination for ${entry.skill.name}: invalid source directory name`,
+          `Failed to resolve safe destination for ${String(entry.skill.name)}: invalid source directory name`,
         );
         continue;
       }
@@ -638,7 +641,7 @@ export async function syncSkillsToWorkspace(params: {
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : JSON.stringify(error);
-        skillsLogger.warn(`Failed to copy ${entry.skill.name} to sandbox: ${message}`);
+        skillsLogger.warn(`Failed to copy ${String(entry.skill.name)} to sandbox: ${message}`);
       }
     }
   });
@@ -678,7 +681,7 @@ export function buildWorkspaceSkillCommandSpecs(
 
   const specs: SkillCommandSpec[] = [];
   for (const entry of userInvocable) {
-    const rawName = entry.skill.name;
+    const rawName = String(entry.skill.name);
     const base = sanitizeSkillCommandName(rawName);
     if (base !== rawName) {
       debugSkillCommandOnce(


### PR DESCRIPTION
## Summary

When SKILL.md frontmatter has `name: 12306` (without quotes), YAML parses it as a number instead of a string. Subsequent calls to `.startsWith()` or `.includes()` on the name throw `TypeError: name.startsWith is not a function`, silently dropping the skill from the available skills list.

## Fix

Add `String()` coercion in `filterSkillEntries` and `isBundledSkillAllowed` to defensively handle numeric names from YAML parsing.

## Files Changed

- `src/agents/skills/workspace.ts`: Add String() coercion in filterSkillEntries
- `src/agents/skills/config.ts`: Add String() coercion in isBundledSkillAllowed

## Testing

All 80 skills tests pass.

Fixes #35252