### PR TITLE
WhatsApp: show allowFrom-specific error for blocked direct targets

### DIFF
--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -139,6 +139,25 @@ describe("resolveWhatsAppOutboundTarget", () => {
       expectDeniedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "implicit" });
     });
 
+    it("returns allowFrom-specific error when target is not in allowList", () => {
+      vi.mocked(normalize.normalizeWhatsAppTarget)
+        .mockReturnValueOnce(SECONDARY_TARGET) // allowFrom[0]
+        .mockReturnValueOnce(PRIMARY_TARGET); // to
+      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
+      const result = resolveWhatsAppOutboundTarget({
+        to: PRIMARY_TARGET,
+        allowFrom: [SECONDARY_TARGET],
+        mode: "implicit",
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) {
+        throw new Error("expected resolution to fail");
+      }
+      expect(result.error.message).toContain(`Target "${PRIMARY_TARGET}"`);
+      expect(result.error.message).toContain("WhatsApp allowFrom policy");
+    });
+
     it("handles mixed numeric and string allowList entries", () => {
       vi.mocked(normalize.normalizeWhatsAppTarget)
         .mockReturnValueOnce("+11234567890") // for 'to' param

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -41,7 +41,9 @@ export function resolveWhatsAppOutboundTarget(params: {
     }
     return {
       ok: false,
-      error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+      error: new Error(
+        `Target "${normalizedTo}" is not listed in the configured WhatsApp allowFrom policy.`,
+      ),
     };
   }
 


### PR DESCRIPTION
## Summary
- keep format-validation errors for invalid WhatsApp targets
- return a clearer error when target normalization succeeds but the target is blocked by `allowFrom`
- add regression coverage to distinguish allowlist-denied failures from invalid-target failures

## Testing
- pnpm test src/whatsapp/resolve-outbound-target.test.ts

Closes #35580
