### PR TITLE
fix(synology-chat,voice-call): wrap JSON.parse in try-catch for external input

### DIFF
--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -109,7 +109,12 @@ function parseFormBody(body: string): Record<string, unknown> {
 
 function parseJsonBody(body: string): Record<string, unknown> {
   if (!body.trim()) return {};
-  const parsed = JSON.parse(body);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new Error("Invalid JSON body");
+  }
   if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") {
     throw new Error("Invalid JSON body");
   }

--- a/extensions/voice-call/src/providers/shared/guarded-json-api.ts
+++ b/extensions/voice-call/src/providers/shared/guarded-json-api.ts
@@ -35,7 +35,12 @@ export async function guardedJsonApiRequest<T = unknown>(
     }
 
     const text = await response.text();
-    return text ? (JSON.parse(text) as T) : (undefined as T);
+    if (!text) return undefined as T;
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      throw new Error(`${params.errorPrefix}: invalid JSON response`);
+    }
   } finally {
     await release();
   }


### PR DESCRIPTION
## Summary

Two unguarded `JSON.parse` calls on external input:

1. **`extensions/synology-chat/src/webhook-handler.ts`** — `parseJsonBody` receives raw HTTP request bodies from Synology Chat webhooks. A malformed POST body (truncated, wrong content-type, proxy error page) causes an unhandled `SyntaxError` that crashes the webhook handler instead of returning a proper error.

2. **`extensions/voice-call/src/providers/shared/guarded-json-api.ts`** — After checking `response.ok`, the response body is passed directly to `JSON.parse`. A truncated response or encoding issue could still produce invalid JSON, causing `SyntaxError` instead of a descriptive error.

Both now wrap `JSON.parse` in try-catch and throw descriptive error messages.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — no single issue.

## User-Visible Changes

Malformed JSON in Synology Chat webhook requests and voice-call API responses now produce clear error messages instead of unhandled SyntaxErrors.

## Security Impact

1. Does this change handle user input? **Yes** — HTTP request bodies and API responses
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] 190 tests pass across synology-chat and voice-call extensions
- [x] Formatted with `oxfmt`

## Evidence

```
 Test Files  22 passed (23, 1 flaky pre-existing)
      Tests  190 passed (191)
```

## Human Verification

- Send a malformed JSON POST body to the Synology Chat webhook — should get "Invalid JSON body" error instead of SyntaxError
- Simulate a truncated API response from telephony provider — should get descriptive error

## Compatibility

Fully backward compatible. Valid JSON is parsed identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| New error message text differs from SyntaxError | The error is caught and re-thrown with a descriptive message; callers handle Error instances generically |