### PR TITLE
fix(whatsapp): return actionable allowFrom policy error instead of generic E.164 hint

### DIFF
--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -194,6 +194,20 @@ describe("resolveWhatsAppOutboundTarget", () => {
       expectDeniedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "broadcast" });
     });
 
+    it("returns allowFrom policy error (not generic E.164 error) when blocked", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
+      const result = resolveWhatsAppOutboundTarget({
+        to: PRIMARY_TARGET,
+        allowFrom: [SECONDARY_TARGET],
+        mode: "implicit",
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain("allowFrom");
+        expect(result.error.message).not.toContain("<E.164");
+      }
+    });
+
     it("allows message in custom mode string when target is in allowList", () => {
       mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
       expectAllowedForTarget({ allowFrom: [PRIMARY_TARGET], mode: "broadcast" });

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -41,7 +41,9 @@ export function resolveWhatsAppOutboundTarget(params: {
     }
     return {
       ok: false,
-      error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+      error: new Error(
+        `Target "${normalizedTo}" is not in the configured WhatsApp allowFrom policy`,
+      ),
     };
   }
 


### PR DESCRIPTION
## Summary

When a valid E.164 number is blocked by the WhatsApp `allowFrom` policy, the error message was `Delivering to WhatsApp requires target <E.164|group JID>` — implying the number format is wrong. This is misleading because the number IS valid; the issue is that it's not in the allow list.

Now returns: `Target "+18585551234" is not in the configured WhatsApp allowFrom policy` — immediately telling the user what to fix.

The generic `missingTargetError` is still used for truly invalid/missing targets (empty input, normalization failure).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Closes #35580

## User-Visible Changes

Error message for allowFrom-blocked WhatsApp targets now says "not in the configured WhatsApp allowFrom policy" instead of the generic "requires target <E.164|group JID>".

## Security Impact

1. Does this change handle user input? **Yes** — outbound target resolution
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 22 tests pass (21 existing + 1 new)
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ src/whatsapp/resolve-outbound-target.test.ts (22 tests) 4ms
 Test Files  1 passed (1)
      Tests  22 passed (22)
```

## Human Verification

- Configure WhatsApp with `allowFrom: ["+15550001111"]`
- Send a message to `+18585551234` (not in list)
- Error should say "Target +18585551234 is not in the configured WhatsApp allowFrom policy"
- Send a message to `not-a-number` — error should still say "requires target <E.164|group JID>"

## Compatibility

Fully backward compatible. Only the error message text changes for one specific code path.

## Failure Recovery

Revert this single commit to restore the previous generic error message.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Downstream code parsing error message text | Error messages are for human consumption; no code should parse them |