### PR TITLE
fix(discord): respect groupPolicy open for unmatched channels

### DIFF
--- a/src/discord/monitor.test.ts
+++ b/src/discord/monitor.test.ts
@@ -16,6 +16,7 @@ import {
   resolveDiscordShouldRequireMention,
   resolveGroupDmAllow,
   sanitizeDiscordThreadName,
+  shouldDenyDiscordChannelByAllowedFlag,
   shouldEmitDiscordReactionNotification,
 } from "./monitor.js";
 import { DiscordMessageListener, DiscordReactionListener } from "./monitor/listeners.js";
@@ -607,6 +608,35 @@ describe("discord groupPolicy gating", () => {
     for (const testCase of cases) {
       expect(isDiscordGroupAllowedByPolicy(testCase.input), testCase.name).toBe(testCase.expected);
     }
+  });
+});
+
+describe("discord channel deny gating", () => {
+  it("allows fallback channel misses in open policy", () => {
+    expect(
+      shouldDenyDiscordChannelByAllowedFlag({
+        groupPolicy: "open",
+        channelConfig: { allowed: false },
+      }),
+    ).toBe(false);
+  });
+
+  it("still denies explicit allow=false entries in open policy", () => {
+    expect(
+      shouldDenyDiscordChannelByAllowedFlag({
+        groupPolicy: "open",
+        channelConfig: { allowed: false, matchKey: "123", matchSource: "direct" },
+      }),
+    ).toBe(true);
+  });
+
+  it("denies channel allow=false under allowlist policy", () => {
+    expect(
+      shouldDenyDiscordChannelByAllowedFlag({
+        groupPolicy: "allowlist",
+        channelConfig: { allowed: false },
+      }),
+    ).toBe(true);
   });
 });
 

--- a/src/discord/monitor.ts
+++ b/src/discord/monitor.ts
@@ -14,6 +14,7 @@ export {
   resolveDiscordGuildEntry,
   resolveDiscordShouldRequireMention,
   resolveGroupDmAllow,
+  shouldDenyDiscordChannelByAllowedFlag,
   shouldEmitDiscordReactionNotification,
 } from "./monitor/allow-list.js";
 export type { DiscordMessageEvent, DiscordMessageHandler } from "./monitor/listeners.js";

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -528,6 +528,22 @@ export function isDiscordGroupAllowedByPolicy(params: {
   return channelAllowed;
 }
 
+export function shouldDenyDiscordChannelByAllowedFlag(params: {
+  groupPolicy: "open" | "disabled" | "allowlist";
+  channelConfig?: DiscordChannelConfigResolved | null;
+}): boolean {
+  const { groupPolicy, channelConfig } = params;
+  if (channelConfig?.allowed !== false) {
+    return false;
+  }
+  if (groupPolicy !== "open") {
+    return true;
+  }
+  // In open policy, unmatched channels fall back to { allowed: false } without match metadata.
+  // Only explicit channel entries (direct/parent/wildcard) should still deny.
+  return Boolean(channelConfig.matchSource);
+}
+
 export function resolveGroupDmAllow(params: {
   channels?: string[];
   channelId: string;

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -350,7 +350,7 @@ type DiscordReactionIngressAuthorizationParams = {
   groupPolicy: "open" | "allowlist" | "disabled";
   allowNameMatching: boolean;
   guildInfo: import("./allow-list.js").DiscordGuildEntryResolved | null;
-  channelConfig?: { allowed?: boolean } | null;
+  channelConfig?: import("./allow-list.js").DiscordChannelConfigResolved | null;
 };
 
 async function authorizeDiscordReactionIngress(

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -27,6 +27,7 @@ import {
   resolveDiscordChannelConfigWithFallback,
   resolveGroupDmAllow,
   resolveDiscordGuildEntry,
+  shouldDenyDiscordChannelByAllowedFlag,
   shouldEmitDiscordReactionNotification,
 } from "./allow-list.js";
 import { formatDiscordReactionEmoji, formatDiscordUserTag } from "./format.js";
@@ -421,7 +422,12 @@ async function authorizeDiscordReactionIngress(
   ) {
     return { allowed: false, reason: "guild-policy" };
   }
-  if (params.channelConfig?.allowed === false) {
+  if (
+    shouldDenyDiscordChannelByAllowedFlag({
+      groupPolicy: params.groupPolicy,
+      channelConfig: params.channelConfig,
+    })
+  ) {
     return { allowed: false, reason: "guild-channel-denied" };
   }
   return { allowed: true };

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -38,6 +38,7 @@ import {
   resolveDiscordOwnerAccess,
   resolveDiscordShouldRequireMention,
   resolveGroupDmAllow,
+  shouldDenyDiscordChannelByAllowedFlag,
 } from "./allow-list.js";
 import { resolveDiscordDmCommandAccess } from "./dm-command-auth.js";
 import { handleDiscordDmCommandDecision } from "./dm-command-decision.js";
@@ -519,7 +520,13 @@ export async function preflightDiscordMessage(
     return null;
   }
 
-  if (isGuildMessage && channelConfig?.allowed === false) {
+  if (
+    isGuildMessage &&
+    shouldDenyDiscordChannelByAllowedFlag({
+      groupPolicy: params.groupPolicy,
+      channelConfig,
+    })
+  ) {
     logDebug(`[discord-preflight] drop: channelConfig.allowed===false`);
     logVerbose(
       `Blocked discord channel ${messageChannelId} not in guild channel allowlist (${channelMatchMeta})`,

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -62,6 +62,7 @@ import {
   resolveDiscordMemberAccessState,
   resolveDiscordOwnerAccess,
   resolveDiscordOwnerAllowFrom,
+  shouldDenyDiscordChannelByAllowedFlag,
 } from "./allow-list.js";
 import { resolveDiscordDmCommandAccess } from "./dm-command-auth.js";
 import { handleDiscordDmCommandDecision } from "./dm-command-decision.js";
@@ -1329,11 +1330,22 @@ async function dispatchDiscordCommandInteraction(params: {
         scope: isThreadChannel ? "thread" : "channel",
       })
     : null;
+  const { groupPolicy } = resolveOpenProviderRuntimeGroupPolicy({
+    providerConfigPresent: cfg.channels?.discord !== undefined,
+    groupPolicy: discordConfig?.groupPolicy,
+    defaultGroupPolicy: cfg.channels?.defaults?.groupPolicy,
+  });
   if (channelConfig?.enabled === false) {
     await respond("This channel is disabled.");
     return;
   }
-  if (interaction.guild && channelConfig?.allowed === false) {
+  if (
+    interaction.guild &&
+    shouldDenyDiscordChannelByAllowedFlag({
+      groupPolicy,
+      channelConfig,
+    })
+  ) {
     await respond("This channel is not allowed.");
     return;
   }
@@ -1341,11 +1353,6 @@ async function dispatchDiscordCommandInteraction(params: {
     const channelAllowlistConfigured =
       Boolean(guildInfo?.channels) && Object.keys(guildInfo?.channels ?? {}).length > 0;
     const channelAllowed = channelConfig?.allowed !== false;
-    const { groupPolicy } = resolveOpenProviderRuntimeGroupPolicy({
-      providerConfigPresent: cfg.channels?.discord !== undefined,
-      groupPolicy: discordConfig?.groupPolicy,
-      defaultGroupPolicy: cfg.channels?.defaults?.groupPolicy,
-    });
     const allowByPolicy = isDiscordGroupAllowedByPolicy({
       groupPolicy,
       guildAllowlisted: Boolean(guildInfo),

--- a/src/discord/voice/command.ts
+++ b/src/discord/voice/command.ts
@@ -22,6 +22,7 @@ import {
   resolveDiscordChannelConfigWithFallback,
   resolveDiscordGuildEntry,
   resolveDiscordMemberAccessState,
+  shouldDenyDiscordChannelByAllowedFlag,
 } from "../monitor/allow-list.js";
 import { resolveDiscordChannelInfo } from "../monitor/message-utils.js";
 import { resolveDiscordSenderIdentity } from "../monitor/sender-identity.js";
@@ -137,7 +138,10 @@ async function authorizeVoiceCommand(
       channelAllowlistConfigured,
       channelAllowed,
     }) ||
-    channelConfig?.allowed === false
+    shouldDenyDiscordChannelByAllowedFlag({
+      groupPolicy: params.groupPolicy,
+      channelConfig,
+    })
   ) {
     const channelId = channelOverride?.id ?? channel?.id;
     const channelLabel = channelId ? formatMention({ channelId }) : "This channel";


### PR DESCRIPTION
## Summary
- add `shouldDenyDiscordChannelByAllowedFlag` to distinguish fallback `{ allowed: false }` misses from explicit channel deny entries
- update Discord preflight, reaction ingress, native slash command, and voice command gating to use the helper
- preserve explicit `allow: false` channel denies while allowing unmatched channels when `groupPolicy: "open"`
- add regression unit coverage for open-policy fallback behavior

## Testing
- pnpm test -- src/discord/monitor.test.ts src/discord/monitor/message-handler.preflight.test.ts src/discord/voice/command.test.ts
- pnpm test -- src/discord/monitor/listeners.test.ts src/discord/monitor/native-command.options.test.ts src/discord/monitor/native-command.model-picker.test.ts src/discord/monitor/native-command.plugin-dispatch.test.ts

Fixes #15769
