### PR TITLE
fix(feishu): default to non-topic group replies

### DIFF
--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -9,6 +9,9 @@ describe("FeishuConfigSchema webhook validation", () => {
     expect(result.webhookPath).toBe("/feishu/events");
     expect(result.dmPolicy).toBe("pairing");
     expect(result.groupPolicy).toBe("allowlist");
+    expect(result.groupSessionScope).toBe("group");
+    expect(result.topicSessionMode).toBe("disabled");
+    expect(result.replyInThread).toBe("disabled");
     expect(result.requireMention).toBe(true);
   });
 
@@ -22,6 +25,9 @@ describe("FeishuConfigSchema webhook validation", () => {
     expect(result.accounts?.main?.dmPolicy).toBeUndefined();
     expect(result.accounts?.main?.groupPolicy).toBeUndefined();
     expect(result.accounts?.main?.requireMention).toBeUndefined();
+    expect(result.accounts?.main?.groupSessionScope).toBeUndefined();
+    expect(result.accounts?.main?.topicSessionMode).toBeUndefined();
+    expect(result.accounts?.main?.replyInThread).toBeUndefined();
   });
 
   it("rejects top-level webhook mode without verificationToken", () => {
@@ -112,9 +118,9 @@ describe("FeishuConfigSchema replyInThread", () => {
     expect(result.replyInThread).toBe("enabled");
   });
 
-  it("defaults replyInThread to undefined when not set", () => {
+  it("defaults replyInThread to disabled when not set", () => {
     const result = FeishuConfigSchema.parse({});
-    expect(result.replyInThread).toBeUndefined();
+    expect(result.replyInThread).toBe("disabled");
   });
 
   it("rejects invalid replyInThread value", () => {

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -206,12 +206,13 @@ export const FeishuConfigSchema = z
     connectionMode: FeishuConnectionModeSchema.optional().default("websocket"),
     webhookPath: z.string().optional().default("/feishu/events"),
     ...FeishuSharedConfigShape,
+    replyInThread: ReplyInThreadSchema.default("disabled"),
     dmPolicy: DmPolicySchema.optional().default("pairing"),
     reactionNotifications: ReactionNotificationModeSchema.optional().default("own"),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     requireMention: z.boolean().optional().default(true),
-    groupSessionScope: GroupSessionScopeSchema,
-    topicSessionMode: TopicSessionModeSchema,
+    groupSessionScope: GroupSessionScopeSchema.default("group"),
+    topicSessionMode: TopicSessionModeSchema.default("disabled"),
     // Dynamic agent creation for DM users
     dynamicAgentCreation: DynamicAgentCreationSchema,
     // Optimization flags


### PR DESCRIPTION
## Summary

Set Feishu top-level defaults so group chats do not create/reply via topic threads unless explicitly enabled.

- `channels.feishu.groupSessionScope` defaults to `group`
- `channels.feishu.topicSessionMode` defaults to `disabled`
- `channels.feishu.replyInThread` defaults to `disabled`

This is a default-only change. The feature itself remains opt-in via existing config fields.

## Why

A number of users have reported unexpected topic-thread behavior after upgrades, especially in group chats where older behavior expected normal in-thread replies.

## Related Issues

- #35478 (open): Feishu DM topics/threads: optionally scope sessions + allow reply-in-thread
- #19784 (open): Feishu: reply-in-thread, parallel group sessions, and fire-and-forget message handling
- #32958 (closed): Feishu topic group - Bot creates new topic instead of replying in existing thread
- #32980 (closed): fix(feishu): group reply targets root message instead of triggering message
- #35518 (open): Feishu: reply should follow reply_to_id instead of thread root
- #28273 (closed): Feishu 话题群流式回复创建新话题问题
- #24685 (closed): Feishu topicSessionMode breaks binding matching for group chats

## Validation

- Updated schema defaults tests in:
  - `extensions/feishu/src/config-schema.ts`
  - `extensions/feishu/src/config-schema.test.ts`
- Verified config-schema assertions for new defaults and account-level override behavior.
