### PR TITLE
fix(cron): create backup before writing new content

### DIFF
--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -74,8 +74,7 @@ export async function saveCronStore(storePath: string, store: CronStoreFile) {
     serializedStoreCache.set(storePath, json);
     return;
   }
-  const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.promises.writeFile(tmp, json, "utf-8");
+  // Create backup BEFORE writing new content, so the backup reflects the original state
   if (previous !== null) {
     try {
       await fs.promises.copyFile(storePath, `${storePath}.bak`);
@@ -83,6 +82,8 @@ export async function saveCronStore(storePath: string, store: CronStoreFile) {
       // best-effort
     }
   }
+  const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
+  await fs.promises.writeFile(tmp, json, "utf-8");
   await renameWithRetry(tmp, storePath);
   serializedStoreCache.set(storePath, json);
 }


### PR DESCRIPTION
When using openclaw cron edit to modify a cron job, the backup file jobs.json.bak was created after the modification, making it identical to the current jobs.json. This defeats the purpose of having a backup.

Now the backup is created before writing the new content, so users can see the difference between the original and modified versions.

Closes #35195