### PR TITLE
fix: Gateway crash: Uncaught TypeError in undici TLS setSession during sub-agent failover storm (#35257)

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -6,7 +6,10 @@ import { formatUncaughtError } from "../infra/errors.js";
 import { isMainModule } from "../infra/is-main.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
-import { installUnhandledRejectionHandler } from "../infra/unhandled-rejections.js";
+import {
+  installUnhandledRejectionHandler,
+  isTransientUncaughtError,
+} from "../infra/unhandled-rejections.js";
 import { enableConsoleCapture } from "../logging.js";
 import { getCommandPathWithRootOptions, getPrimaryCommand, hasHelpOrVersion } from "./argv.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./profile.js";
@@ -97,6 +100,14 @@ export async function runCli(argv: string[] = process.argv) {
   installUnhandledRejectionHandler();
 
   process.on("uncaughtException", (error) => {
+    if (isTransientUncaughtError(error)) {
+      console.warn(
+        "[openclaw] Suppressed transient uncaught exception:",
+        formatUncaughtError(error),
+      );
+      return;
+    }
+
     console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
     process.exit(1);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,10 @@ import {
   PortInUseError,
 } from "./infra/ports.js";
 import { assertSupportedRuntime } from "./infra/runtime-guard.js";
-import { installUnhandledRejectionHandler } from "./infra/unhandled-rejections.js";
+import {
+  installUnhandledRejectionHandler,
+  isTransientUncaughtError,
+} from "./infra/unhandled-rejections.js";
 import { enableConsoleCapture } from "./logging.js";
 import { runCommandWithTimeout, runExec } from "./process/exec.js";
 import { assertWebChannel, normalizeE164, toWhatsappJid } from "./utils.js";
@@ -82,6 +85,14 @@ if (isMain) {
   installUnhandledRejectionHandler();
 
   process.on("uncaughtException", (error) => {
+    if (isTransientUncaughtError(error)) {
+      console.warn(
+        "[openclaw] Suppressed transient uncaught exception:",
+        formatUncaughtError(error),
+      );
+      return;
+    }
+
     console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
     process.exit(1);
   });

--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { isAbortError, isTransientNetworkError } from "./unhandled-rejections.js";
+import {
+  isAbortError,
+  isTransientNetworkError,
+  isTransientUncaughtError,
+} from "./unhandled-rejections.js";
 
 describe("isAbortError", () => {
   it("returns true for error with name AbortError", () => {
@@ -155,5 +159,28 @@ describe("isTransientNetworkError", () => {
   it("returns false for AggregateError with only non-network errors", () => {
     const error = new AggregateError([new Error("regular error")], "Multiple errors");
     expect(isTransientNetworkError(error)).toBe(false);
+  });
+});
+
+describe("isTransientUncaughtError", () => {
+  it("returns true for known undici tls setSession null-deref race", () => {
+    const error = new TypeError("Cannot read properties of null (reading 'setSession')");
+    error.stack = [
+      "TypeError: Cannot read properties of null (reading 'setSession')",
+      "    at TLSSocket.setSession (node:_tls_wrap:1132:16)",
+      "    at Client.connect (openclaw/node_modules/undici/lib/core/connect.js:70:20)",
+    ].join("\n");
+
+    expect(isTransientUncaughtError(error)).toBe(true);
+  });
+
+  it("returns false for unrelated null-deref errors", () => {
+    const error = new TypeError("Cannot read properties of null (reading 'setSession')");
+    error.stack = [
+      "TypeError: Cannot read properties of null (reading 'setSession')",
+      "    at doThing (/tmp/example.ts:10:1)",
+    ].join("\n");
+
+    expect(isTransientUncaughtError(error)).toBe(false);
   });
 });

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -180,6 +180,53 @@ export function isTransientNetworkError(err: unknown): boolean {
   return false;
 }
 
+function isKnownUndiciTlsSessionRace(err: unknown): boolean {
+  for (const candidate of collectErrorGraphCandidates(err, (current) => {
+    const nested: Array<unknown> = [
+      current.cause,
+      current.reason,
+      current.original,
+      current.error,
+      current.data,
+    ];
+    if (Array.isArray(current.errors)) {
+      nested.push(...current.errors);
+    }
+    return nested;
+  })) {
+    if (!candidate || typeof candidate !== "object") {
+      continue;
+    }
+
+    const rawMessage = (candidate as { message?: unknown }).message;
+    const rawStack = (candidate as { stack?: unknown }).stack;
+    const message = typeof rawMessage === "string" ? rawMessage.toLowerCase() : "";
+    const stack = typeof rawStack === "string" ? rawStack.toLowerCase() : "";
+    if (!message) {
+      continue;
+    }
+
+    const hasSetSessionNullDeref =
+      message.includes("cannot read properties of null") &&
+      (message.includes("reading 'setsession'") || message.includes('reading "setsession"'));
+    if (!hasSetSessionNullDeref) {
+      continue;
+    }
+
+    const likelyUndiciTlsConnectPath =
+      stack.includes("node:_tls_wrap") && stack.includes("undici/lib/core/connect.js");
+    if (likelyUndiciTlsConnectPath) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function isTransientUncaughtError(err: unknown): boolean {
+  return isAbortError(err) || isTransientNetworkError(err) || isKnownUndiciTlsSessionRace(err);
+}
+
 export function registerUnhandledRejectionHandler(handler: UnhandledRejectionHandler): () => void {
   handlers.add(handler);
   return () => {


### PR DESCRIPTION
Closes #35257

## Summary

- Problem: Gateway crash: Uncaught TypeError in undici TLS setSession during sub-agent failover storm
- Why it matters: Reported in #35257
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35257
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35257