### PR TITLE
fix(heartbeat): suppress delivery when target is 'heartbeat' placeholder

### DIFF
--- a/src/infra/heartbeat-runner.placeholder-target.test.ts
+++ b/src/infra/heartbeat-runner.placeholder-target.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
+import { seedMainSessionStore, withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
+
+vi.mock("jiti", () => ({ createJiti: () => () => ({}) }));
+
+installHeartbeatRunnerTestRuntime();
+
+describe("heartbeat placeholder target suppression (#35300)", () => {
+  it("does not set OriginatingChannel when session lastTo is 'heartbeat' placeholder", async () => {
+    await withTempHeartbeatSandbox(
+      async ({ tmpDir, storePath, replySpy }) => {
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: {
+              workspace: tmpDir,
+              heartbeat: {
+                every: "5m",
+                target: "last",
+              },
+            },
+          },
+          session: { store: storePath },
+        };
+
+        // Simulate a session where lastChannel is telegram but lastTo is
+        // the "heartbeat" placeholder (no real user has interacted yet).
+        await seedMainSessionStore(storePath, cfg, {
+          lastChannel: "telegram",
+          lastProvider: "telegram",
+          lastTo: "heartbeat",
+        });
+
+        const ctxCapture: Record<string, unknown>[] = [];
+        replySpy.mockImplementation(async (ctx: Record<string, unknown>) => {
+          ctxCapture.push({ ...ctx });
+          return { text: "HEARTBEAT_OK" };
+        });
+
+        await runHeartbeatOnce({
+          cfg,
+          deps: {
+            getQueueSize: () => 0,
+            nowMs: () => 0,
+          },
+        });
+
+        // The heartbeat should have run
+        expect(replySpy).toHaveBeenCalled();
+
+        // OriginatingChannel should NOT be set to telegram because the
+        // delivery target "heartbeat" is a placeholder, not a real user.
+        // Setting it would pollute the session's deliveryContext and cause
+        // cross-channel delivery errors (#35300).
+        const ctx = ctxCapture[0];
+        expect(ctx?.OriginatingChannel).toBeUndefined();
+        expect(ctx?.OriginatingTo).toBeUndefined();
+      },
+      { prefix: "openclaw-hb-placeholder-" },
+    );
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -665,8 +665,12 @@ export async function runHeartbeatOnce(opts: {
     accountId: delivery.accountId,
   }).responsePrefix;
 
+  // When delivery.to is the "heartbeat" placeholder (no real user has
+  // interacted yet), suppress delivery to avoid sending to channels that
+  // don't recognize "heartbeat" as a valid user ID (#35300).
+  const isPlaceholderTarget = delivery.to === "heartbeat";
   const canRelayToUser = Boolean(
-    delivery.channel !== "none" && delivery.to && visibility.showAlerts,
+    delivery.channel !== "none" && delivery.to && !isPlaceholderTarget && visibility.showAlerts,
   );
   const { prompt, hasExecCompletion, hasCronEvents } = resolveHeartbeatRunPrompt({
     cfg,
@@ -678,10 +682,15 @@ export async function runHeartbeatOnce(opts: {
     Body: appendCronStyleCurrentTimeLine(prompt, cfg, startedAt),
     From: sender,
     To: sender,
-    OriginatingChannel: delivery.channel !== "none" ? delivery.channel : undefined,
-    OriginatingTo: delivery.to,
-    AccountId: delivery.accountId,
-    MessageThreadId: delivery.threadId,
+    // When the delivery target is a placeholder ("heartbeat"), don't set
+    // OriginatingChannel/To.  Otherwise the session's deliveryContext gets
+    // polluted with the placeholder, causing cross-channel delivery errors
+    // on subsequent turns (#35300).
+    OriginatingChannel:
+      delivery.channel !== "none" && !isPlaceholderTarget ? delivery.channel : undefined,
+    OriginatingTo: !isPlaceholderTarget ? delivery.to : undefined,
+    AccountId: !isPlaceholderTarget ? delivery.accountId : undefined,
+    MessageThreadId: !isPlaceholderTarget ? delivery.threadId : undefined,
     Provider: hasExecCompletion ? "exec-event" : hasCronEvents ? "cron-event" : "heartbeat",
     SessionKey: sessionKey,
   };

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -715,7 +715,12 @@ export async function runHeartbeatOnce(opts: {
     visibility.showOk && delivery.channel !== "none" && delivery.to,
   );
   const maybeSendHeartbeatOk = async () => {
-    if (!canAttemptHeartbeatOk || delivery.channel === "none" || !delivery.to) {
+    if (
+      !canAttemptHeartbeatOk ||
+      delivery.channel === "none" ||
+      !delivery.to ||
+      isPlaceholderTarget
+    ) {
       return false;
     }
     const heartbeatPlugin = getChannelPlugin(delivery.channel);


### PR DESCRIPTION
## What
Prevents heartbeat delivery when the session's `lastTo` is the `"heartbeat"` placeholder string.

## Why
Fixes #35300 — In multi-channel setups (e.g. webchat + feishu), when a heartbeat runs before any real user has interacted, the session's `lastTo` is `"heartbeat"` (the fallback from `resolveHeartbeatSenderId`). The delivery target resolution then routes to the bound channel (feishu) with `"heartbeat"` as the user ID, causing:
- Feishu API error: `Invalid ids: [heartbeat]`
- Failed messages enter delivery-queue retry loop
- Gateway logs fill with errors on every restart

## How
1. Detect `delivery.to === "heartbeat"` as a placeholder target (`isPlaceholderTarget`)
2. Suppress `canRelayToUser` when the target is a placeholder
3. Clear `OriginatingChannel`, `OriginatingTo`, `AccountId`, and `MessageThreadId` in the heartbeat context to prevent polluting the session's `deliveryContext`

This ensures the heartbeat still runs (system events, cron checks, etc.) but doesn't attempt to deliver responses to an invalid target.

## Testing
- [x] `pnpm build && pnpm check` pass
- [x] All 100 heartbeat tests pass (13 test files)
- [x] New test: `heartbeat-runner.placeholder-target.test.ts` — verifies `OriginatingChannel` is undefined when `lastTo` is `"heartbeat"`
- [x] AI-assisted (Claude, fully tested)
