### PR TITLE
fix(agents): guard context pruning against malformed content blocks

### DIFF
--- a/src/agents/pi-extensions/context-pruning/pruner.test.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.test.ts
@@ -1,0 +1,78 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import { pruneContextMessages } from "./pruner.js";
+import { DEFAULT_CONTEXT_PRUNING_SETTINGS } from "./settings.js";
+
+function makeAssistantMsg(content: unknown[]): AgentMessage {
+  return { role: "assistant", content } as unknown as AgentMessage;
+}
+
+function makeToolResultMsg(content: unknown[]): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: "t1",
+    toolName: "exec",
+    content,
+  } as unknown as AgentMessage;
+}
+
+const defaultCtx = { model: { contextWindow: 100_000 } };
+
+describe("pruneContextMessages — malformed content blocks", () => {
+  it("does not crash on assistant message with malformed thinking block (missing thinking string)", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "hello" } as unknown as AgentMessage,
+      makeAssistantMsg([{ type: "thinking" }, { type: "text", text: "ok" }]),
+    ];
+    expect(() =>
+      pruneContextMessages({
+        messages,
+        settings: { ...DEFAULT_CONTEXT_PRUNING_SETTINGS, softTrimRatio: 0 },
+        ctx: defaultCtx,
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not crash on assistant message with null content entry", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "hello" } as unknown as AgentMessage,
+      makeAssistantMsg([null, { type: "text", text: "ok" }]),
+    ];
+    expect(() =>
+      pruneContextMessages({
+        messages,
+        settings: { ...DEFAULT_CONTEXT_PRUNING_SETTINGS, softTrimRatio: 0 },
+        ctx: defaultCtx,
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not crash on toolResult with malformed text block (missing text string)", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "hello" } as unknown as AgentMessage,
+      makeAssistantMsg([{ type: "text", text: "calling tool" }]),
+      makeToolResultMsg([{ type: "text" }]),
+    ];
+    expect(() =>
+      pruneContextMessages({
+        messages,
+        settings: { ...DEFAULT_CONTEXT_PRUNING_SETTINGS, softTrimRatio: 0 },
+        ctx: defaultCtx,
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not crash on assistant message with text block missing text string", () => {
+    const messages: AgentMessage[] = [
+      { role: "user", content: "hello" } as unknown as AgentMessage,
+      makeAssistantMsg([{ type: "text" }]),
+    ];
+    expect(() =>
+      pruneContextMessages({
+        messages,
+        settings: { ...DEFAULT_CONTEXT_PRUNING_SETTINGS, softTrimRatio: 0 },
+        ctx: defaultCtx,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -16,7 +16,12 @@ function asText(text: string): TextContent {
 function collectTextSegments(content: ReadonlyArray<TextContent | ImageContent>): string[] {
   const parts: string[] = [];
   for (const block of content) {
-    if (block.type === "text") {
+    if (
+      block != null &&
+      typeof block === "object" &&
+      block.type === "text" &&
+      typeof block.text === "string"
+    ) {
       parts.push(block.text);
     }
   }
@@ -89,7 +94,7 @@ function takeTailFromJoinedText(parts: string[], maxChars: number): string {
 
 function hasImageBlocks(content: ReadonlyArray<TextContent | ImageContent>): boolean {
   for (const block of content) {
-    if (block.type === "image") {
+    if (block != null && typeof block === "object" && block.type === "image") {
       return true;
     }
   }
@@ -99,7 +104,10 @@ function hasImageBlocks(content: ReadonlyArray<TextContent | ImageContent>): boo
 function estimateTextAndImageChars(content: ReadonlyArray<TextContent | ImageContent>): number {
   let chars = 0;
   for (const block of content) {
-    if (block.type === "text") {
+    if (block == null || typeof block !== "object") {
+      continue;
+    }
+    if (block.type === "text" && typeof block.text === "string") {
       chars += block.text.length;
     }
     if (block.type === "image") {
@@ -121,11 +129,14 @@ function estimateMessageChars(message: AgentMessage): number {
   if (message.role === "assistant") {
     let chars = 0;
     for (const b of message.content) {
-      if (b.type === "text") {
+      if (b == null || typeof b !== "object") {
+        continue;
+      }
+      if (b.type === "text" && typeof b.text === "string") {
         chars += b.text.length;
       }
-      if (b.type === "thinking") {
-        chars += b.thinking.length;
+      if (b.type === "thinking" && typeof (b as Record<string, unknown>).thinking === "string") {
+        chars += ((b as Record<string, unknown>).thinking as string).length;
       }
       if (b.type === "toolCall") {
         try {


### PR DESCRIPTION
## Summary

- Problem: Context pruning crashes with `TypeError: Cannot read properties of undefined (reading 'length')` when session history contains malformed content blocks — either `{type:"thinking"}` without a `thinking` string, or `{type:"text"}` without a `text` string, or `null` entries. The crash is deterministic on every subsequent message, locking the session.
- Why it matters: A single malformed content block (from a plugin returning `undefined`, or a provider emitting incomplete structured output) permanently breaks the session.
- What changed: Added null/typeof guards in `estimateMessageChars`, `collectTextSegments`, `estimateTextAndImageChars`, and `hasImageBlocks` so malformed entries are treated as zero-length and skipped.
- What did NOT change (scope boundary): All pruning logic (soft trim, hard clear, cutoff index) is untouched. Only the defensive guards around property access were added.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35026
- Closes #35017

## User-visible / Behavior Changes

None — malformed entries that previously caused a crash loop are now silently skipped during char estimation.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime/container: Node.js v22 + vitest
- Model/provider: Any
- Integration/channel: Any
- Relevant config: context pruning enabled (default)

### Steps

1. Build a message list with an assistant message containing `content: [{"type":"thinking"}]` (no `thinking` string)
2. Call `pruneContextMessages(...)` with pruning enabled
3. Before fix: `TypeError: Cannot read properties of undefined (reading 'length')`
4. After fix: Function completes, malformed block treated as zero-length

### Expected

Pruner should skip malformed blocks and continue without crashing.

### Actual

- Before: Throws `TypeError` — session locked in crash loop
- After: Malformed blocks treated as zero-length, pruning completes normally

## Evidence

- [x] Failing test/log before + passing after

Created `pruner.test.ts` with 4 regression tests:
- malformed thinking block (missing `thinking` string)
- null content entry in assistant message
- malformed text block in toolResult (missing `text` string)
- malformed text block in assistant message (missing `text` string)

All 4 tests pass.

## Human Verification (required)

- Verified scenarios: All 4 malformed content variants described in #35026 and #35017
- Edge cases checked: null entries, undefined properties, mixed valid + malformed blocks
- What you did **not** verify: End-to-end session replay with real corrupted transcript files

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/agents/pi-extensions/context-pruning/pruner.ts`
- Known bad symptoms reviewers should watch for: Context pruning under-counting chars (unlikely — only malformed entries are affected)

## Risks and Mitigations

- Risk: Malformed blocks being silently ignored could mask upstream data corruption
  - Mitigation: The root cause of malformed blocks is tracked separately; this fix prevents the crash loop while the underlying issue is addressed