### PR TITLE
Fix: Windows node onboarding UX improvements

### DIFF
--- a/src/cli/node-cli/daemon.ts
+++ b/src/cli/node-cli/daemon.ts
@@ -12,6 +12,7 @@ import {
 import { resolveGatewayLogPaths } from "../../daemon/launchd.js";
 import { resolveNodeService } from "../../daemon/node-service.js";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
+import { trimToUndefined } from "../../gateway/credentials.js";
 import { loadNodeHostConfig } from "../../node-host/config.js";
 import { defaultRuntime } from "../../runtime.js";
 import { colorize } from "../../terminal/theme.js";
@@ -41,6 +42,7 @@ type NodeDaemonInstallOptions = {
   tlsFingerprint?: string;
   nodeId?: string;
   displayName?: string;
+  token?: string;
   runtime?: string;
   force?: boolean;
   json?: boolean;
@@ -150,6 +152,10 @@ export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
 
   const tlsFingerprint = opts.tlsFingerprint?.trim() || config?.gateway?.tlsFingerprint;
   const tls = Boolean(opts.tls) || Boolean(tlsFingerprint) || Boolean(config?.gateway?.tls);
+  const token =
+    trimToUndefined(opts.token) ??
+    trimToUndefined(process.env.OPENCLAW_GATEWAY_TOKEN) ??
+    trimToUndefined(process.env.CLAWDBOT_GATEWAY_TOKEN);
   const { programArguments, workingDirectory, environment, description } =
     await buildNodeInstallPlan({
       env: process.env,
@@ -159,6 +165,7 @@ export async function runNodeDaemonInstall(opts: NodeDaemonInstallOptions) {
       tlsFingerprint: tlsFingerprint || undefined,
       nodeId: opts.nodeId,
       displayName: opts.displayName,
+      token,
       runtime: runtimeRaw,
       warn: (message) => {
         if (json) {

--- a/src/cli/node-cli/register.ts
+++ b/src/cli/node-cli/register.ts
@@ -43,6 +43,7 @@ export function registerNodeCli(program: Command) {
     .option("--port <port>", "Gateway port")
     .option("--tls", "Use TLS for the gateway connection", false)
     .option("--tls-fingerprint <sha256>", "Expected TLS certificate fingerprint (sha256)")
+    .option("--token <token>", "Gateway token override for service auth")
     .option("--node-id <id>", "Override node id (clears pairing token)")
     .option("--display-name <name>", "Override node display name")
     .action(async (opts) => {

--- a/src/cli/nodes-cli/cli-utils.test.ts
+++ b/src/cli/nodes-cli/cli-utils.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+const defaultRuntime = {
+  error: vi.fn(),
+  exit: vi.fn(),
+};
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime,
+}));
+
+const { runNodesCommand } = await import("./cli-utils.js");
+
+describe("runNodesCommand", () => {
+  it("hints where to inspect pairing requests", async () => {
+    defaultRuntime.error.mockClear();
+    defaultRuntime.exit.mockClear();
+
+    await runNodesCommand("status", async () => {
+      throw new Error("Pairing required: requestId: 3f3d");
+    });
+
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(defaultRuntime.error).toHaveBeenCalledWith(
+      expect.stringContaining("nodes status failed: Error: Pairing required: requestId: 3f3d"),
+    );
+    expect(defaultRuntime.error).toHaveBeenCalledWith(
+      expect.stringContaining("openclaw devices list"),
+    );
+  });
+});

--- a/src/cli/nodes-cli/cli-utils.ts
+++ b/src/cli/nodes-cli/cli-utils.ts
@@ -3,6 +3,13 @@ import { isRich, theme } from "../../terminal/theme.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { unauthorizedHintForMessage } from "./rpc.js";
 
+function resolvePairingRequiredHint(message: string): string | null {
+  if (!/pairing required/i.test(message)) {
+    return null;
+  }
+  return "Pairing required. Run `openclaw devices list` to inspect pending pairing requests.";
+}
+
 export function getNodesTheme() {
   const rich = isRich();
   const color = (fn: (value: string) => string) => (value: string) => (rich ? fn(value) : value);
@@ -21,6 +28,10 @@ export function runNodesCommand(label: string, action: () => Promise<void>) {
     const message = String(err);
     const { error, warn } = getNodesTheme();
     defaultRuntime.error(error(`nodes ${label} failed: ${message}`));
+    const pairingHint = resolvePairingRequiredHint(message);
+    if (pairingHint) {
+      defaultRuntime.error(warn(pairingHint));
+    }
     const hint = unauthorizedHintForMessage(message);
     if (hint) {
       defaultRuntime.error(warn(hint));

--- a/src/commands/node-daemon-install-helpers.ts
+++ b/src/commands/node-daemon-install-helpers.ts
@@ -25,6 +25,7 @@ export async function buildNodeInstallPlan(params: {
   nodeId?: string;
   displayName?: string;
   runtime: NodeDaemonRuntime;
+  token?: string;
   devMode?: boolean;
   nodePath?: string;
   warn?: DaemonInstallWarnFn;
@@ -56,7 +57,7 @@ export async function buildNodeInstallPlan(params: {
     title: "Node daemon runtime",
   });
 
-  const environment = buildNodeServiceEnvironment({ env: params.env });
+  const environment = buildNodeServiceEnvironment({ env: params.env, token: params.token });
   const description = formatNodeServiceDescription({
     version: environment.OPENCLAW_SERVICE_VERSION,
   });

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -375,6 +375,26 @@ describe("buildNodeServiceEnvironment", () => {
     expect(env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
   });
 
+  it("prefers explicit token over OPENCLAW_GATEWAY_TOKEN for node services", () => {
+    const env = buildNodeServiceEnvironment({
+      env: { HOME: "/home/user", OPENCLAW_GATEWAY_TOKEN: "env-token" },
+      token: "explicit-token",
+    });
+    expect(env.OPENCLAW_GATEWAY_TOKEN).toBe("explicit-token");
+  });
+
+  it("falls back to OPENCLAW_GATEWAY_TOKEN when explicit token is empty", () => {
+    const env = buildNodeServiceEnvironment({
+      env: {
+        HOME: "/home/user",
+        OPENCLAW_GATEWAY_TOKEN: "env-token",
+        CLAWDBOT_GATEWAY_TOKEN: "legacy-token",
+      },
+      token: "   ",
+    });
+    expect(env.OPENCLAW_GATEWAY_TOKEN).toBe("env-token");
+  });
+
   it("forwards proxy environment variables for node services", () => {
     const env = buildNodeServiceEnvironment({
       env: {

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -1,5 +1,6 @@
 import os from "node:os";
 import path from "node:path";
+import { trimToUndefined } from "../gateway/credentials.js";
 import { VERSION } from "../version.js";
 import {
   GATEWAY_SERVICE_KIND,
@@ -270,13 +271,16 @@ export function buildServiceEnvironment(params: {
 
 export function buildNodeServiceEnvironment(params: {
   env: Record<string, string | undefined>;
+  token?: string;
   platform?: NodeJS.Platform;
 }): Record<string, string | undefined> {
-  const { env } = params;
+  const { env, token } = params;
   const platform = params.platform ?? process.platform;
   const sharedEnv = resolveSharedServiceEnvironmentFields(env, platform);
   const gatewayToken =
-    env.OPENCLAW_GATEWAY_TOKEN?.trim() || env.CLAWDBOT_GATEWAY_TOKEN?.trim() || undefined;
+    trimToUndefined(token) ??
+    trimToUndefined(env.OPENCLAW_GATEWAY_TOKEN) ??
+    trimToUndefined(env.CLAWDBOT_GATEWAY_TOKEN);
   return {
     ...buildCommonServiceEnvironment(env, sharedEnv),
     OPENCLAW_GATEWAY_TOKEN: gatewayToken,

--- a/src/node-host/config.ts
+++ b/src/node-host/config.ts
@@ -60,6 +60,9 @@ export async function saveNodeHostConfig(config: NodeHostConfig): Promise<void> 
 
 export async function ensureNodeHostConfig(): Promise<NodeHostConfig> {
   const existing = await loadNodeHostConfig();
+  if (existing) {
+    return existing;
+  }
   const normalized = normalizeConfig(existing);
   await saveNodeHostConfig(normalized);
   return normalized;

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -191,25 +191,39 @@ export async function resolveNodeHostGatewayCredentials(params: {
 }
 
 export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
-  const config = await ensureNodeHostConfig();
+  const existingConfig = await loadNodeHostConfig();
+  const config = existingConfig ?? (await ensureNodeHostConfig());
+  let shouldPersistConfig = existingConfig == null;
+  const cfg = loadConfig();
+
   const nodeId = opts.nodeId?.trim() || config.nodeId;
   if (nodeId !== config.nodeId) {
     config.nodeId = nodeId;
+    shouldPersistConfig = true;
   }
   const displayName =
     opts.displayName?.trim() || config.displayName || (await getMachineDisplayName());
-  config.displayName = displayName;
+  if (displayName !== config.displayName) {
+    config.displayName = displayName;
+    shouldPersistConfig = true;
+  }
 
   const gateway: NodeHostGatewayConfig = {
     host: opts.gatewayHost,
     port: opts.gatewayPort,
-    tls: opts.gatewayTls ?? loadConfig().gateway?.tls?.enabled ?? false,
+    tls: opts.gatewayTls ?? cfg.gateway?.tls?.enabled ?? false,
     tlsFingerprint: opts.gatewayTlsFingerprint,
   };
-  config.gateway = gateway;
-  await saveNodeHostConfig(config);
+  if (
+    config.gateway?.host !== gateway.host ||
+    config.gateway?.port !== gateway.port ||
+    config.gateway?.tls !== gateway.tls ||
+    config.gateway?.tlsFingerprint !== gateway.tlsFingerprint
+  ) {
+    config.gateway = gateway;
+    shouldPersistConfig = true;
+  }
 
-  const cfg = loadConfig();
   const resolvedBrowser = resolveBrowserConfig(cfg.browser, cfg);
   const browserProxyEnabled =
     cfg.nodeHost?.browserProxy?.enabled !== false && resolvedBrowser.enabled;
@@ -217,6 +231,13 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
     config: cfg,
     env: process.env,
   });
+  if (token !== undefined && token !== config.token) {
+    config.token = token;
+    shouldPersistConfig = true;
+  }
+  if (shouldPersistConfig) {
+    await saveNodeHostConfig(config);
+  }
 
   const host = gateway.host ?? "127.0.0.1";
   const port = gateway.port ?? 18789;
@@ -264,8 +285,21 @@ export async function runNodeHost(opts: NodeHostRunOptions): Promise<void> {
       console.error(`node host gateway connect failed: ${err.message}`);
     },
     onClose: (code, reason) => {
+      const reasonText = String(reason ?? "");
       // eslint-disable-next-line no-console
-      console.error(`node host gateway closed (${code}): ${reason}`);
+      console.error(`node host gateway closed (${code}): ${reasonText}`);
+      if (/pairing required/i.test(reasonText)) {
+        // eslint-disable-next-line no-console
+        console.error(
+          "Pairing required. Run `openclaw devices list` to check pending requests, then approve from that output.",
+        );
+      }
+      if (/gateway token mismatch/i.test(reasonText)) {
+        // eslint-disable-next-line no-console
+        console.error(
+          "Hint: verify OPENCLAW_GATEWAY_TOKEN / --token passed to openclaw node install and restart the node host.",
+        );
+      }
     },
   });
 


### PR DESCRIPTION

## Summary
- Add --token flag to "openclaw node install" command for gateway token
- Make node restart preserve token from environment/config instead of overwriting
- Add helpful error hints when pairing required or token mismatch occurs
- Improve existing config handling to not overwrite on every run

## Security Impact
- N/A

## Repro+Verification
- Fresh Windows node install should accept --token flag
- Node restart should not overwrite node.json token
- Pairing required error should hint to run "openclaw devices list"
- Token mismatch error should hint about OPENCLAW_GATEWAY_TOKEN

## Testing
- pnpm test src/daemon/service-env.test.ts - passed
- pnpm test src/cli/nodes-cli/cli-utils.test.ts - passed

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35796
