### PR TITLE
fix(plugins): guard null group.name and friend.displayName in zalouser

### DIFF
--- a/extensions/zalouser/src/channel.ts
+++ b/extensions/zalouser/src/channel.ts
@@ -489,7 +489,7 @@ export const zalouserPlugin: ChannelPlugin<ResolvedZalouserAccount> = {
           } else {
             const groups = await listZaloGroupsMatching(account.profile, trimmed);
             const best =
-              groups.find((group) => group.name.toLowerCase() === trimmed.toLowerCase()) ??
+              groups.find((group) => (group.name ?? "").toLowerCase() === trimmed.toLowerCase()) ??
               groups[0];
             results.push({
               input,

--- a/extensions/zalouser/src/zalo-js.ts
+++ b/extensions/zalouser/src/zalo-js.ts
@@ -722,7 +722,7 @@ export async function listZaloGroupsMatching(
   }
   return groups.filter((group) => {
     const id = group.groupId.toLowerCase();
-    const name = group.name.toLowerCase();
+    const name = (group.name ?? "").toLowerCase();
     return id.includes(q) || name.includes(q);
   });
 }
@@ -1326,7 +1326,7 @@ export async function resolveZaloGroupsByEntries(params: {
   const groups = await listZaloGroups(params.profile);
   const byName = new Map<string, ZaloGroup[]>();
   for (const group of groups) {
-    const key = group.name.trim().toLowerCase();
+    const key = (group.name ?? "").trim().toLowerCase();
     if (!key) {
       continue;
     }
@@ -1356,7 +1356,7 @@ export async function resolveZaloAllowFromEntries(params: {
   const friends = await listZaloFriends(params.profile);
   const byName = new Map<string, ZcaFriend[]>();
   for (const friend of friends) {
-    const key = friend.displayName.trim().toLowerCase();
+    const key = (friend.displayName ?? "").trim().toLowerCase();
     if (!key) {
       continue;
     }


### PR DESCRIPTION
## Summary

The Zalo API can return `null` for `group.name` and `friend.displayName` fields. Four call sites called `.trim().toLowerCase()` or `.toLowerCase()` directly on these nullable values, causing `TypeError: Cannot read properties of null (reading 'trim')` crashes:

1. **`resolveZaloGroupsByEntries`** — `group.name.trim().toLowerCase()` on line 1329
2. **`resolveZaloAllowFromEntries`** — `friend.displayName.trim().toLowerCase()` on line 1359
3. **channel directory lookup** — `group.name.toLowerCase()` in a `.find()` callback on line 492
4. **`listZaloGroupsMatching`** — `group.name.toLowerCase()` in a `.filter()` callback on line 725

All four now use nullish coalescing `(value ?? "")` before string operations.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — Zalo API data contains nullable string fields.

## User-Visible Changes

Zalo group resolution and friend lookup no longer crash when the API returns null for name/displayName fields. Groups/friends with null names are gracefully skipped or matched by ID.

## Security Impact

1. Does this change handle user input? **No** — only API response data
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 40 zalouser tests pass (7 passing test files; 5 files fail due to pre-existing missing zca-js dependency)
- [x] Formatted with oxfmt

## Evidence

\`\`\`
 Test Files  7 passed (12)
      Tests  40 passed (40)
\`\`\`

## Human Verification

- Create a Zalo group with no name -> group resolution should skip it instead of crashing
- Have a friend with null displayName -> friend resolution should skip instead of crashing
- Search for groups with listZaloGroupsMatching when some groups have null names -> filter should work without crashing

## Compatibility

Fully backward compatible. Non-null names behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| None | Null names are skipped via empty-string fallback |