### PR TITLE
fix(tui): skip history reload on final event with renderable content

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -323,7 +323,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     );
   });
 
-  it("refreshes history after a non-local chat final", () => {
+  it("skips history reload when non-local chat final has renderable content", () => {
     const { state, loadHistory, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: null },
     });
@@ -333,6 +333,21 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       sessionKey: state.currentSessionKey,
       state: "final",
       message: { content: [{ type: "text", text: "done" }] },
+    });
+
+    expect(loadHistory).not.toHaveBeenCalled();
+  });
+
+  it("refreshes history when non-local chat final has no renderable content", () => {
+    const { state, loadHistory, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null },
+    });
+
+    handleChatEvent({
+      runId: "external-run",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [] },
     });
 
     expect(loadHistory).toHaveBeenCalledTimes(1);

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -194,7 +194,6 @@ export function createEventHandlers(context: EventHandlerContext) {
         tui.requestRender();
         return;
       }
-      maybeRefreshHistoryForRun(evt.runId);
       const stopReason =
         evt.message && typeof evt.message === "object" && !Array.isArray(evt.message)
           ? typeof (evt.message as Record<string, unknown>).stopReason === "string"
@@ -207,6 +206,7 @@ export function createEventHandlers(context: EventHandlerContext) {
         finalText === "(no output)" && !isLocalRunId?.(evt.runId);
       if (suppressEmptyExternalPlaceholder) {
         chatLog.dropAssistant(evt.runId);
+        maybeRefreshHistoryForRun(evt.runId);
       } else {
         chatLog.finalizeAssistant(finalText, evt.runId);
       }


### PR DESCRIPTION
## Summary

- **Problem:** TUI doesn't display assistant messages until restart. When a non-local chat run emits a final event, `maybeRefreshHistoryForRun` triggers `loadHistory()` which calls `chatLog.clearAll()`. If the new message hasn't been persisted to the history API yet, it disappears from the UI.
- **Why it matters:** Users see their message sent but receive no visible response until they restart the TUI — making it appear broken.
- **What changed:** Moved `maybeRefreshHistoryForRun` call from before `finalizeAssistant` to only the `suppressEmptyExternalPlaceholder` branch. When the final event carries a renderable assistant message, `finalizeAssistant` renders it directly without a history reload. When the final has no displayable content (empty placeholder from non-local run), the history refresh still fires as before.
- **What did NOT change:** History refresh for `!evt.message`, command messages, aborted, and error states remains unchanged. Local run handling is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35523

## User-visible / Behavior Changes

- TUI now immediately displays assistant messages from non-local runs without requiring a restart.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22
- Integration/channel: TUI

### Steps

1. Run `openclaw tui`
2. Send a message
3. Observe assistant response

### Expected

- Assistant message appears immediately in TUI

### Actual

- Before fix: Message not visible until TUI restart
- After fix: Message appears immediately via `finalizeAssistant`

## Evidence

Test output (14/14 pass, including updated test coverage):
```
✓ src/tui/tui-event-handlers.test.ts (14 tests) 5ms
Test Files  1 passed (1)
     Tests  14 passed (14)
```

Updated test: split "refreshes history after a non-local chat final" into two cases:
- `skips history reload when non-local chat final has renderable content` — verifies `loadHistory` is NOT called when final has text content
- `refreshes history when non-local chat final has no renderable content` — verifies `loadHistory` IS called when final produces empty placeholder

## Human Verification (required)

- Verified scenarios: Non-local final with content → no reload; non-local final with empty content → reload; local final → no reload; command message final → reload; no-message final → reload
- Edge cases checked: Concurrent active runs (unchanged behavior); aborted/error states (unchanged)
- What I did **not** verify: Live TUI session (no gateway running in test environment)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; history reload fires on every non-local final again
- Files/config to restore: `src/tui/tui-event-handlers.ts`
- Known bad symptoms: If reverted, assistant messages may disappear until TUI restart (original bug)

## Risks and Mitigations

- Risk: Non-local runs that produce content but the content differs from what history would show (e.g. tool outputs rendered differently). Mitigation: `finalizeAssistant` uses the same `streamAssembler.finalize` path as the streaming display, so the final render is consistent. History would be loaded on next session switch or manual refresh.

