### PR TITLE
fix(agents): default cleanup to "delete" for run-mode subagent spawns

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -280,7 +280,7 @@ export async function spawnSubagentDirect(
       ? "keep"
       : params.cleanup === "keep" || params.cleanup === "delete"
         ? params.cleanup
-        : "keep";
+        : "delete";
   const expectsCompletionMessage = params.expectsCompletionMessage !== false;
   const requesterOrigin = normalizeDeliveryContext({
     channel: ctx.agentChannel,


### PR DESCRIPTION
## Summary

- **Problem:** \`sessions_spawn\` with \`mode="run"\` defaulted \`cleanup\` to \`"keep"\`, leaving finished subagent sessions visible in \`sessions_list\` indefinitely.
- **Why it matters:** Run-mode spawns are ephemeral one-shot tasks. Accumulating their sessions pollutes the session list and confuses users who expect only active sessions.
- **What changed:** Changed the default cleanup from \`"keep"\` to \`"delete"\` for non-session (run) mode in \`src/agents/subagent-spawn.ts\`. Session mode still defaults to \`"keep"\`.
- **What did NOT change:** Explicit \`cleanup="keep"\` still works for users who want to preserve run-mode sessions. Session-mode cleanup unchanged. The deletion logic in \`subagent-announce.ts\` is already implemented.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35646

## User-visible / Behavior Changes

- Completed run-mode subagent sessions are now automatically deleted from the session list.
- Users can pass \`cleanup="keep"\` to preserve them if needed.

## Security Impact (required)

- New permissions/capabilities? \`No\`
- Secrets/tokens handling changed? \`No\`
- New/changed network calls? \`No\`
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: any (TUI, webchat, etc.)

### Steps

1. Spawn a run-mode subagent: \`sessions_spawn\` with \`mode="run"\`
2. Wait for the subagent to complete
3. Check \`sessions_list\`

### Expected

- Completed run-mode session is not in the list

### Actual

- Before fix: Completed session remains in the list indefinitely
- After fix: Completed session is automatically deleted

## Evidence

Single-line change in \`subagent-spawn.ts:283\`: \`"keep"\` → \`"delete"\`

The deletion logic already exists in \`subagent-announce.ts:1014-1026\` — it calls \`sessions.delete\` when \`cleanup === "delete"\`. This change only affects the default behavior.

## Human Verification (required)

- Verified scenarios: Default run-mode cleanup, explicit cleanup="keep" override, session-mode unchanged
- Edge cases checked: Thread-bound sessions (session mode), explicit cleanup parameter
- What I did **not** verify: Live subagent spawn lifecycle

## Compatibility / Migration

- Backward compatible? \`Mostly\` — users relying on run-mode sessions persisting will need to pass \`cleanup="keep"\` explicitly
- Config/env changes? \`No\`
- Migration needed? \`No\`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit
- Files/config to restore: \`src/agents/subagent-spawn.ts\`
- Known bad symptoms: Run-mode sessions disappear after completion (by design)

## Risks and Mitigations

- Risk: Existing workflows that depend on run-mode sessions persisting. Mitigated by allowing explicit \`cleanup="keep"\` override.
