### PR TITLE
fix(agents): guard context truncation against malformed text blocks

### DIFF
--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
@@ -7,7 +7,12 @@ const IMAGE_CHAR_ESTIMATE = 8_000;
 export type MessageCharEstimateCache = WeakMap<AgentMessage, number>;
 
 function isTextBlock(block: unknown): block is { type: "text"; text: string } {
-  return !!block && typeof block === "object" && (block as { type?: unknown }).type === "text";
+  return (
+    !!block &&
+    typeof block === "object" &&
+    (block as { type?: unknown }).type === "text" &&
+    typeof (block as { text?: unknown }).text === "string"
+  );
 }
 
 function isImageBlock(block: unknown): boolean {

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -238,6 +238,32 @@ describe("installToolResultContextGuard", () => {
     expect(newResultText).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
   });
 
+  it("handles malformed content blocks with missing text property without crashing", async () => {
+    const agent = makeGuardableAgent();
+
+    installToolResultContextGuard({
+      agent,
+      contextWindowTokens: 1_000,
+    });
+
+    const contextForNextCall = [
+      makeUser("u".repeat(2_000)),
+      castAgentMessage({
+        role: "toolResult",
+        toolCallId: "call_malformed",
+        toolName: "some_plugin",
+        content: [{ type: "text" }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+      makeToolResult("call_normal", "y".repeat(1_000)),
+    ];
+
+    await expect(
+      agent.transformContext?.(contextForNextCall, new AbortController().signal),
+    ).resolves.not.toThrow();
+  });
+
   it("drops oversized read-tool details payloads when compacting tool results", async () => {
     const agent = makeGuardableAgent();
 


### PR DESCRIPTION
## Summary

Fixes #34979.

- Harden `isTextBlock` type guard in `tool-result-char-estimator.ts` to verify `typeof block.text === "string"`, preventing `TypeError` crashes when plugin tool handlers return `undefined` and produce malformed `{type: "text"}` content blocks (no `text` property)
- Add test confirming malformed content blocks don't crash context truncation

## Test plan

- [x] New test: malformed `{type: "text"}` block passes through `installToolResultContextGuard` without crashing
- [x] All 218 existing `pi-embedded-runner` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)