### PR TITLE
fix(config): add missing discovery.wideArea.domain field to Zod schema

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -270,6 +270,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Wide-area discovery configuration group for exposing discovery signals beyond local-link scopes. Enable only in deployments that intentionally aggregate gateway presence across sites.",
   "discovery.wideArea.enabled":
     "Enables wide-area discovery signaling when your environment needs non-local gateway discovery. Keep disabled unless cross-network discovery is operationally required.",
+  "discovery.wideArea.domain":
+    'Optional unicast DNS-SD domain for wide-area discovery (e.g. "openclaw.internal"). Only set this when running dedicated unicast DNS-SD infrastructure across sites.',
   "discovery.mdns":
     "mDNS discovery configuration group for local network advertisement and discovery behavior tuning. Keep minimal mode for routine LAN discovery unless extra metadata is required.",
   tools:

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -602,6 +602,7 @@ export const FIELD_LABELS: Record<string, string> = {
   discovery: "Discovery",
   "discovery.wideArea": "Wide-area Discovery",
   "discovery.wideArea.enabled": "Wide-area Discovery Enabled",
+  "discovery.wideArea.domain": "Wide-area Discovery Domain",
   "discovery.mdns": "mDNS Discovery",
   canvasHost: "Canvas Host",
   "canvasHost.enabled": "Canvas Host Enabled",

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -537,6 +537,8 @@ export const OpenClawSchema = z
         wideArea: z
           .object({
             enabled: z.boolean().optional(),
+            /** Optional unicast DNS-SD domain (e.g. "openclaw.internal"). */
+            domain: z.string().optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
Fixes #35614.

## Root Cause

Type/schema drift: `domain` was added to `WideAreaDiscoveryConfig` in `types.gateway.ts` and used throughout the codebase (gateway registration, DNS CLI, server discovery runtime), but never added to the corresponding Zod schema. Since the `wideArea` object uses `.strict()`, any config with `discovery.wideArea.domain` was rejected with a validation error.

## Changes

- `src/config/zod-schema.ts`: add `domain: z.string().optional()` to the `wideArea` schema
- `src/config/schema.help.ts`: add help text for the new `discovery.wideArea.domain` key

## Test Plan

- [x] `pnpm tsgo` passes
- [x] `src/config/schema.help.quality.test.ts` passes (20 tests)