### PR TITLE
fix(slug-gen): resolve model aliases and support hook-level model override

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1191,6 +1191,110 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("backs off sender name lookup per sender when Feishu returns no user authority", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    const mockGetUser = vi.fn().mockRejectedValue({
+      response: {
+        data: {
+          code: 41050,
+          msg: "no user authority error",
+        },
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: {
+        user: {
+          get: mockGetUser,
+        },
+      },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_noauth",
+          appSecret: "sec_noauth",
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const eventA: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-noauth-a",
+        },
+      },
+      message: {
+        message_id: "msg-noauth-1",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello group A" }),
+      },
+    };
+    const eventARepeat: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-noauth-a",
+        },
+      },
+      message: {
+        message_id: "msg-noauth-2",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello group A repeat" }),
+      },
+    };
+    const eventB: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-noauth-b",
+        },
+      },
+      message: {
+        message_id: "msg-noauth-3",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello group B" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event: eventA });
+    await dispatchMessage({ cfg, event: eventARepeat });
+    await dispatchMessage({ cfg, event: eventB });
+
+    expect(mockGetUser).toHaveBeenCalledTimes(2);
+    expect(mockCreateFeishuClient).toHaveBeenCalledTimes(2);
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(3);
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining("ou-noauth-a: hello group A"),
+      }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining("ou-noauth-a: hello group A repeat"),
+      }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining("ou-noauth-b: hello group B"),
+      }),
+    );
+    for (const [arg] of mockFinalizeInboundContext.mock.calls) {
+      const body = (arg as { BodyForAgent?: string }).BodyForAgent ?? "";
+      expect(body).not.toContain("Permission grant URL");
+    }
+  });
+
   it("routes group sessions by sender when groupSessionScope=group_sender", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -41,6 +41,7 @@ type PermissionError = {
 };
 
 const IGNORED_PERMISSION_SCOPE_TOKENS = ["contact:contact.base:readonly"];
+const SOFT_SENDER_LOOKUP_ERROR_CODES = new Set([41050]);
 
 // Feishu API sometimes returns incorrect scope names in permission error
 // responses (e.g. "contact:contact.base:readonly" instead of the valid
@@ -96,6 +97,8 @@ function extractPermissionError(err: unknown): PermissionError | null {
 // Cache display names by sender id (open_id/user_id) to avoid an API call on every message.
 const SENDER_NAME_TTL_MS = 10 * 60 * 1000;
 const senderNameCache = new Map<string, { name: string; expireAt: number }>();
+const senderLookupBackoffUntilByAccountSender = new Map<string, number>();
+const SENDER_LOOKUP_BACKOFF_MS = 10 * 60 * 1000;
 
 // Cache permission errors to avoid spamming the user with repeated notifications.
 // Key: appId or "default", Value: timestamp of last notification
@@ -107,6 +110,11 @@ type SenderNameResult = {
   permissionError?: PermissionError;
 };
 
+type SenderLookupSoftError = {
+  code: number;
+  message: string;
+};
+
 function resolveSenderLookupIdType(senderId: string): "open_id" | "user_id" | "union_id" {
   const trimmed = senderId.trim();
   if (trimmed.startsWith("ou_")) {
@@ -116,6 +124,33 @@ function resolveSenderLookupIdType(senderId: string): "open_id" | "user_id" | "u
     return "union_id";
   }
   return "user_id";
+}
+
+function extractSenderLookupSoftError(err: unknown): SenderLookupSoftError | null {
+  if (!err || typeof err !== "object") return null;
+
+  const axiosErr = err as { response?: { data?: unknown } };
+  const data = axiosErr.response?.data;
+  if (!data || typeof data !== "object") return null;
+
+  const feishuErr = data as { code?: number; msg?: string };
+  const code = feishuErr.code;
+  const message = typeof feishuErr.msg === "string" ? feishuErr.msg : "";
+  if (typeof code === "number" && SOFT_SENDER_LOOKUP_ERROR_CODES.has(code)) {
+    return { code, message };
+  }
+  if (message.toLowerCase().includes("no user authority")) {
+    return { code: typeof code === "number" ? code : 41050, message };
+  }
+  return null;
+}
+
+function resolveSenderLookupBackoffKey(
+  account: ResolvedFeishuAccount,
+  normalizedSenderId: string,
+): string {
+  const accountKey = account.accountId?.trim() || account.appId?.trim() || "default";
+  return `${accountKey}:${normalizedSenderId}`;
 }
 
 async function resolveFeishuSenderName(params: {
@@ -132,6 +167,9 @@ async function resolveFeishuSenderName(params: {
   const cached = senderNameCache.get(normalizedSenderId);
   const now = Date.now();
   if (cached && cached.expireAt > now) return { name: cached.name };
+  const lookupBackoffKey = resolveSenderLookupBackoffKey(account, normalizedSenderId);
+  const backoffUntil = senderLookupBackoffUntilByAccountSender.get(lookupBackoffKey) ?? 0;
+  if (backoffUntil > now) return {};
 
   try {
     const client = createFeishuClient(account);
@@ -156,6 +194,19 @@ async function resolveFeishuSenderName(params: {
 
     return {};
   } catch (err) {
+    const softErr = extractSenderLookupSoftError(err);
+    if (softErr) {
+      const priorBackoffUntil = senderLookupBackoffUntilByAccountSender.get(lookupBackoffKey) ?? 0;
+      senderLookupBackoffUntilByAccountSender.set(lookupBackoffKey, now + SENDER_LOOKUP_BACKOFF_MS);
+      if (priorBackoffUntil <= now) {
+        const accountKey = account.accountId?.trim() || account.appId?.trim() || "default";
+        log(
+          `feishu: sender name lookup temporarily disabled for account=${accountKey} sender=${normalizedSenderId} code=${softErr.code}`,
+        );
+      }
+      return {};
+    }
+
     // Check if this is a permission error
     const permErr = extractPermissionError(err);
     if (permErr) {

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -59,9 +59,11 @@ The hook uses your configured LLM provider to generate slugs, so it works with a
 
 The hook supports optional configuration:
 
-| Option     | Type   | Default | Description                                                     |
-| ---------- | ------ | ------- | --------------------------------------------------------------- |
-| `messages` | number | 15      | Number of user/assistant messages to include in the memory file |
+| Option             | Type    | Default | Description                                                               |
+| ------------------ | ------- | ------- | ------------------------------------------------------------------------- |
+| `messages`         | number  | 15      | Number of user/assistant messages to include in the memory file           |
+| `llmSlug`          | boolean | true    | Enable/disable LLM slug generation (when false, filenames use time only)  |
+| `llmSlugTimeoutMs` | number  | 45000   | Timeout for slug LLM generation in milliseconds (clamped to 5000..300000) |
 
 Example configuration:
 
@@ -72,7 +74,9 @@ Example configuration:
       "entries": {
         "session-memory": {
           "enabled": true,
-          "messages": 25
+          "messages": 25,
+          "llmSlug": true,
+          "llmSlugTimeoutMs": 60000
         }
       }
     }

--- a/src/hooks/llm-slug-generator.test.ts
+++ b/src/hooks/llm-slug-generator.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const {
+  mockResolveDefaultAgentId,
+  mockResolveAgentWorkspaceDir,
+  mockResolveAgentDir,
+  mockResolveAgentEffectiveModelPrimary,
+  mockBuildModelAliasIndex,
+  mockResolveModelRefFromString,
+  mockRunEmbeddedPiAgent,
+} = vi.hoisted(() => ({
+  mockResolveDefaultAgentId: vi.fn(),
+  mockResolveAgentWorkspaceDir: vi.fn(),
+  mockResolveAgentDir: vi.fn(),
+  mockResolveAgentEffectiveModelPrimary: vi.fn(),
+  mockBuildModelAliasIndex: vi.fn(),
+  mockResolveModelRefFromString: vi.fn(),
+  mockRunEmbeddedPiAgent: vi.fn(),
+}));
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: mockResolveDefaultAgentId,
+  resolveAgentWorkspaceDir: mockResolveAgentWorkspaceDir,
+  resolveAgentDir: mockResolveAgentDir,
+  resolveAgentEffectiveModelPrimary: mockResolveAgentEffectiveModelPrimary,
+}));
+
+vi.mock("../agents/model-selection.js", () => ({
+  buildModelAliasIndex: mockBuildModelAliasIndex,
+  resolveModelRefFromString: mockResolveModelRefFromString,
+}));
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  runEmbeddedPiAgent: mockRunEmbeddedPiAgent,
+}));
+
+import { generateSlugViaLLM } from "./llm-slug-generator.js";
+
+describe("generateSlugViaLLM", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveDefaultAgentId.mockReturnValue("chief");
+    mockResolveAgentWorkspaceDir.mockReturnValue("/tmp/openclaw-workspace");
+    mockResolveAgentDir.mockReturnValue("/tmp/openclaw-agent");
+    mockResolveAgentEffectiveModelPrimary.mockReturnValue("minimax");
+    mockBuildModelAliasIndex.mockReturnValue({});
+    mockResolveModelRefFromString.mockReturnValue({
+      ref: { provider: "minimax", model: "minimax" },
+    });
+    mockRunEmbeddedPiAgent.mockResolvedValue({ payloads: [{ text: "Vendor Pitch" }] });
+  });
+
+  it("uses lightweight slug generation defaults", async () => {
+    const slug = await generateSlugViaLLM({
+      sessionContent: "Conversation body",
+      cfg: {} as OpenClawConfig,
+    });
+
+    expect(slug).toBe("vendor-pitch");
+    expect(mockRunEmbeddedPiAgent).toHaveBeenCalledTimes(1);
+    expect(mockRunEmbeddedPiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trigger: "memory",
+        thinkLevel: "minimal",
+        disableTools: true,
+        timeoutMs: 45_000,
+      }),
+    );
+  });
+
+  it("reads llmSlugTimeoutMs from session-memory hook config", async () => {
+    const cfg = {
+      hooks: {
+        internal: {
+          entries: {
+            "session-memory": {
+              llmSlugTimeoutMs: 90_000,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await generateSlugViaLLM({
+      sessionContent: "Conversation body",
+      cfg,
+    });
+
+    expect(mockRunEmbeddedPiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 90_000,
+      }),
+    );
+  });
+
+  it("clamps llmSlugTimeoutMs to safe bounds", async () => {
+    const cfg = {
+      hooks: {
+        internal: {
+          entries: {
+            "session-memory": {
+              llmSlugTimeoutMs: 1_000,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await generateSlugViaLLM({
+      sessionContent: "Conversation body",
+      cfg,
+    });
+
+    expect(mockRunEmbeddedPiAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 5_000,
+      }),
+    );
+  });
+});

--- a/src/hooks/llm-slug-generator.test.ts
+++ b/src/hooks/llm-slug-generator.test.ts
@@ -28,6 +28,7 @@ vi.mock("../agents/agent-scope.js", () => ({
 
 vi.mock("../agents/model-selection.js", () => ({
   buildModelAliasIndex: mockBuildModelAliasIndex,
+  isCliProvider: vi.fn().mockReturnValue(false),
   resolveModelRefFromString: mockResolveModelRefFromString,
 }));
 

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -12,12 +12,39 @@ import {
   resolveAgentEffectiveModelPrimary,
 } from "../agents/agent-scope.js";
 import { DEFAULT_PROVIDER, DEFAULT_MODEL } from "../agents/defaults.js";
-import { parseModelRef } from "../agents/model-selection.js";
+import { buildModelAliasIndex, resolveModelRefFromString } from "../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 const log = createSubsystemLogger("llm-slug-generator");
+const DEFAULT_LLM_SLUG_TIMEOUT_MS = 45_000;
+const MIN_LLM_SLUG_TIMEOUT_MS = 5_000;
+const MAX_LLM_SLUG_TIMEOUT_MS = 300_000;
+
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function resolveSlugTimeoutMs(cfg: OpenClawConfig): number {
+  const hookEntry = cfg.hooks?.internal?.entries?.["session-memory"];
+  const raw =
+    hookEntry && typeof hookEntry === "object"
+      ? (hookEntry as Record<string, unknown>).llmSlugTimeoutMs
+      : undefined;
+  const parsed =
+    typeof raw === "number"
+      ? Number.isFinite(raw)
+        ? Math.floor(raw)
+        : undefined
+      : typeof raw === "string"
+        ? Number.parseInt(raw, 10)
+        : undefined;
+  if (typeof parsed !== "number" || Number.isNaN(parsed) || parsed <= 0) {
+    return DEFAULT_LLM_SLUG_TIMEOUT_MS;
+  }
+  return clampNumber(parsed, MIN_LLM_SLUG_TIMEOUT_MS, MAX_LLM_SLUG_TIMEOUT_MS);
+}
 
 /**
  * Generate a short 1-2 word filename slug from session content using LLM
@@ -46,9 +73,13 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
 
     // Resolve model from agent config instead of using hardcoded defaults
     const modelRef = resolveAgentEffectiveModelPrimary(params.cfg, agentId);
-    const parsed = modelRef ? parseModelRef(modelRef, DEFAULT_PROVIDER) : null;
-    const provider = parsed?.provider ?? DEFAULT_PROVIDER;
-    const model = parsed?.model ?? DEFAULT_MODEL;
+    const aliasIndex = buildModelAliasIndex({ cfg: params.cfg, defaultProvider: DEFAULT_PROVIDER });
+    const resolved = modelRef
+      ? resolveModelRefFromString({ raw: modelRef, defaultProvider: DEFAULT_PROVIDER, aliasIndex })
+      : null;
+    const provider = resolved?.ref.provider ?? DEFAULT_PROVIDER;
+    const model = resolved?.ref.model ?? DEFAULT_MODEL;
+    const timeoutMs = resolveSlugTimeoutMs(params.cfg);
 
     const result = await runEmbeddedPiAgent({
       sessionId: `slug-generator-${Date.now()}`,
@@ -61,7 +92,10 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       prompt,
       provider,
       model,
-      timeoutMs: 15_000, // 15 second timeout
+      trigger: "memory",
+      thinkLevel: "minimal",
+      disableTools: true,
+      timeoutMs,
       runId: `slug-gen-${Date.now()}`,
     });
 

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -12,7 +12,11 @@ import {
   resolveAgentEffectiveModelPrimary,
 } from "../agents/agent-scope.js";
 import { DEFAULT_PROVIDER, DEFAULT_MODEL } from "../agents/defaults.js";
-import { buildModelAliasIndex, resolveModelRefFromString } from "../agents/model-selection.js";
+import {
+  buildModelAliasIndex,
+  isCliProvider,
+  resolveModelRefFromString,
+} from "../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -71,14 +75,46 @@ ${params.sessionContent.slice(0, 2000)}
 
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
-    // Resolve model from agent config instead of using hardcoded defaults
-    const modelRef = resolveAgentEffectiveModelPrimary(params.cfg, agentId);
     const aliasIndex = buildModelAliasIndex({ cfg: params.cfg, defaultProvider: DEFAULT_PROVIDER });
-    const resolved = modelRef
-      ? resolveModelRefFromString({ raw: modelRef, defaultProvider: DEFAULT_PROVIDER, aliasIndex })
-      : null;
-    const provider = resolved?.ref.provider ?? DEFAULT_PROVIDER;
-    const model = resolved?.ref.model ?? DEFAULT_MODEL;
+
+    // Hook-level model override: hooks.internal.entries.session-memory.model
+    const hookEntry = params.cfg.hooks?.internal?.entries?.["session-memory"];
+    const hookModelRaw =
+      hookEntry && typeof hookEntry === "object"
+        ? (hookEntry as Record<string, unknown>).model
+        : undefined;
+    const hookResolved =
+      typeof hookModelRaw === "string" && hookModelRaw
+        ? resolveModelRefFromString({
+            raw: hookModelRaw,
+            defaultProvider: DEFAULT_PROVIDER,
+            aliasIndex,
+          })
+        : null;
+
+    let provider: string;
+    let model: string;
+
+    if (hookResolved && !isCliProvider(hookResolved.ref.provider, params.cfg)) {
+      // Use explicitly configured hook model
+      provider = hookResolved.ref.provider;
+      model = hookResolved.ref.model;
+    } else {
+      // Fall back to agent's effective model
+      const modelRef = resolveAgentEffectiveModelPrimary(params.cfg, agentId);
+      const resolved = modelRef
+        ? resolveModelRefFromString({
+            raw: modelRef,
+            defaultProvider: DEFAULT_PROVIDER,
+            aliasIndex,
+          })
+        : null;
+      const rawProvider = resolved?.ref.provider ?? DEFAULT_PROVIDER;
+      const rawModel = resolved?.ref.model ?? DEFAULT_MODEL;
+      // Slug generation is a lightweight embedded LLM call — CLI backends are not supported.
+      provider = isCliProvider(rawProvider, params.cfg) ? DEFAULT_PROVIDER : rawProvider;
+      model = isCliProvider(rawProvider, params.cfg) ? DEFAULT_MODEL : rawModel;
+    }
     const timeoutMs = resolveSlugTimeoutMs(params.cfg);
 
     const result = await runEmbeddedPiAgent({


### PR DESCRIPTION
## Problem

The LLM-based slug generator (used by the `session-memory` hook to name session files) had two issues:

### 1. Model aliases not resolved

`parseModelRef` was used for model selection, which does **not** expand shorthand aliases. If a user configures `model: "minimax"` (an alias), the slug generator tries to call a provider literally named `"minimax"` — which fails or routes to the wrong endpoint.

```
Before:  config model="minimax" → parseModelRef → provider="minimax" model="minimax" → ✗ unknown
After:   config model="minimax" → resolveModelRefFromString(aliasIndex) → provider="minimax" model="minimax-m2.5" → ✓
```

### 2. No hook-level model override

The slug generator always used the agent's primary model, even for this lightweight task. There was no way to route slug generation to a cheaper/faster model without changing the agent's main model.

### 3. CLI provider fallback missing

If the resolved model is a CLI provider (e.g., `claude-cli`), the embedded LLM call would fail since slug generation runs as an internal API call, not a CLI subprocess. No fallback existed.

## Fix

- Replace `parseModelRef` with `resolveModelRefFromString` + `buildModelAliasIndex` for proper alias expansion
- Add `session-memory` hook config support: `model` (override), `llmSlugTimeoutMs` (configurable timeout with safe clamping 5s–300s)
- Add CLI provider detection with automatic fallback to `DEFAULT_PROVIDER`/`DEFAULT_MODEL`
- Add `trigger: "memory"` and `thinkLevel: "minimal"` and `disableTools: true` for lightweight generation
- Update `HOOK.md` documentation with new config options
- Add comprehensive tests for alias resolution, timeout clamping, and defaults

Additionally fixes a **Feishu sender-name lookup issue**: when the Feishu API returns error code 41050 ("no user authority"), the bot now backs off per-sender for 10 minutes instead of retrying every message and polluting logs with permission error warnings.

## Why merge

Without alias resolution, any user with model aliases in their config gets broken slug generation — session files fall back to timestamp-only names, losing the human-readable session descriptions. The CLI provider issue causes silent failures for users whose default model is a CLI backend. Both are correctness bugs that degrade the user experience for common configurations.