### PR TITLE
fix(telegram): restart stale polling when inbound updates stop

### DIFF
--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -71,6 +71,11 @@ const { startTelegramWebhookSpy } = vi.hoisted(() => ({
   startTelegramWebhookSpy: vi.fn(async () => ({ server: { close: vi.fn() }, stop: vi.fn() })),
 }));
 
+const { readTelegramUpdateOffsetMock, writeTelegramUpdateOffsetMock } = vi.hoisted(() => ({
+  readTelegramUpdateOffsetMock: vi.fn(async () => null as number | null),
+  writeTelegramUpdateOffsetMock: vi.fn(async () => undefined),
+}));
+
 type RunnerStub = {
   task: () => Promise<void>;
   stop: ReturnType<typeof vi.fn<() => void | Promise<void>>>;
@@ -183,6 +188,11 @@ vi.mock("./webhook.js", () => ({
   startTelegramWebhook: startTelegramWebhookSpy,
 }));
 
+vi.mock("./update-offset-store.js", () => ({
+  readTelegramUpdateOffset: readTelegramUpdateOffsetMock,
+  writeTelegramUpdateOffset: writeTelegramUpdateOffsetMock,
+}));
+
 vi.mock("../auto-reply/reply.js", () => ({
   getReplyFromConfig: async (ctx: { Body?: string }) => ({
     text: `echo:${ctx.Body}`,
@@ -206,6 +216,8 @@ describe("monitorTelegramProvider (grammY)", () => {
     computeBackoff.mockClear();
     sleepWithAbort.mockClear();
     startTelegramWebhookSpy.mockClear();
+    readTelegramUpdateOffsetMock.mockReset().mockResolvedValue(null);
+    writeTelegramUpdateOffsetMock.mockReset().mockResolvedValue(undefined);
     registerUnhandledRejectionHandlerMock.mockClear();
     resetUnhandledRejection();
     createTelegramBotErrors.length = 0;
@@ -422,6 +434,57 @@ describe("monitorTelegramProvider (grammY)", () => {
     expect(computeBackoff).toHaveBeenCalled();
     expect(sleepWithAbort).toHaveBeenCalled();
     expect(runSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("restarts stale polling when inbound updates stop for too long", async () => {
+    vi.useFakeTimers();
+    try {
+      readTelegramUpdateOffsetMock.mockResolvedValueOnce(42);
+      const abort = new AbortController();
+      let running = true;
+      let releaseTask: (() => void) | undefined;
+      const stop = vi.fn(async () => {
+        running = false;
+        releaseTask?.();
+      });
+
+      runSpy
+        .mockImplementationOnce(() =>
+          makeRunnerStub({
+            task: () =>
+              new Promise<void>((resolve) => {
+                releaseTask = resolve;
+              }),
+            stop,
+            isRunning: () => running,
+          }),
+        )
+        .mockImplementationOnce(() =>
+          makeRunnerStub({
+            task: async () => {
+              abort.abort();
+            },
+          }),
+        );
+
+      const monitor = monitorTelegramProvider({
+        token: "tok",
+        abortSignal: abort.signal,
+        pollingStallAfterMs: 60_000,
+        pollingStallCheckMs: 5_000,
+      });
+
+      await vi.waitFor(() => expect(runSpy).toHaveBeenCalledTimes(1));
+      await vi.advanceTimersByTimeAsync(65_000);
+      await monitor;
+
+      expect(stop).toHaveBeenCalled();
+      expect(computeBackoff).toHaveBeenCalled();
+      expect(sleepWithAbort).toHaveBeenCalled();
+      expect(runSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("passes configured webhookHost to webhook listener", async () => {

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -103,7 +103,8 @@ const isGrammyHttpError = (err: unknown): boolean => {
 export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
   const log = opts.runtime?.error ?? console.error;
   let activeRunner: ReturnType<typeof run> | undefined;
-  let forceRestarted = false;
+  type ForcedRestartReason = "unhandled-network-error" | "stale-polling-watchdog";
+  let forcedRestartReason: ForcedRestartReason | null = null;
 
   // Register handler for Grammy HttpError unhandled rejections.
   // This catches network errors that escape the polling loop's try-catch
@@ -118,7 +119,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
     // Network failures can surface outside the runner task promise and leave
     // polling stuck; force-stop the active runner so the loop can recover.
     if (isNetworkError && activeRunner && activeRunner.isRunning()) {
-      forceRestarted = true;
+      forcedRestartReason = "unhandled-network-error";
       void activeRunner.stop().catch(() => {});
       log(
         `[telegram] Restarting polling after unhandled network error: ${formatErrorMessage(err)}`,
@@ -299,7 +300,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
           if (staleForMs < stallAfterMs) {
             return;
           }
-          forceRestarted = true;
+          forcedRestartReason = "stale-polling-watchdog";
           // Reset local timer to avoid repeated stop calls before restart loop runs.
           lastInboundAtMs = Date.now();
           void stopRunner();
@@ -328,16 +329,19 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         if (opts.abortSignal?.aborted) {
           return "exit";
         }
-        const reason = forceRestarted
-          ? "unhandled network error"
-          : "runner stopped (maxRetryTime exceeded or graceful stop)";
-        forceRestarted = false;
+        const reason =
+          forcedRestartReason === "unhandled-network-error"
+            ? "unhandled network error"
+            : forcedRestartReason === "stale-polling-watchdog"
+              ? "stale polling watchdog"
+              : "runner stopped (maxRetryTime exceeded or graceful stop)";
+        forcedRestartReason = null;
         const shouldRestart = await waitBeforeRestart(
           (delay) => `Telegram polling runner stopped (${reason}); restarting in ${delay}.`,
         );
         return shouldRestart ? "continue" : "exit";
       } catch (err) {
-        forceRestarted = false;
+        forcedRestartReason = null;
         if (opts.abortSignal?.aborted) {
           throw err;
         }

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -30,6 +30,10 @@ export type MonitorTelegramOpts = {
   webhookHost?: string;
   proxyFetch?: typeof fetch;
   webhookUrl?: string;
+  /** Testing/advanced override: how long inbound silence is tolerated before polling restart. */
+  pollingStallAfterMs?: number;
+  /** Testing/advanced override: watchdog check cadence for stale polling detection. */
+  pollingStallCheckMs?: number;
 };
 
 export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
@@ -60,6 +64,9 @@ const TELEGRAM_POLL_RESTART_POLICY = {
   factor: 1.8,
   jitter: 0.25,
 };
+
+const DEFAULT_POLLING_STALL_AFTER_MS = 4 * 60 * 60 * 1000;
+const DEFAULT_POLLING_STALL_CHECK_MS = 60 * 1000;
 
 type TelegramBot = ReturnType<typeof createTelegramBot>;
 
@@ -141,11 +148,13 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       accountId: account.accountId,
       botToken: token,
     });
+    let lastInboundAtMs = Date.now();
     const persistUpdateId = async (updateId: number) => {
       if (lastUpdateId !== null && updateId <= lastUpdateId) {
         return;
       }
       lastUpdateId = updateId;
+      lastInboundAtMs = Date.now();
       try {
         await writeTelegramUpdateOffset({
           accountId: account.accountId,
@@ -270,6 +279,36 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
           });
         return stopPromise;
       };
+
+      const stallAfterMs = Math.max(
+        60_000,
+        opts.pollingStallAfterMs ?? DEFAULT_POLLING_STALL_AFTER_MS,
+      );
+      const stallCheckMs = Math.max(
+        5_000,
+        opts.pollingStallCheckMs ?? DEFAULT_POLLING_STALL_CHECK_MS,
+      );
+      let stallWatchdog: ReturnType<typeof setInterval> | undefined;
+      // Start stale polling watchdog only after we've received at least one update.
+      if (lastUpdateId !== null) {
+        stallWatchdog = setInterval(() => {
+          if (opts.abortSignal?.aborted || !runner.isRunning()) {
+            return;
+          }
+          const staleForMs = Date.now() - lastInboundAtMs;
+          if (staleForMs < stallAfterMs) {
+            return;
+          }
+          forceRestarted = true;
+          // Reset local timer to avoid repeated stop calls before restart loop runs.
+          lastInboundAtMs = Date.now();
+          void stopRunner();
+          log(
+            `[telegram] Polling appears stale (no inbound updates for ${formatDurationPrecise(staleForMs)}); restarting runner`,
+          );
+        }, stallCheckMs);
+        stallWatchdog.unref?.();
+      }
       const stopBot = () => {
         return Promise.resolve(bot.stop())
           .then(() => undefined)
@@ -314,6 +353,9 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         );
         return shouldRestart ? "continue" : "exit";
       } finally {
+        if (stallWatchdog) {
+          clearInterval(stallWatchdog);
+        }
         opts.abortSignal?.removeEventListener("abort", stopOnAbort);
         await stopRunner();
         await stopBot();


### PR DESCRIPTION
## Problem
Telegram polling could appear alive while inbound updates silently stopped for long periods, leaving sessions stale until an external restart.

## Root cause
The polling loop retried on explicit failures, but had no watchdog for prolonged inbound silence when the runner stayed nominally running.

## Fix
- Add a stale-polling watchdog in `monitorTelegramProvider` that tracks last inbound update timestamp.
- If no inbound updates exceed threshold, force a runner stop/restart cycle through existing backoff path.
- Add configurable test/advanced overrides (`pollingStallAfterMs`, `pollingStallCheckMs`) with safe minimum clamps.
- Add regression test: `restarts stale polling when inbound updates stop for too long`.

## Testing
- `pnpm -s vitest run src/telegram/monitor.test.ts`

AI-assisted: yes (implementation + test generation), human-reviewed and validated locally.
