### PR TITLE
Fix: TUI heartbeat and delivery context persistence

### DIFF
--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -152,6 +152,7 @@ export async function getReplyFromConfig(
     ctx: finalized,
     cfg,
     commandAuthorized,
+    persistDeliveryContext: opts?.persistDeliveryContext ?? true,
   });
   let {
     sessionCtx,

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1640,6 +1640,50 @@ describe("initSessionState internal channel routing preservation", () => {
     expect(result.sessionEntry.lastTo).toBeUndefined();
   });
 
+  it("ignores stale delivery context when persistDeliveryContext is false", async () => {
+    const storePath = await createStorePath("ignore-stale-delivery-route-");
+    const sessionKey = "agent:main:main";
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: "sess-stale-route",
+        updatedAt: Date.now(),
+        lastChannel: "telegram",
+        lastTo: "12345",
+        lastAccountId: "default",
+        deliveryContext: {
+          channel: "telegram",
+          to: "12345",
+          accountId: "default",
+        },
+      },
+    });
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "from tui",
+        SessionKey: sessionKey,
+        OriginatingChannel: "webchat",
+      },
+      cfg,
+      commandAuthorized: true,
+      persistDeliveryContext: false,
+    });
+
+    expect(result.sessionEntry.lastChannel).toBe("webchat");
+    expect(result.sessionEntry.lastTo).toBeUndefined();
+    expect(result.sessionEntry.deliveryContext).toBeUndefined();
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      SessionEntry
+    >;
+    const persistedEntry = persisted[sessionKey];
+    expect(persistedEntry.lastChannel).toBe("webchat");
+    expect(persistedEntry.lastTo).toBeUndefined();
+    expect(persistedEntry.deliveryContext).toEqual({ channel: "webchat" });
+  });
+
   it("prefers webchat route over persisted external route for main session turns", async () => {
     const storePath = await createStorePath("prefer-webchat-main-route-");
     const sessionKey = "agent:main:main";

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -66,8 +66,10 @@ export async function initSessionState(params: {
   ctx: MsgContext;
   cfg: OpenClawConfig;
   commandAuthorized: boolean;
+  persistDeliveryContext?: boolean;
 }): Promise<SessionInitResult> {
   const { ctx, cfg, commandAuthorized } = params;
+  const shouldPersistDeliveryContext = params.persistDeliveryContext !== false;
   // Native slash commands (Telegram/Discord/Slack) are delivered on a separate
   // "slash session" key, but should mutate the target chat session.
   const targetSessionKey =
@@ -248,22 +250,25 @@ export async function initSessionState(params: {
   const originatingChannelRaw = ctx.OriginatingChannel as string | undefined;
   const lastChannelRaw = resolveLastChannelRaw({
     originatingChannelRaw,
-    persistedLastChannel: baseEntry?.lastChannel,
+    persistedLastChannel: shouldPersistDeliveryContext ? baseEntry?.lastChannel : undefined,
     sessionKey,
   });
   const lastToRaw = resolveLastToRaw({
     originatingChannelRaw,
     originatingToRaw: ctx.OriginatingTo,
     toRaw: ctx.To,
-    persistedLastTo: baseEntry?.lastTo,
-    persistedLastChannel: baseEntry?.lastChannel,
+    persistedLastTo: shouldPersistDeliveryContext ? baseEntry?.lastTo : undefined,
+    persistedLastChannel: shouldPersistDeliveryContext ? baseEntry?.lastChannel : undefined,
     sessionKey,
   });
-  const lastAccountIdRaw = ctx.AccountId || baseEntry?.lastAccountId;
+  const lastAccountIdRaw =
+    ctx.AccountId || (shouldPersistDeliveryContext ? baseEntry?.lastAccountId : undefined);
   // Only fall back to persisted threadId for thread sessions.  Non-thread
   // sessions (e.g. DM without topics) must not inherit a stale threadId from a
   // previous interaction that happened inside a topic/thread.
-  const lastThreadIdRaw = ctx.MessageThreadId || (isThread ? baseEntry?.lastThreadId : undefined);
+  const lastThreadIdRaw =
+    ctx.MessageThreadId ||
+    (isThread && shouldPersistDeliveryContext ? baseEntry?.lastThreadId : undefined);
   const deliveryFields = normalizeSessionDeliveryFields({
     deliveryContext: {
       channel: lastChannelRaw,
@@ -303,7 +308,7 @@ export async function initSessionState(params: {
     subject: baseEntry?.subject,
     groupChannel: baseEntry?.groupChannel,
     space: baseEntry?.space,
-    deliveryContext: deliveryFields.deliveryContext,
+    deliveryContext: shouldPersistDeliveryContext ? deliveryFields.deliveryContext : undefined,
     // Track originating channel for subagent announce routing.
     lastChannel,
     lastTo,

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -38,6 +38,11 @@ export type GetReplyOptions = {
   typingPolicy?: TypingPolicy;
   /** Force-disable typing indicators for this run (system/internal/cross-channel routes). */
   suppressTyping?: boolean;
+  /**
+   * If false, ignore persisted/internal routing hints from the turn and avoid
+   * persisting delivery context changes from this run.
+   */
+  persistDeliveryContext?: boolean;
   /** Resolved heartbeat model override (provider/model string from merged per-agent config). */
   heartbeatModelOverride?: string;
   /** Controls bootstrap workspace context injection (default: full). */

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -894,6 +894,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       const isFromWebchatClient =
         isWebchatClient(client?.connect?.client) || clientMode === GATEWAY_CLIENT_MODES.UI;
       const configuredMainKey = (cfg.session?.mainKey ?? "main").trim().toLowerCase();
+      const shouldPersistDeliveryContext = !isFromWebchatClient || shouldDeliverExternally;
       const isConfiguredMainSessionScope =
         normalizedSessionScopeHead.length > 0 && normalizedSessionScopeHead === configuredMainKey;
       // Channel-agnostic session scopes (main, direct:<peer>, etc.) can leak
@@ -981,6 +982,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         replyOptions: {
           runId: clientRunId,
           abortSignal: abortController.signal,
+          persistDeliveryContext: shouldPersistDeliveryContext,
           images: parsedImages.length > 0 ? parsedImages : undefined,
           onAgentRunStart: (runId) => {
             agentRunStarted = true;

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -821,7 +821,11 @@ describe("runHeartbeatOnce", () => {
             To: testCase.peerId,
             Provider: "heartbeat",
           }),
-          expect.objectContaining({ isHeartbeat: true, suppressToolErrorWarnings: false }),
+          expect.objectContaining({
+            isHeartbeat: true,
+            suppressToolErrorWarnings: false,
+            persistDeliveryContext: false,
+          }),
           cfg,
         );
       }

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -751,8 +751,14 @@ export async function runHeartbeatOnce(opts: {
           heartbeatModelOverride,
           suppressToolErrorWarnings,
           bootstrapContextMode,
+          persistDeliveryContext: false,
         }
-      : { isHeartbeat: true, suppressToolErrorWarnings, bootstrapContextMode };
+      : {
+          isHeartbeat: true,
+          suppressToolErrorWarnings,
+          bootstrapContextMode,
+          persistDeliveryContext: false,
+        };
     const replyResult = await getReplyFromConfig(ctx, replyOpts, cfg);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
     const includeReasoning = heartbeat?.includeReasoning === true;


### PR DESCRIPTION
## Summary
- Fix issue #35589: prevent stale delivery context from leaking into non-delivery TUI/UI turns.
- Add a non-persistent delivery-context mode for reply/session initialization.
- Ensure heartbeat reply runs do not persist external routing context.

## Security Impact
- N/A

## Repro+Verification
- Reproduce with TUI/UI chat sessions where external delivery context was previously persisted.
- Before: a stale external route could be reused in later non-delivery turns.
- After: non-delivery turns ignore persisted external hints and do not persist delivery context.

## Testing
- `pnpm test src/auto-reply/reply/session.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts` (67 passed)

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35589
