### PR TITLE
fix(plugins): defensive guards for export-html entries and thread-ownership resp.json

### DIFF
--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -115,10 +115,15 @@ export default function register(api: OpenClawPluginApi) {
       }
 
       if (resp.status === 409) {
-        // Another agent owns this thread — cancel the send.
-        const body = (await resp.json()) as { owner?: string };
+        let owner: string | undefined;
+        try {
+          const body = (await resp.json()) as { owner?: string };
+          owner = body.owner;
+        } catch {
+          // non-JSON 409 response
+        }
         api.logger.info?.(
-          `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${body.owner}`,
+          `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${owner ?? "unknown"}`,
         );
         return { cancel: true };
       }

--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -12,7 +12,8 @@
     bytes[i] = binary.charCodeAt(i);
   }
   const data = JSON.parse(new TextDecoder("utf-8").decode(bytes));
-  const { header, entries, leafId: defaultLeafId, systemPrompt, tools, renderedTools } = data;
+  const { header, entries: rawEntries, leafId: defaultLeafId, systemPrompt, tools, renderedTools } = data;
+  const entries = Array.isArray(rawEntries) ? rawEntries : [];
 
   // ============================================================
   // URL PARAMETER HANDLING
@@ -1037,7 +1038,7 @@
     const statusClass = result ? (isError ? "error" : "success") : "pending";
 
     const getResultText = () => {
-      if (!result) {
+      if (!result || !Array.isArray(result.content)) {
         return "";
       }
       const textBlocks = result.content.filter((c) => c.type === "text");
@@ -1045,7 +1046,7 @@
     };
 
     const getResultImages = () => {
-      if (!result) {
+      if (!result || !Array.isArray(result.content)) {
         return [];
       }
       return result.content.filter((c) => c.type === "image");


### PR DESCRIPTION
## Summary

Two defensive programming fixes:

1. **`src/auto-reply/reply/export-html/template.js`** — The exported HTML session viewer iterated over `entries` from parsed session data without checking if it's a valid array. If the embedded session data is corrupted and `entries` is `undefined`, the page crashes with `TypeError: entries is not iterable`. Now uses `Array.isArray()` to safely default to an empty array. Also added `Array.isArray(result.content)` guards before `.filter()`/`.map()` calls on tool result content.

2. **`extensions/thread-ownership/index.ts`** — The `resp.json()` call in the 409 (conflict) branch was unguarded. If the ownership service returns a non-JSON 409 response, this crashed with `SyntaxError`. Now wrapped in try-catch, falling back to "owned by unknown" in the log.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — follows pattern from PR #35668 and #35678.

## User-Visible Changes

- Exported HTML session pages no longer crash on corrupted session data
- Thread ownership plugin no longer crashes on non-JSON 409 responses

## Security Impact

1. Does this change handle user input? **No** — only internal data handling
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 9 thread-ownership tests pass
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ extensions/thread-ownership/index.test.ts (9 tests) 13ms
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

## Human Verification

- Open an exported HTML session with a corrupted `entries` field → should render empty instead of crashing
- Simulate a non-JSON 409 from ownership service → plugin should log "owned by unknown" and cancel send

## Compatibility

Fully backward compatible. Valid data behaves identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| None | All guards add fallback paths; success paths unchanged |