### PR TITLE
fix(discord): add allowBotIds config to selectively allow bot messages (#11199)

### DIFF
--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -225,6 +225,13 @@ export type DiscordAccountConfig = {
   /** Allow bot-authored messages to trigger replies (default: false). Set "mentions" to gate on mentions. */
   allowBots?: boolean | "mentions";
   /**
+   * Explicit allowlist of Discord bot user IDs whose messages should be processed
+   * even when `allowBots` is false. Useful when multiple agent bots share a server
+   * and need to communicate without enabling all bot messages globally.
+   * Self-echo protection (botUserId) still applies regardless of this list.
+   */
+  allowBotIds?: string[];
+  /**
    * Break-glass override: allow mutable identity matching (names/tags/slugs) in allowlists.
    * Default behavior is ID-only matching.
    */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -425,6 +425,7 @@ export const DiscordAccountSchema = z
     token: SecretInputSchema.optional().register(sensitive),
     proxy: z.string().optional(),
     allowBots: z.union([z.boolean(), z.literal("mentions")]).optional(),
+    allowBotIds: z.array(z.string()).optional(),
     dangerouslyAllowNameMatching: z.boolean().optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     historyLimit: z.number().int().min(0).optional(),

--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -822,6 +822,166 @@ describe("preflightDiscordMessage", () => {
     expect(result).not.toBeNull();
     expect(result?.wasMentioned).toBe(true);
   });
+
+  it("allows messages from explicitly listed bot IDs even when allowBots=false", async () => {
+    // Scenario: two agent bots share a Discord server.
+    // Bot B (agent-bot-b) mentions Bot A (openclaw-bot-a) to route a task.
+    // Without allowBotIds, allowBots=false drops all bot messages before they reach
+    // any mention-gating or routing logic. The fix lets explicitly listed bots through.
+    const channelId = "channel-multi-bot-allow";
+    const guildId = "guild-multi-bot-allow";
+    const allowedBotId = "agent-bot-b";
+    const primaryBotId = "openclaw-bot-a";
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === channelId) {
+          return {
+            id: channelId,
+            type: ChannelType.GuildText,
+            name: "general",
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+    // Bot B explicitly mentions Bot A so the message passes the default mention gate
+    // (requireMention=true when no guild config is set).
+    const message = {
+      id: "m-multi-bot-allow-1",
+      content: `<@${primaryBotId}> run the analysis`,
+      timestamp: new Date().toISOString(),
+      channelId,
+      attachments: [],
+      mentionedUsers: [{ id: primaryBotId }],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: allowedBotId,
+        bot: true,
+        username: "AgentBotB",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: {
+        session: {
+          mainKey: "main",
+          scope: "per-sender",
+        },
+      } as import("../../config/config.js").OpenClawConfig,
+      discordConfig: {
+        allowBots: false,
+        allowBotIds: [allowedBotId],
+      } as unknown as NonNullable<
+        import("../../config/config.js").OpenClawConfig["channels"]
+      >["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: primaryBotId,
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "open",
+      threadBindings: createNoopThreadBindingManager("default"),
+      data: {
+        channel_id: channelId,
+        guild_id: guildId,
+        guild: {
+          id: guildId,
+          name: "Multi-Bot Guild",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    // Bot message from an explicitly allowlisted bot ID should reach the agent
+    // even when the global allowBots setting is false.
+    expect(result).not.toBeNull();
+  });
+
+  it("still drops bot messages when allowBots=false and bot ID is not in allowBotIds", async () => {
+    const channelId = "channel-multi-bot-deny";
+    const guildId = "guild-multi-bot-deny";
+    const primaryBotId = "openclaw-bot-a";
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === channelId) {
+          return {
+            id: channelId,
+            type: ChannelType.GuildText,
+            name: "general",
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+    const message = {
+      id: "m-multi-bot-deny-1",
+      content: `<@${primaryBotId}> do something`,
+      timestamp: new Date().toISOString(),
+      channelId,
+      attachments: [],
+      mentionedUsers: [{ id: primaryBotId }],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "some-unknown-bot",
+        bot: true,
+        username: "UnknownBot",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: {
+        session: {
+          mainKey: "main",
+          scope: "per-sender",
+        },
+      } as import("../../config/config.js").OpenClawConfig,
+      discordConfig: {
+        allowBots: false,
+        allowBotIds: ["agent-bot-b"],
+      } as unknown as NonNullable<
+        import("../../config/config.js").OpenClawConfig["channels"]
+      >["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: primaryBotId,
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "open",
+      threadBindings: createNoopThreadBindingManager("default"),
+      data: {
+        channel_id: channelId,
+        guild_id: guildId,
+        guild: {
+          id: guildId,
+          name: "Multi-Bot Guild",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    // Unknown bot (not in allowBotIds) should still be dropped with allowBots=false.
+    expect(result).toBeNull();
+  });
 });
 
 describe("shouldIgnoreBoundThreadWebhookMessage", () => {

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -183,8 +183,13 @@ export async function preflightDiscordMessage(
 
   if (author.bot) {
     if (allowBotsMode === "off" && !sender.isPluralKit) {
-      logVerbose("discord: drop bot message (allowBots=false)");
-      return null;
+      const allowBotIds = params.discordConfig?.allowBotIds ?? [];
+      const isExplicitlyAllowedBot = allowBotIds.includes(author.id);
+      if (!isExplicitlyAllowedBot) {
+        logVerbose("discord: drop bot message (allowBots=false)");
+        return null;
+      }
+      logVerbose(`discord: allow explicitly listed bot ${author.id} (allowBotIds)`);
     }
   }
 

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -300,7 +300,7 @@ async function resolveImagesForRequest(
   for (const url of urls) {
     const source = parseImageUrlToSource(url);
     if (source.type === "base64") {
-      totalBytes += estimateBase64DecodedBytes(source.data);
+      totalBytes += estimateBase64DecodedBytes(source.data ?? "");
       if (totalBytes > limits.maxTotalImageBytes) {
         throw new Error(
           `Total image payload too large (${totalBytes}; limit ${limits.maxTotalImageBytes})`,


### PR DESCRIPTION
## Problem

When multiple agent bots share a Discord server, the current bot-filtering logic is all-or-nothing. With `allowBots: false` (the default), **every** bot message is dropped — including intentional bot-to-bot communication where Bot B needs to reach Bot A. With `allowBots: true`, all bots are admitted globally with no way to whitelist specific trusted bots.

## Root cause

`src/discord/monitor/message-handler.preflight.ts` lines ~181–185: when `allowBotsMode === "off"`, the preflight returns `null` for every bot author unconditionally. There is no `allowBotIds` config field, so there is no per-ID exception path.

## Fix

Added `allowBotIds?: string[]` to `DiscordAccountConfig` and the Zod runtime schema. The bot-drop guard now checks the list before returning `null`:

```ts
if (allowBotsMode === "off" && !sender.isPluralKit) {
  const allowBotIds = params.discordConfig?.allowBotIds ?? [];
  const isExplicitlyAllowedBot = allowBotIds.includes(author.id);
  if (!isExplicitlyAllowedBot) {
    logVerbose("discord: drop bot message (allowBots=false)");
    return null;
  }
  logVerbose(`discord: allow explicitly listed bot ${author.id} (allowBotIds)`);
}
```

Operators can now whitelist specific bots:

```yaml
channels:
  discord:
    allowBots: false      # default — still blocks all unknown bots
    allowBotIds:
      - "1234567890"      # Bot B — trusted agent, allowed through
```

## Verification
- **Test:** `src/discord/monitor/message-handler.preflight.test.ts` — two new tests:
  - "allows messages from explicitly listed bot IDs even when allowBots=false" — **fails on main, passes on fix**
  - "still drops bot messages when allowBots=false and bot ID is not in allowBotIds" — passes on both (regression guard)
- **Build:** clean compile (`build-output.log` — `BUILD_STATUS: success`)
- **Test suite:** 812 passed, 0 regressions (`test-output.log` — `TEST_STATUS: success`)
- **Code proof:** old unconditional drop removed, `allowBotIds` guard confirmed in preflight + types + schema (`step6-verify.log`)

Closes #11199