### PR TITLE
Models: guard list/scan paths for missing model.input

### DIFF
--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -326,12 +326,13 @@ async function probeImage(
 }
 
 function ensureImageInput(model: OpenAIModel): OpenAIModel {
-  if (model.input.includes("image")) {
+  const inputModes = Array.isArray(model.input) ? model.input : ["text"];
+  if (inputModes.includes("image")) {
     return model;
   }
   return {
     ...model,
-    input: Array.from(new Set([...model.input, "image"])),
+    input: Array.from(new Set([...inputModes, "image"])),
   };
 }
 
@@ -472,7 +473,8 @@ export async function scanOpenRouterModels(
       };
 
       const toolResult = await probeTool(model, apiKey, timeoutMs);
-      const imageResult = model.input.includes("image")
+      const imageInputModes = Array.isArray(model.input) ? model.input : [];
+      const imageResult = imageInputModes.includes("image")
         ? await probeImage(ensureImageInput(model), apiKey, timeoutMs)
         : { ok: false, latencyMs: null, skipped: true };
 

--- a/src/agents/model-scan.ts
+++ b/src/agents/model-scan.ts
@@ -326,7 +326,9 @@ async function probeImage(
 }
 
 function ensureImageInput(model: OpenAIModel): OpenAIModel {
-  const inputModes = Array.isArray(model.input) ? model.input : ["text"];
+  const inputModes: Array<"text" | "image"> = Array.isArray(model.input)
+    ? model.input.filter((mode): mode is "text" | "image" => mode === "text" || mode === "image")
+    : ["text"];
   if (inputModes.includes("image")) {
     return model;
   }

--- a/src/commands/models/list.registry.test.ts
+++ b/src/commands/models/list.registry.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { toModelRow } from "./list.registry.js";
+
+describe("toModelRow", () => {
+  it("falls back to text input when model.input is missing", () => {
+    const row = toModelRow({
+      model: {
+        id: "custom/missing-input",
+        name: "Missing Input",
+        provider: "custom",
+        baseUrl: "https://example.com/v1",
+      } as unknown as Parameters<typeof toModelRow>[0]["model"],
+      key: "custom/missing-input",
+      tags: [],
+    });
+
+    expect(row.input).toBe("text");
+  });
+});

--- a/src/commands/models/list.registry.ts
+++ b/src/commands/models/list.registry.ts
@@ -144,7 +144,8 @@ export function toModelRow(params: {
     };
   }
 
-  const input = model.input.join("+") || "text";
+  const inputModes = Array.isArray(model.input) ? model.input : ["text"];
+  const input = inputModes.join("+") || "text";
   const local = isLocalBaseUrl(model.baseUrl);
   // Prefer model-level registry availability when present.
   // Fall back to provider-level auth heuristics only if registry availability isn't available.


### PR DESCRIPTION
## Summary
- guard models list/scan paths when `model.input` is missing or malformed
- default to `text` input in model listing (`toModelRow`)
- harden OpenRouter scan image probe gating against non-array `model.input`
- add regression test for listing fallback behavior

## Testing
- pnpm test src/agents/model-scan.test.ts src/commands/models/list.registry.test.ts

Closes #35416
