### PR TITLE
Fix: scope ACP read path resolution for WSL Windows drive paths

### DIFF
--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -227,6 +227,20 @@ describe("resolvePermissionRequest", () => {
     });
   });
 
+  it("auto-approves read when rawInput Windows-style path maps to WSL workdir", async () => {
+    await expectAutoAllowWithoutPrompt({
+      request: {
+        toolCall: {
+          toolCallId: "tool-read-inside-cwd-wsl-windows-path",
+          title: "read: ignored-by-raw-input",
+          status: "pending",
+          rawInput: { path: "C:\\openclaw-acp-cwd\\docs\\security.md" },
+        },
+      },
+      cwd: "/mnt/c/openclaw-acp-cwd",
+    });
+  });
+
   it("auto-approves read when rawInput file URL resolves inside cwd", async () => {
     await expectAutoAllowWithoutPrompt({
       request: {

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -144,19 +144,48 @@ function resolveAbsoluteScopedPath(value: string, cwd: string): string | undefin
   if (!candidate) {
     return undefined;
   }
-  if (candidate.startsWith("file://")) {
+
+  const fileUrlPath = (() => {
+    if (!candidate.startsWith("file://")) {
+      return undefined;
+    }
     try {
-      const parsed = new URL(candidate);
-      candidate = decodeURIComponent(parsed.pathname || "");
+      return fileURLToPath(candidate);
     } catch {
       return undefined;
     }
+  })();
+  if (fileUrlPath !== undefined) {
+    candidate = fileUrlPath;
   }
-  if (candidate === "~") {
-    candidate = homedir();
-  } else if (candidate.startsWith("~/")) {
-    candidate = path.join(homedir(), candidate.slice(2));
+
+  if (candidate.startsWith("~")) {
+    if (candidate === "~") {
+      candidate = homedir();
+    } else if (candidate.startsWith("~/")) {
+      candidate = path.join(homedir(), candidate.slice(2));
+    }
   }
+  if (/^\/[a-zA-Z]:[\\/]/.test(candidate)) {
+    candidate = candidate.slice(1);
+  }
+
+  const windowsDriveMatch = /^[a-zA-Z]:[\\/](.*)/.exec(candidate);
+  if (!path.isAbsolute(candidate) && windowsDriveMatch && process.platform !== "win32") {
+    const mountMatch = /^\/mnt\/([a-zA-Z])(\/|$)/.exec(cwd);
+    const driveLetter = windowsDriveMatch[1]?.toLowerCase();
+    if (mountMatch && mountMatch[1]?.toLowerCase() === driveLetter) {
+      const afterDrive = windowsDriveMatch[2] ?? "";
+      candidate = `/mnt/${driveLetter}/${afterDrive.replaceAll("\\", "/").replace(/^[/\\]+/, "")}`;
+    } else {
+      candidate = path.win32.normalize(candidate);
+    }
+  }
+
+  if (candidate === "") {
+    return undefined;
+  }
+
   const absolute = path.isAbsolute(candidate)
     ? path.normalize(candidate)
     : path.resolve(cwd, candidate);


### PR DESCRIPTION
## Summary
- Fix issue #35793: ACP read path scoping for Windows-style paths in WSL-like environments.
- Normalize Windows drive paths in ACP read permission resolution on non-Windows hosts.
- Map `C:\...` paths to `/mnt/<drive>/...` when cwd is under the same mounted drive.
- Add regression coverage for Windows-style rawInput paths inside WSL workdir.

## Security Impact
- N/A

## Repro+Verification
- Use ACP read/import with Windows-style paths while running under `/mnt/<drive>/...`.
- Before: valid in-workdir paths were mis-scoped and not auto-approved.
- After: valid in-workdir paths resolve correctly and preserve containment checks.

## Testing
- `pnpm test src/acp/client.test.ts` (32 passed)

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35793
