### PR TITLE
fix: remove deprecated BARE_SESSION_RESET_PROMPT export

### DIFF
--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -16,6 +16,3 @@ export function buildBareSessionResetPrompt(cfg?: OpenClawConfig, nowMs?: number
     nowMs ?? Date.now(),
   );
 }
-
-/** @deprecated Use buildBareSessionResetPrompt(cfg) instead */
-export const BARE_SESSION_RESET_PROMPT = BARE_SESSION_RESET_PROMPT_BASE;

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import { BARE_SESSION_RESET_PROMPT } from "../../auto-reply/reply/session-reset-prompt.js";
 import { agentHandlers } from "./agent.js";
 import type { GatewayRequestContext } from "./types.js";
 
@@ -532,7 +531,6 @@ describe("gateway agent handler", () => {
     // Message is now dynamically built with current date — check key substrings
     expect(call?.message).toContain("Execute your Session Startup sequence now");
     expect(call?.message).toContain("Current time:");
-    expect(call?.message).not.toBe(BARE_SESSION_RESET_PROMPT);
     expect(call?.sessionId).toBe("reset-session-id");
   });
 


### PR DESCRIPTION
## Summary

Complete the BARE_SESSION_RESET_PROMPT deprecation by relying solely on
`buildBareSessionResetPrompt` for reset messages. The deprecated constant
export is removed, and tests now assert on the dynamic prompt content
(startup instruction + timestamp) without importing the old symbol.

## Changes

- `src/auto-reply/reply/session-reset-prompt.ts`: remove the deprecated
  `BARE_SESSION_RESET_PROMPT` export; keep the internal base string and
  `buildBareSessionResetPrompt(cfg, nowMs)`.
- `src/gateway/server-methods/agent.test.ts`: drop the import of
  `BARE_SESSION_RESET_PROMPT` and assert only on key substrings
  (startup sequence text + `Current time:`) for the reset message.

## Testing

- `pnpm test src/gateway/server-methods/agent.test.ts --run`