### PR TITLE
telegram: preserve topic session targeting for native commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Security/audit Windows ACL locale handling: recognize Russian `NT AUTHORITY\\СИСТЕМА` principal as trusted SYSTEM so localized Windows installs no longer report false-positive `perms_writable` findings for SYSTEM-only ACL entries. (#35834)
+- Telegram/native command topic routing: treat `is_topic_message=true` as forum context even when `chat.is_forum` is absent, so `/new` and `/reset` in forum topics keep topic-scoped session targeting instead of falling back to General. (#35963)
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.
 - Agents/xAI tool-call argument decoding: decode HTML-entity encoded xAI/Grok tool-call argument values (`&amp;`, `&quot;`, `&lt;`, `&gt;`, numeric entities) before tool execution so commands with shell operators and quotes no longer fail with parse errors. (#35276) Thanks @Sid-Qin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
+- Security/audit Windows ACL locale handling: recognize Russian `NT AUTHORITY\\СИСТЕМА` principal as trusted SYSTEM so localized Windows installs no longer report false-positive `perms_writable` findings for SYSTEM-only ACL entries. (#35834)
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.
 - Agents/xAI tool-call argument decoding: decode HTML-entity encoded xAI/Grok tool-call argument values (`&amp;`, `&quot;`, `&lt;`, `&gt;`, numeric entities) before tool execution so commands with shell operators and quotes no longer fail with parse errors. (#35276) Thanks @Sid-Qin.

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -56,6 +56,7 @@ export function buildThreadingToolContext(params: {
         ChatType: sessionCtx.ChatType,
         CurrentMessageId: currentMessageId,
         ReplyToId: sessionCtx.ReplyToId,
+        ChannelId: sessionCtx.ChannelId,
         ThreadLabel: sessionCtx.ThreadLabel,
         MessageThreadId: sessionCtx.MessageThreadId,
       },

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -48,6 +48,8 @@ export type MsgContext = {
   AccountId?: string;
   ParentSessionKey?: string;
   MessageSid?: string;
+  /** Underlying provider channel identifier for inbound payload routing context. */
+  ChannelId?: string;
   /** Provider-specific full message id when MessageSid is a shortened alias. */
   MessageSidFull?: string;
   MessageSids?: string[];

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -255,6 +255,7 @@ export type ChannelThreadingContext = {
   CurrentMessageId?: string | number;
   ReplyToId?: string;
   ReplyToIdFull?: string;
+  ChannelId?: string;
   ThreadLabel?: string;
   MessageThreadId?: string | number;
 };

--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -492,6 +492,10 @@ Successfully processed 1 files`;
       expectTrustedOnly([aclEntry({ principal: "AUTORIDAD NT\\SYSTEM" })]);
     });
 
+    it("classifies Russian SYSTEM (NT AUTHORITY\\СИСТЕМА) as trusted", () => {
+      expectTrustedOnly([aclEntry({ principal: "NT AUTHORITY\\СИСТЕМА" })]);
+    });
+
     it("French Windows full scenario: user + Système only → no untrusted", () => {
       const entries: WindowsAclEntry[] = [
         aclEntry({ principal: "MYPC\\Pierre" }),

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -33,14 +33,15 @@ const TRUSTED_BASE = new Set([
   "system",
   "builtin\\administrators",
   "creator owner",
-  // Localized SYSTEM account names (French, German, Spanish, Portuguese)
+  // Localized SYSTEM account names (French, German, Spanish, Portuguese, Russian)
   "autorite nt\\système",
   "nt-autorität\\system",
   "autoridad nt\\system",
   "autoridade nt\\system",
+  "nt authority\\система",
 ]);
 const WORLD_SUFFIXES = ["\\users", "\\authenticated users"];
-const TRUSTED_SUFFIXES = ["\\administrators", "\\system", "\\système"];
+const TRUSTED_SUFFIXES = ["\\administrators", "\\system", "\\système", "\\система"];
 
 const SID_RE = /^s-\d+-\d+(-\d+)+$/i;
 const TRUSTED_SIDS = new Set([

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -704,6 +704,7 @@ export async function prepareSlackMessage(params: {
     ReplyToId: threadContext.replyToId,
     // Preserve thread context for routed tool notifications.
     MessageThreadId: threadContext.messageThreadId,
+    ChannelId: message.channel,
     ParentSessionKey: threadKeys.parentSessionKey,
     // Only include thread starter body for NEW sessions (existing sessions already have it in their transcript)
     ThreadStarterBody: !threadSessionPreviousTimestamp ? threadStarterBody : undefined,

--- a/src/slack/threading-tool-context.test.ts
+++ b/src/slack/threading-tool-context.test.ts
@@ -136,6 +136,20 @@ describe("buildSlackThreadingToolContext", () => {
     expect(result.replyToMode).toBe("first");
   });
 
+  it("uses context ChannelId for DM when To is not channel-based", () => {
+    const result = buildSlackThreadingToolContext({
+      cfg: emptyCfg,
+      accountId: null,
+      context: {
+        ChatType: "direct",
+        To: "user:U123",
+        ChannelId: "D1234567890",
+      },
+    });
+
+    expect(result.currentChannelId).toBe("D1234567890");
+  });
+
   it("defaults to off when no replyToMode is configured", () => {
     const result = buildSlackThreadingToolContext({
       cfg: emptyCfg,

--- a/src/slack/threading-tool-context.ts
+++ b/src/slack/threading-tool-context.ts
@@ -19,10 +19,10 @@ export function buildSlackThreadingToolContext(params: {
   const hasExplicitThreadTarget = params.context.MessageThreadId != null;
   const effectiveReplyToMode = hasExplicitThreadTarget ? "all" : configuredReplyToMode;
   const threadId = params.context.MessageThreadId ?? params.context.ReplyToId;
+  const slackChannelId = params.context.ChannelId?.trim();
+  const to = params.context.To?.trim();
   return {
-    currentChannelId: params.context.To?.startsWith("channel:")
-      ? params.context.To.slice("channel:".length)
-      : undefined,
+    currentChannelId: to?.startsWith("channel:") ? to.slice("channel:".length) : slackChannelId,
     currentThreadTs: threadId != null ? String(threadId) : undefined,
     replyToMode: effectiveReplyToMode,
     hasRepliedRef: params.hasRepliedRef,

--- a/src/telegram/bot-native-commands.session-meta.test.ts
+++ b/src/telegram/bot-native-commands.session-meta.test.ts
@@ -102,6 +102,25 @@ function buildStatusTopicCommandContext() {
   };
 }
 
+function buildStatusTopicCommandContextWithoutChatForumFlag() {
+  return {
+    match: "",
+    message: {
+      message_id: 3,
+      date: Math.floor(Date.now() / 1000),
+      chat: {
+        id: -1001234567890,
+        type: "supergroup" as const,
+        title: "OpenClaw",
+      },
+      // Telegram topic messages can include this even when chat.is_forum is absent.
+      is_topic_message: true,
+      message_thread_id: 42,
+      from: { id: 200, username: "bob" },
+    },
+  };
+}
+
 function registerAndResolveStatusHandler(params: {
   cfg: OpenClawConfig;
   allowFrom?: string[];
@@ -265,6 +284,22 @@ describe("registerTelegramNativeCommands — session metadata", () => {
       >
     )[0]?.[0];
     expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe(boundSessionKey);
+  });
+
+  it("keeps topic routing for native commands when chat.is_forum is absent but message is topic-scoped", async () => {
+    const { handler } = registerAndResolveStatusHandler({
+      cfg: {},
+      allowFrom: ["200"],
+      groupAllowFrom: ["200"],
+    });
+    await handler(buildStatusTopicCommandContextWithoutChatForumFlag());
+
+    const dispatchCall = (
+      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
+        [{ ctx?: { CommandTargetSessionKey?: string } }]
+      >
+    )[0]?.[0];
+    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toContain(":topic:42");
   });
 
   it("aborts native command dispatch when configured ACP topic binding cannot initialize", async () => {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -173,7 +173,9 @@ async function resolveTelegramCommandAuth(params: {
   const chatId = msg.chat.id;
   const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
   const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
-  const isForum = (msg.chat as { is_forum?: boolean }).is_forum === true;
+  const isForum =
+    (msg.chat as { is_forum?: boolean }).is_forum === true ||
+    (msg as { is_topic_message?: boolean }).is_topic_message === true;
   const threadSpec = resolveTelegramThreadSpec({
     isGroup,
     isForum,


### PR DESCRIPTION
## Summary

- Problem: Telegram native commands (`/new`, `/reset`, etc.) could lose topic scope when `chat.is_forum` is absent, causing command routing/session targeting to fall back to General.
- Why it matters: topic-local reset/new actions can affect the wrong conversation/session.
- What changed: native command auth now treats `message.is_topic_message=true` as forum context in addition to `chat.is_forum=true`; added regression test to lock topic routing behavior when chat forum flag is missing.
- What did NOT change (scope boundary): no changes to non-topic/group auth rules or delivery paths outside Telegram native commands.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35963
- Related #35589

## User-visible / Behavior Changes

- In Telegram forum topics, native slash commands now keep topic-scoped session targeting even when `chat.is_forum` is not present but `is_topic_message` is true.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (tests), target behavior: Telegram topic command routing
- Runtime/container: Node + pnpm local dev
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): topic-scoped Telegram native command handling

### Steps

1. Build a Telegram native command context with `message_thread_id` and `is_topic_message=true`.
2. Omit `chat.is_forum` in message chat payload.
3. Run native command handler and inspect `CommandTargetSessionKey`.

### Expected

- Command target session key remains topic-scoped (`...:topic:<id>`).

### Actual

- ✅ Session key remains topic-scoped after this fix.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm vitest run src/telegram/bot-native-commands.session-meta.test.ts` passes (7/7).

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added regression test for topic command routing with `is_topic_message=true` and missing `chat.is_forum`.
  - Confirmed `CommandTargetSessionKey` retains `:topic:42`.
- Edge cases checked:
  - Existing topic binding/session-meta tests still pass.
- What you did **not** verify:
  - Full repository `pnpm check` (environment has unrelated `extensions/tlon` dependency resolution failures).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/telegram/bot-native-commands.ts`
  - `src/telegram/bot-native-commands.session-meta.test.ts`
- Known bad symptoms reviewers should watch for:
  - Native commands in non-topic chats unexpectedly receiving topic session keys.

## Risks and Mitigations

- Risk: forum inference could classify unexpected payloads as topic messages.
  - Mitigation: inference is narrowly scoped to explicit `is_topic_message===true` in native command flow.
