### PR TITLE
fix(agents): inject messageToolHints into sub-agent prompts in minimal mode

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -155,6 +155,35 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain("## Skills");
   });
 
+  it("injects messageToolHints under Platform Formatting in minimal mode (refs #35795)", () => {
+    // Sub-agents (promptMode="minimal") must still receive channel-specific formatting
+    // hints so their completion messages respect the channel's requirements.
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "minimal",
+      messageToolHints: ["Output HTML, not Markdown.", "Wrap links with <a href=...>."],
+      toolNames: ["message"],
+    });
+
+    expect(prompt).toContain("## Platform Formatting");
+    expect(prompt).toContain("Output HTML, not Markdown.");
+    expect(prompt).toContain("Wrap links with <a href=...>.");
+    // The full Messaging section should still be suppressed.
+    expect(prompt).not.toContain("## Messaging");
+  });
+
+  it("omits Platform Formatting section when messageToolHints is empty in minimal mode", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "minimal",
+      messageToolHints: [],
+      toolNames: ["message"],
+    });
+
+    expect(prompt).not.toContain("## Platform Formatting");
+    expect(prompt).not.toContain("## Messaging");
+  });
+
   it("includes safety guardrails in full prompts", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -125,7 +125,16 @@ function buildMessagingSection(params: {
   messageToolHints?: string[];
 }) {
   if (params.isMinimal) {
-    return [];
+    // Sub-agents still need to know about channel-specific formatting requirements
+    // (e.g. "output HTML, not Markdown" for Campfire/Synology Chat) even though the
+    // full messaging section is suppressed in minimal mode.  Without these hints the
+    // sub-agent completes in raw Markdown regardless of what the channel expects.
+    // Refs #35795.
+    const hints = params.messageToolHints?.filter(Boolean) ?? [];
+    if (hints.length === 0) {
+      return [];
+    }
+    return ["## Platform Formatting", ...hints, ""];
   }
   return [
     "## Messaging",


### PR DESCRIPTION
Fixes #35795

## Problem

Sub-agents use `promptMode="minimal"`, which causes `buildMessagingSection` to return an empty array — suppressing the entire Messaging section including `messageToolHints`.

```typescript
// src/agents/system-prompt.ts — before this fix
if (params.isMinimal) {
  return [];  // ← messageToolHints discarded even when present
}
```

Because `messageToolHints` are never injected into sub-agent system prompts, the sub-agent has no knowledge of the channel's formatting requirements. It completes in raw Markdown regardless of whether the channel expects HTML (Campfire, Synology Chat), Mattermost wiki syntax, or any other non-Markdown format.

## Root Cause

`buildMessagingSection` treats `isMinimal` as a signal to skip **everything**, including the lightweight per-channel formatting hints that have nothing to do with routing or the `message` tool docs.

## Fix

Check for non-empty `messageToolHints` before the early-return in minimal mode. When hints are present, emit them under a concise `## Platform Formatting` section instead of the full `## Messaging` block:

```typescript
if (params.isMinimal) {
  const hints = params.messageToolHints?.filter(Boolean) ?? [];
  if (hints.length === 0) {
    return [];
  }
  return ["## Platform Formatting", ...hints, ""];
}
```

The full Messaging section (cross-session routing, `message` tool docs, inline-buttons guidance, etc.) continues to be suppressed in minimal mode.

## Tests

Two new cases in `system-prompt.test.ts`:

1. **`messageToolHints` present in minimal mode** → `## Platform Formatting` injected with the hint text; `## Messaging` still absent.
2. **`messageToolHints` empty in minimal mode** → no `## Platform Formatting` section; behaviour unchanged from before.
