### PR TITLE
media: fail fast on oversized responses and log cleanup failures

### DIFF
--- a/src/media/read-response-with-limit.test.ts
+++ b/src/media/read-response-with-limit.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import * as logger from "../logger.js";
+import { readResponseWithLimit } from "./read-response-with-limit.js";
+
+describe("readResponseWithLimit", () => {
+  it("rejects from content-length header before opening the stream", async () => {
+    let getReaderCalls = 0;
+    const res = {
+      headers: {
+        get(name: string) {
+          return name.toLowerCase() === "content-length" ? "10" : null;
+        },
+      },
+      body: {
+        getReader() {
+          getReaderCalls += 1;
+          throw new Error("should not get here");
+        },
+      },
+    } as unknown as Response;
+
+    await expect(readResponseWithLimit(res, 4)).rejects.toThrow("10 bytes");
+    expect(getReaderCalls).toBe(0);
+  });
+
+  it("ignores invalid content-length values and reads the body", async () => {
+    const res = new Response(new Uint8Array([1, 2, 3]), {
+      headers: { "content-length": "not-a-number" },
+    });
+
+    const out = await readResponseWithLimit(res, 10);
+    expect([...out]).toEqual([1, 2, 3]);
+  });
+
+  it("logs cleanup failures instead of swallowing them silently", async () => {
+    const debugSpy = vi.spyOn(logger, "logDebug").mockImplementation(() => {});
+
+    const reader = {
+      read: vi.fn(async () => ({ done: false as const, value: new Uint8Array([1, 2, 3, 4, 5]) })),
+      cancel: vi.fn(async () => {
+        throw new Error("cancel boom");
+      }),
+      releaseLock: vi.fn(() => {
+        throw new Error("release boom");
+      }),
+    };
+
+    const res = {
+      headers: { get: () => null },
+      body: {
+        getReader: () => reader,
+      },
+    } as unknown as Response;
+
+    await expect(
+      readResponseWithLimit(res, 4, {
+        onOverflow: () => new Error("overflow"),
+      }),
+    ).rejects.toThrow("overflow");
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      expect.stringContaining("failed to cancel stream after overflow"),
+    );
+    expect(debugSpy).toHaveBeenCalledWith(expect.stringContaining("failed to release reader lock"));
+    debugSpy.mockRestore();
+  });
+});

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -1,3 +1,18 @@
+import { formatErrorMessage } from "../infra/errors.js";
+import { logDebug } from "../logger.js";
+
+function parseContentLengthHeader(res: Response): number | null {
+  const raw = res.headers.get("content-length")?.trim();
+  if (!raw) {
+    return null;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return null;
+  }
+  return parsed;
+}
+
 export async function readResponseWithLimit(
   res: Response,
   maxBytes: number,
@@ -9,6 +24,11 @@ export async function readResponseWithLimit(
     opts?.onOverflow ??
     ((params: { size: number; maxBytes: number }) =>
       new Error(`Content too large: ${params.size} bytes (limit: ${params.maxBytes} bytes)`));
+
+  const declaredSize = parseContentLengthHeader(res);
+  if (declaredSize !== null && declaredSize > maxBytes) {
+    throw onOverflow({ size: declaredSize, maxBytes, res });
+  }
 
   const body = res.body;
   if (!body || typeof body.getReader !== "function") {
@@ -33,7 +53,11 @@ export async function readResponseWithLimit(
         if (total > maxBytes) {
           try {
             await reader.cancel();
-          } catch {}
+          } catch (err) {
+            logDebug(
+              `media: readResponseWithLimit failed to cancel stream after overflow: ${formatErrorMessage(err)}`,
+            );
+          }
           throw onOverflow({ size: total, maxBytes, res });
         }
         chunks.push(value);
@@ -42,7 +66,11 @@ export async function readResponseWithLimit(
   } finally {
     try {
       reader.releaseLock();
-    } catch {}
+    } catch (err) {
+      logDebug(
+        `media: readResponseWithLimit failed to release reader lock: ${formatErrorMessage(err)}`,
+      );
+    }
   }
 
   return Buffer.concat(


### PR DESCRIPTION
## Summary
- fail fast in `readResponseWithLimit` when a valid `Content-Length` already exceeds `maxBytes`
- replace silent catches in stream cleanup with `logDebug` messages using redacted error formatting
- add focused unit tests for header short-circuiting, invalid header fallback, and cleanup-error observability

## Why
- avoids unnecessary stream reads/allocation for obviously oversized payloads
- improves diagnosability of rare reader cleanup failures that were previously swallowed

## Risk
- low: scoped to media response size enforcement path
- invalid/non-numeric `Content-Length` keeps previous behavior

## Testing
- `pnpm vitest run --config vitest.unit.config.ts src/media/read-response-with-limit.test.ts src/media/fetch.test.ts`
