### PR TITLE
fix(discord): add autoThread to DiscordGuildChannelConfig type

### DIFF
--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -52,6 +52,8 @@ export type DiscordGuildChannelConfig = {
   systemPrompt?: string;
   /** If false, omit thread starter context for this channel (default: true). */
   includeThreadStarter?: boolean;
+  /** If true, auto-create a thread for each message in this channel. */
+  autoThread?: boolean;
 };
 
 export type DiscordReactionNotificationMode = "off" | "own" | "all" | "allowlist";


### PR DESCRIPTION
## Summary

- **Problem:** `DiscordGuildChannelConfig` TypeScript type was missing `autoThread`, creating type/schema drift. The Zod schema and runtime code both use this field.
- **Why it matters:** Type consumers (including discord/monitor modules) had to declare inline workaround types. Type-safe access to `autoThread` was not possible through the canonical type.
- **What changed:** Added `autoThread?: boolean` to `DiscordGuildChannelConfig` in `src/config/types.discord.ts`.
- **What did NOT change:** Zod schema (already had it), runtime behavior (already works), guild-level type (does not need it).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35607

## User-visible / Behavior Changes

None — runtime behavior is unchanged. This fixes a type definition only.

## Security Impact (required)

- New permissions/capabilities? \`No\`
- Secrets/tokens handling changed? \`No\`
- New/changed network calls? \`No\`
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js / TypeScript
- Integration/channel: Discord

### Steps

1. Import \`DiscordGuildChannelConfig\`
2. Access \`.autoThread\` property

### Expected

- TypeScript allows access without errors

### Actual

- Before fix: \`Property 'autoThread' does not exist on type 'DiscordGuildChannelConfig'\`
- After fix: Property is recognized

## Evidence

- \`npx tsc --noEmit\` passes with no Discord-related errors
- Zod schema already includes \`autoThread\` at \`zod-schema.providers-core.ts:358\`
- Runtime usage confirmed in \`discord/monitor/threading.ts:370\`, \`message-handler.process.ts:257\`, \`allow-list.ts:501\`

## Human Verification (required)

- Verified scenarios: Type alignment with Zod schema and runtime
- Edge cases checked: Guild-level type (correctly does not have autoThread)
- What I did **not** verify: Live Discord threading behavior

## Compatibility / Migration

- Backward compatible? \`Yes\`
- Config/env changes? \`No\`
- Migration needed? \`No\`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit
- Files/config to restore: \`src/config/types.discord.ts\`
- Known bad symptoms: None expected

## Risks and Mitigations

None — additive type change only.

