### PR TITLE
fix(agents): handle malformed thinking blocks in context pruning

### DIFF
--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -423,4 +423,23 @@ describe("context-pruning", () => {
     expect(text).toContain("efghij");
     expect(text).toContain("[Tool result trimmed:");
   });
+
+  it("handles malformed thinking blocks in assistant messages without crashing", () => {
+    const messages: AgentMessage[] = [
+      makeUser("u1"),
+      makeAssistant("a1"),
+      {
+        role: "assistant",
+        content: [{ type: "thinking" }],
+      } as unknown as AgentMessage,
+      makeToolResult({
+        toolCallId: "t1",
+        toolName: "exec",
+        text: "x".repeat(20_000),
+      }),
+    ];
+
+    const next = pruneWithAggressiveDefaults(messages);
+    expect(toolText(findToolResult(next, "t1"))).toBe("[cleared]");
+  });
 });

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -122,10 +122,10 @@ function estimateMessageChars(message: AgentMessage): number {
     let chars = 0;
     for (const b of message.content) {
       if (b.type === "text") {
-        chars += b.text.length;
+        chars += typeof b.text === "string" ? b.text.length : 0;
       }
       if (b.type === "thinking") {
-        chars += b.thinking.length;
+        chars += typeof b.thinking === "string" ? b.thinking.length : 0;
       }
       if (b.type === "toolCall") {
         try {


### PR DESCRIPTION
## Summary

- **Problem:** Context pruning could crash when assistant messages contain malformed `thinking` blocks (missing/non-string fields).
- **Why it matters:** Malformed model output should not break pruning or session continuation.
- **What changed:** Hardened char estimation in `src/agents/pi-extensions/context-pruning/pruner.ts` with type guards before reading `.length`, and added regression coverage.
- **What did NOT change:** Normal pruning behavior for valid message blocks remains unchanged.

## Linked Issue

- Fixes #35026

## Files Changed

- `src/agents/pi-extensions/context-pruning/pruner.ts`
- `src/agents/pi-extensions/context-pruning.test.ts`

## Testing

- Regression test added in `context-pruning.test.ts` for malformed thinking-block handling.

## Security Impact

- No new permissions, no token handling changes, no network surface changes.

## AI Assisted

Codex
