### PR TITLE
fix: [Bug]: Matrix channel fails to attach files from agent workspace (Local media path is not under an allowed directory) (#35715)

### DIFF
--- a/extensions/matrix/src/actions.test.ts
+++ b/extensions/matrix/src/actions.test.ts
@@ -1,0 +1,50 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/matrix";
+import { describe, expect, it, vi } from "vitest";
+import { matrixMessageActions } from "./actions.js";
+
+const mocks = vi.hoisted(() => ({
+  handleMatrixAction: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
+vi.mock("./tool-actions.js", () => ({
+  handleMatrixAction: mocks.handleMatrixAction,
+}));
+
+vi.mock("./matrix/accounts.js", () => ({
+  resolveMatrixAccount: vi.fn().mockReturnValue({ enabled: true, configured: true }),
+}));
+
+describe("matrixMessageActions", () => {
+  it("forwards mediaLocalRoots to handleMatrixAction for send", async () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example",
+          accessToken: "token",
+          userId: "@bot:example",
+        },
+      },
+    };
+
+    await matrixMessageActions.handleAction?.({
+      channel: "matrix",
+      action: "send",
+      cfg,
+      params: {
+        to: "room:!room:example",
+        message: "hello",
+        media: "file:///tmp/file.png",
+      },
+      mediaLocalRoots: ["/tmp/workspace"],
+    });
+
+    expect(mocks.handleMatrixAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sendMessage",
+        mediaUrl: "file:///tmp/file.png",
+      }),
+      cfg,
+      { mediaLocalRoots: ["/tmp/workspace"] },
+    );
+  });
+});

--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -54,7 +54,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
     return { to };
   },
   handleAction: async (ctx: ChannelMessageActionContext) => {
-    const { action, params, cfg } = ctx;
+    const { action, params, cfg, mediaLocalRoots } = ctx;
     const resolveRoomId = () =>
       readStringParam(params, "roomId") ??
       readStringParam(params, "channelId") ??
@@ -79,6 +79,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           threadId: threadId ?? undefined,
         },
         cfg as CoreConfig,
+        { mediaLocalRoots },
       );
     }
 
@@ -95,6 +96,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           remove,
         },
         cfg as CoreConfig,
+        { mediaLocalRoots },
       );
     }
 
@@ -109,6 +111,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           limit,
         },
         cfg as CoreConfig,
+        { mediaLocalRoots },
       );
     }
 
@@ -123,6 +126,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           after: readStringParam(params, "after"),
         },
         cfg as CoreConfig,
+        { mediaLocalRoots },
       );
     }
 
@@ -137,6 +141,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           content,
         },
         cfg as CoreConfig,
+        { mediaLocalRoots },
       );
     }
 
@@ -149,6 +154,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           messageId,
         },
         cfg as CoreConfig,
+        { mediaLocalRoots },
       );
     }
 
@@ -165,6 +171,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           messageId,
         },
         cfg as CoreConfig,
+        { mediaLocalRoots },
       );
     }
 
@@ -177,6 +184,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           roomId: readStringParam(params, "roomId") ?? readStringParam(params, "channelId"),
         },
         cfg as CoreConfig,
+        { mediaLocalRoots },
       );
     }
 
@@ -187,6 +195,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           roomId: resolveRoomId(),
         },
         cfg as CoreConfig,
+        { mediaLocalRoots },
       );
     }
 

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -19,12 +19,14 @@ export async function sendMatrixMessage(
     mediaUrl?: string;
     replyToId?: string;
     threadId?: string;
+    mediaLocalRoots?: readonly string[];
   } = {},
 ) {
   return await sendMessageMatrix(to, content, {
     mediaUrl: opts.mediaUrl,
     replyToId: opts.replyToId,
     threadId: opts.threadId,
+    mediaLocalRoots: opts.mediaLocalRoots,
     client: opts.client,
     timeoutMs: opts.timeoutMs,
   });

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -101,6 +101,11 @@ describe("sendMessageMatrix media", () => {
     await sendMessageMatrix("room:!room:example", "caption", {
       client,
       mediaUrl: "file:///tmp/photo.png",
+      mediaLocalRoots: ["/tmp/workspace"],
+    });
+
+    expect(loadWebMediaMock).toHaveBeenCalledWith("file:///tmp/photo.png", undefined, {
+      localRoots: ["/tmp/workspace"],
     });
 
     const uploadArg = uploadContent.mock.calls[0]?.[0];

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -83,7 +83,9 @@ export async function sendMessageMatrix(
       let lastMessageId = "";
       if (opts.mediaUrl) {
         const maxBytes = resolveMediaMaxBytes(opts.accountId, cfg);
-        const media = await getCore().media.loadWebMedia(opts.mediaUrl, maxBytes);
+        const media = await getCore().media.loadWebMedia(opts.mediaUrl, maxBytes, {
+          localRoots: opts.mediaLocalRoots?.length ? opts.mediaLocalRoots : undefined,
+        });
         const uploaded = await uploadMediaMaybeEncrypted(client, roomId, media.buffer, {
           contentType: media.contentType,
           filename: media.fileName,

--- a/extensions/matrix/src/matrix/send/types.ts
+++ b/extensions/matrix/src/matrix/send/types.ts
@@ -88,6 +88,7 @@ export type MatrixSendOpts = {
   cfg?: import("../../types.js").CoreConfig;
   client?: import("@vector-im/matrix-bot-sdk").MatrixClient;
   mediaUrl?: string;
+  mediaLocalRoots?: readonly string[];
   accountId?: string;
   replyToId?: string;
   threadId?: string | number | null;

--- a/extensions/matrix/src/outbound.test.ts
+++ b/extensions/matrix/src/outbound.test.ts
@@ -75,6 +75,7 @@ describe("matrixOutbound cfg threading", () => {
       to: "room:!room:example",
       text: "caption",
       mediaUrl: "file:///tmp/cat.png",
+      mediaLocalRoots: ["/tmp/workspace"],
       accountId: "default",
     });
 
@@ -84,6 +85,7 @@ describe("matrixOutbound cfg threading", () => {
       expect.objectContaining({
         cfg,
         mediaUrl: "file:///tmp/cat.png",
+        mediaLocalRoots: ["/tmp/workspace"],
       }),
     );
   });

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -23,13 +23,24 @@ export const matrixOutbound: ChannelOutboundAdapter = {
       roomId: result.roomId,
     };
   },
-  sendMedia: async ({ cfg, to, text, mediaUrl, deps, replyToId, threadId, accountId }) => {
+  sendMedia: async ({
+    cfg,
+    to,
+    text,
+    mediaUrl,
+    mediaLocalRoots,
+    deps,
+    replyToId,
+    threadId,
+    accountId,
+  }) => {
     const send = deps?.sendMatrix ?? sendMessageMatrix;
     const resolvedThreadId =
       threadId !== undefined && threadId !== null ? String(threadId) : undefined;
     const result = await send(to, text, {
       cfg,
       mediaUrl,
+      mediaLocalRoots,
       replyToId: replyToId ?? undefined,
       threadId: resolvedThreadId,
       accountId: accountId ?? undefined,

--- a/extensions/matrix/src/tool-actions.test.ts
+++ b/extensions/matrix/src/tool-actions.test.ts
@@ -1,0 +1,47 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/matrix";
+import { describe, expect, it, vi } from "vitest";
+import { handleMatrixAction } from "./tool-actions.js";
+
+const mocks = vi.hoisted(() => ({
+  sendMatrixMessage: vi.fn().mockResolvedValue({ messageId: "evt-1", roomId: "!room:example" }),
+}));
+
+vi.mock("./matrix/actions.js", async () => {
+  const actual = await vi.importActual<typeof import("./matrix/actions.js")>("./matrix/actions.js");
+  return {
+    ...actual,
+    sendMatrixMessage: mocks.sendMatrixMessage,
+  };
+});
+
+describe("handleMatrixAction", () => {
+  it("forwards mediaLocalRoots on sendMessage actions", async () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        matrix: {
+          actions: { messages: true },
+        },
+      },
+    };
+
+    await handleMatrixAction(
+      {
+        action: "sendMessage",
+        to: "room:!room:example",
+        content: "caption",
+        mediaUrl: "file:///tmp/file.png",
+      },
+      cfg,
+      { mediaLocalRoots: ["/tmp/workspace"] },
+    );
+
+    expect(mocks.sendMatrixMessage).toHaveBeenCalledWith(
+      "room:!room:example",
+      "caption",
+      expect.objectContaining({
+        mediaUrl: "file:///tmp/file.png",
+        mediaLocalRoots: ["/tmp/workspace"],
+      }),
+    );
+  });
+});

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -40,6 +40,7 @@ function readRoomId(params: Record<string, unknown>, required = true): string {
 export async function handleMatrixAction(
   params: Record<string, unknown>,
   cfg: CoreConfig,
+  opts: { mediaLocalRoots?: readonly string[] } = {},
 ): Promise<AgentToolResult<unknown>> {
   const action = readStringParam(params, "action", { required: true });
   const isActionEnabled = createActionGate(cfg.channels?.matrix?.actions);
@@ -86,6 +87,7 @@ export async function handleMatrixAction(
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyToId ?? undefined,
           threadId: threadId ?? undefined,
+          mediaLocalRoots: opts.mediaLocalRoots,
         });
         return jsonResult({ ok: true, result });
       }

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -403,6 +403,41 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("passes mediaLocalRoots to matrix plugin outbound sendMedia", async () => {
+    const sendMedia = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-txt" }),
+              sendMedia,
+            },
+          }),
+        },
+      ]),
+    );
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "caption", mediaUrl: "file:///tmp/p.png" }],
+      session: { agentId: "work" },
+    });
+
+    expect(sendMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaUrl: "file:///tmp/p.png",
+        mediaLocalRoots: expect.arrayContaining([path.join(STATE_DIR, "workspace-work")]),
+      }),
+    );
+  });
+
   it("uses signal media maxBytes from config", async () => {
     const sendSignal = vi.fn().mockResolvedValue({ messageId: "s1", timestamp: 123 });
     const cfg: OpenClawConfig = { channels: { signal: { mediaMaxMb: 2 } } };

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -56,6 +56,7 @@ type SendMatrixMessage = (
   opts?: {
     cfg?: OpenClawConfig;
     mediaUrl?: string;
+    mediaLocalRoots?: readonly string[];
     replyToId?: string;
     threadId?: string;
     timeoutMs?: number;


### PR DESCRIPTION
Closes #35715

## Summary

- Problem: [Bug]: Matrix channel fails to attach files from agent workspace (Local media path is not under an allowed directory)
- Why it matters: Reported in #35715
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35715
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35715