### PR TITLE
fix(llm-task): add type field to input and schema parameter definitions

### DIFF
--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -74,9 +74,23 @@ export function createLlmTaskTool(api: OpenClawPluginApi) {
       "Run a generic JSON-only LLM task and return schema-validated JSON. Designed for orchestration from Lobster workflows via openclaw.invoke.",
     parameters: Type.Object({
       prompt: Type.String({ description: "Task instruction for the LLM." }),
-      input: Type.Optional(Type.Unknown({ description: "Optional input payload for the task." })),
+      input: Type.Optional(
+        Type.Object(
+          {},
+          {
+            additionalProperties: true,
+            description: "Optional input payload for the task.",
+          },
+        ),
+      ),
       schema: Type.Optional(
-        Type.Unknown({ description: "Optional JSON Schema to validate the returned JSON." }),
+        Type.Object(
+          {},
+          {
+            additionalProperties: true,
+            description: "Optional JSON Schema to validate the returned JSON.",
+          },
+        ),
       ),
       provider: Type.Optional(
         Type.String({ description: "Provider override (e.g. openai-codex, anthropic)." }),


### PR DESCRIPTION
## Summary

The `llm-task` plugin tool's `input` and `schema` parameters used `Type.Unknown()` from TypeBox, which generates JSON Schema definitions containing only a `description` field without a `type` field. While technically valid JSON Schema (implies "any type"), llama.cpp's OpenAI-compatible endpoint rejects it with HTTP 400 during JSON schema-to-grammar conversion:

```
Unrecognized schema: {"description":"Optional input payload for the task."}
```

This breaks **all agents using local LLM backends** (llama.cpp / llama-server) when tools are enabled and `llm-task` is in the tool set.

Changed both parameters to `Type.Object({}, { additionalProperties: true })`, which produces `"type": "object"` in the generated schema while still accepting any JSON object payload.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [x] Agents / Model integration
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Closes #35443

## User-Visible Changes

`llm-task` tool now works with llama.cpp and other strict JSON Schema parsers that require a `type` field.

## Security Impact

1. Does this change handle user input? **No** — only changes parameter schema definition
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] 8 existing llm-task tests pass
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ extensions/llm-task/src/llm-task-tool.test.ts (8 tests) 23ms
 Test Files  1 passed (1)
      Tests  8 passed (8)
```

## Human Verification

- Configure a llama.cpp backend and enable `llm-task` tool — should no longer get 400 errors on tool schema parsing

## Compatibility

Backward compatible. Cloud API providers (OpenAI, Anthropic) accept schemas with or without `type`. The `additionalProperties: true` ensures any JSON object is still accepted as input.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| `input` parameter previously accepted non-object values (arrays, strings) | In practice, `input` is always serialized via JSON.stringify and passed as text; the tool-call parameter type only affects schema validation at the LLM level, not runtime behavior |