### PR TITLE
docs: use canonical discord.gg/clawd link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Welcome to the lobster tank! 🦞
 
 - **GitHub:** https://github.com/openclaw/openclaw
 - **Vision:** [`VISION.md`](VISION.md)
-- **Discord:** https://discord.gg/qkhbAGHRBT
+- **Discord:** https://discord.gg/clawd
 - **X/Twitter:** [@steipete](https://x.com/steipete) / [@openclaw](https://x.com/openclaw)
 
 ## Maintainers


### PR DESCRIPTION
## Summary
- Updates Discord invite link from `https://discord.gg/qkhbAGHRBT` to canonical `https://discord.gg/clawd`
- The canonical link is shorter, more memorable, and redirects to the same server

## Test plan
- [x] Verified `discord.gg/clawd` resolves correctly
- [x] Link matches other occurrences in the codebase (README.md uses the same canonical link)