### PR TITLE
fix(models): switch kimi-coding provider to openai-completions API 

### DIFF
--- a/src/agents/models-config.providers.kimi-coding.test.ts
+++ b/src/agents/models-config.providers.kimi-coding.test.ts
@@ -14,17 +14,17 @@ describe("kimi-coding implicit provider (#22409)", () => {
     try {
       const providers = await resolveImplicitProviders({ agentDir });
       expect(providers?.["kimi-coding"]).toBeDefined();
-      expect(providers?.["kimi-coding"]?.api).toBe("anthropic-messages");
-      expect(providers?.["kimi-coding"]?.baseUrl).toBe("https://api.kimi.com/coding/");
+      expect(providers?.["kimi-coding"]?.api).toBe("openai-completions");
+      expect(providers?.["kimi-coding"]?.baseUrl).toBe("https://api.kimi.com/coding/v1");
     } finally {
       envSnapshot.restore();
     }
   });
 
-  it("should build kimi-coding provider with anthropic-messages API", () => {
+  it("should build kimi-coding provider with openai-completions API", () => {
     const provider = buildKimiCodingProvider();
-    expect(provider.api).toBe("anthropic-messages");
-    expect(provider.baseUrl).toBe("https://api.kimi.com/coding/");
+    expect(provider.api).toBe("openai-completions");
+    expect(provider.baseUrl).toBe("https://api.kimi.com/coding/v1");
     expect(provider.models).toBeDefined();
     expect(provider.models.length).toBeGreaterThan(0);
     expect(provider.models[0].id).toBe("k2p5");

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -120,7 +120,7 @@ const MOONSHOT_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
-const KIMI_CODING_BASE_URL = "https://api.kimi.com/coding/";
+const KIMI_CODING_BASE_URL = "https://api.kimi.com/coding/v1";
 const KIMI_CODING_DEFAULT_MODEL_ID = "k2p5";
 const KIMI_CODING_DEFAULT_CONTEXT_WINDOW = 262144;
 const KIMI_CODING_DEFAULT_MAX_TOKENS = 32768;
@@ -656,7 +656,7 @@ function buildMoonshotProvider(): ProviderConfig {
 export function buildKimiCodingProvider(): ProviderConfig {
   return {
     baseUrl: KIMI_CODING_BASE_URL,
-    api: "anthropic-messages",
+    api: "openai-completions",
     models: [
       {
         id: KIMI_CODING_DEFAULT_MODEL_ID,
@@ -666,6 +666,7 @@ export function buildKimiCodingProvider(): ProviderConfig {
         cost: KIMI_CODING_DEFAULT_COST,
         contextWindow: KIMI_CODING_DEFAULT_CONTEXT_WINDOW,
         maxTokens: KIMI_CODING_DEFAULT_MAX_TOKENS,
+        compat: { supportsDeveloperRole: false },
       },
     ],
   };

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -223,8 +223,8 @@ export function applyKimiCodeProviderConfig(cfg: OpenClawConfig): OpenClawConfig
   return applyProviderConfigWithDefaultModel(cfg, {
     agentModels: models,
     providerId: "kimi-coding",
-    api: "anthropic-messages",
-    baseUrl: "https://api.kimi.com/coding/",
+    api: "openai-completions",
+    baseUrl: "https://api.kimi.com/coding/v1",
     defaultModel,
     defaultModelId: KIMI_CODING_MODEL_ID,
   });


### PR DESCRIPTION
## Summary

  - **Problem:** kimi-coding provider was configured with `api: "anthropic-messages"`, causing tools to be sent as `{name, description, input_schema}` (Anthropic format)
  instead of `{type: "function", function: {name, description, parameters}}` (OpenAI format)
  - **Why it matters:** Kimi Coding API rejects Anthropic-format tools with "Field required" validation errors on ~20-30% of tool calls
  - **What changed:** Switched `api` to `"openai-completions"`, updated `baseUrl` to include `/v1` suffix, added `compat.supportsDeveloperRole: false`, aligned onboarding
  config
  - **What did NOT change:** Auth flow, model ID (`k2p5`), context window, cost config, credential resolution

  ## Change Type (select all)

  - [x] Bug fix

  ## Scope (select all touched areas)

  - [x] Integrations

  ## Linked Issue/PR

  - Closes #35667

  ## User-visible / Behavior Changes

  - kimi-coding provider now uses OpenAI-compatible API format instead of Anthropic format
  - Tool calls to Kimi Coding API should no longer fail with "23 validation errors: Field required"
  - Users who re-run onboarding (`openclaw login kimi-coding`) will get the corrected config

  ## Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? Yes — endpoint path changes from `/v1/messages` (Anthropic) to `/v1/chat/completions` (OpenAI)
  - Command/tool execution surface changed? No
  - Data access scope changed? No
  - If any Yes: Same Kimi API, different endpoint format. No new network destinations.

  ## Repro + Verification

  ### Environment

  - OS: Linux (WSL2) / any
  - Runtime/container: Node v22+
  - Model/provider: kimi-coding/k2p5
  - Relevant config: `KIMI_API_KEY` set

  ### Steps

  1. Configure kimi-coding provider with API key
  2. Start agent session with tool access
  3. Execute tool calls (read, edit, exec)

  ### Expected

  - Tool calls validate and execute without schema errors

  ### Actual (before fix)

  - ~20-30% of tool calls fail with `{'type': 'missing', 'loc': ('body', 'tools', 0, 'function'), 'msg': 'Field required'}`

  ## Evidence

  - [x] Failing test/log before + passing after
  - Unit tests updated and passing (`models-config.providers.kimi-coding.test.ts`, `auth-choice.test.ts`)
  - `pnpm build` passes

  ## Human Verification (required)

  - Verified scenarios: build passes, all kimi-coding and auth-choice tests pass, onboarding config aligned with provider config
  - Edge cases checked: transcript policy correctly adapts (tool ID sanitization switches to OpenAI strict mode), no other code paths depend on kimi-coding being
  anthropic-messages
  - What you did **not** verify: live API call to Kimi Coding (no API key available)

  ## Compatibility / Migration

  - Backward compatible? Yes — implicit provider auto-resolves; explicit config users may need to re-run onboarding
  - Config/env changes? No
  - Migration needed? No — existing users with hardcoded `anthropic-messages` in config will still work via the implicit provider override

  ## Failure Recovery (if this breaks)

  - How to disable/revert: revert this commit; or user can manually set `api: "anthropic-messages"` and `baseUrl: "https://api.kimi.com/coding/"` in their config
  - Known bad symptoms: if Kimi API rejects unknown fields (`store: false`), users may see new errors — fix by adding `supportsStore: false` to compat

  ## Risks and Mitigations

  - Risk: Kimi API endpoint at `/v1/chat/completions` may behave differently than `/v1/messages` for edge cases (e.g., image format, reasoning tokens)
    - Mitigation: The original kimi-coding provider (before c62a6e704) used `openai-completions` with the same `/v1` base URL; this restores that proven configuration
  - Risk: `supportsStore: true` default may send `store: false` field that Kimi rejects
    - Mitigation: Most OpenAI-compatible APIs ignore unknown fields; can add `supportsStore: false` to compat if needed