### PR TITLE
Config: accept plugin channel IDs in hooks mappings

### DIFF
--- a/src/config/config.hooks-channel-validation.test.ts
+++ b/src/config/config.hooks-channel-validation.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObjectWithPlugins } from "./config.js";
+
+describe("config hooks mapping channel validation", () => {
+  it("accepts extension channel IDs in hooks.mappings[].channel", () => {
+    const res = validateConfigObjectWithPlugins({
+      agents: { list: [{ id: "pi" }] },
+      hooks: {
+        mappings: [
+          {
+            match: { path: "custom" },
+            action: "agent",
+            channel: "bluebubbles",
+          },
+        ],
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects empty hooks.mappings[].channel", () => {
+    const res = validateConfigObjectWithPlugins({
+      agents: { list: [{ id: "pi" }] },
+      hooks: {
+        mappings: [
+          {
+            match: { path: "custom" },
+            action: "agent",
+            channel: "   ",
+          },
+        ],
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) {
+      throw new Error("expected validation failure");
+    }
+    expect(res.issues.some((issue) => issue.path === "hooks.mappings.0.channel")).toBe(true);
+  });
+});

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -49,19 +49,10 @@ export const HookMappingSchema = z
     textTemplate: z.string().optional(),
     deliver: z.boolean().optional(),
     allowUnsafeExternalContent: z.boolean().optional(),
-    channel: z
-      .union([
-        z.literal("last"),
-        z.literal("whatsapp"),
-        z.literal("telegram"),
-        z.literal("discord"),
-        z.literal("irc"),
-        z.literal("slack"),
-        z.literal("signal"),
-        z.literal("imessage"),
-        z.literal("msteams"),
-      ])
-      .optional(),
+    // Runtime hook dispatch validates against currently loaded channel plugin IDs.
+    // Keep schema permissive so extension channels can be configured without
+    // requiring hardcoded IDs here.
+    channel: z.string().trim().min(1).optional(),
     to: z.string().optional(),
     model: z.string().optional(),
     thinking: z.string().optional(),


### PR DESCRIPTION
## Summary
- make `hooks.mappings[].channel` schema accept non-empty strings instead of a hardcoded channel enum
- keep runtime channel validation as the source of truth (`last|<loaded plugin ids>`)
- add config regression tests for extension channel IDs (e.g. `bluebubbles`)

Closes #17155
