### PR TITLE
config: accept canonical openclaw browser profile driver

### DIFF
--- a/changelog/fragments/issue-35620-browser-driver-openclaw.md
+++ b/changelog/fragments/issue-35620-browser-driver-openclaw.md
@@ -1,0 +1,1 @@
+- Config/Browser: `browser.profiles.*.driver` now accepts the canonical `"openclaw"` value in strict schema validation while still allowing legacy `"clawd"` for compatibility, so modern profile configs no longer fail validation. Fixes #35620. Thanks @ingyukoh.

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -184,4 +184,20 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it("accepts browser profile driver openclaw in strict schema validation", () => {
+    const res = validateConfigObject({
+      browser: {
+        profiles: {
+          default: {
+            cdpPort: 9222,
+            driver: "openclaw",
+            color: "#FF4500",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -406,7 +406,7 @@ const ENUM_EXPECTATIONS: Record<string, string[]> = {
   "gateway.bind": ['"auto"', '"lan"', '"loopback"', '"custom"', '"tailnet"'],
   "gateway.auth.mode": ['"none"', '"token"', '"password"', '"trusted-proxy"'],
   "gateway.tailscale.mode": ['"off"', '"serve"', '"funnel"'],
-  "browser.profiles.*.driver": ['"clawd"', '"extension"'],
+  "browser.profiles.*.driver": ['"openclaw"', '"extension"', '"clawd"'],
   "discovery.mdns.mode": ['"off"', '"minimal"', '"full"'],
   "wizard.lastRunMode": ['"local"', '"remote"'],
   "diagnostics.otel.protocol": ['"http/protobuf"', '"grpc"'],

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -251,7 +251,7 @@ export const FIELD_HELP: Record<string, string> = {
   "browser.profiles.*.cdpUrl":
     "Per-profile CDP websocket URL used for explicit remote browser routing by profile name. Use this when profile connections terminate on remote hosts or tunnels.",
   "browser.profiles.*.driver":
-    'Per-profile browser driver mode: "clawd" or "extension" depending on connection/runtime strategy. Use the driver that matches your browser control stack to avoid protocol mismatches.',
+    'Per-profile browser driver mode: "openclaw" or "extension" depending on connection/runtime strategy. Use the driver that matches your browser control stack to avoid protocol mismatches. Legacy alias "clawd" is also accepted for compatibility.',
   "browser.profiles.*.attachOnly":
     "Per-profile attach-only override that skips local browser launch and only attaches to an existing CDP endpoint. Useful when one profile is externally managed but others are locally launched.",
   "browser.profiles.*.color":

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -309,7 +309,11 @@ export const OpenClawSchema = z
               .object({
                 cdpPort: z.number().int().min(1).max(65535).optional(),
                 cdpUrl: z.string().optional(),
-                driver: z.union([z.literal("clawd"), z.literal("extension")]).optional(),
+                // Keep legacy "clawd" for backward compatibility, but accept
+                // the canonical "openclaw" value used by runtime/types/tests.
+                driver: z
+                  .union([z.literal("openclaw"), z.literal("clawd"), z.literal("extension")])
+                  .optional(),
                 attachOnly: z.boolean().optional(),
                 color: HexColorSchema,
               })


### PR DESCRIPTION
## Summary
- Accept `browser.profiles.*.driver: "openclaw"` in strict config schema validation.
- Keep legacy `"clawd"` accepted for backward compatibility.
- Add a regression test for `validateConfigObject` so canonical `openclaw` profile configs stay valid.
- Update config help copy and enum quality expectations to reflect canonical + legacy behavior.
- Add changelog fragment for the user-facing validation fix.

## Security Impact
- No privilege model changes.
- This only aligns schema validation with existing runtime/type behavior and preserves backward compatibility.

## Repro + Verification
### Repro
1. Set config with:
   - `browser.profiles.default.cdpPort: 9222`
   - `browser.profiles.default.driver: "openclaw"`
2. Run config validation.
3. Before this fix, strict schema rejects `"openclaw"`.

### Verification
- `pnpm exec vitest run src/config/config.schema-regressions.test.ts src/config/schema.help.quality.test.ts`
- `pnpm exec oxfmt --check src/config/zod-schema.ts src/config/schema.help.ts src/config/schema.help.quality.test.ts src/config/config.schema-regressions.test.ts changelog/fragments/issue-35620-browser-driver-openclaw.md`
- `pnpm exec oxlint src/config/zod-schema.ts src/config/schema.help.ts src/config/schema.help.quality.test.ts src/config/config.schema-regressions.test.ts`

## Human Verification
- Confirmed schema now accepts canonical `openclaw` driver value in strict mode while preserving legacy `clawd` compatibility.

## AI Assisted
- AI-assisted implementation and test drafting, followed by local validation runs.

Fixes #35620
