### PR TITLE
fix(agents): guard context pruning estimator and minimax image tool against malformed content

### DIFF
--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -115,10 +115,16 @@ function estimateMessageChars(message: AgentMessage): number {
     if (typeof content === "string") {
       return content.length;
     }
+    if (!Array.isArray(content)) {
+      return 0;
+    }
     return estimateTextAndImageChars(content);
   }
 
   if (message.role === "assistant") {
+    if (!Array.isArray(message.content)) {
+      return typeof message.content === "string" ? (message.content as string).length : 0;
+    }
     let chars = 0;
     for (const b of message.content) {
       if (b.type === "text") {
@@ -139,6 +145,9 @@ function estimateMessageChars(message: AgentMessage): number {
   }
 
   if (message.role === "toolResult") {
+    if (!Array.isArray(message.content)) {
+      return 0;
+    }
     return estimateTextAndImageChars(message.content);
   }
 

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -231,6 +231,9 @@ async function runImagePrompt(params: {
       // MiniMax VLM only supports a single image; use the first one.
       if (model.provider === "minimax") {
         const first = params.images[0];
+        if (!first) {
+          throw new Error("minimax image tool requires at least one image");
+        }
         const imageDataUrl = `data:${first.mimeType};base64,${first.base64}`;
         const text = await minimaxUnderstandImage({
           apiKey,


### PR DESCRIPTION
## Summary

Two defensive fixes in the agent pipeline:

1. **`src/agents/pi-extensions/context-pruning/pruner.ts`** — `estimateMessageChars` iterates `message.content` for `assistant` and `toolResult` roles without checking `Array.isArray` first. When a plugin tool handler returns `undefined`/`void`, the content block can be persisted as `null` or a bare string. Iterating these with `for...of` throws `TypeError`, which repeats on every subsequent message and locks the session into an unrecoverable crash loop (related to #34979).

   **Fix:** Add `Array.isArray(content)` checks before iteration for user, assistant, and toolResult roles. Non-array content returns 0 or falls back to string length.

2. **`src/agents/tools/image-tool.ts`** — The MiniMax VLM branch accesses `params.images[0]` without checking the array is non-empty. If `images` is empty (edge case from validation gap), `first` is `undefined` and `first.mimeType` throws `TypeError`.

   **Fix:** Add explicit empty-array guard with a descriptive error message.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [x] Agents / Model integration
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Related to #34979 (malformed tool result content block crashes context truncation).

## User-Visible Changes

None. Sessions with malformed content blocks no longer enter a permanent crash loop.

## Security Impact

1. Does this change handle user input? **No** — internal message content
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 11 context-pruning tests pass
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ src/agents/pi-extensions/context-pruning.test.ts (11 tests) 4ms
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

## Human Verification

- Create a session where a plugin tool handler returns `undefined` — subsequent messages should not crash
- Call the image tool with MiniMax provider and empty images array — should throw descriptive error

## Compatibility

Fully backward compatible. Valid messages behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Returning 0 for malformed content underestimates context size | Safer than crashing; the pruner will still function correctly on valid messages |
| MiniMax error message change | Error is now descriptive; previously crashed with opaque TypeError |