### PR TITLE
gateway: relax backend self-pairing local check (#35763)

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -143,6 +143,7 @@ function shouldAllowSilentLocalPairing(params: {
 function shouldSkipBackendSelfPairing(params: {
   connectParams: ConnectParams;
   isLocalClient: boolean;
+  isLoopbackClientIp: boolean;
   hasBrowserOriginHeader: boolean;
   sharedAuthOk: boolean;
   authMethod: GatewayAuthResult["method"];
@@ -155,7 +156,7 @@ function shouldSkipBackendSelfPairing(params: {
   }
   const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
   return (
-    params.isLocalClient &&
+    (params.isLocalClient || params.isLoopbackClientIp) &&
     !params.hasBrowserOriginHeader &&
     params.sharedAuthOk &&
     usesSharedSecretAuth
@@ -757,6 +758,7 @@ export function attachGatewayWsMessageHandler(params: {
           shouldSkipBackendSelfPairing({
             connectParams,
             isLocalClient,
+            isLoopbackClientIp: isLoopbackAddress(clientIp),
             hasBrowserOriginHeader,
             sharedAuthOk,
             authMethod,


### PR DESCRIPTION
## Summary

- Fix backend gateway self-connection pairing bypass to treat loopback client IP connections as local for token/password shared-auth paths.
- This resolves repeated pairing prompts for loopback tool calls with `gateway.bind=loopback` and token-based auth.

Fixes #35763