### PR TITLE
feat: add configurable exec blocked paths guard

### DIFF
--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../infra/heartbeat-wake.js", () => ({
   requestHeartbeatNow: vi.fn(),
@@ -10,10 +13,70 @@ vi.mock("../infra/system-events.js", () => ({
 
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
-import { emitExecSystemEvent } from "./bash-tools.exec-runtime.js";
+import {
+  checkExecBlockedPath,
+  _resetExecBlockedPaths,
+  emitExecSystemEvent,
+} from "./bash-tools.exec-runtime.js";
 
 const requestHeartbeatNowMock = vi.mocked(requestHeartbeatNow);
 const enqueueSystemEventMock = vi.mocked(enqueueSystemEvent);
+
+describe("checkExecBlockedPath", () => {
+  const configPath = path.join(os.homedir(), ".config", "openclaw", "exec-blocked-paths.json");
+  let readFileSyncSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    _resetExecBlockedPaths();
+    readFileSyncSpy = vi
+      .spyOn(fs, "readFileSync")
+      .mockReturnValue(JSON.stringify([".config/", ".ssh/", "rm -r", "CLAUDE.md"]));
+  });
+
+  afterEach(() => {
+    readFileSyncSpy.mockRestore();
+  });
+
+  it("blocks commands containing a blocked path pattern", () => {
+    expect(checkExecBlockedPath("cat ~/.config/secrets/api-key")).toBe(".config/");
+  });
+
+  it("blocks .ssh/ access", () => {
+    expect(checkExecBlockedPath("cat ~/.ssh/id_rsa")).toBe(".ssh/");
+  });
+
+  it("blocks rm -r commands", () => {
+    expect(checkExecBlockedPath("rm -rf /tmp/test")).toBe("rm -r");
+  });
+
+  it("allows safe commands", () => {
+    expect(checkExecBlockedPath("ls /tmp")).toBeNull();
+    expect(checkExecBlockedPath("news-search 'AI news'")).toBeNull();
+  });
+
+  it("blocks CLAUDE.md access", () => {
+    expect(checkExecBlockedPath("cat ~/CLAUDE.md")).toBe("CLAUDE.md");
+  });
+
+  it("reads config from the correct path", () => {
+    checkExecBlockedPath("test");
+    expect(readFileSyncSpy).toHaveBeenCalledWith(configPath, "utf8");
+  });
+
+  it("returns null when config file is missing", () => {
+    readFileSyncSpy.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    _resetExecBlockedPaths();
+    expect(checkExecBlockedPath("cat ~/.ssh/id_rsa")).toBeNull();
+  });
+
+  it("caches blocked paths after first load", () => {
+    checkExecBlockedPath("test1");
+    checkExecBlockedPath("test2");
+    expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("emitExecSystemEvent", () => {
   beforeEach(() => {

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -71,6 +71,18 @@ describe("checkExecBlockedPath", () => {
     expect(checkExecBlockedPath("cat ~/.ssh/id_rsa")).toBeNull();
   });
 
+  it("throws on invalid config format", () => {
+    readFileSyncSpy.mockReturnValue(JSON.stringify({ not: "an array" }));
+    _resetExecBlockedPaths();
+    expect(() => checkExecBlockedPath("test")).toThrow("invalid format");
+  });
+
+  it("throws on malformed JSON", () => {
+    readFileSyncSpy.mockReturnValue("{invalid json");
+    _resetExecBlockedPaths();
+    expect(() => checkExecBlockedPath("test")).toThrow("invalid JSON");
+  });
+
   it("caches blocked paths after first load", () => {
     checkExecBlockedPath("test1");
     checkExecBlockedPath("test2");

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -54,6 +54,11 @@ describe("checkExecBlockedPath", () => {
     expect(checkExecBlockedPath("news-search 'AI news'")).toBeNull();
   });
 
+  it("blocks workdir containing a blocked path pattern", () => {
+    expect(checkExecBlockedPath("/Users/someone/.ssh/keys")).toBe(".ssh/");
+    expect(checkExecBlockedPath("/home/user/.config/secrets")).toBe(".config/");
+  });
+
   it("blocks CLAUDE.md access", () => {
     expect(checkExecBlockedPath("cat ~/CLAUDE.md")).toBe("CLAUDE.md");
   });

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -105,6 +105,13 @@ describe("checkExecBlockedPath", () => {
     checkExecBlockedPath("test2");
     expect(readFileSyncSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("ignores empty and whitespace-only patterns", () => {
+    readFileSyncSpy.mockReturnValue(JSON.stringify([".ssh/", "", "  ", "CLAUDE.md"]));
+    _resetExecBlockedPaths();
+    expect(checkExecBlockedPath("ls /tmp")).toBeNull();
+    expect(checkExecBlockedPath("cat ~/.ssh/id_rsa")).toBe(".ssh/");
+  });
 });
 
 describe("emitExecSystemEvent", () => {

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -64,11 +64,23 @@ describe("checkExecBlockedPath", () => {
   });
 
   it("returns null when config file is missing", () => {
+    const err = new Error("ENOENT") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
     readFileSyncSpy.mockImplementation(() => {
-      throw new Error("ENOENT");
+      throw err;
     });
     _resetExecBlockedPaths();
     expect(checkExecBlockedPath("cat ~/.ssh/id_rsa")).toBeNull();
+  });
+
+  it("throws on permission errors (fail closed)", () => {
+    const err = new Error("EACCES") as NodeJS.ErrnoException;
+    err.code = "EACCES";
+    readFileSyncSpy.mockImplementation(() => {
+      throw err;
+    });
+    _resetExecBlockedPaths();
+    expect(() => checkExecBlockedPath("test")).toThrow("failed to read");
   });
 
   it("throws on invalid config format", () => {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -353,10 +353,11 @@ export async function runExecProcess(opts: {
   onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
 }): Promise<ExecProcessHandle> {
   // L2.5: Block commands referencing sensitive paths before spawning any process
-  // Check both display command and actual exec command (which may differ for safeBins)
+  // Check command, execCommand (safeBins), and workdir (prevents cwd-based bypass)
   const blockedPath =
     checkExecBlockedPath(opts.command) ??
-    (opts.execCommand ? checkExecBlockedPath(opts.execCommand) : null);
+    (opts.execCommand ? checkExecBlockedPath(opts.execCommand) : null) ??
+    checkExecBlockedPath(opts.workdir);
   if (blockedPath) {
     const msg = `Access denied: blocked path (${blockedPath})`;
     logWarn(`exec-blocked: "${opts.command}" → ${msg}`);

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
@@ -271,6 +273,43 @@ export function emitExecSystemEvent(
   requestHeartbeatNow(scopedHeartbeatWakeOptions(sessionKey, { reason: "exec-event" }));
 }
 
+// --- Exec blocked paths guard (L2.5 defense) ---
+// Block commands that reference sensitive paths. Loaded once from config file.
+let _execBlockedPaths: string[] | null = null;
+function getExecBlockedPaths(): string[] {
+  if (_execBlockedPaths !== null) {
+    return _execBlockedPaths;
+  }
+  const configPath = path.join(os.homedir(), ".config", "openclaw", "exec-blocked-paths.json");
+  try {
+    const raw = fs.readFileSync(configPath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.every((p) => typeof p === "string")) {
+      _execBlockedPaths = parsed;
+    } else {
+      logWarn(`exec-blocked-paths: invalid format in ${configPath}, expected string[]`);
+      _execBlockedPaths = [];
+    }
+  } catch {
+    _execBlockedPaths = [];
+  }
+  return _execBlockedPaths;
+}
+
+export function checkExecBlockedPath(command: string): string | null {
+  for (const blocked of getExecBlockedPaths()) {
+    if (command.includes(blocked)) {
+      return blocked;
+    }
+  }
+  return null;
+}
+
+/** @internal Reset cached blocked paths (for testing) */
+export function _resetExecBlockedPaths(): void {
+  _execBlockedPaths = null;
+}
+
 export async function runExecProcess(opts: {
   command: string;
   // Execute this instead of `command` (which is kept for display/session/logging).
@@ -291,6 +330,59 @@ export async function runExecProcess(opts: {
   timeoutSec: number | null;
   onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
 }): Promise<ExecProcessHandle> {
+  // L2.5: Block commands referencing sensitive paths before spawning any process
+  const blockedPath = checkExecBlockedPath(opts.command);
+  if (blockedPath) {
+    const msg = `Access denied: blocked path (${blockedPath})`;
+    logWarn(`exec-blocked: "${opts.command}" → ${msg}`);
+    const startedAt = Date.now();
+    const sessionId = createSessionSlug();
+    const session: ProcessSession = {
+      id: sessionId,
+      command: opts.command,
+      scopeKey: opts.scopeKey,
+      sessionKey: opts.sessionKey,
+      notifyOnExit: false,
+      notifyOnExitEmptySuccess: false,
+      exitNotified: true,
+      child: undefined,
+      stdin: undefined,
+      pid: undefined,
+      startedAt,
+      cwd: opts.workdir,
+      maxOutputChars: 0,
+      pendingMaxOutputChars: 0,
+      totalOutputChars: 0,
+      pendingStdout: [],
+      pendingStderr: [],
+      pendingStdoutChars: 0,
+      pendingStderrChars: 0,
+      aggregated: msg,
+      tail: msg,
+      exited: true,
+      exitCode: 1,
+      exitSignal: undefined as NodeJS.Signals | number | null | undefined,
+      truncated: false,
+      backgrounded: false,
+    };
+    addSession(session);
+    return {
+      session,
+      startedAt,
+      pid: undefined,
+      promise: Promise.resolve({
+        status: "failed" as const,
+        exitCode: 1,
+        exitSignal: null,
+        durationMs: 0,
+        aggregated: msg,
+        timedOut: false,
+        reason: msg,
+      }),
+      kill: () => {},
+    };
+  }
+
   const startedAt = Date.now();
   const sessionId = createSessionSlug();
   const execCommand = opts.execCommand ?? opts.command;

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -287,10 +287,20 @@ function getExecBlockedPaths(): string[] {
     if (Array.isArray(parsed) && parsed.every((p) => typeof p === "string")) {
       _execBlockedPaths = parsed;
     } else {
-      logWarn(`exec-blocked-paths: invalid format in ${configPath}, expected string[]`);
-      _execBlockedPaths = [];
+      // Fail closed: invalid config should not silently disable all blocking
+      throw new Error(`exec-blocked-paths: invalid format in ${configPath}, expected string[]`);
     }
-  } catch {
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      // Malformed JSON: fail closed
+      throw new Error(`exec-blocked-paths: invalid JSON in ${configPath}: ${err.message}`, {
+        cause: err,
+      });
+    }
+    if (err instanceof Error && err.message.startsWith("exec-blocked-paths:")) {
+      throw err;
+    }
+    // File not found: no blocking configured (valid state)
     _execBlockedPaths = [];
   }
   return _execBlockedPaths;
@@ -331,7 +341,10 @@ export async function runExecProcess(opts: {
   onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
 }): Promise<ExecProcessHandle> {
   // L2.5: Block commands referencing sensitive paths before spawning any process
-  const blockedPath = checkExecBlockedPath(opts.command);
+  // Check both display command and actual exec command (which may differ for safeBins)
+  const blockedPath =
+    checkExecBlockedPath(opts.command) ??
+    (opts.execCommand ? checkExecBlockedPath(opts.execCommand) : null);
   if (blockedPath) {
     const msg = `Access denied: blocked path (${blockedPath})`;
     logWarn(`exec-blocked: "${opts.command}" → ${msg}`);

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -285,7 +285,7 @@ function getExecBlockedPaths(): string[] {
     const raw = fs.readFileSync(configPath, "utf8");
     const parsed = JSON.parse(raw);
     if (Array.isArray(parsed) && parsed.every((p) => typeof p === "string")) {
-      _execBlockedPaths = parsed;
+      _execBlockedPaths = parsed.filter((p) => p.trim().length > 0);
     } else {
       // Fail closed: invalid config should not silently disable all blocking
       throw new Error(`exec-blocked-paths: invalid format in ${configPath}, expected string[]`);
@@ -392,6 +392,7 @@ export async function runExecProcess(opts: {
       backgrounded: false,
     };
     addSession(session);
+    markExited(session, 1, null, "failed");
     return {
       session,
       startedAt,

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -387,7 +387,7 @@ export async function runExecProcess(opts: {
       tail: msg,
       exited: true,
       exitCode: 1,
-      exitSignal: undefined as NodeJS.Signals | number | null | undefined,
+      exitSignal: null,
       truncated: false,
       backgrounded: false,
     };

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -300,8 +300,20 @@ function getExecBlockedPaths(): string[] {
     if (err instanceof Error && err.message.startsWith("exec-blocked-paths:")) {
       throw err;
     }
-    // File not found: no blocking configured (valid state)
-    _execBlockedPaths = [];
+    // ENOENT: file not found — no blocking configured (valid state)
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      _execBlockedPaths = [];
+    } else {
+      // EACCES, EPERM, etc.: fail closed
+      throw new Error(`exec-blocked-paths: failed to read ${configPath}: ${String(err)}`, {
+        cause: err,
+      });
+    }
   }
   return _execBlockedPaths;
 }


### PR DESCRIPTION
## Summary

Adds a configurable guard that blocks exec commands from accessing sensitive paths before spawning any process.

- Reads blocked path patterns from `~/.config/openclaw/exec-blocked-paths.json` (string array)
- Checks the command string against patterns before process execution
- Returns immediate `exitCode=1` with descriptive error if blocked — no shell is spawned
- Gracefully handles missing/invalid config (defaults to no blocking)
- Cached after first load for performance

This provides a code-level defense (L2.5) against LLM-initiated access to secrets, SSH keys, and other sensitive files. Model safety training (L0) is inconsistent — e.g., Gemini blocks `cat ~/.ssh/id_rsa` but allows `ls ~/.ssh/`. A deterministic code guard closes this gap.

## Example config

```json
[".config/secrets", ".ssh/", "rm -rf", "CLAUDE.md"]
```

## Test plan

- [x] 8 unit tests added covering: pattern matching, safe command passthrough, missing config handling, cache behavior
- [x] Verified on Telegram: `ls ~/.ssh` → blocked with error message, `news-search 'AI news'` → allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)