### PR TITLE
feat: add CJK fonts to sandbox-browser for correct screenshot rendering

### DIFF
--- a/Dockerfile.sandbox-browser
+++ b/Dockerfile.sandbox-browser
@@ -9,6 +9,7 @@ RUN apt-get update \
     chromium \
     curl \
     fonts-liberation \
+    fonts-noto-cjk \
     fonts-noto-color-emoji \
     git \
     jq \


### PR DESCRIPTION
## Summary

- Problem: The sandbox-browser container lacks CJK (Chinese, Japanese, Korean) fonts
- Why it matters: Browser tool screenshots render all CJK text as □ (tofu), making them unusable for review or sharing
- What changed: Added `fonts-noto-cjk` package to `Dockerfile.sandbox-browser`
- What did NOT change: No code changes, no runtime behavior changes beyond font rendering

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #35597
- Related #

## User-visible / Behavior Changes

- Browser tool screenshots of CJK-language pages now render text correctly instead of showing □ (tofu) characters

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Debian bookworm-slim (sandbox-browser container)
- Runtime/container: Docker (sandbox-browser)
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: Default sandbox-browser configuration

### Steps

1. Build the sandbox-browser image from `Dockerfile.sandbox-browser`
2. Use browser tool to navigate to any page with CJK text (e.g., Japanese Wikipedia)
3. Take a screenshot

### Expected

- CJK text renders correctly in the screenshot

### Actual

- Before: CJK characters appear as □ (tofu)
- After: CJK characters render correctly

## Evidence

- Built the sandbox-browser image with `fonts-noto-cjk` added and deployed it
- Browser tool successfully took screenshots of a Japanese-language web page with CJK text rendering correctly (no tofu)
- Before the change, the same page rendered all Japanese characters as □

## Human Verification (required)

- Verified scenarios: Built and deployed the updated sandbox-browser image; used browser tool to navigate to a Japanese-language page and take screenshots; confirmed Japanese text renders correctly
- Edge cases checked: Page with mixed Latin/CJK text and styled elements renders correctly
- What you did **not** verify: Chinese and Korean text specifically (fonts-noto-cjk covers all three CJK families, so expected to work)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No (rebuild sandbox-browser image to pick up the change)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `fonts-noto-cjk` line from Dockerfile.sandbox-browser and rebuild
- Files/config to restore: `Dockerfile.sandbox-browser`
- Known bad symptoms: Image size increase (~120 MB from fonts-noto-cjk)

## Risks and Mitigations

- Risk: Image size increase (~120 MB)
  - Mitigation: fonts-noto-cjk is the standard CJK font package; smaller alternatives (individual language packages) exist but provide incomplete coverage

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)