### PR TITLE
fix(signal): add typeof string guards before .trim() in reactions and monitor

### DIFF
--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -132,11 +132,12 @@ function normalizeAllowList(raw?: Array<string | number>): string[] {
 
 function resolveSignalReactionTargets(reaction: SignalReactionMessage): SignalReactionTarget[] {
   const targets: SignalReactionTarget[] = [];
-  const uuid = reaction.targetAuthorUuid?.trim();
+  const uuid =
+    typeof reaction.targetAuthorUuid === "string" ? reaction.targetAuthorUuid.trim() : "";
   if (uuid) {
     targets.push({ kind: "uuid", id: uuid, display: `uuid:${uuid}` });
   }
-  const author = reaction.targetAuthor?.trim();
+  const author = typeof reaction.targetAuthor === "string" ? reaction.targetAuthor.trim() : "";
   if (author) {
     const normalized = normalizeE164(author);
     targets.push({ kind: "phone", id: normalized, display: normalized });
@@ -150,9 +151,12 @@ function isSignalReactionMessage(
   if (!reaction) {
     return false;
   }
-  const emoji = reaction.emoji?.trim();
+  const emoji = typeof reaction.emoji === "string" ? reaction.emoji.trim() : "";
   const timestamp = reaction.targetSentTimestamp;
-  const hasTarget = Boolean(reaction.targetAuthor?.trim() || reaction.targetAuthorUuid?.trim());
+  const hasTarget = Boolean(
+    (typeof reaction.targetAuthor === "string" && reaction.targetAuthor.trim()) ||
+    (typeof reaction.targetAuthorUuid === "string" && reaction.targetAuthorUuid.trim()),
+  );
   return Boolean(emoji && typeof timestamp === "number" && timestamp > 0 && hasTarget);
 }
 
@@ -169,7 +173,7 @@ function shouldEmitSignalReactionNotification(params: {
     return false;
   }
   if (effectiveMode === "own") {
-    const accountId = account?.trim();
+    const accountId = typeof account === "string" ? account.trim() : "";
     if (!accountId || !targets || targets.length === 0) {
       return false;
     }
@@ -340,8 +344,11 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
   const groupHistories = new Map<string, HistoryEntry[]>();
   const textLimit = resolveTextChunkLimit(cfg, "signal", accountInfo.accountId);
   const chunkMode = resolveChunkMode(cfg, "signal", accountInfo.accountId);
-  const baseUrl = opts.baseUrl?.trim() || accountInfo.baseUrl;
-  const account = opts.account?.trim() || accountInfo.config.account?.trim();
+  const baseUrl =
+    (typeof opts.baseUrl === "string" ? opts.baseUrl.trim() : "") || accountInfo.baseUrl;
+  const account =
+    (typeof opts.account === "string" ? opts.account.trim() : "") ||
+    (typeof accountInfo.config.account === "string" ? accountInfo.config.account.trim() : "");
   const dmPolicy = accountInfo.config.dmPolicy ?? "pairing";
   const allowFrom = normalizeAllowList(opts.allowFrom ?? accountInfo.config.allowFrom);
   const groupAllowFrom = normalizeAllowList(

--- a/src/signal/send-reactions.test.ts
+++ b/src/signal/send-reactions.test.ts
@@ -62,4 +62,25 @@ describe("sendReactionSignal", () => {
     expect(params.targetAuthor).toBe("+15551230000");
     expect(params.remove).toBe(true);
   });
+
+  it("does not crash when normalizeSignalId receives a non-string at runtime", async () => {
+    await expect(
+      sendReactionSignal(
+        // @ts-expect-error — simulate runtime non-string (e.g. numeric value from JSON)
+        12345,
+        100,
+        "👍",
+      ),
+    ).rejects.toThrow(/Recipient or groupId is required/i);
+  });
+
+  it("skips non-string targetAuthor candidates without crashing", async () => {
+    await sendReactionSignal("+15550001111", 100, "👍", {
+      // @ts-expect-error — simulate numeric value from config
+      targetAuthor: 42,
+    });
+
+    const params = rpcMock.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(params.targetAuthor).toBe("+15550001111");
+  });
 });

--- a/src/signal/send-reactions.ts
+++ b/src/signal/send-reactions.ts
@@ -32,6 +32,9 @@ type SignalReactionErrorMessages = {
 };
 
 function normalizeSignalId(raw: string): string {
+  if (typeof raw !== "string") {
+    return "";
+  }
   const trimmed = raw.trim();
   if (!trimmed) {
     return "";
@@ -57,7 +60,10 @@ function resolveTargetAuthorParams(params: {
 }): { targetAuthor?: string } {
   const candidates = [params.targetAuthor, params.targetAuthorUuid, params.fallback];
   for (const candidate of candidates) {
-    const raw = candidate?.trim();
+    if (typeof candidate !== "string") {
+      continue;
+    }
+    const raw = candidate.trim();
     if (!raw) {
       continue;
     }


### PR DESCRIPTION
## Summary

Several Signal module functions use optional chaining (`?.trim()`) to guard against `null`/`undefined`, but this does NOT guard against non-string truthy values. If the Signal daemon sends a numeric UUID or a user config contains `account: 12345` (unquoted YAML), `(42)?.trim()` throws `TypeError: x?.trim is not a function` because `42` is not nullish but has no `.trim()` method.

Affected locations:

1. **`src/signal/send-reactions.ts`** — `normalizeSignalId` now rejects non-string `raw` early; `resolveTargetAuthorParams` uses `typeof` check instead of `?.trim()` to skip non-string candidates.
2. **`src/signal/monitor.ts`** — `resolveSignalReactionTargets`, `isSignalReactionMessage`, `shouldEmitSignalReactionNotification`, and monitor config resolution (`baseUrl`, `account`) all replaced `?.trim()` with explicit `typeof === "string"` guards.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — no single issue.

## User-Visible Changes

None. Signal reactions and monitoring no longer crash when daemon or config sends non-string values.

## Security Impact

1. Does this change handle user input? **Yes** — daemon JSON-RPC responses and YAML config values
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 11 existing + 2 new tests pass (send-reactions: 5, monitor: 6)
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ src/signal/send-reactions.test.ts (5 tests) 4ms
 ✓ src/signal/monitor.test.ts (6 tests) 2ms
 Test Files  2 passed (2)
      Tests  11 passed (11)
```

## Human Verification

- Set `account: 12345` (numeric, unquoted) in Signal config — monitor should not crash
- Send a reaction to a message from a daemon that returns numeric UUIDs — should not crash
- Verify normal string-valued reactions still resolve correctly

## Compatibility

Fully backward compatible. Valid string inputs behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Non-string values silently become empty string | Matches existing behavior for null/undefined; prevents crash |
| False-positive type rejection on valid string input | typeof check only rejects non-string types; all valid strings pass through |