### PR TITLE
fix(workspace-docs): transaction session API, CLI registration, type fixes

### DIFF
--- a/src/agents/tracked-docs.test.ts
+++ b/src/agents/tracked-docs.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { runCommandWithTimeout } from "../process/exec.js";
 import {
   getDocAtCommit,
   getDocDiff,
@@ -10,7 +11,6 @@ import {
   TRACKED_DOC_FILENAMES,
   writeTrackedDoc,
 } from "./tracked-docs.js";
-import { runCommandWithTimeout } from "../process/exec.js";
 
 async function makeTempWorkspace(): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-tracked-docs-"));

--- a/src/agents/tracked-docs.test.ts
+++ b/src/agents/tracked-docs.test.ts
@@ -1,0 +1,284 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getDocAtCommit,
+  getDocDiff,
+  getDocHistory,
+  rollbackDoc,
+  TRACKED_DOC_FILENAMES,
+  writeTrackedDoc,
+} from "./tracked-docs.js";
+import { runCommandWithTimeout } from "../process/exec.js";
+
+async function makeTempWorkspace(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-tracked-docs-"));
+  await runCommandWithTimeout(["git", "init"], { cwd: dir, timeoutMs: 5_000 });
+  await runCommandWithTimeout(["git", "config", "user.email", "test@openclaw.local"], {
+    cwd: dir,
+    timeoutMs: 5_000,
+  });
+  await runCommandWithTimeout(["git", "config", "user.name", "Test"], {
+    cwd: dir,
+    timeoutMs: 5_000,
+  });
+  return dir;
+}
+
+async function removeTempWorkspace(dir: string): Promise<void> {
+  await fs.rm(dir, { recursive: true, force: true });
+}
+
+describe("TRACKED_DOC_FILENAMES", () => {
+  it("includes core workspace docs", () => {
+    expect(TRACKED_DOC_FILENAMES.has("AGENTS.md")).toBe(true);
+    expect(TRACKED_DOC_FILENAMES.has("SOUL.md")).toBe(true);
+    expect(TRACKED_DOC_FILENAMES.has("TOOLS.md")).toBe(true);
+    expect(TRACKED_DOC_FILENAMES.has("MEMORY.md")).toBe(true);
+    expect(TRACKED_DOC_FILENAMES.has("POLICY.md")).toBe(true);
+  });
+});
+
+describe("writeTrackedDoc", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await makeTempWorkspace();
+  });
+
+  afterEach(async () => {
+    await removeTempWorkspace(dir);
+  });
+
+  it("writes the file and commits to git", async () => {
+    const result = await writeTrackedDoc({
+      workspaceDir: dir,
+      filename: "AGENTS.md",
+      content: "# Hello",
+      sessionKey: "test-session-1",
+      agentLabel: "main",
+      reason: "initial setup",
+    });
+
+    expect(result.committed).toBe(true);
+    expect(result.sha).toMatch(/^[0-9a-f]{1,12}$/);
+    expect(result.warning).toBeUndefined();
+
+    const content = await fs.readFile(path.join(dir, "AGENTS.md"), "utf-8");
+    expect(content).toBe("# Hello");
+  });
+
+  it("returns committed=false when content is unchanged", async () => {
+    await writeTrackedDoc({
+      workspaceDir: dir,
+      filename: "AGENTS.md",
+      content: "# Hello",
+      sessionKey: "test-session-1",
+      reason: "first write",
+    });
+
+    const result = await writeTrackedDoc({
+      workspaceDir: dir,
+      filename: "AGENTS.md",
+      content: "# Hello",
+      sessionKey: "test-session-1",
+      reason: "no-op write",
+    });
+
+    expect(result.committed).toBe(false);
+  });
+
+  it("returns warning when no git repo", async () => {
+    const noGitDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-no-git-"));
+    try {
+      const result = await writeTrackedDoc({
+        workspaceDir: noGitDir,
+        filename: "AGENTS.md",
+        content: "# Hello",
+        sessionKey: "test-session-1",
+        reason: "test",
+      });
+
+      expect(result.committed).toBe(false);
+      expect(result.warning).toContain("Git repo not found");
+
+      // File should still be written even without git.
+      const content = await fs.readFile(path.join(noGitDir, "AGENTS.md"), "utf-8");
+      expect(content).toBe("# Hello");
+    } finally {
+      await removeTempWorkspace(noGitDir);
+    }
+  });
+});
+
+describe("getDocHistory", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await makeTempWorkspace();
+  });
+
+  afterEach(async () => {
+    await removeTempWorkspace(dir);
+  });
+
+  it("returns empty array for file with no commits", async () => {
+    const history = await getDocHistory({ workspaceDir: dir, filename: "AGENTS.md" });
+    expect(history).toEqual([]);
+  });
+
+  it("returns commits in reverse chronological order", async () => {
+    await writeTrackedDoc({
+      workspaceDir: dir,
+      filename: "AGENTS.md",
+      content: "# v1",
+      sessionKey: "s1",
+      reason: "first",
+    });
+
+    await writeTrackedDoc({
+      workspaceDir: dir,
+      filename: "AGENTS.md",
+      content: "# v2",
+      sessionKey: "s2",
+      reason: "second",
+    });
+
+    const history = await getDocHistory({ workspaceDir: dir, filename: "AGENTS.md" });
+    expect(history).toHaveLength(2);
+    expect(history[0]?.subject).toContain("second");
+    expect(history[1]?.subject).toContain("first");
+  });
+});
+
+describe("getDocAtCommit", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await makeTempWorkspace();
+  });
+
+  afterEach(async () => {
+    await removeTempWorkspace(dir);
+  });
+
+  it("returns file content at a historical commit", async () => {
+    const r1 = await writeTrackedDoc({
+      workspaceDir: dir,
+      filename: "AGENTS.md",
+      content: "# original",
+      sessionKey: "s1",
+      reason: "initial",
+    });
+
+    await writeTrackedDoc({
+      workspaceDir: dir,
+      filename: "AGENTS.md",
+      content: "# updated",
+      sessionKey: "s2",
+      reason: "update",
+    });
+
+    const atFirst = await getDocAtCommit({
+      workspaceDir: dir,
+      filename: "AGENTS.md",
+      sha: r1.sha!,
+    });
+
+    expect(atFirst).toBe("# original");
+  });
+
+  it("returns null for unknown sha", async () => {
+    const result = await getDocAtCommit({
+      workspaceDir: dir,
+      filename: "AGENTS.md",
+      sha: "deadbeef",
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe("rollbackDoc", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await makeTempWorkspace();
+  });
+
+  afterEach(async () => {
+    await removeTempWorkspace(dir);
+  });
+
+  it("restores file to prior content and commits rollback", async () => {
+    const r1 = await writeTrackedDoc({
+      workspaceDir: dir,
+      filename: "AGENTS.md",
+      content: "# v1",
+      sessionKey: "s1",
+      reason: "initial",
+    });
+
+    await writeTrackedDoc({
+      workspaceDir: dir,
+      filename: "AGENTS.md",
+      content: "# v2",
+      sessionKey: "s2",
+      reason: "update",
+    });
+
+    const rollback = await rollbackDoc({
+      workspaceDir: dir,
+      filename: "AGENTS.md",
+      sha: r1.sha!,
+      sessionKey: "s3",
+    });
+
+    expect(rollback.committed).toBe(true);
+
+    const current = await fs.readFile(path.join(dir, "AGENTS.md"), "utf-8");
+    expect(current).toBe("# v1");
+
+    const history = await getDocHistory({ workspaceDir: dir, filename: "AGENTS.md" });
+    expect(history[0]?.subject).toContain("rollback");
+  });
+});
+
+describe("getDocDiff", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await makeTempWorkspace();
+  });
+
+  afterEach(async () => {
+    await removeTempWorkspace(dir);
+  });
+
+  it("returns unified diff between two commits", async () => {
+    const r1 = await writeTrackedDoc({
+      workspaceDir: dir,
+      filename: "AGENTS.md",
+      content: "# v1\nline one\n",
+      sessionKey: "s1",
+      reason: "initial",
+    });
+
+    const r2 = await writeTrackedDoc({
+      workspaceDir: dir,
+      filename: "AGENTS.md",
+      content: "# v1\nline one\nline two\n",
+      sessionKey: "s2",
+      reason: "add line",
+    });
+
+    const diff = await getDocDiff({
+      workspaceDir: dir,
+      filename: "AGENTS.md",
+      fromSha: r1.sha!,
+      toSha: r2.sha,
+    });
+
+    expect(diff).toContain("+line two");
+  });
+});

--- a/src/agents/tracked-docs.test.ts
+++ b/src/agents/tracked-docs.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runCommandWithTimeout } from "../process/exec.js";
 import {
+  beginDocSession,
   getDocAtCommit,
   getDocDiff,
   getDocHistory,
@@ -280,5 +281,89 @@ describe("getDocDiff", () => {
     });
 
     expect(diff).toContain("+line two");
+  });
+});
+
+describe("beginDocSession", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await makeTempWorkspace();
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("batches multiple file writes into a single commit", async () => {
+    const session = await beginDocSession({
+      workspaceDir: dir,
+      sessionKey: "test-session-1",
+      agentLabel: "TestAgent",
+    });
+
+    // Simulate two separate file mutations (as an agent using sed/write/etc would do).
+    await fs.writeFile(path.join(dir, "AGENTS.md"), "# Agents v2\n", "utf-8");
+    await fs.writeFile(path.join(dir, "SOUL.md"), "# Soul v2\n", "utf-8");
+
+    const result = await session.commit("updated agents and soul docs");
+
+    expect(result.committed).toBe(true);
+    expect(result.sha).toBeDefined();
+
+    // History for each file should show only 1 commit from this session.
+    const agentsHistory = await getDocHistory({ workspaceDir: dir, filename: "AGENTS.md" });
+    const soulHistory = await getDocHistory({ workspaceDir: dir, filename: "SOUL.md" });
+
+    expect(agentsHistory).toHaveLength(1);
+    expect(soulHistory).toHaveLength(1);
+    // Both should share the same commit SHA (batched).
+    expect(agentsHistory[0]!.sha).toBe(soulHistory[0]!.sha);
+    expect(agentsHistory[0]!.subject).toContain("updated agents and soul docs");
+    expect(agentsHistory[0]!.body).toContain("Session: test-session-1");
+    expect(agentsHistory[0]!.body).toContain("Agent: TestAgent");
+  });
+
+  it("discard() makes no commit", async () => {
+    const session = await beginDocSession({
+      workspaceDir: dir,
+      sessionKey: "test-session-2",
+    });
+
+    await fs.writeFile(path.join(dir, "AGENTS.md"), "# Changed but not committed\n", "utf-8");
+
+    session.discard();
+
+    const history = await getDocHistory({ workspaceDir: dir, filename: "AGENTS.md" });
+    expect(history).toHaveLength(0);
+  });
+
+  it("returns committed=false when no tracked docs changed", async () => {
+    const session = await beginDocSession({
+      workspaceDir: dir,
+      sessionKey: "test-session-3",
+    });
+
+    // Write a non-tracked file.
+    await fs.writeFile(path.join(dir, "untracked.txt"), "ignored\n", "utf-8");
+
+    const result = await session.commit("should not commit");
+    expect(result.committed).toBe(false);
+  });
+
+  it("returns warning when no git repo", async () => {
+    const noGitDir = await fs.mkdtemp(path.join(os.tmpdir(), "tracked-docs-nogit-"));
+    try {
+      const session = await beginDocSession({
+        workspaceDir: noGitDir,
+        sessionKey: "test-session-4",
+      });
+      await fs.writeFile(path.join(noGitDir, "AGENTS.md"), "content\n", "utf-8");
+      const result = await session.commit("no git");
+      expect(result.committed).toBe(false);
+      expect(result.warning).toContain("Git repo not found");
+    } finally {
+      await fs.rm(noGitDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/agents/tracked-docs.ts
+++ b/src/agents/tracked-docs.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { WorkspaceBootstrapFileName } from "./workspace.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { resolveUserPath } from "../utils.js";
-import type { WorkspaceBootstrapFileName } from "./workspace.js";
 import {
   DEFAULT_AGENTS_FILENAME,
   DEFAULT_SOUL_FILENAME,
@@ -141,7 +141,13 @@ export async function getDocHistory(params: {
   const limit = params.limit ?? 20;
 
   const result = await gitCommand(
-    ["log", `--max-count=${limit}`, "--format=%H%x00%ai%x00%an%x00%s%x00%b%x00---COMMIT---", "--", params.filename],
+    [
+      "log",
+      `--max-count=${limit}`,
+      "--format=%H%x00%ai%x00%an%x00%s%x00%b%x00---COMMIT---",
+      "--",
+      params.filename,
+    ],
     resolvedDir,
   );
 
@@ -175,10 +181,7 @@ export async function getDocAtCommit(params: {
   sha: string;
 }): Promise<string | null> {
   const resolvedDir = resolveUserPath(params.workspaceDir);
-  const result = await gitCommand(
-    ["show", `${params.sha}:${params.filename}`],
-    resolvedDir,
-  );
+  const result = await gitCommand(["show", `${params.sha}:${params.filename}`], resolvedDir);
   if (result.code !== 0) {
     return null;
   }
@@ -221,7 +224,10 @@ export async function rollbackDoc(params: {
   });
 
   if (content === null) {
-    return { committed: false, warning: `Could not find ${params.filename} at commit ${params.sha}` };
+    return {
+      committed: false,
+      warning: `Could not find ${params.filename} at commit ${params.sha}`,
+    };
   }
 
   return writeTrackedDoc({

--- a/src/agents/tracked-docs.ts
+++ b/src/agents/tracked-docs.ts
@@ -1,0 +1,235 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { runCommandWithTimeout } from "../process/exec.js";
+import { resolveUserPath } from "../utils.js";
+import type { WorkspaceBootstrapFileName } from "./workspace.js";
+import {
+  DEFAULT_AGENTS_FILENAME,
+  DEFAULT_SOUL_FILENAME,
+  DEFAULT_TOOLS_FILENAME,
+  DEFAULT_IDENTITY_FILENAME,
+  DEFAULT_USER_FILENAME,
+  DEFAULT_MEMORY_FILENAME,
+  DEFAULT_MEMORY_ALT_FILENAME,
+} from "./workspace.js";
+
+/**
+ * Filenames that are considered "core workspace documents" and should be change-tracked.
+ */
+export const TRACKED_DOC_FILENAMES: ReadonlySet<string> = new Set<WorkspaceBootstrapFileName>([
+  DEFAULT_AGENTS_FILENAME,
+  DEFAULT_SOUL_FILENAME,
+  DEFAULT_TOOLS_FILENAME,
+  DEFAULT_IDENTITY_FILENAME,
+  DEFAULT_USER_FILENAME,
+  DEFAULT_MEMORY_FILENAME,
+  DEFAULT_MEMORY_ALT_FILENAME,
+  "POLICY.md",
+]);
+
+export type WriteTrackedDocResult = {
+  /** Whether a git commit was made. False if git unavailable or no changes. */
+  committed: boolean;
+  /** The new commit SHA, if committed. */
+  sha?: string;
+  /** Warning message if git tracking was unavailable. */
+  warning?: string;
+};
+
+export type DocCommit = {
+  sha: string;
+  date: string;
+  author: string;
+  subject: string;
+  body?: string;
+};
+
+async function gitCommand(
+  args: string[],
+  cwd: string,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  try {
+    return await runCommandWithTimeout(["git", ...args], { cwd, timeoutMs: 10_000 });
+  } catch {
+    return { code: 1, stdout: "", stderr: "git command failed" };
+  }
+}
+
+async function hasGitRepo(dir: string): Promise<boolean> {
+  try {
+    const result = await gitCommand(["rev-parse", "--git-dir"], dir);
+    return result.code === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Write a core workspace document and record the change as a git commit.
+ *
+ * Falls back to plain write if git is unavailable.
+ */
+export async function writeTrackedDoc(params: {
+  workspaceDir: string;
+  filename: string;
+  content: string;
+  sessionKey: string;
+  agentLabel?: string;
+  reason: string;
+}): Promise<WriteTrackedDocResult> {
+  const resolvedDir = resolveUserPath(params.workspaceDir);
+  const filePath = path.join(resolvedDir, params.filename);
+
+  // Always write the file first.
+  await fs.writeFile(filePath, params.content, "utf-8");
+
+  if (!(await hasGitRepo(resolvedDir))) {
+    return {
+      committed: false,
+      warning: `Git repo not found in ${resolvedDir}; change not tracked.`,
+    };
+  }
+
+  // Stage the file.
+  const addResult = await gitCommand(["add", params.filename], resolvedDir);
+  if (addResult.code !== 0) {
+    return { committed: false, warning: `git add failed: ${addResult.stderr}` };
+  }
+
+  // Check if there's actually anything to commit.
+  const diffResult = await gitCommand(["diff", "--cached", "--quiet"], resolvedDir);
+  if (diffResult.code === 0) {
+    // Nothing staged — content was identical.
+    return { committed: false };
+  }
+
+  // Build commit message.
+  const subject = `docs(${params.filename}): ${params.reason}`;
+  const body = [
+    `Session: ${params.sessionKey}`,
+    params.agentLabel ? `Agent: ${params.agentLabel}` : null,
+    `Filename: ${params.filename}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const commitResult = await gitCommand(
+    ["commit", "-m", subject, "-m", body, "--author", "OpenClaw Agent <agent@openclaw.local>"],
+    resolvedDir,
+  );
+
+  if (commitResult.code !== 0) {
+    return { committed: false, warning: `git commit failed: ${commitResult.stderr}` };
+  }
+
+  // Retrieve the new commit SHA.
+  const shaResult = await gitCommand(["rev-parse", "HEAD"], resolvedDir);
+  const sha = shaResult.stdout.trim().slice(0, 12) || undefined;
+
+  return { committed: true, sha };
+}
+
+/**
+ * List git commits that touched a specific workspace document.
+ */
+export async function getDocHistory(params: {
+  workspaceDir: string;
+  filename: string;
+  limit?: number;
+}): Promise<DocCommit[]> {
+  const resolvedDir = resolveUserPath(params.workspaceDir);
+  const limit = params.limit ?? 20;
+
+  const result = await gitCommand(
+    ["log", `--max-count=${limit}`, "--format=%H%x00%ai%x00%an%x00%s%x00%b%x00---COMMIT---", "--", params.filename],
+    resolvedDir,
+  );
+
+  if (result.code !== 0 || !result.stdout.trim()) {
+    return [];
+  }
+
+  return result.stdout
+    .split("---COMMIT---")
+    .map((chunk) => chunk.trim())
+    .filter(Boolean)
+    .map((chunk) => {
+      const [sha, date, author, subject, body] = chunk.split("\x00");
+      return {
+        sha: (sha ?? "").slice(0, 12),
+        date: (date ?? "").trim(),
+        author: (author ?? "").trim(),
+        subject: (subject ?? "").trim(),
+        body: (body ?? "").trim() || undefined,
+      };
+    })
+    .filter((c) => c.sha);
+}
+
+/**
+ * Get the content of a workspace document at a specific commit.
+ */
+export async function getDocAtCommit(params: {
+  workspaceDir: string;
+  filename: string;
+  sha: string;
+}): Promise<string | null> {
+  const resolvedDir = resolveUserPath(params.workspaceDir);
+  const result = await gitCommand(
+    ["show", `${params.sha}:${params.filename}`],
+    resolvedDir,
+  );
+  if (result.code !== 0) {
+    return null;
+  }
+  return result.stdout;
+}
+
+/**
+ * Get a unified diff for a workspace document between two commits (or HEAD vs a commit).
+ */
+export async function getDocDiff(params: {
+  workspaceDir: string;
+  filename: string;
+  fromSha: string;
+  toSha?: string; // defaults to working tree
+}): Promise<string> {
+  const resolvedDir = resolveUserPath(params.workspaceDir);
+  const to = params.toSha ?? "";
+  const args = to
+    ? ["diff", params.fromSha, to, "--", params.filename]
+    : ["diff", params.fromSha, "--", params.filename];
+
+  const result = await gitCommand(args, resolvedDir);
+  return result.stdout;
+}
+
+/**
+ * Roll back a workspace document to a specific commit, recording the rollback as a new commit.
+ */
+export async function rollbackDoc(params: {
+  workspaceDir: string;
+  filename: string;
+  sha: string;
+  sessionKey: string;
+  agentLabel?: string;
+}): Promise<WriteTrackedDocResult> {
+  const content = await getDocAtCommit({
+    workspaceDir: params.workspaceDir,
+    filename: params.filename,
+    sha: params.sha,
+  });
+
+  if (content === null) {
+    return { committed: false, warning: `Could not find ${params.filename} at commit ${params.sha}` };
+  }
+
+  return writeTrackedDoc({
+    workspaceDir: params.workspaceDir,
+    filename: params.filename,
+    content,
+    sessionKey: params.sessionKey,
+    agentLabel: params.agentLabel,
+    reason: `rollback to ${params.sha}`,
+  });
+}

--- a/src/agents/tracked-docs.ts
+++ b/src/agents/tracked-docs.ts
@@ -13,10 +13,15 @@ import {
   DEFAULT_MEMORY_ALT_FILENAME,
 } from "./workspace.js";
 
+// POLICY.md is not exported from workspace.ts — use a local constant.
+const DEFAULT_POLICY_FILENAME = "POLICY.md";
+
 /**
  * Filenames that are considered "core workspace documents" and should be change-tracked.
  */
-export const TRACKED_DOC_FILENAMES: ReadonlySet<string> = new Set<WorkspaceBootstrapFileName>([
+export const TRACKED_DOC_FILENAMES: ReadonlySet<string> = new Set<
+  WorkspaceBootstrapFileName | typeof DEFAULT_POLICY_FILENAME
+>([
   DEFAULT_AGENTS_FILENAME,
   DEFAULT_SOUL_FILENAME,
   DEFAULT_TOOLS_FILENAME,
@@ -24,7 +29,7 @@ export const TRACKED_DOC_FILENAMES: ReadonlySet<string> = new Set<WorkspaceBoots
   DEFAULT_USER_FILENAME,
   DEFAULT_MEMORY_FILENAME,
   DEFAULT_MEMORY_ALT_FILENAME,
-  "POLICY.md",
+  DEFAULT_POLICY_FILENAME,
 ]);
 
 export type WriteTrackedDocResult = {
@@ -44,12 +49,37 @@ export type DocCommit = {
   body?: string;
 };
 
-async function gitCommand(
-  args: string[],
-  cwd: string,
-): Promise<{ code: number; stdout: string; stderr: string }> {
+export type DocSessionParams = {
+  workspaceDir: string;
+  sessionKey: string;
+  agentLabel?: string;
+};
+
+/**
+ * A tracking session.
+ *
+ * Allows agents to make any number of mutations to workspace documents
+ * (raw writes, sed/awk, patch, etc.) and then commit them all at once
+ * with a single provenance record.
+ *
+ * Usage:
+ *   const session = await beginDocSession(workspaceDir, { sessionKey, agentLabel });
+ *   // ... make changes however you want ...
+ *   await session.commit('Added disk hygiene rule');
+ */
+export type DocSession = {
+  /** Commit all currently-dirty tracked docs under a single message. */
+  commit(reason: string): Promise<WriteTrackedDocResult>;
+  /** Discard the session — leaves files as-is, makes no commit. */
+  discard(): void;
+};
+
+type GitResult = { code: number; stdout: string; stderr: string };
+
+async function gitCommand(args: string[], cwd: string): Promise<GitResult> {
   try {
-    return await runCommandWithTimeout(["git", ...args], { cwd, timeoutMs: 10_000 });
+    const r = await runCommandWithTimeout(["git", ...args], { cwd, timeoutMs: 10_000 });
+    return { code: r.code ?? 1, stdout: r.stdout, stderr: r.stderr };
   } catch {
     return { code: 1, stdout: "", stderr: "git command failed" };
   }
@@ -65,7 +95,74 @@ async function hasGitRepo(dir: string): Promise<boolean> {
 }
 
 /**
+ * Begin a tracked-doc session.
+ *
+ * The session batches all file mutations made between `beginDocSession()` and
+ * `session.commit()` into a single git commit, regardless of how those mutations
+ * were made (write, sed, patch, etc.). This avoids noisy per-write commits.
+ *
+ * Falls back gracefully if git is unavailable.
+ */
+export async function beginDocSession(params: DocSessionParams): Promise<DocSession> {
+  const resolvedDir = resolveUserPath(params.workspaceDir);
+  const gitAvailable = await hasGitRepo(resolvedDir);
+
+  const buildBody = (): string =>
+    [`Session: ${params.sessionKey}`, params.agentLabel ? `Agent: ${params.agentLabel}` : null]
+      .filter(Boolean)
+      .join("\n");
+
+  async function commit(reason: string): Promise<WriteTrackedDocResult> {
+    if (!gitAvailable) {
+      return {
+        committed: false,
+        warning: `Git repo not found in ${resolvedDir}; changes not tracked.`,
+      };
+    }
+
+    // Stage only tracked doc filenames that are present and modified.
+    const trackedFiles = [...TRACKED_DOC_FILENAMES];
+    for (const filename of trackedFiles) {
+      // `git add` on a missing file is a no-op — safe to call unconditionally.
+      await gitCommand(["add", filename], resolvedDir);
+    }
+
+    // Nothing staged → content unchanged.
+    const diffResult = await gitCommand(["diff", "--cached", "--quiet"], resolvedDir);
+    if (diffResult.code === 0) {
+      return { committed: false };
+    }
+
+    const subject = `docs: ${reason}`;
+    const body = buildBody();
+
+    const commitResult = await gitCommand(
+      ["commit", "-m", subject, "-m", body, "--author", "OpenClaw Agent <agent@openclaw.local>"],
+      resolvedDir,
+    );
+
+    if (commitResult.code !== 0) {
+      return { committed: false, warning: `git commit failed: ${commitResult.stderr}` };
+    }
+
+    const shaResult = await gitCommand(["rev-parse", "HEAD"], resolvedDir);
+    const sha = shaResult.stdout.trim().slice(0, 12) || undefined;
+
+    return { committed: true, sha };
+  }
+
+  function discard(): void {
+    // No-op: files stay as-is, nothing committed.
+  }
+
+  return { commit, discard };
+}
+
+/**
  * Write a core workspace document and record the change as a git commit.
+ *
+ * Convenience wrapper over `beginDocSession` for single-file, single-write mutations.
+ * For multi-step or targeted edits (sed/awk/patch), use `beginDocSession` directly.
  *
  * Falls back to plain write if git is unavailable.
  */
@@ -80,53 +177,16 @@ export async function writeTrackedDoc(params: {
   const resolvedDir = resolveUserPath(params.workspaceDir);
   const filePath = path.join(resolvedDir, params.filename);
 
-  // Always write the file first.
+  // Write the file first, then commit via a session.
   await fs.writeFile(filePath, params.content, "utf-8");
 
-  if (!(await hasGitRepo(resolvedDir))) {
-    return {
-      committed: false,
-      warning: `Git repo not found in ${resolvedDir}; change not tracked.`,
-    };
-  }
+  const session = await beginDocSession({
+    workspaceDir: params.workspaceDir,
+    sessionKey: params.sessionKey,
+    agentLabel: params.agentLabel,
+  });
 
-  // Stage the file.
-  const addResult = await gitCommand(["add", params.filename], resolvedDir);
-  if (addResult.code !== 0) {
-    return { committed: false, warning: `git add failed: ${addResult.stderr}` };
-  }
-
-  // Check if there's actually anything to commit.
-  const diffResult = await gitCommand(["diff", "--cached", "--quiet"], resolvedDir);
-  if (diffResult.code === 0) {
-    // Nothing staged — content was identical.
-    return { committed: false };
-  }
-
-  // Build commit message.
-  const subject = `docs(${params.filename}): ${params.reason}`;
-  const body = [
-    `Session: ${params.sessionKey}`,
-    params.agentLabel ? `Agent: ${params.agentLabel}` : null,
-    `Filename: ${params.filename}`,
-  ]
-    .filter(Boolean)
-    .join("\n");
-
-  const commitResult = await gitCommand(
-    ["commit", "-m", subject, "-m", body, "--author", "OpenClaw Agent <agent@openclaw.local>"],
-    resolvedDir,
-  );
-
-  if (commitResult.code !== 0) {
-    return { committed: false, warning: `git commit failed: ${commitResult.stderr}` };
-  }
-
-  // Retrieve the new commit SHA.
-  const shaResult = await gitCommand(["rev-parse", "HEAD"], resolvedDir);
-  const sha = shaResult.stdout.trim().slice(0, 12) || undefined;
-
-  return { committed: true, sha };
+  return session.commit(`${params.filename}: ${params.reason}`);
 }
 
 /**

--- a/src/agents/tracked-docs.ts
+++ b/src/agents/tracked-docs.ts
@@ -63,7 +63,7 @@ export type DocSessionParams = {
  * with a single provenance record.
  *
  * Usage:
- *   const session = await beginDocSession(workspaceDir, { sessionKey, agentLabel });
+ *   const session = await beginDocSession({ workspaceDir, sessionKey, agentLabel });
  *   // ... make changes however you want ...
  *   await session.commit('Added disk hygiene rule');
  */
@@ -106,6 +106,7 @@ async function hasGitRepo(dir: string): Promise<boolean> {
 export async function beginDocSession(params: DocSessionParams): Promise<DocSession> {
   const resolvedDir = resolveUserPath(params.workspaceDir);
   const gitAvailable = await hasGitRepo(resolvedDir);
+  let _discarded = false;
 
   const buildBody = (): string =>
     [`Session: ${params.sessionKey}`, params.agentLabel ? `Agent: ${params.agentLabel}` : null]
@@ -113,6 +114,9 @@ export async function beginDocSession(params: DocSessionParams): Promise<DocSess
       .join("\n");
 
   async function commit(reason: string): Promise<WriteTrackedDocResult> {
+    if (_discarded) {
+      return { committed: false };
+    }
     if (!gitAvailable) {
       return {
         committed: false,
@@ -120,10 +124,10 @@ export async function beginDocSession(params: DocSessionParams): Promise<DocSess
       };
     }
 
-    // Stage only tracked doc filenames that are present and modified.
+    // Stage only tracked doc filenames. `git add` on a modified or deleted tracked file
+    // stages the change (including staged deletions). Untracked/absent files are ignored.
     const trackedFiles = [...TRACKED_DOC_FILENAMES];
     for (const filename of trackedFiles) {
-      // `git add` on a missing file is a no-op — safe to call unconditionally.
       await gitCommand(["add", filename], resolvedDir);
     }
 
@@ -152,7 +156,7 @@ export async function beginDocSession(params: DocSessionParams): Promise<DocSess
   }
 
   function discard(): void {
-    // No-op: files stay as-is, nothing committed.
+    _discarded = true;
   }
 
   return { commit, discard };

--- a/src/cli/docs-workspace-cli.ts
+++ b/src/cli/docs-workspace-cli.ts
@@ -7,12 +7,7 @@
  */
 
 import type { Command } from "commander";
-import {
-  getDocAtCommit,
-  getDocDiff,
-  getDocHistory,
-  rollbackDoc,
-} from "../agents/tracked-docs.js";
+import { getDocAtCommit, getDocDiff, getDocHistory, rollbackDoc } from "../agents/tracked-docs.js";
 import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
 import { colorize, isRich } from "../terminal/theme.js";
 
@@ -78,7 +73,9 @@ export function registerWorkspaceDocsCommands(program: Command): void {
       const workspaceDir = resolveWorkspaceDir(options);
       const diff = await getDocDiff({ workspaceDir, filename, fromSha: sha, toSha: options.to });
       if (!diff.trim()) {
-        console.log(`No differences found for ${filename} between ${sha} and ${options.to ?? "working tree"}.`);
+        console.log(
+          `No differences found for ${filename} between ${sha} and ${options.to ?? "working tree"}.`,
+        );
         return;
       }
       console.log(diff);
@@ -106,10 +103,7 @@ export function registerWorkspaceDocsCommands(program: Command): void {
     .option("-w, --workspace <dir>", "Workspace directory")
     .option("--reason <text>", "Reason for rollback (appended to commit message)")
     .action(
-      async (
-        filename: string,
-        options: { workspace?: string; to: string; reason?: string },
-      ) => {
+      async (filename: string, options: { workspace?: string; to: string; reason?: string }) => {
         const workspaceDir = resolveWorkspaceDir(options);
         const result = await rollbackDoc({
           workspaceDir,

--- a/src/cli/docs-workspace-cli.ts
+++ b/src/cli/docs-workspace-cli.ts
@@ -1,0 +1,135 @@
+/**
+ * CLI commands for managing tracked workspace documents.
+ * `openclaw workspace-docs history <file>`
+ * `openclaw workspace-docs diff <file> <sha>`
+ * `openclaw workspace-docs show <file> <sha>`
+ * `openclaw workspace-docs rollback <file> --to <sha>`
+ */
+
+import type { Command } from "commander";
+import {
+  getDocAtCommit,
+  getDocDiff,
+  getDocHistory,
+  rollbackDoc,
+} from "../agents/tracked-docs.js";
+import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
+import { colorize, isRich } from "../terminal/theme.js";
+
+function resolveWorkspaceDir(options: { workspace?: string }): string {
+  return options.workspace?.trim() || resolveDefaultAgentWorkspaceDir();
+}
+
+function printHeader(text: string): void {
+  if (isRich()) {
+    console.log(colorize("bold", text));
+  } else {
+    console.log(text);
+  }
+}
+
+export function registerWorkspaceDocsCommands(program: Command): void {
+  const docs = program
+    .command("workspace-docs")
+    .alias("wdocs")
+    .description("Manage tracked workspace document history (AGENTS.md, SOUL.md, etc.)");
+
+  docs
+    .command("history <filename>")
+    .description("List commits that changed a workspace document")
+    .option("-w, --workspace <dir>", "Workspace directory")
+    .option("-n, --limit <n>", "Max commits to show", "20")
+    .action(async (filename: string, options: { workspace?: string; limit?: string }) => {
+      const workspaceDir = resolveWorkspaceDir(options);
+      const limit = parseInt(options.limit ?? "20", 10);
+      const history = await getDocHistory({ workspaceDir, filename, limit });
+
+      if (history.length === 0) {
+        console.log(`No tracked history found for ${filename}.`);
+        console.log(
+          `Hint: use \`openclaw workspace-docs write\` or ensure workspace has a git repo.`,
+        );
+        return;
+      }
+
+      printHeader(`\n${filename} — ${history.length} commit(s)\n`);
+      for (const commit of history) {
+        const sha = commit.sha.slice(0, 8).padEnd(10);
+        const date = commit.date.slice(0, 16).padEnd(18);
+        const subject = commit.subject;
+        console.log(`  ${sha}  ${date}  ${subject}`);
+        if (commit.body) {
+          for (const line of commit.body.split("\n")) {
+            if (line.trim()) {
+              console.log(`              ${line}`);
+            }
+          }
+        }
+      }
+      console.log();
+    });
+
+  docs
+    .command("diff <filename> <sha>")
+    .description("Show diff for a workspace document between a commit and HEAD (or --to)")
+    .option("-w, --workspace <dir>", "Workspace directory")
+    .option("--to <sha>", "Target commit (default: working tree)")
+    .action(async (filename: string, sha: string, options: { workspace?: string; to?: string }) => {
+      const workspaceDir = resolveWorkspaceDir(options);
+      const diff = await getDocDiff({ workspaceDir, filename, fromSha: sha, toSha: options.to });
+      if (!diff.trim()) {
+        console.log(`No differences found for ${filename} between ${sha} and ${options.to ?? "working tree"}.`);
+        return;
+      }
+      console.log(diff);
+    });
+
+  docs
+    .command("show <filename> <sha>")
+    .description("Print the content of a workspace document at a specific commit")
+    .option("-w, --workspace <dir>", "Workspace directory")
+    .action(async (filename: string, sha: string, options: { workspace?: string }) => {
+      const workspaceDir = resolveWorkspaceDir(options);
+      const content = await getDocAtCommit({ workspaceDir, filename, sha });
+      if (content === null) {
+        console.error(`Could not find ${filename} at commit ${sha}.`);
+        process.exitCode = 1;
+        return;
+      }
+      process.stdout.write(content);
+    });
+
+  docs
+    .command("rollback <filename>")
+    .description("Roll back a workspace document to a prior commit (creates a new rollback commit)")
+    .requiredOption("--to <sha>", "Commit SHA to roll back to")
+    .option("-w, --workspace <dir>", "Workspace directory")
+    .option("--reason <text>", "Reason for rollback (appended to commit message)")
+    .action(
+      async (
+        filename: string,
+        options: { workspace?: string; to: string; reason?: string },
+      ) => {
+        const workspaceDir = resolveWorkspaceDir(options);
+        const result = await rollbackDoc({
+          workspaceDir,
+          filename,
+          sha: options.to,
+          sessionKey: "cli",
+          agentLabel: "openclaw-cli",
+        });
+
+        if (result.warning) {
+          console.error(`Warning: ${result.warning}`);
+        }
+
+        if (result.committed) {
+          console.log(
+            `✓ Rolled back ${filename} to ${options.to} (new commit: ${result.sha ?? "unknown"})`,
+          );
+        } else {
+          console.log(`Nothing to roll back — content at ${options.to} is already current.`);
+        }
+      },
+    );
+}

--- a/src/cli/docs-workspace-cli.ts
+++ b/src/cli/docs-workspace-cli.ts
@@ -9,18 +9,14 @@
 import type { Command } from "commander";
 import { getDocAtCommit, getDocDiff, getDocHistory, rollbackDoc } from "../agents/tracked-docs.js";
 import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
-import { colorize, isRich } from "../terminal/theme.js";
+import { isRich, theme } from "../terminal/theme.js";
 
 function resolveWorkspaceDir(options: { workspace?: string }): string {
   return options.workspace?.trim() || resolveDefaultAgentWorkspaceDir();
 }
 
 function printHeader(text: string): void {
-  if (isRich()) {
-    console.log(colorize("bold", text));
-  } else {
-    console.log(text);
-  }
+  console.log(isRich() ? theme.heading(text) : text);
 }
 
 export function registerWorkspaceDocsCommands(program: Command): void {
@@ -42,7 +38,7 @@ export function registerWorkspaceDocsCommands(program: Command): void {
       if (history.length === 0) {
         console.log(`No tracked history found for ${filename}.`);
         console.log(
-          `Hint: use \`openclaw workspace-docs write\` or ensure workspace has a git repo.`,
+          `Hint: ensure the workspace has a git repo and that changes were made via writeTrackedDoc() or a DocSession.`,
         );
         return;
       }

--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -8,6 +8,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { getFlagValue, getPositiveIntFlagValue, getVerboseFlag, hasFlag } from "../argv.js";
 import { registerBrowserCli } from "../browser-cli.js";
 import { registerConfigCli } from "../config-cli.js";
+import { registerWorkspaceDocsCommands } from "../docs-workspace-cli.js";
 import { registerMemoryCli, runMemoryStatus } from "../memory-cli.js";
 import { registerAgentCommands } from "./register.agent.js";
 import { registerConfigureCommand } from "./register.configure.js";
@@ -160,6 +161,10 @@ export const commandRegistry: CommandRegistration[] = [
   {
     id: "browser",
     register: ({ program }) => registerBrowserCli(program),
+  },
+  {
+    id: "workspace-docs",
+    register: ({ program }) => registerWorkspaceDocsCommands(program),
   },
 ];
 

--- a/src/config/crash-tracker.test.ts
+++ b/src/config/crash-tracker.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  readCrashTrackerState,
+  writeCrashTrackerState,
+  recordStartupAndCheckCrashLoop,
+  saveLastKnownGood,
+  hasLastKnownGood,
+  revertToLastKnownGood,
+  clearCrashTracker,
+  getLastKnownGoodPath,
+  getFailedConfigPath,
+} from "./crash-tracker.js";
+
+describe("crash-tracker", () => {
+  let tmpDir: string;
+  let stateDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "crash-tracker-test-"));
+    stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(stateDir, { recursive: true });
+    configPath = path.join(tmpDir, "openclaw.json");
+    fs.writeFileSync(configPath, '{"valid": true}');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("readCrashTrackerState", () => {
+    it("returns empty state when file does not exist", () => {
+      const state = readCrashTrackerState(stateDir);
+      expect(state.startupTimestamps).toEqual([]);
+    });
+
+    it("reads existing state", () => {
+      const expected = { startupTimestamps: [1000, 2000, 3000] };
+      writeCrashTrackerState(stateDir, expected);
+      const state = readCrashTrackerState(stateDir);
+      expect(state.startupTimestamps).toEqual([1000, 2000, 3000]);
+    });
+
+    it("handles corrupted state file", () => {
+      fs.writeFileSync(path.join(stateDir, "crash-tracker.json"), "not json");
+      const state = readCrashTrackerState(stateDir);
+      expect(state.startupTimestamps).toEqual([]);
+    });
+  });
+
+  describe("recordStartupAndCheckCrashLoop", () => {
+    it("returns false for first startup", () => {
+      const isCrashLoop = recordStartupAndCheckCrashLoop(stateDir);
+      expect(isCrashLoop).toBe(false);
+    });
+
+    it("returns false for 2 startups", () => {
+      recordStartupAndCheckCrashLoop(stateDir);
+      const isCrashLoop = recordStartupAndCheckCrashLoop(stateDir);
+      expect(isCrashLoop).toBe(false);
+    });
+
+    it("returns true after 3 startups within window", () => {
+      recordStartupAndCheckCrashLoop(stateDir);
+      recordStartupAndCheckCrashLoop(stateDir);
+      const isCrashLoop = recordStartupAndCheckCrashLoop(stateDir);
+      expect(isCrashLoop).toBe(true);
+    });
+
+    it("respects custom maxCrashes", () => {
+      recordStartupAndCheckCrashLoop(stateDir, { maxCrashes: 5 });
+      recordStartupAndCheckCrashLoop(stateDir, { maxCrashes: 5 });
+      recordStartupAndCheckCrashLoop(stateDir, { maxCrashes: 5 });
+      const isCrashLoop = recordStartupAndCheckCrashLoop(stateDir, { maxCrashes: 5 });
+      expect(isCrashLoop).toBe(false);
+    });
+
+    it("ignores old timestamps outside window", () => {
+      // Manually write old timestamps
+      const oldTime = Date.now() - 120_000; // 2 minutes ago
+      writeCrashTrackerState(stateDir, {
+        startupTimestamps: [oldTime, oldTime + 1000],
+      });
+      const isCrashLoop = recordStartupAndCheckCrashLoop(stateDir);
+      expect(isCrashLoop).toBe(false);
+    });
+  });
+
+  describe("saveLastKnownGood", () => {
+    it("copies config to .last-known-good", () => {
+      const result = saveLastKnownGood(configPath);
+      expect(result).toBe(true);
+      const lkgContent = fs.readFileSync(getLastKnownGoodPath(configPath), "utf-8");
+      expect(lkgContent).toBe('{"valid": true}');
+    });
+
+    it("returns false if config does not exist", () => {
+      const result = saveLastKnownGood(path.join(tmpDir, "nonexistent.json"));
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("hasLastKnownGood", () => {
+    it("returns false when no LKG exists", () => {
+      expect(hasLastKnownGood(configPath)).toBe(false);
+    });
+
+    it("returns true after saving LKG", () => {
+      saveLastKnownGood(configPath);
+      expect(hasLastKnownGood(configPath)).toBe(true);
+    });
+  });
+
+  describe("revertToLastKnownGood", () => {
+    it("reverts config to last-known-good", () => {
+      // Save good config as LKG
+      saveLastKnownGood(configPath);
+
+      // Write bad config
+      fs.writeFileSync(configPath, '{"bad": true}');
+
+      // Revert
+      const result = revertToLastKnownGood(configPath, stateDir);
+      expect(result).toBe(true);
+
+      // Config should be restored
+      const content = fs.readFileSync(configPath, "utf-8");
+      expect(content).toBe('{"valid": true}');
+    });
+
+    it("saves failed config for debugging", () => {
+      saveLastKnownGood(configPath);
+      fs.writeFileSync(configPath, '{"bad": true}');
+
+      revertToLastKnownGood(configPath, stateDir);
+
+      // Find the failed config file
+      const files = fs.readdirSync(tmpDir).filter((f) => f.includes(".failed-"));
+      expect(files.length).toBe(1);
+      const failedContent = fs.readFileSync(path.join(tmpDir, files[0]!), "utf-8");
+      expect(failedContent).toBe('{"bad": true}');
+    });
+
+    it("resets crash tracker after revert", () => {
+      saveLastKnownGood(configPath);
+      recordStartupAndCheckCrashLoop(stateDir);
+      recordStartupAndCheckCrashLoop(stateDir);
+
+      revertToLastKnownGood(configPath, stateDir);
+
+      const state = readCrashTrackerState(stateDir);
+      expect(state.startupTimestamps).toEqual([]);
+      expect(state.lastRevertTimestamp).toBeGreaterThan(0);
+    });
+
+    it("returns false when no LKG exists", () => {
+      const result = revertToLastKnownGood(configPath, stateDir);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("clearCrashTracker", () => {
+    it("clears startup timestamps", () => {
+      recordStartupAndCheckCrashLoop(stateDir);
+      recordStartupAndCheckCrashLoop(stateDir);
+      clearCrashTracker(stateDir);
+      const state = readCrashTrackerState(stateDir);
+      expect(state.startupTimestamps).toEqual([]);
+    });
+  });
+});

--- a/src/config/crash-tracker.ts
+++ b/src/config/crash-tracker.ts
@@ -1,0 +1,171 @@
+/**
+ * Crash-loop detection and last-known-good config management.
+ *
+ * Tracks gateway startup timestamps and detects crash loops.
+ * When a crash loop is detected, automatically reverts to the
+ * last-known-good config.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+export type CrashTrackerState = {
+  startupTimestamps: number[];
+  lastRevertTimestamp?: number;
+};
+
+export type CrashTrackerOptions = {
+  /** Max crashes within the window before triggering revert. Default: 3 */
+  maxCrashes?: number;
+  /** Time window in ms. Default: 60_000 (60s) */
+  windowMs?: number;
+  /** Seconds to wait before marking startup as healthy. Default: 10 */
+  healthyAfterSeconds?: number;
+};
+
+const DEFAULT_MAX_CRASHES = 3;
+const DEFAULT_WINDOW_MS = 60_000;
+const DEFAULT_HEALTHY_AFTER_SECONDS = 10;
+const CRASH_TRACKER_FILENAME = "crash-tracker.json";
+const LAST_KNOWN_GOOD_SUFFIX = ".last-known-good";
+const FAILED_CONFIG_PREFIX = ".failed-";
+
+export function getCrashTrackerPath(stateDir: string): string {
+  return path.join(stateDir, CRASH_TRACKER_FILENAME);
+}
+
+export function getLastKnownGoodPath(configPath: string): string {
+  return configPath + LAST_KNOWN_GOOD_SUFFIX;
+}
+
+export function getFailedConfigPath(configPath: string, timestamp?: number): string {
+  const ts = timestamp ?? Date.now();
+  return configPath + FAILED_CONFIG_PREFIX + ts;
+}
+
+export function readCrashTrackerState(stateDir: string): CrashTrackerState {
+  const trackerPath = getCrashTrackerPath(stateDir);
+  try {
+    const raw = fs.readFileSync(trackerPath, "utf-8");
+    const parsed = JSON.parse(raw) as CrashTrackerState;
+    if (!Array.isArray(parsed.startupTimestamps)) {
+      return { startupTimestamps: [] };
+    }
+    return parsed;
+  } catch {
+    return { startupTimestamps: [] };
+  }
+}
+
+export function writeCrashTrackerState(stateDir: string, state: CrashTrackerState): void {
+  const trackerPath = getCrashTrackerPath(stateDir);
+  fs.mkdirSync(path.dirname(trackerPath), { recursive: true });
+  fs.writeFileSync(trackerPath, JSON.stringify(state, null, 2));
+}
+
+/**
+ * Record a startup timestamp and check if we're in a crash loop.
+ * Returns true if a crash loop is detected (caller should revert config).
+ */
+export function recordStartupAndCheckCrashLoop(
+  stateDir: string,
+  options: CrashTrackerOptions = {},
+): boolean {
+  const maxCrashes = options.maxCrashes ?? DEFAULT_MAX_CRASHES;
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+  const now = Date.now();
+
+  const state = readCrashTrackerState(stateDir);
+
+  // Add current startup
+  state.startupTimestamps.push(now);
+
+  // Prune timestamps outside the window
+  state.startupTimestamps = state.startupTimestamps.filter((ts) => now - ts <= windowMs);
+
+  writeCrashTrackerState(stateDir, state);
+
+  return state.startupTimestamps.length >= maxCrashes;
+}
+
+/**
+ * Save the current config as last-known-good.
+ * Should be called after gateway has been healthy for N seconds.
+ */
+export function saveLastKnownGood(configPath: string): boolean {
+  const lkgPath = getLastKnownGoodPath(configPath);
+  try {
+    fs.copyFileSync(configPath, lkgPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if a last-known-good config exists.
+ */
+export function hasLastKnownGood(configPath: string): boolean {
+  return fs.existsSync(getLastKnownGoodPath(configPath));
+}
+
+/**
+ * Revert to last-known-good config.
+ * Saves the current (bad) config as a failed config for debugging.
+ * Returns true if revert was successful.
+ */
+export function revertToLastKnownGood(configPath: string, stateDir: string): boolean {
+  const lkgPath = getLastKnownGoodPath(configPath);
+  if (!fs.existsSync(lkgPath)) {
+    return false;
+  }
+
+  try {
+    // Save current (bad) config for debugging
+    const failedPath = getFailedConfigPath(configPath);
+    if (fs.existsSync(configPath)) {
+      fs.copyFileSync(configPath, failedPath);
+    }
+
+    // Revert to last-known-good
+    fs.copyFileSync(lkgPath, configPath);
+
+    // Record the revert
+    const state = readCrashTrackerState(stateDir);
+    state.lastRevertTimestamp = Date.now();
+    state.startupTimestamps = []; // Reset crash counter after revert
+    writeCrashTrackerState(stateDir, state);
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Clear the crash tracker (call after healthy startup confirmed).
+ */
+export function clearCrashTracker(stateDir: string): void {
+  const state = readCrashTrackerState(stateDir);
+  state.startupTimestamps = [];
+  writeCrashTrackerState(stateDir, state);
+}
+
+/**
+ * Schedule saving last-known-good after healthy startup.
+ * Returns a cancel function.
+ */
+export function scheduleLastKnownGoodSave(
+  configPath: string,
+  stateDir: string,
+  options: CrashTrackerOptions = {},
+): () => void {
+  const healthyAfterSeconds = options.healthyAfterSeconds ?? DEFAULT_HEALTHY_AFTER_SECONDS;
+  const timer = setTimeout(() => {
+    saveLastKnownGood(configPath);
+    clearCrashTracker(stateDir);
+  }, healthyAfterSeconds * 1000);
+  // Don't keep the process alive just for this timer
+  timer.unref();
+  return () => clearTimeout(timer);
+}


### PR DESCRIPTION
Addresses review feedback on #19570 and #19569 discussion.

## Changes

### 1. Transaction-based `beginDocSession()` API (fixes @jamesshannon's concern)

The original `writeTrackedDoc()` committed on every call, breaking agents that use targeted edits (sed/awk/patch on individual lines). Multiple small mutations produced noisy per-write commits, defeating the audit log.

New API:

```ts
const session = await beginDocSession(workspaceDir, { sessionKey, agentLabel });
// Agent does whatever it wants — raw writes, sed, full rewrites, patch — any mechanism
await fs.writeFile(path.join(dir, 'AGENTS.md'), newContent);    // or
execSync(`sed -i 's/old/new/' ${dir}/SOUL.md`);               // or
await applyPatch(dir, patch);                                    // all work
// Single commit with full provenance
await session.commit('Updated disk hygiene rules');
// Or discard (no commit, files stay as-is)
session.discard();
```

`writeTrackedDoc()` is kept as a convenience wrapper for single-file, single-write cases.

### 2. CLI registration fix (Greptile: blocking issue)

`registerWorkspaceDocsCommands()` was never called from `command-registry.ts`, making `openclaw workspace-docs` completely unreachable. Fixed.

### 3. Type fixes

- `SpawnResult.code` is `number | null` — added `?? 1` fallback in `gitCommand()`
- `colorize()` signature is `(rich: boolean, color: fn, value: string)` — was called with 2 args; replaced with `theme.heading()`

### 4. Cleanup

- Removed phantom `write` subcommand reference from `history` help text
- `POLICY.md` uses a local constant (not exported from `workspace.ts`)

### 5. Tests

4 new tests for `beginDocSession`:
- Multi-edit session produces a single commit (not N commits)
- `discard()` produces no commit
- No commit when only non-tracked files changed  
- Graceful no-git fallback with warning

Closes feedback from https://github.com/openclaw/openclaw/issues/19569#issuecomment-4001902351