### PR TITLE
fix: Bug: YAML skill name as bare number causes TypeError in skill discovery (name.startsWith is not a function) (#35252)

### DIFF
--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -140,6 +140,25 @@ describe("loadWorkspaceSkillEntries", () => {
     expect(entries.map((entry) => entry.skill.name)).toContain("diffs");
   });
 
+  it("coerces unquoted numeric frontmatter skill names to strings", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const managedDir = path.join(workspaceDir, ".managed");
+    await fs.mkdir(path.join(workspaceDir, "skills", "numeric-name"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, "skills", "numeric-name", "SKILL.md"),
+      "---\nname: 12306\ndescription: Numeric name\n---\n",
+      "utf-8",
+    );
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+    });
+    const numeric = entries.find((entry) => entry.skill.description === "Numeric name");
+
+    expect(numeric?.skill.name).toBe("12306");
+  });
+
   it("excludes diffs plugin skill when the plugin is disabled", async () => {
     const { workspaceDir, managedDir, bundledDir } = await setupWorkspaceWithDiffsPlugin();
 

--- a/src/agents/skills/bundled-context.test.ts
+++ b/src/agents/skills/bundled-context.test.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { captureEnv } from "../../test-utils/env.js";
+import { resolveBundledSkillsContext } from "./bundled-context.js";
+
+describe("resolveBundledSkillsContext", () => {
+  let envSnapshot: ReturnType<typeof captureEnv>;
+
+  beforeEach(() => {
+    envSnapshot = captureEnv(["OPENCLAW_BUNDLED_SKILLS_DIR"]);
+  });
+
+  afterEach(() => {
+    envSnapshot.restore();
+  });
+
+  it("coerces unquoted numeric frontmatter skill names to strings", async () => {
+    const bundledDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bundled-context-"));
+    const numericSkillDir = path.join(bundledDir, "numeric-name");
+    await fs.mkdir(numericSkillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(numericSkillDir, "SKILL.md"),
+      "---\nname: 12306\ndescription: Numeric bundled name\n---\n",
+      "utf-8",
+    );
+
+    process.env.OPENCLAW_BUNDLED_SKILLS_DIR = bundledDir;
+    const context = resolveBundledSkillsContext();
+
+    expect(context.names.has("12306")).toBe(true);
+  });
+});

--- a/src/agents/skills/bundled-context.ts
+++ b/src/agents/skills/bundled-context.ts
@@ -1,6 +1,10 @@
+import fs from "node:fs";
+import path from "node:path";
 import { loadSkillsFromDir } from "@mariozechner/pi-coding-agent";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveBundledSkillsDir, type BundledSkillsResolveOptions } from "./bundled-dir.js";
+import { parseFrontmatter } from "./frontmatter.js";
+import { normalizeLoadedSkills } from "./normalize.js";
 
 const skillsLogger = createSubsystemLogger("skills");
 let hasWarnedMissingBundledDir = false;
@@ -30,9 +34,37 @@ export function resolveBundledSkillsContext(
     return { dir, names: new Set(cachedBundledContext.names) };
   }
   const result = loadSkillsFromDir({ dir, source: "openclaw-bundled" });
-  for (const skill of result.skills) {
+  for (const skill of normalizeLoadedSkills(result.skills)) {
     if (skill.name.trim()) {
       names.add(skill.name);
+    }
+  }
+  const dirEntries = (() => {
+    try {
+      return fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+  })();
+  for (const entry of dirEntries) {
+    if (entry.name.startsWith(".") || entry.name === "node_modules" || !entry.isDirectory()) {
+      continue;
+    }
+    const skillMdPath = path.join(dir, entry.name, "SKILL.md");
+    if (!fs.existsSync(skillMdPath)) {
+      continue;
+    }
+    try {
+      const raw = fs.readFileSync(skillMdPath, "utf-8");
+      const frontmatter = parseFrontmatter(raw);
+      const name = (
+        typeof frontmatter.name === "string" ? frontmatter.name : String(frontmatter.name ?? "")
+      ).trim();
+      if (name) {
+        names.add(name);
+      }
+    } catch {
+      // Ignore malformed bundled skill files.
     }
   }
   cachedBundledContext = { dir, names: new Set(names) };

--- a/src/agents/skills/normalize.ts
+++ b/src/agents/skills/normalize.ts
@@ -1,0 +1,20 @@
+import type { Skill } from "@mariozechner/pi-coding-agent";
+
+function normalizeSkillName(name: unknown): string {
+  return (typeof name === "string" ? name : String(name ?? "")).trim();
+}
+
+export function normalizeLoadedSkills(skills: ReadonlyArray<Skill>): Skill[] {
+  const normalized: Skill[] = [];
+  for (const skill of skills) {
+    const name = normalizeSkillName((skill as { name?: unknown }).name);
+    if (!name) {
+      continue;
+    }
+    normalized.push({
+      ...skill,
+      name,
+    });
+  }
+  return normalized;
+}

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -18,6 +18,7 @@ import {
   resolveOpenClawMetadata,
   resolveSkillInvocationPolicy,
 } from "./frontmatter.js";
+import { normalizeLoadedSkills } from "./normalize.js";
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
 import { serializeByKey } from "./serialize.js";
 import type {
@@ -207,15 +208,55 @@ function resolveNestedSkillsRoot(
 
 function unwrapLoadedSkills(loaded: unknown): Skill[] {
   if (Array.isArray(loaded)) {
-    return loaded as Skill[];
+    return normalizeLoadedSkills(loaded as Skill[]);
   }
   if (loaded && typeof loaded === "object" && "skills" in loaded) {
     const skills = (loaded as { skills?: unknown }).skills;
     if (Array.isArray(skills)) {
-      return skills as Skill[];
+      return normalizeLoadedSkills(skills as Skill[]);
     }
   }
   return [];
+}
+
+function normalizeSkillFrontmatterString(value: unknown): string {
+  return (typeof value === "string" ? value : String(value ?? "")).trim();
+}
+
+function loadSkillFromSkillMd(params: { skillDir: string; source: string }): Skill | null {
+  const skillMdPath = path.join(params.skillDir, "SKILL.md");
+  if (!fs.existsSync(skillMdPath)) {
+    return null;
+  }
+  try {
+    const raw = fs.readFileSync(skillMdPath, "utf-8");
+    const frontmatter = parseFrontmatter(raw);
+    const parentDirName = path.basename(params.skillDir).trim();
+    const name = normalizeSkillFrontmatterString(frontmatter.name) || parentDirName;
+    const description = normalizeSkillFrontmatterString(frontmatter.description);
+    if (!description) {
+      return null;
+    }
+    return {
+      name,
+      description,
+      filePath: skillMdPath,
+      baseDir: params.skillDir,
+      source: params.source,
+      disableModelInvocation: frontmatter["disable-model-invocation"] === true,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function loadSkillsFromDirWithFallback(params: { dir: string; source: string }): Skill[] {
+  const loaded = unwrapLoadedSkills(loadSkillsFromDir(params));
+  if (loaded.length > 0) {
+    return loaded;
+  }
+  const fallback = loadSkillFromSkillMd({ skillDir: params.dir, source: params.source });
+  return fallback ? [fallback] : [];
 }
 
 function loadSkillEntries(
@@ -252,8 +293,7 @@ function loadSkillEntries(
         return [];
       }
 
-      const loaded = loadSkillsFromDir({ dir: baseDir, source: params.source });
-      return unwrapLoadedSkills(loaded);
+      return loadSkillsFromDirWithFallback({ dir: baseDir, source: params.source });
     }
 
     const childDirs = listChildDirectories(baseDir);
@@ -303,8 +343,7 @@ function loadSkillEntries(
         continue;
       }
 
-      const loaded = loadSkillsFromDir({ dir: skillDir, source: params.source });
-      loadedSkills.push(...unwrapLoadedSkills(loaded));
+      loadedSkills.push(...loadSkillsFromDirWithFallback({ dir: skillDir, source: params.source }));
 
       if (loadedSkills.length >= limits.maxSkillsLoadedPerSource) {
         break;


### PR DESCRIPTION
Closes #35252

## Summary

- Problem: Bug: YAML skill name as bare number causes TypeError in skill discovery (name.startsWith is not a function)
- Why it matters: Reported in #35252
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35252
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35252