### PR TITLE
fix(cron): add typeof string guards before .trim() on parsed data

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -46,8 +46,9 @@ export function matchesMessagingToolDeliveryTarget(
   if (!delivery.channel || !delivery.to || !target.to) {
     return false;
   }
-  const channel = delivery.channel.trim().toLowerCase();
-  const provider = target.provider?.trim().toLowerCase();
+  const channel = typeof delivery.channel === "string" ? delivery.channel.trim().toLowerCase() : "";
+  const provider =
+    typeof target.provider === "string" ? target.provider.trim().toLowerCase() : undefined;
   if (provider && provider !== "message" && provider !== channel) {
     return false;
   }

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -348,7 +348,7 @@ export async function readCronRunLogEntriesPage(
   const raw = await fs.readFile(path.resolve(filePath), "utf-8").catch(() => "");
   const statuses = normalizeRunStatuses(opts);
   const deliveryStatuses = normalizeDeliveryStatuses(opts);
-  const query = opts?.query?.trim().toLowerCase() ?? "";
+  const query = typeof opts?.query === "string" ? opts.query.trim().toLowerCase() : "";
   const sortDir: CronRunLogSortDir = opts?.sortDir === "asc" ? "asc" : "desc";
   const all = parseAllRunLogEntries(raw, { jobId: opts?.jobId });
   const filtered = filterRunLogEntries(all, {
@@ -381,7 +381,7 @@ export async function readCronRunLogEntriesPageAll(
   const limit = Math.max(1, Math.min(200, Math.floor(opts.limit ?? 50)));
   const statuses = normalizeRunStatuses(opts);
   const deliveryStatuses = normalizeDeliveryStatuses(opts);
-  const query = opts.query?.trim().toLowerCase() ?? "";
+  const query = typeof opts.query === "string" ? opts.query.trim().toLowerCase() : "";
   const sortDir: CronRunLogSortDir = opts.sortDir === "asc" ? "asc" : "desc";
   const runsDir = path.resolve(path.dirname(path.resolve(opts.storePath)), "runs");
   const files = await fs.readdir(runsDir, { withFileTypes: true }).catch(() => []);

--- a/src/cron/service/normalize.ts
+++ b/src/cron/service/normalize.ts
@@ -81,7 +81,9 @@ export function inferLegacyName(job: {
 
 export function normalizePayloadToSystemText(payload: CronPayload) {
   if (payload.kind === "systemEvent") {
-    return payload.text.trim();
+    return typeof payload.text === "string" ? payload.text.trim() : String(payload.text ?? "");
   }
-  return payload.message.trim();
+  return typeof payload.message === "string"
+    ? payload.message.trim()
+    : String(payload.message ?? "");
 }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -194,7 +194,7 @@ function sortJobs(jobs: CronJob[], sortBy: CronJobsSortBy, sortDir: CronSortDir)
 export async function listPage(state: CronServiceState, opts?: CronListPageOptions) {
   return await locked(state, async () => {
     await ensureLoadedForRead(state);
-    const query = opts?.query?.trim().toLowerCase() ?? "";
+    const query = typeof opts?.query === "string" ? opts.query.trim().toLowerCase() : "";
     const enabledFilter = resolveEnabledFilter(opts);
     const sortBy = opts?.sortBy ?? "nextRunAtMs";
     const sortDir = opts?.sortDir ?? "asc";

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -241,7 +241,9 @@ function emitFailureAlert(
   },
 ) {
   const safeJobName = params.job.name || params.job.id;
-  const truncatedError = (params.error?.trim() || "unknown error").slice(0, 200);
+  const truncatedError = (
+    typeof params.error === "string" ? params.error.trim() : "unknown error"
+  ).slice(0, 200);
   const text = [
     `Cron job "${safeJobName}" failed ${params.consecutiveErrors} times`,
     `Last error: ${truncatedError}`,


### PR DESCRIPTION
## Summary

Five files in the cron module call `.trim()` or `.toLowerCase()` on values from parsed JSON, config, or API input without verifying they are strings. If a field is unexpectedly a number or object (e.g., from a manually edited cron store or malformed API input), the call throws `TypeError`.

**Files fixed:**

1. **`cron/service/normalize.ts`** — `payload.text.trim()` and `payload.message.trim()` without type check. Cron payloads are loaded from JSON store files that can be hand-edited.

2. **`cron/isolated-agent/delivery-dispatch.ts`** — `delivery.channel.trim().toLowerCase()` and `target.provider?.trim().toLowerCase()` without type check.

3. **`cron/service/ops.ts`** — `opts?.query?.trim().toLowerCase()` — query from API request body.

4. **`cron/service/timer.ts`** — `params.error?.trim()` — error can be an Error object or non-string.

5. **`cron/run-log.ts`** — Two instances of `opts.query?.trim().toLowerCase()` from API request.

All now use `typeof === "string"` checks before calling string methods.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [x] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — no single issue.

## User-Visible Changes

None. Cron operations now handle non-string fields gracefully instead of crashing.

## Security Impact

1. Does this change handle user input? **Yes** — cron config and API query parameters
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 406 cron tests pass (53 test files)
- [x] Formatted with `oxfmt`

## Evidence

```
 Test Files  53 passed (53)
      Tests  406 passed (406)
```

## Human Verification

- Manually edit a cron store JSON file to set `text` to a number — cron should not crash
- Send a cron list API request with a non-string query parameter — should not crash

## Compatibility

Fully backward compatible. String inputs behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| `String(value)` produces "[object Object]" for objects | Better than crashing; message content is still usable for display |