### PR TITLE
gateway: honor control-ui device auth bypass for webchat-ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
+- Gateway/control-ui device-auth bypass: honor `gateway.controlUi.dangerouslyDisableDeviceAuth=true` for both `openclaw-control-ui` and `webchat-ui` browser clients so stale/rotated device tokens no longer cause Control UI websocket `device token mismatch` disconnect loops. (#35944)
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.
 - Agents/xAI tool-call argument decoding: decode HTML-entity encoded xAI/Grok tool-call argument values (`&amp;`, `&quot;`, `&lt;`, `&gt;`, numeric entities) before tool execution so commands with shell operators and quotes no longer fail with parse errors. (#35276) Thanks @Sid-Qin.

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -347,6 +347,44 @@ export function registerControlUiAndPairingSuite(): void {
     }
   });
 
+  test("allows webchat-ui client with stale device identity when control-ui device auth is disabled", async () => {
+    testState.gatewayControlUi = { dangerouslyDisableDeviceAuth: true };
+    testState.gatewayAuth = { mode: "token", token: "secret" };
+    const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
+    try {
+      await withGatewayServer(async ({ port }) => {
+        const ws = await openWs(port, { origin: originForPort(port) });
+        const challengeNonce = await readConnectChallengeNonce(ws);
+        expect(challengeNonce).toBeTruthy();
+        const { device } = await createSignedDevice({
+          token: "secret",
+          scopes: [],
+          clientId: GATEWAY_CLIENT_NAMES.WEBCHAT_UI,
+          clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
+          signedAtMs: Date.now() - 60 * 60 * 1000,
+          nonce: String(challengeNonce),
+        });
+        const res = await connectReq(ws, {
+          token: "secret",
+          scopes: ["operator.read"],
+          device,
+          client: {
+            ...CONTROL_UI_CLIENT,
+            id: GATEWAY_CLIENT_NAMES.WEBCHAT_UI,
+          },
+        });
+        expect(res.ok).toBe(true);
+        expect((res.payload as { auth?: unknown } | undefined)?.auth).toBeUndefined();
+        const health = await rpcReq(ws, "health");
+        expect(health.ok).toBe(true);
+        ws.close();
+      });
+    } finally {
+      restoreGatewayToken(prevToken);
+    }
+  });
+
   test("device token auth matrix", async () => {
     const { server, ws, port, prevToken } = await startServerWithClient("secret");
     const { deviceToken, deviceIdentityPath } = await ensurePairedDeviceTokenForCurrentIdentity(ws);

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -495,6 +495,7 @@ export function attachGatewayWsMessageHandler(params: {
         connectParams.scopes = scopes;
 
         const isControlUi = connectParams.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
+        const isControlUiWebchatClient = connectParams.client.id === GATEWAY_CLIENT_IDS.WEBCHAT_UI;
         const isWebchat = isWebchatConnect(connectParams);
         if (enforceOriginCheckForAnyClient || isControlUi || isWebchat) {
           const hostHeaderOriginFallbackEnabled =
@@ -538,7 +539,7 @@ export function attachGatewayWsMessageHandler(params: {
         const hasPasswordAuth = Boolean(connectParams.auth?.password);
         const hasSharedAuth = hasTokenAuth || hasPasswordAuth;
         const controlUiAuthPolicy = resolveControlUiAuthPolicy({
-          isControlUi,
+          isControlUi: isControlUi || isControlUiWebchatClient,
           controlUiConfig: configSnapshot.gateway?.controlUi,
           deviceRaw,
         });


### PR DESCRIPTION
## Summary

- Problem: `gateway.controlUi.dangerouslyDisableDeviceAuth=true` only bypassed device identity for `openclaw-control-ui`, not `webchat-ui`.
- Why it matters: browser clients can still hit websocket disconnect loops with `unauthorized: device token mismatch` even when the control-ui bypass toggle is enabled.
- What changed: treat `webchat-ui` as a control-ui browser surface for `resolveControlUiAuthPolicy` in ws connect handling; add regression coverage for stale device identity on `webchat-ui` with bypass enabled.
- What did NOT change (scope boundary): no change to auth behavior for non-browser/non-control-ui clients.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35944
- Related #20684

## User-visible / Behavior Changes

- With `gateway.controlUi.dangerouslyDisableDeviceAuth=true`, `webchat-ui` clients now follow the same device-auth bypass behavior as `openclaw-control-ui` clients.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node + pnpm local dev
- Model/provider: N/A
- Integration/channel (if any): Gateway websocket (Control UI/Webchat)
- Relevant config (redacted):
  - `gateway.controlUi.dangerouslyDisableDeviceAuth: true`
  - `gateway.auth.mode: token`

### Steps

1. Start gateway with control-ui bypass enabled.
2. Connect as `webchat-ui` with stale device identity and valid shared token.
3. Verify connect + health calls succeed.

### Expected

- `webchat-ui` should connect successfully when bypass is enabled.

### Actual

- ✅ Connection succeeds after this fix; regression test added.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm vitest run src/gateway/server.auth.control-ui.test.ts` passes (20/20).

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added and ran a new regression test that exercises `webchat-ui` stale-device flow under bypass.
  - Confirmed ws connect policy wiring now applies bypass to control-ui browser IDs (`openclaw-control-ui` + `webchat-ui`).
- Edge cases checked:
  - Existing control-ui stale-device bypass test still passes.
- What you did **not** verify:
  - Full repository `pnpm check` (repo currently has unrelated `extensions/tlon` dependency resolution issues in this environment).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/gateway/server/ws-connection/message-handler.ts`
  - `src/gateway/server.auth.control-ui.suite.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected bypass behavior for non-control-ui browser clients.

## Risks and Mitigations

- Risk: widening bypass to `webchat-ui` could unintentionally cover non-target browser flows.
  - Mitigation: change is scoped to explicit known client ID `webchat-ui` only, not generic mode-based broadening.
