### PR TITLE
fix(bluebubbles): preserve iMessage/SMS service when normalizing DM chat_guid targets

### DIFF
--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -206,6 +206,73 @@ describe("send", () => {
       expect(result).toBe("iMessage;-;+15551234567");
     });
 
+    it("prefers iMessage chat over SMS when service is 'imessage' and both exist", async () => {
+      // Reproduces the SMS fallback bug: when a contact has both iMessage and SMS chats,
+      // targeting with service "imessage" should return the iMessage chat, not the first result.
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: [
+              {
+                // SMS chat appears first in API response
+                guid: "SMS;-;+15551234567",
+                participants: [{ address: "+15551234567" }],
+              },
+              {
+                // iMessage chat appears second
+                guid: "iMessage;-;+15551234567",
+                participants: [{ address: "+15551234567" }],
+              },
+            ],
+          }),
+      });
+
+      const target: BlueBubblesSendTarget = {
+        kind: "handle",
+        address: "+15551234567",
+        service: "imessage",
+      };
+      const result = await resolveChatGuidForTarget({
+        baseUrl: "http://localhost:1234",
+        password: "test",
+        target,
+      });
+
+      // Should return iMessage chat, not the SMS chat that appeared first
+      expect(result).toBe("iMessage;-;+15551234567");
+    });
+
+    it("falls back to wrong-service chat when preferred service chat not found", async () => {
+      // If only an SMS chat exists but iMessage is requested, fall back to SMS
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              data: [{ guid: "SMS;-;+15551234567", participants: [{ address: "+15551234567" }] }],
+            }),
+        })
+        // Empty second page to stop pagination
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ data: [] }),
+        });
+
+      const target: BlueBubblesSendTarget = {
+        kind: "handle",
+        address: "+15551234567",
+        service: "imessage",
+      };
+      const result = await resolveChatGuidForTarget({
+        baseUrl: "http://localhost:1234",
+        password: "test",
+        target,
+      });
+
+      expect(result).toBe("SMS;-;+15551234567");
+    });
+
     it("returns null when handle only exists in group chat (not DM)", async () => {
       // This is the critical fix: if a phone number only exists as a participant in a group chat
       // (no direct DM chat), we should NOT send to that group. Return null instead.

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -284,7 +284,7 @@ export async function resolveChatGuidForTarget(params: {
       if (normalizedHandle) {
         const guid = extractChatGuid(chat);
         const directHandle = guid ? extractHandleFromChatGuid(guid) : null;
-        if (directHandle && directHandle === normalizedHandle) {
+        if (guid && directHandle && directHandle === normalizedHandle) {
           if (!targetService) {
             // No service preference ("auto"): return first match immediately.
             return guid;

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -225,7 +225,16 @@ export async function resolveChatGuidForTarget(params: {
     params.target.kind === "chat_identifier" ? params.target.chatIdentifier : null;
 
   const limit = 500;
+  // Track the best match by service specificity:
+  // - serviceMatch: direct handle match with the correct service (highest priority)
+  // - serviceAgnosticMatch: direct handle match but wrong service (fallback)
+  // - participantMatch: handle found in chat participant list (lowest priority)
+  let serviceAgnosticMatch: string | null = null;
   let participantMatch: string | null = null;
+  const targetService =
+    params.target.kind === "handle" && params.target.service !== "auto"
+      ? params.target.service
+      : null;
   for (let offset = 0; offset < 5000; offset += limit) {
     const chats = await queryChats({
       baseUrl: params.baseUrl,
@@ -276,7 +285,18 @@ export async function resolveChatGuidForTarget(params: {
         const guid = extractChatGuid(chat);
         const directHandle = guid ? extractHandleFromChatGuid(guid) : null;
         if (directHandle && directHandle === normalizedHandle) {
-          return guid;
+          if (!targetService) {
+            // No service preference ("auto"): return first match immediately.
+            return guid;
+          }
+          // Service-aware: prefer chat whose GUID service matches target service.
+          const guidService = guid.split(";")[0]?.trim().toLowerCase();
+          if (guidService === targetService) {
+            return guid;
+          }
+          if (!serviceAgnosticMatch) {
+            serviceAgnosticMatch = guid;
+          }
         }
         if (!participantMatch && guid) {
           // Only consider DM chats (`;-;` separator) as participant matches.
@@ -295,7 +315,7 @@ export async function resolveChatGuidForTarget(params: {
       }
     }
   }
-  return participantMatch;
+  return serviceAgnosticMatch ?? participantMatch;
 }
 
 /**

--- a/extensions/bluebubbles/src/targets.test.ts
+++ b/extensions/bluebubbles/src/targets.test.ts
@@ -22,17 +22,17 @@ describe("normalizeBlueBubblesMessagingTarget", () => {
     );
   });
 
-  it("extracts handle from DM chat_guid for cross-context matching", () => {
-    // DM format: service;-;handle
+  it("preserves service info from DM chat_guid for correct service routing", () => {
+    // DM format: service;-;handle — service is now preserved to prevent SMS fallback
     expect(normalizeBlueBubblesMessagingTarget("chat_guid:iMessage;-;+19257864429")).toBe(
-      "+19257864429",
+      "imessage:+19257864429",
     );
     expect(normalizeBlueBubblesMessagingTarget("chat_guid:SMS;-;+15551234567")).toBe(
-      "+15551234567",
+      "sms:+15551234567",
     );
     // Email handles
     expect(normalizeBlueBubblesMessagingTarget("chat_guid:iMessage;-;user@example.com")).toBe(
-      "user@example.com",
+      "imessage:user@example.com",
     );
   });
 
@@ -47,7 +47,9 @@ describe("normalizeBlueBubblesMessagingTarget", () => {
     expect(normalizeBlueBubblesMessagingTarget("iMessage;+;chat660250192681427962")).toBe(
       "chat_guid:iMessage;+;chat660250192681427962",
     );
-    expect(normalizeBlueBubblesMessagingTarget("iMessage;-;+19257864429")).toBe("+19257864429");
+    expect(normalizeBlueBubblesMessagingTarget("iMessage;-;+19257864429")).toBe(
+      "imessage:+19257864429",
+    );
   });
 
   it("normalizes chat<digits> pattern to chat_identifier format", () => {

--- a/extensions/bluebubbles/src/targets.ts
+++ b/extensions/bluebubbles/src/targets.ts
@@ -162,10 +162,16 @@ export function normalizeBlueBubblesMessagingTarget(raw: string): string | undef
       return `chat_id:${parsed.chatId}`;
     }
     if (parsed.kind === "chat_guid") {
-      // For DM chat_guids, normalize to just the handle for easier comparison.
-      // This allows "chat_guid:iMessage;-;+1234567890" to match "+1234567890".
+      // For DM chat_guids, normalize to a service-prefixed handle to enable both
+      // cross-context matching and correct service routing (iMessage vs SMS).
+      // e.g. "chat_guid:iMessage;-;+1234567890" → "imessage:+1234567890"
+      // This prevents SMS fallback when both iMessage and SMS chats exist for a number.
       const handle = extractHandleFromChatGuid(parsed.chatGuid);
       if (handle) {
+        const service = parsed.chatGuid.split(";")[0]?.trim().toLowerCase();
+        if (service === "imessage" || service === "sms") {
+          return `${service}:${handle}`;
+        }
         return handle;
       }
       // For group chats or unrecognized formats, keep the full chat_guid

--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -134,9 +134,22 @@ describe("resolveWhatsAppOutboundTarget", () => {
       expectAllowedForTarget({ allowFrom: [PRIMARY_TARGET], mode: "implicit" });
     });
 
-    it("denies message when target is not in allowList", () => {
-      mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
-      expectDeniedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "implicit" });
+    it("denies message when target is not in allowList with actionable error", () => {
+      // normalizeWhatsAppTarget is called for allowFrom entries first, then for `to`.
+      // mockReturnValueOnce order: allowFrom[0] → SECONDARY_TARGET, to → PRIMARY_TARGET.
+      mockNormalizedDirectMessage(SECONDARY_TARGET, PRIMARY_TARGET);
+      const result = resolveWhatsAppOutboundTarget({
+        to: PRIMARY_TARGET,
+        allowFrom: [SECONDARY_TARGET],
+        mode: "implicit",
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) {
+        throw new Error("expected failure");
+      }
+      // Error should mention the target and hint at allowFrom config, not just E.164 format.
+      expect(result.error.message).toContain(PRIMARY_TARGET);
+      expect(result.error.message).toContain("allowFrom");
     });
 
     it("handles mixed numeric and string allowList entries", () => {

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -41,7 +41,9 @@ export function resolveWhatsAppOutboundTarget(params: {
     }
     return {
       ok: false,
-      error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+      error: new Error(
+        `WhatsApp target "${normalizedTo}" is not listed in the configured allowFrom policy. Add it to channels.whatsapp.allowFrom in your config.`,
+      ),
     };
   }
 


### PR DESCRIPTION
## Summary

- **Problem**: When the AI agent sends a message with `to: "chat_guid:iMessage;-;+xxx"`, the target normalization in `resolveChannelTarget` calls `normalizeBlueBubblesMessagingTarget`, which strips the service prefix and returns just `"+xxx"`. Downstream, `resolveChatGuidForTarget` receives `{ service: "auto" }` and returns the first matching DM chat — which could be SMS when the contact has both iMessage and SMS chats.
- **Why it matters**: Users explicitly specifying `chat_guid:iMessage;-;+xxx` always get routed through SMS instead, even when Private API is enabled and iMessage is the intended channel.
- **What changed**:
  1. `normalizeBlueBubblesMessagingTarget`: DM chat_guids now normalize to `service:handle` (e.g. `"imessage:+xxx"`) instead of bare `"+xxx"`, preserving the service for downstream routing.
  2. `resolveChatGuidForTarget`: When `target.service` is `"imessage"` or `"sms"` (not `"auto"`), prefer the chat whose GUID service matches exactly; only fall back to wrong-service chats when no exact match is found across all pages.
- **What did NOT change**: `service: "auto"` behavior is unchanged (first match returned immediately). Group chats are still excluded from participant-based matching. The `chat_guid` kind still bypasses chat lookups entirely.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

Closes #35624

Note: the diff against `main` also includes the WhatsApp allowFrom fix from #35643 (same branch ancestry). The net-new change for this PR is only the BlueBubbles service-routing fix.

## Test Plan

- [x] Added `resolveChatGuidForTarget` test: SMS chat listed first in API response, iMessage chat listed second — with `service: "imessage"` target, confirms iMessage GUID is returned.
- [x] Added fallback test: only SMS chat exists, `service: "imessage"` target — confirms fallback to wrong-service chat instead of null.
- [x] Updated `normalizeBlueBubblesMessagingTarget` tests: DM chat_guid now yields `"imessage:+xxx"` / `"sms:+xxx"` instead of bare handle.
- [x] All 6629 tests pass (1 pre-existing locale failure unrelated to this change).