### PR TITLE
fix(gateway): scope notifications.changed heartbeat wake like exec events

### DIFF
--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -388,7 +388,6 @@ describe("notifications changed events", () => {
     );
     expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
       reason: "notifications-event",
-      sessionKey: "node-node-n1",
     });
   });
 
@@ -409,7 +408,6 @@ describe("notifications changed events", () => {
     );
     expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
       reason: "notifications-event",
-      sessionKey: "node-node-n2",
     });
   });
 

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -492,7 +492,9 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         contextKey: `notification:${key}`,
       });
       if (queued) {
-        requestHeartbeatNow({ reason: "notifications-event", sessionKey });
+        requestHeartbeatNow(
+          scopedHeartbeatWakeOptions(sessionKey, { reason: "notifications-event" }),
+        );
       }
       return;
     }


### PR DESCRIPTION
## Summary

- **Problem:** When a `notifications.changed` event arrives from a node without an explicit `sessionKey`, the handler falls back to `node-${nodeId}` and passes it directly to `requestHeartbeatNow`. This becomes `forcedSessionKey` in `resolveHeartbeatSession`, which takes precedence over the user-configured `heartbeat.session` value — effectively ignoring the configuration.
- **Why it matters:** Users who configure `heartbeat.session` to route heartbeat responses to a specific session (e.g. a monitoring channel) find that notification events bypass this setting and create orphaned sessions with `node-*` keys.
- **What changed:** Applied `scopedHeartbeatWakeOptions` to the `notifications.changed` handler, consistent with the existing `exec.started`/`exec.finished`/`exec.denied` handlers. For synthetic `node-*` keys (which don't parse as agent session keys), the `sessionKey` is omitted from the wake request, allowing `resolveHeartbeatSession` to use the configured `heartbeat.session`.
- **What did NOT change:** The system event `enqueueSystemEvent` still uses the full session key for routing. Only the heartbeat wake scoping changed. Canonical agent keys (e.g. `agent:main:node-n1`) still pass through correctly.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35310

## User-visible / Behavior Changes

- Notification-triggered heartbeats now respect the configured `heartbeat.session` instead of overriding it with synthetic `node-*` keys.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Gateway (node events)

### Steps

1. Configure `heartbeat.session` to a specific session key
2. Trigger a `notifications.changed` event from a node without explicit `sessionKey`
3. Observe which session the heartbeat runs against

### Expected

- Heartbeat uses the configured `heartbeat.session`

### Actual

- Before fix: Heartbeat uses `node-${nodeId}` as forced session key, overriding configuration
- After fix: Heartbeat uses the configured `heartbeat.session` for unscoped node keys

## Evidence

```
✓ enqueues notifications.changed posted events (sessionKey omitted from wake)
✓ enqueues notifications.changed removed events (sessionKey omitted from wake)
✓ wakes heartbeat on payload sessionKey when provided (agent key preserved)
✓ canonicalizes notifications session key before enqueue and wake (agent key preserved)
```

## Human Verification (required)

- Verified scenarios: node-* fallback key (sessionKey stripped), explicit agent key (sessionKey preserved), canonical agent key from loadSessionEntry (preserved)
- Edge cases checked: Canonical keys with `agent:` prefix pass through; dedup still prevents double-wake
- What I did **not** verify: Live node with notifications.changed events

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the `scopedHeartbeatWakeOptions` wrapping in `server-node-events.ts`
- Files/config to restore: `src/gateway/server-node-events.ts`
- Known bad symptoms: If reverted, notification wakes override `heartbeat.session` again

## Risks and Mitigations

- Risk: Users who relied on the current (broken) behavior where notifications forced a specific session. Mitigation: The exec event path already uses the same scoping, so this aligns notification behavior with exec behavior.
