### PR TITLE
fix(agents): recognize model_context_window_exceeded as context overflow error

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -98,6 +98,7 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     lower.includes("prompt is too long") ||
     lower.includes("exceeds model context window") ||
     lower.includes("model token limit") ||
+    lower.includes("model_context_window_exceeded") ||
     (hasRequestSizeExceeds && hasContextWindow) ||
     lower.includes("context overflow:") ||
     lower.includes("exceed context limit") ||


### PR DESCRIPTION
## Summary

- **Problem:** Providers like GLM-5 via Anthropic/Bedrock return `stop_reason: "model_context_window_exceeded"`, which the SDK surfaces as `stopReason: "error"` with `errorMessage: "Unhandled stop reason: model_context_window_exceeded"`. `isContextOverflowError()` did not match this string, so overflow recovery (compaction) was never triggered. Sessions entered a permanent error loop.
- **Why it matters:** Heartbeat, cron, and announce sessions with long histories hit the context limit and fail repeatedly with no recovery, wasting API credits and blocking the agent.
- **What changed:** Added `"model_context_window_exceeded"` to the overflow detection patterns in `isContextOverflowError()`.
- **What did NOT change:** No changes to the overflow recovery logic itself, compaction, lifecycle handlers, or payload building — only the detection predicate was updated.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35868

## User-visible / Behavior Changes

- Sessions that hit `model_context_window_exceeded` now trigger the standard context overflow recovery (compaction or truncation) instead of entering a permanent error loop.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Any (heartbeat/cron/announce sessions)

### Steps

1. Configure an agent with a model that returns `model_context_window_exceeded` (e.g. GLM-5 via Anthropic)
2. Accumulate enough context to exceed the model's window
3. Trigger a turn (heartbeat, cron, or manual)

### Expected

- Overflow recovery is triggered (compaction/truncation) and the session continues

### Actual

- Before fix: `Unhandled stop reason: model_context_window_exceeded` error loops indefinitely
- After fix: `isContextOverflowError()` returns true, triggering the standard overflow recovery path

## Evidence

The existing overflow detection patterns in `isContextOverflowError()` cover various provider error formats:

```typescript
lower.includes("context length exceeded") ||
lower.includes("prompt is too long") ||
lower.includes("exceeds model context window") ||
lower.includes("model token limit") ||
lower.includes("model_context_window_exceeded") ||  // ← added
```

The SDK maps unknown stop reasons to `stopReason: "error"` with `errorMessage` containing the original reason string, so the existing `stopReason === "error"` → `assistantErrorText` → `isContextOverflowError()` pipeline handles it correctly once the pattern is added.

## Human Verification (required)

- Verified scenarios: TypeScript compiles cleanly, existing tests unaffected
- Edge cases checked: The pattern is case-insensitive (uses `lower.includes()`), works for both raw `model_context_window_exceeded` and `Unhandled stop reason: model_context_window_exceeded`
- What I did **not** verify: End-to-end test with a GLM-5 model (no API key available)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single-line addition in `errors.ts`
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts`
- Known bad symptoms: None — worst case is the same error loop behavior as before

## Risks and Mitigations

None — additive pattern to an existing detection function. Does not change any behavior for providers that don't return this stop reason.

