### PR TITLE
fix(acp,agents,gateway): validate Date before calling toISOString()

### DIFF
--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -198,7 +198,13 @@ export class AcpGatewayAgent implements Agent {
         sessionId: session.key,
         cwd,
         title: session.displayName ?? session.label ?? session.key,
-        updatedAt: session.updatedAt ? new Date(session.updatedAt).toISOString() : undefined,
+        updatedAt: (() => {
+          if (session.updatedAt == null) {
+            return undefined;
+          }
+          const d = new Date(session.updatedAt);
+          return Number.isFinite(d.getTime()) ? d.toISOString() : undefined;
+        })(),
         _meta: {
           sessionKey: session.key,
           kind: session.kind,

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -119,7 +119,10 @@ function adoptNewerMainOAuthCredential(params: {
       log.info("adopted newer OAuth credentials from main agent", {
         profileId: params.profileId,
         agentDir: params.agentDir,
-        expires: new Date(mainCred.expires).toISOString(),
+        expires: (() => {
+          const d = new Date(mainCred.expires);
+          return Number.isFinite(d.getTime()) ? d.toISOString() : String(mainCred.expires);
+        })(),
       });
       return mainCred;
     }
@@ -421,7 +424,10 @@ export async function resolveApiKeyForProfile(
           log.info("inherited fresh OAuth credentials from main agent", {
             profileId,
             agentDir: params.agentDir,
-            expires: new Date(mainCred.expires).toISOString(),
+            expires: (() => {
+              const d = new Date(mainCred.expires);
+              return Number.isFinite(d.getTime()) ? d.toISOString() : String(mainCred.expires);
+            })(),
           });
           return buildOAuthProfileResult({
             provider: mainCred.provider,

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -748,6 +748,9 @@ export const usageHandlers: GatewayRequestHandlers = {
     // Format dates back to YYYY-MM-DD strings
     const formatDateStr = (ms: number) => {
       const d = new Date(ms);
+      if (!Number.isFinite(d.getTime())) {
+        return "Invalid";
+      }
       return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
     };
 


### PR DESCRIPTION
## Summary

`new Date(invalidValue).toISOString()` throws `RangeError: Invalid time value` when the input is not a valid date. Three locations called `toISOString()` on potentially invalid input:

1. **`src/acp/translator.ts`** — `session.updatedAt` from gateway response could be an invalid date string
2. **`src/agents/auth-profiles/oauth.ts`** — `mainCred.expires` from file store could be corrupted (2 log.info call sites)
3. **`src/gateway/server-methods/usage.ts`** — `formatDateStr(ms)` receives aggregated usage data timestamps that could be NaN

All now check `Number.isFinite(d.getTime())` before calling `toISOString()`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [x] Agents / Model integration
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [x] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — no single issue.

## User-Visible Changes

None. Invalid dates now produce fallback strings instead of crashing.

## Security Impact

1. Does this change handle user input? **Yes** — session timestamps, credential expiry, usage data
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] 93 ACP tests pass
- [x] 67 auth-profiles tests pass
- [x] Formatted with `oxfmt`

## Evidence

```
 Test Files  13 passed (13) [acp]
      Tests  93 passed (93)
 Test Files  6 passed (6) [auth-profiles]
      Tests  67 passed (67)
```

## Human Verification

- Set a session's updatedAt to an invalid string — ACP translator should return undefined instead of crashing
- Corrupt an OAuth credential file's expires field — log should show the raw value instead of crashing

## Compatibility

Fully backward compatible. Valid dates behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Fallback values hide data corruption | Invalid dates are logged as strings or "Invalid" — the underlying data issue is still visible |