### PR TITLE
fix(agents): use correct Ollama thinking field name instead of reasoning

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -104,20 +104,20 @@ describe("buildAssistantMessage", () => {
     expect(result.usage.totalTokens).toBe(15);
   });
 
-  it("falls back to reasoning when content is empty", () => {
+  it("falls back to thinking when content is empty", () => {
     const response = {
       model: "qwen3:32b",
       created_at: "2026-01-01T00:00:00Z",
       message: {
         role: "assistant" as const,
         content: "",
-        reasoning: "Reasoning output",
+        thinking: "Thinking output",
       },
       done: true,
     };
     const result = buildAssistantMessage(response, modelInfo);
     expect(result.stopReason).toBe("stop");
-    expect(result.content).toEqual([{ type: "text", text: "Reasoning output" }]);
+    expect(result.content).toEqual([{ type: "text", text: "Thinking output" }]);
   });
 
   it("builds response with tool calls", () => {
@@ -397,11 +397,11 @@ describe("createOllamaStreamFn", () => {
     );
   });
 
-  it("accumulates reasoning chunks when content is empty", async () => {
+  it("accumulates thinking chunks when content is empty", async () => {
     await withMockNdjsonFetch(
       [
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","reasoning":"reasoned"},"done":false}',
-        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","reasoning":" output"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":"reasoned"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":" output"},"done":false}',
         '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":2}',
       ],
       async () => {

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -185,7 +185,7 @@ interface OllamaChatResponse {
   message: {
     role: "assistant";
     content: string;
-    reasoning?: string;
+    thinking?: string;
     tool_calls?: OllamaToolCall[];
   };
   done: boolean;
@@ -323,10 +323,10 @@ export function buildAssistantMessage(
 ): AssistantMessage {
   const content: (TextContent | ToolCall)[] = [];
 
-  // Qwen 3 (and potentially other reasoning models) may return their final
-  // answer in a `reasoning` field with an empty `content`. Fall back to
-  // `reasoning` so the response isn't silently dropped.
-  const text = response.message.content || response.message.reasoning || "";
+  // Thinking-capable models (Qwen 3, DeepSeek R1, etc.) may return their
+  // chain-of-thought in the `thinking` field with an empty `content`.
+  // Fall back to `thinking` so the response isn't silently dropped.
+  const text = response.message.content || response.message.thinking || "";
   if (text) {
     content.push({ type: "text", text });
   }
@@ -474,9 +474,9 @@ export function createOllamaStreamFn(
         for await (const chunk of parseNdjsonStream(reader)) {
           if (chunk.message?.content) {
             accumulatedContent += chunk.message.content;
-          } else if (chunk.message?.reasoning) {
-            // Qwen 3 reasoning mode: content may be empty, output in reasoning
-            accumulatedContent += chunk.message.reasoning;
+          } else if (chunk.message?.thinking) {
+            // Thinking-capable models: content may be empty, output in thinking
+            accumulatedContent += chunk.message.thinking;
           }
 
           // Ollama sends tool_calls in intermediate (done:false) chunks,


### PR DESCRIPTION
## Summary

The Ollama native API (`/api/chat`) uses `message.thinking` for chain-of-thought output from thinking-capable models (Qwen 3, DeepSeek R1, etc.), but the stream handler in `ollama-stream.ts` was reading `message.reasoning` — a field that does not exist in the Ollama API. This caused all thinking content to be silently discarded, and when `content` was empty the model appeared to return no output at all.

This PR renames the field access from `.reasoning` to `.thinking` in:
1. The `OllamaChatResponse` type definition
2. The non-streaming `buildAssistantMessage` fallback path
3. The streaming accumulation loop in `createOllamaStreamFn`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [x] Agents / Model integration
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Configuration

## Linked Issues

Closes #34722

## User-Visible Changes

Thinking-capable models (Qwen 3, DeepSeek R1, kimi-k2.5, etc.) running via the native Ollama API will now correctly return their thinking/reasoning output instead of silently discarding it.

## Security Impact

1. Does this change handle user input? **No**
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Steps to Reproduce the Bug

1. Configure a thinking-capable model (e.g., Qwen 3) via the native Ollama provider
2. Enable thinking mode
3. Send a prompt that triggers chain-of-thought reasoning
4. Observe that the response is empty or missing the thinking output

## Verification

- [x] Existing tests updated to use correct field name (`thinking` instead of `reasoning`)
- [x] `buildAssistantMessage` test verifies fallback to `thinking` when `content` is empty
- [x] `createOllamaStreamFn` test verifies streaming `thinking` chunks are accumulated
- [x] All 21 tests pass

## Evidence

```
 ✓ src/agents/ollama-stream.test.ts (21 tests) 7ms
 Test Files  1 passed (1)
      Tests  21 passed (21)
```

## Human Verification

- Verify that a thinking-capable model (Qwen 3, DeepSeek R1) via native Ollama now returns thinking content
- Verify that non-thinking models still work normally (no regression)
- Verify that the streaming path correctly accumulates thinking chunks across multiple NDJSON lines

## Compatibility

- Fully backward compatible — only affects the native Ollama API path (`/api/chat`)
- Models that don't use the `thinking` field are unaffected (empty optional field)
- OpenAI-compatible Ollama endpoint (`/v1/`) is not affected

## Failure Recovery

If this change causes issues, revert this single commit. The previous behavior (silently discarding thinking content) will be restored.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Older Ollama versions might not send `thinking` field | Field is accessed with optional chaining (`?.`), returns `undefined` gracefully |
| Some models might use both `content` and `thinking` | Logic uses `\|\|` fallback — `content` takes priority, `thinking` only used when `content` is empty |