### PR TITLE
fix(doctor): avoid account-scoped Telegram top-level key injection

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -107,6 +107,54 @@ describe("doctor config flow", () => {
     ).toBe(false);
   });
 
+  it("does not warn for account-scoped telegram configs that omit top-level policy keys", async () => {
+    const doctorWarnings = await collectDoctorWarnings({
+      channels: {
+        telegram: {
+          accounts: {
+            default: {
+              botToken: "123:abc",
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["123456"],
+              allowFrom: ["123456"],
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      doctorWarnings.some(
+        (line) =>
+          line.includes('channels.telegram.groupPolicy is "allowlist"') &&
+          line.includes("groupAllowFrom"),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not mark account-scoped telegram config as a repair write", async () => {
+    const result = await runDoctorConfigWithInput({
+      repair: true,
+      config: {
+        channels: {
+          telegram: {
+            accounts: {
+              default: {
+                botToken: "123:abc",
+                groupPolicy: "allowlist",
+                groupAllowFrom: ["123456"],
+                allowFrom: ["123456"],
+              },
+            },
+          },
+        },
+      },
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    expect((result as { shouldWriteConfig?: boolean }).shouldWriteConfig).toBe(false);
+  });
+
   it("warns when imessage group allowlist is empty even if allowFrom is set", async () => {
     const doctorWarnings = await collectDoctorWarnings({
       channels: {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1152,6 +1152,20 @@ function hasAllowFromEntries(list?: Array<string | number>) {
   return Array.isArray(list) && list.map((v) => String(v).trim()).filter(Boolean).length > 0;
 }
 
+function isAccountScopedTelegramSourceConfig(channelConfig: Record<string, unknown>): boolean {
+  const accounts = asObjectRecord(channelConfig.accounts);
+  if (!accounts || Object.keys(accounts).length === 0) {
+    return false;
+  }
+  for (const key of Object.keys(channelConfig)) {
+    if (key === "accounts" || key === "defaultAccount") {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
 async function maybeRepairAllowlistPolicyAllowFrom(cfg: OpenClawConfig): Promise<{
   config: OpenClawConfig;
   changes: string[];
@@ -1311,12 +1325,13 @@ async function maybeRepairAllowlistPolicyAllowFrom(cfg: OpenClawConfig): Promise
  * allowlist. Common after upgrades that remove external allowlist
  * file support.
  */
-function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
+function detectEmptyAllowlistPolicy(cfg: OpenClawConfig, sourceConfig?: OpenClawConfig): string[] {
   const channels = cfg.channels;
   if (!channels || typeof channels !== "object") {
     return [];
   }
 
+  const sourceChannels = asObjectRecord(sourceConfig?.channels);
   const warnings: string[] = [];
 
   const usesSenderBasedGroupAllowlist = (channelName?: string): boolean => {
@@ -1414,7 +1429,16 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
     if (!channelConfig || typeof channelConfig !== "object") {
       continue;
     }
-    checkAccount(channelConfig, `channels.${channelName}`, undefined, channelName);
+
+    const sourceChannel = asObjectRecord(sourceChannels?.[channelName]);
+    const skipTopLevelAllowlistCheck =
+      channelName === "telegram" &&
+      Boolean(sourceChannel) &&
+      isAccountScopedTelegramSourceConfig(sourceChannel);
+
+    if (!skipTopLevelAllowlistCheck) {
+      checkAccount(channelConfig, `channels.${channelName}`, undefined, channelName);
+    }
 
     const accounts = channelConfig.accounts;
     if (accounts && typeof accounts === "object") {
@@ -1905,7 +1929,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       cfg = allowlistRepair.config;
     }
 
-    const emptyAllowlistWarnings = detectEmptyAllowlistPolicy(candidate);
+    const emptyAllowlistWarnings = detectEmptyAllowlistPolicy(candidate, snapshot.resolved);
     if (emptyAllowlistWarnings.length > 0) {
       note(emptyAllowlistWarnings.join("\n"), "Doctor warnings");
     }
@@ -1962,7 +1986,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
       );
     }
 
-    const emptyAllowlistWarnings = detectEmptyAllowlistPolicy(candidate);
+    const emptyAllowlistWarnings = detectEmptyAllowlistPolicy(candidate, snapshot.resolved);
     if (emptyAllowlistWarnings.length > 0) {
       note(emptyAllowlistWarnings.join("\n"), "Doctor warnings");
     }

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1433,7 +1433,7 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig, sourceConfig?: OpenClaw
     const sourceChannel = asObjectRecord(sourceChannels?.[channelName]);
     const skipTopLevelAllowlistCheck =
       channelName === "telegram" &&
-      Boolean(sourceChannel) &&
+      sourceChannel !== null &&
       isAccountScopedTelegramSourceConfig(sourceChannel);
 
     if (!skipTopLevelAllowlistCheck) {

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -83,6 +83,26 @@ describe("applyPluginAutoEnable", () => {
     expect(result.config.plugins?.allow).toBeUndefined();
   });
 
+  it("does not auto-enable built-in channels when config is account-scoped", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        channels: {
+          telegram: {
+            accounts: {
+              default: {
+                botToken: "123:abc",
+              },
+            },
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(result.config.channels?.telegram?.enabled).toBeUndefined();
+    expect(result.changes).toEqual([]);
+  });
+
   it("ignores channels.modelByChannel for plugin auto-enable", () => {
     const result = applyPluginAutoEnable({
       config: {

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -185,6 +185,14 @@ function isGenericChannelConfigured(cfg: OpenClawConfig, channelId: string): boo
   return recordHasKeys(entry);
 }
 
+function hasImplicitAccountScopedChannelEnable(channelConfig: Record<string, unknown>): boolean {
+  if (Object.prototype.hasOwnProperty.call(channelConfig, "enabled")) {
+    return false;
+  }
+  const accounts = channelConfig.accounts;
+  return isRecord(accounts) && Object.keys(accounts).length > 0;
+}
+
 export function isChannelConfigured(
   cfg: OpenClawConfig,
   channelId: string,
@@ -515,7 +523,11 @@ export function applyPluginAutoEnable(params: {
             ) {
               return false;
             }
-            return (channelConfig as { enabled?: unknown }).enabled === true;
+            const typedChannelConfig = channelConfig as Record<string, unknown>;
+            if (typedChannelConfig.enabled === true) {
+              return true;
+            }
+            return hasImplicitAccountScopedChannelEnable(typedChannelConfig);
           })()
         : next.plugins?.entries?.[entry.pluginId]?.enabled === true;
     if (alreadyEnabled && !allowMissing) {


### PR DESCRIPTION
## Summary
- treat built-in channels with account-scoped config and no explicit `enabled` key as already enabled in plugin auto-enable
- skip top-level Telegram allowlist warnings in doctor when source config is account-scoped (`accounts`/`defaultAccount` only)
- pass source config into allowlist warning detection to avoid schema-default false positives
- add regressions for both auto-enable and doctor flow

## Testing
- pnpm exec vitest run src/config/plugin-auto-enable.test.ts src/commands/doctor-config-flow.test.ts

Fixes #35560
