### PR TITLE
Config: accept discovery.wideArea.domain in strict schema

### DIFF
--- a/src/config/config.discovery-widearea-domain.test.ts
+++ b/src/config/config.discovery-widearea-domain.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("discovery wideArea schema", () => {
+  it("accepts discovery.wideArea.domain", () => {
+    const res = OpenClawSchema.safeParse({
+      discovery: {
+        wideArea: {
+          enabled: true,
+          domain: "openclaw.internal",
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+  });
+});

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -270,6 +270,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Wide-area discovery configuration group for exposing discovery signals beyond local-link scopes. Enable only in deployments that intentionally aggregate gateway presence across sites.",
   "discovery.wideArea.enabled":
     "Enables wide-area discovery signaling when your environment needs non-local gateway discovery. Keep disabled unless cross-network discovery is operationally required.",
+  "discovery.wideArea.domain":
+    "Discovery DNS zone used for unicast DNS-SD (for example `openclaw.internal`). Set this when wide-area discovery is enabled so clients can resolve `_openclaw._tcp` records.",
   "discovery.mdns":
     "mDNS discovery configuration group for local network advertisement and discovery behavior tuning. Keep minimal mode for routine LAN discovery unless extra metadata is required.",
   tools:

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -602,6 +602,7 @@ export const FIELD_LABELS: Record<string, string> = {
   discovery: "Discovery",
   "discovery.wideArea": "Wide-area Discovery",
   "discovery.wideArea.enabled": "Wide-area Discovery Enabled",
+  "discovery.wideArea.domain": "Wide-area Discovery Domain",
   "discovery.mdns": "mDNS Discovery",
   canvasHost: "Canvas Host",
   "canvasHost.enabled": "Canvas Host Enabled",

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -537,6 +537,7 @@ export const OpenClawSchema = z
         wideArea: z
           .object({
             enabled: z.boolean().optional(),
+            domain: z.string().optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
## Summary
- add `discovery.wideArea.domain` to the strict root config schema
- add label/help entries for the new config key
- add a regression config parse test for `discovery.wideArea.domain`

## Testing
- pnpm test src/config/config.discovery-widearea-domain.test.ts src/config/schema.help.quality.test.ts

Closes #35614
