### PR TITLE
feat(agents): add heartbeat pre-flight command to skip idle turns

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -208,6 +208,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Avatar image path (relative to the agent workspace only) or a remote URL/data URL.",
   "agents.defaults.heartbeat.suppressToolErrorWarnings":
     "Suppress tool error warning payloads during heartbeat runs.",
+  "agents.defaults.heartbeat.preFlightCommand":
+    "Shell command run before each heartbeat agent turn. If stdout contains HEARTBEAT_OK the turn is skipped entirely, saving tokens. Useful for lightweight external checks (API probes, file watchers) that determine whether the agent needs to act.",
   "agents.list[].heartbeat.suppressToolErrorWarnings":
     "Suppress tool error warning payloads during heartbeat runs.",
   browser:

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -434,6 +434,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.heartbeat.directPolicy": "Heartbeat Direct Policy",
   "agents.list.*.heartbeat.directPolicy": "Heartbeat Direct Policy",
   "agents.defaults.heartbeat.suppressToolErrorWarnings": "Heartbeat Suppress Tool Error Warnings",
+  "agents.defaults.heartbeat.preFlightCommand": "Heartbeat Pre-Flight Command",
   "agents.defaults.sandbox.browser.network": "Sandbox Browser Network",
   "agents.defaults.sandbox.browser.cdpSourceRange": "Sandbox Browser CDP Source Port Range",
   "agents.defaults.sandbox.docker.dangerouslyAllowContainerNamespaceJoin":

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -260,6 +260,17 @@ export type AgentDefaultsConfig = {
      * Default: false (only the final heartbeat payload is delivered).
      */
     includeReasoning?: boolean;
+    /**
+     * Shell command run before each heartbeat agent turn.  If the command's
+     * stdout contains `HEARTBEAT_OK`, the agent session is skipped entirely,
+     * saving tokens.  Any other output (or a non-zero exit code) lets the
+     * heartbeat proceed normally — the script's stdout is **not** passed to
+     * the agent.
+     *
+     * The command runs with the agent workspace directory as its cwd.
+     * Maximum execution time: 30 seconds.
+     */
+    preFlightCommand?: string;
   };
   /** Max concurrent agent runs across all conversations. Default: 1 (sequential). */
   maxConcurrent?: number;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -34,6 +34,7 @@ export const HeartbeatSchema = z
     ackMaxChars: z.number().int().nonnegative().optional(),
     suppressToolErrorWarnings: z.boolean().optional(),
     lightContext: z.boolean().optional(),
+    preFlightCommand: z.string().optional(),
   })
   .strict()
   .superRefine((val, ctx) => {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -24,6 +24,7 @@ import type { ChannelHeartbeatDeps } from "../channels/plugins/types.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
+import { runCommandWithTimeout } from "../process/exec.js";
 import {
   canonicalizeMainSessionAlias,
   loadSessionStore,
@@ -475,7 +476,7 @@ type HeartbeatReasonFlags = {
   isWakeReason: boolean;
 };
 
-type HeartbeatSkipReason = "empty-heartbeat-file";
+type HeartbeatSkipReason = "empty-heartbeat-file" | "preflight-command-ok";
 
 type HeartbeatPreflight = HeartbeatReasonFlags & {
   session: ReturnType<typeof resolveHeartbeatSession>;
@@ -635,6 +636,34 @@ export async function runHeartbeatOnce(opts: {
     });
     return { status: "skipped", reason: preflight.skipReason };
   }
+
+  const preFlightCommand = heartbeat?.preFlightCommand?.trim();
+  if (preFlightCommand) {
+    const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+    try {
+      const argv =
+        process.platform === "win32"
+          ? ["cmd.exe", "/d", "/s", "/c", preFlightCommand]
+          : ["sh", "-c", preFlightCommand];
+      const result = await runCommandWithTimeout(argv, {
+        cwd: workspaceDir,
+        timeoutMs: 30_000,
+      });
+      const stdout = typeof result.stdout === "string" ? result.stdout : "";
+      if (stdout.includes("HEARTBEAT_OK")) {
+        log.info("heartbeat: pre-flight command returned HEARTBEAT_OK, skipping agent turn");
+        emitHeartbeatEvent({
+          status: "skipped",
+          reason: "preflight-command-ok",
+          durationMs: Date.now() - startedAt,
+        });
+        return { status: "skipped", reason: "preflight-command-ok" };
+      }
+    } catch (err) {
+      log.warn(`heartbeat: pre-flight command failed, proceeding with agent turn: ${String(err)}`);
+    }
+  }
+
   const { entry, sessionKey, storePath } = preflight.session;
   const previousUpdatedAt = entry?.updatedAt;
   const delivery = resolveHeartbeatDeliveryTarget({ cfg, entry, heartbeat });


### PR DESCRIPTION
## Summary

- **Problem:** Well-tuned heartbeats often find nothing to act on but still spin up a full agent session every 30 minutes, burning tokens for a `HEARTBEAT_OK` reply.
- **Why it matters:** At typical Opus pricing, each unnecessary heartbeat turn costs ~$0.01–0.05. Over 48 heartbeats/day, this adds up to $0.50–2.50/day per instance with zero value.
- **What changed:** 5 files: added `agents.defaults.heartbeat.preFlightCommand` config field. When set, a shell command runs before each heartbeat agent turn. If stdout contains `HEARTBEAT_OK`, the agent session is skipped entirely — no tokens consumed.
- **What did NOT change:** Existing heartbeat flow, HEARTBEAT.md gating, active hours, or delivery logic.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34986

## User-visible / Behavior Changes

- New config option: `agents.defaults.heartbeat.preFlightCommand` (string, optional)
- Example: `"curl -sf https://api.example.com/status | grep -q 'needs-attention' || echo HEARTBEAT_OK"`
- When stdout contains `HEARTBEAT_OK`: heartbeat skipped, no tokens consumed
- When command fails or returns other output: heartbeat proceeds normally
- 30-second timeout to prevent hung scripts from blocking the heartbeat loop

## Security Impact (required)

- New permissions/capabilities? `No` — the command runs with the same privileges as the OpenClaw process, in the agent workspace directory
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (the user's script may make network calls, but OpenClaw itself does not)
- Command/tool execution surface changed? `No` — this is config-driven, not agent-driven
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any (cross-platform: sh on Unix, cmd.exe on Windows)
- Runtime: Node.js
- Integration/channel: Any heartbeat-enabled setup

### Steps

1. Set `agents.defaults.heartbeat.preFlightCommand: "echo HEARTBEAT_OK"` in `openclaw.json`
2. Wait for next heartbeat interval
3. Observe logs

### Expected

- Log: `heartbeat: pre-flight command returned HEARTBEAT_OK, skipping agent turn`
- No agent session created, no tokens consumed

### Actual

- Before fix: Every heartbeat creates an agent session (~$0.01–0.05 per turn)
- After fix: Pre-flight can skip the turn in milliseconds at zero token cost

## Evidence

All 99 heartbeat tests pass across 12 test files:

```
Test Files  12 passed (12)
     Tests  99 passed (99)
```

Files changed (5):
- `src/config/types.agent-defaults.ts` — type definition with JSDoc
- `src/config/zod-schema.agent-runtime.ts` — Zod validation
- `src/config/schema.labels.ts` — UI label
- `src/config/schema.help.ts` — help text
- `src/infra/heartbeat-runner.ts` — pre-flight execution logic + import

## Human Verification (required)

- Verified scenarios: Command returns HEARTBEAT_OK (skip), command returns other output (proceed), command fails (proceed), command not configured (no-op)
- Edge cases checked: Empty command string (trimmed to falsy, skipped), timeout (30s), Windows vs Unix shell selection
- What I did **not** verify: Live end-to-end with actual cron-like script

## Compatibility / Migration

- Backward compatible? `Yes` — field is optional; omitting it preserves existing behaviour
- Config/env changes? `No` (new optional field only)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `preFlightCommand` from config or revert commit
- Files/config to restore: 5 files listed above
- Known bad symptoms: If the pre-flight script hangs beyond 30s timeout, the heartbeat proceeds normally (timeout is handled as a failed command)

## Risks and Mitigations

- **Risk:** User's pre-flight script could be slow or hang. **Mitigation:** 30-second timeout; failures are caught and logged, heartbeat proceeds.
- **Risk:** Command injection via config. **Mitigation:** The config file is trusted (same trust model as all other config-driven commands in OpenClaw).

