### PR TITLE
Config: accept channels.signal.accountUuid in strict schema

### DIFF
--- a/src/config/config.signal-accountuuid-schema.test.ts
+++ b/src/config/config.signal-accountuuid-schema.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./config.js";
+
+describe("signal accountUuid schema", () => {
+  it("accepts channels.signal.accountUuid", () => {
+    const res = validateConfigObject({
+      channels: {
+        signal: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          accountUuid: "00000000-0000-0000-0000-000000000001",
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -927,6 +927,7 @@ export const SignalAccountSchemaBase = z
     enabled: z.boolean().optional(),
     configWrites: z.boolean().optional(),
     account: z.string().optional(),
+    accountUuid: z.string().optional(),
     httpUrl: z.string().optional(),
     httpHost: z.string().optional(),
     httpPort: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary
- add missing `accountUuid` to strict `SignalAccountSchemaBase`
- add a regression config validation test for `channels.signal.accountUuid`

## Testing
- pnpm test src/config/config.signal-accountuuid-schema.test.ts

Closes #35577
Closes #35601
