### PR TITLE
fix(cron): enforce secure permissions for cron store and run logs

### DIFF
--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -95,6 +95,26 @@ describe("cron run log", () => {
     });
   });
 
+  it.skipIf(process.platform === "win32")(
+    "creates runs dir as 0700 and log files as 0600",
+    async () => {
+      await withRunLogDir("openclaw-cron-log-perms-", async (dir) => {
+        const logPath = path.join(dir, "runs", "job-perms.jsonl");
+        await appendCronRunLog(logPath, {
+          ts: 1,
+          jobId: "job-perms",
+          action: "finished",
+          status: "ok",
+        });
+
+        const runsDirMode = (await fs.stat(path.dirname(logPath))).mode & 0o777;
+        const logFileMode = (await fs.stat(logPath)).mode & 0o777;
+        expect(runsDirMode).toBe(0o700);
+        expect(logFileMode).toBe(0o600);
+      });
+    },
+  );
+
   it("reads newest entries and filters by jobId", async () => {
     await withRunLogDir("openclaw-cron-log-read-", async (dir) => {
       const logPathA = path.join(dir, "runs", "a.jsonl");

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -125,8 +125,9 @@ async function pruneIfNeeded(filePath: string, opts: { maxBytes: number; keepLin
   const kept = lines.slice(Math.max(0, lines.length - opts.keepLines));
   const { randomBytes } = await import("node:crypto");
   const tmp = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.writeFile(tmp, `${kept.join("\n")}\n`, "utf-8");
+  await fs.writeFile(tmp, `${kept.join("\n")}\n`, { encoding: "utf-8", mode: 0o600 });
   await fs.rename(tmp, filePath);
+  await fs.chmod(filePath, 0o600).catch(() => undefined);
 }
 
 export async function appendCronRunLog(
@@ -139,8 +140,12 @@ export async function appendCronRunLog(
   const next = prev
     .catch(() => undefined)
     .then(async () => {
-      await fs.mkdir(path.dirname(resolved), { recursive: true });
-      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, "utf-8");
+      await fs.mkdir(path.dirname(resolved), { recursive: true, mode: 0o700 });
+      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, {
+        encoding: "utf-8",
+        mode: 0o600,
+      });
+      await fs.chmod(resolved, 0o600).catch(() => undefined);
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,
         keepLines: opts?.keepLines ?? DEFAULT_CRON_RUN_LOG_KEEP_LINES,

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -79,6 +79,23 @@ describe("cron store", () => {
     expect(JSON.parse(currentRaw)).toEqual(second);
     expect(JSON.parse(backupRaw)).toEqual(first);
   });
+
+  it.skipIf(process.platform === "win32")(
+    "writes store and backup with 0600 permissions",
+    async () => {
+      const store = await makeStorePath();
+      const first = makeStore("job-1", true);
+      const second = makeStore("job-2", false);
+
+      await saveCronStore(store.storePath, first);
+      await saveCronStore(store.storePath, second);
+
+      const storeMode = (await fs.stat(store.storePath)).mode & 0o777;
+      const backupMode = (await fs.stat(`${store.storePath}.bak`)).mode & 0o777;
+      expect(storeMode).toBe(0o600);
+      expect(backupMode).toBe(0o600);
+    },
+  );
 });
 
 describe("saveCronStore", () => {

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -61,7 +61,7 @@ export async function saveCronStore(
   store: CronStoreFile,
   opts?: SaveCronStoreOptions,
 ) {
-  await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.promises.mkdir(path.dirname(storePath), { recursive: true, mode: 0o700 });
   const json = JSON.stringify(store, null, 2);
   const cached = serializedStoreCache.get(storePath);
   if (cached === json) {
@@ -83,15 +83,18 @@ export async function saveCronStore(
     return;
   }
   const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.promises.writeFile(tmp, json, "utf-8");
+  await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: 0o600 });
   if (previous !== null && !opts?.skipBackup) {
     try {
-      await fs.promises.copyFile(storePath, `${storePath}.bak`);
+      const backupPath = `${storePath}.bak`;
+      await fs.promises.copyFile(storePath, backupPath);
+      await fs.promises.chmod(backupPath, 0o600).catch(() => undefined);
     } catch {
       // best-effort
     }
   }
   await renameWithRetry(tmp, storePath);
+  await fs.promises.chmod(storePath, 0o600).catch(() => undefined);
   serializedStoreCache.set(storePath, json);
 }
 

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -88,13 +88,13 @@ export async function saveCronStore(
     try {
       const backupPath = `${storePath}.bak`;
       await fs.promises.copyFile(storePath, backupPath);
-      await fs.promises.chmod(backupPath, 0o600).catch(() => undefined);
+      void fs.promises.chmod(backupPath, 0o600).catch(() => undefined);
     } catch {
       // best-effort
     }
   }
   await renameWithRetry(tmp, storePath);
-  await fs.promises.chmod(storePath, 0o600).catch(() => undefined);
+  void fs.promises.chmod(storePath, 0o600).catch(() => undefined);
   serializedStoreCache.set(storePath, json);
 }
 


### PR DESCRIPTION
## Summary
- enforce `0700` on cron store and run-log directories when created
- enforce `0600` on `cron/jobs.json`, `cron/jobs.json.bak`, and `cron/runs/*.jsonl` after writes/rotations
- add regression tests for POSIX file modes (skipped on Windows)

## Why
Fixes #35881. Cron files can contain schedule metadata, delivery targets, and message content. They should be owner-only readable/writable by default.

## Testing
- [x] `corepack pnpm vitest run src/cron/store.test.ts src/cron/run-log.test.ts`
- [ ] full suite not run in this environment

## AI-assisted
This PR was AI-assisted. I verified the changes and ran targeted tests locally.
