### PR TITLE
fix(agents): guard openai-ws parsers against malformed content entries

### DIFF
--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -1185,3 +1185,61 @@ describe("releaseWsSession / hasWsSession", () => {
     expect(() => releaseWsSession("nonexistent-session")).not.toThrow();
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("malformed content entry guards", () => {
+  it("convertMessagesToInputItems does not crash on null entries in assistant content", () => {
+    const msg = {
+      role: "assistant" as const,
+      content: [null, { type: "text", text: "ok" }],
+      stopReason: "stop",
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: {},
+      timestamp: 0,
+    };
+    expect(() =>
+      convertMessagesToInputItems([msg] as Parameters<typeof convertMessagesToInputItems>[0]),
+    ).not.toThrow();
+  });
+
+  it("convertMessagesToInputItems does not crash on null entries in user content array", () => {
+    const msg = {
+      role: "user" as const,
+      content: [null, { type: "text", text: "hello" }],
+      timestamp: 0,
+    };
+    expect(() =>
+      convertMessagesToInputItems([msg] as Parameters<typeof convertMessagesToInputItems>[0]),
+    ).not.toThrow();
+  });
+
+  it("buildAssistantMessageFromResponse does not crash on null entries in message content", () => {
+    const modelInfo = { api: "openai-responses", provider: "openai", id: "gpt-5.2" };
+    const response: ResponseObject = {
+      id: "resp_malformed",
+      object: "response",
+      created_at: Date.now(),
+      status: "completed",
+      model: "gpt-5.2",
+      output: [
+        {
+          type: "message",
+          id: "item_1",
+          role: "assistant",
+          content: [
+            null,
+            { type: "output_text", text: "ok" },
+          ] as unknown as ResponseObject["output"][0] extends { content?: infer C } ? C : never,
+        } as ResponseObject["output"][0],
+      ],
+      usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+    };
+    expect(() => buildAssistantMessageFromResponse(response, modelInfo)).not.toThrow();
+    const msg = buildAssistantMessageFromResponse(response, modelInfo);
+    expect(msg.content).toHaveLength(1);
+    expect((msg.content[0] as { text: string }).text).toBe("ok");
+  });
+});

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -138,6 +138,9 @@ function contentToOpenAIParts(content: unknown): ContentPart[] {
     data?: string;
     mimeType?: string;
   }>) {
+    if (part == null || typeof part !== "object") {
+      continue;
+    }
     if (part.type === "text" && typeof part.text === "string") {
       parts.push({ type: "input_text", text: part.text });
     } else if (part.type === "image" && typeof part.data === "string") {
@@ -205,6 +208,9 @@ export function convertMessagesToInputItems(messages: Message[]): InputItem[] {
           arguments?: Record<string, unknown>;
           thinking?: string;
         }>) {
+          if (block == null || typeof block !== "object") {
+            continue;
+          }
           if (block.type === "text" && typeof block.text === "string") {
             textParts.push(block.text);
           } else if (block.type === "thinking" && typeof block.thinking === "string") {
@@ -293,6 +299,9 @@ export function buildAssistantMessageFromResponse(
   for (const item of response.output ?? []) {
     if (item.type === "message") {
       for (const part of item.content ?? []) {
+        if (part == null || typeof part !== "object") {
+          continue;
+        }
         if (part.type === "output_text" && part.text) {
           content.push({ type: "text", text: part.text });
         }


### PR DESCRIPTION
## Summary

- Problem: `contentToOpenAIParts`, `convertMessagesToInputItems` (assistant branch), and `buildAssistantMessageFromResponse` all crash with `TypeError: Cannot read properties of null (reading 'type')` when content arrays contain malformed entries (e.g. `null`).
- Why it matters: A single malformed content entry from a provider or plugin breaks request preparation or response parsing, causing the entire agent turn to fail.
- What changed: Added `block == null || typeof block !== "object"` guards before reading `.type` in all three functions so malformed entries are skipped.
- What did NOT change (scope boundary): All existing parsing logic for well-formed content blocks remains identical.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35045
- Closes #35051

## User-visible / Behavior Changes

None — malformed entries that previously crashed are now silently skipped.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime/container: Node.js v22 + vitest
- Model/provider: OpenAI (WebSocket path)
- Integration/channel: Any
- Relevant config: N/A

### Steps

1. Build a WS response object with `output: [{ type: "message", content: [null, { type: "output_text", text: "ok" }] }]`
2. Call `buildAssistantMessageFromResponse(response, ...)`
3. Before fix: `TypeError: Cannot read properties of null (reading 'type')`
4. After fix: Null entry skipped, valid `output_text` extracted

### Expected

Parsers should skip malformed entries and process valid ones.

### Actual

- Before: Throws `TypeError`
- After: Malformed entries skipped, valid content processed correctly

## Evidence

- [x] Failing test/log before + passing after

Added 3 regression tests in `openai-ws-stream.test.ts`:
- `convertMessagesToInputItems does not crash on null entries in assistant content`
- `convertMessagesToInputItems does not crash on null entries in user content array`
- `buildAssistantMessageFromResponse does not crash on null entries in message content`

All 43 tests pass.

## Human Verification (required)

- Verified scenarios: null entries in assistant content, user content, and response message content
- Edge cases checked: Mixed null + valid blocks, empty content arrays
- What you did **not** verify: Live WebSocket session with real malformed provider output

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/agents/openai-ws-stream.ts`
- Known bad symptoms reviewers should watch for: Valid content blocks being skipped (would mean guard is too broad)

## Risks and Mitigations

- Risk: Guard skips valid primitive content entries (if API ever sends non-object content)
  - Mitigation: OpenAI API content blocks are always objects; primitive entries are inherently malformed