### PR TITLE
fix(media): surface non-fatal stream reader errors on max-bytes overflow

### DIFF
--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -54,6 +54,46 @@ describe("fetchRemoteMedia", () => {
     ).rejects.toThrow("exceeds maxBytes");
   });
 
+  it("includes stream warnings when overflow cleanup emits non-fatal reader errors", async () => {
+    const lookupFn = vi.fn(async () => [
+      { address: "93.184.216.34", family: 4 },
+    ]) as unknown as LookupFn;
+
+    const reader = {
+      read: vi
+        .fn<() => Promise<ReadableStreamReadResult<Uint8Array>>>()
+        .mockResolvedValueOnce({ done: false, value: new Uint8Array([1, 2, 3]) }),
+      cancel: vi.fn(async () => {
+        throw new Error("cancel failed");
+      }),
+      releaseLock: vi.fn(() => undefined),
+    };
+
+    const fetchImpl = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: new Headers(),
+          body: {
+            getReader: () => reader,
+          },
+          arrayBuffer: async () => new ArrayBuffer(0),
+          url: "https://example.com/file.bin",
+        }) as unknown as Response,
+    );
+
+    await expect(
+      fetchRemoteMedia({
+        url: "https://example.com/file.bin",
+        fetchImpl,
+        maxBytes: 2,
+        lookupFn,
+      }),
+    ).rejects.toThrow("stream warning: cancel: Error: cancel failed");
+  });
+
   it("blocks private IP literals before fetching", async () => {
     const fetchImpl = vi.fn();
     await expect(

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -142,13 +142,20 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
       }
     }
 
+    const readerWarnings: string[] = [];
     const buffer = maxBytes
       ? await readResponseWithLimit(res, maxBytes, {
-          onOverflow: ({ maxBytes, res }) =>
-            new MediaFetchError(
+          onOverflow: ({ maxBytes, res }) => {
+            const warningSuffix =
+              readerWarnings.length > 0 ? ` (stream warning: ${readerWarnings.join("; ")})` : "";
+            return new MediaFetchError(
               "max_bytes",
-              `Failed to fetch media from ${res.url || url}: payload exceeds maxBytes ${maxBytes}`,
-            ),
+              `Failed to fetch media from ${res.url || url}: payload exceeds maxBytes ${maxBytes}${warningSuffix}`,
+            );
+          },
+          onReaderError: ({ phase, error }) => {
+            readerWarnings.push(`${phase}: ${String(error)}`);
+          },
         })
       : Buffer.from(await res.arrayBuffer());
     let fileNameFromUrl: string | undefined;

--- a/src/media/read-response-with-limit.test.ts
+++ b/src/media/read-response-with-limit.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { readResponseWithLimit } from "./read-response-with-limit.js";
+
+function makeResponseWithReader(reader: {
+  read: () => Promise<ReadableStreamReadResult<Uint8Array>>;
+  cancel: () => Promise<void>;
+  releaseLock: () => void;
+}): Response {
+  return {
+    body: {
+      getReader: () => reader,
+    },
+    arrayBuffer: async () => new ArrayBuffer(0),
+    url: "https://example.com/file.bin",
+  } as unknown as Response;
+}
+
+describe("readResponseWithLimit", () => {
+  it("reports reader.cancel errors through onReaderError during overflow", async () => {
+    const cancelError = new Error("cancel failed");
+    const reader = {
+      read: vi
+        .fn<() => Promise<ReadableStreamReadResult<Uint8Array>>>()
+        .mockResolvedValueOnce({ done: false, value: new Uint8Array([1, 2, 3]) })
+        .mockResolvedValueOnce({ done: true, value: undefined }),
+      cancel: vi.fn(async () => {
+        throw cancelError;
+      }),
+      releaseLock: vi.fn(() => undefined),
+    };
+
+    const onReaderError = vi.fn();
+
+    await expect(
+      readResponseWithLimit(makeResponseWithReader(reader), 2, {
+        onOverflow: () => new Error("overflow"),
+        onReaderError,
+      }),
+    ).rejects.toThrow("overflow");
+
+    expect(onReaderError).toHaveBeenCalledWith({ phase: "cancel", error: cancelError });
+    expect(reader.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports reader.releaseLock errors through onReaderError", async () => {
+    const releaseError = new Error("release failed");
+    const reader = {
+      read: vi
+        .fn<() => Promise<ReadableStreamReadResult<Uint8Array>>>()
+        .mockResolvedValueOnce({ done: false, value: new Uint8Array([1, 2]) })
+        .mockResolvedValueOnce({ done: true, value: undefined }),
+      cancel: vi.fn(async () => undefined),
+      releaseLock: vi.fn(() => {
+        throw releaseError;
+      }),
+    };
+
+    const onReaderError = vi.fn();
+    const buffer = await readResponseWithLimit(makeResponseWithReader(reader), 8, {
+      onReaderError,
+    });
+
+    expect(buffer).toEqual(Buffer.from([1, 2]));
+    expect(onReaderError).toHaveBeenCalledWith({ phase: "releaseLock", error: releaseError });
+  });
+});

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -1,8 +1,14 @@
+export type ReadResponseWithLimitReaderError = {
+  phase: "cancel" | "releaseLock";
+  error: unknown;
+};
+
 export async function readResponseWithLimit(
   res: Response,
   maxBytes: number,
   opts?: {
     onOverflow?: (params: { size: number; maxBytes: number; res: Response }) => Error;
+    onReaderError?: (params: ReadResponseWithLimitReaderError) => void;
   },
 ): Promise<Buffer> {
   const onOverflow =
@@ -33,7 +39,9 @@ export async function readResponseWithLimit(
         if (total > maxBytes) {
           try {
             await reader.cancel();
-          } catch {}
+          } catch (error) {
+            opts?.onReaderError?.({ phase: "cancel", error });
+          }
           throw onOverflow({ size: total, maxBytes, res });
         }
         chunks.push(value);
@@ -42,7 +50,9 @@ export async function readResponseWithLimit(
   } finally {
     try {
       reader.releaseLock();
-    } catch {}
+    } catch (error) {
+      opts?.onReaderError?.({ phase: "releaseLock", error });
+    }
   }
 
   return Buffer.concat(


### PR DESCRIPTION
## Summary
- add an `onReaderError` callback to `readResponseWithLimit` so cleanup failures are no longer silently swallowed
- propagate captured reader cleanup warnings into `fetchRemoteMedia` max-bytes errors for better diagnostics
- add focused unit coverage for cancel/releaseLock error reporting and max-bytes warning propagation

## Why
`reader.cancel()` / `reader.releaseLock()` failures were intentionally non-fatal, but silently swallowing them made real-world fetch overflows difficult to debug. This keeps behavior non-fatal while preserving visibility.

## Risk
Low. Existing success/error behavior is unchanged; only optional observability hooks and richer error text were added.

## Testing
- `pnpm vitest run --config vitest.unit.config.ts src/media/read-response-with-limit.test.ts src/media/fetch.test.ts`
