### PR TITLE
fix(bluebubbles): avoid debounce crash on null text

### DIFF
--- a/extensions/bluebubbles/src/monitor-debounce.test.ts
+++ b/extensions/bluebubbles/src/monitor-debounce.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import type { NormalizedWebhookMessage } from "./monitor-normalize.js";
+import { createBlueBubblesDebounceRegistry } from "./monitor-debounce.js";
+
+function buildMessage(overrides: Partial<NormalizedWebhookMessage> = {}): NormalizedWebhookMessage {
+  return {
+    text: "hello",
+    senderId: "+15551234567",
+    isGroup: false,
+    ...overrides,
+  };
+}
+
+describe("bluebubbles monitor debounce", () => {
+  it("does not throw when combining entries with null text", async () => {
+    const processed: NormalizedWebhookMessage[] = [];
+
+    const registry = createBlueBubblesDebounceRegistry({
+      processMessage: async (message) => {
+        processed.push(message);
+      },
+    });
+
+    const target = {
+      account: { accountId: "default", config: {} },
+      config: {},
+      runtime: {},
+      core: {
+        logging: { shouldLogVerbose: () => false },
+        channel: {
+          debounce: {
+            resolveInboundDebounceMs: () => 0,
+            createInboundDebouncer: ({ onFlush }: any) => {
+              let flushEntries: any[] = [];
+              return {
+                enqueue: async (entry: any) => {
+                  flushEntries.push(entry);
+                },
+                flushKey: async () => {
+                  await onFlush(flushEntries);
+                  flushEntries = [];
+                },
+              };
+            },
+          },
+          text: { hasControlCommand: () => false },
+        },
+      },
+    } as any;
+
+    const debouncer = registry.getOrCreateDebouncer(target);
+
+    await debouncer.enqueue({ message: buildMessage({ text: null as any }), target });
+    await debouncer.enqueue({ message: buildMessage({ text: "  hello  " }), target });
+    await debouncer.flushKey("ignored");
+
+    expect(processed).toHaveLength(1);
+    expect(processed[0].text).toBe("hello");
+  });
+});

--- a/extensions/bluebubbles/src/monitor-debounce.ts
+++ b/extensions/bluebubbles/src/monitor-debounce.ts
@@ -48,7 +48,7 @@ function combineDebounceEntries(entries: BlueBubblesDebounceEntry[]): Normalized
   const textParts: string[] = [];
 
   for (const entry of entries) {
-    const text = entry.message.text.trim();
+    const text = (entry.message.text ?? "").trim();
     if (!text) {
       continue;
     }


### PR DESCRIPTION
Fix inbound debounce coalescing to handle `null` message text safely.

When BlueBubbles sends `text: null` (e.g. attachment-only/system events), debounce coalescing called `.trim()` and threw, dropping the entire batch.

Adds a focused regression test.

Closes #35777