### PR TITLE
fix(cron): set secure file permissions (600) for cron job files

### DIFF
--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -126,6 +126,7 @@ async function pruneIfNeeded(filePath: string, opts: { maxBytes: number; keepLin
   const { randomBytes } = await import("node:crypto");
   const tmp = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
   await fs.writeFile(tmp, `${kept.join("\n")}\n`, "utf-8");
+  await fs.chmod(tmp, 0o600);
   await fs.rename(tmp, filePath);
 }
 
@@ -139,8 +140,13 @@ export async function appendCronRunLog(
   const next = prev
     .catch(() => undefined)
     .then(async () => {
-      await fs.mkdir(path.dirname(resolved), { recursive: true });
+      await fs.mkdir(path.dirname(resolved), { recursive: true, mode: 0o700 });
       await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, "utf-8");
+      try {
+        await fs.chmod(resolved, 0o600);
+      } catch {
+        // File may not exist yet, ignore
+      }
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,
         keepLines: opts?.keepLines ?? DEFAULT_CRON_RUN_LOG_KEEP_LINES,

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -61,7 +61,7 @@ export async function saveCronStore(
   store: CronStoreFile,
   opts?: SaveCronStoreOptions,
 ) {
-  await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.promises.mkdir(path.dirname(storePath), { recursive: true, mode: 0o700 });
   const json = JSON.stringify(store, null, 2);
   const cached = serializedStoreCache.get(storePath);
   if (cached === json) {
@@ -83,10 +83,11 @@ export async function saveCronStore(
     return;
   }
   const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.promises.writeFile(tmp, json, "utf-8");
+  await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: 0o600 });
   if (previous !== null && !opts?.skipBackup) {
     try {
       await fs.promises.copyFile(storePath, `${storePath}.bak`);
+      await fs.promises.chmod(`${storePath}.bak`, 0o600);
     } catch {
       // best-effort
     }


### PR DESCRIPTION
## Summary

When the Gateway writes jobs.json.bak and files under ~/.openclaw/cron/runs/, it creates them with 0644 permissions instead of 0600.

## Changes

- Set mode 0o600 when writing jobs.json and jobs.json.bak
- Set mode 0o700 for cron runs/ directory
- Set mode 0o600 for run log .jsonl files

## Impact

jobs.json.bak contains cron job configurations (schedules, message content, delivery targets). While parent directory ~/.openclaw/cron/ is 700 (protecting files from other users), it's still desirable to have defense-in-depth with secure file permissions.

Fixes #35881