### PR TITLE
fix: add missing editMessage and createForumTopic fields to Telegram actions schema

### DIFF
--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -226,7 +226,9 @@ export const TelegramAccountSchemaBase = z
         reactions: z.boolean().optional(),
         sendMessage: z.boolean().optional(),
         deleteMessage: z.boolean().optional(),
+        editMessage: z.boolean().optional(),
         sticker: z.boolean().optional(),
+        createForumTopic: z.boolean().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Fixes #35497

The `TelegramActionConfig` TypeScript type defines six action fields, but the Zod validation schema only included four. This caused "Unrecognized key(s)" errors when users tried to configure `editMessage` or `createForumTopic` actions.

## Changes

- Added `editMessage: z.boolean().optional()` to the Telegram actions Zod schema
- Added `createForumTopic: z.boolean().optional()` to the Telegram actions Zod schema
- Schema now matches the TypeScript type definition exactly

## Testing

- All 759 config tests pass ✓
- Code passes linter checks ✓

## Impact

Users can now properly configure all documented Telegram actions without validation errors. The schema correctly validates both existing and newly added action fields.

---

Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)