### PR TITLE
fix(exec): bypass cmd.exe for explicit PowerShell invocations on Windows

### DIFF
--- a/src/infra/node-shell.test.ts
+++ b/src/infra/node-shell.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { buildNodeShellCommand } from "./node-shell.js";
+
+describe("buildNodeShellCommand", () => {
+  describe("non-Windows platforms", () => {
+    it("wraps in /bin/sh -lc on linux", () => {
+      expect(buildNodeShellCommand("ls -la", "linux")).toEqual(["/bin/sh", "-lc", "ls -la"]);
+    });
+
+    it("wraps in /bin/sh -lc on darwin", () => {
+      expect(buildNodeShellCommand("echo hello", "darwin")).toEqual([
+        "/bin/sh",
+        "-lc",
+        "echo hello",
+      ]);
+    });
+
+    it("defaults to /bin/sh -lc when platform is absent", () => {
+      expect(buildNodeShellCommand("cat file.txt")).toEqual(["/bin/sh", "-lc", "cat file.txt"]);
+    });
+  });
+
+  describe("Windows non-PowerShell commands", () => {
+    it("wraps cmd commands in cmd.exe /d /s /c", () => {
+      expect(buildNodeShellCommand("dir /b", "win32")).toEqual([
+        "cmd.exe",
+        "/d",
+        "/s",
+        "/c",
+        "dir /b",
+      ]);
+    });
+
+    it("wraps arbitrary commands in cmd.exe on windows", () => {
+      expect(buildNodeShellCommand("ipconfig /all", "win32")).toEqual([
+        "cmd.exe",
+        "/d",
+        "/s",
+        "/c",
+        "ipconfig /all",
+      ]);
+    });
+  });
+
+  describe("Windows PowerShell commands — bypass cmd.exe (refs #35807)", () => {
+    it("invokes powershell.exe directly without cmd.exe wrapper", () => {
+      const result = buildNodeShellCommand("powershell -Command Get-Process", "win32");
+      expect(result[0]).not.toBe("cmd.exe");
+      expect(result[0]?.toLowerCase()).toBe("powershell");
+    });
+
+    it("preserves -Command flag and inline script as separate argv tokens", () => {
+      const result = buildNodeShellCommand(
+        'powershell -NoProfile -Command "Get-Process | Where-Object {$_.CPU -gt 10}"',
+        "win32",
+      );
+      expect(result).toEqual([
+        "powershell",
+        "-NoProfile",
+        "-Command",
+        "Get-Process | Where-Object {$_.CPU -gt 10}",
+      ]);
+    });
+
+    it("handles pwsh (PowerShell 7) the same way", () => {
+      const result = buildNodeShellCommand('pwsh -Command "Get-ChildItem"', "win32");
+      expect(result[0]).toBe("pwsh");
+      expect(result).not.toContain("cmd.exe");
+    });
+
+    it("handles powershell.exe with .exe extension", () => {
+      const result = buildNodeShellCommand("powershell.exe -File script.ps1", "win32");
+      expect(result[0]).toBe("powershell.exe");
+      expect(result).toEqual(["powershell.exe", "-File", "script.ps1"]);
+    });
+
+    it("handles pwsh.exe with .exe extension", () => {
+      const result = buildNodeShellCommand('pwsh.exe -NonInteractive -Command "1+1"', "win32");
+      expect(result[0]).toBe("pwsh.exe");
+    });
+
+    it("is case-insensitive for PowerShell detection", () => {
+      const result = buildNodeShellCommand('PowerShell -Command "Get-Date"', "win32");
+      expect(result[0]).toBe("PowerShell");
+      expect(result).not.toContain("cmd.exe");
+    });
+
+    it("preserves pipeline variables inside quoted -Command arg", () => {
+      // Regression: $ should not be mangled when passed through PowerShell directly
+      const script = "Get-Process | ForEach-Object { $_.Name }";
+      const result = buildNodeShellCommand(`powershell -Command "${script}"`, "win32");
+      expect(result).toContain(script);
+      expect(result).not.toContain("cmd.exe");
+    });
+
+    it("preserves -f string format operator (single-quoted PowerShell string)", () => {
+      // PowerShell typically uses single quotes for strings with -f; double-quoted
+      // wrapping around the -Command value is handled correctly by the tokenizer.
+      const script = "'Result: {0}' -f (1 + 2)";
+      const result = buildNodeShellCommand(`powershell -Command "${script}"`, "win32");
+      expect(result).toContain(script);
+    });
+  });
+});

--- a/src/infra/node-shell.ts
+++ b/src/infra/node-shell.ts
@@ -1,8 +1,63 @@
+/**
+ * Tokenize a Windows-style command line string into an argv array, respecting
+ * double-quoted segments.  Quotes are stripped (the content is preserved), so
+ * the resulting strings can be passed directly to spawn() without any further
+ * shell interpretation.
+ *
+ * This is intentionally minimal: it handles the common pattern of
+ *   powershell.exe -NoProfile -Command "..."
+ * well enough to bypass cmd.exe wrapping (#35807).  It does not attempt to
+ * replicate the full Windows CommandLineToArgvW semantics (e.g. escaped quotes
+ * inside quoted strings are not handled).
+ */
+function tokenizeWindowsCommandLine(cmd: string): string[] {
+  const args: string[] = [];
+  let current = "";
+  let inQuotes = false;
+  for (const ch of cmd) {
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+    } else if (ch === " " && !inQuotes) {
+      if (current.length > 0) {
+        args.push(current);
+        current = "";
+      }
+    } else {
+      current += ch;
+    }
+  }
+  if (current.length > 0) {
+    args.push(current);
+  }
+  return args;
+}
+
+/** Returns true when the first token of `command` is a PowerShell executable. */
+function startsWithPowerShell(command: string): boolean {
+  const firstToken = command.trimStart().split(/[\s"]/)[0] ?? "";
+  const normalized = firstToken.toLowerCase().replace(/\.exe$/, "");
+  return normalized === "powershell" || normalized === "pwsh";
+}
+
 export function buildNodeShellCommand(command: string, platform?: string | null) {
   const normalized = String(platform ?? "")
     .trim()
     .toLowerCase();
   if (normalized.startsWith("win")) {
+    // When the agent explicitly invokes PowerShell, bypass cmd.exe entirely.
+    // cmd.exe's /d /s /c processing mangles PowerShell-specific syntax:
+    //   - $pipeline_var ($_ etc.) is interpreted as a cmd variable
+    //   - | is treated as a cmd pipe, splitting the command unexpectedly
+    //   - backticks and the -f format operator fail with parse errors
+    // By tokenizing the command and spawning PowerShell directly we avoid all
+    // of these issues while keeping the standard cmd.exe path for everything
+    // else.  Fixes #35807.
+    if (startsWithPowerShell(command)) {
+      const argv = tokenizeWindowsCommandLine(command.trim());
+      if (argv.length > 0) {
+        return argv;
+      }
+    }
     return ["cmd.exe", "/d", "/s", "/c", command];
   }
   return ["/bin/sh", "-lc", command];


### PR DESCRIPTION
Fixes #35807

## Problem

On Windows, the exec tool wraps all commands with `cmd.exe /d /s /c "..."`. When the command is an explicit PowerShell invocation, `cmd.exe` corrupts PowerShell-specific syntax **before** PowerShell ever sees it:

| Syntax | What cmd.exe does |
|--------|-------------------|
| `$_` pipeline variables | Stripped or expanded as cmd variables |
| `\|` in `-Command "..."` | Treated as a cmd pipe, splitting the command |
| Backticks | Interpreted as escape sequences |
| `-f` format operator | Parse errors due to quote mangling via `/s` |

The `/s /c` combination strips the outer quotes of the command string, then cmd.exe re-parses the result — destroying PowerShell semantics at the process boundary.

## Root Cause

`buildNodeShellCommand` in `src/infra/node-shell.ts` always produces `["cmd.exe", "/d", "/s", "/c", command]` on Windows:

```typescript
if (normalized.startsWith("win")) {
  return ["cmd.exe", "/d", "/s", "/c", command];  // ← wraps everything through cmd
}
```

## Fix

When the first token of the command is `powershell`, `pwsh`, `powershell.exe`, or `pwsh.exe` (case-insensitive), skip the `cmd.exe` wrapper and build an argv array directly using a minimal Windows-style double-quote-aware tokenizer:

```typescript
// e.g. 'powershell -NoProfile -Command "Get-Process | Where-Object {$_.CPU -gt 10}"'
// becomes: ["powershell", "-NoProfile", "-Command", "Get-Process | Where-Object {$_.CPU -gt 10}"]
```

The quoted `-Command "..."` argument becomes a single argv element passed to `spawn()`, which the OS delivers verbatim to PowerShell — no cmd.exe interpretation in the way.

All other Windows commands (cmd, ipconfig, etc.) continue to use `cmd.exe /d /s /c` unchanged.

## Workaround (before this fix)

Write the command to a `.ps1` file and execute with `powershell -File script.ps1` — adds 2–3 extra tool calls per operation.

## Tests

Adds `src/infra/node-shell.test.ts` covering:
- POSIX (linux, darwin, no-platform) paths — all use `/bin/sh -lc`
- Windows non-PowerShell commands — use `cmd.exe /d /s /c`
- Windows PowerShell: direct spawn without cmd.exe wrapper
- Quoted `-Command "..."` tokenized correctly (preserves `|`, `$_`, `-f`)
- `pwsh`, `.exe` variants, case-insensitive detection
