### PR TITLE
fix(discovery): add missing domain to wideArea Zod config schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 - Android/onboarding QR scan: switch setup QR scanning to Google Code Scanner so onboarding uses a more reliable scanner instead of the legacy embedded ZXing flow. (#45021) Thanks @obviyus.
 - Config/web fetch: restore runtime validation for documented `tools.web.fetch.readability` and `tools.web.fetch.firecrawl` settings so valid web fetch configs no longer fail with unrecognized-key errors. (#42583) Thanks @stim64045-spec.
 - Signal/config validation: add `channels.signal.groups` schema support so per-group `requireMention`, `tools`, and `toolsBySender` overrides no longer get rejected during config validation. (#27199) Thanks @unisone.
+- Config/discovery: accept `discovery.wideArea.domain` in strict config validation so unicast DNS-SD gateway configs no longer fail with an unrecognized-key error. (#35615) Thanks @ingyukoh.
 
 ## 2026.3.12
 

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -211,4 +211,17 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts discovery.wideArea.domain for unicast DNS-SD", () => {
+    const res = validateConfigObject({
+      discovery: {
+        wideArea: {
+          enabled: true,
+          domain: "openclaw.internal",
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -296,6 +296,7 @@ const TARGET_KEYS = [
   "web.reconnect.jitter",
   "web.reconnect.maxAttempts",
   "discovery",
+  "discovery.wideArea.domain",
   "discovery.wideArea.enabled",
   "discovery.mdns",
   "discovery.mdns.mode",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -292,6 +292,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Wide-area discovery configuration group for exposing discovery signals beyond local-link scopes. Enable only in deployments that intentionally aggregate gateway presence across sites.",
   "discovery.wideArea.enabled":
     "Enables wide-area discovery signaling when your environment needs non-local gateway discovery. Keep disabled unless cross-network discovery is operationally required.",
+  "discovery.wideArea.domain":
+    "Optional unicast DNS-SD domain for wide-area discovery, such as openclaw.internal. Use this when you intentionally publish gateway discovery beyond local mDNS scopes.",
   "discovery.mdns":
     "mDNS discovery configuration group for local network advertisement and discovery behavior tuning. Keep minimal mode for routine LAN discovery unless extra metadata is required.",
   tools:

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -654,6 +654,7 @@ export const FIELD_LABELS: Record<string, string> = {
   discovery: "Discovery",
   "discovery.wideArea": "Wide-area Discovery",
   "discovery.wideArea.enabled": "Wide-area Discovery Enabled",
+  "discovery.wideArea.domain": "Wide-area Discovery Domain",
   "discovery.mdns": "mDNS Discovery",
   canvasHost: "Canvas Host",
   "canvasHost.enabled": "Canvas Host Enabled",

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -596,6 +596,7 @@ export const OpenClawSchema = z
         wideArea: z
           .object({
             enabled: z.boolean().optional(),
+            domain: z.string().optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
Closes #35614

## Summary

- Add `domain` field to wideArea schema in `zod-schema.ts`
- Add regression test in `config.schema-regressions.test.ts`

## Problem

The wideArea schema uses `.strict()` but was missing the `domain` field that is:
- Defined in the type (`types.gateway.ts:21`)
- Used across gateway, CLI, and infrastructure code for unicast DNS-SD
- Referenced in 10+ locations across the codebase

Users setting `discovery.wideArea.domain` get a validation error.

## Test plan

- [x] New regression test: `accepts discovery.wideArea.domain for unicast DNS-SD`
- [x] CI passes
