### PR TITLE
feat: add baseUrl support to messages.tts.openai config

### DIFF
--- a/src/config/types.tts.ts
+++ b/src/config/types.tts.ts
@@ -60,6 +60,7 @@ export type TtsConfig = {
     apiKey?: SecretInput;
     model?: string;
     voice?: string;
+    baseUrl?: string;
   };
   /** Microsoft Edge (node-edge-tts) configuration. */
   edge?: {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -403,6 +403,7 @@ export const TtsConfigSchema = z
         apiKey: SecretInputSchema.optional().register(sensitive),
         model: z.string().optional(),
         voice: z.string().optional(),
+        baseUrl: z.string().optional(),
       })
       .strict()
       .optional(),

--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -334,15 +334,14 @@ export const OPENAI_TTS_MODELS = ["gpt-4o-mini-tts", "tts-1", "tts-1-hd"] as con
  *
  * Note: Read at runtime (not module load) to support config.env loading.
  */
-function getOpenAITtsBaseUrl(): string {
-  return (process.env.OPENAI_TTS_BASE_URL?.trim() || "https://api.openai.com/v1").replace(
-    /\/+$/,
-    "",
-  );
+function getOpenAITtsBaseUrl(baseUrl?: string): string {
+  const url =
+    baseUrl?.trim() || process.env.OPENAI_TTS_BASE_URL?.trim() || "https://api.openai.com/v1";
+  return url.replace(/\/+$/, "");
 }
 
-function isCustomOpenAIEndpoint(): boolean {
-  return getOpenAITtsBaseUrl() !== "https://api.openai.com/v1";
+function isCustomOpenAIEndpoint(baseUrl?: string): boolean {
+  return getOpenAITtsBaseUrl(baseUrl) !== "https://api.openai.com/v1";
 }
 export const OPENAI_TTS_VOICES = [
   "alloy",
@@ -363,17 +362,17 @@ export const OPENAI_TTS_VOICES = [
 
 type OpenAiTtsVoice = (typeof OPENAI_TTS_VOICES)[number];
 
-export function isValidOpenAIModel(model: string): boolean {
+export function isValidOpenAIModel(model: string, baseUrl?: string): boolean {
   // Allow any model when using custom endpoint (e.g., Kokoro, LocalAI)
-  if (isCustomOpenAIEndpoint()) {
+  if (isCustomOpenAIEndpoint(baseUrl)) {
     return true;
   }
   return OPENAI_TTS_MODELS.includes(model as (typeof OPENAI_TTS_MODELS)[number]);
 }
 
-export function isValidOpenAIVoice(voice: string): voice is OpenAiTtsVoice {
+export function isValidOpenAIVoice(voice: string, baseUrl?: string): voice is OpenAiTtsVoice {
   // Allow any voice when using custom endpoint (e.g., Kokoro Chinese voices)
-  if (isCustomOpenAIEndpoint()) {
+  if (isCustomOpenAIEndpoint(baseUrl)) {
     return true;
   }
   return OPENAI_TTS_VOICES.includes(voice as OpenAiTtsVoice);
@@ -595,8 +594,9 @@ export async function openaiTTS(params: {
   voice: string;
   responseFormat: "mp3" | "opus" | "pcm";
   timeoutMs: number;
+  baseUrl?: string;
 }): Promise<Buffer> {
-  const { text, apiKey, model, voice, responseFormat, timeoutMs } = params;
+  const { text, apiKey, model, voice, responseFormat, timeoutMs, baseUrl } = params;
 
   if (!isValidOpenAIModel(model)) {
     throw new Error(`Invalid model: ${model}`);
@@ -609,7 +609,7 @@ export async function openaiTTS(params: {
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    const response = await fetch(`${getOpenAITtsBaseUrl()}/audio/speech`, {
+    const response = await fetch(`${getOpenAITtsBaseUrl(baseUrl)}/audio/speech`, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${apiKey}`,

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -115,6 +115,7 @@ export type ResolvedTtsConfig = {
     apiKey?: string;
     model: string;
     voice: string;
+    baseUrl?: string;
   };
   edge: {
     enabled: boolean;
@@ -296,6 +297,7 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
       }),
       model: raw.openai?.model ?? DEFAULT_OPENAI_MODEL,
       voice: raw.openai?.voice ?? DEFAULT_OPENAI_VOICE,
+      baseUrl: raw.openai?.baseUrl?.trim() || undefined,
     },
     edge: {
       enabled: raw.edge?.enabled ?? true,
@@ -685,6 +687,7 @@ export async function textToSpeech(params: {
           voice: openaiVoiceOverride ?? config.openai.voice,
           responseFormat: output.openai,
           timeoutMs: config.timeoutMs,
+          baseUrl: config.openai.baseUrl,
         });
       }
 
@@ -781,6 +784,7 @@ export async function textToSpeechTelephony(params: {
         voice: config.openai.voice,
         responseFormat: output.format,
         timeoutMs: config.timeoutMs,
+        baseUrl: config.openai.baseUrl,
       });
 
       return {


### PR DESCRIPTION
## Summary

Allow configuring a custom OpenAI-compatible base URL for TTS.
This enables using third-party TTS providers like murmr.dev while keeping STT on OpenAI.

## Changes

- Add `baseUrl` field to `messages.tts.openai` config schema
- Add `baseUrl` to TypeScript types (TtsConfig, ResolvedTtsConfig)
- Pass `baseUrl` to `openaiTTS()` function
- Update validation functions to check custom endpoint

## Usage

```json
{
  "messages": {
    "tts": {
      "provider": "openai",
      "openai": {
        "baseUrl": "https://api.murmr.dev",
        "apiKey": "${MURMR_API_KEY}",
        "voice": "voice_18ca42aa688b"
      }
    }
  }
}
```

Closes #35304