### PR TITLE
Fix: subagents should inherit skill allowlist from parent agent

### DIFF
--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1,5 +1,6 @@
 import {
   resolveAgentDir,
+  resolveAgentIdFromSessionKey,
   resolveAgentWorkspaceDir,
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
@@ -67,11 +68,11 @@ export async function getReplyFromConfig(
     sessionKey: agentSessionKey,
     config: cfg,
   });
-  const mergedSkillFilter = mergeSkillFilters(
+  let mergedSkillFilter = mergeSkillFilters(
     opts?.skillFilter,
     resolveAgentSkillsFilter(cfg, agentId),
   );
-  const resolvedOpts =
+  let resolvedOpts =
     mergedSkillFilter !== undefined ? { ...opts, skillFilter: mergedSkillFilter } : opts;
   const agentCfg = cfg.agents?.defaults;
   const sessionCfg = cfg.session;
@@ -171,6 +172,15 @@ export async function getReplyFromConfig(
     triggerBodyNormalized,
     bodyStripped,
   } = sessionState;
+
+  const parentSessionKey = sessionEntry?.spawnedBy?.trim();
+  if (parentSessionKey) {
+    const parentAgentId = resolveAgentIdFromSessionKey(parentSessionKey);
+    const parentSkillFilter = resolveAgentSkillsFilter(cfg, parentAgentId);
+    mergedSkillFilter = mergeSkillFilters(mergedSkillFilter, parentSkillFilter);
+    resolvedOpts =
+      mergedSkillFilter !== undefined ? { ...opts, skillFilter: mergedSkillFilter } : opts;
+  }
 
   await applyResetModelOverride({
     cfg,


### PR DESCRIPTION
## Summary

- **Problem:** Sub-agents could miss parent skill allowlist constraints during reply pipeline setup.
- **Why it matters:** Sub-agent tool/skill permissions should inherit parent policy for consistent safety and behavior.
- **What changed:** Updated inheritance path in `src/auto-reply/reply/get-reply.ts` so sub-agents receive the parent skill allowlist.
- **What did NOT change:** Non-sub-agent reply flow and existing allowlist enforcement semantics remain unchanged.

## Linked Issue

- Fixes #35262

## Testing

- Verified sub-agent inheritance path at reply construction level.
- No new automated test files were added in this PR.

## Security Impact

- No new permissions, no token handling changes, no network surface changes.

## AI Assisted

Codex
