### PR TITLE
Fix: TUI messages displaying twice in terminal UI

### DIFF
--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -29,6 +29,16 @@ describe("ChatLog", () => {
     expect(rendered).toContain("recreated");
   });
 
+  it("does not append duplicate assistant components when a run is started twice", () => {
+    const chatLog = new ChatLog(40);
+    chatLog.startAssistant("first", "run-dup");
+    chatLog.startAssistant("second", "run-dup");
+
+    const rendered = chatLog.render(120).join("\n");
+    expect(rendered).toContain("second");
+    expect(rendered).not.toContain("first");
+  });
+
   it("drops stale tool references when old components are pruned", () => {
     const chatLog = new ChatLog(20);
     chatLog.startTool("tool-1", "read_file", { path: "a.txt" });

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -65,8 +65,14 @@ export class ChatLog extends Container {
   }
 
   startAssistant(text: string, runId?: string) {
+    const effectiveRunId = this.resolveRunId(runId);
+    const existing = this.streamingRuns.get(effectiveRunId);
+    if (existing) {
+      existing.setText(text);
+      return existing;
+    }
     const component = new AssistantMessageComponent(text);
-    this.streamingRuns.set(this.resolveRunId(runId), component);
+    this.streamingRuns.set(effectiveRunId, component);
     this.append(component);
     return component;
   }


### PR DESCRIPTION
## Summary
- Fix TUI messages displaying twice when startAssistant called twice with same runId
- Now reuses existing component instead of creating duplicates

## Testing
- Added test for duplicate prevention

## AI Assisted
Codex

## Fixes #35278