### PR TITLE
fix: openclaw-tui: Messages displaying twice in terminal UI (#35277)

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -426,4 +426,30 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.dropAssistant).toHaveBeenCalledWith("run-silent");
     expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
   });
+
+  it("suppresses duplicate local final text after a non-local final", () => {
+    const { state, chatLog, noteLocalRunId, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null },
+    });
+
+    handleChatEvent({
+      runId: "run-external",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "same reply" }] },
+    });
+    expect(chatLog.finalizeAssistant).toHaveBeenCalledWith("same reply", "run-external");
+
+    noteLocalRunId("run-local");
+    chatLog.finalizeAssistant.mockClear();
+
+    handleChatEvent({
+      runId: "run-local",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [{ type: "text", text: "same reply" }] },
+    });
+
+    expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
+  });
 });

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -47,6 +47,14 @@ export function createEventHandlers(context: EventHandlerContext) {
   const sessionRuns = new Map<string, number>();
   let streamAssembler = new TuiStreamAssembler();
   let lastSessionKey = state.currentSessionKey;
+  let lastRenderedAssistantFinal:
+    | {
+        runId: string;
+        text: string;
+        isLocalRun: boolean;
+        ts: number;
+      }
+    | undefined;
 
   const pruneRunMap = (runs: Map<string, number>) => {
     if (runs.size <= 200) {
@@ -79,6 +87,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     finalizedRuns.clear();
     sessionRuns.clear();
     streamAssembler = new TuiStreamAssembler();
+    lastRenderedAssistantFinal = undefined;
     clearLocalRunIds?.();
   };
 
@@ -177,6 +186,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     if (evt.state === "final") {
       const wasActiveRun = state.activeChatRunId === evt.runId;
+      const isLocalRun = Boolean(isLocalRunId?.(evt.runId));
       if (!evt.message) {
         maybeRefreshHistoryForRun(evt.runId);
         chatLog.dropAssistant(evt.runId);
@@ -203,12 +213,28 @@ export function createEventHandlers(context: EventHandlerContext) {
           : "";
 
       const finalText = streamAssembler.finalize(evt.runId, evt.message, state.showThinking);
-      const suppressEmptyExternalPlaceholder =
-        finalText === "(no output)" && !isLocalRunId?.(evt.runId);
-      if (suppressEmptyExternalPlaceholder) {
+      const shouldSuppressDuplicateLocalFinal = Boolean(
+        isLocalRun &&
+        lastRenderedAssistantFinal &&
+        !lastRenderedAssistantFinal.isLocalRun &&
+        lastRenderedAssistantFinal.text === finalText &&
+        Date.now() - lastRenderedAssistantFinal.ts <= 2_000,
+      );
+      const suppressEmptyExternalPlaceholder = finalText === "(no output)" && !isLocalRun;
+      if (shouldSuppressDuplicateLocalFinal) {
+        // Some gateways can emit a non-local finalized run followed by the local
+        // client run final with identical text. Avoid rendering the same assistant
+        // reply twice in TUI while still finalizing run state.
+      } else if (suppressEmptyExternalPlaceholder) {
         chatLog.dropAssistant(evt.runId);
       } else {
         chatLog.finalizeAssistant(finalText, evt.runId);
+        lastRenderedAssistantFinal = {
+          runId: evt.runId,
+          text: finalText,
+          isLocalRun,
+          ts: Date.now(),
+        };
       }
       finalizeRun({
         runId: evt.runId,


### PR DESCRIPTION
Closes #35277

## Summary

- Problem: openclaw-tui: Messages displaying twice in terminal UI
- Why it matters: Reported in #35277
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35277
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35277