### PR TITLE
Fix: support OPENCLAW_VERBOSE env for verbose without --verbose flag

### DIFF
--- a/src/cli/argv.ts
+++ b/src/cli/argv.ts
@@ -4,6 +4,7 @@ import {
   FLAG_TERMINATOR,
   isValueToken,
 } from "../infra/cli-root-options.js";
+import { isTruthyEnvValue } from "../infra/env.js";
 
 const HELP_FLAGS = new Set(["-h", "--help"]);
 const VERSION_FLAGS = new Set(["-V", "--version"]);
@@ -126,6 +127,9 @@ export function getFlagValue(argv: string[], name: string): string | null | unde
 
 export function getVerboseFlag(argv: string[], options?: { includeDebug?: boolean }): boolean {
   if (hasFlag(argv, "--verbose")) {
+    return true;
+  }
+  if (isTruthyEnvValue(process.env.OPENCLAW_VERBOSE)) {
     return true;
   }
   if (options?.includeDebug && hasFlag(argv, "--debug")) {

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -41,6 +41,7 @@ let originalProcessArgv: string[];
 let originalProcessTitle: string;
 let originalNodeNoWarnings: string | undefined;
 let originalHideBanner: string | undefined;
+let originalOpenclawVerbose: string | undefined;
 
 beforeAll(async () => {
   ({ registerPreActionHooks } = await import("./preaction.js"));
@@ -52,8 +53,10 @@ beforeEach(() => {
   originalProcessTitle = process.title;
   originalNodeNoWarnings = process.env.NODE_NO_WARNINGS;
   originalHideBanner = process.env.OPENCLAW_HIDE_BANNER;
+  originalOpenclawVerbose = process.env.OPENCLAW_VERBOSE;
   delete process.env.NODE_NO_WARNINGS;
   delete process.env.OPENCLAW_HIDE_BANNER;
+  delete process.env.OPENCLAW_VERBOSE;
 });
 
 afterEach(() => {
@@ -68,6 +71,11 @@ afterEach(() => {
     delete process.env.OPENCLAW_HIDE_BANNER;
   } else {
     process.env.OPENCLAW_HIDE_BANNER = originalHideBanner;
+  }
+  if (originalOpenclawVerbose === undefined) {
+    delete process.env.OPENCLAW_VERBOSE;
+  } else {
+    process.env.OPENCLAW_VERBOSE = originalOpenclawVerbose;
   }
 });
 
@@ -182,6 +190,18 @@ describe("registerPreActionHooks", () => {
 
     expect(emitCliBannerMock).not.toHaveBeenCalled();
     expect(ensureConfigReadyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("enables verbose preaction from OPENCLAW_VERBOSE env", async () => {
+    process.env.OPENCLAW_VERBOSE = "true";
+
+    await runPreAction({
+      parseArgv: ["status"],
+      processArgv: ["node", "openclaw", "status"],
+    });
+
+    expect(setVerboseMock).toHaveBeenCalledWith(true);
+    expect(process.env.NODE_NO_WARNINGS).toBeUndefined();
   });
 
   it("applies --json stdout suppression only for explicit JSON output commands", async () => {


### PR DESCRIPTION
## Summary
- Add OPENCLAW_VERBOSE env support for verbose mode without --verbose flag
- Allows setting verbose via environment variable

## Testing
- Added test for env-based verbose

## AI Assisted
Codex

## Fixes #35264