### PR TITLE
config: accept legacy controlUi keys for startup compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
+- Config/controlUi legacy compatibility: accept deprecated `gateway.controlUi.autoApproveDevices` and `gateway.controlUi.requirePairing` keys in strict schema parsing so upgraded installs no longer fail startup on stale config keys (fields are compatibility no-ops). (#35957)
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.
 - Agents/xAI tool-call argument decoding: decode HTML-entity encoded xAI/Grok tool-call argument values (`&amp;`, `&quot;`, `&lt;`, `&gt;`, numeric entities) before tool execution so commands with shell operators and quotes no longer fail with parse errors. (#35276) Thanks @Sid-Qin.

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -184,4 +184,17 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it("accepts legacy gateway.controlUi compatibility keys", () => {
+    const res = validateConfigObject({
+      gateway: {
+        controlUi: {
+          autoApproveDevices: true,
+          requirePairing: false,
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -104,6 +104,16 @@ export type GatewayControlUiConfig = {
   allowInsecureAuth?: boolean;
   /** DANGEROUS: Disable device identity checks for the Control UI (default: false). */
   dangerouslyDisableDeviceAuth?: boolean;
+  /**
+   * Legacy compatibility field retained for config parsing only.
+   * No longer affects runtime behavior.
+   */
+  autoApproveDevices?: boolean;
+  /**
+   * Legacy compatibility field retained for config parsing only.
+   * No longer affects runtime behavior.
+   */
+  requirePairing?: boolean;
 };
 
 export type GatewayAuthMode = "none" | "token" | "password" | "trusted-proxy";

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -607,6 +607,10 @@ export const OpenClawSchema = z
             dangerouslyAllowHostHeaderOriginFallback: z.boolean().optional(),
             allowInsecureAuth: z.boolean().optional(),
             dangerouslyDisableDeviceAuth: z.boolean().optional(),
+            // Legacy compatibility keys kept as no-op accepts to avoid startup failures
+            // on upgraded configs that still contain these fields.
+            autoApproveDevices: z.boolean().optional(),
+            requirePairing: z.boolean().optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
## Summary

- Problem: strict config parsing rejected `gateway.controlUi.autoApproveDevices` / `gateway.controlUi.requirePairing`, which can block gateway startup on upgraded installs with stale keys.
- Why it matters: users can end up with a startup outage until they manually edit config.
- What changed: added both legacy keys as optional compatibility accepts in `gateway.controlUi` schema, reflected in gateway config type, and added a schema regression test.
- What did NOT change (scope boundary): no runtime behavior change for Control UI auth/pairing flows; fields are accepted for compatibility only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35957
- Related #29385

## User-visible / Behavior Changes

- Configs containing `gateway.controlUi.autoApproveDevices` and/or `gateway.controlUi.requirePairing` no longer fail strict schema validation.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm local dev
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted):
  - `gateway.controlUi.autoApproveDevices: true`
  - `gateway.controlUi.requirePairing: false`

### Steps

1. Validate config object that includes the two legacy keys under `gateway.controlUi`.
2. Confirm strict schema parse result.
3. Run targeted regression test.

### Expected

- Config validates successfully.

### Actual

- ✅ Config validates successfully after this change.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm vitest run src/config/config.schema-regressions.test.ts` passes (14/14).

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added regression test for `gateway.controlUi.autoApproveDevices` and `gateway.controlUi.requirePairing` acceptance.
  - Confirmed strict schema change is scoped to compatibility accepts.
- Edge cases checked:
  - Existing `gateway.controlUi` security toggles remain unchanged.
- What you did **not** verify:
  - Full repository `pnpm check` currently fails in unrelated existing `extensions/tlon` dependency resolution (`@tloncorp/api` missing).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/config/zod-schema.ts`
  - `src/config/types.gateway.ts`
  - `src/config/config.schema-regressions.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected strict-parse acceptance beyond these two legacy keys.

## Risks and Mitigations

- Risk: Accepting deprecated keys could be mistaken as active runtime knobs.
  - Mitigation: fields are documented in code comments as compatibility-only no-ops and runtime logic is unchanged.
