### PR TITLE
feat(agents): add optional model attribution suffix to responses

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.model-attribution.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.model-attribution.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { buildPayloads } from "./payloads.test-helpers.js";
+import { resolveModelAttributionSuffix } from "./payloads.js";
+import type { OpenClawConfig } from "../../../config/config.js";
+
+describe("resolveModelAttributionSuffix", () => {
+  it("returns undefined when config is missing", () => {
+    expect(resolveModelAttributionSuffix(undefined, "openai", "gpt-5.2")).toBeUndefined();
+  });
+
+  it("returns undefined when modelAttribution is not set", () => {
+    const config = { agents: { defaults: {} } } as OpenClawConfig;
+    expect(resolveModelAttributionSuffix(config, "openai", "gpt-5.2")).toBeUndefined();
+  });
+
+  it("returns undefined when modelAttribution is false", () => {
+    const config = { agents: { defaults: { modelAttribution: false } } } as OpenClawConfig;
+    expect(resolveModelAttributionSuffix(config, "openai", "gpt-5.2")).toBeUndefined();
+  });
+
+  it("returns default template when modelAttribution is true", () => {
+    const config = { agents: { defaults: { modelAttribution: true } } } as OpenClawConfig;
+    expect(resolveModelAttributionSuffix(config, "openai", "gpt-5.2")).toBe(
+      "⚡ via openai/gpt-5.2",
+    );
+  });
+
+  it("supports custom template string", () => {
+    const config = {
+      agents: { defaults: { modelAttribution: "Model: {model} ({provider})" } },
+    } as OpenClawConfig;
+    expect(resolveModelAttributionSuffix(config, "anthropic", "claude-opus-4-6")).toBe(
+      "Model: claude-opus-4-6 (anthropic)",
+    );
+  });
+
+  it("replaces multiple occurrences of placeholders", () => {
+    const config = {
+      agents: { defaults: { modelAttribution: "{model} | {model} via {provider}" } },
+    } as OpenClawConfig;
+    expect(resolveModelAttributionSuffix(config, "openai", "gpt-5.2")).toBe(
+      "gpt-5.2 | gpt-5.2 via openai",
+    );
+  });
+
+  it("uses 'unknown' when provider/model are undefined", () => {
+    const config = { agents: { defaults: { modelAttribution: true } } } as OpenClawConfig;
+    expect(resolveModelAttributionSuffix(config, undefined, undefined)).toBe(
+      "⚡ via unknown/unknown",
+    );
+  });
+});
+
+describe("buildEmbeddedRunPayloads model attribution", () => {
+  it("appends attribution to the last text payload", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Hello world"],
+      config: { agents: { defaults: { modelAttribution: true } } } as OpenClawConfig,
+      provider: "openai",
+      model: "gpt-5.2",
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toContain("Hello world");
+    expect(payloads[0]?.text).toContain("⚡ via openai/gpt-5.2");
+  });
+
+  it("does not append attribution when disabled", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Hello world"],
+      config: { agents: { defaults: {} } } as OpenClawConfig,
+      provider: "openai",
+      model: "gpt-5.2",
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Hello world");
+  });
+
+  it("does not append attribution to error payloads", () => {
+    const payloads = buildPayloads({
+      assistantTexts: [],
+      lastToolError: { toolName: "write", error: "fail", mutatingAction: true },
+      config: { agents: { defaults: { modelAttribution: true } } } as OpenClawConfig,
+      provider: "openai",
+      model: "gpt-5.2",
+      verboseLevel: "on",
+    });
+
+    for (const p of payloads) {
+      if (p.isError) {
+        expect(p.text).not.toContain("⚡ via");
+      }
+    }
+  });
+
+  it("appends attribution to the last non-error text item", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["First message", "Second message"],
+      config: { agents: { defaults: { modelAttribution: true } } } as OpenClawConfig,
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+    });
+
+    expect(payloads.length).toBeGreaterThanOrEqual(2);
+    const lastNonError = [...payloads].reverse().find((p) => !p.isError && p.text);
+    expect(lastNonError?.text).toContain("⚡ via anthropic/claude-opus-4-6");
+  });
+
+  it("uses custom template when provided as string", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Hello"],
+      config: {
+        agents: { defaults: { modelAttribution: "Powered by {model}" } },
+      } as OpenClawConfig,
+      provider: "openai",
+      model: "gpt-5.2",
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toContain("Powered by gpt-5.2");
+  });
+});

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -20,6 +20,23 @@ import {
 } from "../../pi-embedded-utils.js";
 import { isLikelyMutatingToolName } from "../../tool-mutation.js";
 
+const DEFAULT_ATTRIBUTION_TEMPLATE = "⚡ via {provider}/{model}";
+
+export function resolveModelAttributionSuffix(
+  config: OpenClawConfig | undefined,
+  provider: string | undefined,
+  model: string | undefined,
+): string | undefined {
+  const setting = config?.agents?.defaults?.modelAttribution;
+  if (!setting) {
+    return undefined;
+  }
+  const p = provider ?? "unknown";
+  const m = model ?? "unknown";
+  const template = typeof setting === "string" ? setting : DEFAULT_ATTRIBUTION_TEMPLATE;
+  return template.replace(/\{provider\}/g, p).replace(/\{model\}/g, m);
+}
+
 type ToolMetaEntry = { toolName: string; meta?: string };
 type LastToolError = {
   toolName: string;
@@ -316,8 +333,10 @@ export function buildEmbeddedRunPayloads(params: {
     }
   }
 
+  const attribution = resolveModelAttributionSuffix(params.config, params.provider, params.model);
+
   const hasAudioAsVoiceTag = replyItems.some((item) => item.audioAsVoice);
-  return replyItems
+  const mapped = replyItems
     .map((item) => ({
       text: item.text?.trim() ? item.text.trim() : undefined,
       mediaUrls: item.media?.length ? item.media : undefined,
@@ -337,4 +356,15 @@ export function buildEmbeddedRunPayloads(params: {
       }
       return true;
     });
+
+  if (attribution) {
+    for (let i = mapped.length - 1; i >= 0; i -= 1) {
+      if (mapped[i].text && !mapped[i].isError) {
+        mapped[i] = { ...mapped[i], text: `${mapped[i].text}\n\n${attribution}` };
+        break;
+      }
+    }
+  }
+
+  return mapped;
 }

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -701,6 +701,8 @@ export const FIELD_HELP: Record<string, string> = {
   "auth.cooldowns.failureWindowHours": "Failure window (hours) for backoff counters (default: 24).",
   "agents.defaults.workspace":
     "Default workspace path exposed to agent runtime tools for filesystem context and repo-aware behavior. Set this explicitly when running from wrappers so path resolution stays deterministic.",
+  "agents.defaults.modelAttribution":
+    "Append model attribution to assistant responses so users know which model generated each reply. Set to `true` for the default format or provide a custom template string with `{provider}` and `{model}` placeholders.",
   "agents.defaults.bootstrapMaxChars":
     "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
   "agents.defaults.bootstrapTotalMaxChars":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -275,6 +275,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "skills.load.watch": "Watch Skills",
   "skills.load.watchDebounceMs": "Skills Watch Debounce (ms)",
   "agents.defaults.workspace": "Workspace",
+  "agents.defaults.modelAttribution": "Model Attribution",
   "agents.defaults.repoRoot": "Repo Root",
   "agents.defaults.bootstrapMaxChars": "Bootstrap Max Chars",
   "agents.defaults.bootstrapTotalMaxChars": "Bootstrap Total Max Chars",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -120,6 +120,13 @@ export type CliBackendConfig = {
 export type AgentDefaultsConfig = {
   /** Primary model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   model?: AgentModelConfig;
+  /**
+   * Append model attribution to assistant responses so users know which model
+   * generated each reply. When `true`, appends e.g. "⚡ via openai/gpt-5.2".
+   * When a string, uses that as a custom template — `{provider}` and `{model}`
+   * placeholders are replaced. Default: `false` (no attribution).
+   */
+  modelAttribution?: boolean | string;
   /** Optional image-capable model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   imageModel?: AgentModelConfig;
   /** Optional PDF-capable model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -17,6 +17,7 @@ import {
 export const AgentDefaultsSchema = z
   .object({
     model: AgentModelSchema.optional(),
+    modelAttribution: z.union([z.boolean(), z.string()]).optional(),
     imageModel: AgentModelSchema.optional(),
     pdfModel: AgentModelSchema.optional(),
     pdfMaxBytesMb: z.number().positive().optional(),


### PR DESCRIPTION
## Summary

- **Problem:** Users with multiple providers cannot tell which model generated each response, especially when silent fallbacks are active.
- **Why it matters:** Without model attribution, unexpected fallbacks (e.g. from billing issues) go unnoticed, and debugging multi-model setups is harder.
- **What changed:** Added `agents.defaults.modelAttribution` config option that appends a model identifier suffix to assistant responses. Updated config types, Zod schema, labels, help text, payload builder, and added 12 new tests.
- **What did NOT change:** No changes to failover logic, streaming pipeline, or channel delivery. Only the final payload text is modified.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33975

## User-visible / Behavior Changes

When `agents.defaults.modelAttribution` is enabled, assistant responses include a model attribution suffix:

```yaml
agents:
  defaults:
    modelAttribution: true
```

Produces responses like:
> Here is your answer...
>
> ⚡ via openai/gpt-5.2

Custom templates are also supported:
```yaml
modelAttribution: "Model: {model} ({provider})"
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+
- Integration/channel: Any

### Steps

1. Set `agents.defaults.modelAttribution: true` in `openclaw.json`
2. Send a message to any agent
3. Check that the response includes the model attribution suffix

### Expected

- Response text ends with "⚡ via {provider}/{model}"

### Actual

- Before fix: No model identification in responses
- After fix: Model attribution appended to last text payload

## Evidence

Test results (47/47 passing including 12 new):
```
✓ src/agents/pi-embedded-runner/run/payloads.test.ts (7 tests)
✓ src/agents/pi-embedded-runner/run/payloads.errors.test.ts (28 tests)
✓ src/agents/pi-embedded-runner/run/payloads.model-attribution.test.ts (12 tests)
```

## Human Verification (required)

- Verified scenarios: attribution with `true`, custom string template, disabled/false/missing config, error-only payloads, multiple text blocks
- Edge cases checked: undefined provider/model, multiple placeholder occurrences, error payloads excluded
- What I did **not** verify: Streaming (block reply) path — attribution is only applied in the final payload builder

## Compatibility / Migration

- Backward compatible? `Yes` — feature is opt-in, default is no attribution
- Config/env changes? Optional new config field `agents.defaults.modelAttribution`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `modelAttribution` from config or set to `false`
- Files/config to restore: `src/agents/pi-embedded-runner/run/payloads.ts`
- Known bad symptoms: Extra text appended to responses (cosmetic only, no functional impact)

## Risks and Mitigations

- Attribution text is appended after payload filtering, so it won't interfere with silent reply detection or error formatting
- Only the last non-error text item gets attribution, preventing duplicate suffixes across multi-part responses
