### PR TITLE
fix(ui): persist tool toggles for implicit agents

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -66,7 +66,11 @@ import {
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
 import { icons } from "./icons.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
-import { resolveConfiguredCronModelSuggestions, sortLocaleStrings } from "./views/agents-utils.ts";
+import {
+  resolveAgentConfigEntryIndex,
+  resolveConfiguredCronModelSuggestions,
+  sortLocaleStrings,
+} from "./views/agents-utils.ts";
 import { renderAgents } from "./views/agents.ts";
 import { renderChannels } from "./views/channels.ts";
 import { renderChat } from "./views/chat.ts";
@@ -663,23 +667,14 @@ export function renderApp(state: AppViewState) {
                   void saveAgentFile(state, resolvedAgentId, name, content);
                 },
                 onToolsProfileChange: (agentId, profile, clearAllow) => {
-                  if (!configValue) {
+                  const resolved = resolveAgentConfigEntryIndex(configValue, agentId);
+                  if (!resolved) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
+                  for (const patch of resolved.bootstrapPatches) {
+                    updateConfigFormValue(state, patch.path, patch.value);
                   }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
+                  const index = resolved.index;
                   const basePath = ["agents", "list", index, "tools"];
                   if (profile) {
                     updateConfigFormValue(state, [...basePath, "profile"], profile);
@@ -691,23 +686,14 @@ export function renderApp(state: AppViewState) {
                   }
                 },
                 onToolsOverridesChange: (agentId, alsoAllow, deny) => {
-                  if (!configValue) {
+                  const resolved = resolveAgentConfigEntryIndex(configValue, agentId);
+                  if (!resolved) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
+                  for (const patch of resolved.bootstrapPatches) {
+                    updateConfigFormValue(state, patch.path, patch.value);
                   }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
+                  const index = resolved.index;
                   const basePath = ["agents", "list", index, "tools"];
                   if (alsoAllow.length > 0) {
                     updateConfigFormValue(state, [...basePath, "alsoAllow"], alsoAllow);

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  resolveAgentConfigEntryIndex,
   resolveConfiguredCronModelSuggestions,
   resolveEffectiveModelFallbacks,
   sortLocaleStrings,
@@ -96,5 +97,62 @@ describe("sortLocaleStrings", () => {
 
   it("accepts any iterable input, including sets", () => {
     expect(sortLocaleStrings(new Set(["beta", "alpha"]))).toEqual(["alpha", "beta"]);
+  });
+});
+
+describe("resolveAgentConfigEntryIndex", () => {
+  it("bootstraps agents.list when missing", () => {
+    const result = resolveAgentConfigEntryIndex({}, "main");
+
+    expect(result).toEqual({
+      index: 0,
+      bootstrapPatches: [
+        {
+          path: ["agents", "list"],
+          value: [{ id: "main" }],
+        },
+      ],
+    });
+  });
+
+  it("returns existing agent index without bootstrap patches", () => {
+    const result = resolveAgentConfigEntryIndex(
+      {
+        agents: {
+          list: [{ id: "main" }, { id: "writer" }],
+        },
+      },
+      "writer",
+    );
+
+    expect(result).toEqual({
+      index: 1,
+      bootstrapPatches: [],
+    });
+  });
+
+  it("appends a missing agent to the existing list", () => {
+    const result = resolveAgentConfigEntryIndex(
+      {
+        agents: {
+          list: [{ id: "main" }],
+        },
+      },
+      "ops",
+    );
+
+    expect(result).toEqual({
+      index: 1,
+      bootstrapPatches: [
+        {
+          path: ["agents", "list", 1],
+          value: { id: "ops" },
+        },
+      ],
+    });
+  });
+
+  it("returns null for invalid list shape", () => {
+    expect(resolveAgentConfigEntryIndex({ agents: { list: {} } }, "main")).toBeNull();
   });
 });

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -134,6 +134,56 @@ export function resolveAgentConfig(config: Record<string, unknown> | null, agent
   };
 }
 
+export type AgentConfigEntryResolution = {
+  index: number;
+  bootstrapPatches: Array<{
+    path: Array<string | number>;
+    value: unknown;
+  }>;
+};
+
+export function resolveAgentConfigEntryIndex(
+  config: Record<string, unknown> | null,
+  agentId: string,
+): AgentConfigEntryResolution | null {
+  const normalizedAgentId = agentId.trim();
+  if (!normalizedAgentId) {
+    return null;
+  }
+  const cfg = config as ConfigSnapshot | null;
+  const list = cfg?.agents?.list;
+  if (list == null) {
+    return {
+      index: 0,
+      bootstrapPatches: [
+        {
+          path: ["agents", "list"],
+          value: [{ id: normalizedAgentId }],
+        },
+      ],
+    };
+  }
+  if (!Array.isArray(list)) {
+    return null;
+  }
+  const existingIndex = list.findIndex(
+    (entry) =>
+      entry && typeof entry === "object" && "id" in entry && entry.id === normalizedAgentId,
+  );
+  if (existingIndex >= 0) {
+    return { index: existingIndex, bootstrapPatches: [] };
+  }
+  return {
+    index: list.length,
+    bootstrapPatches: [
+      {
+        path: ["agents", "list", list.length],
+        value: { id: normalizedAgentId },
+      },
+    ],
+  };
+}
+
 export type AgentContext = {
   workspace: string;
   model: string;


### PR DESCRIPTION
## Summary
- create/resolve agent config entries for tools edits when `agents.list` is missing or the selected agent has no explicit entry
- apply bootstrap patches before writing tools profile/overrides so toggles mark config dirty and save can persist
- add focused unit coverage for agent-entry resolution paths

## Testing
- pnpm test -- ui/src/ui/views/agents-utils.test.ts ui/src/ui/views/agents-panels-tools-skills.browser.test.ts
- pnpm test -- ui/src/ui/controllers/agents.test.ts
- pnpm test -- ui/src/ui/views/agents-utils.test.ts

Fixes #35297
