### PR TITLE
Fix: coerce skill name to string to prevent YAML number parsing issue

### DIFF
--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -155,4 +155,24 @@ describe("loadWorkspaceSkillEntries", () => {
 
     expect(entries.map((entry) => entry.skill.name)).not.toContain("diffs");
   });
+
+  it("coerces numeric YAML skill names to strings", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const managedDir = path.join(workspaceDir, ".managed");
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    const numericSkillDir = path.join(workspaceDir, "skills", "numeric-name");
+    await fs.mkdir(numericSkillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(numericSkillDir, "SKILL.md"),
+      `---\nname: 123\ndescription: number name\n---\n`,
+      "utf-8",
+    );
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: bundledDir,
+    });
+
+    expect(entries.map((entry) => entry.skill.name)).toContain("123");
+  });
 });

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -206,16 +206,35 @@ function resolveNestedSkillsRoot(
 }
 
 function unwrapLoadedSkills(loaded: unknown): Skill[] {
-  if (Array.isArray(loaded)) {
-    return loaded as Skill[];
-  }
-  if (loaded && typeof loaded === "object" && "skills" in loaded) {
-    const skills = (loaded as { skills?: unknown }).skills;
-    if (Array.isArray(skills)) {
-      return skills as Skill[];
+  const rawSkills = (() => {
+    if (Array.isArray(loaded)) {
+      return loaded;
     }
+    if (loaded && typeof loaded === "object" && "skills" in loaded) {
+      const skills = (loaded as { skills?: unknown }).skills;
+      if (Array.isArray(skills)) {
+        return skills;
+      }
+    }
+    return [];
+  })();
+
+  const normalized: Skill[] = [];
+  for (const skill of rawSkills) {
+    if (!skill || typeof skill !== "object") {
+      continue;
+    }
+    const rawName = (skill as { name?: unknown }).name;
+    const name = String(rawName ?? "").trim();
+    if (!name) {
+      continue;
+    }
+    normalized.push({
+      ...(skill as Skill),
+      name,
+    });
   }
-  return [];
+  return normalized;
 }
 
 function loadSkillEntries(


### PR DESCRIPTION
## Summary
- Coerce skill name to string to prevent YAML number parsing issues
- Handle numeric frontmatter names in skill loading

## Testing
- Added test for numeric skill names

## AI Assisted
Codex

## Fixes #35270