### PR TITLE
fix(agents): buffer user messages during compaction instead of dropping

### DIFF
--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -12,6 +12,7 @@ type EmbeddedPiQueueHandle = {
 };
 
 const ACTIVE_EMBEDDED_RUNS = new Map<string, EmbeddedPiQueueHandle>();
+const COMPACTION_PENDING_MESSAGES = new Map<string, string[]>();
 type EmbeddedRunWaiter = {
   resolve: (ended: boolean) => void;
   timer: NodeJS.Timeout;
@@ -29,8 +30,11 @@ export function queueEmbeddedPiMessage(sessionId: string, text: string): boolean
     return false;
   }
   if (handle.isCompacting()) {
-    diag.debug(`queue message failed: sessionId=${sessionId} reason=compacting`);
-    return false;
+    diag.debug(`queue message buffered during compaction: sessionId=${sessionId}`);
+    const pending = COMPACTION_PENDING_MESSAGES.get(sessionId) ?? [];
+    pending.push(text);
+    COMPACTION_PENDING_MESSAGES.set(sessionId, pending);
+    return true;
   }
   logMessageQueued({ sessionId, source: "pi-embedded-runner" });
   void handle.queueMessage(text);
@@ -140,6 +144,7 @@ export function clearActiveEmbeddedRun(
 ) {
   if (ACTIVE_EMBEDDED_RUNS.get(sessionId) === handle) {
     ACTIVE_EMBEDDED_RUNS.delete(sessionId);
+    COMPACTION_PENDING_MESSAGES.delete(sessionId);
     logSessionStateChange({ sessionId, sessionKey, state: "idle", reason: "run_completed" });
     if (!sessionId.startsWith("probe-")) {
       diag.debug(`run cleared: sessionId=${sessionId} totalActive=${ACTIVE_EMBEDDED_RUNS.size}`);
@@ -147,6 +152,25 @@ export function clearActiveEmbeddedRun(
     notifyEmbeddedRunEnded(sessionId);
   } else {
     diag.debug(`run clear skipped: sessionId=${sessionId} reason=handle_mismatch`);
+  }
+}
+
+export function flushCompactionPendingMessages(sessionId: string): void {
+  const pending = COMPACTION_PENDING_MESSAGES.get(sessionId);
+  if (!pending || pending.length === 0) {
+    COMPACTION_PENDING_MESSAGES.delete(sessionId);
+    return;
+  }
+  COMPACTION_PENDING_MESSAGES.delete(sessionId);
+  const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
+  if (!handle) {
+    diag.debug(`flush pending messages skipped: sessionId=${sessionId} reason=no_active_run`);
+    return;
+  }
+  diag.debug(`flushing ${pending.length} buffered message(s) after compaction: sessionId=${sessionId}`);
+  for (const text of pending) {
+    logMessageQueued({ sessionId, source: "pi-embedded-runner:compaction-flush" });
+    void handle.queueMessage(text);
   }
 }
 

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -2,6 +2,7 @@ import type { AgentEvent } from "@mariozechner/pi-agent-core";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
+import { flushCompactionPendingMessages } from "./pi-embedded-runner/runs.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
 
 export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
@@ -54,6 +55,9 @@ export function handleAutoCompactionEnd(
   } else {
     ctx.maybeResolveCompactionWait();
     clearStaleAssistantUsageOnSessionMessages(ctx);
+    if (ctx.params.sessionId) {
+      flushCompactionPendingMessages(ctx.params.sessionId);
+    }
   }
   emitAgentEvent({
     runId: ctx.params.runId,


### PR DESCRIPTION
## Summary

- **Problem:** `queueEmbeddedPiMessage` silently rejects user messages when `isCompacting()` is true (returns `false`). Messages arriving during the compaction window are permanently lost — the user sees their message sent but the agent never responds.
- **Why it matters:** Silent data loss; users have no indication their message was dropped, leading to confusion and manual resends.
- **What changed:** Two files modified:
  - `src/agents/pi-embedded-runner/runs.ts`: Instead of returning `false` during compaction, messages are buffered in a per-session `COMPACTION_PENDING_MESSAGES` map. A new `flushCompactionPendingMessages(sessionId)` function drains the buffer by calling `handle.queueMessage()` for each pending message. The buffer is also cleaned up in `clearActiveEmbeddedRun` to prevent stale data.
  - `src/agents/pi-embedded-subscribe.handlers.compaction.ts`: `handleAutoCompactionEnd` calls `flushCompactionPendingMessages` after compaction completes (non-retry path), so buffered messages are delivered to the post-compaction session.
- **What did NOT change:** Behavior when `!handle` (no active run) or `!handle.isStreaming()` (not streaming) — these still reject. The compaction retry path does not flush (messages stay buffered until the final successful compaction). No changes to compaction logic itself.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35522

## User-visible / Behavior Changes

- User messages sent during auto-compaction are no longer silently dropped. They are buffered and delivered to the agent once compaction completes.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux x86_64 / macOS
- Runtime: Node.js 22
- Integration/channel: Any (Telegram, TUI, webchat)

### Steps

1. Have an active session approaching the compaction threshold (~200k tokens)
2. Send a user message at the moment compaction fires
3. Observe whether the message is processed after compaction

### Expected

- Message is buffered during compaction and delivered after compaction completes

### Actual

- Before fix: Message silently dropped, agent never responds
- After fix: Message buffered and flushed after compaction ends

## Evidence

Existing compaction tests pass (10/10):
```
✓ src/agents/compaction.test.ts (10 tests) 4ms
Test Files  1 passed (1)
     Tests  10 passed (10)
```

TypeScript compilation: no errors introduced.

## Human Verification (required)

- Verified scenarios: Message during compaction → buffered → flushed on compaction end; compaction retry → messages stay buffered until final end; run cleared → buffer cleaned
- Edge cases checked: Multiple messages during compaction (all buffered, flushed in order); no active run when flush fires (messages discarded with debug log); compaction with retry (buffer not flushed until final success)
- What I did **not** verify: Live compaction scenario (requires a session at threshold with precise timing)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; returns to the old drop-on-compacting behavior
- Files/config to restore: `src/agents/pi-embedded-runner/runs.ts`, `src/agents/pi-embedded-subscribe.handlers.compaction.ts`
- Known bad symptoms: If `flushCompactionPendingMessages` fails, buffered messages would be lost (same as current behavior). The buffer is in-memory so process restart also clears it.

## Risks and Mitigations

- Risk: Buffered messages may arrive in the post-compaction session with stale context (the compaction summary doesn't include them). Mitigation: This is strictly better than dropping them entirely — the agent sees the message and can respond. The compaction summary covers history up to the compaction point; the buffered message is new user input that arrives after.
- Risk: Memory pressure from very large pending buffers. Mitigation: The buffer is per-session and messages are text-only strings; a realistic worst case is a handful of messages during a 10-30s compaction window.

