### PR TITLE
fix(infra,security): add defensive guards for JSON.parse and parseInt

### DIFF
--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -127,8 +127,18 @@ export async function ackDelivery(id: string, stateDir?: string): Promise<void> 
 /** Update a queue entry after a failed delivery attempt. */
 export async function failDelivery(id: string, error: string, stateDir?: string): Promise<void> {
   const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
-  const raw = await fs.promises.readFile(filePath, "utf-8");
-  const entry: QueuedDelivery = JSON.parse(raw);
+  let raw: string;
+  try {
+    raw = await fs.promises.readFile(filePath, "utf-8");
+  } catch {
+    return;
+  }
+  let entry: QueuedDelivery;
+  try {
+    entry = JSON.parse(raw);
+  } catch {
+    return;
+  }
   entry.retryCount += 1;
   entry.lastAttemptAt = Date.now();
   entry.lastError = error;

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -135,6 +135,19 @@ describe("delivery-queue", () => {
       expect(entry.lastAttemptAt).toBeGreaterThan(0);
       expect(entry.lastError).toBe("connection refused");
     });
+
+    it("does not crash when queue file contains corrupted JSON", async () => {
+      const queueDir = path.join(tmpDir, "delivery-queue");
+      fs.mkdirSync(queueDir, { recursive: true });
+      const id = "corrupted-entry";
+      fs.writeFileSync(path.join(queueDir, `${id}.json`), "NOT-VALID-JSON{{{", "utf-8");
+
+      await expect(failDelivery(id, "retry", tmpDir)).resolves.toBeUndefined();
+    });
+
+    it("does not crash when queue file is missing", async () => {
+      await expect(failDelivery("nonexistent-id", "retry", tmpDir)).resolves.toBeUndefined();
+    });
   });
 
   describe("moveToFailed", () => {

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -85,9 +85,12 @@ async function readPluginManifestExtensions(pluginPath: string): Promise<string[
     return [];
   }
 
-  const parsed = JSON.parse(raw) as Partial<
-    Record<typeof MANIFEST_KEY, { extensions?: unknown }>
-  > | null;
+  let parsed: Partial<Record<typeof MANIFEST_KEY, { extensions?: unknown }>> | null;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
   const extensions = parsed?.[MANIFEST_KEY]?.extensions;
   if (!Array.isArray(extensions)) {
     return [];

--- a/src/security/skill-scanner.test.ts
+++ b/src/security/skill-scanner.test.ts
@@ -143,6 +143,16 @@ const ws = new WebSocket("ws://remote.host:9999");
     );
   });
 
+  it("does not flag WebSocket to standard ports", () => {
+    const source = `
+const ws1 = new WebSocket("ws://example.com:443");
+const ws2 = new WebSocket("ws://example.com:80");
+const ws3 = new WebSocket("ws://example.com:8080");
+`;
+    const findings = scanSource(source, "plugin.ts");
+    expect(findings.some((f) => f.ruleId === "suspicious-network")).toBe(false);
+  });
+
   it("detects process.env access combined with network send (env harvesting)", () => {
     const source = `
 const secrets = JSON.stringify(process.env);

--- a/src/security/skill-scanner.ts
+++ b/src/security/skill-scanner.ts
@@ -241,7 +241,7 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
       // Special handling for suspicious-network: check port
       if (rule.ruleId === "suspicious-network") {
         const port = parseInt(match[1], 10);
-        if (STANDARD_PORTS.has(port)) {
+        if (Number.isNaN(port) || STANDARD_PORTS.has(port)) {
           continue;
         }
       }


### PR DESCRIPTION
## Summary

Three defensive-programming fixes that prevent crashes from corrupted data in edge-case scenarios:

1. **`src/infra/outbound/delivery-queue.ts`** — `failDelivery()` calls `JSON.parse` on the queue file without a try-catch. A corrupted or truncated `.json` file (e.g., from a process crash during write) throws an unhandled error, crashing the retry pipeline and permanently blocking delivery for all queued entries.

2. **`src/security/skill-scanner.ts`** — The `suspicious-network` rule calls `parseInt(match[1], 10)` on the port capture group. If the capture is undefined (regex edge case), `parseInt` returns `NaN`, which passes through `STANDARD_PORTS.has(NaN)` as `false`, producing a false-positive security finding.

3. **`src/security/audit-extra.async.ts`** — `readPluginManifestExtensions()` calls `JSON.parse` on plugin `package.json` without a try-catch. A corrupted or hand-edited manifest file crashes the entire security audit flow.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [x] Gateway
- [x] Security

## Linked Issues

Proactive defensive fix — no single issue. Related patterns reported in #34979 (malformed content blocks crashing pipelines).

## User-Visible Changes

None. These are internal resilience improvements. The system now silently recovers from corrupted files instead of crashing.

## Security Impact

1. Does this change handle user input? **No**
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No** — only how corrupted data is handled
5. Does this change modify security-sensitive code paths? **Yes** — the skill scanner and audit flow are security-sensitive

## Verification

- [x] All 88 tests pass (28 skill-scanner + 60 outbound)
- [x] Formatted with `oxfmt`
- [x] New tests: corrupted JSON file, missing file, standard port no-flag

## Evidence

```
 ✓ src/security/skill-scanner.test.ts (28 tests) 19ms
 ✓ src/infra/outbound/outbound.test.ts (60 tests) 37ms
 Test Files  2 passed (2)
      Tests  88 passed (88)
```

## Human Verification

- Corrupt a `.json` file in `~/.openclaw/state/delivery-queue/` and send a message to trigger retry — no crash
- Place a corrupt `package.json` in an extensions plugin dir and run `openclaw doctor` — no crash
- Verify WebSocket to port 443 is not flagged as suspicious-network

## Compatibility

Fully backward compatible. No API or config changes.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| `failDelivery` silently ignoring corrupted entries | Entries will be retried on next cycle when the file is readable; if permanently corrupt, `loadPendingDeliveries` (which already has try-catch) will skip them |
| Masking audit errors | The audit flow already uses `catch(() => "")` for file reads; wrapping parse is consistent |