### PR TITLE
fix(hooks): fire message:sent internal hook regardless of session key availability

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -33,6 +33,7 @@ const queueMocks = vi.hoisted(() => ({
 }));
 const logMocks = vi.hoisted(() => ({
   warn: vi.fn(),
+  debug: vi.fn(),
 }));
 
 vi.mock("../../config/sessions.js", async () => {
@@ -62,7 +63,7 @@ vi.mock("../../logging/subsystem.js", () => ({
       warn: logMocks.warn,
       info: vi.fn(),
       error: vi.fn(),
-      debug: vi.fn(),
+      debug: logMocks.debug,
       child: vi.fn(() => makeLogger()),
     });
     return makeLogger();
@@ -203,6 +204,7 @@ describe("deliverOutboundPayloads", () => {
     queueMocks.failDelivery.mockClear();
     queueMocks.failDelivery.mockResolvedValue(undefined);
     logMocks.warn.mockClear();
+    logMocks.debug.mockClear();
   });
 
   afterEach(() => {
@@ -689,11 +691,17 @@ describe("deliverOutboundPayloads", () => {
     expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
   });
 
-  it("does not emit internal message:sent hook when neither mirror nor sessionKey is provided", async () => {
+  it("emits internal message:sent hook with empty sessionKey when neither mirror nor sessionKey is provided", async () => {
     await deliverSingleWhatsAppForHookTest();
 
-    expect(internalHookMocks.createInternalHookEvent).not.toHaveBeenCalled();
-    expect(internalHookMocks.triggerInternalHook).not.toHaveBeenCalled();
+    expect(internalHookMocks.createInternalHookEvent).toHaveBeenCalledTimes(1);
+    expect(internalHookMocks.createInternalHookEvent).toHaveBeenCalledWith(
+      "message",
+      "sent",
+      "",
+      expectSuccessfulWhatsAppInternalHookPayload({ content: "hello", messageId: "w1" }),
+    );
+    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
   });
 
   it("emits internal message:sent hook when sessionKey is provided without mirror", async () => {
@@ -709,7 +717,7 @@ describe("deliverOutboundPayloads", () => {
     expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
   });
 
-  it("warns when session.agentId is set without a session key", async () => {
+  it("logs debug when session.agentId is set without a session key", async () => {
     const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
     hookMocks.runner.hasHooks.mockReturnValue(true);
 
@@ -722,8 +730,8 @@ describe("deliverOutboundPayloads", () => {
       session: { agentId: "agent-main" },
     });
 
-    expect(logMocks.warn).toHaveBeenCalledWith(
-      "deliverOutboundPayloads: session.agentId present without session key; internal message:sent hook will be skipped",
+    expect(logMocks.debug).toHaveBeenCalledWith(
+      "deliverOutboundPayloads: session.agentId present without session key; message:sent internal hook will fire with empty sessionKey",
       expect.objectContaining({ channel: "whatsapp", to: "+1555", agentId: "agent-main" }),
     );
   });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -337,13 +337,9 @@ function createMessageSentEmitter(params: {
   sessionKeyForInternalHooks?: string;
   mirrorIsGroup?: boolean;
   mirrorGroupId?: string;
-}): { emitMessageSent: (event: MessageSentEvent) => void; hasMessageSentHooks: boolean } {
+}): { emitMessageSent: (event: MessageSentEvent) => void } {
   const hasMessageSentHooks = params.hookRunner?.hasHooks("message_sent") ?? false;
-  const canEmitInternalHook = Boolean(params.sessionKeyForInternalHooks);
   const emitMessageSent = (event: MessageSentEvent) => {
-    if (!hasMessageSentHooks && !canEmitInternalHook) {
-      return;
-    }
     const canonical = buildCanonicalSentMessageHookContext({
       to: params.to,
       content: event.content,
@@ -368,15 +364,16 @@ function createMessageSentEmitter(params: {
         },
       );
     }
-    if (!canEmitInternalHook) {
-      return;
-    }
+    // Fire internal hook for managed file hooks (registered via registerInternalHook).
+    // triggerInternalHook is a no-op when no handlers are registered, so this is always safe.
+    // When no session key is available (non-mirrored, non-session paths), we use an empty string;
+    // handlers can still access full channel/content context via event.context.
     fireAndForgetHook(
       triggerInternalHook(
         createInternalHookEvent(
           "message",
           "sent",
-          params.sessionKeyForInternalHooks!,
+          params.sessionKeyForInternalHooks ?? "",
           toInternalMessageSentContext(canonical),
         ),
       ),
@@ -386,7 +383,7 @@ function createMessageSentEmitter(params: {
       },
     );
   };
-  return { emitMessageSent, hasMessageSentHooks };
+  return { emitMessageSent };
 }
 
 async function applyMessageSendingHook(params: {
@@ -667,7 +664,7 @@ async function deliverOutboundPayloadsCore(
   const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.session?.key;
   const mirrorIsGroup = params.mirror?.isGroup;
   const mirrorGroupId = params.mirror?.groupId;
-  const { emitMessageSent, hasMessageSentHooks } = createMessageSentEmitter({
+  const { emitMessageSent } = createMessageSentEmitter({
     hookRunner,
     channel,
     to,
@@ -677,9 +674,9 @@ async function deliverOutboundPayloadsCore(
     mirrorGroupId,
   });
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
-  if (hasMessageSentHooks && params.session?.agentId && !sessionKeyForInternalHooks) {
-    log.warn(
-      "deliverOutboundPayloads: session.agentId present without session key; internal message:sent hook will be skipped",
+  if (params.session?.agentId && !sessionKeyForInternalHooks) {
+    log.debug(
+      "deliverOutboundPayloads: session.agentId present without session key; message:sent internal hook will fire with empty sessionKey",
       {
         channel,
         to,

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -438,6 +438,7 @@ export const dispatchTelegramMessage = async ({
     chunkMode,
     linkPreview: telegramCfg.linkPreview,
     replyQuoteText,
+    sessionKey: ctxPayload.SessionKey,
   };
   const applyTextToPayload = (payload: ReplyPayload, text: string): ReplyPayload => {
     if (payload.text === text) {

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -4,6 +4,12 @@ import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { ReplyToMode } from "../../config/config.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
 import { danger, logVerbose } from "../../globals.js";
+import { fireAndForgetHook } from "../../hooks/fire-and-forget.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import {
+  buildCanonicalSentMessageHookContext,
+  toInternalMessageSentContext,
+} from "../../hooks/message-hook-mappers.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { buildOutboundMediaLoadOptions } from "../../media/load-options.js";
 import { isGifMedia, kindFromMime } from "../../media/mime.js";
@@ -444,6 +450,8 @@ export async function deliverReplies(params: {
   linkPreview?: boolean;
   /** Optional quote text for Telegram reply_parameters. */
   replyQuoteText?: string;
+  /** Session key for internal message:sent hook dispatch (managed file hooks). */
+  sessionKey?: string;
 }): Promise<{ delivered: boolean }> {
   const progress: DeliveryProgress = {
     hasReplied: false,
@@ -453,6 +461,36 @@ export async function deliverReplies(params: {
   const hookRunner = getGlobalHookRunner();
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
   const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
+  // Fire message:sent hooks (both plugin hooks and managed file hooks via internal hook system).
+  const emitMessageSent = (success: boolean, content: string, error?: string) => {
+    const canonical = buildCanonicalSentMessageHookContext({
+      to: params.chatId,
+      content,
+      success,
+      error,
+      channelId: "telegram",
+      accountId: params.accountId,
+      conversationId: params.chatId,
+    });
+    if (hasMessageSentHooks) {
+      void hookRunner?.runMessageSent(
+        { to: params.chatId, content, success, ...(error ? { error } : {}) },
+        { channelId: "telegram", accountId: params.accountId, conversationId: params.chatId },
+      );
+    }
+    // triggerInternalHook is a no-op if no handlers are registered.
+    fireAndForgetHook(
+      triggerInternalHook(
+        createInternalHookEvent(
+          "message",
+          "sent",
+          params.sessionKey ?? "",
+          toInternalMessageSentContext(canonical),
+        ),
+      ),
+      "deliverReplies: message:sent internal hook failed",
+    );
+  };
   const chunkText = buildChunkTextResolver({
     textLimit: params.textLimit,
     chunkMode: params.chunkMode ?? "length",
@@ -547,37 +585,14 @@ export async function deliverReplies(params: {
         });
       }
 
-      if (hasMessageSentHooks) {
-        const deliveredThisReply = progress.deliveredCount > deliveredCountBeforeReply;
-        void hookRunner?.runMessageSent(
-          {
-            to: params.chatId,
-            content: contentForSentHook,
-            success: deliveredThisReply,
-          },
-          {
-            channelId: "telegram",
-            accountId: params.accountId,
-            conversationId: params.chatId,
-          },
-        );
-      }
+      const deliveredThisReply = progress.deliveredCount > deliveredCountBeforeReply;
+      emitMessageSent(deliveredThisReply, contentForSentHook);
     } catch (error) {
-      if (hasMessageSentHooks) {
-        void hookRunner?.runMessageSent(
-          {
-            to: params.chatId,
-            content: contentForSentHook,
-            success: false,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          {
-            channelId: "telegram",
-            accountId: params.accountId,
-            conversationId: params.chatId,
-          },
-        );
-      }
+      emitMessageSent(
+        false,
+        contentForSentHook,
+        error instanceof Error ? error.message : String(error),
+      );
       throw error;
     }
   }


### PR DESCRIPTION
Fixes #35557.

## Root Cause

`triggerInternalHook("message", "sent", ...)` (used by managed file hooks registered via `~/.openclaw/hooks/*/` with `events: [message:sent]`) was only called when `sessionKeyForInternalHooks` was set. This required either a `mirror.sessionKey` (only present for mirrored sessions) or a `session.key` (only populated when `sessionKey` is explicitly threaded through). For direct agent responses — the common case — `sessionKeyForInternalHooks` was always `undefined`, so the internal hook was silently skipped.

Additionally, the Telegram native bot path (`deliverReplies`) only fired plugin hooks (`hookRunner.runMessageSent()`) but never called `triggerInternalHook`, so Telegram responses would never trigger managed file hooks regardless.

## Changes

**`src/infra/outbound/deliver.ts`**
- Remove the `canEmitInternalHook` guard that blocked `triggerInternalHook` when `sessionKeyForInternalHooks` was unavailable
- Always fire `triggerInternalHook` with `sessionKeyForInternalHooks ?? ""` as fallback — it is a no-op when no handlers are registered, so there is no overhead penalty
- Downgrade the "session.agentId without session key" log from `warn` to `debug` (hook now fires with empty session key instead of being skipped)
- Remove now-unused `hasMessageSentHooks` from `createMessageSentEmitter` return value

**`src/telegram/bot/delivery.replies.ts`**
- Add optional `sessionKey` parameter
- Refactor duplicate hook-firing blocks into a shared `emitMessageSent` helper
- Fire `triggerInternalHook("message", "sent", ...)` from the Telegram native bot delivery path so managed file hooks fire for Telegram responses

**`src/telegram/bot-message-dispatch.ts`**
- Pass `sessionKey: ctxPayload.SessionKey` in `deliveryBaseOptions` so Telegram native responses fire the internal hook with the correct session key

## Test Plan

- [x] Updated test: "does not emit internal message:sent hook when neither mirror nor sessionKey is provided" → now verifies the hook fires with empty `sessionKey`
- [x] Updated test: "warns when session.agentId is set without a session key" → now checks `debug` level with updated message
- [x] All 2190 tests in `src/infra/`, `src/telegram/`, `src/hooks/` pass
- [x] TypeScript checks pass (`pnpm tsgo`)
- [x] Lint/format clean (`pnpm check`)