### PR TITLE
fix(compaction): redact write/message path args from transcript history

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -435,6 +435,45 @@ describe("sanitizeToolCallInputs", () => {
     const attachments = (inputObj.attachments ?? []) as Array<Record<string, unknown>>;
     expect(attachments[0]?.content).toBe("__OPENCLAW_REDACTED__");
   });
+
+  it("redacts path-like arguments for write and message tool calls", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_write",
+            name: "write",
+            arguments: { path: "/tmp/secret.txt", content: "keep body" },
+          },
+          {
+            type: "toolUse",
+            id: "call_message",
+            name: "message",
+            input: {
+              to: "telegram:123",
+              filePath: "/tmp/secret.txt",
+              attachments: [{ file: "/tmp/another-secret.png" }],
+            },
+          },
+        ],
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input);
+    const toolCalls = getAssistantToolCallBlocks(out) as Array<Record<string, unknown>>;
+
+    expect(toolCalls).toHaveLength(2);
+    expect((toolCalls[0]?.arguments as Record<string, unknown>)?.path).toBe(
+      "__OPENCLAW_REDACTED_PATH__",
+    );
+    expect((toolCalls[0]?.arguments as Record<string, unknown>)?.content).toBe("keep body");
+    const messageInput = (toolCalls[1]?.input ?? {}) as Record<string, unknown>;
+    expect(messageInput.filePath).toBe("__OPENCLAW_REDACTED_PATH__");
+    const attachments = (messageInput.attachments ?? []) as Array<Record<string, unknown>>;
+    expect(attachments[0]?.file).toBe("__OPENCLAW_REDACTED_PATH__");
+  });
   it("preserves other block properties when trimming tool names", () => {
     const toolCalls = sanitizeAssistantToolCalls([
       { type: "toolCall", id: "call_1", name: " read ", arguments: { path: "/tmp/test" } },

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -95,6 +95,55 @@ function redactSessionsSpawnAttachmentsArgs(value: unknown): unknown {
   return { ...rec, attachments: next };
 }
 
+const REDACTED_PATH_VALUE = "__OPENCLAW_REDACTED_PATH__";
+
+function isPathLikeKey(key: string): boolean {
+  const normalized = key.trim().toLowerCase();
+  return (
+    normalized === "path" ||
+    normalized === "file" ||
+    normalized === "filepath" ||
+    normalized.endsWith("path") ||
+    normalized.endsWith("file") ||
+    normalized.endsWith("filepath")
+  );
+}
+
+function redactPathLikeFields(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next = value.map((item) => {
+      const redacted = redactPathLikeFields(item);
+      if (redacted !== item) {
+        changed = true;
+      }
+      return redacted;
+    });
+    return changed ? next : value;
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  const record = value as Record<string, unknown>;
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(record)) {
+    if (typeof child === "string" && isPathLikeKey(key)) {
+      next[key] = REDACTED_PATH_VALUE;
+      if (child !== REDACTED_PATH_VALUE) {
+        changed = true;
+      }
+      continue;
+    }
+    const redactedChild = redactPathLikeFields(child);
+    if (redactedChild !== child) {
+      changed = true;
+    }
+    next[key] = redactedChild;
+  }
+  return changed ? next : value;
+}
+
 function sanitizeToolCallBlock(block: RawToolCallBlock): RawToolCallBlock {
   const rawName = typeof block.name === "string" ? block.name : undefined;
   const trimmedName = rawName?.trim();
@@ -102,19 +151,14 @@ function sanitizeToolCallBlock(block: RawToolCallBlock): RawToolCallBlock {
   const normalizedName = hasTrimmedName ? trimmedName : undefined;
   const nameChanged = hasTrimmedName && rawName !== trimmedName;
 
-  const isSessionsSpawn = normalizedName?.toLowerCase() === "sessions_spawn";
-
-  if (!isSessionsSpawn) {
-    if (!nameChanged) {
-      return block;
-    }
-    return { ...(block as Record<string, unknown>), name: normalizedName } as RawToolCallBlock;
-  }
-
-  // Redact large/sensitive inline attachment content from persisted transcripts.
-  // Apply redaction to both `.arguments` and `.input` properties since block structures can vary
-  const nextArgs = redactSessionsSpawnAttachmentsArgs(block.arguments);
-  const nextInput = redactSessionsSpawnAttachmentsArgs(block.input);
+  const lowerName = normalizedName?.toLowerCase();
+  const shouldRedactPathArgs = lowerName === "write" || lowerName === "message";
+  const nextArgs = shouldRedactPathArgs
+    ? redactPathLikeFields(block.arguments)
+    : redactSessionsSpawnAttachmentsArgs(block.arguments);
+  const nextInput = shouldRedactPathArgs
+    ? redactPathLikeFields(block.input)
+    : redactSessionsSpawnAttachmentsArgs(block.input);
   if (nextArgs === block.arguments && nextInput === block.input && !nameChanged) {
     return block;
   }
@@ -259,35 +303,12 @@ export function repairToolCallInputs(
           (block as { type?: unknown }).type === "toolUse" ||
           (block as { type?: unknown }).type === "functionCall"
         ) {
-          // Only sanitize (redact) sessions_spawn blocks; all others are passed through
-          // unchanged to preserve provider-specific shapes (e.g. toolUse.input for Anthropic).
-          const blockName =
-            typeof (block as { name?: unknown }).name === "string"
-              ? (block as { name: string }).name.trim()
-              : undefined;
-          if (blockName?.toLowerCase() === "sessions_spawn") {
-            const sanitized = sanitizeToolCallBlock(block);
-            if (sanitized !== block) {
-              changed = true;
-              messageChanged = true;
-            }
-            nextContent.push(sanitized as typeof block);
-          } else {
-            if (typeof (block as { name?: unknown }).name === "string") {
-              const rawName = (block as { name: string }).name;
-              const trimmedName = rawName.trim();
-              if (rawName !== trimmedName && trimmedName) {
-                const renamed = { ...(block as object), name: trimmedName } as typeof block;
-                nextContent.push(renamed);
-                changed = true;
-                messageChanged = true;
-              } else {
-                nextContent.push(block);
-              }
-            } else {
-              nextContent.push(block);
-            }
+          const sanitized = sanitizeToolCallBlock(block);
+          if (sanitized !== block) {
+            changed = true;
+            messageChanged = true;
           }
+          nextContent.push(sanitized as typeof block);
           continue;
         }
       } else {


### PR DESCRIPTION
## Summary

- Problem: transcript history sanitization preserved raw `write`/`message` tool path arguments, so compaction could absorb literal file paths into summary context.
- Why it matters: those path fragments can surface in later user-facing replies after compaction, and may leak sensitive local paths.
- What changed: path-like argument fields are now redacted for `write` and `message` tool-call blocks during history sanitization (`sanitizeToolCallInputs` path), with regression coverage.
- What did NOT change (scope boundary): no changes to tool execution behavior, no runtime mutation of outbound message payloads, and no compaction prompt/model logic changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35244
- Related #14869

## User-visible / Behavior Changes

Compaction/session-history context no longer carries literal file-path argument values from `write`/`message` tool-call blocks; those fields are stored as redacted placeholders in sanitized history.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: n/a (unit-level transcript sanitization path used by compaction)
- Integration/channel (if any): generic transcript sanitation path
- Relevant config (redacted): default transcript policy path; no special env required

### Steps

1. Build session history with assistant tool-call blocks for `write`/`message` that include path-like args (for example `path`, `filePath`, nested attachment `file`).
2. Run `sanitizeToolCallInputs` via the standard session-history sanitization path.
3. Inspect resulting tool-call argument payloads used for compaction context.

### Expected

- Path-like argument fields are redacted before sanitized history is fed into compaction/model context.

### Actual

- Before fix: those path strings were preserved and could leak into post-compaction summaries/replies.
- After fix: path-like fields are replaced with `__OPENCLAW_REDACTED_PATH__` for `write`/`message` tool calls.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added regression test asserting redaction for `write`/`message` path-like fields (including nested attachment path fields).
  - Existing `sessions_spawn` attachment redaction behavior still passes.
- Edge cases checked:
  - Non-path fields (for example `content`, `to`) remain unchanged.
- What you did **not** verify:
  - Full live channel E2E reproduction with real Feishu traffic.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/agents/session-transcript-repair.ts`
- Known bad symptoms reviewers should watch for: over-redaction if a non-path field key incorrectly matches path-key heuristics.

## Risks and Mitigations

- Risk: key-based heuristic could redact a field unintentionally for `write`/`message`.
  - Mitigation: redaction is limited to those two tool names and path-like key patterns; tests cover intended fields and preservation of non-path fields.

