### PR TITLE
fix(bluebubbles): guard against null text in debounce flush

### DIFF
--- a/extensions/bluebubbles/src/monitor-debounce.ts
+++ b/extensions/bluebubbles/src/monitor-debounce.ts
@@ -48,7 +48,7 @@ function combineDebounceEntries(entries: BlueBubblesDebounceEntry[]): Normalized
   const textParts: string[] = [];
 
   for (const entry of entries) {
-    const text = entry.message.text.trim();
+    const text = (entry.message.text ?? "").trim();
     if (!text) {
       continue;
     }
@@ -154,7 +154,7 @@ export function createBlueBubblesDebounceRegistry(params: {
             return false;
           }
           // Skip debouncing for control commands - process immediately
-          if (core.channel.text.hasControlCommand(msg.text, config)) {
+          if (core.channel.text.hasControlCommand(msg.text ?? "", config)) {
             return false;
           }
           // Debounce all other messages to coalesce rapid-fire webhook events


### PR DESCRIPTION
## Summary
- Fix crash in BlueBubbles debounce flush when `message.text` is `null`
- BlueBubbles webhook messages may have null text (e.g. attachment-only messages), causing `.trim()` to throw
- Added nullish coalescing (`?? ""`) in two locations:
  - `combineDebounceEntries()` — line 51: `entry.message.text.trim()` → `(entry.message.text ?? "").trim()`
  - `shouldDebounce()` — line 157: `hasControlCommand(msg.text, config)` → `hasControlCommand(msg.text ?? "", config)`

## Test plan
- [ ] Send an attachment-only message (no text) through BlueBubbles webhook — should no longer crash
- [ ] Send a normal text message — should still debounce and combine correctly
- [ ] Send a control command — should still bypass debounce

Fixes #35777

🤖 Generated with [Claude Code](https://claude.com/claude-code)