### PR TITLE
Telegram: scope /models selection checkmark to provider/model

### DIFF
--- a/src/telegram/model-buttons.test.ts
+++ b/src/telegram/model-buttons.test.ts
@@ -223,6 +223,19 @@ describe("buildModelsKeyboard", () => {
     }
   });
 
+  it("does not mark same model id as selected when current model is from another provider", () => {
+    const result = buildModelsKeyboard({
+      provider: "nexus-a",
+      models: ["claude-opus-4-6", "claude-sonnet-4-6"],
+      currentModel: "nexus-d/claude-opus-4-6",
+      currentPage: 1,
+      totalPages: 1,
+    });
+
+    expect(result[0]?.[0]?.text).toBe("claude-opus-4-6");
+    expect(result[1]?.[0]?.text).toBe("claude-sonnet-4-6");
+  });
+
   it("renders pagination controls for first, middle, and last pages", () => {
     const cases = [
       {

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -195,6 +195,7 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
   const pageModels = models.slice(startIndex, endIndex);
 
   // Model buttons - one per row
+  const currentModelProvider = currentModel?.includes("/") ? currentModel.split("/", 1)[0] : null;
   const currentModelId = currentModel?.includes("/")
     ? currentModel.split("/").slice(1).join("/")
     : currentModel;
@@ -206,7 +207,10 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
       continue;
     }
 
-    const isCurrentModel = model === currentModelId;
+    const isCurrentModel =
+      currentModelProvider && currentModelId
+        ? currentModelProvider === provider && currentModelId === model
+        : model === currentModelId;
     const displayText = truncateModelId(model, 38);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
 


### PR DESCRIPTION
## Summary
- fix Telegram `/models` keyboard selection highlighting to compare full `provider/model` when current model contains both parts
- keep backward-compatible fallback for legacy model-only current refs
- add regression coverage so identical model IDs across providers no longer show as selected on the wrong provider page

## Testing
- pnpm test src/telegram/model-buttons.test.ts

Fixes #35476
