### PR TITLE
fix(feishu): check response.ok before JSON parse in streaming card API calls

### DIFF
--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -67,6 +67,13 @@ async function getToken(creds: Credentials): Promise<string> {
     policy: { allowedHostnames: resolveAllowedHostnames(creds.domain) },
     auditContext: "feishu.streaming-card.token",
   });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    await release();
+    throw new Error(
+      `Feishu token request failed: HTTP ${response.status} ${text || response.statusText}`,
+    );
+  }
   const data = (await response.json()) as {
     code: number;
     msg: string;
@@ -198,6 +205,13 @@ export class FeishuStreamingSession {
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.create",
     });
+    if (!createRes.ok) {
+      const text = await createRes.text().catch(() => "");
+      await releaseCreate();
+      throw new Error(
+        `Feishu card create failed: HTTP ${createRes.status} ${text || createRes.statusText}`,
+      );
+    }
     const createData = (await createRes.json()) as {
       code: number;
       msg: string;


### PR DESCRIPTION
## Summary

Two unguarded `response.json()` calls in the Feishu streaming card module:

1. **`getToken()`** — The tenant_access_token endpoint response was parsed via `response.json()` without checking `response.ok`. A non-2xx HTTP response (e.g., 502 from proxy, CDN timeout, rate-limit page) returns HTML instead of JSON, causing an unhandled `SyntaxError` that crashes streaming card setup.

2. **`createCard()`** — The card creation endpoint (`/cardkit/v1/cards`) response was parsed without checking `response.ok`. Same failure mode: non-JSON error pages cause SyntaxError.

Both now check `response.ok` before JSON parsing and throw descriptive errors including the HTTP status code and response text.

Supersedes #35706.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — follows pattern from PR #35628 which fixed the same issue in other Feishu API calls.

## User-Visible Changes

Feishu streaming card API failures now produce clear error messages with HTTP status instead of cryptic SyntaxError crashes.

## Security Impact

1. Does this change handle user input? **No** — API credentials and internal card data only
2. Does this change affect authentication or authorization? **No** (error path only)
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 7 streaming-card tests pass
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ extensions/feishu/src/streaming-card.test.ts (7 tests) 2ms
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

## Human Verification

- Simulate a 502 response from Feishu token endpoint → should get "HTTP 502" error
- Simulate a 500 response from card creation endpoint → should get "HTTP 500" error

## Compatibility

Fully backward compatible. Successful responses behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| release() must be called on error path | Added `await release*()` before throwing to prevent SSRF guard leak |