### PR TITLE
fix(telegram): check response.ok before response.json() in probe and audit

### DIFF
--- a/src/telegram/audit-membership-runtime.ts
+++ b/src/telegram/audit-membership-runtime.ts
@@ -24,8 +24,20 @@ export async function auditTelegramGroupMembershipImpl(
     try {
       const url = `${base}/getChatMember?chat_id=${encodeURIComponent(chatId)}&user_id=${encodeURIComponent(String(params.botId))}`;
       const res = await fetchWithTimeout(url, {}, params.timeoutMs, fetcher);
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        groups.push({
+          chatId,
+          ok: false,
+          status: null,
+          error: text || `getChatMember failed (${res.status})`,
+          matchKey: chatId,
+          matchSource: "id",
+        });
+        continue;
+      }
       const json = (await res.json()) as TelegramApiOk<{ status?: string }> | TelegramApiErr;
-      if (!res.ok || !isRecord(json) || !json.ok) {
+      if (!isRecord(json) || !json.ok) {
         const desc =
           isRecord(json) && !json.ok && typeof json.description === "string"
             ? json.description

--- a/src/telegram/probe.test.ts
+++ b/src/telegram/probe.test.ts
@@ -100,10 +100,7 @@ describe("probeTelegram retry logic", () => {
     const mockResponse = {
       ok: false,
       status: 401,
-      json: vi.fn().mockResolvedValue({
-        ok: false,
-        description: "Unauthorized",
-      }),
+      text: vi.fn().mockResolvedValue("Unauthorized"),
     };
     fetchMock.mockResolvedValueOnce(mockResponse);
 

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -55,6 +55,12 @@ export async function probeTelegram(
       throw fetchError;
     }
 
+    if (!meRes.ok) {
+      result.status = meRes.status;
+      const text = await meRes.text().catch(() => "");
+      result.error = text || `getMe failed (${meRes.status})`;
+      return { ...result, elapsedMs: Date.now() - started };
+    }
     const meJson = (await meRes.json()) as {
       ok?: boolean;
       description?: string;
@@ -66,7 +72,7 @@ export async function probeTelegram(
         supports_inline_queries?: boolean;
       };
     };
-    if (!meRes.ok || !meJson?.ok) {
+    if (!meJson?.ok) {
       result.status = meRes.status;
       result.error = meJson?.description ?? `getMe failed (${meRes.status})`;
       return { ...result, elapsedMs: Date.now() - started };
@@ -90,15 +96,17 @@ export async function probeTelegram(
     // Try to fetch webhook info, but don't fail health if it errors.
     try {
       const webhookRes = await fetchWithTimeout(`${base}/getWebhookInfo`, {}, timeoutMs, fetcher);
-      const webhookJson = (await webhookRes.json()) as {
-        ok?: boolean;
-        result?: { url?: string; has_custom_certificate?: boolean };
-      };
-      if (webhookRes.ok && webhookJson?.ok) {
-        result.webhook = {
-          url: webhookJson.result?.url ?? null,
-          hasCustomCert: webhookJson.result?.has_custom_certificate ?? null,
+      if (webhookRes.ok) {
+        const webhookJson = (await webhookRes.json()) as {
+          ok?: boolean;
+          result?: { url?: string; has_custom_certificate?: boolean };
         };
+        if (webhookJson?.ok) {
+          result.webhook = {
+            url: webhookJson.result?.url ?? null,
+            hasCustomCert: webhookJson.result?.has_custom_certificate ?? null,
+          };
+        }
       }
     } catch {
       // ignore webhook errors for probe


### PR DESCRIPTION
## Summary

Both `probeTelegram()` and `auditTelegramGroupMembershipImpl()` called `response.json()` before checking `response.ok`. When the Telegram API returns a non-JSON HTTP error (e.g., 502 HTML from a reverse proxy, CDN timeout page, or rate-limit HTML), this causes a `SyntaxError` instead of a meaningful status-based error message.

**Files changed:**
- `src/telegram/probe.ts` — two `response.json()` calls (getMe + getWebhookInfo) now guarded
- `src/telegram/audit-membership-runtime.ts` — `response.json()` call now guarded

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [x] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — follows pattern from PR #35628 and #35714.

## User-Visible Changes

Telegram health probe and group membership audit now return clear HTTP status errors instead of cryptic `SyntaxError` when the Telegram API is behind a misbehaving proxy.

## Security Impact

1. Does this change handle user input? **No** — only HTTP response handling
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 5 probe tests pass
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ src/telegram/probe.test.ts (5 tests) 4ms
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

## Human Verification

- Simulate a 502 HTML response from Telegram API → probe should report "HTTP 502" instead of SyntaxError
- Simulate a 429 rate-limit response → audit should report the status text

## Compatibility

Fully backward compatible. Successful responses behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| None | Error paths produce clearer messages; success paths unchanged |