### PR TITLE
fix(agents): prevent Gemini PDF URL duplication /v1beta/v1beta (#34312)

### DIFF
--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -137,10 +137,9 @@ export async function geminiAnalyzePdf(params: {
   }
   parts.push({ text: params.prompt });
 
-  const baseUrl = (params.baseUrl ?? "https://generativelanguage.googleapis.com").replace(
-    /\/+$/,
-    "",
-  );
+  const baseUrl = (params.baseUrl ?? "https://generativelanguage.googleapis.com")
+    .replace(/\/+$/, "")
+    .replace(/\/v1beta$/, ""); // Bug fix for #34312: Strip existing /v1beta to avoid duplication
   const url = `${baseUrl}/v1beta/models/${encodeURIComponent(params.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
 
   const res = await fetch(url, {


### PR DESCRIPTION
## Summary

Fixes #34312 - Gemini PDF URL duplication causing `/v1beta/v1beta` in API requests.

## Problem

When users configure a custom `baseUrl` that already includes `/v1beta` (e.g., `https://example.com/v1beta`), the PDF native provider code unconditionally appends another `/v1beta`, resulting in invalid URLs:

```
https://example.com/v1beta/v1beta/models/gemini-3-pro-preview:generateContent
                       ^^^^^^^^^^^^^^ ← duplication
```

This causes all PDF analysis requests to fail with 404 errors.

## Root Cause

In `pdf-native-providers.ts` lines 140-144, the code only strips trailing slashes but doesn't check for existing `/v1beta` suffix:

**Buggy code:**
```typescript
const baseUrl = (params.baseUrl ?? "https://generativelanguage.googleapis.com").replace(
  /\/+$/,
  "",
);
const url = `${baseUrl}/v1beta/models/${...}`;  // ❌ Always appends /v1beta
```

## Solution

Strip any existing `/v1beta` suffix before appending:

```typescript
const baseUrl = (params.baseUrl ?? "https://generativelanguage.googleapis.com")
  .replace(/\/+$/, "")
  .replace(/\/v1beta$/, ""); // ✅ Remove existing /v1beta first
const url = `${baseUrl}/v1beta/models/${...}`;
```

## Test Cases

### Before Fix ❌
```typescript
baseUrl: "https://example.com/v1beta"
→ URL: "https://example.com/v1beta/v1beta/models/..." ❌ Invalid
```

### After Fix ✅
```typescript
baseUrl: "https://example.com/v1beta"
→ URL: "https://example.com/v1beta/models/..." ✅ Correct

baseUrl: "https://example.com"
→ URL: "https://example.com/v1beta/models/..." ✅ Correct

baseUrl: "https://example.com/"
→ URL: "https://example.com/v1beta/models/..." ✅ Correct
```

## Impact

- **Affected users**: Anyone using custom Gemini API endpoints with `/v1beta` in baseUrl
- **Frequency**: 100% when baseUrl includes `/v1beta`
- **Severity**: High (complete feature breakage for PDF analysis)
- **Benefits**: PDF analysis works correctly with custom endpoints

## User Confirmation

User reported in #34312:
> "After removing /v1beta from baseUrl config, PDF analysis works correctly"

This confirms the root cause and validates the fix approach.

## Change Size

+3 lines, -4 lines (net -1 line, cleaner code)

## Files Changed

- `src/agents/tools/pdf-native-providers.ts` (1 line modified, comment added)
