### PR TITLE
Fix: WhatsApp E.164 validation error message

### DIFF
--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -41,7 +41,9 @@ export function resolveWhatsAppOutboundTarget(params: {
     }
     return {
       ok: false,
-      error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+      error: new Error(
+        `Target "${trimmed}" is not listed in the configured WhatsApp allowFrom policy.`,
+      ),
     };
   }
 


### PR DESCRIPTION
## Summary
- Fix issue #35580: misleading WhatsApp outbound error for targets blocked by allowFrom policy.
- Replace the generic message `Delivering to WhatsApp requires target <E.164|group JID>` with a policy-specific message:
  - `Target "<number>" is not listed in the configured WhatsApp allowFrom policy.`

## Security Impact
- N/A

## Repro+Verification
- Configure WhatsApp plugin with an allowFrom list.
- Send to a valid E.164 number that is not in allowFrom.
- Before: error implies invalid E.164 target format.
- After: error explicitly states target is not allowed by allowFrom policy.

## Testing
- `pnpm test src/whatsapp/resolve-outbound-target.test.ts` (21 passed)

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35580
