### PR TITLE
fix: pass OPENCLAW_DOCKER_APT_PACKAGES build-arg in setup-podman.sh

### DIFF
--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -209,7 +209,10 @@ if ! run_as_openclaw test -f "$OPENCLAW_JSON"; then
 fi
 
 echo "Building image from $REPO_PATH..."
-podman build -t openclaw:local -f "$REPO_PATH/Dockerfile" "$REPO_PATH"
+podman build \
+  --build-arg "OPENCLAW_DOCKER_APT_PACKAGES=${OPENCLAW_DOCKER_APT_PACKAGES:-}" \
+  --build-arg "OPENCLAW_INSTALL_DOCKER_CLI=${OPENCLAW_INSTALL_DOCKER_CLI:-}" \
+  -t openclaw:local -f "$REPO_PATH/Dockerfile" "$REPO_PATH"
 
 echo "Loading image into $OPENCLAW_USER's Podman store..."
 TMP_IMAGE="$(mktemp -p /tmp openclaw-image.XXXXXX.tar)"


### PR DESCRIPTION
## Summary
- `setup-podman.sh` did not forward `OPENCLAW_DOCKER_APT_PACKAGES` or `OPENCLAW_INSTALL_DOCKER_CLI` to `podman build`, so user-requested packages were silently ignored
- `docker-setup.sh` already passes these build-args correctly
- Added both `--build-arg` flags to the `podman build` command for parity

Fixes #35397

## Test plan
- [ ] Set `OPENCLAW_DOCKER_APT_PACKAGES="curl vim"` and run `setup-podman.sh` — verify packages are installed in the resulting image
- [ ] Run without the env var — verify build still works (defaults to empty string)
- [ ] Set `OPENCLAW_INSTALL_DOCKER_CLI=1` — verify Docker CLI is installed in the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)