### PR TITLE
refactor(cron-cli): use central parseDurationMs, drop duplicate implementation

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -128,7 +128,7 @@ expressions such as `0 7 * * *` remain exact.
 For any cron schedule, you can set an explicit stagger window with `schedule.staggerMs`
 (`0` keeps exact timing). CLI shortcuts:
 
-- `--stagger 30s` (or `1m`, `5m`) to set an explicit stagger window.
+- `--stagger 30s` (or `1m`, `5m`) to set an explicit stagger window. Duration format: units `ms`/`s`/`m`/`h`/`d`, or composites like `1h30m`.
 - `--exact` to force `staggerMs = 0`.
 
 ### Main vs isolated execution

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -603,6 +603,21 @@ describe("cron cli", () => {
     ]);
   });
 
+  it("rejects --every 0s (zero duration) on cron add", async () => {
+    await expectCronCommandExit([
+      "cron",
+      "add",
+      "--name",
+      "z",
+      "--every",
+      "0s",
+      "--session",
+      "main",
+      "--system-event",
+      "tick",
+    ]);
+  });
+
   it("sets explicit stagger for cron edit", async () => {
     await runCronCommand(["cron", "edit", "job-1", "--cron", "0 * * * *", "--stagger", "30s"]);
 
@@ -628,6 +643,10 @@ describe("cron cli", () => {
 
   it("rejects --exact on edit when existing job is not cron", async () => {
     await expectCronEditWithScheduleLookupExit({ kind: "every", everyMs: 60_000 }, ["--exact"]);
+  });
+
+  it("rejects --every 0s (zero duration) on cron edit", async () => {
+    await expectCronCommandExit(["cron", "edit", "job-1", "--every", "0s"]);
   });
 
   it("patches failure alert settings on cron edit", async () => {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -130,6 +130,9 @@ export function registerCronAddCommand(cron: Command) {
               } catch {
                 throw new Error("Invalid --every; use e.g. 10m, 1h, 1d");
               }
+              if (!everyMs) {
+                throw new Error("--every must be positive; use e.g. 10m, 1h, 1d");
+              }
               return { kind: "every" as const, everyMs };
             }
             const staggerMs = parseCronStaggerMs({ staggerRaw, useExact });

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -124,8 +124,10 @@ export function registerCronAddCommand(cron: Command) {
               return { kind: "at" as const, at: atIso };
             }
             if (every) {
-              const everyMs = parseDurationMs(every);
-              if (!everyMs) {
+              let everyMs: number;
+              try {
+                everyMs = parseDurationMs(every);
+              } catch {
                 throw new Error("Invalid --every; use e.g. 10m, 1h, 1d");
               }
               return { kind: "every" as const, everyMs };

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -174,6 +174,9 @@ export function registerCronEditCommand(cron: Command) {
             } catch {
               throw new Error("Invalid --every");
             }
+            if (!everyMs) {
+              throw new Error("--every must be positive; use e.g. 10m, 1h, 1d");
+            }
             patch.schedule = { kind: "every", everyMs };
           } else if (opts.cron) {
             patch.schedule = {

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -168,8 +168,10 @@ export function registerCronEditCommand(cron: Command) {
             }
             patch.schedule = { kind: "at", at: atIso };
           } else if (opts.every) {
-            const everyMs = parseDurationMs(String(opts.every));
-            if (!everyMs) {
+            let everyMs: number;
+            try {
+              everyMs = parseDurationMs(String(opts.every));
+            } catch {
               throw new Error("Invalid --every");
             }
             patch.schedule = { kind: "every", everyMs };
@@ -314,8 +316,10 @@ export function registerCronEditCommand(cron: Command) {
               failureAlert.to = to ? to : undefined;
             }
             if (hasFailureAlertCooldown) {
-              const cooldownMs = parseDurationMs(String(opts.failureAlertCooldown));
-              if (!cooldownMs && cooldownMs !== 0) {
+              let cooldownMs: number;
+              try {
+                cooldownMs = parseDurationMs(String(opts.failureAlertCooldown));
+              } catch {
                 throw new Error("Invalid --failure-alert-cooldown.");
               }
               failureAlert.cooldownMs = cooldownMs;

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -7,6 +7,12 @@ import { defaultRuntime } from "../../runtime.js";
 import { colorize, isRich, theme } from "../../terminal/theme.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { callGatewayFromCli } from "../gateway-rpc.js";
+import {
+  type DurationMsParseOptions,
+  parseDurationMs as parseDurationMsCentral,
+} from "../parse-duration.js";
+
+export { parseDurationMs } from "../parse-duration.js";
 
 export const getCronChannelOptions = () =>
   ["last", ...listChannelPlugins().map((plugin) => plugin.id)].join("|");
@@ -35,31 +41,20 @@ export async function warnIfCronSchedulerDisabled(opts: GatewayRpcOpts) {
   }
 }
 
-export function parseDurationMs(input: string): number | null {
+/** Parses a duration string; returns null on empty or invalid (does not throw). */
+export function parseDurationMsOptional(
+  input: string,
+  opts?: DurationMsParseOptions,
+): number | null {
   const raw = input.trim();
   if (!raw) {
     return null;
   }
-  const match = raw.match(/^(\d+(?:\.\d+)?)(ms|s|m|h|d)$/i);
-  if (!match) {
+  try {
+    return parseDurationMsCentral(raw, opts);
+  } catch {
     return null;
   }
-  const n = Number.parseFloat(match[1] ?? "");
-  if (!Number.isFinite(n) || n <= 0) {
-    return null;
-  }
-  const unit = (match[2] ?? "").toLowerCase();
-  const factor =
-    unit === "ms"
-      ? 1
-      : unit === "s"
-        ? 1000
-        : unit === "m"
-          ? 60_000
-          : unit === "h"
-            ? 3_600_000
-            : 86_400_000;
-  return Math.floor(n * factor);
 }
 
 export function parseCronStaggerMs(params: {
@@ -72,11 +67,11 @@ export function parseCronStaggerMs(params: {
   if (!params.staggerRaw) {
     return undefined;
   }
-  const parsed = parseDurationMs(params.staggerRaw);
-  if (!parsed) {
+  try {
+    return parseDurationMsCentral(params.staggerRaw, { defaultUnit: "s" });
+  } catch {
     throw new Error("Invalid --stagger; use e.g. 30s, 1m, 5m");
   }
-  return parsed;
 }
 
 export function parseAt(input: string): string | null {
@@ -88,7 +83,7 @@ export function parseAt(input: string): string | null {
   if (absolute !== null) {
     return new Date(absolute).toISOString();
   }
-  const dur = parseDurationMs(raw);
+  const dur = parseDurationMsOptional(raw);
   if (dur !== null) {
     return new Date(Date.now() + dur).toISOString();
   }


### PR DESCRIPTION
## Summary

Use the shared `parseDurationMs` from `src/cli/parse-duration.ts` in the cron CLI and remove the duplicate implementation in `src/cli/cron-cli/shared.ts`. Cron `--every`, `--stagger`, and `--at` (+duration) now use the same parser and support composite durations (e.g. `1h30m`, `2m500ms`).

## Changes

### Code

- **`src/cli/cron-cli/shared.ts`**
  - Re-export `parseDurationMs` from `../parse-duration.js` (throwing API).
  - Add `parseDurationMsOptional(input, opts?)` that returns `number | null` on invalid/empty (used by `parseAt`).
  - Remove the local ~25-line `parseDurationMs` implementation.
  - `parseCronStaggerMs`: call central `parseDurationMs` in try/catch and throw the same friendly message on error.
  - `parseAt`: use `parseDurationMsOptional` for the relative-duration branch.

- **`src/cli/cron-cli/register.cron-add.ts`**
  - `--every`: wrap `parseDurationMs(every)` in try/catch and throw "Invalid --every; use e.g. 10m, 1h, 1d" on error.

- **`src/cli/cron-cli/register.cron-edit.ts`**
  - `--every` and `--failure-alert-cooldown`: wrap `parseDurationMs(...)` in try/catch and throw the same friendly error messages on error.

### Docs

- **`docs/automation/cron-jobs.md`**: Document duration format for `--stagger` (units `ms`/`s`/`m`/`h`/`d` and composites like `1h30m`). Doc formatting verified with `pnpm format:docs:check`.

## Behavior

- **Single-token and composite**: Cron CLI now accepts the same duration strings as the rest of the codebase (e.g. `30s`, `1h30m`, `2m500ms`).
- **Errors**: Invalid duration still produces the same user-facing messages (e.g. "Invalid --stagger; use e.g. 30s, 1m, 5m").
- **Tests**: `src/cli/cron-cli/shared.test.ts`, `src/cli/cron-cli.test.ts`, and `src/cli/cli-utils.test.ts` (parseDurationMs) all pass.