### PR TITLE
fix(config): accept openclaw browser profile driver

### DIFF
--- a/src/config/zod-schema.browser-driver.test.ts
+++ b/src/config/zod-schema.browser-driver.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("OpenClawSchema browser profile driver", () => {
+  it("accepts openclaw and legacy clawd drivers", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        browser: {
+          profiles: {
+            default: {
+              cdpPort: 9222,
+              driver: "openclaw",
+            },
+            legacy: {
+              cdpPort: 9223,
+              driver: "clawd",
+            },
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/config/zod-schema.browser-driver.test.ts
+++ b/src/config/zod-schema.browser-driver.test.ts
@@ -10,10 +10,12 @@ describe("OpenClawSchema browser profile driver", () => {
             default: {
               cdpPort: 9222,
               driver: "openclaw",
+              color: "#1a2b3c",
             },
             legacy: {
               cdpPort: 9223,
               driver: "clawd",
+              color: "#3c2b1a",
             },
           },
         },

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -309,7 +309,9 @@ export const OpenClawSchema = z
               .object({
                 cdpPort: z.number().int().min(1).max(65535).optional(),
                 cdpUrl: z.string().optional(),
-                driver: z.union([z.literal("clawd"), z.literal("extension")]).optional(),
+                driver: z
+                  .union([z.literal("openclaw"), z.literal("clawd"), z.literal("extension")])
+                  .optional(),
                 attachOnly: z.boolean().optional(),
                 color: HexColorSchema,
               })


### PR DESCRIPTION
## Summary
Fixes #35620.

`browser.profiles.*.driver: "openclaw"` was rejected by config schema validation, even though runtime/types already use `"openclaw"` as the canonical value.

## Root Cause
`OpenClawSchema` only allowed:
- `"clawd"` (legacy)
- `"extension"`

but did not allow `"openclaw"`.

## Changes
- Updated browser profile driver schema to accept:
  - `"openclaw"` (current)
  - `"clawd"` (legacy compatibility)
  - `"extension"`
- Added regression test to verify both `"openclaw"` and legacy `"clawd"` are accepted.

## Files
- `src/config/zod-schema.ts`
- `src/config/zod-schema.browser-driver.test.ts`

## Risk
Low, small scope:
- config validation only
- no runtime behavior changes
- backward compatible with legacy `clawd`
