### PR TITLE
fix(gateway): exit gracefully when start() fails during restart loop

### DIFF
--- a/extensions/mattermost/src/group-mentions.test.ts
+++ b/extensions/mattermost/src/group-mentions.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it } from "vitest";
 import { resolveMattermostGroupRequireMention } from "./group-mentions.js";
 

--- a/extensions/mattermost/src/group-mentions.ts
+++ b/extensions/mattermost/src/group-mentions.ts
@@ -1,4 +1,7 @@
-import { resolveChannelGroupRequireMention, type ChannelGroupContext } from "openclaw/plugin-sdk";
+import {
+  resolveChannelGroupRequireMention,
+  type ChannelGroupContext,
+} from "openclaw/plugin-sdk/mattermost";
 import { resolveMattermostAccount } from "./mattermost/accounts.js";
 
 export function resolveMattermostGroupRequireMention(

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it, vi } from "vitest";
 import { resolveMattermostAccount } from "./accounts.js";
 import {

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -22,13 +22,9 @@ const gatewayLog = {
   error: vi.fn(),
 };
 
-vi.mock("../../infra/gateway-lock.js", async (importOriginal) => {
-  const original = await importOriginal<typeof import("../../infra/gateway-lock.js")>();
-  return {
-    GatewayLockError: original.GatewayLockError,
-    acquireGatewayLock: (opts?: { port?: number }) => acquireGatewayLock(opts),
-  };
-});
+vi.mock("../../infra/gateway-lock.js", () => ({
+  acquireGatewayLock: (opts?: { port?: number }) => acquireGatewayLock(opts),
+}));
 
 vi.mock("../../infra/restart.js", () => ({
   consumeGatewaySigusr1RestartAuthorization: () => consumeGatewaySigusr1RestartAuthorization(),

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -381,6 +381,32 @@ describe("runGatewayLoop", () => {
     });
   });
 
+  it("propagates first-start errors to the caller for GatewayLockError diagnostics", async () => {
+    vi.clearAllMocks();
+
+    await withIsolatedSignals(async () => {
+      const startError = new Error("EADDRINUSE");
+      const start = vi.fn().mockRejectedValueOnce(startError);
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+
+      const { runGatewayLoop } = await import("./run-loop.js");
+      await expect(
+        runGatewayLoop({
+          start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+          runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+        }),
+      ).rejects.toThrow("EADDRINUSE");
+
+      // The error should NOT be caught internally — runtime.exit should not be called.
+      expect(runtime.exit).not.toHaveBeenCalled();
+      expect(runtime.error).not.toHaveBeenCalled();
+    });
+  });
+
   it("exits when lock reacquire fails during in-process restart fallback", async () => {
     vi.clearAllMocks();
 

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -22,9 +22,13 @@ const gatewayLog = {
   error: vi.fn(),
 };
 
-vi.mock("../../infra/gateway-lock.js", () => ({
-  acquireGatewayLock: (opts?: { port?: number }) => acquireGatewayLock(opts),
-}));
+vi.mock("../../infra/gateway-lock.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../infra/gateway-lock.js")>();
+  return {
+    GatewayLockError: original.GatewayLockError,
+    acquireGatewayLock: (opts?: { port?: number }) => acquireGatewayLock(opts),
+  };
+});
 
 vi.mock("../../infra/restart.js", () => ({
   consumeGatewaySigusr1RestartAuthorization: () => consumeGatewaySigusr1RestartAuthorization(),

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -191,17 +191,24 @@ describe("runGatewayLoop", () => {
         return { close: closeSecond };
       });
 
-      start.mockRejectedValueOnce(new Error("stop-loop"));
-
-      const { runGatewayLoop } = await import("./run-loop.js");
-      const runtime = {
+      let resolveThirdExit: ((code: number) => void) | null = null;
+      const thirdExited = new Promise<number>((resolve) => {
+        resolveThirdExit = resolve;
+      });
+      const thirdRuntime = {
         log: vi.fn(),
         error: vi.fn(),
-        exit: vi.fn(),
+        exit: vi.fn((code: number) => {
+          resolveThirdExit?.(code);
+        }),
       };
+
+      start.mockRejectedValueOnce(new Error("bad-config"));
+
+      const { runGatewayLoop } = await import("./run-loop.js");
       const loopPromise = runGatewayLoop({
         start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
-        runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+        runtime: thirdRuntime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
       });
 
       await startedFirst;
@@ -226,7 +233,12 @@ describe("runGatewayLoop", () => {
 
       process.emit("SIGUSR1");
 
-      await expect(loopPromise).rejects.toThrow("stop-loop");
+      await thirdExited;
+      await loopPromise;
+      expect(thirdRuntime.exit).toHaveBeenCalledWith(1);
+      expect(gatewayLog.error).toHaveBeenCalledWith(
+        expect.stringContaining("gateway failed to start"),
+      );
       expect(closeSecond).toHaveBeenCalledWith({
         reason: "gateway restarting",
         restartExpectedMs: 1500,
@@ -276,12 +288,22 @@ describe("runGatewayLoop", () => {
       const closeSecond = vi.fn(async () => {});
       restartGatewayProcessWithFreshPid.mockReturnValueOnce({ mode: "disabled" });
 
+      let resolveExit: ((code: number) => void) | null = null;
+      const exited = new Promise<number>((resolve) => {
+        resolveExit = resolve;
+      });
       const start = vi
         .fn()
         .mockResolvedValueOnce({ close: closeFirst })
         .mockResolvedValueOnce({ close: closeSecond })
-        .mockRejectedValueOnce(new Error("stop-loop"));
-      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+        .mockRejectedValueOnce(new Error("bad-config"));
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn((code: number) => {
+          resolveExit?.(code);
+        }),
+      };
       const { runGatewayLoop } = await import("./run-loop.js");
       const loopPromise = runGatewayLoop({
         start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
@@ -294,10 +316,64 @@ describe("runGatewayLoop", () => {
       await new Promise<void>((resolve) => setImmediate(resolve));
       process.emit("SIGUSR1");
 
-      await expect(loopPromise).rejects.toThrow("stop-loop");
+      await exited;
+      await loopPromise;
+      expect(runtime.exit).toHaveBeenCalledWith(1);
       expect(acquireGatewayLock).toHaveBeenNthCalledWith(1, { port: 18789 });
       expect(acquireGatewayLock).toHaveBeenNthCalledWith(2, { port: 18789 });
       expect(acquireGatewayLock).toHaveBeenNthCalledWith(3, { port: 18789 });
+    });
+  });
+
+  it("exits gracefully when start() throws on restart instead of crashing", async () => {
+    vi.clearAllMocks();
+
+    await withIsolatedSignals(async () => {
+      const close = vi.fn(async () => {});
+      let resolveStarted: (() => void) | null = null;
+      const started = new Promise<void>((resolve) => {
+        resolveStarted = resolve;
+      });
+      const start = vi.fn();
+      start.mockImplementationOnce(async () => {
+        resolveStarted?.();
+        return { close };
+      });
+      start.mockRejectedValueOnce(new Error("Invalid config at openclaw.json"));
+
+      let resolveExit: ((code: number) => void) | null = null;
+      const exited = new Promise<number>((resolve) => {
+        resolveExit = resolve;
+      });
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn((code: number) => {
+          resolveExit?.(code);
+        }),
+      };
+
+      const { runGatewayLoop } = await import("./run-loop.js");
+      const loopPromise = runGatewayLoop({
+        start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+        runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+      });
+
+      await started;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      process.emit("SIGUSR1");
+
+      const exitCode = await exited;
+      await loopPromise;
+      expect(exitCode).toBe(1);
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(gatewayLog.error).toHaveBeenCalledWith(
+        expect.stringContaining("gateway failed to start"),
+      );
+      expect(gatewayLog.error).toHaveBeenCalledWith(
+        expect.stringContaining("Invalid config at openclaw.json"),
+      );
     });
   });
 

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -378,6 +378,10 @@ describe("runGatewayLoop", () => {
       expect(gatewayLog.error).toHaveBeenCalledWith(
         expect.stringContaining("Invalid config at openclaw.json"),
       );
+      // runtime.error is also called so the message is visible when subsystem logs are filtered.
+      expect(runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("Gateway failed to start"),
+      );
     });
   });
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -185,22 +185,28 @@ export async function runGatewayLoop(params: {
 
     // Keep process alive; SIGUSR1 triggers an in-process restart (no supervisor required).
     // SIGTERM/SIGINT still exit after a graceful shutdown.
+    let firstStart = true;
     // eslint-disable-next-line no-constant-condition
     while (true) {
       onIteration();
-      try {
+      if (firstStart) {
+        // Let first-start errors propagate to the caller so run.ts can
+        // surface GatewayLockError diagnostics (port-usage hints, etc.).
         server = await params.start();
-      } catch (err) {
-        // Exit gracefully instead of crashing on startup failures (e.g.
-        // invalid config after a restart). An unhandled crash causes the OS
-        // to respawn a new process which on macOS loses TCC permissions
-        // (Full Disk Access) granted to the original process.
-        gatewayLog.error(`gateway failed to start: ${String(err)}`);
-        // Also emit via runtime.error so the message is visible even when
-        // subsystem logs are filtered (e.g. --claude-cli-logs mode).
-        params.runtime.error(`Gateway failed to start: ${String(err)}`);
-        exitProcess(1);
-        return;
+        firstStart = false;
+      } else {
+        try {
+          server = await params.start();
+        } catch (err) {
+          // Exit gracefully instead of crashing on restart failures (e.g.
+          // invalid config after a SIGUSR1 restart). An unhandled crash
+          // causes the OS to respawn a new process which on macOS loses
+          // TCC permissions (Full Disk Access) granted to the original process.
+          gatewayLog.error(`gateway failed to start: ${String(err)}`);
+          params.runtime.error(`Gateway failed to start: ${String(err)}`);
+          exitProcess(1);
+          return;
+        }
       }
       await new Promise<void>((resolve) => {
         restartResolver = resolve;

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,5 +1,5 @@
 import type { startGatewayServer } from "../../gateway/server.js";
-import { acquireGatewayLock } from "../../infra/gateway-lock.js";
+import { acquireGatewayLock, GatewayLockError } from "../../infra/gateway-lock.js";
 import { restartGatewayProcessWithFreshPid } from "../../infra/process-respawn.js";
 import {
   consumeGatewaySigusr1RestartAuthorization,
@@ -191,9 +191,14 @@ export async function runGatewayLoop(params: {
       try {
         server = await params.start();
       } catch (err) {
-        // If the server fails to start (e.g. invalid config after a restart),
-        // exit gracefully instead of crashing. An unhandled crash causes the
-        // OS to respawn a new process which on macOS loses TCC permissions
+        // Let GatewayLockError propagate so the outer CLI handler can show
+        // user-facing diagnostics (e.g. "gateway stop" hint).
+        if (err instanceof GatewayLockError) {
+          throw err;
+        }
+        // For other failures (e.g. invalid config after a restart), exit
+        // gracefully instead of crashing. An unhandled crash causes the OS
+        // to respawn a new process which on macOS loses TCC permissions
         // (Full Disk Access) granted to the original process.
         gatewayLog.error(`gateway failed to start: ${String(err)}`);
         exitProcess(1);

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,5 +1,5 @@
 import type { startGatewayServer } from "../../gateway/server.js";
-import { acquireGatewayLock, GatewayLockError } from "../../infra/gateway-lock.js";
+import { acquireGatewayLock } from "../../infra/gateway-lock.js";
 import { restartGatewayProcessWithFreshPid } from "../../infra/process-respawn.js";
 import {
   consumeGatewaySigusr1RestartAuthorization,
@@ -191,13 +191,8 @@ export async function runGatewayLoop(params: {
       try {
         server = await params.start();
       } catch (err) {
-        // Let GatewayLockError propagate so the outer CLI handler can show
-        // user-facing diagnostics (e.g. "gateway stop" hint).
-        if (err instanceof GatewayLockError) {
-          throw err;
-        }
-        // For other failures (e.g. invalid config after a restart), exit
-        // gracefully instead of crashing. An unhandled crash causes the OS
+        // Exit gracefully instead of crashing on startup failures (e.g.
+        // invalid config after a restart). An unhandled crash causes the OS
         // to respawn a new process which on macOS loses TCC permissions
         // (Full Disk Access) granted to the original process.
         gatewayLog.error(`gateway failed to start: ${String(err)}`);

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -201,6 +201,9 @@ export async function runGatewayLoop(params: {
         // to respawn a new process which on macOS loses TCC permissions
         // (Full Disk Access) granted to the original process.
         gatewayLog.error(`gateway failed to start: ${String(err)}`);
+        // Also emit via runtime.error so the message is visible even when
+        // subsystem logs are filtered (e.g. --claude-cli-logs mode).
+        params.runtime.error(`Gateway failed to start: ${String(err)}`);
         exitProcess(1);
         return;
       }

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -188,7 +188,17 @@ export async function runGatewayLoop(params: {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       onIteration();
-      server = await params.start();
+      try {
+        server = await params.start();
+      } catch (err) {
+        // If the server fails to start (e.g. invalid config after a restart),
+        // exit gracefully instead of crashing. An unhandled crash causes the
+        // OS to respawn a new process which on macOS loses TCC permissions
+        // (Full Disk Access) granted to the original process.
+        gatewayLog.error(`gateway failed to start: ${String(err)}`);
+        exitProcess(1);
+        return;
+      }
       await new Promise<void>((resolve) => {
         restartResolver = resolve;
       });

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -44,6 +44,7 @@ export { createReplyPrefixOptions } from "../channels/reply-prefix.js";
 export { createTypingCallbacks } from "../channels/typing.js";
 export type { OpenClawConfig } from "../config/config.js";
 export { isDangerousNameMatchingEnabled } from "../config/dangerous-name-matching.js";
+export { resolveChannelGroupRequireMention } from "../config/group-policy.js";
 export {
   resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,


### PR DESCRIPTION
## Summary

- Wrap `params.start()` in the gateway run loop with try-catch so that startup
  failures (e.g. invalid config after a SIGUSR1 restart) trigger a graceful
  `exit(1)` instead of an unhandled exception
- On macOS, an unhandled crash causes the OS to respawn a new process that does
  not inherit TCC permissions (Full Disk Access), requiring manual re-grant in
  System Settings

## Test plan

- [x] New test: "exits gracefully when start() throws on restart instead of crashing"
- [x] Updated existing tests to match new behavior (start failure → exit(1) instead of rejected promise)
- [x] All 9 run-loop tests pass

Closes #35862