### PR TITLE
fix(models): normalize legacy Cloudflare Gateway bearer header

### DIFF
--- a/extensions/googlechat/src/auth.test.ts
+++ b/extensions/googlechat/src/auth.test.ts
@@ -25,6 +25,26 @@ describe("verifyGoogleChatRequest", () => {
     vi.clearAllMocks();
   });
 
+  it("accepts trusted Chat issuer even when email_verified is missing", async () => {
+    verifyIdTokenMock.mockResolvedValue({
+      getPayload: () => ({
+        email: "chat@system.gserviceaccount.com",
+      }),
+    });
+
+    const result = await verifyGoogleChatRequest({
+      bearer: "token",
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+    });
+
+    expect(verifyIdTokenMock).toHaveBeenCalledWith({
+      idToken: "token",
+      audience: "https://example.com/googlechat",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
   it("accepts trusted add-on issuer even when email_verified is missing", async () => {
     verifyIdTokenMock.mockResolvedValue({
       getPayload: () => ({

--- a/extensions/googlechat/src/auth.test.ts
+++ b/extensions/googlechat/src/auth.test.ts
@@ -62,6 +62,26 @@ describe("verifyGoogleChatRequest", () => {
     expect(result).toEqual({ ok: false, reason: "invalid issuer: user@example.com" });
   });
 
+  it("rejects trusted add-on issuer when email_verified is false", async () => {
+    verifyIdTokenMock.mockResolvedValue({
+      getPayload: () => ({
+        email: "service-123@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+        email_verified: false,
+      }),
+    });
+
+    const result = await verifyGoogleChatRequest({
+      bearer: "token",
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "invalid issuer: service-123@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+    });
+  });
+
   it("fails closed when token or audience is missing", async () => {
     await expect(
       verifyGoogleChatRequest({

--- a/extensions/googlechat/src/auth.test.ts
+++ b/extensions/googlechat/src/auth.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { verifyIdTokenMock, verifySignedJwtWithCertsAsyncMock } = vi.hoisted(() => ({
+  verifyIdTokenMock: vi.fn(),
+  verifySignedJwtWithCertsAsyncMock: vi.fn(),
+}));
+
+vi.mock("google-auth-library", () => {
+  class GoogleAuth {
+    getClient = vi.fn();
+  }
+
+  class OAuth2Client {
+    verifyIdToken = verifyIdTokenMock;
+    verifySignedJwtWithCertsAsync = verifySignedJwtWithCertsAsyncMock;
+  }
+
+  return { GoogleAuth, OAuth2Client };
+});
+
+import { verifyGoogleChatRequest } from "./auth.js";
+
+describe("verifyGoogleChatRequest", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("accepts trusted add-on issuer even when email_verified is missing", async () => {
+    verifyIdTokenMock.mockResolvedValue({
+      getPayload: () => ({
+        email: "service-123@gcp-sa-gsuiteaddons.iam.gserviceaccount.com",
+      }),
+    });
+
+    const result = await verifyGoogleChatRequest({
+      bearer: "token",
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+    });
+
+    expect(verifyIdTokenMock).toHaveBeenCalledWith({
+      idToken: "token",
+      audience: "https://example.com/googlechat",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects app-url tokens from non-Google-Chat issuer emails", async () => {
+    verifyIdTokenMock.mockResolvedValue({
+      getPayload: () => ({
+        email: "user@example.com",
+        email_verified: true,
+      }),
+    });
+
+    const result = await verifyGoogleChatRequest({
+      bearer: "token",
+      audienceType: "app-url",
+      audience: "https://example.com/googlechat",
+    });
+
+    expect(result).toEqual({ ok: false, reason: "invalid issuer: user@example.com" });
+  });
+
+  it("fails closed when token or audience is missing", async () => {
+    await expect(
+      verifyGoogleChatRequest({
+        audienceType: "app-url",
+        audience: "https://example.com/googlechat",
+      }),
+    ).resolves.toEqual({ ok: false, reason: "missing token" });
+
+    await expect(
+      verifyGoogleChatRequest({
+        bearer: "token",
+        audienceType: "app-url",
+      }),
+    ).resolves.toEqual({ ok: false, reason: "missing audience" });
+  });
+});

--- a/extensions/googlechat/src/auth.ts
+++ b/extensions/googlechat/src/auth.ts
@@ -113,7 +113,9 @@ export async function verifyGoogleChatRequest(params: {
       });
       const payload = ticket.getPayload();
       const email = payload?.email ?? "";
-      const ok = email === CHAT_ISSUER || ADDON_ISSUER_PATTERN.test(email);
+      const ok =
+        (email === CHAT_ISSUER || ADDON_ISSUER_PATTERN.test(email)) &&
+        payload?.email_verified !== false;
       return ok ? { ok: true } : { ok: false, reason: `invalid issuer: ${email}` };
     } catch (err) {
       return { ok: false, reason: err instanceof Error ? err.message : "invalid token" };

--- a/extensions/googlechat/src/auth.ts
+++ b/extensions/googlechat/src/auth.ts
@@ -113,8 +113,7 @@ export async function verifyGoogleChatRequest(params: {
       });
       const payload = ticket.getPayload();
       const email = payload?.email ?? "";
-      const ok =
-        payload?.email_verified && (email === CHAT_ISSUER || ADDON_ISSUER_PATTERN.test(email));
+      const ok = email === CHAT_ISSUER || ADDON_ISSUER_PATTERN.test(email);
       return ok ? { ok: true } : { ok: false, reason: `invalid issuer: ${email}` };
     } catch (err) {
       return { ok: false, reason: err instanceof Error ? err.message : "invalid token" };

--- a/package.json
+++ b/package.json
@@ -380,7 +380,7 @@
     "sharp": "^0.34.5",
     "sqlite-vec": "0.1.7-alpha.2",
     "strip-ansi": "^7.2.0",
-    "tar": "7.5.9",
+    "tar": "7.5.10",
     "tslog": "^4.10.2",
     "undici": "^7.22.0",
     "ws": "^8.19.0",
@@ -429,7 +429,7 @@
       "qs": "6.14.2",
       "node-domexception": "npm:@nolyfill/domexception@^1.0.28",
       "@sinclair/typebox": "0.34.48",
-      "tar": "7.5.9",
+      "tar": "7.5.10",
       "tough-cookie": "4.1.3"
     },
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   qs: 6.14.2
   node-domexception: npm:@nolyfill/domexception@^1.0.28
   '@sinclair/typebox': 0.34.48
-  tar: 7.5.9
+  tar: 7.5.10
   tough-cookie: 4.1.3
 
 importers:
@@ -179,8 +179,8 @@ importers:
         specifier: ^7.2.0
         version: 7.2.0
       tar:
-        specifier: 7.5.9
-        version: 7.5.9
+        specifier: 7.5.10
+        version: 7.5.10
       tslog:
         specifier: ^4.10.2
         version: 4.10.2
@@ -462,7 +462,7 @@ importers:
     dependencies:
       '@tloncorp/api':
         specifier: git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87
-        version: git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87
+        version: https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87
       '@tloncorp/tlon-skill':
         specifier: 0.1.9
         version: 0.1.9
@@ -2938,8 +2938,8 @@ packages:
     resolution: {integrity: sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA==}
     engines: {node: '>=12.17.0'}
 
-  '@tloncorp/api@git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87':
-    resolution: {commit: 7eede1c1a756977b09f96aa14a92e2b06318ae87, repo: https://github.com/tloncorp/api-beta.git, type: git}
+  '@tloncorp/api@https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87':
+    resolution: {tarball: https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87}
     version: 0.0.2
 
   '@tloncorp/tlon-skill-darwin-arm64@0.1.9':
@@ -5700,10 +5700,9 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
-  tar@7.5.9:
-    resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
+  tar@7.5.10:
+    resolution: {integrity: sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -6962,7 +6961,7 @@ snapshots:
       npmlog: 5.0.1
       rimraf: 3.0.2
       semver: 7.7.4
-      tar: 7.5.9
+      tar: 7.5.10
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -8908,7 +8907,7 @@ snapshots:
 
   '@tinyhttp/content-disposition@2.2.4': {}
 
-  '@tloncorp/api@git+https://github.com/tloncorp/api-beta.git#7eede1c1a756977b09f96aa14a92e2b06318ae87':
+  '@tloncorp/api@https://codeload.github.com/tloncorp/api-beta/tar.gz/7eede1c1a756977b09f96aa14a92e2b06318ae87':
     dependencies:
       '@aws-sdk/client-s3': 3.1000.0
       '@aws-sdk/s3-request-presigner': 3.1000.0
@@ -9729,7 +9728,7 @@ snapshots:
       node-api-headers: 1.8.0
       rc: 1.2.8
       semver: 7.7.4
-      tar: 7.5.9
+      tar: 7.5.10
       url-join: 4.0.1
       which: 6.0.1
       yargs: 17.7.2
@@ -11246,7 +11245,7 @@ snapshots:
       sharp: 0.34.5
       sqlite-vec: 0.1.7-alpha.2
       strip-ansi: 7.2.0
-      tar: 7.5.9
+      tar: 7.5.10
       tslog: 4.10.2
       undici: 7.22.0
       ws: 8.19.0
@@ -12191,7 +12190,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  tar@7.5.9:
+  tar@7.5.10:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/src/agents/models-config.providers.normalize-keys.test.ts
+++ b/src/agents/models-config.providers.normalize-keys.test.ts
@@ -73,4 +73,30 @@ describe("normalizeProviders", () => {
       await fs.rm(agentDir, { recursive: true, force: true });
     }
   });
+
+  it("normalizes legacy Cloudflare Gateway bearer header syntax", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    try {
+      const providers: NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]> = {
+        "cloudflare-ai-gateway": {
+          baseUrl: "https://gateway.ai.cloudflare.com/v1/account/gateway/anthropic",
+          api: "openai-completions",
+          apiKey: "CLOUDFLARE_AI_GATEWAY_API_KEY",
+          headers: {
+            "cf-aig-authorization": "Bearer: test-token",
+            "X-Other": "keep",
+          },
+          models: [],
+        },
+      };
+
+      const normalized = normalizeProviders({ providers, agentDir });
+      expect(normalized?.["cloudflare-ai-gateway"]?.headers?.["cf-aig-authorization"]).toBe(
+        "Bearer test-token",
+      );
+      expect(normalized?.["cloudflare-ai-gateway"]?.headers?.["X-Other"]).toBe("keep");
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -390,6 +390,39 @@ function normalizeApiKeyConfig(value: string): string {
   return match?.[1] ?? trimmed;
 }
 
+function normalizeCloudflareGatewayAuthHeaderValue(value: string): string {
+  const match = /^Bearer:\s*(.+)$/i.exec(value.trim());
+  if (!match) {
+    return value;
+  }
+  const token = match[1]?.trim();
+  if (!token) {
+    return value;
+  }
+  // Backward compatibility for legacy docs/configs that used "Bearer: <token>".
+  return `Bearer ${token}`;
+}
+
+function normalizeProviderHeaders(providerKey: string, provider: ProviderConfig): ProviderConfig {
+  if (providerKey !== "cloudflare-ai-gateway" || !provider.headers) {
+    return provider;
+  }
+  let mutated = false;
+  const headers = { ...provider.headers };
+  for (const [headerName, headerValue] of Object.entries(headers)) {
+    if (headerName.toLowerCase() !== "cf-aig-authorization") {
+      continue;
+    }
+    const normalizedValue = normalizeCloudflareGatewayAuthHeaderValue(headerValue);
+    if (normalizedValue === headerValue) {
+      continue;
+    }
+    headers[headerName] = normalizedValue;
+    mutated = true;
+  }
+  return mutated ? { ...provider, headers } : provider;
+}
+
 function resolveEnvApiKeyVarName(provider: string): string | undefined {
   const resolved = resolveEnvApiKey(provider);
   if (!resolved) {
@@ -559,6 +592,12 @@ export function normalizeProviders(params: {
         mutated = true;
       }
       normalizedProvider = antigravityNormalized;
+    }
+
+    const headersNormalized = normalizeProviderHeaders(normalizedKey, normalizedProvider);
+    if (headersNormalized !== normalizedProvider) {
+      mutated = true;
+      normalizedProvider = headersNormalized;
     }
 
     const existing = next[normalizedKey];


### PR DESCRIPTION
## Summary
- normalize `models.providers.cloudflare-ai-gateway.headers.cf-aig-authorization` when configured as legacy `Bearer: <token>` syntax
- keep all other provider headers unchanged
- add a targeted regression test for `normalizeProviders`

## Testing
- pnpm test src/agents/models-config.providers.normalize-keys.test.ts

Fixes #34788
