### PR TITLE
feat: add configurable FTS5 tokenizer for CJK text support

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -35,6 +35,9 @@ export type ResolvedMemorySearchConfig = {
   store: {
     driver: "sqlite";
     path: string;
+    fts: {
+      tokenizer: "unicode61" | "trigram";
+    };
     vector: {
       enabled: boolean;
       extensionPath?: string;
@@ -207,9 +210,13 @@ function mergeConfig(
     extensionPath:
       overrides?.store?.vector?.extensionPath ?? defaults?.store?.vector?.extensionPath,
   };
+  const fts = {
+    tokenizer: overrides?.store?.fts?.tokenizer ?? defaults?.store?.fts?.tokenizer ?? "unicode61",
+  };
   const store = {
     driver: overrides?.store?.driver ?? defaults?.store?.driver ?? "sqlite",
     path: resolveStorePath(agentId, overrides?.store?.path ?? defaults?.store?.path),
+    fts,
     vector,
   };
   const chunking = {

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -358,6 +358,10 @@ export type MemorySearchConfig = {
   store?: {
     driver?: "sqlite";
     path?: string;
+    fts?: {
+      /** FTS5 tokenizer (default: "unicode61"). Use "trigram" for CJK text support. */
+      tokenizer?: "unicode61" | "trigram";
+    };
     vector?: {
       /** Enable sqlite-vec extension for vector search (default: true). */
       enabled?: boolean;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -604,6 +604,12 @@ export const MemorySearchSchema = z
       .object({
         driver: z.literal("sqlite").optional(),
         path: z.string().optional(),
+        fts: z
+          .object({
+            tokenizer: z.union([z.literal("unicode61"), z.literal("trigram")]).optional(),
+          })
+          .strict()
+          .optional(),
         vector: z
           .object({
             enabled: z.boolean().optional(),

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -53,6 +53,7 @@ type MemoryIndexMeta = {
   chunkTokens: number;
   chunkOverlap: number;
   vectorDims?: number;
+  ftsTokenizer?: string;
 };
 
 type MemorySyncProgressState = {
@@ -349,6 +350,7 @@ export abstract class MemoryManagerSyncOps {
       embeddingCacheTable: EMBEDDING_CACHE_TABLE,
       ftsTable: FTS_TABLE,
       ftsEnabled: this.fts.enabled,
+      ftsTokenizer: this.settings.store.fts.tokenizer,
     });
     this.fts.available = result.ftsAvailable;
     if (result.ftsError) {
@@ -872,7 +874,8 @@ export abstract class MemoryManagerSyncOps {
       this.metaSourcesDiffer(meta, configuredSources) ||
       meta.chunkTokens !== this.settings.chunking.tokens ||
       meta.chunkOverlap !== this.settings.chunking.overlap ||
-      (vectorReady && !meta?.vectorDims);
+      (vectorReady && !meta?.vectorDims) ||
+      (meta.ftsTokenizer ?? "unicode61") !== this.settings.store.fts.tokenizer;
     try {
       if (needsFullReindex) {
         if (
@@ -1084,6 +1087,7 @@ export abstract class MemoryManagerSyncOps {
         sources: this.resolveConfiguredSourcesForMeta(),
         chunkTokens: this.settings.chunking.tokens,
         chunkOverlap: this.settings.chunking.overlap,
+        ftsTokenizer: this.settings.store.fts.tokenizer,
       };
       if (!nextMeta) {
         throw new Error("Failed to compute memory index metadata for reindexing.");
@@ -1155,6 +1159,7 @@ export abstract class MemoryManagerSyncOps {
       sources: this.resolveConfiguredSourcesForMeta(),
       chunkTokens: this.settings.chunking.tokens,
       chunkOverlap: this.settings.chunking.overlap,
+      ftsTokenizer: this.settings.store.fts.tokenizer,
     };
     if (this.vector.available && this.vector.dims) {
       nextMeta.vectorDims = this.vector.dims;
@@ -1169,9 +1174,10 @@ export abstract class MemoryManagerSyncOps {
     this.db.exec(`DELETE FROM chunks`);
     if (this.fts.enabled && this.fts.available) {
       try {
-        this.db.exec(`DELETE FROM ${FTS_TABLE}`);
+        this.db.exec(`DROP TABLE IF EXISTS ${FTS_TABLE}`);
       } catch {}
     }
+    this.ensureSchema();
     this.dropVectorTable();
     this.vector.dims = undefined;
     this.sessionsDirtyFiles.clear();

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -272,7 +272,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
       // Extract keywords for better FTS matching on conversational queries
       // e.g., "that thing we discussed about the API" → ["discussed", "API"]
-      const keywords = extractKeywords(cleaned);
+      const keywords = extractKeywords(cleaned, {
+        ftsTokenizer: this.settings.store.fts.tokenizer,
+      });
       const searchTerms = keywords.length > 0 ? keywords : [cleaned];
 
       // Search with each keyword and merge results

--- a/src/memory/memory-schema.ts
+++ b/src/memory/memory-schema.ts
@@ -5,6 +5,7 @@ export function ensureMemoryIndexSchema(params: {
   embeddingCacheTable: string;
   ftsTable: string;
   ftsEnabled: boolean;
+  ftsTokenizer?: "unicode61" | "trigram";
 }): { ftsAvailable: boolean; ftsError?: string } {
   params.db.exec(`
     CREATE TABLE IF NOT EXISTS meta (
@@ -55,6 +56,8 @@ export function ensureMemoryIndexSchema(params: {
   let ftsError: string | undefined;
   if (params.ftsEnabled) {
     try {
+      const tokenizer = params.ftsTokenizer ?? "unicode61";
+      const tokenizeClause = tokenizer === "trigram" ? `, tokenize='trigram case_sensitive 0'` : "";
       params.db.exec(
         `CREATE VIRTUAL TABLE IF NOT EXISTS ${params.ftsTable} USING fts5(\n` +
           `  text,\n` +
@@ -64,7 +67,7 @@ export function ensureMemoryIndexSchema(params: {
           `  model UNINDEXED,\n` +
           `  start_line UNINDEXED,\n` +
           `  end_line UNINDEXED\n` +
-          `);`,
+          `${tokenizeClause});`,
       );
       ftsAvailable = true;
     } catch (err) {

--- a/src/memory/query-expansion.test.ts
+++ b/src/memory/query-expansion.test.ts
@@ -174,6 +174,49 @@ describe("extractKeywords", () => {
     const testCount = keywords.filter((k) => k === "test").length;
     expect(testCount).toBe(1);
   });
+
+  describe("with trigram tokenizer", () => {
+    const trigramOpts = { ftsTokenizer: "trigram" as const };
+
+    it("skips Chinese bigrams in trigram mode", () => {
+      const defaultKeywords = extractKeywords("之前讨论的那个方案");
+      const trigramKeywords = extractKeywords("之前讨论的那个方案", trigramOpts);
+      // Default mode produces bigrams
+      expect(defaultKeywords).toContain("讨论");
+      expect(defaultKeywords).toContain("方案");
+      // Trigram mode skips bigrams — only unigrams remain
+      expect(trigramKeywords).not.toContain("讨论");
+      expect(trigramKeywords).not.toContain("方案");
+    });
+
+    it("skips Japanese kanji bigrams in trigram mode", () => {
+      const defaultKeywords = extractKeywords("経済政策について");
+      const trigramKeywords = extractKeywords("経済政策について", trigramOpts);
+      // Default mode adds kanji bigrams: 経済, 済政, 政策
+      expect(defaultKeywords).toContain("経済");
+      expect(defaultKeywords).toContain("済政");
+      expect(defaultKeywords).toContain("政策");
+      // Trigram mode keeps the full kanji block but skips bigram splitting
+      expect(trigramKeywords).toContain("経済政策");
+      expect(trigramKeywords).not.toContain("済政");
+    });
+
+    it("still filters stop words in trigram mode", () => {
+      const keywords = extractKeywords("これ それ そして どう", trigramOpts);
+      expect(keywords).not.toContain("これ");
+      expect(keywords).not.toContain("それ");
+      expect(keywords).not.toContain("そして");
+      expect(keywords).not.toContain("どう");
+    });
+
+    it("does not affect English keyword extraction", () => {
+      const keywords = extractKeywords("that thing we discussed about the API", trigramOpts);
+      expect(keywords).toContain("discussed");
+      expect(keywords).toContain("api");
+      expect(keywords).not.toContain("that");
+      expect(keywords).not.toContain("the");
+    });
+  });
 });
 
 describe("expandQueryForFts", () => {

--- a/src/memory/query-expansion.ts
+++ b/src/memory/query-expansion.ts
@@ -670,7 +670,8 @@ function isValidKeyword(token: string): boolean {
  * For Chinese, we do character-based splitting since we don't have a proper segmenter.
  * For English, we split on whitespace and punctuation.
  */
-function tokenize(text: string): string[] {
+function tokenize(text: string, opts?: { ftsTokenizer?: "unicode61" | "trigram" }): string[] {
+  const useTrigram = opts?.ftsTokenizer === "trigram";
   const tokens: string[] = [];
   const normalized = text.toLowerCase().trim();
 
@@ -686,8 +687,10 @@ function tokenize(text: string): string[] {
       for (const part of jpParts) {
         if (/^[\u4e00-\u9fff]+$/.test(part)) {
           tokens.push(part);
-          for (let i = 0; i < part.length - 1; i++) {
-            tokens.push(part[i] + part[i + 1]);
+          if (!useTrigram) {
+            for (let i = 0; i < part.length - 1; i++) {
+              tokens.push(part[i] + part[i + 1]);
+            }
           }
         } else {
           tokens.push(part);
@@ -699,9 +702,11 @@ function tokenize(text: string): string[] {
       const chars = Array.from(segment).filter((c) => /[\u4e00-\u9fff]/.test(c));
       // Add individual characters
       tokens.push(...chars);
-      // Add bigrams for better phrase matching
-      for (let i = 0; i < chars.length - 1; i++) {
-        tokens.push(chars[i] + chars[i + 1]);
+      // Add bigrams for better phrase matching (skip when using trigram tokenizer)
+      if (!useTrigram) {
+        for (let i = 0; i < chars.length - 1; i++) {
+          tokens.push(chars[i] + chars[i + 1]);
+        }
       }
     } else if (/[\uac00-\ud7af\u3131-\u3163]/.test(segment)) {
       // For Korean (Hangul syllables and jamo), keep the word as-is unless it is
@@ -732,8 +737,11 @@ function tokenize(text: string): string[] {
  * - "之前讨论的那个方案" → ["讨论", "方案"]
  * - "what was the solution for the bug" → ["solution", "bug"]
  */
-export function extractKeywords(query: string): string[] {
-  const tokens = tokenize(query);
+export function extractKeywords(
+  query: string,
+  opts?: { ftsTokenizer?: "unicode61" | "trigram" },
+): string[] {
+  const tokens = tokenize(query, opts);
   const keywords: string[] = [];
   const seen = new Set<string>();
 


### PR DESCRIPTION
## Summary

- Problem: FTS5 with the default `unicode61` tokenizer cannot tokenize CJK (Chinese, Japanese, Korean) text — entire runs of CJK characters become a single token, so substring queries never match
- Why it matters: The BM25 component of hybrid search is completely ineffective for all CJK users (Japanese, Korean, Chinese)
- What changed: Added a `memorySearch.store.fts.tokenizer` config option (`"unicode61"` | `"trigram"`). When `"trigram"` is selected, FTS5 indexes 3-character sliding windows, enabling substring matching for CJK text
- What did NOT change: Default behavior (unicode61), vector search, query-expansion stop word filtering, hybrid scoring

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #20730

## User-visible / Behavior Changes

- New config option: `memorySearch.store.fts.tokenizer` (default: `"unicode61"`)
- Setting `"trigram"` triggers automatic FTS index rebuild on next sync
- Known limitation: trigram does not match queries shorter than 3 characters via FTS MATCH. In hybrid mode, vector search covers these cases.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Amazon Linux 2023 (aarch64)
- Runtime/container: Node.js 22+
- Model/provider: OpenAI text-embedding-3-small
- Relevant config: `{"memorySearch": {"store": {"fts": {"tokenizer": "trigram"}}, "query": {"hybrid": {"vectorWeight": 0.7, "textWeight": 0.3}}}}`

### Steps

1. Add Japanese/Chinese/Korean content to memory files
2. Set `memorySearch.store.fts.tokenizer` to `"trigram"` in config
3. Restart gateway and let memory sync complete (FTS index rebuilds automatically)
4. Search with a CJK substring (e.g. "ネパール" for Japanese)

### Expected

- CJK substring queries return matching results via FTS

### Actual

- Verified: "ネパール" (4 chars, Japanese katakana) returns 1 hit from text containing "本格的にネパールのカレー"
- Before (unicode61): 0 results for the same query

## Evidence

- [x] Tested on live environment with Japanese content in memory files
- [x] `pnpm check` passes
- [x] `pnpm test` passes (813 tests, includes 4 new trigram-specific tests in query-expansion.test.ts)

## Human Verification (required)

- Verified scenarios: Japanese katakana query ("ネパール") against unicode61 (0 hits) and trigram (1 hit) on a live instance
- Edge cases checked: Existing users without `ftsTokenizer` in metadata don't trigger unnecessary reindex (defaults to "unicode61")
- What I did **not** verify: Chinese and Korean queries on a live instance (tested via unit tests only); LIKE/GLOB fallback for sub-3-char queries

## Compatibility / Migration

- Backward compatible? Yes — default remains `unicode61`, no behavior change unless user opts in
- Config/env changes? New optional config key `memorySearch.store.fts.tokenizer`
- Migration needed? No — changing the config triggers automatic FTS index rebuild via existing `runSafeReindex` mechanism

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `store.fts.tokenizer` from config (or set to `"unicode61"`) and restart. FTS index will rebuild automatically.
- Known bad symptoms: If trigram tokenizer is not available in the SQLite build, FTS table creation fails gracefully (caught in try/catch, FTS disabled with warning log)

## Risks and Mitigations

- Risk: Trigram indexes are larger than unicode61 indexes (each character appears in multiple trigrams)
  - Mitigation: Only affects users who explicitly opt in. Memory files are typically small enough that index size is not a concern.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)