### PR TITLE
Config: add discord ignoreOtherMentions schema regression tests

### DIFF
--- a/src/config/config.discord-ignore-other-mentions-schema.test.ts
+++ b/src/config/config.discord-ignore-other-mentions-schema.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("discord ignoreOtherMentions schema", () => {
+  it("accepts ignoreOtherMentions for top-level guild and channel rules", () => {
+    const res = OpenClawSchema.safeParse({
+      channels: {
+        discord: {
+          guilds: {
+            "1478741694391255140": {
+              ignoreOtherMentions: true,
+              channels: {
+                "1478741694391255141": {
+                  ignoreOtherMentions: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+    if (!res.success) {
+      console.error(res.error.format());
+      return;
+    }
+
+    expect(res.data.channels?.discord?.guilds?.["1478741694391255140"]?.ignoreOtherMentions).toBe(
+      true,
+    );
+    expect(
+      res.data.channels?.discord?.guilds?.["1478741694391255140"]?.channels?.["1478741694391255141"]
+        ?.ignoreOtherMentions,
+    ).toBe(true);
+  });
+
+  it("accepts ignoreOtherMentions for account-scoped guild and channel rules", () => {
+    const res = OpenClawSchema.safeParse({
+      channels: {
+        discord: {
+          accounts: {
+            vincent: {
+              guilds: {
+                "1478741694391255140": {
+                  ignoreOtherMentions: true,
+                  channels: {
+                    "1478741694391255141": {
+                      ignoreOtherMentions: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+    if (!res.success) {
+      console.error(res.error.format());
+      return;
+    }
+
+    expect(
+      res.data.channels?.discord?.accounts?.vincent?.guilds?.["1478741694391255140"]
+        ?.ignoreOtherMentions,
+    ).toBe(true);
+    expect(
+      res.data.channels?.discord?.accounts?.vincent?.guilds?.["1478741694391255140"]?.channels?.[
+        "1478741694391255141"
+      ]?.ignoreOtherMentions,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add focused regression coverage for `channels.discord.guilds.*.ignoreOtherMentions`
- add matching regression coverage for `channels.discord.accounts.*.guilds.*.ignoreOtherMentions`
- verify both guild-level and channel-level schema acceptance for the documented key

## Testing
- pnpm test src/config/config.discord-ignore-other-mentions-schema.test.ts

Closes #35219
