### PR TITLE
fix(discord): accept agentComponents in strict config schema

### DIFF
--- a/src/config/config.discord.test.ts
+++ b/src/config/config.discord.test.ts
@@ -58,6 +58,18 @@ describe("config discord", () => {
     );
   });
 
+  it("accepts discord agentComponents config", () => {
+    const res = validateConfigObject({
+      channels: {
+        discord: {
+          agentComponents: { enabled: false },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects numeric discord allowlist entries", () => {
     const res = validateConfigObject({
       channels: {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -474,6 +474,12 @@ export const DiscordAccountSchema = z
       })
       .strict()
       .optional(),
+    agentComponents: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     ui: DiscordUiSchema,
     slashCommand: z
       .object({


### PR DESCRIPTION
## Summary
- add `channels.discord.agentComponents` to `DiscordAccountSchema` in strict zod provider schema
- keep shape minimal (`enabled?: boolean`) to match runtime/types usage
- add regression test to verify config validation accepts `agentComponents`

## Why
`channels.discord` schema is strict, but `agentComponents` exists in runtime and types. This caused valid configs to be rejected.

Closes #35564