### PR TITLE
fix(discord): add missing agentComponents to Zod config schema

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -184,4 +184,18 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it("accepts discord agentComponents enabled", () => {
+    const res = validateConfigObject({
+      channels: {
+        discord: {
+          agentComponents: {
+            enabled: true,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -474,6 +474,12 @@ export const DiscordAccountSchema = z
       })
       .strict()
       .optional(),
+    agentComponents: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     ui: DiscordUiSchema,
     slashCommand: z
       .object({


### PR DESCRIPTION
Closes #35564

## Summary

- Add `agentComponents` field to `DiscordAccountSchema` in `zod-schema.providers-core.ts`
- Add regression test in `config.schema-regressions.test.ts`

## Problem

`DiscordAccountSchema` uses `.strict()` but was missing the `agentComponents` field that is:
- Defined in the type (`types.discord.ts:301`)
- Used at runtime (`discord/monitor/provider.ts:544`)
- Tested (`discord/monitor/provider.test.ts:87`)

Users setting `channels.discord.agentComponents.enabled: true` in their config get a validation error.

## Test plan

- [x] New regression test: `accepts discord agentComponents enabled`
- [x] CI passes
