### PR TITLE
fix: Bug: Delivery queue messages retry infinitely with no expiry or dead-letter mechanism (#35250)

### DIFF
--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -9,6 +9,8 @@ import type { OutboundChannel } from "./targets.js";
 const QUEUE_DIRNAME = "delivery-queue";
 const FAILED_DIRNAME = "failed";
 const MAX_RETRIES = 5;
+const MAX_ENTRY_AGE_MS = 24 * 60 * 60 * 1000;
+const QUEUE_WARN_THRESHOLD = 100;
 
 /** Backoff delays in milliseconds indexed by retry count (1-based). */
 const BACKOFF_MS: readonly number[] = [
@@ -55,6 +57,7 @@ export type RecoverySummary = {
   recovered: number;
   failed: number;
   skippedMaxRetries: number;
+  skippedExpired: number;
   deferredBackoff: number;
 };
 
@@ -285,19 +288,31 @@ export async function recoverPendingDeliveries(opts: {
 }): Promise<RecoverySummary> {
   const pending = await loadPendingDeliveries(opts.stateDir);
   if (pending.length === 0) {
-    return { recovered: 0, failed: 0, skippedMaxRetries: 0, deferredBackoff: 0 };
+    return {
+      recovered: 0,
+      failed: 0,
+      skippedMaxRetries: 0,
+      skippedExpired: 0,
+      deferredBackoff: 0,
+    };
   }
 
   // Process oldest first.
   pending.sort((a, b) => a.enqueuedAt - b.enqueuedAt);
 
   opts.log.info(`Found ${pending.length} pending delivery entries — starting recovery`);
+  if (pending.length > QUEUE_WARN_THRESHOLD) {
+    opts.log.warn(
+      `Delivery queue depth is high (${pending.length} entries, threshold ${QUEUE_WARN_THRESHOLD})`,
+    );
+  }
 
   const deadline = Date.now() + (opts.maxRecoveryMs ?? 60_000);
 
   let recovered = 0;
   let failed = 0;
   let skippedMaxRetries = 0;
+  let skippedExpired = 0;
   let deferredBackoff = 0;
 
   for (const entry of pending) {
@@ -306,6 +321,18 @@ export async function recoverPendingDeliveries(opts: {
       const deferred = pending.length - recovered - failed - skippedMaxRetries - deferredBackoff;
       opts.log.warn(`Recovery time budget exceeded — ${deferred} entries deferred to next restart`);
       break;
+    }
+    if (isEntryExpired(entry, now)) {
+      opts.log.warn(
+        `Delivery ${entry.id} expired after ${MAX_ENTRY_AGE_MS}ms in queue — moving to failed/`,
+      );
+      try {
+        await moveToFailed(entry.id, opts.stateDir);
+      } catch (err) {
+        opts.log.error(`Failed to move expired entry ${entry.id} to failed/: ${String(err)}`);
+      }
+      skippedExpired += 1;
+      continue;
     }
     if (entry.retryCount >= MAX_RETRIES) {
       opts.log.warn(
@@ -370,9 +397,9 @@ export async function recoverPendingDeliveries(opts: {
   }
 
   opts.log.info(
-    `Delivery recovery complete: ${recovered} recovered, ${failed} failed, ${skippedMaxRetries} skipped (max retries), ${deferredBackoff} deferred (backoff)`,
+    `Delivery recovery complete: ${recovered} recovered, ${failed} failed, ${skippedMaxRetries} skipped (max retries), ${skippedExpired} skipped (expired), ${deferredBackoff} deferred (backoff)`,
   );
-  return { recovered, failed, skippedMaxRetries, deferredBackoff };
+  return { recovered, failed, skippedMaxRetries, skippedExpired, deferredBackoff };
 }
 
 export { MAX_RETRIES };
@@ -391,4 +418,15 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
 
 export function isPermanentDeliveryError(error: string): boolean {
   return PERMANENT_ERROR_PATTERNS.some((re) => re.test(error));
+}
+
+function isEntryExpired(entry: QueuedDelivery, now: number): boolean {
+  const hasEnqueuedTimestamp =
+    typeof entry.enqueuedAt === "number" &&
+    Number.isFinite(entry.enqueuedAt) &&
+    entry.enqueuedAt > 0;
+  if (!hasEnqueuedTimestamp) {
+    return false;
+  }
+  return now - entry.enqueuedAt >= MAX_ENTRY_AGE_MS;
 }

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -328,6 +328,7 @@ describe("delivery-queue", () => {
       expect(result.recovered).toBe(2);
       expect(result.failed).toBe(0);
       expect(result.skippedMaxRetries).toBe(0);
+      expect(result.skippedExpired).toBe(0);
       expect(result.deferredBackoff).toBe(0);
 
       // Queue should be empty after recovery.
@@ -348,11 +349,39 @@ describe("delivery-queue", () => {
 
       expect(deliver).not.toHaveBeenCalled();
       expect(result.skippedMaxRetries).toBe(1);
+      expect(result.skippedExpired).toBe(0);
       expect(result.deferredBackoff).toBe(0);
 
       // Entry should be in failed/ directory.
       const failedDir = path.join(tmpDir, "delivery-queue", "failed");
       expect(fs.existsSync(path.join(failedDir, `${id}.json`))).toBe(true);
+    });
+
+    it("moves expired entries to failed/ without retrying", async () => {
+      const id = await enqueueDelivery(
+        { channel: "whatsapp", to: "+1", payloads: [{ text: "stale" }] },
+        tmpDir,
+      );
+      setEntryState(id, {
+        retryCount: 0,
+        enqueuedAt: Date.now() - 25 * 60 * 60 * 1000,
+      });
+
+      const deliver = vi.fn();
+      const log = createLog();
+      const { result } = await runRecovery({ deliver, log });
+
+      expect(deliver).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        recovered: 0,
+        failed: 0,
+        skippedMaxRetries: 0,
+        skippedExpired: 1,
+        deferredBackoff: 0,
+      });
+      const failedDir = path.join(tmpDir, "delivery-queue", "failed");
+      expect(fs.existsSync(path.join(failedDir, `${id}.json`))).toBe(true);
+      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("expired"));
     });
 
     it("increments retryCount on failed recovery attempt", async () => {
@@ -363,6 +392,7 @@ describe("delivery-queue", () => {
 
       expect(result.failed).toBe(1);
       expect(result.recovered).toBe(0);
+      expect(result.skippedExpired).toBe(0);
 
       // Entry should still be in queue with incremented retryCount.
       const entries = await loadPendingDeliveries(tmpDir);
@@ -384,6 +414,7 @@ describe("delivery-queue", () => {
 
       expect(result.failed).toBe(1);
       expect(result.recovered).toBe(0);
+      expect(result.skippedExpired).toBe(0);
       const remaining = await loadPendingDeliveries(tmpDir);
       expect(remaining).toHaveLength(0);
       const failedDir = path.join(tmpDir, "delivery-queue", "failed");
@@ -449,6 +480,7 @@ describe("delivery-queue", () => {
       expect(result.recovered).toBe(0);
       expect(result.failed).toBe(0);
       expect(result.skippedMaxRetries).toBe(0);
+      expect(result.skippedExpired).toBe(0);
       expect(result.deferredBackoff).toBe(0);
 
       // All entries should still be in the queue.
@@ -457,6 +489,19 @@ describe("delivery-queue", () => {
 
       // Should have logged a warning about deferred entries.
       expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("deferred to next restart"));
+    });
+
+    it("warns when queue size exceeds threshold", async () => {
+      for (let i = 0; i < 101; i += 1) {
+        await enqueueDelivery(
+          { channel: "whatsapp", to: `+1${i}`, payloads: [{ text: String(i) }] },
+          tmpDir,
+        );
+      }
+      const deliver = vi.fn().mockResolvedValue([]);
+      const log = createLog();
+      await runRecovery({ deliver, log, maxRecoveryMs: 0 });
+      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("queue depth is high"));
     });
 
     it("defers entries until backoff becomes eligible", async () => {
@@ -477,6 +522,7 @@ describe("delivery-queue", () => {
         recovered: 0,
         failed: 0,
         skippedMaxRetries: 0,
+        skippedExpired: 0,
         deferredBackoff: 1,
       });
 
@@ -507,6 +553,7 @@ describe("delivery-queue", () => {
         recovered: 1,
         failed: 0,
         skippedMaxRetries: 0,
+        skippedExpired: 0,
         deferredBackoff: 1,
       });
       expect(deliver).toHaveBeenCalledTimes(1);
@@ -536,6 +583,7 @@ describe("delivery-queue", () => {
         recovered: 0,
         failed: 0,
         skippedMaxRetries: 0,
+        skippedExpired: 0,
         deferredBackoff: 1,
       });
       expect(firstDeliver).not.toHaveBeenCalled();
@@ -547,6 +595,7 @@ describe("delivery-queue", () => {
         recovered: 1,
         failed: 0,
         skippedMaxRetries: 0,
+        skippedExpired: 0,
         deferredBackoff: 0,
       });
       expect(secondDeliver).toHaveBeenCalledTimes(1);
@@ -565,6 +614,7 @@ describe("delivery-queue", () => {
         recovered: 0,
         failed: 0,
         skippedMaxRetries: 0,
+        skippedExpired: 0,
         deferredBackoff: 0,
       });
       expect(deliver).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes #35250

## Summary

- Problem: Bug: Delivery queue messages retry infinitely with no expiry or dead-letter mechanism
- Why it matters: Reported in #35250
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35250
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35250