### PR TITLE
fix(agent): strip pipe-delimited suffix from tool call IDs in ws stream

### DIFF
--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -521,6 +521,85 @@ describe("convertMessagesToInputItems", () => {
   it("returns empty array for empty messages", () => {
     expect(convertMessagesToInputItems([])).toEqual([]);
   });
+
+  it("strips pipe-delimited suffix from assistant tool call IDs", () => {
+    const msg = assistantMsg(
+      [],
+      [{ id: "call_LfY3urEtRi084Bpt2xnm9MjO|fc_07c5279abc", name: "exec", args: { cmd: "ls" } }],
+    );
+    const items = convertMessagesToInputItems([msg] as unknown as Parameters<
+      typeof convertMessagesToInputItems
+    >[0]);
+    const fcItem = items.find((i) => i.type === "function_call") as {
+      call_id: string;
+    };
+    expect(fcItem).toBeDefined();
+    expect(fcItem.call_id).toBe("call_LfY3urEtRi084Bpt2xnm9MjO");
+  });
+
+  it("strips pipe-delimited suffix from tool result toolCallId", () => {
+    const msg = toolResultMsg("call_abc123|fc_item456", "output text");
+    const items = convertMessagesToInputItems([msg] as Parameters<
+      typeof convertMessagesToInputItems
+    >[0]);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      type: "function_call_output",
+      call_id: "call_abc123",
+      output: "output text",
+    });
+  });
+
+  it("leaves non-pipe IDs unchanged", () => {
+    const msg = assistantMsg([], [{ id: "call_plain123", name: "exec", args: { cmd: "pwd" } }]);
+    const items = convertMessagesToInputItems([msg] as unknown as Parameters<
+      typeof convertMessagesToInputItems
+    >[0]);
+    const fcItem = items.find((i) => i.type === "function_call") as {
+      call_id: string;
+    };
+    expect(fcItem.call_id).toBe("call_plain123");
+  });
+
+  it("handles pipe-delimited IDs in a full multi-turn conversation", () => {
+    const pipeId = "call_xyz|fc_reasoning_item";
+    const messages: FakeMessage[] = [
+      userMsg("Run ls"),
+      assistantMsg([], [{ id: pipeId, name: "exec", args: { cmd: "ls" } }]),
+      toolResultMsg(pipeId, "file.txt"),
+    ];
+    const items = convertMessagesToInputItems(
+      messages as Parameters<typeof convertMessagesToInputItems>[0],
+    );
+    const fcItem = items.find((i) => i.type === "function_call") as {
+      call_id: string;
+    };
+    const outputItem = items.find((i) => i.type === "function_call_output") as {
+      call_id: string;
+    };
+    expect(fcItem.call_id).toBe("call_xyz");
+    expect(outputItem.call_id).toBe("call_xyz");
+  });
+
+  it("strips pipe-delimited suffix from toolUseId fallback", () => {
+    const msg = {
+      role: "toolResult" as const,
+      toolUseId: "call_use123|fc_item789",
+      toolName: "test_tool",
+      content: [{ type: "text", text: "ok" }],
+      isError: false,
+      timestamp: 0,
+    };
+    const items = convertMessagesToInputItems([msg] as unknown as Parameters<
+      typeof convertMessagesToInputItems
+    >[0]);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      type: "function_call_output",
+      call_id: "call_use123",
+      output: "ok",
+    });
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -109,6 +109,19 @@ function toNonEmptyString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+/**
+ * Extract the call_id from a potentially pipe-delimited tool call ID.
+ *
+ * pi-ai stores OpenAI Responses API tool call IDs as `{call_id}|{item_id}`
+ * compound strings.  The WebSocket path must send only the `call_id` portion
+ * back to the API (the `item_id` / `fc_*` part is handled separately by the
+ * Responses API provider when it builds the outbound `function_call` items).
+ */
+function extractCallId(id: string): string {
+  const pipeIndex = id.indexOf("|");
+  return pipeIndex > 0 ? id.slice(0, pipeIndex) : id;
+}
+
 /** Convert pi-ai content (string | ContentPart[]) to plain text. */
 function contentToText(content: unknown): string {
   if (typeof content === "string") {
@@ -219,7 +232,8 @@ export function convertMessagesToInputItems(messages: Message[]): InputItem[] {
               });
               textParts.length = 0;
             }
-            const callId = toNonEmptyString(block.id);
+            const rawId = toNonEmptyString(block.id);
+            const callId = rawId ? extractCallId(rawId) : null;
             const toolName = toNonEmptyString(block.name);
             if (!callId || !toolName) {
               continue;
@@ -263,7 +277,8 @@ export function convertMessagesToInputItems(messages: Message[]): InputItem[] {
         content: unknown;
         isError: boolean;
       };
-      const callId = toNonEmptyString(tr.toolCallId) ?? toNonEmptyString(tr.toolUseId);
+      const rawCallId = toNonEmptyString(tr.toolCallId) ?? toNonEmptyString(tr.toolUseId);
+      const callId = rawCallId ? extractCallId(rawCallId) : null;
       if (!callId) {
         continue;
       }


### PR DESCRIPTION
Fixes #35528

## Problem

The `openai-codex` provider, when using the WebSocket transport (`openai-ws-stream.ts`), fails to correctly handle pipe-delimited tool call IDs (e.g., `call_abc|fc_xyz`). These compound IDs are created by the HTTP-based `openai-responses` provider (used as a fallback or in other turns) and persisted in the session transcript.

The `convertMessagesToInputItems` function in `openai-ws-stream.ts` directly uses these pipe-delimited strings as the `call_id` for `function_call` and `function_call_output` items sent to the API. The Codex API rejects these IDs as they do not match the required pattern (`[a-zA-Z0-9_-]+`), causing a `string_pattern_mismatch` error.

## Solution

This PR introduces a small, targeted fix inside `openai-ws-stream.ts`:

1.  **Added `extractCallId` helper function**: This utility safely extracts the `call_id` portion (the part before the `|`) from a potentially pipe-delimited ID string. It is designed to be idempotent and handles non-pipe IDs gracefully.

2.  **Applied `extractCallId` in `convertMessagesToInputItems`**: The function is now used in two places to sanitize the `call_id` before it is sent to the API:
    *   When creating `function_call` items from assistant message tool call blocks.
    *   When creating `function_call_output` items from tool result messages.

This ensures that only the valid, non-pipe part of the ID is used, resolving the API validation error while maintaining compatibility with how the `openai-responses` provider generates and consumes these IDs.

## Verification

- Added 5 new unit tests to `openai-ws-stream.test.ts` to cover various scenarios with pipe-delimited and standard tool call IDs.
