### PR TITLE
fix(plugins): add missing error handlers for spawn and chokidar watcher

### DIFF
--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -274,6 +274,11 @@ async function stopTailscaleTunnel(mode: "serve" | "funnel", path: string): Prom
       resolve();
     }, 5000);
 
+    proc.on("error", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+
     proc.on("close", () => {
       clearTimeout(timeout);
       resolve();

--- a/extensions/voice-call/src/webhook/tailscale.ts
+++ b/extensions/voice-call/src/webhook/tailscale.ts
@@ -25,6 +25,11 @@ function runTailscaleCommand(
       resolve({ code: -1, stdout: "" });
     }, timeoutMs);
 
+    proc.on("error", () => {
+      clearTimeout(timer);
+      resolve({ code: -1, stdout: "" });
+    });
+
     proc.on("close", (code) => {
       clearTimeout(timer);
       resolve({ code: code ?? -1, stdout });

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -402,6 +402,7 @@ export abstract class MemoryManagerSyncOps {
     this.watcher.on("add", markDirty);
     this.watcher.on("change", markDirty);
     this.watcher.on("unlink", markDirty);
+    this.watcher.on("error", () => {});
   }
 
   protected ensureSessionListener() {


### PR DESCRIPTION
## Summary

Three missing error handlers that can cause unhandled exceptions and process crashes:

1. **`extensions/voice-call/src/webhook/tailscale.ts`** — `runTailscaleCommand` spawns the `tailscale` binary without `.on("error")`. If the binary is not installed (ENOENT) or cannot be executed, Node.js emits an unhandled `error` event on the ChildProcess that crashes the entire gateway. Added error handler that resolves with `code: -1`.

2. **`extensions/voice-call/src/tunnel.ts`** — `stopTailscaleTunnel` spawns `tailscale` without `.on("error")`. Same ENOENT risk as above. Added error handler that resolves the promise gracefully.

3. **`src/memory/manager-sync-ops.ts`** — `chokidar.watch()` without `.on("error")`. Chokidar emits error events on watch failures (permission denied, watched directory deleted, inotify limit reached). Without a handler, these propagate as uncaught exceptions and crash the process. Added no-op error handler to suppress these non-fatal watch errors.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [x] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — unhandled error events from child_process and chokidar.

## User-Visible Changes

- Voice-call plugin no longer crashes when tailscale binary is missing
- Memory sync watcher no longer crashes on filesystem errors

## Security Impact

1. Does this change handle user input? **No**
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 229 passing memory tests still pass (5 pre-existing failures in batch tests unrelated to this change)
- [x] Formatted with `oxfmt`

## Human Verification

- Uninstall tailscale and trigger voice-call webhook → should fail gracefully instead of crashing
- Remove a watched memory directory while sync is running → should not crash

## Compatibility

Fully backward compatible. Existing behavior unchanged when no errors occur.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Silenced chokidar errors hide real issues | Chokidar errors are typically transient filesystem issues; the sync will retry on next scheduled run |