### PR TITLE
Fix: don't force wake sessionKey for node notifications.changed

### DIFF
--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -492,7 +492,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         contextKey: `notification:${key}`,
       });
       if (queued) {
-        requestHeartbeatNow({ reason: "notifications-event", sessionKey });
+        requestHeartbeatNow({ reason: "notifications-event" });
       }
       return;
     }


### PR DESCRIPTION
## Summary

- **Problem:** `notifications.changed` forced a specific `sessionKey` into `requestHeartbeatNow`, which could over-constrain wake routing.
- **Why it matters:** Heartbeat dispatch should select the appropriate target session based on runtime state.
- **What changed:** Removed forced `sessionKey` in `src/gateway/server-node-events.ts` for `notifications.changed` handling.
- **What did NOT change:** Heartbeat triggering semantics remain the same; only forced session scoping was removed.

## Linked Issue

- Fixes #35357

## Testing

- Verified behavior via manual event-path check for `notifications.changed`.
- No new automated test files were added in this PR.

## Security Impact

- No new permissions, no token handling changes, no network surface changes.

## AI Assisted

Codex
