### PR TITLE
fix(feishu): classify invalid receive_id as permanent delivery error

### DIFF
--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -11,7 +11,11 @@ export function assertFeishuMessageApiSuccess(
   errorPrefix: string,
 ) {
   if (response.code !== 0) {
-    throw new Error(`${errorPrefix}: ${response.msg || `code ${response.code}`}`);
+    // Always include both msg and code for diagnostics and error classification.
+    const detail = response.msg
+      ? `${response.msg} (code ${response.code})`
+      : `code ${response.code}`;
+    throw new Error(`${errorPrefix}: ${detail}`);
   }
 }
 

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -387,6 +387,8 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
+  // Feishu / Lark: invalid recipient (e.g. cross-app open_id mismatch)
+  /invalid receive.?id/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -166,6 +166,8 @@ describe("delivery-queue", () => {
       "Forbidden: bot was kicked from the group chat",
       "chat_id is empty",
       "Outbound not configured for channel: msteams",
+      "Feishu send failed: invalid receive_id, please check (code 230001)",
+      "Feishu send failed: Invalid receive id (code 230001)",
     ])("returns true for permanent error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(true);
     });


### PR DESCRIPTION
## Summary

- Problem: When a Feishu bot sends messages using an `open_id` from a different Feishu application, the API returns an "invalid receive_id" error (code 230001). The delivery queue treats this as a transient failure and retries 5 times with exponential backoff before moving to `failed/`.
- Why it matters: Cross-app `open_id` mismatches are permanent — retries will never succeed. This causes 5 wasted API calls per message and queue backlog when many messages target invalid recipients (as reported: 155+ queued messages).
- What changed: Added `/invalid receive.?id/i` to `PERMANENT_ERROR_PATTERNS` so these failures are immediately classified as permanent. Also improved `assertFeishuMessageApiSuccess` to always include both `msg` and `code` in thrown errors for reliable pattern matching and diagnostics.
- What did NOT change (scope boundary): No changes to the Feishu send flow, target resolution, or delivery queue retry/backoff logic. Only error classification and error message formatting were modified.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #35253

## User-visible / Behavior Changes

Messages to invalid Feishu recipients (e.g. cross-app `open_id`) now fail immediately instead of retrying 5 times over ~12 minutes. Failed entries move directly to the `failed/` directory, making the error visible for debugging sooner.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Runtime: Node 22+ / Bun
- Integration/channel: Feishu / Lark

### Steps

1. Configure a Feishu bot in App A
2. Attempt to send a message to an `open_id` obtained from App B
3. Observe the Feishu API returns error code 230001 ("invalid receive_id")

### Expected

- Delivery is immediately classified as a permanent failure
- Entry is moved to `failed/` directory without retries
- Error message includes both the human-readable msg and numeric code

### Actual (before fix)

- Delivery retries 5 times with exponential backoff (5s, 25s, 2m, 10m)
- Queue accumulates failed entries
- Error message only showed msg OR code (not both), making pattern matching unreliable

## Evidence

- [x] Failing test/log before + passing after

All 60 delivery queue tests pass including 2 new test cases that verify the permanent error pattern matches real Feishu API error formats:
- `"Feishu send failed: invalid receive_id, please check (code 230001)"`
- `"Feishu send failed: Invalid receive id (code 230001)"`

## Human Verification (required)

- Verified scenarios: Ran full `outbound.test.ts` suite (60 tests pass); verified regex matches both "receive_id" and "receive id" variants with case-insensitive matching
- Edge cases checked: Verified the pattern does not false-positive on unrelated error messages containing "receive" or "id" separately; confirmed improved error format preserves backward compatibility (existing patterns still match)
- What I did **not** verify: Live Feishu API testing with actual cross-app open_id (requires two Feishu apps)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the `/invalid receive.?id/i` line from `PERMANENT_ERROR_PATTERNS` in `src/infra/outbound/delivery-queue.ts`
- Files/config to restore: `src/infra/outbound/delivery-queue.ts`, `extensions/feishu/src/send-result.ts`
- Known bad symptoms reviewers should watch for: If the regex is too broad, legitimate transient Feishu errors could be misclassified as permanent. The pattern is intentionally narrow (requires "invalid" + "receive" + optional separator + "id").

## Risks and Mitigations

- Risk: The regex `/invalid receive.?id/i` could theoretically match an unexpected Feishu error message that is actually transient.
  - Mitigation: The pattern requires three specific tokens ("invalid", "receive", "id") in sequence, which is highly specific to recipient validation errors. All known Feishu transient errors (rate limiting, network issues, server errors) use entirely different message formats.