### PR TITLE
fix: [BUG] Sub-agents cannot access shared skills from ~/.openclaw/skills despite official documentation stating they should be visible to all agents (#35272)

### DIFF
--- a/src/agents/skills.managed-fallback-subagent.test.ts
+++ b/src/agents/skills.managed-fallback-subagent.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildWorkspaceSkillsPrompt } from "./skills.js";
+import { writeSkill } from "./skills.test-helpers.js";
+
+const tempDirs: string[] = [];
+
+async function createTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0, tempDirs.length).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("managed skills fallback for sub-agent workspaces", () => {
+  it("loads shared sibling skills when managed dir resolves to workspace/skills", async () => {
+    const stateDir = await createTempDir("openclaw-state-");
+    const workspaceDir = path.join(stateDir, "workspace-max");
+    const sharedSkillsDir = path.join(stateDir, "skills", "shared-skill");
+
+    await writeSkill({
+      dir: sharedSkillsDir,
+      name: "shared-skill",
+      description: "Shared skill from state root",
+    });
+
+    const prompt = buildWorkspaceSkillsPrompt(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, "skills"),
+      bundledSkillsDir: path.join(stateDir, ".bundled"),
+    });
+
+    expect(prompt).toContain("Shared skill from state root");
+    expect(prompt.replaceAll("\\", "/")).toContain("skills/shared-skill/SKILL.md");
+  });
+
+  it("keeps workspace precedence over shared sibling fallback", async () => {
+    const stateDir = await createTempDir("openclaw-state-");
+    const workspaceDir = path.join(stateDir, "workspace-max");
+    const sharedSkillsDir = path.join(stateDir, "skills", "demo-skill");
+    const workspaceSkillDir = path.join(workspaceDir, "skills", "demo-skill");
+
+    await writeSkill({
+      dir: sharedSkillsDir,
+      name: "demo-skill",
+      description: "Shared version",
+    });
+    await writeSkill({
+      dir: workspaceSkillDir,
+      name: "demo-skill",
+      description: "Workspace version",
+    });
+
+    const prompt = buildWorkspaceSkillsPrompt(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, "skills"),
+      bundledSkillsDir: path.join(stateDir, ".bundled"),
+    });
+
+    expect(prompt).toContain("Workspace version");
+    expect(prompt).not.toContain("Shared version");
+  });
+});

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -218,6 +218,38 @@ function unwrapLoadedSkills(loaded: unknown): Skill[] {
   return [];
 }
 
+function isDirectory(targetPath: string): boolean {
+  try {
+    return fs.statSync(targetPath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function resolveManagedSkillsDir(params: {
+  workspaceDir: string;
+  managedSkillsDir?: string;
+}): string {
+  const configured =
+    params.managedSkillsDir && params.managedSkillsDir.trim()
+      ? path.resolve(params.managedSkillsDir)
+      : path.join(CONFIG_DIR, "skills");
+  const workspaceSkillsDir = path.resolve(params.workspaceDir, "skills");
+  const sharedSiblingSkillsDir = path.resolve(params.workspaceDir, "..", "skills");
+
+  // Sub-agent environments can incorrectly resolve managed skills to <workspace>/skills.
+  // Prefer the shared sibling state dir (<state>/skills) when it exists.
+  if (
+    (configured === workspaceSkillsDir || !isDirectory(configured)) &&
+    sharedSiblingSkillsDir !== configured &&
+    isDirectory(sharedSiblingSkillsDir)
+  ) {
+    return sharedSiblingSkillsDir;
+  }
+
+  return configured;
+}
+
 function loadSkillEntries(
   workspaceDir: string,
   opts?: {
@@ -321,7 +353,10 @@ function loadSkillEntries(
     return loadedSkills;
   };
 
-  const managedSkillsDir = opts?.managedSkillsDir ?? path.join(CONFIG_DIR, "skills");
+  const managedSkillsDir = resolveManagedSkillsDir({
+    workspaceDir,
+    managedSkillsDir: opts?.managedSkillsDir,
+  });
   const workspaceSkillsDir = path.resolve(workspaceDir, "skills");
   const bundledSkillsDir = opts?.bundledSkillsDir ?? resolveBundledSkillsDir();
   const extraDirsRaw = opts?.config?.skills?.load?.extraDirs ?? [];


### PR DESCRIPTION
Closes #35272

## Summary

- Problem: [BUG] Sub-agents cannot access shared skills from ~/.openclaw/skills despite official documentation stating they should be visible to all agents
- Why it matters: Reported in #35272
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35272
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35272