### PR TITLE
fix: [Bug]:  TUI messages routed to Discord DM instead of TUI (#35254)

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -148,6 +148,7 @@ async function runNonStreamingChatSend(params: {
   idempotencyKey: string;
   message?: string;
   sessionKey?: string;
+  deliver?: boolean;
   client?: unknown;
   expectBroadcast?: boolean;
 }) {
@@ -155,6 +156,7 @@ async function runNonStreamingChatSend(params: {
     params: {
       sessionKey: params.sessionKey ?? "main",
       message: params.message ?? "hello",
+      deliver: params.deliver,
       idempotencyKey: params.idempotencyKey,
     },
     respond: params.respond as unknown as Parameters<
@@ -369,6 +371,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-origin-routing",
       sessionKey: "agent:main:telegram:direct:6812765697",
+      deliver: true,
       expectBroadcast: false,
     });
 
@@ -403,6 +406,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-feishu-origin-routing",
       sessionKey: "agent:main:feishu:direct:ou_feishu_direct_123",
+      deliver: true,
       expectBroadcast: false,
     });
 
@@ -436,6 +440,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-per-account-channel-peer-routing",
       sessionKey: "agent:main:telegram:account-a:direct:6812765697",
+      deliver: true,
       expectBroadcast: false,
     });
 
@@ -469,6 +474,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-legacy-channel-peer-routing",
       sessionKey: "agent:main:telegram:6812765697",
+      deliver: true,
       expectBroadcast: false,
     });
 
@@ -504,6 +510,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-legacy-thread-channel-peer-routing",
       sessionKey: "agent:main:telegram:6812765697:thread:42",
+      deliver: true,
       expectBroadcast: false,
     });
 
@@ -573,6 +580,39 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       // Keep a second custom scope token so legacy-shape detection is exercised.
       // "agent:main:work" only yields one rest token and does not hit that path.
       sessionKey: "agent:main:work:ticket-123",
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        OriginatingChannel: "webchat",
+        OriginatingTo: undefined,
+        AccountId: undefined,
+      }),
+    );
+  });
+
+  it("chat.send keeps internal routing when deliver is not requested", async () => {
+    createTranscriptFixture("openclaw-chat-send-no-deliver-no-route-inherit-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "discord",
+        to: "discord:1234567890",
+        accountId: "default",
+      },
+      lastChannel: "discord",
+      lastTo: "discord:1234567890",
+      lastAccountId: "default",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-no-deliver-no-route-inherit",
+      sessionKey: "agent:main:discord:direct:1234567890",
       expectBroadcast: false,
     });
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -863,6 +863,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       const routeAccountIdCandidate =
         entry?.deliveryContext?.accountId ?? entry?.lastAccountId ?? undefined;
       const routeThreadIdCandidate = entry?.deliveryContext?.threadId ?? entry?.lastThreadId;
+      const wantsDelivery = p.deliver === true;
       const parsedSessionKey = parseAgentSessionKey(sessionKey);
       const sessionScopeParts = (parsedSessionKey?.rest ?? sessionKey).split(":").filter(Boolean);
       const sessionScopeHead = sessionScopeParts[0];
@@ -890,6 +891,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         (isChannelScopedSession || hasLegacyChannelPeerShape),
       );
       const hasDeliverableRoute =
+        wantsDelivery &&
         canInheritDeliverableRoute &&
         routeChannelCandidate &&
         routeChannelCandidate !== INTERNAL_MESSAGE_CHANNEL &&


### PR DESCRIPTION
Closes #35254

## Summary

- Problem: [Bug]:  TUI messages routed to Discord DM instead of TUI
- Why it matters: Reported in #35254
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35254
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35254