### PR TITLE
fix(ios): make chat run timeout handling soft for large models

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -41,7 +41,7 @@ public final class OpenClawChatViewModel {
 
     @ObservationIgnored
     private nonisolated(unsafe) var pendingRunTimeoutTasks: [String: Task<Void, Never>] = [:]
-    private let pendingRunTimeoutMs: UInt64 = 120_000
+    private let pendingRunTimeoutMs: UInt64
 
     private var pendingToolCallsById: [String: OpenClawChatPendingToolCall] = [:] {
         didSet {
@@ -52,9 +52,14 @@ public final class OpenClawChatViewModel {
 
     private var lastHealthPollAt: Date?
 
-    public init(sessionKey: String, transport: any OpenClawChatTransport) {
+    public init(
+        sessionKey: String,
+        transport: any OpenClawChatTransport,
+        pendingRunTimeoutMs: UInt64 = 120_000)
+    {
         self.sessionKey = sessionKey
         self.transport = transport
+        self.pendingRunTimeoutMs = pendingRunTimeoutMs
 
         self.eventTask = Task { [weak self] in
             guard let self else { return }
@@ -589,8 +594,12 @@ public final class OpenClawChatViewModel {
             await MainActor.run { [weak self] in
                 guard let self else { return }
                 guard self.pendingRuns.contains(runId) else { return }
-                self.clearPendingRun(runId)
-                self.errorText = "Timed out waiting for a reply; try again or refresh."
+                // Keep tracking long-running runs so late final events still refresh history.
+                self.errorText = "Still waiting for the model; large-model replies can take longer."
+                Task {
+                    await self.refreshHistoryAfterRun()
+                    await self.pollHealthIfNeeded(force: true)
+                }
             }
         }
     }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -48,10 +48,16 @@ private func sessionEntry(key: String, updatedAt: Double) -> OpenClawChatSession
 private func makeViewModel(
     sessionKey: String = "main",
     historyResponses: [OpenClawChatHistoryPayload],
-    sessionsResponses: [OpenClawChatSessionsListResponse] = []) async -> (TestChatTransport, OpenClawChatViewModel)
+    sessionsResponses: [OpenClawChatSessionsListResponse] = [],
+    pendingRunTimeoutMs: UInt64 = 120_000) async -> (TestChatTransport, OpenClawChatViewModel)
 {
     let transport = TestChatTransport(historyResponses: historyResponses, sessionsResponses: sessionsResponses)
-    let vm = await MainActor.run { OpenClawChatViewModel(sessionKey: sessionKey, transport: transport) }
+    let vm = await MainActor.run {
+        OpenClawChatViewModel(
+            sessionKey: sessionKey,
+            transport: transport,
+            pendingRunTimeoutMs: pendingRunTimeoutMs)
+    }
     return (transport, vm)
 }
 
@@ -405,6 +411,45 @@ extension TestChatTransportState {
             await MainActor.run { vm.messages.contains(where: { $0.role == "assistant" }) }
         }
         #expect(await MainActor.run { vm.errorText == nil })
+    }
+
+    @Test func softTimeoutKeepsRunTrackedAndAcceptsLateFinal() async throws {
+        let now = Date().timeIntervalSince1970 * 1000
+        let history1 = historyPayload()
+        let history2 = historyPayload(messages: [chatTextMessage(role: "user", text: "hello", timestamp: now)])
+        let history3 = historyPayload(
+            messages: [
+                chatTextMessage(role: "user", text: "hello", timestamp: now),
+                chatTextMessage(role: "assistant", text: "late answer", timestamp: now + 1),
+            ])
+
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history1, history2, history3],
+            pendingRunTimeoutMs: 20)
+        try await loadAndWaitBootstrap(vm: vm)
+
+        await sendUserMessage(vm, text: "hello")
+        let runId = try #require(await transport.lastSentRunId())
+        try await waitUntil("warning appears after soft timeout") {
+            await MainActor.run {
+                vm.errorText == "Still waiting for the model; large-model replies can take longer."
+                    && vm.pendingRunCount == 1
+            }
+        }
+
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: runId,
+                    sessionKey: "main",
+                    state: "final",
+                    message: nil,
+                    errorMessage: nil)))
+
+        try await waitUntil("late final clears pending run") { await MainActor.run { vm.pendingRunCount == 0 } }
+        try await waitUntil("history includes late assistant reply") {
+            await MainActor.run { vm.messages.contains(where: { $0.role == "assistant" }) }
+        }
     }
 
     @Test func sessionChoicesPreferMainAndRecent() async throws {


### PR DESCRIPTION
## Summary

- **Problem:** Chat runs in iOS/OpenClawKit used hard timeout behavior that could mark long-running model runs as failed too aggressively.
- **Why it matters:** Large/slow model responses should remain observable and allow late final events to refresh history instead of appearing dropped.
- **What changed:** Updated `OpenClawChatUI` timeout handling to a soft-timeout model in `ChatViewModel.swift`, with regression coverage in `ChatViewModelTests.swift`.
- **What did NOT change:** Core gateway routing and non-iOS timeout behavior remain unchanged.

## Linked Issue

- Fixes #35227

## Files Changed

- `apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift`
- `apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift`

## Testing

- iOS timeout behavior verified by `ChatViewModelTests.swift` updates included in this PR.

## Security Impact

- No new permissions, no token handling changes, no network surface changes.

## AI Assisted

Codex
