### PR TITLE
fix(canvas,matrix): guard decodeURIComponent against malformed percent-encoding

### DIFF
--- a/extensions/matrix/src/matrix/monitor/location.test.ts
+++ b/extensions/matrix/src/matrix/monitor/location.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { resolveMatrixLocation } from "./location.js";
+
+describe("resolveMatrixLocation", () => {
+  const eventType = "m.room.message";
+
+  function makeContent(geoUri: string) {
+    return {
+      msgtype: "m.location",
+      body: "My location",
+      geo_uri: geoUri,
+    } as any;
+  }
+
+  it("parses a standard geo URI", () => {
+    const result = resolveMatrixLocation({
+      eventType,
+      content: makeContent("geo:37.786971,-122.399677"),
+    });
+    expect(result).not.toBeNull();
+    expect(result!.text).toContain("37.786971");
+  });
+
+  it("parses a geo URI with accuracy parameter", () => {
+    const result = resolveMatrixLocation({
+      eventType,
+      content: makeContent("geo:37.786971,-122.399677;u=65"),
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it("does not throw on malformed percent-encoded parameter values", () => {
+    const result = resolveMatrixLocation({
+      eventType,
+      content: makeContent("geo:37.786971,-122.399677;desc=%ZZinvalid"),
+    });
+    expect(result).not.toBeNull();
+  });
+
+  it("returns null for empty geo URI", () => {
+    const result = resolveMatrixLocation({
+      eventType,
+      content: makeContent(""),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null for invalid coordinates", () => {
+    const result = resolveMatrixLocation({
+      eventType,
+      content: makeContent("geo:abc,def"),
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/location.ts
+++ b/extensions/matrix/src/matrix/monitor/location.ts
@@ -17,6 +17,14 @@ type GeoUriParams = {
   accuracy?: number;
 };
 
+function safeDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 function parseGeoUri(value: string): GeoUriParams | null {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -51,7 +59,7 @@ function parseGeoUri(value: string): GeoUriParams | null {
       continue;
     }
     const valuePart = rawValue.trim();
-    params.set(key, valuePart ? decodeURIComponent(valuePart) : "");
+    params.set(key, valuePart ? safeDecodeURIComponent(valuePart) : "");
   }
 
   const accuracyRaw = params.get("u");

--- a/src/canvas-host/file-resolver.test.ts
+++ b/src/canvas-host/file-resolver.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { normalizeUrlPath } from "./file-resolver.js";
+
+describe("normalizeUrlPath", () => {
+  it("normalizes a simple path", () => {
+    expect(normalizeUrlPath("/foo/bar")).toBe("/foo/bar");
+  });
+
+  it("returns / for empty string", () => {
+    expect(normalizeUrlPath("")).toBe("/");
+  });
+
+  it("decodes percent-encoded characters", () => {
+    expect(normalizeUrlPath("/hello%20world")).toBe("/hello world");
+  });
+
+  it("does not throw on malformed percent-encoding", () => {
+    const result = normalizeUrlPath("/%ZZbad");
+    expect(result).toBe("/%ZZbad");
+  });
+
+  it("does not throw on trailing percent sign", () => {
+    const result = normalizeUrlPath("/path%");
+    expect(result).toBe("/path%");
+  });
+
+  it("normalizes double slashes", () => {
+    expect(normalizeUrlPath("//foo//bar")).toBe("/foo/bar");
+  });
+});

--- a/src/canvas-host/file-resolver.ts
+++ b/src/canvas-host/file-resolver.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 import { SafeOpenError, openFileWithinRoot, type SafeOpenResult } from "../infra/fs-safe.js";
 
 export function normalizeUrlPath(rawPath: string): string {
-  const decoded = decodeURIComponent(rawPath || "/");
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(rawPath || "/");
+  } catch {
+    decoded = rawPath || "/";
+  }
   const normalized = path.posix.normalize(decoded);
   return normalized.startsWith("/") ? normalized : `/${normalized}`;
 }


### PR DESCRIPTION
## Summary

`decodeURIComponent` throws `URIError` on malformed percent-encoded sequences (e.g. `%ZZ`, trailing `%`). Two locations in the codebase call `decodeURIComponent` on external input without try-catch:

1. **`src/canvas-host/file-resolver.ts`** — `normalizeUrlPath` decodes the raw HTTP request URL path. A crafted request like `GET /%ZZbad` crashes the request handler with an unhandled `URIError`.
2. **`extensions/matrix/src/matrix/monitor/location.ts`** — The geo URI parameter parser decodes parameter values from `geo:lat,lng;key=%ZZvalue`. A Matrix user sending a location message with malformed parameters crashes the monitor.

Both now fall back to the raw (un-decoded) string on decode failure, matching the defensive pattern used elsewhere in the codebase (e.g. `src/discord/monitor/native-command.ts`, `src/slack/monitor/slash.ts`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [x] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — no single issue.

## User-Visible Changes

Malformed percent-encoded URL paths and geo URI parameters no longer crash the canvas host or Matrix monitor.

## Security Impact

1. Does this change handle user input? **Yes** — HTTP request URL paths and Matrix geo URI parameters
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] 11 new unit tests pass (6 for `normalizeUrlPath`, 5 for Matrix location)
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ src/canvas-host/file-resolver.test.ts (6 tests) 2ms
 ✓ extensions/matrix/src/matrix/monitor/location.test.ts (5 tests) 2ms

 Test Files  2 passed (2)
      Tests  11 passed (11)
```

## Human Verification

- Send `GET /%ZZbad` to the canvas host — should return a 404 or index.html instead of crashing
- Send a Matrix location message with `geo:37.7,-122.4;u=%ZZ` — should parse coordinates and skip the malformed parameter

## Compatibility

Fully backward compatible. Valid percent-encoded strings decode identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Raw (un-decoded) string may contain percent sequences in file paths | File lookup will fail gracefully with 404 — no security or crash risk |
| Matrix parameter value kept encoded | Only affects non-standard geo URI parameters; coordinates are unaffected |