### PR TITLE
fix(gateway): let dangerouslyDisableDeviceAuth fully bypass device identity check

### DIFF
--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -58,6 +58,26 @@ describe("ws connect policy", () => {
       }).kind,
     ).toBe("allow");
 
+    // dangerouslyDisableDeviceAuth bypasses device identity even without shared auth.
+    const bypassPolicy = resolveControlUiAuthPolicy({
+      isControlUi: true,
+      controlUiConfig: { dangerouslyDisableDeviceAuth: true },
+      deviceRaw: null,
+    });
+    expect(
+      evaluateMissingDeviceIdentity({
+        hasDeviceIdentity: false,
+        role: "operator",
+        isControlUi: true,
+        controlUiAuthPolicy: bypassPolicy,
+        trustedProxyAuthOk: false,
+        sharedAuthOk: false,
+        authOk: false,
+        hasSharedAuth: false,
+        isLocalClient: false,
+      }).kind,
+    ).toBe("allow");
+
     const controlUiStrict = resolveControlUiAuthPolicy({
       isControlUi: true,
       controlUiConfig: { allowInsecureAuth: true, dangerouslyDisableDeviceAuth: false },

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -82,12 +82,10 @@ export function evaluateMissingDeviceIdentity(params: {
   if (params.isControlUi && params.trustedProxyAuthOk) {
     return { kind: "allow" };
   }
-  if (params.isControlUi && !params.controlUiAuthPolicy.allowBypass) {
-    // Allow localhost Control UI connections when allowInsecureAuth is configured.
-    // Localhost has no network interception risk, and browser SubtleCrypto
-    // (needed for device identity) is unavailable in insecure HTTP contexts.
-    // Remote connections are still rejected to preserve the MitM protection
-    // that the security fix (#20684) intended.
+  if (params.isControlUi && params.controlUiAuthPolicy.allowBypass) {
+    return { kind: "allow" };
+  }
+  if (params.isControlUi) {
     if (!params.controlUiAuthPolicy.allowInsecureAuthConfigured || !params.isLocalClient) {
       return { kind: "reject-control-ui-insecure-auth" };
     }


### PR DESCRIPTION
## Summary

- **Problem:** `gateway.controlUi.dangerouslyDisableDeviceAuth=true` does not fully bypass device identity checks. `evaluateMissingDeviceIdentity()` skipped the insecure-auth rejection when `allowBypass` was true, but still fell through to `roleCanSkipDeviceIdentity()` which requires valid shared auth. On environments where the shared token is not delivered correctly (WSL, SSH tunnels, some reverse proxy setups), the connection is still rejected despite the dangerous bypass flag.
- **Why it matters:** Users who explicitly enable this dangerous flag expect it to work unconditionally. On WSL/Linux environments where HTTPS/SubtleCrypto is unavailable and shared tokens may not propagate correctly, the Control UI becomes completely inaccessible.
- **What changed:** Added an explicit early-return `{ kind: "allow" }` in `evaluateMissingDeviceIdentity()` when the Control UI bypass policy (`allowBypass`) is active. Added a test case verifying the bypass works without shared auth.
- **What did NOT change:** Non-Control-UI connections are unaffected. The `allowBypass` flag is only set when both `isControlUi=true` AND `dangerouslyDisableDeviceAuth=true` (see `resolveControlUiAuthPolicy`). Device token verification in `resolveConnectAuthDecision` is unmodified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35944

## User-visible / Behavior Changes

- When `gateway.controlUi.dangerouslyDisableDeviceAuth=true`, Control UI connections no longer require valid shared auth to bypass device identity checks. The bypass is unconditional for Control UI.

## Security Impact (required)

- New permissions/capabilities? `No` — the flag already existed and was documented as dangerous
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — the flag already intended to disable device auth; this fix makes it actually work

## Repro + Verification

### Environment

- OS: WSL (Ubuntu on Windows 11), also reproducible on Linux
- Runtime: Node.js
- Integration/channel: Control UI (WebSocket)

### Steps

1. Set `gateway.controlUi.dangerouslyDisableDeviceAuth=true` in config
2. Restart gateway
3. Open Control UI dashboard URL

### Expected

- Dashboard connects successfully

### Actual

- Before fix: `1008 unauthorized: device token mismatch` (or similar auth rejection)
- After fix: Dashboard connects without device identity verification

## Evidence

Test added in `connect-policy.test.ts`:

```typescript
// dangerouslyDisableDeviceAuth bypasses device identity even without shared auth.
const bypassPolicy = resolveControlUiAuthPolicy({
  isControlUi: true,
  controlUiConfig: { dangerouslyDisableDeviceAuth: true },
  deviceRaw: null,
});
expect(
  evaluateMissingDeviceIdentity({
    hasDeviceIdentity: false,
    role: "operator",
    isControlUi: true,
    controlUiAuthPolicy: bypassPolicy,
    sharedAuthOk: false,  // no shared auth
    authOk: false,
    hasSharedAuth: false,
    isLocalClient: false,  // remote
  }).kind,
).toBe("allow");
```

All 4 tests pass.

## Human Verification (required)

- Verified scenarios: TypeScript compiles cleanly, all connect-policy tests pass (4/4)
- Edge cases checked: Non-Control-UI connections unaffected; bypass only active when both `isControlUi` and `dangerouslyDisableDeviceAuth` are true
- What I did **not** verify: End-to-end test on WSL with a real gateway (no WSL environment available)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove the early-return in `evaluateMissingDeviceIdentity`, revert to previous behavior
- Files/config to restore: `src/gateway/server/ws-connection/connect-policy.ts`
- Known bad symptoms: None — worst case is the same rejection behavior as before

## Risks and Mitigations

- **Risk:** The bypass now allows Control UI connections without any auth when `dangerouslyDisableDeviceAuth=true`. This is intentional — the flag is named "dangerously" for this reason. Users who set it accept the risk.
- **Mitigation:** The flag only affects Control UI (not node/operator connections), and is opt-in.

