### PR TITLE
fix(cli): honor systemPromptWhen=always on session resume

### DIFF
--- a/src/agents/cli-runner.test.ts
+++ b/src/agents/cli-runner.test.ts
@@ -107,6 +107,77 @@ describe("runCliAgent with process supervisor", () => {
     expect(input.scopeKey).toContain("thread-123");
   });
 
+  it("resends system prompt on resumed claude sessions when configured", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-runner-resume-always-"));
+    const skillDir = path.join(tempDir, "skills", "resume-skill-always");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      [
+        "---",
+        "name: resume-skill-always",
+        "description: Resume-skill description for always mode",
+        "---",
+        "",
+        "Use this skill after resume in always mode.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: '{"content":[{"type":"text","text":"ok"}]}',
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": {
+              command: "claude",
+              systemPromptWhen: "always",
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    try {
+      await runCliAgent({
+        sessionId: "s1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: tempDir,
+        prompt: "hi",
+        provider: "claude-cli",
+        model: "sonnet",
+        timeoutMs: 1_000,
+        runId: "run-claude-resume-always",
+        cliSessionId: "existing-claude-session",
+        config: cfg,
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+
+    const input = supervisorSpawnMock.mock.calls[0]?.[0] as { argv?: string[] };
+    expect(input.argv).toContain("--resume");
+    expect(input.argv).toContain("existing-claude-session");
+    expect(input.argv).toContain("--append-system-prompt");
+    const systemPromptIndex = input.argv?.indexOf("--append-system-prompt") ?? -1;
+    expect(systemPromptIndex).toBeGreaterThanOrEqual(0);
+    const systemPrompt = input.argv?.[systemPromptIndex + 1] ?? "";
+    expect(systemPrompt).toContain("<available_skills>");
+    expect(systemPrompt).toContain("resume-skill-always");
+  });
+
   it("fails with timeout when no-output watchdog trips", async () => {
     supervisorSpawnMock.mockResolvedValueOnce(
       createManagedRun({

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -359,7 +359,7 @@ export function buildCliArgs(params: {
   if (!params.useResume && params.backend.modelArg && params.modelId) {
     args.push(params.backend.modelArg, params.modelId);
   }
-  if (!params.useResume && params.systemPrompt && params.backend.systemPromptArg) {
+  if (params.systemPrompt && params.backend.systemPromptArg) {
     args.push(params.backend.systemPromptArg, params.systemPrompt);
   }
   if (!params.useResume && params.sessionId) {


### PR DESCRIPTION
## Problem

When a CLI backend session (e.g., Claude Code) is **resumed** with `--resume`, the system prompt is silently dropped because of this guard:

```typescript
// Before (broken):
if (!params.useResume && params.systemPrompt && params.backend.systemPromptArg) {
  args.push(params.backend.systemPromptArg, params.systemPrompt);
}
```

This means resumed sessions lose access to **skills, workspace context, and agent instructions** — the model operates "blind" without its configured system prompt.

```
Session flow WITHOUT this fix:

  New session:     claude --system-prompt "skills + context" -p "task"     ✓ has context
  Resumed session: claude --resume <id> -p "follow-up"                    ✗ no context!

Session flow WITH this fix (systemPromptWhen=always):

  New session:     claude --system-prompt "skills + context" -p "task"     ✓ has context
  Resumed session: claude --resume <id> --append-system-prompt "..." -p   ✓ has context
```

## Fix

Remove the `!params.useResume` guard from the system prompt argument builder. When `systemPromptWhen` is set to `"always"` in the CLI backend config, the system prompt is now passed on every invocation, including resumed sessions.

Added a test that verifies `--append-system-prompt` is included in argv when resuming with `systemPromptWhen=always`, and that the prompt contains `<available_skills>`.

## Why merge

Without this fix, any multi-turn CLI agent session loses its identity after the first turn. The model forgets its skills, workspace layout, and behavioral instructions on resume. This causes degraded responses, inability to use skills, and effectively breaks multi-turn agent workflows for all CLI backends.