### PR TITLE
fix(reply): resolve elevated allowFrom provider from channel context

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.test.ts
+++ b/src/auto-reply/reply/get-reply-directives.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { MsgContext, TemplateContext } from "../templating.js";
+import { resolveMessageProviderKey } from "./get-reply-directives.js";
+
+describe("resolveMessageProviderKey", () => {
+  it("prefers resolved command channel over direct runtime provider", () => {
+    const provider = resolveMessageProviderKey({
+      commandChannelId: "telegram",
+      sessionCtx: {
+        Provider: "direct",
+        Surface: "direct",
+      } as unknown as TemplateContext,
+      ctx: {
+        Provider: "direct",
+        Surface: "direct",
+        OriginatingChannel: "telegram",
+      } as unknown as MsgContext,
+    });
+
+    expect(provider).toBe("telegram");
+  });
+
+  it("falls back to originating channel before provider", () => {
+    const provider = resolveMessageProviderKey({
+      sessionCtx: {
+        Provider: "direct",
+        Surface: "direct",
+        OriginatingChannel: "telegram",
+      } as unknown as TemplateContext,
+      ctx: {
+        Provider: "direct",
+        Surface: "direct",
+      } as unknown as MsgContext,
+    });
+
+    expect(provider).toBe("telegram");
+  });
+
+  it("uses provider when no channel hints exist", () => {
+    const provider = resolveMessageProviderKey({
+      sessionCtx: {
+        Provider: "direct",
+      } as unknown as TemplateContext,
+      ctx: {} as MsgContext,
+    });
+
+    expect(provider).toBe("direct");
+  });
+});

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -4,6 +4,7 @@ import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import type { SkillCommandSpec } from "../../agents/skills.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { listChatCommands, shouldHandleTextCommands } from "../commands-registry.js";
 import { listSkillCommandsForWorkspace } from "../skill-commands.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
@@ -83,6 +84,25 @@ function resolveExecOverrides(params: {
 export type ReplyDirectiveResult =
   | { kind: "reply"; reply: ReplyPayload | ReplyPayload[] | undefined }
   | { kind: "continue"; result: ReplyDirectiveContinuation };
+
+export function resolveMessageProviderKey(params: {
+  commandChannelId?: string;
+  sessionCtx: TemplateContext;
+  ctx: MsgContext;
+}): string {
+  if (params.commandChannelId?.trim()) {
+    return params.commandChannelId.trim().toLowerCase();
+  }
+  return (
+    normalizeMessageChannel(params.sessionCtx.OriginatingChannel) ??
+    normalizeMessageChannel(params.ctx.OriginatingChannel) ??
+    normalizeMessageChannel(params.sessionCtx.Surface) ??
+    normalizeMessageChannel(params.ctx.Surface) ??
+    normalizeMessageChannel(params.sessionCtx.Provider) ??
+    normalizeMessageChannel(params.ctx.Provider) ??
+    ""
+  );
+}
 
 export async function resolveReplyDirectives(params: {
   ctx: MsgContext;
@@ -303,8 +323,11 @@ export async function resolveReplyDirectives(params: {
   sessionCtx.Body = cleanedBody;
   sessionCtx.BodyStripped = cleanedBody;
 
-  const messageProviderKey =
-    sessionCtx.Provider?.trim().toLowerCase() ?? ctx.Provider?.trim().toLowerCase() ?? "";
+  const messageProviderKey = resolveMessageProviderKey({
+    commandChannelId: command.channelId,
+    sessionCtx,
+    ctx,
+  });
   const elevated = resolveElevatedPermissions({
     cfg,
     agentId,


### PR DESCRIPTION
## Summary
- resolve elevated directive provider keys from resolved command channel/originating channel context instead of raw runtime `Provider`
- prevent `Provider=direct` sessions from incorrectly checking `tools.elevated.allowFrom.direct` when the real channel is Telegram
- add unit coverage for provider-key resolution precedence

## Testing
- pnpm test src/auto-reply/reply/get-reply-directives.test.ts src/auto-reply/reply/reply-elevated.test.ts

Fixes #17471
