### PR TITLE
fix(matrix): import KeyedAsyncQueue from plugin-sdk/matrix subpath

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/matrix";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 

--- a/src/plugin-sdk/matrix.ts
+++ b/src/plugin-sdk/matrix.ts
@@ -108,3 +108,5 @@ export {
   buildProbeChannelStatusSummary,
   collectStatusIssuesFromLastError,
 } from "./status-helpers.js";
+export { KeyedAsyncQueue } from "./keyed-async-queue.js";
+export type { KeyedAsyncQueueHooks } from "./keyed-async-queue.js";


### PR DESCRIPTION
## Summary

Fix Matrix plugin failing to load with `Cannot find module 'openclaw/plugin-sdk/keyed-async-queue'` when built from source.

Fixes #35869

## Problem

`extensions/matrix/src/matrix/send-queue.ts` imports `KeyedAsyncQueue` from the standalone `openclaw/plugin-sdk/keyed-async-queue` subpath. When building OpenClaw from source, the dist file for this subpath may not exist, causing the Matrix plugin to fail to load entirely.

## Solution

Re-export `KeyedAsyncQueue` and `KeyedAsyncQueueHooks` from `src/plugin-sdk/matrix.ts` (the matrix-scoped plugin-sdk subpath), and update the import in `send-queue.ts` to use `openclaw/plugin-sdk/matrix`.

This follows the same pattern used by other bundled plugins — all imports go through the channel-scoped plugin-sdk subpath rather than standalone utility subpaths.

### Changes
- `src/plugin-sdk/matrix.ts` — Added `KeyedAsyncQueue` class + `KeyedAsyncQueueHooks` type export
- `extensions/matrix/src/matrix/send-queue.ts` — Updated import path

### Tests
- 108 matrix tests pass ✅
- TypeScript check clean ✅
- Monolithic plugin-sdk lint clean ✅