### PR TITLE
fix(agents,gateway): guard Math.max/Math.floor against NaN timeout values

### DIFF
--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -404,9 +404,14 @@ export async function scanOpenRouterModels(
     throw new Error("Missing OpenRouter API key. Set OPENROUTER_API_KEY to run models scan.");
   }
 
-  const timeoutMs = Math.max(1, Math.floor(options.timeoutMs ?? DEFAULT_TIMEOUT_MS));
-  const concurrency = Math.max(1, Math.floor(options.concurrency ?? DEFAULT_CONCURRENCY));
-  const minParamB = Math.max(0, Math.floor(options.minParamB ?? 0));
+  const rawTimeoutMs = Math.floor(options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  const timeoutMs = Number.isFinite(rawTimeoutMs) ? Math.max(1, rawTimeoutMs) : DEFAULT_TIMEOUT_MS;
+  const rawConcurrency = Math.floor(options.concurrency ?? DEFAULT_CONCURRENCY);
+  const concurrency = Number.isFinite(rawConcurrency)
+    ? Math.max(1, rawConcurrency)
+    : DEFAULT_CONCURRENCY;
+  const rawMinParamB = Math.floor(options.minParamB ?? 0);
+  const minParamB = Number.isFinite(rawMinParamB) ? Math.max(0, rawMinParamB) : 0;
   const maxAgeDays = Math.max(0, Math.floor(options.maxAgeDays ?? 0));
   const providerFilter = options.providerFilter?.trim().toLowerCase() ?? "";
 

--- a/src/gateway/server-methods/agent-wait-dedupe.ts
+++ b/src/gateway/server-methods/agent-wait-dedupe.ts
@@ -201,7 +201,10 @@ export async function waitForTerminalGatewayDedupe(params: {
       return;
     }
 
-    const timeoutDelayMs = Math.max(1, Math.min(Math.floor(params.timeoutMs), 2_147_483_647));
+    const rawDelay = Math.floor(params.timeoutMs);
+    const timeoutDelayMs = Number.isFinite(rawDelay)
+      ? Math.max(1, Math.min(rawDelay, 2_147_483_647))
+      : 30_000;
     timeoutHandle = setTimeout(() => finish(null), timeoutDelayMs);
     timeoutHandle.unref?.();
 


### PR DESCRIPTION
## Summary

`Math.max(1, Math.floor(NaN))` returns `NaN`, not `1`. When config-derived timeout or concurrency values are `NaN`, these expressions silently produce `NaN`, which causes `setTimeout(fn, NaN)` to behave as `setTimeout(fn, 0)` — firing immediately instead of after a meaningful delay.

1. **`src/agents/model-scan.ts`** — `options.timeoutMs` and `options.concurrency` from config now include `Number.isFinite()` checks, falling back to `DEFAULT_TIMEOUT_MS` / `DEFAULT_CONCURRENCY` when NaN.

2. **`src/gateway/server-methods/agent-wait-dedupe.ts`** — `params.timeoutMs` now includes `Number.isFinite()` check, falling back to 30s when NaN, preventing immediate timeout that could cause "no response" behavior.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [x] Agents / Model integration
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [x] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — no single issue.

## User-Visible Changes

None. NaN timeout values now use sensible defaults instead of firing immediately.

## Security Impact

1. Does this change handle user input? **No** — config values
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 9 tests pass (2 model-scan + 7 agent-wait-dedupe)
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ src/agents/model-scan.test.ts (2 tests) 4ms
 ✓ src/gateway/server-methods/agent-wait-dedupe.test.ts (7 tests) 5ms
 Test Files  2 passed (2)
      Tests  9 passed (9)
```

## Human Verification

- Set `timeoutMs` to a non-numeric value in model scan config — should use default 30s
- Create an agent-wait-dedupe call with NaN timeout — should use 30s fallback

## Compatibility

Fully backward compatible. Valid numeric inputs behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Fallback value may not match user intent | NaN was never a valid intent; defaults are well-chosen |