### PR TITLE
Fix: enforce private cron store and run-log file permissions

### DIFF
--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -69,6 +69,7 @@ describe("cron run log", () => {
   it("appends JSONL and prunes by line count", async () => {
     await withRunLogDir("openclaw-cron-log-", async (dir) => {
       const logPath = path.join(dir, "runs", "job-1.jsonl");
+      const runsDir = path.join(dir, "runs");
 
       for (let i = 0; i < 10; i++) {
         await appendCronRunLog(
@@ -92,6 +93,12 @@ describe("cron run log", () => {
       expect(lines.length).toBe(3);
       const last = JSON.parse(lines[2] ?? "{}") as { ts?: number };
       expect(last.ts).toBe(1009);
+      if (process.platform !== "win32") {
+        const runsMode = (await fs.stat(runsDir)).mode & 0o777;
+        const fileMode = (await fs.stat(logPath)).mode & 0o777;
+        expect(runsMode).toBe(0o700);
+        expect(fileMode).toBe(0o600);
+      }
     });
   });
 

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -125,7 +125,7 @@ async function pruneIfNeeded(filePath: string, opts: { maxBytes: number; keepLin
   const kept = lines.slice(Math.max(0, lines.length - opts.keepLines));
   const { randomBytes } = await import("node:crypto");
   const tmp = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.writeFile(tmp, `${kept.join("\n")}\n`, "utf-8");
+  await fs.writeFile(tmp, `${kept.join("\n")}\n`, { encoding: "utf-8", mode: 0o600 });
   await fs.rename(tmp, filePath);
 }
 
@@ -139,8 +139,11 @@ export async function appendCronRunLog(
   const next = prev
     .catch(() => undefined)
     .then(async () => {
-      await fs.mkdir(path.dirname(resolved), { recursive: true });
-      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, "utf-8");
+      await fs.mkdir(path.dirname(resolved), { recursive: true, mode: 0o700 });
+      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, {
+        encoding: "utf-8",
+        mode: 0o600,
+      });
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,
         keepLines: opts?.keepLines ?? DEFAULT_CRON_RUN_LOG_KEEP_LINES,

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -66,6 +66,22 @@ describe("cron store", () => {
     await expect(fs.stat(`${store.storePath}.bak`)).rejects.toThrow();
   });
 
+  it("stores files with private permissions", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+
+    const store = await makeStorePath();
+    const payload = makeStore("job-perms", true);
+    await saveCronStore(store.storePath, payload);
+
+    const fileMode = (await fs.stat(store.storePath)).mode & 0o777;
+    const dirMode = (await fs.stat(path.dirname(store.storePath))).mode & 0o777;
+
+    expect(fileMode).toBe(0o600);
+    expect(dirMode).toBe(0o700);
+  });
+
   it("backs up previous content before replacing the store", async () => {
     const store = await makeStorePath();
     const first = makeStore("job-1", true);
@@ -78,6 +94,10 @@ describe("cron store", () => {
     const backupRaw = await fs.readFile(`${store.storePath}.bak`, "utf-8");
     expect(JSON.parse(currentRaw)).toEqual(second);
     expect(JSON.parse(backupRaw)).toEqual(first);
+    if (process.platform !== "win32") {
+      const backupMode = (await fs.stat(`${store.storePath}.bak`)).mode & 0o777;
+      expect(backupMode).toBe(0o600);
+    }
   });
 });
 

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -61,7 +61,7 @@ export async function saveCronStore(
   store: CronStoreFile,
   opts?: SaveCronStoreOptions,
 ) {
-  await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.promises.mkdir(path.dirname(storePath), { recursive: true, mode: 0o700 });
   const json = JSON.stringify(store, null, 2);
   const cached = serializedStoreCache.get(storePath);
   if (cached === json) {
@@ -83,7 +83,7 @@ export async function saveCronStore(
     return;
   }
   const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.promises.writeFile(tmp, json, "utf-8");
+  await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: 0o600 });
   if (previous !== null && !opts?.skipBackup) {
     try {
       await fs.promises.copyFile(storePath, `${storePath}.bak`);


### PR DESCRIPTION
## Summary
- Fix issue #35881: insecure cron persistence file permissions.
- Ensure cron directory and runs directory are created with `0700`.
- Ensure `jobs.json`, backup files, and run-log files are written with private `0600` permissions.
- Keep cron persistence behavior unchanged while tightening filesystem permissions.

## Security Impact
- Reduces accidental exposure risk for cron job metadata and run logs on shared systems.

## Repro+Verification
- Create/update cron jobs and generate run logs.
- Before: files could be created with permissive modes (for example `0644`).
- After: cron store and run-log artifacts are created with private owner-only permissions.

## Testing
- `pnpm test src/cron/store.test.ts src/cron/run-log.test.ts`

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35881
