### PR TITLE
fix: model selection checkmark and stale contextTokens after model switch

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -449,10 +449,13 @@ export async function runReplyAgent(params: {
     const cliSessionId = isCliProvider(providerUsed, cfg)
       ? runResult.meta?.agentMeta?.sessionId?.trim()
       : undefined;
-    // Only fall back to the session's cached contextTokens when the model hasn't
-    // changed; otherwise the stale value from a previous model gets stuck (#35372).
+    // Only fall back to the session's cached contextTokens when neither model nor
+    // provider has changed; otherwise the stale value from a previous model/provider
+    // gets stuck (#35372).
     const sessionContextTokensFallback =
-      modelUsed === activeSessionEntry?.model ? activeSessionEntry?.contextTokens : undefined;
+      modelUsed === activeSessionEntry?.model && providerUsed === activeSessionEntry?.modelProvider
+        ? activeSessionEntry?.contextTokens
+        : undefined;
     const contextTokensUsed =
       agentCfgContextTokens ??
       lookupContextTokens(modelUsed) ??

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -449,10 +449,14 @@ export async function runReplyAgent(params: {
     const cliSessionId = isCliProvider(providerUsed, cfg)
       ? runResult.meta?.agentMeta?.sessionId?.trim()
       : undefined;
+    // Only fall back to the session's cached contextTokens when the model hasn't
+    // changed; otherwise the stale value from a previous model gets stuck (#35372).
+    const sessionContextTokensFallback =
+      modelUsed === activeSessionEntry?.model ? activeSessionEntry?.contextTokens : undefined;
     const contextTokensUsed =
       agentCfgContextTokens ??
       lookupContextTokens(modelUsed) ??
-      activeSessionEntry?.contextTokens ??
+      sessionContextTokensFallback ??
       DEFAULT_CONTEXT_TOKENS;
 
     await persistRunSessionUsage({

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -234,10 +234,13 @@ export function createFollowupRunner(params: {
       const usage = runResult.meta?.agentMeta?.usage;
       const promptTokens = runResult.meta?.agentMeta?.promptTokens;
       const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
-      // Only fall back to the session's cached contextTokens when the model hasn't
-      // changed; otherwise the stale value from a previous model gets stuck (#35372).
+      // Only fall back to the session's cached contextTokens when neither model nor
+      // provider has changed; otherwise the stale value from a previous model/provider
+      // gets stuck (#35372).
       const sessionContextTokensFallback =
-        modelUsed === sessionEntry?.model ? sessionEntry?.contextTokens : undefined;
+        modelUsed === sessionEntry?.model && fallbackProvider === sessionEntry?.modelProvider
+          ? sessionEntry?.contextTokens
+          : undefined;
       const contextTokensUsed =
         agentCfgContextTokens ??
         lookupContextTokens(modelUsed) ??

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -234,10 +234,14 @@ export function createFollowupRunner(params: {
       const usage = runResult.meta?.agentMeta?.usage;
       const promptTokens = runResult.meta?.agentMeta?.promptTokens;
       const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
+      // Only fall back to the session's cached contextTokens when the model hasn't
+      // changed; otherwise the stale value from a previous model gets stuck (#35372).
+      const sessionContextTokensFallback =
+        modelUsed === sessionEntry?.model ? sessionEntry?.contextTokens : undefined;
       const contextTokensUsed =
         agentCfgContextTokens ??
         lookupContextTokens(modelUsed) ??
-        sessionEntry?.contextTokens ??
+        sessionContextTokensFallback ??
         DEFAULT_CONTEXT_TOKENS;
 
       if (storePath && sessionKey) {

--- a/src/telegram/model-buttons.test.ts
+++ b/src/telegram/model-buttons.test.ts
@@ -261,6 +261,32 @@ describe("buildModelsKeyboard", () => {
     }
   });
 
+  it("only marks the current provider's model, not other providers with same modelId", () => {
+    // When currentModel is "nexus-a/claude-opus-4-6", viewing "nexus-d" models
+    // should NOT show a checkmark on "claude-opus-4-6".
+    const result = buildModelsKeyboard({
+      provider: "nexus-d",
+      models: ["claude-opus-4-6", "claude-sonnet-4"],
+      currentModel: "nexus-a/claude-opus-4-6",
+      currentPage: 1,
+      totalPages: 1,
+    });
+    // Neither model should be marked as current (wrong provider).
+    expect(result[0]?.[0]?.text).toBe("claude-opus-4-6");
+    expect(result[1]?.[0]?.text).toBe("claude-sonnet-4");
+
+    // Same modelId under the correct provider should show checkmark.
+    const result2 = buildModelsKeyboard({
+      provider: "nexus-a",
+      models: ["claude-opus-4-6", "claude-sonnet-4"],
+      currentModel: "nexus-a/claude-opus-4-6",
+      currentPage: 1,
+      totalPages: 1,
+    });
+    expect(result2[0]?.[0]?.text).toBe("claude-opus-4-6 ✓");
+    expect(result2[1]?.[0]?.text).toBe("claude-sonnet-4");
+  });
+
   it("keeps short display IDs untouched and truncates overly long IDs", () => {
     const cases = [
       {

--- a/src/telegram/model-buttons.test.ts
+++ b/src/telegram/model-buttons.test.ts
@@ -287,6 +287,20 @@ describe("buildModelsKeyboard", () => {
     expect(result2[1]?.[0]?.text).toBe("claude-sonnet-4");
   });
 
+  it("falls back to bare modelId comparison when currentModel has no provider prefix", () => {
+    // Session override without provider (storedOverride.provider is undefined)
+    // passes a bare model ID like "gpt-4" as currentModel.
+    const result = buildModelsKeyboard({
+      provider: "openai",
+      models: ["gpt-4", "gpt-3.5-turbo"],
+      currentModel: "gpt-4",
+      currentPage: 1,
+      totalPages: 1,
+    });
+    expect(result[0]?.[0]?.text).toBe("gpt-4 ✓");
+    expect(result[1]?.[0]?.text).toBe("gpt-3.5-turbo");
+  });
+
   it("keeps short display IDs untouched and truncates overly long IDs", () => {
     const cases = [
       {

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -195,10 +195,6 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
   const pageModels = models.slice(startIndex, endIndex);
 
   // Model buttons - one per row
-  const currentModelId = currentModel?.includes("/")
-    ? currentModel.split("/").slice(1).join("/")
-    : currentModel;
-
   for (const model of pageModels) {
     const callbackData = buildModelSelectionCallbackData({ provider, model });
     // Skip models that still exceed Telegram's callback_data limit.
@@ -206,7 +202,8 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
       continue;
     }
 
-    const isCurrentModel = model === currentModelId;
+    // Compare full provider/model key to avoid marking all providers with the same modelId.
+    const isCurrentModel = `${provider}/${model}` === currentModel;
     const displayText = truncateModelId(model, 38);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
 

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -203,7 +203,10 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
     }
 
     // Compare full provider/model key to avoid marking all providers with the same modelId.
-    const isCurrentModel = `${provider}/${model}` === currentModel;
+    // Fall back to bare modelId comparison when currentModel has no provider prefix.
+    const isCurrentModel = currentModel?.includes("/")
+      ? `${provider}/${model}` === currentModel
+      : model === currentModel;
     const displayText = truncateModelId(model, 38);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
 


### PR DESCRIPTION
## Summary

### #35476 — /model UI marks all providers with same model ID as selected
buildModelsKeyboard compared only bare modelId, ignoring provider. Fixed to compare
full provider/model key, with bare modelId fallback for sessions without provider prefix.

### #35372 — Session contextTokens stuck at lower model limit after model switch
agent-runner.ts and followup-runner.ts fell back to stale session contextTokens
unconditionally. Fixed to only use cached value when the model hasn't changed.

## Test plan
- New tests for multi-provider checkmark and bare modelId fallback
- 104 existing related tests pass
- Type-check and format clean

Closes #35476
Closes #35372