### PR TITLE
fix(feishu): wrap URL parsing in try-catch for docx media filename resolution

### DIFF
--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -508,8 +508,12 @@ async function resolveUploadInput(
 
   if (url) {
     const fetched = await getFeishuRuntime().channel.media.fetchRemoteMedia({ url, maxBytes });
-    const urlPath = new URL(url).pathname;
-    const guessed = urlPath.split("/").pop() || "upload.bin";
+    let guessed = "upload.bin";
+    try {
+      guessed = new URL(url).pathname.split("/").pop() || "upload.bin";
+    } catch {
+      // Invalid URL — use default filename
+    }
     return {
       buffer: fetched.buffer,
       fileName: explicitFileName || guessed,
@@ -549,8 +553,12 @@ async function processImages(
 
     try {
       const buffer = await downloadImage(url, maxBytes);
-      const urlPath = new URL(url).pathname;
-      const fileName = urlPath.split("/").pop() || `image_${i}.png`;
+      let fileName = `image_${i}.png`;
+      try {
+        fileName = new URL(url).pathname.split("/").pop() || fileName;
+      } catch {
+        // Invalid URL — use default filename
+      }
       const fileToken = await uploadImageToDocx(client, blockId, buffer, fileName, docToken);
 
       await client.docx.documentBlock.patch({


### PR DESCRIPTION
## Summary

The Feishu docx tool uses `new URL(url)` to extract a filename from media/image URLs. When the agent provides a malformed or relative URL, `new URL()` throws a TypeError, crashing the docx operation instead of falling back to a default filename.

Two locations fixed:
1. Media upload filename resolution (`resolveDocxMediaInput`)
2. Image download filename resolution (image insertion loop)

Both now wrap `new URL()` in try-catch and fall back to default filenames (`upload.bin` and `image_N.png`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — no single issue.

## User-Visible Changes

Malformed media URLs in Feishu docx operations now fall back to default filenames instead of crashing.

## Security Impact

1. Does this change handle user input? **Yes** — agent-provided URLs
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] 321 Feishu extension tests pass
- [x] Formatted with `oxfmt`

## Evidence

\`\`\`
 Test Files  32 passed (32)
      Tests  321 passed (321)
\`\`\`

## Human Verification

- Pass a malformed URL to the Feishu docx upload tool — should use "upload.bin" as filename instead of crashing

## Compatibility

Fully backward compatible. Valid URLs behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Default filename may not match content type | The file is still uploaded correctly; only the display name differs |