### PR TITLE
feat(hooks): add message_sending and message_sent hooks

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1749,6 +1749,7 @@ export async function runEmbeddedAttempt(
                 sessionId: params.sessionId,
                 workspaceDir: params.workspaceDir,
                 messageProvider: params.messageProvider ?? undefined,
+                runId: params.runId,
               },
             )
             .catch((err) => {

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { dispatchInboundMessage, withReplyDispatcher } from "./dispatch.js";
+import * as hookRunnerGlobal from "../plugins/hook-runner-global.js";
+import {
+  dispatchInboundMessage,
+  dispatchInboundMessageWithBufferedDispatcher,
+  withReplyDispatcher,
+} from "./dispatch.js";
 import type { ReplyDispatcher } from "./reply/reply-dispatcher.js";
 import { buildTestCtx } from "./reply/test-ctx.js";
 
@@ -87,5 +92,37 @@ describe("withReplyDispatcher", () => {
     });
 
     expect(order).toEqual(["sendFinalReply", "markComplete", "waitForIdle"]);
+  });
+
+  it("derives channel context for buffered dispatcher message hooks", async () => {
+    const runMessageSending = vi.fn().mockResolvedValue(undefined);
+    const hookRunner = {
+      hasHooks: (name: string) => name === "message_sending",
+      runMessageSending,
+    };
+    const hookSpy = vi
+      .spyOn(hookRunnerGlobal, "getGlobalHookRunner")
+      .mockReturnValue(hookRunner as never);
+
+    await dispatchInboundMessageWithBufferedDispatcher({
+      ctx: buildTestCtx({
+        Surface: "slack",
+        From: "channel:C123",
+        AccountId: "acc-1",
+      }),
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions: {
+        deliver: async () => undefined,
+      },
+      replyResolver: async () => ({ text: "ok" }),
+    });
+
+    expect(runMessageSending).toHaveBeenCalledTimes(1);
+    expect(runMessageSending.mock.calls[0]?.[1]).toMatchObject({
+      channelId: "slack",
+      accountId: "acc-1",
+      conversationId: "channel:C123",
+    });
+    hookSpy.mockRestore();
   });
 });

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -14,6 +14,24 @@ import type { GetReplyOptions } from "./types.js";
 
 export type DispatchInboundResult = DispatchFromConfigResult;
 
+function deriveChannelHookContext(
+  ctx: MsgContext | FinalizedMsgContext,
+): ReplyDispatcherOptions["channelContext"] {
+  const channelId =
+    typeof ctx.Surface === "string" && ctx.Surface.length > 0
+      ? ctx.Surface
+      : typeof ctx.Provider === "string" && ctx.Provider.length > 0
+        ? ctx.Provider
+        : undefined;
+  const accountId =
+    typeof ctx.AccountId === "string" && ctx.AccountId.length > 0 ? ctx.AccountId : undefined;
+  const conversationId = typeof ctx.From === "string" && ctx.From.length > 0 ? ctx.From : undefined;
+  if (!channelId && !accountId && !conversationId) {
+    return undefined;
+  }
+  return { channelId, accountId, conversationId };
+}
+
 export async function withReplyDispatcher<T>(params: {
   dispatcher: ReplyDispatcher;
   run: () => Promise<T>;
@@ -60,9 +78,12 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping(
-    params.dispatcherOptions,
-  );
+  const channelContext =
+    params.dispatcherOptions.channelContext ?? deriveChannelHookContext(params.ctx);
+  const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
+    ...params.dispatcherOptions,
+    channelContext,
+  });
   try {
     return await dispatchInboundMessage({
       ctx: params.ctx,
@@ -86,7 +107,12 @@ export async function dispatchInboundMessageWithDispatcher(params: {
   replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
-  const dispatcher = createReplyDispatcher(params.dispatcherOptions);
+  const channelContext =
+    params.dispatcherOptions.channelContext ?? deriveChannelHookContext(params.ctx);
+  const dispatcher = createReplyDispatcher({
+    ...params.dispatcherOptions,
+    channelContext,
+  });
   return await dispatchInboundMessage({
     ctx: params.ctx,
     cfg: params.cfg,

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -1,5 +1,6 @@
 import type { TypingCallbacks } from "../../channels/typing.js";
 import type { HumanDelayConfig } from "../../config/types.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { sleep } from "../../utils.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
@@ -62,6 +63,8 @@ export type ReplyDispatcherOptions = {
   onSkip?: ReplyDispatchSkipHandler;
   /** Human-like delay between block replies for natural rhythm. */
   humanDelay?: HumanDelayConfig;
+  /** Whether dispatcher should run message_sending/message_sent hooks. */
+  enableMessageHooks?: boolean;
   /** Channel context for message_sending/message_sent hooks. */
   channelContext?: ChannelHookContext;
 };
@@ -165,7 +168,8 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           }
         }
 
-        const hookRunner = getGlobalHookRunner();
+        const shouldRunMessageHooks = options.enableMessageHooks !== false;
+        const hookRunner = shouldRunMessageHooks ? getGlobalHookRunner() : undefined;
         const ctx = options.channelContext ?? {};
         const channelId = ctx.channelId ?? "unknown";
         const targetId = ctx.conversationId ?? channelId;
@@ -199,30 +203,31 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
 
         // Call original deliver
         let success = true;
+        let deliveryError: unknown;
         try {
           await options.deliver(effectivePayload, { kind });
         } catch (err) {
           success = false;
+          deliveryError = err;
           throw err;
         } finally {
           // Run message_sent hook
           if (hookRunner?.hasHooks("message_sent")) {
-            try {
-              await hookRunner.runMessageSent(
+            void hookRunner
+              .runMessageSent(
                 {
                   to: targetId,
                   content: effectivePayload.text ?? "",
                   success,
+                  error: deliveryError != null ? formatErrorMessage(deliveryError) : undefined,
                 },
                 {
                   channelId,
                   accountId: ctx.accountId,
                   conversationId: ctx.conversationId,
                 },
-              );
-            } catch {
-              // Ignore hook errors
-            }
+              )
+              .catch(() => {});
           }
         }
       })

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -1,5 +1,6 @@
 import type { TypingCallbacks } from "../../channels/typing.js";
 import type { HumanDelayConfig } from "../../config/types.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { sleep } from "../../utils.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { registerDispatcher } from "./dispatcher-registry.js";
@@ -40,6 +41,12 @@ function getHumanDelay(config: HumanDelayConfig | undefined): number {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
+export type ChannelHookContext = {
+  channelId?: string;
+  accountId?: string;
+  conversationId?: string;
+};
+
 export type ReplyDispatcherOptions = {
   deliver: ReplyDispatchDeliverer;
   responsePrefix?: string;
@@ -55,6 +62,8 @@ export type ReplyDispatcherOptions = {
   onSkip?: ReplyDispatchSkipHandler;
   /** Human-like delay between block replies for natural rhythm. */
   humanDelay?: HumanDelayConfig;
+  /** Channel context for message_sending/message_sent hooks. */
+  channelContext?: ChannelHookContext;
 };
 
 export type ReplyDispatcherWithTypingOptions = Omit<ReplyDispatcherOptions, "onIdle"> & {
@@ -155,9 +164,67 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
             await sleep(delayMs);
           }
         }
-        // Safe: deliver is called inside an async .then() callback, so even a synchronous
-        // throw becomes a rejection that flows through .catch()/.finally(), ensuring cleanup.
-        await options.deliver(normalized, { kind });
+
+        const hookRunner = getGlobalHookRunner();
+        const ctx = options.channelContext ?? {};
+        const channelId = ctx.channelId ?? "unknown";
+        const targetId = ctx.conversationId ?? channelId;
+
+        // Run message_sending hook (may modify content or cancel)
+        let effectivePayload = normalized;
+        if (hookRunner?.hasHooks("message_sending")) {
+          try {
+            const sendingResult = await hookRunner.runMessageSending(
+              {
+                to: targetId,
+                content: normalized.text ?? "",
+                metadata: { kind, channelId },
+              },
+              {
+                channelId,
+                accountId: ctx.accountId,
+                conversationId: ctx.conversationId,
+              },
+            );
+            if (sendingResult?.cancel) {
+              return; // Cancel sending
+            }
+            if (sendingResult?.content != null) {
+              effectivePayload = { ...normalized, text: sendingResult.content };
+            }
+          } catch {
+            // Don't block delivery on hook failure
+          }
+        }
+
+        // Call original deliver
+        let success = true;
+        try {
+          await options.deliver(effectivePayload, { kind });
+        } catch (err) {
+          success = false;
+          throw err;
+        } finally {
+          // Run message_sent hook
+          if (hookRunner?.hasHooks("message_sent")) {
+            try {
+              await hookRunner.runMessageSent(
+                {
+                  to: targetId,
+                  content: effectivePayload.text ?? "",
+                  success,
+                },
+                {
+                  channelId,
+                  accountId: ctx.accountId,
+                  conversationId: ctx.conversationId,
+                },
+              );
+            } catch {
+              // Ignore hook errors
+            }
+          }
+        }
       })
       .catch((err) => {
         options.onError?.(err, { kind });

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -191,6 +191,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
               },
             );
             if (sendingResult?.cancel) {
+              queuedCounts[kind] = Math.max(0, queuedCounts[kind] - 1);
               return; // Cancel sending
             }
             if (sendingResult?.content != null) {

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -21,7 +21,7 @@ type ReplyDispatchSkipHandler = (
 type ReplyDispatchDeliverer = (
   payload: ReplyPayload,
   info: { kind: ReplyDispatchKind },
-) => Promise<void>;
+) => Promise<boolean | void>;
 
 const DEFAULT_HUMAN_DELAY_MIN_MS = 800;
 const DEFAULT_HUMAN_DELAY_MAX_MS = 2500;
@@ -205,7 +205,10 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         let success = true;
         let deliveryError: unknown;
         try {
-          await options.deliver(effectivePayload, { kind });
+          const delivered = await options.deliver(effectivePayload, { kind });
+          if (delivered === false) {
+            success = false;
+          }
         } catch (err) {
           success = false;
           deliveryError = err;

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { expectInboundContextContract } from "../../../test/helpers/inbound-contract.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import * as hookRunnerGlobal from "../../plugins/hook-runner-global.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { MsgContext } from "../templating.js";
 import { HEARTBEAT_TOKEN, SILENT_REPLY_TOKEN } from "../tokens.js";
@@ -1388,6 +1389,60 @@ describe("createReplyDispatcher", () => {
     expect(deliver).toHaveBeenCalledTimes(2);
 
     vi.useRealTimers();
+  });
+
+  it("includes error details in message_sent hook on delivery failure", async () => {
+    const runMessageSent = vi.fn().mockResolvedValue(undefined);
+    const hookRunner = {
+      hasHooks: (name: string) => name === "message_sent",
+      runMessageSent,
+    };
+    const hookSpy = vi
+      .spyOn(hookRunnerGlobal, "getGlobalHookRunner")
+      .mockReturnValue(hookRunner as never);
+    const dispatcher = createReplyDispatcher({
+      deliver: async () => {
+        throw new Error("send failed");
+      },
+    });
+
+    dispatcher.sendFinalReply({ text: "x" });
+    await dispatcher.waitForIdle();
+
+    expect(runMessageSent).toHaveBeenCalledTimes(1);
+    expect(runMessageSent.mock.calls[0]?.[0]).toMatchObject({
+      success: false,
+      error: "send failed",
+    });
+    hookSpy.mockRestore();
+  });
+
+  it("does not block queue on pending message_sent hooks", async () => {
+    let resolveSent: (() => void) | undefined;
+    const pendingSent = new Promise<void>((resolve) => {
+      resolveSent = resolve;
+    });
+    const runMessageSent = vi.fn().mockImplementation(() => pendingSent);
+    const hookRunner = {
+      hasHooks: (name: string) => name === "message_sent",
+      runMessageSent,
+    };
+    const hookSpy = vi
+      .spyOn(hookRunnerGlobal, "getGlobalHookRunner")
+      .mockReturnValue(hookRunner as never);
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = createReplyDispatcher({ deliver });
+
+    dispatcher.sendFinalReply({ text: "first" });
+    dispatcher.sendFinalReply({ text: "second" });
+    for (let i = 0; i < 20 && deliver.mock.calls.length < 2; i += 1) {
+      await Promise.resolve();
+    }
+
+    expect(deliver).toHaveBeenCalledTimes(2);
+    resolveSent?.();
+    await dispatcher.waitForIdle();
+    hookSpy.mockRestore();
   });
 });
 

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1441,6 +1441,26 @@ describe("createReplyDispatcher", () => {
     hookSpy.mockRestore();
   });
 
+  it("rolls back queued counts when message_sending cancels delivery", async () => {
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const runMessageSending = vi.fn().mockResolvedValue({ cancel: true });
+    const hookRunner = {
+      hasHooks: (name: string) => name === "message_sending",
+      runMessageSending,
+    };
+    const hookSpy = vi
+      .spyOn(hookRunnerGlobal, "getGlobalHookRunner")
+      .mockReturnValue(hookRunner as never);
+    const dispatcher = createReplyDispatcher({ deliver });
+
+    dispatcher.sendFinalReply({ text: "x" });
+    await dispatcher.waitForIdle();
+
+    expect(deliver).not.toHaveBeenCalled();
+    expect(dispatcher.getQueuedCounts().final).toBe(0);
+    hookSpy.mockRestore();
+  });
+
   it("does not block queue on pending message_sent hooks", async () => {
     let resolveSent: (() => void) | undefined;
     const pendingSent = new Promise<void>((resolve) => {

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1417,6 +1417,30 @@ describe("createReplyDispatcher", () => {
     hookSpy.mockRestore();
   });
 
+  it("marks message_sent as unsuccessful when deliver returns false", async () => {
+    const runMessageSent = vi.fn().mockResolvedValue(undefined);
+    const hookRunner = {
+      hasHooks: (name: string) => name === "message_sent",
+      runMessageSent,
+    };
+    const hookSpy = vi
+      .spyOn(hookRunnerGlobal, "getGlobalHookRunner")
+      .mockReturnValue(hookRunner as never);
+    const dispatcher = createReplyDispatcher({
+      deliver: async () => false,
+    });
+
+    dispatcher.sendFinalReply({ text: "x" });
+    await dispatcher.waitForIdle();
+
+    expect(runMessageSent).toHaveBeenCalledTimes(1);
+    expect(runMessageSent.mock.calls[0]?.[0]).toMatchObject({
+      success: false,
+      error: undefined,
+    });
+    hookSpy.mockRestore();
+  });
+
   it("does not block queue on pending message_sent hooks", async () => {
     let resolveSent: (() => void) | undefined;
     const pendingSent = new Promise<void>((resolve) => {

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -598,14 +598,19 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       ...prefixOptions,
       humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
       typingCallbacks,
+      channelContext: {
+        channelId: "discord",
+        accountId: route.accountId,
+        conversationId: deliverTarget,
+      },
       deliver: async (payload: ReplyPayload, info) => {
         if (isProcessAborted(abortSignal)) {
-          return;
+          return false;
         }
         const isFinal = info.kind === "final";
         if (payload.isReasoning) {
           // Reasoning/thinking payloads should not be delivered to Discord.
-          return;
+          return false;
         }
         if (draftStream && isFinal) {
           await flushDraft();
@@ -625,7 +630,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
           if (canFinalizeViaPreviewEdit) {
             await draftStream.stop();
             if (isProcessAborted(abortSignal)) {
-              return;
+              return false;
             }
             try {
               await editMessageDiscord(
@@ -636,7 +641,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
               );
               finalizedViaPreviewMessage = true;
               replyReference.markSent();
-              return;
+              return true;
             } catch (err) {
               logVerbose(
                 `discord: preview final edit failed; falling back to standard send (${String(err)})`,
@@ -648,7 +653,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
           if (!finalizedViaPreviewMessage) {
             await draftStream.stop();
             if (isProcessAborted(abortSignal)) {
-              return;
+              return false;
             }
             const messageIdAfterStop = draftStream.messageId();
             if (
@@ -666,7 +671,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
                 );
                 finalizedViaPreviewMessage = true;
                 replyReference.markSent();
-                return;
+                return true;
               } catch (err) {
                 logVerbose(
                   `discord: post-stop preview edit failed; falling back to standard send (${String(err)})`,
@@ -681,7 +686,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
           }
         }
         if (isProcessAborted(abortSignal)) {
-          return;
+          return false;
         }
 
         const replyToId = replyReference.use();
@@ -703,6 +708,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
           mediaLocalRoots,
         });
         replyReference.markSent();
+        return true;
       },
       onError: (err, info) => {
         runtime.error?.(danger(`discord ${info.kind} reply failed: ${String(err)}`));

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -963,13 +963,14 @@ export const chatHandlers: GatewayRequestHandlers = {
         },
         deliver: async (payload, info) => {
           if (info.kind !== "final") {
-            return;
+            return false;
           }
           const text = payload.text?.trim() ?? "";
           if (!text) {
-            return;
+            return false;
           }
           finalReplyParts.push(text);
+          return true;
         },
       });
 

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -374,11 +374,16 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     const dispatcher = createReplyDispatcher({
       ...prefixOptions,
       humanDelay: resolveHumanDelayConfig(cfg, decision.route.agentId),
+      channelContext: {
+        channelId: "imessage",
+        accountId: decision.route.accountId,
+        conversationId: ctxPayload.To ?? ctxPayload.From,
+      },
       deliver: async (payload) => {
         const target = ctxPayload.To;
         if (!target) {
           runtime.error?.(danger("imessage: missing delivery target"));
-          return;
+          return false;
         }
         await deliverReplies({
           replies: [payload],
@@ -390,6 +395,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           textLimit,
           sentMessageCache,
         });
+        return true;
       },
       onError: (err, info) => {
         runtime.error?.(danger(`imessage ${info.kind} reply failed: ${String(err)}`));

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -340,6 +340,8 @@ export type PluginHookAgentContext = {
   sessionId?: string;
   workspaceDir?: string;
   messageProvider?: string;
+  runId?: string;
+  conversationId?: string;
   /** What initiated this agent run: "user", "heartbeat", "cron", or "memory". */
   trigger?: string;
   /** Channel identifier (e.g. "telegram", "discord", "whatsapp"). */
@@ -492,6 +494,7 @@ export type PluginHookToolContext = {
   sessionId?: string;
   /** Stable run identifier for this agent invocation. */
   runId?: string;
+  conversationId?: string;
   toolName: string;
   /** Provider-specific tool call ID when available. */
   toolCallId?: string;

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -249,6 +249,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       ...prefixOptions,
       humanDelay: resolveHumanDelayConfig(deps.cfg, route.agentId),
       typingCallbacks,
+      channelContext: {
+        channelId: "signal",
+        accountId: route.accountId,
+        conversationId: ctxPayload.To ?? ctxPayload.From,
+      },
       deliver: async (payload) => {
         await deps.deliverReplies({
           replies: [payload],

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -295,10 +295,15 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     ...prefixOptions,
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
     typingCallbacks,
+    channelContext: {
+      channelId: "slack",
+      accountId: route.accountId,
+      conversationId: prepared.replyTarget,
+    },
     deliver: async (payload) => {
       if (useStreaming) {
         await deliverWithStreaming(payload);
-        return;
+        return true;
       }
 
       const mediaCount = payload.mediaUrls?.length ?? (payload.mediaUrl ? 1 : 0);
@@ -324,7 +329,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             ts: draftMessageId,
             text: normalizeSlackOutboundText(finalText.trim()),
           });
-          return;
+          return true;
         } catch (err) {
           logVerbose(
             `slack: preview final edit failed; falling back to standard send (${String(err)})`,
@@ -351,6 +356,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       }
 
       await deliverNormally(payload);
+      return true;
     },
     onError: (err, info) => {
       runtime.error?.(danger(`slack ${info.kind} reply failed: ${String(err)}`));

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -510,6 +510,7 @@ export const dispatchTelegramMessage = async ({
       dispatcherOptions: {
         ...prefixOptions,
         typingCallbacks,
+        enableMessageHooks: false,
         deliver: async (payload, info) => {
           if (info.kind === "final") {
             // Assistant callbacks are fire-and-forget; ensure queued boundary

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -658,6 +658,7 @@ export const registerTelegramNativeCommands = ({
             cfg,
             dispatcherOptions: {
               ...prefixOptions,
+              enableMessageHooks: false,
               deliver: async (payload, _info) => {
                 const result = await deliverReplies({
                   replies: [payload],

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -399,7 +399,7 @@ export async function processMessage(params: {
           // Only deliver final replies to external messaging channels (WhatsApp).
           // Block (reasoning/thinking) and tool updates are meant for the internal
           // web UI only; sending them here leaks chain-of-thought to end users.
-          return;
+          return false;
         }
         await deliverWebReply({
           replyResult: payload,
@@ -428,6 +428,7 @@ export async function processMessage(params: {
           const preview = payload.text != null ? elide(payload.text, 400) : "<media>";
           whatsappOutboundLog.debug(`Reply body: ${preview}${hasMedia ? " (media)" : ""}`);
         }
+        return true;
       },
       onError: (err, info) => {
         const label =


### PR DESCRIPTION
## Background
The plugin hook pipeline currently lacks stable lifecycle events around message delivery, making it hard to implement reliable auditing, metrics, and post-send extensions.

## Why this change
- No unified pre-send hook before a message is actually delivered.
- No unified post-send hook to capture final delivery status.
- Existing hook context is missing key fields required by plugin implementations.

## What changed
- Added two lifecycle hooks: `message_sending` and `message_sent`.
- Expanded related hook context fields so plugins can access consistent runtime metadata.
- Updated dispatch sequencing to make hook timing explicit and stable.

## Expected benefits
- Lower plugin integration complexity.
- Standardized extension points across message delivery lifecycle.
- Better observability and post-processing capability.

## Compatibility and migration
- No migration required, direct replacement.

## Impact scope
- Plugin hook extension mechanism.
- Message delivery pipeline (no protocol or external API changes).
