### PR TITLE
fix(agents): guard promoteThinkingTagsToBlocks against malformed content entries

### DIFF
--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractAssistantText,
   formatReasoningMessage,
+  promoteThinkingTagsToBlocks,
   stripDowngradedToolCallText,
 } from "./pi-embedded-utils.js";
 
@@ -555,5 +556,32 @@ describe("empty input handling", () => {
     for (const helper of helpers) {
       expect(helper("")).toBe("");
     }
+  });
+});
+
+describe("promoteThinkingTagsToBlocks", () => {
+  it("does not crash when content contains null entries", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [null, { type: "text", text: "ok" }] as unknown as AssistantMessage["content"],
+    });
+    expect(() => promoteThinkingTagsToBlocks(msg)).not.toThrow();
+  });
+
+  it("does not crash when content contains undefined entries", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [undefined, { type: "text", text: "ok" }] as unknown as AssistantMessage["content"],
+    });
+    expect(() => promoteThinkingTagsToBlocks(msg)).not.toThrow();
+  });
+
+  it("preserves well-formed content with no thinking tags", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "hello world" }] as AssistantMessage["content"],
+    });
+    promoteThinkingTagsToBlocks(msg);
+    expect(msg.content).toEqual([{ type: "text", text: "hello world" }]);
   });
 });

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -333,7 +333,9 @@ export function promoteThinkingTagsToBlocks(message: AssistantMessage): void {
   if (!Array.isArray(message.content)) {
     return;
   }
-  const hasThinkingBlock = message.content.some((block) => block.type === "thinking");
+  const hasThinkingBlock = message.content.some(
+    (block) => block != null && typeof block === "object" && block.type === "thinking",
+  );
   if (hasThinkingBlock) {
     return;
   }
@@ -342,6 +344,10 @@ export function promoteThinkingTagsToBlocks(message: AssistantMessage): void {
   let changed = false;
 
   for (const block of message.content) {
+    if (block == null || typeof block !== "object") {
+      next.push(block);
+      continue;
+    }
     if (block.type !== "text") {
       next.push(block);
       continue;


### PR DESCRIPTION
## Summary

- Problem: `promoteThinkingTagsToBlocks` crashes with `Cannot read properties of null (reading 'type')` when assistant message content contains malformed non-object entries (e.g. `null`).
- Why it matters: A single malformed content entry in session history causes a hard crash, potentially breaking the entire session.
- What changed: Added `null`/`typeof` guards before reading `block.type` in both the `some()` check and the `for` loop, so malformed entries are passed through unchanged.
- What did NOT change (scope boundary): All existing behavior for well-formed content blocks remains identical; the thinking-tag promotion logic is untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35032

## User-visible / Behavior Changes

None — malformed entries that previously crashed are now silently passed through.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime/container: Node.js v22 + vitest
- Model/provider: Any (crash occurs during content processing)
- Integration/channel: Any
- Relevant config: N/A

### Steps

1. Construct an assistant message with `content: [null, {"type":"text","text":"ok"}]`
2. Call `promoteThinkingTagsToBlocks(message)`
3. Before fix: `TypeError: Cannot read properties of null (reading 'type')`
4. After fix: Function completes without error

### Expected

Function should not throw on malformed content entries.

### Actual

- Before: Throws `TypeError`
- After: Passes through malformed entries unchanged

## Evidence

- [x] Failing test/log before + passing after

Added 3 regression tests in `pi-embedded-utils.test.ts`:
- `does not crash when content contains null entries`
- `does not crash when content contains undefined entries`
- `preserves well-formed content with no thinking tags`

All 33 tests pass.

## Human Verification (required)

- Verified scenarios: null entries, undefined entries, well-formed content (no regression)
- Edge cases checked: Mixed array with null + valid blocks, content with existing thinking blocks (early return path)
- What you did **not** verify: End-to-end gateway session replay with real malformed history

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/agents/pi-embedded-utils.ts`
- Known bad symptoms reviewers should watch for: Thinking tags not being promoted from text (would mean the guard is too aggressive)

## Risks and Mitigations

- Risk: Guard is too broad and skips valid blocks
  - Mitigation: Guard only skips entries where `block == null || typeof block !== "object"` — all valid content blocks are objects and pass through