### PR TITLE
fix(agents): recognize streaming server_error as failover-worthy

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -154,4 +154,29 @@ describe("failover-error", () => {
     expect(described.message).toBe("123");
     expect(described.reason).toBeUndefined();
   });
+
+  it("infers timeout from streaming server_error in Codex/Responses API format", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        message:
+          'Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request.","param":null},"sequence_number":2}',
+      }),
+    ).toBe("timeout");
+  });
+
+  it("infers timeout from server_error keyword in error messages", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        message: "LLM error server_error: something went wrong",
+      }),
+    ).toBe("timeout");
+  });
+
+  it("infers timeout from OpenAI WebSocket response.failed with server_error type", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        message: 'OpenAI WebSocket response failed: {"type":"server_error","message":"Internal error"}',
+      }),
+    ).toBe("timeout");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -662,6 +662,26 @@ function isJsonApiInternalServerError(raw: string): boolean {
   return value.includes('"type":"api_error"') && value.includes("internal server error");
 }
 
+export function isStreamingProviderServerError(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  const value = raw.toLowerCase();
+  // Codex/OpenAI Responses API returns streaming error events like:
+  // {"type":"error","error":{"type":"server_error","code":"server_error",...}}
+  // which are formatted as 'Codex error: {...}' or
+  // 'OpenAI WebSocket response failed: ...' by upstream handlers.
+  if (value.includes('"type":"server_error"') || value.includes('"code":"server_error"')) {
+    return true;
+  }
+  // Also match "server_error" as a standalone token from providers that
+  // surface the error type directly in the message.
+  if (/\bserver_error\b/.test(value)) {
+    return true;
+  }
+  return false;
+}
+
 export function parseImageDimensionError(raw: string): {
   maxDimensionPx?: number;
   messageIndex?: number;
@@ -795,6 +815,9 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
     return "timeout";
   }
   if (isJsonApiInternalServerError(raw)) {
+    return "timeout";
+  }
+  if (isStreamingProviderServerError(raw)) {
     return "timeout";
   }
   if (isRateLimitErrorMessage(raw)) {


### PR DESCRIPTION
## Summary

- **Problem:** When the Codex/OpenAI Responses API returns a streaming `server_error` event, the error is not recognized as failover-worthy. The session terminates with `stopReason: "error"` but no fallback model is attempted, even when a full fallback chain is configured.
- **Why it matters:** Agents using Codex as primary with fallbacks get zero fallback protection against server errors. Cron-scheduled tasks fail silently with no retry.
- **What changed:** Added `isStreamingProviderServerError()` in `pi-embedded-helpers/errors.ts` that matches `server_error` in streaming error messages (JSON payloads with `"type":"server_error"` or bare `server_error` tokens). Wired it into `classifyFailoverReason()` so these errors return `"timeout"`, triggering the existing model fallback path.
- **What did NOT change:** HTTP-status-based failover (`resolveFailoverReasonFromError`), other error classification patterns, the fallback orchestration logic (`runWithModelFallback`).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35220

## User-visible / Behavior Changes

- Streaming `server_error` from Codex/OpenAI Responses API now triggers model fallback instead of terminating the session
- Applies to all providers that surface `server_error` in streaming error events

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+
- Integration/channel: Any

### Steps

1. Configure an agent with Codex as primary and fallback models
2. Trigger a session where Codex returns a streaming `server_error`
3. Observe fallback model is attempted

### Expected

- Fallback models are tried when Codex returns `server_error`

### Actual

- Before fix: Session terminates with `stopReason: "error"`, no fallback
- After fix: `classifyFailoverReason` returns `"timeout"` for `server_error`, triggering `FailoverError` and model fallback

## Evidence

All 20 tests pass including 3 new test cases:

```
✓ infers timeout from streaming server_error in Codex/Responses API format
✓ infers timeout from server_error keyword in error messages
✓ infers timeout from OpenAI WebSocket response.failed with server_error type
```

## Human Verification (required)

- Verified scenarios: JSON-formatted Codex streaming error, bare `server_error` token, WebSocket response.failed with server_error type
- Edge cases checked: Empty strings return false; non-server_error messages are not affected; existing error patterns still work correctly
- What I did **not** verify: End-to-end with a live Codex API key triggering a real server_error

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert `isStreamingProviderServerError` and its call in `classifyFailoverReason`
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts`
- Known bad symptoms: If a non-transient error happens to contain "server_error" in its message, it would be incorrectly classified as retryable (unlikely given the specificity of the pattern)

## Risks and Mitigations

- **Risk:** False positives if a permanent error message contains "server_error". **Mitigation:** The function checks after model-not-found, image errors, and session-expired patterns, which are more specific. The `server_error` pattern is specific enough to avoid collisions with auth/billing errors.
