### PR TITLE
fix: openclaw-tui: Messages displaying twice in terminal UI (#35278)

### DIFF
--- a/src/tui/components/chat-log.test.ts
+++ b/src/tui/components/chat-log.test.ts
@@ -41,4 +41,17 @@ describe("ChatLog", () => {
 
     expect(chatLog.children.length).toBe(20);
   });
+
+  it("does not duplicate streaming assistant components for the same run", () => {
+    const chatLog = new ChatLog(20);
+    chatLog.startAssistant("first", "run-1");
+    const initialChildCount = chatLog.children.length;
+
+    chatLog.startAssistant("updated", "run-1");
+
+    expect(chatLog.children.length).toBe(initialChildCount);
+    const rendered = chatLog.render(120).join("\n");
+    expect(rendered).toContain("updated");
+    expect(rendered).not.toContain("first");
+  });
 });

--- a/src/tui/components/chat-log.ts
+++ b/src/tui/components/chat-log.ts
@@ -65,8 +65,14 @@ export class ChatLog extends Container {
   }
 
   startAssistant(text: string, runId?: string) {
+    const effectiveRunId = this.resolveRunId(runId);
+    const existing = this.streamingRuns.get(effectiveRunId);
+    if (existing) {
+      existing.setText(text);
+      return existing;
+    }
     const component = new AssistantMessageComponent(text);
-    this.streamingRuns.set(this.resolveRunId(runId), component);
+    this.streamingRuns.set(effectiveRunId, component);
     this.append(component);
     return component;
   }


### PR DESCRIPTION
Closes #35278

## Summary

- Problem: openclaw-tui: Messages displaying twice in terminal UI
- Why it matters: Reported in #35278
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35278
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35278