### PR TITLE
acpx: recover NO_SESSION ensures with sessions new fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- ACP/acpx session init fallback: treat `NO_SESSION` from `sessions ensure` as recoverable and continue with `sessions new` fallback so `sessions_spawn(runtime="acp")` no longer fails early when backends report missing sessions during ensure. (#35861) Thanks @zhoumo-creator.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.

--- a/extensions/acpx/src/runtime-internals/test-fixtures.ts
+++ b/extensions/acpx/src/runtime-internals/test-fixtures.ts
@@ -75,6 +75,14 @@ const setValue = command === "set" ? String(args[commandIndex + 2] || "") : "";
 
 if (command === "sessions" && args[commandIndex + 1] === "ensure") {
   writeLog({ kind: "ensure", agent, args, sessionName: ensureName });
+  if (process.env.MOCK_ACPX_ENSURE_NO_SESSION === "1") {
+    emitJson({
+      type: "error",
+      code: "NO_SESSION",
+      message: "Resource not found",
+    });
+    process.exit(0);
+  }
   if (process.env.MOCK_ACPX_ENSURE_EMPTY === "1") {
     emitJson({ action: "session_ensured", name: ensureName });
   } else {

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -399,6 +399,27 @@ describe("AcpxRuntime", () => {
     }
   });
 
+  it("falls back to 'sessions new' when 'sessions ensure' returns NO_SESSION", async () => {
+    process.env.MOCK_ACPX_ENSURE_NO_SESSION = "1";
+    try {
+      const { runtime, logPath } = await createMockRuntimeFixture();
+      const handle = await runtime.ensureSession({
+        sessionKey: "agent:claude:acp:fallback-no-session",
+        agent: "claude",
+        mode: "persistent",
+      });
+      expect(handle.backend).toBe("acpx");
+      expect(handle.acpxRecordId).toBe("rec-agent:claude:acp:fallback-no-session");
+      expect(handle.agentSessionId).toBe("inner-agent:claude:acp:fallback-no-session");
+
+      const logs = await readMockRuntimeLogEntries(logPath);
+      expect(logs.some((entry) => entry.kind === "ensure")).toBe(true);
+      expect(logs.some((entry) => entry.kind === "new")).toBe(true);
+    } finally {
+      delete process.env.MOCK_ACPX_ENSURE_NO_SESSION;
+    }
+  });
+
   it("fails with ACP_SESSION_INIT_FAILED when both ensure and new omit session IDs", async () => {
     process.env.MOCK_ACPX_ENSURE_EMPTY = "1";
     process.env.MOCK_ACPX_NEW_EMPTY = "1";

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -186,6 +186,7 @@ export class AcpxRuntime implements AcpRuntime {
       }),
       cwd,
       fallbackCode: "ACP_SESSION_INIT_FAILED",
+      ignoreNoSession: true,
     });
     let ensuredEvent = events.find(
       (event) =>


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: ACP runtime `ensureSession` failed immediately when `sessions ensure` returned a `NO_SESSION` error event.
- Why it matters: `sessions_spawn(runtime="acp")` could fail with `ACP_TURN_FAILED`/exit-code errors even though `sessions new` fallback should recover.
- What changed: `ensureSession` now treats `NO_SESSION` on `sessions ensure` as recoverable and proceeds to the existing `sessions new` fallback path.
- What did NOT change (scope boundary): no changes to prompt execution, runtime permissions, or non-`NO_SESSION` error handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35861
- Related #

## User-visible / Behavior Changes

- ACP session spawn is now resilient when backend ensure reports `NO_SESSION`; runtime falls back to creating the session instead of failing early.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js + Vitest
- Model/provider: ACP runtime backend (`acpx` mock harness)
- Integration/channel (if any): ACP sessions runtime
- Relevant config (redacted): ACP backend `acpx` with `runtime="acp"`

### Steps

1. Run ACP ensure flow where `sessions ensure` emits `{ type: "error", code: "NO_SESSION" }`.
2. Call runtime `ensureSession(...)`.
3. Verify runtime executes `sessions new` fallback and returns valid session identifiers.

### Expected

- `ensureSession` succeeds by falling back to `sessions new`.

### Actual

- New regression test confirms fallback occurs and returns valid handle metadata.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: new test path where ensure emits `NO_SESSION`, fallback executes, and handle IDs are returned.
- Edge cases checked: existing ensure-empty fallback path still passes; hard-failure path (ensure+new both missing IDs) still fails with `ACP_SESSION_INIT_FAILED`.
- What you did **not** verify: end-to-end ACP run against a live external acpx backend binary.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `extensions/acpx/src/runtime.ts` and runtime tests.
- Known bad symptoms reviewers should watch for: repeated ensure retries without reaching `sessions new` fallback.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: swallowing `NO_SESSION` in ensure could hide unexpected backend states.
  - Mitigation: fallback still requires valid session IDs from `sessions new`, and non-`NO_SESSION` errors remain fail-fast.
