### PR TITLE
fix(telegram): keep draft stream previews unthreaded

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -183,8 +183,11 @@ export const dispatchTelegramMessage = async ({
   const canStreamAnswerDraft =
     previewStreamingEnabled && !accountBlockStreamingEnabled && !forceBlockStreamingForReasoning;
   const canStreamReasoningDraft = canStreamAnswerDraft || streamReasoningDraft;
-  const draftReplyToMessageId =
-    replyToMode !== "off" && typeof msg.message_id === "number" ? msg.message_id : undefined;
+  // Keep draft preview messages unthreaded. Drafts are transient and can be
+  // deleted/cleared during finalization; threading them can make Telegram show
+  // a "Deleted message" quote block when reply tags are used.
+  // Final delivery still applies reply threading via deliverReplies.
+  const draftReplyToMessageId = undefined;
   const draftMinInitialChars = DRAFT_MIN_INITIAL_CHARS;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const archivedAnswerPreviews: ArchivedPreview[] = [];


### PR DESCRIPTION
## Summary
- stop attaching `reply_to_message_id` to transient Telegram draft preview messages
- keep final reply threading unchanged via `deliverReplies`
- avoid "Deleted message" quote artifacts when `[[reply_to_current]]` is used and previews are later deleted

## Validation
- `pnpm test src/telegram/bot-message-dispatch.test.ts`

## Collision check
- Searched open PRs/issues for issue #35632 keywords before opening this PR; no active fix found.
