### PR TITLE
fix(memory-lancedb): guard parseInt result for CLI search limit

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -516,7 +516,9 @@ const memoryPlugin = {
           .option("--limit <n>", "Max results", "5")
           .action(async (query, opts) => {
             const vector = await embeddings.embed(query);
-            const results = await db.search(vector, parseInt(opts.limit), 0.3);
+            const rawLimit = parseInt(opts.limit, 10);
+            const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? rawLimit : 5;
+            const results = await db.search(vector, limit, 0.3);
             // Strip vectors for output
             const output = results.map((r) => ({
               id: r.entry.id,


### PR DESCRIPTION
## Summary

The memory-lancedb CLI `search` command passes `parseInt(opts.limit)` directly to `db.search()` without validating the result. If a user provides a non-numeric `--limit` argument (e.g. `--limit abc`), `parseInt` returns NaN which propagates into the LanceDB search query, causing unpredictable behavior.

Now validates the parsed value with `Number.isFinite()` and falls back to the default of 5.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — no single issue.

## User-Visible Changes

Invalid `--limit` values now fall back to 5 instead of producing errors or empty results.

## Security Impact

1. Does this change handle user input? **Yes** — CLI argument
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] 12 existing memory-lancedb tests pass
- [x] Formatted with `oxfmt`

## Evidence

\`\`\`
 ✓ extensions/memory-lancedb/index.test.ts (12 tests) 76ms
 Test Files  1 passed (1)
      Tests  12 passed | 1 skipped (13)
\`\`\`

## Human Verification

- Run \`openclaw memory search "test" --limit abc\` — should return 5 results (default) instead of erroring

## Compatibility

Fully backward compatible. Valid numeric limits behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Silent fallback hides user typo | The default of 5 is documented in the --limit option help text |