### PR TITLE
gateway: honor chat.send deliver=false for channel-scoped sessions

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -148,6 +148,7 @@ async function runNonStreamingChatSend(params: {
   idempotencyKey: string;
   message?: string;
   sessionKey?: string;
+  deliver?: boolean;
   client?: unknown;
   expectBroadcast?: boolean;
 }) {
@@ -155,6 +156,7 @@ async function runNonStreamingChatSend(params: {
     params: {
       sessionKey: params.sessionKey ?? "main",
       message: params.message ?? "hello",
+      ...(typeof params.deliver === "boolean" ? { deliver: params.deliver } : {}),
       idempotencyKey: params.idempotencyKey,
     },
     respond: params.respond as unknown as Parameters<
@@ -538,6 +540,40 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-main-no-cross-route",
       sessionKey: "main",
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        OriginatingChannel: "webchat",
+        OriginatingTo: undefined,
+        AccountId: undefined,
+      }),
+    );
+  });
+
+  it("chat.send keeps webchat routing when deliver=false on channel-scoped sessions", async () => {
+    createTranscriptFixture("openclaw-chat-send-channel-no-deliver-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "discord",
+        to: "discord:1234567890",
+        accountId: "default",
+      },
+      lastChannel: "discord",
+      lastTo: "discord:1234567890",
+      lastAccountId: "default",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-channel-no-deliver",
+      sessionKey: "agent:main:discord:direct:1234567890",
+      deliver: false,
       expectBroadcast: false,
     });
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -889,7 +889,9 @@ export const chatHandlers: GatewayRequestHandlers = {
         !isChannelAgnosticSessionScope &&
         (isChannelScopedSession || hasLegacyChannelPeerShape),
       );
+      const shouldDeliverExternally = p.deliver !== false;
       const hasDeliverableRoute =
+        shouldDeliverExternally &&
         canInheritDeliverableRoute &&
         routeChannelCandidate &&
         routeChannelCandidate !== INTERNAL_MESSAGE_CHANNEL &&


### PR DESCRIPTION
## Summary
- honor `chat.send` `deliver: false` when deciding whether to inherit external delivery routing metadata
- keep existing behavior for `deliver: true` or unset
- add a regression test that verifies channel-scoped sessions stay on `webchat` routing when delivery is disabled

## Testing
- `pnpm test src/gateway/server-methods/chat.directive-tags.test.ts`

Fixes #35254
