### PR TITLE
fix: Doctor injects orphan top-level keys into multi-account telegram config on every CLI command (#35560)

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -251,6 +251,60 @@ describe("doctor config flow", () => {
     }
   });
 
+  it("does not inject default telegram top-level keys when accounts.default is configured", async () => {
+    const result = await runDoctorConfigWithInput({
+      config: {
+        channels: {
+          telegram: {
+            accounts: {
+              default: {
+                enabled: true,
+                botToken: "123:abc",
+                groupPolicy: "allowlist",
+                groupAllowFrom: ["123456"],
+                allowFrom: ["123456"],
+              },
+            },
+          },
+        },
+      },
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    const cfg = result.cfg as {
+      channels: {
+        telegram: {
+          enabled?: boolean;
+          dmPolicy?: string;
+          groupPolicy?: string;
+          streaming?: string;
+          accounts?: {
+            default?: {
+              enabled?: boolean;
+              botToken?: string;
+              groupPolicy?: string;
+              groupAllowFrom?: string[];
+              allowFrom?: string[];
+            };
+          };
+        };
+      };
+    };
+    expect(cfg.channels.telegram.enabled).toBeUndefined();
+    expect(cfg.channels.telegram.dmPolicy).toBeUndefined();
+    expect(cfg.channels.telegram.groupPolicy).toBeUndefined();
+    expect(cfg.channels.telegram.streaming).toBeUndefined();
+    expect(cfg.channels.telegram.accounts?.default).toEqual({
+      enabled: true,
+      botToken: "123:abc",
+      dmPolicy: "pairing",
+      groupPolicy: "allowlist",
+      groupAllowFrom: ["123456"],
+      allowFrom: ["123456"],
+      streaming: "partial",
+    });
+  });
+
   it("converts numeric discord ids to strings on repair", async () => {
     await withTempHome(async (home) => {
       const configDir = path.join(home, ".openclaw");

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -454,6 +454,64 @@ function scanTelegramAllowFromUsernameEntries(cfg: OpenClawConfig): TelegramAllo
   return hits;
 }
 
+function stripDefaultInjectedTelegramTopLevelKeys(params: {
+  cfg: OpenClawConfig;
+  resolvedSource: unknown;
+}): OpenClawConfig {
+  const telegram = asObjectRecord(params.cfg.channels?.telegram);
+  if (!telegram) {
+    return params.cfg;
+  }
+  const accounts = asObjectRecord(telegram.accounts);
+  if (!accounts) {
+    return params.cfg;
+  }
+  const hasDefaultAccount = Object.keys(accounts).some(
+    (accountId) => normalizeAccountId(accountId) === DEFAULT_ACCOUNT_ID,
+  );
+  if (!hasDefaultAccount) {
+    return params.cfg;
+  }
+
+  const sourceChannels = asObjectRecord(asObjectRecord(params.resolvedSource)?.channels);
+  const sourceTelegram = asObjectRecord(sourceChannels?.telegram);
+  const sourceHasOwnKey = (key: string) =>
+    sourceTelegram ? Object.prototype.hasOwnProperty.call(sourceTelegram, key) : false;
+
+  const defaultValues: Record<string, unknown> = {
+    enabled: true,
+    dmPolicy: "pairing",
+    groupPolicy: "allowlist",
+    streaming: "partial",
+  };
+
+  let changed = false;
+  const nextTelegram: Record<string, unknown> = { ...telegram };
+  for (const [key, defaultValue] of Object.entries(defaultValues)) {
+    if (sourceHasOwnKey(key)) {
+      continue;
+    }
+    if (!(key in nextTelegram)) {
+      continue;
+    }
+    if (nextTelegram[key] !== defaultValue) {
+      continue;
+    }
+    delete nextTelegram[key];
+    changed = true;
+  }
+  if (!changed) {
+    return params.cfg;
+  }
+  return {
+    ...params.cfg,
+    channels: {
+      ...params.cfg.channels,
+      telegram: nextTelegram as OpenClawConfig["channels"]["telegram"],
+    },
+  };
+}
+
 async function maybeRepairTelegramAllowFromUsernames(cfg: OpenClawConfig): Promise<{
   config: OpenClawConfig;
   changes: string[];
@@ -1797,7 +1855,10 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   }
 
   let snapshot = await readConfigFileSnapshot();
-  const baseCfg = snapshot.config ?? {};
+  const baseCfg = stripDefaultInjectedTelegramTopLevelKeys({
+    cfg: snapshot.config ?? {},
+    resolvedSource: snapshot.resolved,
+  });
   let cfg: OpenClawConfig = baseCfg;
   let candidate = structuredClone(baseCfg);
   let pendingChanges = false;


### PR DESCRIPTION
Closes #35560

## Summary

- Problem: Doctor injects orphan top-level keys into multi-account telegram config on every CLI command
- Why it matters: Reported in #35560
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35560
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35560