### PR TITLE
fix(discord): add autoThread field to DiscordGuildChannelConfig type

### DIFF
--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -52,6 +52,8 @@ export type DiscordGuildChannelConfig = {
   systemPrompt?: string;
   /** If false, omit thread starter context for this channel (default: true). */
   includeThreadStarter?: boolean;
+  /** If true, automatically create a thread for new messages in this channel. */
+  autoThread?: boolean;
 };
 
 export type DiscordReactionNotificationMode = "off" | "own" | "all" | "allowlist";


### PR DESCRIPTION
## Summary
- Problem: DiscordGuildChannelConfig type is missing autoThread field
- Solution: Added autoThread?: boolean to type definition
- Tests: pnpm test src/config/schema.test.ts passed (10/10)

## Change Type
- [x] Bug fix

## Scope
- [x] Types

## Linked Issue
- Closes #35607

## AI/Vibe-Coded Disclosure
- AI-assisted: Yes
- Testing degree: Local tests passed