### PR TITLE
Fix: sub-agents can access shared skills from ~/.openclaw/skills

### DIFF
--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -1,15 +1,38 @@
+import path from "node:path";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadWorkspaceSkillEntries, type SkillEntry, type SkillSnapshot } from "../skills.js";
+
+function isSkillPathInsideWorkspace(workspaceDir: string, filePath: string): boolean {
+  const workspaceRoot = path.resolve(workspaceDir);
+  const resolvedSkillPath = path.resolve(filePath);
+  const relative = path.relative(workspaceRoot, resolvedSkillPath);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
 
 export function resolveEmbeddedRunSkillEntries(params: {
   workspaceDir: string;
   config?: OpenClawConfig;
   skillsSnapshot?: SkillSnapshot;
+  enforceWorkspacePaths?: boolean;
 }): {
   shouldLoadSkillEntries: boolean;
   skillEntries: SkillEntry[];
 } {
-  const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
+  const enforceWorkspacePaths = params.enforceWorkspacePaths ?? true;
+  const hasResolvedSkills = Boolean(params.skillsSnapshot?.resolvedSkills);
+  const snapshotHasOutOfWorkspacePaths =
+    enforceWorkspacePaths &&
+    hasResolvedSkills &&
+    (params.skillsSnapshot?.resolvedSkills ?? []).some(
+      (skill) => !isSkillPathInsideWorkspace(params.workspaceDir, skill.filePath),
+    );
+  const shouldLoadSkillEntries =
+    !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills || snapshotHasOutOfWorkspacePaths;
+  if (shouldLoadSkillEntries && params.skillsSnapshot) {
+    // Force resolveSkillsPromptForRun(...) to rebuild prompt text from runtime skill entries.
+    params.skillsSnapshot.prompt = "";
+    delete params.skillsSnapshot.resolvedSkills;
+  }
   return {
     shouldLoadSkillEntries,
     skillEntries: shouldLoadSkillEntries


### PR DESCRIPTION
## Summary
- Sub-agents can now access shared skills from ~/.openclaw/skills
- Fixed workspace path enforcement for skill snapshots

## Testing
- Added test for out-of-workspace skill paths

## AI Assisted
Codex

## Fixes #35272