### PR TITLE
CLI: include commit hash in --version output

### DIFF
--- a/scripts/docker/install-sh-common/cli-verify.sh
+++ b/scripts/docker/install-sh-common/cli-verify.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+extract_cli_semver() {
+  local raw="$1"
+  printf '%s\n' "$raw" | sed -E 's/^OpenClaw ([^ ]+)( \\([0-9a-f]{7}\\))?$/\\1/'
+}
+
 verify_installed_cli() {
   local package_name="$1"
   local expected_version="$2"
@@ -31,6 +36,8 @@ verify_installed_cli() {
   else
     installed_version="$(node "$entry_path" --version 2>/dev/null | head -n 1 | tr -d '\r')"
   fi
+
+  installed_version="$(extract_cli_semver "$installed_version")"
 
   echo "cli=$cli_name installed=$installed_version expected=$expected_version"
   if [[ "$installed_version" != "$expected_version" ]]; then

--- a/scripts/docker/install-sh-e2e/run.sh
+++ b/scripts/docker/install-sh-e2e/run.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+extract_cli_semver() {
+  local raw="$1"
+  printf '%s\n' "$raw" | sed -E 's/^OpenClaw ([^ ]+)( \\([0-9a-f]{7}\\))?$/\\1/'
+}
+
 INSTALL_URL="${OPENCLAW_INSTALL_URL:-${CLAWDBOT_INSTALL_URL:-https://openclaw.bot/install.sh}}"
 MODELS_MODE="${OPENCLAW_E2E_MODELS:-${CLAWDBOT_E2E_MODELS:-both}}" # both|openai|anthropic
 INSTALL_TAG="${OPENCLAW_INSTALL_TAG:-${CLAWDBOT_INSTALL_TAG:-latest}}"
@@ -69,6 +74,7 @@ fi
 
 echo "==> Verify installed version"
 INSTALLED_VERSION="$(openclaw --version 2>/dev/null | head -n 1 | tr -d '\r')"
+INSTALLED_VERSION="$(extract_cli_semver "$INSTALLED_VERSION")"
 echo "installed=$INSTALLED_VERSION expected=$EXPECTED_VERSION"
 if [[ "$INSTALLED_VERSION" != "$EXPECTED_VERSION" ]]; then
   echo "ERROR: expected openclaw@$EXPECTED_VERSION, got openclaw@$INSTALLED_VERSION" >&2

--- a/src/cli/program/help.test.ts
+++ b/src/cli/program/help.test.ts
@@ -5,6 +5,7 @@ import type { ProgramContext } from "./context.js";
 const hasEmittedCliBannerMock = vi.fn(() => false);
 const formatCliBannerLineMock = vi.fn(() => "BANNER-LINE");
 const formatDocsLinkMock = vi.fn((_path: string, full: string) => `https://${full}`);
+const resolveCommitHashMock = vi.fn(() => "abc1234");
 
 vi.mock("../../terminal/links.js", () => ({
   formatDocsLink: formatDocsLinkMock,
@@ -24,6 +25,10 @@ vi.mock("../../terminal/theme.js", () => ({
 vi.mock("../banner.js", () => ({
   formatCliBannerLine: formatCliBannerLineMock,
   hasEmittedCliBanner: hasEmittedCliBannerMock,
+}));
+
+vi.mock("../../infra/git-commit.js", () => ({
+  resolveCommitHash: resolveCommitHashMock,
 }));
 
 vi.mock("../cli-name.js", () => ({
@@ -55,6 +60,7 @@ describe("configureProgramHelp", () => {
     vi.clearAllMocks();
     originalArgv = [...process.argv];
     hasEmittedCliBannerMock.mockReturnValue(false);
+    resolveCommitHashMock.mockReturnValue("abc1234");
   });
 
   afterEach(() => {
@@ -116,7 +122,7 @@ describe("configureProgramHelp", () => {
 
     const program = makeProgramWithCommands();
     expect(() => configureProgramHelp(program, testProgramContext)).toThrow("exit:0");
-    expect(logSpy).toHaveBeenCalledWith("9.9.9-test");
+    expect(logSpy).toHaveBeenCalledWith("OpenClaw 9.9.9-test (abc1234)");
     expect(exitSpy).toHaveBeenCalledWith(0);
 
     logSpy.mockRestore();

--- a/src/cli/program/help.test.ts
+++ b/src/cli/program/help.test.ts
@@ -128,4 +128,22 @@ describe("configureProgramHelp", () => {
     logSpy.mockRestore();
     exitSpy.mockRestore();
   });
+
+  it("prints version and exits immediately without commit metadata", () => {
+    process.argv = ["node", "openclaw", "--version"];
+    resolveCommitHashMock.mockReturnValue(null);
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code ?? ""}`);
+    }) as typeof process.exit);
+
+    const program = makeProgramWithCommands();
+    expect(() => configureProgramHelp(program, testProgramContext)).toThrow("exit:0");
+    expect(logSpy).toHaveBeenCalledWith("OpenClaw 9.9.9-test");
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
 });

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -111,7 +111,9 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     hasRootVersionAlias(process.argv)
   ) {
     const commit = resolveCommitHash();
-    console.log(commit ? `OpenClaw ${ctx.programVersion} (${commit})` : ctx.programVersion);
+    console.log(
+      commit ? `OpenClaw ${ctx.programVersion} (${commit})` : `OpenClaw ${ctx.programVersion}`,
+    );
     process.exit(0);
   }
 

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { resolveCommitHash } from "../../infra/git-commit.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { isRich, theme } from "../../terminal/theme.js";
 import { escapeRegExp } from "../../utils.js";
@@ -109,7 +110,8 @@ export function configureProgramHelp(program: Command, ctx: ProgramContext) {
     hasFlag(process.argv, "--version") ||
     hasRootVersionAlias(process.argv)
   ) {
-    console.log(ctx.programVersion);
+    const commit = resolveCommitHash();
+    console.log(commit ? `OpenClaw ${ctx.programVersion} (${commit})` : ctx.programVersion);
     process.exit(0);
   }
 

--- a/src/infra/git-commit.ts
+++ b/src/infra/git-commit.ts
@@ -11,10 +11,44 @@ const formatCommit = (value?: string | null) => {
   if (!trimmed) {
     return null;
   }
-  return trimmed.length > 7 ? trimmed.slice(0, 7) : trimmed;
+  const match = trimmed.match(/[0-9a-fA-F]{7,40}/);
+  if (!match) {
+    return null;
+  }
+  return match[0].slice(0, 7).toLowerCase();
 };
 
 let cachedCommit: string | null | undefined;
+
+const safeReadFilePrefix = (filePath: string, limit = 256) => {
+  const fd = fs.openSync(filePath, "r");
+  try {
+    const buf = Buffer.alloc(limit);
+    const bytesRead = fs.readSync(fd, buf, 0, limit, 0);
+    return buf.subarray(0, bytesRead).toString("utf-8");
+  } finally {
+    fs.closeSync(fd);
+  }
+};
+
+const resolveRefPath = (headPath: string, ref: string) => {
+  if (!ref.startsWith("refs/")) {
+    return null;
+  }
+  if (path.isAbsolute(ref)) {
+    return null;
+  }
+  if (ref.split(/[/]/).includes("..")) {
+    return null;
+  }
+  const gitDir = path.dirname(headPath);
+  const resolved = path.resolve(gitDir, ref);
+  const rel = path.relative(gitDir, resolved);
+  if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) {
+    return null;
+  }
+  return resolved;
+};
 
 const readCommitFromPackageJson = () => {
   try {
@@ -79,15 +113,19 @@ export const resolveCommitHash = (options: { cwd?: string; env?: NodeJS.ProcessE
       cachedCommit = null;
       return cachedCommit;
     }
-    const head = fs.readFileSync(headPath, "utf-8").trim();
+    const head = safeReadFilePrefix(headPath).trim();
     if (!head) {
       cachedCommit = null;
       return cachedCommit;
     }
     if (head.startsWith("ref:")) {
       const ref = head.replace(/^ref:\s*/i, "").trim();
-      const refPath = path.resolve(path.dirname(headPath), ref);
-      const refHash = fs.readFileSync(refPath, "utf-8").trim();
+      const refPath = resolveRefPath(headPath, ref);
+      if (!refPath) {
+        cachedCommit = null;
+        return cachedCommit;
+      }
+      const refHash = safeReadFilePrefix(refPath).trim();
       cachedCommit = formatCommit(refHash);
       return cachedCommit;
     }


### PR DESCRIPTION
## Summary
- include commit SHA in top-level `-v/--version` output when available
- keep existing behavior for environments where commit metadata is unavailable
- add test coverage for the updated version output format

Closes #34972
