### PR TITLE
fix: [Bug]: feishu：receive events or callbacks through persistent connection only available in self-build & Feishu app (#35275)

### DIFF
--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -68,6 +68,15 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     expect(ctx.senderId).toBe("u_mobile_only");
   });
 
+  it("falls back to sender union_id when open_id/user_id are missing", () => {
+    const event = makeEvent("p2p", []);
+    (event as any).sender.sender_id = { union_id: "on_union_only" };
+
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.senderOpenId).toBe("on_union_only");
+    expect(ctx.senderId).toBe("on_union_only");
+  });
+
   it("returns mentionedBot=true when bot is mentioned", () => {
     const event = makeEvent("group", [
       { key: "@_user_1", name: "Bot", id: { open_id: BOT_OPEN_ID } },

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -783,12 +783,13 @@ export function parseFeishuMessageEvent(
   );
   const senderOpenId = event.sender.sender_id.open_id?.trim();
   const senderUserId = event.sender.sender_id.user_id?.trim();
-  const senderFallbackId = senderOpenId || senderUserId || "";
+  const senderUnionId = event.sender.sender_id.union_id?.trim();
+  const senderFallbackId = senderOpenId || senderUserId || senderUnionId || "";
 
   const ctx: FeishuMessageContext = {
     chatId: event.message.chat_id,
     messageId: event.message.message_id,
-    senderId: senderUserId || senderOpenId || "",
+    senderId: senderUserId || senderOpenId || senderUnionId || "",
     // Keep the historical field name, but fall back to user_id when open_id is unavailable
     // (common in some mobile app deliveries).
     senderOpenId: senderFallbackId,
@@ -894,6 +895,7 @@ export async function handleFeishuMessage(params: {
   const isGroup = ctx.chatType === "group";
   const isDirect = !isGroup;
   const senderUserId = event.sender.sender_id.user_id?.trim() || undefined;
+  const senderUnionId = event.sender.sender_id.union_id?.trim() || undefined;
 
   // Handle merge_forward messages: fetch full message via API then expand sub-messages
   if (event.message.message_type === "merge_forward") {
@@ -1034,7 +1036,7 @@ export async function handleFeishuMessage(params: {
         groupPolicy: "allowlist",
         allowFrom: effectiveSenderAllowFrom,
         senderId: ctx.senderOpenId,
-        senderIds: [senderUserId],
+        senderIds: [senderUserId, senderUnionId],
         senderName: ctx.senderName,
       });
       if (!senderAllowed) {
@@ -1094,7 +1096,7 @@ export async function handleFeishuMessage(params: {
     const dmAllowed = resolveFeishuAllowlistMatch({
       allowFrom: effectiveDmAllowFrom,
       senderId: ctx.senderOpenId,
-      senderIds: [senderUserId],
+      senderIds: [senderUserId, senderUnionId],
       senderName: ctx.senderName,
     }).allowed;
 
@@ -1137,7 +1139,7 @@ export async function handleFeishuMessage(params: {
     const senderAllowedForCommands = resolveFeishuAllowlistMatch({
       allowFrom: commandAllowFrom,
       senderId: ctx.senderOpenId,
-      senderIds: [senderUserId],
+      senderIds: [senderUserId, senderUnionId],
       senderName: ctx.senderName,
     }).allowed;
     const commandAuthorized = shouldComputeCommandAuthorized

--- a/extensions/feishu/src/targets.test.ts
+++ b/extensions/feishu/src/targets.test.ts
@@ -10,6 +10,10 @@ describe("resolveReceiveIdType", () => {
     expect(resolveReceiveIdType("ou_123")).toBe("open_id");
   });
 
+  it("resolves union IDs by on_ prefix", () => {
+    expect(resolveReceiveIdType("on_123")).toBe("union_id");
+  });
+
   it("defaults unprefixed IDs to user_id", () => {
     expect(resolveReceiveIdType("u_123")).toBe("user_id");
   });
@@ -24,6 +28,10 @@ describe("resolveReceiveIdType", () => {
 
   it("treats dm-prefixed open IDs as open_id", () => {
     expect(resolveReceiveIdType("dm:ou_123")).toBe("open_id");
+  });
+
+  it("treats dm-prefixed union IDs as union_id", () => {
+    expect(resolveReceiveIdType("dm:on_123")).toBe("union_id");
   });
 });
 
@@ -51,6 +59,10 @@ describe("normalizeFeishuTarget", () => {
   it("strips provider and dm prefixes", () => {
     expect(normalizeFeishuTarget("lark:dm:ou_123")).toBe("ou_123");
   });
+
+  it("strips provider and union_id prefixes", () => {
+    expect(normalizeFeishuTarget("feishu:union_id:on_123")).toBe("on_123");
+  });
 });
 
 describe("looksLikeFeishuId", () => {
@@ -66,5 +78,10 @@ describe("looksLikeFeishuId", () => {
     expect(looksLikeFeishuId("feishu:group:oc_123")).toBe(true);
     expect(looksLikeFeishuId("group:oc_123")).toBe(true);
     expect(looksLikeFeishuId("channel:oc_456")).toBe(true);
+  });
+
+  it("accepts union_id-prefixed and raw on_ IDs", () => {
+    expect(looksLikeFeishuId("union_id:on_123")).toBe(true);
+    expect(looksLikeFeishuId("on_123")).toBe(true);
   });
 });

--- a/extensions/feishu/src/targets.ts
+++ b/extensions/feishu/src/targets.ts
@@ -2,6 +2,7 @@ import type { FeishuIdType } from "./types.js";
 
 const CHAT_ID_PREFIX = "oc_";
 const OPEN_ID_PREFIX = "ou_";
+const UNION_ID_PREFIX = "on_";
 const USER_ID_REGEX = /^[a-zA-Z0-9_-]+$/;
 
 function stripProviderPrefix(raw: string): string {
@@ -15,6 +16,9 @@ export function detectIdType(id: string): FeishuIdType | null {
   }
   if (trimmed.startsWith(OPEN_ID_PREFIX)) {
     return "open_id";
+  }
+  if (trimmed.startsWith(UNION_ID_PREFIX)) {
+    return "union_id";
   }
   if (USER_ID_REGEX.test(trimmed)) {
     return "user_id";
@@ -48,6 +52,9 @@ export function normalizeFeishuTarget(raw: string): string | null {
   if (lowered.startsWith("open_id:")) {
     return withoutProvider.slice("open_id:".length).trim() || null;
   }
+  if (lowered.startsWith("union_id:")) {
+    return withoutProvider.slice("union_id:".length).trim() || null;
+  }
 
   return withoutProvider;
 }
@@ -63,7 +70,7 @@ export function formatFeishuTarget(id: string, type?: FeishuIdType): string {
   return trimmed;
 }
 
-export function resolveReceiveIdType(id: string): "chat_id" | "open_id" | "user_id" {
+export function resolveReceiveIdType(id: string): "chat_id" | "open_id" | "union_id" | "user_id" {
   const trimmed = id.trim();
   const lowered = trimmed.toLowerCase();
   if (
@@ -76,15 +83,27 @@ export function resolveReceiveIdType(id: string): "chat_id" | "open_id" | "user_
   if (lowered.startsWith("open_id:")) {
     return "open_id";
   }
+  if (lowered.startsWith("union_id:")) {
+    return "union_id";
+  }
   if (lowered.startsWith("user:") || lowered.startsWith("dm:")) {
     const normalized = trimmed.replace(/^(user|dm):/i, "").trim();
-    return normalized.startsWith(OPEN_ID_PREFIX) ? "open_id" : "user_id";
+    if (normalized.startsWith(OPEN_ID_PREFIX)) {
+      return "open_id";
+    }
+    if (normalized.startsWith(UNION_ID_PREFIX)) {
+      return "union_id";
+    }
+    return "user_id";
   }
   if (trimmed.startsWith(CHAT_ID_PREFIX)) {
     return "chat_id";
   }
   if (trimmed.startsWith(OPEN_ID_PREFIX)) {
     return "open_id";
+  }
+  if (trimmed.startsWith(UNION_ID_PREFIX)) {
+    return "union_id";
   }
   return "user_id";
 }
@@ -94,13 +113,16 @@ export function looksLikeFeishuId(raw: string): boolean {
   if (!trimmed) {
     return false;
   }
-  if (/^(chat|group|channel|user|dm|open_id):/i.test(trimmed)) {
+  if (/^(chat|group|channel|user|dm|open_id|union_id):/i.test(trimmed)) {
     return true;
   }
   if (trimmed.startsWith(CHAT_ID_PREFIX)) {
     return true;
   }
   if (trimmed.startsWith(OPEN_ID_PREFIX)) {
+    return true;
+  }
+  if (trimmed.startsWith(UNION_ID_PREFIX)) {
     return true;
   }
   return false;


### PR DESCRIPTION
Closes #35275

## Summary

- Problem: [Bug]: feishu：receive events or callbacks through persistent connection only available in self-build & Feishu app
- Why it matters: Reported in #35275
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35275
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35275