### PR TITLE
Fix: treat star-prefixed SYSTEM SID as trusted in Windows ACL parsing

### DIFF
--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -146,6 +146,13 @@ Successfully processed 1 files`;
       expect(entries[1].principal).toBe("S-1-5-21-1824257776-4070701511-781240313-1001");
     });
 
+    it("parses starred SYSTEM SID principals", () => {
+      const output = "C:\\test\\file.txt NT AUTHORITY\\*S-1-5-18:(F)";
+      const entries = parseIcaclsOutput(output, "C:\\test\\file.txt");
+      expect(entries).toHaveLength(1);
+      expect(entries[0].principal).toBe("NT AUTHORITY\\*S-1-5-18");
+    });
+
     it("ignores malformed ACL lines that contain ':' but no rights tokens", () => {
       const output = `C:\\test\\file.txt random:message
                      C:\\test\\file.txt BUILTIN\\Administrators:(F)`;
@@ -236,6 +243,16 @@ Successfully processed 1 files`;
       const env = { USERNAME: "TestUser", USERDOMAIN: "WORKGROUP" };
       const summary = summarizeWindowsAcl(entries, env);
       expect(summary.untrustedGroup).toHaveLength(1);
+    });
+  });
+
+  describe("summarizeWindowsAcl — starred SID trusted entries", () => {
+    it("classifies *S-1-5-18 as trusted", () => {
+      const entries = [aclEntry({ principal: "NT AUTHORITY\\*S-1-5-18" })];
+      const summary = summarizeWindowsAcl(entries);
+      expect(summary.trusted).toHaveLength(1);
+      expect(summary.untrustedWorld).toHaveLength(0);
+      expect(summary.untrustedGroup).toHaveLength(0);
     });
   });
 

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -42,7 +42,7 @@ const TRUSTED_BASE = new Set([
 const WORLD_SUFFIXES = ["\\users", "\\authenticated users"];
 const TRUSTED_SUFFIXES = ["\\administrators", "\\system", "\\système"];
 
-const SID_RE = /^s-\d+-\d+(-\d+)+$/i;
+const SID_RE = /^\*?s-\d+-\d+(-\d+)+$/i;
 const TRUSTED_SIDS = new Set([
   "s-1-5-18",
   "s-1-5-32-544",
@@ -89,6 +89,12 @@ function classifyPrincipal(
   trustedPrincipals: Set<string>,
 ): "trusted" | "world" | "group" {
   const normalized = normalize(principal);
+
+  const extractedSid = normalized.match(/s-\d+-\d+(?:-\d+)+/i)?.[0];
+  if (extractedSid && SID_RE.test(`*${extractedSid}`)) {
+    const sid = extractedSid.toLowerCase();
+    return TRUSTED_SIDS.has(sid) || trustedPrincipals.has(sid) ? "trusted" : "group";
+  }
 
   if (SID_RE.test(normalized)) {
     return TRUSTED_SIDS.has(normalized) || trustedPrincipals.has(normalized) ? "trusted" : "group";


### PR DESCRIPTION
## Summary
- Fix issue #35834: avoid false-positive writable ACL findings on localized Windows.
- Treat `*S-1-5-18` (SYSTEM SID with leading `*`) as trusted during ACL classification.
- Add regression tests for starred SYSTEM SID parsing and trust classification.

## Security Impact
- N/A

## Repro+Verification
- Reproduce security audit on localized Windows where ACL output contains starred SYSTEM SID tokens.
- Before: audit could report a false positive as if SYSTEM were untrusted/others-writable.
- After: SYSTEM SID entries are correctly recognized as trusted.

## Testing
- `pnpm test src/security/windows-acl.test.ts` (42 passed)

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35834
