### PR TITLE
fix(outbound): include sessionKey for message:sent internal hooks (#35557)

### DIFF
--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -523,6 +523,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
       channel,
       params,
       agentId,
+      sessionKey: outboundRoute?.sessionKey ?? input.sessionKey,
       accountId: accountId ?? undefined,
       gateway,
       toolContext: input.toolContext,

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -16,6 +16,7 @@ vi.mock("../../channels/plugins/index.js", () => ({
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveDefaultAgentId: () => "main",
   resolveAgentWorkspaceDir: () => "/tmp/openclaw-test-workspace",
+  resolveSessionAgentId: () => "main",
 }));
 
 vi.mock("../../config/plugin-auto-enable.js", () => ({
@@ -65,6 +66,25 @@ describe("sendMessage", () => {
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
         session: expect.objectContaining({ agentId: "work" }),
+        channel: "telegram",
+        to: "123456",
+      }),
+    );
+  });
+
+  it("passes sessionKey to outbound delivery so internal message:sent hooks can fire without mirror", async () => {
+    await sendMessage({
+      cfg: {},
+      channel: "telegram",
+      to: "123456",
+      content: "hi",
+      agentId: "work",
+      sessionKey: "s-test",
+    });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({ agentId: "work", key: "s-test" }),
         channel: "telegram",
         to: "123456",
       }),

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -34,6 +34,8 @@ type MessageSendParams = {
   content: string;
   /** Active agent id for per-agent outbound media root scoping. */
   agentId?: string;
+  /** Canonical session key used for internal hook dispatch (message:sent). */
+  sessionKey?: string;
   channel?: string;
   mediaUrl?: string;
   mediaUrls?: string[];
@@ -211,7 +213,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
     const outboundSession = buildOutboundSessionContext({
       cfg,
       agentId: params.agentId,
-      sessionKey: params.mirror?.sessionKey,
+      sessionKey: params.sessionKey ?? params.mirror?.sessionKey,
     });
     const results = await deliverOutboundPayloads({
       cfg,

--- a/src/infra/outbound/outbound-send-service.test.ts
+++ b/src/infra/outbound/outbound-send-service.test.ts
@@ -61,6 +61,35 @@ describe("executeSendAction", () => {
     );
   });
 
+  it("forwards ctx.sessionKey to sendMessage so internal message:sent hooks can dispatch", async () => {
+    mocks.dispatchChannelMessageAction.mockResolvedValue(null);
+    mocks.sendMessage.mockResolvedValue({
+      channel: "discord",
+      to: "channel:123",
+      via: "direct",
+      mediaUrl: null,
+    });
+
+    await executeSendAction({
+      ctx: {
+        cfg: {},
+        channel: "discord",
+        params: {},
+        agentId: "work",
+        sessionKey: "s-test",
+        dryRun: false,
+      },
+      to: "channel:123",
+      message: "hello",
+    });
+
+    expect(mocks.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "s-test",
+      }),
+    );
+  });
+
   it("uses plugin poll action when available", async () => {
     mocks.dispatchChannelMessageAction.mockResolvedValue({
       ok: true,

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -26,6 +26,8 @@ export type OutboundSendContext = {
   params: Record<string, unknown>;
   /** Active agent id for per-agent outbound media root scoping. */
   agentId?: string;
+  /** Canonical session key used for internal hook dispatch (message:sent). */
+  sessionKey?: string;
   accountId?: string | null;
   gateway?: OutboundGatewayContext;
   toolContext?: ChannelThreadingToolContext;
@@ -128,6 +130,7 @@ export async function executeSendAction(params: {
     to: params.to,
     content: params.message,
     agentId: params.ctx.agentId,
+    sessionKey: params.ctx.sessionKey,
     mediaUrl: params.mediaUrl || undefined,
     mediaUrls: params.mediaUrls,
     channel: params.ctx.channel || undefined,


### PR DESCRIPTION
## Summary

- Problem: Managed hooks listening for `message:sent` can be silently skipped when outbound sends have `session.agentId` but no `session.key`.
- Why it matters: Hook-based automation (logging/analytics/indicators) cannot reliably observe outbound messages for direct agent sends.
- What changed: Plumbed an explicit `sessionKey` through the outbound send stack so `deliverOutboundPayloads` always receives a canonical session key for internal hook dispatch.
- What did NOT change (scope boundary): No changes to provider adapters or message content; plugin `message_sent` hook behavior is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35557

## User-visible / Behavior Changes

- Managed hooks registered for `message:sent` now fire for direct outbound sends when a session key is available.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Register a managed hook for `message:sent`.
2. Trigger a direct outbound send via the message tool/action.
3. Observe the hook handler receives the event.

### Expected

- `message:sent` internal hook fires for outbound sends tied to a session key.

### Actual

- Previously, the internal hook could be skipped when the send path did not populate `session.key`.

## Evidence

- [x] Passing after: `pnpm test src/infra/outbound/message.test.ts src/infra/outbound/outbound-send-service.test.ts`
- [x] Passing after: `pnpm check`

## Human Verification (required)

- Verified scenarios: local unit tests + `pnpm check`
- Edge cases checked: send path with agentId + sessionKey but no mirror session
- What you did **not** verify: full end-to-end hook execution against a live gateway

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- Revert this commit.

## Risks and Mitigations

None.
