### PR TITLE
fix(telegram): add editMessage and createForumTopic fields to schema

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -310,6 +310,9 @@ function buildPollSchema() {
 
 function buildChannelTargetSchema() {
   return {
+    chatId: Type.Optional(
+      Type.String({ description: "Chat id for Telegram edit/delete/topic-create actions." }),
+    ),
     channelId: Type.Optional(
       Type.String({ description: "Channel id filter (search/thread list/event create)." }),
     ),
@@ -341,6 +344,12 @@ function buildThreadSchema() {
     threadName: Type.Optional(Type.String()),
     autoArchiveMin: Type.Optional(Type.Number()),
     appliedTags: Type.Optional(Type.Array(Type.String())),
+    iconColor: Type.Optional(
+      Type.Number({ description: "Telegram forum topic icon color (integer)." }),
+    ),
+    iconCustomEmojiId: Type.Optional(
+      Type.String({ description: "Telegram forum topic custom emoji id." }),
+    ),
   };
 }
 


### PR DESCRIPTION
Issue #35497: Telegram actions schema missing editMessage and createForumTopic fields.

Added missing fields:
- chatId to buildChannelTargetSchema()
- iconColor and iconCustomEmojiId to buildThreadSchema()