### PR TITLE
feat(agents): flush reply pipeline before compaction wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Agents/reply delivery timing: flush embedded Pi block replies before waiting on compaction retries so already-generated assistant replies reach channels before compaction wait completes. (#35489) thanks @Sid-Qin.
 - Gateway/chat streaming tool-boundary text retention: merge assistant delta segments into per-run chat buffers so pre-tool text is preserved in live chat deltas/finals when providers emit post-tool assistant segments as non-prefix snapshots. (#36957) Thanks @Datyedyeguy.
 - TUI/model indicator freshness: prevent stale session snapshots from overwriting freshly patched model selection (and reset per-session freshness when switching session keys) so `/model` updates reflect immediately instead of lagging by one or more commands. (#21255) Thanks @kowza.
 - TUI/final-error rendering fallback: when a chat `final` event has no renderable assistant content but includes envelope `errorMessage`, render the formatted error text instead of collapsing to `"(no output)"`, preserving actionable failure context in-session. (#14687) Thanks @Mquarmoc.
@@ -161,6 +160,7 @@ Docs: https://docs.openclaw.ai
 - Discord/inbound timeout isolation: separate inbound worker timeout tracking from listener timeout budgets so queued Discord replies are no longer dropped when listener watchdog windows expire mid-run. (#36602) Thanks @dutifulbob.
 - Memory/doctor SecretRef handling: treat SecretRef-backed memory-search API keys as configured, and fail embedding setup with explicit unresolved-secret errors instead of crashing. (#36835) Thanks @joshavant.
 - Memory/flush default prompt: ban timestamped variant filenames during default memory flush runs so durable notes stay in the canonical daily `memory/YYYY-MM-DD.md` file. (#34951) thanks @zerone0x.
+- Agents/reply delivery timing: flush embedded Pi block replies before waiting on compaction retries so already-generated assistant replies reach channels before compaction wait completes. (#35489) thanks @Sid-Qin.
 
 ## 2026.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/reply delivery timing: flush embedded Pi block replies before waiting on compaction retries so already-generated assistant replies reach channels before compaction wait completes. (#35489) thanks @Sid-Qin.
 - Gateway/chat streaming tool-boundary text retention: merge assistant delta segments into per-run chat buffers so pre-tool text is preserved in live chat deltas/finals when providers emit post-tool assistant segments as non-prefix snapshots. (#36957) Thanks @Datyedyeguy.
 - TUI/model indicator freshness: prevent stale session snapshots from overwriting freshly patched model selection (and reset per-session freshness when switching session keys) so `/model` updates reflect immediately instead of lagging by one or more commands. (#21255) Thanks @kowza.
 - TUI/final-error rendering fallback: when a chat `final` event has no renderable assistant content but includes envelope `errorMessage`, render the formatted error text instead of collapsing to `"(no output)"`, preserving actionable failure context in-session. (#14687) Thanks @Mquarmoc.

--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -26,8 +26,8 @@ async function loadRunEmbeddedPiAgent(): Promise<RunEmbeddedPiAgentFn> {
 
   // Bundled install (built)
   // NOTE: there is no src/ tree in a packaged install. Prefer a stable internal entrypoint.
-  const distModulePath = "../../../dist/extensionAPI.js";
-  const mod = await import(distModulePath);
+  const distExtensionApi = "../../../dist/extensionAPI.js";
+  const mod = (await import(distExtensionApi)) as { runEmbeddedPiAgent?: unknown };
   // oxlint-disable-next-line typescript/no-explicit-any
   const fn = (mod as any).runEmbeddedPiAgent;
   if (typeof fn !== "function") {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1688,6 +1688,14 @@ export async function runEmbeddedAttempt(
         const preCompactionSessionId = activeSession.sessionId;
 
         try {
+          // Flush buffered block replies before waiting for compaction so the
+          // user receives the assistant response immediately.  Without this,
+          // coalesced/buffered blocks stay in the pipeline until compaction
+          // finishes — which can take minutes on large contexts (#35074).
+          if (params.onBlockReplyFlush) {
+            await params.onBlockReplyFlush();
+          }
+
           await abortable(waitForCompactionRetry());
         } catch (err) {
           if (isRunnerAbortError(err)) {

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -73,6 +73,11 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
   }
 
   ctx.flushBlockReplyBuffer();
+  // Flush the reply pipeline so the response reaches the channel before
+  // compaction wait blocks the run.  This mirrors the pattern used by
+  // handleToolExecutionStart and ensures delivery is not held hostage to
+  // long-running compaction (#35074).
+  void ctx.params.onBlockReplyFlush?.();
 
   ctx.state.blockState.thinking = false;
   ctx.state.blockState.final = false;


### PR DESCRIPTION
## Summary

- **Problem:** Auto-compaction blocks the run pipeline after `prompt()` returns. Buffered block replies (the assistant's response) sit in the delivery pipeline until compaction finishes — which can take 7+ minutes on large contexts (141 messages / 139K chars on Opus 4.6). The user sees no reply for the entire duration despite the response being fully generated.
- **Why it matters:** Any long-running iMessage/Telegram/WhatsApp session approaching the compaction threshold experiences invisible multi-minute delays, making the assistant appear unresponsive.
- **What changed:** Two files:
  - `src/agents/pi-embedded-runner/run/attempt.ts` — calls `onBlockReplyFlush()` before `waitForCompactionRetry()` so the pipeline drains while compaction may still be running
  - `src/agents/pi-embedded-subscribe.handlers.lifecycle.ts` — calls `onBlockReplyFlush()` after `flushBlockReplyBuffer()` in `handleAgentEnd` (mirroring the existing pattern in `handleToolExecutionStart`)
- **What did NOT change:** Compaction logic itself, session management, message ordering, or any channel-specific delivery code.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35074

## User-visible / Behavior Changes

- Assistant responses are now delivered to the channel **immediately** after generation, rather than being held until post-turn compaction completes. Compaction still runs normally but no longer blocks delivery.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.4 (Apple Silicon M4)
- Runtime: Node.js, Opus 4.6
- Integration/channel: iMessage (also affects Telegram, WhatsApp, any messaging channel)

### Steps

1. Run a long conversation (100+ messages, approaching compaction threshold)
2. Send a message that triggers the model to respond
3. Observe response delivery timing relative to compaction

### Expected

- Response delivered within seconds of generation, compaction runs in background

### Actual

- Before fix: Response held for 7+ minutes while compaction runs (444,767ms observed)
- After fix: Response delivered immediately, compaction runs concurrently

## Evidence

All 477 tests pass across 67 test files:

```
# Subscribe handler tests
Test Files  27 passed (27)
     Tests  132 passed (132)

# Runner tests
Test Files  40 passed (40)
     Tests  345 passed (345)
```

The fix mirrors the existing flush pattern already used by `handleToolExecutionStart` (lines 184–188 of `pi-embedded-subscribe.handlers.tools.ts`).

## Human Verification (required)

- Verified scenarios: `onBlockReplyFlush` called before compaction wait in attempt.ts, `onBlockReplyFlush` called in handleAgentEnd mirroring tool handler pattern
- Edge cases checked: `onBlockReplyFlush` is optional (guarded with `?.` and `if` check), no-op when pipeline is already empty
- What I did **not** verify: Live multi-minute compaction with real iMessage channel (tested at pipeline/handler level only)

## Compatibility / Migration

- Backward compatible? `Yes` — delivery simply happens earlier in the pipeline; compaction behaviour is unchanged
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit; delivery returns to post-compaction timing
- Files/config to restore: `attempt.ts`, `handlers.lifecycle.ts`
- Known bad symptoms: If reverted, users on long sessions will again see 7+ minute invisible delays

## Risks and Mitigations

- **Risk:** Flushing before compaction could theoretically deliver a partial response if the model is still streaming. **Mitigation:** The flush happens after `prompt()` returns (model generation complete) and after `handleAgentEnd` fires (agent turn complete), so the response is always fully generated at this point.
- **Risk:** `onBlockReplyFlush` throws. **Mitigation:** The `await` in attempt.ts is inside the existing try/catch for the compaction wait; the `void` in handleAgentEnd is fire-and-forget matching tool handler semantics.

