### PR TITLE
fix(agents): notify parent session when subagent run is orphaned before runTimeout

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -278,6 +278,58 @@ describe("resolveModel", () => {
     expect(result.model?.reasoning).toBe(true);
   });
 
+  it("prefers configured provider api metadata over discovered registry model", () => {
+    mockDiscoveredModel({
+      provider: "onehub",
+      modelId: "glm-5",
+      templateModel: {
+        id: "glm-5",
+        name: "GLM-5 (cached)",
+        provider: "onehub",
+        api: "anthropic-messages",
+        baseUrl: "https://old-provider.example.com/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 8192,
+        maxTokens: 2048,
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          onehub: {
+            baseUrl: "http://new-provider.example.com/v1",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("glm-5"),
+                api: "openai-completions",
+                reasoning: true,
+                contextWindow: 198000,
+                maxTokens: 16000,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("onehub", "glm-5", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "onehub",
+      id: "glm-5",
+      api: "openai-completions",
+      baseUrl: "http://new-provider.example.com/v1",
+      reasoning: true,
+      contextWindow: 198000,
+      maxTokens: 16000,
+    });
+  });
+
   it("builds an openai-codex fallback for gpt-5.3-codex", () => {
     mockOpenAICodexTemplateModel();
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -41,7 +41,12 @@ function applyConfiguredProviderOverrides(params: {
     return discoveredModel;
   }
   const configuredModel = providerConfig.models?.find((candidate) => candidate.id === modelId);
-  if (!configuredModel && !providerConfig.baseUrl && !providerConfig.api && !providerConfig.headers) {
+  if (
+    !configuredModel &&
+    !providerConfig.baseUrl &&
+    !providerConfig.api &&
+    !providerConfig.headers
+  ) {
     return discoveredModel;
   }
   return {
@@ -56,9 +61,9 @@ function applyConfiguredProviderOverrides(params: {
     headers:
       providerConfig.headers || configuredModel?.headers
         ? {
-            ...(discoveredModel.headers ?? {}),
-            ...(providerConfig.headers ?? {}),
-            ...(configuredModel?.headers ?? {}),
+            ...discoveredModel.headers,
+            ...providerConfig.headers,
+            ...configuredModel?.headers,
           }
         : discoveredModel.headers,
     compat: configuredModel?.compat ?? discoveredModel.compat,

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -7,7 +7,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { buildModelAliasLines } from "../model-alias-lines.js";
 import { normalizeModelCompat } from "../model-compat.js";
 import { resolveForwardCompatModel } from "../model-forward-compat.js";
-import { normalizeProviderId } from "../model-selection.js";
+import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
 import { discoverAuthStorage, discoverModels } from "../pi-model-discovery.js";
 
 type InlineModelEntry = ModelDefinitionConfig & {
@@ -23,6 +23,47 @@ type InlineProviderConfig = {
 };
 
 export { buildModelAliasLines };
+
+function resolveConfiguredProviderConfig(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+): InlineProviderConfig | undefined {
+  return findNormalizedProviderValue(cfg?.models?.providers, provider);
+}
+
+function applyConfiguredProviderOverrides(params: {
+  discoveredModel: Model<Api>;
+  providerConfig?: InlineProviderConfig;
+  modelId: string;
+}): Model<Api> {
+  const { discoveredModel, providerConfig, modelId } = params;
+  if (!providerConfig) {
+    return discoveredModel;
+  }
+  const configuredModel = providerConfig.models?.find((candidate) => candidate.id === modelId);
+  if (!configuredModel && !providerConfig.baseUrl && !providerConfig.api && !providerConfig.headers) {
+    return discoveredModel;
+  }
+  return {
+    ...discoveredModel,
+    api: configuredModel?.api ?? providerConfig.api ?? discoveredModel.api,
+    baseUrl: providerConfig.baseUrl ?? discoveredModel.baseUrl,
+    reasoning: configuredModel?.reasoning ?? discoveredModel.reasoning,
+    input: configuredModel?.input ?? discoveredModel.input,
+    cost: configuredModel?.cost ?? discoveredModel.cost,
+    contextWindow: configuredModel?.contextWindow ?? discoveredModel.contextWindow,
+    maxTokens: configuredModel?.maxTokens ?? discoveredModel.maxTokens,
+    headers:
+      providerConfig.headers || configuredModel?.headers
+        ? {
+            ...(discoveredModel.headers ?? {}),
+            ...(providerConfig.headers ?? {}),
+            ...(configuredModel?.headers ?? {}),
+          }
+        : discoveredModel.headers,
+    compat: configuredModel?.compat ?? discoveredModel.compat,
+  };
+}
 
 export function buildInlineProviderModels(
   providers: Record<string, InlineProviderConfig>,
@@ -59,6 +100,7 @@ export function resolveModel(
   const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
   const authStorage = discoverAuthStorage(resolvedAgentDir);
   const modelRegistry = discoverModels(authStorage, resolvedAgentDir);
+  const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
   const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
 
   if (!model) {
@@ -100,7 +142,7 @@ export function resolveModel(
       } as Model<Api>);
       return { model: fallbackModel, authStorage, modelRegistry };
     }
-    const providerCfg = providers[provider];
+    const providerCfg = providerConfig;
     if (providerCfg || modelId.startsWith("mock-")) {
       const configuredModel = providerCfg?.models?.find((candidate) => candidate.id === modelId);
       const fallbackModel: Model<Api> = normalizeModelCompat({
@@ -133,21 +175,17 @@ export function resolveModel(
       modelRegistry,
     };
   }
-  const providerOverride = cfg?.models?.providers?.[provider] as InlineProviderConfig | undefined;
-  if (providerOverride?.baseUrl || providerOverride?.headers) {
-    const overridden: Model<Api> & { headers?: Record<string, string> } = { ...model };
-    if (providerOverride.baseUrl) {
-      overridden.baseUrl = providerOverride.baseUrl;
-    }
-    if (providerOverride.headers) {
-      overridden.headers = {
-        ...(model as Model<Api> & { headers?: Record<string, string> }).headers,
-        ...providerOverride.headers,
-      };
-    }
-    return { model: normalizeModelCompat(overridden), authStorage, modelRegistry };
-  }
-  return { model: normalizeModelCompat(model), authStorage, modelRegistry };
+  return {
+    model: normalizeModelCompat(
+      applyConfiguredProviderOverrides({
+        discoveredModel: model,
+        providerConfig,
+        modelId,
+      }),
+    ),
+    authStorage,
+    modelRegistry,
+  };
 }
 
 /**

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -173,22 +173,25 @@ function reconcileOrphanedRun(params: {
     params.entry.endedReason = SUBAGENT_ENDED_REASON_ERROR;
     changed = true;
   }
-  if (params.entry.cleanupHandled !== true) {
-    params.entry.cleanupHandled = true;
-    changed = true;
-  }
-  if (typeof params.entry.cleanupCompletedAt !== "number") {
-    params.entry.cleanupCompletedAt = now;
-    changed = true;
-  }
-  const removed = subagentRuns.delete(params.runId);
   resumedRuns.delete(params.runId);
-  if (!removed && !changed) {
+  if (!changed) {
     return false;
   }
   defaultRuntime.log(
-    `[warn] Subagent orphan run pruned source=${params.source} run=${params.runId} child=${params.entry.childSessionKey} reason=${params.reason}`,
+    `[warn] Subagent orphan run detected source=${params.source} run=${params.runId} child=${params.entry.childSessionKey} reason=${params.reason}`,
   );
+  // Trigger the normal completion+announce flow so the requester session receives
+  // a failure notification. completeSubagentRun handles idempotency (via cleanupHandled)
+  // and will delete the entry from subagentRuns after the announce completes.
+  void completeSubagentRun({
+    runId: params.runId,
+    endedAt: params.entry.endedAt,
+    outcome: orphanOutcome,
+    reason: SUBAGENT_ENDED_REASON_ERROR,
+    sendFarewell: true,
+    accountId: params.entry.requesterOrigin?.accountId,
+    triggerCleanup: true,
+  });
   return true;
 }
 


### PR DESCRIPTION
## Summary

Fixes #35791.

When a subagent run was detected as orphaned (child session gone before `runTimeout` fired), `reconcileOrphanedRun` was silently deleting the entry from `subagentRuns` and setting `cleanupHandled = true` without triggering the normal announce flow. This caused:

1. `waitForSubagentCompletion` to find no entry and return silently (the parent session's wait resolved with no result).
2. No failure notification was delivered to the requester session.
3. The parent session appeared to hang indefinitely, waiting for a subagent that had already been cleaned up.

**Fix:** Remove the silent delete + `cleanupHandled` marking from `reconcileOrphanedRun`. Instead, fire `completeSubagentRun` through the normal completion+announce flow, which:
- Delivers a failure notification to the requester session.
- Handles idempotency via `cleanupHandled` (as it always has).
- Deletes the entry from `subagentRuns` after the announce completes.

## Test plan

- [ ] Manual: start a task with a subagent; kill the child session before `runTimeout` fires; verify parent session receives a failure notification instead of hanging.
- [ ] Existing subagent/orchestration tests pass (`pnpm test`).