### PR TITLE
fix(whatsapp): clarify allowFrom target rejection error

### DIFF
--- a/src/channels/plugins/plugins-channel.test.ts
+++ b/src/channels/plugins/plugins-channel.test.ts
@@ -167,6 +167,9 @@ describe("whatsappOutbound.resolveTarget", () => {
     });
 
     expectWhatsAppTargetResolutionError(result);
+    expect(result?.error.message).toBe(
+      'Target "+15550000000" is not listed in the configured WhatsApp allowFrom policy.',
+    );
   });
 
   it("keeps group JID targets even when allowFrom does not contain them", () => {

--- a/src/channels/plugins/plugins-channel.test.ts
+++ b/src/channels/plugins/plugins-channel.test.ts
@@ -167,7 +167,10 @@ describe("whatsappOutbound.resolveTarget", () => {
     });
 
     expectWhatsAppTargetResolutionError(result);
-    expect(result?.error.message).toBe(
+    if (!result || result.ok) {
+      throw new Error("expected WhatsApp target resolution to fail");
+    }
+    expect(result.error.message).toBe(
       'Target "+15550000000" is not listed in the configured WhatsApp allowFrom policy.',
     );
   });

--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -20,6 +20,15 @@ function expectResolutionError(params: ResolveParams) {
   expect(result.error.message).toContain("WhatsApp");
 }
 
+function expectResolutionErrorMessage(params: ResolveParams, expectedMessage: string) {
+  const result = resolveWhatsAppOutboundTarget(params);
+  expect(result.ok).toBe(false);
+  if (result.ok) {
+    throw new Error("expected resolution to fail");
+  }
+  expect(result.error.message).toBe(expectedMessage);
+}
+
 function expectResolutionOk(params: ResolveParams, expectedTarget: string) {
   const result = resolveWhatsAppOutboundTarget(params);
   expect(result).toEqual({ ok: true, to: expectedTarget });
@@ -136,7 +145,14 @@ describe("resolveWhatsAppOutboundTarget", () => {
 
     it("denies message when target is not in allowList", () => {
       mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
-      expectDeniedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "implicit" });
+      expectResolutionErrorMessage(
+        {
+          to: PRIMARY_TARGET,
+          allowFrom: [SECONDARY_TARGET],
+          mode: "implicit",
+        },
+        `Target "${PRIMARY_TARGET}" is not listed in the configured WhatsApp allowFrom policy.`,
+      );
     });
 
     it("handles mixed numeric and string allowList entries", () => {

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -6,7 +6,9 @@ export type WhatsAppOutboundTargetResolution =
   | { ok: false; error: Error };
 
 function whatsappAllowFromPolicyError(rawTarget: string): Error {
-  return new Error(`Target "${rawTarget}" is not listed in the configured WhatsApp allowFrom policy.`);
+  return new Error(
+    `Target "${rawTarget}" is not listed in the configured WhatsApp allowFrom policy.`,
+  );
 }
 
 export function resolveWhatsAppOutboundTarget(params: {

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -5,6 +5,10 @@ export type WhatsAppOutboundTargetResolution =
   | { ok: true; to: string }
   | { ok: false; error: Error };
 
+function whatsappAllowFromPolicyError(rawTarget: string): Error {
+  return new Error(`Target "${rawTarget}" is not listed in the configured WhatsApp allowFrom policy.`);
+}
+
 export function resolveWhatsAppOutboundTarget(params: {
   to: string | null | undefined;
   allowFrom: Array<string | number> | null | undefined;
@@ -41,7 +45,7 @@ export function resolveWhatsAppOutboundTarget(params: {
     }
     return {
       ok: false,
-      error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+      error: whatsappAllowFromPolicyError(trimmed),
     };
   }
 


### PR DESCRIPTION
## Summary
- return a specific error when WhatsApp target is valid but blocked by allowFrom
- keep the existing missing-target error for empty/invalid targets
- add regression tests for the new allowFrom rejection message

## Testing
- PATH="/opt/homebrew/bin:$PATH" pnpm exec vitest run src/whatsapp/resolve-outbound-target.test.ts src/channels/plugins/plugins-channel.test.ts --config vitest.unit.config.ts

Closes #35580