### PR TITLE
fix(config): use explicit Claude Sonnet default for OpenRouter instead of auto-routing

### DIFF
--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -657,7 +657,7 @@ describe("applyAuthChoice", () => {
         expectEnvPrompt: true,
         expectedTextCalls: 0,
         expectedKey: "sk-openrouter-test",
-        expectedModel: "openrouter/auto",
+        expectedModel: "openrouter/anthropic/claude-sonnet-4-6",
       },
       {
         authChoice: "ai-gateway-api-key",

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -330,7 +330,7 @@ export async function setVeniceApiKey(
 
 export const ZAI_DEFAULT_MODEL_REF = "zai/glm-5";
 export const XIAOMI_DEFAULT_MODEL_REF = "xiaomi/mimo-v2-flash";
-export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
+export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/anthropic/claude-sonnet-4-6";
 export const HUGGINGFACE_DEFAULT_MODEL_REF = "huggingface/deepseek-ai/DeepSeek-R1";
 export const TOGETHER_DEFAULT_MODEL_REF = "together/moonshotai/Kimi-K2.5";
 export const LITELLM_DEFAULT_MODEL_REF = "litellm/claude-opus-4-6";


### PR DESCRIPTION
## Summary

- **Problem:** The onboarding flow sets `openrouter/auto` as the default model, which delegates model selection to OpenRouter's auto-routing. This silently routes to non-Claude models (Gemini, etc.), surprising users who chose OpenRouter expecting Claude.
- **Why it matters:** Users configure OpenRouter as a provider specifically for Claude access. Auto-routing undermines this expectation and can produce inconsistent behavior across sessions.
- **What changed:** Changed `OPENROUTER_DEFAULT_MODEL_REF` from `"openrouter/auto"` to `"openrouter/anthropic/claude-sonnet-4-6"`. Updated the corresponding test expectation.
- **What did NOT change:** Existing configs that already specify a model are not affected. The `openrouter/auto` model ID is still available for explicit selection via `/model` command or config. `HIDDEN_ROUTER_MODELS` in `model-picker.ts` still hides `openrouter/auto` from the picker. `model-scan.ts` baseline scan still uses `openrouter/auto` for probing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35842

## User-visible / Behavior Changes

- New OpenRouter setups default to `openrouter/anthropic/claude-sonnet-4-6` instead of `openrouter/auto`. Existing configurations are unchanged.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: CLI onboarding

### Steps

1. Run `openclaw auth` and select OpenRouter
2. Enter API key
3. Check the resulting config model

### Expected

- Default model is `openrouter/anthropic/claude-sonnet-4-6`

### Actual

- Before fix: Default model is `openrouter/auto` (auto-routing, may use non-Claude models)
- After fix: Default model is `openrouter/anthropic/claude-sonnet-4-6`

## Evidence

All 57 tests pass (`auth-choice.test.ts` 26/26, `onboard-auth.test.ts` 31/31).

## Human Verification (required)

- Verified scenarios: TypeScript compiles cleanly, all auth tests pass (57/57)
- Edge cases checked: Existing configs with explicit models are unaffected; `openrouter/auto` remains usable via manual config
- What I did **not** verify: Full onboarding flow in interactive mode

## Compatibility / Migration

- Backward compatible? `Yes` — only affects new setups
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the constant change in `onboard-auth.credentials.ts`
- Files/config to restore: `src/commands/onboard-auth.credentials.ts`
- Known bad symptoms: None

## Risks and Mitigations

- **Risk:** The model `anthropic/claude-sonnet-4-6` might not be available on all OpenRouter plans → Users can change it via `/model` command. This is the same pattern used by other defaults (e.g. `litellm/claude-opus-4-6`).

