### PR TITLE
fix(gateway): gate chat.send external route behind deliver flag

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -148,6 +148,7 @@ async function runNonStreamingChatSend(params: {
   idempotencyKey: string;
   message?: string;
   sessionKey?: string;
+  deliver?: boolean;
   client?: unknown;
   expectBroadcast?: boolean;
 }) {
@@ -156,6 +157,7 @@ async function runNonStreamingChatSend(params: {
       sessionKey: params.sessionKey ?? "main",
       message: params.message ?? "hello",
       idempotencyKey: params.idempotencyKey,
+      deliver: params.deliver,
     },
     respond: params.respond as unknown as Parameters<
       (typeof chatHandlers)["chat.send"]
@@ -369,6 +371,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-origin-routing",
       sessionKey: "agent:main:telegram:direct:6812765697",
+      deliver: true,
       expectBroadcast: false,
     });
 
@@ -403,6 +406,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-feishu-origin-routing",
       sessionKey: "agent:main:feishu:direct:ou_feishu_direct_123",
+      deliver: true,
       expectBroadcast: false,
     });
 
@@ -436,6 +440,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-per-account-channel-peer-routing",
       sessionKey: "agent:main:telegram:account-a:direct:6812765697",
+      deliver: true,
       expectBroadcast: false,
     });
 
@@ -469,6 +474,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-legacy-channel-peer-routing",
       sessionKey: "agent:main:telegram:6812765697",
+      deliver: true,
       expectBroadcast: false,
     });
 
@@ -504,6 +510,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-legacy-thread-channel-peer-routing",
       sessionKey: "agent:main:telegram:6812765697:thread:42",
+      deliver: true,
       expectBroadcast: false,
     });
 
@@ -573,6 +580,40 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       // Keep a second custom scope token so legacy-shape detection is exercised.
       // "agent:main:work" only yields one rest token and does not hit that path.
       sessionKey: "agent:main:work:ticket-123",
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        OriginatingChannel: "webchat",
+        OriginatingTo: undefined,
+        AccountId: undefined,
+      }),
+    );
+  });
+
+  it("chat.send keeps replies on the internal surface when deliver is not enabled", async () => {
+    createTranscriptFixture("openclaw-chat-send-no-deliver-internal-surface-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "discord",
+        to: "user:1234567890",
+        accountId: "default",
+      },
+      lastChannel: "discord",
+      lastTo: "user:1234567890",
+      lastAccountId: "default",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-no-deliver-internal-surface",
+      sessionKey: "agent:main:discord:direct:1234567890",
+      deliver: false,
       expectBroadcast: false,
     });
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -856,6 +856,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       );
       const commandBody = injectThinking ? `/think ${p.thinking} ${parsedMessage}` : parsedMessage;
       const clientInfo = client?.connect?.client;
+      const shouldDeliverExternally = p.deliver === true;
       const routeChannelCandidate = normalizeMessageChannel(
         entry?.deliveryContext?.channel ?? entry?.lastChannel,
       );
@@ -890,6 +891,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         (isChannelScopedSession || hasLegacyChannelPeerShape),
       );
       const hasDeliverableRoute =
+        shouldDeliverExternally &&
         canInheritDeliverableRoute &&
         routeChannelCandidate &&
         routeChannelCandidate !== INTERNAL_MESSAGE_CHANNEL &&


### PR DESCRIPTION
## Summary

- **Problem:** `chat.send` could inherit external route context even when the caller was not in deliver mode, causing TUI-origin messages to route to external channels (for example Discord DM) unexpectedly.
- **Why it matters:** Non-deliver chat clients should stay local and must not leak into channel delivery routes.
- **What changed:** Added explicit gating in gateway chat send routing so external route inheritance is only applied when deliver semantics are active.
- **What did NOT change:** Normal channel delivery behavior for explicit deliver-mode traffic remains unchanged.

## Linked Issue

- Fixes #35254

## Files Changed

- `src/gateway/server-methods/chat.ts`
- `src/gateway/server-methods/chat.directive-tags.test.ts`

## Testing

- Covered by `chat.directive-tags` routing tests in this PR.

## Security Impact

- No new permissions, no token handling changes, no network surface changes.

## AI Assisted

Codex
