### PR TITLE
security: use /sid for Windows ACL audit

### DIFF
--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -244,11 +244,19 @@ Successfully processed 1 files`;
       expectTrustedOnly([aclEntry({ principal: "S-1-5-18" })]);
     });
 
+    it("classifies *-prefixed SYSTEM SID as trusted", () => {
+      expectTrustedOnly([aclEntry({ principal: "*S-1-5-18" })]);
+    });
+
     it("classifies BUILTIN\\Administrators SID (S-1-5-32-544) as trusted", () => {
       const entries: WindowsAclEntry[] = [aclEntry({ principal: "S-1-5-32-544" })];
       const summary = summarizeWindowsAcl(entries);
       expect(summary.trusted).toHaveLength(1);
       expect(summary.untrustedGroup).toHaveLength(0);
+    });
+
+    it("classifies *-prefixed BUILTIN\\Administrators SID as trusted", () => {
+      expectTrustedOnly([aclEntry({ principal: "*S-1-5-32-544" })]);
     });
 
     it("classifies caller SID from USERSID env var as trusted", () => {
@@ -279,6 +287,34 @@ Successfully processed 1 files`;
       expect(summary.untrustedGroup).toHaveLength(1);
       expect(summary.untrustedWorld).toHaveLength(0);
       expect(summary.trusted).toHaveLength(0);
+    });
+
+    it("classifies Everyone SID as world", () => {
+      const summary = summarizeWindowsAcl([
+        aclEntry({
+          principal: "*S-1-1-0",
+          rights: ["R"],
+          rawRights: "(R)",
+          canRead: true,
+          canWrite: false,
+        }),
+      ]);
+      expect(summary.untrustedWorld).toHaveLength(1);
+      expect(summary.untrustedGroup).toHaveLength(0);
+    });
+
+    it("classifies BUILTIN\\Users SID as world", () => {
+      const summary = summarizeWindowsAcl([
+        aclEntry({
+          principal: "*S-1-5-32-545",
+          rights: ["R"],
+          rawRights: "(R)",
+          canRead: true,
+          canWrite: false,
+        }),
+      ]);
+      expect(summary.untrustedWorld).toHaveLength(1);
+      expect(summary.untrustedGroup).toHaveLength(0);
     });
 
     it("full scenario: SYSTEM SID + owner SID only → no findings", () => {
@@ -319,7 +355,7 @@ Successfully processed 1 files`;
         exec: mockExec,
       });
       expectInspectSuccess(result, 2);
-      expect(mockExec).toHaveBeenCalledWith("icacls", ["C:\\test\\file.txt"]);
+      expect(mockExec).toHaveBeenCalledWith("icacls", ["C:\\test\\file.txt", "/sid"]);
     });
 
     it("returns error state on exec failure", async () => {
@@ -335,14 +371,32 @@ Successfully processed 1 files`;
 
     it("combines stdout and stderr for parsing", async () => {
       const mockExec = vi.fn().mockResolvedValue({
-        stdout: "C:\\test\\file.txt BUILTIN\\Administrators:(F)",
-        stderr: "C:\\test\\file.txt NT AUTHORITY\\SYSTEM:(F)",
+        stdout: "C:\\test\\file.txt *S-1-5-32-544:(F)",
+        stderr: "C:\\test\\file.txt *S-1-5-18:(F)",
       });
 
       const result = await inspectWindowsAcl("C:\\test\\file.txt", {
         exec: mockExec,
       });
       expectInspectSuccess(result, 2);
+    });
+
+    it("treats /sid output as trusted-only when entries are SYSTEM + owner SID", async () => {
+      const ownerSid = "S-1-5-21-1824257776-4070701511-781240313-1001";
+      const mockExec = vi.fn().mockResolvedValue({
+        stdout: `C:\\test\\file.txt *S-1-5-18:(F)\n                  *${ownerSid}:(F)`,
+        stderr: "",
+      });
+
+      const result = await inspectWindowsAcl("C:\\test\\file.txt", {
+        exec: mockExec,
+        env: { USERSID: ownerSid },
+      });
+
+      expectInspectSuccess(result, 2);
+      expect(result.trusted).toHaveLength(2);
+      expect(result.untrustedWorld).toHaveLength(0);
+      expect(result.untrustedGroup).toHaveLength(0);
     });
   });
 

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -42,12 +42,13 @@ const TRUSTED_BASE = new Set([
 const WORLD_SUFFIXES = ["\\users", "\\authenticated users"];
 const TRUSTED_SUFFIXES = ["\\administrators", "\\system", "\\système"];
 
-const SID_RE = /^s-\d+-\d+(-\d+)+$/i;
+const SID_RE = /^\*?s-\d+-\d+(-\d+)+$/i;
 const TRUSTED_SIDS = new Set([
   "s-1-5-18",
   "s-1-5-32-544",
   "s-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464",
 ]);
+const WORLD_SIDS = new Set(["s-1-1-0", "s-1-5-11", "s-1-5-32-545"]);
 const STATUS_PREFIXES = [
   "successfully processed",
   "processed",
@@ -56,6 +57,10 @@ const STATUS_PREFIXES = [
 ];
 
 const normalize = (value: string) => value.trim().toLowerCase();
+const normalizeSid = (value: string) => {
+  const normalized = normalize(value);
+  return normalized.startsWith("*") ? normalized.slice(1) : normalized;
+};
 
 export function resolveWindowsUserPrincipal(env?: NodeJS.ProcessEnv): string | null {
   const username = env?.USERNAME?.trim() || os.userInfo().username?.trim();
@@ -77,7 +82,7 @@ function buildTrustedPrincipals(env?: NodeJS.ProcessEnv): Set<string> {
       trusted.add(normalize(userOnly));
     }
   }
-  const userSid = normalize(env?.USERSID ?? "");
+  const userSid = normalizeSid(env?.USERSID ?? "");
   if (userSid && SID_RE.test(userSid)) {
     trusted.add(userSid);
   }
@@ -91,7 +96,14 @@ function classifyPrincipal(
   const normalized = normalize(principal);
 
   if (SID_RE.test(normalized)) {
-    return TRUSTED_SIDS.has(normalized) || trustedPrincipals.has(normalized) ? "trusted" : "group";
+    const sid = normalizeSid(normalized);
+    if (TRUSTED_SIDS.has(sid) || trustedPrincipals.has(sid)) {
+      return "trusted";
+    }
+    if (WORLD_SIDS.has(sid)) {
+      return "world";
+    }
+    return "group";
   }
 
   if (
@@ -249,7 +261,7 @@ export async function inspectWindowsAcl(
 ): Promise<WindowsAclSummary> {
   const exec = opts?.exec ?? runExec;
   try {
-    const { stdout, stderr } = await exec("icacls", [targetPath]);
+    const { stdout, stderr } = await exec("icacls", [targetPath, "/sid"]);
     const output = `${stdout}\n${stderr}`.trim();
     const entries = parseIcaclsOutput(output, targetPath);
     const { trusted, untrustedWorld, untrustedGroup } = summarizeWindowsAcl(entries, opts?.env);


### PR DESCRIPTION
## Summary

- Problem: Windows ACL audit uses locale-dependent `icacls` principal names, which can misclassify trusted entries on non-English Windows and raise false-positive writable findings.
- Why it matters: localized output should not downgrade the security audit signal or force users to reason about translated account names.
- What changed: `inspectWindowsAcl` now calls `icacls /sid`, `classifyPrincipal` accepts the `*`-prefixed SID format that `icacls /sid` returns, and world-equivalent SIDs stay classified as `world` instead of being downgraded to `group`.
- What did NOT change (scope boundary): no Slack/threading/templating code remains in this PR; no ACL remediation commands or non-Windows audit paths changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35834

## User-visible / Behavior Changes

- Windows security audit now uses locale-independent SID output from `icacls`, reducing false positives on localized Windows installs.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: n/a

## Repro + Verification

### Environment

- OS: macOS for unit/build validation, target behavior: Windows ACL parsing
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: n/a
- Integration/channel (if any): n/a
- Relevant config (redacted): n/a

### Steps

1. Inspect a Windows path via `inspectWindowsAcl` when `icacls` emits `*S-...` principals.
2. Verify SYSTEM / Administrators SIDs remain trusted.
3. Verify Everyone / BUILTIN\\Users SIDs still map to `world` severity.

### Expected

- Locale-dependent principal names no longer determine trust classification.
- `*S-1-5-18` and owner SIDs remain trusted.
- `*S-1-1-0` / `*S-1-5-32-545` remain `world`.

### Actual

- After this patch, the audit reads SID output directly and preserves trusted/world classification semantics.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `*S-1-5-18` and `*S-1-5-32-544` are trusted.
  - `*S-1-1-0` and `*S-1-5-32-545` remain `world`.
  - `inspectWindowsAcl` end-to-end with `/sid` mock returns trusted-only for owner + SYSTEM.
- Edge cases checked:
  - existing localized-name trust tests still pass.
  - `pnpm build` succeeds with the `/sid` change.
- What you did **not** verify:
  - live execution on a real localized Windows host.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: n/a

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `ac69ffc74`
- Files/config to restore: `src/security/windows-acl.ts`, `src/security/windows-acl.test.ts`
- Known bad symptoms reviewers should watch for: Windows ACL output unexpectedly reporting all entries as groups after `/sid` parsing.

## Risks and Mitigations

- Risk: `icacls /sid` changes the principal shape from names to `*S-...` tokens.
- Mitigation: the patch adds explicit trusted and world SID coverage plus end-to-end `/sid` parsing tests.

## AI Disclosure

- AI-assisted: Yes. Human-reviewed and validated with the commands below.

## Validation

- `pnpm test src/security/windows-acl.test.ts`
- `pnpm exec oxlint src/security/windows-acl.ts src/security/windows-acl.test.ts`
- `pnpm exec oxfmt --check src/security/windows-acl.ts src/security/windows-acl.test.ts`
- `pnpm build`
- `pnpm check` (fails on existing baseline `extensions/tlon` missing `@tloncorp/api`, unrelated to this patch)
