### PR TITLE
feat: show status reaction during context compaction

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -376,11 +376,15 @@ export async function runAgentTurnWithFallback(params: {
                     await params.opts?.onToolStart?.({ name, phase });
                   }
                 }
-                // Track auto-compaction completion
+                // Track auto-compaction completion and notify UI layer
                 if (evt.stream === "compaction") {
                   const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
+                  if (phase === "start") {
+                    await params.opts?.onCompactionStart?.();
+                  }
                   if (phase === "end") {
                     autoCompactionCompleted = true;
+                    await params.opts?.onCompactionEnd?.();
                   }
                 }
               },

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -54,6 +54,10 @@ export type GetReplyOptions = {
   onToolResult?: (payload: ReplyPayload) => Promise<void> | void;
   /** Called when a tool phase starts/updates, before summary payloads are emitted. */
   onToolStart?: (payload: { name?: string; phase?: string }) => Promise<void> | void;
+  /** Called when context auto-compaction starts (allows UX feedback during the pause). */
+  onCompactionStart?: () => Promise<void> | void;
+  /** Called when context auto-compaction completes. */
+  onCompactionEnd?: () => Promise<void> | void;
   /** Called when the actual model is selected (including after fallback).
    * Use this to get model/provider/thinkLevel for responsePrefix template interpolation. */
   onModelSelected?: (ctx: ModelSelectedContext) => void;

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -24,6 +24,7 @@ export type StatusReactionEmojis = {
   error?: string; // Default: "❌"
   stallSoft?: string; // Default: "⏳"
   stallHard?: string; // Default: "⚠️"
+  compacting?: string; // Default: "✍"
 };
 
 export type StatusReactionTiming = {
@@ -38,6 +39,7 @@ export type StatusReactionController = {
   setQueued: () => Promise<void> | void;
   setThinking: () => Promise<void> | void;
   setTool: (toolName?: string) => Promise<void> | void;
+  setCompacting: () => Promise<void> | void;
   setDone: () => Promise<void>;
   setError: () => Promise<void>;
   clear: () => Promise<void>;
@@ -58,6 +60,7 @@ export const DEFAULT_EMOJIS: Required<StatusReactionEmojis> = {
   error: "😱",
   stallSoft: "🥱",
   stallHard: "😨",
+  compacting: "✍",
 };
 
 export const DEFAULT_TIMING: Required<StatusReactionTiming> = {
@@ -162,6 +165,7 @@ export function createStatusReactionController(params: {
     emojis.error,
     emojis.stallSoft,
     emojis.stallHard,
+    emojis.compacting,
   ]);
 
   /**
@@ -306,6 +310,10 @@ export function createStatusReactionController(params: {
     scheduleEmoji(emoji);
   }
 
+  function setCompacting(): void {
+    scheduleEmoji(emojis.compacting);
+  }
+
   function finishWithEmoji(emoji: string): Promise<void> {
     if (!enabled) {
       return Promise.resolve();
@@ -375,6 +383,7 @@ export function createStatusReactionController(params: {
     setQueued,
     setThinking,
     setTool,
+    setCompacting,
     setDone,
     setError,
     clear,

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -770,6 +770,18 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
           }
           await statusReactions.setTool(payload.name);
         },
+        onCompactionStart: async () => {
+          if (isProcessAborted(abortSignal)) {
+            return;
+          }
+          await statusReactions.setCompacting();
+        },
+        onCompactionEnd: async () => {
+          if (isProcessAborted(abortSignal)) {
+            return;
+          }
+          await statusReactions.setThinking();
+        },
       },
     });
     if (isProcessAborted(abortSignal)) {

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -673,6 +673,12 @@ export const dispatchTelegramMessage = async ({
               await statusReactionController.setTool(payload.name);
             }
           : undefined,
+        onCompactionStart: statusReactionController
+          ? () => statusReactionController.setCompacting()
+          : undefined,
+        onCompactionEnd: statusReactionController
+          ? () => statusReactionController.setThinking()
+          : undefined,
         onModelSelected,
       },
     }));

--- a/src/telegram/status-reaction-variants.ts
+++ b/src/telegram/status-reaction-variants.ts
@@ -90,6 +90,7 @@ export const TELEGRAM_STATUS_REACTION_VARIANTS: Record<StatusReactionEmojiKey, s
   error: ["😱", "😨", "🤯"],
   stallSoft: ["🥱", "😴", "🤔"],
   stallHard: ["😨", "😱", "⚡"],
+  compacting: ["✍", "🤔", "🤯"],
 };
 
 const STATUS_REACTION_EMOJI_KEYS: StatusReactionEmojiKey[] = [
@@ -102,6 +103,7 @@ const STATUS_REACTION_EMOJI_KEYS: StatusReactionEmojiKey[] = [
   "error",
   "stallSoft",
   "stallHard",
+  "compacting",
 ];
 
 function normalizeEmoji(value: string | undefined): string | undefined {
@@ -129,6 +131,7 @@ export function resolveTelegramStatusReactionEmojis(params: {
     error: normalizeEmoji(overrides?.error) ?? DEFAULT_EMOJIS.error,
     stallSoft: normalizeEmoji(overrides?.stallSoft) ?? DEFAULT_EMOJIS.stallSoft,
     stallHard: normalizeEmoji(overrides?.stallHard) ?? DEFAULT_EMOJIS.stallHard,
+    compacting: normalizeEmoji(overrides?.compacting) ?? DEFAULT_EMOJIS.compacting,
   };
 }
 


### PR DESCRIPTION
## Summary

When context auto-compaction runs on Telegram/Discord, the bot appears frozen for 10-30s with no feedback. This PR adds a `✍` (writing) status reaction during compaction so users know the bot is still working.

- Adds `compacting` state to `StatusReactionController` with `✍` emoji (debounced, same pattern as `setThinking`)
- Adds `onCompactionStart`/`onCompactionEnd` callbacks to `GetReplyOptions`
- Wires existing `onAgentEvent` compaction events (`stream: "compaction"`, `phase: "start"/"end"`) to the status reaction system
- On compaction end, resumes `thinking` reaction so the status flow continues naturally
- Applies to both Telegram and Discord channels
- Telegram variants: `["✍", "🤔", "🤯"]` (all in Telegram's supported reaction set)

## Files changed

| File | Change |
|------|--------|
| `src/channels/status-reactions.ts` | Add `compacting` emoji type + `setCompacting()` method |
| `src/telegram/status-reaction-variants.ts` | Add `compacting` emoji variants |
| `src/auto-reply/types.ts` | Add `onCompactionStart/End` callbacks |
| `src/auto-reply/reply/agent-runner-execution.ts` | Wire compaction events to callbacks |
| `src/telegram/bot-message-dispatch.ts` | Pass `setCompacting` via callbacks |
| `src/discord/monitor/message-handler.process.ts` | Same wiring for Discord |

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm tsgo` passes (type check)
- [x] `pnpm check` passes (lint/format)
- [x] Existing status reaction tests pass (51/51)
- [ ] Manual test on Telegram: send long conversation to trigger compaction, observe `✍` reaction
- [ ] Manual test: verify reaction switches back to `🤔`/`👍` after compaction completes
- [ ] Edge case: compaction with status reactions disabled — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)