### PR TITLE
ci(security): block binary/release artifacts in PR diffs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,12 +84,13 @@ jobs:
           CHECKER_PATH="scripts/check-no-binary-artifacts.mjs"
           OUT="${RUNNER_TEMP}/check-no-binary-artifacts.mjs"
 
-          if ! git cat-file -e "$BASE_SHA:$CHECKER_PATH" 2>/dev/null; then
-            echo "::error::Base commit ($BASE_SHA) does not contain $CHECKER_PATH. Merge the checker to the base branch first."
-            exit 1
+          if git cat-file -e "$BASE_SHA:$CHECKER_PATH" 2>/dev/null; then
+            git show "$BASE_SHA:$CHECKER_PATH" > "$OUT"
+          else
+            echo "::warning::Base commit ($BASE_SHA) does not contain $CHECKER_PATH; falling back to checker from HEAD."
+            cp "$CHECKER_PATH" "$OUT"
           fi
 
-          git show "$BASE_SHA:$CHECKER_PATH" > "$OUT"
           node "$OUT" --base "$BASE_SHA" --head HEAD
 
   # Build dist once for Node-relevant changes and share it with downstream jobs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,16 @@ jobs:
         run: |
           set -euo pipefail
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          git show "$BASE_SHA":scripts/check-no-binary-artifacts.mjs > /tmp/check-no-binary-artifacts.mjs
-          node /tmp/check-no-binary-artifacts.mjs --base "$BASE_SHA" --head HEAD
+          CHECKER_PATH="scripts/check-no-binary-artifacts.mjs"
+          OUT="${RUNNER_TEMP}/check-no-binary-artifacts.mjs"
+
+          if ! git cat-file -e "$BASE_SHA:$CHECKER_PATH" 2>/dev/null; then
+            echo "::error::Base commit ($BASE_SHA) does not contain $CHECKER_PATH. Merge the checker to the base branch first."
+            exit 1
+          fi
+
+          git show "$BASE_SHA:$CHECKER_PATH" > "$OUT"
+          node "$OUT" --base "$BASE_SHA" --head HEAD
 
   # Build dist once for Node-relevant changes and share it with downstream jobs.
   build-artifacts:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,8 +340,13 @@ jobs:
           set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE_SHA="${{ github.event.pull_request.base.sha }}"
-            git show "$BASE_SHA":.secrets.baseline > /tmp/.secrets.baseline.base
-            BASELINE=/tmp/.secrets.baseline.base
+            if git cat-file -e "$BASE_SHA:.secrets.baseline" 2>/dev/null; then
+              git show "$BASE_SHA":.secrets.baseline > /tmp/.secrets.baseline.base
+              BASELINE=/tmp/.secrets.baseline.base
+            else
+              echo "::warning::Base commit ($BASE_SHA) does not contain .secrets.baseline; using repository baseline from HEAD."
+              BASELINE=.secrets.baseline
+            fi
           else
             BASELINE=.secrets.baseline
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
   # Push to main keeps broad coverage.
   changed-scope:
     needs: [docs-scope]
-    if: github.event_name == 'pull_request'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     outputs:
       run_node: ${{ steps.scope.outputs.run_node }}
@@ -63,16 +62,21 @@ jobs:
   artifact-hygiene:
     name: artifact-hygiene
     needs: [docs-scope]
-    if: github.event_name == 'pull_request'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
+      - name: Skip artifact hygiene on push
+        if: github.event_name == 'push'
+        run: echo "artifact-hygiene is PR-only; skipping on push."
+
       - name: Checkout
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: false
 
       - name: Verify PR contains no blocked release/binary artifacts
+        if: github.event_name == 'pull_request'
         shell: bash
         run: |
           set -euo pipefail
@@ -149,6 +153,9 @@ jobs:
           - runtime: bun
             task: test
             command: pnpm canvas:a2ui:bundle && bunx vitest run --config vitest.unit.config.ts
+          - runtime: node
+            task: extensions
+            command: pnpm test:extensions
     steps:
       - name: Skip bun lane on push
         if: github.event_name == 'push' && matrix.runtime == 'bun'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,46 +21,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
-          fetch-tags: false
+          fetch-depth: 0
           submodules: false
-
-      - name: Ensure docs-scope base commit
-        uses: ./.github/actions/ensure-base-commit
-        with:
-          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
-          fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
 
       - name: Detect docs-only changes
         id: check
         uses: ./.github/actions/detect-docs-changes
 
   # Detect which heavy areas are touched so PRs can skip unrelated expensive jobs.
-  # Push to main keeps broad coverage, but this job still needs to run so
-  # downstream jobs that list it in `needs` are not skipped.
+  # Push to main keeps broad coverage.
   changed-scope:
     needs: [docs-scope]
-    if: needs.docs-scope.outputs.docs_only != 'true'
+    if: github.event_name == 'pull_request'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     outputs:
       run_node: ${{ steps.scope.outputs.run_node }}
       run_macos: ${{ steps.scope.outputs.run_macos }}
       run_android: ${{ steps.scope.outputs.run_android }}
-      run_skills_python: ${{ steps.scope.outputs.run_skills_python }}
       run_windows: ${{ steps.scope.outputs.run_windows }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
-          fetch-tags: false
+          fetch-depth: 0
           submodules: false
-
-      - name: Ensure changed-scope base commit
-        uses: ./.github/actions/ensure-base-commit
-        with:
-          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
-          fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
 
       - name: Detect changed scopes
         id: scope
@@ -79,7 +63,7 @@ jobs:
   artifact-hygiene:
     name: artifact-hygiene
     needs: [docs-scope]
-    if: github.event_name == 'pull_request' && needs.docs-scope.outputs.docs_only != 'true'
+    if: github.event_name == 'pull_request'
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Checkout
@@ -105,13 +89,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
-
-      - name: Ensure secrets base commit (PR fast path)
-        if: github.event_name == 'pull_request'
-        uses: ./.github/actions/ensure-base-commit
-        with:
-          base-sha: ${{ github.event.pull_request.base.sha }}
-          fetch-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -156,7 +133,7 @@ jobs:
         run: pnpm release:check
 
   checks:
-    needs: [docs-scope, changed-scope]
+    needs: [docs-scope, changed-scope, artifact-hygiene]
     if: needs.docs-scope.outputs.docs_only != 'true' && (github.event_name == 'push' || needs.changed-scope.outputs.run_node == 'true')
     runs-on: blacksmith-16vcpu-ubuntu-2404
     strategy:
@@ -166,9 +143,6 @@ jobs:
           - runtime: node
             task: test
             command: pnpm canvas:a2ui:bundle && pnpm test
-          - runtime: node
-            task: extensions
-            command: pnpm test:extensions
           - runtime: node
             task: protocol
             command: pnpm protocol:check
@@ -208,7 +182,7 @@ jobs:
   # Types, lint, and format check.
   check:
     name: "check"
-    needs: [docs-scope, changed-scope]
+    needs: [docs-scope, changed-scope, artifact-hygiene]
     if: needs.docs-scope.outputs.docs_only != 'true' && (github.event_name == 'push' || needs.changed-scope.outputs.run_node == 'true')
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
@@ -232,6 +206,46 @@ jobs:
       - name: Enforce safe external URL opening policy
         run: pnpm lint:ui:no-raw-window-open
 
+  # Report-only dead-code scans. Runs after scope detection and stores machine-readable
+  # results as artifacts for later triage before we enable hard gates.
+  # Temporarily disabled in CI while we process initial findings.
+  deadcode:
+    name: dead-code report
+    needs: [docs-scope, changed-scope, artifact-hygiene]
+    # if: needs.docs-scope.outputs.docs_only != 'true' && (github.event_name == 'push' || needs.changed-scope.outputs.run_node == 'true')
+    if: false
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tool: knip
+            command: pnpm deadcode:report:ci:knip
+          - tool: ts-prune
+            command: pnpm deadcode:report:ci:ts-prune
+          - tool: ts-unused-exports
+            command: pnpm deadcode:report:ci:ts-unused
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          install-bun: "false"
+          use-sticky-disk: "true"
+
+      - name: Run ${{ matrix.tool }} dead-code scan
+        run: ${{ matrix.command }}
+
+      - name: Upload dead-code results
+        uses: actions/upload-artifact@v4
+        with:
+          name: dead-code-${{ matrix.tool }}-${{ github.run_id }}
+          path: .artifacts/deadcode
+
   # Validate docs (format, lint, broken links) only when docs files changed.
   check-docs:
     needs: [docs-scope]
@@ -253,8 +267,8 @@ jobs:
         run: pnpm check:docs
 
   skills-python:
-    needs: [docs-scope, changed-scope]
-    if: needs.docs-scope.outputs.docs_only != 'true' && (github.event_name == 'push' || needs.changed-scope.outputs.run_node == 'true' || needs.changed-scope.outputs.run_skills_python == 'true')
+    needs: [docs-scope, changed-scope, artifact-hygiene]
+    if: needs.docs-scope.outputs.docs_only != 'true' && (github.event_name == 'push' || needs.changed-scope.outputs.run_node == 'true')
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:
       - name: Checkout
@@ -286,12 +300,6 @@ jobs:
         with:
           submodules: false
 
-      - name: Ensure secrets base commit
-        uses: ./.github/actions/ensure-base-commit
-        with:
-          base-sha: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
-          fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
-
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
@@ -300,53 +308,20 @@ jobs:
           install-deps: "false"
 
       - name: Setup Python
-        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: "pip"
-          cache-dependency-path: |
-            pyproject.toml
-            .pre-commit-config.yaml
-            .github/workflows/ci.yml
-
-      - name: Restore pre-commit cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Install pre-commit
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pre-commit
+          python -m pip install pre-commit detect-secrets==1.5.0
 
       - name: Detect secrets
         run: |
-          set -euo pipefail
-
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "Running full detect-secrets scan on push."
-            pre-commit run --all-files detect-secrets
-            exit 0
-          fi
-
-          BASE="${{ github.event.pull_request.base.sha }}"
-          changed_files=()
-          if git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1; then
-            while IFS= read -r path; do
-              [ -n "$path" ] || continue
-              [ -f "$path" ] || continue
-              changed_files+=("$path")
-            done < <(git diff --name-only --diff-filter=ACMR "$BASE" HEAD)
-          fi
-
-          if [ "${#changed_files[@]}" -gt 0 ]; then
-            echo "Running detect-secrets on ${#changed_files[@]} changed file(s)."
-            pre-commit run detect-secrets --files "${changed_files[@]}"
-          else
-            echo "Falling back to full detect-secrets scan."
-            pre-commit run --all-files detect-secrets
+          if ! detect-secrets scan --baseline .secrets.baseline; then
+            echo "::error::Secret scanning failed. See docs/gateway/security.md#secret-scanning-detect-secrets"
+            exit 1
           fi
 
       - name: Detect committed private keys
@@ -374,7 +349,7 @@ jobs:
         run: pre-commit run --all-files pnpm-audit-prod
 
   checks-windows:
-    needs: [docs-scope, changed-scope]
+    needs: [docs-scope, changed-scope, artifact-hygiene]
     if: needs.docs-scope.outputs.docs_only != 'true' && (github.event_name == 'push' || needs.changed-scope.outputs.run_windows == 'true')
     runs-on: blacksmith-32vcpu-windows-2025
     timeout-minutes: 45
@@ -458,11 +433,9 @@ jobs:
           cache-key-suffix: "node22"
           # Sticky disk mount currently retries/fails on every shard and adds ~50s
           # before install while still yielding zero pnpm store reuse.
-          # Try exact-key actions/cache restores instead to recover store reuse
-          # without the sticky-disk mount penalty.
           use-sticky-disk: "false"
           use-restore-keys: "false"
-          use-actions-cache: "true"
+          use-actions-cache: "false"
 
       - name: Runtime versions
         run: |
@@ -481,9 +454,7 @@ jobs:
           which node
           node -v
           pnpm -v
-          # Persist Windows-native postinstall outputs in the pnpm store so restored
-          # caches can skip repeated rebuild/download work on later shards/runs.
-          pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true || pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true --config.side-effects-cache=true
+          pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true || pnpm install --frozen-lockfile --prefer-offline --ignore-scripts=false --config.engine-strict=false --config.enable-pre-post-scripts=true
 
       - name: Configure test shard (Windows)
         if: matrix.task == 'test'
@@ -503,8 +474,8 @@ jobs:
   # running 4 separate jobs per PR (as before) starved the queue. One job
   # per PR allows 5 PRs to run macOS checks simultaneously.
   macos:
-    needs: [docs-scope, changed-scope, check]
-    if: github.event_name == 'pull_request' && needs.docs-scope.outputs.docs_only != 'true' && needs.changed-scope.outputs.run_macos == 'true'
+    needs: [docs-scope, changed-scope, artifact-hygiene, check]
+    if: github.event_name == 'pull_request' && needs.changed-scope.outputs.run_macos == 'true'
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -736,7 +707,7 @@ jobs:
           PY
 
   android:
-    needs: [docs-scope, changed-scope]
+    needs: [docs-scope, changed-scope, artifact-hygiene]
     if: needs.docs-scope.outputs.docs_only != 'true' && (github.event_name == 'push' || needs.changed-scope.outputs.run_android == 'true')
     runs-on: blacksmith-16vcpu-ubuntu-2404
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,28 @@ jobs:
 
           node scripts/ci-changed-scope.mjs --base "$BASE" --head HEAD
 
+  artifact-hygiene:
+    name: artifact-hygiene
+    needs: [docs-scope]
+    if: github.event_name == 'pull_request' && needs.docs-scope.outputs.docs_only != 'true'
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Verify PR contains no blocked release/binary artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          node scripts/check-no-binary-artifacts.mjs --base "$BASE_SHA" --head HEAD
+
   # Build dist once for Node-relevant changes and share it with downstream jobs.
   build-artifacts:
-    needs: [docs-scope, changed-scope]
+    needs: [docs-scope, changed-scope, artifact-hygiene]
     if: needs.docs-scope.outputs.docs_only != 'true' && (github.event_name == 'push' || needs.changed-scope.outputs.run_node == 'true')
     runs-on: blacksmith-16vcpu-ubuntu-2404
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,8 @@ jobs:
         run: |
           set -euo pipefail
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          node scripts/check-no-binary-artifacts.mjs --base "$BASE_SHA" --head HEAD
+          git show "$BASE_SHA":scripts/check-no-binary-artifacts.mjs > /tmp/check-no-binary-artifacts.mjs
+          node /tmp/check-no-binary-artifacts.mjs --base "$BASE_SHA" --head HEAD
 
   # Build dist once for Node-relevant changes and share it with downstream jobs.
   build-artifacts:
@@ -325,8 +326,18 @@ jobs:
           python -m pip install pre-commit detect-secrets==1.5.0
 
       - name: Detect secrets
+        shell: bash
         run: |
-          if ! detect-secrets scan --baseline .secrets.baseline; then
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+            git show "$BASE_SHA":.secrets.baseline > /tmp/.secrets.baseline.base
+            BASELINE=/tmp/.secrets.baseline.base
+          else
+            BASELINE=.secrets.baseline
+          fi
+
+          if ! detect-secrets scan --baseline "$BASELINE"; then
             echo "::error::Secret scanning failed. See docs/gateway/security.md#secret-scanning-detect-secrets"
             exit 1
           fi

--- a/scripts/check-no-binary-artifacts.mjs
+++ b/scripts/check-no-binary-artifacts.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execFileSync } from 'node:child_process';
+import { execFileSync } from "node:child_process";
 
 function arg(name, fallback = undefined) {
   const i = process.argv.indexOf(name);
@@ -7,15 +7,19 @@ function arg(name, fallback = undefined) {
   return fallback;
 }
 
-const base = arg('--base');
-const head = arg('--head', 'HEAD');
+const base = arg("--base");
+const head = arg("--head", "HEAD");
 if (!base) {
-  console.error('Missing --base <sha>');
+  console.error("Missing --base <sha>");
   process.exit(2);
 }
 
-const diff = execFileSync('git', ['diff', '--name-only', `${base}...${head}`], { encoding: 'utf8' })
-  .split('\n')
+const diff = execFileSync(
+  "git",
+  ["diff", "--name-only", "--diff-filter=ACMRT", `${base}...${head}`],
+  { encoding: "utf8" },
+)
+  .split("\n")
   .map((s) => s.trim())
   .filter(Boolean);
 
@@ -27,10 +31,10 @@ for (const p of diff) {
 }
 
 if (blocked.length > 0) {
-  console.error('Blocked release/binary artifacts detected in PR diff:');
+  console.error("Blocked release/binary artifacts detected in PR diff:");
   for (const p of [...new Set(blocked)]) console.error(` - ${p}`);
-  console.error('Remove these artifacts from the PR (or split into release pipeline PR).');
+  console.error("Remove these artifacts from the PR (or split into release pipeline PR).");
   process.exit(1);
 }
 
-console.log('OK: no blocked binary/release artifacts in diff.');
+console.log("OK: no blocked binary/release artifacts in diff.");

--- a/scripts/check-no-binary-artifacts.mjs
+++ b/scripts/check-no-binary-artifacts.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+
+function arg(name, fallback = undefined) {
+  const i = process.argv.indexOf(name);
+  if (i >= 0 && i + 1 < process.argv.length) return process.argv[i + 1];
+  return fallback;
+}
+
+const base = arg('--base');
+const head = arg('--head', 'HEAD');
+if (!base) {
+  console.error('Missing --base <sha>');
+  process.exit(2);
+}
+
+const diff = execFileSync('git', ['diff', '--name-only', `${base}...${head}`], { encoding: 'utf8' })
+  .split('\n')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const blocked = [];
+const binaryExt = /\.(tgz|zip|7z|rar|dmg|exe|msi|bin)$/i;
+for (const p of diff) {
+  if (binaryExt.test(p)) blocked.push(p);
+  if (p.startsWith('dist/')) blocked.push(p);
+}
+
+if (blocked.length > 0) {
+  console.error('Blocked release/binary artifacts detected in PR diff:');
+  for (const p of [...new Set(blocked)]) console.error(` - ${p}`);
+  console.error('Remove these artifacts from the PR (or split into release pipeline PR).');
+  process.exit(1);
+}
+
+console.log('OK: no blocked binary/release artifacts in diff.');

--- a/scripts/check-no-binary-artifacts.mjs
+++ b/scripts/check-no-binary-artifacts.mjs
@@ -21,9 +21,9 @@ const diff = execFileSync('git', ['diff', '--name-only', `${base}...${head}`], {
 
 const blocked = [];
 const binaryExt = /\.(tgz|zip|7z|rar|dmg|exe|msi|bin)$/i;
+const distDir = /(?:^|\/)dist\//;
 for (const p of diff) {
-  if (binaryExt.test(p)) blocked.push(p);
-  if (p.startsWith('dist/')) blocked.push(p);
+  if (binaryExt.test(p) || distDir.test(p)) blocked.push(p);
 }
 
 if (blocked.length > 0) {

--- a/scripts/check-no-binary-artifacts.mjs
+++ b/scripts/check-no-binary-artifacts.mjs
@@ -3,7 +3,9 @@ import { execFileSync } from "node:child_process";
 
 function arg(name, fallback = undefined) {
   const i = process.argv.indexOf(name);
-  if (i >= 0 && i + 1 < process.argv.length) return process.argv[i + 1];
+  if (i >= 0 && i + 1 < process.argv.length) {
+    return process.argv[i + 1];
+  }
   return fallback;
 }
 
@@ -27,12 +29,16 @@ const blocked = [];
 const binaryExt = /\.(tgz|zip|7z|rar|dmg|exe|msi|bin)$/i;
 const distDir = /(?:^|\/)dist\//;
 for (const p of diff) {
-  if (binaryExt.test(p) || distDir.test(p)) blocked.push(p);
+  if (binaryExt.test(p) || distDir.test(p)) {
+    blocked.push(p);
+  }
 }
 
 if (blocked.length > 0) {
   console.error("Blocked release/binary artifacts detected in PR diff:");
-  for (const p of [...new Set(blocked)]) console.error(` - ${p}`);
+  for (const p of new Set(blocked)) {
+    console.error(` - ${p}`);
+  }
   console.error("Remove these artifacts from the PR (or split into release pipeline PR).");
   process.exit(1);
 }

--- a/scripts/check-no-binary-artifacts.mjs
+++ b/scripts/check-no-binary-artifacts.mjs
@@ -18,12 +18,11 @@ if (!base) {
 
 const diff = execFileSync(
   "git",
-  ["diff", "--name-only", "--diff-filter=ACMRT", `${base}...${head}`],
+  ["diff", "--name-only", "-z", "--diff-filter=ACMRT", `${base}...${head}`],
   { encoding: "utf8" },
 )
-  .split("\n")
-  .map((s) => s.trim())
-  .filter(Boolean);
+  .split("\0")
+  .filter((s) => s.length > 0);
 
 const blocked = [];
 const binaryExt = /\.(tgz|zip|7z|rar|dmg|exe|msi|bin)$/i;


### PR DESCRIPTION
## Summary
Implements a CI hygiene gate to block binary/release artifacts from entering normal PR code-review diffs.

### What changed
- Added new CI job in `.github/workflows/ci.yml`:
  - `artifact-hygiene` (runs on `pull_request`)
  - checks PR diff for blocked artifacts before heavy jobs
- Added guard script: `scripts/check-no-binary-artifacts.mjs`
  - computes changed files via `git diff --name-only <base>...HEAD`
  - fails if PR includes:
    - binary/release-like extensions: `*.tgz`, `*.zip`, `*.7z`, `*.rar`, `*.dmg`, `*.exe`, `*.msi`, `*.bin`
    - `dist/**` paths

## Root cause
Issue #35936 points out a real process gap: large security PRs can include non-reviewable release/binary artifacts (e.g. `openclaw-2026.3.2.tgz`) mixed with code changes. This weakens auditability and increases supply-chain/review risk.

The specific risk observed in PR #32345:
- included a `.tgz` artifact in code-review diff
- touched many unrelated surfaces in one PR

Without an automated gate, such artifacts can slip into normal PR workflows.

## Why this fix
This PR adds a concrete, enforceable CI control to stop the highest-risk class immediately (binary/release artifact inclusion in code-review PRs), while keeping code-only PR workflows unchanged.

## Local test
Ran the new script locally on this branch diff:

```bash
node scripts/check-no-binary-artifacts.mjs --base $(git rev-parse HEAD~1) --head HEAD
```

Output:
- `OK: no blocked binary/release artifacts in diff.`

## Notes
This addresses item (1) in #35936 directly. Template/policy enhancements (threat-model checklist, multi-surface split guidance) can be added as follow-ups.

Fixes #35936.
