### PR TITLE
fix: Bug: Queued messages expose raw metadata (sender_id, message_id) to LLM when session history is empty (#35251)

### DIFF
--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -10,12 +10,19 @@ import {
   waitForQueueDebounce,
 } from "../../../utils/queue-helpers.js";
 import { isRoutableChannel } from "../route-reply.js";
+import { stripLeadingInboundMetadata } from "../strip-inbound-meta.js";
 import { FOLLOWUP_QUEUES } from "./state.js";
 import type { FollowupRun } from "./types.js";
 
 // Persists the most recent runFollowup callback per queue key so that
 // enqueueFollowupRun can restart a drain that finished and deleted the queue.
 const FOLLOWUP_RUN_CALLBACKS = new Map<string, (run: FollowupRun) => Promise<void>>();
+const QUEUED_MESSAGE_UNAVAILABLE_PLACEHOLDER = "[message content unavailable]";
+
+function renderCollectQueueItemPrompt(prompt: string): string {
+  const sanitized = stripLeadingInboundMetadata(prompt).trim();
+  return sanitized || QUEUED_MESSAGE_UNAVAILABLE_PLACEHOLDER;
+}
 
 export function clearFollowupDrainCallback(key: string): void {
   FOLLOWUP_RUN_CALLBACKS.delete(key);
@@ -114,7 +121,8 @@ export function scheduleFollowupDrain(
             title: "[Queued messages while agent was busy]",
             items,
             summary,
-            renderItem: (item, idx) => `---\nQueued #${idx + 1}\n${item.prompt}`.trim(),
+            renderItem: (item, idx) =>
+              `---\nQueued #${idx + 1}\n${renderCollectQueueItemPrompt(item.prompt)}`.trim(),
           });
           await runFollowup({
             prompt,

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1015,6 +1015,83 @@ describe("followup queue collect routing", () => {
     expect(calls[0]?.prompt).toContain("Queued #2\ntwo");
   });
 
+  it("strips inbound metadata blocks from collected queued prompts", async () => {
+    const key = `test-collect-strip-meta-${Date.now()}`;
+    const calls: FollowupRun[] = [];
+    const done = createDeferred<void>();
+    const runFollowup = async (run: FollowupRun) => {
+      calls.push(run);
+      done.resolve();
+    };
+    const settings: QueueSettings = {
+      mode: "collect",
+      debounceMs: 0,
+      cap: 50,
+      dropPolicy: "summarize",
+    };
+
+    enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: `Conversation info (untrusted metadata):
+\`\`\`json
+{
+  "sender_id": "ou_123",
+  "message_id": "msg_456"
+}
+\`\`\`
+
+hello there`,
+      }),
+      settings,
+    );
+
+    scheduleFollowupDrain(key, runFollowup);
+    await done.promise;
+
+    expect(calls[0]?.prompt).toContain("Queued #1\nhello there");
+    expect(calls[0]?.prompt).not.toContain("Conversation info (untrusted metadata):");
+    expect(calls[0]?.prompt).not.toContain('"sender_id"');
+    expect(calls[0]?.prompt).not.toContain('"message_id"');
+  });
+
+  it("uses a placeholder when a collected queued prompt only contains metadata", async () => {
+    const key = `test-collect-meta-only-${Date.now()}`;
+    const calls: FollowupRun[] = [];
+    const done = createDeferred<void>();
+    const runFollowup = async (run: FollowupRun) => {
+      calls.push(run);
+      done.resolve();
+    };
+    const settings: QueueSettings = {
+      mode: "collect",
+      debounceMs: 0,
+      cap: 50,
+      dropPolicy: "summarize",
+    };
+
+    enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: `Conversation info (untrusted metadata):
+\`\`\`json
+{
+  "sender_id": "ou_123",
+  "message_id": "msg_456"
+}
+\`\`\``,
+      }),
+      settings,
+    );
+
+    scheduleFollowupDrain(key, runFollowup);
+    await done.promise;
+
+    expect(calls[0]?.prompt).toContain("Queued #1\n[message content unavailable]");
+    expect(calls[0]?.prompt).not.toContain('"sender_id"');
+    expect(calls[0]?.prompt).not.toContain('"message_id"');
+  });
+
   it("retries overflow summary delivery without losing dropped previews", async () => {
     const key = `test-overflow-summary-retry-${Date.now()}`;
     const calls: FollowupRun[] = [];


### PR DESCRIPTION
Closes #35251

## Summary

- Problem: Bug: Queued messages expose raw metadata (sender_id, message_id) to LLM when session history is empty
- Why it matters: Reported in #35251
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35251
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35251