### PR TITLE
fix(browser): align extension connect payload with gateway schema

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -338,7 +338,6 @@ function sendToRelay(payload) {
 
 function ensureGatewayHandshakeStarted(payload) {
   if (relayConnectRequestId) return
-  const nonce = typeof payload?.nonce === 'string' ? payload.nonce.trim() : ''
   relayConnectRequestId = `ext-connect-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`
   sendToRelay({
     type: 'req',
@@ -348,7 +347,8 @@ function ensureGatewayHandshakeStarted(payload) {
       minProtocol: 3,
       maxProtocol: 3,
       client: {
-        id: 'chrome-relay-extension',
+        // Must remain a gateway-validated client id.
+        id: 'webchat-ui',
         version: '1.0.0',
         platform: 'chrome-extension',
         mode: 'webchat',
@@ -357,7 +357,6 @@ function ensureGatewayHandshakeStarted(payload) {
       scopes: ['operator.read', 'operator.write'],
       caps: [],
       commands: [],
-      nonce: nonce || undefined,
       auth: relayGatewayToken ? { token: relayGatewayToken } : undefined,
     },
   })

--- a/src/browser/chrome-extension-handshake.test.ts
+++ b/src/browser/chrome-extension-handshake.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readBackgroundScript(): string {
+  const scriptPath = resolve(process.cwd(), "assets/chrome-extension/background.js");
+  return readFileSync(scriptPath, "utf8");
+}
+
+describe("chrome extension handshake payload", () => {
+  it("uses a gateway-recognized client id", () => {
+    const source = readBackgroundScript();
+    expect(source).toContain("id: 'webchat-ui'");
+    expect(source).not.toContain("id: 'chrome-relay-extension'");
+  });
+
+  it("does not send unsupported top-level nonce in connect params", () => {
+    const source = readBackgroundScript();
+    expect(source).not.toMatch(/^\s*nonce:\s*nonce\s*\|\|\s*undefined\s*,?\s*$/m);
+  });
+});


### PR DESCRIPTION
## Summary
- remove unsupported top-level `nonce` from the Chrome extension gateway `connect` payload
- switch extension `client.id` to `webchat-ui` so the handshake uses a gateway-recognized client id
- add a regression test that locks the extension handshake payload contract

Fixes #35405

## Testing
- pnpm test -- src/browser/chrome-extension-handshake.test.ts src/browser/chrome-extension-manifest.test.ts src/browser/chrome-extension-background-utils.test.ts
