### PR TITLE
config: accept discovery.wideArea.domain in strict schema

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -175,6 +175,19 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts discovery.wideArea.domain", () => {
+    const res = validateConfigObject({
+      discovery: {
+        wideArea: {
+          enabled: true,
+          domain: "openclaw.internal",
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects browser.extraArgs with non-array value", () => {
     const res = validateConfigObject({
       browser: {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -537,6 +537,7 @@ export const OpenClawSchema = z
         wideArea: z
           .object({
             enabled: z.boolean().optional(),
+            domain: z.string().optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
## Summary

- Problem: strict config validation rejected `discovery.wideArea.domain` though runtime and types support it.
- Why it matters: users cannot configure unicast DNS-SD domain in validated config.
- What changed: added `domain?: string` to `discovery.wideArea` in `OpenClawSchema` and added a regression test.
- What did NOT change (scope boundary): no runtime discovery logic changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35614
- Related #35945

## User-visible / Behavior Changes

`discovery.wideArea.domain` now passes strict config validation.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): config validation
- Relevant config (redacted):

### Steps

1. Include `discovery.wideArea.domain` in config.
2. Validate with `validateConfigObject`.

### Expected

- Config validates.

### Actual

- Verified by regression test.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm exec vitest run src/config/config.schema-regressions.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `discovery.wideArea.enabled: true` + `domain: "openclaw.internal"` validates.
- Edge cases checked:
  - Existing `discovery.wideArea.enabled` path remains valid.
- What you did **not** verify:
  - End-to-end DNS-SD runtime behavior (out of scope).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this commit.
- Files/config to restore:
  - `src/config/zod-schema.ts`
  - `src/config/config.schema-regressions.test.ts`
- Known bad symptoms reviewers should watch for:
  - None expected.

## Risks and Mitigations

- Risk:
  - Minimal schema surface expansion for one existing typed/runtime field.
  - Mitigation:
  - Field already exists in canonical type and discovery code paths; regression test protects against drift.
