### PR TITLE
fix(security): reduce API key exposure in maskApiKey from 16 to 8 chars

### DIFF
--- a/src/utils/mask-api-key.test.ts
+++ b/src/utils/mask-api-key.test.ts
@@ -14,7 +14,14 @@ describe("maskApiKey", () => {
     expect(maskApiKey(" ab ")).toBe("a...b");
   });
 
-  it("masks long values with first and last 8 chars", () => {
-    expect(maskApiKey("1234567890abcdefghijklmnop")).toBe("12345678...ijklmnop");
+  it("masks long values with first and last 4 chars only", () => {
+    expect(maskApiKey("1234567890abcdefghijklmnop")).toBe("1234...mnop");
+  });
+
+  it("exposes at most 8 characters for any key", () => {
+    const key = "sk-ant-api03-very-long-key-1234567890abcdef";
+    const masked = maskApiKey(key);
+    const visibleChars = masked.replace("...", "").length;
+    expect(visibleChars).toBeLessThanOrEqual(8);
   });
 });

--- a/src/utils/mask-api-key.ts
+++ b/src/utils/mask-api-key.ts
@@ -9,5 +9,5 @@ export const maskApiKey = (value: string): string => {
   if (trimmed.length <= 16) {
     return `${trimmed.slice(0, 2)}...${trimmed.slice(-2)}`;
   }
-  return `${trimmed.slice(0, 8)}...${trimmed.slice(-8)}`;
+  return `${trimmed.slice(0, 4)}...${trimmed.slice(-4)}`;
 };


### PR DESCRIPTION
## Summary

`maskApiKey()` in `src/utils/mask-api-key.ts` previously exposed the first 8 + last 8 characters (16 total) for API keys longer than 16 characters. This masked value is displayed in chat channels via `/models list` and status commands, where it's sent as plaintext to Telegram, Discord, Slack, etc.

Exposing 16 characters of an API key significantly aids credential enumeration attacks. This PR reduces the exposure to first 4 + last 4 characters (8 total), which still provides enough context to identify which key is in use (e.g., distinguishing between multiple Anthropic keys) while halving the attack surface.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [x] Security

## Linked Issues

Closes #34452

## User-Visible Changes

The `/models list` and `/status` commands now show less of the API key. For example:
- Before: `sk-ant-a...wxyz1234` (16 chars visible)
- After: `sk-a...1234` (8 chars visible)

Short keys (<=16 chars) are unchanged: they already expose at most 4 characters.

## Security Impact

1. Does this change handle user input? **No** — API keys come from config
2. Does this change affect authentication or authorization? **No** — keys are only masked for display
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **Yes** — reduces plaintext key material in chat messages
5. Does this change modify security-sensitive code paths? **Yes** — this is the credential masking utility

## Verification

- [x] All 4 tests pass including new exposure-limit test
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ src/utils/mask-api-key.test.ts (4 tests) 2ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

## Human Verification

- Run `/models list` and verify API keys show only 4+4 characters
- Verify the masked output is still sufficient to distinguish between multiple keys

## Compatibility

Backward compatible. The masked output format is the same (prefix...suffix), only the visible portion is shorter. No API changes.

## Failure Recovery

Revert this single commit to restore the previous 8+8 masking behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Users can no longer distinguish keys with same prefix/suffix | 4 chars on each side provides 8 chars of differentiation — sufficient for typical key formats |
| Breaking existing key-matching logic that depends on masked output | Searched codebase — masked values are only used for display, never for matching |