### PR TITLE
fix: resolve discord bot message receive failure

### DIFF
--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -617,6 +617,11 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
   }
 
   const gateway = client.getPlugin<GatewayPlugin>("gateway");
+  if (gateway?.isConnected) {
+    gateway.disconnect();
+    gateway.connect(false);
+    runtime.log?.("discord: reconnected gateway after listener registration");
+  }
   if (gateway) {
     registerGateway(account.accountId, gateway);
   }


### PR DESCRIPTION
Closes #24637

Problem: Discord bot connects but doesn't receive messages
Fix: Force a gateway reconnect right after listener registration so MESSAGE_CREATE and related events are subscribed with active listeners even when the gateway auto-connects before listeners are attached.