### PR TITLE
Config: accept telegram actions editMessage/createForumTopic

### DIFF
--- a/src/config/config.telegram-actions-schema.test.ts
+++ b/src/config/config.telegram-actions-schema.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./config.js";
+
+describe("telegram actions schema", () => {
+  it("accepts editMessage and createForumTopic action toggles", () => {
+    const res = validateConfigObject({
+      channels: {
+        telegram: {
+          actions: {
+            editMessage: true,
+            createForumTopic: true,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -226,7 +226,9 @@ export const TelegramAccountSchemaBase = z
         reactions: z.boolean().optional(),
         sendMessage: z.boolean().optional(),
         deleteMessage: z.boolean().optional(),
+        editMessage: z.boolean().optional(),
         sticker: z.boolean().optional(),
+        createForumTopic: z.boolean().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary
- add missing `editMessage` and `createForumTopic` to strict `channels.telegram.actions` schema
- add a regression config validation test for both fields

## Testing
- pnpm test src/config/config.telegram-actions-schema.test.ts

Closes #35497
