### PR TITLE
bluebubbles: preserve service when normalizing dm chat_guid targets

### DIFF
--- a/extensions/bluebubbles/src/send.test.ts
+++ b/extensions/bluebubbles/src/send.test.ts
@@ -191,6 +191,38 @@ describe("send", () => {
       expect(result).toBe("iMessage;-;+15551234567");
     });
 
+    it("respects requested service when both SMS and iMessage chats exist", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            data: [
+              {
+                guid: "SMS;-;+15551234567",
+                participants: [{ address: "+15551234567" }],
+              },
+              {
+                guid: "iMessage;-;+15551234567",
+                participants: [{ address: "+15551234567" }],
+              },
+            ],
+          }),
+      });
+
+      const target: BlueBubblesSendTarget = {
+        kind: "handle",
+        address: "+15551234567",
+        service: "imessage",
+      };
+      const result = await resolveChatGuidForTarget({
+        baseUrl: "http://localhost:1234",
+        password: "test",
+        target,
+      });
+
+      expect(result).toBe("iMessage;-;+15551234567");
+    });
+
     it("prefers direct chat guid when handle also appears in a group chat", async () => {
       const result = await resolveHandleTargetGuid([
         {

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -146,6 +146,14 @@ function extractChatIdentifierFromChatGuid(chatGuid: string): string | null {
   return identifier ? identifier : null;
 }
 
+function extractServiceFromChatGuid(chatGuid: string): "imessage" | "sms" | "auto" {
+  const service = chatGuid.split(";")[0]?.trim().toLowerCase();
+  if (service === "imessage" || service === "sms") {
+    return service;
+  }
+  return "auto";
+}
+
 function extractParticipantAddresses(chat: BlueBubblesChatRecord): string[] {
   const raw =
     (Array.isArray(chat.participants) ? chat.participants : null) ??
@@ -220,6 +228,8 @@ export async function resolveChatGuidForTarget(params: {
 
   const normalizedHandle =
     params.target.kind === "handle" ? normalizeBlueBubblesHandle(params.target.address) : "";
+  const targetService =
+    params.target.kind === "handle" ? (params.target.service ?? "auto") : "auto";
   const targetChatId = params.target.kind === "chat_id" ? params.target.chatId : null;
   const targetChatIdentifier =
     params.target.kind === "chat_identifier" ? params.target.chatIdentifier : null;
@@ -276,14 +286,22 @@ export async function resolveChatGuidForTarget(params: {
         const guid = extractChatGuid(chat);
         const directHandle = guid ? extractHandleFromChatGuid(guid) : null;
         if (directHandle && directHandle === normalizedHandle) {
-          return guid;
+          if (!guid) {
+            continue;
+          }
+          if (targetService === "auto" || extractServiceFromChatGuid(guid) === targetService) {
+            return guid;
+          }
+          continue;
         }
         if (!participantMatch && guid) {
           // Only consider DM chats (`;-;` separator) as participant matches.
           // Group chats (`;+;` separator) should never match when searching by handle/phone.
           // This prevents routing "send to +1234567890" to a group chat that contains that number.
           const isDmChat = guid.includes(";-;");
-          if (isDmChat) {
+          const serviceMatches =
+            targetService === "auto" || extractServiceFromChatGuid(guid) === targetService;
+          if (isDmChat && serviceMatches) {
             const participants = extractParticipantAddresses(chat).map((entry) =>
               normalizeBlueBubblesHandle(entry),
             );

--- a/extensions/bluebubbles/src/targets.test.ts
+++ b/extensions/bluebubbles/src/targets.test.ts
@@ -25,14 +25,14 @@ describe("normalizeBlueBubblesMessagingTarget", () => {
   it("extracts handle from DM chat_guid for cross-context matching", () => {
     // DM format: service;-;handle
     expect(normalizeBlueBubblesMessagingTarget("chat_guid:iMessage;-;+19257864429")).toBe(
-      "+19257864429",
+      "imessage:+19257864429",
     );
     expect(normalizeBlueBubblesMessagingTarget("chat_guid:SMS;-;+15551234567")).toBe(
-      "+15551234567",
+      "sms:+15551234567",
     );
     // Email handles
     expect(normalizeBlueBubblesMessagingTarget("chat_guid:iMessage;-;user@example.com")).toBe(
-      "user@example.com",
+      "imessage:user@example.com",
     );
   });
 
@@ -47,7 +47,9 @@ describe("normalizeBlueBubblesMessagingTarget", () => {
     expect(normalizeBlueBubblesMessagingTarget("iMessage;+;chat660250192681427962")).toBe(
       "chat_guid:iMessage;+;chat660250192681427962",
     );
-    expect(normalizeBlueBubblesMessagingTarget("iMessage;-;+19257864429")).toBe("+19257864429");
+    expect(normalizeBlueBubblesMessagingTarget("iMessage;-;+19257864429")).toBe(
+      "imessage:+19257864429",
+    );
   });
 
   it("normalizes chat<digits> pattern to chat_identifier format", () => {

--- a/extensions/bluebubbles/src/targets.ts
+++ b/extensions/bluebubbles/src/targets.ts
@@ -147,6 +147,14 @@ export function extractHandleFromChatGuid(chatGuid: string): string | null {
   return null;
 }
 
+function extractServiceFromChatGuid(chatGuid: string): BlueBubblesService | null {
+  const service = chatGuid.split(";")[0]?.trim().toLowerCase();
+  if (service === "imessage" || service === "sms") {
+    return service;
+  }
+  return null;
+}
+
 export function normalizeBlueBubblesMessagingTarget(raw: string): string | undefined {
   let trimmed = raw.trim();
   if (!trimmed) {
@@ -166,7 +174,8 @@ export function normalizeBlueBubblesMessagingTarget(raw: string): string | undef
       // This allows "chat_guid:iMessage;-;+1234567890" to match "+1234567890".
       const handle = extractHandleFromChatGuid(parsed.chatGuid);
       if (handle) {
-        return handle;
+        const service = extractServiceFromChatGuid(parsed.chatGuid);
+        return service ? `${service}:${handle}` : handle;
       }
       // For group chats or unrecognized formats, keep the full chat_guid
       return `chat_guid:${parsed.chatGuid}`;


### PR DESCRIPTION
## Summary

- Problem: BlueBubbles `chat_guid:iMessage;-;+...` targets were normalized to bare handles, dropping service information.
- Why it matters: when both SMS and iMessage chats exist for the same handle, proactive sends can resolve to the wrong service.
- What changed: DM `chat_guid` normalization now preserves service (`imessage:` / `sms:`), and `resolveChatGuidForTarget` now respects explicit handle service when selecting chat GUIDs.
- What did NOT change (scope boundary): group chat GUID behavior and direct `chat_guid` send path remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35624
- Related #35951

## User-visible / Behavior Changes

BlueBubbles proactive sends that specify iMessage/SMS target service now resolve to the matching chat GUID instead of falling back to whichever service appears first.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): BlueBubbles extension
- Relevant config (redacted):

### Steps

1. Normalize a DM `chat_guid` target (e.g. `chat_guid:iMessage;-;+1555...`).
2. Resolve handle target when both `SMS;-;...` and `iMessage;-;...` chats exist.

### Expected

- Normalization preserves service prefix.
- Resolver chooses chat GUID matching requested service.

### Actual

- Verified by updated unit tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm exec vitest run extensions/bluebubbles/src/targets.test.ts extensions/bluebubbles/src/send.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `normalizeBlueBubblesMessagingTarget("chat_guid:iMessage;-;+...")` returns `imessage:+...`.
  - Service-specific handle resolution prefers `iMessage` over `SMS` when both exist.
- Edge cases checked:
  - Group `chat_guid` normalization still preserves full `chat_guid:*` form.
  - `service: "auto"` behavior remains unchanged.
- What you did **not** verify:
  - Live BlueBubbles server end-to-end send behavior (covered via unit-level resolver tests only).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this commit.
- Files/config to restore:
  - `extensions/bluebubbles/src/targets.ts`
  - `extensions/bluebubbles/src/send.ts`
  - `extensions/bluebubbles/src/targets.test.ts`
  - `extensions/bluebubbles/src/send.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected routing to mismatched service when explicit `imessage:` or `sms:` is used.

## Risks and Mitigations

- Risk:
  - Service-aware matching may alter target choice in mixed-history chats.
  - Mitigation:
  - Change only applies when service is explicit; `auto` keeps existing behavior, and tests cover mixed SMS/iMessage ordering.
