### PR TITLE
fix(cron): deliver full cron output for announce mode (#13812)

### DIFF
--- a/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
@@ -19,7 +19,7 @@ describe("runCronIsolatedAgentTurn forum topic delivery", () => {
     await withTempCronHome(async (home) => {
       const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
       const deps = createCliDeps();
-      mockAgentPayloads([{ text: "forum message" }]);
+      mockAgentPayloads([{ text: "forum " }, { text: "message" }]);
 
       const res = await runTelegramAnnounceTurn({
         home,
@@ -38,7 +38,7 @@ describe("runCronIsolatedAgentTurn forum topic delivery", () => {
       });
 
       vi.clearAllMocks();
-      mockAgentPayloads([{ text: "plain message" }]);
+      mockAgentPayloads([{ text: "plain " }, { text: "message" }]);
 
       const plainRes = await runTelegramAnnounceTurn({
         home,
@@ -49,6 +49,9 @@ describe("runCronIsolatedAgentTurn forum topic delivery", () => {
 
       expect(plainRes.status).toBe("ok");
       expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0]).toMatchObject({
+        roundOneReply: "plain message",
+      });
       const announceArgs = vi.mocked(runSubagentAnnounceFlow).mock.calls[0]?.[0] as
         | { expectsCompletionMessage?: boolean }
         | undefined;

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -10,6 +10,23 @@ type DeliveryPayload = {
   isError?: boolean;
 };
 
+export function mergeNonErrorTextPayloads(payloads: DeliveryPayload[]): string | undefined {
+  let merged = "";
+  let sawText = false;
+  for (const payload of payloads) {
+    if (payload?.isError) {
+      continue;
+    }
+    const text = typeof payload?.text === "string" ? payload.text : "";
+    if (!text) {
+      continue;
+    }
+    merged += text;
+    sawText = true;
+  }
+  return sawText ? merged : undefined;
+}
+
 export function pickSummaryFromOutput(text: string | undefined) {
   const clean = (text ?? "").trim();
   if (!clean) {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -59,6 +59,7 @@ import {
 import { resolveDeliveryTarget } from "./delivery-target.js";
 import {
   isHeartbeatOnlyResponse,
+  mergeNonErrorTextPayloads,
   pickLastDeliverablePayload,
   pickLastNonEmptyTextFromPayloads,
   pickSummaryFromOutput,
@@ -620,19 +621,24 @@ export async function runCronIsolatedAgentTurn(params: {
   }
   const firstText = payloads[0]?.text ?? "";
   let summary = pickSummaryFromPayloads(payloads) ?? pickSummaryFromOutput(firstText);
-  let outputText = pickLastNonEmptyTextFromPayloads(payloads);
-  let synthesizedText = outputText?.trim() || summary?.trim() || undefined;
+  const mergedTextCandidate = mergeNonErrorTextPayloads(payloads);
   const deliveryPayload = pickLastDeliverablePayload(payloads);
-  let deliveryPayloads =
-    deliveryPayload !== undefined
-      ? [deliveryPayload]
-      : synthesizedText
-        ? [{ text: synthesizedText }]
-        : [];
   const deliveryPayloadHasStructuredContent =
     Boolean(deliveryPayload?.mediaUrl) ||
     (deliveryPayload?.mediaUrls?.length ?? 0) > 0 ||
     Object.keys(deliveryPayload?.channelData ?? {}).length > 0;
+  const mergedText = deliveryPayloadHasStructuredContent ? undefined : mergedTextCandidate;
+
+  let outputText = mergedText ?? pickLastNonEmptyTextFromPayloads(payloads);
+  let synthesizedText = outputText?.trim() || summary?.trim() || undefined;
+  let deliveryPayloads =
+    deliveryPayload !== undefined && deliveryPayloadHasStructuredContent
+      ? [deliveryPayload]
+      : mergedText
+        ? [{ text: mergedText }]
+        : synthesizedText
+          ? [{ text: synthesizedText }]
+          : [];
   const deliveryBestEffort = resolveCronDeliveryBestEffort(params.job);
   const hasErrorPayload = payloads.some((payload) => payload?.isError === true);
   const runLevelError = runResult.meta?.error;


### PR DESCRIPTION
## Summary

- Problem: Cron `delivery.mode="announce"` could deliver only the last text chunk when an isolated cron run produced multiple text payloads (common for long/multi-line reports), which looks like “summary-only” output for targets like Telegram topics.
- Why it matters: Scheduled reports become incomplete/unusable and can confuse users who can see the full output in the cron run artifacts but only receive a tail fragment in their channel.
- What changed: For text-only cron outputs, OpenClaw now merges non-error text payloads into a single delivery text before dispatching via direct delivery or the announce flow.
- What did NOT change (scope boundary): Structured payload delivery (media/channelData) behavior is unchanged; this does not affect non-cron message delivery.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #13812

## User-visible / Behavior Changes

- Cron announce deliveries send the full text output (even when the agent reply is split into multiple text payloads).

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22
- Model/provider: N/A (unit test)
- Integration/channel (if any): Telegram (topic delivery path)
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm test src/cron/isolated-agent.direct-delivery-forum-topics.test.ts`.

### Expected

- Telegram `:topic:` deliveries include the full concatenated text output.
- Plain Telegram announce path passes the merged text into the announce flow.

### Actual

- Before: only the last text payload was delivered.
- After: the full merged text is delivered.

## Evidence

- [x] Passing after: `pnpm test src/cron/isolated-agent.direct-delivery-forum-topics.test.ts`

## Human Verification (required)

- Verified scenarios: Updated unit test covering multi-payload text for Telegram topic + announce path.
- Edge cases checked: Error payloads are excluded from merged delivery text.
- What you did **not** verify: End-to-end delivery on a live Telegram bot.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- Revert this commit.

## Risks and Mitigations

None.
