### PR TITLE
fix(skills): reject empty name and description in quick_validate

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -115,36 +115,38 @@ def validate_skill(skill_path):
     if not isinstance(name, str):
         return False, f"Name must be a string, got {type(name).__name__}"
     name = name.strip()
-    if name:
-        if not re.match(r"^[a-z0-9-]+$", name):
-            return (
-                False,
-                f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)",
-            )
-        if name.startswith("-") or name.endswith("-") or "--" in name:
-            return (
-                False,
-                f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens",
-            )
-        if len(name) > MAX_SKILL_NAME_LENGTH:
-            return (
-                False,
-                f"Name is too long ({len(name)} characters). "
-                f"Maximum is {MAX_SKILL_NAME_LENGTH} characters.",
-            )
+    if not name:
+        return False, "Name cannot be empty"
+    if not re.match(r"^[a-z0-9-]+$", name):
+        return (
+            False,
+            f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)",
+        )
+    if name.startswith("-") or name.endswith("-") or "--" in name:
+        return (
+            False,
+            f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens",
+        )
+    if len(name) > MAX_SKILL_NAME_LENGTH:
+        return (
+            False,
+            f"Name is too long ({len(name)} characters). "
+            f"Maximum is {MAX_SKILL_NAME_LENGTH} characters.",
+        )
 
     description = frontmatter.get("description", "")
     if not isinstance(description, str):
         return False, f"Description must be a string, got {type(description).__name__}"
     description = description.strip()
-    if description:
-        if "<" in description or ">" in description:
-            return False, "Description cannot contain angle brackets (< or >)"
-        if len(description) > 1024:
-            return (
-                False,
-                f"Description is too long ({len(description)} characters). Maximum is 1024 characters.",
-            )
+    if not description:
+        return False, "Description cannot be empty"
+    if "<" in description or ">" in description:
+        return False, "Description cannot contain angle brackets (< or >)"
+    if len(description) > 1024:
+        return (
+            False,
+            f"Description is too long ({len(description)} characters). Maximum is 1024 characters.",
+        )
 
     return True, "Skill is valid!"
 


### PR DESCRIPTION
## Summary

- Problem: `quick_validate.py` silently accepts skills with empty `name` or `description` fields, returning "Skill is valid!" instead of an error.
- Why it matters: Broken skills with empty metadata can be packaged and installed without any warning, causing downstream failures in skill discovery and registration.
- What changed: Replaced conditional `if name:` / `if description:` guards with early-return checks that reject empty values with a clear error message.
- What did NOT change (scope boundary): All other validation logic (format checks, length limits, allowed keys) remains identical.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35110

## User-visible / Behavior Changes

- `quick_validate.py` now returns "Name cannot be empty" (exit 1) when `name` is empty or missing value.
- `quick_validate.py` now returns "Description cannot be empty" (exit 1) when `description` is empty or missing value.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime/container: Python 3.12
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: N/A

### Steps

1. Create a skill with empty name: `name:` (YAML null) or `name: ""` (empty string)
2. Run `python3 quick_validate.py <skill_dir>`
3. Observe the error message and exit code 1

### Expected

- "Name cannot be empty" with exit code 1

### Actual

- Before fix: "Skill is valid!" with exit code 0
- After fix: "Name cannot be empty" with exit code 1

## Evidence

- [x] Failing test/log before + passing after

Before fix:
```
$ python3 quick_validate.py /tmp/empty-skill
Skill is valid!    # exit 0 — WRONG
```

After fix:
```
$ python3 quick_validate.py /tmp/empty-skill
Name cannot be empty    # exit 1 — CORRECT
```

Tested all variants: YAML null (`name:`), empty string (`name: ""`), whitespace-only (`name: "  "`), and valid name (`name: my-skill`).

## Human Verification (required)

- Verified scenarios: empty name (YAML null + empty string), empty description (YAML null + empty string), valid skill (still passes), whitespace-only values
- Edge cases checked: YAML null vs empty string vs whitespace-only for both fields
- What you did **not** verify: Integration with `openclaw skill install` end-to-end pipeline

## Compatibility / Migration

- Backward compatible? Yes — only rejects previously-invalid input that was silently accepted
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit on `quick_validate.py`
- Files/config to restore: `skills/skill-creator/scripts/quick_validate.py`
- Known bad symptoms reviewers should watch for: Valid skills being rejected (false positive)

## Risks and Mitigations

- Risk: Skills with intentionally empty name (edge case — unlikely by design)
  - Mitigation: Empty names are invalid per skill spec; this aligns validation with the intended contract