### PR TITLE
fix(msteams): strip stray double-quote from Graph API messageId

### DIFF
--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -526,6 +526,18 @@ const GRAPH_URL_EXPECTATION_CASES: GraphUrlExpectationCase[] = [
     },
     expectedPath: "/chats/19%3Achat%40thread.v2/messages/456",
   }),
+  withLabel(
+    "strips trailing double-quote from messageId (ngrok DM attachment regression, refs #35822)",
+    {
+      params: {
+        conversationType: "groupChat" as const,
+        conversationId: "19:chat@thread.v2",
+        // Bot Framework / ngrok can inject a stray trailing " into the messageId
+        messageId: '1772701673666"',
+      },
+      expectedPath: "/chats/19%3Achat%40thread.v2/messages/1772701673666",
+    },
+  ),
 ];
 
 type GraphFetchMockOptions = {

--- a/extensions/msteams/src/attachments/graph.ts
+++ b/extensions/msteams/src/attachments/graph.ts
@@ -59,7 +59,15 @@ export function buildMSTeamsGraphMessageUrls(params: {
   const conversationType = params.conversationType?.trim().toLowerCase() ?? "";
   const messageIdCandidates = new Set<string>();
   const pushCandidate = (value: string | null | undefined) => {
-    const trimmed = typeof value === "string" ? value.trim() : "";
+    // Strip surrounding double-quote characters that can appear in Bot Framework
+    // activity messageId fields when using ngrok tunnels (#35822).
+    const trimmed =
+      typeof value === "string"
+        ? value
+            .trim()
+            .replace(/^"+|"+$/g, "")
+            .trim()
+        : "";
     if (trimmed) {
       messageIdCandidates.add(trimmed);
     }


### PR DESCRIPTION
Fixes #35822 (partial — addresses the `%22` messageId encoding issue)

## Problem

When using an ngrok tunnel, the Teams Bot Framework delivers a `messageId` with a stray trailing double-quote character, e.g. `1772701673666"`.

`buildMSTeamsGraphMessageUrls()` passes this value directly to `encodeURIComponent()`, producing a Graph API URL that ends with `%22`:

```
https://graph.microsoft.com/v1.0/chats/.../messages/1772701673666%22
                                                                  ^^^
```

Both `hostedStatus` and `attachmentStatus` return **404** because the URL is malformed.

## Root Cause

The `pushCandidate` helper in `attachments/graph.ts` trims whitespace but does not strip quote characters:

```typescript
const trimmed = typeof value === "string" ? value.trim() : "";
//                                                 ^^^^^^ whitespace only
```

## Fix

Strip any leading/trailing double-quote characters after the whitespace trim:

```typescript
const trimmed =
  typeof value === "string" ? value.trim().replace(/^"+|"+$/g, "").trim() : "";
```

This normalises `1772701673666"` → `1772701673666` before it reaches `encodeURIComponent`.

## Test

Added a regression test case to `GRAPH_URL_EXPECTATION_CASES`:

- Input `messageId: '1772701673666"'` (trailing quote, as seen with ngrok)
- Expected URL path: `/chats/.../messages/1772701673666` (no `%22`)

## Scope

This PR addresses only the trailing-quote / `%22` encoding issue.  
The chatId format mismatch (`a:xxx` vs `19:xxx@thread.v2`) described in the issue is a separate, more invasive fix that would require mapping Bot Framework conversation IDs to Graph API chat IDs.
