### PR TITLE
fix(utils,agents): guard NaN debounce loop and coerce Gemini error to string

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -680,7 +680,7 @@ async function runGeminiSearch(params: {
       }
 
       if (data.error) {
-        const rawMsg = data.error.message || data.error.status || "unknown";
+        const rawMsg = String(data.error.message || data.error.status || "unknown");
         const safeMsg = rawMsg.replace(/key=[^&\s]+/gi, "key=***");
         throw new Error(`Gemini API error (${data.error.code}): ${safeMsg}`);
       }

--- a/src/utils/queue-helpers.test.ts
+++ b/src/utils/queue-helpers.test.ts
@@ -5,6 +5,7 @@ import {
   clearQueueSummaryState,
   drainCollectItemIfNeeded,
   previewQueueSummaryPrompt,
+  waitForQueueDebounce,
 } from "./queue-helpers.js";
 
 describe("applyQueueRuntimeSettings", () => {
@@ -165,5 +166,19 @@ describe("drainCollectItemIfNeeded", () => {
 
     expect(result).toBe("empty");
     expect(forced).toBe(true);
+  });
+});
+
+describe("waitForQueueDebounce", () => {
+  it("resolves immediately when debounceMs is NaN", async () => {
+    const start = Date.now();
+    await waitForQueueDebounce({ debounceMs: NaN, lastEnqueuedAt: Date.now() });
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it("resolves immediately when debounceMs is 0", async () => {
+    const start = Date.now();
+    await waitForQueueDebounce({ debounceMs: 0, lastEnqueuedAt: Date.now() });
+    expect(Date.now() - start).toBeLessThan(50);
   });
 });

--- a/src/utils/queue-helpers.ts
+++ b/src/utils/queue-helpers.ts
@@ -116,7 +116,7 @@ export function waitForQueueDebounce(queue: {
     return Promise.resolve();
   }
   const debounceMs = Math.max(0, queue.debounceMs);
-  if (debounceMs <= 0) {
+  if (!(debounceMs > 0)) {
     return Promise.resolve();
   }
   return new Promise<void>((resolve) => {


### PR DESCRIPTION
## Summary

Two defensive fixes:

1. **`src/utils/queue-helpers.ts`** — `waitForQueueDebounce` uses `Math.max(0, debounceMs)` followed by `debounceMs <= 0` to short-circuit. When `debounceMs` is `NaN` (e.g., from a corrupt config or invalid runtime setting), `Math.max(0, NaN)` returns `NaN`, and `NaN <= 0` is `false`, so the check passes through. Inside the loop, `since >= NaN` is always `false`, and `setTimeout(check, NaN)` behaves as `setTimeout(check, 0)`, creating a tight recursive loop that starves the event loop.

   **Fix:** Replace `debounceMs <= 0` with `!(debounceMs > 0)`, which correctly catches `NaN` (since `NaN > 0` is `false`).

2. **`src/agents/tools/web-search.ts`** — When the Gemini API returns an error response, `data.error.message` or `data.error.status` can be a structured object rather than a string. The code calls `.replace(/key=.../gi, "key=***")` directly on the value, which throws `TypeError: rawMsg.replace is not a function` if the value is not a string.

   **Fix:** Wrap with `String()` to safely coerce any value to string before calling `.replace()`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [x] Agents / Model integration
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [x] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — no single issue.

## User-Visible Changes

None. NaN-derived debounce values now resolve immediately instead of spinning, and Gemini error messages are displayed correctly instead of crashing.

## Security Impact

1. Does this change handle user input? **No** — config values and API responses
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 38 tests pass (10 queue-helpers + 28 web-search)
- [x] Formatted with `oxfmt`
- [x] New tests: NaN debounceMs, zero debounceMs

## Evidence

```
 ✓ src/utils/queue-helpers.test.ts (10 tests) 3ms
 ✓ src/agents/tools/web-search.test.ts (28 tests) 5ms
 Test Files  2 passed (2)
      Tests  38 passed (38)
```

## Human Verification

- Set `debounceMs` to a non-numeric string in runtime settings — should not cause event loop starvation
- Trigger a Gemini API error with a structured error object — should throw with readable message

## Compatibility

Fully backward compatible. Valid numeric debounce values behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| `!(debounceMs > 0)` catches more values than `<= 0` | Only additional case is NaN, which should be treated as "no debounce" |
| `String()` changes error message format | Output is nearly identical for strings; objects now show "[object Object]" instead of crashing |