### PR TITLE
fix(agents): add null guards to content block iteration across modules

### DIFF
--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -442,7 +442,8 @@ export class AcpGatewayAgent implements Agent {
     messageData: Record<string, unknown>,
   ): Promise<void> {
     const content = messageData.content as Array<{ type: string; text?: string }> | undefined;
-    const fullText = content?.find((c) => c.type === "text")?.text ?? "";
+    const fullText =
+      content?.find((c) => c != null && typeof c === "object" && c.type === "text")?.text ?? "";
     const pending = this.pendingPrompts.get(sessionId);
     if (!pending) {
       return;

--- a/src/agents/live-test-helpers.ts
+++ b/src/agents/live-test-helpers.ts
@@ -17,7 +17,7 @@ export function extractNonEmptyAssistantText(
   }>,
 ) {
   return content
-    .filter((block) => block.type === "text")
+    .filter((block) => block != null && typeof block === "object" && block.type === "text")
     .map((block) => block.text?.trim() ?? "")
     .filter(Boolean)
     .join(" ");

--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -269,7 +269,9 @@ async function probeTool(
       } satisfies OpenAICompletionsOptions),
     );
 
-    const hasToolCall = message.content.some((block) => block.type === "toolCall");
+    const hasToolCall = message.content.some(
+      (block) => block != null && typeof block === "object" && block.type === "toolCall",
+    );
     if (!hasToolCall) {
       return {
         ok: false,

--- a/src/agents/pi-embedded-runner/thinking.test.ts
+++ b/src/agents/pi-embedded-runner/thinking.test.ts
@@ -46,6 +46,25 @@ describe("dropThinkingBlocks", () => {
     expect(assistant.content).toEqual([{ type: "text", text: "final" }]);
   });
 
+  it("does not crash on null or non-object entries in content arrays", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "assistant",
+        content: [
+          null,
+          undefined,
+          "stray-string",
+          { type: "thinking", thinking: "internal" },
+          { type: "text", text: "ok" },
+        ] as unknown as Array<{ type: string }>,
+      }),
+    ];
+
+    const result = dropThinkingBlocks(messages);
+    const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
+    expect(assistant.content).toEqual([{ type: "text", text: "ok" }]);
+  });
+
   it("keeps assistant turn structure when all content blocks were thinking", () => {
     const messages: AgentMessage[] = [
       castAgentMessage({

--- a/src/agents/pi-embedded-runner/thinking.ts
+++ b/src/agents/pi-embedded-runner/thinking.ts
@@ -33,7 +33,10 @@ export function dropThinkingBlocks(messages: AgentMessage[]): AgentMessage[] {
     const nextContent: AssistantContentBlock[] = [];
     let changed = false;
     for (const block of msg.content) {
-      if (block && typeof block === "object" && (block as { type?: unknown }).type === "thinking") {
+      if (block == null || typeof block !== "object") {
+        continue;
+      }
+      if ((block as { type?: unknown }).type === "thinking") {
         touched = true;
         changed = true;
         continue;

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -93,7 +93,13 @@ export async function anthropicAnalyzePdf(params: {
   }
 
   const text = responseContent
-    .filter((block) => block.type === "text" && typeof block.text === "string")
+    .filter(
+      (block) =>
+        block != null &&
+        typeof block === "object" &&
+        block.type === "text" &&
+        typeof block.text === "string",
+    )
     .map((block) => block.text!)
     .join("");
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -328,6 +328,9 @@ export async function handleOpenResponsesHttpRequest(
       for (const item of payload.input) {
         if (item.type === "message" && typeof item.content !== "string") {
           for (const part of item.content) {
+            if (part == null || typeof part !== "object") {
+              continue;
+            }
             if (part.type === "input_image") {
               const source = part.source as {
                 type?: string;


### PR DESCRIPTION
## Summary

Several modules iterate over content arrays (from LLM responses, API inputs, or ACP messages) and access `.type` without first checking that the entry is a non-null object. Malformed entries (`null`, `undefined`, or primitive strings) injected by providers, plugins, or edge-case API responses cause `TypeError: Cannot read properties of null (reading 'type')` crashes.

This PR adds defensive `block != null && typeof block === "object"` guards to six files, following the same pattern established in #35032, #35026, #35017, and #35045.

**Files fixed:**
- `src/agents/model-scan.ts` — `probeToolCall` content `.some()` guard
- `src/agents/live-test-helpers.ts` — `extractNonEmptyAssistantText` `.filter()` guard
- `src/agents/tools/pdf-native-providers.ts` — Anthropic PDF response content `.filter()` guard
- `src/agents/pi-embedded-runner/thinking.ts` — `dropThinkingBlocks` skips null/non-object entries instead of pushing them to output
- `src/gateway/openresponses-http.ts` — Responses API input content part iteration guard
- `src/acp/translator.ts` — `handleDeltaEvent` content `.find()` guard

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [x] Agents / Model integration
- [x] Gateway
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [ ] Configuration

## Linked Issues

Closes #34979

## User-Visible Changes

Sessions that previously crash-looped due to malformed content blocks in assistant responses, tool results, or API inputs will now gracefully skip the invalid entries instead of throwing.

## Security Impact

1. Does this change handle user input? **No** — guards are applied to LLM/API response content, not direct user input
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Steps to Reproduce the Bug

1. Trigger a scenario where an LLM provider returns a content array containing `null` entries (e.g., malformed Anthropic response, corrupted cache, or provider plugin injecting bad data)
2. The session enters a permanent crash loop with `TypeError: Cannot read properties of null (reading 'type')`
3. Restarting the gateway does not help — the malformed message is replayed from session history

## Verification

- [x] Added test for `dropThinkingBlocks` with null/undefined/primitive entries in content
- [x] All existing tests pass (no regressions)
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ src/agents/pi-embedded-runner/thinking.test.ts (5 tests) 3ms
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

## Human Verification

- Inject a `null` entry into an assistant message content array in a session file and verify the session recovers instead of crash-looping
- Verify that normal (well-formed) messages continue to work correctly

## Compatibility

Fully backward compatible. The guards only affect malformed entries that would previously cause crashes. Well-formed content arrays are unaffected.

## Failure Recovery

Revert this single commit to restore previous behavior. Note that reverting will re-expose the crash-loop vulnerability for sessions with malformed content.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Silently skipping entries could hide legitimate bugs in providers | Guards only skip `null`/non-object entries, which are never valid content blocks per the schema |
| Performance impact of additional type checks | Negligible — one `typeof` check per array element in hot paths that already iterate the full array |