### PR TITLE
fix(feishu): check response.ok before parsing streaming card token response

### DIFF
--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -67,6 +67,13 @@ async function getToken(creds: Credentials): Promise<string> {
     policy: { allowedHostnames: resolveAllowedHostnames(creds.domain) },
     auditContext: "feishu.streaming-card.token",
   });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    await release();
+    throw new Error(
+      `Feishu token request failed: HTTP ${response.status} ${text || response.statusText}`,
+    );
+  }
   const data = (await response.json()) as {
     code: number;
     msg: string;


### PR DESCRIPTION
## Summary

The Feishu streaming card token endpoint (`/auth/v3/tenant_access_token/internal`) response was parsed via `response.json()` without first checking `response.ok`. When the Feishu API returns a non-2xx HTTP response (e.g., 502 from a proxy, CDN timeout, or rate-limit page), the response body is typically HTML, and `response.json()` throws an unhandled `SyntaxError` that crashes the streaming card setup instead of providing a clear error.

Added an explicit `response.ok` check before JSON parsing, with a descriptive error message including the HTTP status code and response text.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — follows pattern from PR #35628 which fixed the same issue in other Feishu API calls.

## User-Visible Changes

Feishu streaming card token request failures now produce clear error messages with HTTP status instead of cryptic SyntaxError.

## Security Impact

1. Does this change handle user input? **No** — API credentials only
2. Does this change affect authentication or authorization? **No** (error path only)
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 321 Feishu tests pass
- [x] Formatted with `oxfmt`

## Evidence

```
 Test Files  32 passed (32)
      Tests  321 passed (321)
```

## Human Verification

- Simulate a 502 response from Feishu token endpoint → should get "HTTP 502" error instead of SyntaxError

## Compatibility

Fully backward compatible. Successful responses behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| release() must be called on error path | Added `await release()` before throwing to prevent SSRF guard leak |