### PR TITLE
fix(auto-reply,gateway): guard for-of loops on optional array fields

### DIFF
--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -63,7 +63,7 @@ export function buildInboundMediaNote(ctx: MsgContext): string | undefined {
       if (decision.outcome !== "success") {
         continue;
       }
-      for (const attachment of decision.attachments) {
+      for (const attachment of decision.attachments ?? []) {
         if (attachment.chosen?.outcome === "success") {
           suppressed.add(attachment.attachmentIndex);
           if (decision.capability === "audio") {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -327,7 +327,7 @@ export async function handleOpenResponsesHttpRequest(
     if (Array.isArray(payload.input)) {
       for (const item of payload.input) {
         if (item.type === "message" && typeof item.content !== "string") {
-          for (const part of item.content) {
+          for (const part of item.content ?? []) {
             if (part.type === "input_image") {
               const source = part.source as {
                 type?: string;


### PR DESCRIPTION
## Summary

Two `for...of` loops iterate values that can be `undefined` or `null`, causing `TypeError: undefined is not iterable`:

1. **`src/auto-reply/media-note.ts`** — `decision.attachments` is iterated without a nullish fallback. The parent array `ctx.MediaUnderstandingDecisions` IS guarded with `Array.isArray`, but the inner `attachments` field on each decision can be `undefined` when the API returns a partial success response or a decision without attachments.

2. **`src/gateway/openresponses-http.ts`** — `item.content` is checked as `typeof !== "string"` but could still be `null`/`undefined` (e.g., a message item with no content field). The `for...of` loop then crashes during Responses API HTTP input parsing.

Both now use `?? []` to provide an empty array fallback.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [x] Agents / Model integration
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [x] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — no single issue.

## User-Visible Changes

None. Malformed API responses no longer crash media understanding or Responses API.

## Security Impact

1. Does this change handle user input? **Yes** — API request payloads
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 16 tests pass (11 media-note + 5 openresponses-http)
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ src/auto-reply/media-note.test.ts (11 tests) 3ms
 ✓ src/gateway/openresponses-http.test.ts (5 tests) 4144ms
 Test Files  2 passed (2)
      Tests  16 passed (16)
```

## Human Verification

- Send a media understanding decision with missing `attachments` field — should not crash
- Send a Responses API request with a message item that has `content: null` — should not crash

## Compatibility

Fully backward compatible. Valid inputs behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Empty array fallback skips processing | The alternative is a crash; skipping undefined fields is correct behavior |