### PR TITLE
fix(agents): detect Venice provider proxying xAI/Grok models for schema cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.
 - Feishu/streaming card delivery synthesis: unify snapshot and delta streaming merge semantics, apply overlap-aware final merge, suppress duplicate final text delivery (including text+media final packets), prefer topic-thread `message.reply` routing when a reply target exists, and tune card print cadence to avoid duplicate incremental rendering. (from #33245, #32896, #33840) Thanks @rexl2018, @kcinzgg, and @aerelune.
 - Security/dependency audit: patch transitive Hono vulnerabilities by pinning `hono` to `4.12.5` and `@hono/node-server` to `1.19.10` in production resolution paths. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (#35355) thanks @Sid-Qin.
+- Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.
 - Feishu/streaming card delivery synthesis: unify snapshot and delta streaming merge semantics, apply overlap-aware final merge, suppress duplicate final text delivery (including text+media final packets), prefer topic-thread `message.reply` routing when a reply target exists, and tune card print cadence to avoid duplicate incremental rendering. (from #33245, #32896, #33840) Thanks @rexl2018, @kcinzgg, and @aerelune.
 - Security/dependency audit: patch transitive Hono vulnerabilities by pinning `hono` to `4.12.5` and `@hono/node-server` to `1.19.10` in production resolution paths. Thanks @shakkernerd.

--- a/src/agents/schema/clean-for-xai.test.ts
+++ b/src/agents/schema/clean-for-xai.test.ts
@@ -29,6 +29,18 @@ describe("isXaiProvider", () => {
   it("handles undefined provider", () => {
     expect(isXaiProvider(undefined)).toBe(false);
   });
+
+  it("matches venice provider with grok model id", () => {
+    expect(isXaiProvider("venice", "grok-4.1-fast")).toBe(true);
+  });
+
+  it("matches venice provider with venice/ prefixed grok model id", () => {
+    expect(isXaiProvider("venice", "venice/grok-4.1-fast")).toBe(true);
+  });
+
+  it("does not match venice provider with non-grok model id", () => {
+    expect(isXaiProvider("venice", "llama-3.3-70b")).toBe(false);
+  });
 });
 
 describe("stripXaiUnsupportedKeywords", () => {

--- a/src/agents/schema/clean-for-xai.ts
+++ b/src/agents/schema/clean-for-xai.ts
@@ -48,8 +48,13 @@ export function isXaiProvider(modelProvider?: string, modelId?: string): boolean
   if (provider.includes("xai") || provider.includes("x-ai")) {
     return true;
   }
+  const lowerModelId = modelId?.toLowerCase() ?? "";
   // OpenRouter proxies to xAI when the model id starts with "x-ai/"
-  if (provider === "openrouter" && modelId?.toLowerCase().startsWith("x-ai/")) {
+  if (provider === "openrouter" && lowerModelId.startsWith("x-ai/")) {
+    return true;
+  }
+  // Venice proxies to xAI/Grok models
+  if (provider === "venice" && lowerModelId.includes("grok")) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Summary

- Problem: `isXaiProvider()` does not detect Venice as a proxy for xAI/Grok models. When Venice serves `grok-4.1-fast`, the provider string is `venice` — containing neither `xai` nor `x-ai` — so JSON Schema keyword stripping is skipped and requests fail with "Invalid arguments passed to the model".
- Why it matters: Users configuring Venice + Grok cannot use any tool with schema constraints (minLength, maxLength, etc.).
- What changed: Added a `venice` + `grok` model ID detection branch in `isXaiProvider()`.
- What did NOT change (scope boundary): The `stripXaiUnsupportedKeywords` function and all other provider detection paths are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34955
- Related #32080

## User-visible / Behavior Changes

Venice + Grok model configurations now correctly strip unsupported JSON Schema keywords, preventing "Invalid arguments" errors.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime/container: Node.js v22 + vitest
- Model/provider: Venice / grok-4.1-fast
- Integration/channel: Any
- Relevant config: `"primary": "venice/grok-4.1-fast"`

### Steps

1. Configure OpenClaw with Venice provider and a Grok model
2. Send any agent request that uses a tool with schema constraints
3. Before fix: "Invalid arguments passed to the model"
4. After fix: Request succeeds (schema keywords stripped)

### Expected

`isXaiProvider("venice", "grok-4.1-fast")` returns `true`.

### Actual

- Before: Returns `false` — schema cleaning skipped
- After: Returns `true` — schema cleaning applied

## Evidence

- [x] Failing test/log before + passing after

Added 3 test cases in `clean-for-xai.test.ts`:
- `matches venice provider with grok model id`
- `matches venice provider with venice/ prefixed grok model id`
- `does not match venice provider with non-grok model id`

All 18 tests pass.

## Human Verification (required)

- Verified scenarios: `venice/grok-4.1-fast`, `grok-4.1-fast`, `venice/llama-3.3-70b` (should NOT match)
- Edge cases checked: Model ID without provider prefix, case insensitivity
- What you did **not** verify: Live Venice API call with Grok model

## Compatibility / Migration

- Backward compatible? Yes — only adds a new detection branch
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/agents/schema/clean-for-xai.ts`
- Known bad symptoms reviewers should watch for: Non-Grok Venice models having schema keywords incorrectly stripped

## Risks and Mitigations

- Risk: Venice model ID matching is too broad (matches any model containing "grok")
  - Mitigation: Only xAI produces models named "grok"; no other vendor uses this prefix. Guard is scoped to `provider === "venice"` only.