### PR TITLE
Fix: decode HTML entities in xAI/Grok tool call arguments

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -147,8 +147,13 @@ describe("wrapStreamFnTrimToolCallNames", () => {
   async function invokeWrappedStream(
     baseFn: (...args: never[]) => unknown,
     allowedToolNames?: Set<string>,
+    decodeHtmlEntitiesInArguments?: boolean,
   ) {
-    const wrappedFn = wrapStreamFnTrimToolCallNames(baseFn as never, allowedToolNames);
+    const wrappedFn = wrapStreamFnTrimToolCallNames(
+      baseFn as never,
+      allowedToolNames,
+      decodeHtmlEntitiesInArguments,
+    );
     return await wrappedFn({} as never, {} as never, {} as never);
   }
 
@@ -294,6 +299,92 @@ describe("wrapStreamFnTrimToolCallNames", () => {
 
     expect(finalToolCall.name).toBe("read");
     expect(finalToolCall.id).toBe("call_42");
+  });
+
+  it("decodes HTML entities in tool call arguments when enabled", async () => {
+    const partialToolCall = {
+      type: "toolCall",
+      name: " read ",
+      arguments: "{&quot;path&quot;:&quot;/tmp/a&amp;b&quot;}",
+    };
+    const finalToolCall = {
+      type: "toolCall",
+      name: " read ",
+      arguments: "{&quot;path&quot;:&quot;/tmp/c&amp;d&quot;}",
+    };
+    const event = {
+      type: "toolcall_delta",
+      partial: { role: "assistant", content: [partialToolCall] },
+    };
+    const finalMessage = { role: "assistant", content: [finalToolCall] };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [event],
+        resultMessage: finalMessage,
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn, undefined, true);
+    for await (const _item of stream) {
+      // drain
+    }
+    await stream.result();
+
+    expect(partialToolCall.arguments).toBe('{"path":"/tmp/a&b"}');
+    expect(finalToolCall.arguments).toBe('{"path":"/tmp/c&d"}');
+  });
+
+  it("decodes HTML entities in toolUse/functionCall input when enabled", async () => {
+    const partialToolUse = {
+      type: "toolUse",
+      name: " read ",
+      input: "{&quot;path&quot;:&quot;/tmp/a&amp;b&quot;}",
+    };
+    const finalFunctionCall = {
+      type: "functionCall",
+      name: " read ",
+      input: "{&quot;path&quot;:&quot;/tmp/c&amp;d&quot;}",
+    };
+    const event = {
+      type: "toolcall_delta",
+      partial: { role: "assistant", content: [partialToolUse] },
+    };
+    const finalMessage = { role: "assistant", content: [finalFunctionCall] };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [event],
+        resultMessage: finalMessage,
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn, undefined, true);
+    for await (const _item of stream) {
+      // drain
+    }
+    await stream.result();
+
+    expect(partialToolUse.input).toBe('{"path":"/tmp/a&b"}');
+    expect(finalFunctionCall.input).toBe('{"path":"/tmp/c&d"}');
+  });
+
+  it("leaves HTML entities unchanged when decoding is disabled", async () => {
+    const finalToolCall = {
+      type: "toolCall",
+      name: " read ",
+      arguments: "{&quot;path&quot;:&quot;/tmp/a&amp;b&quot;}",
+    };
+    const finalMessage = { role: "assistant", content: [finalToolCall] };
+    const baseFn = vi.fn(() =>
+      createFakeStream({
+        events: [],
+        resultMessage: finalMessage,
+      }),
+    );
+
+    const stream = await invokeWrappedStream(baseFn);
+    await stream.result();
+
+    expect(finalToolCall.arguments).toBe("{&quot;path&quot;:&quot;/tmp/a&amp;b&quot;}");
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -65,6 +65,7 @@ import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
 import { resolveSandboxContext } from "../../sandbox.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
+import { isXaiProvider } from "../../schema/clean-for-xai.js";
 import { repairSessionFileIfNeeded } from "../../session-file-repair.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import { sanitizeToolUseResultPairing } from "../../session-transcript-repair.js";
@@ -266,6 +267,65 @@ function normalizeToolCallNameForDispatch(rawName: string, allowedToolNames?: Se
   return caseInsensitiveMatch ?? trimmed;
 }
 
+function decodeHtmlEntities(value: string): string {
+  return value.replace(
+    /&(?:amp|lt|gt|quot|apos|#39|#x27|#x2F|#47|#x60|#96|#x3D|#61);|&#\d+;|&#x[0-9a-f]+;/gi,
+    (entity) => {
+      const lowered = entity.toLowerCase();
+      switch (lowered) {
+        case "&amp;":
+          return "&";
+        case "&lt;":
+          return "<";
+        case "&gt;":
+          return ">";
+        case "&quot;":
+          return '"';
+        case "&apos;":
+        case "&#39;":
+        case "&#x27;":
+          return "'";
+        case "&#x2f;":
+        case "&#47;":
+          return "/";
+        case "&#x60;":
+        case "&#96;":
+          return "`";
+        case "&#x3d;":
+        case "&#61;":
+          return "=";
+      }
+      if (/^&#\d+;$/i.test(entity)) {
+        const codePoint = Number.parseInt(entity.slice(2, -1), 10);
+        return Number.isNaN(codePoint) ? entity : String.fromCodePoint(codePoint);
+      }
+      if (/^&#x[0-9a-f]+;$/i.test(entity)) {
+        const codePoint = Number.parseInt(entity.slice(3, -1), 16);
+        return Number.isNaN(codePoint) ? entity : String.fromCodePoint(codePoint);
+      }
+      return entity;
+    },
+  );
+}
+
+function decodeHtmlEntitiesDeep(value: unknown): unknown {
+  if (typeof value === "string") {
+    return decodeHtmlEntities(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => decodeHtmlEntitiesDeep(entry));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
+        key,
+        decodeHtmlEntitiesDeep(entry),
+      ]),
+    );
+  }
+  return value;
+}
+
 function isToolCallBlockType(type: unknown): boolean {
   return type === "toolCall" || type === "toolUse" || type === "functionCall";
 }
@@ -342,6 +402,7 @@ export function resolveOllamaBaseUrlForRun(params: {
 function trimWhitespaceFromToolCallNamesInMessage(
   message: unknown,
   allowedToolNames?: Set<string>,
+  decodeHtmlEntitiesInArguments = false,
 ): void {
   if (!message || typeof message !== "object") {
     return;
@@ -354,13 +415,32 @@ function trimWhitespaceFromToolCallNamesInMessage(
     if (!block || typeof block !== "object") {
       continue;
     }
-    const typedBlock = block as { type?: unknown; name?: unknown };
-    if (typedBlock.type !== "toolCall" || typeof typedBlock.name !== "string") {
+    const typedBlock = block as {
+      type?: unknown;
+      name?: unknown;
+      arguments?: unknown;
+      input?: unknown;
+    };
+    if (!isToolCallBlockType(typedBlock.type)) {
       continue;
     }
-    const normalized = normalizeToolCallNameForDispatch(typedBlock.name, allowedToolNames);
-    if (normalized !== typedBlock.name) {
-      typedBlock.name = normalized;
+    if (typedBlock.type === "toolCall" && typeof typedBlock.name === "string") {
+      const normalized = normalizeToolCallNameForDispatch(typedBlock.name, allowedToolNames);
+      if (normalized !== typedBlock.name) {
+        typedBlock.name = normalized;
+      }
+    }
+    if (decodeHtmlEntitiesInArguments) {
+      if (typeof typedBlock.arguments === "string") {
+        typedBlock.arguments = decodeHtmlEntities(typedBlock.arguments);
+      } else {
+        typedBlock.arguments = decodeHtmlEntitiesDeep(typedBlock.arguments);
+      }
+      if (typeof typedBlock.input === "string") {
+        typedBlock.input = decodeHtmlEntities(typedBlock.input);
+      } else {
+        typedBlock.input = decodeHtmlEntitiesDeep(typedBlock.input);
+      }
     }
   }
   normalizeToolCallIdsInMessage(message);
@@ -369,11 +449,16 @@ function trimWhitespaceFromToolCallNamesInMessage(
 function wrapStreamTrimToolCallNames(
   stream: ReturnType<typeof streamSimple>,
   allowedToolNames?: Set<string>,
+  decodeHtmlEntitiesInArguments = false,
 ): ReturnType<typeof streamSimple> {
   const originalResult = stream.result.bind(stream);
   stream.result = async () => {
     const message = await originalResult();
-    trimWhitespaceFromToolCallNamesInMessage(message, allowedToolNames);
+    trimWhitespaceFromToolCallNamesInMessage(
+      message,
+      allowedToolNames,
+      decodeHtmlEntitiesInArguments,
+    );
     return message;
   };
 
@@ -389,8 +474,16 @@ function wrapStreamTrimToolCallNames(
               partial?: unknown;
               message?: unknown;
             };
-            trimWhitespaceFromToolCallNamesInMessage(event.partial, allowedToolNames);
-            trimWhitespaceFromToolCallNamesInMessage(event.message, allowedToolNames);
+            trimWhitespaceFromToolCallNamesInMessage(
+              event.partial,
+              allowedToolNames,
+              decodeHtmlEntitiesInArguments,
+            );
+            trimWhitespaceFromToolCallNamesInMessage(
+              event.message,
+              allowedToolNames,
+              decodeHtmlEntitiesInArguments,
+            );
           }
           return result;
         },
@@ -409,15 +502,20 @@ function wrapStreamTrimToolCallNames(
 export function wrapStreamFnTrimToolCallNames(
   baseFn: StreamFn,
   allowedToolNames?: Set<string>,
+  decodeHtmlEntitiesInArguments = false,
 ): StreamFn {
   return (model, context, options) => {
     const maybeStream = baseFn(model, context, options);
     if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
       return Promise.resolve(maybeStream).then((stream) =>
-        wrapStreamTrimToolCallNames(stream, allowedToolNames),
+        wrapStreamTrimToolCallNames(stream, allowedToolNames, decodeHtmlEntitiesInArguments),
       );
     }
-    return wrapStreamTrimToolCallNames(maybeStream, allowedToolNames);
+    return wrapStreamTrimToolCallNames(
+      maybeStream,
+      allowedToolNames,
+      decodeHtmlEntitiesInArguments,
+    );
   };
 }
 
@@ -1156,6 +1254,7 @@ export async function runEmbeddedAttempt(
       activeSession.agent.streamFn = wrapStreamFnTrimToolCallNames(
         activeSession.agent.streamFn,
         allowedToolNames,
+        isXaiProvider(params.provider, params.modelId),
       );
 
       if (anthropicPayloadLogger) {


### PR DESCRIPTION
## Summary
- Decode HTML entities in xAI/Grok tool call arguments
- Fixes issue where tool calls had encoded entities like &amp;

## Testing
- Added test for HTML entity decoding

## AI Assisted
Codex

## Fixes #35276