### PR TITLE
fix(telegram): bypass preview streaming for explicit reply tags

### DIFF
--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -207,6 +207,43 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
+  it("bypasses preview streaming for explicit reply tags and sends only the final reply", async () => {
+    const { answerDraftStream, reasoningDraftStream } = setupDraftStreams({
+      answerMessageId: 9001,
+      reasoningMessageId: 9002,
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({
+          text: "partial tagged",
+          replyToId: "456",
+          replyToTag: true,
+        });
+        await dispatcherOptions.deliver(
+          {
+            text: "final tagged",
+            replyToId: "456",
+            replyToTag: true,
+          },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(answerDraftStream.update).not.toHaveBeenCalled();
+    expect(reasoningDraftStream.update).not.toHaveBeenCalled();
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [expect.objectContaining({ text: "final tagged", replyToId: "456" })],
+      }),
+    );
+  });
+
   it("uses 30-char preview debounce for legacy block stream mode", async () => {
     const draftStream = createDraftStream();
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -522,6 +522,25 @@ export const dispatchTelegramMessage = async ({
           const split = splitTextIntoLaneSegments(payload.text);
           const segments = split.segments;
           const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+          const hasExplicitReplyTag = payload.replyToTag === true;
+
+          // Explicit reply tags (for example [[reply_to_current]]) should bypass
+          // preview lanes so the final message always carries the native reply.
+          if (hasExplicitReplyTag) {
+            if (info.kind !== "final") {
+              return;
+            }
+            await answerLane.stream?.stop();
+            await reasoningLane.stream?.stop();
+            reasoningStepState.resetForNextStep();
+            const canSendAsIs =
+              hasMedia || (typeof payload.text === "string" && payload.text.length > 0);
+            if (!canSendAsIs) {
+              return;
+            }
+            await sendPayload(payload);
+            return;
+          }
 
           const flushBufferedFinalAnswer = async () => {
             const buffered = reasoningStepState.takeBufferedFinalAnswer();
@@ -626,9 +645,11 @@ export const dispatchTelegramMessage = async ({
         onPartialReply:
           answerLane.stream || reasoningLane.stream
             ? (payload) =>
-                enqueueDraftLaneEvent(async () => {
-                  await ingestDraftLaneSegments(payload.text);
-                })
+                payload.replyToTag
+                  ? undefined
+                  : enqueueDraftLaneEvent(async () => {
+                      await ingestDraftLaneSegments(payload.text);
+                    })
             : undefined,
         onReasoningStream: reasoningLane.stream
           ? (payload) =>


### PR DESCRIPTION
## Summary
- bypass Telegram draft preview streaming when a payload carries an explicit reply tag (for example `[[reply_to_current]]`)
- deliver only the final tagged payload through normal send path so native reply metadata is preserved
- add a regression test covering tagged partial+final flow to ensure no preview update/edit occurs

## Testing
- pnpm test -- src/telegram/bot-message-dispatch.test.ts

Fixes #35632
