### PR TITLE
fix(cron): stop retrying announce delivery on invalid recipient 400s

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -149,6 +149,9 @@ const PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /forbidden: bot was kicked/i,
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
+  /request failed with status code 400/i,
+  /invalid\s+(?:open_id|user_id|chat_id|receive_id)/i,
+  /receive_id\s+.*\s+not\s+exist/i,
 ];
 
 function isTransientAnnounceDeliveryError(error: unknown): boolean {

--- a/src/i18n/registry.test.ts
+++ b/src/i18n/registry.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 import {
   DEFAULT_LOCALE,
   SUPPORTED_LOCALES,
   loadLazyLocaleTranslation,
   resolveNavigatorLocale,
 } from "../../ui/src/i18n/lib/registry.ts";
+import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 
 function getNestedTranslation(map: TranslationMap | null, ...path: string[]): string | undefined {
   let value: string | TranslationMap | undefined = map ?? undefined;


### PR DESCRIPTION
## Summary
- classify HTTP 400 recipient-resolution failures as permanent in announce delivery retry logic
- add explicit patterns for invalid open_id/receive_id style errors

## Why
Issue #35830 reports cron announce jobs repeatedly retrying malformed/hallucinated Feishu recipient IDs. Those errors are non-transient and should fail fast instead of burning retries.

## Testing
- Not run (regex-only classification change)

Closes #35830