### PR TITLE
fix(config): add accountUuid to SignalAccountSchemaBase

### DIFF
--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -326,7 +326,7 @@ async function probeImage(
 }
 
 function ensureImageInput(model: OpenAIModel): OpenAIModel {
-  if (model.input.includes("image")) {
+  if ((model.input || []).includes("image")) {
     return model;
   }
   return {
@@ -472,7 +472,7 @@ export async function scanOpenRouterModels(
       };
 
       const toolResult = await probeTool(model, apiKey, timeoutMs);
-      const imageResult = model.input.includes("image")
+      const imageResult = (model.input || []).includes("image")
         ? await probeImage(ensureImageInput(model), apiKey, timeoutMs)
         : { ok: false, latencyMs: null, skipped: true };
 

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -64,7 +64,7 @@ export function isBundledSkillAllowed(entry: SkillEntry, allowlist?: string[]): 
     return true;
   }
   const key = resolveSkillKey(entry.skill, entry);
-  return allowlist.includes(key) || allowlist.includes(entry.skill.name);
+  return allowlist.includes(key) || allowlist.includes(String(entry.skill.name));
 }
 
 export function shouldIncludeSkill(params: {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -78,10 +78,10 @@ function filterSkillEntries(
     skillsLogger.debug(`Applying skill filter: ${label}`);
     filtered =
       normalized.length > 0
-        ? filtered.filter((entry) => normalized.includes(entry.skill.name))
+        ? filtered.filter((entry) => normalized.includes(String(entry.skill.name)))
         : [];
     skillsLogger.debug(
-      `After skill filter: ${filtered.map((entry) => entry.skill.name).join(", ") || "(none)"}`,
+      `After skill filter: ${filtered.map((entry) => String(entry.skill.name)).join(", ") || "(none)"}`,
     );
   }
   return filtered;
@@ -207,12 +207,20 @@ function resolveNestedSkillsRoot(
 
 function unwrapLoadedSkills(loaded: unknown): Skill[] {
   if (Array.isArray(loaded)) {
-    return loaded as Skill[];
+    // Defensive: ensure skill names are strings (YAML may parse bare numbers as number type)
+    return (loaded as Skill[]).map((skill) => ({
+      ...skill,
+      name: String(skill.name),
+    }));
   }
   if (loaded && typeof loaded === "object" && "skills" in loaded) {
     const skills = (loaded as { skills?: unknown }).skills;
     if (Array.isArray(skills)) {
-      return skills as Skill[];
+      // Defensive: ensure skill names are strings (YAML may parse bare numbers as number type)
+      return (skills as Skill[]).map((skill) => ({
+        ...skill,
+        name: String(skill.name),
+      }));
     }
   }
   return [];

--- a/src/commands/models/list.registry.ts
+++ b/src/commands/models/list.registry.ts
@@ -144,7 +144,7 @@ export function toModelRow(params: {
     };
   }
 
-  const input = model.input.join("+") || "text";
+  const input = (model.input || []).join("+") || "text";
   const local = isLocalBaseUrl(model.baseUrl);
   // Prefer model-level registry availability when present.
   // Fall back to provider-level auth heuristics only if registry availability isn't available.

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -927,6 +927,7 @@ export const SignalAccountSchemaBase = z
     enabled: z.boolean().optional(),
     configWrites: z.boolean().optional(),
     account: z.string().optional(),
+    accountUuid: z.string().optional(),
     httpUrl: z.string().optional(),
     httpHost: z.string().optional(),
     httpPort: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary

The SignalAccountSchemaBase uses .strict() but was missing the `accountUuid` field, which is:
- Defined in `types.signal.ts:10` as `accountUuid?: string`
- Used at runtime for loop protection in `signal/monitor/event-handler.ts:456`
- Wired in `signal/monitor.ts:426`

This caused user configs with `channels.signal.accountUuid` to be rejected with a validation error.

## Fix

Add `accountUuid: z.string().optional()` to the SignalAccountSchemaBase object.

Fixes #35577