### PR TITLE
fix(security): add Russian Cyrillic SYSTEM locale for Windows ACL audit

### DIFF
--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -492,12 +492,34 @@ Successfully processed 1 files`;
       expectTrustedOnly([aclEntry({ principal: "AUTORIDAD NT\\SYSTEM" })]);
     });
 
+    it("classifies Russian SYSTEM (NT AUTHORITY\\СИСТЕМА) as trusted", () => {
+      // Russian Cyrillic СИСТЕМА = SYSTEM
+      expectTrustedOnly([aclEntry({ principal: "NT AUTHORITY\\СИСТЕМА" })]);
+    });
+
+    it("classifies standalone Russian СИСТЕМА as trusted", () => {
+      expectTrustedOnly([aclEntry({ principal: "СИСТЕМА" })]);
+    });
+
     it("French Windows full scenario: user + Système only → no untrusted", () => {
       const entries: WindowsAclEntry[] = [
         aclEntry({ principal: "MYPC\\Pierre" }),
         aclEntry({ principal: "AUTORITE NT\\Système" }),
       ];
       const env = { USERNAME: "Pierre", USERDOMAIN: "MYPC" };
+      const { trusted, untrustedWorld, untrustedGroup } = summarizeWindowsAcl(entries, env);
+      expect(trusted).toHaveLength(2);
+      expect(untrustedWorld).toHaveLength(0);
+      expect(untrustedGroup).toHaveLength(0);
+    });
+
+    it("Russian Windows full scenario: user + СИСТЕМА only → no untrusted (issue #35834)", () => {
+      // Reproduces the false positive reported in issue #35834 on Russian Windows
+      const entries: WindowsAclEntry[] = [
+        aclEntry({ principal: "WIN-1OJ4F69CGN3\\user" }),
+        aclEntry({ principal: "NT AUTHORITY\\СИСТЕМА", rawRights: "(OI)(CI)(F)" }),
+      ];
+      const env = { USERNAME: "user", USERDOMAIN: "WIN-1OJ4F69CGN3" };
       const { trusted, untrustedWorld, untrustedGroup } = summarizeWindowsAcl(entries, env);
       expect(trusted).toHaveLength(2);
       expect(untrustedWorld).toHaveLength(0);

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -33,14 +33,17 @@ const TRUSTED_BASE = new Set([
   "system",
   "builtin\\administrators",
   "creator owner",
-  // Localized SYSTEM account names (French, German, Spanish, Portuguese)
+  // Localized SYSTEM account names (French, German, Spanish, Portuguese, Russian)
   "autorite nt\\système",
   "nt-autorität\\system",
   "autoridad nt\\system",
   "autoridade nt\\system",
+  // Russian: NT AUTHORITY\СИСТЕМА (СИСТЕМА = SYSTEM in Cyrillic)
+  "nt authority\\система",
+  "система",
 ]);
 const WORLD_SUFFIXES = ["\\users", "\\authenticated users"];
-const TRUSTED_SUFFIXES = ["\\administrators", "\\system", "\\système"];
+const TRUSTED_SUFFIXES = ["\\administrators", "\\system", "\\système", "\\система"];
 
 const SID_RE = /^s-\d+-\d+(-\d+)+$/i;
 const TRUSTED_SIDS = new Set([


### PR DESCRIPTION
## Summary

Fixes false positive security audit findings on Russian Windows where the SYSTEM account is displayed as `NT AUTHORITY\СИСТЕМА` (Cyrillic).

## Problem

On Russian localized Windows, `icacls` outputs:
```
NT AUTHORITY\СИСТЕМА:(OI)(CI)(F)
```

The existing code:
1. Has locale handling for French, German, Spanish, Portuguese
2. Has a diacritics-stripping fallback (using Unicode NFD normalization)

However, Cyrillic characters are **not diacritical marks** — they are entirely different Unicode code points. The NFD normalization only strips combining diacritical marks (like accents), not whole character replacements.

## Solution

Adds explicit Russian Cyrillic entries:
- `nt authority\система` and `система` to `TRUSTED_BASE`
- `\система` to `TRUSTED_SUFFIXES`

This ensures that properly-restricted ACLs (owner + SYSTEM only) are not flagged as "writable by others" on Russian localized Windows.

## Test Plan

Added test cases:
- `classifies Russian SYSTEM (NT AUTHORITY\СИСТЕМА) as trusted`
- `classifies standalone Russian СИСТЕМА as trusted`
- `Russian Windows full scenario: user + СИСТЕМА only → no untrusted (issue #35834)`

All 43 tests pass.

Closes #35834