### PR TITLE
fix(whatsapp): actionable error when target blocked by allowFrom policy (#35580)

### DIFF
--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -139,6 +139,25 @@ describe("resolveWhatsAppOutboundTarget", () => {
       expectDeniedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "implicit" });
     });
 
+    it("returns actionable allowFrom error when target is valid but not in allowList (#35580)", () => {
+      vi.mocked(normalize.normalizeWhatsAppTarget)
+        .mockReturnValueOnce(PRIMARY_TARGET)
+        .mockReturnValueOnce(SECONDARY_TARGET);
+      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
+
+      const result = resolveWhatsAppOutboundTarget({
+        to: PRIMARY_TARGET,
+        allowFrom: [SECONDARY_TARGET],
+        mode: "implicit",
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) {
+        throw new Error("expected error");
+      }
+      expect(result.error.message).toContain(PRIMARY_TARGET);
+      expect(result.error.message).toContain("allowFrom");
+    });
+
     it("handles mixed numeric and string allowList entries", () => {
       vi.mocked(normalize.normalizeWhatsAppTarget)
         .mockReturnValueOnce("+11234567890") // for 'to' param

--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -140,9 +140,13 @@ describe("resolveWhatsAppOutboundTarget", () => {
     });
 
     it("returns actionable allowFrom error when target is valid but not in allowList (#35580)", () => {
+      // allowFrom list normalization runs first (one call per entry),
+      // then the to-target is normalized.  With allowFrom: [SECONDARY_TARGET],
+      // normalizeWhatsAppTarget is called: (1) for SECONDARY_TARGET entry → PRIMARY_TARGET,
+      // (2) for the to-value → SECONDARY_TARGET (the normalizedTo used in the error message).
       vi.mocked(normalize.normalizeWhatsAppTarget)
-        .mockReturnValueOnce(PRIMARY_TARGET)
-        .mockReturnValueOnce(SECONDARY_TARGET);
+        .mockReturnValueOnce(PRIMARY_TARGET) // allowFrom[0] normalization
+        .mockReturnValueOnce(SECONDARY_TARGET); // to-value normalization → normalizedTo
       vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
 
       const result = resolveWhatsAppOutboundTarget({
@@ -154,7 +158,8 @@ describe("resolveWhatsAppOutboundTarget", () => {
       if (result.ok) {
         throw new Error("expected error");
       }
-      expect(result.error.message).toContain(PRIMARY_TARGET);
+      // Error message should use normalizedTo (the canonical E.164 form), not trimmed.
+      expect(result.error.message).toContain(SECONDARY_TARGET);
       expect(result.error.message).toContain("allowFrom");
     });
 

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -41,7 +41,10 @@ export function resolveWhatsAppOutboundTarget(params: {
     }
     return {
       ok: false,
-      error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+      error: new Error(
+        `Target "${trimmed}" is not listed in the configured WhatsApp allowFrom policy. ` +
+          `Add it to the allowFrom list in your openclaw.json to permit outbound messages to this number.`,
+      ),
     };
   }
 

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -42,7 +42,7 @@ export function resolveWhatsAppOutboundTarget(params: {
     return {
       ok: false,
       error: new Error(
-        `Target "${trimmed}" is not listed in the configured WhatsApp allowFrom policy. ` +
+        `Target "${normalizedTo}" is not listed in the configured WhatsApp allowFrom policy. ` +
           `Add it to the allowFrom list in your openclaw.json to permit outbound messages to this number.`,
       ),
     };


### PR DESCRIPTION
## Problem

When sending to a valid E.164 number that is not in the `allowFrom` config, the error returned is:

```
WhatsApp: <E.164|group JID>
```

This looks like a format-validation error, making users think their phone number format is wrong — when the real fix is simply adding the number to `allowFrom` in `openclaw.json`.

## Fix

Distinguish the two error paths:

1. **Invalid format** (`normalizeWhatsAppTarget` returns `null`) → keep the original `missingTargetError` with format hint
2. **Valid format, blocked by policy** → new actionable error:
   > `Target "+18585551234" is not listed in the configured WhatsApp allowFrom policy. Add it to the allowFrom list in your openclaw.json to permit outbound messages to this number.`

## Tests

Added a new test case `"returns actionable allowFrom error when target is valid but not in allowList (#35580)"` that asserts the error message contains both the blocked number and the word `allowFrom`.

All 22 existing WhatsApp outbound-target tests pass.

Closes #35580