### PR TITLE
gateway: validate config before call when config is loaded from disk

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -68,6 +68,7 @@ When validation fails:
 
 - The Gateway does not boot
 - Only diagnostic commands work (`openclaw doctor`, `openclaw logs`, `openclaw health`, `openclaw status`)
+- Commands that contact the gateway (e.g. `cron add`, `message send`, `status --deep`) fail immediately with a clear Invalid config error (including the config file path) and a hint to run `openclaw doctor`; they do not proceed with a broken config
 - Run `openclaw doctor` to see exact issues
 - Run `openclaw doctor --fix` (or `--yes`) to apply repairs
 
@@ -75,7 +76,7 @@ When validation fails:
 
 <AccordionGroup>
   <Accordion title="Set up a channel (WhatsApp, Telegram, Discord, etc.)">
-    Each channel has its own config section under `channels.<provider>`. See the dedicated channel page for setup steps:
+    Each channel has its own config section under `channels.&lt;provider&gt;`. See the dedicated channel page for setup steps:
 
     - [WhatsApp](/channels/whatsapp) — `channels.whatsapp`
     - [Telegram](/channels/telegram) — `channels.telegram`

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -5,6 +5,7 @@ import {
   loadConfigMock as loadConfig,
   pickPrimaryLanIPv4Mock as pickPrimaryLanIPv4,
   pickPrimaryTailnetIPv4Mock as pickPrimaryTailnetIPv4,
+  readConfigFileSnapshotMock,
   resolveGatewayPortMock as resolveGatewayPort,
 } from "./gateway-connection.test-mocks.js";
 
@@ -65,8 +66,23 @@ vi.mock("./client.js", () => ({
 const { buildGatewayConnectionDetails, callGateway, callGatewayCli, callGatewayScoped } =
   await import("./call.js");
 
+const validConfigSnapshot = {
+  path: "/tmp/openclaw.json",
+  exists: true,
+  valid: true,
+  raw: "{}",
+  parsed: {},
+  resolved: {},
+  config: {},
+  issues: [],
+  warnings: [],
+  legacyIssues: [],
+};
+
 function resetGatewayCallMocks() {
   loadConfig.mockClear();
+  readConfigFileSnapshotMock.mockClear();
+  readConfigFileSnapshotMock.mockResolvedValue(validConfigSnapshot);
   resolveGatewayPort.mockClear();
   pickPrimaryTailnetIPv4.mockClear();
   pickPrimaryLanIPv4.mockClear();
@@ -319,6 +335,44 @@ describe("callGateway url resolution", () => {
 
     await callGatewayScoped({ method: "health", scopes: [] });
     expect(lastClientOptions?.scopes).toEqual([]);
+  });
+});
+
+describe("callGateway config validation", () => {
+  beforeEach(() => {
+    resetGatewayCallMocks();
+  });
+
+  it("throws when config is not passed and snapshot is invalid", async () => {
+    setLocalLoopbackGatewayConfig();
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...validConfigSnapshot,
+      exists: true,
+      valid: false,
+      path: "/home/user/.openclaw/openclaw.json",
+      issues: [{ path: "gateway.mode", message: "must be local or remote" }],
+    });
+    await expect(
+      callGatewayScoped({ method: "health", scopes: ["operator.read"] }),
+    ).rejects.toThrow(/Invalid config at/);
+    await expect(
+      callGatewayScoped({ method: "health", scopes: ["operator.read"] }),
+    ).rejects.toThrow(/openclaw doctor/);
+  });
+
+  it("proceeds when config is explicitly passed (skips snapshot check)", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...validConfigSnapshot,
+      exists: true,
+      valid: false,
+    });
+    setLocalLoopbackGatewayConfig();
+    await callGatewayScoped({
+      method: "health",
+      scopes: ["operator.read"],
+      config: { gateway: { mode: "local", bind: "loopback" } },
+    });
+    expect(lastClientOptions?.scopes).toEqual(["operator.read"]);
   });
 });
 

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -2,10 +2,12 @@ import { randomUUID } from "node:crypto";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   loadConfig,
+  readConfigFileSnapshot,
   resolveConfigPath,
   resolveGatewayPort,
   resolveStateDir,
 } from "../config/config.js";
+import { formatConfigIssueLines } from "../config/issue-format.js";
 import { hasConfiguredSecretInput, resolveSecretInputRef } from "../config/types.secrets.js";
 import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
@@ -682,6 +684,18 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
 ): Promise<T> {
   const { timeoutMs, safeTimerTimeoutMs } = resolveGatewayCallTimeout(opts.timeoutMs);
   const context = resolveGatewayCallContext(opts);
+  if (opts.config === undefined) {
+    const snapshot = await readConfigFileSnapshot();
+    if (snapshot.exists && !snapshot.valid) {
+      const issues =
+        snapshot.issues.length > 0
+          ? formatConfigIssueLines(snapshot.issues, "-", { normalizeRoot: true }).join("\n")
+          : "Unknown validation issue.";
+      throw new Error(
+        `Invalid config at ${snapshot.path}.\n${issues}\nRun 'openclaw doctor' to repair, then retry.`,
+      );
+    }
+  }
   const resolvedCredentials = await resolveGatewayCredentials(context);
   ensureExplicitGatewayAuth({
     urlOverride: context.urlOverride,

--- a/src/gateway/gateway-connection.test-mocks.ts
+++ b/src/gateway/gateway-connection.test-mocks.ts
@@ -3,6 +3,7 @@ import { vi } from "vitest";
 type TestMock = ReturnType<typeof vi.fn>;
 
 export const loadConfigMock: TestMock = vi.fn();
+export const readConfigFileSnapshotMock: TestMock = vi.fn();
 export const resolveGatewayPortMock: TestMock = vi.fn();
 export const pickPrimaryTailnetIPv4Mock: TestMock = vi.fn();
 export const pickPrimaryLanIPv4Mock: TestMock = vi.fn();
@@ -12,6 +13,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
   return {
     ...actual,
     loadConfig: loadConfigMock,
+    readConfigFileSnapshot: readConfigFileSnapshotMock,
     resolveGatewayPort: resolveGatewayPortMock,
   };
 });


### PR DESCRIPTION
## Summary

When CLI (or any caller) invokes the gateway without passing `config`, `resolveGatewayCallContext` uses `loadConfig()`. If the config file exists but is **invalid**, `loadConfig()` currently swallows validation errors and returns `{}`, so the process continues with an empty config and fails later with unclear errors (e.g. missing `gateway.remote.url`).

This change adds a guard in `callGatewayWithScopes`: when `opts.config === undefined`, we call `readConfigFileSnapshot()` and, if the file exists and is invalid, throw a clear error that includes the config path, formatted validation issues, and a hint to run `openclaw doctor`. Callers that pass `config` explicitly skip this check.

## Changes

- **src/gateway/call.ts**: After `resolveGatewayCallContext(opts)`, when `opts.config` is not passed, await `readConfigFileSnapshot()`; if `snapshot.exists && !snapshot.valid`, throw with `formatConfigIssueLines` and doctor hint.
- **src/gateway/gateway-connection.test-mocks.ts**: Mock `readConfigFileSnapshot` so tests can control snapshot validity.
- **src/gateway/call.test.ts**: New describe "callGateway config validation" with (1) test that rejects when config is not passed and snapshot is invalid, (2) test that proceeds when config is explicitly passed (no snapshot check).

## Testing

- `pnpm test src/gateway/call.test.ts --run` — 53 tests passed.
- `pnpm test src/tui/gateway-chat.test.ts --run` — 8 tests passed (same mocks).