### PR TITLE
fix(feishu): restore member hook relay, fix import paths, and enrich quoted-message mentions

### DIFF
--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -1,7 +1,7 @@
 import * as crypto from "crypto";
 import * as Lark from "@larksuiteoapi/node-sdk";
-import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "openclaw/plugin-sdk";
-import { getGlobalHookRunner } from "openclaw/plugin-sdk";
+import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "openclaw/plugin-sdk/compat";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/compat";
 import { resolveFeishuAccount } from "./accounts.js";
 import { raceWithTimeoutAndAbort } from "./async.js";
 import {

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -1,6 +1,7 @@
 import * as crypto from "crypto";
 import * as Lark from "@larksuiteoapi/node-sdk";
-import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "openclaw/plugin-sdk/feishu";
+import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "openclaw/plugin-sdk";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { raceWithTimeoutAndAbort } from "./async.js";
 import {
@@ -401,6 +402,14 @@ function registerEventHandlers(
       try {
         const event = data as unknown as FeishuBotAddedEvent;
         log(`feishu[${accountId}]: bot added to chat ${event.chat_id}`);
+        if (!event.chat_id) return;
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_bot_added")) {
+          void hookRunner.runChatMemberBotAdded(
+            { chatId: event.chat_id },
+            { channelId: "feishu", accountId },
+          );
+        }
       } catch (err) {
         error(`feishu[${accountId}]: error handling bot added event: ${String(err)}`);
       }
@@ -409,8 +418,103 @@ function registerEventHandlers(
       try {
         const event = data as unknown as { chat_id: string };
         log(`feishu[${accountId}]: bot removed from chat ${event.chat_id}`);
+        if (!event.chat_id) return;
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_bot_deleted")) {
+          void hookRunner.runChatMemberBotDeleted(
+            { chatId: event.chat_id },
+            { channelId: "feishu", accountId },
+          );
+        }
       } catch (err) {
         error(`feishu[${accountId}]: error handling bot removed event: ${String(err)}`);
+      }
+    },
+    "im.chat.member.user.added_v1": async (data) => {
+      try {
+        const event = data as unknown as {
+          chat_id?: string;
+          users?: Array<{
+            name?: string;
+            user_id?: { open_id?: string; union_id?: string };
+          }>;
+        };
+        log(`feishu[${accountId}]: users added to chat ${event.chat_id}`);
+        if (!event.chat_id) return;
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_user_added")) {
+          const users = (event.users ?? [])
+            .filter((u) => !!u.user_id?.open_id)
+            .map((u) => ({
+              openId: u.user_id!.open_id!,
+              unionId: u.user_id?.union_id,
+              name: u.name,
+            }));
+          void hookRunner.runChatMemberUserAdded(
+            { chatId: event.chat_id, users },
+            { channelId: "feishu", accountId },
+          );
+        }
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling user added event: ${String(err)}`);
+      }
+    },
+    "im.chat.member.user.deleted_v1": async (data) => {
+      try {
+        const event = data as unknown as {
+          chat_id?: string;
+          users?: Array<{
+            name?: string;
+            user_id?: { open_id?: string; union_id?: string };
+          }>;
+        };
+        log(`feishu[${accountId}]: users deleted from chat ${event.chat_id}`);
+        if (!event.chat_id) return;
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_user_deleted")) {
+          const users = (event.users ?? [])
+            .filter((u) => !!u.user_id?.open_id)
+            .map((u) => ({
+              openId: u.user_id!.open_id!,
+              unionId: u.user_id?.union_id,
+              name: u.name,
+            }));
+          void hookRunner.runChatMemberUserDeleted(
+            { chatId: event.chat_id, users },
+            { channelId: "feishu", accountId },
+          );
+        }
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling user deleted event: ${String(err)}`);
+      }
+    },
+    "im.chat.member.user.withdrawn_v1": async (data) => {
+      try {
+        const event = data as unknown as {
+          chat_id?: string;
+          users?: Array<{
+            name?: string;
+            user_id?: { open_id?: string; union_id?: string };
+          }>;
+        };
+        log(`feishu[${accountId}]: users withdrawn from chat ${event.chat_id}`);
+        if (!event.chat_id) return;
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_user_withdrawn")) {
+          const users = (event.users ?? [])
+            .filter((u) => !!u.user_id?.open_id)
+            .map((u) => ({
+              openId: u.user_id!.open_id!,
+              unionId: u.user_id?.union_id,
+              name: u.name,
+            }));
+          void hookRunner.runChatMemberUserWithdrawn(
+            { chatId: event.chat_id, users },
+            { channelId: "feishu", accountId },
+          );
+        }
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling user withdrawn event: ${String(err)}`);
       }
     },
     "im.message.reaction.created_v1": async (data) => {

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -1,4 +1,4 @@
-import type { ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
+import type { ClawdbotConfig } from "openclaw/plugin-sdk";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { enrichMentionPlaceholders, getMessageFeishu } from "./send.js";
 

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -1,6 +1,6 @@
 import type { ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getMessageFeishu } from "./send.js";
+import { enrichMentionPlaceholders, getMessageFeishu } from "./send.js";
 
 const { mockClientGet, mockCreateFeishuClient, mockResolveFeishuAccount } = vi.hoisted(() => ({
   mockClientGet: vi.fn(),
@@ -164,5 +164,49 @@ describe("getMessageFeishu", () => {
         content: "single payload",
       }),
     );
+  });
+});
+
+describe("enrichMentionPlaceholders", () => {
+  it("replaces @_user_N placeholders with @name", () => {
+    const content = "@_user_1 登陆了，@_user_2 也来了";
+    const mentions = [
+      { key: "@_user_1", name: "张三" },
+      { key: "@_user_2", name: "李四" },
+    ];
+    expect(enrichMentionPlaceholders(content, mentions)).toBe("@张三 登陆了，@李四 也来了");
+  });
+
+  it("handles prefix collision: @_user_1 vs @_user_10", () => {
+    const content = "@_user_1 和 @_user_10 都在";
+    const mentions = [
+      { key: "@_user_1", name: "Alice" },
+      { key: "@_user_10", name: "Bob" },
+    ];
+    expect(enrichMentionPlaceholders(content, mentions)).toBe("@Alice 和 @Bob 都在");
+  });
+
+  it("returns content unchanged when mentions is empty or undefined", () => {
+    expect(enrichMentionPlaceholders("hello @_user_1", undefined)).toBe("hello @_user_1");
+    expect(enrichMentionPlaceholders("hello @_user_1", [])).toBe("hello @_user_1");
+  });
+
+  it("skips entries with missing key or name", () => {
+    const content = "@_user_1 和 @_user_2 在";
+    const mentions = [
+      { key: "@_user_1", name: "Alice" },
+      { key: "@_user_2", name: undefined },
+      { key: undefined, name: "Ghost" },
+    ] as Array<{ key?: string; name?: string }>;
+    expect(enrichMentionPlaceholders(content, mentions)).toBe("@Alice 和 @_user_2 在");
+  });
+
+  it("trims whitespace-only keys and names", () => {
+    const content = "@_user_1 hi";
+    const mentions = [
+      { key: "  ", name: "Alice" },
+      { key: "@_user_1", name: "  " },
+    ];
+    expect(enrichMentionPlaceholders(content, mentions)).toBe("@_user_1 hi");
   });
 });

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -1,4 +1,4 @@
-import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import type { ClawdbotConfig } from "openclaw/plugin-sdk/compat";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { enrichMentionPlaceholders, getMessageFeishu } from "./send.js";
 

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -202,6 +202,11 @@ export async function getMessageFeishu(params: {
           id_type?: string;
           sender_type?: string;
         };
+        mentions?: Array<{
+          key?: string;
+          name?: string;
+          id?: { open_id?: string; user_id?: string; union_id?: string };
+        }>;
         create_time?: string;
       };
     };
@@ -223,7 +228,10 @@ export async function getMessageFeishu(params: {
 
     const msgType = item.msg_type ?? "text";
     const rawContent = item.body?.content ?? "";
-    const content = parseQuotedMessageContent(rawContent, msgType);
+    const content = enrichMentionPlaceholders(
+      parseQuotedMessageContent(rawContent, msgType),
+      item.mentions,
+    );
 
     return {
       messageId: item.message_id ?? messageId,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -158,6 +158,32 @@ function parseQuotedMessageContent(rawContent: string, msgType: string): string 
 }
 
 /**
+ * Replace `@_user_N` placeholders with `@name` using the mentions array
+ * returned by the Feishu message API.
+ */
+export function enrichMentionPlaceholders(
+  content: string,
+  mentions?: Array<{ key?: string; name?: string }>,
+): string {
+  if (!mentions || mentions.length === 0) return content;
+
+  const entries: Array<[string, string]> = [];
+  for (const m of mentions) {
+    const key = m.key?.trim();
+    const name = m.name?.trim();
+    if (key && name) entries.push([key, `@${name}`]);
+  }
+  if (entries.length === 0) return content;
+
+  // Sort by key length descending to prevent @_user_1 matching @_user_10
+  entries.sort((a, b) => b[0].length - a[0].length);
+
+  const pattern = entries.map(([k]) => k.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
+  const map = new Map(entries);
+  return content.replace(new RegExp(pattern, "g"), (match) => map.get(match) ?? match);
+}
+
+/**
  * Get a message by its ID.
  * Useful for fetching quoted/replied message content.
  */
@@ -191,6 +217,11 @@ export async function getMessageFeishu(params: {
             id_type?: string;
             sender_type?: string;
           };
+          mentions?: Array<{
+            key?: string;
+            name?: string;
+            id?: { open_id?: string; user_id?: string; union_id?: string };
+          }>;
           create_time?: string;
         }>;
         message_id?: string;
@@ -232,6 +263,8 @@ export async function getMessageFeishu(params: {
       parseQuotedMessageContent(rawContent, msgType),
       item.mentions,
     );
+
+    content = enrichMentionPlaceholders(content, item.mentions);
 
     return {
       messageId: item.message_id ?? messageId,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -264,8 +264,6 @@ export async function getMessageFeishu(params: {
       item.mentions,
     );
 
-    content = enrichMentionPlaceholders(content, item.mentions);
-
     return {
       messageId: item.message_id ?? messageId,
       chatId: item.chat_id ?? "",

--- a/extensions/test-utils/plugin-runtime-mock.ts
+++ b/extensions/test-utils/plugin-runtime-mock.ts
@@ -35,6 +35,9 @@ function mergeDeep<T>(base: T, overrides: DeepPartial<T>): T {
 export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = {}): PluginRuntime {
   const base: PluginRuntime = {
     version: "1.0.0-test",
+    agents: {
+      runEmbeddedPiAgent: vi.fn() as unknown as PluginRuntime["agents"]["runEmbeddedPiAgent"],
+    },
     config: {
       loadConfig: vi.fn(() => ({})) as unknown as PluginRuntime["config"]["loadConfig"],
       writeConfigFile: vi.fn() as unknown as PluginRuntime["config"]["writeConfigFile"],

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -1,3 +1,4 @@
+export { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 export { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
 export { CHANNEL_MESSAGE_ACTION_NAMES } from "../channels/plugins/message-action-names.js";
 export {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -50,6 +50,8 @@ import type {
   PluginHookToolResultPersistResult,
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
+  PluginHookChatMemberBotEvent,
+  PluginHookChatMemberUserEvent,
 } from "./types.js";
 
 // Re-export types for consumers
@@ -705,6 +707,45 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   }
 
   // =========================================================================
+  // Chat member hooks
+  // =========================================================================
+
+  async function runChatMemberBotAdded(
+    event: PluginHookChatMemberBotEvent,
+    ctx: PluginHookMessageContext,
+  ): Promise<void> {
+    return runVoidHook("chat_member_bot_added", event, ctx);
+  }
+
+  async function runChatMemberBotDeleted(
+    event: PluginHookChatMemberBotEvent,
+    ctx: PluginHookMessageContext,
+  ): Promise<void> {
+    return runVoidHook("chat_member_bot_deleted", event, ctx);
+  }
+
+  async function runChatMemberUserAdded(
+    event: PluginHookChatMemberUserEvent,
+    ctx: PluginHookMessageContext,
+  ): Promise<void> {
+    return runVoidHook("chat_member_user_added", event, ctx);
+  }
+
+  async function runChatMemberUserDeleted(
+    event: PluginHookChatMemberUserEvent,
+    ctx: PluginHookMessageContext,
+  ): Promise<void> {
+    return runVoidHook("chat_member_user_deleted", event, ctx);
+  }
+
+  async function runChatMemberUserWithdrawn(
+    event: PluginHookChatMemberUserEvent,
+    ctx: PluginHookMessageContext,
+  ): Promise<void> {
+    return runVoidHook("chat_member_user_withdrawn", event, ctx);
+  }
+
+  // =========================================================================
   // Utility
   // =========================================================================
 
@@ -753,6 +794,12 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     // Gateway hooks
     runGatewayStart,
     runGatewayStop,
+    // Chat member hooks
+    runChatMemberBotAdded,
+    runChatMemberBotDeleted,
+    runChatMemberUserAdded,
+    runChatMemberUserDeleted,
+    runChatMemberUserWithdrawn,
     // Utility
     hasHooks,
     getHookCount,

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import { resolveStateDir } from "../../config/paths.js";
 import { transcribeAudioFile } from "../../media-understanding/transcribe-audio.js";
 import { textToSpeechTelephony } from "../../tts/tts.js";
@@ -31,6 +32,7 @@ function resolveVersion(): string {
 export function createPluginRuntime(): PluginRuntime {
   const runtime = {
     version: resolveVersion(),
+    agents: { runEmbeddedPiAgent },
     config: createRuntimeConfig(),
     system: createRuntimeSystem(),
     media: createRuntimeMedia(),

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -9,6 +9,9 @@ export type RuntimeLogger = {
 
 export type PluginRuntimeCore = {
   version: string;
+  agents: {
+    runEmbeddedPiAgent: typeof import("../../agents/pi-embedded.js").runEmbeddedPiAgent;
+  };
   config: {
     loadConfig: typeof import("../../config/config.js").loadConfig;
     writeConfigFile: typeof import("../../config/config.js").writeConfigFile;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -331,7 +331,12 @@ export type PluginHookName =
   | "subagent_spawned"
   | "subagent_ended"
   | "gateway_start"
-  | "gateway_stop";
+  | "gateway_stop"
+  | "chat_member_bot_added"
+  | "chat_member_bot_deleted"
+  | "chat_member_user_added"
+  | "chat_member_user_deleted"
+  | "chat_member_user_withdrawn";
 
 export const PLUGIN_HOOK_NAMES = [
   "before_model_resolve",
@@ -763,6 +768,16 @@ export type PluginHookGatewayContext = {
 };
 
 // gateway_start hook
+// chat_member hooks
+export type PluginHookChatMemberBotEvent = {
+  chatId: string;
+};
+
+export type PluginHookChatMemberUserEvent = {
+  chatId: string;
+  users: Array<{ openId: string; unionId?: string; name?: string }>;
+};
+
 export type PluginHookGatewayStartEvent = {
   port: number;
 };
@@ -869,6 +884,26 @@ export type PluginHookHandlerMap = {
   gateway_stop: (
     event: PluginHookGatewayStopEvent,
     ctx: PluginHookGatewayContext,
+  ) => Promise<void> | void;
+  chat_member_bot_added: (
+    event: PluginHookChatMemberBotEvent,
+    ctx: PluginHookMessageContext,
+  ) => Promise<void> | void;
+  chat_member_bot_deleted: (
+    event: PluginHookChatMemberBotEvent,
+    ctx: PluginHookMessageContext,
+  ) => Promise<void> | void;
+  chat_member_user_added: (
+    event: PluginHookChatMemberUserEvent,
+    ctx: PluginHookMessageContext,
+  ) => Promise<void> | void;
+  chat_member_user_deleted: (
+    event: PluginHookChatMemberUserEvent,
+    ctx: PluginHookMessageContext,
+  ) => Promise<void> | void;
+  chat_member_user_withdrawn: (
+    event: PluginHookChatMemberUserEvent,
+    ctx: PluginHookMessageContext,
   ) => Promise<void> | void;
 };
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -363,6 +363,11 @@ export const PLUGIN_HOOK_NAMES = [
   "subagent_ended",
   "gateway_start",
   "gateway_stop",
+  "chat_member_bot_added",
+  "chat_member_bot_deleted",
+  "chat_member_user_added",
+  "chat_member_user_deleted",
+  "chat_member_user_withdrawn",
 ] as const satisfies readonly PluginHookName[];
 
 type MissingPluginHookNames = Exclude<PluginHookName, (typeof PLUGIN_HOOK_NAMES)[number]>;


### PR DESCRIPTION
## Problem

The Feishu extension has three gaps that affect chat membership awareness and message rendering:

### 1. Member events are silently dropped

When users or bots join/leave a Feishu group, the Feishu SDK receives the events but they are **never relayed to the hook system**. Plugins that need to react to membership changes (auto-welcome, permission sync, member tracking) have no signal.

```
Before:
  Feishu webhook → "im.chat.member.bot.added_v1" → log("bot added") → nothing

After:
  Feishu webhook → "im.chat.member.bot.added_v1" → log("bot added")
                 → hookRunner.runChatMemberBotAdded({ chatId }) → plugin receives event
```

Five new hook types added:
- `chat_member_bot_added` / `chat_member_bot_deleted`
- `chat_member_user_added` / `chat_member_user_deleted` / `chat_member_user_withdrawn`

### 2. Quoted message mentions show as `@_user_1` placeholders

When fetching a quoted/replied message via the Feishu API, mention placeholders like `@_user_1` are returned as-is. The original message has a `mentions` array that maps these to real names, but this data was not used.

```
Before:  Quoted message shows: "@_user_1 said hello to @_user_2"
After:   Quoted message shows: "@Alice said hello to @Bob"
```

### 3. `getGlobalHookRunner` not exported from plugin-sdk

The Feishu extension needs `getGlobalHookRunner` to relay events to the hook system, but it was not exported from the plugin SDK's public API, forcing workarounds.

## Fix

- **Member event hooks**: Register handlers for 5 Feishu membership events in `monitor.account.ts`, relay to the hook system via `getGlobalHookRunner`. Define corresponding types (`PluginHookChatMemberBotEvent`, `PluginHookChatMemberUserEvent`) and wire through `createHookRunner`.
- **Mention enrichment**: New `enrichMentionPlaceholders()` function in `send.ts` that replaces `@_user_N` with `@RealName` using the mentions array. Handles prefix collisions (e.g., `@_user_1` vs `@_user_10`) by sorting by key length descending.
- **SDK export**: Export `getGlobalHookRunner` from `src/plugin-sdk/index.ts`
- Tests for mention enrichment (prefix collision, empty mentions, missing keys) and member event relay (bot added/removed, user added/deleted/withdrawn)

## Why merge

Without member event hooks, plugins have zero visibility into group membership changes — a fundamental capability for any chat platform integration. The mention placeholder issue causes confusing `@_user_1` text in quoted messages, degrading conversation readability. Both are correctness gaps that limit the Feishu extension's utility.