### PR TITLE
Config: accept browser profile driver openclaw

### DIFF
--- a/src/config/config.browser-driver-schema.test.ts
+++ b/src/config/config.browser-driver-schema.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("browser profile driver schema", () => {
+  it("accepts driver=openclaw", () => {
+    const res = OpenClawSchema.safeParse({
+      browser: {
+        profiles: {
+          primary: {
+            cdpUrl: "ws://127.0.0.1:9222/devtools/browser/test",
+            driver: "openclaw",
+            color: "#123456",
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+  });
+
+  it("keeps legacy driver=clawd for backward compatibility", () => {
+    const res = OpenClawSchema.safeParse({
+      browser: {
+        profiles: {
+          legacy: {
+            cdpUrl: "ws://127.0.0.1:9222/devtools/browser/test",
+            driver: "clawd",
+            color: "#654321",
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+  });
+});

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -406,7 +406,7 @@ const ENUM_EXPECTATIONS: Record<string, string[]> = {
   "gateway.bind": ['"auto"', '"lan"', '"loopback"', '"custom"', '"tailnet"'],
   "gateway.auth.mode": ['"none"', '"token"', '"password"', '"trusted-proxy"'],
   "gateway.tailscale.mode": ['"off"', '"serve"', '"funnel"'],
-  "browser.profiles.*.driver": ['"clawd"', '"extension"'],
+  "browser.profiles.*.driver": ['"openclaw"', '"clawd"', '"extension"'],
   "discovery.mdns.mode": ['"off"', '"minimal"', '"full"'],
   "wizard.lastRunMode": ['"local"', '"remote"'],
   "diagnostics.otel.protocol": ['"http/protobuf"', '"grpc"'],

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -237,7 +237,7 @@ export const FIELD_HELP: Record<string, string> = {
   "browser.profiles.*.cdpUrl":
     "Per-profile CDP websocket URL used for explicit remote browser routing by profile name. Use this when profile connections terminate on remote hosts or tunnels.",
   "browser.profiles.*.driver":
-    'Per-profile browser driver mode: "clawd" or "extension" depending on connection/runtime strategy. Use the driver that matches your browser control stack to avoid protocol mismatches.',
+    'Per-profile browser driver mode: "openclaw" or "extension" depending on connection/runtime strategy. Use "openclaw" for the built-in driver; legacy "clawd" remains accepted for backward compatibility.',
   "browser.profiles.*.attachOnly":
     "Per-profile attach-only override that skips local browser launch and only attaches to an existing CDP endpoint. Useful when one profile is externally managed but others are locally launched.",
   "browser.profiles.*.color":

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -309,7 +309,9 @@ export const OpenClawSchema = z
               .object({
                 cdpPort: z.number().int().min(1).max(65535).optional(),
                 cdpUrl: z.string().optional(),
-                driver: z.union([z.literal("clawd"), z.literal("extension")]).optional(),
+                driver: z
+                  .union([z.literal("openclaw"), z.literal("clawd"), z.literal("extension")])
+                  .optional(),
                 attachOnly: z.boolean().optional(),
                 color: HexColorSchema,
               })


### PR DESCRIPTION
## Summary
- accept `browser.profiles.*.driver: "openclaw"` in config schema
- keep legacy `"clawd"` accepted for backward compatibility
- update config help + enum help quality expectations
- add a regression test for both `openclaw` and `clawd`

## Testing
- pnpm test src/config/config.browser-driver-schema.test.ts src/config/schema.help.quality.test.ts

Closes #35620
