### PR TITLE
fix(telegram): cap sent-message cache growth with LRU eviction

### DIFF
--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -87,6 +87,43 @@ describe("sent-message-cache", () => {
     clearSentMessageCache();
     expect(wasSentByBot(123, 1)).toBe(false);
   });
+
+  it("evicts oldest chats when chat cache grows beyond cap", () => {
+    for (let i = 0; i < 1100; i += 1) {
+      recordSentMessage(`chat-${i}`, 1);
+    }
+
+    expect(wasSentByBot("chat-0", 1)).toBe(false);
+    expect(wasSentByBot("chat-1099", 1)).toBe(true);
+  });
+
+  it("evicts oldest message ids per chat when chat history exceeds cap", () => {
+    for (let i = 1; i <= 1100; i += 1) {
+      recordSentMessage(123, i);
+    }
+
+    expect(wasSentByBot(123, 1)).toBe(false);
+    expect(wasSentByBot(123, 1100)).toBe(true);
+  });
+
+  it("removes expired chat buckets after ttl and still accepts new writes", () => {
+    vi.useFakeTimers();
+    try {
+      const now = new Date("2026-01-01T00:00:00.000Z");
+      vi.setSystemTime(now);
+
+      recordSentMessage(999, 1);
+      expect(wasSentByBot(999, 1)).toBe(true);
+
+      vi.setSystemTime(new Date(now.getTime() + 24 * 60 * 60 * 1000 + 1));
+      expect(wasSentByBot(999, 1)).toBe(false);
+
+      recordSentMessage(999, 2);
+      expect(wasSentByBot(999, 2)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("buildInlineKeyboard", () => {

--- a/src/telegram/sent-message-cache.ts
+++ b/src/telegram/sent-message-cache.ts
@@ -4,6 +4,9 @@
  */
 
 const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const CLEANUP_TRIGGER = 100;
+const MAX_MESSAGES_PER_CHAT = 1000;
+const MAX_CHAT_ENTRIES = 1024;
 
 type CacheEntry = {
   timestamps: Map<number, number>;
@@ -15,12 +18,36 @@ function getChatKey(chatId: number | string): string {
   return String(chatId);
 }
 
-function cleanupExpired(entry: CacheEntry): void {
-  const now = Date.now();
+function cleanupExpired(entry: CacheEntry, now = Date.now()): void {
   for (const [msgId, timestamp] of entry.timestamps) {
     if (now - timestamp > TTL_MS) {
       entry.timestamps.delete(msgId);
     }
+  }
+}
+
+function trimOldestMessages(entry: CacheEntry): void {
+  while (entry.timestamps.size > MAX_MESSAGES_PER_CHAT) {
+    const oldestId = entry.timestamps.keys().next().value;
+    if (typeof oldestId !== "number") {
+      break;
+    }
+    entry.timestamps.delete(oldestId);
+  }
+}
+
+function touchChatEntry(key: string, entry: CacheEntry): void {
+  sentMessages.delete(key);
+  sentMessages.set(key, entry);
+}
+
+function evictOldestChats(): void {
+  while (sentMessages.size > MAX_CHAT_ENTRIES) {
+    const oldestKey = sentMessages.keys().next().value;
+    if (typeof oldestKey !== "string") {
+      break;
+    }
+    sentMessages.delete(oldestKey);
   }
 }
 
@@ -29,16 +56,21 @@ function cleanupExpired(entry: CacheEntry): void {
  */
 export function recordSentMessage(chatId: number | string, messageId: number): void {
   const key = getChatKey(chatId);
-  let entry = sentMessages.get(key);
-  if (!entry) {
-    entry = { timestamps: new Map() };
-    sentMessages.set(key, entry);
-  }
+  const entry = sentMessages.get(key) ?? { timestamps: new Map<number, number>() };
+
   entry.timestamps.set(messageId, Date.now());
-  // Periodic cleanup
-  if (entry.timestamps.size > 100) {
+  if (entry.timestamps.size > CLEANUP_TRIGGER) {
     cleanupExpired(entry);
   }
+  trimOldestMessages(entry);
+
+  if (entry.timestamps.size === 0) {
+    sentMessages.delete(key);
+    return;
+  }
+
+  touchChatEntry(key, entry);
+  evictOldestChats();
 }
 
 /**
@@ -50,8 +82,16 @@ export function wasSentByBot(chatId: number | string, messageId: number): boolea
   if (!entry) {
     return false;
   }
-  // Clean up expired entries on read
+
+  // Clean up expired entries on read.
   cleanupExpired(entry);
+  if (entry.timestamps.size === 0) {
+    sentMessages.delete(key);
+    return false;
+  }
+
+  // Keep frequently accessed chats hot in LRU order.
+  touchChatEntry(key, entry);
   return entry.timestamps.has(messageId);
 }
 


### PR DESCRIPTION
## Summary
- add hard bounds to telegram sent-message cache to prevent unbounded growth in long-running bots
- enforce per-chat message cap (1000) by evicting oldest message ids
- enforce global chat cap (1024) with oldest-chat eviction
- remove empty chat buckets after TTL cleanup and refresh recency on reads/writes
- add regression tests for chat-cap eviction, per-chat eviction, and TTL-expiry recovery

## Why
The sent-message cache previously relied on TTL cleanup only. Under high throughput or many distinct chats, maps could still grow significantly before expirations, causing unnecessary memory pressure.

## Risk
Low. This cache is a best-effort heuristic for filtering bot-owned messages; on eviction, behavior safely falls back to not matching very old entries. Message send paths are unaffected.

## Testing
- pnpm -s vitest run src/telegram/send.test.ts