### PR TITLE
telegram: cap sticker cache size with oldest-entry eviction

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -540,6 +540,8 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     Stickers are described once (when possible) and cached to reduce repeated vision calls.
 
+    Cache size is capped at 1000 stickers; when exceeded, the oldest entries are evicted automatically.
+
     Enable sticker actions:
 
 ```json5

--- a/docs/zh-CN/channels/telegram.md
+++ b/docs/zh-CN/channels/telegram.md
@@ -471,6 +471,8 @@ OpenClaw 支持接收和发送 Telegram 贴纸，并具有智能缓存功能。
 
 **缓存位置：** `~/.openclaw/telegram/sticker-cache.json`
 
+**缓存上限：** 最多 1000 条，超出时会自动淘汰最早的记录。
+
 **缓存条目格式：**
 
 ```json

--- a/src/infra/json-file.test.ts
+++ b/src/infra/json-file.test.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadJsonFile, saveJsonFile } from "./json-file.js";
+
+const tempDirs: string[] = [];
+
+function createTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "json-file-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("json-file", () => {
+  it("reads existing JSON without an existsSync preflight", () => {
+    const dir = createTempDir();
+    const file = path.join(dir, "cache.json");
+    fs.writeFileSync(file, '{"ok":true}\n', "utf8");
+
+    const existsSpy = vi.spyOn(fs, "existsSync");
+    expect(loadJsonFile(file)).toEqual({ ok: true });
+    expect(existsSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined for missing files without an existsSync preflight", () => {
+    const dir = createTempDir();
+    const file = path.join(dir, "missing.json");
+
+    const existsSpy = vi.spyOn(fs, "existsSync");
+    expect(loadJsonFile(file)).toBeUndefined();
+    expect(existsSpy).not.toHaveBeenCalled();
+  });
+
+  it("creates parent directories and writes JSON without existsSync", () => {
+    const dir = createTempDir();
+    const file = path.join(dir, "nested", "cache.json");
+
+    const existsSpy = vi.spyOn(fs, "existsSync");
+    saveJsonFile(file, { count: 1 });
+
+    expect(existsSpy).not.toHaveBeenCalled();
+    expect(loadJsonFile(file)).toEqual({ count: 1 });
+  });
+});

--- a/src/infra/json-file.ts
+++ b/src/infra/json-file.ts
@@ -3,9 +3,6 @@ import path from "node:path";
 
 export function loadJsonFile(pathname: string): unknown {
   try {
-    if (!fs.existsSync(pathname)) {
-      return undefined;
-    }
     const raw = fs.readFileSync(pathname, "utf8");
     return JSON.parse(raw) as unknown;
   } catch {
@@ -15,9 +12,7 @@ export function loadJsonFile(pathname: string): unknown {
 
 export function saveJsonFile(pathname: string, data: unknown) {
   const dir = path.dirname(pathname);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-  }
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   fs.writeFileSync(pathname, `${JSON.stringify(data, null, 2)}\n`, "utf8");
   fs.chmodSync(pathname, 0o600);
 }

--- a/src/telegram/sticker-cache.test.ts
+++ b/src/telegram/sticker-cache.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  MAX_STICKER_CACHE_ENTRIES,
   cacheSticker,
   getAllCachedStickers,
   getCachedSticker,
@@ -112,6 +113,21 @@ describe("sticker-cache", () => {
       const result = getCachedSticker("unique789");
       expect(result?.description).toBe("Updated description");
       expect(result?.fileId).toBe("file789-new");
+    });
+
+    it("evicts oldest entries when cache exceeds max size", () => {
+      for (let i = 0; i < MAX_STICKER_CACHE_ENTRIES + 1; i += 1) {
+        cacheSticker({
+          fileId: `file-${i}`,
+          fileUniqueId: `unique-${i}`,
+          description: `Sticker ${i}`,
+          cachedAt: new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString(),
+        });
+      }
+
+      expect(getCacheStats().count).toBe(MAX_STICKER_CACHE_ENTRIES);
+      expect(getCachedSticker("unique-0")).toBeNull();
+      expect(getCachedSticker(`unique-${MAX_STICKER_CACHE_ENTRIES}`)).not.toBeNull();
     });
   });
 

--- a/src/telegram/sticker-cache.ts
+++ b/src/telegram/sticker-cache.ts
@@ -16,6 +16,7 @@ import { resolveAutoImageModel } from "../media-understanding/runner.js";
 
 const CACHE_FILE = path.join(STATE_DIR, "telegram", "sticker-cache.json");
 const CACHE_VERSION = 1;
+export const MAX_STICKER_CACHE_ENTRIES = 1000;
 
 export interface CachedSticker {
   fileId: string;
@@ -49,6 +50,26 @@ function saveCache(cache: StickerCache): void {
   saveJsonFile(CACHE_FILE, cache);
 }
 
+function stickerCachedAtMs(sticker: CachedSticker): number {
+  const parsed = Date.parse(sticker.cachedAt);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function pruneCacheIfNeeded(cache: StickerCache): void {
+  const entries = Object.entries(cache.stickers);
+  if (entries.length <= MAX_STICKER_CACHE_ENTRIES) {
+    return;
+  }
+  const overflow = entries.length - MAX_STICKER_CACHE_ENTRIES;
+  const oldestIds = entries
+    .toSorted(([, a], [, b]) => stickerCachedAtMs(a) - stickerCachedAtMs(b))
+    .slice(0, overflow)
+    .map(([id]) => id);
+  for (const id of oldestIds) {
+    delete cache.stickers[id];
+  }
+}
+
 /**
  * Get a cached sticker by its unique ID.
  */
@@ -63,6 +84,7 @@ export function getCachedSticker(fileUniqueId: string): CachedSticker | null {
 export function cacheSticker(sticker: CachedSticker): void {
   const cache = loadCache();
   cache.stickers[sticker.fileUniqueId] = sticker;
+  pruneCacheIfNeeded(cache);
   saveCache(cache);
 }
 


### PR DESCRIPTION
## Summary
- cap Telegram sticker cache to 1000 entries
- evict oldest entries by `cachedAt` when the cap is exceeded
- add test coverage for overflow eviction behavior
- document the cache limit in both English and Chinese Telegram docs

## Why
The sticker cache currently grows without bounds over time. In long-running deployments this can cause unnecessary disk growth and larger cache load/search overhead.

## Risk
Low and isolated. The only behavioral change is on cache writes after overflow; read/search APIs stay the same.
