### PR TITLE
fix(config): add discord guild channel autoThread type

### DIFF
--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -52,6 +52,8 @@ export type DiscordGuildChannelConfig = {
   systemPrompt?: string;
   /** If false, omit thread starter context for this channel (default: true). */
   includeThreadStarter?: boolean;
+  /** If true, auto-create threads for eligible guild messages. */
+  autoThread?: boolean;
 };
 
 export type DiscordReactionNotificationMode = "off" | "own" | "all" | "allowlist";


### PR DESCRIPTION
## Summary
- add missing `autoThread?: boolean` to `DiscordGuildChannelConfig`
- align canonical TypeScript type with existing Zod schema and runtime usage

## Why
Issue #35607 reports type/schema drift:
- schema already accepts `autoThread`
- runtime already reads `autoThread`
- canonical type was missing the field

This patch is intentionally minimal and low risk (type-only change, no runtime behavior change).

## Changes
- `src/config/types.discord.ts`
  - add doc comment and `autoThread?: boolean` in `DiscordGuildChannelConfig`

## Validation
- `pnpm dlx oxfmt --check src/config/types.discord.ts`

Closes #35607
