### PR TITLE
Config: add Signal groups schema support

### DIFF
--- a/src/config/config.signal-groups-schema.test.ts
+++ b/src/config/config.signal-groups-schema.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./config.js";
+
+describe("signal groups config schema", () => {
+  it("accepts channels.signal.groups with requireMention", () => {
+    const res = validateConfigObject({
+      channels: {
+        signal: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groups: {
+            "*": { requireMention: true },
+            "group-123": { requireMention: false },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts channels.signal.accounts.*.groups overrides", () => {
+    const res = validateConfigObject({
+      channels: {
+        signal: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          accounts: {
+            work: {
+              groups: {
+                "*": { requireMention: true, skills: ["calendar"] },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+});

--- a/src/config/types.signal.ts
+++ b/src/config/types.signal.ts
@@ -1,5 +1,13 @@
 import type { CommonChannelMessagingConfig } from "./types.channel-messaging-common.js";
 
+export type SignalGroupConfig = {
+  requireMention?: boolean;
+  skills?: string[];
+  enabled?: boolean;
+  allowFrom?: Array<string | number>;
+  systemPrompt?: string;
+};
+
 export type SignalReactionNotificationMode = "off" | "own" | "all" | "allowlist";
 export type SignalReactionLevel = "off" | "ack" | "minimal" | "extensive";
 
@@ -43,6 +51,8 @@ export type SignalAccountConfig = CommonChannelMessagingConfig & {
    * - "extensive": Agent can react liberally
    */
   reactionLevel?: SignalReactionLevel;
+  /** Per-group overrides keyed by group id (or "*" defaults). */
+  groups?: Record<string, SignalGroupConfig>;
 };
 
 export type SignalConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -942,6 +942,23 @@ export const SignalAccountSchemaBase = z
     defaultTo: z.string().optional(),
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+    groups: z
+      .record(
+        z.string(),
+        z
+          .object({
+            requireMention: z.boolean().optional(),
+            tools: ToolPolicySchema,
+            toolsBySender: ToolPolicyBySenderSchema,
+            skills: z.array(z.string()).optional(),
+            enabled: z.boolean().optional(),
+            allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+            systemPrompt: z.string().optional(),
+          })
+          .strict()
+          .optional(),
+      )
+      .optional(),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),


### PR DESCRIPTION
## Summary
- add `channels.signal.groups` schema support (including account-level overrides)
- align Signal config types with runtime group mention-gating behavior
- add regression coverage for top-level and per-account Signal group configs

Closes #20397
