### PR TITLE
docs: add PR description checklist to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,24 @@ Welcome to the lobster tank! 🦞
 - Describe what & why
 - **Include screenshots** — one showing the problem/before, one showing the fix/after (for UI or visual changes)
 
+## PR Description Checklist
+
+When opening a PR, use the [PR template](.github/pull_request_template.md) and ensure all required sections are completed:
+
+- [ ] **Summary** — Problem, why it matters, what changed
+- [ ] **Change Type** — Bug fix / Feature / Refactor / Docs / Security / Chore
+- [ ] **Scope** — Gateway / Skills / Auth / Memory / Integrations / API / UI / CI
+- [ ] **Linked Issue** — Closes # or Related #
+- [ ] **User-visible Changes** — What users will see (or `None`)
+- [ ] **Security Impact** — All questions answered
+- [ ] **Repro + Verification** — Steps to reproduce, expected vs actual
+- [ ] **Evidence** — Test log, screenshot, or perf numbers
+- [ ] **Human Verification** — What you personally verified
+- [ ] **Compatibility** — Backward compatible, migration needed?
+- [ ] **Failure Recovery** — How to revert if this breaks
+
+Filling out the template helps reviewers understand your change faster.
+
 ## Control UI Decorators
 
 The Control UI uses Lit with **legacy** decorators (current Rollup parsing does not support

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ When opening a PR, use the [PR template](.github/pull_request_template.md) and e
 
 - [ ] **Summary** — Problem, why it matters, what changed
 - [ ] **Change Type** — Bug fix / Feature / Refactor / Docs / Security / Chore
-- [ ] **Scope** — Gateway / Skills / Auth / Memory / Integrations / API / UI / CI
+- [ ] **Scope** — Gateway / Skills / Auth / Memory / Integrations / API / UI / CI / Config / Schema
 - [ ] **Linked Issue** — Closes # or Related #
 - [ ] **User-visible Changes** — What users will see (or `None`)
 - [ ] **Security Impact** — All questions answered

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,7 @@ When opening a PR, use the [PR template](.github/pull_request_template.md) and e
 - [ ] **Human Verification** — What you personally verified
 - [ ] **Compatibility** — Backward compatible, migration needed?
 - [ ] **Failure Recovery** — How to revert if this breaks
+- [ ] **Risks and Mitigations** — Real risks and their mitigations (or `None`)
 
 Filling out the template helps reviewers understand your change faster.
 


### PR DESCRIPTION
## Summary
- Problem: PR template fields were easy to miss from CONTRIBUTING.
- Why it matters: Missing details slow review.
- What changed: Added a PR Description Checklist section to CONTRIBUTING.
- What did NOT change: No runtime/API/CLI behavior.

## Change Type
- [x] Docs

## Scope
- [x] UI / DX

## Linked Issue
- Closes #35454

## User-visible / Behavior Changes
None

## Security Impact
- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Human Verification
- Verified scenarios: checklist content and placement in CONTRIBUTING.
- Edge cases checked: docs-only change scope.
- What not verified: resolving unrelated pre-existing formatting debt.

## Compatibility
- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## AI/Vibe-Coded Disclosure
- AI-assisted: Yes
- Testing degree: Lightly tested