### PR TITLE
fix(channels): add null guards to Discord, Telegram, and Slack iterations

### DIFF
--- a/src/discord/send.components.ts
+++ b/src/discord/send.components.ts
@@ -33,6 +33,9 @@ const DISCORD_FORUM_LIKE_TYPES = new Set<number>([ChannelType.GuildForum, Channe
 function extractComponentAttachmentNames(spec: DiscordComponentMessageSpec): string[] {
   const names: string[] = [];
   for (const block of spec.blocks ?? []) {
+    if (block == null || typeof block !== "object") {
+      continue;
+    }
     if (block.type === "file") {
       names.push(resolveDiscordComponentAttachmentName(block.file));
     }

--- a/src/slack/monitor/events/interactions.ts
+++ b/src/slack/monitor/events/interactions.ts
@@ -392,7 +392,13 @@ function isBulkActionsBlock(block: InteractionMessageBlock): boolean {
     block.type === "actions" &&
     Array.isArray(block.elements) &&
     block.elements.length > 0 &&
-    block.elements.every((el) => typeof el.action_id === "string" && el.action_id.includes("_all_"))
+    block.elements.every(
+      (el) =>
+        el != null &&
+        typeof el === "object" &&
+        typeof el.action_id === "string" &&
+        el.action_id.includes("_all_"),
+    )
   );
 }
 

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -483,7 +483,7 @@ export const buildTelegramMessageContext = async ({
   }
 
   const hasAnyMention = (msg.entities ?? msg.caption_entities ?? []).some(
-    (ent) => ent.type === "mention",
+    (ent) => ent != null && typeof ent === "object" && ent.type === "mention",
   );
   const explicitlyMentioned = botUsername ? hasBotMention(msg, botUsername) : false;
 


### PR DESCRIPTION
## Summary

Three channel modules iterate over external data arrays (from Discord API, Telegram API, and Slack API) without checking for null/non-object entries, risking `TypeError` crashes when APIs return malformed data:

1. **`src/discord/send.components.ts`** — `extractComponentAttachmentNames` iterates `spec.blocks` and accesses `block.type` without null guard. A null entry from a malformed component spec would crash.
2. **`src/telegram/bot-message-context.ts`** — Mention detection iterates `msg.entities` / `msg.caption_entities` and accesses `ent.type` without null guard. Telegram API edge cases could include null entity entries.
3. **`src/slack/monitor/events/interactions.ts`** — `isBulkActionsBlock` calls `elements.every()` accessing `el.action_id` without null guard. Malformed Slack block elements could crash the interaction handler.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [x] Channels / Plugins
- [ ] Agents / Model integration
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Configuration

## Linked Issues

Related to #34979 (malformed content blocks cause crashes)

## User-Visible Changes

Discord component messages, Telegram mention detection, and Slack interaction handlers no longer crash when their respective APIs return null entries in data arrays.

## Security Impact

1. Does this change handle user input? **No** — guards are on API response data
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] Formatted with `oxfmt`
- [x] Minimal changes — only adds null/typeof guards before property access

## Human Verification

- Send a Discord message with component blocks — verify no regression
- Test Telegram mention detection in groups — verify mentions still work
- Test Slack button interactions — verify interaction handler still works

## Compatibility

Fully backward compatible. Well-formed data paths are identical.

## Failure Recovery

Revert this single commit.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Silently skipping valid entries | Guards only skip null/non-object entries which are never valid per the respective API schemas |