### PR TITLE
config: accept discovery.wideArea.domain in strict schema

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -175,6 +175,19 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts discovery.wideArea.domain", () => {
+    const res = validateConfigObject({
+      discovery: {
+        wideArea: {
+          enabled: true,
+          domain: "openclaw.internal",
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects browser.extraArgs with non-array value", () => {
     const res = validateConfigObject({
       browser: {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -537,6 +537,7 @@ export const OpenClawSchema = z
         wideArea: z
           .object({
             enabled: z.boolean().optional(),
+            domain: z.string().optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
## Summary

- Problem: strict config validation rejected `discovery.wideArea.domain` even though runtime and types already support it.
- Why it matters: users cannot configure unicast DNS-SD domain via validated config.
- What changed: added `domain?: string` to `discovery.wideArea` in `OpenClawSchema` and added a regression test.
- What did NOT change (scope boundary): no runtime discovery behavior changes; only schema acceptance + test coverage.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35614
- Related #35938

## User-visible / Behavior Changes

`discovery.wideArea.domain` is now accepted by strict config validation.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): config validation
- Relevant config (redacted):

### Steps

1. Set `discovery.wideArea.domain` in config object.
2. Validate via `validateConfigObject`.

### Expected

- Config validates successfully.

### Actual

- Verified by regression test.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm exec vitest run src/config/config.schema-regressions.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `discovery.wideArea.domain: "openclaw.internal"` validates under strict schema.
- Edge cases checked:
  - Existing `discovery.wideArea.enabled` behavior remains unchanged.
- What you did **not** verify:
  - End-to-end DNS runtime behavior (out of scope for schema drift fix).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/config/zod-schema.ts`
  - `src/config/config.schema-regressions.test.ts`
- Known bad symptoms reviewers should watch for:
  - None expected; only schema acceptance path changed.

## Risks and Mitigations

- Risk:
  - Broader schema acceptance for one field could hide typo if wrong key name was intended.
  - Mitigation:
  - Field already exists in canonical type and runtime codepaths; regression test locks intended key.
