### PR TITLE
chore(scripts): add llms.txt docs generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ apps/ios/*.mobileprovision
 # Local untracked files
 .local/
 docs/.local/
+docs/.llm/
 IDENTITY.md
 USER.md
 .tgz

--- a/scripts/docs-llms-txt.js
+++ b/scripts/docs-llms-txt.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+/**
+ * 基于 docs-list.js 生成渐进式 llms.txt
+ * 用法: node scripts/docs-llms-txt.js
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+const DOCS = join(process.cwd(), "docs");
+const OUT = join(DOCS, ".llm");
+mkdirSync(OUT, { recursive: true });
+
+const raw = spawnSync("node", ["scripts/docs-list.js"], { encoding: "utf8" }).stdout;
+const lines = raw.split("\n").filter((l) => l.includes(" - ") || l.match(/^\w/));
+
+const SKIP_CATS = new Set(["zh-CN", "ja-JP"]);
+
+const cats = new Map();
+for (const line of lines) {
+  const [path, summary] = line.split(" - ", 2);
+  if (!path.endsWith(".md")) {
+    continue;
+  }
+  const cat = path.includes("/") ? path.split("/")[0] : "_root";
+  if (SKIP_CATS.has(cat)) {
+    continue;
+  }
+  if (!cats.has(cat)) {
+    cats.set(cat, []);
+  }
+  cats.get(cat).push({ path, title: basename(path, ".md"), summary });
+}
+
+const index = ["# OpenClaw", "", "## Categories", ""];
+for (const [cat, docs] of [...cats].toSorted(([a], [b]) => a.localeCompare(b))) {
+  const file = `llms-${cat === "_root" ? "root" : cat}.txt`;
+  index.push(`- ${cat} (${docs.length}) → [${file}](.llm/${file})`);
+  const content = docs.map((d) =>
+    d.summary ? `- [${d.title}](${d.path}): ${d.summary}` : `- [${d.title}](${d.path})`,
+  );
+  writeFileSync(join(OUT, file), `# ${cat}\n\n${content.join("\n")}\n`);
+  for (const d of docs) {
+    const dest = join(OUT, d.path);
+    mkdirSync(dirname(dest), { recursive: true });
+    let text = readFileSync(join(DOCS, d.path), "utf8");
+    text = text.replace(
+      /<(Columns|Card|Steps|Step|Tabs|Tab|Frame|Note|Warning|Info|Tip|Check|Accordion|AccordionGroup)[^>]*>[\s\S]*?<\/\1>/gi,
+      "",
+    );
+    text = text.replace(
+      /<(Columns|Card|Steps|Step|Tabs|Tab|Frame|Note|Warning|Info|Tip|Check|Accordion|AccordionGroup)[^>]*\/>/gi,
+      "",
+    );
+    text = text.replace(/<\/?[A-Z][a-zA-Z]*[^>]*>/g, "");
+    text = text.replace(/<p[^>]*>[\s\S]*?<\/p>/gi, "");
+    text = text.replace(/<img[^>]*\/?>/gi, "");
+    text = text.replace(/\n{3,}/g, "\n\n");
+    writeFileSync(dest, text);
+  }
+}
+writeFileSync(join(OUT, "llms.txt"), index.join("\n") + "\n");
+
+console.log(`生成: docs/.llm/ (${cats.size} 分类)`);

--- a/scripts/docs-llms-txt.js
+++ b/scripts/docs-llms-txt.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
 /**
- * 基于 docs-list.js 生成渐进式 llms.txt
- * 用法: node scripts/docs-llms-txt.js
+ * Generate progressive llms.txt files from docs-list.js.
+ * Usage: node scripts/docs-llms-txt.js
  */
+import { spawnSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
@@ -11,14 +11,20 @@ const DOCS = join(process.cwd(), "docs");
 const OUT = join(DOCS, ".llm");
 mkdirSync(OUT, { recursive: true });
 
-const raw = spawnSync("node", ["scripts/docs-list.js"], { encoding: "utf8" }).stdout;
+const listResult = spawnSync("node", ["scripts/docs-list.js"], { encoding: "utf8" });
+if (listResult.status !== 0 || listResult.error) {
+  console.error("docs-list.js failed:", listResult.stderr || listResult.error?.message);
+  process.exit(1);
+}
+const raw = listResult.stdout;
 const lines = raw.split("\n").filter((l) => l.includes(" - ") || l.match(/^\w/));
 
 const SKIP_CATS = new Set(["zh-CN", "ja-JP"]);
 
 const cats = new Map();
 for (const line of lines) {
-  const [path, summary] = line.split(" - ", 2);
+  const [path, rawSummary] = line.split(" - ", 2);
+  const summary = rawSummary?.startsWith("[") && rawSummary.endsWith("]") ? undefined : rawSummary;
   if (!path.endsWith(".md")) {
     continue;
   }
@@ -45,11 +51,7 @@ for (const [cat, docs] of [...cats].toSorted(([a], [b]) => a.localeCompare(b))) 
     mkdirSync(dirname(dest), { recursive: true });
     let text = readFileSync(join(DOCS, d.path), "utf8");
     text = text.replace(
-      /<(Columns|Card|Steps|Step|Tabs|Tab|Frame|Note|Warning|Info|Tip|Check|Accordion|AccordionGroup)[^>]*>[\s\S]*?<\/\1>/gi,
-      "",
-    );
-    text = text.replace(
-      /<(Columns|Card|Steps|Step|Tabs|Tab|Frame|Note|Warning|Info|Tip|Check|Accordion|AccordionGroup)[^>]*\/>/gi,
+      /<\/?(Columns|Card|Steps|Step|Tabs|Tab|Frame|Note|Warning|Info|Tip|Check|Accordion|AccordionGroup)\b[^>]*>/gi,
       "",
     );
     text = text.replace(/<\/?[A-Z][a-zA-Z]*[^>]*>/g, "");
@@ -61,4 +63,4 @@ for (const [cat, docs] of [...cats].toSorted(([a], [b]) => a.localeCompare(b))) 
 }
 writeFileSync(join(OUT, "llms.txt"), index.join("\n") + "\n");
 
-console.log(`生成: docs/.llm/ (${cats.size} 分类)`);
+console.log(`Generated: docs/.llm/ (${cats.size} categories)`);

--- a/scripts/docs-llms-txt.js
+++ b/scripts/docs-llms-txt.js
@@ -4,11 +4,12 @@
  * Usage: node scripts/docs-llms-txt.js
  */
 import { spawnSync } from "node:child_process";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
 const DOCS = join(process.cwd(), "docs");
 const OUT = join(DOCS, ".llm");
+rmSync(OUT, { recursive: true, force: true });
 mkdirSync(OUT, { recursive: true });
 
 const listResult = spawnSync("node", ["scripts/docs-list.js"], { encoding: "utf8" });
@@ -55,7 +56,7 @@ for (const [cat, docs] of [...cats].toSorted(([a], [b]) => a.localeCompare(b))) 
       "",
     );
     text = text.replace(/<\/?[A-Z][a-zA-Z]*[^>]*>/g, "");
-    text = text.replace(/<p[^>]*>[\s\S]*?<\/p>/gi, "");
+    text = text.replace(/<\/?p\b[^>]*>/gi, "");
     text = text.replace(/<img[^>]*\/?>/gi, "");
     text = text.replace(/\n{3,}/g, "\n\n");
     writeFileSync(dest, text);


### PR DESCRIPTION
## Background
To improve documentation readability and consumability for LLM workflows, this PR adds llms.txt generation support.

## Changes
- Add script: scripts/docs-llms-txt.js to generate LLM-oriented docs index/content.
- Update ignore rules in .gitignore to align with generated outputs.

## Validation
- This PR changes scripts/ignore rules only and does not affect runtime code paths.
- The branch was split independently; this PR contains only related changes.

## Compatibility & Migration
- No migration required; direct replacement.

## Scope
- docs / scripts maintenance workflow
- No business logic or external API changes