### PR TITLE
channels: add line to core chat registry and dock

### DIFF
--- a/src/channels/dock.test.ts
+++ b/src/channels/dock.test.ts
@@ -100,7 +100,7 @@ describe("channels dock", () => {
     expect(formatted).toEqual(["user", "foo", "plain"]);
   });
 
-  it("line allowFrom formatter trims, strips prefixes, and lowercases", () => {
+  it("line allowFrom formatter trims and strips prefixes while preserving casing", () => {
     const lineDock = getChannelDock("line");
 
     const formatted = lineDock?.config?.formatAllowFrom?.({
@@ -108,6 +108,6 @@ describe("channels dock", () => {
       allowFrom: [" LINE:user:U123 ", "line:U456", "U789"],
     });
 
-    expect(formatted).toEqual(["u123", "u456", "u789"]);
+    expect(formatted).toEqual(["U123", "U456", "U789"]);
   });
 });

--- a/src/channels/dock.test.ts
+++ b/src/channels/dock.test.ts
@@ -99,4 +99,15 @@ describe("channels dock", () => {
 
     expect(formatted).toEqual(["user", "foo", "plain"]);
   });
+
+  it("line allowFrom formatter trims, strips prefixes, and lowercases", () => {
+    const lineDock = getChannelDock("line");
+
+    const formatted = lineDock?.config?.formatAllowFrom?.({
+      cfg: emptyConfig(),
+      allowFrom: [" LINE:user:U123 ", "line:U456", "U789"],
+    });
+
+    expect(formatted).toEqual(["u123", "u456", "u789"]);
+  });
 });

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -295,13 +295,7 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
           resolveLineAccount({ cfg, accountId: accountId ?? undefined }).config.allowFrom ?? [],
         ),
       formatAllowFrom: ({ allowFrom }) =>
-        trimAllowFromEntries(allowFrom)
-          .map((entry) =>
-            entry
-              .replace(/^line:/i, "")
-              .replace(/^user:/i, ""),
-          )
-          .map((entry) => entry.toLowerCase()),
+        formatAllowFromWithReplacements(allowFrom, [/^line:/i, /^user:/i]),
     },
     groups: {
       resolveRequireMention: ({ cfg, accountId, groupId }) => {

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -3,6 +3,7 @@ import {
   resolveChannelGroupToolsPolicy,
 } from "../config/group-policy.js";
 import { resolveDiscordAccount } from "../discord/accounts.js";
+import { resolveLineAccount } from "../line/accounts.js";
 import {
   formatTrimmedAllowFromEntries,
   formatWhatsAppConfigAllowFromEntries,
@@ -13,7 +14,6 @@ import {
 } from "../plugin-sdk/channel-config-helpers.js";
 import { requireActivePluginRegistry } from "../plugins/runtime.js";
 import { normalizeAccountId } from "../routing/session-key.js";
-import { resolveLineAccount } from "../line/accounts.js";
 import { resolveSignalAccount } from "../signal/accounts.js";
 import { resolveSlackAccount, resolveSlackReplyToMode } from "../slack/accounts.js";
 import { buildSlackThreadingToolContext } from "../slack/threading-tool-context.js";

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -291,7 +291,9 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
     outbound: DEFAULT_OUTBOUND_TEXT_CHUNK_LIMIT_4000,
     config: {
       resolveAllowFrom: ({ cfg, accountId }) =>
-        stringifyAllowFrom(resolveLineAccount({ cfg, accountId }).config.allowFrom ?? []),
+        stringifyAllowFrom(
+          resolveLineAccount({ cfg, accountId: accountId ?? undefined }).config.allowFrom ?? [],
+        ),
       formatAllowFrom: ({ allowFrom }) =>
         trimAllowFromEntries(allowFrom)
           .map((entry) =>

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -13,6 +13,7 @@ import {
 } from "../plugin-sdk/channel-config-helpers.js";
 import { requireActivePluginRegistry } from "../plugins/runtime.js";
 import { normalizeAccountId } from "../routing/session-key.js";
+import { resolveLineAccount } from "../line/accounts.js";
 import { resolveSignalAccount } from "../signal/accounts.js";
 import { resolveSlackAccount, resolveSlackReplyToMode } from "../slack/accounts.js";
 import { buildSlackThreadingToolContext } from "../slack/threading-tool-context.js";
@@ -277,6 +278,54 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
           currentMessageId,
           hasRepliedRef,
         };
+      },
+    },
+  },
+  line: {
+    id: "line",
+    capabilities: {
+      chatTypes: ["direct", "group"],
+      media: true,
+      blockStreaming: true,
+    },
+    outbound: DEFAULT_OUTBOUND_TEXT_CHUNK_LIMIT_4000,
+    config: {
+      resolveAllowFrom: ({ cfg, accountId }) =>
+        stringifyAllowFrom(resolveLineAccount({ cfg, accountId }).config.allowFrom ?? []),
+      formatAllowFrom: ({ allowFrom }) =>
+        trimAllowFromEntries(allowFrom)
+          .map((entry) =>
+            entry
+              .replace(/^line:/i, "")
+              .replace(/^user:/i, ""),
+          )
+          .map((entry) => entry.toLowerCase()),
+    },
+    groups: {
+      resolveRequireMention: ({ cfg, accountId, groupId }) => {
+        if (!groupId) {
+          return true;
+        }
+        return resolveChannelGroupRequireMention({
+          cfg,
+          channel: "line",
+          groupId,
+          accountId,
+        });
+      },
+      resolveToolPolicy: ({ cfg, accountId, groupId, senderId, senderName, senderUsername }) => {
+        if (!groupId) {
+          return undefined;
+        }
+        return resolveChannelGroupToolsPolicy({
+          cfg,
+          channel: "line",
+          groupId,
+          accountId,
+          senderId,
+          senderName,
+          senderUsername,
+        });
       },
     },
   },

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -288,14 +288,16 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
       media: true,
       blockStreaming: true,
     },
-    outbound: DEFAULT_OUTBOUND_TEXT_CHUNK_LIMIT_4000,
+    outbound: { textChunkLimit: 5000 },
     config: {
       resolveAllowFrom: ({ cfg, accountId }) =>
         stringifyAllowFrom(
           resolveLineAccount({ cfg, accountId: accountId ?? undefined }).config.allowFrom ?? [],
         ),
       formatAllowFrom: ({ allowFrom }) =>
-        formatAllowFromWithReplacements(allowFrom, [/^line:/i, /^user:/i]),
+        trimAllowFromEntries(allowFrom).map((entry) =>
+          entry.replace(/^line:/i, "").replace(/^user:/i, ""),
+        ),
     },
     groups: {
       resolveRequireMention: ({ cfg, accountId, groupId }) => {

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -309,20 +309,6 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
           accountId,
         });
       },
-      resolveToolPolicy: ({ cfg, accountId, groupId, senderId, senderName, senderUsername }) => {
-        if (!groupId) {
-          return undefined;
-        }
-        return resolveChannelGroupToolsPolicy({
-          cfg,
-          channel: "line",
-          groupId,
-          accountId,
-          senderId,
-          senderName,
-          senderUsername,
-        });
-      },
     },
   },
   whatsapp: {

--- a/src/channels/registry.helpers.test.ts
+++ b/src/channels/registry.helpers.test.ts
@@ -11,6 +11,7 @@ describe("channel registry helpers", () => {
     expect(normalizeChatChannelId("gchat")).toBe("googlechat");
     expect(normalizeChatChannelId("google-chat")).toBe("googlechat");
     expect(normalizeChatChannelId("internet-relay-chat")).toBe("irc");
+    expect(normalizeChatChannelId("line")).toBe("line");
     expect(normalizeChatChannelId("telegram")).toBe("telegram");
     expect(normalizeChatChannelId("web")).toBeNull();
     expect(normalizeChatChannelId("nope")).toBeNull();

--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -6,6 +6,7 @@ import type { ChannelId } from "./plugins/types.js";
 // register the plugin in its extension entrypoint and keep protocol IDs in sync.
 export const CHAT_CHANNEL_ORDER = [
   "telegram",
+  "line",
   "whatsapp",
   "discord",
   "irc",
@@ -36,6 +37,16 @@ const CHAT_CHANNEL_META: Record<ChatChannelId, ChannelMeta> = {
     selectionDocsPrefix: "",
     selectionDocsOmitLabel: true,
     selectionExtras: [WEBSITE_URL],
+  },
+  line: {
+    id: "line",
+    label: "LINE",
+    selectionLabel: "LINE (Messaging API)",
+    detailLabel: "LINE Bot",
+    docsPath: "/channels/line",
+    docsLabel: "line",
+    blurb: "official LINE webhook bot for Taiwan/Japan user flows.",
+    systemImage: "message",
   },
   whatsapp: {
     id: "whatsapp",


### PR DESCRIPTION
## Summary
- Add `line` to `CHAT_CHANNEL_ORDER` and core channel metadata.
- Add a core `DOCKS.line` entry so shared channel paths handle LINE consistently.
- Add regression tests for LINE registry normalization and `allowFrom` formatting.

## Why
Some shared channel flows rely on core registry + dock metadata. Since LINE was missing from these core tables, behavior could diverge from other built-in channels.

## Scope
- core channel registry/dock only
- no config schema changes
- backward compatible with existing configs

## Validation
- Updated unit tests in channel registry and dock suites.
- Local test execution is not available in this environment (missing `vitest` dependency).

## CI note
A previous run failed on a nullable `accountId` type mismatch in `src/channels/dock.ts`; this has been fixed in the latest commit.
