### PR TITLE
fix(infra): add TTL expiry and retryCount guards to delivery queue

### DIFF
--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -10,6 +10,9 @@ const QUEUE_DIRNAME = "delivery-queue";
 const FAILED_DIRNAME = "failed";
 const MAX_RETRIES = 5;
 
+/** Messages older than this are expired and moved to failed/ on recovery. Default: 24 hours. */
+const MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
 /** Backoff delays in milliseconds indexed by retry count (1-based). */
 const BACKOFF_MS: readonly number[] = [
   5_000, // retry 1: 5s
@@ -56,6 +59,7 @@ export type RecoverySummary = {
   failed: number;
   skippedMaxRetries: number;
   deferredBackoff: number;
+  expired: number;
 };
 
 function resolveQueueDir(stateDir?: string): string {
@@ -129,7 +133,10 @@ export async function failDelivery(id: string, error: string, stateDir?: string)
   const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
   const raw = await fs.promises.readFile(filePath, "utf-8");
   const entry: QueuedDelivery = JSON.parse(raw);
-  entry.retryCount += 1;
+  const currentCount = typeof entry.retryCount === "number" && Number.isFinite(entry.retryCount)
+    ? entry.retryCount
+    : 0;
+  entry.retryCount = currentCount + 1;
   entry.lastAttemptAt = Date.now();
   entry.lastError = error;
   const tmp = `${filePath}.${process.pid}.tmp`;
@@ -234,19 +241,28 @@ function normalizeLegacyQueuedDeliveryEntry(entry: QueuedDelivery): {
   entry: QueuedDelivery;
   migrated: boolean;
 } {
-  const hasAttemptTimestamp =
-    typeof entry.lastAttemptAt === "number" &&
-    Number.isFinite(entry.lastAttemptAt) &&
-    entry.lastAttemptAt > 0;
-  if (hasAttemptTimestamp || entry.retryCount <= 0) {
-    return { entry, migrated: false };
+  let migrated = false;
+
+  if (typeof entry.retryCount !== "number" || !Number.isFinite(entry.retryCount)) {
+    entry = { ...entry, retryCount: 0 };
+    migrated = true;
   }
+
   const hasEnqueuedTimestamp =
     typeof entry.enqueuedAt === "number" &&
     Number.isFinite(entry.enqueuedAt) &&
     entry.enqueuedAt > 0;
   if (!hasEnqueuedTimestamp) {
-    return { entry, migrated: false };
+    entry = { ...entry, enqueuedAt: Date.now() };
+    migrated = true;
+  }
+
+  const hasAttemptTimestamp =
+    typeof entry.lastAttemptAt === "number" &&
+    Number.isFinite(entry.lastAttemptAt) &&
+    entry.lastAttemptAt > 0;
+  if (hasAttemptTimestamp || entry.retryCount <= 0) {
+    return { entry, migrated };
   }
   return {
     entry: {
@@ -285,7 +301,7 @@ export async function recoverPendingDeliveries(opts: {
 }): Promise<RecoverySummary> {
   const pending = await loadPendingDeliveries(opts.stateDir);
   if (pending.length === 0) {
-    return { recovered: 0, failed: 0, skippedMaxRetries: 0, deferredBackoff: 0 };
+    return { recovered: 0, failed: 0, skippedMaxRetries: 0, deferredBackoff: 0, expired: 0 };
   }
 
   // Process oldest first.
@@ -293,20 +309,46 @@ export async function recoverPendingDeliveries(opts: {
 
   opts.log.info(`Found ${pending.length} pending delivery entries — starting recovery`);
 
+  if (pending.length > 50) {
+    opts.log.warn(
+      `Delivery queue has ${pending.length} entries — consider investigating failed deliveries in ${resolveFailedDir(opts.stateDir)}/`,
+    );
+  }
+
   const deadline = Date.now() + (opts.maxRecoveryMs ?? 60_000);
 
   let recovered = 0;
   let failed = 0;
   let skippedMaxRetries = 0;
   let deferredBackoff = 0;
+  let expiredCount = 0;
 
   for (const entry of pending) {
     const now = Date.now();
     if (now >= deadline) {
-      const deferred = pending.length - recovered - failed - skippedMaxRetries - deferredBackoff;
+      const deferred = pending.length - recovered - failed - skippedMaxRetries - deferredBackoff - expiredCount;
       opts.log.warn(`Recovery time budget exceeded — ${deferred} entries deferred to next restart`);
       break;
     }
+
+    const hasValidEnqueuedAt =
+      typeof entry.enqueuedAt === "number" &&
+      Number.isFinite(entry.enqueuedAt) &&
+      entry.enqueuedAt > 0;
+    const entryAge = hasValidEnqueuedAt ? now - entry.enqueuedAt : 0;
+    if (entryAge > MAX_AGE_MS) {
+      opts.log.warn(
+        `Delivery ${entry.id} expired (age: ${Math.round(entryAge / 3600_000)}h) — moving to failed/`,
+      );
+      try {
+        await moveToFailed(entry.id, opts.stateDir);
+      } catch (err) {
+        opts.log.error(`Failed to move expired entry ${entry.id} to failed/: ${String(err)}`);
+      }
+      expiredCount += 1;
+      continue;
+    }
+
     if (entry.retryCount >= MAX_RETRIES) {
       opts.log.warn(
         `Delivery ${entry.id} exceeded max retries (${entry.retryCount}/${MAX_RETRIES}) — moving to failed/`,
@@ -370,12 +412,12 @@ export async function recoverPendingDeliveries(opts: {
   }
 
   opts.log.info(
-    `Delivery recovery complete: ${recovered} recovered, ${failed} failed, ${skippedMaxRetries} skipped (max retries), ${deferredBackoff} deferred (backoff)`,
+    `Delivery recovery complete: ${recovered} recovered, ${failed} failed, ${skippedMaxRetries} skipped (max retries), ${expiredCount} expired, ${deferredBackoff} deferred (backoff)`,
   );
-  return { recovered, failed, skippedMaxRetries, deferredBackoff };
+  return { recovered, failed, skippedMaxRetries, deferredBackoff, expired: expiredCount };
 }
 
-export { MAX_RETRIES };
+export { MAX_RETRIES, MAX_AGE_MS };
 
 const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /no conversation reference found/i,

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -14,6 +14,7 @@ import {
   isEntryEligibleForRecoveryRetry,
   isPermanentDeliveryError,
   loadPendingDeliveries,
+  MAX_AGE_MS,
   MAX_RETRIES,
   moveToFailed,
   recoverPendingDeliveries,
@@ -478,6 +479,7 @@ describe("delivery-queue", () => {
         failed: 0,
         skippedMaxRetries: 0,
         deferredBackoff: 1,
+        expired: 0,
       });
 
       const remaining = await loadPendingDeliveries(tmpDir);
@@ -508,6 +510,7 @@ describe("delivery-queue", () => {
         failed: 0,
         skippedMaxRetries: 0,
         deferredBackoff: 1,
+        expired: 0,
       });
       expect(deliver).toHaveBeenCalledTimes(1);
       expect(deliver).toHaveBeenCalledWith(
@@ -537,6 +540,7 @@ describe("delivery-queue", () => {
         failed: 0,
         skippedMaxRetries: 0,
         deferredBackoff: 1,
+        expired: 0,
       });
       expect(firstDeliver).not.toHaveBeenCalled();
 
@@ -548,6 +552,7 @@ describe("delivery-queue", () => {
         failed: 0,
         skippedMaxRetries: 0,
         deferredBackoff: 0,
+        expired: 0,
       });
       expect(secondDeliver).toHaveBeenCalledTimes(1);
 
@@ -566,8 +571,69 @@ describe("delivery-queue", () => {
         failed: 0,
         skippedMaxRetries: 0,
         deferredBackoff: 0,
+        expired: 0,
       });
       expect(deliver).not.toHaveBeenCalled();
+    });
+
+    it("expires entries older than MAX_AGE_MS", async () => {
+      const id = await enqueueDelivery(
+        { channel: "whatsapp", to: "+1", payloads: [{ text: "old" }] },
+        tmpDir,
+      );
+      setEntryState(id, { retryCount: 0, enqueuedAt: Date.now() - MAX_AGE_MS - 1 });
+
+      const deliver = vi.fn();
+      const { result, log } = await runRecovery({ deliver, maxRecoveryMs: 60_000 });
+
+      expect(result.expired).toBe(1);
+      expect(result.recovered).toBe(0);
+      expect(deliver).not.toHaveBeenCalled();
+      expect(log.warn).toHaveBeenCalledWith(
+        expect.stringContaining("expired"),
+      );
+
+      const remaining = await loadPendingDeliveries(tmpDir);
+      expect(remaining).toHaveLength(0);
+
+      const failedDir = path.join(tmpDir, "delivery-queue", "failed");
+      const failedFiles = fs.readdirSync(failedDir).filter((f: string) => f.endsWith(".json"));
+      expect(failedFiles).toHaveLength(1);
+    });
+
+    it("handles missing retryCount gracefully in failDelivery", async () => {
+      const id = await enqueueDelivery(
+        { channel: "telegram", to: "42", payloads: [{ text: "test" }] },
+        tmpDir,
+      );
+      const filePath = path.join(tmpDir, "delivery-queue", `${id}.json`);
+      const entry = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+      delete entry.retryCount;
+      fs.writeFileSync(filePath, JSON.stringify(entry), "utf-8");
+
+      await failDelivery(id, "test error", tmpDir);
+
+      const updated = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+      expect(updated.retryCount).toBe(1);
+      expect(updated.lastError).toBe("test error");
+    });
+
+    it("does not expire entries with missing enqueuedAt", async () => {
+      const id = await enqueueDelivery(
+        { channel: "whatsapp", to: "+1", payloads: [{ text: "legacy" }] },
+        tmpDir,
+      );
+      const filePath = path.join(tmpDir, "delivery-queue", `${id}.json`);
+      const entry = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+      delete entry.enqueuedAt;
+      fs.writeFileSync(filePath, JSON.stringify(entry), "utf-8");
+
+      const deliver = vi.fn().mockResolvedValue(undefined);
+      const { result } = await runRecovery({ deliver, maxRecoveryMs: 60_000 });
+
+      expect(result.expired).toBe(0);
+      expect(result.recovered).toBe(1);
+      expect(deliver).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Problem:** Delivery queue messages retry indefinitely with no expiry. Legacy entries without a `retryCount` field cause `NaN` propagation (via `+= 1` on `undefined`), bypassing the `MAX_RETRIES` guard. There is also no age-based TTL, so messages enqueued weeks ago still get retried on every gateway restart.
- **Why it matters:** In one reported case, 155 messages accumulated in the queue, all failing with the same cross-app error. Each gateway restart triggered a flood of failed API calls.
- **What changed:** (1) Added 24h TTL (`MAX_AGE_MS`) — entries older than 24h are moved to `failed/` without attempting delivery. (2) Added `retryCount` normalization in `failDelivery()` and `normalizeLegacyQueuedDeliveryEntry()` to guard against `undefined`/`NaN`. (3) Added `enqueuedAt` backfill in `normalizeLegacyQueuedDeliveryEntry()` — legacy entries without a timestamp get `Date.now()` so TTL starts from first recovery. (4) Safe TTL check: missing/invalid `enqueuedAt` is treated as age 0 (not expired). (5) Added queue size warning when >50 entries are pending. (6) Added `expired` field to `RecoverySummary`.
- **What did NOT change:** The existing `MAX_RETRIES=5` limit, backoff schedule, permanent error detection, and `failed/` dead-letter directory remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #35250

## User-visible / Behavior Changes

- Messages older than 24h in the delivery queue are now expired (moved to `failed/`) on gateway startup recovery
- A warning is logged when the delivery queue exceeds 50 entries
- Legacy queue entries without `retryCount` now correctly increment instead of becoming `NaN`
- Legacy queue entries without `enqueuedAt` are backfilled with `Date.now()` during normalization (TTL starts from first recovery, not epoch)

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux/macOS
- Runtime: Node.js 22+
- Integration/channel: Any with delivery queue (Feishu, Telegram, etc.)

### Steps

1. Enqueue a delivery message that will fail (e.g., cross-app open_id on Feishu)
2. Restart the gateway multiple times over 24+ hours
3. Observe that after 24h, the entry is moved to `failed/` instead of retried

### Expected

- Old entries are expired and moved to `failed/` after 24h
- Legacy entries without `retryCount` correctly count retries
- Legacy entries without `enqueuedAt` are NOT immediately expired

### Actual

- Before fix: Entries retry forever; `retryCount` becomes `NaN` for legacy entries; missing `enqueuedAt` would cause immediate expiry
- After fix: Entries expire after 24h; `retryCount` is properly guarded; missing `enqueuedAt` is backfilled on normalization and treated as age 0 in TTL check

## Evidence

All 61 tests pass including 3 new tests:

```
✓ expires entries older than MAX_AGE_MS
✓ handles missing retryCount gracefully in failDelivery
✓ does not expire entries with missing enqueuedAt
```

## Human Verification (required)

- Verified scenarios: TTL expiry for old entries; retryCount guard for undefined/NaN; enqueuedAt backfill in normalize; safe TTL check for missing enqueuedAt; queue size warning at >50; backward compatibility with existing entries
- Edge cases checked: `retryCount` undefined, `retryCount` NaN, `enqueuedAt` missing (backfilled to `Date.now()` in normalize, treated as age 0 in TTL check), `enqueuedAt` 0, `enqueuedAt` NaN
- What I did **not** verify: End-to-end with a live Feishu setup

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No` — existing entries are transparently normalized (enqueuedAt backfilled, retryCount guarded)

## Failure Recovery (if this breaks)

- How to disable/revert: Revert `delivery-queue.ts` changes; remove TTL check and retryCount guard
- Files/config to restore: `src/infra/outbound/delivery-queue.ts`
- Known bad symptoms: If TTL is too short, valid messages could be expired before delivery. 24h is conservative.

## Risks and Mitigations

- **Risk:** 24h TTL may be too short for some use cases. **Mitigation:** The TTL is a constant (`MAX_AGE_MS`) that can be made configurable in a follow-up. 24h covers the vast majority of transient failures.
