### PR TITLE
fix(bluebubbles): guard against null text in debounce flush and message processing

### DIFF
--- a/extensions/bluebubbles/src/monitor-debounce.ts
+++ b/extensions/bluebubbles/src/monitor-debounce.ts
@@ -48,7 +48,7 @@ function combineDebounceEntries(entries: BlueBubblesDebounceEntry[]): Normalized
   const textParts: string[] = [];
 
   for (const entry of entries) {
-    const text = entry.message.text.trim();
+    const text = (entry.message.text ?? "").trim();
     if (!text) {
       continue;
     }
@@ -154,7 +154,7 @@ export function createBlueBubblesDebounceRegistry(params: {
             return false;
           }
           // Skip debouncing for control commands - process immediately
-          if (core.channel.text.hasControlCommand(msg.text, config)) {
+          if (core.channel.text.hasControlCommand(msg.text ?? "", config)) {
             return false;
           }
           // Debounce all other messages to coalesce rapid-fire webhook events

--- a/extensions/bluebubbles/src/monitor-normalize.test.ts
+++ b/extensions/bluebubbles/src/monitor-normalize.test.ts
@@ -36,6 +36,39 @@ describe("normalizeWebhookMessage", () => {
     expect(result).toBeNull();
   });
 
+  it("coalesces null text to empty string", () => {
+    const result = normalizeWebhookMessage({
+      type: "new-message",
+      data: {
+        guid: "msg-null",
+        text: null,
+        handle: { address: "+15551234567" },
+        isGroup: false,
+        isFromMe: false,
+        chatGuid: "iMessage;-;+15551234567",
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.text).toBe("");
+  });
+
+  it("coalesces undefined text to empty string", () => {
+    const result = normalizeWebhookMessage({
+      type: "new-message",
+      data: {
+        guid: "msg-undef",
+        handle: { address: "+15551234567" },
+        isGroup: false,
+        isFromMe: false,
+        chatGuid: "iMessage;-;+15551234567",
+      },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.text).toBe("");
+  });
+
   it("accepts array-wrapped payload data", () => {
     const result = normalizeWebhookMessage({
       type: "new-message",

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -433,7 +433,7 @@ export async function processMessage(
   const groupFlag = resolveGroupFlagFromChatGuid(message.chatGuid);
   const isGroup = typeof groupFlag === "boolean" ? groupFlag : message.isGroup;
 
-  const text = message.text.trim();
+  const text = (message.text ?? "").trim();
   const attachments = message.attachments ?? [];
   const placeholder = buildMessagePlaceholder(message);
   // Check if text is a tapback pattern (e.g., 'Loved "hello"') and transform to emoji format


### PR DESCRIPTION
## Root Cause

BlueBubbles server sends `text: null` for attachment-only messages and certain system events. The `NormalizedWebhookMessage` type declares `text: string`, but at runtime the field can be `null`. Three call sites access `message.text` without null guards, causing `TypeError: Cannot read properties of null (reading 'trim')`. In the debounce flush path, this crashes the entire batch and **silently drops all queued messages** in that window.

## Solution

Apply nullish coalescing (`text ?? ""`) before `.trim()` at all three unguarded call sites, so null text is treated as empty string. This is consistent with the existing codebase pattern (cf. `history.ts:140` which uses `msg.text?.trim()`). Added unit tests verifying `normalizeWebhookMessage` handles both null and undefined text correctly.

## Files Changed

- `extensions/bluebubbles/src/monitor-debounce.ts` — guard `combineDebounceEntries` and `shouldDebounce`
- `extensions/bluebubbles/src/monitor-processing.ts` — guard `processMessage`
- `extensions/bluebubbles/src/monitor-normalize.test.ts` — add null/undefined text test cases

Fixes #35777