### PR TITLE
Fix: ACP child processes not cleaned up after session TTL expires

### DIFF
--- a/extensions/acpx/src/runtime-internals/process.test.ts
+++ b/extensions/acpx/src/runtime-internals/process.test.ts
@@ -2,14 +2,31 @@ import { spawn } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as killTree from "../../../../src/process/kill-tree.js";
 import { createWindowsCmdShimFixture } from "../../../shared/windows-cmd-shim-test-fixtures.js";
 import {
+  spawnWithResolvedCommand,
   resolveSpawnCommand,
   spawnAndCollect,
   type SpawnCommandCache,
   waitForExit,
 } from "./process.js";
+
+const { spawnSpyMock } = vi.hoisted(() => ({
+  spawnSpyMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawn: (...args: Parameters<typeof actual.spawn>) => {
+      spawnSpyMock(...args);
+      return actual.spawn(...args);
+    },
+  };
+});
 
 const tempDirs: string[] = [];
 
@@ -253,6 +270,23 @@ describe("waitForExit", () => {
 });
 
 describe("spawnAndCollect", () => {
+  it("spawns in a new process group when configured", () => {
+    spawnSpyMock.mockClear();
+    const child = spawnWithResolvedCommand(
+      {
+        command: process.execPath,
+        args: ["-e", "process.exit(0)"],
+        cwd: process.cwd(),
+      },
+      { spawnInNewProcessGroup: true },
+    );
+    expect(spawnSpyMock).toHaveBeenCalledTimes(1);
+    const spawnOptions = spawnSpyMock.mock.calls[0]?.[2];
+    expect(spawnOptions?.detached).toBe(true);
+    spawnSpyMock.mockReset();
+    child.on("error", () => {});
+  });
+
   it("returns abort error immediately when signal is already aborted", async () => {
     const controller = new AbortController();
     controller.abort();
@@ -288,5 +322,38 @@ describe("spawnAndCollect", () => {
 
     const result = await resultPromise;
     expect(result.error?.name).toBe("AbortError");
+  });
+
+  it("kills entire process group when aborting detached child process collection", async () => {
+    const originalKillProcessTree = killTree.killProcessTree;
+    const killCalls: number[] = [];
+    const killProcessTreeSpy = vi.spyOn(killTree, "killProcessTree").mockImplementation((pid) => {
+      killCalls.push(pid);
+      return originalKillProcessTree(pid);
+    });
+    const controller = new AbortController();
+    const resultPromise = spawnAndCollect(
+      {
+        command: process.execPath,
+        args: ["-e", "setTimeout(() => {}, 10_000)"],
+        cwd: process.cwd(),
+      },
+      undefined,
+      {
+        signal: controller.signal,
+        spawnInNewProcessGroup: true,
+      },
+    );
+
+    setTimeout(() => {
+      controller.abort();
+    }, 10);
+
+    const result = await resultPromise;
+    expect(result.error?.name).toBe("AbortError");
+    expect(killCalls.length).toBeGreaterThan(0);
+    expect(killCalls.at(-1)).toBeGreaterThan(0);
+
+    killProcessTreeSpy.mockRestore();
   });
 });

--- a/extensions/acpx/src/runtime-internals/process.ts
+++ b/extensions/acpx/src/runtime-internals/process.ts
@@ -10,6 +10,7 @@ import {
   materializeWindowsSpawnProgram,
   resolveWindowsSpawnProgramCandidate,
 } from "openclaw/plugin-sdk/acpx";
+import { killProcessTree } from "../../../../src/process/kill-tree.js";
 
 export type SpawnExit = {
   code: number | null;
@@ -47,6 +48,7 @@ export type SpawnCommandOptions = {
   strictWindowsCmdWrapper?: boolean;
   cache?: SpawnCommandCache;
   onResolved?: (event: SpawnResolutionEvent) => void;
+  spawnInNewProcessGroup?: boolean;
 };
 
 const DEFAULT_RUNTIME: SpawnRuntime = {
@@ -141,6 +143,7 @@ export function spawnWithResolvedCommand(
     env: { ...process.env, OPENCLAW_SHELL: "acp" },
     stdio: ["pipe", "pipe", "pipe"],
     shell: resolved.shell,
+    detached: options?.spawnInNewProcessGroup === true,
     windowsHide: resolved.windowsHide,
   });
 }
@@ -184,6 +187,7 @@ export async function spawnAndCollect(
   options?: SpawnCommandOptions,
   runtime?: {
     signal?: AbortSignal;
+    spawnInNewProcessGroup?: boolean;
   },
 ): Promise<{
   stdout: string;
@@ -215,6 +219,12 @@ export async function spawnAndCollect(
   let aborted = false;
   const onAbort = () => {
     aborted = true;
+    if (runtime?.spawnInNewProcessGroup) {
+      if (child.pid != null) {
+        killProcessTree(child.pid);
+      }
+      return;
+    }
     try {
       child.kill("SIGTERM");
     } catch {
@@ -222,6 +232,12 @@ export async function spawnAndCollect(
     }
     abortKillTimer = setTimeout(() => {
       if (child.exitCode !== null || child.signalCode !== null) {
+        return;
+      }
+      if (runtime?.spawnInNewProcessGroup) {
+        if (child.pid != null) {
+          killProcessTree(child.pid);
+        }
         return;
       }
       try {

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -1,6 +1,12 @@
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+const { killProcessTreeMock } = vi.hoisted(() => ({
+  killProcessTreeMock: vi.fn(),
+}));
+vi.mock("../../../src/process/kill-tree.js", () => ({
+  killProcessTree: killProcessTreeMock,
+}));
 import { runAcpRuntimeAdapterContract } from "../../../src/acp/runtime/adapter-contract.testkit.js";
 import {
   cleanupMockRuntimeFixtures,
@@ -245,6 +251,34 @@ describe("AcpxRuntime", () => {
     const close = logs.find((entry) => entry.kind === "close");
     expect(cancel?.sessionName).toBe("agent:claude:acp:789");
     expect(close?.sessionName).toBe("agent:claude:acp:789");
+  });
+
+  it("kills tracked prompt process groups when a session is closed", async () => {
+    killProcessTreeMock.mockReset();
+    const { runtime } = await createMockRuntimeFixture({ queueOwnerTtlSeconds: 0.1 });
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:close-cleans",
+      agent: "codex",
+      mode: "persistent",
+    });
+    const events = [];
+    for await (const event of runtime.runTurn({
+      handle,
+      text: "hello world",
+      mode: "prompt",
+      requestId: "req-close-cleans",
+    })) {
+      events.push(event);
+    }
+    expect(events).toContainEqual({
+      type: "done",
+      stopReason: "end_turn",
+    });
+
+    await runtime.close({ handle, reason: "close-cleans" });
+    expect(killProcessTreeMock.mock.calls.length).toBeGreaterThan(0);
+    expect(typeof killProcessTreeMock.mock.calls[0]?.[0]).toBe("number");
+    expect((killProcessTreeMock.mock.calls[0]?.[0] ?? 0) > 0).toBe(true);
   });
 
   it("exposes control capabilities and runs set-mode/set/status commands", async () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -12,6 +12,7 @@ import type {
   PluginLogger,
 } from "openclaw/plugin-sdk/acpx";
 import { AcpRuntimeError } from "openclaw/plugin-sdk/acpx";
+import { killProcessTree } from "../../../src/process/kill-tree.js";
 import { type ResolvedAcpxPluginConfig } from "./config.js";
 import { checkAcpxVersion } from "./ensure.js";
 import {
@@ -42,8 +43,16 @@ export const ACPX_BACKEND_ID = "acpx";
 
 const ACPX_RUNTIME_HANDLE_PREFIX = "acpx:v1:";
 const DEFAULT_AGENT_FALLBACK = "codex";
+const ACPX_PROMPT_PROCESS_REAPER_INTERVAL_MS = 60_000;
+const ACPX_PROMPT_PROCESS_REAPER_STALE_MS = 10 * 60_000;
 const ACPX_CAPABILITIES: AcpRuntimeCapabilities = {
   controls: ["session/set_mode", "session/set_config_option", "session/status"],
+};
+
+type PromptProcessState = {
+  processGroupId: number;
+  lastTouchedAt: number;
+  active: boolean;
 };
 
 export function encodeAcpxRuntimeHandleState(state: AcpxHandleState): string {
@@ -100,6 +109,8 @@ export class AcpxRuntime implements AcpRuntime {
   private readonly spawnCommandCache: SpawnCommandCache = {};
   private readonly spawnCommandOptions: SpawnCommandOptions;
   private readonly loggedSpawnResolutions = new Set<string>();
+  private readonly promptProcessGroups = new Map<string, PromptProcessState>();
+  private readonly promptProcessReaper: ReturnType<typeof setInterval>;
 
   constructor(
     private readonly config: ResolvedAcpxPluginConfig,
@@ -123,6 +134,10 @@ export class AcpxRuntime implements AcpRuntime {
         this.logSpawnResolution(event);
       },
     };
+    this.promptProcessReaper = setInterval(() => {
+      this.reapPromptProcessGroups();
+    }, ACPX_PROMPT_PROCESS_REAPER_INTERVAL_MS);
+    this.promptProcessReaper.unref();
   }
 
   isHealthy(): boolean {
@@ -275,8 +290,12 @@ export class AcpxRuntime implements AcpRuntime {
         args,
         cwd: state.cwd,
       },
-      this.spawnCommandOptions,
+      {
+        ...this.spawnCommandOptions,
+        spawnInNewProcessGroup: true,
+      },
     );
+    this.trackPromptProcess(state.name, child.pid ?? 0);
     child.stdin.on("error", () => {
       // Ignore EPIPE when the child exits before stdin flush completes.
     });
@@ -343,6 +362,7 @@ export class AcpxRuntime implements AcpRuntime {
       }
     } finally {
       lines.close();
+      this.setPromptProcessIdle(state.name);
       if (input.signal) {
         input.signal.removeEventListener("abort", onAbort);
       }
@@ -529,15 +549,19 @@ export class AcpxRuntime implements AcpRuntime {
 
   async close(input: { handle: AcpRuntimeHandle; reason: string }): Promise<void> {
     const state = this.resolveHandleState(input.handle);
-    await this.runControlCommand({
-      args: this.buildControlArgs({
+    try {
+      await this.runControlCommand({
+        args: this.buildControlArgs({
+          cwd: state.cwd,
+          command: [state.agent, "sessions", "close", state.name],
+        }),
         cwd: state.cwd,
-        command: [state.agent, "sessions", "close", state.name],
-      }),
-      cwd: state.cwd,
-      fallbackCode: "ACP_TURN_FAILED",
-      ignoreNoSession: true,
-    });
+        fallbackCode: "ACP_TURN_FAILED",
+        ignoreNoSession: true,
+      });
+    } finally {
+      this.stopPromptProcess(state.name);
+    }
   }
 
   private resolveHandleState(handle: AcpRuntimeHandle): AcpxHandleState {
@@ -583,6 +607,66 @@ export class AcpxRuntime implements AcpRuntime {
     args.push("--ttl", String(this.queueOwnerTtlSeconds));
     args.push(params.agent, "prompt", "--session", params.sessionName, "--file", "-");
     return args;
+  }
+
+  stop(): void {
+    clearInterval(this.promptProcessReaper);
+    this.stopAllPromptProcesses();
+  }
+
+  private trackPromptProcess(sessionName: string, processGroupId: number): void {
+    if (!sessionName || !Number.isFinite(processGroupId) || processGroupId <= 0) {
+      return;
+    }
+    const existing = this.promptProcessGroups.get(sessionName);
+    if (existing && existing.processGroupId !== processGroupId) {
+      this.stopPromptProcess(sessionName);
+    }
+    this.promptProcessGroups.set(sessionName, {
+      processGroupId,
+      lastTouchedAt: Date.now(),
+      active: true,
+    });
+  }
+
+  private setPromptProcessIdle(sessionName: string): void {
+    const current = this.promptProcessGroups.get(sessionName);
+    if (!current) {
+      return;
+    }
+    current.active = false;
+    current.lastTouchedAt = Date.now();
+  }
+
+  private stopPromptProcess(sessionName: string): void {
+    const current = this.promptProcessGroups.get(sessionName);
+    if (!current) {
+      return;
+    }
+    this.promptProcessGroups.delete(sessionName);
+    killProcessTree(current.processGroupId);
+    this.logger?.debug?.(
+      `acpx runtime: stopped prompt process group=${current.processGroupId} session=${sessionName}`,
+    );
+  }
+
+  private stopAllPromptProcesses(): void {
+    for (const sessionName of this.promptProcessGroups.keys()) {
+      this.stopPromptProcess(sessionName);
+    }
+  }
+
+  private reapPromptProcessGroups(): void {
+    const now = Date.now();
+    for (const [sessionName, state] of this.promptProcessGroups) {
+      if (state.active) {
+        continue;
+      }
+      if (now - state.lastTouchedAt < ACPX_PROMPT_PROCESS_REAPER_STALE_MS) {
+        continue;
+      }
+      this.stopPromptProcess(sessionName);
+    }
   }
 
   private async runControlCommand(params: {

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -20,15 +20,18 @@ vi.mock("./ensure.js", () => ({
 type RuntimeStub = AcpRuntime & {
   probeAvailability(): Promise<void>;
   isHealthy(): boolean;
+  stop?: () => void | Promise<void>;
 };
 
 function createRuntimeStub(healthy: boolean): {
   runtime: RuntimeStub;
+  stopSpy: ReturnType<typeof vi.fn>;
   probeAvailabilitySpy: ReturnType<typeof vi.fn>;
   isHealthySpy: ReturnType<typeof vi.fn>;
 } {
   const probeAvailabilitySpy = vi.fn(async () => {});
   const isHealthySpy = vi.fn(() => healthy);
+  const stopSpy = vi.fn(async () => {});
   return {
     runtime: {
       ensureSession: vi.fn(async (input) => ({
@@ -41,6 +44,7 @@ function createRuntimeStub(healthy: boolean): {
       }),
       cancel: vi.fn(async () => {}),
       close: vi.fn(async () => {}),
+      stop: stopSpy,
       async probeAvailability() {
         await probeAvailabilitySpy();
       },
@@ -48,6 +52,7 @@ function createRuntimeStub(healthy: boolean): {
         return isHealthySpy();
       },
     },
+    stopSpy,
     probeAvailabilitySpy,
     isHealthySpy,
   };
@@ -171,5 +176,18 @@ describe("createAcpxRuntimeService", () => {
 
     expect(startResult).toBe("started");
     expect(getAcpRuntimeBackend("acpx")?.runtime).toBe(runtime);
+  });
+
+  it("forwards service stop to runtime stop handler", async () => {
+    const { runtime, stopSpy } = createRuntimeStub(true);
+    const service = createAcpxRuntimeService({
+      runtimeFactory: () => runtime,
+    });
+    const context = createServiceContext();
+
+    await service.start(context);
+    await service.stop?.(context);
+
+    expect(stopSpy).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -12,6 +12,7 @@ import { ACPX_BACKEND_ID, AcpxRuntime } from "./runtime.js";
 type AcpxRuntimeLike = AcpRuntime & {
   probeAvailability(): Promise<void>;
   isHealthy(): boolean;
+  stop?: () => void | Promise<void>;
 };
 
 type AcpxRuntimeFactoryParams = {
@@ -98,7 +99,11 @@ export function createAcpxRuntimeService(
     async stop(_ctx: OpenClawPluginServiceContext): Promise<void> {
       lifecycleRevision += 1;
       unregisterAcpRuntimeBackend(ACPX_BACKEND_ID);
+      const stoppingRuntime = runtime;
       runtime = null;
+      if (stoppingRuntime?.stop) {
+        await Promise.resolve(stoppingRuntime.stop());
+      }
     },
   };
 }


### PR DESCRIPTION

## Summary
- Fix issue #35886: ACP child processes not cleaned up after session TTL expires
- Implements process group based cleanup for ACP sessions
- Spawns prompt processes in detached process groups
- Tracks prompt process groups and kills them on session close
- Adds periodic reaper for stale orphaned processes

## Security Impact
- N/A

## Repro+Verification
- Configure acp.runtime.ttlMinutes and trigger multiple ACP sessions
- Wait for sessions to complete/expire
- Verify no zombie processes accumulate

## Testing
- pnpm test extensions/acpx/src/runtime.test.ts - passed
- pnpm test extensions/acpx/src/runtime-internals/process.test.ts - passed
- pnpm test extensions/acpx/src/service.test.ts - passed

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35886
