### PR TITLE
docs: use canonical discord.gg/clawd link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Welcome to the lobster tank! 🦞
 
 - **GitHub:** https://github.com/openclaw/openclaw
 - **Vision:** [`VISION.md`](VISION.md)
-- **Discord:** https://discord.gg/qkhbAGHRBT
+- **Discord:** https://discord.gg/clawd
 - **X/Twitter:** [@steipete](https://x.com/steipete) / [@openclaw](https://x.com/openclaw)
 
 ## Maintainers


### PR DESCRIPTION
## Summary

This PR updates the Discord invite link in CONTRIBUTING.md to use the canonical  short link, consistent with all other Discord links throughout the repository.

## Details

- **Before:** 
- **After:** 

Both links redirect to the same Discord server ("Friends of the Crustacean 🦞🤝"), but the shorter  link is used everywhere else in the repo (README.md, docs, etc.) for consistency.

## Changes

- Updated the Discord link in the Quick Links section of CONTRIBUTING.md

## Validation

- Verified both links resolve to the same Discord server
- Checked that the new link matches the pattern used in README.md and documentation files
- Markdown lint passes (pre-existing MD034 warnings in the file are unrelated to this change)

---

🤖 AI-assisted contribution