### PR TITLE
Agents: sanitize ZAI tool schemas for Gemini-compatible API

### DIFF
--- a/src/agents/pi-embedded-runner/google.test.ts
+++ b/src/agents/pi-embedded-runner/google.test.ts
@@ -42,6 +42,26 @@ describe("sanitizeToolsForGoogle", () => {
     expectFormatRemoved(sanitized, "additionalProperties");
   });
 
+  it("strips unsupported schema keywords for zai providers", () => {
+    const tool = createTool({
+      type: "object",
+      patternProperties: {
+        "^x-": { type: "string", format: "uuid" },
+      },
+      properties: {
+        foo: {
+          type: "string",
+          format: "uuid",
+        },
+      },
+    });
+    const [sanitized] = sanitizeToolsForGoogle({
+      tools: [tool],
+      provider: "zai",
+    });
+    expectFormatRemoved(sanitized, "patternProperties");
+  });
+
   it("returns original tools for non-google providers", () => {
     const tool = createTool({
       type: "object",

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -245,7 +245,13 @@ export function sanitizeToolsForGoogle<
   // AND Claude models.  This field does not support JSON Schema keywords such as
   // patternProperties, additionalProperties, $ref, etc.  We must clean schemas
   // for every provider that routes through this path.
-  if (params.provider !== "google-gemini-cli") {
+  const normalizedProvider = params.provider.trim().toLowerCase();
+  if (
+    normalizedProvider !== "google-gemini-cli" &&
+    normalizedProvider !== "zai" &&
+    normalizedProvider !== "z-ai" &&
+    normalizedProvider !== "z.ai"
+  ) {
     return params.tools;
   }
   return params.tools.map((tool) => {
@@ -262,7 +268,13 @@ export function sanitizeToolsForGoogle<
 }
 
 export function logToolSchemasForGoogle(params: { tools: AgentTool[]; provider: string }) {
-  if (params.provider !== "google-gemini-cli") {
+  const normalizedProvider = params.provider.trim().toLowerCase();
+  if (
+    normalizedProvider !== "google-gemini-cli" &&
+    normalizedProvider !== "zai" &&
+    normalizedProvider !== "z-ai" &&
+    normalizedProvider !== "z.ai"
+  ) {
     return;
   }
   const toolNames = params.tools.map((tool, index) => `${index}:${tool.name}`);


### PR DESCRIPTION
## Summary
- apply Gemini-compatible tool-schema sanitization for ZAI providers (`zai`, `z-ai`, `z.ai`)
- keep existing behavior for `google-gemini-cli`
- add regression coverage to verify unsupported schema keywords are stripped for ZAI

Closes #21172
