### PR TITLE
fix(gateway): avoid stale-socket restart loops for idle channel accounts

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -489,14 +489,14 @@ describe("channel-health-monitor", () => {
       await expectNoRestart(manager);
     });
 
-    it("restarts a channel that never received any event past the stale threshold", async () => {
+    it("does not restart when no event timestamp has ever been reported", async () => {
       const now = Date.now();
       const manager = createSlackSnapshotManager(
         runningConnectedSlackAccount({
           lastStartAt: now - STALE_THRESHOLD - 60_000,
         }),
       );
-      await expectRestartedChannel(manager, "slack");
+      await expectNoRestart(manager);
     });
 
     it("respects custom staleEventThresholdMs", async () => {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -98,7 +98,7 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: false, reason: "disconnected" });
   });
 
-  it("flags stale sockets when no events arrive beyond threshold", () => {
+  it("does not mark stale-socket when no lifecycle event timestamp is available", () => {
     const evaluation = evaluateChannelHealth(
       {
         running: true,
@@ -114,7 +114,47 @@ describe("evaluateChannelHealth", () => {
         staleEventThresholdMs: 30_000,
       },
     );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
+  it("flags stale sockets only after lifecycle-local events go stale", () => {
+    const now = 200_000;
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: now - 120_000,
+        lastEventAt: now - 80_000,
+      },
+      {
+        now,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
     expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
+  });
+
+  it("ignores stale lastEventAt inherited from a previous lifecycle", () => {
+    const now = 200_000;
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: now - 120_000,
+        lastEventAt: now - 180_000,
+      },
+      {
+        now,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
   });
 });
 

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -59,6 +59,10 @@ export function evaluateChannelHealth(
     typeof snapshot.lastStartAt === "number" && Number.isFinite(snapshot.lastStartAt)
       ? snapshot.lastStartAt
       : null;
+  const lastEventAt =
+    typeof snapshot.lastEventAt === "number" && Number.isFinite(snapshot.lastEventAt)
+      ? snapshot.lastEventAt
+      : null;
   const lastRunActivityAt =
     typeof snapshot.lastRunActivityAt === "number" && Number.isFinite(snapshot.lastRunActivityAt)
       ? snapshot.lastRunActivityAt
@@ -92,12 +96,15 @@ export function evaluateChannelHealth(
   if (snapshot.connected === false) {
     return { healthy: false, reason: "disconnected" };
   }
-  if (snapshot.lastEventAt != null || snapshot.lastStartAt != null) {
-    const upSince = snapshot.lastStartAt ?? 0;
+  const eventStateInitializedForLifecycle =
+    lastEventAt != null && (lastStartAt == null || lastEventAt >= lastStartAt);
+  // Avoid false stale-socket loops when channels do not publish event timestamps
+  // (or when a restart inherits an old lastEventAt from a prior lifecycle).
+  if (eventStateInitializedForLifecycle || lastStartAt == null) {
+    const upSince = lastStartAt ?? 0;
     const upDuration = policy.now - upSince;
     if (upDuration > policy.staleEventThresholdMs) {
-      const lastEvent = snapshot.lastEventAt ?? 0;
-      const eventAge = policy.now - lastEvent;
+      const eventAge = lastEventAt == null ? 0 : policy.now - lastEventAt;
       if (eventAge > policy.staleEventThresholdMs) {
         return { healthy: false, reason: "stale-socket" };
       }


### PR DESCRIPTION
## Summary
- require lifecycle-local `lastEventAt` telemetry before treating a channel as stale-socket
- avoid stale-socket restarts when a channel has not emitted any event timestamp yet
- add coverage for lifecycle-local stale detection and inherited timestamp handling

## Testing
- pnpm test src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts

Fixes #34052
