### PR TITLE
fix(acpx): kill entire process tree on session abort/TTL expiry

### DIFF
--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -292,13 +292,13 @@ describe("spawnAndCollect", () => {
 });
 
 describe("killProcessTree", () => {
-  it("kills the entire process group on Unix", async () => {
+  it("kills the entire process group including grandchild on Unix", async () => {
     // Skip on Windows as process groups work differently
     if (process.platform === "win32") {
       return;
     }
 
-    // Spawn a parent that spawns a child, then test that both are killed
+    // Spawn a parent that spawns a grandchild and prints the grandchild PID
     const child = spawn(
       process.execPath,
       [
@@ -310,6 +310,8 @@ describe("killProcessTree", () => {
           detached: false,
           stdio: 'inherit'
         });
+        // Output the grandchild PID so we can verify it's killed
+        console.log('GRANDCHILD_PID:' + grandchild.pid);
         // Parent also waits forever
         setTimeout(() => {}, 60000);
         `,
@@ -321,8 +323,38 @@ describe("killProcessTree", () => {
       },
     );
 
-    // Wait a moment for the grandchild to spawn
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    // Collect stdout to get the grandchild PID
+    let stdout = "";
+    child.stdout?.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    // Wait for the grandchild PID to be printed
+    await new Promise<void>((resolve) => {
+      const check = () => {
+        if (stdout.includes("GRANDCHILD_PID:")) {
+          resolve();
+        } else {
+          setTimeout(check, 10);
+        }
+      };
+      check();
+    });
+
+    // Parse the grandchild PID
+    const match = stdout.match(/GRANDCHILD_PID:(\d+)/);
+    expect(match).not.toBeNull();
+    const grandchildPid = parseInt(match![1], 10);
+
+    // Verify grandchild is running before we kill
+    let grandchildRunning = false;
+    try {
+      process.kill(grandchildPid, 0); // Signal 0 checks if process exists
+      grandchildRunning = true;
+    } catch {
+      grandchildRunning = false;
+    }
+    expect(grandchildRunning).toBe(true);
 
     // Import killProcessTree dynamically to test it
     const { killProcessTree } = await import("./process.js");
@@ -337,7 +369,20 @@ describe("killProcessTree", () => {
     });
 
     const exitCode = await exitPromise;
-    // Process was killed by signal, so exit code is null and signal is SIGTERM
+    // Process was killed by signal, so exit code is null
     expect(exitCode).toBeNull();
+
+    // Wait a moment for signals to propagate
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Verify grandchild is also killed - this is the key assertion
+    let grandchildStillRunning = false;
+    try {
+      process.kill(grandchildPid, 0);
+      grandchildStillRunning = true;
+    } catch {
+      grandchildStillRunning = false;
+    }
+    expect(grandchildStillRunning).toBe(false);
   });
 });

--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -290,3 +290,54 @@ describe("spawnAndCollect", () => {
     expect(result.error?.name).toBe("AbortError");
   });
 });
+
+describe("killProcessTree", () => {
+  it("kills the entire process group on Unix", async () => {
+    // Skip on Windows as process groups work differently
+    if (process.platform === "win32") {
+      return;
+    }
+
+    // Spawn a parent that spawns a child, then test that both are killed
+    const child = spawn(
+      process.execPath,
+      [
+        "-e",
+        `
+        const { spawn } = require('child_process');
+        // Spawn a grandchild that sleeps forever
+        const grandchild = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60000)'], {
+          detached: false,
+          stdio: 'inherit'
+        });
+        // Parent also waits forever
+        setTimeout(() => {}, 60000);
+        `,
+      ],
+      {
+        cwd: process.cwd(),
+        stdio: ["pipe", "pipe", "pipe"],
+        detached: true, // Create a new process group
+      },
+    );
+
+    // Wait a moment for the grandchild to spawn
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Import killProcessTree dynamically to test it
+    const { killProcessTree } = await import("./process.js");
+
+    // Kill the process tree
+    const killed = killProcessTree(child, "SIGTERM");
+    expect(killed).toBe(true);
+
+    // Wait for the child to exit
+    const exitPromise = new Promise<number | null>((resolve) => {
+      child.once("close", (code) => resolve(code));
+    });
+
+    const exitCode = await exitPromise;
+    // Process was killed by signal, so exit code is null and signal is SIGTERM
+    expect(exitCode).toBeNull();
+  });
+});

--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -120,6 +120,35 @@ function createAbortError(): Error {
   return error;
 }
 
+/**
+ * Kill an entire process tree by sending a signal to the process group.
+ * On Unix, uses negative PID to target the process group (requires detached spawn).
+ * On Windows, falls back to single process kill.
+ */
+export function killProcessTree(
+  child: ChildProcessWithoutNullStreams,
+  signal: NodeJS.Signals,
+): boolean {
+  const pid = child.pid;
+  if (pid == null) {
+    return false;
+  }
+  try {
+    if (process.platform !== "win32") {
+      // Kill the entire process group using negative PID.
+      // This works because we spawn with detached: true on Unix,
+      // making the child the process group leader (PGID = PID).
+      process.kill(-pid, signal);
+    } else {
+      child.kill(signal);
+    }
+    return true;
+  } catch {
+    // Process may have already exited
+    return false;
+  }
+}
+
 export function spawnWithResolvedCommand(
   params: {
     command: string;
@@ -142,6 +171,10 @@ export function spawnWithResolvedCommand(
     stdio: ["pipe", "pipe", "pipe"],
     shell: resolved.shell,
     windowsHide: resolved.windowsHide,
+    // Create a new process group on Unix so we can kill the entire tree
+    // when the session expires. The child becomes the process group leader
+    // with PGID = PID, allowing killProcessTree to use kill(-pid).
+    detached: process.platform !== "win32",
   });
 }
 
@@ -215,20 +248,15 @@ export async function spawnAndCollect(
   let aborted = false;
   const onAbort = () => {
     aborted = true;
-    try {
-      child.kill("SIGTERM");
-    } catch {
-      // Ignore kill races when child already exited.
-    }
+    // Kill the entire process tree, not just the immediate child.
+    // This ensures child processes (e.g., metabase-mcp, claude-agent-acp)
+    // are also terminated when the session is aborted.
+    killProcessTree(child, "SIGTERM");
     abortKillTimer = setTimeout(() => {
       if (child.exitCode !== null || child.signalCode !== null) {
         return;
       }
-      try {
-        child.kill("SIGKILL");
-      } catch {
-        // Ignore kill races when child already exited.
-      }
+      killProcessTree(child, "SIGKILL");
     }, 250);
     abortKillTimer.unref?.();
   };

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -25,6 +25,7 @@ import {
   type SpawnCommandOptions,
   type SpawnResolutionEvent,
   spawnAndCollect,
+  killProcessTree,
   spawnWithResolvedCommand,
   waitForExit,
 } from "./runtime-internals/process.js";
@@ -250,25 +251,17 @@ export class AcpxRuntime implements AcpRuntime {
       cwd: state.cwd,
     });
 
-    const cancelOnAbort = async () => {
+    // Handle already-aborted signal before spawning
+    if (input.signal?.aborted) {
       await this.cancel({
         handle: input.handle,
         reason: "abort-signal",
       }).catch((err) => {
         this.logger?.warn?.(`acpx runtime abort-cancel failed: ${String(err)}`);
       });
-    };
-    const onAbort = () => {
-      void cancelOnAbort();
-    };
-
-    if (input.signal?.aborted) {
-      await cancelOnAbort();
       return;
     }
-    if (input.signal) {
-      input.signal.addEventListener("abort", onAbort, { once: true });
-    }
+
     const child = spawnWithResolvedCommand(
       {
         command: this.config.command,
@@ -277,6 +270,36 @@ export class AcpxRuntime implements AcpRuntime {
       },
       this.spawnCommandOptions,
     );
+
+    // Set up abort handler with access to child process
+    let abortKillTimer: NodeJS.Timeout | undefined;
+    const onAbort = () => {
+      // First, kill the entire process tree to ensure all child processes
+      // (e.g., metabase-mcp, claude-agent-acp) are terminated
+      killProcessTree(child, "SIGTERM");
+
+      // Escalate to SIGKILL if process doesn't exit gracefully
+      abortKillTimer = setTimeout(() => {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          return;
+        }
+        killProcessTree(child, "SIGKILL");
+      }, 500);
+      abortKillTimer.unref?.();
+
+      // Also send cancel command to acpx for graceful cleanup
+      void this.cancel({
+        handle: input.handle,
+        reason: "abort-signal",
+      }).catch((err) => {
+        this.logger?.warn?.(`acpx runtime abort-cancel failed: ${String(err)}`);
+      });
+    };
+
+    if (input.signal) {
+      input.signal.addEventListener("abort", onAbort, { once: true });
+    }
+
     child.stdin.on("error", () => {
       // Ignore EPIPE when the child exits before stdin flush completes.
     });
@@ -346,9 +369,11 @@ export class AcpxRuntime implements AcpRuntime {
       if (input.signal) {
         input.signal.removeEventListener("abort", onAbort);
       }
+      if (abortKillTimer) {
+        clearTimeout(abortKillTimer);
+      }
     }
   }
-
   getCapabilities(): AcpRuntimeCapabilities {
     return ACPX_CAPABILITIES;
   }


### PR DESCRIPTION
## Problem

When an ACP session's TTL expires or is aborted, child processes spawned by the agent (e.g., `metabase-mcp`, `claude-agent-acp`, `npm`, `node`) were **not** being terminated. This causes **unbounded process accumulation** over time.

**Impact:** After 2 days of operation with a 30-minute cron schedule, one user reported 478 zombie processes, consuming ~37 GB RAM.

Affected users: Anyone using the acpx backend for ACP sessions with long-running or frequent cron tasks.

## Root Cause

In `extensions/acpx/src/runtime-internals/process.ts`:

1. `spawnWithResolvedCommand()` spawned processes **without** `detached: true`, so children weren't in a separate process group
2. The abort handler used `child.kill()`, which only terminates the **immediate** child, not its descendants
3. The `cancel` command sent to acpx didn't ensure cleanup of the spawned process tree

## Fix

1. **Process groups on Unix**: Spawn with `detached: true` on Unix to create a new process group where the child is the leader (PGID = PID)

2. **New `killProcessTree()` helper**: Uses `process.kill(-pid, signal)` to send signals to the entire process group on Unix (falls back to single-process kill on Windows)

3. **Updated abort handling**: Both `spawnAndCollect()` and `runTurn()` now use `killProcessTree()` to terminate the entire process tree when aborting

## Testing

- Added unit test for `killProcessTree()` that spawns a parent+grandchild and verifies both are killed
- All 59 existing acpx tests pass

```
pnpm test extensions/acpx/
✓ 8 test files (59 tests) passed
```

## Files Changed

- `extensions/acpx/src/runtime-internals/process.ts` - Added `killProcessTree()`, `detached: true` on Unix
- `extensions/acpx/src/runtime.ts` - Updated `runTurn()` abort handler to kill process tree
- `extensions/acpx/src/runtime-internals/process.test.ts` - Added test for `killProcessTree()`

Fixes #35886

@greptile-apps please review