### PR TITLE
fix: sanitize Codex tool call IDs and honour Feishu reply_to_id

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1631,6 +1631,45 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("replies to parent_id when user replied to a specific message in topic group (#35518)", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group_topic",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-reply-user" } },
+      message: {
+        message_id: "om_new_reply",
+        root_id: "om_thread_root",
+        parent_id: "om_specific_message",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "replying to specific message" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_specific_message",
+        rootId: "om_thread_root",
+      }),
+    );
+  });
+
   it("forces thread replies when inbound message contains thread_id", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1352,12 +1352,13 @@ export async function handleFeishuMessage(params: {
     const configReplyInThread =
       isGroup &&
       (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
-    // When the user replied to a specific message (parentId), honour that target
-    // so the bot's response anchors to the same message instead of the thread root (#35518).
-    const replyTargetMessageId = ctx.parentId
-      ? ctx.parentId
-      : isTopicSession || configReplyInThread
-        ? (ctx.rootId ?? ctx.messageId)
+    // In topic/thread sessions, prefer parentId (the message the user replied to)
+    // over rootId so the bot anchors to the right message (#35518).
+    // Outside topic/thread contexts, avoid parentId — replying to it would push the
+    // bot's message into a sub-thread that may be invisible in the main chat view.
+    const replyTargetMessageId =
+      isTopicSession || configReplyInThread
+        ? (ctx.parentId ?? ctx.rootId ?? ctx.messageId)
         : ctx.messageId;
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1352,8 +1352,13 @@ export async function handleFeishuMessage(params: {
     const configReplyInThread =
       isGroup &&
       (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
-    const replyTargetMessageId =
-      isTopicSession || configReplyInThread ? (ctx.rootId ?? ctx.messageId) : ctx.messageId;
+    // When the user replied to a specific message (parentId), honour that target
+    // so the bot's response anchors to the same message instead of the thread root (#35518).
+    const replyTargetMessageId = ctx.parentId
+      ? ctx.parentId
+      : isTopicSession || configReplyInThread
+        ? (ctx.rootId ?? ctx.messageId)
+        : ctx.messageId;
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
 
     if (broadcastAgents) {

--- a/src/agents/transcript-policy.policy.test.ts
+++ b/src/agents/transcript-policy.policy.test.ts
@@ -13,6 +13,16 @@ describe("resolveTranscriptPolicy e2e smoke", () => {
     expect(policy.toolCallIdMode).toBeUndefined();
   });
 
+  it("sanitizes tool-call IDs for openai-codex-responses API (#35528)", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openai-codex",
+      modelId: "codex-mini-latest",
+      modelApi: "openai-codex-responses",
+    });
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.toolCallIdMode).toBe("strict");
+  });
+
   it("uses strict9 tool-call sanitization for Mistral-family models", () => {
     const policy = resolveTranscriptPolicy({
       provider: "mistral",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -94,7 +94,8 @@ export function resolveTranscriptPolicy(params: {
     (provider === "openrouter" || provider === "opencode" || provider === "kilocode") &&
     modelId.toLowerCase().includes("gemini");
   const isCopilotClaude = provider === "github-copilot" && modelId.toLowerCase().includes("claude");
-  const requiresOpenAiCompatibleToolIdSanitization = params.modelApi === "openai-completions";
+  const requiresOpenAiCompatibleToolIdSanitization =
+    params.modelApi === "openai-completions" || params.modelApi === "openai-codex-responses";
 
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").


### PR DESCRIPTION
## Summary

### #35528 — openai-codex: pipe-delimited tool call IDs break API validation

Tool call IDs like `call_abc|fc_123` cause 100% non-recoverable failures on the
Codex Responses API which requires `[a-zA-Z0-9_-]+`.

`transcript-policy.ts` classified `openai-codex` as an OpenAI provider and skipped
tool call ID sanitization. Added `openai-codex-responses` to the sanitization trigger.

### #35518 — Feishu: reply anchors to thread root instead of replied-to message

When a user replies to a specific message in a Feishu thread, the bot always responded
to the thread root. `bot.ts` ignored `ctx.parentId` when computing `replyTargetMessageId`.

Fixed to check `parentId` first; if present, use it as the reply target.

## Test plan

- [x] New test: Codex transcript policy enables tool call ID sanitization
- [x] New test: Feishu replies to parent_id in topic group
- [x] 21 transcript-policy tests pass
- [x] 52 Feishu bot tests pass
- [x] Type-check clean

Closes #35528
Closes #35518