### PR TITLE
fix(doctor,memory): guard apiKey.trim() against non-string SecretRef values

### DIFF
--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -26,7 +26,8 @@ export async function noteMemorySearchHealth(
   const agentId = resolveDefaultAgentId(cfg);
   const agentDir = resolveAgentDir(cfg, agentId);
   const resolved = resolveMemorySearchConfig(cfg, agentId);
-  const hasRemoteApiKey = Boolean(resolved?.remote?.apiKey?.trim());
+  const rawApiKey = resolved?.remote?.apiKey;
+  const hasRemoteApiKey = Boolean(typeof rawApiKey === "string" ? rawApiKey.trim() : rawApiKey);
 
   if (!resolved) {
     note("Memory search is explicitly disabled (enabled: false).", "Memory search");

--- a/src/memory/embeddings-ollama.ts
+++ b/src/memory/embeddings-ollama.ts
@@ -46,7 +46,8 @@ function resolveOllamaApiBase(configuredBaseUrl?: string): string {
 }
 
 function resolveOllamaApiKey(options: EmbeddingProviderOptions): string | undefined {
-  const remoteApiKey = options.remote?.apiKey?.trim();
+  const rawApiKey = options.remote?.apiKey;
+  const remoteApiKey = typeof rawApiKey === "string" ? rawApiKey.trim() : undefined;
   if (remoteApiKey) {
     return remoteApiKey;
   }


### PR DESCRIPTION
## Summary

`openclaw doctor` crashes with `TypeError: resolved?.remote?.apiKey?.trim is not a function` when the configuration uses SecretRef values (environment variable references like `$OPENAI_API_KEY` or vault-resolved secrets) for API keys. The config resolver returns a SecretRef object instead of a plain string, and calling `.trim()` on it throws.

Two locations fixed:
1. `src/commands/doctor-memory-search.ts` — `hasRemoteApiKey` check
2. `src/memory/embeddings-ollama.ts` — `resolveOllamaApiKey` function

Both now check `typeof rawApiKey === "string"` before calling `.trim()`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [ ] Channels / Plugins
- [x] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Closes #35444

## User-Visible Changes

`openclaw doctor` no longer crashes when API keys are configured via environment variable references or vault secrets.

## Security Impact

1. Does this change handle user input? **No** — configuration values only
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] 16 existing tests pass (14 doctor-memory-search + 2 embeddings-ollama)
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ src/memory/embeddings-ollama.test.ts (2 tests) 6ms
 ✓ src/commands/doctor-memory-search.test.ts (14 tests) 5ms
 Test Files  2 passed (2)
      Tests  16 passed (16)
```

## Human Verification

- Configure `openclaw.json` with `$OPENAI_API_KEY` env reference for memory search API key
- Run `openclaw doctor` — should complete without TypeError

## Compatibility

Fully backward compatible. String API keys behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| SecretRef objects treated as truthy when checking hasRemoteApiKey | This is correct behavior — a SecretRef indicates a key was configured, even if not yet resolved to a string |