### PR TITLE
fix(gateway): use gateway config for cron agent resolution instead of loadConfig()

### DIFF
--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -151,7 +151,7 @@ export function buildGatewayCronService(params: {
   const cronEnabled = process.env.OPENCLAW_SKIP_CRON !== "1" && params.cfg.cron?.enabled !== false;
 
   const resolveCronAgent = (requested?: string | null) => {
-    const runtimeConfig = loadConfig();
+    const runtimeConfig = params.cfg;
     const normalized =
       typeof requested === "string" && requested.trim() ? normalizeAgentId(requested) : undefined;
     const hasAgent =
@@ -200,7 +200,7 @@ export function buildGatewayCronService(params: {
   };
 
   const resolveCronWakeTarget = (opts?: { agentId?: string; sessionKey?: string | null }) => {
-    const runtimeConfig = loadConfig();
+    const runtimeConfig = params.cfg;
     const requestedAgentId = opts?.agentId ? resolveCronAgent(opts.agentId).agentId : undefined;
     const derivedAgentId =
       requestedAgentId ??


### PR DESCRIPTION
## Summary

- **Problem:** Cron isolated sessions run on the gateway host instead of the Docker sandbox on headless Linux, because `resolveCronAgent` and `resolveCronWakeTarget` call `loadConfig()` at runtime which can resolve a different config path lacking `agents.defaults.sandbox.mode`.
- **Why it matters:** Users who configure sandbox mode expect all agent sessions (including cron) to run inside Docker. Silent fallback to host execution breaks sandboxed tools like `exec`, MCP mounts, and isolation guarantees.
- **What changed:** Replaced `loadConfig()` calls in `resolveCronAgent` and `resolveCronWakeTarget` with `params.cfg` (the gateway's own config passed at construction time). The cron service is rebuilt with fresh config on hot-reload (`server-reload-handlers.ts`), so runtime changes are still picked up.
- **What did NOT change:** No changes to sandbox resolution logic, session key construction, or any other cron internals. Only the config source for these two closures changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35636

## User-visible / Behavior Changes

- Cron isolated sessions now correctly inherit the gateway's sandbox configuration and run inside Docker when `agents.defaults.sandbox.mode` is set.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` (restores intended sandbox execution)
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Headless Linux (systemd)
- Runtime: Node.js
- Integration/channel: Cron isolated sessions

### Steps

1. Set `agents.defaults.sandbox.mode: "all"` with a custom Docker image
2. Add isolated cron job: `openclaw cron add --agent main --session isolated --at "2m" --message "Use exec to run: test -f /.dockerenv && echo DOCKER || echo NOT_DOCKER"`
3. Wait for cron execution
4. Check `docker ps` during execution

### Expected

- Cron session runs inside Docker container; `exec` returns `DOCKER`

### Actual

- Before fix: Cron session runs on gateway host; `exec host=sandbox` fails with "sandbox runtime is unavailable"
- After fix: Cron session uses gateway config's sandbox settings and runs in Docker

## Evidence

The root cause is in `server-cron.ts`:

Before:
```typescript
const resolveCronAgent = (requested?: string | null) => {
  const runtimeConfig = loadConfig(); // re-resolves config at runtime
  // ...
};
```

After:
```typescript
const resolveCronAgent = (requested?: string | null) => {
  const runtimeConfig = params.cfg; // uses gateway's own config
  // ...
};
```

Config reload rebuilds the cron service (`server-reload-handlers.ts:76`):
```typescript
if (plan.restartCron) {
  state.cronState.cron.stop();
  nextState.cronState = buildGatewayCronService({
    cfg: nextConfig, // fresh config
    ...
  });
}
```

Existing tests pass: `npx vitest run src/gateway/server-cron.test.ts` → 2/2 passed.

## Human Verification (required)

- Verified scenarios: TypeScript compiles cleanly, existing unit tests pass (2/2)
- Edge cases checked: Config reload path (cron service is rebuilt with new config), `resolveCronWakeTarget` also updated for consistency
- What I did **not** verify: End-to-end test on headless Linux with Docker sandbox

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the two-line change in `server-cron.ts`
- Files/config to restore: `src/gateway/server-cron.ts`
- Known bad symptoms: If cron service is somehow not rebuilt on config reload, cron jobs would use stale config (same as current behavior for all other gateway subsystems using params.cfg)

## Risks and Mitigations

- **Risk:** If a code path exists where cron config needs to differ from gateway config → Mitigated: no such path exists; the gateway config is the authoritative source.
- **Risk:** Hot-reload missing `restartCron` → Mitigated: verified `server-reload-handlers.ts` calls `buildGatewayCronService` with `nextConfig` when `plan.restartCron` is true.

