### PR TITLE
fix(agents): honour explicit contextWindow/maxTokens overrides in model merge

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -258,8 +258,10 @@ describe("models-config", () => {
         const kimi = parsed.providers.moonshot?.models?.find((model) => model.id === "kimi-k2.5");
         expect(kimi?.input).toEqual(["text", "image"]);
         expect(kimi?.reasoning).toBe(false);
-        expect(kimi?.contextWindow).toBe(256000);
-        expect(kimi?.maxTokens).toBe(8192);
+        // User explicitly set contextWindow/maxTokens — honour their values
+        // even when they are lower than the implicit catalog (fixes #35436).
+        expect(kimi?.contextWindow).toBe(1024);
+        expect(kimi?.maxTokens).toBe(256);
         // Preserve explicit user pricing overrides when refreshing capabilities.
         expect(kimi?.cost?.input).toBe(123);
         expect(kimi?.cost?.output).toBe(456);

--- a/src/agents/models-config.respects-explicit-contextwindow-override.test.ts
+++ b/src/agents/models-config.respects-explicit-contextwindow-override.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
+import {
+  installModelsConfigTestHooks,
+  withModelsTempHome as withTempHome,
+} from "./models-config.e2e-harness.js";
+import { ensureOpenClawModelsJson } from "./models-config.js";
+import { readGeneratedModelsJson } from "./models-config.test-utils.js";
+
+installModelsConfigTestHooks();
+
+type ModelEntry = {
+  id: string;
+  contextWindow?: number;
+  maxTokens?: number;
+};
+
+type ModelsJson = {
+  providers: Record<string, { models?: ModelEntry[] }>;
+};
+
+const PROVIDER_KEY = "custom-proxy";
+const MODEL_ID = "qwen3:4b";
+const TEST_KEY = "sk-test";
+
+const baseProvider = {
+  baseUrl: "http://localhost:11434/v1",
+  apiKey: TEST_KEY,
+  api: "openai-completions",
+} as const;
+
+const baseModel: ModelDefinitionConfig = {
+  id: MODEL_ID,
+  name: "Qwen3 4B",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128000,
+  maxTokens: 8192,
+};
+
+function makeConfig(overrides: {
+  contextWindow: number;
+  maxTokens: number;
+}): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        [PROVIDER_KEY]: {
+          ...baseProvider,
+          models: [
+            {
+              ...baseModel,
+              contextWindow: overrides.contextWindow,
+              maxTokens: overrides.maxTokens,
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+async function readModel(): Promise<ModelEntry | undefined> {
+  const parsed = await readGeneratedModelsJson<ModelsJson>();
+  return parsed.providers[PROVIDER_KEY]?.models?.find((m) => m.id === MODEL_ID);
+}
+
+describe("models-config: explicit contextWindow / maxTokens override (#35436)", () => {
+  it("honours user contextWindow when it is lower than the implicit catalog value", async () => {
+    await withTempHome(async () => {
+      const cfg = makeConfig({ contextWindow: 4096, maxTokens: 2048 });
+      await ensureOpenClawModelsJson(cfg);
+      const m = await readModel();
+      expect(m).toBeDefined();
+      expect(m?.contextWindow).toBe(4096);
+      expect(m?.maxTokens).toBe(2048);
+    });
+  });
+
+  it("honours user contextWindow when it is higher than the implicit value", async () => {
+    await withTempHome(async () => {
+      const cfg = makeConfig({ contextWindow: 256000, maxTokens: 32000 });
+      await ensureOpenClawModelsJson(cfg);
+      const m = await readModel();
+      expect(m).toBeDefined();
+      expect(m?.contextWindow).toBe(256000);
+      expect(m?.maxTokens).toBe(32000);
+    });
+  });
+
+  it("preserves explicit contextWindow even when equal to implicit", async () => {
+    await withTempHome(async () => {
+      const cfg = makeConfig({ contextWindow: 128000, maxTokens: 8192 });
+      await ensureOpenClawModelsJson(cfg);
+      const m = await readModel();
+      expect(m).toBeDefined();
+      expect(m?.contextWindow).toBe(128000);
+      expect(m?.maxTokens).toBe(8192);
+    });
+  });
+});

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -16,10 +16,18 @@ type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 
 const DEFAULT_MODE: NonNullable<ModelsConfig["mode"]> = "merge";
 
-function resolvePreferredTokenLimit(explicitValue: number, implicitValue: number): number {
-  // Keep catalog refresh behavior for stale low values while preserving
-  // intentional larger user overrides (for example Ollama >128k contexts).
-  return explicitValue > implicitValue ? explicitValue : implicitValue;
+function resolvePreferredTokenLimit(
+  explicitValue: number | undefined,
+  implicitValue: number,
+): number {
+  // When the user explicitly sets a value in their config (field is present),
+  // honour it unconditionally — they may intentionally lower the limit (e.g.
+  // Ollama users on constrained hardware reducing contextWindow to 4096).
+  // Only fall back to the implicit catalog value when the user omits the field.
+  if (explicitValue !== undefined && Number.isFinite(explicitValue) && explicitValue > 0) {
+    return explicitValue;
+  }
+  return implicitValue;
 }
 
 function mergeProviderModels(implicit: ProviderConfig, explicit: ProviderConfig): ProviderConfig {
@@ -63,10 +71,13 @@ function mergeProviderModels(implicit: ProviderConfig, explicit: ProviderConfig)
       input: implicitModel.input,
       reasoning: "reasoning" in explicitModel ? explicitModel.reasoning : implicitModel.reasoning,
       contextWindow: resolvePreferredTokenLimit(
-        explicitModel.contextWindow,
+        "contextWindow" in explicitModel ? explicitModel.contextWindow : undefined,
         implicitModel.contextWindow,
       ),
-      maxTokens: resolvePreferredTokenLimit(explicitModel.maxTokens, implicitModel.maxTokens),
+      maxTokens: resolvePreferredTokenLimit(
+        "maxTokens" in explicitModel ? explicitModel.maxTokens : undefined,
+        implicitModel.maxTokens,
+      ),
     };
   });
 


### PR DESCRIPTION
## Summary

- **Problem:** `resolvePreferredTokenLimit` always picks the larger value between the user's explicit `contextWindow`/`maxTokens` and the implicit catalog default. Users cannot lower these values — critical for Ollama users on constrained hardware (e.g. `num_ctx=4096` on 16GB RAM) where the discovered/default 128K context causes Ollama to request 36GB+ of memory.
- **Why it matters:** Any Ollama user with <40GB RAM cannot use OpenClaw at all; 100% reproducible on the majority of consumer hardware.
- **What changed:** `src/agents/models-config.ts` — `resolvePreferredTokenLimit` now honours the user's explicit value unconditionally when present; the implicit catalog value is only used as a fallback when the user omits the field. The merge callsite uses `"contextWindow" in explicitModel` to detect explicit presence.
- **What did NOT change:** Implicit catalog discovery, Ollama native stream path, OpenAI-compat `num_ctx` injection, or any other provider logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35436

## User-visible / Behavior Changes

- Users can now set `contextWindow` to a value **lower** than the implicit catalog default and have it respected. Previously the merge logic always picked the larger value, silently ignoring lower overrides.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any (reproduced on Windows 11 + macOS)
- Runtime: Node.js 24.x
- Integration/channel: Ollama provider (any model)

### Steps

1. Add Ollama as a provider in `openclaw.json` with `contextWindow: 4096` on a model
2. Start gateway, send any message
3. Check Ollama runner logs for `KvSize` / `num_ctx`

### Expected

- Ollama receives `num_ctx=4096`

### Actual

- Before fix: Ollama receives `num_ctx=128000` (from implicit catalog), requesting 36GB+ RAM
- After fix: Ollama receives `num_ctx=4096` as configured

## Evidence

All 73 tests pass across 18 test files:

```
Test Files  18 passed (18)
     Tests  73 passed (73)
```

New test file: `models-config.respects-explicit-contextwindow-override.test.ts` (3 cases):
- Lower explicit contextWindow (4096) is honoured
- Higher explicit contextWindow (256000) is honoured
- Equal explicit contextWindow (128000) is preserved

Updated test: `models-config.fills-missing-provider-apikey-from-env-var.test.ts`:
- "refreshes stale explicit moonshot model capabilities" now expects user's explicit value to win

## Human Verification (required)

- Verified scenarios: Lower override (4096), higher override (256000), equal override (128000), omitted field falls back to implicit
- Edge cases checked: `undefined` explicit value, non-finite values, zero/negative values all fall back to implicit
- What I did **not** verify: Live Ollama instance with actual `num_ctx` passthrough (tested at model merge layer only)

## Compatibility / Migration

- Backward compatible? `Yes` — users who never set `contextWindow` explicitly see no change (implicit catalog value used as before). Users who set it to a higher-than-catalog value also see no change (their value is already respected). Only users who set it **lower** see the fix.
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit; the merge logic returns to "pick larger value"
- Files/config to restore: `src/agents/models-config.ts`
- Known bad symptoms: If reverted, Ollama users on constrained hardware will again fail with OOM

## Risks and Mitigations

- **Risk:** Users with genuinely stale `contextWindow` values in their config (e.g. left over from an older catalog) will no longer be auto-upgraded to the catalog's larger value. **Mitigation:** This is the correct trade-off — an explicit user setting should always win. Users who want the catalog default can simply remove `contextWindow` from their model config.

