### PR TITLE
config: accept openclaw browser profile driver

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -191,6 +191,22 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it('accepts legacy browser.profiles.*.driver value "clawd"', () => {
+    const res = validateConfigObject({
+      browser: {
+        profiles: {
+          default: {
+            cdpPort: 9222,
+            driver: "clawd",
+            color: "#FF4500",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects browser.extraArgs with non-array value", () => {
     const res = validateConfigObject({
       browser: {

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -175,6 +175,22 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it('accepts browser.profiles.*.driver value "openclaw"', () => {
+    const res = validateConfigObject({
+      browser: {
+        profiles: {
+          default: {
+            cdpPort: 9222,
+            driver: "openclaw",
+            color: "#FF4500",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects browser.extraArgs with non-array value", () => {
     const res = validateConfigObject({
       browser: {

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -406,7 +406,7 @@ const ENUM_EXPECTATIONS: Record<string, string[]> = {
   "gateway.bind": ['"auto"', '"lan"', '"loopback"', '"custom"', '"tailnet"'],
   "gateway.auth.mode": ['"none"', '"token"', '"password"', '"trusted-proxy"'],
   "gateway.tailscale.mode": ['"off"', '"serve"', '"funnel"'],
-  "browser.profiles.*.driver": ['"clawd"', '"extension"'],
+  "browser.profiles.*.driver": ['"openclaw"', '"clawd"', '"extension"'],
   "discovery.mdns.mode": ['"off"', '"minimal"', '"full"'],
   "wizard.lastRunMode": ['"local"', '"remote"'],
   "diagnostics.otel.protocol": ['"http/protobuf"', '"grpc"'],

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -251,7 +251,7 @@ export const FIELD_HELP: Record<string, string> = {
   "browser.profiles.*.cdpUrl":
     "Per-profile CDP websocket URL used for explicit remote browser routing by profile name. Use this when profile connections terminate on remote hosts or tunnels.",
   "browser.profiles.*.driver":
-    'Per-profile browser driver mode: "clawd" or "extension" depending on connection/runtime strategy. Use the driver that matches your browser control stack to avoid protocol mismatches.',
+    'Per-profile browser driver mode: "openclaw" or "extension" (legacy "clawd" is also accepted for compatibility) depending on connection/runtime strategy. Use the driver that matches your browser control stack to avoid protocol mismatches.',
   "browser.profiles.*.attachOnly":
     "Per-profile attach-only override that skips local browser launch and only attaches to an existing CDP endpoint. Useful when one profile is externally managed but others are locally launched.",
   "browser.profiles.*.color":

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -309,7 +309,9 @@ export const OpenClawSchema = z
               .object({
                 cdpPort: z.number().int().min(1).max(65535).optional(),
                 cdpUrl: z.string().optional(),
-                driver: z.union([z.literal("clawd"), z.literal("extension")]).optional(),
+                driver: z
+                  .union([z.literal("openclaw"), z.literal("clawd"), z.literal("extension")])
+                  .optional(),
                 attachOnly: z.boolean().optional(),
                 color: HexColorSchema,
               })


### PR DESCRIPTION
## Summary

- Problem: strict config schema rejected `browser.profiles.*.driver: "openclaw"` and only accepted legacy `"clawd"`.
- Why it matters: current documented/default driver value fails validation.
- What changed: schema now accepts `"openclaw"` (and keeps legacy `"clawd"` compatibility), plus docs/help enum expectations and regression coverage were updated.
- What did NOT change (scope boundary): no browser runtime behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35620
- Related #35946

## User-visible / Behavior Changes

`browser.profiles.*.driver: "openclaw"` now validates successfully.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): config validation
- Relevant config (redacted):

### Steps

1. Set `browser.profiles.default.driver: "openclaw"` with valid profile fields.
2. Validate config.

### Expected

- Config validates.

### Actual

- Verified by regression test.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm exec vitest run src/config/config.schema-regressions.test.ts src/config/schema.help.quality.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `driver: "openclaw"` validates for browser profiles.
  - Help text + enum quality expectations include `"openclaw"` and compatibility alias `"clawd"`.
- Edge cases checked:
  - Existing `"extension"`/legacy `"clawd"` acceptance remains intact via enum set.
- What you did **not** verify:
  - End-to-end browser launch behavior (runtime unchanged, out of scope).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this commit.
- Files/config to restore:
  - `src/config/zod-schema.ts`
  - `src/config/schema.help.ts`
  - `src/config/schema.help.quality.test.ts`
  - `src/config/config.schema-regressions.test.ts`
- Known bad symptoms reviewers should watch for:
  - None expected (schema/help alignment only).

## Risks and Mitigations

- Risk:
  - Broadened enum acceptance in profile driver parsing.
  - Mitigation:
  - Restricted to explicit literals (`openclaw`, `clawd`, `extension`) and covered by regression + quality tests.
