### PR TITLE
fix(infra,security): wrap unguarded JSON.parse calls in try-catch

### DIFF
--- a/src/infra/outbound/delivery-queue.test.ts
+++ b/src/infra/outbound/delivery-queue.test.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { failDelivery } from "./delivery-queue.js";
+
+describe("failDelivery", () => {
+  it("does not throw when queue file contains malformed JSON", async () => {
+    const tmpDir = fs.mkdtempSync(path.join("/tmp", "delivery-queue-test-"));
+    const queueDir = path.join(tmpDir, "delivery-queue");
+    fs.mkdirSync(queueDir, { recursive: true });
+
+    const id = "bad-entry";
+    fs.writeFileSync(path.join(queueDir, `${id}.json`), "NOT VALID JSON{{{", "utf-8");
+
+    await expect(failDelivery(id, "test error", tmpDir)).resolves.toBeUndefined();
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("updates retry count for valid queue entry", async () => {
+    const tmpDir = fs.mkdtempSync(path.join("/tmp", "delivery-queue-test-"));
+    const queueDir = path.join(tmpDir, "delivery-queue");
+    fs.mkdirSync(queueDir, { recursive: true });
+
+    const id = "good-entry";
+    const entry = {
+      id,
+      retryCount: 0,
+      lastAttemptAt: 0,
+      lastError: "",
+      createdAt: Date.now(),
+      delivery: { channel: "telegram", to: "+15550001111" },
+      replies: [],
+    };
+    fs.writeFileSync(path.join(queueDir, `${id}.json`), JSON.stringify(entry), "utf-8");
+
+    await failDelivery(id, "delivery failed", tmpDir);
+
+    const updated = JSON.parse(fs.readFileSync(path.join(queueDir, `${id}.json`), "utf-8"));
+    expect(updated.retryCount).toBe(1);
+    expect(updated.lastError).toBe("delivery failed");
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -128,7 +128,12 @@ export async function ackDelivery(id: string, stateDir?: string): Promise<void> 
 export async function failDelivery(id: string, error: string, stateDir?: string): Promise<void> {
   const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
   const raw = await fs.promises.readFile(filePath, "utf-8");
-  const entry: QueuedDelivery = JSON.parse(raw);
+  let entry: QueuedDelivery;
+  try {
+    entry = JSON.parse(raw);
+  } catch {
+    return;
+  }
   entry.retryCount += 1;
   entry.lastAttemptAt = Date.now();
   entry.lastError = error;

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -85,9 +85,12 @@ async function readPluginManifestExtensions(pluginPath: string): Promise<string[
     return [];
   }
 
-  const parsed = JSON.parse(raw) as Partial<
-    Record<typeof MANIFEST_KEY, { extensions?: unknown }>
-  > | null;
+  let parsed: Partial<Record<typeof MANIFEST_KEY, { extensions?: unknown }>> | null;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
   const extensions = parsed?.[MANIFEST_KEY]?.extensions;
   if (!Array.isArray(extensions)) {
     return [];
@@ -388,7 +391,7 @@ async function readSandboxBrowserHashLabels(params: {
     if (result.code !== 0) {
       return null;
     }
-    const [hashRaw, epochRaw] = result.stdout.toString("utf8").split("\t");
+    const [hashRaw, epochRaw = ""] = result.stdout.toString("utf8").split("\t");
     return {
       configHash: normalizeDockerLabelValue(hashRaw),
       epoch: normalizeDockerLabelValue(epochRaw),


### PR DESCRIPTION
## Summary

Two `JSON.parse` calls in production code lacked try-catch guards:

1. **`src/infra/outbound/delivery-queue.ts`** `failDelivery` — reads a queue entry JSON file and parses it. If the file is corrupted (disk error, partial write, manual edit), `JSON.parse` throws and the delivery retry loop crashes. The sibling `loadPendingDeliveries` already has a try-catch but `failDelivery` did not.

2. **`src/security/audit-extra.async.ts`** `readPluginManifestExtensions` — reads a plugin's `package.json` and parses it. If the file is malformed or tampered, the security scanner crashes instead of gracefully skipping the plugin.

Additionally, the Docker label destructuring `[hashRaw, epochRaw]` lacked a default for `epochRaw`, which would be `undefined` if the docker inspect output has no tab separator.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [x] Gateway
- [x] Security

## Linked Issues

Proactive defensive fix — no single issue.

## User-Visible Changes

None. Corrupted queue files or malformed plugin manifests no longer crash the process.

## Security Impact

1. Does this change handle user input? **Yes** — file system data (queue entries, plugin manifests)
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **Yes** — security scanner now handles malformed manifests gracefully

## Verification

- [x] 2 new delivery-queue tests pass
- [x] 7 existing audit-extra tests pass
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ src/infra/outbound/delivery-queue.test.ts (2 tests) 3ms
 ✓ src/security/audit-extra.sync.test.ts (7 tests) 3ms
 Test Files  2 passed (2)
      Tests  9 passed (9)
```

## Human Verification

- Manually corrupt a `delivery-queue/*.json` file with invalid JSON
- Trigger a delivery failure — `failDelivery` should silently return instead of crashing
- Place a plugin with malformed `package.json` — security scan should skip it

## Compatibility

Fully backward compatible. Valid JSON files behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Silently skipping corrupted queue entries hides data loss | The entry remains on disk; `loadPendingDeliveries` already skips malformed entries |
| Skipping malformed manifests reduces scan coverage | Corrupted manifests are not scannable anyway; now the scan continues to other plugins |