### PR TITLE
fix(gateway): wrap decodeURIComponent in try-catch for URL/URI parsing

### DIFF
--- a/extensions/matrix/src/matrix/monitor/location.ts
+++ b/extensions/matrix/src/matrix/monitor/location.ts
@@ -51,7 +51,15 @@ function parseGeoUri(value: string): GeoUriParams | null {
       continue;
     }
     const valuePart = rawValue.trim();
-    params.set(key, valuePart ? decodeURIComponent(valuePart) : "");
+    let decodedValue = valuePart;
+    if (valuePart) {
+      try {
+        decodedValue = decodeURIComponent(valuePart);
+      } catch {
+        // malformed percent-encoding; keep raw value
+      }
+    }
+    params.set(key, decodedValue);
   }
 
   const accuracyRaw = params.get("u");

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -149,7 +149,13 @@ function mapContainerWorkspaceFileUrl(params: {
   }
   // Sandbox paths are Linux-style (/workspace/*). Parse the URL path directly so
   // Windows hosts can still accept file:///workspace/... media references.
-  const normalizedPathname = decodeURIComponent(parsed.pathname).replace(/\\/g, "/");
+  let decodedPathname: string;
+  try {
+    decodedPathname = decodeURIComponent(parsed.pathname);
+  } catch {
+    return undefined;
+  }
+  const normalizedPathname = decodedPathname.replace(/\\/g, "/");
   if (
     normalizedPathname !== SANDBOX_CONTAINER_WORKDIR &&
     !normalizedPathname.startsWith(`${SANDBOX_CONTAINER_WORKDIR}/`)

--- a/src/canvas-host/file-resolver.ts
+++ b/src/canvas-host/file-resolver.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 import { SafeOpenError, openFileWithinRoot, type SafeOpenResult } from "../infra/fs-safe.js";
 
 export function normalizeUrlPath(rawPath: string): string {
-  const decoded = decodeURIComponent(rawPath || "/");
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(rawPath || "/");
+  } catch {
+    decoded = rawPath || "/";
+  }
   const normalized = path.posix.normalize(decoded);
   return normalized.startsWith("/") ? normalized : `/${normalized}`;
 }


### PR DESCRIPTION
## Summary

Three unguarded `decodeURIComponent()` calls that throw `URIError` on malformed percent-encoded sequences (e.g., `%ZZ`, `%G1`):

1. **`src/canvas-host/file-resolver.ts`** — `normalizeUrlPath` decoded the raw HTTP request path without `try-catch`. Malformed URLs (e.g., `/%ZZfoo`) crash the canvas host server with `URIError: URI malformed`. Now falls back to the raw path.

2. **`extensions/matrix/src/matrix/monitor/location.ts`** — geo URI parameter values were decoded without `try-catch`. Malformed location payloads crash the Matrix monitor. Now falls back to the raw parameter value.

3. **`src/agents/sandbox-paths.ts`** — file URL pathnames from agent media references were decoded without `try-catch`. Malformed `file://` URLs crash media resolution. Now returns `undefined` (rejected) for undecodable paths.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [x] Gateway
- [x] Security

## Linked Issues

Proactive defensive fix — follows pattern from PR #35701.

## User-Visible Changes

- Canvas host no longer crashes on malformed URL paths
- Matrix location parsing no longer crashes on malformed geo URI parameters
- Sandbox media resolution rejects malformed file URLs gracefully

## Security Impact

1. Does this change handle user input? **Yes** — URL paths and URI parameters from external sources
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **Yes** — sandbox-paths.ts now rejects malformed file URLs instead of crashing, improving security posture

## Verification

- [x] All 7 canvas-host tests pass
- [x] All 20 sandbox-paths tests pass
- [x] Formatted with `oxfmt`

## Evidence

```
 ✓ src/canvas-host/ (7 tests)
 ✓ src/agents/sandbox-paths.test.ts (20 tests)
```

## Human Verification

- Send a request with `%ZZ` in the URL path to canvas host → should serve 404 instead of crashing
- Send a geo URI with `u=%ZZ` in Matrix → should parse without crashing
- Reference a file URL with `file:///workspace/foo%ZZbar` → should return undefined

## Compatibility

Fully backward compatible. Valid percent-encoded sequences behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Raw (undecoded) path may differ from expected | Only triggered by already-invalid input; degraded behavior is better than crash |