### PR TITLE
Fix: prevent duplicate skills loading on workspace reload

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -191,22 +191,28 @@ export async function ensureSkillSnapshot(params: {
     systemSent = true;
   }
 
-  const skillsSnapshot = shouldRefreshSnapshot
-    ? buildWorkspaceSkillSnapshot(workspaceDir, {
-        config: cfg,
-        skillFilter,
-        eligibility: { remote: remoteEligibility },
-        snapshotVersion,
-      })
-    : (nextEntry?.skillsSnapshot ??
-      (isFirstTurnInSession
-        ? undefined
-        : buildWorkspaceSkillSnapshot(workspaceDir, {
-            config: cfg,
-            skillFilter,
-            eligibility: { remote: remoteEligibility },
-            snapshotVersion,
-          })));
+  const existingSnapshot = nextEntry?.skillsSnapshot;
+  const hasFreshExistingSnapshot =
+    existingSnapshot &&
+    (!shouldRefreshSnapshot || (existingSnapshot.version ?? 0) >= snapshotVersion);
+  const skillsSnapshot = hasFreshExistingSnapshot
+    ? existingSnapshot
+    : shouldRefreshSnapshot
+      ? buildWorkspaceSkillSnapshot(workspaceDir, {
+          config: cfg,
+          skillFilter,
+          eligibility: { remote: remoteEligibility },
+          snapshotVersion,
+        })
+      : (nextEntry?.skillsSnapshot ??
+        (isFirstTurnInSession
+          ? undefined
+          : buildWorkspaceSkillSnapshot(workspaceDir, {
+              config: cfg,
+              skillFilter,
+              eligibility: { remote: remoteEligibility },
+              snapshotVersion,
+            })));
   if (
     skillsSnapshot &&
     sessionStore &&


### PR DESCRIPTION
## Summary

- **Problem:** Workspace skill snapshots could be rebuilt unnecessarily on reload, causing duplicate skill loading behavior.
- **Why it matters:** Duplicate/redundant snapshot rebuilds add overhead and can produce inconsistent skill visibility.
- **What changed:** Added snapshot version reuse check in `src/auto-reply/reply/session-updates.ts` to avoid rebuilding when existing snapshot is current.
- **What did NOT change:** Skill discovery semantics and snapshot content generation logic remain unchanged.

## Linked Issue

- Fixes #35259

## Testing

- Verified behavior through code-path validation for version reuse branch.
- No new automated test files were added in this PR.

## Security Impact

- No new permissions, no token handling changes, no network surface changes.

## AI Assisted

Codex
