### PR TITLE
fix: improve WhatsApp allowFrom mismatch error

### DIFF
--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -136,7 +136,18 @@ describe("resolveWhatsAppOutboundTarget", () => {
 
     it("denies message when target is not in allowList", () => {
       mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
-      expectDeniedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "implicit" });
+      const result = resolveWhatsAppOutboundTarget({
+        to: PRIMARY_TARGET,
+        allowFrom: [SECONDARY_TARGET],
+        mode: "implicit",
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) {
+        throw new Error("expected resolution to fail");
+      }
+      expect(result.error.message).toContain(
+        `Target "${PRIMARY_TARGET}" is not listed in the configured WhatsApp allowFrom policy.`,
+      );
     });
 
     it("handles mixed numeric and string allowList entries", () => {

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -41,7 +41,9 @@ export function resolveWhatsAppOutboundTarget(params: {
     }
     return {
       ok: false,
-      error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+      error: new Error(
+        `Target "${trimmed}" is not listed in the configured WhatsApp allowFrom policy.`,
+      ),
     };
   }
 


### PR DESCRIPTION
## Summary
Improve outbound WhatsApp error messaging when a direct target is valid but not permitted by llowFrom.

## Changes
- Keep existing <E.164|group JID> error for missing/invalid 	o
- Return a specific policy error when target is blocked by llowFrom
- Add/adjust test assertion to verify the new message

## Testing
- npm exec vitest run src/whatsapp/resolve-outbound-target.test.ts

Fixes #35580