### PR TITLE
fix(telegram): only mark selected model ✓ for the matching provider

### DIFF
--- a/src/telegram/model-buttons.test.ts
+++ b/src/telegram/model-buttons.test.ts
@@ -305,6 +305,35 @@ describe("buildModelsKeyboard", () => {
 
     expect(result[0]?.[0]?.callback_data).toBe(`mdl_sel/${model}`);
   });
+
+  it("marks ✓ only on the provider whose model is selected, not on identically-named models from other providers", () => {
+    // Regression test for #35476: when multiple providers expose a model with the
+    // same id (e.g. both "anthropic" and "nexus-d" expose "claude-opus-4"), selecting
+    // "nexus-d/claude-opus-4" must only show ✓ in the nexus-d page, not the anthropic page.
+    const models = ["claude-opus-4", "claude-sonnet-4"];
+
+    // Viewing the nexus-d page while nexus-d/claude-opus-4 is the current model.
+    const nexusDResult = buildModelsKeyboard({
+      provider: "nexus-d",
+      models,
+      currentModel: "nexus-d/claude-opus-4",
+      currentPage: 1,
+      totalPages: 1,
+    });
+    expect(nexusDResult[0]?.[0]?.text).toBe("claude-opus-4 ✓"); // selected here
+    expect(nexusDResult[1]?.[0]?.text).toBe("claude-sonnet-4"); // not selected
+
+    // Viewing the anthropic page for the same model id — should NOT show ✓.
+    const anthropicResult = buildModelsKeyboard({
+      provider: "anthropic",
+      models,
+      currentModel: "nexus-d/claude-opus-4",
+      currentPage: 1,
+      totalPages: 1,
+    });
+    expect(anthropicResult[0]?.[0]?.text).toBe("claude-opus-4"); // no ✓ for wrong provider
+    expect(anthropicResult[1]?.[0]?.text).toBe("claude-sonnet-4"); // not selected
+  });
 });
 
 describe("buildBrowseProvidersButton", () => {

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -195,9 +195,14 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
   const pageModels = models.slice(startIndex, endIndex);
 
   // Model buttons - one per row
-  const currentModelId = currentModel?.includes("/")
-    ? currentModel.split("/").slice(1).join("/")
-    : currentModel;
+  // When currentModel carries a provider prefix (e.g. "nexus-d/claude-opus-4-6"), split it so
+  // we can compare both parts independently and avoid marking every provider's identically-named
+  // model as selected. Refs #35476.
+  const currentModelSlash = currentModel?.indexOf("/") ?? -1;
+  const currentModelProvider =
+    currentModelSlash !== -1 ? currentModel?.slice(0, currentModelSlash) : undefined;
+  const currentModelId =
+    currentModelSlash !== -1 ? currentModel?.slice(currentModelSlash + 1) : currentModel;
 
   for (const model of pageModels) {
     const callbackData = buildModelSelectionCallbackData({ provider, model });
@@ -206,7 +211,8 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
       continue;
     }
 
-    const isCurrentModel = model === currentModelId;
+    const isCurrentModel =
+      model === currentModelId && (!currentModelProvider || currentModelProvider === provider);
     const displayText = truncateModelId(model, 38);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
 


### PR DESCRIPTION
Fixes #35476

## Problem

When multiple providers expose a model with the same identifier (e.g. both `anthropic` and `nexus-d` list `claude-opus-4`), selecting `nexus-d/claude-opus-4` causes every provider page containing a model named `claude-opus-4` to render it with a ✓ check mark — making it appear as though the model is active across all providers simultaneously.

## Root Cause

`buildModelsKeyboard` correctly strips the provider prefix from `currentModel` to get the bare model id, but then only compares that bare id when determining `isCurrentModel`:

```typescript
// strips prefix: "nexus-d/claude-opus-4" → "claude-opus-4"
const currentModelId = currentModel?.includes("/")
  ? currentModel.split("/").slice(1).join("/")
  : currentModel;

// BUG: matches any provider's "claude-opus-4", not just nexus-d's
const isCurrentModel = model === currentModelId;
```

## Fix

Also extract the provider segment from `currentModel` and require it to match the page's `provider` parameter before marking the entry as selected:

```typescript
const currentModelSlash = currentModel?.indexOf("/") ?? -1;
const currentModelProvider =
  currentModelSlash !== -1 ? currentModel?.slice(0, currentModelSlash) : undefined;
const currentModelId =
  currentModelSlash !== -1 ? currentModel?.slice(currentModelSlash + 1) : currentModel;

const isCurrentModel =
  model === currentModelId && (!currentModelProvider || currentModelProvider === provider);
```

When `currentModel` has no provider prefix the behaviour is unchanged — the `!currentModelProvider` guard passes through as before.

## Test

Added a regression test that builds keyboards for two providers (`nexus-d` and `anthropic`) both containing `claude-opus-4`, with `nexus-d/claude-opus-4` as the current selection, and asserts ✓ appears only on the `nexus-d` page.
