### PR TITLE
fix(telegram): make model picker checkmark provider-aware for duplicate model IDs 

### DIFF
--- a/src/telegram/model-buttons.test.ts
+++ b/src/telegram/model-buttons.test.ts
@@ -198,17 +198,25 @@ describe("buildModelsKeyboard", () => {
       {
         name: "no current model",
         currentModel: undefined,
+        provider: "anthropic",
         firstText: "claude-sonnet-4",
       },
       {
-        name: "current model marked",
+        name: "current model marked when provider matches",
         currentModel: "anthropic/claude-sonnet-4",
+        provider: "anthropic",
         firstText: "claude-sonnet-4 ✓",
+      },
+      {
+        name: "does not mark model when provider differs",
+        currentModel: "openrouter/claude-sonnet-4",
+        provider: "anthropic",
+        firstText: "claude-sonnet-4",
       },
     ] as const;
     for (const testCase of cases) {
       const result = buildModelsKeyboard({
-        provider: "anthropic",
+        provider: testCase.provider,
         models: ["claude-sonnet-4", "claude-opus-4"],
         currentModel: testCase.currentModel,
         currentPage: 1,
@@ -217,7 +225,7 @@ describe("buildModelsKeyboard", () => {
       // 2 model rows + back button
       expect(result, testCase.name).toHaveLength(3);
       expect(result[0]?.[0]?.text).toBe(testCase.firstText);
-      expect(result[0]?.[0]?.callback_data).toBe("mdl_sel_anthropic/claude-sonnet-4");
+      expect(result[0]?.[0]?.callback_data).toBe(`mdl_sel_${testCase.provider}/claude-sonnet-4`);
       expect(result[1]?.[0]?.text).toBe("claude-opus-4");
       expect(result[2]?.[0]?.text).toBe("<< Back");
     }

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -195,6 +195,7 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
   const pageModels = models.slice(startIndex, endIndex);
 
   // Model buttons - one per row
+  const currentModelProvider = currentModel?.includes("/") ? currentModel.split("/")[0] : undefined;
   const currentModelId = currentModel?.includes("/")
     ? currentModel.split("/").slice(1).join("/")
     : currentModel;
@@ -206,7 +207,8 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
       continue;
     }
 
-    const isCurrentModel = model === currentModelId;
+    const isCurrentModel =
+      model === currentModelId && (!currentModelProvider || currentModelProvider === provider);
     const displayText = truncateModelId(model, 38);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
 


### PR DESCRIPTION
Closes #35476

## Summary
Fixes a selection-highlight bug in Telegram model picker when multiple providers expose the same model id (e.g. `claude-opus-4-6`).

Previously, the checkmark logic compared only model id, so all providers with the same id looked selected.

Now the checkmark is provider-aware: a model row is marked selected only when both provider and model id match the current selection.

## Root cause
`buildModelsKeyboard` extracted only the model part from `currentModel` and compared `model === currentModelId`, ignoring provider.

## Fix
- Parse both provider and model from `currentModel` when available.
- Mark as selected only when:
  - model id matches, and
  - provider matches (or provider is absent for backward compatibility).

## Tests
Updated `src/telegram/model-buttons.test.ts` to add regression coverage:
- still marks selection when provider matches
- does **not** mark selection when provider differs but model id is the same

## Notes
- Focused PR touching Telegram model button rendering + tests only.
