### PR TITLE
fix(moonshot): Enhance moonshot provider configuration: prioritize ba…

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -318,6 +318,14 @@ export async function runEmbeddedPiAgent(
         });
       }
 
+      // Moonshot: prefer config baseUrl so .cn key is used with api.moonshot.cn (not .ai).
+      if (normalizeProviderId(provider) === "moonshot") {
+        const moonshotBaseUrl = params.config?.models?.providers?.moonshot?.baseUrl;
+        if (typeof moonshotBaseUrl === "string" && moonshotBaseUrl.trim()) {
+          (model as { baseUrl?: string }).baseUrl = moonshotBaseUrl.trim();
+        }
+      }
+
       const ctxInfo = resolveContextWindowInfo({
         cfg: params.config,
         provider,


### PR DESCRIPTION
## Summary
Describe the problem and fix in 2–5 bullets:
- **Problem:** Moonshot (Kimi) requests returned HTTP 401 when using a .cn API key. Auth was resolved from an auth profile first (wrong/empty key), and the request was sent to the default `api.moonshot.ai` instead of `api.moonshot.cn`, so .cn keys were rejected.
- **Why it matters:** Users with Moonshot .cn keys or config-only API keys could not use the agent (e.g. via feishu) .
- **What changed:** (1) When `models.providers.moonshot.baseUrl` is set in config, that baseUrl is used for the request so .cn keys hit `api.moonshot.cn`. 
- **What did NOT change (scope boundary):** No change to other providers’ auth order, to profile storage, or to non-Moonshot models. No new config keys required if baseUrl was already set.
## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra
## Scope (select all touched areas)
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra
## Linked Issue/PR
- Closes #25227
## User-visible / Behavior Changes
- Moonshot: When `models.providers.moonshot.baseUrl` is set (e.g. `https://api.moonshot.cn/v1`), that URL is used instead of the default `api.moonshot.ai`.
## Security Impact (required)
- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No** (only resolution order and baseUrl; no new storage or exposure).
- New/changed network calls? **No** (same Moonshot API; only endpoint can switch to .cn when configured).
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A
## Repro + Verification
### Environment
- OS: macOS
- Runtime/container: Node 22+, pnpm
- Model/provider: moonshot/kimi-k2.5, Moonshot .cn API key
- Integration/channel (if any): feishu
- Relevant config (redacted): `models.providers.moonshot.baseUrl: "https://api.moonshot.cn/v1"`, `apiKey` set in config
### Steps
1. Set `models.providers.moonshot.baseUrl` to `https://api.moonshot.cn/v1` and set apiKey with a .cn key.
2. Run gateway and send a message (e.g. via DingTalk).
3. Check logs for `moonshot auth: source=... baseUrl=https://api.moonshot.cn/v1` and successful completion.
### Expected
- Request goes to `api.moonshot.cn`; no 401 when key is valid .cn key.
### Actual
- Before: 401 when profile had wrong key or baseUrl was .ai. After: request succeeds when config baseUrl is .cn and key is from config/env.
## Evidence
Attach at least one:
- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
#25227 
<img width="690" height="289" alt="image" src="https://github.com/user-attachments/assets/e7d9e724-4a29-493d-a071-267dec9bb98b" />

- [ ] Perf numbers (if relevant)
## Human Verification (required)
- **Verified scenarios:** Moonshot with .cn key and `baseUrl: "https://api.moonshot.cn/v1"` in config; env key used when set; log shows correct source and baseUrl.
- **Edge cases checked:** Config without baseUrl still uses registry default (.ai); profile no longer overrides config/env for moonshot.
- **What you did not verify:** Other providers; Moonshot OAuth/profile when env and config are unset.
## Compatibility / Migration
- Backward compatible? **Yes**
- Config/env changes? **No** (optional: set `models.providers.moonshot.baseUrl` for .cn).
- Migration needed? **No**
- If yes, exact upgrade steps: N/A
## Failure Recovery (if this breaks)
- **How to disable/revert:** Revert the PR or remove Moonshot-specific block in `model-auth.ts` and baseUrl patch in `run.ts`.
- **Files/config to restore:** `src/agents/model-auth.ts`, `src/agents/pi-embedded-runner/run.ts`.
- **Known bad symptoms:** If baseUrl is misconfigured (e.g. typo), Moonshot requests may 401 or hit wrong endpoint; log line shows the baseUrl in use.
## Risks and Mitigations
- **Risk:** Moonshot users who relied on a profile with a .ai key and no baseUrl in config could see behavior change if env/config now wins and points to .cn.
  - **Mitigation:** Document that .cn keys require `baseUrl: "https://api.moonshot.cn/v1"`; profile is still used when env and config do not supply a key.
- **Risk:** Log line exposes auth source and baseUrl (not the key).
  - **Mitigation:** No secrets logged; baseUrl and source are operational diagnostics only.