### PR TITLE
fix: [Bug] Discord agentComponents config rejected by strict Zod schema (#35564)

### DIFF
--- a/src/config/config.discord.test.ts
+++ b/src/config/config.discord.test.ts
@@ -85,4 +85,21 @@ describe("config discord", () => {
       ).toBe(true);
     }
   });
+
+  it("accepts discord agentComponents config", () => {
+    const res = validateConfigObject({
+      channels: {
+        discord: {
+          agentComponents: { enabled: true },
+          accounts: {
+            main: {
+              agentComponents: { enabled: false },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -475,6 +475,12 @@ export const DiscordAccountSchema = z
       .strict()
       .optional(),
     ui: DiscordUiSchema,
+    agentComponents: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     slashCommand: z
       .object({
         ephemeral: z.boolean().optional(),


### PR DESCRIPTION
Closes #35564

## Summary

- Problem: [Bug] Discord agentComponents config rejected by strict Zod schema
- Why it matters: Reported in #35564
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35564
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35564