### PR TITLE
fix(canvas-host,agents): guard decodeURIComponent against malformed percent sequences

### DIFF
--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -277,4 +277,14 @@ describe("resolveSandboxedMediaSource", () => {
     });
     expect(result).toBe("");
   });
+
+  it("does not crash on file URL with malformed percent encoding", async () => {
+    await withSandboxRoot(async (sandboxDir) => {
+      const result = await resolveSandboxedMediaSource({
+        media: "file:///workspace/data/%ZZbad%path",
+        sandboxRoot: sandboxDir,
+      });
+      expect(typeof result).toBe("string");
+    });
+  });
 });

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -149,7 +149,12 @@ function mapContainerWorkspaceFileUrl(params: {
   }
   // Sandbox paths are Linux-style (/workspace/*). Parse the URL path directly so
   // Windows hosts can still accept file:///workspace/... media references.
-  const normalizedPathname = decodeURIComponent(parsed.pathname).replace(/\\/g, "/");
+  let normalizedPathname: string;
+  try {
+    normalizedPathname = decodeURIComponent(parsed.pathname).replace(/\\/g, "/");
+  } catch {
+    normalizedPathname = parsed.pathname.replace(/\\/g, "/");
+  }
   if (
     normalizedPathname !== SANDBOX_CONTAINER_WORKDIR &&
     !normalizedPathname.startsWith(`${SANDBOX_CONTAINER_WORKDIR}/`)

--- a/src/canvas-host/file-resolver.test.ts
+++ b/src/canvas-host/file-resolver.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { normalizeUrlPath } from "./file-resolver.js";
+
+describe("normalizeUrlPath", () => {
+  it("decodes a percent-encoded path", () => {
+    expect(normalizeUrlPath("/foo%20bar")).toBe("/foo bar");
+  });
+
+  it("normalizes path traversal", () => {
+    expect(normalizeUrlPath("/a/../b")).toBe("/b");
+  });
+
+  it("falls back to raw path on malformed percent encoding", () => {
+    const result = normalizeUrlPath("/bad%ZZpath");
+    expect(result).toBe("/bad%ZZpath");
+  });
+
+  it("returns / for empty input", () => {
+    expect(normalizeUrlPath("")).toBe("/");
+  });
+});

--- a/src/canvas-host/file-resolver.ts
+++ b/src/canvas-host/file-resolver.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 import { SafeOpenError, openFileWithinRoot, type SafeOpenResult } from "../infra/fs-safe.js";
 
 export function normalizeUrlPath(rawPath: string): string {
-  const decoded = decodeURIComponent(rawPath || "/");
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(rawPath || "/");
+  } catch {
+    decoded = rawPath || "/";
+  }
   const normalized = path.posix.normalize(decoded);
   return normalized.startsWith("/") ? normalized : `/${normalized}`;
 }


### PR DESCRIPTION
## Summary

`decodeURIComponent` throws `URIError` on malformed `%XX` sequences (e.g. `%ZZ`, truncated `%2`). Two call sites accept user-controlled or API-derived paths without try-catch:

1. **`src/canvas-host/file-resolver.ts`** — `normalizeUrlPath()` receives raw URL paths from HTTP requests. A crafted path like `/bad%ZZfile` crashes the canvas file server.

2. **`src/agents/sandbox-paths.ts`** — `resolveSandboxedMediaSource()` decodes `file://` URL pathnames from LLM/API output. Malformed percent encoding in the pathname crashes media resolution.

Both now fall back to the raw (un-decoded) string on `URIError` instead of crashing.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [x] Agents / Model integration
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [x] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — no single issue. Addresses a class of `URIError` crashes from malformed input.

## User-Visible Changes

None. Paths with malformed percent sequences are now handled gracefully instead of crashing.

## Security Impact

1. Does this change handle user input? **Yes** — URL paths from HTTP requests
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 25 tests pass (4 file-resolver + 21 sandbox-paths)
- [x] Formatted with `oxfmt`
- [x] New tests: malformed percent encoding, empty input, path traversal

## Evidence

```
 ✓ src/canvas-host/file-resolver.test.ts (4 tests) 2ms
 ✓ src/agents/sandbox-paths.test.ts (21 tests) 16ms
 Test Files  2 passed (2)
      Tests  25 passed (25)
```

## Human Verification

- Send a request to the canvas host with a path containing `%ZZ` — should return 404, not crash
- Use an LLM that outputs a `file:///workspace/%ZZbroken` media reference — should not crash

## Compatibility

Fully backward compatible. Valid percent-encoded paths continue to be decoded normally.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Raw undecoded path produces wrong file lookup | The alternative is a crash; a wrong lookup returns 404 which is safer |