### PR TITLE
Config: allow agents.list thinkingDefault override

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -307,6 +307,15 @@ describe("config paths", () => {
 });
 
 describe("config strict validation", () => {
+  it("accepts agents.list[].thinkingDefault", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [{ id: "pi", thinkingDefault: "medium" }],
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects unknown fields", async () => {
     const res = validateConfigObject({
       agents: { list: [{ id: "pi" }] },

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -687,6 +687,17 @@ export const AgentEntrySchema = z
     workspace: z.string().optional(),
     agentDir: z.string().optional(),
     model: AgentModelSchema.optional(),
+    thinkingDefault: z
+      .union([
+        z.literal("off"),
+        z.literal("minimal"),
+        z.literal("low"),
+        z.literal("medium"),
+        z.literal("high"),
+        z.literal("xhigh"),
+        z.literal("adaptive"),
+      ])
+      .optional(),
     skills: z.array(z.string()).optional(),
     memorySearch: MemorySearchSchema,
     humanDelay: HumanDelaySchema.optional(),


### PR DESCRIPTION
## Summary
- allow `agents.list[].thinkingDefault` in config schema
- keep accepted values aligned with `agents.defaults.thinkingDefault`
- add regression coverage to ensure per-agent thinking defaults parse successfully

Closes #21097
