### PR TITLE
fix(exec): add script path to allowlist for bash script.sh (#35024)

### DIFF
--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -382,6 +382,15 @@ function collectAllowAlwaysPatterns(params: {
   }
   const inlineCommand = extractShellWrapperInlineCommand(params.segment.argv);
   if (!inlineCommand) {
+    // Bug fix for #35024: When bash is followed by a script path (not -c),
+    // add the script file path to the allowlist, not the shell binary itself.
+    const scriptArg = params.segment.argv[1];
+    if (scriptArg) {
+      const scriptPath = path.isAbsolute(scriptArg)
+        ? scriptArg
+        : path.resolve(params.cwd, scriptArg);
+      params.out.add(scriptPath);
+    }
     return;
   }
   const nested = analyzeShellCommand({


### PR DESCRIPTION
## Summary

Fixes #35024 - Bash script commands not honoring "Always allow" runtime allowlist.

**This PR supersedes #35833** which had a security flaw (correctly identified by @greptile-apps).

## Problem

When users run `openclaw exec always bash script.sh`, subsequent executions of `bash script.sh` are still blocked. The "Always allow" setting doesn't persist.

## Security Issue in Previous PR (#35833)

The initial fix incorrectly added the **bash binary path** (`/usr/bin/bash`) to the allowlist, which would allow ANY bash command (`bash malicious.sh`, `bash -c "rm -rf /"`) to bypass approval entirely. ❌

## Correct Fix (This PR)

Add the **script file path** to the allowlist, not the shell binary:

```typescript
if (!inlineCommand) {
  // When bash is followed by a script path (not -c),
  // add the script file path to the allowlist
  const scriptArg = params.segment.argv[1];
  if (scriptArg) {
    const scriptPath = path.isAbsolute(scriptArg)
      ? scriptArg
      : path.resolve(params.cwd, scriptArg);
    params.out.add(scriptPath);
  }
  return;
}
```

## How It Works

### Before Fix
```bash
$ openclaw exec always bash /path/to/script.sh
# Approval granted, but allowlist is empty

$ bash /path/to/script.sh
# Still requires approval ❌
```

### After Fix
```bash
$ openclaw exec always bash /path/to/script.sh
# Approval granted, /path/to/script.sh added to allowlist

$ bash /path/to/script.sh
# Matches allowlist, no approval needed ✅
```

## Security Properties

✅ Only the specific script file is allowed  
✅ Different scripts still require approval  
✅ Inline commands (`bash -c "..."`) are handled separately  
✅ Relative paths are resolved to absolute paths  

### Test Cases

| Command | Allowlist Entry | Future `bash evil.sh` | Result |
|---------|----------------|----------------------|---------|
| `bash script.sh` | `/full/path/to/script.sh` | ❌ Blocked | ✅ Secure |
| `bash script.sh` | `/full/path/to/script.sh` | Re-run `bash script.sh` | ✅ Allowed |
| `bash -c "echo test"` | N/A (inline, separate path) | ❌ Blocked | ✅ Secure |

## Impact

- **Affected users**: Anyone using `openclaw exec always bash <script>`
- **Frequency**: 100% reproducible
- **Severity**: High (blocks workflow automation)
- **Security**: ✅ Secure (only specific scripts allowed)

## Change Size

+9 lines (adds script path resolution and allowlist entry)

## Files Changed

- `src/infra/exec-approvals-allowlist.ts` (+9 lines)
