### PR TITLE
fix(pi-embedded): forward top_p/presence_penalty / 修正 top_p/presence_penalty 透傳

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -118,6 +118,12 @@ function createStreamFnWithExtraParams(
   if (typeof extraParams.maxTokens === "number") {
     streamParams.maxTokens = extraParams.maxTokens;
   }
+  if (typeof extraParams.topP === "number") {
+    (streamParams as Record<string, unknown>).topP = extraParams.topP;
+  }
+  if (typeof extraParams.presencePenalty === "number") {
+    (streamParams as Record<string, unknown>).presencePenalty = extraParams.presencePenalty;
+  }
   const transport = extraParams.transport;
   if (transport === "sse" || transport === "websocket" || transport === "auto") {
     streamParams.transport = transport;
@@ -157,6 +163,21 @@ function createStreamFnWithExtraParams(
 
   const underlying = baseStreamFn ?? streamSimple;
   const wrappedStreamFn: StreamFn = (model, context, options) => {
+    const originalOnPayload =
+      options && typeof options === "object"
+        ? (options as { onPayload?: unknown }).onPayload
+        : undefined;
+    const injectedTopP =
+      options && typeof options === "object" && (options as { topP?: unknown }).topP !== undefined
+        ? (options as { topP?: unknown }).topP
+        : extraParams?.topP;
+    const injectedPresencePenalty =
+      options &&
+      typeof options === "object" &&
+      (options as { presencePenalty?: unknown }).presencePenalty !== undefined
+        ? (options as { presencePenalty?: unknown }).presencePenalty
+        : extraParams?.presencePenalty;
+
     // When provider routing is configured, inject it into model.compat so
     // pi-ai picks it up via model.compat.openRouterRouting.
     const effectiveModel = providerRouting
@@ -168,6 +189,20 @@ function createStreamFnWithExtraParams(
     return underlying(effectiveModel, context, {
       ...streamParams,
       ...options,
+      onPayload: (payload: unknown) => {
+        if (payload && typeof payload === "object") {
+          const obj = payload as Record<string, unknown>;
+          if (typeof injectedTopP === "number" && obj.top_p === undefined) {
+            obj.top_p = injectedTopP;
+          }
+          if (typeof injectedPresencePenalty === "number" && obj.presence_penalty === undefined) {
+            obj.presence_penalty = injectedPresencePenalty;
+          }
+        }
+        if (typeof originalOnPayload === "function") {
+          (originalOnPayload as (p: unknown) => void)(payload);
+        }
+      },
     });
   };
 


### PR DESCRIPTION
## 背景（問題）
在 OpenClaw 的 model params 設定 `topP` / `presencePenalty` 後，HTTP OpenAI-compatible `POST /v1/chat/completions` 實際送出的 request body 仍可能缺少 `top_p` / `presence_penalty`，導致下游（例如 Bifrost→vLLM）採用預設 SamplingParams。

## 變更內容
- 在 `src/agents/pi-embedded-runner/extra-params.ts` 的 `createStreamFnWithExtraParams()`：
  - 從 extra params 解析 `topP` / `presencePenalty`
  - 透過 `onPayload` 在送出前補上 `top_p` / `presence_penalty`（若尚未存在）

## 影響範圍
- 僅影響有在 extra params 設定 `topP` / `presencePenalty` 的模型；未設定者行為不變。

## 驗證方式
- 觀察下游服務（例如 vLLM）的 SamplingParams / request payload 是否出現 `top_p` 與 `presence_penalty`。

---

## Context
When configuring `topP` / `presencePenalty` in OpenClaw model params, outgoing OpenAI-compatible `POST /v1/chat/completions` requests could still miss `top_p` / `presence_penalty`, causing downstream services (e.g., Bifrost→vLLM) to fall back to defaults.

## Changes
- In `createStreamFnWithExtraParams()` (`src/agents/pi-embedded-runner/extra-params.ts`):
  - Read `topP` / `presencePenalty` from extra params
  - Inject `top_p` / `presence_penalty` via `onPayload` before sending (only if absent)

## Impact
- Only affects models where `topP` / `presencePenalty` are configured; otherwise behavior is unchanged.

## Verification
- Confirm downstream request payloads / sampling params include `top_p` and `presence_penalty`.
