### PR TITLE
fix(system-prompt): include channel messageToolHints in minimal mode

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -105,6 +105,14 @@ describe("buildAgentSystemPrompt", () => {
       docsPath: "/tmp/openclaw/docs",
       extraSystemPrompt: "Subagent details",
       ttsHint: "Voice (TTS) is enabled.",
+      // No runtime channel → no channel-specific messageToolHints to include.
+      runtimeInfo: {
+        host: "test",
+        os: "test",
+        arch: "x64",
+        node: "v0.0.0",
+        model: "test/test",
+      },
     });
 
     expect(prompt).not.toContain("## Authorized Senders");
@@ -113,11 +121,14 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain("## Memory Recall");
     expect(prompt).not.toContain("## Documentation");
     expect(prompt).not.toContain("## Reply Tags");
+    // Minimal mode suppresses the full Messaging section but may still include
+    // channel-specific formatting hints when provided.
     expect(prompt).not.toContain("## Messaging");
     expect(prompt).not.toContain("## Voice (TTS)");
     expect(prompt).not.toContain("## Silent Replies");
     expect(prompt).not.toContain("## Heartbeats");
     expect(prompt).toContain("## Safety");
+    expect(prompt).not.toContain("## Channel Formatting");
     expect(prompt).toContain(
       "For long waits, avoid rapid poll loops: use exec with enough yieldMs or process(action=poll, timeout=<ms>).",
     );
@@ -144,6 +155,28 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("## Skills (mandatory)");
     expect(prompt).toContain("<available_skills>");
+  });
+
+  it("includes channel formatting hints in minimal prompt mode when messageToolHints are provided", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "minimal",
+      toolNames: ["message"],
+      messageToolHints: ["", "### Synology Chat Formatting", "- No markdown"],
+      runtimeInfo: {
+        host: "test",
+        os: "test",
+        arch: "x64",
+        node: "v0.0.0",
+        model: "test/test",
+        channel: "synology-chat",
+      },
+    });
+
+    expect(prompt).toContain("## Channel Formatting");
+    expect(prompt).toContain("### Synology Chat Formatting");
+    expect(prompt).toContain("- No markdown");
+    expect(prompt).not.toContain("## Messaging");
   });
 
   it("omits skills in minimal prompt mode when skillsPrompt is absent", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -124,9 +124,17 @@ function buildMessagingSection(params: {
   runtimeChannel?: string;
   messageToolHints?: string[];
 }) {
+  // Minimal prompts (subagents + some cron sessions) still need channel-specific
+  // formatting guidance; otherwise completion messages may be delivered with the
+  // wrong markup for the channel.
   if (params.isMinimal) {
-    return [];
+    const hints = (params.messageToolHints ?? []).map((line) => line.trim()).filter(Boolean);
+    if (hints.length === 0) {
+      return [];
+    }
+    return ["## Channel Formatting", ...hints, ""];
   }
+
   return [
     "## Messaging",
     "- Reply in current session → automatically routes to the source channel (Signal, Telegram, etc.)",


### PR DESCRIPTION
Closes #35795

### What changed
- Minimal (subagent/cron) system prompts now include channel-specific `messageToolHints` as a small `## Channel Formatting` section when available.
- This helps subagents format their completion messages correctly for channels that don't support Markdown (e.g. Synology Chat, Campfire-style HTML).

### Why
Subagent sessions run in minimal prompt mode, which previously suppressed the entire Messaging section (including messageToolHints), so completion messages were produced in raw Markdown.

### Validation
- npm test -- --run src/agents/system-prompt.test.ts
- npm test -- --run src/agents/subagent-announce-dispatch.test.ts
- npm test -- --run src/agents/subagent-announce-queue.test.ts
- npm test -- --run src/agents/system-prompt-stability.test.ts
- npm test -- --run src/agents/system-prompt-params.test.ts
