### PR TITLE
fix(whatsapp): clarify allowFrom policy denial

### DIFF
--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -11,11 +11,15 @@ type ResolveParams = Parameters<typeof resolveWhatsAppOutboundTarget>[0];
 const PRIMARY_TARGET = "+11234567890";
 const SECONDARY_TARGET = "+19876543210";
 
-function expectResolutionError(params: ResolveParams) {
+function expectResolutionError(params: ResolveParams, expectedMessage?: string) {
   const result = resolveWhatsAppOutboundTarget(params);
   expect(result.ok).toBe(false);
   if (result.ok) {
     throw new Error("expected resolution to fail");
+  }
+  if (expectedMessage) {
+    expect(result.error.message).toContain(expectedMessage);
+    return;
   }
   expect(result.error.message).toContain("WhatsApp");
 }
@@ -53,12 +57,16 @@ function expectDeniedForTarget(params: {
   allowFrom: ResolveParams["allowFrom"];
   mode: ResolveParams["mode"];
   to?: string;
+  expectedMessage?: string;
 }) {
-  expectResolutionError({
-    to: params.to ?? PRIMARY_TARGET,
-    allowFrom: params.allowFrom,
-    mode: params.mode,
-  });
+  expectResolutionError(
+    {
+      to: params.to ?? PRIMARY_TARGET,
+      allowFrom: params.allowFrom,
+      mode: params.mode,
+    },
+    params.expectedMessage,
+  );
 }
 
 describe("resolveWhatsAppOutboundTarget", () => {
@@ -134,9 +142,13 @@ describe("resolveWhatsAppOutboundTarget", () => {
       expectAllowedForTarget({ allowFrom: [PRIMARY_TARGET], mode: "implicit" });
     });
 
-    it("denies message when target is not in allowList", () => {
+    it("denies message when target is not in allowList with allowFrom policy error", () => {
       mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
-      expectDeniedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "implicit" });
+      expectDeniedForTarget({
+        allowFrom: [SECONDARY_TARGET],
+        mode: "implicit",
+        expectedMessage: "allowFrom policy",
+      });
     });
 
     it("handles mixed numeric and string allowList entries", () => {
@@ -172,9 +184,13 @@ describe("resolveWhatsAppOutboundTarget", () => {
       expectAllowedForTarget({ allowFrom: [PRIMARY_TARGET], mode: "heartbeat" });
     });
 
-    it("denies message when target is not in allowList in heartbeat mode", () => {
+    it("denies message when target is not in allowList in heartbeat mode with allowFrom policy error", () => {
       mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
-      expectDeniedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "heartbeat" });
+      expectDeniedForTarget({
+        allowFrom: [SECONDARY_TARGET],
+        mode: "heartbeat",
+        expectedMessage: "allowFrom policy",
+      });
     });
   });
 
@@ -189,9 +205,13 @@ describe("resolveWhatsAppOutboundTarget", () => {
       expectAllowedForTarget({ allowFrom: undefined, mode: undefined });
     });
 
-    it("enforces allowList in custom mode string", () => {
+    it("enforces allowList in custom mode string with allowFrom policy error", () => {
       mockNormalizedDirectMessage(SECONDARY_TARGET, PRIMARY_TARGET);
-      expectDeniedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "broadcast" });
+      expectDeniedForTarget({
+        allowFrom: [SECONDARY_TARGET],
+        mode: "broadcast",
+        expectedMessage: "allowFrom policy",
+      });
     });
 
     it("allows message in custom mode string when target is in allowList", () => {

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -5,6 +5,13 @@ export type WhatsAppOutboundTargetResolution =
   | { ok: true; to: string }
   | { ok: false; error: Error };
 
+function allowFromPolicyError(target: string): Error {
+  return new Error(
+    `Target "${target}" is not listed in the configured WhatsApp allowFrom policy. ` +
+      `Add it to "channels.whatsapp.allowFrom" (or use "*" for any direct-message target).`,
+  );
+}
+
 export function resolveWhatsAppOutboundTarget(params: {
   to: string | null | undefined;
   allowFrom: Array<string | number> | null | undefined;
@@ -41,7 +48,7 @@ export function resolveWhatsAppOutboundTarget(params: {
     }
     return {
       ok: false,
-      error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+      error: allowFromPolicyError(trimmed),
     };
   }
 


### PR DESCRIPTION
Closes #35580

### What changed
- When a WhatsApp outbound target is denied by `channels.whatsapp.allowFrom`, return a dedicated allowFrom-policy error (instead of a generic missing-target error).
- Update unit tests to assert the new error messaging in implicit/heartbeat/broadcast modes.

### Validation
- `pnpm -s vitest run --config vitest.unit.config.ts src/whatsapp/resolve-outbound-target.test.ts`