### PR TITLE
fix(browser): remove unsupported --disable-blink-features=AutomationControlled

### DIFF
--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -267,7 +267,8 @@ export async function launchOpenClawChrome(
     }
 
     // Stealth: hide navigator.webdriver from automation detection (#80)
-    args.push("--disable-blink-features=AutomationControlled");
+    // NOTE: --disable-blink-features=AutomationControlled is removed as it's no longer
+    // supported in newer Chrome versions and causes a warning (#35721)
 
     // Append user-configured extra arguments (e.g., stealth flags, window size)
     if (resolved.extraArgs.length > 0) {


### PR DESCRIPTION
## Summary

Chrome displays warning `您使用的是不受支持的命令行标记：--disable-blink-features=AutomationControlled` in newer versions. This switch is no longer supported and causes cosmetic warnings for users without functional impact.

## Fix

Remove the `--disable-blink-features=AutomationControlled` argument from Chrome launch args.

## Issue

Fixes #35721