### PR TITLE
discord: align autoThread channel type with schema

### DIFF
--- a/changelog/fragments/issue-35607-discord-autothread-type.md
+++ b/changelog/fragments/issue-35607-discord-autothread-type.md
@@ -1,0 +1,1 @@
+- Config/Discord: `DiscordGuildChannelConfig` now includes `autoThread`, matching schema/runtime behavior and removing local shadow typing in monitor allow-list resolution. Fixes #35607. Thanks @ingyukoh.

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -184,4 +184,25 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it("accepts channels.discord.guilds.*.channels.*.autoThread", () => {
+    const res = validateConfigObject({
+      channels: {
+        discord: {
+          guilds: {
+            "123456789": {
+              channels: {
+                general: {
+                  allow: true,
+                  autoThread: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -31,6 +31,8 @@ export type DiscordDmConfig = {
 
 export type DiscordGuildChannelConfig = {
   allow?: boolean;
+  /** If true, auto-create reply threads from inbound messages (default: false). */
+  autoThread?: boolean;
   requireMention?: boolean;
   /**
    * If true, drop messages that mention another user/role but not this one (not @everyone/@here).

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -6,6 +6,7 @@ import {
   resolveChannelMatchConfig,
   type ChannelMatchSource,
 } from "../../channels/channel-config.js";
+import type { DiscordGuildChannelConfig } from "../../config/types.js";
 import { formatDiscordUserTag } from "./format.js";
 
 export type DiscordAllowList = {
@@ -26,21 +27,7 @@ export type DiscordGuildEntryResolved = {
   reactionNotifications?: "off" | "own" | "all" | "allowlist";
   users?: string[];
   roles?: string[];
-  channels?: Record<
-    string,
-    {
-      allow?: boolean;
-      requireMention?: boolean;
-      ignoreOtherMentions?: boolean;
-      skills?: string[];
-      enabled?: boolean;
-      users?: string[];
-      roles?: string[];
-      systemPrompt?: string;
-      includeThreadStarter?: boolean;
-      autoThread?: boolean;
-    }
-  >;
+  channels?: Record<string, DiscordGuildChannelConfig>;
 };
 
 export type DiscordChannelConfigResolved = {


### PR DESCRIPTION
## Summary
- Add missing `autoThread?: boolean` to canonical `DiscordGuildChannelConfig` type.
- Replace local shadow channel type in `discord/monitor/allow-list.ts` with canonical `DiscordGuildChannelConfig` import.
- Add strict-schema regression coverage for `channels.discord.guilds.*.channels.*.autoThread`.
- Add changelog fragment for this type/schema alignment fix.

## Security Impact
- No privilege or policy changes.
- This is a type/schema alignment fix that removes drift and improves maintainability.

## Repro + Verification
### Repro
1. Configure Discord guild channel with `autoThread: true`.
2. Before this fix, canonical `DiscordGuildChannelConfig` type omitted `autoThread`, forcing local shadow typing in monitor code.
3. After this fix, canonical type and usage are aligned.

### Verification
- `pnpm exec vitest run src/config/config.schema-regressions.test.ts src/discord/monitor.test.ts`
- `pnpm exec oxfmt --check src/config/types.discord.ts src/discord/monitor/allow-list.ts src/config/config.schema-regressions.test.ts changelog/fragments/issue-35607-discord-autothread-type.md`
- `pnpm exec oxlint src/config/types.discord.ts src/discord/monitor/allow-list.ts src/config/config.schema-regressions.test.ts`

## Human Verification
- Confirmed canonical discord channel config type now includes `autoThread` and monitor allow-list uses that canonical type directly.

## AI Assisted
- AI-assisted implementation and test drafting, followed by local validation runs.

Fixes #35607
