### PR TITLE
Fix: detect Venice provider proxying xAI/Grok models for schema cleaning

### DIFF
--- a/src/agents/schema/clean-for-xai.ts
+++ b/src/agents/schema/clean-for-xai.ts
@@ -45,11 +45,16 @@ export function stripXaiUnsupportedKeywords(schema: unknown): unknown {
 
 export function isXaiProvider(modelProvider?: string, modelId?: string): boolean {
   const provider = modelProvider?.toLowerCase() ?? "";
+  const model = modelId?.toLowerCase() ?? "";
   if (provider.includes("xai") || provider.includes("x-ai")) {
     return true;
   }
+  // Venice proxies xAI models under Grok ids.
+  if (provider === "venice" && (model === "grok" || model.startsWith("grok-") || model.includes("/grok-"))) {
+    return true;
+  }
   // OpenRouter proxies to xAI when the model id starts with "x-ai/"
-  if (provider === "openrouter" && modelId?.toLowerCase().startsWith("x-ai/")) {
+  if (provider === "openrouter" && model.startsWith("x-ai/")) {
     return true;
   }
   return false;


### PR DESCRIPTION
## Summary

- **Problem:** Venice can proxy Grok/xAI models, but schema-cleaning provider detection did not reliably classify this path.
- **Why it matters:** Misclassification can apply the wrong schema-cleaning branch for Grok-compatible traffic.
- **What changed:** Updated provider detection in `src/agents/schema/clean-for-xai.ts` to treat Venice+Grok model IDs as xAI-compatible for cleaning.
- **What did NOT change:** Non-Venice and non-Grok model handling remains unchanged.

## Linked Issue

- Fixes #35355

## Testing

- Verified logic path by code-level validation of Venice+Grok provider/model detection.
- No new automated test files were added in this PR.

## Security Impact

- No new permissions, no token handling changes, no network surface changes.

## AI Assisted

Codex
