### PR TITLE
fix(channels): add defensive guards to content arrays and API data

### DIFF
--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -380,7 +380,10 @@ export async function handleBashChatCommand(params: {
     const output =
       result.details?.status === "completed"
         ? result.details.aggregated
-        : result.content.map((chunk) => (chunk.type === "text" ? chunk.text : "")).join("\n");
+        : (Array.isArray(result.content) ? result.content : [])
+            .filter((chunk) => chunk != null && typeof chunk === "object")
+            .map((chunk) => (chunk.type === "text" ? chunk.text : ""))
+            .join("\n");
     return {
       text: [
         `⚙️ bash: ${commandText}`,

--- a/src/discord/monitor/preflight-audio.ts
+++ b/src/discord/monitor/preflight-audio.ts
@@ -12,7 +12,9 @@ function collectAudioAttachments(
   if (!Array.isArray(attachments)) {
     return [];
   }
-  return attachments.filter((att) => att.content_type?.startsWith("audio/"));
+  return attachments.filter(
+    (att) => att != null && typeof att === "object" && att.content_type?.startsWith("audio/"),
+  );
 }
 
 export async function resolveDiscordPreflightAudioMentionContext(params: {

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -769,9 +769,14 @@ export async function registerSlackMonitorSlashCommands(params: {
         await ack({ options: [] });
         return;
       }
-      const query = typedBody.value?.trim().toLowerCase() ?? "";
+      const rawValue = typedBody.value;
+      const query = typeof rawValue === "string" ? rawValue.trim().toLowerCase() : "";
       const options = entry.choices
-        .filter((choice) => !query || choice.label.toLowerCase().includes(query))
+        .filter(
+          (choice) =>
+            !query ||
+            (typeof choice.label === "string" && choice.label.toLowerCase().includes(query)),
+        )
         .slice(0, SLACK_COMMAND_ARG_SELECT_OPTIONS_MAX)
         .map((choice) => ({
           text: { type: "plain_text", text: choice.label.slice(0, 75) },

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -35,11 +35,14 @@ function formatArgs(toolName: string, args: unknown): string {
 }
 
 function extractText(result?: ToolResult): string {
-  if (!result?.content) {
+  if (!result?.content || !Array.isArray(result.content)) {
     return "";
   }
   const lines: string[] = [];
   for (const entry of result.content) {
+    if (entry == null || typeof entry !== "object") {
+      continue;
+    }
     if (entry.type === "text" && entry.text) {
       lines.push(sanitizeRenderableText(entry.text));
     } else if (entry.type === "image") {


### PR DESCRIPTION
## Summary

Several channel and UI modules iterate over content arrays or API response data without proper null/type checks, risking `TypeError` crashes from malformed entries. This is the same class of defensive-programming fix as #35032, #35026, #35017, #34979, and #35063.

**Files fixed:**

1. **`src/tui/components/tool-execution.ts`** — `extractText` now validates `result.content` is a proper array via `Array.isArray()` and skips null/non-object entries before accessing `.type`
2. **`src/auto-reply/reply/bash-command.ts`** — The non-completed fallback path now guards `result.content` with `Array.isArray()` and filters null entries before mapping
3. **`src/discord/monitor/preflight-audio.ts`** — `collectAudioAttachments` filter now skips null/non-object entries in the attachments array
4. **`src/slack/monitor/slash.ts`** — External select options handler now uses `typeof` checks on `typedBody.value` and `choice.label` before calling `.trim()` / `.toLowerCase()` / `.includes()`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [x] Channels / Plugins
- [x] CLI / TUI
- [ ] Agents / Model integration
- [ ] Gateway
- [ ] Configuration

## Linked Issues

Related to #34979 (malformed content blocks cause crashes)

## User-Visible Changes

- TUI tool execution display no longer crashes when tool results contain malformed content
- Bash command output fallback no longer crashes when result.content is missing or malformed
- Discord audio attachment detection no longer crashes on null attachment entries
- Slack slash command option search no longer crashes on non-string values

## Security Impact

1. Does this change handle user input? **Partially** — Slack search query input is now type-checked before use
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] Formatted with `oxfmt`
- [x] Changes are minimal defensive guards with no behavioral change for well-formed data

## Human Verification

- Use TUI with a tool that returns malformed content blocks — verify no crash
- Test Discord audio message detection with normal attachments — verify no regression
- Test Slack slash command with external select menus — verify search still works

## Compatibility

Fully backward compatible. Well-formed data paths are identical.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Silently dropping valid entries | Guards only skip null/non-object entries which are never valid content blocks |
| Type coercion changing behavior | String checks use strict `typeof` — no implicit coercion |