### PR TITLE
fix(browser): allow disabling AutomationControlled flag

### DIFF
--- a/src/browser/chrome.test.ts
+++ b/src/browser/chrome.test.ts
@@ -14,6 +14,7 @@ import {
   isChromeCdpReady,
   isChromeReachable,
   resolveBrowserExecutableForPlatform,
+  buildOpenClawChromeArgs,
   stopOpenClawChrome,
 } from "./chrome.js";
 import {
@@ -202,6 +203,23 @@ describe("browser chrome profile decoration", () => {
 });
 
 describe("browser chrome helpers", () => {
+  it("supports best-effort negation of OpenClaw-injected args via !-- prefix", () => {
+    const args = buildOpenClawChromeArgs(
+      {
+        headless: false,
+        noSandbox: false,
+        extraArgs: ["!--disable-blink-features=AutomationControlled"],
+      },
+      { cdpPort: 9222, name: "openclaw" },
+      "/tmp/openclaw-profile",
+    );
+
+    // negation directive is not forwarded
+    expect(args).not.toContain("!--disable-blink-features=AutomationControlled");
+    // OpenClaw default arg is removed
+    expect(args).not.toContain("--disable-blink-features=AutomationControlled");
+  });
+
   function mockExistsSync(match: (pathValue: string) => boolean) {
     return vi.spyOn(fs, "existsSync").mockImplementation((p) => match(String(p)));
   }

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -212,6 +212,70 @@ export async function isChromeCdpReady(
   return await canRunCdpHealthCommand(wsUrl, handshakeTimeoutMs);
 }
 
+export function buildOpenClawChromeArgs(
+  resolved: Pick<ResolvedBrowserConfig, "headless" | "noSandbox" | "extraArgs">,
+  profile: Pick<ResolvedBrowserProfile, "cdpPort" | "name">,
+  userDataDir: string,
+): string[] {
+  const args: string[] = [
+    `--remote-debugging-port=${profile.cdpPort}`,
+    `--user-data-dir=${userDataDir}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--disable-sync",
+    "--disable-background-networking",
+    "--disable-component-update",
+    "--disable-features=Translate,MediaRouter",
+    "--disable-session-crashed-bubble",
+    "--hide-crash-restore-bubble",
+    "--password-store=basic",
+  ];
+
+  if (resolved.headless) {
+    // Best-effort; older Chromes may ignore.
+    args.push("--headless=new");
+    args.push("--disable-gpu");
+  }
+  if (resolved.noSandbox) {
+    args.push("--no-sandbox");
+    args.push("--disable-setuid-sandbox");
+  }
+  if (process.platform === "linux") {
+    args.push("--disable-dev-shm-usage");
+  }
+
+  // Stealth: hide navigator.webdriver from automation detection (#80)
+  // Newer Chromes show a warning for this unsupported switch.
+  // Allow users to opt out by adding "!--disable-blink-features=AutomationControlled" to browser.extraArgs.
+  args.push("--disable-blink-features=AutomationControlled");
+
+  // Support a best-effort negation convention: "!--flag".
+  // This is a config directive and is NOT forwarded to Chrome.
+  const negations = new Set(
+    resolved.extraArgs.filter((arg) => arg.startsWith("!--")).map((arg) => arg.slice(1)),
+  );
+
+  // Apply negations only to OpenClaw-injected args (i.e., before appending user args).
+  for (const flag of negations) {
+    const idx = args.indexOf(flag);
+    if (idx >= 0) {
+      args.splice(idx, 1);
+    }
+  }
+
+  // Append user-configured extra arguments (e.g., stealth flags, window size)
+  for (const arg of resolved.extraArgs) {
+    if (!arg.startsWith("!--")) {
+      args.push(arg);
+    }
+  }
+
+  // Always open a blank tab to ensure a target exists.
+  args.push("about:blank");
+
+  return args;
+}
+
 export async function launchOpenClawChrome(
   resolved: ResolvedBrowserConfig,
   profile: ResolvedBrowserProfile,
@@ -239,57 +303,7 @@ export async function launchOpenClawChrome(
 
   // First launch to create preference files if missing, then decorate and relaunch.
   const spawnOnce = () => {
-    const args: string[] = [
-      `--remote-debugging-port=${profile.cdpPort}`,
-      `--user-data-dir=${userDataDir}`,
-      "--no-first-run",
-      "--no-default-browser-check",
-      "--disable-sync",
-      "--disable-background-networking",
-      "--disable-component-update",
-      "--disable-features=Translate,MediaRouter",
-      "--disable-session-crashed-bubble",
-      "--hide-crash-restore-bubble",
-      "--password-store=basic",
-    ];
-
-    if (resolved.headless) {
-      // Best-effort; older Chromes may ignore.
-      args.push("--headless=new");
-      args.push("--disable-gpu");
-    }
-    if (resolved.noSandbox) {
-      args.push("--no-sandbox");
-      args.push("--disable-setuid-sandbox");
-    }
-    if (process.platform === "linux") {
-      args.push("--disable-dev-shm-usage");
-    }
-
-    // Stealth: hide navigator.webdriver from automation detection (#80)
-    // Newer Chromes show a warning for this unsupported switch.
-    // Allow users to opt out by adding "!--disable-blink-features=AutomationControlled" to browser.extraArgs.
-    args.push("--disable-blink-features=AutomationControlled");
-
-    // Append user-configured extra arguments (e.g., stealth flags, window size)
-    if (resolved.extraArgs.length > 0) {
-      args.push(...resolved.extraArgs);
-    }
-
-    // Users may want to explicitly remove the automation-controlled switch to avoid Chrome warnings.
-    // Support a best-effort negation convention: "!--flag".
-    // (Only applies to OpenClaw-added flags; we don't attempt to diff/normalize arbitrary args.)
-    for (const arg of resolved.extraArgs) {
-      if (arg === "!--disable-blink-features=AutomationControlled") {
-        const idx = args.indexOf("--disable-blink-features=AutomationControlled");
-        if (idx >= 0) {
-          args.splice(idx, 1);
-        }
-      }
-    }
-
-    // Always open a blank tab to ensure a target exists.
-    args.push("about:blank");
+    const args = buildOpenClawChromeArgs(resolved, profile, userDataDir);
 
     return spawn(exe.path, args, {
       stdio: "pipe",

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -267,11 +267,25 @@ export async function launchOpenClawChrome(
     }
 
     // Stealth: hide navigator.webdriver from automation detection (#80)
+    // Newer Chromes show a warning for this unsupported switch.
+    // Allow users to opt out by adding "!--disable-blink-features=AutomationControlled" to browser.extraArgs.
     args.push("--disable-blink-features=AutomationControlled");
 
     // Append user-configured extra arguments (e.g., stealth flags, window size)
     if (resolved.extraArgs.length > 0) {
       args.push(...resolved.extraArgs);
+    }
+
+    // Users may want to explicitly remove the automation-controlled switch to avoid Chrome warnings.
+    // Support a best-effort negation convention: "!--flag".
+    // (Only applies to OpenClaw-added flags; we don't attempt to diff/normalize arbitrary args.)
+    for (const arg of resolved.extraArgs) {
+      if (arg === "!--disable-blink-features=AutomationControlled") {
+        const idx = args.indexOf("--disable-blink-features=AutomationControlled");
+        if (idx >= 0) {
+          args.splice(idx, 1);
+        }
+      }
     }
 
     // Always open a blank tab to ensure a target exists.


### PR DESCRIPTION
Chrome 近期版本会对 --disable-blink-features=AutomationControlled 显示 unsupported switch 警告。此 PR 允许用户通过 browser.extraArgs 添加 "!--disable-blink-features=AutomationControlled" 来移除 OpenClaw 默认注入的该参数，从而消除警告（需要时仍可显式添加回去）。\n\nCloses #35721