### PR TITLE
feishu: surface cross-app open_id delivery errors

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -305,7 +305,7 @@ export async function sendImageFeishu(params: {
         ...(replyInThread ? { reply_in_thread: true } : {}),
       },
     });
-    assertFeishuMessageApiSuccess(response, "Feishu image reply failed");
+    assertFeishuMessageApiSuccess(response, "Feishu image reply failed", { receiveIdType });
     return toFeishuSendResult(response, receiveId);
   }
 
@@ -317,7 +317,7 @@ export async function sendImageFeishu(params: {
       msg_type: "image",
     },
   });
-  assertFeishuMessageApiSuccess(response, "Feishu image send failed");
+  assertFeishuMessageApiSuccess(response, "Feishu image send failed", { receiveIdType });
   return toFeishuSendResult(response, receiveId);
 }
 
@@ -352,7 +352,7 @@ export async function sendFileFeishu(params: {
         ...(replyInThread ? { reply_in_thread: true } : {}),
       },
     });
-    assertFeishuMessageApiSuccess(response, "Feishu file reply failed");
+    assertFeishuMessageApiSuccess(response, "Feishu file reply failed", { receiveIdType });
     return toFeishuSendResult(response, receiveId);
   }
 
@@ -364,7 +364,7 @@ export async function sendFileFeishu(params: {
       msg_type: msgType,
     },
   });
-  assertFeishuMessageApiSuccess(response, "Feishu file send failed");
+  assertFeishuMessageApiSuccess(response, "Feishu file send failed", { receiveIdType });
   return toFeishuSendResult(response, receiveId);
 }
 

--- a/extensions/feishu/src/send-result.test.ts
+++ b/extensions/feishu/src/send-result.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { assertFeishuMessageApiSuccess } from "./send-result.js";
+
+describe("assertFeishuMessageApiSuccess", () => {
+  it("adds a clear hint for explicit cross-app open_id errors", () => {
+    expect(() =>
+      assertFeishuMessageApiSuccess(
+        { code: 400, msg: "cross app open_id is invalid" },
+        "Feishu send failed",
+        { receiveIdType: "open_id" },
+      ),
+    ).toThrow("open_id belongs to a different Feishu app/account");
+  });
+
+  it("adds a cross-app hint when open_id delivery returns invalid user_id", () => {
+    expect(() =>
+      assertFeishuMessageApiSuccess({ code: 400, msg: "invalid user_id" }, "Feishu send failed", {
+        receiveIdType: "open_id",
+      }),
+    ).toThrow("open_id belongs to a different Feishu app/account");
+  });
+
+  it("keeps invalid user_id generic for non-open_id targets", () => {
+    let thrown: unknown;
+    try {
+      assertFeishuMessageApiSuccess({ code: 400, msg: "invalid user_id" }, "Feishu send failed", {
+        receiveIdType: "chat_id",
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toBe("Feishu send failed: invalid user_id");
+  });
+});

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -6,12 +6,44 @@ export type FeishuMessageApiResponse = {
   };
 };
 
+export type FeishuMessageApiErrorContext = {
+  receiveIdType?: string;
+};
+
+const CROSS_APP_HINT =
+  "open_id belongs to a different Feishu app/account; route using the account that owns this open_id";
+
+function looksLikeCrossAppOpenIdError(params: {
+  response: FeishuMessageApiResponse;
+  context?: FeishuMessageApiErrorContext;
+}): boolean {
+  const msg = params.response.msg?.toLowerCase() ?? "";
+  if (!msg) {
+    return false;
+  }
+
+  if (/cross[\s-]?app|different app|跨应用|跨\s*app/i.test(msg)) {
+    return true;
+  }
+
+  const receiveIdType = params.context?.receiveIdType?.toLowerCase();
+  const isOpenIdTarget = receiveIdType === "open_id";
+  if (isOpenIdTarget && /invalid\s+user_?id/i.test(msg)) {
+    return true;
+  }
+
+  return false;
+}
+
 export function assertFeishuMessageApiSuccess(
   response: FeishuMessageApiResponse,
   errorPrefix: string,
+  context?: FeishuMessageApiErrorContext,
 ) {
   if (response.code !== 0) {
-    throw new Error(`${errorPrefix}: ${response.msg || `code ${response.code}`}`);
+    const detail = response.msg || `code ${response.code}`;
+    const hint = looksLikeCrossAppOpenIdError({ response, context }) ? `; ${CROSS_APP_HINT}` : "";
+    throw new Error(`${errorPrefix}: ${detail}${hint}`);
   }
 }
 

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -70,7 +70,7 @@ async function sendFallbackDirect(
       msg_type: params.msgType,
     },
   });
-  assertFeishuMessageApiSuccess(response, errorPrefix);
+  assertFeishuMessageApiSuccess(response, errorPrefix, { receiveIdType: params.receiveIdType });
   return toFeishuSendResult(response, params.receiveId);
 }
 
@@ -316,7 +316,7 @@ export async function sendMessageFeishu(
     if (shouldFallbackFromReplyTarget(response)) {
       return sendFallbackDirect(client, directParams, "Feishu send failed");
     }
-    assertFeishuMessageApiSuccess(response, "Feishu reply failed");
+    assertFeishuMessageApiSuccess(response, "Feishu reply failed", { receiveIdType });
     return toFeishuSendResult(response, receiveId);
   }
 
@@ -360,7 +360,7 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
     if (shouldFallbackFromReplyTarget(response)) {
       return sendFallbackDirect(client, directParams, "Feishu card send failed");
     }
-    assertFeishuMessageApiSuccess(response, "Feishu card reply failed");
+    assertFeishuMessageApiSuccess(response, "Feishu card reply failed", { receiveIdType });
     return toFeishuSendResult(response, receiveId);
   }
 


### PR DESCRIPTION
## Summary
- detect Feishu cross-app `open_id` delivery failures from API error messages
- append an explicit hint to send/reply/file/image errors when the target `open_id` appears to belong to another Feishu app/account
- thread `receiveIdType` into Feishu send error assertions so hinting only triggers for relevant targets
- add focused unit tests for cross-app hint detection behavior

## Testing
- pnpm test extensions/feishu/src/send-result.test.ts extensions/feishu/src/send.reply-fallback.test.ts
- pnpm test extensions/feishu/src/send-result.test.ts

Fixes #35253
