### PR TITLE
feat: show status reaction during context compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction safeguard: route missing-model and missing-API-key cancellation warnings through the shared subsystem logger so they land in structured and file logs. (#9974) Thanks @dinakars777.
 - Cron/doctor: stop flagging canonical `agentTurn` and `systemEvent` payload kinds as legacy cron storage, while still normalizing whitespace-padded and non-canonical variants. (#44012) Thanks @shuicici.
 - ACP/client final-message delivery: preserve terminal assistant text snapshots before resolving `end_turn`, so ACP clients no longer drop the last visible reply when the gateway sends the final message body on the terminal chat event. (#17615) Thanks @pjeby.
+- Telegram/Discord status reactions: show a temporary compacting reaction during auto-compaction pauses and restore thinking afterward so the bot no longer appears frozen while context is being compacted. (#35474) thanks @Cypherm.
 
 ## 2026.3.11
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -393,11 +393,15 @@ export async function runAgentTurnWithFallback(params: {
                     await params.opts?.onToolStart?.({ name, phase });
                   }
                 }
-                // Track auto-compaction completion
+                // Track auto-compaction completion and notify UI layer
                 if (evt.stream === "compaction") {
                   const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
+                  if (phase === "start") {
+                    await params.opts?.onCompactionStart?.();
+                  }
                   if (phase === "end") {
                     autoCompactionCompleted = true;
+                    await params.opts?.onCompactionEnd?.();
                   }
                 }
               },

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -54,6 +54,10 @@ export type GetReplyOptions = {
   onToolResult?: (payload: ReplyPayload) => Promise<void> | void;
   /** Called when a tool phase starts/updates, before summary payloads are emitted. */
   onToolStart?: (payload: { name?: string; phase?: string }) => Promise<void> | void;
+  /** Called when context auto-compaction starts (allows UX feedback during the pause). */
+  onCompactionStart?: () => Promise<void> | void;
+  /** Called when context auto-compaction completes. */
+  onCompactionEnd?: () => Promise<void> | void;
   /** Called when the actual model is selected (including after fallback).
    * Use this to get model/provider/thinkLevel for responsePrefix template interpolation. */
   onModelSelected?: (ctx: ModelSelectedContext) => void;

--- a/src/channels/status-reactions.test.ts
+++ b/src/channels/status-reactions.test.ts
@@ -148,6 +148,15 @@ describe("createStatusReactionController", () => {
     expect(calls).toContainEqual({ method: "set", emoji: DEFAULT_EMOJIS.thinking });
   });
 
+  it("should debounce setCompacting and eventually call adapter", async () => {
+    const { calls, controller } = createEnabledController();
+
+    void controller.setCompacting();
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs);
+
+    expect(calls).toContainEqual({ method: "set", emoji: DEFAULT_EMOJIS.compacting });
+  });
+
   it("should classify tool name and debounce", async () => {
     const { calls, controller } = createEnabledController();
 
@@ -243,6 +252,19 @@ describe("createStatusReactionController", () => {
 
     // Should not add another call
     expect(calls.length).toBe(callsAfterFirst);
+  });
+
+  it("should cancel a pending compacting emoji before resuming thinking", async () => {
+    const { calls, controller } = createEnabledController();
+
+    void controller.setCompacting();
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs - 1);
+    controller.cancelPending();
+    void controller.setThinking();
+    await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.debounceMs);
+
+    const setEmojis = calls.filter((call) => call.method === "set").map((call) => call.emoji);
+    expect(setEmojis).toEqual([DEFAULT_EMOJIS.thinking]);
   });
 
   it("should call removeReaction when adapter supports it and emoji changes", async () => {
@@ -446,6 +468,7 @@ describe("constants", () => {
     const emojiKeys = [
       "queued",
       "thinking",
+      "compacting",
       "tool",
       "coding",
       "web",

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -24,6 +24,7 @@ export type StatusReactionEmojis = {
   error?: string; // Default: "❌"
   stallSoft?: string; // Default: "⏳"
   stallHard?: string; // Default: "⚠️"
+  compacting?: string; // Default: "✍"
 };
 
 export type StatusReactionTiming = {
@@ -38,6 +39,7 @@ export type StatusReactionController = {
   setQueued: () => Promise<void> | void;
   setThinking: () => Promise<void> | void;
   setTool: (toolName?: string) => Promise<void> | void;
+  setCompacting: () => Promise<void> | void;
   setDone: () => Promise<void>;
   setError: () => Promise<void>;
   clear: () => Promise<void>;
@@ -58,6 +60,7 @@ export const DEFAULT_EMOJIS: Required<StatusReactionEmojis> = {
   error: "😱",
   stallSoft: "🥱",
   stallHard: "😨",
+  compacting: "✍",
 };
 
 export const DEFAULT_TIMING: Required<StatusReactionTiming> = {
@@ -162,6 +165,7 @@ export function createStatusReactionController(params: {
     emojis.error,
     emojis.stallSoft,
     emojis.stallHard,
+    emojis.compacting,
   ]);
 
   /**
@@ -306,6 +310,10 @@ export function createStatusReactionController(params: {
     scheduleEmoji(emoji);
   }
 
+  function setCompacting(): void {
+    scheduleEmoji(emojis.compacting);
+  }
+
   function finishWithEmoji(emoji: string): Promise<void> {
     if (!enabled) {
       return Promise.resolve();
@@ -375,6 +383,7 @@ export function createStatusReactionController(params: {
     setQueued,
     setThinking,
     setTool,
+    setCompacting,
     setDone,
     setError,
     clear,

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -40,6 +40,8 @@ export type StatusReactionController = {
   setThinking: () => Promise<void> | void;
   setTool: (toolName?: string) => Promise<void> | void;
   setCompacting: () => Promise<void> | void;
+  /** Cancel any pending debounced emoji (useful before forcing a state transition). */
+  cancelPending: () => void;
   setDone: () => Promise<void>;
   setError: () => Promise<void>;
   clear: () => Promise<void>;
@@ -314,6 +316,11 @@ export function createStatusReactionController(params: {
     scheduleEmoji(emojis.compacting);
   }
 
+  function cancelPending(): void {
+    clearDebounceTimer();
+    pendingEmoji = "";
+  }
+
   function finishWithEmoji(emoji: string): Promise<void> {
     if (!enabled) {
       return Promise.resolve();
@@ -384,6 +391,7 @@ export function createStatusReactionController(params: {
     setThinking,
     setTool,
     setCompacting,
+    cancelPending,
     setDone,
     setError,
     clear,

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1481,7 +1481,7 @@ export const FIELD_HELP: Record<string, string> = {
   "messages.statusReactions.enabled":
     "Enable lifecycle status reactions for Telegram. When enabled, the ack reaction becomes the initial 'queued' state and progresses through thinking, tool, done/error automatically. Default: false.",
   "messages.statusReactions.emojis":
-    "Override default status reaction emojis. Keys: thinking, tool, coding, web, done, error, stallSoft, stallHard. Must be valid Telegram reaction emojis.",
+    "Override default status reaction emojis. Keys: thinking, compacting, tool, coding, web, done, error, stallSoft, stallHard. Must be valid Telegram reaction emojis.",
   "messages.statusReactions.timing":
     "Override default timing. Keys: debounceMs (700), stallSoftMs (25000), stallHardMs (60000), doneHoldMs (1500), errorHoldMs (2500).",
   "messages.inbound.debounceMs":

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -58,6 +58,7 @@ export type StatusReactionsEmojiConfig = {
   error?: string;
   stallSoft?: string;
   stallHard?: string;
+  compacting?: string;
 };
 
 export type StatusReactionsTimingConfig = {

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -169,6 +169,7 @@ export const MessagesSchema = z
             error: z.string().optional(),
             stallSoft: z.string().optional(),
             stallHard: z.string().optional(),
+            compacting: z.string().optional(),
           })
           .strict()
           .optional(),

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -47,15 +47,19 @@ type DispatchInboundParams = {
     onReasoningStream?: () => Promise<void> | void;
     onReasoningEnd?: () => Promise<void> | void;
     onToolStart?: (payload: { name?: string }) => Promise<void> | void;
+    onCompactionStart?: () => Promise<void> | void;
+    onCompactionEnd?: () => Promise<void> | void;
     onPartialReply?: (payload: { text?: string }) => Promise<void> | void;
     onAssistantMessageStart?: () => Promise<void> | void;
   };
 };
-const dispatchInboundMessage = vi.fn(async (_params?: DispatchInboundParams) => ({
-  queuedFinal: false,
-  counts: { final: 0, tool: 0, block: 0 },
-}));
-const recordInboundSession = vi.fn(async () => {});
+const dispatchInboundMessage = vi.hoisted(() =>
+  vi.fn(async (_params?: DispatchInboundParams) => ({
+    queuedFinal: false,
+    counts: { final: 0, tool: 0, block: 0 },
+  })),
+);
+const recordInboundSession = vi.hoisted(() => vi.fn(async () => {}));
 const configSessionsMocks = vi.hoisted(() => ({
   readSessionUpdatedAt: vi.fn(() => undefined),
   resolveStorePath: vi.fn(() => "/tmp/openclaw-discord-process-test-sessions.json"),
@@ -344,6 +348,39 @@ describe("processDiscordMessage ack reactions", () => {
     const emojis = getReactionEmojis();
     expect(emojis).toContain("🟦");
     expect(emojis).toContain("🏁");
+  });
+
+  it("shows compacting reaction during auto-compaction and resumes thinking", async () => {
+    vi.useFakeTimers();
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onCompactionStart?.();
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+      await params?.replyOptions?.onCompactionEnd?.();
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createBaseContext({
+      cfg: {
+        messages: {
+          ackReaction: "👀",
+          statusReactions: {
+            timing: { debounceMs: 0 },
+          },
+        },
+        session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
+      },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const runPromise = processDiscordMessage(ctx as any);
+    await vi.advanceTimersByTimeAsync(2_500);
+    await vi.runAllTimersAsync();
+    await runPromise;
+
+    const emojis = getReactionEmojis();
+    expect(emojis).toContain(DEFAULT_EMOJIS.compacting);
+    expect(emojis).toContain(DEFAULT_EMOJIS.thinking);
   });
 
   it("clears status reactions when dispatch aborts and removeAckAfterReply is enabled", async () => {

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -779,6 +779,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
           if (isProcessAborted(abortSignal)) {
             return;
           }
+          statusReactions.cancelPending();
           await statusReactions.setThinking();
         },
       },

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -769,6 +769,18 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
           }
           await statusReactions.setTool(payload.name);
         },
+        onCompactionStart: async () => {
+          if (isProcessAborted(abortSignal)) {
+            return;
+          }
+          await statusReactions.setCompacting();
+        },
+        onCompactionEnd: async () => {
+          if (isProcessAborted(abortSignal)) {
+            return;
+          }
+          await statusReactions.setThinking();
+        },
       },
     });
     if (isProcessAborted(abortSignal)) {

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -75,6 +75,8 @@ describe("resolveProxyFetchFromEnv", () => {
   it("returns proxy fetch using EnvHttpProxyAgent when HTTPS_PROXY is set", async () => {
     vi.stubEnv("HTTP_PROXY", "");
     vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+    delete process.env.https_proxy;
+    delete process.env.http_proxy;
     undiciFetch.mockResolvedValue({ ok: true });
 
     const fetchFn = resolveProxyFetchFromEnv();
@@ -91,6 +93,8 @@ describe("resolveProxyFetchFromEnv", () => {
   it("returns proxy fetch when HTTP_PROXY is set", () => {
     vi.stubEnv("HTTPS_PROXY", "");
     vi.stubEnv("HTTP_PROXY", "http://fallback.test:3128");
+    delete process.env.https_proxy;
+    delete process.env.http_proxy;
 
     const fetchFn = resolveProxyFetchFromEnv();
     expect(fetchFn).toBeDefined();

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -2182,4 +2182,41 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
     expect(finalTextSentViaDeliverReplies).toBe(true);
   });
+
+  it("shows compacting reaction during auto-compaction and resumes thinking", async () => {
+    const statusReactionController = {
+      setThinking: vi.fn(async () => {}),
+      setCompacting: vi.fn(async () => {}),
+      setTool: vi.fn(async () => {}),
+      setDone: vi.fn(async () => {}),
+      setError: vi.fn(async () => {}),
+      setQueued: vi.fn(async () => {}),
+      cancelPending: vi.fn(() => {}),
+      clear: vi.fn(async () => {}),
+      restoreInitial: vi.fn(async () => {}),
+    };
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onCompactionStart?.();
+      await replyOptions?.onCompactionEnd?.();
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({
+      context: createContext({
+        statusReactionController: statusReactionController as never,
+      }),
+      streamMode: "off",
+    });
+
+    expect(statusReactionController.setCompacting).toHaveBeenCalledTimes(1);
+    expect(statusReactionController.cancelPending).toHaveBeenCalledTimes(1);
+    expect(statusReactionController.setThinking).toHaveBeenCalledTimes(2);
+    expect(statusReactionController.setCompacting.mock.invocationCallOrder[0]).toBeLessThan(
+      statusReactionController.cancelPending.mock.invocationCallOrder[0],
+    );
+    expect(statusReactionController.cancelPending.mock.invocationCallOrder[0]).toBeLessThan(
+      statusReactionController.setThinking.mock.invocationCallOrder[1],
+    );
+  });
 });

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -717,7 +717,10 @@ export const dispatchTelegramMessage = async ({
           ? () => statusReactionController.setCompacting()
           : undefined,
         onCompactionEnd: statusReactionController
-          ? () => statusReactionController.setThinking()
+          ? async () => {
+              statusReactionController.cancelPending();
+              await statusReactionController.setThinking();
+            }
           : undefined,
         onModelSelected,
       },

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -713,6 +713,12 @@ export const dispatchTelegramMessage = async ({
               await statusReactionController.setTool(payload.name);
             }
           : undefined,
+        onCompactionStart: statusReactionController
+          ? () => statusReactionController.setCompacting()
+          : undefined,
+        onCompactionEnd: statusReactionController
+          ? () => statusReactionController.setThinking()
+          : undefined,
         onModelSelected,
       },
     }));

--- a/src/telegram/status-reaction-variants.ts
+++ b/src/telegram/status-reaction-variants.ts
@@ -90,6 +90,7 @@ export const TELEGRAM_STATUS_REACTION_VARIANTS: Record<StatusReactionEmojiKey, s
   error: ["😱", "😨", "🤯"],
   stallSoft: ["🥱", "😴", "🤔"],
   stallHard: ["😨", "😱", "⚡"],
+  compacting: ["✍", "🤔", "🤯"],
 };
 
 const STATUS_REACTION_EMOJI_KEYS: StatusReactionEmojiKey[] = [
@@ -102,6 +103,7 @@ const STATUS_REACTION_EMOJI_KEYS: StatusReactionEmojiKey[] = [
   "error",
   "stallSoft",
   "stallHard",
+  "compacting",
 ];
 
 function normalizeEmoji(value: string | undefined): string | undefined {
@@ -129,6 +131,7 @@ export function resolveTelegramStatusReactionEmojis(params: {
     error: normalizeEmoji(overrides?.error) ?? DEFAULT_EMOJIS.error,
     stallSoft: normalizeEmoji(overrides?.stallSoft) ?? DEFAULT_EMOJIS.stallSoft,
     stallHard: normalizeEmoji(overrides?.stallHard) ?? DEFAULT_EMOJIS.stallHard,
+    compacting: normalizeEmoji(overrides?.compacting) ?? DEFAULT_EMOJIS.compacting,
   };
 }
 

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -115,9 +115,14 @@ describe("agentLogoUrl", () => {
 describe("resolveAgentAvatarUrl", () => {
   it("prefers a runtime avatar URL over non-URL identity avatars", () => {
     expect(
-      resolveAgentAvatarUrl({ identity: { avatar: "A", avatarUrl: "/avatar/main" } }, {
-        avatar: "A",
-      } as { avatar: string }),
+      resolveAgentAvatarUrl(
+        { identity: { avatar: "A", avatarUrl: "/avatar/main" } },
+        {
+          agentId: "main",
+          avatar: "A",
+          name: "Main",
+        },
+      ),
     ).toBe("/avatar/main");
   });
 


### PR DESCRIPTION
Closes #35545

## Summary

When context auto-compaction runs on Telegram/Discord, the bot appears frozen for 10-30s with no feedback. This PR adds a `✍` (writing) status reaction during compaction so users know the bot is still working.

- Adds `compacting` state to `StatusReactionController` with `✍` emoji (debounced, same pattern as `setThinking`)
- Adds `onCompactionStart`/`onCompactionEnd` callbacks to `GetReplyOptions`
- Wires existing `onAgentEvent` compaction events (`stream: "compaction"`, `phase: "start"/"end"`) to the status reaction system
- On compaction end, resumes `thinking` reaction so the status flow continues naturally
- Applies to both Telegram and Discord channels
- Telegram variants: `["✍", "🤔", "🤯"]` (all in Telegram's supported reaction set)

## Files changed

| File | Change |
|------|--------|
| `src/channels/status-reactions.ts` | Add `compacting` emoji type + `setCompacting()` method |
| `src/telegram/status-reaction-variants.ts` | Add `compacting` emoji variants |
| `src/auto-reply/types.ts` | Add `onCompactionStart/End` callbacks |
| `src/auto-reply/reply/agent-runner-execution.ts` | Wire compaction events to callbacks |
| `src/telegram/bot-message-dispatch.ts` | Pass `setCompacting` via callbacks |
| `src/discord/monitor/message-handler.process.ts` | Same wiring for Discord |

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm tsgo` passes (type check)
- [x] `pnpm check` passes (lint/format)
- [x] Existing status reaction tests pass (51/51)
- [ ] Manual test on Telegram: send long conversation to trigger compaction, observe `✍` reaction
- [ ] Manual test: verify reaction switches back to `🤔`/`👍` after compaction completes
- [ ] Edge case: compaction with status reactions disabled — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)