### PR TITLE
fix(mattermost): resolve non-id outbound targets by channel name

### DIFF
--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -112,7 +112,12 @@ Use these target formats with `openclaw message send` or cron/webhooks:
 - `user:<id>` for a DM
 - `@username` for a DM (resolved via the Mattermost API)
 
-Bare IDs are treated as channels.
+Bare values are treated as channel targets:
+
+- If the value looks like a channel id, OpenClaw uses it directly.
+- Otherwise, OpenClaw resolves it as a channel name across teams visible to the bot.
+
+When in doubt, prefer `channel:<id>` for unambiguous routing.
 
 ## Reactions (message tool)
 

--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { createMattermostClient } from "./client.js";
+import { createMattermostClient, patchMattermostPost } from "./client.js";
 
 describe("mattermost client", () => {
   it("request returns undefined on 204 responses", async () => {
@@ -15,5 +15,32 @@ describe("mattermost client", () => {
 
     const result = await client.request<unknown>("/anything", { method: "DELETE" });
     expect(result).toBeUndefined();
+  });
+
+  it("patchMattermostPost updates a post via /patch endpoint", async () => {
+    const fetchImpl = vi.fn(async () => {
+      return new Response(JSON.stringify({ id: "post-123", message: "updated" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const client = createMattermostClient({
+      baseUrl: "https://chat.example.com",
+      botToken: "test-token",
+      fetchImpl: fetchImpl as any,
+    });
+
+    const post = await patchMattermostPost(client, {
+      postId: "post-123",
+      message: "updated",
+    });
+
+    expect(post).toMatchObject({ id: "post-123", message: "updated" });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://chat.example.com/api/v4/posts/post-123/patch");
+    expect(init.method).toBe("PUT");
+    expect(String(init.body)).toBe(JSON.stringify({ message: "updated" }));
   });
 });

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -190,6 +190,25 @@ export async function createMattermostPost(
   });
 }
 
+export async function patchMattermostPost(
+  client: MattermostClient,
+  params: {
+    postId: string;
+    message: string;
+  },
+): Promise<MattermostPost> {
+  const postId = params.postId?.trim();
+  if (!postId) {
+    throw new Error("Mattermost post id is required");
+  }
+  return await client.request<MattermostPost>(`/posts/${postId}/patch`, {
+    method: "PUT",
+    body: JSON.stringify({
+      message: params.message,
+    }),
+  });
+}
+
 export async function uploadMattermostFile(
   client: MattermostClient,
   params: {

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -21,6 +21,12 @@ export type MattermostChannel = {
   team_id?: string | null;
 };
 
+export type MattermostTeam = {
+  id: string;
+  name?: string | null;
+  display_name?: string | null;
+};
+
 export type MattermostPost = {
   id: string;
   user_id?: string | null;
@@ -136,6 +142,27 @@ export async function fetchMattermostChannel(
   channelId: string,
 ): Promise<MattermostChannel> {
   return await client.request<MattermostChannel>(`/channels/${channelId}`);
+}
+
+export async function fetchMattermostTeams(client: MattermostClient): Promise<MattermostTeam[]> {
+  return await client.request<MattermostTeam[]>("/users/me/teams");
+}
+
+export async function fetchMattermostChannelByTeamAndName(
+  client: MattermostClient,
+  params: { teamId: string; channelName: string },
+): Promise<MattermostChannel> {
+  const teamId = params.teamId.trim();
+  const channelName = params.channelName.trim();
+  if (!teamId) {
+    throw new Error("Mattermost team id is required");
+  }
+  if (!channelName) {
+    throw new Error("Mattermost channel name is required");
+  }
+  return await client.request<MattermostChannel>(
+    `/teams/${encodeURIComponent(teamId)}/channels/name/${encodeURIComponent(channelName)}`,
+  );
 }
 
 export async function sendMattermostTyping(

--- a/extensions/mattermost/src/mattermost/monitor.require-mention.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.require-mention.test.ts
@@ -1,0 +1,46 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { resolveMattermostRequireMention } from "./monitor.js";
+
+describe("resolveMattermostRequireMention", () => {
+  const cfg: OpenClawConfig = {};
+
+  it("does not require mention in direct chats", () => {
+    const resolveRequireMention = vi.fn(() => true);
+
+    const result = resolveMattermostRequireMention({
+      kind: "direct",
+      cfg,
+      accountId: "default",
+      groupId: "group-1",
+      requireMention: true,
+      resolveRequireMention,
+    });
+
+    expect(result).toBe(false);
+    expect(resolveRequireMention).not.toHaveBeenCalled();
+  });
+
+  it("passes account mention defaults as fallback for group chats", () => {
+    const resolveRequireMention = vi.fn(() => false);
+
+    const result = resolveMattermostRequireMention({
+      kind: "channel",
+      cfg,
+      accountId: "default",
+      groupId: "group-1",
+      requireMention: false,
+      resolveRequireMention,
+    });
+
+    expect(result).toBe(false);
+    expect(resolveRequireMention).toHaveBeenCalledWith({
+      cfg,
+      channel: "mattermost",
+      accountId: "default",
+      groupId: "group-1",
+      requireMentionOverride: false,
+      overrideOrder: "after-config",
+    });
+  });
+});

--- a/extensions/mattermost/src/mattermost/monitor.require-mention.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.require-mention.test.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { describe, expect, it, vi } from "vitest";
-import { resolveMattermostRequireMention } from "./monitor.js";
+import { resolveMattermostRequireMention } from "./monitor.ts";
 
 describe("resolveMattermostRequireMention", () => {
   const cfg: OpenClawConfig = {};

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -126,6 +126,37 @@ function channelChatType(kind: ChatType): "direct" | "group" | "channel" {
   return "channel";
 }
 
+type ResolveGroupRequireMentionFn = (params: {
+  cfg: OpenClawConfig;
+  channel: "mattermost";
+  accountId?: string | null;
+  groupId?: string | null;
+  requireMentionOverride?: boolean;
+  overrideOrder?: "before-config" | "after-config";
+}) => boolean;
+
+export function resolveMattermostRequireMention(params: {
+  kind: ChatType;
+  cfg: OpenClawConfig;
+  accountId: string;
+  groupId: string;
+  requireMention?: boolean;
+  resolveRequireMention: ResolveGroupRequireMentionFn;
+}): boolean {
+  if (params.kind === "direct") {
+    return false;
+  }
+  return params.resolveRequireMention({
+    cfg: params.cfg,
+    channel: "mattermost",
+    accountId: params.accountId,
+    groupId: params.groupId,
+    // chatmode should set the default mention behavior when no per-group override exists.
+    requireMentionOverride: params.requireMention,
+    overrideOrder: "after-config",
+  });
+}
+
 function normalizeAllowEntry(entry: string): string {
   const trimmed = entry.trim();
   if (!trimmed) {
@@ -547,14 +578,14 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       : { triggered: false, stripped: rawText };
     const oncharTriggered = oncharResult.triggered;
 
-    const shouldRequireMention =
-      kind !== "direct" &&
-      core.channel.groups.resolveRequireMention({
-        cfg,
-        channel: "mattermost",
-        accountId: account.accountId,
-        groupId: channelId,
-      });
+    const shouldRequireMention = resolveMattermostRequireMention({
+      kind,
+      cfg,
+      accountId: account.accountId,
+      groupId: channelId,
+      requireMention: account.requireMention,
+      resolveRequireMention: core.channel.groups.resolveRequireMention,
+    });
     const shouldBypassMention =
       isControlCommand && shouldRequireMention && !wasMentioned && commandAuthorized;
     const effectiveWasMentioned = wasMentioned || shouldBypassMention || oncharTriggered;

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -12,7 +12,6 @@ import {
   logInboundDrop,
   logTypingFailure,
   buildPendingHistoryContextFromMap,
-  clearHistoryEntriesIfEnabled,
   DEFAULT_GROUP_HISTORY_LIMIT,
   recordPendingHistoryEntryIfEnabled,
   resolveControlCommandGate,
@@ -22,11 +21,13 @@ import {
 import { getMattermostRuntime } from "../runtime.js";
 import { resolveMattermostAccount } from "./accounts.js";
 import {
+  createMattermostPost,
   createMattermostClient,
   fetchMattermostChannel,
   fetchMattermostMe,
   fetchMattermostUser,
   normalizeMattermostBaseUrl,
+  patchMattermostPost,
   sendMattermostTyping,
   type MattermostChannel,
   type MattermostPost,
@@ -70,6 +71,8 @@ const RECENT_MATTERMOST_MESSAGE_TTL_MS = 5 * 60_000;
 const RECENT_MATTERMOST_MESSAGE_MAX = 2000;
 const CHANNEL_CACHE_TTL_MS = 5 * 60_000;
 const USER_CACHE_TTL_MS = 10 * 60_000;
+const MATTERMOST_STREAM_PREVIEW_MAX_CHARS = 4000;
+const MATTERMOST_STREAM_PREVIEW_THROTTLE_MS = 1000;
 
 const recentInboundMessages = createDedupeCache({
   ttlMs: RECENT_MATTERMOST_MESSAGE_TTL_MS,
@@ -224,6 +227,23 @@ function buildMattermostWsUrl(baseUrl: string): string {
   }
   const wsBase = normalized.replace(/^http/i, "ws");
   return `${wsBase}/api/v4/websocket`;
+}
+
+function normalizeMattermostStreamPreviewText(text: string, maxChars: number): string {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (trimmed.length <= maxChars) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
+}
+
+function buildMattermostToolStatusText(params: { name?: string; phase?: string }): string {
+  const phase = params.phase === "update" ? "Running" : "Starting";
+  const tool = params.name?.trim() ? ` \`${params.name.trim()}\`` : " tool";
+  return `Status: ${phase}${tool}...`;
 }
 
 export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}): Promise<void> {
@@ -541,6 +561,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     });
     const sessionKey = threadKeys.sessionKey;
     const historyKey = kind === "direct" ? null : sessionKey;
+    const threadLabel = threadRootId ? `Mattermost thread ${roomLabel}` : undefined;
 
     const mentionRegexes = core.channel.mentions.buildMentionRegexes(cfg, route.agentId);
     const wasMentioned =
@@ -610,6 +631,15 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     if (!bodyText) {
       return;
     }
+    const currentHistoryEntry =
+      historyKey && bodyText.trim()
+        ? {
+            sender: senderName,
+            body: bodyText.trim(),
+            timestamp: typeof post.create_at === "number" ? post.create_at : undefined,
+            messageId: post.id ?? undefined,
+          }
+        : null;
 
     core.channel.activity.record({
       channel: "mattermost",
@@ -708,6 +738,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         allMessageIds.length > 1 ? allMessageIds[allMessageIds.length - 1] : undefined,
       ReplyToId: threadRootId,
       MessageThreadId: threadRootId,
+      ThreadLabel: threadLabel,
       Timestamp: typeof post.create_at === "number" ? post.create_at : undefined,
       WasMentioned: kind !== "direct" ? effectiveWasMentioned : undefined,
       CommandAuthorized: commandAuthorized,
@@ -769,13 +800,145 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         });
       },
     });
+    const streamPreviewMaxChars = Math.min(textLimit, MATTERMOST_STREAM_PREVIEW_MAX_CHARS);
+    let streamPreviewPostId: string | undefined;
+    let streamPreviewLastText = "";
+    let streamPreviewPendingText: string | undefined;
+    let streamPreviewLastSentAt = 0;
+    let streamPreviewDisabled = false;
+    let streamPreviewTimer: ReturnType<typeof setTimeout> | undefined;
+    let streamPreviewQueue: Promise<void> = Promise.resolve();
+
+    const updateStreamPreviewNow = async (text: string): Promise<void> => {
+      if (streamPreviewDisabled) {
+        return;
+      }
+      const normalized = normalizeMattermostStreamPreviewText(text, streamPreviewMaxChars);
+      if (!normalized || normalized === streamPreviewLastText) {
+        return;
+      }
+      try {
+        if (streamPreviewPostId) {
+          await patchMattermostPost(client, {
+            postId: streamPreviewPostId,
+            message: normalized,
+          });
+        } else {
+          const sent = await createMattermostPost(client, {
+            channelId,
+            message: normalized,
+            rootId: threadRootId,
+          });
+          const postId = sent.id?.trim();
+          if (!postId) {
+            throw new Error("missing preview post id");
+          }
+          streamPreviewPostId = postId;
+        }
+        streamPreviewLastText = normalized;
+        streamPreviewLastSentAt = Date.now();
+      } catch (err) {
+        streamPreviewDisabled = true;
+        logVerboseMessage(`mattermost stream preview disabled: ${String(err)}`);
+      }
+    };
+
+    const flushQueuedStreamPreview = async (): Promise<void> => {
+      const nextText = streamPreviewPendingText;
+      streamPreviewPendingText = undefined;
+      if (!nextText || streamPreviewDisabled) {
+        return;
+      }
+      await updateStreamPreviewNow(nextText);
+      if (streamPreviewPendingText && !streamPreviewTimer) {
+        const elapsed = Date.now() - streamPreviewLastSentAt;
+        const delay = Math.max(0, MATTERMOST_STREAM_PREVIEW_THROTTLE_MS - elapsed);
+        streamPreviewTimer = setTimeout(() => {
+          streamPreviewTimer = undefined;
+          streamPreviewQueue = streamPreviewQueue.then(flushQueuedStreamPreview).catch(() => {});
+        }, delay);
+      }
+    };
+
+    const queueStreamPreviewUpdate = (text?: string): void => {
+      if (streamPreviewDisabled) {
+        return;
+      }
+      const normalized = normalizeMattermostStreamPreviewText(text ?? "", streamPreviewMaxChars);
+      if (!normalized) {
+        return;
+      }
+      streamPreviewPendingText = normalized;
+      const elapsed = Date.now() - streamPreviewLastSentAt;
+      if (elapsed >= MATTERMOST_STREAM_PREVIEW_THROTTLE_MS && !streamPreviewTimer) {
+        streamPreviewQueue = streamPreviewQueue.then(flushQueuedStreamPreview).catch(() => {});
+        return;
+      }
+      if (!streamPreviewTimer) {
+        const delay = Math.max(0, MATTERMOST_STREAM_PREVIEW_THROTTLE_MS - elapsed);
+        streamPreviewTimer = setTimeout(() => {
+          streamPreviewTimer = undefined;
+          streamPreviewQueue = streamPreviewQueue.then(flushQueuedStreamPreview).catch(() => {});
+        }, delay);
+      }
+    };
+
+    const flushStreamPreview = async (): Promise<void> => {
+      if (streamPreviewTimer) {
+        clearTimeout(streamPreviewTimer);
+        streamPreviewTimer = undefined;
+      }
+      streamPreviewQueue = streamPreviewQueue.then(flushQueuedStreamPreview).catch(() => {});
+      await streamPreviewQueue;
+    };
+
+    const previewTextForPayload = (payload: ReplyPayload): string => {
+      return core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode).trim();
+    };
+
+    const finalizeStreamPreviewWithPayload = async (payload: ReplyPayload): Promise<boolean> => {
+      const finalText = previewTextForPayload(payload);
+      const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
+      const canFinalizeViaEdit =
+        Boolean(streamPreviewPostId) &&
+        mediaUrls.length === 0 &&
+        !payload.isError &&
+        finalText.length > 0 &&
+        finalText.length <= streamPreviewMaxChars;
+      if (!canFinalizeViaEdit || !streamPreviewPostId) {
+        return false;
+      }
+      try {
+        await patchMattermostPost(client, {
+          postId: streamPreviewPostId,
+          message: finalText,
+        });
+        streamPreviewLastText = finalText;
+        streamPreviewLastSentAt = Date.now();
+        return true;
+      } catch (err) {
+        logVerboseMessage(`mattermost stream final edit failed: ${String(err)}`);
+        return false;
+      }
+    };
+
     const { dispatcher, replyOptions, markDispatchIdle } =
       core.channel.reply.createReplyDispatcherWithTyping({
         ...prefixOptions,
         humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
         deliver: async (payload: ReplyPayload) => {
+          await flushStreamPreview();
+          if (await finalizeStreamPreviewWithPayload(payload)) {
+            runtime.log?.(`delivered streamed reply to ${to}`);
+            return;
+          }
+
           const mediaUrls = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
           const text = core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode);
+          if (streamPreviewPostId && mediaUrls.length > 0) {
+            queueStreamPreviewUpdate("Status: complete. Final answer posted below.");
+            await flushStreamPreview();
+          }
           if (mediaUrls.length === 0) {
             const chunkMode = core.channel.text.resolveChunkMode(
               cfg,
@@ -812,24 +975,41 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         onReplyStart: typingCallbacks.onReplyStart,
       });
 
-    await core.channel.reply.dispatchReplyFromConfig({
-      ctx: ctxPayload,
-      cfg,
-      dispatcher,
-      replyOptions: {
-        ...replyOptions,
-        disableBlockStreaming:
-          typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
-        onModelSelected,
-      },
-    });
-    markDispatchIdle();
-    if (historyKey) {
-      clearHistoryEntriesIfEnabled({
-        historyMap: channelHistories,
-        historyKey,
-        limit: historyLimit,
+    try {
+      await core.channel.reply.dispatchReplyFromConfig({
+        ctx: ctxPayload,
+        cfg,
+        dispatcher,
+        replyOptions: {
+          ...replyOptions,
+          disableBlockStreaming:
+            typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
+          onPartialReply: async (payload) => {
+            await replyOptions.onPartialReply?.(payload);
+            queueStreamPreviewUpdate(payload.text);
+          },
+          onReasoningStream: async (payload) => {
+            await replyOptions.onReasoningStream?.(payload);
+            queueStreamPreviewUpdate(payload.text);
+          },
+          onToolStart: async (payload) => {
+            await replyOptions.onToolStart?.(payload);
+            queueStreamPreviewUpdate(buildMattermostToolStatusText(payload));
+          },
+          onModelSelected,
+        },
       });
+    } finally {
+      await flushStreamPreview();
+      markDispatchIdle();
+      if (historyKey) {
+        recordPendingHistoryEntryIfEnabled({
+          historyMap: channelHistories,
+          historyKey,
+          limit: historyLimit,
+          entry: currentHistoryEntry,
+        });
+      }
     }
   };
 

--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -1,0 +1,152 @@
+import type { OpenClawConfig, PluginRuntime } from "openclaw/plugin-sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setMattermostRuntime } from "../runtime.js";
+import { sendMessageMattermost } from "./send.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+let currentConfig: OpenClawConfig = {};
+const recordActivity = vi.fn();
+
+const runtimeStub = {
+  config: {
+    loadConfig: () => currentConfig,
+  },
+  logging: {
+    getChildLogger: () => ({
+      debug: vi.fn(),
+    }),
+    shouldLogVerbose: () => false,
+  },
+  media: {
+    loadWebMedia: vi.fn(),
+  },
+  channel: {
+    text: {
+      resolveMarkdownTableMode: () => "off",
+      convertMarkdownTables: (text: string) => text,
+    },
+    activity: {
+      record: recordActivity,
+    },
+  },
+} as unknown as PluginRuntime;
+
+describe("sendMessageMattermost target resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMattermostRuntime(runtimeStub);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves channel:<name> via team channel lookup before posting", async () => {
+    currentConfig = {
+      channels: {
+        mattermost: {
+          enabled: true,
+          botToken: "token-name-lookup",
+          baseUrl: "https://chat.example.com",
+        },
+      },
+    };
+
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/v4/users/me/teams") {
+        return jsonResponse([{ id: "team-1" }]);
+      }
+      if (url.pathname === "/api/v4/teams/team-1/channels/name/private-notes") {
+        return jsonResponse({ id: "uzuybrkzk3y3fjr9ufgcdumtzy", name: "private-notes" });
+      }
+      if (url.pathname === "/api/v4/posts") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          channel_id?: string;
+          message?: string;
+        };
+        expect(body.channel_id).toBe("uzuybrkzk3y3fjr9ufgcdumtzy");
+        expect(body.message).toBe("hello from test");
+        return jsonResponse({ id: "post-1", channel_id: body.channel_id });
+      }
+      throw new Error(`Unexpected fetch URL: ${url.pathname}`);
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const result = await sendMessageMattermost("channel:private-notes", "hello from test");
+    expect(result).toEqual({
+      messageId: "post-1",
+      channelId: "uzuybrkzk3y3fjr9ufgcdumtzy",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps id-like channel targets as direct ids", async () => {
+    currentConfig = {
+      channels: {
+        mattermost: {
+          enabled: true,
+          botToken: "token-id-direct",
+          baseUrl: "https://chat.example.com",
+        },
+      },
+    };
+
+    const targetId = "jr5g74ppopgwpkymb45u57myxe";
+    const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/v4/posts") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { channel_id?: string };
+        expect(body.channel_id).toBe(targetId);
+        return jsonResponse({ id: "post-2", channel_id: targetId });
+      }
+      throw new Error(`Unexpected fetch URL: ${url.pathname}`);
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const result = await sendMessageMattermost(targetId, "id route");
+    expect(result.channelId).toBe(targetId);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a clear error when channel name cannot be resolved", async () => {
+    currentConfig = {
+      channels: {
+        mattermost: {
+          enabled: true,
+          botToken: "token-missing-name",
+          baseUrl: "https://chat.example.com",
+        },
+      },
+    };
+
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = new URL(String(input));
+      if (url.pathname === "/api/v4/users/me/teams") {
+        return jsonResponse([{ id: "team-1" }]);
+      }
+      if (url.pathname === "/api/v4/teams/team-1/channels/name/not-found") {
+        return jsonResponse(
+          {
+            id: "app.channel.get_by_name.missing.app_error",
+            message: "Channel does not exist.",
+            status_code: 404,
+          },
+          404,
+        );
+      }
+      throw new Error(`Unexpected fetch URL: ${url.pathname}`);
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    await expect(sendMessageMattermost("not-found", "hello")).rejects.toThrow(
+      'Mattermost channel "not-found" was not found for this bot account.',
+    );
+  });
+});

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -4,7 +4,9 @@ import {
   createMattermostClient,
   createMattermostDirectChannel,
   createMattermostPost,
+  fetchMattermostChannelByTeamAndName,
   fetchMattermostMe,
+  fetchMattermostTeams,
   fetchMattermostUserByUsername,
   normalizeMattermostBaseUrl,
   uploadMattermostFile,
@@ -30,6 +32,8 @@ type MattermostTarget =
 
 const botUserCache = new Map<string, MattermostUser>();
 const userByNameCache = new Map<string, MattermostUser>();
+const teamsCache = new Map<string, string[]>();
+const channelByNameCache = new Map<string, string>();
 
 const getCore = () => getMattermostRuntime();
 
@@ -45,6 +49,22 @@ function normalizeMessage(text: string, mediaUrl?: string): string {
 
 function isHttpUrl(value: string): boolean {
   return /^https?:\/\//i.test(value);
+}
+
+function looksLikeMattermostChannelId(value: string): boolean {
+  return /^[a-z0-9]{26}$/i.test(value.trim());
+}
+
+function isMattermostNotFoundError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const message = err.message.toLowerCase();
+  return message.includes(" 404 ") || message.includes('status_code":404');
+}
+
+function channelNameCacheKey(baseUrl: string, token: string, channelName: string): string {
+  return `${cacheKey(baseUrl, token)}::${channelName.toLowerCase()}`;
 }
 
 function parseMattermostTarget(raw: string): MattermostTarget {
@@ -113,13 +133,91 @@ async function resolveUserIdByUsername(params: {
   return user.id;
 }
 
+async function resolveTeamIds(params: { baseUrl: string; token: string }): Promise<string[]> {
+  const key = cacheKey(params.baseUrl, params.token);
+  const cached = teamsCache.get(key);
+  if (cached && cached.length > 0) {
+    return cached;
+  }
+  const client = createMattermostClient({
+    baseUrl: params.baseUrl,
+    botToken: params.token,
+  });
+  const teams = await fetchMattermostTeams(client);
+  const teamIds = teams.map((team) => team.id?.trim()).filter((id): id is string => Boolean(id));
+  if (teamIds.length > 0) {
+    teamsCache.set(key, teamIds);
+  }
+  return teamIds;
+}
+
+async function resolveChannelIdByName(params: {
+  baseUrl: string;
+  token: string;
+  channelName: string;
+}): Promise<string> {
+  const channelName = params.channelName.trim();
+  const cached = channelByNameCache.get(
+    channelNameCacheKey(params.baseUrl, params.token, channelName),
+  );
+  if (cached) {
+    return cached;
+  }
+
+  const teamIds = await resolveTeamIds({
+    baseUrl: params.baseUrl,
+    token: params.token,
+  });
+  if (teamIds.length === 0) {
+    throw new Error("Mattermost channel lookup failed: bot is not a member of any teams.");
+  }
+
+  const client = createMattermostClient({
+    baseUrl: params.baseUrl,
+    botToken: params.token,
+  });
+
+  for (const teamId of teamIds) {
+    try {
+      const channel = await fetchMattermostChannelByTeamAndName(client, {
+        teamId,
+        channelName,
+      });
+      if (channel.id) {
+        channelByNameCache.set(
+          channelNameCacheKey(params.baseUrl, params.token, channelName),
+          channel.id,
+        );
+        return channel.id;
+      }
+    } catch (err) {
+      if (isMattermostNotFoundError(err)) {
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  throw new Error(
+    `Mattermost channel "${channelName}" was not found for this bot account. Use channel:<id> for explicit routing.`,
+  );
+}
+
 async function resolveTargetChannelId(params: {
   target: MattermostTarget;
   baseUrl: string;
   token: string;
 }): Promise<string> {
   if (params.target.kind === "channel") {
-    return params.target.id;
+    const rawTarget = params.target.id.trim();
+    if (looksLikeMattermostChannelId(rawTarget)) {
+      return rawTarget;
+    }
+    return await resolveChannelIdByName({
+      baseUrl: params.baseUrl,
+      token: params.token,
+      channelName: rawTarget,
+    });
   }
   const userId = params.target.id
     ? params.target.id


### PR DESCRIPTION
## Summary
Fix Mattermost outbound target routing so non-ID channel targets resolve by channel name before posting.

## Root Cause
Outbound sends for heartbeat/cron/recovery use `sendMessageMattermost`.
That path parsed bare targets as `channel` and treated the value as a channel ID.
So `channel:private-notes` (or bare `private-notes`) was passed to `/posts` as `channel_id=private-notes`, which fails.

## Changes
- add Mattermost client helpers:
  - `fetchMattermostTeams()`
  - `fetchMattermostChannelByTeamAndName(teamId, channelName)`
- update outbound send target resolution:
  - keep direct route for ID-like targets (`^[a-z0-9]{26}$`)
  - otherwise resolve channel name across teams visible to the bot
  - cache team IDs + channel-name lookups
  - return explicit error when name cannot be resolved
- update docs to describe ID-vs-name behavior and recommend `channel:<id>` for unambiguous routing
- add tests for:
  - channel-name resolution path
  - direct ID path
  - not-found error path

## Why this is generic
This does not assume local topology or specific team/channel IDs. It uses standard Mattermost APIs with bot-visible teams, so it works for any deployment where the bot can access the target channel.

## Testing
- `pnpm vitest run extensions/mattermost/src/mattermost/client.test.ts extensions/mattermost/src/channel.test.ts extensions/mattermost/src/mattermost/send.test.ts`
