### PR TITLE
telegram: accept editMessage and createForumTopic action config

### DIFF
--- a/changelog/fragments/issue-35497-telegram-actions-schema.md
+++ b/changelog/fragments/issue-35497-telegram-actions-schema.md
@@ -1,0 +1,1 @@
+- Config/Telegram: strict schema validation now accepts `channels.telegram.actions.editMessage` and `channels.telegram.actions.createForumTopic`, matching existing Telegram action config types. Fixes #35497. Thanks @vincentkoc.

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -184,4 +184,19 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it("accepts channels.telegram.actions.editMessage and createForumTopic", () => {
+    const res = validateConfigObject({
+      channels: {
+        telegram: {
+          actions: {
+            editMessage: true,
+            createForumTopic: true,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -226,7 +226,9 @@ export const TelegramAccountSchemaBase = z
         reactions: z.boolean().optional(),
         sendMessage: z.boolean().optional(),
         deleteMessage: z.boolean().optional(),
+        editMessage: z.boolean().optional(),
         sticker: z.boolean().optional(),
+        createForumTopic: z.boolean().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary
- Add missing `editMessage` and `createForumTopic` keys to Telegram actions strict schema.
- Add regression coverage so `channels.telegram.actions.editMessage` and `channels.telegram.actions.createForumTopic` stay valid.
- Add changelog fragment for this user-facing schema fix.

## Security Impact
- No security-boundary changes.
- This only aligns strict schema validation with existing Telegram action config types.

## Repro + Verification
### Repro
1. Configure:
   - `channels.telegram.actions.editMessage: true`
   - `channels.telegram.actions.createForumTopic: true`
2. Run config validation.
3. Before this fix, strict schema rejected these keys as unrecognized.

### Verification
- `pnpm exec vitest run src/config/config.schema-regressions.test.ts`
- `pnpm exec oxfmt --check src/config/zod-schema.providers-core.ts src/config/config.schema-regressions.test.ts changelog/fragments/issue-35497-telegram-actions-schema.md`
- `pnpm exec oxlint src/config/zod-schema.providers-core.ts src/config/config.schema-regressions.test.ts`

## Human Verification
- Confirmed both keys now pass strict config validation in local tests.

## AI Assisted
- AI-assisted implementation and test drafting, followed by local validation runs.

Fixes #35497
