### PR TITLE
fix(agents): guard against null entries in Grok web-search parser

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -217,6 +217,49 @@ describe("web_search grok response parsing", () => {
     expect(result.text).toBe("direct output text");
     expect(result.annotationCitations).toEqual(["https://example.com/direct"]);
   });
+
+  it("does not crash when output array contains null or non-object entries", () => {
+    const result = extractGrokContent({
+      output: [
+        null,
+        undefined,
+        "stray",
+        { type: "message", content: [{ type: "output_text", text: "ok" }] },
+      ],
+    } as Parameters<typeof extractGrokContent>[0]);
+    expect(result.text).toBe("ok");
+  });
+
+  it("does not crash when content array contains null entries", () => {
+    const result = extractGrokContent({
+      output: [
+        {
+          type: "message",
+          content: [null, { type: "output_text", text: "survived" }],
+        },
+      ],
+    } as Parameters<typeof extractGrokContent>[0]);
+    expect(result.text).toBe("survived");
+  });
+
+  it("does not crash when annotations contain null entries", () => {
+    const result = extractGrokContent({
+      output: [
+        {
+          type: "message",
+          content: [
+            {
+              type: "output_text",
+              text: "cited",
+              annotations: [null, { type: "url_citation", url: "https://ok.com" }, undefined],
+            },
+          ],
+        },
+      ],
+    } as Parameters<typeof extractGrokContent>[0]);
+    expect(result.text).toBe("cited");
+    expect(result.annotationCitations).toEqual(["https://ok.com"]);
+  });
 });
 
 describe("web_search kimi config resolution", () => {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -283,11 +283,23 @@ function extractGrokContent(data: GrokSearchResponse): {
 } {
   // xAI Responses API format: find the message output with text content
   for (const output of data.output ?? []) {
+    if (output == null || typeof output !== "object") {
+      continue;
+    }
     if (output.type === "message") {
       for (const block of output.content ?? []) {
+        if (block == null || typeof block !== "object") {
+          continue;
+        }
         if (block.type === "output_text" && typeof block.text === "string" && block.text) {
           const urls = (block.annotations ?? [])
-            .filter((a) => a.type === "url_citation" && typeof a.url === "string")
+            .filter(
+              (a) =>
+                a != null &&
+                typeof a === "object" &&
+                a.type === "url_citation" &&
+                typeof a.url === "string",
+            )
             .map((a) => a.url as string);
           return { text: block.text, annotationCitations: [...new Set(urls)] };
         }
@@ -305,7 +317,11 @@ function extractGrokContent(data: GrokSearchResponse): {
         "annotations" in output && Array.isArray(output.annotations) ? output.annotations : [];
       const urls = rawAnnotations
         .filter(
-          (a: Record<string, unknown>) => a.type === "url_citation" && typeof a.url === "string",
+          (a: Record<string, unknown>) =>
+            a != null &&
+            typeof a === "object" &&
+            a.type === "url_citation" &&
+            typeof a.url === "string",
         )
         .map((a: Record<string, unknown>) => a.url as string);
       return { text: output.text, annotationCitations: [...new Set(urls)] };


### PR DESCRIPTION
## Summary

The `extractGrokContent` function in `web-search.ts` iterates over `output`, `content`, and `annotations` arrays from the xAI Responses API without checking for null or non-object entries. Malformed API responses (which can occur during xAI service degradation, rate limiting, or edge-case tool outputs) may contain null entries that cause `TypeError: Cannot read properties of null (reading 'type')` crashes.

This PR adds defensive `!= null && typeof === "object"` guards to all three iteration levels in the Grok parser, following the same pattern used in the existing fixes for #35032, #35026, #35017, and #34979.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [x] Agents / Model integration
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Configuration

## Linked Issues

Closes #35063

## User-Visible Changes

Web searches using the Grok/xAI provider will no longer crash when the API returns malformed response entries. The parser gracefully skips null/non-object entries and continues extracting valid content.

## Security Impact

1. Does this change handle user input? **No** — guards are applied to xAI API response data
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Steps to Reproduce the Bug

1. Use the Grok/xAI provider for web_search
2. Receive a malformed response where `output`, `content`, or `annotations` arrays contain null entries
3. The web_search tool crashes with `TypeError: Cannot read properties of null (reading 'type')`

## Verification

- [x] Added 3 new test cases covering null entries in output, content, and annotations arrays
- [x] All 31 tests pass
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ src/agents/tools/web-search.test.ts (31 tests) 5ms
 Test Files  1 passed (1)
      Tests  31 passed (31)
```

## Human Verification

- Verify Grok web_search still works with well-formed responses (no regression)
- Verify that a malformed response with null output entries doesn't crash the session

## Compatibility

Fully backward compatible. Well-formed responses are processed identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Silently dropping valid entries | Guards only skip `null`/non-object entries which are never valid per the xAI API schema |