### PR TITLE
fix(security): include Gemini, Grok, and Kimi in web search key audit

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -329,7 +329,17 @@ function resolveToolPolicies(params: {
 function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
   return Boolean(
-    search?.apiKey || search?.perplexity?.apiKey || env.BRAVE_API_KEY || env.PERPLEXITY_API_KEY,
+    search?.apiKey ||
+      search?.perplexity?.apiKey ||
+      search?.gemini?.apiKey ||
+      search?.grok?.apiKey ||
+      search?.kimi?.apiKey ||
+      env.BRAVE_API_KEY ||
+      env.PERPLEXITY_API_KEY ||
+      env.GEMINI_API_KEY ||
+      env.XAI_API_KEY ||
+      env.KIMI_API_KEY ||
+      env.MOONSHOT_API_KEY,
   );
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** \`hasWebSearchKey\` only checked Brave (\`search.apiKey\`, \`BRAVE_API_KEY\`) and Perplexity (\`search.perplexity.apiKey\`, \`PERPLEXITY_API_KEY\`). Users with Gemini, Grok, or Kimi configured saw incorrect audit results.
- **Why it matters:** The web search audit gates whether \`web_search\` is reported as available. Missing provider keys causes false negatives.
- **What changed:** Added 3 config paths (\`search.gemini.apiKey\`, \`search.grok.apiKey\`, \`search.kimi.apiKey\`) and 4 env vars (\`GEMINI_API_KEY\`, \`XAI_API_KEY\`, \`KIMI_API_KEY\`, \`MOONSHOT_API_KEY\`) to \`hasWebSearchKey\`.
- **What did NOT change:** Runtime \`web_search\` tool (already supports all providers). Brave and Perplexity checks unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34509

## User-visible / Behavior Changes

- Web search audit now correctly reports availability when Gemini, Grok, or Kimi API keys are configured.

## Security Impact (required)

- New permissions/capabilities? \`No\`
- Secrets/tokens handling changed? \`No\` — only reads existing config/env values for truthiness check
- New/changed network calls? \`No\`
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: any

### Steps

1. Configure \`tools.web.search.gemini.apiKey\` (or set \`GEMINI_API_KEY\` env var)
2. Run \`openclaw doctor\` or trigger the security audit

### Expected

- Web search is reported as available

### Actual

- Before fix: Web search incorrectly reported as unavailable
- After fix: Web search correctly detected

## Evidence

Config paths verified against runtime resolution in \`web-search.ts\`:
- \`resolveGeminiApiKey\` → \`search.gemini.apiKey\` / \`GEMINI_API_KEY\`
- \`resolveGrokApiKey\` → \`search.grok.apiKey\` / \`XAI_API_KEY\`
- \`resolveKimiApiKey\` → \`search.kimi.apiKey\` / \`KIMI_API_KEY\` / \`MOONSHOT_API_KEY\`

## Human Verification (required)

- Verified scenarios: All five provider key paths aligned with runtime
- Edge cases checked: Empty strings (remain falsy via Boolean check)
- What I did **not** verify: Live audit output

## Compatibility / Migration

- Backward compatible? \`Yes\`
- Config/env changes? \`No\`
- Migration needed? \`No\`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit
- Files/config to restore: \`src/security/audit-extra.sync.ts\`
- Known bad symptoms: None expected

## Risks and Mitigations

None — only adds more checks, cannot cause false positives.

