### PR TITLE
feat(sessions): add rm and clear subcommands

### DIFF
--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -4,6 +4,8 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const statusCommand = vi.fn();
 const healthCommand = vi.fn();
 const sessionsCommand = vi.fn();
+const sessionsRemoveCommand = vi.fn();
+const sessionsClearCommand = vi.fn();
 const sessionsCleanupCommand = vi.fn();
 const setVerbose = vi.fn();
 
@@ -23,6 +25,11 @@ vi.mock("../../commands/health.js", () => ({
 
 vi.mock("../../commands/sessions.js", () => ({
   sessionsCommand,
+}));
+
+vi.mock("../../commands/sessions-delete.js", () => ({
+  sessionsRemoveCommand,
+  sessionsClearCommand,
 }));
 
 vi.mock("../../commands/sessions-cleanup.js", () => ({
@@ -55,6 +62,8 @@ describe("registerStatusHealthSessionsCommands", () => {
     statusCommand.mockResolvedValue(undefined);
     healthCommand.mockResolvedValue(undefined);
     sessionsCommand.mockResolvedValue(undefined);
+    sessionsRemoveCommand.mockResolvedValue(undefined);
+    sessionsClearCommand.mockResolvedValue(undefined);
     sessionsCleanupCommand.mockResolvedValue(undefined);
   });
 
@@ -186,6 +195,53 @@ describe("registerStatusHealthSessionsCommands", () => {
         enforce: true,
         fixMissing: true,
         activeKey: "agent:main:main",
+        json: true,
+      }),
+      runtime,
+    );
+  });
+
+  it("runs sessions rm subcommand with forwarded options", async () => {
+    await runCli([
+      "sessions",
+      "rm",
+      "agent:main:main",
+      "--store",
+      "/tmp/sessions.json",
+      "--dry-run",
+      "--json",
+    ]);
+
+    expect(sessionsRemoveCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "agent:main:main",
+        store: "/tmp/sessions.json",
+        dryRun: true,
+        json: true,
+      }),
+      runtime,
+    );
+  });
+
+  it("forwards parent-level all-agents to sessions rm", async () => {
+    await runCli(["sessions", "--all-agents", "rm", "agent:main:main"]);
+
+    expect(sessionsRemoveCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "agent:main:main",
+        allAgents: true,
+      }),
+      runtime,
+    );
+  });
+
+  it("runs sessions clear subcommand with forwarded options", async () => {
+    await runCli(["sessions", "clear", "--older-than", "60", "--dry-run", "--json"]);
+
+    expect(sessionsClearCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        olderThan: "60",
+        dryRun: true,
         json: true,
       }),
       runtime,

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { healthCommand } from "../../commands/health.js";
 import { sessionsCleanupCommand } from "../../commands/sessions-cleanup.js";
+import { sessionsClearCommand, sessionsRemoveCommand } from "../../commands/sessions-delete.js";
 import { sessionsCommand } from "../../commands/sessions.js";
 import { statusCommand } from "../../commands/status.js";
 import { setVerbose } from "../../globals.js";
@@ -154,6 +155,98 @@ export function registerStatusHealthSessionsCommands(program: Command) {
       );
     });
   sessionsCmd.enablePositionalOptions();
+
+  sessionsCmd
+    .command("rm <key>")
+    .description("Remove one session by key")
+    .option("--store <path>", "Path to session store (default: resolved from config)")
+    .option("--agent <id>", "Agent id to mutate (default: configured default agent)")
+    .option("--all-agents", "Apply to all configured agents", false)
+    .option("--dry-run", "Preview matching sessions without writing", false)
+    .option("--json", "Output JSON", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw sessions rm agent:main:main", "Delete one session by exact key."],
+          [
+            "openclaw sessions --all-agents rm agent:main:main --dry-run",
+            "Preview cross-agent key matches.",
+          ],
+          ["openclaw sessions rm agent:main:main --json", "Machine-readable output."],
+        ])}`,
+    )
+    .action(async (key, opts, command) => {
+      const parentOpts = command.parent?.opts() as
+        | {
+            store?: string;
+            agent?: string;
+            allAgents?: boolean;
+            json?: boolean;
+          }
+        | undefined;
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await sessionsRemoveCommand(
+          {
+            key,
+            store: (opts.store as string | undefined) ?? parentOpts?.store,
+            agent: (opts.agent as string | undefined) ?? parentOpts?.agent,
+            allAgents: Boolean(opts.allAgents || parentOpts?.allAgents),
+            dryRun: Boolean(opts.dryRun),
+            json: Boolean(opts.json || parentOpts?.json),
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  sessionsCmd
+    .command("clear")
+    .description("Remove sessions in bulk")
+    .option("--store <path>", "Path to session store (default: resolved from config)")
+    .option("--agent <id>", "Agent id to mutate (default: configured default agent)")
+    .option("--all-agents", "Apply to all configured agents", false)
+    .option("--older-than <minutes>", "Only remove sessions older than this many minutes")
+    .option("--dry-run", "Preview matching sessions without writing", false)
+    .option("--json", "Output JSON", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          [
+            "openclaw sessions clear --dry-run",
+            "Preview deleting all sessions in the active store.",
+          ],
+          ["openclaw sessions clear --older-than 1440", "Delete sessions older than one day."],
+          [
+            "openclaw sessions --all-agents clear --older-than 120",
+            "Apply age filter to all agents.",
+          ],
+        ])}`,
+    )
+    .action(async (opts, command) => {
+      const parentOpts = command.parent?.opts() as
+        | {
+            store?: string;
+            agent?: string;
+            allAgents?: boolean;
+            json?: boolean;
+          }
+        | undefined;
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await sessionsClearCommand(
+          {
+            store: (opts.store as string | undefined) ?? parentOpts?.store,
+            agent: (opts.agent as string | undefined) ?? parentOpts?.agent,
+            allAgents: Boolean(opts.allAgents || parentOpts?.allAgents),
+            olderThan: opts.olderThan as string | undefined,
+            dryRun: Boolean(opts.dryRun),
+            json: Boolean(opts.json || parentOpts?.json),
+          },
+          defaultRuntime,
+        );
+      });
+    });
 
   sessionsCmd
     .command("cleanup")

--- a/src/commands/sessions-delete.test.ts
+++ b/src/commands/sessions-delete.test.ts
@@ -1,0 +1,126 @@
+import fs from "node:fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
+import type { RuntimeEnv } from "../runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(),
+  resolveSessionStoreTargetsOrExit: vi.fn(),
+  loadSessionStore: vi.fn(),
+  updateSessionStore: vi.fn(),
+  resolveSessionFilePath: vi.fn(),
+  resolveSessionFilePathOptions: vi.fn(),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: mocks.loadConfig,
+}));
+
+vi.mock("./session-store-targets.js", () => ({
+  resolveSessionStoreTargetsOrExit: mocks.resolveSessionStoreTargetsOrExit,
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: mocks.loadSessionStore,
+  updateSessionStore: mocks.updateSessionStore,
+  resolveSessionFilePath: mocks.resolveSessionFilePath,
+  resolveSessionFilePathOptions: mocks.resolveSessionFilePathOptions,
+}));
+
+import { sessionsClearCommand, sessionsRemoveCommand } from "./sessions-delete.js";
+
+function makeRuntime(): { runtime: RuntimeEnv; logs: string[] } {
+  const logs: string[] = [];
+  return {
+    runtime: {
+      log: (msg: unknown) => logs.push(String(msg)),
+      error: (msg: unknown) => logs.push(`ERROR:${String(msg)}`),
+      exit: (code?: number) => {
+        throw new Error(`exit ${code ?? 0}`);
+      },
+    },
+    logs,
+  };
+}
+
+describe("sessions delete commands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadConfig.mockReturnValue({});
+    mocks.resolveSessionStoreTargetsOrExit.mockReturnValue([
+      {
+        agentId: "main",
+        storePath: "/tmp/sessions.json",
+      },
+    ]);
+    mocks.resolveSessionFilePathOptions.mockReturnValue({});
+    mocks.resolveSessionFilePath.mockImplementation(
+      (sessionId: string) => `/tmp/${sessionId}.jsonl`,
+    );
+    vi.spyOn(fs.promises, "rm").mockResolvedValue(undefined);
+  });
+
+  it("removes a matching session key and transcript", async () => {
+    mocks.updateSessionStore.mockImplementation(
+      async (_storePath: string, mutator: (store: Record<string, SessionEntry>) => unknown) => {
+        const store: Record<string, SessionEntry> = {
+          "agent:main:main": { sessionId: "sess-1", updatedAt: 1 },
+          "agent:main:other": { sessionId: "sess-2", updatedAt: 2 },
+        };
+        return await mutator(store);
+      },
+    );
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsRemoveCommand({ key: "agent:main:main" }, runtime);
+
+    expect(mocks.updateSessionStore).toHaveBeenCalledTimes(1);
+    expect(fs.promises.rm).toHaveBeenCalledWith("/tmp/sess-1.jsonl", { force: true });
+    expect(logs.some((line) => line.includes("removed 1 session"))).toBe(true);
+  });
+
+  it("fails when removing a key that does not exist", async () => {
+    mocks.updateSessionStore.mockImplementation(
+      async (_storePath: string, mutator: (store: Record<string, SessionEntry>) => unknown) =>
+        await mutator({ "agent:main:other": { sessionId: "sess-2", updatedAt: 2 } }),
+    );
+
+    const { runtime } = makeRuntime();
+    await expect(sessionsRemoveCommand({ key: "agent:main:main" }, runtime)).rejects.toThrow(
+      "exit 1",
+    );
+  });
+
+  it("clears sessions older than a threshold", async () => {
+    const now = Date.now();
+    mocks.updateSessionStore.mockImplementation(
+      async (_storePath: string, mutator: (store: Record<string, SessionEntry>) => unknown) => {
+        const store: Record<string, SessionEntry> = {
+          old: { sessionId: "sess-old", updatedAt: now - 120 * 60_000 },
+          recent: { sessionId: "sess-recent", updatedAt: now - 5 * 60_000 },
+        };
+        return await mutator(store);
+      },
+    );
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsClearCommand({ olderThan: "60" }, runtime);
+
+    expect(fs.promises.rm).toHaveBeenCalledWith("/tmp/sess-old.jsonl", { force: true });
+    expect(logs.some((line) => line.includes("removed 1 session"))).toBe(true);
+  });
+
+  it("supports dry-run clear without mutating the store", async () => {
+    mocks.loadSessionStore.mockReturnValue({
+      old: { sessionId: "sess-old", updatedAt: Date.now() - 120 * 60_000 },
+      recent: { sessionId: "sess-recent", updatedAt: Date.now() - 5 * 60_000 },
+    });
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsClearCommand({ dryRun: true, olderThan: "60" }, runtime);
+
+    expect(mocks.updateSessionStore).not.toHaveBeenCalled();
+    expect(fs.promises.rm).not.toHaveBeenCalled();
+    expect(logs.some((line) => line.includes("Dry-run session clear"))).toBe(true);
+  });
+});

--- a/src/commands/sessions-delete.ts
+++ b/src/commands/sessions-delete.ts
@@ -1,0 +1,303 @@
+import fs from "node:fs";
+import { loadConfig } from "../config/config.js";
+import {
+  loadSessionStore,
+  resolveSessionFilePath,
+  resolveSessionFilePathOptions,
+  updateSessionStore,
+  type SessionEntry,
+} from "../config/sessions.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { resolveSessionStoreTargetsOrExit } from "./session-store-targets.js";
+
+type SessionMutationBaseOptions = {
+  store?: string;
+  agent?: string;
+  allAgents?: boolean;
+  dryRun?: boolean;
+  json?: boolean;
+};
+
+export type SessionsRemoveOptions = SessionMutationBaseOptions & {
+  key: string;
+};
+
+export type SessionsClearOptions = SessionMutationBaseOptions & {
+  olderThan?: string;
+};
+
+type SessionDeletionResult = {
+  key: string;
+  entry: SessionEntry;
+};
+
+type SessionDeletionStoreSummary = {
+  agentId: string;
+  storePath: string;
+  beforeCount: number;
+  afterCount: number;
+  removedKeys: string[];
+  removedTranscripts: string[];
+  dryRun: boolean;
+};
+
+function normalizeSessionKey(input: string): string {
+  return input.trim().toLowerCase();
+}
+
+function parseOlderThanMinutes(value: string | undefined, runtime: RuntimeEnv): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    runtime.error("--older-than must be a positive integer (minutes)");
+    runtime.exit(1);
+    return undefined;
+  }
+  return parsed;
+}
+
+function collectRemovalsByPredicate(
+  store: Record<string, SessionEntry>,
+  shouldDelete: (params: { key: string; entry: SessionEntry }) => boolean,
+): SessionDeletionResult[] {
+  const removals: SessionDeletionResult[] = [];
+  for (const [key, entry] of Object.entries(store)) {
+    if (!entry || !shouldDelete({ key, entry })) {
+      continue;
+    }
+    removals.push({ key, entry });
+    delete store[key];
+  }
+  return removals;
+}
+
+async function removeTranscriptFiles(params: {
+  removals: SessionDeletionResult[];
+  remainingStore: Record<string, SessionEntry>;
+  storePath: string;
+  agentId: string;
+}): Promise<string[]> {
+  const remainingSessionIds = new Set(
+    Object.values(params.remainingStore)
+      .map((entry) => entry?.sessionId)
+      .filter((sessionId): sessionId is string => Boolean(sessionId)),
+  );
+  const pathOpts = resolveSessionFilePathOptions({
+    storePath: params.storePath,
+    agentId: params.agentId,
+  });
+  const removedPaths: string[] = [];
+  for (const { entry } of params.removals) {
+    if (!entry.sessionId || remainingSessionIds.has(entry.sessionId)) {
+      continue;
+    }
+    const transcriptPath = resolveSessionFilePath(entry.sessionId, entry, pathOpts);
+    await fs.promises.rm(transcriptPath, { force: true }).catch(() => undefined);
+    removedPaths.push(transcriptPath);
+  }
+  return removedPaths;
+}
+
+async function deleteSessionsByPredicate(params: {
+  runtime: RuntimeEnv;
+  opts: SessionMutationBaseOptions;
+  shouldDelete: (args: { key: string; entry: SessionEntry; nowMs: number }) => boolean;
+}): Promise<SessionDeletionStoreSummary[] | null> {
+  const cfg = loadConfig();
+  const targets = resolveSessionStoreTargetsOrExit({
+    cfg,
+    opts: {
+      store: params.opts.store,
+      agent: params.opts.agent,
+      allAgents: params.opts.allAgents,
+    },
+    runtime: params.runtime,
+  });
+  if (!targets) {
+    return null;
+  }
+
+  const nowMs = Date.now();
+  const summaries: SessionDeletionStoreSummary[] = [];
+
+  for (const target of targets) {
+    if (params.opts.dryRun) {
+      const store = loadSessionStore(target.storePath, { skipCache: true });
+      const beforeCount = Object.keys(store).length;
+      const removals = collectRemovalsByPredicate(structuredClone(store), ({ key, entry }) =>
+        params.shouldDelete({ key, entry, nowMs }),
+      );
+      summaries.push({
+        agentId: target.agentId,
+        storePath: target.storePath,
+        beforeCount,
+        afterCount: beforeCount - removals.length,
+        removedKeys: removals.map((row) => row.key),
+        removedTranscripts: [],
+        dryRun: true,
+      });
+      continue;
+    }
+
+    const mutationResult = await updateSessionStore(target.storePath, (store) => {
+      const beforeCount = Object.keys(store).length;
+      const removals = collectRemovalsByPredicate(store, ({ key, entry }) =>
+        params.shouldDelete({ key, entry, nowMs }),
+      );
+      return {
+        beforeCount,
+        afterCount: Object.keys(store).length,
+        removals,
+        remainingStore: structuredClone(store),
+      };
+    });
+
+    const removedTranscripts = await removeTranscriptFiles({
+      removals: mutationResult.removals,
+      remainingStore: mutationResult.remainingStore,
+      storePath: target.storePath,
+      agentId: target.agentId,
+    });
+
+    summaries.push({
+      agentId: target.agentId,
+      storePath: target.storePath,
+      beforeCount: mutationResult.beforeCount,
+      afterCount: mutationResult.afterCount,
+      removedKeys: mutationResult.removals.map((row) => row.key),
+      removedTranscripts,
+      dryRun: false,
+    });
+  }
+
+  return summaries;
+}
+
+function totalRemovedCount(summaries: SessionDeletionStoreSummary[]): number {
+  return summaries.reduce((sum, row) => sum + row.removedKeys.length, 0);
+}
+
+function renderTextSummary(params: {
+  runtime: RuntimeEnv;
+  label: string;
+  summaries: SessionDeletionStoreSummary[];
+}): void {
+  const stores = params.summaries.length;
+  const removed = totalRemovedCount(params.summaries);
+  params.runtime.log(`${params.label}: removed ${removed} session(s) across ${stores} store(s).`);
+  for (const summary of params.summaries) {
+    const deleted = summary.removedKeys.length;
+    const transcriptCount = summary.removedTranscripts.length;
+    params.runtime.log(
+      `- ${summary.agentId}: ${summary.beforeCount} -> ${summary.afterCount} (removed ${deleted}, transcripts ${transcriptCount})`,
+    );
+  }
+}
+
+function renderJsonSummary(params: {
+  runtime: RuntimeEnv;
+  action: "rm" | "clear";
+  summaries: SessionDeletionStoreSummary[];
+  dryRun?: boolean;
+  key?: string;
+  olderThanMinutes?: number;
+}): void {
+  params.runtime.log(
+    JSON.stringify(
+      {
+        action: params.action,
+        dryRun: Boolean(params.dryRun),
+        key: params.key,
+        olderThanMinutes: params.olderThanMinutes ?? null,
+        removed: totalRemovedCount(params.summaries),
+        stores: params.summaries,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+export async function sessionsRemoveCommand(opts: SessionsRemoveOptions, runtime: RuntimeEnv) {
+  const key = opts.key?.trim();
+  if (!key) {
+    runtime.error("Session key is required");
+    runtime.exit(1);
+    return;
+  }
+  const normalized = normalizeSessionKey(key);
+  const summaries = await deleteSessionsByPredicate({
+    runtime,
+    opts,
+    shouldDelete: ({ key: candidateKey }) => normalizeSessionKey(candidateKey) === normalized,
+  });
+  if (!summaries) {
+    return;
+  }
+
+  const removed = totalRemovedCount(summaries);
+  if (removed === 0) {
+    runtime.error(`No matching session found for key: ${key}`);
+    runtime.exit(1);
+    return;
+  }
+
+  if (opts.json) {
+    renderJsonSummary({
+      runtime,
+      action: "rm",
+      key,
+      dryRun: opts.dryRun,
+      summaries,
+    });
+    return;
+  }
+  renderTextSummary({
+    runtime,
+    label: opts.dryRun ? "Dry-run session remove" : "Session remove",
+    summaries,
+  });
+}
+
+export async function sessionsClearCommand(opts: SessionsClearOptions, runtime: RuntimeEnv) {
+  const olderThanMinutes = parseOlderThanMinutes(opts.olderThan, runtime);
+  if (opts.olderThan !== undefined && olderThanMinutes === undefined) {
+    return;
+  }
+  const olderThanMs = olderThanMinutes ? olderThanMinutes * 60_000 : undefined;
+
+  const summaries = await deleteSessionsByPredicate({
+    runtime,
+    opts,
+    shouldDelete: ({ entry, nowMs }) => {
+      if (olderThanMs === undefined) {
+        return true;
+      }
+      if (!entry.updatedAt) {
+        return false;
+      }
+      return nowMs - entry.updatedAt >= olderThanMs;
+    },
+  });
+  if (!summaries) {
+    return;
+  }
+
+  if (opts.json) {
+    renderJsonSummary({
+      runtime,
+      action: "clear",
+      dryRun: opts.dryRun,
+      olderThanMinutes,
+      summaries,
+    });
+    return;
+  }
+  renderTextSummary({
+    runtime,
+    label: opts.dryRun ? "Dry-run session clear" : "Session clear",
+    summaries,
+  });
+}


### PR DESCRIPTION
## Summary
- add `openclaw sessions rm <key>` to remove a single session by exact key
- add `openclaw sessions clear` for bulk removal with optional `--older-than` filtering
- support `--store`, `--agent`, `--all-agents`, `--dry-run`, and `--json` for both subcommands
- remove orphan transcript files when a session is deleted (when no remaining store entry references the same sessionId)

## Why
`openclaw sessions` currently lists sessions but does not provide a direct command path to remove one or many entries. Users currently have to edit `sessions.json` manually.

## Validation
- `corepack pnpm vitest run src/cli/program/register.status-health-sessions.test.ts src/commands/sessions-delete.test.ts`
- `corepack pnpm exec oxlint src/cli/program/register.status-health-sessions.ts src/cli/program/register.status-health-sessions.test.ts src/commands/sessions-delete.ts src/commands/sessions-delete.test.ts`