### PR TITLE
fix(acpx): kill child process tree on session close to prevent zombie accumulation

### DIFF
--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -136,12 +136,17 @@ export function spawnWithResolvedCommand(
     options,
   );
 
+  // Use detached on Unix so the child becomes a process group leader.
+  // This allows killChildProcessTree() to terminate all descendants
+  // when the session is closed or evicted, preventing zombie accumulation.
+  const detached = process.platform !== "win32";
   return spawn(resolved.command, resolved.args, {
     cwd: params.cwd,
     env: { ...process.env, OPENCLAW_SHELL: "acp" },
     stdio: ["pipe", "pipe", "pipe"],
     shell: resolved.shell,
     windowsHide: resolved.windowsHide,
+    detached,
   });
 }
 
@@ -262,6 +267,73 @@ export function resolveSpawnFailure(
     return null;
   }
   return directoryExists(cwd) ? "missing-command" : "missing-cwd";
+}
+
+const KILL_TREE_GRACE_MS = 3000;
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Kill a child process and all its descendants.
+ * Requires the child to have been spawned with `detached: true` (Unix)
+ * so it is a process group leader.
+ */
+export function killChildProcessTree(pid: number): void {
+  if (!Number.isFinite(pid) || pid <= 0) {
+    return;
+  }
+
+  if (process.platform === "win32") {
+    // taskkill /T kills the entire process tree on Windows.
+    try {
+      spawn("taskkill", ["/T", "/PID", String(pid)], { stdio: "ignore", detached: true });
+    } catch {
+      // ignore
+    }
+    setTimeout(() => {
+      if (!isProcessAlive(pid)) {
+        return;
+      }
+      try {
+        spawn("taskkill", ["/F", "/T", "/PID", String(pid)], { stdio: "ignore", detached: true });
+      } catch {
+        // ignore
+      }
+    }, KILL_TREE_GRACE_MS).unref();
+    return;
+  }
+
+  // Unix: send SIGTERM to process group, then SIGKILL after grace period.
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      return;
+    }
+  }
+
+  setTimeout(() => {
+    if (isProcessAlive(pid)) {
+      try {
+        process.kill(-pid, "SIGKILL");
+      } catch {
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {
+          // already gone
+        }
+      }
+    }
+  }, KILL_TREE_GRACE_MS).unref();
 }
 
 function directoryExists(cwd: string): boolean {

--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -293,7 +293,7 @@ export function killChildProcessTree(pid: number): void {
   if (process.platform === "win32") {
     // taskkill /T kills the entire process tree on Windows.
     try {
-      spawn("taskkill", ["/T", "/PID", String(pid)], { stdio: "ignore", detached: true });
+      spawn("taskkill", ["/T", "/PID", String(pid)], { stdio: "ignore", detached: true }).unref();
     } catch {
       // ignore
     }
@@ -302,7 +302,10 @@ export function killChildProcessTree(pid: number): void {
         return;
       }
       try {
-        spawn("taskkill", ["/F", "/T", "/PID", String(pid)], { stdio: "ignore", detached: true });
+        spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
+          stdio: "ignore",
+          detached: true,
+        }).unref();
       } catch {
         // ignore
       }
@@ -321,16 +324,16 @@ export function killChildProcessTree(pid: number): void {
     }
   }
 
+  // Unconditionally attempt SIGKILL on the process group. The leader may
+  // have exited while descendants that caught/ignored SIGTERM are still alive.
   setTimeout(() => {
-    if (isProcessAlive(pid)) {
+    try {
+      process.kill(-pid, "SIGKILL");
+    } catch {
       try {
-        process.kill(-pid, "SIGKILL");
+        process.kill(pid, "SIGKILL");
       } catch {
-        try {
-          process.kill(pid, "SIGKILL");
-        } catch {
-          // already gone
-        }
+        // already gone
       }
     }
   }, KILL_TREE_GRACE_MS).unref();

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -20,6 +20,7 @@ import {
   toAcpxErrorEvent,
 } from "./runtime-internals/events.js";
 import {
+  killChildProcessTree,
   resolveSpawnFailure,
   type SpawnCommandCache,
   type SpawnCommandOptions,
@@ -100,6 +101,8 @@ export class AcpxRuntime implements AcpRuntime {
   private readonly spawnCommandCache: SpawnCommandCache = {};
   private readonly spawnCommandOptions: SpawnCommandOptions;
   private readonly loggedSpawnResolutions = new Set<string>();
+  /** PIDs of active prompt child processes, used for cleanup on close. */
+  private readonly activeChildPids = new Set<number>();
 
   constructor(
     private readonly config: ResolvedAcpxPluginConfig,
@@ -277,6 +280,9 @@ export class AcpxRuntime implements AcpRuntime {
       },
       this.spawnCommandOptions,
     );
+    if (child.pid) {
+      this.activeChildPids.add(child.pid);
+    }
     child.stdin.on("error", () => {
       // Ignore EPIPE when the child exits before stdin flush completes.
     });
@@ -345,6 +351,12 @@ export class AcpxRuntime implements AcpRuntime {
       lines.close();
       if (input.signal) {
         input.signal.removeEventListener("abort", onAbort);
+      }
+      // Kill the process tree to prevent orphaned grandchildren (e.g.
+      // claude-agent-acp, metabase-mcp) from accumulating as zombies.
+      if (child.pid) {
+        this.activeChildPids.delete(child.pid);
+        killChildProcessTree(child.pid);
       }
     }
   }
@@ -538,6 +550,12 @@ export class AcpxRuntime implements AcpRuntime {
       fallbackCode: "ACP_TURN_FAILED",
       ignoreNoSession: true,
     });
+    // Force-kill any remaining child process trees that survived the
+    // graceful close to prevent zombie process accumulation.
+    for (const pid of this.activeChildPids) {
+      killChildProcessTree(pid);
+    }
+    this.activeChildPids.clear();
   }
 
   private resolveHandleState(handle: AcpRuntimeHandle): AcpxHandleState {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -101,8 +101,8 @@ export class AcpxRuntime implements AcpRuntime {
   private readonly spawnCommandCache: SpawnCommandCache = {};
   private readonly spawnCommandOptions: SpawnCommandOptions;
   private readonly loggedSpawnResolutions = new Set<string>();
-  /** PIDs of active prompt child processes, used for cleanup on close. */
-  private readonly activeChildPids = new Set<number>();
+  /** PIDs of active prompt child processes, keyed by session name for scoped cleanup. */
+  private readonly activeChildPids = new Map<string, Set<number>>();
 
   constructor(
     private readonly config: ResolvedAcpxPluginConfig,
@@ -281,7 +281,12 @@ export class AcpxRuntime implements AcpRuntime {
       this.spawnCommandOptions,
     );
     if (child.pid) {
-      this.activeChildPids.add(child.pid);
+      let pids = this.activeChildPids.get(state.name);
+      if (!pids) {
+        pids = new Set();
+        this.activeChildPids.set(state.name, pids);
+      }
+      pids.add(child.pid);
     }
     child.stdin.on("error", () => {
       // Ignore EPIPE when the child exits before stdin flush completes.
@@ -355,7 +360,7 @@ export class AcpxRuntime implements AcpRuntime {
       // Kill the process tree to prevent orphaned grandchildren (e.g.
       // claude-agent-acp, metabase-mcp) from accumulating as zombies.
       if (child.pid) {
-        this.activeChildPids.delete(child.pid);
+        this.activeChildPids.get(state.name)?.delete(child.pid);
         killChildProcessTree(child.pid);
       }
     }
@@ -550,12 +555,15 @@ export class AcpxRuntime implements AcpRuntime {
       fallbackCode: "ACP_TURN_FAILED",
       ignoreNoSession: true,
     });
-    // Force-kill any remaining child process trees that survived the
-    // graceful close to prevent zombie process accumulation.
-    for (const pid of this.activeChildPids) {
-      killChildProcessTree(pid);
+    // Force-kill child process trees belonging to this session that survived
+    // the graceful close to prevent zombie process accumulation.
+    const pids = this.activeChildPids.get(state.name);
+    if (pids) {
+      for (const pid of pids) {
+        killChildProcessTree(pid);
+      }
+      this.activeChildPids.delete(state.name);
     }
-    this.activeChildPids.clear();
   }
 
   private resolveHandleState(handle: AcpRuntimeHandle): AcpxHandleState {


### PR DESCRIPTION
## Summary

- Spawn acpx prompt processes with `detached: true` (Unix) so each child
  becomes a process group leader, enabling group-level termination
- Track active prompt child PIDs in `AcpxRuntime`
- Kill the process tree in the `runTurn` finally block after the acpx process
  exits, preventing orphaned grandchildren (e.g. claude-agent-acp, metabase-mcp)
- Kill any remaining tracked PIDs in `close()` when sessions are evicted by TTL,
  as a safety net for processes that survived the graceful `sessions close` command
- Add `killChildProcessTree()` utility in the acpx extension (mirrors core
  `killProcessTree` pattern: SIGTERM → grace period → SIGKILL)

## Test plan

- [x] All 58 existing acpx tests pass
- [x] Type check passes
- [x] Lint passes

Closes #35886