### PR TITLE
gateway: reduce sync transcript scans for abort idempotency checks

### DIFF
--- a/src/gateway/server-methods/chat.abort-persistence.test.ts
+++ b/src/gateway/server-methods/chat.abort-persistence.test.ts
@@ -273,6 +273,69 @@ describe("chat abort transcript persistence", () => {
     });
   });
 
+  it("keeps abort idempotency dedupe even when prior key is outside tail window", async () => {
+    const { transcriptPath, sessionId } = await createTranscriptFixture(
+      "openclaw-chat-abort-idem-tail-",
+    );
+    const runId = "idem-abort-tail-window";
+    await fs.appendFile(
+      transcriptPath,
+      `${JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Existing partial" }],
+          timestamp: Date.now(),
+          stopReason: "stop",
+          idempotencyKey: `${runId}:assistant`,
+          openclawAbort: { aborted: true, origin: "rpc", runId },
+        },
+      })}
+`,
+      "utf-8",
+    );
+
+    const filler = "x".repeat(8_192);
+    for (let i = 0; i < 40; i += 1) {
+      await fs.appendFile(
+        transcriptPath,
+        `${JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: `${i}:${filler}` }],
+            timestamp: Date.now(),
+            stopReason: "stop",
+          },
+        })}
+`,
+        "utf-8",
+      );
+    }
+
+    const respond = vi.fn();
+    const context = createChatAbortContext({
+      chatAbortControllers: new Map([[runId, createActiveRun("main", sessionId)]]),
+      chatRunBuffers: new Map([[runId, "Partial from retry"]]),
+      chatDeltaSentAt: new Map([[runId, Date.now()]]),
+      removeChatRun: vi.fn().mockReturnValue({ sessionKey: "main", clientRunId: "client-retry" }),
+      agentRunSeq: new Map<string, number>([[runId, 1]]),
+    });
+
+    await invokeChatAbort(context, { sessionKey: "main", runId }, respond);
+
+    const [ok, payload] = respond.mock.calls.at(-1) ?? [];
+    expect(ok).toBe(true);
+    expect(payload).toMatchObject({ aborted: true, runIds: [runId] });
+
+    const lines = await readTranscriptLines(transcriptPath);
+    const persisted = lines
+      .map((line) => line.message)
+      .filter((message) => message?.idempotencyKey === `${runId}:assistant`);
+
+    expect(persisted).toHaveLength(1);
+  });
+
   it("skips run-scoped transcript persistence when partial text is blank", async () => {
     const { transcriptPath, sessionId } = await createTranscriptFixture(
       "openclaw-chat-abort-run-blank-",

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -71,6 +71,7 @@ type AbortedPartialSnapshot = {
 const CHAT_HISTORY_TEXT_MAX_CHARS = 12_000;
 const CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES = 128 * 1024;
 const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
+const TRANSCRIPT_IDEMPOTENCY_TAIL_BYTES = 256 * 1024;
 let chatHistoryPlaceholderEmitCount = 0;
 const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
   "main",
@@ -371,19 +372,81 @@ function ensureTranscriptFile(params: { transcriptPath: string; sessionId: strin
   }
 }
 
-function transcriptHasIdempotencyKey(transcriptPath: string, idempotencyKey: string): boolean {
-  try {
-    const lines = fs.readFileSync(transcriptPath, "utf-8").split(/\r?\n/);
-    for (const line of lines) {
-      if (!line.trim()) {
-        continue;
-      }
+function transcriptChunkHasIdempotencyKey(chunk: string, idempotencyKey: string): boolean {
+  const lines = chunk.split(/\r?\n/);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    if (!line || !line.includes('"idempotencyKey"')) {
+      continue;
+    }
+    try {
       const parsed = JSON.parse(line) as { message?: { idempotencyKey?: unknown } };
       if (parsed?.message?.idempotencyKey === idempotencyKey) {
         return true;
       }
+    } catch {
+      continue;
     }
-    return false;
+  }
+  return false;
+}
+
+function readTranscriptTail(params: {
+  transcriptPath: string;
+  maxBytes: number;
+}): { text: string; complete: boolean } | null {
+  const { transcriptPath, maxBytes } = params;
+  if (maxBytes <= 0) {
+    return { text: "", complete: true };
+  }
+  let fd: number | undefined;
+  try {
+    const stat = fs.statSync(transcriptPath);
+    const size = Number.isFinite(stat.size) ? Math.max(0, Math.floor(stat.size)) : 0;
+    if (size <= 0) {
+      return { text: "", complete: true };
+    }
+    const bytes = Math.min(size, maxBytes);
+    const offset = size - bytes;
+    const buffer = Buffer.allocUnsafe(bytes);
+    fd = fs.openSync(transcriptPath, "r");
+    const readBytes = fs.readSync(fd, buffer, 0, bytes, offset);
+    return {
+      text: buffer.subarray(0, Math.max(0, readBytes)).toString("utf-8"),
+      complete: bytes === size,
+    };
+  } catch {
+    return null;
+  } finally {
+    if (typeof fd === "number") {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // best effort
+      }
+    }
+  }
+}
+
+function transcriptHasIdempotencyKey(transcriptPath: string, idempotencyKey: string): boolean {
+  try {
+    const tail = readTranscriptTail({
+      transcriptPath,
+      maxBytes: TRANSCRIPT_IDEMPOTENCY_TAIL_BYTES,
+    });
+    if (tail === null) {
+      return false;
+    }
+    if (tail.text && transcriptChunkHasIdempotencyKey(tail.text, idempotencyKey)) {
+      return true;
+    }
+    if (tail.complete) {
+      return false;
+    }
+    return transcriptChunkHasIdempotencyKey(
+      fs.readFileSync(transcriptPath, "utf-8"),
+      idempotencyKey,
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- optimize `transcriptHasIdempotencyKey` by scanning a bounded transcript tail first (256KB)
- keep full-scan fallback when the key is not found in tail so behavior stays unchanged
- skip JSON parsing for lines without an `idempotencyKey` marker
- add regression coverage for keys that exist outside the tail window

## Why
Aborted-partial persistence performs idempotency checks against transcript JSONL. On long transcripts, always reading/parsing the full file is a synchronous hot path during retry/duplicate abort flows.

## Impact
- lower sync I/O + parse cost in common duplicate-retry scenarios
- unchanged correctness for older keys (full fallback path)

## Risk
Low. Existing semantics are preserved via fallback, and tests cover both near-tail and far-history dedupe behavior.

## Test
- `pnpm -s vitest src/gateway/server-methods/chat.abort-persistence.test.ts src/gateway/server-methods/chat.directive-tags.test.ts`
