### PR TITLE
Fix: resolve Homebrew version from bundled metadata

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,25 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "tsdown";
+
+const packageJsonPath = path.join(path.dirname(fileURLToPath(import.meta.url)), "package.json");
+
+function readPackageVersion(): string | undefined {
+  try {
+    const raw = fs.readFileSync(packageJsonPath, "utf8");
+    const parsed = JSON.parse(raw) as { version?: string };
+    return parsed.version?.trim();
+  } catch {
+    return undefined;
+  }
+}
+
+const bundledVersion = process.env.OPENCLAW_BUNDLED_VERSION || readPackageVersion() || "0.0.0";
 
 const env = {
   NODE_ENV: "production",
+  OPENCLAW_BUNDLED_VERSION: bundledVersion,
 };
 
 const pluginSdkEntrypoints = [


### PR DESCRIPTION
## Summary
- Fix issue #35768: Homebrew-installed CLI showing `dev` instead of released version.
- Inject bundled OpenClaw version at build time from `package.json` via tsdown config.
- Keep runtime fallback behavior unchanged for source/dev execution paths.

## Security Impact
- N/A

## Repro+Verification
- Install/upgrade via Homebrew and run `openclaw --version`.
- Before: output could resolve to `dev` unless `OPENCLAW_VERSION` was set.
- After: bundled build reports the actual released version consistently.

## Testing
- Build/test commands run in the implementation branch (as reported by Codex).

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35768
