### PR TITLE
fix(gateway): guard Buffer.from(base64) and new URL() against malformed input

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -335,7 +335,12 @@ export async function writeCliImages(
     const image = images[i];
     const ext = resolveImageExtension(image.mimeType);
     const filePath = path.join(tempDir, `image-${i + 1}.${ext}`);
-    const buffer = Buffer.from(image.data, "base64");
+    let buffer: Buffer;
+    try {
+      buffer = Buffer.from(image.data, "base64");
+    } catch {
+      continue;
+    }
     await fs.writeFile(filePath, buffer, { mode: 0o600 });
     paths.push(filePath);
   }

--- a/src/agents/tools/image-tool.helpers.ts
+++ b/src/agents/tools/image-tool.helpers.ts
@@ -23,7 +23,12 @@ export function decodeDataUrl(dataUrl: string): {
     throw new Error(`Unsupported data URL type: ${mimeType || "unknown"}`);
   }
   const b64 = (match[2] ?? "").trim();
-  const buffer = Buffer.from(b64, "base64");
+  let buffer: Buffer;
+  try {
+    buffer = Buffer.from(b64, "base64");
+  } catch {
+    throw new Error("Invalid data URL: malformed base64 payload.");
+  }
   if (buffer.length === 0) {
     throw new Error("Invalid data URL: empty payload.");
   }

--- a/src/browser/proxy-files.ts
+++ b/src/browser/proxy-files.ts
@@ -12,7 +12,12 @@ export async function persistBrowserProxyFiles(files: BrowserProxyFile[] | undef
   }
   const mapping = new Map<string, string>();
   for (const file of files) {
-    const buffer = Buffer.from(file.base64, "base64");
+    let buffer: Buffer;
+    try {
+      buffer = Buffer.from(file.base64, "base64");
+    } catch {
+      continue;
+    }
     const saved = await saveMediaBuffer(buffer, file.mimeType, "browser", buffer.byteLength);
     mapping.set(file.path, saved.path);
   }

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -142,7 +142,12 @@ export async function handleToolsInvokeHttpRequest(
     rateLimiter?: AuthRateLimiter;
   },
 ): Promise<boolean> {
-  const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  let url: URL;
+  try {
+    url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+  } catch {
+    return false;
+  }
   if (url.pathname !== "/tools/invoke") {
     return false;
   }


### PR DESCRIPTION
## Summary

Four defensive fixes for uncaught exceptions from external/untrusted data:

1. **`src/browser/proxy-files.ts`** — `Buffer.from(file.base64, "base64")` can throw on malformed base64 from browser proxy payloads (e.g., non-Latin1 characters). Wrapped in `try-catch`; malformed files are silently skipped.

2. **`src/agents/tools/image-tool.helpers.ts`** — `decodeDataUrl` parsed base64 from data URLs without `try-catch`. Malformed base64 now throws a descriptive `"Invalid data URL: malformed base64 payload"` error instead of a raw Buffer error.

3. **`src/agents/cli-runner/helpers.ts`** — `Buffer.from(image.data, "base64")` decoded tool-provided image data without `try-catch`. Malformed images are now skipped instead of crashing the CLI runner.

4. **`src/gateway/tools-invoke-http.ts`** — `new URL()` constructed from `req.url` and `req.headers.host` (both from HTTP request headers) without `try-catch`. Malformed values now cause the handler to return `false` (not matched) instead of crashing with `TypeError`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [x] Agents / Model integration
- [ ] Channels / Plugins
- [ ] CLI / TUI
- [x] Gateway
- [x] Security

## Linked Issues

Proactive defensive fix — uncaught exceptions from malformed external data.

## User-Visible Changes

- Browser proxy no longer crashes on malformed base64 file data
- Image tool provides clearer error for corrupt data URLs
- CLI runner skips corrupt images instead of crashing
- Gateway HTTP handler rejects malformed requests gracefully

## Security Impact

1. Does this change handle user input? **Yes** — HTTP request headers, browser proxy data, tool parameters
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **Yes** — gateway HTTP request parsing now rejects malformed URLs instead of crashing

## Verification

- [x] All 50 related tests pass (image-tool, cli-runner, gateway, browser)
- [x] Formatted with `oxfmt`

## Evidence

```
 Test Files  4 passed (4)
      Tests  50 passed (50)
```

## Human Verification

- Send a browser proxy payload with invalid base64 (e.g., containing unicode) -> should skip the file
- Pass a corrupt data URL to the image tool -> should get "malformed base64 payload" error
- Send HTTP request with malformed Host header -> gateway should return false

## Compatibility

Fully backward compatible. Valid inputs behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Skipped corrupt images in CLI runner may cause incomplete output | Better than crashing; the tool call still completes with available images |