### PR TITLE
fix(telegram): deduplicate skill commands in bot menu

### DIFF
--- a/src/auto-reply/skill-commands.test.ts
+++ b/src/auto-reply/skill-commands.test.ts
@@ -297,3 +297,46 @@ describe("listSkillCommandsForAgents", () => {
     expect(commands.map((entry) => entry.skillName)).toContain("demo-skill");
   });
 });
+
+describe("dedupeSkillCommands", () => {
+  it("removes duplicate skill commands by skillName", async () => {
+    const { dedupeSkillCommands } = await import("./skill-commands.js");
+    const commands = [
+      { name: "weather", skillName: "weather", description: "d1" },
+      { name: "weather_2", skillName: "weather", description: "d2" },
+      { name: "weather_3", skillName: "weather", description: "d3" },
+      { name: "github", skillName: "github", description: "d4" },
+    ] as Parameters<typeof dedupeSkillCommands>[0];
+
+    const result = dedupeSkillCommands(commands);
+    expect(result.map((c) => c.name)).toEqual(["weather", "github"]);
+  });
+
+  it("preserves commands with empty skillName", async () => {
+    const { dedupeSkillCommands } = await import("./skill-commands.js");
+    const commands = [
+      { name: "cmd1", skillName: "", description: "d1" },
+      { name: "cmd2", skillName: "", description: "d2" },
+    ] as Parameters<typeof dedupeSkillCommands>[0];
+
+    const result = dedupeSkillCommands(commands);
+    expect(result).toHaveLength(2);
+  });
+
+  it("deduplicates case-insensitively", async () => {
+    const { dedupeSkillCommands } = await import("./skill-commands.js");
+    const commands = [
+      { name: "Weather", skillName: "Weather", description: "d1" },
+      { name: "weather_2", skillName: "weather", description: "d2" },
+    ] as Parameters<typeof dedupeSkillCommands>[0];
+
+    const result = dedupeSkillCommands(commands);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Weather");
+  });
+
+  it("returns empty array for empty input", async () => {
+    const { dedupeSkillCommands } = await import("./skill-commands.js");
+    expect(dedupeSkillCommands([])).toEqual([]);
+  });
+});

--- a/src/auto-reply/skill-commands.ts
+++ b/src/auto-reply/skill-commands.ts
@@ -46,6 +46,26 @@ export function listSkillCommandsForWorkspace(params: {
   });
 }
 
+export function dedupeSkillCommands(
+  skillCommands: SkillCommandSpec[],
+): SkillCommandSpec[] {
+  const seen = new Set<string>();
+  const deduped: SkillCommandSpec[] = [];
+  for (const command of skillCommands) {
+    const key = command.skillName.trim().toLowerCase();
+    if (!key) {
+      deduped.push(command);
+      continue;
+    }
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(command);
+  }
+  return deduped;
+}
+
 export function listSkillCommandsForAgents(params: {
   cfg: OpenClawConfig;
   agentIds?: string[];

--- a/src/discord/monitor/provider.skill-dedupe.test.ts
+++ b/src/discord/monitor/provider.skill-dedupe.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { __testing } from "./provider.js";
 
-describe("dedupeSkillCommandsForDiscord", () => {
+describe("dedupeSkillCommands", () => {
   it("keeps first command per skillName and drops suffix duplicates", () => {
     const input = [
       { name: "github", skillName: "github", description: "GitHub" },
@@ -10,7 +10,7 @@ describe("dedupeSkillCommandsForDiscord", () => {
       { name: "weather_2", skillName: "weather", description: "Weather" },
     ];
 
-    const output = __testing.dedupeSkillCommandsForDiscord(input);
+    const output = __testing.dedupeSkillCommands(input);
     expect(output.map((entry) => entry.name)).toEqual(["github", "weather"]);
   });
 
@@ -19,7 +19,7 @@ describe("dedupeSkillCommandsForDiscord", () => {
       { name: "ClawHub", skillName: "ClawHub", description: "ClawHub" },
       { name: "clawhub_2", skillName: "clawhub", description: "ClawHub" },
     ];
-    const output = __testing.dedupeSkillCommandsForDiscord(input);
+    const output = __testing.dedupeSkillCommands(input);
     expect(output).toHaveLength(1);
     expect(output[0]?.name).toBe("ClawHub");
   });

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -16,7 +16,7 @@ import { resolveTextChunkLimit } from "../../auto-reply/chunk.js";
 import type { NativeCommandSpec } from "../../auto-reply/commands-registry.js";
 import { listNativeCommandSpecsForConfig } from "../../auto-reply/commands-registry.js";
 import type { HistoryEntry } from "../../auto-reply/reply/history.js";
-import { listSkillCommandsForAgents } from "../../auto-reply/skill-commands.js";
+import { dedupeSkillCommands, listSkillCommandsForAgents } from "../../auto-reply/skill-commands.js";
 import {
   resolveThreadBindingIdleTimeoutMs,
   resolveThreadBindingMaxAgeMs,
@@ -124,26 +124,6 @@ function summarizeGuilds(entries?: Record<string, unknown>) {
 function formatThreadBindingDurationForConfigLabel(durationMs: number): string {
   const label = formatThreadBindingDurationLabel(durationMs);
   return label === "disabled" ? "off" : label;
-}
-
-function dedupeSkillCommandsForDiscord(
-  skillCommands: ReturnType<typeof listSkillCommandsForAgents>,
-) {
-  const seen = new Set<string>();
-  const deduped: ReturnType<typeof listSkillCommandsForAgents> = [];
-  for (const command of skillCommands) {
-    const key = command.skillName.trim().toLowerCase();
-    if (!key) {
-      deduped.push(command);
-      continue;
-    }
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    deduped.push(command);
-  }
-  return deduped;
 }
 
 function appendPluginCommandSpecs(params: {
@@ -434,7 +414,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   const maxDiscordCommands = 100;
   let skillCommands =
     nativeEnabled && nativeSkillsEnabled
-      ? dedupeSkillCommandsForDiscord(listSkillCommandsForAgents({ cfg }))
+      ? dedupeSkillCommands(listSkillCommandsForAgents({ cfg }))
       : [];
   let commandSpecs = nativeEnabled
     ? listNativeCommandSpecsForConfig(cfg, { skillCommands, provider: "discord" })
@@ -819,7 +799,7 @@ async function clearDiscordNativeCommands(params: {
 
 export const __testing = {
   createDiscordGatewayPlugin,
-  dedupeSkillCommandsForDiscord,
+  dedupeSkillCommands,
   resolveDiscordRuntimeGroupPolicy: resolveOpenProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   resolveDiscordRestFetch,

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -11,7 +11,7 @@ import {
 } from "../auto-reply/commands-registry.js";
 import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
 import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
-import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
+import { dedupeSkillCommands, listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
 import { resolveCommandAuthorizedFromAuthorizers } from "../channels/command-gating.js";
 import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
 import { recordInboundSessionMetaSafe } from "../channels/session-meta.js";
@@ -331,7 +331,7 @@ export const registerTelegramNativeCommands = ({
   }
   const skillCommands =
     nativeEnabled && nativeSkillsEnabled && boundRoute
-      ? listSkillCommandsForAgents({ cfg, agentIds: [boundRoute.agentId] })
+      ? dedupeSkillCommands(listSkillCommandsForAgents({ cfg, agentIds: [boundRoute.agentId] }))
       : [];
   const nativeCommands = nativeEnabled
     ? listNativeCommandSpecsForConfig(cfg, {


### PR DESCRIPTION
## Summary

- **Problem:** Telegram skill commands were registered multiple times in the bot menu with `_2` and `_3` suffixes (e.g. `/weather`, `/weather_2`, `/weather_3`), creating 75 commands when there should be ~25.
- **Why it matters:** Users see a cluttered, confusing bot menu with duplicate commands. The suffixed commands work but are unexpected and unprofessional.
- **What changed:** Extracted `dedupeSkillCommands` from the Discord-local `dedupeSkillCommandsForDiscord` into the shared `src/auto-reply/skill-commands.ts` module. Applied it in both Telegram (`bot-native-commands.ts`) and Discord (`provider.ts`) command registration paths.
- **What did NOT change:** The underlying `resolveUniqueSkillCommandName` logic that generates `_2`/`_3` suffixes is unchanged — it's still needed internally for workspace-level uniqueness. The dedup happens at the channel registration layer.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35285

## User-visible / Behavior Changes

- Telegram bot menu now shows each skill command only once (no more `_2`, `_3` suffixes)
- Discord behavior unchanged (already had dedup, now uses the shared implementation)

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Telegram, Discord

### Steps

1. Configure multiple agents with overlapping skills
2. Start gateway
3. Check Telegram bot menu commands

### Expected

- Each skill appears once in the menu

### Actual

- Before fix: `/weather`, `/weather_2`, `/weather_3` (75 total)
- After fix: `/weather` (25 total)

## Evidence

```
✓ dedupeSkillCommands > removes duplicate skill commands by skillName
✓ dedupeSkillCommands > preserves commands with empty skillName
✓ dedupeSkillCommands > deduplicates case-insensitively
✓ dedupeSkillCommands > returns empty array for empty input
```

## Human Verification (required)

- Verified scenarios: Duplicate skill names deduplicated; empty skillName preserved; case-insensitive matching
- Edge cases checked: Empty input, mixed case skillNames, commands with no skillName
- What I did **not** verify: Live Telegram bot menu (verified via unit tests)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the import change in `bot-native-commands.ts`
- Files/config to restore: `src/telegram/bot-native-commands.ts`, `src/auto-reply/skill-commands.ts`, `src/discord/monitor/provider.ts`
- Known bad symptoms: If reverted, duplicate commands reappear in Telegram menu

## Risks and Mitigations

None — the dedup logic is identical to what Discord already had; this PR just shares it with Telegram.
