### PR TITLE
OpenAI WS: harden response parser for malformed message content

### DIFF
--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -537,6 +537,25 @@ describe("buildAssistantMessageFromResponse", () => {
     expect(textBlock.text).toBe("Hello from assistant");
   });
 
+  it("skips malformed message content entries without throwing", () => {
+    const response = {
+      id: "resp_malformed",
+      output: [
+        {
+          type: "message",
+          content: [null, { type: "output_text", text: "ok" }],
+        },
+      ],
+      usage: {},
+    } as unknown as Parameters<typeof buildAssistantMessageFromResponse>[0];
+
+    expect(() => buildAssistantMessageFromResponse(response, modelInfo)).not.toThrow();
+    const msg = buildAssistantMessageFromResponse(response, modelInfo);
+    const textBlock = msg.content[0] as { type: string; text: string };
+    expect(textBlock.type).toBe("text");
+    expect(textBlock.text).toBe("ok");
+  });
+
   it("sets stopReason to 'stop' for text-only responses", () => {
     const response = makeResponseObject("resp_1", "Just text");
     const msg = buildAssistantMessageFromResponse(response, modelInfo);

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -290,9 +290,17 @@ export function buildAssistantMessageFromResponse(
 ): AssistantMessage {
   const content: (TextContent | ToolCall)[] = [];
 
-  for (const item of response.output ?? []) {
+  for (const itemEntry of response.output ?? []) {
+    if (!itemEntry || typeof itemEntry !== "object") {
+      continue;
+    }
+    const item = itemEntry;
     if (item.type === "message") {
-      for (const part of item.content ?? []) {
+      for (const partEntry of item.content ?? []) {
+        if (!partEntry || typeof partEntry !== "object") {
+          continue;
+        }
+        const part = partEntry as { type?: string; text?: string };
         if (part.type === "output_text" && part.text) {
           content.push({ type: "text", text: part.text });
         }


### PR DESCRIPTION
## Summary
- harden `buildAssistantMessageFromResponse` against malformed output/message content entries (`null` / non-object entries)
- guard nested `item.content[]` traversal before accessing `part.type`
- add a regression test that verifies malformed content is skipped and valid text still parses

## Testing
- pnpm test src/agents/openai-ws-stream.test.ts

Closes #35045
