### PR TITLE
Fix: avoid exposing raw metadata in queued messages

### DIFF
--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -10,6 +10,7 @@ import {
   waitForQueueDebounce,
 } from "../../../utils/queue-helpers.js";
 import { isRoutableChannel } from "../route-reply.js";
+import { stripInboundMetadata } from "../strip-inbound-meta.js";
 import { FOLLOWUP_QUEUES } from "./state.js";
 import type { FollowupRun } from "./types.js";
 
@@ -114,7 +115,10 @@ export function scheduleFollowupDrain(
             title: "[Queued messages while agent was busy]",
             items,
             summary,
-            renderItem: (item, idx) => `---\nQueued #${idx + 1}\n${item.prompt}`.trim(),
+            renderItem: (item, idx) => {
+              const sanitizedPrompt = stripInboundMetadata(item.prompt).trim() || "[message omitted]";
+              return `---\nQueued #${idx + 1}\n${sanitizedPrompt}`.trim();
+            },
           });
           await runFollowup({
             prompt,

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -1,4 +1,5 @@
 import { applyQueueDropPolicy, shouldSkipQueueItem } from "../../../utils/queue-helpers.js";
+import { stripInboundMetadata } from "../strip-inbound-meta.js";
 import { kickFollowupDrainIfIdle } from "./drain.js";
 import { getExistingFollowupQueue, getFollowupQueue } from "./state.js";
 import type { FollowupRun, QueueDedupeMode, QueueSettings } from "./types.js";
@@ -47,7 +48,11 @@ export function enqueueFollowupRun(
 
   const shouldEnqueue = applyQueueDropPolicy({
     queue,
-    summarize: (item) => item.summaryLine?.trim() || item.prompt.trim(),
+    summarize: (item) => {
+      const rawSummary = item.summaryLine?.trim() || item.prompt.trim();
+      const sanitized = stripInboundMetadata(rawSummary).trim();
+      return sanitized || "[message omitted]";
+    },
   });
   if (!shouldEnqueue) {
     return false;


### PR DESCRIPTION
## Summary
- Strip raw metadata blocks from queued messages
- Prevents exposing internal metadata in message prompts

## Testing
- Added test for metadata stripping

## AI Assisted
Codex

## Fixes #35266