### PR TITLE
config: allow channels.signal.accountUuid in strict schema

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -75,6 +75,18 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts channels.signal.accountUuid", () => {
+    const res = validateConfigObject({
+      channels: {
+        signal: {
+          accountUuid: "123e4567-e89b-12d3-a456-426614174000",
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects unsafe iMessage remoteHost", () => {
     const res = validateConfigObject({
       channels: {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -927,6 +927,7 @@ export const SignalAccountSchemaBase = z
     enabled: z.boolean().optional(),
     configWrites: z.boolean().optional(),
     account: z.string().optional(),
+    accountUuid: z.string().optional(),
     httpUrl: z.string().optional(),
     httpHost: z.string().optional(),
     httpPort: z.number().int().positive().optional(),


### PR DESCRIPTION
## What changed
- Added `accountUuid` to `SignalAccountSchemaBase` in `src/config/zod-schema.providers-core.ts`.
- Added a regression test in `src/config/config.schema-regressions.test.ts` to verify `channels.signal.accountUuid` is accepted by `validateConfigObject()`.

## Why
- `channels.signal.accountUuid` is already part of the Signal config types and runtime loop-protection path, but the strict Zod schema rejected it as an unknown key.
- This removes type/schema drift and allows valid Signal configs to pass validation.

## Testing
- ✅ `scripts/clone_and_test.sh openclaw/openclaw` (pass: 16 passed)

Fixes #35577
