### PR TITLE
fix(security): avoid localized NT AUTHORITY ACL false positives on Windows

### DIFF
--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -209,10 +209,24 @@ Successfully processed 1 files`;
           rawRights: "(R)",
           canWrite: false,
         }),
+        aclEntry({
+          principal: "NT AUTHORITY\\Authenticated Users",
+          rights: ["R"],
+          rawRights: "(R)",
+          canWrite: false,
+        }),
       ];
       const summary = summarizeWindowsAcl(entries);
       expect(summary.trusted).toHaveLength(0);
-      expect(summary.untrustedWorld).toHaveLength(2);
+      expect(summary.untrustedWorld).toHaveLength(3);
+      expect(summary.untrustedGroup).toHaveLength(0);
+    });
+
+    it("classifies mojibake NT AUTHORITY principals as trusted", () => {
+      const entries: WindowsAclEntry[] = [aclEntry({ principal: "NT AUTHORITY\\�������" })];
+      const summary = summarizeWindowsAcl(entries);
+      expect(summary.trusted).toHaveLength(1);
+      expect(summary.untrustedWorld).toHaveLength(0);
       expect(summary.untrustedGroup).toHaveLength(0);
     });
 

--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -519,6 +519,22 @@ Successfully processed 1 files`;
     });
   });
 
+  describe("summarizeWindowsAcl — NT AUTHORITY edge principals", () => {
+    it("keeps NT AUTHORITY\\ANONYMOUS LOGON as world", () => {
+      const entries: WindowsAclEntry[] = [aclEntry({ principal: "NT AUTHORITY\\ANONYMOUS LOGON" })];
+      const summary = summarizeWindowsAcl(entries);
+      expect(summary.untrustedWorld).toHaveLength(1);
+      expect(summary.trusted).toHaveLength(0);
+    });
+
+    it("keeps NT AUTHORITY\\INTERACTIVE as group", () => {
+      const entries: WindowsAclEntry[] = [aclEntry({ principal: "NT AUTHORITY\\INTERACTIVE" })];
+      const summary = summarizeWindowsAcl(entries);
+      expect(summary.untrustedGroup).toHaveLength(1);
+      expect(summary.trusted).toHaveLength(0);
+    });
+  });
+
   describe("formatIcaclsResetCommand — uses SID for SYSTEM", () => {
     it("uses *S-1-5-18 instead of SYSTEM in reset command", () => {
       const cmd = formatIcaclsResetCommand("C:\\test.json", {

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -95,16 +95,24 @@ function classifyPrincipal(
   }
 
   if (
+    WORLD_PRINCIPALS.has(normalized) ||
+    WORLD_SUFFIXES.some((suffix) => normalized.endsWith(suffix))
+  ) {
+    return "world";
+  }
+
+  if (
     trustedPrincipals.has(normalized) ||
     TRUSTED_SUFFIXES.some((suffix) => normalized.endsWith(suffix))
   ) {
     return "trusted";
   }
-  if (
-    WORLD_PRINCIPALS.has(normalized) ||
-    WORLD_SUFFIXES.some((suffix) => normalized.endsWith(suffix))
-  ) {
-    return "world";
+
+  // Locale/encoding guard: icacls can emit localized NT AUTHORITY account names
+  // with mojibake in non-UTF8 shells. Treat NT AUTHORITY principals as trusted
+  // (after explicit world-principal checks above) to avoid false positives.
+  if (normalized.startsWith("nt authority\\")) {
+    return "trusted";
   }
 
   // Fallback: strip diacritics and re-check for localized SYSTEM variants

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -41,6 +41,8 @@ const TRUSTED_BASE = new Set([
 ]);
 const WORLD_SUFFIXES = ["\\users", "\\authenticated users"];
 const TRUSTED_SUFFIXES = ["\\administrators", "\\system", "\\système"];
+const NT_AUTHORITY_WORLD_SUFFIXES = new Set(["anonymous logon", "everyone"]);
+const NT_AUTHORITY_GROUP_SUFFIXES = new Set(["network", "interactive"]);
 
 const SID_RE = /^s-\d+-\d+(-\d+)+$/i;
 const TRUSTED_SIDS = new Set([
@@ -109,9 +111,16 @@ function classifyPrincipal(
   }
 
   // Locale/encoding guard: icacls can emit localized NT AUTHORITY account names
-  // with mojibake in non-UTF8 shells. Treat NT AUTHORITY principals as trusted
-  // (after explicit world-principal checks above) to avoid false positives.
+  // with mojibake in non-UTF8 shells. Keep clearly dangerous principals untrusted,
+  // then trust the remaining NT AUTHORITY variants to avoid localized false positives.
   if (normalized.startsWith("nt authority\\")) {
+    const suffix = normalized.slice("nt authority\\".length);
+    if (NT_AUTHORITY_WORLD_SUFFIXES.has(suffix)) {
+      return "world";
+    }
+    if (NT_AUTHORITY_GROUP_SUFFIXES.has(suffix)) {
+      return "group";
+    }
     return "trusted";
   }
 


### PR DESCRIPTION
## Summary\n- avoid false positives when icacls returns localized or mojibake NT AUTHORITY\\... account names\n- keep explicit world principal detection first (e.g. NT AUTHORITY\\Authenticated Users)\n- treat remaining NT AUTHORITY\\* principals as trusted built-in identities\n\n## Why\nIssue #35834 reports Windows RU locale output where SYSTEM appears as garbled NT AUTHORITY\\�������, which was classified as untrusted group and triggered writable-by-others findings.\n\n## Changes\n- reordered principal classification to evaluate world principals first\n- added locale/encoding guard: classify non-world NT AUTHORITY\\* principals as trusted\n- added regression tests:\n  - NT AUTHORITY\\Authenticated Users remains world\n  - mojibake NT AUTHORITY\\������� is trusted\n\n## Testing\n- 
px vitest run src/security/windows-acl.test.ts\n- 
px vitest run src/security/audit.test.ts\n\nFixes #35834