### PR TITLE
fix(telegram): suppress duplicate finals in partial streaming

### DIFF
--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -343,6 +343,32 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.stop).toHaveBeenCalled();
   });
 
+  it("suppresses duplicate identical final payloads after preview finalization", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Primary result" });
+        await dispatcherOptions.deliver({ text: "Primary result" }, { kind: "final" });
+        await dispatcherOptions.deliver({ text: "Primary result" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      999,
+      "Primary result",
+      expect.any(Object),
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("keeps streamed preview visible when final text regresses after a tool warning", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -372,6 +372,21 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       !hasMedia && text.length > 0 && text.length <= params.draftMaxChars && !payload.isError;
 
     if (infoKind === "final") {
+      if (
+        params.finalizedPreviewByLane[laneName] &&
+        !hasMedia &&
+        !payload.isError &&
+        text.length > 0 &&
+        text === lane.lastPartialText
+      ) {
+        // Some providers can duplicate final callbacks with the same payload text.
+        // If this lane already finalized that preview text, suppress the duplicate send.
+        params.log(
+          `telegram: ${laneName} preview already finalized for identical final text; skipping duplicate final send`,
+        );
+        params.markDelivered();
+        return "preview-finalized";
+      }
       if (laneName === "answer") {
         const archivedResult = await consumeArchivedAnswerPreviewForFinal({
           lane,


### PR DESCRIPTION
## Summary

- **Problem:** In Telegram `partial` streaming mode, providers may emit duplicate identical `final` callbacks after a preview is already finalized, causing duplicate final assistant messages.
- **Why it matters:** Users can receive repeated identical final replies in Telegram, which is noisy and confusing.
- **What changed:** Added a duplicate-final guard in `src/telegram/lane-delivery.ts`.
  - If a lane preview has already been finalized
  - and a new `final` payload is text-only, non-error, and identical to the last partial text
  - then the duplicate final send is suppressed.
- **What did NOT change:** Non-identical finals, media/error payloads, and normal draft/finalization flow remain unchanged.

## Files Changed

- `src/telegram/lane-delivery.ts`
- `src/telegram/bot-message-dispatch.test.ts`
- `CHANGELOG.md`

## Testing

- Added regression test: `suppresses duplicate identical final payloads after preview finalization` in `src/telegram/bot-message-dispatch.test.ts`.

## Linked Issue

- Fixes #34790

## Security Impact

- No new permissions, no token handling changes, no network surface changes.

## AI Assisted

Codex
