### PR TITLE
fix(plugins): check response.ok before response.json() in Zalo, Discord proxy, and Firecrawl

### DIFF
--- a/extensions/zalo/src/api.ts
+++ b/extensions/zalo/src/api.ts
@@ -110,6 +110,15 @@ export async function callZaloApi<T = unknown>(
       signal: controller.signal,
     });
 
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new ZaloApiError(
+        text || `Zalo API HTTP error: ${method} (${response.status})`,
+        response.status,
+        text || undefined,
+      );
+    }
+
     const data = (await response.json()) as ZaloApiResponse<T>;
 
     if (!data.ok) {

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -386,6 +386,13 @@ export async function fetchFirecrawlContent(params: {
     signal: withTimeout(undefined, params.timeoutSeconds * 1000),
   });
 
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "");
+    throw new Error(
+      `Firecrawl fetch failed (${res.status}): ${wrapWebContent(detail || res.statusText, "web_fetch")}`.trim(),
+    );
+  }
+
   const payload = (await res.json()) as {
     success?: boolean;
     data?: {
@@ -401,7 +408,7 @@ export async function fetchFirecrawlContent(params: {
     error?: string;
   };
 
-  if (!res.ok || payload?.success === false) {
+  if (payload?.success === false) {
     const detail = payload?.error ?? "";
     throw new Error(
       `Firecrawl fetch failed (${res.status}): ${wrapWebContent(detail || res.statusText, "web_fetch")}`.trim(),

--- a/src/discord/monitor/gateway-plugin.ts
+++ b/src/discord/monitor/gateway-plugin.ts
@@ -63,6 +63,10 @@ export function createDiscordGatewayPlugin(params: {
               },
               dispatcher: fetchAgent,
             } as Record<string, unknown>);
+            if (!response.ok) {
+              const text = await response.text().catch(() => "");
+              throw new Error(`HTTP ${response.status}: ${text || response.statusText}`);
+            }
             this.gatewayInfo = (await response.json()) as APIGatewayBotInfo;
           } catch (error) {
             throw new Error(


### PR DESCRIPTION
## Summary

Three unguarded `response.json()` calls that crash with `SyntaxError` when the upstream API returns a non-JSON HTTP error response (e.g., 502 HTML page from a reverse proxy, CDN timeout, rate-limit page):

1. **`extensions/zalo/src/api.ts`** — `callZaloApi` parsed the response body via `response.json()` before checking HTTP status. A non-2xx non-JSON response crashes with SyntaxError. Now throws `ZaloApiError` with the raw error text for non-2xx responses.

2. **`src/discord/monitor/gateway-plugin.ts`** — The proxy gateway plugin parsed the Discord `/gateway/bot` response without checking `response.ok`. Now checks HTTP status first and throws a descriptive error.

3. **`src/agents/tools/web-fetch.ts`** — Firecrawl fetch parsed JSON before checking `res.ok`. Now checks HTTP status first and returns the raw error text for non-2xx responses.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — follows pattern from PR #35628, #35714, and #35737.

## User-Visible Changes

API errors from Zalo, Discord (via proxy), and Firecrawl now produce clear HTTP status messages instead of cryptic `SyntaxError` crashes.

## Security Impact

1. Does this change handle user input? **No** — only HTTP response handling
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 29 Zalo tests pass
- [x] Formatted with `oxfmt`

## Evidence

```
 Test Files  7 passed (7)
      Tests  29 passed (29)
```

## Human Verification

- Simulate a 502 HTML response from Zalo API → should get ZaloApiError with status text
- Simulate a 401 from Discord gateway/bot endpoint via proxy → should get "HTTP 401: ..." error
- Simulate a 503 from Firecrawl → should get "Firecrawl fetch failed (503): ..."

## Compatibility

Fully backward compatible. Successful responses behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| None | Error paths produce clearer messages; success paths unchanged |