### PR TITLE
fix: [Bug] Gateway restart causes Telegram group sessions to reset instead of restoring from sessions.json (#35283)

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -496,6 +496,82 @@ describe("initSessionState RawBody", () => {
       vi.unstubAllEnvs();
     }
   });
+
+  it("restores telegram group sessions from legacy mixed-case keys", async () => {
+    const root = await makeCaseDir("openclaw-telegram-group-key-case-");
+    const storePath = path.join(root, "sessions.json");
+    const legacyKey = "Agent:Main:Telegram:Group:-1001234567890";
+    const canonicalKey = "agent:main:telegram:group:-1001234567890";
+    const existingSessionId = "telegram-group-existing";
+
+    await writeSessionStoreFast(storePath, {
+      [legacyKey]: {
+        sessionId: existingSessionId,
+        updatedAt: Date.now(),
+        chatType: "group",
+        channel: "telegram",
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: {
+        Body: "hello",
+        ChatType: "group",
+        Provider: "telegram",
+        Surface: "telegram",
+        SessionKey: canonicalKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionEntry.sessionId).toBe(existingSessionId);
+    expect(result.sessionKey).toBe(canonicalKey);
+
+    const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, SessionEntry>;
+    expect(store[canonicalKey]?.sessionId).toBe(existingSessionId);
+    expect(store[legacyKey]).toBeUndefined();
+  });
+
+  it("restores telegram group sessions from legacy channel-shaped keys", async () => {
+    const root = await makeCaseDir("openclaw-telegram-group-channel-legacy-");
+    const storePath = path.join(root, "sessions.json");
+    const legacyChannelKey = "agent:main:telegram:channel:-1001234567890";
+    const canonicalGroupKey = "agent:main:telegram:group:-1001234567890";
+    const existingSessionId = "telegram-group-channel-legacy";
+
+    await writeSessionStoreFast(storePath, {
+      [legacyChannelKey]: {
+        sessionId: existingSessionId,
+        updatedAt: Date.now(),
+        chatType: "group",
+        channel: "telegram",
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: {
+        Body: "hello",
+        ChatType: "group",
+        Provider: "telegram",
+        Surface: "telegram",
+        SessionKey: canonicalGroupKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionEntry.sessionId).toBe(existingSessionId);
+    expect(result.sessionKey).toBe(canonicalGroupKey);
+
+    const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, SessionEntry>;
+    expect(store[canonicalGroupKey]?.sessionId).toBe(existingSessionId);
+    expect(store[legacyChannelKey]).toBeUndefined();
+  });
 });
 
 describe("initSessionState reset policy", () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -43,6 +43,70 @@ import { buildSessionEndHookPayload, buildSessionStartHookPayload } from "./sess
 
 const log = createSubsystemLogger("session-init");
 
+function normalizeStoreSessionKey(sessionKey: string): string {
+  return sessionKey.trim().toLowerCase();
+}
+
+function resolveStoreSessionEntry(params: {
+  store: Record<string, SessionEntry>;
+  sessionKey: string;
+}): {
+  normalizedKey: string;
+  existing: SessionEntry | undefined;
+  legacyKeys: string[];
+} {
+  const trimmedKey = params.sessionKey.trim();
+  const normalizedKey = normalizeStoreSessionKey(trimmedKey);
+  const equivalentNormalizedKeys = new Set([normalizedKey]);
+  if (normalizedKey.includes(":group:")) {
+    equivalentNormalizedKeys.add(normalizedKey.replace(":group:", ":channel:"));
+  } else if (normalizedKey.includes(":channel:")) {
+    equivalentNormalizedKeys.add(normalizedKey.replace(":channel:", ":group:"));
+  }
+  const legacyKeySet = new Set<string>();
+  if (
+    trimmedKey !== normalizedKey &&
+    Object.prototype.hasOwnProperty.call(params.store, trimmedKey)
+  ) {
+    legacyKeySet.add(trimmedKey);
+  }
+  let existing =
+    params.store[normalizedKey] ?? (legacyKeySet.size > 0 ? params.store[trimmedKey] : undefined);
+  if (!existing) {
+    for (const equivalentKey of equivalentNormalizedKeys) {
+      if (equivalentKey === normalizedKey) {
+        continue;
+      }
+      const candidate = params.store[equivalentKey];
+      if (candidate) {
+        existing = candidate;
+        legacyKeySet.add(equivalentKey);
+        break;
+      }
+    }
+  }
+  let existingUpdatedAt = existing?.updatedAt ?? 0;
+  for (const [candidateKey, candidateEntry] of Object.entries(params.store)) {
+    if (candidateKey === normalizedKey) {
+      continue;
+    }
+    if (!equivalentNormalizedKeys.has(candidateKey.toLowerCase())) {
+      continue;
+    }
+    legacyKeySet.add(candidateKey);
+    const candidateUpdatedAt = candidateEntry?.updatedAt ?? 0;
+    if (!existing || candidateUpdatedAt > existingUpdatedAt) {
+      existing = candidateEntry;
+      existingUpdatedAt = candidateUpdatedAt;
+    }
+  }
+  return {
+    normalizedKey,
+    existing,
+    legacyKeys: [...legacyKeySet],
+  };
+}
+
 export type SessionInitResult = {
   sessionCtx: TemplateContext;
   sessionEntry: SessionEntry;
@@ -185,7 +249,15 @@ export async function initSessionState(params: {
   if (retiredLegacyMainDelivery) {
     sessionStore[retiredLegacyMainDelivery.key] = retiredLegacyMainDelivery.entry;
   }
-  const entry = sessionStore[sessionKey];
+  const resolvedEntry = resolveStoreSessionEntry({ store: sessionStore, sessionKey });
+  const entry = resolvedEntry.existing;
+  sessionKey = resolvedEntry.normalizedKey;
+  if (resolvedEntry.legacyKeys.length > 0 && entry) {
+    sessionStore[sessionKey] = entry;
+    for (const legacyKey of resolvedEntry.legacyKeys) {
+      delete sessionStore[legacyKey];
+    }
+  }
   const previousSessionEntry = resetTriggered && entry ? { ...entry } : undefined;
   const now = Date.now();
   const isThread = resolveThreadFlag({
@@ -396,6 +468,9 @@ export async function initSessionState(params: {
     (store) => {
       // Preserve per-session overrides while resetting compaction state on /new.
       store[sessionKey] = { ...store[sessionKey], ...sessionEntry };
+      for (const legacyKey of resolvedEntry.legacyKeys) {
+        delete store[legacyKey];
+      }
       if (retiredLegacyMainDelivery) {
         store[retiredLegacyMainDelivery.key] = retiredLegacyMainDelivery.entry;
       }

--- a/src/config/sessions/store.session-key-normalization.test.ts
+++ b/src/config/sessions/store.session-key-normalization.test.ts
@@ -109,6 +109,39 @@ describe("session store key normalization", () => {
     expect(store[MIXED_CASE_KEY]).toBeUndefined();
   });
 
+  it("migrates legacy group/channel alias entries to the requested canonical key", async () => {
+    const channelAliasKey = "agent:main:webchat:channel:mixed-user";
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [channelAliasKey]: {
+            sessionId: "legacy-channel-alias",
+            updatedAt: 1,
+            chatType: "group",
+            channel: "webchat",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    clearSessionStoreCacheForTest();
+
+    await updateLastRoute({
+      storePath,
+      sessionKey: CANONICAL_KEY.replace(":dm:", ":group:"),
+      channel: "webchat",
+      to: "webchat:user-3",
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    const canonicalGroupKey = CANONICAL_KEY.replace(":dm:", ":group:");
+    expect(store[canonicalGroupKey]?.sessionId).toBe("legacy-channel-alias");
+    expect(store[channelAliasKey]).toBeUndefined();
+  });
+
   it("preserves updatedAt when recording inbound metadata for an existing session", async () => {
     await fs.writeFile(
       storePath,

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -122,6 +122,12 @@ function resolveStoreSessionEntry(params: {
 } {
   const trimmedKey = params.sessionKey.trim();
   const normalizedKey = normalizeStoreSessionKey(trimmedKey);
+  const equivalentNormalizedKeys = new Set([normalizedKey]);
+  if (normalizedKey.includes(":group:")) {
+    equivalentNormalizedKeys.add(normalizedKey.replace(":group:", ":channel:"));
+  } else if (normalizedKey.includes(":channel:")) {
+    equivalentNormalizedKeys.add(normalizedKey.replace(":channel:", ":group:"));
+  }
   const legacyKeySet = new Set<string>();
   if (
     trimmedKey !== normalizedKey &&
@@ -131,12 +137,25 @@ function resolveStoreSessionEntry(params: {
   }
   let existing =
     params.store[normalizedKey] ?? (legacyKeySet.size > 0 ? params.store[trimmedKey] : undefined);
+  if (!existing) {
+    for (const equivalentKey of equivalentNormalizedKeys) {
+      if (equivalentKey === normalizedKey) {
+        continue;
+      }
+      const candidate = params.store[equivalentKey];
+      if (candidate) {
+        existing = candidate;
+        legacyKeySet.add(equivalentKey);
+        break;
+      }
+    }
+  }
   let existingUpdatedAt = existing?.updatedAt ?? 0;
   for (const [candidateKey, candidateEntry] of Object.entries(params.store)) {
     if (candidateKey === normalizedKey) {
       continue;
     }
-    if (candidateKey.toLowerCase() !== normalizedKey) {
+    if (!equivalentNormalizedKeys.has(candidateKey.toLowerCase())) {
       continue;
     }
     legacyKeySet.add(candidateKey);


### PR DESCRIPTION
Closes #35283

## Summary

- Problem: [Bug] Gateway restart causes Telegram group sessions to reset instead of restoring from sessions.json
- Why it matters: Reported in #35283
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35283
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35283