### PR TITLE
fix(zalo,voice-call): add response.ok check and host header fallback

### DIFF
--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -322,7 +322,7 @@ export class VoiceCallWebhookServer {
     req: http.IncomingMessage,
     webhookPath: string,
   ): Promise<WebhookResponsePayload> {
-    const url = new URL(req.url || "/", `http://${req.headers.host}`);
+    const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
 
     if (url.pathname === "/voice/hold-music") {
       return {
@@ -360,7 +360,7 @@ export class VoiceCallWebhookServer {
     const ctx: WebhookContext = {
       headers: req.headers as Record<string, string | string[] | undefined>,
       rawBody: body,
-      url: `http://${req.headers.host}${req.url}`,
+      url: `http://${req.headers.host || "localhost"}${req.url}`,
       method: "POST",
       query: Object.fromEntries(url.searchParams),
       remoteAddress: req.socket.remoteAddress ?? undefined,

--- a/extensions/zalo/src/api.test.ts
+++ b/extensions/zalo/src/api.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { callZaloApi, ZaloApiError } from "./api.js";
+
+describe("callZaloApi", () => {
+  it("returns parsed data on success", async () => {
+    const mockFetch = async () =>
+      new Response(JSON.stringify({ ok: true, result: { id: "123" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    const data = await callZaloApi("getMe", "test-token", undefined, { fetch: mockFetch });
+    expect(data.ok).toBe(true);
+    expect(data.result).toEqual({ id: "123" });
+  });
+
+  it("throws ZaloApiError when response.ok is false (HTTP error)", async () => {
+    const mockFetch = async () =>
+      new Response("<html>Bad Gateway</html>", {
+        status: 502,
+        statusText: "Bad Gateway",
+      });
+
+    await expect(
+      callZaloApi("getMe", "test-token", undefined, { fetch: mockFetch }),
+    ).rejects.toThrow(ZaloApiError);
+  });
+
+  it("throws ZaloApiError when API returns ok: false", async () => {
+    const mockFetch = async () =>
+      new Response(JSON.stringify({ ok: false, error_code: 401, description: "Unauthorized" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+
+    await expect(
+      callZaloApi("getMe", "test-token", undefined, { fetch: mockFetch }),
+    ).rejects.toThrow(ZaloApiError);
+  });
+});

--- a/extensions/zalo/src/api.ts
+++ b/extensions/zalo/src/api.ts
@@ -110,6 +110,14 @@ export async function callZaloApi<T = unknown>(
       signal: controller.signal,
     });
 
+    if (!response.ok) {
+      throw new ZaloApiError(
+        `Zalo API HTTP error: ${method} returned ${response.status}`,
+        response.status,
+        `HTTP ${response.status} ${response.statusText}`,
+      );
+    }
+
     const data = (await response.json()) as ZaloApiResponse<T>;
 
     if (!data.ok) {


### PR DESCRIPTION
## Summary

Two defensive fixes for external input handling in channel extensions:

1. **Zalo API (`extensions/zalo/src/api.ts`)**: `callZaloApi` calls `response.json()` without checking `response.ok`. When Zalo returns an HTTP 502/503 with an HTML error page, `response.json()` throws a `SyntaxError` instead of a descriptive `ZaloApiError`. Added `!response.ok` check before JSON parsing, matching the pattern used in the Feishu extension.

2. **Voice-call webhook (`extensions/voice-call/src/webhook.ts`)**: `req.headers.host` is used without fallback in `runWebhookPipeline` and the webhook context URL builder. HTTP/1.0 requests or misconfigured proxies may omit the Host header, producing `http://undefined` as the base URL. Added `|| "localhost"` fallback, matching the defensive pattern already used in `getUpgradePathname` and other handlers.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — no single issue.

## User-Visible Changes

- Zalo API errors from HTTP failures now produce clear `ZaloApiError` messages instead of cryptic `SyntaxError: Unexpected token '<'`
- Voice-call webhooks remain functional when Host header is missing

## Security Impact

1. Does this change handle user input? **Yes** — HTTP responses from Zalo API, HTTP request headers from telephony providers
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] 139 tests pass across 25 test files (Zalo + voice-call)
- [x] 3 new unit tests for `callZaloApi` (success, HTTP error, API error)
- [x] Formatted with `oxfmt`

## Evidence

```
 Test Files  25 passed (25)
      Tests  139 passed (139)
```

## Human Verification

- Configure Zalo bot with an invalid API endpoint that returns HTML — should get `ZaloApiError: Zalo API HTTP error` instead of `SyntaxError`
- Send a webhook request without Host header to voice-call endpoint — should process normally

## Compatibility

Fully backward compatible. Valid API responses and requests with Host headers behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Zalo API returning non-200 with valid JSON body | Unlikely for Zalo; standard HTTP APIs return JSON only on 2xx. If needed, the catch can be extended to try JSON parsing on error responses |
| Host header fallback masking routing issues | "localhost" fallback only affects URL construction for webhook signature verification; the actual request routing is handled by the HTTP server |