### PR TITLE
fix: llm-task tool schema compatibility with llama.cpp + doctor SecretRef crash

### DIFF
--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -74,9 +74,17 @@ export function createLlmTaskTool(api: OpenClawPluginApi) {
       "Run a generic JSON-only LLM task and return schema-validated JSON. Designed for orchestration from Lobster workflows via openclaw.invoke.",
     parameters: Type.Object({
       prompt: Type.String({ description: "Task instruction for the LLM." }),
-      input: Type.Optional(Type.Unknown({ description: "Optional input payload for the task." })),
+      input: Type.Optional(
+        Type.Unsafe<unknown>({
+          type: "object",
+          description: "Optional input payload for the task.",
+        }),
+      ),
       schema: Type.Optional(
-        Type.Unknown({ description: "Optional JSON Schema to validate the returned JSON." }),
+        Type.Unsafe<unknown>({
+          type: "object",
+          description: "Optional JSON Schema to validate the returned JSON.",
+        }),
       ),
       provider: Type.Optional(
         Type.String({ description: "Provider override (e.g. openai-codex, anthropic)." }),

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -26,7 +26,10 @@ export async function noteMemorySearchHealth(
   const agentId = resolveDefaultAgentId(cfg);
   const agentDir = resolveAgentDir(cfg, agentId);
   const resolved = resolveMemorySearchConfig(cfg, agentId);
-  const hasRemoteApiKey = Boolean(resolved?.remote?.apiKey?.trim());
+  const rawApiKey = resolved?.remote?.apiKey;
+  const hasRemoteApiKey = Boolean(
+    typeof rawApiKey === "string" ? rawApiKey.trim() : rawApiKey,
+  );
 
   if (!resolved) {
     note("Memory search is explicitly disabled (enabled: false).", "Memory search");


### PR DESCRIPTION
## Summary

Two small fixes for local LLM backend compatibility and `openclaw doctor` reliability.

### 1. `llm-task` tool schema — breaks llama.cpp backends (#35443)

The `llm-task` plugin defines `input` and `schema` parameters using `Type.Unknown()`, which produces JSON Schema without a `type` field:

```json
{"description": "Optional input payload for the task."}
```

llama.cpp's OpenAI-compatible endpoint rejects this during JSON schema-to-grammar conversion:

```
JSON schema conversion failed: Unrecognized schema: {"description":"Optional input payload for the task."}
```

**Fix:** Replace `Type.Unknown()` with `Type.Unsafe<unknown>({type: "object", ...})` to emit a concrete `type` field. Both parameters accept JSON objects in practice (`input` is a payload, `schema` is a JSON Schema definition).

**Impact:** Any agent with `llm-task` enabled that routes through llama.cpp-based backends (directly or via TensorZero) gets a 400 on every request. Streaming requests return `data: [DONE]` immediately with no content.

### 2. `openclaw doctor` crashes on SecretRef apiKey (#35444)

`doctor-memory-search.ts` calls `.trim()` on `resolved?.remote?.apiKey`, which crashes when the value is a SecretRef object (env var reference) rather than a resolved string:

```
TypeError: resolved?.remote?.apiKey?.trim is not a function
```

**Fix:** Guard with `typeof rawApiKey === "string"` before calling `.trim()`.

## Testing

**llm-task fix verified** by sending tool definitions with and without `type` fields to llama-server (Qwen3.5-35B-A3B, Qwen3.5-9B):
- Without `type`: 400 error (reproducible)
- With `type: "object"`: 200 OK

**doctor fix verified** by confirming the TypeError occurs at the exact line changed, and that the SecretRef is a non-string object at runtime while the gateway resolves it correctly.

## Environment tested on

- OpenClaw 2026.3.2
- llama.cpp (llama-server, OpenAI-compatible mode)
- Models: Qwen3.5-35B-A3B, Qwen3.5-9B (both via TensorZero routing)
- macOS arm64, Node v25.6.1