### PR TITLE
fix(cli,line,oauth): guard URL parsing and encodeURIComponent inputs

### DIFF
--- a/src/auto-reply/reply/line-directives.ts
+++ b/src/auto-reply/reply/line-directives.ts
@@ -43,7 +43,9 @@ export function parseLineDirectives(payload: ReplyPayload): ReplyPayload {
     const base = [`line.action=${encodeURIComponent(action)}`];
     if (extras) {
       for (const [key, value] of Object.entries(extras)) {
-        base.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`);
+        if (value != null) {
+          base.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`);
+        }
       }
     }
     return base.join("&");

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -79,7 +79,12 @@ export async function writeUrlToFile(
   url: string,
   opts: { expectedHost: string },
 ) {
-  const parsed = new URL(url);
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`writeUrlToFile: invalid URL: ${url}`);
+  }
   if (parsed.protocol !== "https:") {
     throw new Error(`writeUrlToFile: only https URLs are allowed, got ${parsed.protocol}`);
   }

--- a/src/plugin-sdk/oauth-utils.ts
+++ b/src/plugin-sdk/oauth-utils.ts
@@ -2,6 +2,7 @@ import { createHash, randomBytes } from "node:crypto";
 
 export function toFormUrlEncoded(data: Record<string, string>): string {
   return Object.entries(data)
+    .filter(([, v]) => v != null)
     .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
     .join("&");
 }


### PR DESCRIPTION
## Summary

Three defensive fixes for external input handling:

1. **`src/cli/nodes-camera.ts`** — `writeUrlToFile` calls `new URL(url)` on camera node payload without try-catch. A malformed URL throws an unhandled `TypeError` instead of a descriptive error message. Now wrapped in try-catch with a clear error.

2. **`src/auto-reply/reply/line-directives.ts`** — `lineActionData` iterates `extras` record and passes values directly to `encodeURIComponent`. If a value is `undefined` (e.g., unresolved config), `encodeURIComponent(undefined)` throws `TypeError`. Now filters null/undefined values before encoding.

3. **`src/plugin-sdk/oauth-utils.ts`** — `toFormUrlEncoded` passes record values to `encodeURIComponent`. Callers may have `undefined` values from optional config fields. Now filters null/undefined entries before encoding.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [x] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — no single issue.

## User-Visible Changes

- Malformed camera URLs produce a clear error instead of uncaught TypeError
- LINE quick-reply actions with missing device keys no longer crash
- OAuth token requests with optional parameters no longer crash

## Security Impact

1. Does this change handle user input? **Yes** — URLs from camera nodes, LINE device keys, OAuth config
2. Does this change affect authentication or authorization? **No** (oauth-utils change only affects encoding, not auth logic)
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **Yes** — URL validation in nodes-camera, but change adds defense

## Verification

- [x] 17 nodes-camera tests pass
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ src/cli/nodes-camera.test.ts (17 tests) 14ms
 Test Files  1 passed (1)
      Tests  17 passed (17)
```

## Human Verification

- Pass a malformed URL to writeUrlToFile → should get "invalid URL" error
- Create LINE quick-reply extras with undefined value → should not crash

## Compatibility

Fully backward compatible. Valid inputs behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Filtering null/undefined values in toFormUrlEncoded silently drops fields | These fields would have crashed previously; silent drop is safer |