### PR TITLE
Cron: recover flat model patch in cron.update

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -546,4 +546,38 @@ describe("cron tool", () => {
     expect(params?.patch?.sessionTarget).toBe("main");
     expect(params?.patch?.failureAlert).toEqual({ after: 3, cooldownMs: 60_000 });
   });
+
+  it("recovers flat model/thinking/timeout patch params for update action", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+
+    const tool = createCronTool();
+    await tool.execute("call-update-flat-model", {
+      action: "update",
+      id: "job-3",
+      model: "openai/gpt-4o-mini",
+      thinking: "low",
+      timeoutSeconds: 30,
+    });
+
+    const params = expectSingleGatewayCallMethod("cron.update") as
+      | {
+          id?: string;
+          patch?: {
+            payload?: {
+              kind?: string;
+              model?: string;
+              thinking?: string;
+              timeoutSeconds?: number;
+            };
+          };
+        }
+      | undefined;
+    expect(params?.id).toBe("job-3");
+    expect(params?.patch?.payload).toMatchObject({
+      kind: "agentTurn",
+      model: "openai/gpt-4o-mini",
+      thinking: "low",
+      timeoutSeconds: 30,
+    });
+  });
 });

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -459,7 +459,16 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
               "sessionTarget",
               "wakeMode",
               "failureAlert",
+              "message",
+              "model",
+              "thinking",
+              "timeoutSeconds",
+              "lightContext",
               "allowUnsafeExternalContent",
+              "deliver",
+              "channel",
+              "to",
+              "bestEffortDeliver",
             ]);
             const synthetic: Record<string, unknown> = {};
             let found = false;
@@ -470,6 +479,34 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
               }
             }
             if (found) {
+              if (!("payload" in synthetic) || typeof synthetic.payload !== "object") {
+                const agentTurnPatch = {
+                  kind: "agentTurn",
+                  ...(typeof synthetic.message === "string" ? { message: synthetic.message } : {}),
+                  ...(typeof synthetic.model === "string" ? { model: synthetic.model } : {}),
+                  ...(typeof synthetic.thinking === "string"
+                    ? { thinking: synthetic.thinking }
+                    : {}),
+                  ...(typeof synthetic.timeoutSeconds === "number"
+                    ? { timeoutSeconds: synthetic.timeoutSeconds }
+                    : {}),
+                  ...(typeof synthetic.lightContext === "boolean"
+                    ? { lightContext: synthetic.lightContext }
+                    : {}),
+                  ...(typeof synthetic.allowUnsafeExternalContent === "boolean"
+                    ? { allowUnsafeExternalContent: synthetic.allowUnsafeExternalContent }
+                    : {}),
+                  ...(typeof synthetic.deliver === "boolean" ? { deliver: synthetic.deliver } : {}),
+                  ...(typeof synthetic.channel === "string" ? { channel: synthetic.channel } : {}),
+                  ...(typeof synthetic.to === "string" ? { to: synthetic.to } : {}),
+                  ...(typeof synthetic.bestEffortDeliver === "boolean"
+                    ? { bestEffortDeliver: synthetic.bestEffortDeliver }
+                    : {}),
+                };
+                if (Object.keys(agentTurnPatch).length > 1) {
+                  synthetic.payload = agentTurnPatch;
+                }
+              }
               params.patch = synthetic;
             }
           }


### PR DESCRIPTION
## Summary
- teach `cron` tool update flat-param recovery to carry agent-turn fields (`model`, `thinking`, `timeoutSeconds`, etc.)
- synthesize `patch.payload.kind="agentTurn"` when flat update hints target agent-turn payload
- add regression coverage for flat `model/thinking/timeoutSeconds` updates

Closes #11826
