### PR TITLE
fix(hooks): derive session key from agentId so message:sent hook fires

### DIFF
--- a/src/infra/outbound/session-context.test.ts
+++ b/src/infra/outbound/session-context.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { buildOutboundSessionContext } from "./session-context.js";
+
+describe("buildOutboundSessionContext", () => {
+  const cfg = {};
+
+  it("returns undefined when neither sessionKey nor agentId is provided", () => {
+    expect(buildOutboundSessionContext({ cfg })).toBeUndefined();
+  });
+
+  it("returns key and agentId when sessionKey is provided", () => {
+    const result = buildOutboundSessionContext({ cfg, sessionKey: "agent:bot:main" });
+    expect(result).toEqual({ key: "agent:bot:main", agentId: "bot" });
+  });
+
+  it("derives key from agentId when sessionKey is not provided", () => {
+    const result = buildOutboundSessionContext({ cfg, agentId: "mybot" });
+    expect(result).toEqual({ key: "agent:mybot:main", agentId: "mybot" });
+  });
+
+  it("prefers explicit sessionKey over derived key", () => {
+    const result = buildOutboundSessionContext({
+      cfg,
+      sessionKey: "agent:mybot:custom",
+      agentId: "mybot",
+    });
+    expect(result).toEqual({ key: "agent:mybot:custom", agentId: "mybot" });
+  });
+
+  it("normalizes blank/null sessionKey and derives from agentId", () => {
+    expect(buildOutboundSessionContext({ cfg, sessionKey: "  ", agentId: "x" })).toEqual({
+      key: "agent:x:main",
+      agentId: "x",
+    });
+    expect(buildOutboundSessionContext({ cfg, sessionKey: null, agentId: "x" })).toEqual({
+      key: "agent:x:main",
+      agentId: "x",
+    });
+  });
+
+  it("returns undefined for blank agentId without sessionKey", () => {
+    expect(buildOutboundSessionContext({ cfg, agentId: "  " })).toBeUndefined();
+    expect(buildOutboundSessionContext({ cfg, agentId: null })).toBeUndefined();
+  });
+});

--- a/src/infra/outbound/session-context.test.ts
+++ b/src/infra/outbound/session-context.test.ts
@@ -42,4 +42,10 @@ describe("buildOutboundSessionContext", () => {
     expect(buildOutboundSessionContext({ cfg, agentId: "  " })).toBeUndefined();
     expect(buildOutboundSessionContext({ cfg, agentId: null })).toBeUndefined();
   });
+
+  it("respects session.mainKey config when deriving key from agentId", () => {
+    const cfgWithMainKey = { session: { mainKey: "custom" } };
+    const result = buildOutboundSessionContext({ cfg: cfgWithMainKey, agentId: "mybot" });
+    expect(result).toEqual({ key: "agent:mybot:custom", agentId: "mybot" });
+  });
 });

--- a/src/infra/outbound/session-context.ts
+++ b/src/infra/outbound/session-context.ts
@@ -1,5 +1,6 @@
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { buildAgentMainSessionKey } from "../../routing/session-key.js";
 
 export type OutboundSessionContext = {
   /** Canonical session key used for internal hook dispatch. */
@@ -30,8 +31,11 @@ export function buildOutboundSessionContext(params: {
   if (!key && !agentId) {
     return undefined;
   }
+  // When agentId is known but no explicit session key was provided, derive a
+  // default key so that internal hooks (message:sent) can still fire.
+  const effectiveKey = key ?? (agentId ? buildAgentMainSessionKey({ agentId }) : undefined);
   return {
-    ...(key ? { key } : {}),
+    ...(effectiveKey ? { key: effectiveKey } : {}),
     ...(agentId ? { agentId } : {}),
   };
 }

--- a/src/infra/outbound/session-context.ts
+++ b/src/infra/outbound/session-context.ts
@@ -1,6 +1,6 @@
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { buildAgentMainSessionKey } from "../../routing/session-key.js";
+import { resolveAgentMainSessionKey } from "../../config/sessions/main-session.js";
 
 export type OutboundSessionContext = {
   /** Canonical session key used for internal hook dispatch. */
@@ -33,7 +33,8 @@ export function buildOutboundSessionContext(params: {
   }
   // When agentId is known but no explicit session key was provided, derive a
   // default key so that internal hooks (message:sent) can still fire.
-  const effectiveKey = key ?? (agentId ? buildAgentMainSessionKey({ agentId }) : undefined);
+  const effectiveKey =
+    key ?? (agentId ? resolveAgentMainSessionKey({ cfg: params.cfg, agentId }) : undefined);
   return {
     ...(effectiveKey ? { key: effectiveKey } : {}),
     ...(agentId ? { agentId } : {}),


### PR DESCRIPTION
## Summary

- Problem: `buildOutboundSessionContext` returns no `key` when only `agentId` is provided (no explicit `sessionKey`). This causes `deliverOutboundPayloads` to skip the internal `message:sent` hook because `sessionKeyForInternalHooks` resolves to `undefined`.
- Why it matters: Managed hooks registered for `message:sent` never fire for direct agent responses sent via `sendMessage()` (which only passes `agentId`, not a session key). Users who rely on `message:sent` hooks for logging, analytics, or downstream integrations get no events for these outbound messages.
- What changed: `buildOutboundSessionContext` now derives a default session key (`agent:<id>:main`) from the provided `agentId` when no explicit `sessionKey` is supplied, using the existing `buildAgentMainSessionKey` utility.
- What did NOT change (scope boundary): No changes to `deliverOutboundPayloads`, `sendMessage`, or any callers. The `session.key` field is only consumed for internal hook dispatch (line 667 of `deliver.ts`) and logging (line 78 of `delivery.ts`) — mirror behavior, transcript writes, and message routing are unaffected.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #35557

## User-visible / Behavior Changes

Managed hooks subscribed to the `message:sent` event will now fire for outbound messages sent via `sendMessage()` when an `agentId` is known but no explicit session key was passed. Previously these events were silently dropped.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+ / Bun
- Integration/channel (if any): Any outbound channel

### Steps

1. Create a managed hook directory under `~/.openclaw/hooks/` with `HOOK.md` containing `events: [message:sent]`
2. Send a message via `sendMessage()` (e.g. through a direct agent tool-call response) with an `agentId` but without a mirror session key
3. Observe whether the `message:sent` hook fires

### Expected

- The `message:sent` managed hook fires with a properly-formed event payload including the derived session key `agent:<id>:main`

### Actual (before fix)

- The `message:sent` hook is never triggered; `sessionKeyForInternalHooks` is `undefined` and `canEmitInternalHook` is `false`

## Evidence

- [x] Failing test/log before + passing after

New unit tests in `session-context.test.ts` verify:
- Key is derived from `agentId` when `sessionKey` is absent → `{ key: "agent:mybot:main", agentId: "mybot" }`
- Explicit `sessionKey` takes precedence over derived key
- Blank/null `sessionKey` falls back to derivation
- No key derived when both `sessionKey` and `agentId` are absent

All 38 existing `deliver.test.ts` tests continue to pass, including the warning-log test for direct `session: { agentId }` without key (which tests `deliverOutboundPayloads` directly, bypassing `buildOutboundSessionContext`).

## Human Verification (required)

- Verified scenarios: `session-context.test.ts` (6 tests), `deliver.test.ts` (38 tests), `message.test.ts` (2 tests) — all pass
- Edge cases checked: blank string sessionKey, null sessionKey, null agentId, both present, neither present
- What you did **not** verify: End-to-end hook execution in a running gateway (unit-tested only)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit in `session-context.ts` (remove the `effectiveKey` derivation line and restore the original `key` spread)
- Files/config to restore: `src/infra/outbound/session-context.ts`
- Known bad symptoms reviewers should watch for: Duplicate hook events for paths that already supply both `sessionKey` and `agentId` (verified this doesn't happen — explicit key takes precedence)

## Risks and Mitigations

- Risk: Internal hooks now fire for paths that previously skipped them, which could surface latent bugs in hook handlers.
  - Mitigation: This is the intended behavior per the hook contract — hooks should fire for all outbound messages with a known agent context. The derived key follows the canonical `agent:<id>:main` format used everywhere else.