### PR TITLE
feat(memory): configurable slug generation model and timestamp mode

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -784,6 +784,10 @@ export const FIELD_HELP: Record<string, string> = {
   memory: "Memory backend configuration (global).",
   "memory.backend":
     'Selects the global memory engine: "builtin" uses OpenClaw memory internals, while "qmd" uses the QMD sidecar pipeline. Keep "builtin" unless you intentionally operate QMD.',
+  "memory.slugMode":
+    'How session-memory filenames are generated. "llm" (default) uses a lightweight LLM call to produce a descriptive 1-2 word slug. "timestamp" skips the LLM entirely and uses YYYY-MM-DD-HHMMSS — useful when rate-limited or on metered providers.',
+  "memory.slugModel":
+    "Override the model used for LLM-based slug generation (provider/model format). When unset, the agent's primary model is used, which may waste RPM on expensive frontier models for a trivial text task.",
   "memory.citations":
     'Controls citation visibility in replies: "auto" shows citations when useful, "on" always shows them, and "off" hides them. Keep "auto" for a balanced signal-to-noise default.',
   "memory.qmd.command":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -327,6 +327,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.memorySearch.cache.maxEntries": "Memory Search Embedding Cache Max Entries",
   memory: "Memory",
   "memory.backend": "Memory Backend",
+  "memory.slugMode": "Slug Generation Mode",
+  "memory.slugModel": "Slug Generation Model",
   "memory.citations": "Memory Citations Mode",
   "memory.qmd.command": "QMD Binary",
   "memory.qmd.mcporter": "QMD MCPorter",

--- a/src/config/types.memory.ts
+++ b/src/config/types.memory.ts
@@ -4,10 +4,25 @@ export type MemoryBackend = "builtin" | "qmd";
 export type MemoryCitationsMode = "auto" | "on" | "off";
 export type MemoryQmdSearchMode = "query" | "search" | "vsearch";
 
+export type MemorySlugMode = "llm" | "timestamp";
+
 export type MemoryConfig = {
   backend?: MemoryBackend;
   citations?: MemoryCitationsMode;
   qmd?: MemoryQmdConfig;
+  /**
+   * How session-memory filenames (slugs) are generated.
+   * - "llm" (default): uses a lightweight LLM call to produce a 1–2 word slug.
+   * - "timestamp": skips the LLM call entirely and uses YYYY-MM-DD-HHMMSS.
+   */
+  slugMode?: MemorySlugMode;
+  /**
+   * Override the model used for LLM-based slug generation.
+   * Accepts "provider/model" format (e.g. "openrouter/google/gemini-flash-2.0").
+   * When unset, the agent's primary model is used — which may waste RPM on
+   * expensive frontier models for a trivial text task.
+   */
+  slugModel?: string;
 };
 
 export type MemoryQmdConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -116,6 +116,8 @@ const MemorySchema = z
     backend: z.union([z.literal("builtin"), z.literal("qmd")]).optional(),
     citations: z.union([z.literal("auto"), z.literal("on"), z.literal("off")]).optional(),
     qmd: MemoryQmdSchema.optional(),
+    slugMode: z.union([z.literal("llm"), z.literal("timestamp")]).optional(),
+    slugModel: z.string().optional(),
   })
   .strict()
   .optional();

--- a/src/hooks/bundled/session-memory/handler.slug-mode.test.ts
+++ b/src/hooks/bundled/session-memory/handler.slug-mode.test.ts
@@ -1,0 +1,121 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../../config/config.js";
+import { writeWorkspaceFile } from "../../../test-helpers/workspace.js";
+import type { HookHandler } from "../../hooks.js";
+import { createHookEvent } from "../../hooks.js";
+
+const generateSlugViaLLM = vi.fn().mockResolvedValue("llm-slug");
+
+vi.mock("../../llm-slug-generator.js", () => ({
+  generateSlugViaLLM: (...args: unknown[]) => generateSlugViaLLM(...args),
+}));
+
+let handler: HookHandler;
+let suiteWorkspaceRoot = "";
+let caseCounter = 0;
+
+async function createCaseWorkspace(): Promise<string> {
+  const dir = path.join(suiteWorkspaceRoot, `slug-case-${caseCounter}`);
+  caseCounter += 1;
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+function createMockSessionContent(): string {
+  return [
+    JSON.stringify({
+      type: "message",
+      message: { role: "user", content: "Hello" },
+    }),
+    JSON.stringify({
+      type: "message",
+      message: { role: "assistant", content: "Hi there!" },
+    }),
+  ].join("\n");
+}
+
+beforeAll(async () => {
+  ({ default: handler } = await import("./handler.js"));
+  suiteWorkspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-slug-mode-"));
+});
+
+afterAll(async () => {
+  await fs.rm(suiteWorkspaceRoot, { recursive: true, force: true }).catch(() => {});
+});
+
+async function runSlugTest(
+  workspace: string,
+  cfg: OpenClawConfig,
+): Promise<string[]> {
+  const sessionsDir = path.join(workspace, "sessions");
+  await fs.mkdir(sessionsDir, { recursive: true });
+
+  const sessionFile = await writeWorkspaceFile({
+    dir: sessionsDir,
+    name: "test-session.jsonl",
+    content: createMockSessionContent(),
+  });
+
+  const event = createHookEvent("command", "new", "agent:main:main", {
+    cfg,
+    previousSessionEntry: {
+      sessionId: "test-session",
+      sessionFile,
+    },
+  });
+
+  await handler(event);
+
+  const memoryDir = path.join(workspace, "memory");
+  return fs.readdir(memoryDir).catch(() => []);
+}
+
+describe("session-memory slug mode config (#35289)", () => {
+  it("uses timestamp fallback in test env when slugMode is default (VITEST blocks LLM)", async () => {
+    generateSlugViaLLM.mockClear();
+    const workspace = await createCaseWorkspace();
+    const cfg = { agents: { defaults: { workspace } } } as OpenClawConfig;
+    const files = await runSlugTest(workspace, cfg);
+
+    expect(files.length).toBe(1);
+    expect(files[0]).toMatch(/^\d{4}-\d{2}-\d{2}-\d{4}\.md$/);
+  });
+
+  it("skips LLM entirely and uses full HHMMSS timestamp when slugMode is 'timestamp'", async () => {
+    generateSlugViaLLM.mockClear();
+    const workspace = await createCaseWorkspace();
+    const cfg = {
+      agents: { defaults: { workspace } },
+      memory: { slugMode: "timestamp" },
+    } as OpenClawConfig;
+    const files = await runSlugTest(workspace, cfg);
+
+    expect(generateSlugViaLLM).not.toHaveBeenCalled();
+    expect(files.length).toBe(1);
+    expect(files[0]).toMatch(/^\d{4}-\d{2}-\d{2}-\d{6}\.md$/);
+  });
+
+  it("slugMode 'timestamp' produces longer filename than default HHMM fallback", async () => {
+    const ws1 = await createCaseWorkspace();
+    const ws2 = await createCaseWorkspace();
+
+    const cfgDefault = { agents: { defaults: { workspace: ws1 } } } as OpenClawConfig;
+    const cfgTs = {
+      agents: { defaults: { workspace: ws2 } },
+      memory: { slugMode: "timestamp" },
+    } as OpenClawConfig;
+
+    const [defaultFiles, tsFiles] = await Promise.all([
+      runSlugTest(ws1, cfgDefault),
+      runSlugTest(ws2, cfgTs),
+    ]);
+
+    const defaultSlug = defaultFiles[0]?.replace(/^\d{4}-\d{2}-\d{2}-/, "").replace(".md", "");
+    const tsSlug = tsFiles[0]?.replace(/^\d{4}-\d{2}-\d{2}-/, "").replace(".md", "");
+    expect(defaultSlug?.length).toBe(4); // HHMM
+    expect(tsSlug?.length).toBe(6); // HHMMSS
+  });
+});

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -243,7 +243,9 @@ const saveSessionToMemory: HookHandler = async (event) => {
     let slug: string | null = null;
     let sessionContent: string | null = null;
 
-    if (sessionFile) {
+    const slugMode = cfg?.memory?.slugMode ?? "llm";
+
+    if (sessionFile && slugMode !== "timestamp") {
       // Get recent conversation content, with fallback to rotated reset transcript.
       sessionContent = await getRecentSessionContentWithResetFallback(sessionFile, messageCount);
       log.debug("Session content loaded", {
@@ -269,9 +271,14 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     // If no slug, use timestamp
     if (!slug) {
-      const timeSlug = now.toISOString().split("T")[1].split(".")[0].replace(/:/g, "");
-      slug = timeSlug.slice(0, 4); // HHMM
-      log.debug("Using fallback timestamp slug", { slug });
+      if (slugMode === "timestamp") {
+        const ts = now.toISOString().split("T")[1].split(".")[0].replace(/:/g, "");
+        slug = ts; // HHMMSS
+      } else {
+        const timeSlug = now.toISOString().split("T")[1].split(".")[0].replace(/:/g, "");
+        slug = timeSlug.slice(0, 4); // HHMM
+      }
+      log.debug("Using fallback timestamp slug", { slug, slugMode });
     }
 
     // Create filename with date and slug

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -44,9 +44,10 @@ ${params.sessionContent.slice(0, 2000)}
 
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
-    // Resolve model from agent config instead of using hardcoded defaults
-    const modelRef = resolveAgentEffectiveModelPrimary(params.cfg, agentId);
-    const parsed = modelRef ? parseModelRef(modelRef, DEFAULT_PROVIDER) : null;
+    // Resolve model: prefer memory.slugModel override, then agent primary model
+    const slugModelRef = params.cfg.memory?.slugModel?.trim() || undefined;
+    const effectiveRef = slugModelRef ?? resolveAgentEffectiveModelPrimary(params.cfg, agentId);
+    const parsed = effectiveRef ? parseModelRef(effectiveRef, DEFAULT_PROVIDER) : null;
     const provider = parsed?.provider ?? DEFAULT_PROVIDER;
     const model = parsed?.model ?? DEFAULT_MODEL;
 


### PR DESCRIPTION
## Summary

- **Problem:** Session-memory slug generation always uses the agent's primary model, wasting RPM on expensive frontier models for a trivial text task. During rate-limit storms, slug-gen retries compound the request pile-up.
- **Why it matters:** Users on rate-limited providers cannot isolate slug generation from primary session work, leading to unnecessary backoff and delays.
- **What changed:** Added `memory.slugModel` and `memory.slugMode` config options. Updated slug generator to prefer `slugModel` override. Updated handler to skip LLM entirely when `slugMode: "timestamp"`.
- **What did NOT change:** Default behavior is unchanged (LLM slug generation using primary model). Existing session-memory tests all pass.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35289

## User-visible / Behavior Changes

New config options under `memory`:

```yaml
memory:
  slugModel: "openrouter/google/gemini-flash-2.0"  # cheap model for naming files
  slugMode: "timestamp"  # skip LLM, use YYYY-MM-DD-HHMMSS.md
```

- `slugModel`: Uses a separate (cheap/fast) model for slug generation, preserving primary model RPM
- `slugMode: "timestamp"`: Skips LLM entirely, produces `YYYY-MM-DD-HHMMSS` filenames with zero API calls

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (optionally routes to a different model, but same API pattern)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+
- Integration/channel: Any

### Steps

1. Set `memory.slugMode: "timestamp"` in `openclaw.json`
2. Trigger `/new` command
3. Verify memory file is named with HHMMSS timestamp instead of LLM-generated slug

### Expected

- `slugMode: "timestamp"` produces HHMMSS-based filenames with no LLM call
- `slugModel` routes slug generation to the configured model

### Actual

- Before fix: Always uses primary model, always calls LLM
- After fix: Respects `slugMode` and `slugModel` config

## Evidence

Test results (19/19 passing including 3 new):
```
✓ src/hooks/bundled/session-memory/handler.test.ts (16 tests)
✓ src/hooks/bundled/session-memory/handler.slug-mode.test.ts (3 tests)
  - uses timestamp fallback in test env when slugMode is default
  - skips LLM entirely with slugMode 'timestamp'
  - slugMode 'timestamp' produces longer filename than default HHMM fallback
```

## Human Verification (required)

- Verified scenarios: Default behavior unchanged, timestamp mode skips LLM, timestamp produces HHMMSS format
- Edge cases checked: Missing config, empty slugModel string, existing tests backward compatible
- What I did **not** verify: Actual LLM slug generation with `slugModel` override (blocked by test env)

## Compatibility / Migration

- Backward compatible? `Yes` — both new fields are optional, defaults match existing behavior
- Config/env changes? Two new optional fields: `memory.slugMode`, `memory.slugModel`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `slugMode`/`slugModel` from config (falls back to existing behavior)
- Files/config to restore: `src/hooks/bundled/session-memory/handler.ts`, `src/hooks/llm-slug-generator.ts`
- Known bad symptoms: Wrong filename format (cosmetic), or slug model not found (falls back gracefully to primary)

## Risks and Mitigations

- `slugModel` could reference a non-existent model — mitigated by the existing error handling in `generateSlugViaLLM` which catches and falls back to timestamp
- `slugMode: "timestamp"` produces less descriptive filenames — this is the explicit trade-off users opt into
