### PR TITLE
fix(config): accept deprecated controlUi keys to prevent startup failure on upgrade

### DIFF
--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -607,6 +607,8 @@ export const OpenClawSchema = z
             dangerouslyAllowHostHeaderOriginFallback: z.boolean().optional(),
             allowInsecureAuth: z.boolean().optional(),
             dangerouslyDisableDeviceAuth: z.boolean().optional(),
+            autoApproveDevices: z.boolean().optional(),
+            requirePairing: z.boolean().optional(),
           })
           .strict()
           .optional(),


### PR DESCRIPTION
## Summary

- **Problem:** v2026.3.3 removed `autoApproveDevices` and `requirePairing` from `gateway.controlUi`, but existing configs from v2026.3.2 still contain them. Because the schema uses `.strict()`, these unrecognized keys cause a validation error that prevents the gateway from starting — an 18+ hour outage for affected users with no clear remediation until manual key removal.
- **Why it matters:** Users upgrading from v2026.3.2 to v2026.3.3 cannot start their gateway without manually editing the config file, which is undocumented and non-obvious.
- **What changed:** Re-added `autoApproveDevices` and `requirePairing` as `z.boolean().optional()` in the `gateway.controlUi` Zod schema so old configs pass validation. The keys are accepted but have no runtime effect — they are not referenced in any code path.
- **What did NOT change:** No runtime behavior changes. The keys are simply tolerated during parsing and silently ignored. No migration logic was added — `openclaw doctor` can strip them later.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35957

## User-visible / Behavior Changes

- Configs containing `gateway.controlUi.autoApproveDevices` or `gateway.controlUi.requirePairing` no longer cause a startup failure. The keys are silently ignored.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any (reported on macOS Darwin 25.3.0)
- Runtime: Node.js
- Integration/channel: Gateway startup

### Steps

1. Have a v2026.3.2 config with `gateway.controlUi.autoApproveDevices` and/or `requirePairing`
2. Upgrade to v2026.3.3
3. Start the gateway

### Expected

- Gateway starts successfully, ignoring the deprecated keys

### Actual

- Before fix: `gateway.controlUi: Unrecognized keys: "autoApproveDevices", "requirePairing"` — gateway fails to start
- After fix: Gateway starts normally, keys are silently accepted and ignored

## Evidence

The `.strict()` modifier on the `controlUi` schema object rejects any key not explicitly listed. Adding the two deprecated keys with `.optional()` makes them pass validation:

```typescript
controlUi: z
  .object({
    // ... existing keys ...
    dangerouslyDisableDeviceAuth: z.boolean().optional(),
    autoApproveDevices: z.boolean().optional(),   // deprecated, accepted for compat
    requirePairing: z.boolean().optional(),        // deprecated, accepted for compat
  })
  .strict()
  .optional(),
```

## Human Verification (required)

- Verified scenarios: TypeScript compiles cleanly; schema now accepts old configs
- Edge cases checked: Boolean values (true/false), missing keys, combination with other controlUi options
- What I did **not** verify: Full gateway startup with a real v2026.3.2 config (no access to affected environment)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No` — keys are simply tolerated; `openclaw doctor` can strip them later

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the 2-line addition in `zod-schema.ts`
- Files/config to restore: `src/config/zod-schema.ts`
- Known bad symptoms: None

## Risks and Mitigations

None — purely additive schema change. The keys have no runtime effect and are not referenced in any code path.

