### PR TITLE
ci: retry setup-node in setup-node-env composite action

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -44,11 +44,26 @@ runs:
         done
         exit 1
 
-    - name: Setup Node.js
+    - name: Setup Node.js (attempt 1)
+      id: setup_node_first
+      continue-on-error: true
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ inputs.node-version }}
         check-latest: false
+
+    - name: Setup Node.js (retry on transient failure)
+      if: steps.setup_node_first.outcome == 'failure'
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        check-latest: false
+
+    - name: Verify Node.js availability
+      shell: bash
+      run: |
+        set -euo pipefail
+        node -v
 
     - name: Setup pnpm + cache store
       uses: ./.github/actions/setup-pnpm-store-cache


### PR DESCRIPTION
## Summary

Fix flaky CI failures caused by transient `actions/setup-node` download errors (HTTP 404) on some runners.

- make first setup-node attempt non-fatal (`continue-on-error: true`)
- retry setup-node once when first attempt fails
- add explicit `node -v` verification step so hard failures still fail fast

## Why

Recent runs failed before tests started in:

- `checks (bun, test, pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts)`

with:

- `Setup Node environment`
- `Error: Unexpected HTTP response: 404`

This hardens CI against transient setup-node/network/backend flakiness while preserving real failure behavior.

## Scope

No product/runtime behavior changes. CI workflow infrastructure only.