### PR TITLE
Fix: normalize Feishu group slash command parsing

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -569,6 +569,53 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("normalizes CommandBody for group slash commands with a leading bot mention", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-admin",
+        },
+      },
+      message: {
+        message_id: "msg-group-command-mention-normalization",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "@_bot_1 /model foo" }),
+        mentions: [{ key: "@_bot_1", id: { open_id: "ou-bot-123" }, name: "Bot", tenant_key: "" }],
+      },
+    };
+
+    await handleFeishuMessage({
+      cfg,
+      event,
+      botOpenId: "ou-bot-123",
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        CommandBody: "/model foo",
+        BodyForCommands: "/model foo",
+      }),
+    );
+  });
+
   it("allows group sender when global groupSenderAllowFrom includes sender", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -504,6 +504,35 @@ function normalizeMentions(
 }
 
 /**
+ * Feishu command parsing should ignore a leading bot mention, even in group chats,
+ * while preserving the full message context used for user-facing prompts.
+ */
+function normalizeFeishuCommandBody(text: string, botStripId?: string): string {
+  if (!botStripId) {
+    return text;
+  }
+
+  const trimmed = text.trimStart();
+  const botTagPrefix = `<at user_id="${botStripId}">`;
+  if (!trimmed.startsWith(botTagPrefix)) {
+    return text;
+  }
+
+  const closingTag = "</at>";
+  const closeIndex = trimmed.indexOf(closingTag);
+  if (closeIndex === -1) {
+    return text;
+  }
+
+  const afterTag = trimmed.slice(closeIndex + closingTag.length).trimStart();
+  if (!afterTag || !/^[!\/]/.test(afterTag)) {
+    return text;
+  }
+
+  return afterTag;
+}
+
+/**
  * Parse media keys from message content based on message type.
  */
 function parseMediaKeys(
@@ -1299,6 +1328,8 @@ export async function handleFeishuMessage(params: {
         : undefined;
 
     // --- Shared context builder for dispatch ---
+    const commandBodyForParsing = normalizeFeishuCommandBody(ctx.content, botOpenId?.trim());
+
     const buildCtxPayloadForAgent = (
       agentSessionKey: string,
       agentAccountId: string,
@@ -1311,7 +1342,8 @@ export async function handleFeishuMessage(params: {
         ReplyToId: ctx.parentId,
         RootMessageId: ctx.rootId,
         RawBody: ctx.content,
-        CommandBody: ctx.content,
+        CommandBody: commandBodyForParsing,
+        BodyForCommands: commandBodyForParsing,
         From: feishuFrom,
         To: feishuTo,
         SessionKey: agentSessionKey,


### PR DESCRIPTION
## Summary
- Fix issue #35994: slash command parsing in Feishu group chats.
- Normalize group messages by stripping leading bot mentions before command parsing.
- Keep user-facing message content unchanged while ensuring command body extraction is stable.
- Add regression coverage for `CommandBody` and `BodyForCommands` normalization.

## Security Impact
- N/A

## Repro+Verification
- In a Feishu group, send slash commands with a leading bot mention.
- Before: parser may fail or misread `/model`, `/reset`, `/new` in group context.
- After: command parser receives normalized command text and executes correctly.

## Testing
- Added regression test for command normalization in Feishu group parsing.

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35994
