### PR TITLE
fix: avoid inheriting external delivery route for control UI

### DIFF
--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MsgContext } from "../../auto-reply/templating.js";
-import { GATEWAY_CLIENT_CAPS, GATEWAY_CLIENT_MODES } from "../protocol/client-info.js";
+import {
+  GATEWAY_CLIENT_CAPS,
+  GATEWAY_CLIENT_IDS,
+  GATEWAY_CLIENT_MODES,
+} from "../protocol/client-info.js";
 import type { GatewayRequestContext } from "./types.js";
 
 const mockState = vi.hoisted(() => ({
@@ -596,6 +600,46 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
           client: {
             mode: GATEWAY_CLIENT_MODES.UI,
             id: "openclaw-tui",
+          },
+        },
+      } as unknown,
+      sessionKey: "agent:main:main",
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        OriginatingChannel: "webchat",
+        OriginatingTo: undefined,
+        AccountId: undefined,
+      }),
+    );
+  });
+
+  it("chat.send does not inherit external delivery context for control-ui clients on main sessions", async () => {
+    createTranscriptFixture("openclaw-chat-send-main-control-ui-routes-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "signal",
+        to: "+15551234567",
+        accountId: "default",
+      },
+      lastChannel: "signal",
+      lastTo: "+15551234567",
+      lastAccountId: "default",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-main-control-ui-routes",
+      client: {
+        connect: {
+          client: {
+            id: GATEWAY_CLIENT_IDS.CONTROL_UI,
           },
         },
       } as unknown,

--- a/src/utils/message-channel.test.ts
+++ b/src/utils/message-channel.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
+import { GATEWAY_CLIENT_IDS } from "../gateway/protocol/client-info.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createMSTeamsTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
-import { resolveGatewayMessageChannel } from "./message-channel.js";
+import { isWebchatClient, resolveGatewayMessageChannel } from "./message-channel.js";
 
 const emptyRegistry = createTestRegistry([]);
 const msteamsPlugin: ChannelPlugin = {
@@ -30,5 +31,13 @@ describe("message-channel", () => {
       createTestRegistry([{ pluginId: "msteams", plugin: msteamsPlugin, source: "test" }]),
     );
     expect(resolveGatewayMessageChannel("teams")).toBe("msteams");
+  });
+
+  it("treats control-ui as webchat client", () => {
+    expect(
+      isWebchatClient({
+        id: GATEWAY_CLIENT_IDS.CONTROL_UI,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -5,6 +5,7 @@ import {
   normalizeChatChannelId,
 } from "../channels/registry.js";
 import {
+  GATEWAY_CLIENT_IDS,
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
   type GatewayClientMode,
@@ -49,7 +50,8 @@ export function isWebchatClient(client?: GatewayClientInfoLike | null): boolean 
   if (mode === GATEWAY_CLIENT_MODES.WEBCHAT) {
     return true;
   }
-  return normalizeGatewayClientName(client?.id) === GATEWAY_CLIENT_NAMES.WEBCHAT_UI;
+  const clientId = normalizeGatewayClientName(client?.id);
+  return clientId === GATEWAY_CLIENT_NAMES.WEBCHAT_UI || clientId === GATEWAY_CLIENT_IDS.CONTROL_UI;
 }
 
 export function normalizeMessageChannel(raw?: string | null): string | undefined {


### PR DESCRIPTION
Fixes #34647

Control-UI clients can currently be treated as non-webchat when client mode is missing, which causes webchat-originated messages on shared main sessions to inherit stale external delivery routes (e.g. slack/signal). This updates webchat client detection to include CONTROL_UI so those turns stay on webchat and do not leak replies to external channels.

Refs: #34647