### PR TITLE
fix(heartbeat): don't force wake sessionKey for node notifications.changed

### DIFF
--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -11,7 +11,7 @@ const buildSessionLookup = (
     updatedAt?: number;
   } = {},
 ): ReturnType<typeof loadSessionEntryType> => ({
-  cfg: { session: { mainKey: "agent:main:main" } } as OpenClawConfig,
+  cfg: { session: { mainKey: "main" } } as OpenClawConfig,
   storePath: "/tmp/sessions.json",
   store: {} as ReturnType<typeof loadSessionEntryType>["store"],
   entry: {
@@ -37,10 +37,14 @@ vi.mock("../commands/agent.js", () => ({
   agentCommandFromIngress: ingressAgentCommandMock,
 }));
 vi.mock("../config/config.js", () => ({
-  loadConfig: vi.fn(() => ({ session: { mainKey: "agent:main:main" } })),
+  loadConfig: vi.fn(() => ({ session: { mainKey: "main" } })),
   STATE_DIR: "/tmp/openclaw-state",
 }));
 vi.mock("../config/sessions.js", () => ({
+  canonicalizeMainSessionAlias: vi.fn(({ sessionKey }: { sessionKey: string }) =>
+    sessionKey.toLowerCase(),
+  ),
+  resolveAgentMainSessionKey: vi.fn(({ agentId }: { agentId: string }) => `agent:${agentId}:main`),
   updateSessionStore: vi.fn(),
 }));
 vi.mock("./session-utils.js", () => ({
@@ -199,7 +203,7 @@ describe("node exec events", () => {
 
   it("suppresses exec.started when notifyOnExit is false", async () => {
     loadConfigMock.mockReturnValueOnce({
-      session: { mainKey: "agent:main:main" },
+      session: { mainKey: "main" },
       tools: { exec: { notifyOnExit: false } },
     } as ReturnType<typeof loadConfig>);
     const ctx = buildCtx();
@@ -218,7 +222,7 @@ describe("node exec events", () => {
 
   it("suppresses exec.finished when notifyOnExit is false", async () => {
     loadConfigMock.mockReturnValueOnce({
-      session: { mainKey: "agent:main:main" },
+      session: { mainKey: "main" },
       tools: { exec: { notifyOnExit: false } },
     } as ReturnType<typeof loadConfig>);
     const ctx = buildCtx();
@@ -238,7 +242,7 @@ describe("node exec events", () => {
 
   it("suppresses exec.denied when notifyOnExit is false", async () => {
     loadConfigMock.mockReturnValueOnce({
-      session: { mainKey: "agent:main:main" },
+      session: { mainKey: "main" },
       tools: { exec: { notifyOnExit: false } },
     } as ReturnType<typeof loadConfig>);
     const ctx = buildCtx();
@@ -384,11 +388,11 @@ describe("notifications changed events", () => {
 
     expect(enqueueSystemEventMock).toHaveBeenCalledWith(
       "Notification posted (node=node-n1 key=notif-1 package=com.example.chat): Message - Ping from Alex",
-      { sessionKey: "node-node-n1", contextKey: "notification:notif-1" },
+      { sessionKey: "agent:main:main", contextKey: "notification:notif-1" },
     );
     expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
       reason: "notifications-event",
-      sessionKey: "node-node-n1",
+      agentId: "main",
     });
   });
 
@@ -405,15 +409,15 @@ describe("notifications changed events", () => {
 
     expect(enqueueSystemEventMock).toHaveBeenCalledWith(
       "Notification removed (node=node-n2 key=notif-2 package=com.example.mail)",
-      { sessionKey: "node-node-n2", contextKey: "notification:notif-2" },
+      { sessionKey: "agent:main:main", contextKey: "notification:notif-2" },
     );
     expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
       reason: "notifications-event",
-      sessionKey: "node-node-n2",
+      agentId: "main",
     });
   });
 
-  it("wakes heartbeat on payload sessionKey when provided", async () => {
+  it("wakes only the resolved agent even when payload sessionKey is provided", async () => {
     const ctx = buildCtx();
     await handleNodeEvent(ctx, "node-n4", {
       event: "notifications.changed",
@@ -426,11 +430,31 @@ describe("notifications changed events", () => {
 
     expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
       reason: "notifications-event",
-      sessionKey: "agent:main:main",
+      agentId: "main",
     });
   });
 
-  it("canonicalizes notifications session key before enqueue and wake", async () => {
+  it("resolves wake agentId from canonicalized notification session key", async () => {
+    loadSessionEntryMock.mockReturnValueOnce({
+      ...buildSessionLookup("node-node-n4b"),
+      canonicalKey: "agent:ops:node-node-n4b",
+    });
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-n4b", {
+      event: "notifications.changed",
+      payloadJSON: JSON.stringify({
+        change: "posted",
+        key: "notif-4b",
+      }),
+    });
+
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "notifications-event",
+      agentId: "ops",
+    });
+  });
+
+  it("routes notification events to the heartbeat session while scoping wake by agent", async () => {
     loadSessionEntryMock.mockReturnValueOnce({
       ...buildSessionLookup("node-node-n5"),
       canonicalKey: "agent:main:node-node-n5",
@@ -447,11 +471,45 @@ describe("notifications changed events", () => {
     expect(loadSessionEntryMock).toHaveBeenCalledWith("node-node-n5");
     expect(enqueueSystemEventMock).toHaveBeenCalledWith(
       "Notification posted (node=node-n5 key=notif-5)",
-      { sessionKey: "agent:main:node-node-n5", contextKey: "notification:notif-5" },
+      { sessionKey: "agent:main:main", contextKey: "notification:notif-5" },
     );
     expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
       reason: "notifications-event",
-      sessionKey: "agent:main:node-node-n5",
+      agentId: "main",
+    });
+  });
+
+  it("routes notifications to configured heartbeat.session when provided", async () => {
+    loadSessionEntryMock.mockReturnValueOnce({
+      ...buildSessionLookup("node-node-n5b"),
+      cfg: {
+        session: { mainKey: "main" },
+        agents: {
+          defaults: {
+            heartbeat: {
+              session: "agent:main:direct:choury",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      canonicalKey: "agent:main:node-node-n5b",
+    });
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-n5b", {
+      event: "notifications.changed",
+      payloadJSON: JSON.stringify({
+        change: "posted",
+        key: "notif-5b",
+      }),
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      "Notification posted (node=node-n5b key=notif-5b)",
+      { sessionKey: "agent:main:direct:choury", contextKey: "notification:notif-5b" },
+    );
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "notifications-event",
+      agentId: "main",
     });
   });
 

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -1,16 +1,27 @@
 import { randomUUID } from "node:crypto";
+import { resolveAgentConfig, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { normalizeChannelId } from "../channels/plugins/index.js";
 import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
 import { loadConfig } from "../config/config.js";
-import { updateSessionStore } from "../config/sessions.js";
+import {
+  canonicalizeMainSessionAlias,
+  resolveAgentMainSessionKey,
+  updateSessionStore,
+} from "../config/sessions.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { resolveOutboundTarget } from "../infra/outbound/targets.js";
 import { registerApnsToken } from "../infra/push-apns.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
-import { normalizeMainKey, scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import {
+  normalizeAgentId,
+  normalizeMainKey,
+  resolveAgentIdFromSessionKey,
+  scopedHeartbeatWakeOptions,
+  toAgentStoreSessionKey,
+} from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import { parseMessageWithAttachments } from "./chat-attachments.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./server-methods/attachment-normalize.js";
@@ -133,6 +144,45 @@ function compactNotificationEventText(raw: string) {
   }
   const safe = Math.max(1, MAX_NOTIFICATION_EVENT_TEXT_CHARS - 1);
   return `${normalized.slice(0, safe)}…`;
+}
+
+function resolveNotificationHeartbeatTarget(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  sourceSessionKey: string;
+}): { agentId: string; sessionKey: string } {
+  const fallbackAgentId = resolveAgentIdFromSessionKey(params.sourceSessionKey);
+  const agentId = normalizeAgentId(fallbackAgentId || resolveDefaultAgentId(params.cfg));
+
+  if (params.cfg.session?.scope === "global") {
+    return { agentId, sessionKey: "global" };
+  }
+
+  const mainSessionKey = resolveAgentMainSessionKey({ cfg: params.cfg, agentId });
+  const configuredSession =
+    resolveAgentConfig(params.cfg, agentId)?.heartbeat?.session?.trim() ??
+    params.cfg.agents?.defaults?.heartbeat?.session?.trim() ??
+    "";
+
+  if (!configuredSession) {
+    return { agentId, sessionKey: mainSessionKey };
+  }
+
+  const normalizedConfigured = configuredSession.toLowerCase();
+  if (normalizedConfigured === "main" || normalizedConfigured === "global") {
+    return { agentId, sessionKey: mainSessionKey };
+  }
+
+  const candidate = toAgentStoreSessionKey({
+    agentId,
+    requestKey: configuredSession,
+    mainKey: params.cfg.session?.mainKey,
+  });
+  const sessionKey = canonicalizeMainSessionAlias({
+    cfg: params.cfg,
+    agentId,
+    sessionKey: candidate,
+  });
+  return { agentId, sessionKey };
 }
 
 type LoadedSessionEntry = ReturnType<typeof loadSessionEntry>;
@@ -470,7 +520,11 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         return;
       }
       const sessionKeyRaw = normalizeNonEmptyString(obj.sessionKey) ?? `node-${nodeId}`;
-      const { canonicalKey: sessionKey } = loadSessionEntry(sessionKeyRaw);
+      const { canonicalKey: sourceSessionKey, cfg } = loadSessionEntry(sessionKeyRaw);
+      const heartbeatTarget = resolveNotificationHeartbeatTarget({
+        cfg,
+        sourceSessionKey,
+      });
       const packageName = normalizeNonEmptyString(obj.packageName);
       const title = compactNotificationEventText(normalizeNonEmptyString(obj.title) ?? "");
       const text = compactNotificationEventText(normalizeNonEmptyString(obj.text) ?? "");
@@ -488,11 +542,14 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       }
 
       const queued = enqueueSystemEvent(summary, {
-        sessionKey,
+        sessionKey: heartbeatTarget.sessionKey,
         contextKey: `notification:${key}`,
       });
       if (queued) {
-        requestHeartbeatNow({ reason: "notifications-event", sessionKey });
+        requestHeartbeatNow({
+          reason: "notifications-event",
+          agentId: heartbeatTarget.agentId,
+        });
       }
       return;
     }


### PR DESCRIPTION
## Summary

- `notifications.changed` currently enqueues a node-scoped system event and then calls `requestHeartbeatNow({ reason: "notifications-event", sessionKey })`.
- This forces heartbeat routing to the node session (e.g. `agent:main:node-<nodeId>`) and can override explicitly configured `heartbeat.session`.
- Fix: for `notifications.changed`, wake heartbeat without forcing a session key:
  - `requestHeartbeatNow({ reason: "notifications-event" })`
- Keep session scoping for the **event queue** itself unchanged (`enqueueSystemEvent(..., { sessionKey, contextKey })`).

## Why

This preserves notification event dedupe/context while preventing node notification wakes from hijacking configured heartbeat session routing.

## Tests

Updated `src/gateway/server-node-events.test.ts` expectations:

- posted/removed notification events wake with `{ reason: "notifications-event" }` only
- payload-provided `sessionKey` no longer forces wake target
- canonicalized notification session key is still used for `enqueueSystemEvent`

Run:

```bash
corepack pnpm vitest run src/gateway/server-node-events.test.ts
```

All tests in that file pass.

## Linked issue

Fixes #35310
