### PR TITLE
fix(telegram): fall back when draft final materialize fails

### DIFF
--- a/src/telegram/lane-delivery.test.ts
+++ b/src/telegram/lane-delivery.test.ts
@@ -293,6 +293,32 @@ describe("createLaneTextDeliverer", () => {
     );
   });
 
+  it("falls back to normal send when draft materialize throws", async () => {
+    const answerStream = createTestDraftStream({ previewMode: "draft" });
+    answerStream.materialize.mockRejectedValue(new Error("boom"));
+    const harness = createHarness({
+      answerStream: answerStream as DraftLaneState["stream"],
+      answerHasStreamedMessage: true,
+      answerLastPartialText: "Hello final",
+    });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Hello final",
+      payload: { text: "Hello final" },
+      infoKind: "final",
+    });
+
+    expect(result).toBe("sent");
+    expect(answerStream.materialize).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Hello final" }),
+    );
+    expect(harness.log).toHaveBeenCalledWith(
+      expect.stringContaining("draft preview materialize failed"),
+    );
+  });
+
   it("does not use DM draft final shortcut for media payloads", async () => {
     const answerStream = createTestDraftStream({ previewMode: "draft" });
     const harness = createHarness({

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -179,8 +179,16 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     }
     // Draft previews have no message_id to edit; materialize the final text
     // into a real message and treat that as the finalized delivery.
-    stream.update(args.text);
-    const materializedMessageId = await stream.materialize?.();
+    let materializedMessageId: number | undefined;
+    try {
+      stream.update(args.text);
+      materializedMessageId = await stream.materialize?.();
+    } catch (err) {
+      params.log(
+        `telegram: ${args.laneName} draft preview materialize failed; falling back to standard send (${String(err)})`,
+      );
+      return false;
+    }
     if (typeof materializedMessageId !== "number") {
       params.log(
         `telegram: ${args.laneName} draft preview materialize produced no message id; falling back to standard send`,


### PR DESCRIPTION
## Summary
- catch errors thrown by draft-preview `materialize()` in Telegram lane finalization
- fall back to the existing standard `sendPayload` path when materialization fails
- add regression coverage for the thrown-error branch

## Why
When DM draft-final shortcut is active, `tryMaterializeDraftPreviewForFinal` previously allowed `materialize()` rejections to bubble. That can abort final delivery instead of using the normal send fallback.

## Changes
- wrapped `stream.update + stream.materialize` in `try/catch` in `src/telegram/lane-delivery.ts`
- on error, log and return `false` so caller proceeds with standard send path
- added test `falls back to normal send when draft materialize throws` in `src/telegram/lane-delivery.test.ts`

## Validation
- `pnpm test src/telegram/lane-delivery.test.ts`
- `pnpm build && pnpm check && pnpm test`

This PR is AI-assisted. Code has been fully tested locally. I understand what this code does.
