### PR TITLE
fix: skip compaction pipeline for sessions with no real messages

### DIFF
--- a/src/agents/pi-embedded-runner/compact.session-has-real-messages.test.ts
+++ b/src/agents/pi-embedded-runner/compact.session-has-real-messages.test.ts
@@ -1,0 +1,62 @@
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { sessionHasRealMessages } from "./compact.js";
+
+function createInMemorySession(
+  messages: Array<{ role: string; content: string | Array<{ type: string; text: string }> }>,
+): SessionManager {
+  const sm = SessionManager.inMemory("/tmp/test");
+  for (const msg of messages) {
+    sm.appendMessage(msg as never);
+  }
+  return sm;
+}
+
+describe("sessionHasRealMessages", () => {
+  it("returns false for a session with no entries", () => {
+    const sm = SessionManager.inMemory("/tmp/test");
+    expect(sessionHasRealMessages(sm)).toBe(false);
+  });
+
+  it("returns false for a session with only system-like entries", () => {
+    const sm = SessionManager.inMemory("/tmp/test");
+    // Custom entries are not real conversation messages
+    sm.appendCustomEntry("some-extension", { foo: "bar" });
+    expect(sessionHasRealMessages(sm)).toBe(false);
+  });
+
+  it("returns true for a session with a user message", () => {
+    const sm = createInMemorySession([{ role: "user", content: "Hello" }]);
+    expect(sessionHasRealMessages(sm)).toBe(true);
+  });
+
+  it("returns true for a session with an assistant message", () => {
+    const sm = createInMemorySession([
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: [{ type: "text", text: "Hi there" }] },
+    ]);
+    expect(sessionHasRealMessages(sm)).toBe(true);
+  });
+
+  it("returns true for a session with a toolResult message", () => {
+    const sm = SessionManager.inMemory("/tmp/test");
+    sm.appendMessage({ role: "user", content: "run a tool" } as never);
+    sm.appendMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "tool-1",
+          name: "test",
+          input: {},
+        },
+      ],
+    } as never);
+    sm.appendMessage({
+      role: "toolResult",
+      toolCallId: "tool-1",
+      content: "result",
+    } as never);
+    expect(sessionHasRealMessages(sm)).toBe(true);
+  });
+});

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -540,6 +540,29 @@ export async function compactEmbeddedPiSessionDirect(
         allowedToolNames,
       });
       trackSessionManagerAccess(params.sessionFile);
+
+      // Early bail-out: skip compaction when the session contains no real
+      // conversation messages (user/assistant/toolResult).  This avoids the
+      // entire extension-factory + createAgentSession + session.compact()
+      // pipeline — including potential LLM API calls — for idle or
+      // system-only sessions (e.g. isolated cron sessions with no interactions).
+      const hasRealMessages = sessionManager.messages?.some(
+        (m: { role?: unknown }) =>
+          m.role === "user" || m.role === "assistant" || m.role === "toolResult",
+      );
+      if (!hasRealMessages) {
+        log.debug(
+          `[compaction-diag] end runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
+            `diagId=${diagId} trigger=${trigger} outcome=skipped reason=no_real_messages ` +
+            `durationMs=${Date.now() - startedAt}`,
+        );
+        return {
+          ok: false,
+          compacted: false,
+          reason: "no real conversation messages to compact",
+        };
+      }
+
       const settingsManager = createPreparedEmbeddedPiSettingsManager({
         cwd: effectiveWorkspace,
         agentDir,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -240,6 +240,18 @@ function classifyCompactionReason(reason?: string): string {
   return "unknown";
 }
 
+const REAL_MESSAGE_ROLES = new Set(["user", "assistant", "toolResult"]);
+
+/** Check whether a session has at least one real conversation message. */
+export function sessionHasRealMessages(sessionManager: SessionManager): boolean {
+  const entries = sessionManager.getEntries();
+  return entries.some(
+    (entry) =>
+      entry.type === "message" &&
+      REAL_MESSAGE_ROLES.has((entry as { message?: { role?: string } }).message?.role ?? ""),
+  );
+}
+
 /**
  * Core compaction logic without lane queueing.
  * Use this when already inside a session/global lane to avoid deadlocks.
@@ -546,10 +558,7 @@ export async function compactEmbeddedPiSessionDirect(
       // entire extension-factory + createAgentSession + session.compact()
       // pipeline — including potential LLM API calls — for idle or
       // system-only sessions (e.g. isolated cron sessions with no interactions).
-      const hasRealMessages = sessionManager.messages?.some(
-        (m: { role?: unknown }) =>
-          m.role === "user" || m.role === "assistant" || m.role === "toolResult",
-      );
+      const hasRealMessages = sessionHasRealMessages(sessionManager);
       if (!hasRealMessages) {
         log.debug(
           `[compaction-diag] end runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +


### PR DESCRIPTION
## Summary
- The compaction pipeline ran full setup (model resolution, API key validation, session creation) for sessions with no real conversation messages, wasting LLM API calls
- Added early bail-out after `SessionManager.open()` that checks for real messages (user/assistant/toolResult roles) before proceeding to extension factories and model setup
- The early return is inside the outer try block so the session lock is properly released in the finally block

Fixes #34935

## Test plan
- [ ] Verify sessions with no real messages return early with `{ ok: false, compacted: false, reason: "no real conversation messages to compact" }`
- [ ] Verify sessions with real messages proceed through normal compaction flow
- [ ] Verify session lock is properly released on early return
- [ ] Verify diagnostic logging includes the skip reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)