### PR TITLE
feat(agents): expand reminder-guard phrase detection for CN + EN variants

### DIFF
--- a/src/auto-reply/reply/agent-runner-reminder-guard.test.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasUnbackedReminderCommitment,
+  appendUnscheduledReminderNote,
+  UNSCHEDULED_REMINDER_NOTE,
+} from "./agent-runner-reminder-guard.js";
+
+describe("hasUnbackedReminderCommitment", () => {
+  describe("English — original patterns", () => {
+    it.each([
+      "I'll remind you about this later",
+      "I will follow up on this tomorrow",
+      "I'll check back in 30 minutes",
+      "I will circle back with the results",
+      "I'll make sure to remind you",
+      "I'll set a reminder for you",
+      "I will create a reminder",
+      "I will schedule a reminder for 3pm",
+    ])("matches: %s", (text) => {
+      expect(hasUnbackedReminderCommitment(text)).toBe(true);
+    });
+  });
+
+  describe("English — new expanded patterns", () => {
+    it.each([
+      "I'll let you know when it's done",
+      "I will update you with the results",
+      "I'll get back to you shortly",
+      "I will notify you when the task completes",
+      "I'll message you later today",
+      "I'll ping you when it's ready",
+      "I will reach out after the meeting",
+      "I'll touch base with you tomorrow",
+      "I'll keep you posted on progress",
+      "I will keep you updated",
+      "I'll keep you informed",
+    ])("matches: %s", (text) => {
+      expect(hasUnbackedReminderCommitment(text)).toBe(true);
+    });
+  });
+
+  describe("Chinese patterns", () => {
+    it.each([
+      "稍后提醒你",
+      "之后通知你结果",
+      "待会儿告诉你",
+      "回头同步一下进度",
+      "晚点更新你",
+      "等下反馈给你",
+      "到时候告诉你",
+      "到时通知你",
+      "完成后通知你",
+      "做完之后告诉你",
+      "搞定以后同步一下",
+      "我会提醒你的",
+      "我来通知你",
+      "我会告诉你结果",
+      "我会同步进度",
+      "我会给你反馈",
+      "我会给你回馈",
+      "过会儿提醒你",
+      "到时候给你反馈",
+    ])("matches: %s", (text) => {
+      expect(hasUnbackedReminderCommitment(text)).toBe(true);
+    });
+  });
+
+  describe("negative cases — should NOT trigger", () => {
+    it.each([
+      "Here is the information you requested.",
+      "The task is complete.",
+      "I've finished the analysis.",
+      "Let me know if you need anything else.",
+      "Sure, I can help with that.",
+      "这是你要的信息。",
+      "任务已完成。",
+      "需要其他帮助吗？",
+      "",
+      "   ",
+    ])("does not match: %s", (text) => {
+      expect(hasUnbackedReminderCommitment(text)).toBe(false);
+    });
+  });
+
+  it("does not match when the unscheduled note is already present", () => {
+    const text = `I'll remind you later.\n\n${UNSCHEDULED_REMINDER_NOTE}`;
+    expect(hasUnbackedReminderCommitment(text)).toBe(false);
+  });
+});
+
+describe("appendUnscheduledReminderNote", () => {
+  it("appends note to first matching payload", () => {
+    const payloads = [{ text: "I'll let you know when done." }];
+    const result = appendUnscheduledReminderNote(payloads);
+    expect(result[0].text).toContain(UNSCHEDULED_REMINDER_NOTE);
+  });
+
+  it("does not append to error payloads", () => {
+    const payloads = [{ text: "I'll remind you later.", isError: true }];
+    const result = appendUnscheduledReminderNote(payloads);
+    expect(result[0].text).not.toContain(UNSCHEDULED_REMINDER_NOTE);
+  });
+
+  it("appends only once across multiple payloads", () => {
+    const payloads = [
+      { text: "I'll remind you about task A." },
+      { text: "I'll remind you about task B." },
+    ];
+    const result = appendUnscheduledReminderNote(payloads);
+    expect(result[0].text).toContain(UNSCHEDULED_REMINDER_NOTE);
+    expect(result[1].text).not.toContain(UNSCHEDULED_REMINDER_NOTE);
+  });
+
+  it("works with Chinese follow-up promise text", () => {
+    const payloads = [{ text: "好的，完成后通知你。" }];
+    const result = appendUnscheduledReminderNote(payloads);
+    expect(result[0].text).toContain(UNSCHEDULED_REMINDER_NOTE);
+  });
+
+  it("leaves non-matching payloads unchanged", () => {
+    const payloads = [{ text: "Here is your answer." }];
+    const result = appendUnscheduledReminderNote(payloads);
+    expect(result[0].text).toBe("Here is your answer.");
+  });
+});

--- a/src/auto-reply/reply/agent-runner-reminder-guard.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.ts
@@ -5,8 +5,15 @@ export const UNSCHEDULED_REMINDER_NOTE =
   "Note: I did not schedule a reminder in this turn, so this will not trigger automatically.";
 
 const REMINDER_COMMITMENT_PATTERNS: RegExp[] = [
-  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?(?:remember|remind|ping|follow up|follow-up|check back|circle back)\b/i,
-  /\b(?:i\s*['’]?ll|i will)\s+(?:set|create|schedule)\s+(?:a\s+)?reminder\b/i,
+  /\b(?:i\s*['\u2018\u2019]?ll|i will)\s+(?:make sure to\s+)?(?:remember|remind|ping|follow up|follow-up|check back|circle back)\b/i,
+  /\b(?:i\s*['\u2018\u2019]?ll|i will)\s+(?:set|create|schedule)\s+(?:a\s+)?reminder\b/i,
+  /\b(?:i\s*['\u2018\u2019]?ll|i will)\s+(?:let you know|update you|get back to you|notify you|message you)\b/i,
+  /\b(?:i\s*['\u2018\u2019]?ll|i will)\s+(?:ping|poke|nudge|buzz)\s+you\b/i,
+  /\b(?:i\s*['\u2018\u2019]?ll|i will)\s+(?:reach out|touch base|keep you (?:posted|updated|informed))\b/i,
+  /(?:稍后|之后|待会儿?|回头|晚[点些]|过[会一]儿?|等下|到时候?)\s*(?:提醒|通知|告[诉知]|同步|反馈|回复|更新|汇报)/,
+  /(?:完成|做完|搞定|结束|好了)\s*(?:后|之后|以后)\s*(?:提醒|通知|告[诉知]|同步|更新|汇报)/,
+  /(?:我[会来])\s*(?:提醒你|通知你|告诉你|同步进度|更新你|给你[回反]馈)/,
+  /(?:到时候?)\s*(?:告诉你|通知你|提醒你|给你[回反]馈|同步)/,
 ];
 
 export function hasUnbackedReminderCommitment(text: string): boolean {


### PR DESCRIPTION
## Summary

- **Problem:** The reminder-commitment guard only catches a narrow set of English phrases. Users who see Chinese follow-up promises or expanded English variants like "I'll let you know when done" do not receive the helpful "no reminder scheduled" note.
- **Why it matters:** Without the note, users interpret agent follow-up promises as real scheduled actions, leading to confusion when no automatic reminder fires.
- **What changed:** Expanded `REMINDER_COMMITMENT_PATTERNS` in `agent-runner-reminder-guard.ts` with 7 new regex patterns (3 English, 4 Chinese). Added 54 comprehensive test cases in a new test file.
- **What did NOT change:** The guard logic, cron store check, and payload append mechanism are unchanged. Only the pattern list is expanded.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35462

## User-visible / Behavior Changes

The "no reminder scheduled" note now triggers for more follow-up promise phrases:

**English (new):**
- "I'll let you know when done"
- "I will update you / get back to you / notify you / message you"
- "I'll ping/poke/nudge/buzz you"
- "I'll keep you posted/updated/informed"
- "I'll reach out / touch base"

**Chinese (new):**
- "稍后提醒你" / "之后通知你" / "回头同步" / "等下反馈"
- "完成后通知你" / "做完之后告诉你" / "搞定以后同步"
- "我会提醒你" / "我来通知你" / "我会同步进度"
- "到时候告诉你" / "到时通知你"

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+
- Integration/channel: Any

### Steps

1. Send a prompt that causes the agent to reply with a follow-up promise (e.g. "帮我做这个任务，做完通知我" or "Can you do this and let me know when it's done?")
2. Verify that the response includes the "Note: I did not schedule a reminder..." suffix

### Expected

- Follow-up promise phrases in both English and Chinese trigger the guard note

### Actual

- Before fix: Only narrow English phrases triggered
- After fix: Comprehensive EN + CN coverage

## Evidence

Test results (54/54 passing):
```
✓ src/auto-reply/reply/agent-runner-reminder-guard.test.ts (54 tests) 5ms
  - English original (8 cases)
  - English expanded (11 cases)
  - Chinese patterns (19 cases)
  - Negative cases (11 cases)
  - appendUnscheduledReminderNote (5 cases)
```

## Human Verification (required)

- Verified scenarios: All 54 test cases covering positive EN, positive CN, negative cases, and payload append behavior
- Edge cases checked: Empty string, whitespace-only, already-appended note, error payloads, multiple payloads
- What I did **not** verify: Real-time agent responses with actual LLM output

## Compatibility / Migration

- Backward compatible? `Yes` — only adds more patterns, does not remove existing ones
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove the new regex patterns from `REMINDER_COMMITMENT_PATTERNS` array
- Files/config to restore: `src/auto-reply/reply/agent-runner-reminder-guard.ts`
- Known bad symptoms: False positives (guard note appears on non-promise text) — mitigated by conservative patterns and negative test cases

## Risks and Mitigations

- Risk of false positives with Chinese patterns — mitigated by requiring both a time-word AND an action verb, reducing accidental matches
- Curly quote handling in English patterns preserved from original code via `‘’` Unicode escapes
