### PR TITLE
OpenAI WS: guard input conversion against malformed content entries

### DIFF
--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -518,6 +518,37 @@ describe("convertMessagesToInputItems", () => {
     expect((items[0] as { content?: unknown }).content).toBe("Here is my answer.");
   });
 
+  it("skips malformed user content entries without throwing", () => {
+    const msg = {
+      role: "user" as const,
+      content: [null, { type: "text", text: "hello" }],
+      timestamp: 0,
+    };
+    const items = convertMessagesToInputItems([msg] as unknown as Parameters<
+      typeof convertMessagesToInputItems
+    >[0]);
+    expect(items).toHaveLength(1);
+    expect((items[0] as { content?: unknown }).content).toBe("hello");
+  });
+
+  it("skips malformed assistant content entries without throwing", () => {
+    const msg = {
+      role: "assistant" as const,
+      content: [null, { type: "text", text: "ok" }],
+      stopReason: "stop",
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: {},
+      timestamp: 0,
+    };
+    const items = convertMessagesToInputItems([msg] as unknown as Parameters<
+      typeof convertMessagesToInputItems
+    >[0]);
+    expect(items).toHaveLength(1);
+    expect((items[0] as { content?: unknown }).content).toBe("ok");
+  });
+
   it("returns empty array for empty messages", () => {
     expect(convertMessagesToInputItems([])).toEqual([]);
   });

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -109,6 +109,13 @@ function toNonEmptyString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function toRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
 /** Convert pi-ai content (string | ContentPart[]) to plain text. */
 function contentToText(content: unknown): string {
   if (typeof content === "string") {
@@ -132,12 +139,11 @@ function contentToOpenAIParts(content: unknown): ContentPart[] {
     return [];
   }
   const parts: ContentPart[] = [];
-  for (const part of content as Array<{
-    type?: string;
-    text?: string;
-    data?: string;
-    mimeType?: string;
-  }>) {
+  for (const partEntry of content as unknown[]) {
+    const part = toRecord(partEntry);
+    if (!part) {
+      continue;
+    }
     if (part.type === "text" && typeof part.text === "string") {
       parts.push({ type: "input_text", text: part.text });
     } else if (part.type === "image" && typeof part.data === "string") {
@@ -197,14 +203,11 @@ export function convertMessagesToInputItems(messages: Message[]): InputItem[] {
       if (Array.isArray(content)) {
         // Collect text blocks and tool calls separately
         const textParts: string[] = [];
-        for (const block of content as Array<{
-          type?: string;
-          text?: string;
-          id?: string;
-          name?: string;
-          arguments?: Record<string, unknown>;
-          thinking?: string;
-        }>) {
+        for (const blockEntry of content as unknown[]) {
+          const block = toRecord(blockEntry);
+          if (!block) {
+            continue;
+          }
           if (block.type === "text" && typeof block.text === "string") {
             textParts.push(block.text);
           } else if (block.type === "thinking" && typeof block.thinking === "string") {

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -147,11 +147,15 @@ function contentToOpenAIParts(content: unknown): ContentPart[] {
     if (part.type === "text" && typeof part.text === "string") {
       parts.push({ type: "input_text", text: part.text });
     } else if (part.type === "image" && typeof part.data === "string") {
+      const mimeType =
+        typeof part.mimeType === "string" && part.mimeType.trim().length > 0
+          ? part.mimeType
+          : "image/jpeg";
       parts.push({
         type: "input_image",
         source: {
           type: "base64",
-          media_type: part.mimeType ?? "image/jpeg",
+          media_type: mimeType,
           data: part.data,
         },
       });


### PR DESCRIPTION
## Summary
- harden `convertMessagesToInputItems` against malformed `content` entries (for example `null`)
- add object guards in both user content-part conversion and assistant block conversion paths
- add regression tests for malformed user and assistant content arrays

## Testing
- pnpm test src/agents/openai-ws-stream.test.ts

Closes #35051
