### PR TITLE
fix(cli): return to section menu on ESC inside configure sub-section (#20495)

### DIFF
--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   waitForGatewayReachable: vi.fn(),
   resolveControlUiLinks: vi.fn(),
   summarizeExistingConfig: vi.fn(),
+  promptGatewayConfig: vi.fn(),
 }));
 
 vi.mock("@clack/prompts", () => ({
@@ -68,7 +69,7 @@ vi.mock("./health-format.js", () => ({
 }));
 
 vi.mock("./configure.gateway.js", () => ({
-  promptGatewayConfig: vi.fn(),
+  promptGatewayConfig: mocks.promptGatewayConfig,
 }));
 
 vi.mock("./configure.gateway-auth.js", () => ({
@@ -133,6 +134,45 @@ describe("runConfigureWizard", () => {
         gateway: expect.objectContaining({ mode: "local" }),
       }),
     );
+  });
+
+  it("returns to section menu instead of exiting when ESC pressed inside a section", async () => {
+    // Regression test for #20495: pressing ESC inside a sub-section (e.g. gateway config)
+    // should cancel that section and return to the section selection menu, not quit the wizard.
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      exists: false,
+      valid: true,
+      config: {},
+      issues: [],
+    });
+    mocks.resolveGatewayPort.mockReturnValue(18789);
+    mocks.probeGatewayReachable.mockResolvedValue({ ok: false });
+    mocks.resolveControlUiLinks.mockReturnValue({ wsUrl: "ws://127.0.0.1:18789" });
+    mocks.summarizeExistingConfig.mockReturnValue("");
+    mocks.createClackPrompter.mockReturnValue({});
+    mocks.ensureControlUiAssetsBuilt.mockResolvedValue({ ok: true });
+
+    // Section picker: local mode → gateway section → user ESCs inside gateway → back to picker → continue
+    const selectQueue = ["local", "gateway", "__continue"];
+    mocks.clackSelect.mockImplementation(async () => selectQueue.shift());
+    mocks.clackIntro.mockResolvedValue(undefined);
+    mocks.clackOutro.mockResolvedValue(undefined);
+
+    // Simulate user pressing ESC inside the gateway section
+    mocks.promptGatewayConfig.mockRejectedValue(new WizardCancelledError());
+
+    await runConfigureWizard({ command: "configure" }, runtime);
+
+    // The wizard should NOT have exited — it should have returned to section menu
+    expect(runtime.exit).not.toHaveBeenCalledWith(1);
+    // The wizard should have completed normally and persisted config
+    expect(mocks.writeConfigFile).toHaveBeenCalled();
   });
 
   it("exits with code 1 when configure wizard is cancelled", async () => {

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -565,52 +565,60 @@ export async function runConfigureWizard(
         }
         ranSection = true;
 
-        if (choice === "workspace") {
-          await configureWorkspace();
-          await persistConfig();
-        }
-
-        if (choice === "model") {
-          nextConfig = await promptAuthConfig(nextConfig, runtime, prompter);
-          await persistConfig();
-        }
-
-        if (choice === "web") {
-          nextConfig = await promptWebToolsConfig(nextConfig, runtime);
-          await persistConfig();
-        }
-
-        if (choice === "gateway") {
-          const gateway = await promptGatewayConfig(nextConfig, runtime);
-          nextConfig = gateway.config;
-          gatewayPort = gateway.port;
-          didConfigureGateway = true;
-          await persistConfig();
-        }
-
-        if (choice === "channels") {
-          await configureChannelsSection();
-          await persistConfig();
-        }
-
-        if (choice === "skills") {
-          const wsDir = resolveUserPath(workspaceDir);
-          nextConfig = await setupSkills(nextConfig, wsDir, runtime, prompter);
-          await persistConfig();
-        }
-
-        if (choice === "daemon") {
-          if (!didConfigureGateway) {
-            await promptDaemonPort();
+        try {
+          if (choice === "workspace") {
+            await configureWorkspace();
+            await persistConfig();
           }
-          await maybeInstallDaemon({
-            runtime,
-            port: gatewayPort,
-          });
-        }
 
-        if (choice === "health") {
-          await runGatewayHealthCheck({ cfg: nextConfig, runtime, port: gatewayPort });
+          if (choice === "model") {
+            nextConfig = await promptAuthConfig(nextConfig, runtime, prompter);
+            await persistConfig();
+          }
+
+          if (choice === "web") {
+            nextConfig = await promptWebToolsConfig(nextConfig, runtime);
+            await persistConfig();
+          }
+
+          if (choice === "gateway") {
+            const gateway = await promptGatewayConfig(nextConfig, runtime);
+            nextConfig = gateway.config;
+            gatewayPort = gateway.port;
+            didConfigureGateway = true;
+            await persistConfig();
+          }
+
+          if (choice === "channels") {
+            await configureChannelsSection();
+            await persistConfig();
+          }
+
+          if (choice === "skills") {
+            const wsDir = resolveUserPath(workspaceDir);
+            nextConfig = await setupSkills(nextConfig, wsDir, runtime, prompter);
+            await persistConfig();
+          }
+
+          if (choice === "daemon") {
+            if (!didConfigureGateway) {
+              await promptDaemonPort();
+            }
+            await maybeInstallDaemon({
+              runtime,
+              port: gatewayPort,
+            });
+          }
+
+          if (choice === "health") {
+            await runGatewayHealthCheck({ cfg: nextConfig, runtime, port: gatewayPort });
+          }
+        } catch (sectionErr) {
+          if (sectionErr instanceof WizardCancelledError) {
+            // ESC inside a sub-section: cancel the section and return to the section menu
+            continue;
+          }
+          throw sectionErr;
         }
       }
 

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -300,7 +300,7 @@ async function resolveImagesForRequest(
   for (const url of urls) {
     const source = parseImageUrlToSource(url);
     if (source.type === "base64") {
-      totalBytes += estimateBase64DecodedBytes(source.data);
+      totalBytes += estimateBase64DecodedBytes(source.data ?? "");
       if (totalBytes > limits.maxTotalImageBytes) {
         throw new Error(
           `Total image payload too large (${totalBytes}; limit ${limits.maxTotalImageBytes})`,


### PR DESCRIPTION
## Problem
Pressing ESC inside any sub-section of the `openclaw configure` wizard (e.g. gateway config, channel setup) exits the entire wizard with code 1 instead of returning to the section selection menu. Users who accidentally press ESC while filling in a prompt lose all progress and must restart.

## Root cause
`src/commands/configure.wizard.ts` — the `while (true)` section-selection loop at line ~518 calls section handlers (`promptGatewayConfig`, `setupChannels`, `promptAuthConfig`, etc.) that internally call `guardCancel()`. When ESC is pressed, `guardCancel()` throws `WizardCancelledError`. This propagates unimpeded to the outer `try/catch` at line 637 which calls `runtime.exit(1)` unconditionally, quitting the wizard.

## Fix
Added a local `try/catch` for `WizardCancelledError` wrapping all section handler calls inside the `while (true)` loop. When ESC is pressed inside a sub-section, the error is caught and the loop `continue`s — returning to the section picker. ESC at the top-level section picker (from `promptConfigureSection`) still propagates to the outer catch and exits normally.

## Verification
- **Test:** `src/commands/configure.wizard.test.ts` — fails on main (`runtime.exit(1)` called), passes on fix (wizard continues)
- **Build:** clean compile (`build-output.log`)
- **Test suite:** pre-existing sandbox timeout, both fix and baseline exit 124 (`test-output.log`)
- **Code proof:** inner `catch (sectionErr)` present, outer catch preserved (`step6-verify.log`)

Closes #20495