### PR TITLE
discord: accept agentComponents in strict config schema

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -175,6 +175,20 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts channels.discord.agentComponents.enabled", () => {
+    const res = validateConfigObject({
+      channels: {
+        discord: {
+          agentComponents: {
+            enabled: true,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects browser.extraArgs with non-array value", () => {
     const res = validateConfigObject({
       browser: {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -385,6 +385,13 @@ const DiscordUiSchema = z
   .strict()
   .optional();
 
+const DiscordAgentComponentsSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+  })
+  .strict()
+  .optional();
+
 const DiscordVoiceAutoJoinSchema = z
   .object({
     guildId: z.string().min(1),
@@ -474,6 +481,7 @@ export const DiscordAccountSchema = z
       })
       .strict()
       .optional(),
+    agentComponents: DiscordAgentComponentsSchema,
     ui: DiscordUiSchema,
     slashCommand: z
       .object({


### PR DESCRIPTION
## Summary

- Problem: strict validation rejected `channels.discord.agentComponents` although type + runtime already support it.
- Why it matters: valid Discord config fails at load time, blocking interactive components toggle.
- What changed: added `agentComponents` to `DiscordAccountSchema` with strict object schema and added a regression test.
- What did NOT change (scope boundary): no runtime behavior changes to Discord component handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35564
- Related #35942

## User-visible / Behavior Changes

`channels.discord.agentComponents.enabled` now passes strict config validation.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): Discord config validation
- Relevant config (redacted):

### Steps

1. Set `channels.discord.agentComponents.enabled: true` in config object.
2. Validate via `validateConfigObject`.

### Expected

- Config validates successfully.

### Actual

- Verified by regression test.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm exec vitest run src/config/config.schema-regressions.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `channels.discord.agentComponents.enabled: true` validates under strict schema.
- Edge cases checked:
  - Existing `channels.discord.ui` and neighboring fields continue to validate.
- What you did **not** verify:
  - Runtime Discord component interaction flow (out of scope for schema drift fix).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/config/zod-schema.providers-core.ts`
  - `src/config/config.schema-regressions.test.ts`
- Known bad symptoms reviewers should watch for:
  - None expected; only schema acceptance path changed.

## Risks and Mitigations

- Risk:
  - Accepting an extra object key in strict schema could hide misconfigured values if field type were wrong.
  - Mitigation:
  - Field shape is constrained (`enabled?: boolean`) and already matches canonical runtime usage.
