### PR TITLE
Config: accept channels.discord.agentComponents

### DIFF
--- a/src/config/config.discord.test.ts
+++ b/src/config/config.discord.test.ts
@@ -30,6 +30,9 @@ describe("config discord", () => {
               stickerUploads: false,
               channels: true,
             },
+            agentComponents: {
+              enabled: false,
+            },
             guilds: {
               "123": {
                 slug: "friends-of-openclaw",
@@ -52,6 +55,7 @@ describe("config discord", () => {
         expect(cfg.channels?.discord?.actions?.emojiUploads).toBe(true);
         expect(cfg.channels?.discord?.actions?.stickerUploads).toBe(false);
         expect(cfg.channels?.discord?.actions?.channels).toBe(true);
+        expect(cfg.channels?.discord?.agentComponents?.enabled).toBe(false);
         expect(cfg.channels?.discord?.guilds?.["123"]?.slug).toBe("friends-of-openclaw");
         expect(cfg.channels?.discord?.guilds?.["123"]?.channels?.general?.allow).toBe(true);
       },

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -385,6 +385,13 @@ const DiscordUiSchema = z
   .strict()
   .optional();
 
+const DiscordAgentComponentsSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
 const DiscordVoiceAutoJoinSchema = z
   .object({
     guildId: z.string().min(1),
@@ -474,6 +481,7 @@ export const DiscordAccountSchema = z
       })
       .strict()
       .optional(),
+    agentComponents: DiscordAgentComponentsSchema,
     ui: DiscordUiSchema,
     slashCommand: z
       .object({


### PR DESCRIPTION
## Summary
- add missing `agentComponents` to strict `DiscordAccountSchema`
- wire it to a strict `DiscordAgentComponentsSchema`
- extend Discord config regression test to validate parsing `agentComponents.enabled`

## Testing
- pnpm test src/config/config.discord.test.ts

Closes #35564
