### PR TITLE
UI: make Agents Files editor fill the right pane

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2434,6 +2434,19 @@
   border-radius: var(--radius-lg);
   padding: 16px;
   background: var(--card);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.agent-files-editor .field {
+  flex: 1;
+  min-height: 0;
+}
+
+.agent-files-editor .field textarea {
+  height: 100%;
+  min-height: 320px;
 }
 
 .agent-file-header {


### PR DESCRIPTION
## Summary
- make the right-side `Agents > Files` editor container a vertical flex layout
- make the editor field fill remaining height in that pane
- make the textarea default to full available height with a larger minimum height

## Testing
- `pnpm check` *(fails before lint/typecheck due an existing unrelated format issue in `src/i18n/registry.test.ts`)*
