### PR TITLE
docs: add PR description checklist to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,17 @@ Welcome to the lobster tank! 🦞
 - Describe what & why
 - **Include screenshots** — one showing the problem/before, one showing the fix/after (for UI or visual changes)
 
+## PR Description Checklist
+
+Use the repository PR template and complete every section before requesting review:
+
+- Summary / Change Type / Scope / Linked Issue
+- Security Impact (permissions, secrets, network surface, data exposure)
+- Repro + Verification + Evidence + Human Verification
+- Compatibility/Migration + Failure Recovery + Risks/Mitigations
+
+Template source: `.github/pull_request_template.md`
+
 ## Control UI Decorators
 
 The Control UI uses Lit with **legacy** decorators (current Rollup parsing does not support


### PR DESCRIPTION
## Summary
- Problem: PR template fields were easy to miss from CONTRIBUTING.
- Why it matters: Missing details slow review.
- What changed: Added a PR Description Checklist section to CONTRIBUTING.
- What did NOT change: No runtime/API/CLI behavior.

## Change Type (select all)
- [x] Docs

## Scope (select all touched areas)
- [x] UI / DX

## Linked Issue/PR
- Closes #
- Related #

## User-visible / Behavior Changes
None

## Security Impact (required)
- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification
### Environment
- OS: macOS
- Runtime/container: local pnpm workspace

### Steps
1. Open CONTRIBUTING.md.
2. Check the new PR Description Checklist section.

### Expected
- Required PR fields are visible in one concise checklist.

### Actual
- Checklist section is present and references .github/pull_request_template.md.

## Evidence
- Ran: pnpm build && pnpm check && pnpm test
- Result: build passed; check failed on pre-existing formatting issues under docs/.llm/** unrelated to this PR.

## Human Verification (required)
- Verified scenarios: checklist content and placement in CONTRIBUTING.
- Edge cases checked: docs-only change scope.
- What not verified: resolving unrelated pre-existing formatting debt.

## Compatibility / Migration
- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)
- Revert this PR commit.
- Restore CONTRIBUTING.md.
- Known bad symptoms: None (docs-only).

## Risks and Mitigations
- Risk: checklist drift from template.
  - Mitigation: direct source reference to .github/pull_request_template.md.

## AI/Vibe-Coded Disclosure
- AI-assisted: Yes
- Testing degree: Lightly tested