### PR TITLE
status: resolve shared model context windows by provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Status/context window resolution: keep provider-scoped context window cache entries for shared model IDs and prefer provider/model lookups in status/session context resolution so `/status` no longer under-reports limits when multiple providers expose the same model id with different windows. (#35976) Thanks @akari-musubi.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -34,6 +34,49 @@ describe("lookupContextTokens", () => {
     expect(lookupContextTokens("openrouter/claude-sonnet")).toBe(321_000);
   });
 
+  it("prefers provider-scoped cache values when provider/model are provided", async () => {
+    vi.doMock("../config/config.js", () => ({
+      loadConfig: () => ({
+        models: {
+          providers: {
+            "github-copilot": {
+              models: [{ id: "gemini-3.1-pro-preview", contextWindow: 128_000 }],
+            },
+            "google-gemini-cli": {
+              models: [{ id: "gemini-3.1-pro-preview", contextWindow: 1_048_576 }],
+            },
+          },
+        },
+      }),
+    }));
+    vi.doMock("./models-config.js", () => ({
+      ensureOpenClawModelsJson: vi.fn(async () => {}),
+    }));
+    vi.doMock("./agent-paths.js", () => ({
+      resolveOpenClawAgentDir: () => "/tmp/openclaw-agent",
+    }));
+    vi.doMock("./pi-model-discovery.js", () => ({
+      discoverAuthStorage: vi.fn(() => ({})),
+      discoverModels: vi.fn(() => ({
+        getAll: () => [],
+      })),
+    }));
+
+    const { resolveContextTokensForModel } = await import("./context.js");
+    expect(
+      resolveContextTokensForModel({
+        provider: "google-gemini-cli",
+        model: "gemini-3.1-pro-preview",
+      }),
+    ).toBe(1_048_576);
+    expect(
+      resolveContextTokensForModel({
+        provider: "github-copilot",
+        model: "gemini-3.1-pro-preview",
+      }),
+    ).toBe(128_000);
+  });
+
   it("does not skip eager warmup when --profile is followed by -- terminator", async () => {
     const loadConfigMock = vi.fn(() => ({ models: {} }));
     vi.doMock("../config/config.js", () => ({

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -20,6 +20,29 @@ describe("applyDiscoveredContextWindows", () => {
 
     expect(cache.get("claude-sonnet-4-5")).toBe(200_000);
   });
+
+  it("stores provider-scoped values when providers share a model id", () => {
+    const cache = new Map<string, number>();
+    applyDiscoveredContextWindows({
+      cache,
+      models: [
+        {
+          provider: "github-copilot",
+          id: "gemini-3.1-pro-preview",
+          contextWindow: 128_000,
+        },
+        {
+          provider: "google-gemini-cli",
+          id: "gemini-3.1-pro-preview",
+          contextWindow: 1_048_576,
+        },
+      ],
+    });
+
+    expect(cache.get("github-copilot/gemini-3.1-pro-preview")).toBe(128_000);
+    expect(cache.get("google-gemini-cli/gemini-3.1-pro-preview")).toBe(1_048_576);
+    expect(cache.get("gemini-3.1-pro-preview")).toBe(128_000);
+  });
 });
 
 describe("applyConfiguredContextWindows", () => {
@@ -58,6 +81,26 @@ describe("applyConfiguredContextWindows", () => {
 
     expect(cache.get("custom/model")).toBe(150_000);
     expect(cache.has("bad/model")).toBe(false);
+  });
+
+  it("stores provider-scoped configured values for shared model ids", () => {
+    const cache = new Map<string, number>();
+    applyConfiguredContextWindows({
+      cache,
+      modelsConfig: {
+        providers: {
+          "github-copilot": {
+            models: [{ id: "gemini-3.1-pro-preview", contextWindow: 128_000 }],
+          },
+          "google-gemini-cli": {
+            models: [{ id: "gemini-3.1-pro-preview", contextWindow: 1_048_576 }],
+          },
+        },
+      },
+    });
+
+    expect(cache.get("github-copilot/gemini-3.1-pro-preview")).toBe(128_000);
+    expect(cache.get("google-gemini-cli/gemini-3.1-pro-preview")).toBe(1_048_576);
   });
 });
 

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -8,7 +8,7 @@ import { consumeRootOptionToken, FLAG_TERMINATOR } from "../infra/cli-root-optio
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
 
-type ModelEntry = { id: string; contextWindow?: number };
+type ModelEntry = { id: string; provider?: string; contextWindow?: number };
 type ModelRegistryLike = {
   getAvailable?: () => ModelEntry[];
   getAll: () => ModelEntry[];
@@ -40,6 +40,12 @@ export function applyDiscoveredContextWindows(params: {
     if (!contextWindow || contextWindow <= 0) {
       continue;
     }
+    const providerScopedKey = toProviderScopedModelKey(model.provider, model.id);
+    if (providerScopedKey && providerScopedKey !== model.id) {
+      // Keep provider-specific values so status/context calculations can use the
+      // correct limit even when multiple providers share the same model id.
+      params.cache.set(providerScopedKey, contextWindow);
+    }
     const existing = params.cache.get(model.id);
     // When multiple providers expose the same model id with different limits,
     // prefer the smaller window so token budgeting is fail-safe (no overestimation).
@@ -57,7 +63,7 @@ export function applyConfiguredContextWindows(params: {
   if (!providers || typeof providers !== "object") {
     return;
   }
-  for (const provider of Object.values(providers)) {
+  for (const [providerName, provider] of Object.entries(providers)) {
     if (!Array.isArray(provider?.models)) {
       continue;
     }
@@ -69,6 +75,10 @@ export function applyConfiguredContextWindows(params: {
         continue;
       }
       params.cache.set(modelId, contextWindow);
+      const providerScopedKey = toProviderScopedModelKey(providerName, modelId);
+      if (providerScopedKey && providerScopedKey !== modelId) {
+        params.cache.set(providerScopedKey, contextWindow);
+      }
     }
   }
 }
@@ -236,6 +246,21 @@ function resolveProviderModelRef(params: {
   return { provider, model };
 }
 
+function toProviderScopedModelKey(provider?: string, modelId?: string): string | undefined {
+  const normalizedModel = modelId?.trim();
+  if (!normalizedModel) {
+    return undefined;
+  }
+  if (normalizedModel.includes("/")) {
+    return normalizedModel;
+  }
+  const normalizedProvider = provider?.trim().toLowerCase();
+  if (!normalizedProvider) {
+    return undefined;
+  }
+  return `${normalizedProvider}/${normalizedModel}`;
+}
+
 function isAnthropic1MModel(provider: string, model: string): boolean {
   if (provider !== "anthropic") {
     return false;
@@ -266,6 +291,12 @@ export function resolveContextTokensForModel(params: {
     const modelParams = resolveConfiguredModelParams(params.cfg, ref.provider, ref.model);
     if (modelParams?.context1m === true && isAnthropic1MModel(ref.provider, ref.model)) {
       return ANTHROPIC_CONTEXT_1M_TOKENS;
+    }
+    const providerScopedTokens = lookupContextTokens(
+      toProviderScopedModelKey(ref.provider, ref.model),
+    );
+    if (providerScopedTokens !== undefined) {
+      return providerScopedTokens;
     }
   }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `/status` could show a too-small context window when multiple providers expose the same model id with different limits.
- Why it matters: operators see incorrect context capacity in status/session views and may mis-tune prompts/compaction.
- What changed: context cache now stores provider-scoped keys (for example `google-gemini-cli/gemini-3.1-pro-preview`) and `resolveContextTokensForModel` now prefers provider/model lookups before generic model-id fallback.
- What did NOT change (scope boundary): runtime provider request behavior and token budgeting safety fallback were not changed; unscoped lookups still keep conservative behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35976
- Related #

## User-visible / Behavior Changes

- `/status` and other provider-aware context resolution paths now show/use the correct provider-specific context window when shared model ids exist across providers.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + Vitest
- Model/provider: mixed provider config (`github-copilot` + `google-gemini-cli`) sharing `gemini-3.1-pro-preview`
- Integration/channel (if any): N/A
- Relevant config (redacted): `models.providers.<provider>.models[].{ id, contextWindow }`

### Steps

1. Configure two providers with the same model id and different `contextWindow` values.
2. Resolve context via `resolveContextTokensForModel({ provider, model })`.
3. Compare returned values for each provider.

### Expected

- Provider-specific context windows are returned (no cross-provider min collision for provider-aware resolution).

### Actual

- Verified provider-specific values are returned with new tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: provider-scoped cache insertion for discovered/configured entries; provider-aware resolution preference.
- Edge cases checked: duplicate model ids across providers, invalid/empty model entries ignored, legacy unscoped fallback retained.
- What you did **not** verify: full end-to-end `/status` output on a live gateway with real provider credentials.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/context.ts` and related tests.
- Known bad symptoms reviewers should watch for: provider-aware lookups unexpectedly returning fallback values.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: mixed-case model ids could still rely on caller consistency.
  - Mitigation: preserve existing lookup behavior and keep unscoped fallback path unchanged.
