### PR TITLE
fix: Bug: Feishu cross-app open_id causes silent message delivery failure (no user-facing error) (#35253)

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -477,7 +477,8 @@ openclaw pairing list feishu
 
 1. Ensure the app has `im:message:send_as_bot` permission
 2. Ensure the app is published
-3. Check logs for detailed errors
+3. In multi-app setups, ensure the target `open_id` belongs to the same Feishu app that is sending
+4. Check logs for detailed errors
 
 ---
 
@@ -509,6 +510,8 @@ openclaw pairing list feishu
 ```
 
 `defaultAccount` controls which Feishu account is used when outbound APIs do not specify an `accountId` explicitly.
+
+`open_id` values are app-scoped. If App X tries to send to an `open_id` from App Y, Feishu returns a 400 cross-app error. OpenClaw surfaces this as: `open_id belongs to a different Feishu app`.
 
 ### Message limits
 

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -6,13 +6,62 @@ export type FeishuMessageApiResponse = {
   };
 };
 
+function isFeishuCrossAppOpenIdMessage(raw: string): boolean {
+  const normalized = raw.toLowerCase();
+  return normalized.includes("cross app") && normalized.includes("open_id");
+}
+
+export function isFeishuCrossAppOpenIdError(err: unknown): boolean {
+  if (typeof err === "string") {
+    return isFeishuCrossAppOpenIdMessage(err);
+  }
+  if (typeof err !== "object" || err === null) {
+    return false;
+  }
+
+  const errorLike = err as {
+    message?: string;
+    msg?: string;
+    response?: {
+      data?: {
+        msg?: string;
+        message?: string;
+      };
+    };
+  };
+
+  const candidates = [
+    errorLike.message,
+    errorLike.msg,
+    errorLike.response?.data?.msg,
+    errorLike.response?.data?.message,
+  ];
+  return candidates.some((candidate) =>
+    typeof candidate === "string" ? isFeishuCrossAppOpenIdMessage(candidate) : false,
+  );
+}
+
+function formatFeishuCrossAppOpenIdError(errorPrefix: string): string {
+  return `${errorPrefix}: open_id belongs to a different Feishu app`;
+}
+
 export function assertFeishuMessageApiSuccess(
   response: FeishuMessageApiResponse,
   errorPrefix: string,
 ) {
   if (response.code !== 0) {
+    if (isFeishuCrossAppOpenIdError(response.msg ?? "")) {
+      throw new Error(formatFeishuCrossAppOpenIdError(errorPrefix));
+    }
     throw new Error(`${errorPrefix}: ${response.msg || `code ${response.code}`}`);
   }
+}
+
+export function rethrowFeishuCrossAppOpenIdError(err: unknown, errorPrefix: string): never {
+  if (isFeishuCrossAppOpenIdError(err)) {
+    throw new Error(formatFeishuCrossAppOpenIdError(errorPrefix));
+  }
+  throw err;
 }
 
 export function toFeishuSendResult(

--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -176,4 +176,40 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
 
     expect(createMock).not.toHaveBeenCalled();
   });
+
+  it("surfaces a clear cross-app open_id error when create returns 400 cross app", async () => {
+    createMock.mockResolvedValue({
+      code: 400,
+      msg: "Bad Request: cross app open_id is invalid",
+    });
+
+    await expect(
+      sendMessageFeishu({
+        cfg: {} as never,
+        to: "user:ou_target",
+        text: "hello",
+      }),
+    ).rejects.toThrow("open_id belongs to a different Feishu app");
+  });
+
+  it("surfaces a clear cross-app open_id error when reply throws axios cross app", async () => {
+    const axiosError = Object.assign(new Error("Request failed with status code 400"), {
+      response: {
+        status: 400,
+        data: { code: 400, msg: "cross app open_id not allowed" },
+      },
+    });
+    replyMock.mockRejectedValue(axiosError);
+
+    await expect(
+      sendMessageFeishu({
+        cfg: {} as never,
+        to: "user:ou_target",
+        text: "hello",
+        replyToMessageId: "om_parent",
+      }),
+    ).rejects.toThrow("open_id belongs to a different Feishu app");
+
+    expect(createMock).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -5,7 +5,11 @@ import type { MentionTarget } from "./mention.js";
 import { buildMentionedMessage, buildMentionedCardContent } from "./mention.js";
 import { parsePostContent } from "./post.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
+import {
+  assertFeishuMessageApiSuccess,
+  rethrowFeishuCrossAppOpenIdError,
+  toFeishuSendResult,
+} from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
 import type { FeishuSendResult } from "./types.js";
 
@@ -62,14 +66,19 @@ async function sendFallbackDirect(
   },
   errorPrefix: string,
 ): Promise<FeishuSendResult> {
-  const response = await client.im.message.create({
-    params: { receive_id_type: params.receiveIdType },
-    data: {
-      receive_id: params.receiveId,
-      content: params.content,
-      msg_type: params.msgType,
-    },
-  });
+  let response: { code?: number; msg?: string; data?: { message_id?: string } };
+  try {
+    response = await client.im.message.create({
+      params: { receive_id_type: params.receiveIdType },
+      data: {
+        receive_id: params.receiveId,
+        content: params.content,
+        msg_type: params.msgType,
+      },
+    });
+  } catch (err) {
+    rethrowFeishuCrossAppOpenIdError(err, errorPrefix);
+  }
   assertFeishuMessageApiSuccess(response, errorPrefix);
   return toFeishuSendResult(response, params.receiveId);
 }
@@ -309,7 +318,7 @@ export async function sendMessageFeishu(
       });
     } catch (err) {
       if (!isWithdrawnReplyError(err)) {
-        throw err;
+        rethrowFeishuCrossAppOpenIdError(err, "Feishu reply failed");
       }
       return sendFallbackDirect(client, directParams, "Feishu send failed");
     }
@@ -353,7 +362,7 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
       });
     } catch (err) {
       if (!isWithdrawnReplyError(err)) {
-        throw err;
+        rethrowFeishuCrossAppOpenIdError(err, "Feishu card reply failed");
       }
       return sendFallbackDirect(client, directParams, "Feishu card send failed");
     }

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -385,6 +385,7 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /forbidden: bot was kicked/i,
   /chat_id is empty/i,
   /recipient is not a valid/i,
+  /open_id belongs to a different feishu app/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
 ];

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -165,6 +165,7 @@ describe("delivery-queue", () => {
       "Bot was blocked by the user",
       "Forbidden: bot was kicked from the group chat",
       "chat_id is empty",
+      "Feishu send failed: open_id belongs to a different Feishu app",
       "Outbound not configured for channel: msteams",
     ])("returns true for permanent error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(true);


### PR DESCRIPTION
Closes #35253

## Summary

- Problem: Bug: Feishu cross-app open_id causes silent message delivery failure (no user-facing error)
- Why it matters: Reported in #35253
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35253
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35253