### PR TITLE
fix(whatsapp): distinguish allowFrom denial from invalid E.164 format

### DIFF
--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -139,6 +139,19 @@ describe("resolveWhatsAppOutboundTarget", () => {
       expectDeniedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "implicit" });
     });
 
+    it("returns allowFrom-specific error when target is valid but not in allowList", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
+      const result = resolveWhatsAppOutboundTarget({
+        to: PRIMARY_TARGET,
+        allowFrom: [SECONDARY_TARGET],
+        mode: "implicit",
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain("allowFrom");
+      }
+    });
+
     it("handles mixed numeric and string allowList entries", () => {
       vi.mocked(normalize.normalizeWhatsAppTarget)
         .mockReturnValueOnce("+11234567890") // for 'to' param

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -41,7 +41,9 @@ export function resolveWhatsAppOutboundTarget(params: {
     }
     return {
       ok: false,
-      error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+      error: new Error(
+        `WhatsApp target "${normalizedTo}" is not in the configured allowFrom list`,
+      ),
     };
   }
 


### PR DESCRIPTION
## Summary

- **Problem:** When a valid WhatsApp phone number was not in the \`allowFrom\` list, the error said "Delivering to WhatsApp requires target <E.164|group JID>" — suggesting a format problem when the real issue was authorization.
- **Why it matters:** Users waste time debugging E.164 format when they need to update their \`allowFrom\` config. Misleading errors increase support burden.
- **What changed:** The allowList-denied branch in \`resolveWhatsAppOutboundTarget\` now returns a specific error: \`WhatsApp target "<number>" is not in the configured allowFrom list\`.
- **What did NOT change:** Invalid format errors (null normalization result) and missing target errors still use the generic \`missingTargetError\`. Group JID handling unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35580

## User-visible / Behavior Changes

- WhatsApp sends to valid numbers not in allowFrom now show: \`WhatsApp target "+1..." is not in the configured allowFrom list\` instead of the misleading format error.

## Security Impact (required)

- New permissions/capabilities? \`No\`
- Secrets/tokens handling changed? \`No\`
- New/changed network calls? \`No\`
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: WhatsApp

### Steps

1. Configure \`channels.whatsapp.allowFrom: ["+18585551234"]\`
2. Try to send a message to \`+19995551234\` (valid but not in list)

### Expected

- Error mentions allowFrom policy

### Actual

- Before fix: "Delivering to WhatsApp requires target <E.164|group JID>"
- After fix: "WhatsApp target \"+19995551234\" is not in the configured allowFrom list"

## Evidence

New test added: "returns allowFrom-specific error when target is valid but not in allowList"
All 22 tests pass.

## Human Verification (required)

- Verified scenarios: Valid target not in list, invalid target, empty target, group JID
- Edge cases checked: Wildcard allowFrom, empty allowFrom, mixed numeric/string entries
- What I did **not** verify: Live WhatsApp send

## Compatibility / Migration

- Backward compatible? \`Yes\` — error message text is not part of any API contract
- Config/env changes? \`No\`
- Migration needed? \`No\`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit
- Files/config to restore: \`src/whatsapp/resolve-outbound-target.ts\`
- Known bad symptoms: None expected

## Risks and Mitigations

- Risk: Downstream code that matches on the old error message text — mitigated by the fact that error message matching is an anti-pattern and no existing code does this.

