### PR TITLE
fix(cli): include commit SHA in -v/--version output for local builds

### DIFF
--- a/src/cli/program/help.test.ts
+++ b/src/cli/program/help.test.ts
@@ -5,6 +5,11 @@ import type { ProgramContext } from "./context.js";
 const hasEmittedCliBannerMock = vi.fn(() => false);
 const formatCliBannerLineMock = vi.fn(() => "BANNER-LINE");
 const formatDocsLinkMock = vi.fn((_path: string, full: string) => `https://${full}`);
+const resolveCommitHashMock = vi.fn(() => "abc1234");
+
+vi.mock("../../infra/git-commit.js", () => ({
+  resolveCommitHash: (...args: unknown[]) => resolveCommitHashMock(...args),
+}));
 
 vi.mock("../../terminal/links.js", () => ({
   formatDocsLink: formatDocsLinkMock,
@@ -109,6 +114,23 @@ describe("configureProgramHelp", () => {
 
   it("prints version and exits immediately when version flags are present", () => {
     process.argv = ["node", "openclaw", "--version"];
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? ""}`);
+    }) as typeof process.exit);
+
+    const program = makeProgramWithCommands();
+    expect(() => configureProgramHelp(program, testProgramContext)).toThrow("exit:0");
+    expect(logSpy).toHaveBeenCalledWith("9.9.9-test (abc1234)");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("prints version without commit SHA when commit is null", () => {
+    process.argv = ["node", "openclaw", "--version"];
+    resolveCommitHashMock.mockReturnValueOnce(null);
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
       throw new Error(`exit:${code ?? ""}`);

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { resolveCommitHash } from "../../infra/git-commit.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { isRich, theme } from "../../terminal/theme.js";
 import { escapeRegExp } from "../../utils.js";
@@ -11,6 +12,12 @@ import type { ProgramContext } from "./context.js";
 import { getSubCliCommandsWithSubcommands } from "./register.subclis.js";
 
 const CLI_NAME = resolveCliName();
+
+function formatVersionWithCommit(version: string): string {
+  const commit = resolveCommitHash();
+  return commit ? `${version} (${commit})` : version;
+}
+
 const CLI_NAME_PATTERN = escapeRegExp(CLI_NAME);
 const ROOT_COMMANDS_WITH_SUBCOMMANDS = new Set([
   ...getCoreCliCommandsWithSubcommands(),
@@ -109,7 +116,7 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     hasFlag(process.argv, "--version") ||
     hasRootVersionAlias(process.argv)
   ) {
-    console.log(ctx.programVersion);
+    console.log(formatVersionWithCommit(ctx.programVersion));
     process.exit(0);
   }
 


### PR DESCRIPTION
## Summary

- Problem: `openclaw -v` outputs bare version string (`2026.3.1`) while the banner shows version with commit SHA (`OpenClaw 2026.3.1 (b13e19b)`). This makes it hard to verify which local build is running.
- Why it matters: Users running local/dev builds need the commit SHA to distinguish between builds with the same version number.
- What changed: `-v`/`--version` now calls `resolveCommitHash()` and appends the SHA when available, producing `2026.3.1 (b13e19b)`.
- What did NOT change (scope boundary): Banner logic, `resolveCommitHash()` itself, and `--help` output are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34972

## User-visible / Behavior Changes

- `openclaw -v` / `openclaw --version` now outputs `<version> (<commit>)` when a commit hash is available (local/dev builds), and falls back to bare `<version>` for release builds without git context.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime/container: Node.js v22 + vitest
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: N/A

### Steps

1. Run `openclaw -v` in a local/dev build
2. Before fix: `2026.3.1`
3. After fix: `2026.3.1 (b13e19b)`

### Expected

Version output includes commit SHA for local builds.

### Actual

- Before: Bare version string
- After: Version with commit SHA (matching banner)

## Evidence

- [x] Failing test/log before + passing after

Updated existing test and added a new test case:
- `prints version and exits immediately when version flags are present` — now expects `9.9.9-test (abc1234)`
- `prints version without commit SHA when commit is null` — ensures graceful fallback

All 4 tests pass.

## Human Verification (required)

- Verified scenarios: version with commit hash, version without commit hash (null)
- Edge cases checked: `resolveCommitHash()` returning null (release build scenario)
- What you did **not** verify: Actual npm-published release build (no git context)

## Compatibility / Migration

- Backward compatible? Yes — output format is additive
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `src/cli/program/help.ts`
- Known bad symptoms reviewers should watch for: Version output showing `(unknown)` or `(null)` instead of bare version

## Risks and Mitigations

- Risk: Scripts parsing `openclaw -v` output may break on the new format
  - Mitigation: The parenthesized commit suffix is standard and matches the banner format that has been in use for a long time