### PR TITLE
fix(subagents): honor explicit tools.subagents.tools.deny override

### DIFF
--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -62,6 +62,17 @@ describe("resolveSubagentToolPolicy depth awareness", () => {
     expect(isToolAllowedByPolicyName("sessions_send", policy)).toBe(true);
   });
 
+  it("treats subagent tools.deny as an explicit override list", () => {
+    const cfg = {
+      agents: { defaults: { subagents: { maxSpawnDepth: 2 } } },
+      tools: { subagents: { tools: { deny: ["gateway"] } } },
+    } as unknown as OpenClawConfig;
+    const policy = resolveSubagentToolPolicy(cfg, 1);
+    expect(isToolAllowedByPolicyName("gateway", policy)).toBe(false);
+    expect(isToolAllowedByPolicyName("cron", policy)).toBe(true);
+    expect(isToolAllowedByPolicyName("sessions_send", policy)).toBe(true);
+  });
+
   it("merges subagent tools.alsoAllow into tools.allow when both are set", () => {
     const cfg = {
       agents: { defaults: { subagents: { maxSpawnDepth: 2 } } },

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -40,8 +40,8 @@ function makeToolPolicyMatcher(policy: SandboxToolPolicy) {
 }
 
 /**
- * Tools always denied for sub-agents regardless of depth.
- * These are system-level or interactive tools that sub-agents should never use.
+ * Default tools denied for sub-agents regardless of depth.
+ * Operators can replace this list with `tools.subagents.tools.deny`.
  */
 const SUBAGENT_TOOL_DENY_ALWAYS = [
   // System admin - dangerous from subagent
@@ -89,15 +89,15 @@ export function resolveSubagentToolPolicy(cfg?: OpenClawConfig, depth?: number):
     cfg?.agents?.defaults?.subagents?.maxSpawnDepth ?? DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH;
   const effectiveDepth = typeof depth === "number" && depth >= 0 ? depth : 1;
   const baseDeny = resolveSubagentDenyList(effectiveDepth, maxSpawnDepth);
+  const configuredDeny = Array.isArray(configured?.deny) ? configured.deny : undefined;
   const allow = Array.isArray(configured?.allow) ? configured.allow : undefined;
   const alsoAllow = Array.isArray(configured?.alsoAllow) ? configured.alsoAllow : undefined;
   const explicitAllow = new Set(
     [...(allow ?? []), ...(alsoAllow ?? [])].map((toolName) => normalizeToolName(toolName)),
   );
-  const deny = [
-    ...baseDeny.filter((toolName) => !explicitAllow.has(normalizeToolName(toolName))),
-    ...(Array.isArray(configured?.deny) ? configured.deny : []),
-  ];
+  const deny =
+    configuredDeny ??
+    baseDeny.filter((toolName) => !explicitAllow.has(normalizeToolName(toolName)));
   const mergedAllow = allow && alsoAllow ? Array.from(new Set([...allow, ...alsoAllow])) : allow;
   return { allow: mergedAllow, deny };
 }


### PR DESCRIPTION
## Summary
- treat `tools.subagents.tools.deny` as an explicit deny override for spawned subagent sessions
- keep existing default deny behavior when `tools.subagents.tools.deny` is not configured
- add a regression test covering the override case (`deny: ["gateway"]` allows `cron` and `sessions_send`)

## Testing
- pnpm test src/agents/pi-tools.policy.test.ts

Fixes #35434
