### PR TITLE
web_search: add Volcengine Ark provider

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -17,6 +17,11 @@ const {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  resolveArkApiKey,
+  resolveArkModel,
+  resolveArkBaseUrl,
+  extractArkContent,
+  resolveSearchProvider,
 } = __testing;
 
 describe("web_search perplexity baseUrl defaults", () => {
@@ -297,5 +302,163 @@ describe("extractKimiCitations", () => {
         ],
       }).toSorted(),
     ).toEqual(["https://example.com/a", "https://example.com/b", "https://example.com/c"]);
+  });
+});
+
+describe("web_search ark config resolution", () => {
+  it("uses config apiKey when provided", () => {
+    expect(resolveArkApiKey({ apiKey: "ark-test-key" })).toBe("ark-test-key");
+  });
+
+  it("falls back to ARK_API_KEY, then VOLCENGINE_API_KEY, then VOLCANO_ENGINE_API_KEY", () => {
+    withEnv(
+      {
+        ARK_API_KEY: "ark-env",
+        VOLCENGINE_API_KEY: "volc-env",
+        VOLCANO_ENGINE_API_KEY: "volcano-env",
+      },
+      () => {
+        expect(resolveArkApiKey({})).toBe("ark-env");
+      },
+    );
+    withEnv({ ARK_API_KEY: undefined, VOLCENGINE_API_KEY: "volc-env" }, () => {
+      expect(resolveArkApiKey({})).toBe("volc-env");
+    });
+    withEnv(
+      {
+        ARK_API_KEY: undefined,
+        VOLCENGINE_API_KEY: undefined,
+        VOLCANO_ENGINE_API_KEY: "volcano-env",
+      },
+      () => {
+        expect(resolveArkApiKey({})).toBe("volcano-env");
+      },
+    );
+  });
+
+  it("falls back to models.providers.volcengine.apiKey in full config", () => {
+    const fullConfig = {
+      models: {
+        providers: {
+          volcengine: {
+            apiKey: "from-volcengine-provider",
+          },
+        },
+      },
+    };
+    expect(resolveArkApiKey({}, fullConfig)).toBe("from-volcengine-provider");
+  });
+
+  it("returns undefined when no Ark key is configured", () => {
+    withEnv(
+      { ARK_API_KEY: undefined, VOLCENGINE_API_KEY: undefined, VOLCANO_ENGINE_API_KEY: undefined },
+      () => {
+        expect(resolveArkApiKey({})).toBeUndefined();
+        expect(resolveArkApiKey(undefined)).toBeUndefined();
+      },
+    );
+  });
+
+  it("resolves default model and baseUrl", () => {
+    expect(resolveArkModel({})).toBe("doubao-seed-1-6-250615");
+    expect(resolveArkBaseUrl({})).toBe("https://ark.cn-beijing.volces.com/api/v3");
+  });
+
+  it("uses config model and baseUrl when provided", () => {
+    expect(resolveArkModel({ model: "custom-model" })).toBe("custom-model");
+    expect(resolveArkBaseUrl({ baseUrl: "https://custom.ark.com/api/v3" })).toBe(
+      "https://custom.ark.com/api/v3",
+    );
+  });
+});
+
+describe("web_search ark response parsing", () => {
+  it("extracts content from Responses API message blocks", () => {
+    const result = extractArkContent({
+      output: [
+        {
+          type: "message",
+          content: [{ type: "output_text", text: "hello from ark output" }],
+        },
+      ],
+    });
+    expect(result.text).toBe("hello from ark output");
+  });
+
+  it("extracts output_text blocks directly in output array", () => {
+    const result = extractArkContent({
+      output: [
+        { type: "web_search" },
+        {
+          type: "output_text",
+          text: "direct output text from ark",
+        },
+      ],
+    });
+    expect(result.text).toBe("direct output text from ark");
+  });
+
+  it("falls back to output_text field", () => {
+    const result = extractArkContent({ output_text: "hello from output_text field" });
+    expect(result.text).toBe("hello from output_text field");
+  });
+
+  it("returns undefined text when no content found", () => {
+    const result = extractArkContent({});
+    expect(result.text).toBeUndefined();
+  });
+});
+
+describe("web_search ark provider auto-detection", () => {
+  it("auto-detects ark when only ARK_API_KEY is set", () => {
+    withEnv(
+      {
+        ARK_API_KEY: "test-ark-key",
+        BRAVE_API_KEY: undefined,
+        GEMINI_API_KEY: undefined,
+        KIMI_API_KEY: undefined,
+      },
+      () => {
+        expect(resolveSearchProvider({})).toBe("ark");
+      },
+    );
+  });
+
+  it("auto-detects ark when only VOLCENGINE_API_KEY is set", () => {
+    withEnv(
+      {
+        VOLCENGINE_API_KEY: "test-volc-key",
+        BRAVE_API_KEY: undefined,
+        GEMINI_API_KEY: undefined,
+        KIMI_API_KEY: undefined,
+      },
+      () => {
+        expect(resolveSearchProvider({})).toBe("ark");
+      },
+    );
+  });
+
+  it("auto-detects ark when only VOLCANO_ENGINE_API_KEY is set", () => {
+    withEnv(
+      {
+        VOLCANO_ENGINE_API_KEY: "test-volcano-key",
+        BRAVE_API_KEY: undefined,
+        GEMINI_API_KEY: undefined,
+        KIMI_API_KEY: undefined,
+      },
+      () => {
+        expect(resolveSearchProvider({})).toBe("ark");
+      },
+    );
+  });
+
+  it("explicit ark provider always wins", () => {
+    withEnv({ BRAVE_API_KEY: "test-brave-key" }, () => {
+      expect(
+        resolveSearchProvider({
+          provider: "ark",
+        } as unknown as Parameters<typeof resolveSearchProvider>[0]),
+      ).toBe("ark");
+    });
   });
 });

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -23,6 +23,7 @@ import {
 const SEARCH_PROVIDERS = ["brave", "perplexity", "grok", "gemini", "kimi", "ark"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
+const MAX_TIMEOUT_SECONDS = 300;
 
 const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
 const DEFAULT_PERPLEXITY_BASE_URL = "https://openrouter.ai/api/v1";
@@ -83,6 +84,7 @@ const WebSearchSchema = Type.Object({
     Type.Number({
       description: "Request timeout in seconds.",
       minimum: 1,
+      maximum: MAX_TIMEOUT_SECONDS,
     }),
   ),
 });
@@ -136,6 +138,7 @@ type ArkSearchResponse = {
   output?: Array<{
     type?: string;
     role?: string;
+    text?: string;
     content?: Array<{
       type?: string;
       text?: string;
@@ -1518,8 +1521,12 @@ export function createWebSearchTool(options?: {
       }
       const argTimeoutSeconds = readNumberParam(params, "timeoutSeconds", { integer: true });
       const configTimeoutSeconds = search?.timeoutSeconds;
-      const finalTimeoutSeconds =
+      const rawTimeoutSeconds =
         argTimeoutSeconds ?? configTimeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS;
+      const finalTimeoutSeconds = Math.min(
+        Math.max(1, Math.floor(Number(rawTimeoutSeconds))),
+        MAX_TIMEOUT_SECONDS,
+      );
 
       const result = await runWebSearch({
         query,

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -20,7 +20,7 @@ import {
   writeCache,
 } from "./web-shared.js";
 
-const SEARCH_PROVIDERS = ["brave", "perplexity", "grok", "gemini", "kimi"] as const;
+const SEARCH_PROVIDERS = ["brave", "perplexity", "grok", "gemini", "kimi", "ark"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
@@ -39,6 +39,9 @@ const KIMI_WEB_SEARCH_TOOL = {
   type: "builtin_function",
   function: { name: "$web_search" },
 } as const;
+
+const DEFAULT_ARK_BASE_URL = "https://ark.cn-beijing.volces.com/api/v3";
+const DEFAULT_ARK_MODEL = "doubao-seed-1-6-250615";
 
 const SEARCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
 const BRAVE_FRESHNESS_SHORTCUTS = new Set(["pd", "pw", "pm", "py"]);
@@ -74,6 +77,12 @@ const WebSearchSchema = Type.Object({
     Type.String({
       description:
         "Filter results by discovery time. Brave supports 'pd', 'pw', 'pm', 'py', and date range 'YYYY-MM-DDtoYYYY-MM-DD'. Perplexity supports 'pd', 'pw', 'pm', and 'py'.",
+    }),
+  ),
+  timeoutSeconds: Type.Optional(
+    Type.Number({
+      description: "Request timeout in seconds.",
+      minimum: 1,
     }),
   ),
 });
@@ -115,6 +124,24 @@ type KimiConfig = {
   apiKey?: string;
   baseUrl?: string;
   model?: string;
+};
+
+type ArkConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+};
+
+type ArkSearchResponse = {
+  output?: Array<{
+    type?: string;
+    role?: string;
+    content?: Array<{
+      type?: string;
+      text?: string;
+    }>;
+  }>;
+  output_text?: string;
 };
 
 type GrokSearchResponse = {
@@ -321,6 +348,14 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
+  if (provider === "ark") {
+    return {
+      error: "missing_ark_api_key",
+      message:
+        "web_search (ark) needs a Volcengine ARK API key. Set ARK_API_KEY, VOLCENGINE_API_KEY, or VOLCANO_ENGINE_API_KEY in the Gateway environment, configure tools.web.search.ark.apiKey, or set models.providers.volcengine.apiKey.",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
+  }
   return {
     error: "missing_brave_api_key",
     message: `web_search needs a Brave Search API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set BRAVE_API_KEY in the Gateway environment.`,
@@ -328,7 +363,10 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
   };
 }
 
-function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDERS)[number] {
+function resolveSearchProvider(
+  search?: WebSearchConfig,
+  fullConfig?: OpenClawConfig,
+): (typeof SEARCH_PROVIDERS)[number] {
   const raw =
     search && "provider" in search && typeof search.provider === "string"
       ? search.provider.trim().toLowerCase()
@@ -344,6 +382,9 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
   }
   if (raw === "kimi") {
     return "kimi";
+  }
+  if (raw === "ark") {
+    return "ark";
   }
   if (raw === "brave") {
     return "brave";
@@ -374,7 +415,13 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
       );
       return "kimi";
     }
-    // 4. Perplexity
+    // 4. Ark
+    const arkConfig = resolveArkConfig(search);
+    if (resolveArkApiKey(arkConfig, fullConfig)) {
+      logVerbose('web_search: no provider configured, auto-detected "ark" from available API keys');
+      return "ark";
+    }
+    // 5. Perplexity
     const perplexityConfig = resolvePerplexityConfig(search);
     const { apiKey: perplexityKey } = resolvePerplexityApiKey(perplexityConfig);
     if (perplexityKey) {
@@ -383,7 +430,7 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
       );
       return "perplexity";
     }
-    // 5. Grok
+    // 6. Grok
     const grokConfig = resolveGrokConfig(search);
     if (resolveGrokApiKey(grokConfig)) {
       logVerbose(
@@ -594,6 +641,130 @@ function resolveGeminiModel(gemini?: GeminiConfig): string {
   const fromConfig =
     gemini && "model" in gemini && typeof gemini.model === "string" ? gemini.model.trim() : "";
   return fromConfig || DEFAULT_GEMINI_MODEL;
+}
+
+function resolveArkConfig(search?: WebSearchConfig): ArkConfig {
+  if (!search || typeof search !== "object") {
+    return {};
+  }
+  const ark = "ark" in search ? search.ark : undefined;
+  if (!ark || typeof ark !== "object") {
+    return {};
+  }
+  return ark as ArkConfig;
+}
+
+function resolveArkApiKey(ark?: ArkConfig, fullConfig?: OpenClawConfig): string | undefined {
+  const fromConfig = normalizeApiKey(ark?.apiKey);
+  if (fromConfig) {
+    return fromConfig;
+  }
+  const fromEnvArk = normalizeApiKey(process.env.ARK_API_KEY);
+  if (fromEnvArk) {
+    return fromEnvArk;
+  }
+  const fromEnvVolcengine = normalizeApiKey(process.env.VOLCENGINE_API_KEY);
+  if (fromEnvVolcengine) {
+    return fromEnvVolcengine;
+  }
+  const fromEnvVolcanoEngine = normalizeApiKey(process.env.VOLCANO_ENGINE_API_KEY);
+  if (fromEnvVolcanoEngine) {
+    return fromEnvVolcanoEngine;
+  }
+  // Fallback: try to get from models.providers.volcengine.apiKey in main config
+  const volcengineProvider = fullConfig?.models?.providers?.volcengine;
+  if (volcengineProvider && "apiKey" in volcengineProvider) {
+    const fromModelsConfig = normalizeApiKey(volcengineProvider.apiKey);
+    if (fromModelsConfig) {
+      return fromModelsConfig;
+    }
+  }
+  return undefined;
+}
+
+function resolveArkModel(ark?: ArkConfig): string {
+  const fromConfig = ark && "model" in ark && typeof ark.model === "string" ? ark.model.trim() : "";
+  return fromConfig || DEFAULT_ARK_MODEL;
+}
+
+function resolveArkBaseUrl(ark?: ArkConfig): string {
+  const fromConfig =
+    ark && "baseUrl" in ark && typeof ark.baseUrl === "string" ? ark.baseUrl.trim() : "";
+  return fromConfig || DEFAULT_ARK_BASE_URL;
+}
+
+function extractArkContent(data: ArkSearchResponse): { text: string | undefined } {
+  // Ark Responses API format: find the message output with text content
+  for (const output of data.output ?? []) {
+    if (output.type === "message") {
+      for (const block of output.content ?? []) {
+        if (block.type === "output_text" && typeof block.text === "string" && block.text) {
+          return { text: block.text };
+        }
+      }
+    }
+    // Some responses place output_text blocks directly in the output array
+    if (
+      output.type === "output_text" &&
+      "text" in output &&
+      typeof output.text === "string" &&
+      output.text
+    ) {
+      return { text: output.text };
+    }
+  }
+  // Fallback: output_text field
+  const text = typeof data.output_text === "string" ? data.output_text : undefined;
+  return { text };
+}
+
+async function runArkSearch(params: {
+  query: string;
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  timeoutSeconds: number;
+}): Promise<{ content: string; citations: string[] }> {
+  const baseUrl = params.baseUrl.trim().replace(/\/$/, "");
+  const endpoint = `${baseUrl}/responses`;
+
+  const body: Record<string, unknown> = {
+    model: params.model,
+    stream: false,
+    tools: [{ type: "web_search" }],
+    input: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text: params.query,
+          },
+        ],
+      },
+    ],
+  };
+
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${params.apiKey}`,
+    },
+    body: JSON.stringify(body),
+    signal: withTimeout(undefined, params.timeoutSeconds * 1000),
+  });
+
+  if (!res.ok) {
+    return throwWebSearchApiError(res, "Ark");
+  }
+
+  const data = (await res.json()) as ArkSearchResponse;
+  const { text: extractedText } = extractArkContent(data);
+  const content = extractedText ?? "No response";
+
+  // Ark web_search via responses API doesn't return separate citations yet
+  return { content, citations: [] };
 }
 
 async function runGeminiSearch(params: {
@@ -1040,6 +1211,8 @@ async function runWebSearch(params: {
   geminiModel?: string;
   kimiBaseUrl?: string;
   kimiModel?: string;
+  arkBaseUrl?: string;
+  arkModel?: string;
 }): Promise<Record<string, unknown>> {
   const cacheKey = normalizeCacheKey(
     params.provider === "brave"
@@ -1050,7 +1223,9 @@ async function runWebSearch(params: {
           ? `${params.provider}:${params.query}:${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
           : params.provider === "gemini"
             ? `${params.provider}:${params.query}:${params.geminiModel ?? DEFAULT_GEMINI_MODEL}`
-            : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
+            : params.provider === "ark"
+              ? `${params.provider}:${params.query}:${params.arkBaseUrl ?? DEFAULT_ARK_BASE_URL}:${params.arkModel ?? DEFAULT_ARK_MODEL}`
+              : `${params.provider}:${params.query}:${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`,
   );
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {
@@ -1168,6 +1343,33 @@ async function runWebSearch(params: {
     return payload;
   }
 
+  if (params.provider === "ark") {
+    const { content, citations } = await runArkSearch({
+      query: params.query,
+      apiKey: params.apiKey,
+      baseUrl: params.arkBaseUrl ?? DEFAULT_ARK_BASE_URL,
+      model: params.arkModel ?? DEFAULT_ARK_MODEL,
+      timeoutSeconds: params.timeoutSeconds,
+    });
+
+    const payload = {
+      query: params.query,
+      provider: params.provider,
+      model: params.arkModel ?? DEFAULT_ARK_MODEL,
+      tookMs: Date.now() - start,
+      externalContent: {
+        untrusted: true,
+        source: "web_search",
+        provider: params.provider,
+        wrapped: true,
+      },
+      content: wrapWebContent(content),
+      citations,
+    };
+    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    return payload;
+  }
+
   if (params.provider !== "brave") {
     throw new Error("Unsupported web search provider.");
   }
@@ -1241,15 +1443,17 @@ export function createWebSearchTool(options?: {
   sandboxed?: boolean;
 }): AnyAgentTool | null {
   const search = resolveSearchConfig(options?.config);
+  const fullConfig = options?.config;
   if (!resolveSearchEnabled({ search, sandboxed: options?.sandboxed })) {
     return null;
   }
 
-  const provider = resolveSearchProvider(search);
+  const provider = resolveSearchProvider(search, fullConfig);
   const perplexityConfig = resolvePerplexityConfig(search);
   const grokConfig = resolveGrokConfig(search);
   const geminiConfig = resolveGeminiConfig(search);
   const kimiConfig = resolveKimiConfig(search);
+  const arkConfig = resolveArkConfig(search);
 
   const description =
     provider === "perplexity"
@@ -1260,7 +1464,9 @@ export function createWebSearchTool(options?: {
           ? "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search."
           : provider === "gemini"
             ? "Search the web using Gemini with Google Search grounding. Returns AI-synthesized answers with citations from Google Search."
-            : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+            : provider === "ark"
+              ? "Search the web using Volcengine Ark. Returns AI-synthesized answers with citations from real-time web search."
+              : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
     label: "Web Search",
@@ -1279,7 +1485,9 @@ export function createWebSearchTool(options?: {
               ? resolveKimiApiKey(kimiConfig)
               : provider === "gemini"
                 ? resolveGeminiApiKey(geminiConfig)
-                : resolveSearchApiKey(search);
+                : provider === "ark"
+                  ? resolveArkApiKey(arkConfig, fullConfig)
+                  : resolveSearchApiKey(search);
 
       if (!apiKey) {
         return jsonResult(missingSearchKeyPayload(provider));
@@ -1308,11 +1516,16 @@ export function createWebSearchTool(options?: {
           docs: "https://docs.openclaw.ai/tools/web",
         });
       }
+      const argTimeoutSeconds = readNumberParam(params, "timeoutSeconds", { integer: true });
+      const configTimeoutSeconds = search?.timeoutSeconds;
+      const finalTimeoutSeconds =
+        argTimeoutSeconds ?? configTimeoutSeconds ?? DEFAULT_TIMEOUT_SECONDS;
+
       const result = await runWebSearch({
         query,
         count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
         apiKey,
-        timeoutSeconds: resolveTimeoutSeconds(search?.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS),
+        timeoutSeconds: resolveTimeoutSeconds(finalTimeoutSeconds, DEFAULT_TIMEOUT_SECONDS),
         cacheTtlMs: resolveCacheTtlMs(search?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
         provider,
         country,
@@ -1330,6 +1543,8 @@ export function createWebSearchTool(options?: {
         geminiModel: resolveGeminiModel(geminiConfig),
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
+        arkBaseUrl: resolveArkBaseUrl(arkConfig),
+        arkModel: resolveArkModel(arkConfig),
       });
       return jsonResult(result);
     },
@@ -1352,5 +1567,9 @@ export const __testing = {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  resolveArkApiKey,
+  resolveArkModel,
+  resolveArkBaseUrl,
+  extractArkContent,
   resolveRedirectUrl,
 } as const;

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -50,6 +50,32 @@ describe("web search provider config", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts ark provider and config", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        enabled: true,
+        provider: "ark",
+        providerConfig: {
+          apiKey: "test-ark-key",
+          baseUrl: "https://ark.cn-beijing.volces.com/api/v3",
+          model: "doubao-seed-1-6-250615",
+        },
+      }),
+    );
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts ark provider with no extra config", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        provider: "ark",
+      }),
+    );
+
+    expect(res.ok).toBe(true);
+  });
 });
 
 describe("web search provider auto-detection", () => {
@@ -65,6 +91,9 @@ describe("web search provider auto-detection", () => {
     delete process.env.XAI_API_KEY;
     delete process.env.KIMI_API_KEY;
     delete process.env.MOONSHOT_API_KEY;
+    delete process.env.ARK_API_KEY;
+    delete process.env.VOLCENGINE_API_KEY;
+    delete process.env.VOLCANO_ENGINE_API_KEY;
   });
 
   afterEach(() => {
@@ -131,5 +160,35 @@ describe("web search provider auto-detection", () => {
         typeof resolveSearchProvider
       >[0]),
     ).toBe("gemini");
+  });
+
+  it("auto-detects ark when only ARK_API_KEY is set", () => {
+    process.env.ARK_API_KEY = "test-ark-key";
+    expect(resolveSearchProvider({})).toBe("ark");
+  });
+
+  it("auto-detects ark when only VOLCENGINE_API_KEY is set", () => {
+    process.env.VOLCENGINE_API_KEY = "test-volc-key";
+    expect(resolveSearchProvider({})).toBe("ark");
+  });
+
+  it("auto-detects ark when only VOLCANO_ENGINE_API_KEY is set", () => {
+    process.env.VOLCANO_ENGINE_API_KEY = "test-volcano-key";
+    expect(resolveSearchProvider({})).toBe("ark");
+  });
+
+  it("explicit ark provider always wins", () => {
+    process.env.BRAVE_API_KEY = "test-brave-key";
+    expect(
+      resolveSearchProvider({ provider: "ark" } as unknown as Parameters<
+        typeof resolveSearchProvider
+      >[0]),
+    ).toBe("ark");
+  });
+
+  it("follows priority order — brave wins over ark", () => {
+    process.env.BRAVE_API_KEY = "test-brave-key";
+    process.env.ARK_API_KEY = "test-ark-key";
+    expect(resolveSearchProvider({})).toBe("brave");
   });
 });

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -430,8 +430,8 @@ export type ToolsConfig = {
     search?: {
       /** Enable web search tool (default: true when API key is present). */
       enabled?: boolean;
-      /** Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"). */
-      provider?: "brave" | "perplexity" | "grok" | "gemini" | "kimi";
+      /** Search provider ("brave", "perplexity", "grok", "gemini", "kimi", or "ark"). */
+      provider?: "brave" | "perplexity" | "grok" | "gemini" | "kimi" | "ark";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
       apiKey?: string;
       /** Default search results count (1-10). */
@@ -472,6 +472,15 @@ export type ToolsConfig = {
         /** Base URL for API requests (defaults to "https://api.moonshot.ai/v1"). */
         baseUrl?: string;
         /** Model to use (defaults to "moonshot-v1-128k"). */
+        model?: string;
+      };
+      /** Ark (Volcengine)-specific configuration (used when provider="ark"). */
+      ark?: {
+        /** Volcengine ARK API key (defaults to ARK_API_KEY, VOLCENGINE_API_KEY, or VOLCANO_ENGINE_API_KEY env var, or reuses models.providers.volcengine.apiKey). */
+        apiKey?: string;
+        /** Base URL for API requests (defaults to "https://ark.cn-beijing.volces.com/api/v3"). */
+        baseUrl?: string;
+        /** Model to use (defaults to "doubao-seed-1-6-250615"). */
         model?: string;
       };
     };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -263,6 +263,7 @@ export const ToolsWebSearchSchema = z
         z.literal("grok"),
         z.literal("gemini"),
         z.literal("kimi"),
+        z.literal("ark"),
       ])
       .optional(),
     apiKey: z.string().optional().register(sensitive),
@@ -293,6 +294,14 @@ export const ToolsWebSearchSchema = z
       .strict()
       .optional(),
     kimi: z
+      .object({
+        apiKey: z.string().optional().register(sensitive),
+        baseUrl: z.string().optional(),
+        model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    ark: z
       .object({
         apiKey: z.string().optional().register(sensitive),
         baseUrl: z.string().optional(),


### PR DESCRIPTION
## Summary

- **Problem**: web_search tool didn't support Volcengine Ark (Doubao) as a provider
- **Why it matters**: Users with Volcengine Ark access want to use web_search with Doubao models
- **What changed**: Added "ark" provider to web_search, supporting Responses API with web_search tool
- **What did NOT change**: All existing providers (brave, perplexity, grok, gemini, kimi) continue to work unchanged

## Change Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Skills / tool execution

## User-visible / Behavior Changes

- Added \`ark\` as a new web_search provider option
- Added \`tools.web.search.ark\` config block with \`apiKey\`, \`baseUrl\`, \`model\`
- Added env var support: \`ARK_API_KEY\`, \`VOLCENGINE_API_KEY\`, \`VOLCANO_ENGINE_API_KEY\`
- Falls back to \`models.providers.volcengine.apiKey\` if available
- Added \`timeoutSeconds\` optional parameter to web_search tool schema

## Security Impact

- New permissions/capabilities? (\`No\`)
- Secrets/tokens handling changed? (\`No\` - follows existing pattern)
- New/changed network calls? (\`Yes\` - adds calls to Volcengine Ark API)
- Command/tool execution surface changed? (\`No\`)
- Data access scope changed? (\`No\`)
- If any \`Yes\`, explain risk + mitigation: New network calls are to Volcengine Ark API, uses existing \`fetchWithSsrFGuard\` with \`TRUSTED_NETWORK_SSRF_POLICY\`

## Human Verification

- Verified scenarios: Live test with real Volcengine Ark API key, successfully searched and returned results
- Edge cases checked: Auto-detection from various env var names, fallback to volcengine provider config, explicit provider config
- What you did **not** verify: Streaming responses (not implemented)

## Compatibility / Migration

- Backward compatible? (\`Yes\`)
- Config/env changes? (\`Yes\` - new optional configs)
- Migration needed? (\`No\`)

## Risks and Mitigations

- Risk: Ark API responses may change format
  - Mitigation: Added flexible response parsing with fallbacks
- Risk: Timeouts with web_search (can be slow)
  - Mitigation: Added \`timeoutSeconds\` config + tool parameter