### PR TITLE
docs: fix "a OpenClaw" → "an OpenClaw" article grammar

### DIFF
--- a/docs.acp.md
+++ b/docs.acp.md
@@ -20,7 +20,7 @@ Key goals:
 ## How can I use this
 
 Use ACP when an IDE or tooling speaks Agent Client Protocol and you want it to
-drive a OpenClaw Gateway session.
+drive an OpenClaw Gateway session.
 
 Quick steps:
 

--- a/docs/cli/acp.md
+++ b/docs/cli/acp.md
@@ -8,7 +8,7 @@ title: "acp"
 
 # acp
 
-Run the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) bridge that talks to a OpenClaw Gateway.
+Run the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) bridge that talks to an OpenClaw Gateway.
 
 This command speaks ACP over stdio for IDEs and forwards prompts to the Gateway
 over WebSocket. It keeps ACP sessions mapped to Gateway session keys.
@@ -59,7 +59,7 @@ Permission model (client debug mode):
 ## How to use this
 
 Use ACP when an IDE (or other client) speaks Agent Client Protocol and you want
-it to drive a OpenClaw Gateway session.
+it to drive an OpenClaw Gateway session.
 
 1. Ensure the Gateway is running (local or remote).
 2. Configure the Gateway target (config or flags).

--- a/docs/install/migrating.md
+++ b/docs/install/migrating.md
@@ -1,5 +1,5 @@
 ---
-summary: "Move (migrate) a OpenClaw install from one machine to another"
+summary: "Move (migrate) an OpenClaw install from one machine to another"
 read_when:
   - You are moving OpenClaw to a new laptop/server
   - You want to preserve sessions, auth, and channel logins (WhatsApp, etc.)
@@ -8,7 +8,7 @@ title: "Migration Guide"
 
 # Migrating OpenClaw to a new machine
 
-This guide migrates a OpenClaw Gateway from one machine to another **without redoing onboarding**.
+This guide migrates an OpenClaw Gateway from one machine to another **without redoing onboarding**.
 
 The migration is simple conceptually:
 

--- a/docs/platforms/mac/release.md
+++ b/docs/platforms/mac/release.md
@@ -1,7 +1,7 @@
 ---
 summary: "OpenClaw macOS release checklist (Sparkle feed, packaging, signing)"
 read_when:
-  - Cutting or validating a OpenClaw macOS release
+  - Cutting or validating an OpenClaw macOS release
   - Updating the Sparkle appcast or feed assets
 title: "macOS Release"
 ---

--- a/docs/platforms/mac/remote.md
+++ b/docs/platforms/mac/remote.md
@@ -7,7 +7,7 @@ title: "Remote Control"
 
 # Remote OpenClaw (macOS ⇄ remote host)
 
-This flow lets the macOS app act as a full remote control for a OpenClaw gateway running on another host (desktop/server). It’s the app’s **Remote over SSH** (remote run) feature. All features—health checks, Voice Wake forwarding, and Web Chat—reuse the same remote SSH configuration from _Settings → General_.
+This flow lets the macOS app act as a full remote control for an OpenClaw gateway running on another host (desktop/server). It’s the app’s **Remote over SSH** (remote run) feature. All features—health checks, Voice Wake forwarding, and Web Chat—reuse the same remote SSH configuration from _Settings → General_.
 
 ## Modes
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -1,7 +1,7 @@
 ---
 summary: "Plugin manifest + JSON schema requirements (strict config validation)"
 read_when:
-  - You are building a OpenClaw plugin
+  - You are building an OpenClaw plugin
   - You need to ship a plugin config schema or debug plugin validation errors
 title: "Plugin Manifest"
 ---

--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -231,7 +231,7 @@ Triggered by a roof camera: ask OpenClaw to snap a sky photo whenever it looks p
 <Card title="Visual Morning Briefing Scene" icon="robot" href="https://x.com/buddyhadry/status/2010005331925954739">
   **@buddyhadry** • `automation` `briefing` `images` `telegram`
 
-A scheduled prompt generates a single "scene" image each morning (weather, tasks, date, favorite post/quote) via a OpenClaw persona.
+A scheduled prompt generates a single "scene" image each morning (weather, tasks, date, favorite post/quote) via an OpenClaw persona.
 </Card>
 
 <Card title="Padel Court Booking" icon="calendar-check" href="https://github.com/joshp123/padel-cli">

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -169,7 +169,7 @@ Notes:
 ## Browserless (hosted remote CDP)
 
 [Browserless](https://browserless.io) is a hosted Chromium service that exposes
-CDP endpoints over HTTPS. You can point a OpenClaw browser profile at a
+CDP endpoints over HTTPS. You can point an OpenClaw browser profile at a
 Browserless region endpoint and authenticate with your API key.
 
 Example:

--- a/docs/tools/clawhub.md
+++ b/docs/tools/clawhub.md
@@ -66,7 +66,7 @@ pnpm add -g clawhub
 
 ## How it fits into OpenClaw
 
-By default, the CLI installs skills into `./skills` under your current working directory. If a OpenClaw workspace is configured, `clawhub` falls back to that workspace unless you override `--workdir` (or `CLAWHUB_WORKDIR`). OpenClaw loads workspace skills from `<workspace>/skills` and will pick them up in the **next** session. If you already use `~/.openclaw/skills` or bundled skills, workspace skills take precedence.
+By default, the CLI installs skills into `./skills` under your current working directory. If an OpenClaw workspace is configured, `clawhub` falls back to that workspace unless you override `--workdir` (or `CLAWHUB_WORKDIR`). OpenClaw loads workspace skills from `<workspace>/skills` and will pick them up in the **next** session. If you already use `~/.openclaw/skills` or bundled skills, workspace skills take precedence.
 
 For more detail on how skills are loaded, shared, and gated, see
 [Skills](/tools/skills).


### PR DESCRIPTION
English requires "an" before words starting with a vowel sound. "OpenClaw" starts with "O", so "an OpenClaw" is correct.                                                  
                                                                                                                                                                          
  Fixed across 9 documentation files (11 occurrences).                                                                                                                      
                                                                                                                                                                            
  ## Summary

  - Problem: Multiple docs use "a OpenClaw" which is grammatically incorrect
  - Why it matters: Docs are the first thing new users and contributors read — grammar errors hurt credibility
  - What changed: "a OpenClaw" → "an OpenClaw" in 9 files (11 occurrences)
  - What did NOT change (scope boundary): `docs/zh-CN/` files were not touched as they are auto-generated via the i18n pipeline

  ## Change Type (select all)

  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [x] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [x] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  None

  ## User-visible / Behavior Changes

  None — docs text only.

  ## Security Impact (required)

  - New permissions/capabilities? `No`
  - Secrets/tokens handling changed? `No`
  - New/changed network calls? `No`
  - Command/tool execution surface changed? `No`
  - Data access scope changed? `No`

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: N/A (docs only)
  - Model/provider: N/A
  - Integration/channel (if any): N/A
  - Relevant config (redacted): N/A

  ### Steps

  1. Search the repo for `"a OpenClaw"` (case-sensitive)
  2. Verify each occurrence reads better as `"an OpenClaw"`

  ### Expected

  - Zero occurrences of `"a OpenClaw"` in edited files

  ### Actual

  - All 11 occurrences corrected

  ## Evidence

  - [x] `grep -r "a OpenClaw" docs/ docs.acp.md` returns no matches after this change

  ## Human Verification (required)

  - Verified scenarios: Grepped all docs for remaining `"a OpenClaw"` — none left in changed files
  - Edge cases checked: Confirmed `docs/zh-CN/` excluded (auto-generated)
  - What you did **not** verify: Mintlify rendering (no local Mintlify build)

  ## Compatibility / Migration

  - Backward compatible? `Yes`
  - Config/env changes? `No`
  - Migration needed? `No`

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: `git revert <commit>`
  - Files/config to restore: 9 docs files (text-only change)
  - Known bad symptoms reviewers should watch for: None

  ## Risks and Mitigations

  None