### PR TITLE
Fix: prevent memory read-only errors when workspace path is missing

### DIFF
--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -42,6 +42,30 @@ const log = createSubsystemLogger("memory");
 const INDEX_CACHE = new Map<string, MemoryIndexManager>();
 const INDEX_CACHE_PENDING = new Map<string, Promise<MemoryIndexManager>>();
 
+async function validateMemoryWorkspacePath(params: {
+  workspaceDir: string;
+  settings: ResolvedMemorySearchConfig;
+}): Promise<void> {
+  if (!params.settings.sources.includes("memory")) {
+    return;
+  }
+  try {
+    const stat = await fs.stat(params.workspaceDir);
+    if (!stat.isDirectory()) {
+      throw new Error(`memory workspace path is not a directory: ${params.workspaceDir}`);
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT") {
+      throw new Error(`memory workspace path does not exist: ${params.workspaceDir}`);
+    }
+    if (code === "EACCES" || code === "EPERM") {
+      throw new Error(`memory workspace path is not accessible (${code}): ${params.workspaceDir}`);
+    }
+    throw err;
+  }
+}
+
 export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements MemorySearchManager {
   private readonly cacheKey: string;
   protected readonly cfg: OpenClawConfig;
@@ -125,6 +149,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return null;
     }
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+    await validateMemoryWorkspacePath({ workspaceDir, settings });
     const key = `${agentId}:${workspaceDir}:${JSON.stringify(settings)}`;
     const existing = INDEX_CACHE.get(key);
     if (existing) {


### PR DESCRIPTION
## Summary

- **Problem:** Memory index manager could proceed with an invalid workspace path and later fail with unclear read-only/access errors.
- **Why it matters:** Missing or inaccessible workspace paths should fail early with explicit diagnostics.
- **What changed:** Added upfront workspace-path validation in `MemoryIndexManager.create()` via `validateMemoryWorkspacePath()` in `src/memory/manager.ts`.
  - Validates directory existence and type.
  - Maps common FS failures to explicit errors:
    - `ENOENT` -> workspace path does not exist
    - `EACCES`/`EPERM` -> workspace path not accessible
- **What did NOT change:** Memory indexing/search behavior for valid workspace paths is unchanged.

## Files Changed

- `src/memory/manager.ts`

## Testing

- Verified behavior manually for missing-path and permission-denied workspace scenarios.
- No new automated test files were added in this PR.

## Security Impact

- No new permissions, no token handling changes, no network surface changes.

## AI Assisted

Codex
