### PR TITLE
fix: avoid heartbeat placeholder delivery leakage

### DIFF
--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -75,10 +75,16 @@ export function resolveLastToRaw(params: {
   persistedLastTo?: string;
   persistedLastChannel?: string;
   sessionKey?: string;
+  providerRaw?: string;
 }): string | undefined {
   const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
   if (originatingChannel === INTERNAL_MESSAGE_CHANNEL && isMainSessionKey(params.sessionKey)) {
-    return params.originatingToRaw || params.toRaw;
+    const provider = params.providerRaw?.trim().toLowerCase();
+    const candidate = params.originatingToRaw || params.toRaw;
+    if (provider === "heartbeat" && candidate?.trim().toLowerCase() === "heartbeat") {
+      return params.persistedLastTo;
+    }
+    return candidate;
   }
   const persistedChannel = normalizeMessageChannel(params.persistedLastChannel);
   const sessionKeyChannelHint = resolveSessionKeyChannelHint(params.sessionKey);
@@ -94,7 +100,14 @@ export function resolveLastToRaw(params: {
     }
   }
 
-  return params.originatingToRaw || params.toRaw || params.persistedLastTo;
+  const candidate = params.originatingToRaw || params.toRaw || params.persistedLastTo;
+  const provider = params.providerRaw?.trim().toLowerCase();
+  const isHeartbeatPlaceholder =
+    provider === "heartbeat" && candidate?.trim().toLowerCase() === "heartbeat";
+  if (isHeartbeatPlaceholder) {
+    return params.persistedLastTo;
+  }
+  return candidate;
 }
 
 export function maybeRetireLegacyMainDeliveryRoute(params: {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1592,6 +1592,39 @@ describe("initSessionState internal channel routing preservation", () => {
     expect(result.sessionEntry.lastTo).toBe("session:handoff");
   });
 
+  it("does not persist heartbeat placeholder destination for internal turns", async () => {
+    const storePath = await createStorePath("ignore-heartbeat-placeholder-");
+    const sessionKey = "agent:main:main";
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: "sess-heartbeat-placeholder-1",
+        updatedAt: Date.now(),
+        lastChannel: "feishu",
+        deliveryContext: {
+          channel: "feishu",
+        },
+      },
+    });
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "heartbeat tick",
+        SessionKey: sessionKey,
+        OriginatingChannel: "webchat",
+        To: "heartbeat",
+        Provider: "heartbeat",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.sessionEntry.lastChannel).toBe("webchat");
+    expect(result.sessionEntry.lastTo).toBeUndefined();
+    expect(result.sessionEntry.deliveryContext?.channel).toBe("webchat");
+    expect(result.sessionEntry.deliveryContext?.to).toBeUndefined();
+  });
+
   it("keeps webchat channel for webchat/main sessions", async () => {
     const storePath = await createStorePath("preserve-webchat-main-");
     const cfg = { session: { store: storePath } } as OpenClawConfig;

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -258,6 +258,7 @@ export async function initSessionState(params: {
     persistedLastTo: baseEntry?.lastTo,
     persistedLastChannel: baseEntry?.lastChannel,
     sessionKey,
+    providerRaw: ctx.Provider,
   });
   const lastAccountIdRaw = ctx.AccountId || baseEntry?.lastAccountId;
   // Only fall back to persisted threadId for thread sessions.  Non-thread


### PR DESCRIPTION
## Summary

Avoid persisting the synthetic `heartbeat` placeholder as a real delivery destination during heartbeat/webchat turns.

## Changes

- add `providerRaw` support in session delivery route resolution
- when provider is `heartbeat`, ignore `to=heartbeat` placeholder and keep prior destination (or undefined)
- add regression test for main-session internal turns with heartbeat placeholder destination

## Testing

- `pnpm -s vitest src/auto-reply/reply/session.test.ts -t "heartbeat placeholder"`

Fixes openclaw/openclaw#35300
