### PR TITLE
feat(slack): support thread-bound ACP sessions via threadBindings

### DIFF
--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -2,9 +2,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { App } from "@slack/bolt";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { expectInboundContextContract } from "../../../../test/helpers/inbound-contract.js";
 import type { OpenClawConfig } from "../../../config/config.js";
+import {
+  registerSessionBindingAdapter,
+  __testing as sessionBindingTesting,
+} from "../../../infra/outbound/session-binding-service.js";
 import { resolveAgentRoute } from "../../../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../../routing/session-key.js";
 import type { RuntimeEnv } from "../../../runtime.js";
@@ -36,6 +40,10 @@ describe("slack prepareSlackMessage inbound contract", () => {
       fs.rmSync(fixtureRoot, { recursive: true, force: true });
       fixtureRoot = "";
     }
+  });
+
+  afterEach(() => {
+    sessionBindingTesting.resetSessionBindingAdaptersForTests();
   });
 
   function createInboundSlackCtx(params: {
@@ -628,6 +636,55 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared!.ctxPayload.SessionKey).toContain(":thread:500.000");
     // MessageThreadId should be set for the reply
     expect(prepared!.ctxPayload.MessageThreadId).toBe("500.000");
+  });
+
+  it("routes bound Slack thread replies to the bound session key", async () => {
+    registerSessionBindingAdapter({
+      channel: "slack",
+      accountId: "default",
+      listBySession: () => [],
+      resolveByConversation: (ref) =>
+        ref.conversationId === "300.000"
+          ? {
+              bindingId: "default:300.000",
+              targetSessionKey: "agent:codex:acp:session-300",
+              targetKind: "session",
+              conversation: {
+                channel: "slack",
+                accountId: "default",
+                conversationId: "300.000",
+                parentConversationId: "C123",
+              },
+              status: "active",
+              boundAt: Date.now(),
+            }
+          : null,
+    });
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: { slack: { enabled: true, groupPolicy: "open" } },
+      } as OpenClawConfig,
+      defaultRequireMention: true,
+    });
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
+    slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount(),
+      createSlackMessage({
+        channel: "C123",
+        channel_type: "channel",
+        thread_ts: "300.000",
+        ts: "300.100",
+        parent_user_id: "U2",
+        text: "follow up without mention",
+      }),
+    );
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.SessionKey).toBe("agent:codex:acp:session-300");
+    expect(prepared!.ctxPayload.ParentSessionKey).toBeUndefined();
   });
 });
 

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -26,9 +26,13 @@ import { resolveMentionGatingWithBypass } from "../../../channels/mention-gating
 import { recordInboundSession } from "../../../channels/session.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../../config/sessions.js";
 import { logVerbose, shouldLogVerbose } from "../../../globals.js";
+import { getSessionBindingService } from "../../../infra/outbound/session-binding-service.js";
 import { enqueueSystemEvent } from "../../../infra/system-events.js";
 import { resolveAgentRoute } from "../../../routing/resolve-route.js";
-import { resolveThreadSessionKeys } from "../../../routing/session-key.js";
+import {
+  resolveAgentIdFromSessionKey,
+  resolveThreadSessionKeys,
+} from "../../../routing/session-key.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../../../security/dm-policy-shared.js";
 import { resolveSlackReplyToMode, type ResolvedSlackAccount } from "../../accounts.js";
 import { reactSlackMessage } from "../../actions.js";
@@ -106,6 +110,7 @@ type SlackRoutingContext = {
   threadKeys: ReturnType<typeof resolveThreadSessionKeys>;
   sessionKey: string;
   historyKey: string;
+  isBoundThreadSession: boolean;
 };
 
 async function resolveSlackConversationContext(params: {
@@ -297,12 +302,29 @@ function resolveSlackRoutingContext(params: {
     threadId: canonicalThreadId,
     parentSessionKey: canonicalThreadId && ctx.threadInheritParent ? route.sessionKey : undefined,
   });
-  const sessionKey = threadKeys.sessionKey;
+  const threadBinding =
+    isThreadReply && threadTs
+      ? getSessionBindingService().resolveByConversation({
+          channel: "slack",
+          accountId: account.accountId,
+          conversationId: threadTs,
+        })
+      : null;
+  const boundSessionKey = threadBinding?.targetSessionKey?.trim() || undefined;
+  const boundAgentId = boundSessionKey ? resolveAgentIdFromSessionKey(boundSessionKey) : undefined;
+  const sessionKey = boundSessionKey ?? threadKeys.sessionKey;
+  const effectiveRoute = boundSessionKey
+    ? {
+        ...route,
+        sessionKey,
+        agentId: boundAgentId || route.agentId,
+      }
+    : route;
   const historyKey =
     isThreadReply && ctx.threadHistoryScope === "thread" ? sessionKey : message.channel;
 
   return {
-    route,
+    route: effectiveRoute,
     chatType,
     replyToMode,
     threadContext,
@@ -311,6 +333,7 @@ function resolveSlackRoutingContext(params: {
     threadKeys,
     sessionKey,
     historyKey,
+    isBoundThreadSession: Boolean(boundSessionKey && isThreadReply),
   };
 }
 
@@ -361,6 +384,7 @@ export async function prepareSlackMessage(params: {
     threadKeys,
     sessionKey,
     historyKey,
+    isBoundThreadSession,
   } = routing;
 
   const mentionRegexes = resolveCachedMentionRegexes(ctx, route.agentId);
@@ -468,9 +492,10 @@ export async function prepareSlackMessage(params: {
     return null;
   }
 
-  const shouldRequireMention = isRoom
-    ? (channelConfig?.requireMention ?? ctx.defaultRequireMention)
-    : false;
+  const shouldRequireMention =
+    isBoundThreadSession || !isRoom
+      ? false
+      : (channelConfig?.requireMention ?? ctx.defaultRequireMention);
 
   // Allow "control commands" to bypass mention gating if sender is authorized.
   const canDetectMention = Boolean(ctx.botUserId) || mentionRegexes.length > 0;
@@ -704,7 +729,7 @@ export async function prepareSlackMessage(params: {
     ReplyToId: threadContext.replyToId,
     // Preserve thread context for routed tool notifications.
     MessageThreadId: threadContext.messageThreadId,
-    ParentSessionKey: threadKeys.parentSessionKey,
+    ParentSessionKey: isBoundThreadSession ? undefined : threadKeys.parentSessionKey,
     // Only include thread starter body for NEW sessions (existing sessions already have it in their transcript)
     ThreadStarterBody: !threadSessionPreviousTimestamp ? threadStarterBody : undefined,
     ThreadHistoryBody: threadHistoryBody,

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -28,6 +28,7 @@ import { resolveSlackWebClientOptions } from "../client.js";
 import { normalizeSlackWebhookPath, registerSlackHttpHandler } from "../http/index.js";
 import { resolveSlackChannelAllowlist } from "../resolve-channels.js";
 import { resolveSlackUserAllowlist } from "../resolve-users.js";
+import { registerSlackThreadBindingAdapter } from "../thread-bindings.js";
 import { resolveSlackAppToken, resolveSlackBotToken } from "../token.js";
 import { normalizeAllowList } from "./allow-list.js";
 import { resolveSlackSlashCommandConfig } from "./commands.js";
@@ -201,6 +202,11 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
         }
       : null;
   let unregisterHttpHandler: (() => void) | null = null;
+  const unregisterThreadBindingAdapter = registerSlackThreadBindingAdapter({
+    accountId: account.accountId,
+    token: botToken,
+    client: app.client,
+  });
 
   let botUserId = "";
   let teamId = "";
@@ -474,6 +480,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   } finally {
     opts.abortSignal?.removeEventListener("abort", stopOnAbort);
     unregisterHttpHandler?.();
+    unregisterThreadBindingAdapter();
     await app.stop().catch(() => undefined);
   }
 }


### PR DESCRIPTION
## Summary
- Add threadBindings support for Slack ACP sessions
- Enables persistent thread-bound sessions in Slack
- Handle thread state in message preparation

## Security Impact
N/A

## Repro + Verification
- Use Slack with threadBindings enabled
- Verify messages route to correct thread

## Testing
- Added tests for thread binding

## AI Assisted
Codex

## Fixes #35345