### PR TITLE
fix(heartbeat): prevent LLM from delivering HEARTBEAT_OK via message tool

### DIFF
--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -4,7 +4,7 @@ import { HEARTBEAT_TOKEN } from "./tokens.js";
 // Default heartbeat prompt (used when config.agents.defaults.heartbeat.prompt is unset).
 // Keep it tight and avoid encouraging the model to invent/rehash "open loops" from prior chat context.
 export const HEARTBEAT_PROMPT =
-  "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.";
+  "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK as plain text — do NOT use the message tool to send it.";
 export const DEFAULT_HEARTBEAT_EVERY = "30m";
 export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
 


### PR DESCRIPTION
## Problem

The heartbeat prompt tells the model to reply `HEARTBEAT_OK` when idle. But there's no instruction preventing the model from **sending `HEARTBEAT_OK` via the `message` tool** instead of replying as plain text. When this happens:

```
Expected (correct):
  Model → plain text "HEARTBEAT_OK" → OpenClaw strips it → no message sent ✓

What actually happens (bug):
  Model → message(action=send, message="HEARTBEAT_OK") → delivered to chat channel ✗
```

Users see a meaningless "HEARTBEAT_OK" message in their Telegram/Discord/Feishu chats. This is confusing and noisy.

## Fix

One-line change to the default heartbeat prompt — adds explicit instruction: `"reply HEARTBEAT_OK as plain text — do NOT use the message tool to send it."`

## Why merge

Without this fix, every heartbeat cycle has a chance of leaking internal protocol tokens (`HEARTBEAT_OK`) into user-facing channels. The fix is zero-risk (prompt text only, no code logic change) and eliminates the issue at its source.