### PR TITLE
Doctor: handle SecretRef apiKey in memory-search health check

### DIFF
--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -135,6 +135,25 @@ describe("noteMemorySearchHealth", () => {
     await expectNoWarningWithConfiguredRemoteApiKey("openai");
   });
 
+  it("does not warn when remote apiKey is configured as a SecretRef object", async () => {
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "openai",
+      local: {},
+      remote: {
+        apiKey: {
+          source: "env",
+          provider: "default",
+          id: "OPENAI_API_KEY",
+        },
+      },
+    });
+
+    await noteMemorySearchHealth(cfg, {});
+
+    expect(note).not.toHaveBeenCalled();
+    expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
+  });
+
   it("does not warn in auto mode when remote apiKey is configured", async () => {
     await expectNoWarningWithConfiguredRemoteApiKey("auto");
   });

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -4,6 +4,7 @@ import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { hasConfiguredSecretInput } from "../config/types.secrets.js";
 import { resolveMemoryBackendConfig } from "../memory/backend-config.js";
 import { DEFAULT_LOCAL_MODEL } from "../memory/embeddings.js";
 import { note } from "../terminal/note.js";
@@ -26,7 +27,7 @@ export async function noteMemorySearchHealth(
   const agentId = resolveDefaultAgentId(cfg);
   const agentDir = resolveAgentDir(cfg, agentId);
   const resolved = resolveMemorySearchConfig(cfg, agentId);
-  const hasRemoteApiKey = Boolean(resolved?.remote?.apiKey?.trim());
+  const hasRemoteApiKey = hasConfiguredSecretInput(resolved?.remote?.apiKey);
 
   if (!resolved) {
     note("Memory search is explicitly disabled (enabled: false).", "Memory search");


### PR DESCRIPTION
## Summary
- avoid calling string methods on `agents.defaults.memorySearch.remote.apiKey` in doctor health checks
- treat configured `SecretRef` values as valid configured API key input
- add regression coverage to ensure `openclaw doctor` no longer crashes on SecretRef-shaped API keys

## Testing
- pnpm test src/commands/doctor-memory-search.test.ts

Closes #35444
