### PR TITLE
Docker: add Python packages for Monica workspace tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,15 @@ RUN if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
       rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*; \
     fi
 
+# Install Python packages for Monica workspace tools (job_scraper, linkedin-feed, gmail-monitor).
+# Using apt for well-packaged libs; pip (--break-system-packages) for langdetect which is not in Debian repos.
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      python3-pip python3-requests python3-bs4 python3-yaml && \
+    pip3 install --no-cache-dir --break-system-packages langdetect linkedin-api && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
 COPY --chown=node:node package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 COPY --chown=node:node ui/package.json ./ui/package.json
 COPY --chown=node:node patches ./patches


### PR DESCRIPTION
## Summary

Bakes the Python dependencies for Monica's three workspace scripts into the Docker image, so they work in any environment (cloud-ready) without a Mac-native venv:

- `python3-requests`, `python3-bs4`, `python3-yaml` — via apt (Debian-packaged)
- `langdetect` — via pip (not in Debian repos)
- `linkedin-api` — via pip (required by `linkedin-feed/main.py` and `fetch_post.py` for LinkedIn Voyager API access)

**Problem:** Monica's scripts relied on a `venv/` created on macOS (Python 3.12, arm64). Inside the Linux ARM64 Docker container, the Mac venv binaries don't execute. Scripts failed silently with `No such file or directory` and Monica would fabricate plausible-looking output instead of reporting the error.

**Fix:** Packages are now installed at image build time. No venv needed. Scripts use system `python3` directly.

## Test plan

- [ ] Build Docker image: `docker build -t openclaw:local .`
- [ ] Verify packages: `docker run --rm openclaw:local python3 -c "import requests, bs4, yaml, langdetect, linkedin_api; print('OK')"`
- [ ] Run job scraper: `docker exec <container> python3 /home/node/.openclaw/workspace-monica/job_scraper/main.py --new-only`
- [ ] Run linkedin-feed: `docker exec <container> python3 /home/node/.openclaw/workspace-monica/linkedin-feed/main.py --no-bear`

🤖 Generated with [Claude Code](https://claude.com/claude-code)