### PR TITLE
Config: add autoThread to DiscordGuildChannelConfig

### DIFF
--- a/src/config/config.discord-autothread-type.test.ts
+++ b/src/config/config.discord-autothread-type.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import type { DiscordGuildChannelConfig } from "./types.discord.js";
+
+describe("discord guild channel type", () => {
+  it("includes autoThread in DiscordGuildChannelConfig", () => {
+    const channel: DiscordGuildChannelConfig = {
+      requireMention: true,
+      autoThread: true,
+    };
+
+    expect(channel.autoThread).toBe(true);
+  });
+});

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -52,6 +52,8 @@ export type DiscordGuildChannelConfig = {
   systemPrompt?: string;
   /** If false, omit thread starter context for this channel (default: true). */
   includeThreadStarter?: boolean;
+  /** If true, start a thread automatically for qualifying replies in this channel. */
+  autoThread?: boolean;
 };
 
 export type DiscordReactionNotificationMode = "off" | "own" | "all" | "allowlist";


### PR DESCRIPTION
## Summary
- add missing `autoThread?: boolean` to `DiscordGuildChannelConfig`
- add a regression type-level test to ensure the canonical config type accepts `autoThread`

## Testing
- pnpm test src/config/config.discord-autothread-type.test.ts

Closes #35607
