### PR TITLE
fix(cron): narrow error-backoff startup replay guard

### DIFF
--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -286,6 +286,7 @@ describe("CronService restart catch-up", () => {
           nextRunAtMs: Date.parse("2025-12-13T04:10:00.000Z"),
           lastRunAtMs: Date.parse("2025-12-13T04:01:00.000Z"),
           lastStatus: "error",
+          consecutiveErrors: 4,
         },
       },
     ]);
@@ -300,6 +301,52 @@ describe("CronService restart catch-up", () => {
 
     expect(enqueueSystemEvent).not.toHaveBeenCalled();
     expect(requestHeartbeatNow).not.toHaveBeenCalled();
+
+    cron.stop();
+    await store.cleanup();
+  });
+
+  it("replays missed cron slot after restart when error backoff has already elapsed", async () => {
+    vi.setSystemTime(new Date("2025-12-13T04:02:00.000Z"));
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    await writeStoreJobs(store.storePath, [
+      {
+        id: "restart-backoff-elapsed-replay",
+        name: "backoff elapsed replay",
+        enabled: true,
+        createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
+        updatedAtMs: Date.parse("2025-12-13T04:01:10.000Z"),
+        schedule: { kind: "cron", expr: "1,11,21,31,41,51 4-20 * * *", tz: "UTC" },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "replay after backoff elapsed" },
+        state: {
+          // Startup maintenance may already point to a future slot (04:11) even
+          // though 04:01 was missed and the 30s error backoff has elapsed.
+          nextRunAtMs: Date.parse("2025-12-13T04:11:00.000Z"),
+          lastRunAtMs: Date.parse("2025-12-13T03:51:00.000Z"),
+          lastStatus: "error",
+          consecutiveErrors: 1,
+        },
+      },
+    ]);
+
+    const cron = createRestartCronService({
+      storePath: store.storePath,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+    });
+
+    await cron.start();
+
+    expect(enqueueSystemEvent).toHaveBeenCalledWith(
+      "replay after backoff elapsed",
+      expect.objectContaining({ agentId: undefined }),
+    );
+    expect(requestHeartbeatNow).toHaveBeenCalled();
 
     cron.stop();
     await store.cleanup();

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -741,9 +741,10 @@ function isRunnableJob(params: {
     typeof next === "number" &&
     Number.isFinite(next) &&
     next > nowMs &&
-    job.state.lastStatus === "error"
+    isErrorBackoffPending(job, nowMs)
   ) {
-    // Respect persisted retry backoff windows for recurring jobs on restart.
+    // Respect active retry backoff windows on restart, but allow missed-slot
+    // replay once the backoff window has elapsed.
     return false;
   }
   if (!params.allowCronMissedRunByLastRun || job.schedule.kind !== "cron") {
@@ -764,6 +765,22 @@ function isRunnableJob(params: {
     return false;
   }
   return previousRunAtMs > lastRunAtMs;
+}
+
+function isErrorBackoffPending(job: CronJob, nowMs: number): boolean {
+  if (job.schedule.kind === "at" || job.state.lastStatus !== "error") {
+    return false;
+  }
+  const lastRunAtMs = job.state.lastRunAtMs;
+  if (typeof lastRunAtMs !== "number" || !Number.isFinite(lastRunAtMs)) {
+    return false;
+  }
+  const consecutiveErrorsRaw = job.state.consecutiveErrors;
+  const consecutiveErrors =
+    typeof consecutiveErrorsRaw === "number" && Number.isFinite(consecutiveErrorsRaw)
+      ? Math.max(1, Math.floor(consecutiveErrorsRaw))
+      : 1;
+  return nowMs < lastRunAtMs + errorBackoffMs(consecutiveErrors);
 }
 
 function collectRunnableJobs(


### PR DESCRIPTION
## Summary
- narrow startup replay suppression so recurring cron jobs are skipped only while error backoff is still active
- stop using `lastStatus === "error"` alone as a blanket skip condition for future `nextRunAtMs`
- add restart-catchup regression coverage for elapsed-backoff replay and tighten pending-backoff fixture state

## Context
Follow-up to #35351 unresolved review comment:
- https://github.com/openclaw/openclaw/pull/35351#discussion_r2887422169

## Testing
- pnpm install --frozen-lockfile
- pnpm build
- pnpm check
- pnpm test:macmini
