### PR TITLE
fix(gateway): support non-standard protocol origins in allowedOrigins check

### DIFF
--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -100,4 +100,46 @@ describe("checkBrowserOrigin", () => {
     });
     expect(result.ok).toBe(true);
   });
+
+  it("accepts non-standard protocol origins like app://localhost (regression: #35035)", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "host.tail1234.ts.net",
+      origin: "app://localhost",
+      allowedOrigins: ["app://localhost"],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.matchedBy).toBe("allowlist");
+    }
+  });
+
+  it("accepts tauri://localhost via allowlist", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "gateway.example.com:18789",
+      origin: "tauri://localhost",
+      allowedOrigins: ["tauri://localhost"],
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.matchedBy).toBe("allowlist");
+    }
+  });
+
+  it("rejects non-standard protocol origin when not in allowlist", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "gateway.example.com:18789",
+      origin: "app://localhost",
+      allowedOrigins: ["https://control.example.com"],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts non-standard protocol origin with wildcard allowedOrigins", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "gateway.example.com:18789",
+      origin: "app://localhost",
+      allowedOrigins: ["*"],
+    });
+    expect(result.ok).toBe(true);
+  });
 });

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -16,8 +16,15 @@ function parseOrigin(
   }
   try {
     const url = new URL(trimmed);
+    // Non-standard protocols (app://, tauri://, etc.) return "null" from
+    // URL.origin. Reconstruct the origin from protocol + host so that
+    // allowlist matching works for desktop-app origins like app://localhost.
+    const origin =
+      url.origin === "null"
+        ? `${url.protocol}//${url.host}`.toLowerCase()
+        : url.origin.toLowerCase();
     return {
-      origin: url.origin.toLowerCase(),
+      origin,
       host: url.host.toLowerCase(),
       hostname: url.hostname.toLowerCase(),
     };


### PR DESCRIPTION
## Summary

- **Problem:** Desktop apps using non-standard URL schemes (e.g. `app://localhost` for Electron/ClawControl, `tauri://localhost` for Tauri) are rejected by the gateway origin check even when explicitly listed in `gateway.controlUi.allowedOrigins`.
- **Why it matters:** Users of ClawControl desktop app connecting over Tailscale Serve cannot authenticate — they must use the overly permissive `allowedOrigins: ["*"]` workaround.
- **What changed:** `parseOrigin()` in `src/gateway/origin-check.ts` now reconstructs the origin string from `protocol + "//" + host` when `URL.origin` returns `"null"` (which Node.js/browsers do for non-standard protocols). Added 4 test cases covering non-standard protocol matching.
- **What did NOT change:** Standard HTTP/HTTPS origin handling, wildcard matching, host-header fallback, local-loopback logic — all existing behavior is preserved.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35035

## User-visible / Behavior Changes

- `app://localhost`, `tauri://localhost`, and other non-standard protocol origins now work correctly in `gateway.controlUi.allowedOrigins` configuration.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+
- Integration/channel: Gateway WebSocket (ClawControl desktop app)

### Steps

1. Set `gateway.controlUi.allowedOrigins` to `["app://localhost"]`
2. Connect from ClawControl desktop app (Electron) over Tailscale Serve

### Expected

- Connection accepted, matched by allowlist.

### Actual

- Before fix: `origin not allowed` — `URL.origin` returns `"null"` for `app://` scheme, so the allowlist lookup compares `"null"` against `"app://localhost"` and never matches.
- After fix: Origin is reconstructed as `protocol + "//" + host` → `"app://localhost"`, which matches the allowlist entry.

## Evidence

```
> new URL("app://localhost").origin
'null'   // ← this is why matching fails

> const url = new URL("app://localhost")
> `${url.protocol}//${url.host}`
'app://localhost'   // ← reconstructed origin matches allowlist
```

All 15 tests pass including 4 new ones:
```
✓ src/gateway/origin-check.test.ts (15 tests) 3ms
  Tests  15 passed (15)
```

## Human Verification (required)

- Verified scenarios: `app://localhost`, `tauri://localhost`, wildcard with non-standard origins, rejection when non-standard origin is not in allowlist
- Edge cases checked: empty host, case sensitivity (lowercased), standard HTTP/HTTPS origins still work identically
- What I did **not** verify: Live ClawControl desktop app connection (no Electron environment available)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit. The only change is in `parseOrigin()`'s origin construction for non-standard protocols.
- Files/config to restore: `src/gateway/origin-check.ts`
- Known bad symptoms: If the reconstructed origin format is wrong, non-standard origins would still be rejected (same as current behavior — no regression).

## Risks and Mitigations

- **Risk:** Synthetic origin format may differ from what the browser/Electron actually sends. **Mitigation:** The reconstruction uses the same `protocol + "//" + host` pattern that `URL.href` uses for these schemes, and the allowlist comparison is a direct string match against user-configured values — users control both sides.
