### PR TITLE
fix(plugins): guard new URL() and Buffer.from() in webhook, docx, signal

### DIFF
--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -508,7 +508,12 @@ async function resolveUploadInput(
 
   if (url) {
     const fetched = await getFeishuRuntime().channel.media.fetchRemoteMedia({ url, maxBytes });
-    const urlPath = new URL(url).pathname;
+    let urlPath: string;
+    try {
+      urlPath = new URL(url).pathname;
+    } catch {
+      urlPath = url;
+    }
     const guessed = urlPath.split("/").pop() || "upload.bin";
     return {
       buffer: fetched.buffer,

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -322,7 +322,12 @@ export class VoiceCallWebhookServer {
     req: http.IncomingMessage,
     webhookPath: string,
   ): Promise<WebhookResponsePayload> {
-    const url = new URL(req.url || "/", `http://${req.headers.host}`);
+    let url: URL;
+    try {
+      url = new URL(req.url || "/", `http://${req.headers.host}`);
+    } catch {
+      return { statusCode: 400, headers: {}, body: "Bad Request" };
+    }
 
     if (url.pathname === "/voice/hold-music") {
       return {

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -268,7 +268,12 @@ async function fetchAttachment(params: {
   if (!result?.data) {
     return null;
   }
-  const buffer = Buffer.from(result.data, "base64");
+  let buffer: Buffer;
+  try {
+    buffer = Buffer.from(result.data, "base64");
+  } catch {
+    return null;
+  }
   const saved = await saveMediaBuffer(
     buffer,
     attachment.contentType ?? undefined,


### PR DESCRIPTION
## Summary

Three defensive fixes for uncaught exceptions from external data:

1. **`extensions/voice-call/src/webhook.ts`** — `new URL(req.url, host)` in `runWebhookPipeline` constructed from HTTP request headers without `try-catch`. A malformed `Host` header or URL path crashes the webhook server. Now returns `400 Bad Request` gracefully.

2. **`extensions/feishu/src/docx.ts`** — `new URL(url).pathname` for resolving uploaded file names from document content without `try-catch`. Malformed URLs from Feishu document blocks now fall back to using the raw URL string for the filename guess.

3. **`src/signal/monitor.ts`** — `Buffer.from(result.data, "base64")` for attachment data from Signal RPC without `try-catch`. If the RPC returns non-string data (e.g., due to protocol changes or corruption), this crashes the monitor. Now returns `null` (skip attachment) instead.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Test update

## Scope

- [ ] Agents / Model integration
- [x] Channels / Plugins
- [ ] CLI / TUI
- [ ] Gateway
- [ ] Security

## Linked Issues

Proactive defensive fix — uncaught exceptions from external data in plugins.

## User-Visible Changes

- Voice-call webhook no longer crashes on malformed HTTP requests
- Feishu docx export handles malformed image URLs gracefully
- Signal monitor skips corrupt attachments instead of crashing

## Security Impact

1. Does this change handle user input? **Yes** — HTTP request headers, document URLs, RPC data
2. Does this change affect authentication or authorization? **No**
3. Does this change introduce new dependencies? **No**
4. Does this change affect data storage or transmission? **No**
5. Does this change modify security-sensitive code paths? **No**

## Verification

- [x] All 143 related tests pass (voice-call, feishu, signal)
- [x] Formatted with `oxfmt`

## Evidence

```
 Test Files  17 passed (17)
      Tests  143 passed (143)
```

## Human Verification

- Send HTTP request with malformed Host header to voice-call webhook → should get 400 Bad Request
- Insert document block with malformed image URL in Feishu → export should not crash
- Corrupt Signal RPC attachment data → monitor should skip attachment, not crash

## Compatibility

Fully backward compatible. Valid inputs behave identically.

## Failure Recovery

Revert this single commit to restore previous behavior.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| Feishu filename guess uses raw URL string as fallback | Still produces a usable filename; better than crashing |
| Skipped Signal attachments may cause incomplete messages | Better than crashing the entire monitor; user sees text content |