### PR TITLE
fix(telegram): suppress error notifications in group chats

### DIFF
--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -1816,4 +1816,42 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftA.clear).toHaveBeenCalledTimes(1);
     expect(draftB.clear).toHaveBeenCalledTimes(1);
   });
+
+  it("suppresses error payloads in group chats", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        { text: "⚠️ ✉️ Message: 2201 failed", isError: true },
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({
+      context: createContext({ isGroup: true }),
+    });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("delivers error payloads in DM chats", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        { text: "⚠️ ✉️ Message: 2201 failed", isError: true },
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({
+      context: createContext({ isGroup: false }),
+    });
+
+    expect(deliverReplies).toHaveBeenCalled();
+  });
 });

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -511,6 +511,10 @@ export const dispatchTelegramMessage = async ({
         ...prefixOptions,
         typingCallbacks,
         deliver: async (payload, info) => {
+          if (isGroup && payload.isError) {
+            logVerbose("telegram: suppressing error notification in group chat");
+            return;
+          }
           if (info.kind === "final") {
             // Assistant callbacks are fire-and-forget; ensure queued boundary
             // rotations/partials are applied before final delivery mapping.


### PR DESCRIPTION
## Summary

- **Problem:** Tool error warnings (e.g. "⚠️ ✉️ Message: 2201 failed") were posted into Telegram group chats, visible to all members.
- **Why it matters:** Internal system error notifications should not leak to uninvolved group members. They expose implementation details and confuse users.
- **What changed:** In `dispatchTelegramMessage`'s deliver callback, payloads with `isError: true` are now suppressed when `isGroup` is true. A verbose log is emitted for debugging.
- **What did NOT change:** DM error delivery is unaffected. Non-error payloads in groups are unaffected. Other channels (Discord, Slack, etc.) are not touched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35655

## User-visible / Behavior Changes

- Tool error notifications (⚠️ warnings) no longer appear in Telegram group chats.
- DM users still see error notifications as before.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: Telegram group

### Steps

1. Configure a Telegram group chat with `groupPolicy: allowlist`
2. Trigger a message send failure (e.g. send to a deleted message ID)
3. Observe the group chat

### Expected

- No error notification visible in the group chat

### Actual

- Before fix: "⚠️ ✉️ Message: 2201 failed" appears in the group chat
- After fix: Error is suppressed; only logged verbosely

## Evidence

Two new test cases in `bot-message-dispatch.test.ts`:
- `suppresses error payloads in group chats` — verifies `deliverReplies` is NOT called ✅
- `delivers error payloads in DM chats` — verifies DM delivery is unaffected ✅

All 60 tests pass.

## Human Verification (required)

- Verified scenarios: Group chat error suppression, DM error delivery preserved
- Edge cases checked: Error-only final payloads, mixed error+normal payloads
- What I did **not** verify: Live Telegram group (test-only verification)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit
- Files/config to restore: `src/telegram/bot-message-dispatch.ts`
- Known bad symptoms: If reverted, error notifications appear in groups again

## Risks and Mitigations

- Risk: Legitimate error feedback to the triggering user in a group is also suppressed — mitigated by the fact that tool errors are system-level notifications not meant for group audiences. The owner can always check gateway logs.

