### PR TITLE
fix(bluebubbles): preserve iMessage service info in chat_guid normalization

### DIFF
--- a/extensions/bluebubbles/src/actions.ts
+++ b/extensions/bluebubbles/src/actions.ts
@@ -352,8 +352,12 @@ export const bluebubblesMessageActions: ChannelMessageActionAdapter = {
         );
       }
 
-      // Decode base64 to buffer
-      const buffer = Uint8Array.from(atob(base64Buffer), (c) => c.charCodeAt(0));
+      let buffer: Uint8Array;
+      try {
+        buffer = Uint8Array.from(atob(base64Buffer), (c) => c.charCodeAt(0));
+      } catch {
+        throw new Error("BlueBubbles setGroupIcon: invalid base64 buffer");
+      }
 
       await setGroupIconBlueBubbles(resolvedChatGuid, buffer, filename, {
         ...opts,
@@ -416,8 +420,11 @@ export const bluebubblesMessageActions: ChannelMessageActionAdapter = {
 
       let buffer: Uint8Array;
       if (base64Buffer) {
-        // Decode base64 to buffer
-        buffer = Uint8Array.from(atob(base64Buffer), (c) => c.charCodeAt(0));
+        try {
+          buffer = Uint8Array.from(atob(base64Buffer), (c) => c.charCodeAt(0));
+        } catch {
+          throw new Error("BlueBubbles sendAttachment: invalid base64 buffer");
+        }
       } else if (filePath) {
         // Read file from path (will be handled by caller providing buffer)
         throw new Error(

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -276,9 +276,13 @@ export async function resolveChatGuidForTarget(params: {
         const guid = extractChatGuid(chat);
         const directHandle = guid ? extractHandleFromChatGuid(guid) : null;
         if (directHandle && directHandle === normalizedHandle) {
-          return guid;
-        }
-        if (!participantMatch && guid) {
+          if (guid.toLowerCase().startsWith("imessage;")) {
+            return guid;
+          }
+          if (!participantMatch) {
+            participantMatch = guid;
+          }
+        } else if (!participantMatch && guid) {
           // Only consider DM chats (`;-;` separator) as participant matches.
           // Group chats (`;+;` separator) should never match when searching by handle/phone.
           // This prevents routing "send to +1234567890" to a group chat that contains that number.

--- a/extensions/bluebubbles/src/targets.test.ts
+++ b/extensions/bluebubbles/src/targets.test.ts
@@ -22,17 +22,15 @@ describe("normalizeBlueBubblesMessagingTarget", () => {
     );
   });
 
-  it("extracts handle from DM chat_guid for cross-context matching", () => {
-    // DM format: service;-;handle
+  it("preserves service info in DM chat_guid for correct routing", () => {
     expect(normalizeBlueBubblesMessagingTarget("chat_guid:iMessage;-;+19257864429")).toBe(
-      "+19257864429",
+      "chat_guid:iMessage;-;+19257864429",
     );
     expect(normalizeBlueBubblesMessagingTarget("chat_guid:SMS;-;+15551234567")).toBe(
-      "+15551234567",
+      "chat_guid:SMS;-;+15551234567",
     );
-    // Email handles
     expect(normalizeBlueBubblesMessagingTarget("chat_guid:iMessage;-;user@example.com")).toBe(
-      "user@example.com",
+      "chat_guid:iMessage;-;user@example.com",
     );
   });
 
@@ -47,7 +45,9 @@ describe("normalizeBlueBubblesMessagingTarget", () => {
     expect(normalizeBlueBubblesMessagingTarget("iMessage;+;chat660250192681427962")).toBe(
       "chat_guid:iMessage;+;chat660250192681427962",
     );
-    expect(normalizeBlueBubblesMessagingTarget("iMessage;-;+19257864429")).toBe("+19257864429");
+    expect(normalizeBlueBubblesMessagingTarget("iMessage;-;+19257864429")).toBe(
+      "chat_guid:iMessage;-;+19257864429",
+    );
   });
 
   it("normalizes chat<digits> pattern to chat_identifier format", () => {

--- a/extensions/bluebubbles/src/targets.ts
+++ b/extensions/bluebubbles/src/targets.ts
@@ -162,13 +162,9 @@ export function normalizeBlueBubblesMessagingTarget(raw: string): string | undef
       return `chat_id:${parsed.chatId}`;
     }
     if (parsed.kind === "chat_guid") {
-      // For DM chat_guids, normalize to just the handle for easier comparison.
-      // This allows "chat_guid:iMessage;-;+1234567890" to match "+1234567890".
-      const handle = extractHandleFromChatGuid(parsed.chatGuid);
-      if (handle) {
-        return handle;
-      }
-      // For group chats or unrecognized formats, keep the full chat_guid
+      // Preserve the full chat_guid to retain service info (iMessage vs SMS).
+      // Stripping to just the handle loses service routing and causes SMS fallback
+      // when both iMessage and SMS chats exist for the same contact.
       return `chat_guid:${parsed.chatGuid}`;
     }
     if (parsed.kind === "chat_identifier") {


### PR DESCRIPTION
## Summary

When sending proactive messages to contacts with both iMessage and SMS chat histories, OpenClaw routes through SMS instead of iMessage because the target normalization strips service info.

**Root cause (3 issues fixed):**

1. **`targets.ts`**: `normalizeBlueBubblesMessagingTarget` strips `chat_guid:iMessage;-;+xxx` down to just `+xxx`, losing the service prefix that distinguishes iMessage from SMS.

2. **`send.ts`**: `resolveChatGuidForTarget` returns the first matching chat_guid without considering service type. When both `SMS;-;+xxx` and `iMessage;-;+xxx` exist, whichever appears first wins.

3. **`actions.ts`**: `atob()` is called on user-provided base64 buffer input without try-catch. Invalid base64 throws a cryptic `DOMException` instead of a descriptive error.

**Fixes:**
1. Preserve the full `chat_guid` format including service prefix during normalization
2. Prefer `iMessage` service when multiple DM chats match by handle
3. Wrap `atob()` in try-catch with descriptive error messages

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Closes #35624

## User-Visible Changes

- `chat_guid:iMessage;-;+xxx` targets now correctly route through iMessage instead of falling back to SMS
- Invalid base64 in setGroupIcon/sendAttachment returns a clear error message

## Security Impact

1. Does this change handle user input? **Yes** — chat targets and base64 buffers from agent tool calls
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 287 BlueBubbles tests pass (including 2 updated test expectations)
- [x] Formatted with `oxfmt`

## Evidence

```
 Test Files  14 passed (14)
      Tests  287 passed (287)
```

## Human Verification

- Send a message to `chat_guid:iMessage;-;+xxx` when both iMessage and SMS chats exist — should route via iMessage
- Pass invalid base64 to setGroupIcon action — should get "invalid base64 buffer" error

## Compatibility

The normalization change means `chat_guid:iMessage;-;+xxx` now normalizes to `chat_guid:iMessage;-;+xxx` instead of `+xxx`. This is more correct but may affect allowFrom matching if users have bare phone numbers in their allowFrom lists. The `isAllowedParsedChatSender` function handles both formats.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| allowFrom rules matching bare handles may not match full chat_guids | The existing allowFrom parsing already handles both `chat_guid:` prefixed and bare handle formats |
| iMessage preference may send via iMessage when SMS was intended | Users can explicitly use `SMS;-;+xxx` format to force SMS routing |