### PR TITLE
fix(hooks): propagate session key through agent send tool so message:sent internal hook fires

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -278,6 +278,58 @@ describe("resolveModel", () => {
     expect(result.model?.reasoning).toBe(true);
   });
 
+  it("prefers configured provider api metadata over discovered registry model", () => {
+    mockDiscoveredModel({
+      provider: "onehub",
+      modelId: "glm-5",
+      templateModel: {
+        id: "glm-5",
+        name: "GLM-5 (cached)",
+        provider: "onehub",
+        api: "anthropic-messages",
+        baseUrl: "https://old-provider.example.com/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 8192,
+        maxTokens: 2048,
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          onehub: {
+            baseUrl: "http://new-provider.example.com/v1",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("glm-5"),
+                api: "openai-completions",
+                reasoning: true,
+                contextWindow: 198000,
+                maxTokens: 16000,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("onehub", "glm-5", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "onehub",
+      id: "glm-5",
+      api: "openai-completions",
+      baseUrl: "http://new-provider.example.com/v1",
+      reasoning: true,
+      contextWindow: 198000,
+      maxTokens: 16000,
+    });
+  });
+
   it("builds an openai-codex fallback for gpt-5.3-codex", () => {
     mockOpenAICodexTemplateModel();
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -41,7 +41,12 @@ function applyConfiguredProviderOverrides(params: {
     return discoveredModel;
   }
   const configuredModel = providerConfig.models?.find((candidate) => candidate.id === modelId);
-  if (!configuredModel && !providerConfig.baseUrl && !providerConfig.api && !providerConfig.headers) {
+  if (
+    !configuredModel &&
+    !providerConfig.baseUrl &&
+    !providerConfig.api &&
+    !providerConfig.headers
+  ) {
     return discoveredModel;
   }
   return {
@@ -56,9 +61,9 @@ function applyConfiguredProviderOverrides(params: {
     headers:
       providerConfig.headers || configuredModel?.headers
         ? {
-            ...(discoveredModel.headers ?? {}),
-            ...(providerConfig.headers ?? {}),
-            ...(configuredModel?.headers ?? {}),
+            ...discoveredModel.headers,
+            ...providerConfig.headers,
+            ...configuredModel?.headers,
           }
         : discoveredModel.headers,
     compat: configuredModel?.compat ?? discoveredModel.compat,

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -7,7 +7,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { buildModelAliasLines } from "../model-alias-lines.js";
 import { normalizeModelCompat } from "../model-compat.js";
 import { resolveForwardCompatModel } from "../model-forward-compat.js";
-import { normalizeProviderId } from "../model-selection.js";
+import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
 import { discoverAuthStorage, discoverModels } from "../pi-model-discovery.js";
 
 type InlineModelEntry = ModelDefinitionConfig & {
@@ -23,6 +23,47 @@ type InlineProviderConfig = {
 };
 
 export { buildModelAliasLines };
+
+function resolveConfiguredProviderConfig(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+): InlineProviderConfig | undefined {
+  return findNormalizedProviderValue(cfg?.models?.providers, provider);
+}
+
+function applyConfiguredProviderOverrides(params: {
+  discoveredModel: Model<Api>;
+  providerConfig?: InlineProviderConfig;
+  modelId: string;
+}): Model<Api> {
+  const { discoveredModel, providerConfig, modelId } = params;
+  if (!providerConfig) {
+    return discoveredModel;
+  }
+  const configuredModel = providerConfig.models?.find((candidate) => candidate.id === modelId);
+  if (!configuredModel && !providerConfig.baseUrl && !providerConfig.api && !providerConfig.headers) {
+    return discoveredModel;
+  }
+  return {
+    ...discoveredModel,
+    api: configuredModel?.api ?? providerConfig.api ?? discoveredModel.api,
+    baseUrl: providerConfig.baseUrl ?? discoveredModel.baseUrl,
+    reasoning: configuredModel?.reasoning ?? discoveredModel.reasoning,
+    input: configuredModel?.input ?? discoveredModel.input,
+    cost: configuredModel?.cost ?? discoveredModel.cost,
+    contextWindow: configuredModel?.contextWindow ?? discoveredModel.contextWindow,
+    maxTokens: configuredModel?.maxTokens ?? discoveredModel.maxTokens,
+    headers:
+      providerConfig.headers || configuredModel?.headers
+        ? {
+            ...(discoveredModel.headers ?? {}),
+            ...(providerConfig.headers ?? {}),
+            ...(configuredModel?.headers ?? {}),
+          }
+        : discoveredModel.headers,
+    compat: configuredModel?.compat ?? discoveredModel.compat,
+  };
+}
 
 export function buildInlineProviderModels(
   providers: Record<string, InlineProviderConfig>,
@@ -59,6 +100,7 @@ export function resolveModel(
   const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
   const authStorage = discoverAuthStorage(resolvedAgentDir);
   const modelRegistry = discoverModels(authStorage, resolvedAgentDir);
+  const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
   const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
 
   if (!model) {
@@ -100,7 +142,7 @@ export function resolveModel(
       } as Model<Api>);
       return { model: fallbackModel, authStorage, modelRegistry };
     }
-    const providerCfg = providers[provider];
+    const providerCfg = providerConfig;
     if (providerCfg || modelId.startsWith("mock-")) {
       const configuredModel = providerCfg?.models?.find((candidate) => candidate.id === modelId);
       const fallbackModel: Model<Api> = normalizeModelCompat({
@@ -133,21 +175,17 @@ export function resolveModel(
       modelRegistry,
     };
   }
-  const providerOverride = cfg?.models?.providers?.[provider] as InlineProviderConfig | undefined;
-  if (providerOverride?.baseUrl || providerOverride?.headers) {
-    const overridden: Model<Api> & { headers?: Record<string, string> } = { ...model };
-    if (providerOverride.baseUrl) {
-      overridden.baseUrl = providerOverride.baseUrl;
-    }
-    if (providerOverride.headers) {
-      overridden.headers = {
-        ...(model as Model<Api> & { headers?: Record<string, string> }).headers,
-        ...providerOverride.headers,
-      };
-    }
-    return { model: normalizeModelCompat(overridden), authStorage, modelRegistry };
-  }
-  return { model: normalizeModelCompat(model), authStorage, modelRegistry };
+  return {
+    model: normalizeModelCompat(
+      applyConfiguredProviderOverrides({
+        discoveredModel: model,
+        providerConfig,
+        modelId,
+      }),
+    ),
+    authStorage,
+    modelRegistry,
+  };
 }
 
 /**

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -528,6 +528,8 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
       toolContext: input.toolContext,
       deps: input.deps,
       dryRun,
+      // Carry session key so message:sent internal hooks fire even when no outbound route is resolved.
+      sessionKey: input.sessionKey ?? outboundRoute?.sessionKey,
       mirror:
         outboundRoute && !dryRun
           ? {

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -47,6 +47,8 @@ type MessageSendParams = {
   cfg?: OpenClawConfig;
   gateway?: MessageGatewayOptions;
   idempotencyKey?: string;
+  /** Session key for internal hook dispatch when mirror is absent. */
+  sessionKey?: string;
   mirror?: {
     sessionKey: string;
     agentId?: string;
@@ -211,7 +213,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
     const outboundSession = buildOutboundSessionContext({
       cfg,
       agentId: params.agentId,
-      sessionKey: params.mirror?.sessionKey,
+      sessionKey: params.mirror?.sessionKey ?? params.sessionKey,
     });
     const results = await deliverOutboundPayloads({
       cfg,

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -31,6 +31,8 @@ export type OutboundSendContext = {
   toolContext?: ChannelThreadingToolContext;
   deps?: OutboundSendDeps;
   dryRun: boolean;
+  /** Session key for internal hook dispatch when mirror is absent. */
+  sessionKey?: string;
   mirror?: {
     sessionKey: string;
     agentId?: string;
@@ -139,6 +141,7 @@ export async function executeSendAction(params: {
     bestEffort: params.bestEffort ?? undefined,
     deps: params.ctx.deps,
     gateway: params.ctx.gateway,
+    sessionKey: params.ctx.sessionKey,
     mirror: params.ctx.mirror,
     abortSignal: params.ctx.abortSignal,
     silent: params.ctx.silent,


### PR DESCRIPTION
## Summary

Fixes #35557.

When an agent uses the send tool to deliver a message, the `message:sent` internal hook was never fired. The root cause is that `buildOutboundSessionContext` in `message.ts` only pulled the session key from `params.mirror?.sessionKey`. When `outboundRoute` is null (no session route resolved), `mirror` is `undefined`, so `sessionKeyForInternalHooks` in `deliverOutboundPayloads` evaluated to `undefined` and the internal hook was skipped.

**Changes:**

- `MessageSendParams` — add optional `sessionKey` field for explicit hook dispatch when `mirror` is absent
- `buildOutboundSessionContext` in `sendOutboundMessage` — fall back to `params.sessionKey` when `params.mirror?.sessionKey` is absent
- `OutboundSendContext` — add optional `sessionKey` field so it can flow from `executeSendAction` → `sendMessage`
- `executeSendAction` — pass `params.ctx.sessionKey` to `sendMessage`
- `message-action-runner.ts` — set `ctx.sessionKey` from `input.sessionKey ?? outboundRoute?.sessionKey` so the key is available even when `mirror` is not set (e.g. when `outboundRoute` is null)

## Test plan

- [ ] Configure a managed hook with `events: [message:sent]`; send a message via an agent session; verify the hook fires.
- [ ] Existing message hook tests pass: `pnpm test src/hooks/message-hooks.test.ts src/infra/outbound/deliver.test.ts src/infra/outbound/message.test.ts`