### PR TITLE
fix(doctor): handle SecretRef objects in memory search apiKey check

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -2,6 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig, MemorySearchConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
+import type { SecretRef } from "../config/types.secrets.js";
 import { clampInt, clampNumber, resolveUserPath } from "../utils.js";
 import { resolveAgentConfig } from "./agent-scope.js";
 
@@ -12,7 +13,7 @@ export type ResolvedMemorySearchConfig = {
   provider: "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama" | "auto";
   remote?: {
     baseUrl?: string;
-    apiKey?: string;
+    apiKey?: string | SecretRef;
     headers?: Record<string, string>;
     batch?: {
       enabled: boolean;

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -26,7 +26,8 @@ export async function noteMemorySearchHealth(
   const agentId = resolveDefaultAgentId(cfg);
   const agentDir = resolveAgentDir(cfg, agentId);
   const resolved = resolveMemorySearchConfig(cfg, agentId);
-  const hasRemoteApiKey = Boolean(resolved?.remote?.apiKey?.trim());
+  const rawApiKey = resolved?.remote?.apiKey;
+  const hasRemoteApiKey = Boolean(typeof rawApiKey === "string" ? rawApiKey.trim() : rawApiKey);
 
   if (!resolved) {
     note("Memory search is explicitly disabled (enabled: false).", "Memory search");

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -985,11 +985,18 @@ export abstract class MemoryManagerSyncOps {
                 ? DEFAULT_OLLAMA_EMBEDDING_MODEL
                 : this.settings.model;
 
+    const remoteApiKey = this.settings.remote?.apiKey;
+    const resolvedRemote = this.settings.remote
+      ? {
+          ...this.settings.remote,
+          apiKey: typeof remoteApiKey === "string" ? remoteApiKey : undefined,
+        }
+      : undefined;
     const fallbackResult = await createEmbeddingProvider({
       config: this.cfg,
       agentDir: resolveAgentDir(this.cfg, this.agentId),
       provider: fallback,
-      remote: this.settings.remote,
+      remote: resolvedRemote,
       model: fallbackModel,
       fallback: "none",
       local: this.settings.local,

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -135,11 +135,18 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       return pending;
     }
     const createPromise = (async () => {
+      const remoteApiKey = settings.remote?.apiKey;
+      const resolvedRemote = settings.remote
+        ? {
+            ...settings.remote,
+            apiKey: typeof remoteApiKey === "string" ? remoteApiKey : undefined,
+          }
+        : undefined;
       const providerResult = await createEmbeddingProvider({
         config: cfg,
         agentDir: resolveAgentDir(cfg, agentId),
         provider: settings.provider,
-        remote: settings.remote,
+        remote: resolvedRemote,
         model: settings.model,
         fallback: settings.fallback,
         local: settings.local,


### PR DESCRIPTION
## Problem

`openclaw doctor` crashes at the end of its run:

```
TypeError: resolved?.remote?.apiKey?.trim is not a function
```

`resolveMemorySearchConfig()` may return an unresolved SecretRef object for `apiKey` when configured via environment variable reference. The doctor command does not resolve secrets before calling `.trim()`.

## Fix

Guard with `typeof` check before calling `.trim()`:

```typescript
const rawApiKey = resolved?.remote?.apiKey;
const hasRemoteApiKey = Boolean(
  typeof rawApiKey === "string" ? rawApiKey.trim() : rawApiKey,
);
```

## Verified

- Gateway runtime resolves SecretRef correctly (unaffected)
- `openclaw doctor` crashes reproducibly at `doctor-memory-search.ts:29`
- Linter passes (0 warnings, 0 errors)

Fixes #35444.