### PR TITLE
config: accept Signal accountUuid in strict schema

### DIFF
--- a/changelog/fragments/issue-35577-signal-accountuuid-schema.md
+++ b/changelog/fragments/issue-35577-signal-accountuuid-schema.md
@@ -1,0 +1,1 @@
+- Config/Signal: strict config validation now accepts `channels.signal.accountUuid` (including account-level inheritance paths), matching existing Signal loop-protection runtime support. Fixes #35577 and #35601. Thanks @ingyukoh.

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -196,4 +196,19 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("rejects channels.signal.accountUuid when not a UUID", () => {
+    const res = validateConfigObject({
+      channels: {
+        signal: {
+          accountUuid: "not-a-uuid",
+        },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((issue) => issue.path === "channels.signal.accountUuid")).toBe(true);
+    }
+  });
 });

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -184,4 +184,16 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it("accepts channels.signal.accountUuid in strict schema validation", () => {
+    const res = validateConfigObject({
+      channels: {
+        signal: {
+          accountUuid: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -927,7 +927,7 @@ export const SignalAccountSchemaBase = z
     enabled: z.boolean().optional(),
     configWrites: z.boolean().optional(),
     account: z.string().optional(),
-    accountUuid: z.string().optional(),
+    accountUuid: z.string().uuid().optional(),
     httpUrl: z.string().optional(),
     httpHost: z.string().optional(),
     httpPort: z.number().int().positive().optional(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -927,6 +927,7 @@ export const SignalAccountSchemaBase = z
     enabled: z.boolean().optional(),
     configWrites: z.boolean().optional(),
     account: z.string().optional(),
+    accountUuid: z.string().optional(),
     httpUrl: z.string().optional(),
     httpHost: z.string().optional(),
     httpPort: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary
- Add missing `accountUuid` to `SignalAccountSchemaBase` strict schema validation.
- Add regression test so `channels.signal.accountUuid` stays accepted by strict config validation.
- Add changelog fragment for this user-facing config fix.

## Security Impact
- No security boundary changes.
- This aligns strict schema validation with existing Signal runtime loop-protection support.

## Repro + Verification
### Repro
1. Configure:
   - `channels.signal.accountUuid: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"`
2. Run config validation.
3. Before this fix, strict schema rejected `accountUuid` as an unknown key.

### Verification
- `pnpm exec vitest run src/config/config.schema-regressions.test.ts`
- `pnpm exec oxfmt --check src/config/zod-schema.providers-core.ts src/config/config.schema-regressions.test.ts changelog/fragments/issue-35577-signal-accountuuid-schema.md`
- `pnpm exec oxlint src/config/zod-schema.providers-core.ts src/config/config.schema-regressions.test.ts`

## Human Verification
- Confirmed strict schema now accepts `channels.signal.accountUuid` as expected.

## AI Assisted
- AI-assisted implementation and test drafting, followed by local validation runs.

Fixes #35577
Fixes #35601
