### PR TITLE
feat(hooks): support gws as alternative to gog for Gmail Pub/Sub

### DIFF
--- a/docs/automation/gmail-pubsub.md
+++ b/docs/automation/gmail-pubsub.md
@@ -1,5 +1,5 @@
 ---
-summary: "Gmail Pub/Sub push wired into OpenClaw webhooks via gogcli"
+summary: "Gmail Pub/Sub hooks wired into OpenClaw webhooks via gog or gws"
 read_when:
   - Wiring Gmail inbox triggers to OpenClaw
   - Setting up Pub/Sub push for agent wake
@@ -8,9 +8,16 @@ title: "Gmail PubSub"
 
 # Gmail Pub/Sub -> OpenClaw
 
-Goal: Gmail watch -> Pub/Sub push -> `gog gmail watch serve` -> OpenClaw webhook.
+Two CLI backends are supported:
 
-## Prereqs
+| Mode              | CLI   | Model                               | Install                         | Tailscale  |
+| ----------------- | ----- | ----------------------------------- | ------------------------------- | ---------- |
+| **gog** (default) | `gog` | Push (Pub/Sub push -> HTTP server)  | `brew install gogcli` (macOS)   | Required   |
+| **gws**           | `gws` | Pull (polls Pub/Sub, NDJSON stdout) | `npm i -g @googleworkspace/cli` | Not needed |
+
+Set the backend via `hooks.gmail.cli` in config or `--cli` on the command line.
+
+## Prereqs (gog mode, default)
 
 - `gcloud` installed and logged in ([install guide](https://docs.cloud.google.com/sdk/docs/install-sdk)).
 - `gog` (gogcli) installed and authorized for the Gmail account ([gogcli.sh](https://gogcli.sh/)).
@@ -18,6 +25,13 @@ Goal: Gmail watch -> Pub/Sub push -> `gog gmail watch serve` -> OpenClaw webhook
 - `tailscale` logged in ([tailscale.com](https://tailscale.com/)). Supported setup uses Tailscale Funnel for the public HTTPS endpoint.
   Other tunnel services can work, but are DIY/unsupported and require manual wiring.
   Right now, Tailscale is what we support.
+
+## Prereqs (gws mode)
+
+- `gcloud` installed and logged in.
+- `gws` installed and authorized: `npm i -g @googleworkspace/cli && gws auth login`.
+- OpenClaw hooks enabled (see [Webhooks](/automation/webhook)).
+- No Tailscale needed (gws uses pull-based Pub/Sub).
 
 Example hook config (enable Gmail preset mapping):
 
@@ -92,6 +106,8 @@ under `~/.openclaw/hooks/transforms` (see [Webhooks](/automation/webhook)).
 
 ## Wizard (recommended)
 
+### gog mode (default)
+
 Use the OpenClaw helper to wire everything together (installs deps on macOS via brew):
 
 ```bash
@@ -118,21 +134,64 @@ Want a custom endpoint? Use `--push-endpoint <url>` or `--tailscale off`.
 Platform note: on macOS the wizard installs `gcloud`, `gogcli`, and `tailscale`
 via Homebrew; on Linux install them manually first.
 
-Gateway auto-start (recommended):
+### gws mode
+
+```bash
+openclaw webhooks gmail setup \
+  --cli gws \
+  --account openclaw@gmail.com \
+  --project my-gcp-project
+```
+
+What this does:
+
+- Installs `gws` via npm if missing.
+- Creates the Pub/Sub topic and IAM binding (via gcloud).
+- Skips Tailscale and push subscription setup (gws polls Pub/Sub directly).
+- Writes `hooks.gmail.cli: "gws"` and `hooks.gmail.project` to config.
+
+Config example:
+
+```json5
+{
+  hooks: {
+    enabled: true,
+    token: "OPENCLAW_HOOK_TOKEN",
+    presets: ["gmail"],
+    gmail: {
+      cli: "gws",
+      project: "my-gcp-project",
+      account: "openclaw@gmail.com",
+    },
+  },
+}
+```
+
+### Gateway auto-start (recommended)
 
 - When `hooks.enabled=true` and `hooks.gmail.account` is set, the Gateway starts
-  `gog gmail watch serve` on boot and auto-renews the watch.
+  the appropriate watcher on boot.
+- For gog: starts `gog gmail watch serve` and auto-renews the watch.
+- For gws: starts `gws gmail +watch` (pull-based, no renewal needed).
 - Set `OPENCLAW_SKIP_GMAIL_WATCHER=1` to opt out (useful if you run the daemon yourself).
 - Do not run the manual daemon at the same time, or you will hit
-  `listen tcp 127.0.0.1:8788: bind: address already in use`.
+  `listen tcp 127.0.0.1:8788: bind: address already in use` (gog mode only).
 
-Manual daemon (starts `gog gmail watch serve` + auto-renew):
+### Manual daemon
+
+gog mode (starts `gog gmail watch serve` + auto-renew):
 
 ```bash
 openclaw webhooks gmail run
 ```
 
-## One-time setup
+gws mode (starts `gws gmail +watch`, pull-based):
+
+```bash
+openclaw webhooks gmail run --cli gws
+```
+
+## One-time setup (gog mode, manual)
 
 1. Select the GCP project **that owns the OAuth client** used by `gog`.
 

--- a/src/cli/webhooks-cli.ts
+++ b/src/cli/webhooks-cli.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import type { GmailCliMode } from "../config/config.js";
 import { danger } from "../globals.js";
 import {
   type GmailRunOptions,
@@ -30,22 +31,23 @@ export function registerWebhooksCli(program: Command) {
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/webhooks", "docs.openclaw.ai/cli/webhooks")}\n`,
     );
 
-  const gmail = webhooks.command("gmail").description("Gmail Pub/Sub hooks (via gogcli)");
+  const gmail = webhooks.command("gmail").description("Gmail Pub/Sub hooks (via gog or gws)");
 
   gmail
     .command("setup")
     .description("Configure Gmail watch + Pub/Sub + OpenClaw hooks")
+    .option("--cli <mode>", "CLI backend for Gmail Pub/Sub: gog (push, default) or gws (pull)")
     .requiredOption("--account <email>", "Gmail account to watch")
-    .option("--project <id>", "GCP project id (OAuth client owner)")
+    .option("--project <id>", "GCP project id (required for gws, auto-detected for gog)")
     .option("--topic <name>", "Pub/Sub topic name", DEFAULT_GMAIL_TOPIC)
     .option("--subscription <name>", "Pub/Sub subscription name", DEFAULT_GMAIL_SUBSCRIPTION)
     .option("--label <label>", "Gmail label to watch", DEFAULT_GMAIL_LABEL)
     .option("--hook-url <url>", "OpenClaw hook URL")
     .option("--hook-token <token>", "OpenClaw hook token")
-    .option("--push-token <token>", "Push token for gog watch serve")
-    .option("--bind <host>", "gog watch serve bind host", DEFAULT_GMAIL_SERVE_BIND)
-    .option("--port <port>", "gog watch serve port", String(DEFAULT_GMAIL_SERVE_PORT))
-    .option("--path <path>", "gog watch serve path", DEFAULT_GMAIL_SERVE_PATH)
+    .option("--push-token <token>", "Push token for watch serve (gog only)")
+    .option("--bind <host>", "Watch serve bind host (gog only)", DEFAULT_GMAIL_SERVE_BIND)
+    .option("--port <port>", "Watch serve port (gog only)", String(DEFAULT_GMAIL_SERVE_PORT))
+    .option("--path <path>", "Watch serve path (gog only)", DEFAULT_GMAIL_SERVE_PATH)
     .option("--include-body", "Include email body snippets", true)
     .option("--max-bytes <n>", "Max bytes for body snippets", String(DEFAULT_GMAIL_MAX_BYTES))
     .option(
@@ -73,17 +75,18 @@ export function registerWebhooksCli(program: Command) {
 
   gmail
     .command("run")
-    .description("Run gog watch serve + auto-renew loop")
+    .description("Run Gmail watch service (gog serve or gws pull)")
+    .option("--cli <mode>", "CLI backend for Gmail Pub/Sub: gog (push, default) or gws (pull)")
     .option("--account <email>", "Gmail account to watch")
     .option("--topic <topic>", "Pub/Sub topic path (projects/.../topics/..)")
     .option("--subscription <name>", "Pub/Sub subscription name")
     .option("--label <label>", "Gmail label to watch")
     .option("--hook-url <url>", "OpenClaw hook URL")
     .option("--hook-token <token>", "OpenClaw hook token")
-    .option("--push-token <token>", "Push token for gog watch serve")
-    .option("--bind <host>", "gog watch serve bind host")
-    .option("--port <port>", "gog watch serve port")
-    .option("--path <path>", "gog watch serve path")
+    .option("--push-token <token>", "Push token for watch serve (gog only)")
+    .option("--bind <host>", "Watch serve bind host (gog only)")
+    .option("--port <port>", "Watch serve port (gog only)")
+    .option("--path <path>", "Watch serve path (gog only)")
     .option("--include-body", "Include email body snippets")
     .option("--max-bytes <n>", "Max bytes for body snippets")
     .option("--renew-minutes <n>", "Renew watch every N minutes")
@@ -128,8 +131,20 @@ function parseGmailRunOptions(raw: Record<string, unknown>): GmailRunOptions {
   };
 }
 
+function parseCliMode(raw: unknown): GmailCliMode | undefined {
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === "gog" || trimmed === "gws") {
+    return trimmed;
+  }
+  throw new Error(`Invalid --cli value "${raw}"; expected "gog" or "gws"`);
+}
+
 function parseGmailCommonOptions(raw: Record<string, unknown>) {
   return {
+    cli: parseCliMode(raw.cli),
     topic: stringOption(raw.topic),
     subscription: stringOption(raw.subscription),
     label: stringOption(raw.label),
@@ -152,6 +167,7 @@ function gmailOptionsFromCommon(
   common: ReturnType<typeof parseGmailCommonOptions>,
 ): Omit<GmailRunOptions, "account"> {
   return {
+    cli: common.cli,
     topic: common.topic,
     subscription: common.subscription,
     label: common.label,

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -43,7 +43,13 @@ export type HookMappingConfig = {
 
 export type HooksGmailTailscaleMode = "off" | "serve" | "funnel";
 
+export type GmailCliMode = "gog" | "gws";
+
 export type HooksGmailConfig = {
+  /** CLI backend for Gmail Pub/Sub: "gog" (push, default) or "gws" (pull). */
+  cli?: GmailCliMode;
+  /** GCP project ID (required for gws, auto-detected from gog credentials). */
+  project?: string;
   account?: string;
   label?: string;
   topic?: string;

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -120,6 +120,8 @@ export const InternalHooksSchema = z
 
 export const HooksGmailSchema = z
   .object({
+    cli: z.union([z.literal("gog"), z.literal("gws")]).optional(),
+    project: z.string().optional(),
     account: z.string().optional(),
     label: z.string().optional(),
     topic: z.string().optional(),

--- a/src/hooks/gmail-gws-bridge.test.ts
+++ b/src/hooks/gmail-gws-bridge.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createNdjsonLineHandler,
+  postToHookUrl,
+  transformGmailApiMessage,
+} from "./gmail-gws-bridge.js";
+
+describe("transformGmailApiMessage", () => {
+  it("extracts id, from, subject, snippet from a Gmail API message", () => {
+    const msg = {
+      id: "abc123",
+      snippet: "Hey there...",
+      payload: {
+        headers: [
+          { name: "From", value: "alice@example.com" },
+          { name: "Subject", value: "Hello" },
+        ],
+      },
+    };
+    const result = transformGmailApiMessage(msg);
+    expect(result).toEqual({
+      messages: [
+        {
+          id: "abc123",
+          from: "alice@example.com",
+          subject: "Hello",
+          snippet: "Hey there...",
+          body: "",
+        },
+      ],
+    });
+  });
+
+  it("extracts text/plain body from payload", () => {
+    const body = Buffer.from("Hello world!").toString("base64url");
+    const msg = {
+      id: "msg1",
+      snippet: "",
+      payload: {
+        mimeType: "text/plain",
+        headers: [],
+        body: { data: body },
+      },
+    };
+    const result = transformGmailApiMessage(msg, { includeBody: true });
+    expect(result.messages[0]?.body).toBe("Hello world!");
+  });
+
+  it("finds text/plain in multipart message", () => {
+    const body = Buffer.from("nested body").toString("base64url");
+    const msg = {
+      id: "msg2",
+      snippet: "",
+      payload: {
+        mimeType: "multipart/alternative",
+        headers: [],
+        parts: [
+          { mimeType: "text/html", body: { data: "" } },
+          { mimeType: "text/plain", body: { data: body } },
+        ],
+      },
+    };
+    const result = transformGmailApiMessage(msg, { includeBody: true });
+    expect(result.messages[0]?.body).toBe("nested body");
+  });
+
+  it("truncates body to maxBytes", () => {
+    const longText = "a".repeat(100);
+    const body = Buffer.from(longText).toString("base64url");
+    const msg = {
+      id: "msg3",
+      snippet: "",
+      payload: {
+        mimeType: "text/plain",
+        headers: [],
+        body: { data: body },
+      },
+    };
+    const result = transformGmailApiMessage(msg, { includeBody: true, maxBytes: 10 });
+    expect(result.messages[0]?.body).toBe("a".repeat(10));
+  });
+
+  it("skips body when includeBody is false", () => {
+    const body = Buffer.from("secret").toString("base64url");
+    const msg = {
+      id: "msg4",
+      snippet: "",
+      payload: {
+        mimeType: "text/plain",
+        headers: [],
+        body: { data: body },
+      },
+    };
+    const result = transformGmailApiMessage(msg, { includeBody: false });
+    expect(result.messages[0]?.body).toBe("");
+  });
+
+  it("handles missing payload gracefully", () => {
+    const msg = { id: "msg5", snippet: "test" };
+    const result = transformGmailApiMessage(msg);
+    expect(result.messages[0]).toEqual({
+      id: "msg5",
+      from: "",
+      subject: "",
+      snippet: "test",
+      body: "",
+    });
+  });
+
+  it("handles case-insensitive header lookup", () => {
+    const msg = {
+      id: "msg6",
+      snippet: "",
+      payload: {
+        headers: [
+          { name: "from", value: "bob@example.com" },
+          { name: "SUBJECT", value: "Test" },
+        ],
+      },
+    };
+    const result = transformGmailApiMessage(msg);
+    expect(result.messages[0]?.from).toBe("bob@example.com");
+    expect(result.messages[0]?.subject).toBe("Test");
+  });
+});
+
+describe("postToHookUrl", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("sends POST with correct headers and body", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const payload = { messages: [{ id: "1", from: "a", subject: "s", snippet: "sn", body: "b" }] };
+    await postToHookUrl(payload, "http://localhost:18789/hooks/gmail", "tok123");
+
+    expect(globalThis.fetch).toHaveBeenCalledWith("http://localhost:18789/hooks/gmail", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer tok123",
+      },
+      body: JSON.stringify(payload),
+    });
+  });
+
+  it("throws on non-ok response", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response("fail", { status: 401, statusText: "Unauthorized" }),
+    );
+
+    const payload = { messages: [{ id: "1", from: "", subject: "", snippet: "", body: "" }] };
+    await expect(
+      postToHookUrl(payload, "http://localhost:18789/hooks/gmail", "bad-token"),
+    ).rejects.toThrow("Hook POST failed: 401 Unauthorized");
+  });
+});
+
+describe("createNdjsonLineHandler", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("parses JSON line, transforms, and POSTs", () => {
+    const handler = createNdjsonLineHandler({
+      hookUrl: "http://localhost/hooks/gmail",
+      hookToken: "tok",
+      includeBody: true,
+      maxBytes: 20000,
+    });
+
+    const line = JSON.stringify({
+      id: "msg1",
+      snippet: "hi",
+      payload: {
+        headers: [
+          { name: "From", value: "alice@example.com" },
+          { name: "Subject", value: "Test" },
+        ],
+      },
+    });
+
+    handler(line);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = vi.mocked(globalThis.fetch).mock.calls[0] ?? [];
+    expect(url).toBe("http://localhost/hooks/gmail");
+    const body = JSON.parse((opts as RequestInit).body as string) as Record<string, unknown>;
+    const messages = body.messages as Array<Record<string, string>>;
+    expect(messages[0]?.id).toBe("msg1");
+    expect(messages[0]?.from).toBe("alice@example.com");
+  });
+
+  it("ignores empty lines", () => {
+    const handler = createNdjsonLineHandler({
+      hookUrl: "http://localhost/hooks/gmail",
+      hookToken: "tok",
+      includeBody: true,
+      maxBytes: 20000,
+    });
+
+    handler("");
+    handler("   ");
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-JSON lines", () => {
+    const handler = createNdjsonLineHandler({
+      hookUrl: "http://localhost/hooks/gmail",
+      hookToken: "tok",
+      includeBody: true,
+      maxBytes: 20000,
+    });
+
+    handler("not json at all");
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/gmail-gws-bridge.test.ts
+++ b/src/hooks/gmail-gws-bridge.test.ts
@@ -80,6 +80,48 @@ describe("transformGmailApiMessage", () => {
     expect(result.messages[0]?.body).toBe("a".repeat(10));
   });
 
+  it("truncates multi-byte body by bytes, not characters", () => {
+    // Each emoji is 4 bytes in UTF-8; maxBytes=8 should yield exactly 2 emoji
+    const emojiText = "\u{1F600}\u{1F601}\u{1F602}"; // 12 bytes total
+    const body = Buffer.from(emojiText).toString("base64url");
+    const msg = {
+      id: "msg-mb",
+      snippet: "",
+      payload: {
+        mimeType: "text/plain",
+        headers: [],
+        body: { data: body },
+      },
+    };
+    const result = transformGmailApiMessage(msg, { includeBody: true, maxBytes: 8 });
+    const resultBody = result.messages[0]?.body ?? "";
+    // Exactly 2 emoji (8 bytes) — the 3rd is fully excluded at the byte boundary
+    expect(resultBody).toBe("\u{1F600}\u{1F601}");
+    expect(Buffer.byteLength(resultBody, "utf8")).toBe(8);
+  });
+
+  it("does not over-count non-ASCII with string length", () => {
+    // CJK characters are 3 bytes each in UTF-8; "abc" prefix is 3 bytes
+    // "abc\u4e16\u754c" = 3 + 3 + 3 = 9 bytes, but only 5 chars
+    // With maxBytes=6 (old code would pass since 5 chars < 6), but 9 bytes > 6
+    const text = "abc\u4e16\u754c";
+    const body = Buffer.from(text).toString("base64url");
+    const msg = {
+      id: "msg-cjk",
+      snippet: "",
+      payload: {
+        mimeType: "text/plain",
+        headers: [],
+        body: { data: body },
+      },
+    };
+    const result = transformGmailApiMessage(msg, { includeBody: true, maxBytes: 6 });
+    const resultBody = result.messages[0]?.body ?? "";
+    // Should truncate: "abc" (3 bytes) + first CJK char (3 bytes) = 6 bytes
+    expect(resultBody).toBe("abc\u4e16");
+    expect(Buffer.byteLength(resultBody, "utf8")).toBe(6);
+  });
+
   it("skips body when includeBody is false", () => {
     const body = Buffer.from("secret").toString("base64url");
     const msg = {

--- a/src/hooks/gmail-gws-bridge.ts
+++ b/src/hooks/gmail-gws-bridge.ts
@@ -1,0 +1,175 @@
+/**
+ * Gmail GWS Bridge
+ *
+ * Transforms gws gmail +watch NDJSON output into the hook payload format
+ * expected by the gmail hook preset: `{ messages: [{ id, from, subject, snippet, body }] }`.
+ *
+ * gws outputs one JSON object per line (NDJSON) for each new email.
+ */
+
+import { createSubsystemLogger, type SubsystemLogger } from "../logging/subsystem.js";
+
+export type GmailHookMessage = {
+  id: string;
+  from: string;
+  subject: string;
+  snippet: string;
+  body: string;
+};
+
+export type GmailHookPayload = {
+  messages: GmailHookMessage[];
+};
+
+/**
+ * Extract a header value from a Gmail API message's payload headers array.
+ */
+function extractHeader(
+  headers: Array<{ name?: string; value?: string }> | undefined,
+  name: string,
+): string {
+  if (!headers) {
+    return "";
+  }
+  const lower = name.toLowerCase();
+  const entry = headers.find((h) => h.name?.toLowerCase() === lower);
+  return entry?.value ?? "";
+}
+
+/**
+ * Decode base64url-encoded string (Gmail API uses URL-safe base64).
+ */
+function decodeBase64Url(encoded: string): string {
+  const base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+  return Buffer.from(base64, "base64").toString("utf-8");
+}
+
+/**
+ * Recursively find the first text/plain body part in a Gmail API message payload.
+ */
+function findTextBody(
+  payload: { mimeType?: string; body?: { data?: string }; parts?: unknown[] } | undefined,
+): string {
+  if (!payload) {
+    return "";
+  }
+  if (payload.mimeType === "text/plain" && payload.body?.data) {
+    return decodeBase64Url(payload.body.data);
+  }
+  if (Array.isArray(payload.parts)) {
+    for (const part of payload.parts) {
+      const found = findTextBody(part as typeof payload);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return "";
+}
+
+export type TransformOptions = {
+  includeBody?: boolean;
+  maxBytes?: number;
+};
+
+/**
+ * Transform a Gmail API message object (as returned by gws) into
+ * the hook payload format expected by the gmail preset.
+ */
+export function transformGmailApiMessage(
+  msg: Record<string, unknown>,
+  opts?: TransformOptions,
+): GmailHookPayload {
+  const id = typeof msg.id === "string" ? msg.id : "";
+  const snippet = typeof msg.snippet === "string" ? msg.snippet : "";
+
+  const payload = msg.payload as
+    | {
+        headers?: Array<{ name?: string; value?: string }>;
+        mimeType?: string;
+        body?: { data?: string };
+        parts?: unknown[];
+      }
+    | undefined;
+
+  const from = extractHeader(payload?.headers, "From");
+  const subject = extractHeader(payload?.headers, "Subject");
+
+  let body = "";
+  if (opts?.includeBody !== false) {
+    body = findTextBody(payload);
+    const maxBytes = opts?.maxBytes;
+    if (maxBytes && maxBytes > 0 && body.length > maxBytes) {
+      body = body.slice(0, maxBytes);
+    }
+  }
+
+  return {
+    messages: [{ id, from, subject, snippet, body }],
+  };
+}
+
+/**
+ * POST a hook payload to the OpenClaw hook URL.
+ */
+export async function postToHookUrl(
+  payload: GmailHookPayload,
+  hookUrl: string,
+  hookToken: string,
+): Promise<void> {
+  const response = await fetch(hookUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${hookToken}`,
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error(`Hook POST failed: ${response.status} ${response.statusText}`);
+  }
+}
+
+export type NdjsonLineHandlerConfig = {
+  hookUrl: string;
+  hookToken: string;
+  includeBody: boolean;
+  maxBytes: number;
+};
+
+/**
+ * Create a callback that processes a single NDJSON line from gws stdout,
+ * transforms it into a hook payload, and POSTs it.
+ */
+export function createNdjsonLineHandler(
+  cfg: NdjsonLineHandlerConfig,
+  log?: SubsystemLogger,
+): (line: string) => void {
+  const logger = log ?? createSubsystemLogger("gmail-gws-bridge");
+
+  return (line: string) => {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return;
+    }
+    let msg: Record<string, unknown>;
+    try {
+      msg = JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      logger.warn(`ignoring non-JSON line: ${trimmed.slice(0, 120)}`);
+      return;
+    }
+
+    const payload = transformGmailApiMessage(msg, {
+      includeBody: cfg.includeBody,
+      maxBytes: cfg.maxBytes,
+    });
+
+    const id = payload.messages[0]?.id ?? "?";
+    logger.info(`forwarding message ${id} to ${cfg.hookUrl}`);
+
+    void postToHookUrl(payload, cfg.hookUrl, cfg.hookToken).catch((err) => {
+      logger.error(`failed to forward message ${id}: ${String(err)}`);
+    });
+  };
+}

--- a/src/hooks/gmail-gws-bridge.ts
+++ b/src/hooks/gmail-gws-bridge.ts
@@ -99,8 +99,8 @@ export function transformGmailApiMessage(
   if (opts?.includeBody !== false) {
     body = findTextBody(payload);
     const maxBytes = opts?.maxBytes;
-    if (maxBytes && maxBytes > 0 && body.length > maxBytes) {
-      body = body.slice(0, maxBytes);
+    if (maxBytes && maxBytes > 0 && Buffer.byteLength(body, "utf8") > maxBytes) {
+      body = Buffer.from(body, "utf8").subarray(0, maxBytes).toString("utf8");
     }
   }
 

--- a/src/hooks/gmail-gws-bridge.ts
+++ b/src/hooks/gmail-gws-bridge.ts
@@ -100,7 +100,14 @@ export function transformGmailApiMessage(
     body = findTextBody(payload);
     const maxBytes = opts?.maxBytes;
     if (maxBytes && maxBytes > 0 && Buffer.byteLength(body, "utf8") > maxBytes) {
-      body = Buffer.from(body, "utf8").subarray(0, maxBytes).toString("utf8");
+      const buf = Buffer.from(body, "utf8");
+      let end = maxBytes;
+      // Walk back to avoid splitting a multi-byte UTF-8 character.
+      // Continuation bytes have the form 10xxxxxx (0x80..0xBF).
+      while (end > 0 && buf[end] >= 0x80 && buf[end] < 0xc0) {
+        end--;
+      }
+      body = buf.subarray(0, end).toString("utf8");
     }
   }
 

--- a/src/hooks/gmail-ops.ts
+++ b/src/hooks/gmail-ops.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { formatCliCommand } from "../cli/command-format.js";
 import {
+  type GmailCliMode,
   type OpenClawConfig,
   CONFIG_PATH,
   loadConfig,
@@ -18,13 +19,15 @@ import {
   ensureSubscription,
   ensureTailscaleEndpoint,
   ensureTopic,
-  resolveProjectIdFromGogCredentials,
+  resolveProjectIdFromCredentials,
   runGcloud,
 } from "./gmail-setup-utils.js";
+import { spawnGwsWatch } from "./gmail-watcher.js";
 import {
   buildDefaultHookUrl,
   buildGogWatchServeArgs,
   buildGogWatchStartArgs,
+  buildGwsWatchArgs,
   buildTopicPath,
   DEFAULT_GMAIL_LABEL,
   DEFAULT_GMAIL_MAX_BYTES,
@@ -45,6 +48,7 @@ import {
 } from "./gmail.js";
 
 type GmailCommonOptions = {
+  cli?: GmailCliMode;
   topic?: string;
   subscription?: string;
   label?: string;
@@ -76,9 +80,17 @@ export type GmailRunOptions = GmailCommonOptions & {
 const DEFAULT_GMAIL_TOPIC_IAM_MEMBER = "serviceAccount:gmail-api-push@system.gserviceaccount.com";
 
 export async function runGmailSetup(opts: GmailSetupOptions) {
+  const cli: GmailCliMode = opts.cli ?? "gog";
+  const isGws = cli === "gws";
+
   await ensureDependency("gcloud", ["--cask", "gcloud-cli"]);
-  await ensureDependency("gog", ["gogcli"]);
-  if (opts.tailscale !== "off" && !opts.pushEndpoint) {
+  if (isGws) {
+    await ensureDependency("gws", ["@googleworkspace/cli"], "npm");
+  } else {
+    await ensureDependency("gog", ["gogcli"]);
+  }
+  // Tailscale only needed for gog (push-based); gws uses pull
+  if (!isGws && opts.tailscale !== "off" && !opts.pushEndpoint) {
     await ensureDependency("tailscale", ["tailscale"]);
   }
 
@@ -92,18 +104,20 @@ export async function runGmailSetup(opts: GmailSetupOptions) {
   const baseConfig = configSnapshot.config;
   const hooksPath = normalizeHooksPath(baseConfig.hooks?.path);
   const hookToken = opts.hookToken ?? baseConfig.hooks?.token ?? generateHookToken();
-  const pushToken = opts.pushToken ?? baseConfig.hooks?.gmail?.pushToken ?? generateHookToken();
+  const pushToken = isGws
+    ? (opts.pushToken ?? baseConfig.hooks?.gmail?.pushToken ?? "")
+    : (opts.pushToken ?? baseConfig.hooks?.gmail?.pushToken ?? generateHookToken());
 
   const topicInput = opts.topic ?? baseConfig.hooks?.gmail?.topic ?? DEFAULT_GMAIL_TOPIC;
   const parsedTopic = parseTopicPath(topicInput);
   const topicName = parsedTopic?.topicName ?? topicInput;
 
   const projectId =
-    opts.project ?? parsedTopic?.projectId ?? (await resolveProjectIdFromGogCredentials());
-  // Gmail watch requires the Pub/Sub topic to live in the OAuth client project.
+    opts.project ?? parsedTopic?.projectId ?? (await resolveProjectIdFromCredentials(cli));
   if (!projectId) {
+    const hint = isGws ? "gws" : "gog";
     throw new Error(
-      "GCP project id required (use --project or ensure gog credentials are available)",
+      `GCP project id required (use --project or ensure ${hint} credentials are available)`,
     );
   }
 
@@ -134,9 +148,7 @@ export async function runGmailSetup(opts: GmailSetupOptions) {
   const maxBytes = opts.maxBytes ?? DEFAULT_GMAIL_MAX_BYTES;
   const renewEveryMinutes = opts.renewEveryMinutes ?? DEFAULT_GMAIL_RENEW_MINUTES;
 
-  const tailscaleMode = opts.tailscale ?? "funnel";
-  // Tailscale strips the path before proxying; keep a public path while gog
-  // listens on "/" whenever Tailscale is enabled.
+  const tailscaleMode = isGws ? "off" : (opts.tailscale ?? "funnel");
   const servePath = normalizeServePath(
     tailscaleMode !== "off" && !normalizedTailscaleTarget ? "/" : normalizedServePath,
   );
@@ -172,30 +184,34 @@ export async function runGmailSetup(opts: GmailSetupOptions) {
     "--quiet",
   ]);
 
-  const pushEndpoint = opts.pushEndpoint
-    ? opts.pushEndpoint
-    : await ensureTailscaleEndpoint({
-        mode: tailscaleMode,
-        path: tailscalePath,
-        port: servePort,
-        target: normalizedTailscaleTarget,
-        token: pushToken,
-      });
+  // gws handles its own pull subscription; gog needs push endpoint + subscription
+  let pushEndpoint = "";
+  if (!isGws) {
+    pushEndpoint = opts.pushEndpoint
+      ? opts.pushEndpoint
+      : await ensureTailscaleEndpoint({
+          mode: tailscaleMode,
+          path: tailscalePath,
+          port: servePort,
+          target: normalizedTailscaleTarget,
+          token: pushToken,
+        });
 
-  if (!pushEndpoint) {
-    throw new Error("push endpoint required (set --push-endpoint)");
+    if (!pushEndpoint) {
+      throw new Error("push endpoint required (set --push-endpoint)");
+    }
+
+    await ensureSubscription(projectId, subscription, topicName, pushEndpoint);
+
+    await startGmailWatch(
+      {
+        account: opts.account,
+        label,
+        topic: topicPath,
+      },
+      true,
+    );
   }
-
-  await ensureSubscription(projectId, subscription, topicName, pushEndpoint);
-
-  await startGmailWatch(
-    {
-      account: opts.account,
-      label,
-      topic: topicPath,
-    },
-    true,
-  );
 
   const nextConfig: OpenClawConfig = {
     ...baseConfig,
@@ -207,11 +223,13 @@ export async function runGmailSetup(opts: GmailSetupOptions) {
       presets: mergeHookPresets(baseConfig.hooks?.presets, "gmail"),
       gmail: {
         ...baseConfig.hooks?.gmail,
+        cli,
+        project: projectId,
         account: opts.account,
         label,
         topic: topicPath,
         subscription,
-        pushToken,
+        ...(pushToken ? { pushToken } : {}),
         hookUrl,
         includeBody,
         maxBytes,
@@ -238,20 +256,19 @@ export async function runGmailSetup(opts: GmailSetupOptions) {
   }
   await writeConfigFile(validated.config);
 
-  const summary = {
+  const summary: Record<string, unknown> = {
+    cli,
     projectId,
     topic: topicPath,
     subscription,
-    pushEndpoint,
     hookUrl,
     hookToken,
-    pushToken,
-    serve: {
-      bind: serveBind,
-      port: servePort,
-      path: servePath,
-    },
   };
+  if (!isGws) {
+    summary.pushEndpoint = pushEndpoint;
+    summary.pushToken = pushToken;
+    summary.serve = { bind: serveBind, port: servePort, path: servePath };
+  }
 
   if (opts.json) {
     defaultRuntime.log(JSON.stringify(summary, null, 2));
@@ -259,20 +276,32 @@ export async function runGmailSetup(opts: GmailSetupOptions) {
   }
 
   defaultRuntime.log("Gmail hooks configured:");
+  defaultRuntime.log(`- cli: ${cli}`);
   defaultRuntime.log(`- project: ${projectId}`);
   defaultRuntime.log(`- topic: ${topicPath}`);
   defaultRuntime.log(`- subscription: ${subscription}`);
-  defaultRuntime.log(`- push endpoint: ${pushEndpoint}`);
+  if (!isGws) {
+    defaultRuntime.log(`- push endpoint: ${pushEndpoint}`);
+  }
   defaultRuntime.log(`- hook url: ${hookUrl}`);
   defaultRuntime.log(`- config: ${displayPath(CONFIG_PATH)}`);
-  defaultRuntime.log(`Next: ${formatCliCommand("openclaw webhooks gmail run")}`);
+  const runCmd = isGws ? "openclaw webhooks gmail run --cli gws" : "openclaw webhooks gmail run";
+  defaultRuntime.log(`Next: ${formatCliCommand(runCmd)}`);
 }
 
 export async function runGmailService(opts: GmailRunOptions) {
-  await ensureDependency("gog", ["gogcli"]);
   const config = loadConfig();
+  const cli: GmailCliMode = opts.cli ?? config.hooks?.gmail?.cli ?? "gog";
+  const isGws = cli === "gws";
+
+  if (isGws) {
+    await ensureDependency("gws", ["@googleworkspace/cli"], "npm");
+  } else {
+    await ensureDependency("gog", ["gogcli"]);
+  }
 
   const overrides: GmailHookOverrides = {
+    cli,
     account: opts.account,
     topic: opts.topic,
     subscription: opts.subscription,
@@ -298,6 +327,12 @@ export async function runGmailService(opts: GmailRunOptions) {
 
   const runtimeConfig = resolved.value;
 
+  if (isGws) {
+    runGwsService(runtimeConfig);
+    return;
+  }
+
+  // gog path: Tailscale + push watch + serve
   if (runtimeConfig.tailscale.mode !== "off") {
     await ensureDependency("tailscale", ["tailscale"]);
     await ensureTailscaleEndpoint({
@@ -347,6 +382,48 @@ export async function runGmailService(opts: GmailRunOptions) {
         return;
       }
       child = spawnGogServe(runtimeConfig);
+    }, 2000);
+  });
+}
+
+/**
+ * Run the gws-based gmail service (pull mode, NDJSON stdout).
+ */
+function runGwsService(runtimeConfig: GmailHookRuntimeConfig) {
+  const args = buildGwsWatchArgs(runtimeConfig);
+  defaultRuntime.log(`Starting gws ${args.join(" ")}`);
+
+  let shuttingDown = false;
+  let child = spawnGwsWatch(runtimeConfig);
+
+  const detachSignals = () => {
+    process.off("SIGINT", shutdown);
+    process.off("SIGTERM", shutdown);
+  };
+
+  const shutdown = () => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    detachSignals();
+    child.kill("SIGTERM");
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  child.on("exit", () => {
+    if (shuttingDown) {
+      detachSignals();
+      return;
+    }
+    defaultRuntime.log("gws gmail +watch exited; restarting in 2s");
+    setTimeout(() => {
+      if (shuttingDown) {
+        return;
+      }
+      child = spawnGwsWatch(runtimeConfig);
     }, 2000);
   });
 }

--- a/src/hooks/gmail-ops.ts
+++ b/src/hooks/gmail-ops.ts
@@ -371,19 +371,23 @@ export async function runGmailService(opts: GmailRunOptions) {
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
 
-  child.on("exit", () => {
-    if (shuttingDown) {
-      detachSignals();
-      return;
-    }
-    defaultRuntime.log("gog watch serve exited; restarting in 2s");
-    setTimeout(() => {
+  function attachExitHandler(proc: ReturnType<typeof spawnGogServe>) {
+    proc.on("exit", () => {
       if (shuttingDown) {
+        detachSignals();
         return;
       }
-      child = spawnGogServe(runtimeConfig);
-    }, 2000);
-  });
+      defaultRuntime.log("gog watch serve exited; restarting in 2s");
+      setTimeout(() => {
+        if (shuttingDown) {
+          return;
+        }
+        child = spawnGogServe(runtimeConfig);
+        attachExitHandler(child);
+      }, 2000);
+    });
+  }
+  attachExitHandler(child);
 }
 
 /**
@@ -413,19 +417,23 @@ function runGwsService(runtimeConfig: GmailHookRuntimeConfig) {
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
 
-  child.on("exit", () => {
-    if (shuttingDown) {
-      detachSignals();
-      return;
-    }
-    defaultRuntime.log("gws gmail +watch exited; restarting in 2s");
-    setTimeout(() => {
+  function attachExitHandler(proc: ReturnType<typeof spawnGwsWatch>) {
+    proc.on("exit", () => {
       if (shuttingDown) {
+        detachSignals();
         return;
       }
-      child = spawnGwsWatch(runtimeConfig);
-    }, 2000);
-  });
+      defaultRuntime.log("gws gmail +watch exited; restarting in 2s");
+      setTimeout(() => {
+        if (shuttingDown) {
+          return;
+        }
+        child = spawnGwsWatch(runtimeConfig);
+        attachExitHandler(child);
+      }, 2000);
+    });
+  }
+  attachExitHandler(child);
 }
 
 function spawnGogServe(cfg: GmailHookRuntimeConfig) {

--- a/src/hooks/gmail-setup-utils.test.ts
+++ b/src/hooks/gmail-setup-utils.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   ensureTailscaleEndpoint,
+  gwsCredentialsPaths,
   resetGmailSetupUtilsCachesForTest,
   resolvePythonExecutablePath,
 } from "./gmail-setup-utils.js";
@@ -120,5 +121,21 @@ describe("ensureTailscaleEndpoint", () => {
     expect(message).toContain("returned invalid JSON");
     expect(message).toContain("stdout: not-json");
     expect(message).toContain("code=0");
+  });
+});
+
+describe("gwsCredentialsPaths", () => {
+  it("returns paths including ~/.config/gws/client_secret.json", () => {
+    const paths = gwsCredentialsPaths();
+    expect(paths.length).toBeGreaterThan(0);
+    const hasGwsPath = paths.some((p) => p.includes("gws/client_secret.json"));
+    expect(hasGwsPath).toBe(true);
+  });
+
+  it("includes XDG_CONFIG_HOME path when set", async () => {
+    await withEnvAsync({ XDG_CONFIG_HOME: "/tmp/xdg-test" }, async () => {
+      const paths = gwsCredentialsPaths();
+      expect(paths[0]).toBe(path.join("/tmp/xdg-test", "gws", "client_secret.json"));
+    });
   });
 });

--- a/src/hooks/gmail-setup-utils.test.ts
+++ b/src/hooks/gmail-setup-utils.test.ts
@@ -128,7 +128,7 @@ describe("gwsCredentialsPaths", () => {
   it("returns paths including ~/.config/gws/client_secret.json", () => {
     const paths = gwsCredentialsPaths();
     expect(paths.length).toBeGreaterThan(0);
-    const hasGwsPath = paths.some((p) => p.includes("gws/client_secret.json"));
+    const hasGwsPath = paths.some((p) => p.includes(path.join("gws", "client_secret.json")));
     expect(hasGwsPath).toBe(true);
   });
 

--- a/src/hooks/gmail-setup-utils.ts
+++ b/src/hooks/gmail-setup-utils.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { hasBinary } from "../agents/skills.js";
+import type { GmailCliMode } from "../config/config.js";
 import { runCommandWithTimeout, type SpawnResult } from "../process/exec.js";
 import { resolveUserPath } from "../utils.js";
 import { normalizeServePath } from "./gmail.js";
@@ -165,13 +166,36 @@ async function runGcloudCommand(
   });
 }
 
-export async function ensureDependency(bin: string, brewArgs: string[]) {
+export async function ensureDependency(
+  bin: string,
+  installArgs: string[],
+  installMethod: "brew" | "npm" = "brew",
+) {
   if (bin === "gcloud" && ensureGcloudOnPath()) {
     return;
   }
   if (hasBinary(bin)) {
     return;
   }
+
+  if (installMethod === "npm") {
+    const npmBin = hasBinary("npm") ? "npm" : undefined;
+    if (!npmBin) {
+      throw new Error(`${bin} not installed; run 'npm i -g ${installArgs.join(" ")}' and retry`);
+    }
+    const result = await runCommandWithTimeout(["npm", "install", "-g", ...installArgs], {
+      timeoutMs: 600_000,
+    });
+    if (result.code !== 0) {
+      throw new Error(`npm install failed for ${bin}: ${result.stderr || result.stdout}`);
+    }
+    if (!hasBinary(bin)) {
+      throw new Error(`${bin} still not available after npm install`);
+    }
+    return;
+  }
+
+  // brew (default)
   if (process.platform !== "darwin") {
     throw new Error(`${bin} not installed; install it and retry`);
   }
@@ -179,7 +203,7 @@ export async function ensureDependency(bin: string, brewArgs: string[]) {
     throw new Error("Homebrew not installed (install brew and retry)");
   }
   const brewEnv = bin === "gcloud" ? await gcloudEnv() : undefined;
-  const result = await runCommandWithTimeout(["brew", "install", ...brewArgs], {
+  const result = await runCommandWithTimeout(["brew", "install", ...installArgs], {
     timeoutMs: 600_000,
     env: brewEnv,
   });
@@ -352,6 +376,68 @@ export async function resolveProjectIdFromGogCredentials(): Promise<string | nul
     }
   }
   return null;
+}
+
+export function gwsCredentialsPaths(): string[] {
+  const paths: string[] = [];
+  const xdg = process.env.XDG_CONFIG_HOME;
+  if (xdg) {
+    paths.push(path.join(xdg, "gws", "client_secret.json"));
+  }
+  paths.push(resolveUserPath("~/.config/gws/client_secret.json"));
+  if (process.platform === "darwin") {
+    paths.push(resolveUserPath("~/Library/Application Support/gws/client_secret.json"));
+  }
+  return paths;
+}
+
+export async function resolveProjectIdFromGwsCredentials(): Promise<string | null> {
+  const candidates = gwsCredentialsPaths();
+  for (const candidate of candidates) {
+    if (!fs.existsSync(candidate)) {
+      continue;
+    }
+    try {
+      const raw = fs.readFileSync(candidate, "utf-8");
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      const clientId = extractGogClientId(parsed);
+      const projectNumber = extractProjectNumber(clientId);
+      if (!projectNumber) {
+        continue;
+      }
+      const res = await runGcloudCommand(
+        [
+          "projects",
+          "list",
+          "--filter",
+          `projectNumber=${projectNumber}`,
+          "--format",
+          "value(projectId)",
+        ],
+        30_000,
+      );
+      if (res.code !== 0) {
+        continue;
+      }
+      const projectId = res.stdout.trim().split(/\s+/)[0];
+      if (projectId) {
+        return projectId;
+      }
+    } catch {
+      // keep scanning
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve GCP project ID from either gog or gws credentials.
+ */
+export async function resolveProjectIdFromCredentials(cli: GmailCliMode): Promise<string | null> {
+  if (cli === "gws") {
+    return resolveProjectIdFromGwsCredentials();
+  }
+  return resolveProjectIdFromGogCredentials();
 }
 
 function gogCredentialsPaths(): string[] {

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -1,8 +1,12 @@
 /**
  * Gmail Watcher Service
  *
- * Automatically starts `gog gmail watch serve` when the gateway starts,
+ * Automatically starts the Gmail watcher when the gateway starts,
  * if hooks.gmail is configured with an account.
+ *
+ * Supports two backends:
+ * - gog (default): push-based via `gog gmail watch serve`
+ * - gws: pull-based via `gws gmail +watch` (NDJSON on stdout)
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
@@ -10,10 +14,12 @@ import { hasBinary } from "../agents/skills.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { runCommandWithTimeout } from "../process/exec.js";
+import { createNdjsonLineHandler } from "./gmail-gws-bridge.js";
 import { ensureTailscaleEndpoint } from "./gmail-setup-utils.js";
 import {
   buildGogWatchServeArgs,
   buildGogWatchStartArgs,
+  buildGwsWatchArgs,
   type GmailHookRuntimeConfig,
   resolveGmailHookRuntimeConfig,
 } from "./gmail.js";
@@ -31,15 +37,16 @@ let renewInterval: ReturnType<typeof setInterval> | null = null;
 let shuttingDown = false;
 let currentConfig: GmailHookRuntimeConfig | null = null;
 
-/**
- * Check if gog binary is available
- */
 function isGogAvailable(): boolean {
   return hasBinary("gog");
 }
 
+function isGwsAvailable(): boolean {
+  return hasBinary("gws");
+}
+
 /**
- * Start the Gmail watch (registers with Gmail API)
+ * Start the Gmail watch via gog (registers with Gmail API).
  */
 async function startGmailWatch(
   cfg: Pick<GmailHookRuntimeConfig, "account" | "label" | "topic">,
@@ -61,7 +68,7 @@ async function startGmailWatch(
 }
 
 /**
- * Spawn the gog gmail watch serve process
+ * Spawn the gog gmail watch serve process.
  */
 function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
   const args = buildGogWatchServeArgs(cfg);
@@ -120,40 +127,79 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
   return child;
 }
 
-export type GmailWatcherStartResult = {
-  started: boolean;
-  reason?: string;
-};
+/**
+ * Spawn the gws gmail +watch process (pull-based, NDJSON on stdout).
+ */
+export function spawnGwsWatch(cfg: GmailHookRuntimeConfig): ChildProcess {
+  const args = buildGwsWatchArgs(cfg);
+  log.info(`starting gws ${args.join(" ")}`);
+
+  const child = spawn("gws", args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: false,
+  });
+
+  const handleLine = createNdjsonLineHandler(
+    {
+      hookUrl: cfg.hookUrl,
+      hookToken: cfg.hookToken,
+      includeBody: cfg.includeBody,
+      maxBytes: cfg.maxBytes,
+    },
+    log,
+  );
+
+  // Buffer partial lines from stdout (NDJSON may arrive in chunks)
+  let buffer = "";
+  child.stdout?.on("data", (data: Buffer) => {
+    buffer += data.toString();
+    const lines = buffer.split("\n");
+    // Keep last (possibly incomplete) segment in the buffer
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      handleLine(line);
+    }
+  });
+
+  child.stderr?.on("data", (data: Buffer) => {
+    const line = data.toString().trim();
+    if (line) {
+      log.warn(`[gws] ${line}`);
+    }
+  });
+
+  child.on("error", (err) => {
+    log.error(`gws process error: ${String(err)}`);
+  });
+
+  child.on("exit", (code, signal) => {
+    // Flush remaining buffer
+    if (buffer.trim()) {
+      handleLine(buffer);
+      buffer = "";
+    }
+    if (shuttingDown) {
+      return;
+    }
+    log.warn(`gws exited (code=${code}, signal=${signal}); restarting in 5s`);
+    watcherProcess = null;
+    setTimeout(() => {
+      if (shuttingDown || !currentConfig) {
+        return;
+      }
+      watcherProcess = spawnGwsWatch(currentConfig);
+    }, 5000);
+  });
+
+  return child;
+}
 
 /**
- * Start the Gmail watcher service.
- * Called automatically by the gateway if hooks.gmail is configured.
+ * Start the gog-based watcher (push model).
  */
-export async function startGmailWatcher(cfg: OpenClawConfig): Promise<GmailWatcherStartResult> {
-  // Check if gmail hooks are configured
-  if (!cfg.hooks?.enabled) {
-    return { started: false, reason: "hooks not enabled" };
-  }
-
-  if (!cfg.hooks?.gmail?.account) {
-    return { started: false, reason: "no gmail account configured" };
-  }
-
-  // Check if gog is available
-  const gogAvailable = isGogAvailable();
-  if (!gogAvailable) {
-    return { started: false, reason: "gog binary not found" };
-  }
-
-  // Resolve the full runtime config
-  const resolved = resolveGmailHookRuntimeConfig(cfg, {});
-  if (!resolved.ok) {
-    return { started: false, reason: resolved.error };
-  }
-
-  const runtimeConfig = resolved.value;
-  currentConfig = runtimeConfig;
-
+async function startGogWatcher(
+  runtimeConfig: GmailHookRuntimeConfig,
+): Promise<GmailWatcherStartResult> {
   // Set up Tailscale endpoint if needed
   if (runtimeConfig.tailscale.mode !== "off") {
     try {
@@ -197,8 +243,62 @@ export async function startGmailWatcher(cfg: OpenClawConfig): Promise<GmailWatch
   log.info(
     `gmail watcher started for ${runtimeConfig.account} (renew every ${runtimeConfig.renewEveryMinutes}m)`,
   );
-
   return { started: true };
+}
+
+/**
+ * Start the gws-based watcher (pull model, no Tailscale, no renewal).
+ */
+function startGwsWatcher(runtimeConfig: GmailHookRuntimeConfig): GmailWatcherStartResult {
+  shuttingDown = false;
+  watcherProcess = spawnGwsWatch(runtimeConfig);
+  log.info(`gmail watcher (gws) started for ${runtimeConfig.account}`);
+  return { started: true };
+}
+
+export type GmailWatcherStartResult = {
+  started: boolean;
+  reason?: string;
+};
+
+/**
+ * Start the Gmail watcher service.
+ * Called automatically by the gateway if hooks.gmail is configured.
+ */
+export async function startGmailWatcher(cfg: OpenClawConfig): Promise<GmailWatcherStartResult> {
+  if (!cfg.hooks?.enabled) {
+    return { started: false, reason: "hooks not enabled" };
+  }
+
+  if (!cfg.hooks?.gmail?.account) {
+    return { started: false, reason: "no gmail account configured" };
+  }
+
+  const cliMode = cfg.hooks.gmail.cli ?? "gog";
+
+  if (cliMode === "gws") {
+    if (!isGwsAvailable()) {
+      return { started: false, reason: "gws binary not found" };
+    }
+  } else {
+    if (!isGogAvailable()) {
+      return { started: false, reason: "gog binary not found" };
+    }
+  }
+
+  // Resolve the full runtime config
+  const resolved = resolveGmailHookRuntimeConfig(cfg, {});
+  if (!resolved.ok) {
+    return { started: false, reason: resolved.error };
+  }
+
+  const runtimeConfig = resolved.value;
+  currentConfig = runtimeConfig;
+
+  if (cliMode === "gws") {
+    return startGwsWatcher(runtimeConfig);
+  }
+  return startGogWatcher(runtimeConfig);
 }
 
 /**

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -172,23 +172,12 @@ export function spawnGwsWatch(cfg: GmailHookRuntimeConfig): ChildProcess {
     log.error(`gws process error: ${String(err)}`);
   });
 
-  child.on("exit", (code, signal) => {
-    // Flush remaining buffer
+  // Flush remaining buffer on exit (restart logic is handled by callers)
+  child.on("exit", () => {
     if (buffer.trim()) {
       handleLine(buffer);
       buffer = "";
     }
-    if (shuttingDown) {
-      return;
-    }
-    log.warn(`gws exited (code=${code}, signal=${signal}); restarting in 5s`);
-    watcherProcess = null;
-    setTimeout(() => {
-      if (shuttingDown || !currentConfig) {
-        return;
-      }
-      watcherProcess = spawnGwsWatch(currentConfig);
-    }, 5000);
   });
 
   return child;
@@ -251,7 +240,26 @@ async function startGogWatcher(
  */
 function startGwsWatcher(runtimeConfig: GmailHookRuntimeConfig): GmailWatcherStartResult {
   shuttingDown = false;
-  watcherProcess = spawnGwsWatch(runtimeConfig);
+
+  function spawnAndWatch() {
+    const proc = spawnGwsWatch(runtimeConfig);
+    watcherProcess = proc;
+    proc.on("exit", (code, signal) => {
+      if (shuttingDown) {
+        return;
+      }
+      log.warn(`gws exited (code=${code}, signal=${signal}); restarting in 5s`);
+      watcherProcess = null;
+      setTimeout(() => {
+        if (shuttingDown || !currentConfig) {
+          return;
+        }
+        spawnAndWatch();
+      }, 5000);
+    });
+  }
+
+  spawnAndWatch();
   log.info(`gmail watcher (gws) started for ${runtimeConfig.account}`);
   return { started: true };
 }

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -36,6 +36,10 @@ let watcherProcess: ChildProcess | null = null;
 let renewInterval: ReturnType<typeof setInterval> | null = null;
 let shuttingDown = false;
 let currentConfig: GmailHookRuntimeConfig | null = null;
+// Generation counter to prevent stale restart timers from spawning duplicate watchers
+// after a stop+start cycle (hot-reload). Each start/stop bumps the counter, and
+// pending restart timers check their captured generation before respawning.
+let watcherGeneration = 0;
 
 function isGogAvailable(): boolean {
   return hasBinary("gog");
@@ -116,8 +120,9 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
     }
     log.warn(`gog exited (code=${code}, signal=${signal}); restarting in 5s`);
     watcherProcess = null;
+    const gen = watcherGeneration;
     setTimeout(() => {
-      if (shuttingDown || !currentConfig) {
+      if (shuttingDown || !currentConfig || watcherGeneration !== gen) {
         return;
       }
       watcherProcess = spawnGogServe(currentConfig);
@@ -250,8 +255,9 @@ function startGwsWatcher(runtimeConfig: GmailHookRuntimeConfig): GmailWatcherSta
       }
       log.warn(`gws exited (code=${code}, signal=${signal}); restarting in 5s`);
       watcherProcess = null;
+      const gen = watcherGeneration;
       setTimeout(() => {
-        if (shuttingDown || !currentConfig) {
+        if (shuttingDown || !currentConfig || watcherGeneration !== gen) {
           return;
         }
         spawnAndWatch();
@@ -303,6 +309,9 @@ export async function startGmailWatcher(cfg: OpenClawConfig): Promise<GmailWatch
   const runtimeConfig = resolved.value;
   currentConfig = runtimeConfig;
 
+  // Invalidate any pending restart timers from a previous watcher lifecycle
+  watcherGeneration += 1;
+
   if (cliMode === "gws") {
     return startGwsWatcher(runtimeConfig);
   }
@@ -313,6 +322,7 @@ export async function startGmailWatcher(cfg: OpenClawConfig): Promise<GmailWatch
  * Stop the Gmail watcher service.
  */
 export async function stopGmailWatcher(): Promise<void> {
+  watcherGeneration += 1;
   shuttingDown = true;
 
   if (renewInterval) {

--- a/src/hooks/gmail.test.ts
+++ b/src/hooks/gmail.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { type OpenClawConfig, DEFAULT_GATEWAY_PORT } from "../config/config.js";
 import {
   buildDefaultHookUrl,
+  buildGwsWatchArgs,
   buildTopicPath,
   parseTopicPath,
   resolveGmailHookRuntimeConfig,
@@ -123,5 +124,165 @@ describe("gmail hook config", () => {
       tailscale: { mode: "funnel", target },
     });
     expectResolvedPaths(result, { servePath: "/custom", publicPath: "/custom", target });
+  });
+
+  it("defaults cli to gog", () => {
+    const result = resolveGmailHookRuntimeConfig(baseConfig, {});
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.cli).toBe("gog");
+    }
+  });
+
+  it("resolves cli from config", () => {
+    const result = resolveGmailHookRuntimeConfig(
+      {
+        hooks: {
+          token: "hook-token",
+          gmail: {
+            cli: "gws",
+            account: "openclaw@gmail.com",
+          },
+        },
+      },
+      {},
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.cli).toBe("gws");
+    }
+  });
+
+  it("resolves cli from overrides", () => {
+    const result = resolveGmailHookRuntimeConfig(baseConfig, { cli: "gws" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.cli).toBe("gws");
+    }
+  });
+
+  it("does not require pushToken for gws", () => {
+    const result = resolveGmailHookRuntimeConfig(
+      {
+        hooks: {
+          token: "hook-token",
+          gmail: {
+            cli: "gws",
+            account: "openclaw@gmail.com",
+          },
+        },
+      },
+      {},
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.pushToken).toBe("");
+    }
+  });
+
+  it("does not require topic for gws", () => {
+    const result = resolveGmailHookRuntimeConfig(
+      {
+        hooks: {
+          token: "hook-token",
+          gmail: {
+            cli: "gws",
+            account: "openclaw@gmail.com",
+          },
+        },
+      },
+      {},
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("still requires pushToken for gog", () => {
+    const result = resolveGmailHookRuntimeConfig(
+      {
+        hooks: {
+          token: "hook-token",
+          gmail: {
+            account: "openclaw@gmail.com",
+            topic: "projects/demo/topics/gog-gmail-watch",
+          },
+        },
+      },
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("push token");
+    }
+  });
+
+  it("resolves project from config", () => {
+    const result = resolveGmailHookRuntimeConfig(
+      {
+        hooks: {
+          token: "hook-token",
+          gmail: {
+            cli: "gws",
+            project: "my-project",
+            account: "openclaw@gmail.com",
+          },
+        },
+      },
+      {},
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.project).toBe("my-project");
+    }
+  });
+});
+
+describe("buildGwsWatchArgs", () => {
+  it("builds basic args with project and account", () => {
+    const args = buildGwsWatchArgs({
+      account: "openclaw@gmail.com",
+      label: "INBOX",
+      project: "my-project",
+      subscription: "gog-gmail-watch-push",
+    });
+    expect(args).toEqual([
+      "gmail",
+      "+watch",
+      "--project",
+      "my-project",
+      "--account",
+      "openclaw@gmail.com",
+    ]);
+  });
+
+  it("includes label when not INBOX", () => {
+    const args = buildGwsWatchArgs({
+      account: "openclaw@gmail.com",
+      label: "IMPORTANT",
+      project: "my-project",
+      subscription: "gog-gmail-watch-push",
+    });
+    expect(args).toContain("--label");
+    expect(args).toContain("IMPORTANT");
+  });
+
+  it("includes subscription when non-default", () => {
+    const args = buildGwsWatchArgs({
+      account: "openclaw@gmail.com",
+      label: "INBOX",
+      project: "my-project",
+      subscription: "custom-sub",
+    });
+    expect(args).toContain("--subscription");
+    expect(args).toContain("custom-sub");
+  });
+
+  it("omits project when not set", () => {
+    const args = buildGwsWatchArgs({
+      account: "openclaw@gmail.com",
+      label: "INBOX",
+      project: undefined,
+      subscription: "gog-gmail-watch-push",
+    });
+    expect(args).not.toContain("--project");
   });
 });

--- a/src/hooks/gmail.ts
+++ b/src/hooks/gmail.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import {
   type OpenClawConfig,
   DEFAULT_GATEWAY_PORT,
+  type GmailCliMode,
   type HooksGmailTailscaleMode,
   resolveGatewayPort,
 } from "../config/config.js";
@@ -17,6 +18,8 @@ export const DEFAULT_GMAIL_RENEW_MINUTES = 12 * 60;
 export const DEFAULT_HOOKS_PATH = "/hooks";
 
 export type GmailHookOverrides = {
+  cli?: GmailCliMode;
+  project?: string;
   account?: string;
   label?: string;
   topic?: string;
@@ -36,6 +39,8 @@ export type GmailHookOverrides = {
 };
 
 export type GmailHookRuntimeConfig = {
+  cli: GmailCliMode;
+  project?: string;
   account: string;
   label: string;
   topic: string;
@@ -103,6 +108,9 @@ export function resolveGmailHookRuntimeConfig(
 ): { ok: true; value: GmailHookRuntimeConfig } | { ok: false; error: string } {
   const hooks = cfg.hooks;
   const gmail = hooks?.gmail;
+  const cli: GmailCliMode = overrides.cli ?? gmail?.cli ?? "gog";
+  const project = overrides.project ?? gmail?.project;
+
   const hookToken = overrides.hookToken ?? hooks?.token ?? "";
   if (!hookToken) {
     return { ok: false, error: "hooks.token missing (needed for gmail hook)" };
@@ -114,14 +122,16 @@ export function resolveGmailHookRuntimeConfig(
   }
 
   const topic = overrides.topic ?? gmail?.topic ?? "";
-  if (!topic) {
+  // gog requires topic upfront; gws can create its own
+  if (!topic && cli === "gog") {
     return { ok: false, error: "gmail topic required" };
   }
 
   const subscription = overrides.subscription ?? gmail?.subscription ?? DEFAULT_GMAIL_SUBSCRIPTION;
 
   const pushToken = overrides.pushToken ?? gmail?.pushToken ?? "";
-  if (!pushToken) {
+  // pushToken is only required for gog (push-based); gws uses pull-based Pub/Sub
+  if (!pushToken && cli === "gog") {
     return { ok: false, error: "gmail push token required" };
   }
 
@@ -181,6 +191,8 @@ export function resolveGmailHookRuntimeConfig(
   return {
     ok: true,
     value: {
+      cli,
+      project,
       account,
       label: overrides.label ?? gmail?.label ?? DEFAULT_GMAIL_LABEL,
       topic,
@@ -246,6 +258,25 @@ export function buildGogWatchServeArgs(cfg: GmailHookRuntimeConfig): string[] {
   }
   if (cfg.maxBytes > 0) {
     args.push("--max-bytes", String(cfg.maxBytes));
+  }
+  return args;
+}
+
+export function buildGwsWatchArgs(
+  cfg: Pick<GmailHookRuntimeConfig, "account" | "label" | "project" | "subscription">,
+): string[] {
+  const args = ["gmail", "+watch"];
+  if (cfg.project) {
+    args.push("--project", cfg.project);
+  }
+  if (cfg.account) {
+    args.push("--account", cfg.account);
+  }
+  if (cfg.label && cfg.label !== DEFAULT_GMAIL_LABEL) {
+    args.push("--label", cfg.label);
+  }
+  if (cfg.subscription && cfg.subscription !== DEFAULT_GMAIL_SUBSCRIPTION) {
+    args.push("--subscription", cfg.subscription);
   }
   return args;
 }


### PR DESCRIPTION
## Summary

- Adds `hooks.gmail.cli: "gog" | "gws"` config option so users can choose between gog (push-based, Homebrew/macOS) and gws (pull-based, npm, cross-platform) for Gmail Pub/Sub hooks
- gws mode (`--cli gws`) uses `gws gmail +watch` which polls Pub/Sub and outputs NDJSON — no Tailscale, no push endpoint, no renewal interval needed
- New `gmail-gws-bridge.ts` module transforms Gmail API messages from gws stdout into the hook payload format expected by the gmail preset (`{ messages: [{ id, from, subject, snippet, body }] }`)
- `ensureDependency` now supports `npm` install method alongside `brew`

## Changes

- **Config**: `GmailCliMode` type, `cli`/`project` fields in `HooksGmailConfig` + Zod schema
- **Runtime**: `resolveGmailHookRuntimeConfig` relaxes `pushToken`/`topic` requirements for gws; added `buildGwsWatchArgs`
- **Bridge**: `gmail-gws-bridge.ts` — NDJSON parsing, Gmail API message transform, hook POST
- **Setup utils**: npm install path, gws credential paths, unified `resolveProjectIdFromCredentials(cli)`
- **Watcher**: `spawnGwsWatch` with NDJSON line buffering; `startGmailWatcher` branches by cli mode
- **Ops**: `runGmailSetup`/`runGmailService` branch for gws (skip Tailscale/push subscription)
- **CLI**: `--cli <gog|gws>` option on both `setup` and `run` commands
- **Docs**: gws mode comparison table, prerequisites, config example, wizard/daemon instructions

## Test plan

- [x] `pnpm check` passes (lint + format + type check)
- [x] `pnpm test -- src/hooks/gmail` — 41 tests pass across 4 files
- [ ] Manual test with gws installed: `openclaw webhooks gmail setup --cli gws --account X --project P`

🤖 Generated with [Claude Code](https://claude.com/claude-code)