### PR TITLE
fix(telegram): add missing editMessage and createForumTopic to actions Zod schema

### DIFF
--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -226,7 +226,9 @@ export const TelegramAccountSchemaBase = z
         reactions: z.boolean().optional(),
         sendMessage: z.boolean().optional(),
         deleteMessage: z.boolean().optional(),
+        editMessage: z.boolean().optional(),
         sticker: z.boolean().optional(),
+        createForumTopic: z.boolean().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

The `TelegramActionConfig` TypeScript type (`src/config/types.telegram.ts:14-23`) defines 6 fields, but the Zod validation schema in `TelegramAccountSchemaBase` (`src/config/zod-schema.providers-core.ts:224-232`) only had 4. The missing `editMessage` and `createForumTopic` fields caused `.strict()` to reject configs containing those documented options with "Unrecognized key" errors.

## Problem

Users who set `actions.editMessage` or `actions.createForumTopic` in their Telegram config get:

```
Config invalid Problem: - channels.telegram.accounts.main.actions: Unrecognized key(s) in object: 'editMessage'
```

## Fix

Added the two missing optional boolean fields to the Zod schema object, aligning it with the TypeScript type:
- `editMessage: z.boolean().optional()`
- `createForumTopic: z.boolean().optional()`

Both keys are actively used by the action gating logic in `src/channels/plugins/actions/telegram.ts` (lines 87-96) and backed by full implementations in `src/telegram/send.ts` (`editMessageTelegram`, `createForumTopicTelegram`).

## Testing

- [x] Verified the TypeScript type defines both fields
- [x] Verified both fields are used in action gating (`telegram.ts` lines 87, 94)
- [x] Verified both have working implementations in `send.ts`
- [x] Change is purely additive (optional fields) — backward compatible

Fixes #35497