### PR TITLE
feat(agents): guard read tool against binary document formats

### DIFF
--- a/src/agents/pi-tools.read.binary-doc-guard.test.ts
+++ b/src/agents/pi-tools.read.binary-doc-guard.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { createOpenClawReadTool } from "./pi-tools.read.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+
+function createMockReadTool(): AnyAgentTool {
+  return {
+    name: "read",
+    description: "Read a file",
+    schema: {
+      type: "object" as const,
+      properties: {
+        path: { type: "string", description: "File path" },
+      },
+      required: ["path"],
+    },
+    execute: vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "file contents" }],
+    }),
+  } as unknown as AnyAgentTool;
+}
+
+describe("createOpenClawReadTool: binary document guard (#35406)", () => {
+  const binaryExtensions = [
+    ".docx",
+    ".doc",
+    ".xlsx",
+    ".xls",
+    ".pptx",
+    ".ppt",
+    ".pdf",
+    ".odt",
+    ".epub",
+  ];
+
+  for (const ext of binaryExtensions) {
+    it(`blocks reading of ${ext} files and returns a helpful message`, async () => {
+      const base = createMockReadTool();
+      const tool = createOpenClawReadTool(base);
+      const result = await tool.execute("tc1", { path: `/tmp/report${ext}` }, undefined as never);
+      expect(result.content).toHaveLength(1);
+      const block = result.content[0] as { type: string; text: string };
+      expect(block.type).toBe("text");
+      expect(block.text).toContain("binary document");
+      expect(block.text).toContain(ext);
+      expect((base.execute as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    });
+  }
+
+  it("allows reading of normal text files", async () => {
+    const base = createMockReadTool();
+    const tool = createOpenClawReadTool(base);
+    const result = await tool.execute("tc1", { path: "/tmp/readme.md" }, undefined as never);
+    expect((base.execute as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+    expect(result.content).toHaveLength(1);
+    const block = result.content[0] as { type: string; text: string };
+    expect(block.text).toBe("file contents");
+  });
+
+  it("allows reading of image files (handled upstream)", async () => {
+    const base = createMockReadTool();
+    const tool = createOpenClawReadTool(base);
+    const result = await tool.execute("tc1", { path: "/tmp/photo.png" }, undefined as never);
+    expect((base.execute as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+  });
+
+  it("is case-insensitive for extensions", async () => {
+    const base = createMockReadTool();
+    const tool = createOpenClawReadTool(base);
+    const result = await tool.execute("tc1", { path: "/tmp/report.DOCX" }, undefined as never);
+    const block = result.content[0] as { type: string; text: string };
+    expect(block.text).toContain("binary document");
+    expect((base.execute as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -480,6 +480,30 @@ export function createHostWorkspaceEditTool(root: string, options?: { workspaceO
   return wrapToolParamNormalization(withRecovery, CLAUDE_PARAM_GROUPS.edit);
 }
 
+const BINARY_DOC_EXTENSIONS: ReadonlySet<string> = new Set([
+  ".pdf",
+  ".docx",
+  ".doc",
+  ".xlsx",
+  ".xls",
+  ".pptx",
+  ".ppt",
+  ".odt",
+  ".ods",
+  ".odp",
+  ".rtf",
+  ".epub",
+  ".mobi",
+  ".pages",
+  ".numbers",
+  ".key",
+]);
+
+function isBinaryDocumentPath(filePath: string): { ext: string } | null {
+  const ext = path.extname(filePath).toLowerCase();
+  return BINARY_DOC_EXTENSIONS.has(ext) ? { ext } : null;
+}
+
 export function createOpenClawReadTool(
   base: AnyAgentTool,
   options?: OpenClawReadToolOptions,
@@ -493,6 +517,27 @@ export function createOpenClawReadTool(
         normalized ??
         (params && typeof params === "object" ? (params as Record<string, unknown>) : undefined);
       assertRequiredParams(record, CLAUDE_PARAM_GROUPS.read, base.name);
+
+      const filePath = typeof record?.path === "string" ? String(record.path) : "<unknown>";
+      const binaryDoc = isBinaryDocumentPath(filePath);
+      if (binaryDoc) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `This file appears to be a binary document (${binaryDoc.ext}). ` +
+                `The read tool cannot extract meaningful text from binary document formats. ` +
+                `Raw binary content would be garbled and waste tokens.\n\n` +
+                `To work with this file, consider:\n` +
+                `- For .pdf files: use a PDF extraction tool or convert to text first\n` +
+                `- For Office formats (.docx, .xlsx, .pptx): convert to plain text, CSV, or Markdown first\n` +
+                `- Ask the user to provide the content in a text-based format`,
+            },
+          ],
+          details: undefined,
+        } satisfies AgentToolResult<unknown>;
+      }
+
       const result = await executeReadWithAdaptivePaging({
         base,
         toolCallId,
@@ -500,7 +545,6 @@ export function createOpenClawReadTool(
         signal,
         maxBytes: resolveAdaptiveReadMaxBytes(options),
       });
-      const filePath = typeof record?.path === "string" ? String(record.path) : "<unknown>";
       const strippedDetailsResult = stripReadTruncationContentDetails(result);
       const normalizedResult = await normalizeReadImageResult(strippedDetailsResult, filePath);
       return sanitizeToolResultImages(


### PR DESCRIPTION
## Summary

- **Problem:** The read tool decodes all non-image files as UTF-8, producing garbled output for binary documents (.pdf, .docx, .xlsx, .pptx, etc.) and wasting thousands of tokens per read. Agent reasoning degrades when fed raw ZIP/binary content.
- **Why it matters:** Users frequently ask agents to read documents; the garbled binary output confuses the agent and burns tokens with no useful information.
- **What changed:** `src/agents/pi-tools.read.ts` — added an extension-based guard in `createOpenClawReadTool` that intercepts 16 known binary document formats before they reach the upstream reader. Returns a clear, actionable message suggesting alternatives.
- **What did NOT change:** Image handling, text file reading, upstream `@mariozechner/pi-coding-agent` read tool, or any other tool logic.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35406

## User-visible / Behavior Changes

- Reading binary document files now returns a helpful message instead of garbled binary content
- Covered formats: `.pdf`, `.docx`, `.doc`, `.xlsx`, `.xls`, `.pptx`, `.ppt`, `.odt`, `.ods`, `.odp`, `.rtf`, `.epub`, `.mobi`, `.pages`, `.numbers`, `.key`

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Any (read tool is universal)

### Steps

1. Ask the agent to read a `.docx` or `.pdf` file
2. Observe tool result

### Expected

- Clear message explaining the file is binary and suggesting alternatives

### Actual

- Before fix: Raw binary/ZIP content decoded as UTF-8, garbled output, token waste
- After fix: Helpful message with actionable suggestions

## Evidence

All 21 read tool tests pass:

```
Test Files  4 passed (4)
     Tests  21 passed (21)
```

New test file: `pi-tools.read.binary-doc-guard.test.ts` (12 cases):
- 9 blocked formats (.docx, .doc, .xlsx, .xls, .pptx, .ppt, .pdf, .odt, .epub)
- 1 normal text file allowed
- 1 image file allowed
- 1 case-insensitive extension check

## Human Verification (required)

- Verified scenarios: All 16 binary extensions blocked, text/image files pass through, case-insensitive matching
- Edge cases checked: Unknown extensions pass through, `<unknown>` path handling, uppercase extensions
- What I did **not** verify: Live agent conversation with actual binary documents

## Compatibility / Migration

- Backward compatible? `Yes` — previously garbled output is replaced with a clear message; no existing working workflow is broken
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit; reading returns to raw binary decode
- Files/config to restore: `src/agents/pi-tools.read.ts`
- Known bad symptoms: If reverted, binary document reads will again produce garbled output

## Risks and Mitigations

- **Risk:** Some `.rtf` files may be mostly ASCII-readable. **Mitigation:** RTF with embedded objects is still binary; users who need RTF text can convert to plain text first. The guard errs on the side of preventing token waste.

