### PR TITLE
fix: disable automatic -chat suffix for MiniMax and similar providers

### DIFF
--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -20,6 +20,35 @@ function isOpenAINativeEndpoint(baseUrl: string): boolean {
   }
 }
 
+/**
+ * Returns true for providers that do NOT require the automatic "-chat" suffix
+ * appended by pi-ai's openai-completions adapter.
+ *
+ * Some providers like MiniMax use model IDs without the "-chat" suffix.
+ * When pi-ai automatically appends "-chat" to model IDs, it breaks compatibility
+ * with these providers.
+ *
+ * This function identifies providers that should have the automatic suffix
+ * disabled via the `disableAutoModelIdSuffix` compatibility flag.
+ */
+function shouldDisableAutoModelIdSuffix(baseUrl: string): boolean {
+  if (!baseUrl) {
+    return false;
+  }
+
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    // MiniMax API does not use "-chat" suffix in model IDs
+    if (host.includes("minimax")) {
+      return true;
+    }
+    // Add other providers here as needed
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 function isAnthropicMessagesModel(model: Model<Api>): model is Model<"anthropic-messages"> {
   return model.api === "anthropic-messages";
 }
@@ -52,15 +81,35 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
     return model;
   }
 
+  const compat = model.compat ?? undefined;
+
+  // Disable automatic model ID suffix for providers that don't use it.
+  // For example, MiniMax uses model IDs like "abab6.5" without the "-chat" suffix.
+  // If we let pi-ai automatically append "-chat", it becomes "abab6.5-chat" which
+  // the MiniMax API rejects as an unknown model.
+  // This check runs before supportsDeveloperRole handling to ensure it applies
+  // even for models that already have supportsDeveloperRole: false configured.
+  if (shouldDisableAutoModelIdSuffix(baseUrl)) {
+    const newCompat = {
+      ...compat,
+      supportsDeveloperRole: false,
+      disableAutoModelIdSuffix: true,
+    };
+    return {
+      ...model,
+      compat: newCompat,
+    } as typeof model;
+  }
+
   // The `developer` message role is an OpenAI-native convention. All other
   // openai-completions backends (proxies, Qwen, GLM, DeepSeek, Kimi, etc.)
   // only recognise `system`. Force supportsDeveloperRole=false for any model
   // whose baseUrl is not a known native OpenAI endpoint, unless the caller
   // has already pinned the value explicitly.
-  const compat = model.compat ?? undefined;
   if (compat?.supportsDeveloperRole === false) {
     return model;
   }
+
   // When baseUrl is empty the pi-ai library defaults to api.openai.com, so
   // leave compat unchanged and let the existing default behaviour apply.
   // Note: an explicit supportsDeveloperRole: true is intentionally overridden


### PR DESCRIPTION
## Root Cause

The `openai-completions` adapter in `@mariozechner/pi-ai` automatically appends a `-chat` suffix to all model IDs. This works for OpenAI models but breaks compatibility with providers like MiniMax that use model IDs without this suffix. When users configure MiniMax with model ID `abab6.5`, it gets transformed to `abab6.5-chat`, causing the MiniMax API to reject it with HTTP 400: `invalid params, unknown model 'abab6.5-chat'`.

## Solution

Added provider-aware logic in `src/agents/model-compat.ts`:

1. **New function** `shouldDisableAutoModelIdSuffix(baseUrl: string)` - Detects providers that don't require the `-chat` suffix by checking the baseUrl hostname. Currently supports MiniMax.

2. **Modified function** `normalizeModelCompat()` - When processing `openai-completions` models, checks if the provider needs suffix disabled and sets `disableAutoModelIdSuffix: true` in the model's `compat` object. The `pi-ai` library respects this flag and skips automatic suffix appending. **Critically**, this check runs **before** the `supportsDeveloperRole` check to ensure the fix applies even for models that already have `supportsDeveloperRole: false` configured.

Result: Model ID `abab6.5` stays `abab6.5` instead of becoming `abab6.5-chat`.

## Linked Issue

Fixes #35617
