### PR TITLE
discord: accept agentComponents in strict config schema

### DIFF
--- a/changelog/fragments/issue-35564-discord-agent-components-schema.md
+++ b/changelog/fragments/issue-35564-discord-agent-components-schema.md
@@ -1,0 +1,1 @@
+- Config/Discord: strict config validation now accepts `channels.discord.agentComponents.enabled`, matching existing Discord runtime support for agent-controlled components. Fixes #35564. Thanks @ingyukoh.

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -184,4 +184,18 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it("accepts channels.discord.agentComponents.enabled in strict schema validation", () => {
+    const res = validateConfigObject({
+      channels: {
+        discord: {
+          agentComponents: {
+            enabled: true,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -463,6 +463,12 @@ export const DiscordAccountSchema = z
     dm: DiscordDmSchema.optional(),
     guilds: z.record(z.string(), DiscordGuildSchema.optional()).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
+    agentComponents: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     execApprovals: z
       .object({
         enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary
- Add missing `agentComponents` object to `DiscordAccountSchema` strict validation.
- Add regression test to keep `channels.discord.agentComponents.enabled` accepted.
- Add changelog fragment for this user-facing strict-schema fix.

## Security Impact
- No trust-boundary changes.
- This unblocks a config field already used by Discord runtime code.

## Repro + Verification
### Repro
1. Configure:
   - `channels.discord.agentComponents.enabled: true`
2. Run config validation.
3. Before this fix, strict schema rejected `agentComponents` as an unknown key.

### Verification
- `pnpm exec vitest run src/config/config.schema-regressions.test.ts src/discord/monitor/provider.test.ts`
- `pnpm exec oxfmt --check src/config/zod-schema.providers-core.ts src/config/config.schema-regressions.test.ts changelog/fragments/issue-35564-discord-agent-components-schema.md`
- `pnpm exec oxlint src/config/zod-schema.providers-core.ts src/config/config.schema-regressions.test.ts`

## Human Verification
- Confirmed strict schema now accepts `channels.discord.agentComponents.enabled`.

## AI Assisted
- AI-assisted implementation and test drafting, followed by local validation runs.

Fixes #35564
