### PR TITLE
fix: Bug: Orphaned parent session when subagent session is cleaned up before runTimeout fires (#35791)

### DIFF
--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -130,6 +130,7 @@ describe("subagent registry persistence", () => {
     childSessionKey: string;
     task: string;
     cleanup: "keep" | "delete";
+    expectsCompletionMessage?: boolean;
   }) => {
     const now = Date.now();
     return {
@@ -142,6 +143,7 @@ describe("subagent registry persistence", () => {
           requesterDisplayKey: "main",
           task: params.task,
           cleanup: params.cleanup,
+          expectsCompletionMessage: params.expectsCompletionMessage,
           createdAt: now - 2,
           startedAt: now - 1,
           endedAt: now,
@@ -388,6 +390,36 @@ describe("subagent registry persistence", () => {
     };
     expect(after.runs?.["run-orphan-restore"]).toBeUndefined();
     expect(listSubagentRunsForRequester("agent:main:main")).toHaveLength(0);
+  });
+
+  it("reconciles orphaned completion-message runs by dispatching failure cleanup", async () => {
+    const runId = "run-orphan-restore-completion";
+    const persisted = createPersistedEndedRun({
+      runId,
+      childSessionKey: "agent:main:subagent:ghost-restore-completion",
+      task: "orphan restore completion",
+      cleanup: "keep",
+      expectsCompletionMessage: true,
+    });
+    const registryPath = await writePersistedRegistry(persisted, {
+      seedChildSessions: false,
+    });
+
+    await restartRegistryAndFlush();
+
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    const first = (announceSpy.mock.calls as unknown as Array<[unknown]>)[0]?.[0] as
+      | { outcome?: { status?: string; error?: string } }
+      | undefined;
+    expect(first?.outcome?.status).toBe("error");
+    expect(first?.outcome?.error).toContain("orphaned subagent run");
+
+    const after = JSON.parse(await fs.readFile(registryPath, "utf8")) as {
+      runs?: Record<string, { cleanupCompletedAt?: number; outcome?: { status?: string } }>;
+    };
+    expect(after.runs?.[runId]?.cleanupCompletedAt).toBeDefined();
+    expect(after.runs?.[runId]?.outcome?.status).toBe("error");
+    expect(listSubagentRunsForRequester("agent:main:main")).toHaveLength(1);
   });
 
   it("resume guard prunes orphan runs before announce retry", async () => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -173,6 +173,19 @@ function reconcileOrphanedRun(params: {
     params.entry.endedReason = SUBAGENT_ENDED_REASON_ERROR;
     changed = true;
   }
+  const shouldSendCompletionFailure =
+    params.entry.expectsCompletionMessage === true &&
+    typeof params.entry.cleanupCompletedAt !== "number";
+  if (shouldSendCompletionFailure) {
+    if (params.entry.cleanupHandled === true) {
+      params.entry.cleanupHandled = false;
+      changed = true;
+    }
+    defaultRuntime.log(
+      `[warn] Subagent orphan run detected source=${params.source} run=${params.runId} child=${params.entry.childSessionKey} reason=${params.reason}; marking failed for cleanup dispatch`,
+    );
+    return true;
+  }
   if (params.entry.cleanupHandled !== true) {
     params.entry.cleanupHandled = true;
     changed = true;
@@ -430,17 +443,18 @@ function resumeSubagentRun(runId: string) {
   }
   const orphanReason = resolveSubagentRunOrphanReason({ entry });
   if (orphanReason) {
-    if (
-      reconcileOrphanedRun({
-        runId,
-        entry,
-        reason: orphanReason,
-        source: "resume",
-      })
-    ) {
+    const didReconcile = reconcileOrphanedRun({
+      runId,
+      entry,
+      reason: orphanReason,
+      source: "resume",
+    });
+    if (didReconcile) {
       persistSubagentRuns();
     }
-    return;
+    if (!subagentRuns.has(runId)) {
+      return;
+    }
   }
   if (entry.cleanupCompletedAt) {
     return;


### PR DESCRIPTION
Closes #35791

## Summary

- Problem: Bug: Orphaned parent session when subagent session is cleaned up before runTimeout fires
- Why it matters: Reported in #35791
- What changed: Targeted fix generated from issue context
- What did NOT change (scope boundary): Unrelated components

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Linked Issue/PR

- Closes #35791
- Related #N/A

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Human Verification

- Verified scenarios: Automated checks and lint where available
- Edge cases checked: Basic issue reproduction path
- What you did not verify: Full manual exploratory testing across all channels

## AI-Assisted

- Marked as AI-assisted: Yes
- Testing degree: Lightly tested
- Source issue: https://github.com/openclaw/openclaw/issues/35791