### PR TITLE
feat(core): enrich plugin delivery metadata, carry ChannelData, and expose embedded runtime API

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1352,7 +1352,7 @@ export async function handleFeishuMessage(params: {
             ? {
                 mediaPath: mediaList[0].path,
                 mediaType: mediaList[0].contentType,
-                mediaPaths: mediaList.map((m) => m.path),
+                mediaPaths: mediaList.filter((m) => m.contentType).map((m) => m.path),
                 mediaTypes: mediaList.filter((m) => m.contentType).map((m) => m.contentType!),
               }
             : {}),

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -864,6 +864,7 @@ export async function handleFeishuMessage(params: {
   event: FeishuMessageEvent;
   botOpenId?: string;
   botName?: string;
+  botOpenIdsByAccount?: Record<string, string | undefined>;
   runtime?: RuntimeEnv;
   chatHistories?: Map<string, HistoryEntry[]>;
   accountId?: string;
@@ -1332,6 +1333,30 @@ export async function handleFeishuMessage(params: {
         OriginatingChannel: "feishu" as const,
         OriginatingTo: feishuTo,
         GroupSystemPrompt: isGroup ? groupConfig?.systemPrompt?.trim() || undefined : undefined,
+        ChannelData: {
+          messageId: ctx.messageId,
+          chatId: ctx.chatId,
+          chatType: ctx.chatType,
+          accountId: account.accountId,
+          accountBotOpenId: botOpenId,
+          botOpenIdsByAccount: params.botOpenIdsByAccount,
+          messageType: event.message.message_type,
+          rawContent: event.message.content,
+          rootId: ctx.rootId,
+          parentId: ctx.parentId,
+          mentions: event.message.mentions ?? [],
+          senderType: event.sender.sender_type,
+          senderOpenId: ctx.senderOpenId,
+          senderUnionId: event.sender.sender_id.union_id,
+          ...(mediaList.length > 0
+            ? {
+                mediaPath: mediaList[0].path,
+                mediaType: mediaList[0].contentType,
+                mediaPaths: mediaList.map((m) => m.path),
+                mediaTypes: mediaList.filter((m) => m.contentType).map((m) => m.contentType!),
+              }
+            : {}),
+        },
         ...mediaPayload,
       });
 

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -24,6 +24,7 @@ export async function handleFeishuCardAction(params: {
   cfg: ClawdbotConfig;
   event: FeishuCardActionEvent;
   botOpenId?: string;
+  botOpenIdsByAccount?: Record<string, string | undefined>;
   runtime?: RuntimeEnv;
   accountId?: string;
 }): Promise<void> {
@@ -73,6 +74,7 @@ export async function handleFeishuCardAction(params: {
     cfg,
     event: messageEvent,
     botOpenId: params.botOpenId,
+    botOpenIdsByAccount: params.botOpenIdsByAccount,
     runtime,
     accountId,
   });

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -106,6 +106,7 @@ export async function downloadImageFeishu(params: {
 
   const response = await client.im.image.get({
     path: { image_key: normalizedImageKey },
+    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   const buffer = await readFeishuResponseBuffer({
@@ -145,6 +146,7 @@ export async function downloadMessageResourceFeishu(params: {
   const response = await client.im.messageResource.get({
     path: { message_id: messageId, file_key: normalizedFileKey },
     params: { type },
+    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   const buffer = await readFeishuResponseBuffer({
@@ -200,6 +202,7 @@ export async function uploadImageFeishu(params: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
       image: imageData as any,
     },
+    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   // SDK v1.30+ returns data directly without code wrapper on success

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -104,10 +104,11 @@ export async function downloadImageFeishu(params: {
     httpTimeoutMs: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Feishu SDK accepts timeout at request level; types omit it
   const response = await client.im.image.get({
     path: { image_key: normalizedImageKey },
     timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
-  });
+  } as any);
 
   const buffer = await readFeishuResponseBuffer({
     response,
@@ -143,11 +144,12 @@ export async function downloadMessageResourceFeishu(params: {
     httpTimeoutMs: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Feishu SDK accepts timeout at request level; types omit it
   const response = await client.im.messageResource.get({
     path: { message_id: messageId, file_key: normalizedFileKey },
     params: { type },
     timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
-  });
+  } as any);
 
   const buffer = await readFeishuResponseBuffer({
     response,
@@ -196,6 +198,7 @@ export async function uploadImageFeishu(params: {
   // See: https://github.com/larksuite/node-sdk/issues/121
   const imageData = typeof image === "string" ? fs.createReadStream(image) : image;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Feishu SDK accepts timeout at request level; types omit it
   const response = await client.im.image.create({
     data: {
       image_type: imageType,
@@ -203,7 +206,7 @@ export async function uploadImageFeishu(params: {
       image: imageData as any,
     },
     timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
-  });
+  } as any);
 
   // SDK v1.30+ returns data directly without code wrapper on success
   // On error, it throws or returns { code, msg }

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -129,6 +129,8 @@ export async function resolveReactionSyntheticEvent(
 type RegisterEventHandlersContext = {
   cfg: ClawdbotConfig;
   accountId: string;
+  /** Bot open ID for this account — used as fallback when the global botOpenIds map is not yet populated. */
+  botOpenId?: string;
   runtime?: RuntimeEnv;
   chatHistories: Map<string, HistoryEntry[]>;
   fireAndForget?: boolean;
@@ -240,15 +242,24 @@ function registerEventHandlers(
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
   const enqueue = createChatQueue();
+  const resolveBotOpenIdsByAccount = (): Record<string, string | undefined> => {
+    const fromMap = Object.fromEntries(botOpenIds);
+    // Defensive: if the global map is empty (startup race), seed it with at least
+    // the current account's bot open ID so self-message detection still works.
+    if (Object.keys(fromMap).length === 0 && context.botOpenId) {
+      return { [accountId]: context.botOpenId };
+    }
+    return fromMap;
+  };
   const dispatchFeishuMessage = async (event: FeishuMessageEvent) => {
     const chatId = event.message.chat_id?.trim() || "unknown";
     const task = () =>
       handleFeishuMessage({
         cfg,
         event,
-        botOpenId: botOpenIds.get(accountId),
+        botOpenId: botOpenIds.get(accountId) ?? context.botOpenId,
         botName: botNames.get(accountId),
-        botOpenIdsByAccount: Object.fromEntries(botOpenIds),
+        botOpenIdsByAccount: resolveBotOpenIdsByAccount(),
         runtime,
         chatHistories,
         accountId,
@@ -417,7 +428,7 @@ function registerEventHandlers(
     "im.message.reaction.created_v1": async (data) => {
       const processReaction = async () => {
         const event = data as FeishuReactionCreatedEvent;
-        const myBotId = botOpenIds.get(accountId);
+        const myBotId = botOpenIds.get(accountId) ?? context.botOpenId;
         const syntheticEvent = await resolveReactionSyntheticEvent({
           cfg,
           accountId,
@@ -433,7 +444,7 @@ function registerEventHandlers(
           event: syntheticEvent,
           botOpenId: myBotId,
           botName: botNames.get(accountId),
-          botOpenIdsByAccount: Object.fromEntries(botOpenIds),
+          botOpenIdsByAccount: resolveBotOpenIdsByAccount(),
           runtime,
           chatHistories,
           accountId,
@@ -469,8 +480,8 @@ function registerEventHandlers(
         const promise = handleFeishuCardAction({
           cfg,
           event,
-          botOpenId: botOpenIds.get(accountId),
-          botOpenIdsByAccount: Object.fromEntries(botOpenIds),
+          botOpenId: botOpenIds.get(accountId) ?? context.botOpenId,
+          botOpenIdsByAccount: resolveBotOpenIdsByAccount(),
           runtime,
           accountId,
         });
@@ -536,6 +547,7 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
   registerEventHandlers(eventDispatcher, {
     cfg,
     accountId,
+    botOpenId: botOpenId ?? undefined,
     runtime,
     chatHistories,
     fireAndForget: true,

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -248,6 +248,7 @@ function registerEventHandlers(
         event,
         botOpenId: botOpenIds.get(accountId),
         botName: botNames.get(accountId),
+        botOpenIdsByAccount: Object.fromEntries(botOpenIds),
         runtime,
         chatHistories,
         accountId,
@@ -432,6 +433,7 @@ function registerEventHandlers(
           event: syntheticEvent,
           botOpenId: myBotId,
           botName: botNames.get(accountId),
+          botOpenIdsByAccount: Object.fromEntries(botOpenIds),
           runtime,
           chatHistories,
           accountId,
@@ -468,6 +470,7 @@ function registerEventHandlers(
           cfg,
           event,
           botOpenId: botOpenIds.get(accountId),
+          botOpenIdsByAccount: Object.fromEntries(botOpenIds),
           runtime,
           accountId,
         });

--- a/extensions/test-utils/plugin-runtime-mock.ts
+++ b/extensions/test-utils/plugin-runtime-mock.ts
@@ -56,6 +56,9 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       getImageMetadata: vi.fn() as unknown as PluginRuntime["media"]["getImageMetadata"],
       resizeToJpeg: vi.fn() as unknown as PluginRuntime["media"]["resizeToJpeg"],
     },
+    agents: {
+      runEmbeddedPiAgent: vi.fn() as unknown as PluginRuntime["agents"]["runEmbeddedPiAgent"],
+    },
     tts: {
       textToSpeechTelephony: vi.fn() as unknown as PluginRuntime["tts"]["textToSpeechTelephony"],
     },

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1593,6 +1593,12 @@ describe("dispatchReplyFromConfig", () => {
       AccountId: "acc-1",
       GroupSpace: "guild-123",
       GroupChannel: "alerts",
+      ChannelData: {
+        feishu: {
+          messageId: "om_123",
+          chatId: "oc_456",
+        },
+      },
     });
 
     const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
@@ -1607,6 +1613,12 @@ describe("dispatchReplyFromConfig", () => {
           originatingChannel: "Telegram",
           originatingTo: "telegram:999",
           messageId: "sid-full",
+          channelData: {
+            feishu: {
+              messageId: "om_123",
+              chatId: "oc_456",
+            },
+          },
           senderId: "user-1",
           senderName: "Alice",
           senderUsername: "alice",

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -162,6 +162,8 @@ export type MsgContext = {
    * The chat/channel/user ID where the reply should be sent.
    */
   OriginatingTo?: string;
+  /** Provider-specific inbound payload (structured raw event data). */
+  ChannelData?: Record<string, unknown>;
   /**
    * True when the current turn intentionally requested external delivery to
    * OriginatingChannel/OriginatingTo, rather than inheriting stale session route metadata.

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -158,175 +158,187 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it("restarts after SIGUSR1 even when drain times out, and resets lanes for the new iteration", async () => {
-    vi.clearAllMocks();
+  it.runIf(process.platform !== "win32")(
+    "restarts after SIGUSR1 even when drain times out, and resets lanes for the new iteration",
+    async () => {
+      vi.clearAllMocks();
 
-    await withIsolatedSignals(async () => {
-      getActiveTaskCount.mockReturnValueOnce(2).mockReturnValueOnce(0);
-      waitForActiveTasks.mockResolvedValueOnce({ drained: false });
+      await withIsolatedSignals(async () => {
+        getActiveTaskCount.mockReturnValueOnce(2).mockReturnValueOnce(0);
+        waitForActiveTasks.mockResolvedValueOnce({ drained: false });
 
-      type StartServer = () => Promise<{
-        close: (opts: { reason: string; restartExpectedMs: number | null }) => Promise<void>;
-      }>;
+        type StartServer = () => Promise<{
+          close: (opts: { reason: string; restartExpectedMs: number | null }) => Promise<void>;
+        }>;
 
-      const closeFirst = vi.fn(async () => {});
-      const closeSecond = vi.fn(async () => {});
+        const closeFirst = vi.fn(async () => {});
+        const closeSecond = vi.fn(async () => {});
 
-      const start = vi.fn<StartServer>();
-      let resolveFirst: (() => void) | null = null;
-      const startedFirst = new Promise<void>((resolve) => {
-        resolveFirst = resolve;
+        const start = vi.fn<StartServer>();
+        let resolveFirst: (() => void) | null = null;
+        const startedFirst = new Promise<void>((resolve) => {
+          resolveFirst = resolve;
+        });
+        start.mockImplementationOnce(async () => {
+          resolveFirst?.();
+          return { close: closeFirst };
+        });
+
+        let resolveSecond: (() => void) | null = null;
+        const startedSecond = new Promise<void>((resolve) => {
+          resolveSecond = resolve;
+        });
+        start.mockImplementationOnce(async () => {
+          resolveSecond?.();
+          return { close: closeSecond };
+        });
+
+        start.mockRejectedValueOnce(new Error("stop-loop"));
+
+        const { runGatewayLoop } = await import("./run-loop.js");
+        const runtime = {
+          log: vi.fn(),
+          error: vi.fn(),
+          exit: vi.fn(),
+        };
+        const loopPromise = runGatewayLoop({
+          start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+          runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+        });
+
+        await startedFirst;
+        expect(start).toHaveBeenCalledTimes(1);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+
+        process.emit("SIGUSR1");
+
+        await startedSecond;
+        expect(start).toHaveBeenCalledTimes(2);
+        await new Promise<void>((resolve) => setImmediate(resolve));
+
+        expect(waitForActiveTasks).toHaveBeenCalledWith(30_000);
+        expect(markGatewayDraining).toHaveBeenCalledTimes(1);
+        expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
+        expect(closeFirst).toHaveBeenCalledWith({
+          reason: "gateway restarting",
+          restartExpectedMs: 1500,
+        });
+        expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
+        expect(resetAllLanes).toHaveBeenCalledTimes(1);
+
+        process.emit("SIGUSR1");
+
+        await expect(loopPromise).rejects.toThrow("stop-loop");
+        expect(closeSecond).toHaveBeenCalledWith({
+          reason: "gateway restarting",
+          restartExpectedMs: 1500,
+        });
+        expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(2);
+        expect(markGatewayDraining).toHaveBeenCalledTimes(2);
+        expect(resetAllLanes).toHaveBeenCalledTimes(2);
+        expect(acquireGatewayLock).toHaveBeenCalledTimes(3);
       });
-      start.mockImplementationOnce(async () => {
-        resolveFirst?.();
-        return { close: closeFirst };
-      });
+    },
+  );
 
-      let resolveSecond: (() => void) | null = null;
-      const startedSecond = new Promise<void>((resolve) => {
-        resolveSecond = resolve;
-      });
-      start.mockImplementationOnce(async () => {
-        resolveSecond?.();
-        return { close: closeSecond };
-      });
+  it.runIf(process.platform !== "win32")(
+    "releases the lock before exiting on spawned restart",
+    async () => {
+      vi.clearAllMocks();
 
-      start.mockRejectedValueOnce(new Error("stop-loop"));
-
-      const { runGatewayLoop } = await import("./run-loop.js");
-      const runtime = {
-        log: vi.fn(),
-        error: vi.fn(),
-        exit: vi.fn(),
-      };
-      const loopPromise = runGatewayLoop({
-        start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
-        runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
-      });
-
-      await startedFirst;
-      expect(start).toHaveBeenCalledTimes(1);
-      await new Promise<void>((resolve) => setImmediate(resolve));
-
-      process.emit("SIGUSR1");
-
-      await startedSecond;
-      expect(start).toHaveBeenCalledTimes(2);
-      await new Promise<void>((resolve) => setImmediate(resolve));
-
-      expect(waitForActiveTasks).toHaveBeenCalledWith(30_000);
-      expect(markGatewayDraining).toHaveBeenCalledTimes(1);
-      expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
-      expect(closeFirst).toHaveBeenCalledWith({
-        reason: "gateway restarting",
-        restartExpectedMs: 1500,
-      });
-      expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
-      expect(resetAllLanes).toHaveBeenCalledTimes(1);
-
-      process.emit("SIGUSR1");
-
-      await expect(loopPromise).rejects.toThrow("stop-loop");
-      expect(closeSecond).toHaveBeenCalledWith({
-        reason: "gateway restarting",
-        restartExpectedMs: 1500,
-      });
-      expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(2);
-      expect(markGatewayDraining).toHaveBeenCalledTimes(2);
-      expect(resetAllLanes).toHaveBeenCalledTimes(2);
-      expect(acquireGatewayLock).toHaveBeenCalledTimes(3);
-    });
-  });
-
-  it("releases the lock before exiting on spawned restart", async () => {
-    vi.clearAllMocks();
-
-    await withIsolatedSignals(async () => {
-      const lockRelease = vi.fn(async () => {});
-      acquireGatewayLock.mockResolvedValueOnce({
-        release: lockRelease,
-      });
-
-      // Override process-respawn to return "spawned" mode
-      restartGatewayProcessWithFreshPid.mockReturnValueOnce({
-        mode: "spawned",
-        pid: 9999,
-      });
-
-      const exitCallOrder: string[] = [];
-      const { runtime, exited } = await createSignaledLoopHarness(exitCallOrder);
-      lockRelease.mockImplementation(async () => {
-        exitCallOrder.push("lockRelease");
-      });
-
-      process.emit("SIGUSR1");
-
-      await exited;
-      expect(lockRelease).toHaveBeenCalled();
-      expect(runtime.exit).toHaveBeenCalledWith(0);
-      expect(exitCallOrder).toEqual(["lockRelease", "exit"]);
-    });
-  });
-
-  it("forwards lockPort to initial and restart lock acquisitions", async () => {
-    vi.clearAllMocks();
-
-    await withIsolatedSignals(async () => {
-      const closeFirst = vi.fn(async () => {});
-      const closeSecond = vi.fn(async () => {});
-      restartGatewayProcessWithFreshPid.mockReturnValueOnce({ mode: "disabled" });
-
-      const start = vi
-        .fn()
-        .mockResolvedValueOnce({ close: closeFirst })
-        .mockResolvedValueOnce({ close: closeSecond })
-        .mockRejectedValueOnce(new Error("stop-loop"));
-      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
-      const { runGatewayLoop } = await import("./run-loop.js");
-      const loopPromise = runGatewayLoop({
-        start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
-        runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
-        lockPort: 18789,
-      });
-
-      await new Promise<void>((resolve) => setImmediate(resolve));
-      process.emit("SIGUSR1");
-      await new Promise<void>((resolve) => setImmediate(resolve));
-      process.emit("SIGUSR1");
-
-      await expect(loopPromise).rejects.toThrow("stop-loop");
-      expect(acquireGatewayLock).toHaveBeenNthCalledWith(1, { port: 18789 });
-      expect(acquireGatewayLock).toHaveBeenNthCalledWith(2, { port: 18789 });
-      expect(acquireGatewayLock).toHaveBeenNthCalledWith(3, { port: 18789 });
-    });
-  });
-
-  it("exits when lock reacquire fails during in-process restart fallback", async () => {
-    vi.clearAllMocks();
-
-    await withIsolatedSignals(async () => {
-      const lockRelease = vi.fn(async () => {});
-      acquireGatewayLock
-        .mockResolvedValueOnce({
+      await withIsolatedSignals(async () => {
+        const lockRelease = vi.fn(async () => {});
+        acquireGatewayLock.mockResolvedValueOnce({
           release: lockRelease,
-        })
-        .mockRejectedValueOnce(new Error("lock timeout"));
+        });
 
-      restartGatewayProcessWithFreshPid.mockReturnValueOnce({
-        mode: "disabled",
+        // Override process-respawn to return "spawned" mode
+        restartGatewayProcessWithFreshPid.mockReturnValueOnce({
+          mode: "spawned",
+          pid: 9999,
+        });
+
+        const exitCallOrder: string[] = [];
+        const { runtime, exited } = await createSignaledLoopHarness(exitCallOrder);
+        lockRelease.mockImplementation(async () => {
+          exitCallOrder.push("lockRelease");
+        });
+
+        process.emit("SIGUSR1");
+
+        await exited;
+        expect(lockRelease).toHaveBeenCalled();
+        expect(runtime.exit).toHaveBeenCalledWith(0);
+        expect(exitCallOrder).toEqual(["lockRelease", "exit"]);
       });
+    },
+  );
 
-      const { start, exited } = await createSignaledLoopHarness();
-      process.emit("SIGUSR1");
+  it.runIf(process.platform !== "win32")(
+    "forwards lockPort to initial and restart lock acquisitions",
+    async () => {
+      vi.clearAllMocks();
 
-      await expect(exited).resolves.toBe(1);
-      expect(acquireGatewayLock).toHaveBeenCalledTimes(2);
-      expect(start).toHaveBeenCalledTimes(1);
-      expect(gatewayLog.error).toHaveBeenCalledWith(
-        expect.stringContaining("failed to reacquire gateway lock for in-process restart"),
-      );
-    });
-  });
+      await withIsolatedSignals(async () => {
+        const closeFirst = vi.fn(async () => {});
+        const closeSecond = vi.fn(async () => {});
+        restartGatewayProcessWithFreshPid.mockReturnValueOnce({ mode: "disabled" });
+
+        const start = vi
+          .fn()
+          .mockResolvedValueOnce({ close: closeFirst })
+          .mockResolvedValueOnce({ close: closeSecond })
+          .mockRejectedValueOnce(new Error("stop-loop"));
+        const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+        const { runGatewayLoop } = await import("./run-loop.js");
+        const loopPromise = runGatewayLoop({
+          start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+          runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+          lockPort: 18789,
+        });
+
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        process.emit("SIGUSR1");
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        process.emit("SIGUSR1");
+
+        await expect(loopPromise).rejects.toThrow("stop-loop");
+        expect(acquireGatewayLock).toHaveBeenNthCalledWith(1, { port: 18789 });
+        expect(acquireGatewayLock).toHaveBeenNthCalledWith(2, { port: 18789 });
+        expect(acquireGatewayLock).toHaveBeenNthCalledWith(3, { port: 18789 });
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "exits when lock reacquire fails during in-process restart fallback",
+    async () => {
+      vi.clearAllMocks();
+
+      await withIsolatedSignals(async () => {
+        const lockRelease = vi.fn(async () => {});
+        acquireGatewayLock
+          .mockResolvedValueOnce({
+            release: lockRelease,
+          })
+          .mockRejectedValueOnce(new Error("lock timeout"));
+
+        restartGatewayProcessWithFreshPid.mockReturnValueOnce({
+          mode: "disabled",
+        });
+
+        const { start, exited } = await createSignaledLoopHarness();
+        process.emit("SIGUSR1");
+
+        await expect(exited).resolves.toBe(1);
+        expect(acquireGatewayLock).toHaveBeenCalledTimes(2);
+        expect(start).toHaveBeenCalledTimes(1);
+        expect(gatewayLog.error).toHaveBeenCalledWith(
+          expect.stringContaining("failed to reacquire gateway lock for in-process restart"),
+        );
+      });
+    },
+  );
 });
 
 describe("gateway discover routing helpers", () => {

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -63,10 +63,13 @@ vi.mock("../../agents/skills/refresh.js", () => ({
   getSkillsSnapshotVersion: vi.fn().mockReturnValue(42),
 }));
 
-vi.mock("../../agents/workspace.js", () => ({
-  ensureAgentWorkspace: vi.fn().mockResolvedValue({ dir: "/tmp/workspace" }),
-  DEFAULT_IDENTITY_FILENAME: "IDENTITY.md",
-}));
+vi.mock("../../agents/workspace.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/workspace.js")>();
+  return {
+    ...actual,
+    ensureAgentWorkspace: vi.fn().mockResolvedValue({ dir: "/tmp/workspace" }),
+  };
+});
 
 vi.mock("../../agents/model-catalog.js", () => ({
   loadModelCatalog: vi.fn().mockResolvedValue({ models: [] }),

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -65,6 +65,7 @@ vi.mock("../../agents/skills/refresh.js", () => ({
 
 vi.mock("../../agents/workspace.js", () => ({
   ensureAgentWorkspace: vi.fn().mockResolvedValue({ dir: "/tmp/workspace" }),
+  DEFAULT_IDENTITY_FILENAME: "IDENTITY.md",
 }));
 
 vi.mock("../../agents/model-catalog.js", () => ({

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -137,6 +137,7 @@ describe("message hook mappers", () => {
       content: "reply",
       success: false,
       error: "network error",
+      messageId: "out-1",
     });
     expect(toInternalMessageSentContext(canonical)).toEqual({
       to: "telegram:chat:456",

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -106,6 +106,7 @@ export function deriveInboundMessageHookContext(
     originatingTo: ctx.OriginatingTo,
     guildId: ctx.GroupSpace,
     channelName: ctx.GroupChannel,
+    channelData: ctx.ChannelData,
     isGroup,
     groupId: isGroup ? conversationId : undefined,
   };
@@ -120,6 +121,7 @@ export function buildCanonicalSentMessageHookContext(params: {
   accountId?: string;
   conversationId?: string;
   messageId?: string;
+  metadata?: Record<string, unknown>;
   isGroup?: boolean;
   groupId?: string;
 }): CanonicalSentMessageHookContext {
@@ -132,6 +134,7 @@ export function buildCanonicalSentMessageHookContext(params: {
     accountId: params.accountId,
     conversationId: params.conversationId ?? params.to,
     messageId: params.messageId,
+    metadata: params.metadata,
     isGroup: params.isGroup,
     groupId: params.groupId,
   };
@@ -168,6 +171,7 @@ export function toPluginMessageReceivedEvent(
       senderE164: canonical.senderE164,
       guildId: canonical.guildId,
       channelName: canonical.channelName,
+      ...(canonical.channelData ? { channelData: canonical.channelData } : {}),
     },
   };
 }
@@ -179,6 +183,10 @@ export function toPluginMessageSentEvent(
     to: canonical.to,
     content: canonical.content,
     success: canonical.success,
+    ...(canonical.messageId ? { messageId: canonical.messageId } : {}),
+    ...(canonical.metadata && Object.keys(canonical.metadata).length > 0
+      ? { metadata: canonical.metadata }
+      : {}),
     ...(canonical.error ? { error: canonical.error } : {}),
   };
 }

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -37,6 +37,7 @@ export type CanonicalInboundMessageHookContext = {
   originatingTo?: string;
   guildId?: string;
   channelName?: string;
+  channelData?: Record<string, unknown>;
   isGroup: boolean;
   groupId?: string;
 };
@@ -50,6 +51,7 @@ export type CanonicalSentMessageHookContext = {
   accountId?: string;
   conversationId?: string;
   messageId?: string;
+  metadata?: Record<string, unknown>;
   isGroup?: boolean;
   groupId?: string;
 };

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -52,6 +52,7 @@ export type CanonicalSentMessageHookContext = {
   conversationId?: string;
   messageId?: string;
   metadata?: Record<string, unknown>;
+  channelData?: Record<string, unknown>;
   isGroup?: boolean;
   groupId?: string;
 };
@@ -124,6 +125,7 @@ export function buildCanonicalSentMessageHookContext(params: {
   conversationId?: string;
   messageId?: string;
   metadata?: Record<string, unknown>;
+  channelData?: Record<string, unknown>;
   isGroup?: boolean;
   groupId?: string;
 }): CanonicalSentMessageHookContext {
@@ -137,6 +139,7 @@ export function buildCanonicalSentMessageHookContext(params: {
     conversationId: params.conversationId ?? params.to,
     messageId: params.messageId,
     metadata: params.metadata,
+    channelData: params.channelData,
     isGroup: params.isGroup,
     groupId: params.groupId,
   };
@@ -188,6 +191,9 @@ export function toPluginMessageSentEvent(
     ...(canonical.messageId ? { messageId: canonical.messageId } : {}),
     ...(canonical.metadata && Object.keys(canonical.metadata).length > 0
       ? { metadata: canonical.metadata }
+      : {}),
+    ...(canonical.channelData && Object.keys(canonical.channelData).length > 0
+      ? { channelData: canonical.channelData }
       : {}),
     ...(canonical.error ? { error: canonical.error } : {}),
   };

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -820,15 +820,21 @@ describe("deliverOutboundPayloads", () => {
       deps: { sendWhatsApp },
     });
 
-    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
-      expect.objectContaining({ to: "+1555", content: "hello", success: true }),
-      expect.objectContaining({ channelId: "whatsapp" }),
-    );
+    await vi.waitFor(() => {
+      expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+        expect.objectContaining({ to: "+1555", content: "hello", success: true, messageId: "w1" }),
+        expect.objectContaining({ channelId: "whatsapp", conversationId: "+1555" }),
+      );
+    });
   });
 
   it("emits message_sent success for sendPayload deliveries", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
-    const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });
+    const sendPayload = vi.fn().mockResolvedValue({
+      channel: "matrix",
+      messageId: "mx-1",
+      meta: { mentions: [{ id: "ou_bot_beta", name: "Bot Beta" }] },
+    });
     const sendText = vi.fn();
     const sendMedia = vi.fn();
     setActivePluginRegistry(
@@ -851,10 +857,18 @@ describe("deliverOutboundPayloads", () => {
       payloads: [{ text: "payload text", channelData: { mode: "custom" } }],
     });
 
-    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
-      expect.objectContaining({ to: "!room:1", content: "payload text", success: true }),
-      expect.objectContaining({ channelId: "matrix" }),
-    );
+    await vi.waitFor(() => {
+      expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: "!room:1",
+          content: "payload text",
+          success: true,
+          messageId: "mx-1",
+          metadata: { mentions: [{ id: "ou_bot_beta", name: "Bot Beta" }] },
+        }),
+        expect.objectContaining({ channelId: "matrix", conversationId: "!room:1" }),
+      );
+    });
   });
 
   it("preserves channelData-only payloads with empty text for non-WhatsApp sendPayload channels", async () => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -260,6 +260,7 @@ type MessageSentEvent = {
   content: string;
   error?: string;
   messageId?: string;
+  metadata?: Record<string, unknown>;
 };
 
 function hasMediaPayload(payload: ReplyPayload): boolean {
@@ -353,6 +354,7 @@ function createMessageSentEmitter(params: {
       accountId: params.accountId ?? undefined,
       conversationId: params.to,
       messageId: event.messageId,
+      metadata: event.metadata,
       isGroup: params.mirrorIsGroup,
       groupId: params.mirrorGroupId,
     });
@@ -720,6 +722,7 @@ async function deliverOutboundPayloadsCore(
           success: true,
           content: payloadSummary.text,
           messageId: delivery.messageId,
+          metadata: delivery.meta,
         });
         continue;
       }

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -653,6 +653,7 @@ async function deliverOutboundPayloadsCore(
     };
     return {
       channel: "signal" as const,
+      meta: undefined as Record<string, unknown> | undefined,
       ...(await sendSignal(to, formatted.text, {
         cfg,
         mediaUrl,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -738,6 +738,7 @@ async function deliverOutboundPayloadsCore(
           success: results.length > beforeCount,
           content: payloadSummary.text,
           messageId,
+          metadata: results.at(-1)?.meta,
         });
         continue;
       }
@@ -764,12 +765,14 @@ async function deliverOutboundPayloadsCore(
           success: results.length > beforeCount,
           content: payloadSummary.text,
           messageId,
+          metadata: results.at(-1)?.meta,
         });
         continue;
       }
 
       let first = true;
       let lastMessageId: string | undefined;
+      let lastMeta: Record<string, unknown> | undefined;
       for (const url of payloadSummary.mediaUrls) {
         throwIfAborted(abortSignal);
         const caption = first ? payloadSummary.text : "";
@@ -778,16 +781,19 @@ async function deliverOutboundPayloadsCore(
           const delivery = await sendSignalMedia(caption, url);
           results.push(delivery);
           lastMessageId = delivery.messageId;
+          lastMeta = delivery.meta;
         } else {
           const delivery = await handler.sendMedia(caption, url, sendOverrides);
           results.push(delivery);
           lastMessageId = delivery.messageId;
+          lastMeta = delivery.meta;
         }
       }
       emitMessageSent({
         success: true,
         content: payloadSummary.text,
         messageId: lastMessageId,
+        metadata: lastMeta,
       });
     } catch (err) {
       emitMessageSent({

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -261,6 +261,7 @@ type MessageSentEvent = {
   error?: string;
   messageId?: string;
   metadata?: Record<string, unknown>;
+  channelData?: Record<string, unknown>;
 };
 
 function hasMediaPayload(payload: ReplyPayload): boolean {
@@ -355,6 +356,7 @@ function createMessageSentEmitter(params: {
       conversationId: params.to,
       messageId: event.messageId,
       metadata: event.metadata,
+      channelData: event.channelData,
       isGroup: params.mirrorIsGroup,
       groupId: params.mirrorGroupId,
     });
@@ -724,6 +726,7 @@ async function deliverOutboundPayloadsCore(
           content: payloadSummary.text,
           messageId: delivery.messageId,
           metadata: delivery.meta,
+          channelData: effectivePayload.channelData,
         });
         continue;
       }
@@ -734,12 +737,13 @@ async function deliverOutboundPayloadsCore(
         } else {
           await sendTextChunks(payloadSummary.text, sendOverrides);
         }
-        const messageId = results.at(-1)?.messageId;
+        const currentResults = results.slice(beforeCount);
+        const lastResult = currentResults.at(-1);
         emitMessageSent({
-          success: results.length > beforeCount,
+          success: currentResults.length > 0,
           content: payloadSummary.text,
-          messageId,
-          metadata: results.at(-1)?.meta,
+          messageId: lastResult?.messageId,
+          metadata: lastResult?.meta,
         });
         continue;
       }
@@ -761,12 +765,13 @@ async function deliverOutboundPayloadsCore(
         }
         const beforeCount = results.length;
         await sendTextChunks(fallbackText, sendOverrides);
-        const messageId = results.at(-1)?.messageId;
+        const currentResults = results.slice(beforeCount);
+        const lastResult = currentResults.at(-1);
         emitMessageSent({
-          success: results.length > beforeCount,
+          success: currentResults.length > 0,
           content: payloadSummary.text,
-          messageId,
-          metadata: results.at(-1)?.meta,
+          messageId: lastResult?.messageId,
+          metadata: lastResult?.meta,
         });
         continue;
       }

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -26,6 +26,8 @@ export type ApprovedCwdSnapshot = {
 
 const MUTABLE_ARGV1_INTERPRETER_PATTERNS = [
   /^(?:node|nodejs)$/,
+  /^bun$/,
+  /^deno$/,
   /^perl$/,
   /^php$/,
   /^python(?:\d+(?:\.\d+)*)?$/,

--- a/src/node-host/invoke-system-run-plan.ts
+++ b/src/node-host/invoke-system-run-plan.ts
@@ -34,6 +34,9 @@ const MUTABLE_ARGV1_INTERPRETER_PATTERNS = [
   /^ruby$/,
 ] as const;
 
+const DENO_SUBCOMMANDS_WITH_SCRIPT = new Set(["run", "task", "compile", "bundle"]);
+const BUN_SUBCOMMANDS_WITH_SCRIPT = new Set(["run", "x", "build"]);
+
 function normalizeString(value: unknown): string | null {
   if (typeof value !== "string") {
     return null;
@@ -148,6 +151,35 @@ function resolvePosixShellScriptOperandIndex(argv: string[]): number | null {
   return null;
 }
 
+function resolveSubcommandScriptOperandIndex(
+  argv: string[],
+  subcommandIndex: number,
+): number | null {
+  let i = subcommandIndex + 1;
+  let afterDoubleDash = false;
+  while (i < argv.length) {
+    const token = argv[i]?.trim() ?? "";
+    if (!token) {
+      i++;
+      continue;
+    }
+    if (!afterDoubleDash && token === "--") {
+      afterDoubleDash = true;
+      i++;
+      continue;
+    }
+    if (!afterDoubleDash && token.startsWith("-")) {
+      i++;
+      continue;
+    }
+    if (token.startsWith("http://") || token.startsWith("https://")) {
+      return null;
+    }
+    return i;
+  }
+  return null;
+}
+
 function resolveMutableFileOperandIndex(argv: string[]): number | null {
   const unwrapped = unwrapArgvForMutableOperand(argv);
   const executable = normalizeExecutableToken(unwrapped.argv[0] ?? "");
@@ -164,6 +196,17 @@ function resolveMutableFileOperandIndex(argv: string[]): number | null {
   const operand = unwrapped.argv[1]?.trim() ?? "";
   if (!operand || operand === "-" || operand.startsWith("-")) {
     return null;
+  }
+  if (/^bun$/.test(executable)) {
+    if (BUN_SUBCOMMANDS_WITH_SCRIPT.has(operand)) {
+      const scriptLocalIndex = resolveSubcommandScriptOperandIndex(unwrapped.argv, 1);
+      return scriptLocalIndex === null ? null : unwrapped.baseIndex + scriptLocalIndex;
+    }
+  } else if (/^deno$/.test(executable)) {
+    if (DENO_SUBCOMMANDS_WITH_SCRIPT.has(operand)) {
+      const scriptLocalIndex = resolveSubcommandScriptOperandIndex(unwrapped.argv, 1);
+      return scriptLocalIndex === null ? null : unwrapped.baseIndex + scriptLocalIndex;
+    }
   }
   return unwrapped.baseIndex + 1;
 }

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -109,6 +109,30 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     };
   }
 
+  function createNamedInterpreterScriptFixture(
+    tmp: string,
+    interpreterName: string,
+  ): {
+    command: string[];
+    scriptPath: string;
+    initialBody: string;
+    changedBody: string;
+  } {
+    const ext = process.platform === "win32" ? ".exe" : "";
+    const fakeInterpreter = path.join(tmp, `${interpreterName}${ext}`);
+    fs.writeFileSync(fakeInterpreter, "");
+    if (process.platform !== "win32") {
+      fs.chmodSync(fakeInterpreter, 0o755);
+    }
+    const scriptPath = path.join(tmp, "run.js");
+    return {
+      command: [fakeInterpreter, "./run.js"],
+      scriptPath,
+      initialBody: 'console.log("SAFE");\n',
+      changedBody: 'console.log("PWNED");\n',
+    };
+  }
+
   function buildNestedEnvShellCommand(params: { depth: number; payload: string }): string[] {
     return [...Array(params.depth).fill("/usr/bin/env"), "/bin/sh", "-c", params.payload];
   }
@@ -787,6 +811,80 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  for (const interpreterName of ["bun", "deno"] as const) {
+    it(`denies approval-based execution when a ${interpreterName} script operand changes after approval`, async () => {
+      const tmp = fs.mkdtempSync(
+        path.join(os.tmpdir(), `openclaw-approval-${interpreterName}-drift-`),
+      );
+      const fixture = createNamedInterpreterScriptFixture(tmp, interpreterName);
+      fs.writeFileSync(fixture.scriptPath, fixture.initialBody);
+      try {
+        const prepared = buildSystemRunApprovalPlan({
+          command: fixture.command,
+          cwd: tmp,
+        });
+        expect(prepared.ok).toBe(true);
+        if (!prepared.ok) {
+          throw new Error("unreachable");
+        }
+
+        fs.writeFileSync(fixture.scriptPath, fixture.changedBody);
+        const { runCommand, sendInvokeResult } = await runSystemInvoke({
+          preferMacAppExecHost: false,
+          command: prepared.plan.argv,
+          rawCommand: prepared.plan.rawCommand,
+          systemRunPlan: prepared.plan,
+          cwd: prepared.plan.cwd ?? tmp,
+          approved: true,
+          security: "full",
+          ask: "off",
+        });
+
+        expect(runCommand).not.toHaveBeenCalled();
+        expectInvokeErrorMessage(sendInvokeResult, {
+          message: "SYSTEM_RUN_DENIED: approval script operand changed before execution",
+          exact: true,
+        });
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    it(`keeps approved ${interpreterName} script execution working when the script is unchanged`, async () => {
+      const tmp = fs.mkdtempSync(
+        path.join(os.tmpdir(), `openclaw-approval-${interpreterName}-stable-`),
+      );
+      const fixture = createNamedInterpreterScriptFixture(tmp, interpreterName);
+      fs.writeFileSync(fixture.scriptPath, fixture.initialBody);
+      try {
+        const prepared = buildSystemRunApprovalPlan({
+          command: fixture.command,
+          cwd: tmp,
+        });
+        expect(prepared.ok).toBe(true);
+        if (!prepared.ok) {
+          throw new Error("unreachable");
+        }
+
+        const { runCommand, sendInvokeResult } = await runSystemInvoke({
+          preferMacAppExecHost: false,
+          command: prepared.plan.argv,
+          rawCommand: prepared.plan.rawCommand,
+          systemRunPlan: prepared.plan,
+          cwd: prepared.plan.cwd ?? tmp,
+          approved: true,
+          security: "full",
+          ask: "off",
+        });
+
+        expect(runCommand).toHaveBeenCalledTimes(1);
+        expectInvokeOk(sendInvokeResult);
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+  }
 
   it("denies ./sh wrapper spoof in allowlist on-miss mode before execution", async () => {
     const marker = path.join(os.tmpdir(), `openclaw-wrapper-spoof-${process.pid}-${Date.now()}`);

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import { resolveStateDir } from "../../config/paths.js";
 import { transcribeAudioFile } from "../../media-understanding/transcribe-audio.js";
 import { textToSpeechTelephony } from "../../tts/tts.js";
@@ -48,6 +49,7 @@ export type CreatePluginRuntimeOptions = {
 export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): PluginRuntime {
   const runtime = {
     version: resolveVersion(),
+    agents: { runEmbeddedPiAgent },
     config: createRuntimeConfig(),
     subagent: _options.subagent ?? createUnavailableSubagentRuntime(),
     system: createRuntimeSystem(),

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -9,6 +9,9 @@ export type RuntimeLogger = {
 
 export type PluginRuntimeCore = {
   version: string;
+  agents: {
+    runEmbeddedPiAgent: typeof import("../../agents/pi-embedded.js").runEmbeddedPiAgent;
+  };
   config: {
     loadConfig: typeof import("../../config/config.js").loadConfig;
     writeConfigFile: typeof import("../../config/config.js").writeConfigFile;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -587,6 +587,8 @@ export type PluginHookMessageSentEvent = {
   to: string;
   content: string;
   success: boolean;
+  messageId?: string;
+  metadata?: Record<string, unknown>;
   error?: string;
 };
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -589,6 +589,7 @@ export type PluginHookMessageSentEvent = {
   success: boolean;
   messageId?: string;
   metadata?: Record<string, unknown>;
+  channelData?: Record<string, unknown>;
   error?: string;
 };
 


### PR DESCRIPTION
## Problem

The plugin hook system lacks critical context in three areas, limiting what plugins can do:

### 1. Outbound hooks have no delivery metadata

When a `message_sent` hook fires, it only knows `to`, `content`, and `success`. It does **not** know the `messageId` returned by the provider or any provider-specific metadata. Plugins that need to track sent messages (e.g., for reactions, edits, or analytics) have no way to correlate hook events with actual provider messages.

```
Before:  message_sent → { to, content, success }              → plugin can't track message
After:   message_sent → { to, content, success, messageId, metadata }  → plugin can correlate
```

### 2. Inbound hooks have no channel-specific data

The `message_received` hook strips all provider-specific context. Plugins that need raw event data (Feishu mentions, message types, media paths) must re-fetch it from the provider API.

```
Before:  message_received → { from, content, channel }        → no raw event data
After:   message_received → { from, content, channel, channelData }  → full provider context
```

### 3. Plugins can't invoke embedded agents

`PluginRuntime` has no way to call `runEmbeddedPiAgent`. Plugins that need LLM capabilities (summarization, classification, translation) must implement their own LLM integration from scratch.

## Fix

- **`messageId` + `metadata` on `message_sent`**: Thread `messageId` and `metadata` (from provider `sendPayload` result) through `buildCanonicalSentMessageHookContext` → `toPluginMessageSentEvent`
- **`channelData` on `message_received`**: Add `ChannelData` field to `MsgContext`, propagate through `deriveInboundMessageHookContext` → `toPluginMessageReceivedEvent`. Feishu extension now populates this with full event details (chatId, mentions, media, sender info)
- **`agents.runEmbeddedPiAgent` on `PluginRuntime`**: Expose `runEmbeddedPiAgent` as `runtime.agents.runEmbeddedPiAgent`, update `PluginRuntimeCore` types, update test mock

All changes are additive — no existing fields are modified or removed.

## Why merge

These are foundational gaps in the plugin API. Without `messageId` on sent events, plugins cannot implement message editing, reactions, or read tracking. Without `channelData`, plugins cannot access provider-specific features (Feishu cards, Discord embeds, Telegram formatting). Without embedded agent access, plugins must duplicate LLM integration code. These additions are prerequisite for building non-trivial plugins.