### PR TITLE
fix(doctor): avoid crash on SecretRef memory API keys

### DIFF
--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -135,6 +135,28 @@ describe("noteMemorySearchHealth", () => {
     await expectNoWarningWithConfiguredRemoteApiKey("openai");
   });
 
+  it("does not crash when remote apiKey is a SecretRef-like object", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "openai",
+      local: {},
+      remote: { apiKey: { fromEnv: "OPENAI_API_KEY" } },
+    });
+    resolveApiKeyForProvider.mockResolvedValue({
+      apiKey: "k",
+      source: "env: OPENAI_API_KEY",
+      mode: "api-key",
+    });
+
+    await expect(noteMemorySearchHealth(cfg, {})).resolves.toBeUndefined();
+
+    expect(resolveApiKeyForProvider).toHaveBeenCalledWith({
+      provider: "openai",
+      cfg,
+      agentDir: "/tmp/agent-default",
+    });
+    expect(note).not.toHaveBeenCalled();
+  });
+
   it("does not warn in auto mode when remote apiKey is configured", async () => {
     await expectNoWarningWithConfiguredRemoteApiKey("auto");
   });

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -26,7 +26,8 @@ export async function noteMemorySearchHealth(
   const agentId = resolveDefaultAgentId(cfg);
   const agentDir = resolveAgentDir(cfg, agentId);
   const resolved = resolveMemorySearchConfig(cfg, agentId);
-  const hasRemoteApiKey = Boolean(resolved?.remote?.apiKey?.trim());
+  const remoteApiKey = resolved?.remote?.apiKey;
+  const hasRemoteApiKey = typeof remoteApiKey === "string" && remoteApiKey.trim().length > 0;
 
   if (!resolved) {
     note("Memory search is explicitly disabled (enabled: false).", "Memory search");


### PR DESCRIPTION
## Summary
- guard memory-search remote API key checks in `openclaw doctor` so non-string values do not call `.trim()`
- keep existing behavior for string API keys
- add regression coverage for SecretRef-like `remote.apiKey` objects

## Testing
- `pnpm test -- src/commands/doctor-memory-search.test.ts`

Fixes #35444
