### PR TITLE
fix(discord): add missing autoThread to DiscordGuildChannelConfig type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Docs: https://docs.openclaw.ai
 - Signal/config schema: accept `channels.signal.accountUuid` in strict config validation so loop-protection configs no longer fail with an unrecognized-key error. (#35578) Thanks @ingyukoh.
 - Telegram/config schema: accept `channels.telegram.actions.editMessage` and `createForumTopic` in strict config validation so existing Telegram action toggles no longer fail as unrecognized keys. (#35498) Thanks @ingyukoh.
 - Agents/cooldowns: default cooldown windows with no recorded failure history to `unknown` instead of `rate_limit`, avoiding false API rate-limit warnings while preserving cooldown recovery probes. (#42911) Thanks @VibhorGautam.
+- Discord/config typing: expose channel-level `autoThread` on the canonical guild-channel config type so strict config loading matches the existing Discord schema and runtime behavior. (#35608) Thanks @ingyukoh.
 
 ## 2026.3.8
 

--- a/src/config/config.discord.test.ts
+++ b/src/config/config.discord.test.ts
@@ -36,7 +36,7 @@ describe("config discord", () => {
                 requireMention: false,
                 users: ["steipete"],
                 channels: {
-                  general: { allow: true },
+                  general: { allow: true, autoThread: true },
                 },
               },
             },
@@ -54,6 +54,7 @@ describe("config discord", () => {
         expect(cfg.channels?.discord?.actions?.channels).toBe(true);
         expect(cfg.channels?.discord?.guilds?.["123"]?.slug).toBe("friends-of-openclaw");
         expect(cfg.channels?.discord?.guilds?.["123"]?.channels?.general?.allow).toBe(true);
+        expect(cfg.channels?.discord?.guilds?.["123"]?.channels?.general?.autoThread).toBe(true);
       },
     );
   });

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -52,6 +52,8 @@ export type DiscordGuildChannelConfig = {
   systemPrompt?: string;
   /** If false, omit thread starter context for this channel (default: true). */
   includeThreadStarter?: boolean;
+  /** If true, automatically create a thread for each new message in this channel. */
+  autoThread?: boolean;
 };
 
 export type DiscordReactionNotificationMode = "off" | "own" | "all" | "allowlist";


### PR DESCRIPTION
Closes #35607

## Summary

- Add `autoThread?: boolean` to `DiscordGuildChannelConfig` in `types.discord.ts`

## Problem

The `autoThread` field is:
- Present in the Zod schema (`DiscordGuildChannelSchema` line 358)
- Used at runtime (`threading.ts:370`, `message-handler.process.ts:257`, `allow-list.ts:501`)
- Tested extensively (`monitor.test.ts`, `threading.auto-thread.test.ts`)

But missing from the canonical TypeScript type, forcing `allow-list.ts` to maintain a shadow type definition.

## Test plan

- [x] Existing autoThread tests cover runtime behavior
- [x] CI passes (type-only change, no runtime behavior change)
