### PR TITLE
fix(gateway): unref tick-watch interval so CLI commands can exit

### DIFF
--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -469,6 +469,7 @@ export class GatewayClient {
         this.ws?.close(4000, "tick timeout");
       }
     }, interval);
+    this.tickTimer?.unref?.();
   }
 
   private validateTlsFingerprint(): Error | null {


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw status` (and potentially other CLI commands) outputs all content correctly but never exits, hanging indefinitely until killed.
- **Why it matters:** Users must manually Ctrl+C or use `timeout` wrapper, disrupting workflows and automation scripts.
- **What changed:** Added `.unref()` to the tick-watch `setInterval` timer in `GatewayClient.startTickWatch()`. This tells Node.js not to keep the event loop alive solely for this timer.
- **What did NOT change:** The timer still fires and monitors connection health while the client is active. `stop()` still clears it. The only difference is that when the timer is the last remaining handle, Node.js can exit naturally.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35609

## User-visible / Behavior Changes

- `openclaw status` (and other CLI commands using `GatewayClient`) now exit cleanly after completing their output instead of hanging indefinitely.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.3 (arm64)
- Runtime: Node.js 22.22.0
- Install: npm global

### Steps

1. Run `openclaw status`
2. Wait for output to complete

### Expected

- Command outputs status and exits with code 0

### Actual

- Before fix: Command hangs indefinitely after output
- After fix: Command exits cleanly

## Evidence

Gateway client tests pass (15/15):
```
✓ src/gateway/client.test.ts (13 tests) 13ms
✓ src/gateway/client.watchdog.test.ts (2 tests) 300ms
Test Files  2 passed (2)
     Tests  15 passed (15)
```

## Human Verification (required)

- Verified scenarios: `startTickWatch` creates interval with `.unref()`; `stop()` still clears the interval; interval still fires while client is active
- Edge cases checked: `scheduleReconnect` timeout already uses `.unref()` (confirmed no change needed); `call.ts` timeout is short-lived and cleared on completion
- What I did **not** verify: Live `openclaw status` execution with gateway running

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; status command will hang again
- Files/config to restore: `src/gateway/client.ts`
- Known bad symptoms: None expected from `.unref()` — it only affects process exit behavior

## Risks and Mitigations

- Risk: In theory, `.unref()` could allow Node.js to exit while the tick timer is still needed (e.g. during a long-lived gateway session). Mitigation: Long-lived processes (gateway server, TUI) have many other active handles (WebSocket server, HTTP server, stdin listeners) that keep the event loop alive. The tick timer is never the sole reason a long-lived process stays running.

