### PR TITLE
fix(gateway): wrap JSON.parse in try-catch for plugin manifest and delivery queue

### DIFF
--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -128,7 +128,12 @@ export async function ackDelivery(id: string, stateDir?: string): Promise<void> 
 export async function failDelivery(id: string, error: string, stateDir?: string): Promise<void> {
   const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
   const raw = await fs.promises.readFile(filePath, "utf-8");
-  const entry: QueuedDelivery = JSON.parse(raw);
+  let entry: QueuedDelivery;
+  try {
+    entry = JSON.parse(raw);
+  } catch {
+    throw new Error(`Corrupted delivery queue entry: ${id}`);
+  }
   entry.retryCount += 1;
   entry.lastAttemptAt = Date.now();
   entry.lastError = error;

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -85,9 +85,12 @@ async function readPluginManifestExtensions(pluginPath: string): Promise<string[
     return [];
   }
 
-  const parsed = JSON.parse(raw) as Partial<
-    Record<typeof MANIFEST_KEY, { extensions?: unknown }>
-  > | null;
+  let parsed: Partial<Record<typeof MANIFEST_KEY, { extensions?: unknown }>> | null;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
   const extensions = parsed?.[MANIFEST_KEY]?.extensions;
   if (!Array.isArray(extensions)) {
     return [];


### PR DESCRIPTION
## Summary

Two unguarded `JSON.parse()` calls that crash with `SyntaxError` on corrupted data:

1. **`src/security/audit-extra.async.ts`** — `readPluginManifestExtensions` parsed a plugin's `package.json` without `try-catch`. A corrupted or truncated manifest file crashes the security audit instead of gracefully returning an empty extensions list.

2. **`src/infra/outbound/delivery-queue.ts`** — `failDelivery` parsed the queued delivery JSON entry without `try-catch`. A corrupted queue file (e.g., partial write from a crash) crashes the retry logic with an opaque `SyntaxError` instead of a descriptive error.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [x] Gateway
- [x] Security

## Linked Issues

Proactive defensive fix — follows pattern from PR #35668.

## User-Visible Changes

- Security audit no longer crashes on plugins with corrupted `package.json`
- Delivery retry no longer crashes on corrupted queue entries

## Security Impact

1. Does this change handle user input? **No** — only file-system data parsing
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **Partially** — the security audit function now handles parse errors gracefully instead of crashing

## Verification

- [x] All 265 outbound/delivery tests pass
- [x] Formatted with `oxfmt`

## Evidence

```
 Test Files  19 passed (19)
      Tests  265 passed (265)
```

## Human Verification

- Place a corrupted `package.json` in a plugin directory → security audit should skip it gracefully
- Corrupt a delivery queue JSON file → `failDelivery` should throw "Corrupted delivery queue entry" instead of SyntaxError

## Compatibility

Fully backward compatible. Valid JSON files behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| audit-extra now silently ignores corrupt manifests | Returns empty array, same as missing file — consistent with existing behavior |