### PR TITLE
fix(cron): resolve #35185 bot review follow-ups

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -516,6 +516,40 @@ describe("subagent announce formatting", () => {
     expect(msg).not.toContain("There are still 1 active subagent run for this session.");
   });
 
+  it("keeps cron child session when descendants are still pending", async () => {
+    sessionStore = {
+      "agent:main:subagent:test": {
+        sessionId: "child-session-cron-pending-descendants",
+      },
+      "agent:main:main": {
+        sessionId: "requester-session-cron-pending-descendants",
+      },
+    };
+    readLatestAssistantReplyMock.mockResolvedValue("");
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "final answer: cron" }] }],
+    });
+    subagentRegistryMock.countPendingDescendantRuns.mockImplementation((sessionKey: string) =>
+      sessionKey === "agent:main:subagent:test" ? 1 : 0,
+    );
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-direct-cron-pending-descendants",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
+      announceType: "cron job",
+      ...defaultOutcomeAnnounce,
+      cleanup: "delete",
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sessionsDeleteSpy).not.toHaveBeenCalled();
+  });
+
   it("suppresses completion delivery when subagent reply is ANNOUNCE_SKIP", async () => {
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:test",

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1238,12 +1238,14 @@ export async function runSubagentAnnounceFlow(params: {
       // Best-effort only; fall back to direct announce behavior when unavailable.
     }
     const isCronAnnounce = params.announceType === "cron job";
-    if (pendingChildDescendantRuns > 0 && !isCronAnnounce) {
-      // The finished run still has pending descendant subagents (either active,
-      // or ended but still finishing their own announce and cleanup flow). Defer
-      // announcing this run until descendants fully settle.
+    if (pendingChildDescendantRuns > 0) {
+      // Descendants are still pending cleanup/announce work. Keep the child
+      // session alive so descendant routing and retry paths are not orphaned.
       shouldDeleteChildSession = false;
-      return false;
+      if (!isCronAnnounce) {
+        // Non-cron announce flows still defer while descendants settle.
+        return false;
+      }
     }
 
     if (requesterDepth >= 1 && reply?.trim()) {

--- a/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
+++ b/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
@@ -421,6 +421,38 @@ describe("runCronIsolatedAgentTurn", () => {
     });
   });
 
+  it("keeps cron run status ok when announce and direct fallback both fail", async () => {
+    await withTelegramAnnounceFixture(
+      async ({ home, storePath, deps }) => {
+        mockAgentPayloads([{ text: "hello from cron" }]);
+        vi.mocked(runSubagentAnnounceFlow).mockResolvedValueOnce(false);
+
+        const res = await runTelegramAnnounceTurn({
+          home,
+          storePath,
+          deps,
+          delivery: {
+            mode: "announce",
+            channel: "telegram",
+            to: "123",
+            bestEffort: false,
+          },
+        });
+
+        expect(res.status).toBe("ok");
+        expect(res.delivered).toBe(false);
+        expect(res.deliveryAttempted).toBe(true);
+        expect(res.error).toContain("cron announce delivery failed");
+        expect(deps.sendMessageTelegram).toHaveBeenCalledTimes(1);
+      },
+      {
+        deps: {
+          sendMessageTelegram: vi.fn().mockRejectedValue(new Error("direct fallback failed")),
+        },
+      },
+    );
+  });
+
   it("marks attempted when announce delivery reports false and best-effort is enabled", async () => {
     const { res, deps } = await runAnnounceFlowResult(true);
     expect(res.status).toBe("ok");

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -475,15 +475,14 @@ export async function dispatchCronDelivery(
         if (announceDeliveryWasAttempted && !delivered && !params.isAborted()) {
           const directFallback = await deliverViaDirect(params.resolvedDelivery);
           if (directFallback) {
-            return {
-              result: directFallback,
-              delivered,
-              deliveryAttempted,
-              summary,
-              outputText,
-              synthesizedText,
-              deliveryPayloads,
-            };
+            // Preserve announce-mode semantics: announce failure should not
+            // downgrade an otherwise successful cron execution to hard error.
+            // Keep announceResult and only use direct fallback on success.
+            logWarn(
+              `[cron:${params.job.id}] direct fallback after announce failure also failed: ${
+                directFallback.error ?? "unknown error"
+              }`,
+            );
           }
           // If direct delivery succeeded (returned null without error),
           // `delivered` has been set to true by deliverViaDirect.


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: #35185 left two unresolved reviewer findings around cron announce completion handling.
- Why it matters: one path could delete a cron child session while descendants are still pending; another could incorrectly escalate delivery failures to hard run failures.
- What changed: keep cron child sessions alive when descendant runs are still pending, and preserve non-fatal announce semantics when both announce and direct fallback delivery fail.
- What did NOT change (scope boundary): no widening of non-cron announce bypass behavior; no channel-specific delivery narrowing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34966
- Related #35185

## User-visible / Behavior Changes

- Cron completion announce no longer risks deleting the child session while descendants are still pending cleanup/announce work.
- Cron announce-mode delivery failures remain non-fatal to successful run execution, even if direct fallback also fails.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram/Discord via mocked delivery paths
- Relevant config (redacted): default test harness config

### Steps

1. Run `pnpm exec vitest run --config vitest.e2e.config.ts src/agents/subagent-announce.format.e2e.test.ts`
2. Run `pnpm vitest run src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts`
3. Run `pnpm check`

### Expected

- Added cron descendant cleanup/session retention regression passes.
- Added announce+direct-fallback double-failure semantic regression passes.
- Lint/typecheck/check suite passes.

### Actual

- All commands above passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: cron announce with pending descendants + cleanup delete request; announce failure + direct fallback failure with `bestEffort=false`.
- Edge cases checked: non-cron pending-descendant deferral behavior remains intact; successful direct fallback still marks delivery as delivered.
- What you did **not** verify: live external channel delivery against real tokens/accounts.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit from `main`.
- Files/config to restore: `src/agents/subagent-announce.ts`, `src/cron/isolated-agent/delivery-dispatch.ts`.
- Known bad symptoms reviewers should watch for: cron child sessions being deleted too early; cron runs incorrectly marked `error` when delivery fails after successful execution.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: keeping child session while descendants remain pending could retain session state longer than expected.
  - Mitigation: scoped only to pending-descendant window; cleanup resumes once descendants settle.
- Risk: preserving non-fatal announce semantics could hide delivery issues if operators expect hard failures.
  - Mitigation: deliveryAttempted/delivered/error metadata remains populated and warning log is emitted.
