### PR TITLE
fix(config): add missing editMessage and createForumTopic to Telegram actions schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Docs: https://docs.openclaw.ai
 - Security/nodes: treat the `nodes` agent tool as owner-only fallback policy so non-owner senders cannot reach paired-node approval or invoke paths through the shared tool set.
 - Telegram/final preview cleanup follow-up: clear stale cleanup-retain state only for transient preview finals so archived-preview retains no longer leave a stale partial bubble beside a later fallback-sent final. (#41763) Thanks @obviyus.
 - Signal/config schema: accept `channels.signal.accountUuid` in strict config validation so loop-protection configs no longer fail with an unrecognized-key error. (#35578) Thanks @ingyukoh.
+- Telegram/config schema: accept `channels.telegram.actions.editMessage` and `createForumTopic` in strict config validation so existing Telegram action toggles no longer fail as unrecognized keys. (#35498) Thanks @ingyukoh.
 
 ## 2026.3.8
 

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -196,4 +196,19 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts telegram actions editMessage and createForumTopic", () => {
+    const res = validateConfigObject({
+      channels: {
+        telegram: {
+          actions: {
+            editMessage: true,
+            createForumTopic: false,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -244,7 +244,9 @@ export const TelegramAccountSchemaBase = z
         sendMessage: z.boolean().optional(),
         poll: z.boolean().optional(),
         deleteMessage: z.boolean().optional(),
+        editMessage: z.boolean().optional(),
         sticker: z.boolean().optional(),
+        createForumTopic: z.boolean().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

The `TelegramActionConfig` type defines `editMessage` and `createForumTopic` fields, but the Zod schema in `zod-schema.providers-core.ts` was missing them. Because the schema uses `.strict()`, users setting these documented config options get a validation error.

**Root cause:** Schema and type definition drifted apart when the action fields were added to the type but not the Zod schema.

## Changes
- Added `editMessage: z.boolean().optional()` to `TelegramAccountSchemaBase.actions`
- Added `createForumTopic: z.boolean().optional()` to `TelegramAccountSchemaBase.actions`
- Added regression test in `config.schema-regressions.test.ts`

## Test Plan
- [x] Regression test: validates config with `editMessage` and `createForumTopic` is accepted
- [x] Existing `.strict()` constraint still rejects truly unknown fields

Fixes #35497
