### PR TITLE
Fix: avoid brittle plugin-sdk deep import in Matrix queue

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,5 +1,3 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
-
 export const DEFAULT_SEND_GAP_MS = 150;
 
 type MatrixSendQueueOptions = {
@@ -8,7 +6,7 @@ type MatrixSendQueueOptions = {
 };
 
 // Serialize sends per room to preserve Matrix delivery order.
-const roomQueues = new KeyedAsyncQueue();
+const roomQueues = new Map<string, Promise<unknown>>();
 
 export function enqueueSend<T>(
   roomId: string,
@@ -17,10 +15,16 @@ export function enqueueSend<T>(
 ): Promise<T> {
   const gapMs = options?.gapMs ?? DEFAULT_SEND_GAP_MS;
   const delayFn = options?.delayFn ?? delay;
-  return roomQueues.enqueue(roomId, async () => {
-    await delayFn(gapMs);
-    return await fn();
-  });
+  const previous = roomQueues.get(roomId) ?? Promise.resolve();
+  const next = previous.then(() => delayFn(gapMs)).then(() => fn());
+  roomQueues.set(
+    roomId,
+    next.then(
+      () => undefined,
+      () => undefined,
+    ),
+  );
+  return next;
 }
 
 function delay(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary
- Fix issue #35869: Matrix plugin deep import of `openclaw/plugin-sdk/keyed-async-queue`.
- Replace brittle deep import with an internal per-room Promise queue implementation.
- Avoid runtime path resolution failures in `2026.3.2` when resolving plugin-sdk subpaths.

## Security Impact
- N/A

## Repro+Verification
- Load Matrix plugin on `2026.3.2` runtime.
- Before: plugin load could fail due to invalid deep import resolution.
- After: plugin loads and send queue behavior remains stable without deep imports.

## Testing
- Existing Matrix plugin flow validated with updated queue implementation.

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35869
