### PR TITLE
line: keep pending group history when requireMention is enabled

### DIFF
--- a/src/auto-reply/reply/history.ts
+++ b/src/auto-reply/reply/history.ts
@@ -172,6 +172,30 @@ export function clearHistoryEntriesIfEnabled(params: {
   clearHistoryEntries({ historyMap: params.historyMap, historyKey: params.historyKey });
 }
 
+export function clearConsumedHistoryEntriesIfEnabled(params: {
+  historyMap: Map<string, HistoryEntry[]>;
+  historyKey: string;
+  limit: number;
+  consumedCount: number;
+}): void {
+  if (params.limit <= 0) {
+    return;
+  }
+  const consumedCount = Math.max(0, Math.floor(params.consumedCount));
+  if (consumedCount <= 0) {
+    return;
+  }
+  const current = params.historyMap.get(params.historyKey) ?? [];
+  if (current.length === 0) {
+    return;
+  }
+  if (consumedCount >= current.length) {
+    params.historyMap.set(params.historyKey, []);
+    return;
+  }
+  params.historyMap.set(params.historyKey, current.slice(consumedCount));
+}
+
 export function buildHistoryContextFromEntries(params: {
   entries: HistoryEntry[];
   currentMessage: string;

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -653,7 +653,12 @@ describe("handleLineWebhookEvents", () => {
     const processMessage = vi.fn();
     const groupHistories = new Map<string, HistoryEntry[]>();
     buildLineMessageContextMock.mockResolvedValueOnce({
-      ctxPayload: { From: "line:group:group-1", Body: "hello team", RawBody: "hello team" },
+      ctxPayload: {
+        From: "line:group:group-1",
+        Body: "hello team",
+        BodyForAgent: "hello team",
+        RawBody: "hello team",
+      },
       replyToken: "reply-token",
       route: { agentId: "default", sessionKey: "line:group:group-1" },
       isGroup: true,

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -706,6 +706,7 @@ describe("handleLineWebhookEvents", () => {
       ctxPayload: {
         From: "line:group:group-1",
         Body: "@openclaw current",
+        BodyForAgent: "@openclaw current",
         RawBody: "@openclaw current",
       },
       replyToken: "reply-token",
@@ -754,7 +755,71 @@ describe("handleLineWebhookEvents", () => {
     expect(processMessage).toHaveBeenCalledTimes(1);
     const dispatched = processMessage.mock.calls[0]?.[0];
     expect(String(dispatched?.ctxPayload?.Body ?? "")).toContain(HISTORY_CONTEXT_MARKER);
+    expect(String(dispatched?.ctxPayload?.BodyForAgent ?? "")).toContain(HISTORY_CONTEXT_MARKER);
     expect(String(dispatched?.ctxPayload?.Body ?? "")).toContain("previous message");
     expect(groupHistories.get("line:group:group-1")).toEqual([]);
+  });
+
+  it("keeps pending LINE history when mentioned turn processing fails", async () => {
+    const groupHistories = new Map<string, HistoryEntry[]>();
+    groupHistories.set("line:group:group-1", [{ sender: "user:old", body: "previous message" }]);
+    buildLineMessageContextMock.mockResolvedValueOnce({
+      ctxPayload: {
+        From: "line:group:group-1",
+        Body: "@openclaw current",
+        BodyForAgent: "@openclaw current",
+        RawBody: "@openclaw current",
+      },
+      replyToken: "reply-token",
+      route: { agentId: "default", sessionKey: "line:group:group-1" },
+      isGroup: true,
+      userId: "user-1",
+      groupId: "group-1",
+      accountId: "default",
+    });
+    const processMessage = vi.fn(async () => {
+      throw new Error("transient failure");
+    });
+    const event = {
+      type: "message",
+      message: { id: "m-mention-3", type: "text", text: "@openclaw current" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-1", userId: "user-1" },
+      mode: "active",
+      webhookEventId: "evt-mention-3",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    await expect(
+      handleLineWebhookEvents([event], {
+        cfg: {
+          channels: {
+            line: {
+              groupPolicy: "open",
+              groups: { "group-1": { requireMention: true } },
+            },
+          },
+          messages: { groupChat: { mentionPatterns: ["@openclaw"] } },
+        },
+        account: {
+          accountId: "default",
+          enabled: true,
+          channelAccessToken: "token",
+          channelSecret: "secret",
+          tokenSource: "config",
+          config: { groupPolicy: "open", groups: { "group-1": { requireMention: true } } },
+        },
+        runtime: createRuntime(),
+        mediaMaxBytes: 1,
+        processMessage,
+        groupHistories,
+        groupHistoryLimit: 5,
+      }),
+    ).rejects.toThrow("transient failure");
+
+    const retained = groupHistories.get("line:group:group-1") ?? [];
+    expect(retained).toHaveLength(1);
+    expect(retained[0]?.body).toBe("previous message");
   });
 });

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -889,4 +889,70 @@ describe("handleLineWebhookEvents", () => {
     expect(processMessage).toHaveBeenCalledTimes(1);
     expect(groupHistories.has("line:group:group-2")).toBe(false);
   });
+
+  it("preserves newly appended pending history entries during mentioned turn processing", async () => {
+    const groupHistories = new Map<string, HistoryEntry[]>();
+    groupHistories.set("line:group:group-3", [{ sender: "user:old", body: "older context" }]);
+    buildLineMessageContextMock.mockResolvedValueOnce({
+      ctxPayload: {
+        From: "line:group:group-3",
+        Body: "@openclaw current",
+        BodyForAgent: "@openclaw current",
+        RawBody: "@openclaw current",
+      },
+      replyToken: "reply-token",
+      route: { agentId: "default", sessionKey: "line:group:group-3" },
+      isGroup: true,
+      userId: "user-3",
+      groupId: "group-3",
+      accountId: "default",
+    });
+    const processMessage = vi.fn(async () => {
+      const current = groupHistories.get("line:group:group-3") ?? [];
+      groupHistories.set("line:group:group-3", [
+        ...current,
+        { sender: "user:new", body: "arrived during processing" },
+      ]);
+    });
+    const event = {
+      type: "message",
+      message: { id: "m-mention-5", type: "text", text: "@openclaw current" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-3", userId: "user-3" },
+      mode: "active",
+      webhookEventId: "evt-mention-5",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    await handleLineWebhookEvents([event], {
+      cfg: {
+        channels: {
+          line: {
+            groupPolicy: "open",
+            groups: { "group-3": { requireMention: true } },
+          },
+        },
+        messages: { groupChat: { mentionPatterns: ["@openclaw"] } },
+      },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: { groupPolicy: "open", groups: { "group-3": { requireMention: true } } },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+      groupHistories,
+      groupHistoryLimit: 5,
+    });
+
+    expect(processMessage).toHaveBeenCalledTimes(1);
+    expect(groupHistories.get("line:group:group-3")).toEqual([
+      { sender: "user:new", body: "arrived during processing" },
+    ]);
+  });
 });

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -1,5 +1,6 @@
 import type { MessageEvent, PostbackEvent } from "@line/bot-sdk";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { HISTORY_CONTEXT_MARKER, type HistoryEntry } from "../auto-reply/reply/history.js";
 
 // Avoid pulling in globals/pairing/media dependencies; this suite only asserts
 // allowlist/groupPolicy gating and message-context wiring.
@@ -33,10 +34,12 @@ vi.mock("./send.js", () => ({
 
 const { buildLineMessageContextMock, buildLinePostbackContextMock } = vi.hoisted(() => ({
   buildLineMessageContextMock: vi.fn(async () => ({
-    ctxPayload: { From: "line:group:group-1" },
+    ctxPayload: { From: "line:group:group-1", Body: "current", RawBody: "current" },
     replyToken: "reply-token",
-    route: { agentId: "default" },
+    route: { agentId: "default", sessionKey: "line:group:group-1" },
     isGroup: true,
+    userId: "user-1",
+    groupId: "group-1",
     accountId: "default",
   })),
   buildLinePostbackContextMock: vi.fn(async () => null as unknown),
@@ -639,5 +642,119 @@ describe("handleLineWebhookEvents", () => {
     expect(context.runtime.error).toHaveBeenCalledWith(
       expect.stringContaining("line: event handler failed: Error: transient failure"),
     );
+  });
+
+  it("stores unmentioned LINE group messages in pending history when requireMention is enabled", async () => {
+    const processMessage = vi.fn();
+    const groupHistories = new Map<string, HistoryEntry[]>();
+    buildLineMessageContextMock.mockResolvedValueOnce({
+      ctxPayload: { From: "line:group:group-1", Body: "hello team", RawBody: "hello team" },
+      replyToken: "reply-token",
+      route: { agentId: "default", sessionKey: "line:group:group-1" },
+      isGroup: true,
+      userId: "user-1",
+      groupId: "group-1",
+      accountId: "default",
+    });
+    const event = {
+      type: "message",
+      message: { id: "m-mention-1", type: "text", text: "hello team" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-1", userId: "user-1" },
+      mode: "active",
+      webhookEventId: "evt-mention-1",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    await handleLineWebhookEvents([event], {
+      cfg: {
+        channels: {
+          line: {
+            groupPolicy: "open",
+            groups: { "group-1": { requireMention: true } },
+          },
+        },
+        messages: { groupChat: { mentionPatterns: ["@openclaw"] } },
+      },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: { groupPolicy: "open", groups: { "group-1": { requireMention: true } } },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+      groupHistories,
+      groupHistoryLimit: 5,
+    });
+
+    expect(processMessage).not.toHaveBeenCalled();
+    const entries = groupHistories.get("line:group:group-1") ?? [];
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.body).toBe("hello team");
+  });
+
+  it("injects pending LINE group history into context when mention matches", async () => {
+    const processMessage = vi.fn();
+    const groupHistories = new Map<string, HistoryEntry[]>();
+    groupHistories.set("line:group:group-1", [{ sender: "user:old", body: "previous message" }]);
+    buildLineMessageContextMock.mockResolvedValueOnce({
+      ctxPayload: {
+        From: "line:group:group-1",
+        Body: "@openclaw current",
+        RawBody: "@openclaw current",
+      },
+      replyToken: "reply-token",
+      route: { agentId: "default", sessionKey: "line:group:group-1" },
+      isGroup: true,
+      userId: "user-1",
+      groupId: "group-1",
+      accountId: "default",
+    });
+    const event = {
+      type: "message",
+      message: { id: "m-mention-2", type: "text", text: "@openclaw current" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-1", userId: "user-1" },
+      mode: "active",
+      webhookEventId: "evt-mention-2",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    await handleLineWebhookEvents([event], {
+      cfg: {
+        channels: {
+          line: {
+            groupPolicy: "open",
+            groups: { "group-1": { requireMention: true } },
+          },
+        },
+        messages: { groupChat: { mentionPatterns: ["@openclaw"] } },
+      },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: { groupPolicy: "open", groups: { "group-1": { requireMention: true } } },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+      groupHistories,
+      groupHistoryLimit: 5,
+    });
+
+    expect(processMessage).toHaveBeenCalledTimes(1);
+    const dispatched = processMessage.mock.calls[0]?.[0];
+    expect(String(dispatched?.ctxPayload?.Body ?? "")).toContain(HISTORY_CONTEXT_MARKER);
+    expect(String(dispatched?.ctxPayload?.Body ?? "")).toContain("previous message");
+    expect(groupHistories.get("line:group:group-1")).toEqual([]);
   });
 });

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -832,4 +832,61 @@ describe("handleLineWebhookEvents", () => {
     expect(retained).toHaveLength(1);
     expect(retained[0]?.body).toBe("previous message");
   });
+
+  it("does not create empty pending-history keys for mentioned turns without pending entries", async () => {
+    const processMessage = vi.fn();
+    const groupHistories = new Map<string, HistoryEntry[]>();
+    buildLineMessageContextMock.mockResolvedValueOnce({
+      ctxPayload: {
+        From: "line:group:group-2",
+        Body: "@openclaw hello",
+        BodyForAgent: "@openclaw hello",
+        RawBody: "@openclaw hello",
+      },
+      replyToken: "reply-token",
+      route: { agentId: "default", sessionKey: "line:group:group-2" },
+      isGroup: true,
+      userId: "user-2",
+      groupId: "group-2",
+      accountId: "default",
+    });
+    const event = {
+      type: "message",
+      message: { id: "m-mention-4", type: "text", text: "@openclaw hello" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-2", userId: "user-2" },
+      mode: "active",
+      webhookEventId: "evt-mention-4",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    await handleLineWebhookEvents([event], {
+      cfg: {
+        channels: {
+          line: {
+            groupPolicy: "open",
+            groups: { "group-2": { requireMention: true } },
+          },
+        },
+        messages: { groupChat: { mentionPatterns: ["@openclaw"] } },
+      },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: { groupPolicy: "open", groups: { "group-2": { requireMention: true } } },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+      groupHistories,
+      groupHistoryLimit: 5,
+    });
+
+    expect(processMessage).toHaveBeenCalledTimes(1);
+    expect(groupHistories.has("line:group:group-2")).toBe(false);
+  });
 });

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -708,6 +708,63 @@ describe("handleLineWebhookEvents", () => {
     expect(entries[0]?.body).toBe("hello team");
   });
 
+  it("allows control commands in mention-gated LINE groups without storing pending history", async () => {
+    const processMessage = vi.fn();
+    const groupHistories = new Map<string, HistoryEntry[]>();
+    buildLineMessageContextMock.mockResolvedValueOnce({
+      ctxPayload: {
+        From: "line:group:group-1",
+        Body: "/status",
+        BodyForAgent: "/status",
+        RawBody: "/status",
+      },
+      replyToken: "reply-token",
+      route: { agentId: "default", sessionKey: "line:group:group-1" },
+      isGroup: true,
+      userId: "user-1",
+      groupId: "group-1",
+      accountId: "default",
+    });
+    const event = {
+      type: "message",
+      message: { id: "m-mention-command", type: "text", text: "/status" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-1", userId: "user-1" },
+      mode: "active",
+      webhookEventId: "evt-mention-command",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    await handleLineWebhookEvents([event], {
+      cfg: {
+        channels: {
+          line: {
+            groupPolicy: "open",
+            groups: { "group-1": { requireMention: true } },
+          },
+        },
+        messages: { groupChat: { mentionPatterns: ["@openclaw"] } },
+      },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: { groupPolicy: "open", groups: { "group-1": { requireMention: true } } },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+      groupHistories,
+      groupHistoryLimit: 5,
+    });
+
+    expect(processMessage).toHaveBeenCalledTimes(1);
+    expect(groupHistories.get("line:group:group-1")).toBeUndefined();
+  });
+
   it("injects pending LINE group history into context when mention matches", async () => {
     const processMessage = vi.fn();
     const groupHistories = new Map<string, HistoryEntry[]>();

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -34,7 +34,12 @@ vi.mock("./send.js", () => ({
 
 const { buildLineMessageContextMock, buildLinePostbackContextMock } = vi.hoisted(() => ({
   buildLineMessageContextMock: vi.fn(async () => ({
-    ctxPayload: { From: "line:group:group-1", Body: "current", RawBody: "current" },
+    ctxPayload: {
+      From: "line:group:group-1",
+      Body: "current",
+      BodyForAgent: "current",
+      RawBody: "current",
+    },
     replyToken: "reply-token",
     route: { agentId: "default", sessionKey: "line:group:group-1" },
     isGroup: true,

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -10,7 +10,7 @@ import type {
 import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
   buildPendingHistoryContextFromMap,
-  clearHistoryEntriesIfEnabled,
+  clearConsumedHistoryEntriesIfEnabled,
   DEFAULT_GROUP_HISTORY_LIMIT,
   recordPendingHistoryEntryIfEnabled,
   type HistoryEntry,
@@ -446,6 +446,7 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
         historyMap: Map<string, HistoryEntry[]>;
         historyKey: string;
         limit: number;
+        consumedCount: number;
       }
     | undefined;
 
@@ -540,6 +541,7 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
           historyMap,
           historyKey,
           limit: historyLimit,
+          consumedCount: pendingEntries.length,
         };
       }
     }
@@ -547,10 +549,11 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
 
   await processMessage(messageContext);
   if (pendingHistoryToClear) {
-    clearHistoryEntriesIfEnabled({
+    clearConsumedHistoryEntriesIfEnabled({
       historyMap: pendingHistoryToClear.historyMap,
       historyKey: pendingHistoryToClear.historyKey,
       limit: pendingHistoryToClear.limit,
+      consumedCount: pendingHistoryToClear.consumedCount,
     });
   }
 }

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -7,6 +7,7 @@ import type {
   LeaveEvent,
   PostbackEvent,
 } from "@line/bot-sdk";
+import { hasControlCommand } from "../auto-reply/command-detection.js";
 import {
   buildPendingHistoryContextFromMap,
   clearHistoryEntriesIfEnabled,
@@ -15,7 +16,6 @@ import {
   type HistoryEntry,
 } from "../auto-reply/reply/history.js";
 import { buildMentionRegexes, matchesMentionWithExplicit } from "../auto-reply/reply/mentions.js";
-import { hasControlCommand } from "../auto-reply/command-detection.js";
 import { resolveControlCommandGate } from "../channels/command-gating.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
@@ -441,6 +441,13 @@ function resolveLineGroupHistoryLimit(params: {
 async function handleMessageEvent(event: MessageEvent, context: LineHandlerContext): Promise<void> {
   const { cfg, account, runtime, mediaMaxBytes, processMessage } = context;
   const message = event.message;
+  let pendingHistoryToClear:
+    | {
+        historyMap: Map<string, HistoryEntry[]>;
+        historyKey: string;
+        limit: number;
+      }
+    | undefined;
 
   const decision = await shouldProcessLineEvent(event, context);
   if (!decision.allowed) {
@@ -519,23 +526,32 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
         return;
       }
       if (historyMap && historyLimit > 0) {
-        messageContext.ctxPayload.Body = buildPendingHistoryContextFromMap({
+        const bodyWithPendingHistory = buildPendingHistoryContextFromMap({
           historyMap,
           historyKey,
           limit: historyLimit,
           currentMessage: messageContext.ctxPayload.Body ?? "",
           formatEntry: (entry) => `${entry.sender}: ${entry.body}`,
         });
-        clearHistoryEntriesIfEnabled({
+        messageContext.ctxPayload.Body = bodyWithPendingHistory;
+        messageContext.ctxPayload.BodyForAgent = bodyWithPendingHistory;
+        pendingHistoryToClear = {
           historyMap,
           historyKey,
           limit: historyLimit,
-        });
+        };
       }
     }
   }
 
   await processMessage(messageContext);
+  if (pendingHistoryToClear) {
+    clearHistoryEntriesIfEnabled({
+      historyMap: pendingHistoryToClear.historyMap,
+      historyKey: pendingHistoryToClear.historyKey,
+      limit: pendingHistoryToClear.limit,
+    });
+  }
 }
 
 async function handleFollowEvent(event: FollowEvent, _context: LineHandlerContext): Promise<void> {

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -7,6 +7,14 @@ import type {
   LeaveEvent,
   PostbackEvent,
 } from "@line/bot-sdk";
+import {
+  buildPendingHistoryContextFromMap,
+  clearHistoryEntriesIfEnabled,
+  DEFAULT_GROUP_HISTORY_LIMIT,
+  recordPendingHistoryEntryIfEnabled,
+  type HistoryEntry,
+} from "../auto-reply/reply/history.js";
+import { buildMentionRegexes, matchesMentionWithExplicit } from "../auto-reply/reply/mentions.js";
 import { hasControlCommand } from "../auto-reply/command-detection.js";
 import { resolveControlCommandGate } from "../channels/command-gating.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -64,6 +72,8 @@ export interface LineHandlerContext {
   mediaMaxBytes: number;
   processMessage: (ctx: LineInboundContext) => Promise<void>;
   replayCache?: LineWebhookReplayCache;
+  groupHistories?: Map<string, HistoryEntry[]>;
+  groupHistoryLimit?: number;
 }
 
 const LINE_WEBHOOK_REPLAY_WINDOW_MS = 10 * 60 * 1000;
@@ -413,6 +423,21 @@ function resolveEventRawText(event: MessageEvent | PostbackEvent): string {
   return "";
 }
 
+function resolveLineGroupHistoryLimit(params: {
+  cfg: OpenClawConfig;
+  contextLimit?: number;
+}): number {
+  const fromContext = params.contextLimit;
+  if (typeof fromContext === "number") {
+    return Math.max(0, Math.floor(fromContext));
+  }
+  const fromConfig = params.cfg.messages?.groupChat?.historyLimit;
+  if (typeof fromConfig === "number") {
+    return Math.max(0, Math.floor(fromConfig));
+  }
+  return DEFAULT_GROUP_HISTORY_LIMIT;
+}
+
 async function handleMessageEvent(event: MessageEvent, context: LineHandlerContext): Promise<void> {
   const { cfg, account, runtime, mediaMaxBytes, processMessage } = context;
   const message = event.message;
@@ -454,6 +479,60 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   if (!messageContext) {
     logVerbose("line: skipping empty message");
     return;
+  }
+
+  if (messageContext.isGroup) {
+    const groupConfig = resolveLineGroupConfig({
+      config: account.config,
+      groupId: messageContext.groupId,
+      roomId: messageContext.roomId,
+    });
+    const requireMention = groupConfig?.requireMention ?? true;
+    if (requireMention) {
+      const mentionRegexes = buildMentionRegexes(cfg, messageContext.route.agentId);
+      const canDetectMention = mentionRegexes.length > 0;
+      const wasMentioned = matchesMentionWithExplicit({
+        text: resolveEventRawText(event),
+        mentionRegexes,
+      });
+      const historyMap = context.groupHistories;
+      const historyLimit = resolveLineGroupHistoryLimit({
+        cfg,
+        contextLimit: context.groupHistoryLimit,
+      });
+      const historyKey = messageContext.route.sessionKey;
+      if (canDetectMention && !wasMentioned) {
+        if (historyMap) {
+          recordPendingHistoryEntryIfEnabled({
+            historyMap,
+            historyKey,
+            limit: historyLimit,
+            entry: {
+              sender: messageContext.userId ? `user:${messageContext.userId}` : "unknown",
+              body: messageContext.ctxPayload.RawBody ?? "",
+              timestamp: event.timestamp,
+              messageId: message.id,
+            },
+          });
+        }
+        logVerbose(`line: stored group message for context (no mention) session=${historyKey}`);
+        return;
+      }
+      if (historyMap && historyLimit > 0) {
+        messageContext.ctxPayload.Body = buildPendingHistoryContextFromMap({
+          historyMap,
+          historyKey,
+          limit: historyLimit,
+          currentMessage: messageContext.ctxPayload.Body ?? "",
+          formatEntry: (entry) => `${entry.sender}: ${entry.body}`,
+        });
+        clearHistoryEntriesIfEnabled({
+          historyMap,
+          historyKey,
+          limit: historyLimit,
+        });
+      }
+    }
   }
 
   await processMessage(messageContext);

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -499,8 +499,10 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
     if (requireMention) {
       const mentionRegexes = buildMentionRegexes(cfg, messageContext.route.agentId);
       const canDetectMention = mentionRegexes.length > 0;
+      const rawText = resolveEventRawText(event);
+      const shouldBypassMentionGate = decision.commandAuthorized && hasControlCommand(rawText, cfg);
       const wasMentioned = matchesMentionWithExplicit({
-        text: resolveEventRawText(event),
+        text: rawText,
         mentionRegexes,
       });
       const historyMap = context.groupHistories;
@@ -509,7 +511,7 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
         contextLimit: context.groupHistoryLimit,
       });
       const historyKey = messageContext.route.sessionKey;
-      if (canDetectMention && !wasMentioned) {
+      if (canDetectMention && !wasMentioned && !shouldBypassMentionGate) {
         if (historyMap) {
           recordPendingHistoryEntryIfEnabled({
             historyMap,

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -525,7 +525,8 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
         logVerbose(`line: stored group message for context (no mention) session=${historyKey}`);
         return;
       }
-      if (historyMap && historyLimit > 0) {
+      const pendingEntries = historyMap?.get(historyKey);
+      if (historyMap && historyLimit > 0 && (pendingEntries?.length ?? 0) > 0) {
         const bodyWithPendingHistory = buildPendingHistoryContextFromMap({
           historyMap,
           historyKey,

--- a/src/line/bot.ts
+++ b/src/line/bot.ts
@@ -1,5 +1,6 @@
 import type { WebhookRequestBody } from "@line/bot-sdk";
 import type { Request, Response, NextFunction } from "express";
+import type { HistoryEntry } from "../auto-reply/reply/history.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import { logVerbose } from "../globals.js";
@@ -8,7 +9,6 @@ import { resolveLineAccount } from "./accounts.js";
 import { createLineWebhookReplayCache, handleLineWebhookEvents } from "./bot-handlers.js";
 import type { LineInboundContext } from "./bot-message-context.js";
 import type { ResolvedLineAccount } from "./types.js";
-import type { HistoryEntry } from "../auto-reply/reply/history.js";
 import { startLineWebhook } from "./webhook.js";
 
 export interface LineBotOptions {

--- a/src/line/bot.ts
+++ b/src/line/bot.ts
@@ -8,6 +8,7 @@ import { resolveLineAccount } from "./accounts.js";
 import { createLineWebhookReplayCache, handleLineWebhookEvents } from "./bot-handlers.js";
 import type { LineInboundContext } from "./bot-message-context.js";
 import type { ResolvedLineAccount } from "./types.js";
+import type { HistoryEntry } from "../auto-reply/reply/history.js";
 import { startLineWebhook } from "./webhook.js";
 
 export interface LineBotOptions {
@@ -42,6 +43,8 @@ export function createLineBot(opts: LineBotOptions): LineBot {
       logVerbose("line: no message handler configured");
     });
   const replayCache = createLineWebhookReplayCache();
+  const groupHistories = new Map<string, HistoryEntry[]>();
+  const groupHistoryLimit = cfg.messages?.groupChat?.historyLimit;
 
   const handleWebhook = async (body: WebhookRequestBody): Promise<void> => {
     if (!body.events || body.events.length === 0) {
@@ -55,6 +58,8 @@ export function createLineBot(opts: LineBotOptions): LineBot {
       mediaMaxBytes,
       processMessage,
       replayCache,
+      groupHistories,
+      groupHistoryLimit,
     });
   };
 


### PR DESCRIPTION
## Summary
- Keep unmentioned LINE group messages as pending history entries instead of dropping them.
- Inject pending history context when a later mentioned message is processed.
- Clear consumed pending entries after the mentioned turn is accepted.

## Why
With LINE `requireMention` enabled in groups, unmentioned messages were skipped and discarded. That caused later mentioned turns to lose context and produce less coherent replies.

## Scope
- LINE handler only
- no config schema changes
- backward compatible with existing configs

## Validation
- Added unit tests for pending-history record + replay behavior in the LINE group mention flow.
- Local test execution is not available in this environment (missing `vitest` dependency).
