### PR TITLE
fix(telegram): add editMessage and createForumTopic to actions schema

### DIFF
--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -226,7 +226,9 @@ export const TelegramAccountSchemaBase = z
         reactions: z.boolean().optional(),
         sendMessage: z.boolean().optional(),
         deleteMessage: z.boolean().optional(),
+        editMessage: z.boolean().optional(),
         sticker: z.boolean().optional(),
+        createForumTopic: z.boolean().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

- **Problem:** Telegram actions Zod schema used \`.strict()\` but only included 4 of 6 fields from \`TelegramActionConfig\`. Configuring \`editMessage\` or \`createForumTopic\` triggered validation errors.
- **Why it matters:** Users cannot toggle these action features via config without hitting schema rejection.
- **What changed:** Added \`editMessage: z.boolean().optional()\` and \`createForumTopic: z.boolean().optional()\` to the Telegram actions schema in \`zod-schema.providers-core.ts\`.
- **What did NOT change:** TypeScript type (already has both fields), runtime logic in \`telegram-actions.ts\` (already checks both fields).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35497

## User-visible / Behavior Changes

- \`channels.telegram.actions.editMessage\` and \`channels.telegram.actions.createForumTopic\` are now accepted by config validation.

## Security Impact (required)

- New permissions/capabilities? \`No\` — these fields already exist in the type and runtime
- Secrets/tokens handling changed? \`No\`
- New/changed network calls? \`No\`
- Command/tool execution surface changed? \`No\`
- Data access scope changed? \`No\`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: Telegram

### Steps

1. Add \`channels.telegram.actions.editMessage: true\` to config
2. Start the gateway

### Expected

- Config validates successfully

### Actual

- Before fix: Zod rejects with "Unrecognized key(s) in object: 'editMessage'"
- After fix: Config validates

## Evidence

- \`TelegramActionConfig\` type in \`types.telegram.ts:14-23\` defines both fields
- Runtime checks in \`telegram-actions.ts:275-277\` (editMessage) and \`379-381\` (createForumTopic) already handle them

## Human Verification (required)

- Verified scenarios: Schema alignment with TypeScript type and runtime
- Edge cases checked: \`.strict()\` enforcement with all 6 fields
- What I did **not** verify: Live Telegram edit/forum topic actions

## Compatibility / Migration

- Backward compatible? \`Yes\`
- Config/env changes? \`No\`
- Migration needed? \`No\`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit
- Files/config to restore: \`src/config/zod-schema.providers-core.ts\`
- Known bad symptoms: None expected

## Risks and Mitigations

None — additive schema change that aligns with existing type and runtime.

