### PR TITLE
fix(browser): remove unsupported AutomationControlled launch flag

### DIFF
--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -266,9 +266,6 @@ export async function launchOpenClawChrome(
       args.push("--disable-dev-shm-usage");
     }
 
-    // Stealth: hide navigator.webdriver from automation detection (#80)
-    args.push("--disable-blink-features=AutomationControlled");
-
     // Append user-configured extra arguments (e.g., stealth flags, window size)
     if (resolved.extraArgs.length > 0) {
       args.push(...resolved.extraArgs);


### PR DESCRIPTION
## Summary
- Remove the unsupported "--disable-blink-features=AutomationControlled" launch flag from local Chrome browser startup args.
- This flag triggers warning text in newer Chrome versions and is now unnecessary for startup.

## Fixes
- Fixes #35721
