### PR TITLE
fix(ui,export-html,voice-call): guard base64 decode and type-check media payload

### DIFF
--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -151,8 +151,7 @@ export class MediaStreamHandler {
             break;
 
           case "media":
-            if (session && message.media?.payload) {
-              // Forward audio to STT
+            if (session && typeof message.media?.payload === "string") {
               const audioBuffer = Buffer.from(message.media.payload, "base64");
               session.sttSession.sendAudio(audioBuffer);
             }

--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -5,8 +5,19 @@
   // DATA LOADING
   // ============================================================
 
-  const base64 = document.getElementById("session-data").textContent;
-  const binary = atob(base64);
+  const sessionEl = document.getElementById("session-data");
+  const base64 = sessionEl ? sessionEl.textContent : null;
+  if (!base64) {
+    document.body.textContent = "Error: session data not found in page.";
+    return;
+  }
+  let binary;
+  try {
+    binary = atob(base64);
+  } catch {
+    document.body.textContent = "Error: corrupted session data (invalid base64).";
+    return;
+  }
   const bytes = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i++) {
     bytes[i] = binary.charCodeAt(i);

--- a/ui/src/ui/device-identity.ts
+++ b/ui/src/ui/device-identity.ts
@@ -27,7 +27,12 @@ function base64UrlEncode(bytes: Uint8Array): string {
 function base64UrlDecode(input: string): Uint8Array {
   const normalized = input.replaceAll("-", "+").replaceAll("_", "/");
   const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
-  const binary = atob(padded);
+  let binary: string;
+  try {
+    binary = atob(padded);
+  } catch {
+    throw new Error("Invalid base64url-encoded device identity data");
+  }
   const out = new Uint8Array(binary.length);
   for (let i = 0; i < binary.length; i += 1) {
     out[i] = binary.charCodeAt(i);


### PR DESCRIPTION
## Summary

Three defensive fixes for base64/binary data handling across different modules:

1. **`ui/src/ui/device-identity.ts`** — `base64UrlDecode` calls `atob()` on data loaded from localStorage. If localStorage is corrupted or manually edited, `atob()` throws a cryptic `DOMException: The string to be decoded is not correctly encoded`. Now wrapped in try-catch with a descriptive error message.

2. **`src/auto-reply/reply/export-html/template.js`** — The exported HTML page reads session data from a `<script>` element via `getElementById().textContent` and passes it to `atob()`. Two unguarded failure modes: (a) element not found → null passed to `atob()`, (b) corrupted base64 → `DOMException`. Now guards both cases and shows a user-visible error message.

3. **`extensions/voice-call/src/media-stream.ts`** — `Buffer.from(message.media.payload, "base64")` uses truthy check on `payload`. If `payload` is a non-string truthy value (e.g. numeric), `Buffer.from` throws `ERR_INVALID_ARG_TYPE`. Changed to explicit `typeof === "string"` check.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [x] Security

## Linked Issues

Proactive defensive fix — no single issue.

## User-Visible Changes

- Corrupted device identity in localStorage now shows a clear error instead of crashing
- Exported HTML sessions with corrupted data show a readable error message
- Voice-call media stream is more robust against malformed WebSocket payloads

## Security Impact

1. Does this change handle user input? **Yes** — localStorage data, exported HTML content, WebSocket payloads
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **Yes** — device identity parsing, but change is defensive only

## Verification

- [x] 9 related tests pass (3 export-html security + 6 media-stream)
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ src/auto-reply/reply/export-html/template.security.test.ts (3 tests) 62ms
 ✓ extensions/voice-call/src/media-stream.test.ts (6 tests) 143ms
 Test Files  2 passed (2)
      Tests  9 passed (9)
```

## Human Verification

- Corrupt device identity in localStorage → page should show error, not crash
- Open an exported HTML session file with garbled base64 → page should show clear error

## Compatibility

Fully backward compatible. Valid inputs behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| `return` in template.js IIFE stops page rendering | This only triggers for corrupted data that would have crashed anyway; the error message is more helpful than a blank page |