### PR TITLE
fix(feishu): fallback when reply target is unsupported

### DIFF
--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -21,7 +21,7 @@ vi.mock("./runtime.js", () => ({
 
 import { sendCardFeishu, sendMessageFeishu } from "./send.js";
 
-describe("Feishu reply fallback for withdrawn/deleted targets", () => {
+describe("Feishu reply fallback for unavailable/unsupported targets", () => {
   const replyMock = vi.fn();
   const createMock = vi.fn();
 
@@ -103,6 +103,28 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
     expect(createMock).not.toHaveBeenCalled();
   });
 
+  it("falls back to create for unsupported reply targets", async () => {
+    replyMock.mockResolvedValue({
+      code: 999999,
+      msg: "not support reply for this message type",
+    });
+    createMock.mockResolvedValue({
+      code: 0,
+      data: { message_id: "om_reply_unsupported_fallback" },
+    });
+
+    const result = await sendMessageFeishu({
+      cfg: {} as never,
+      to: "user:ou_target",
+      text: "hello",
+      replyToMessageId: "om_card_parent",
+    });
+
+    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(result.messageId).toBe("om_reply_unsupported_fallback");
+  });
+
   it("falls back to create when reply throws a withdrawn SDK error", async () => {
     const sdkError = Object.assign(new Error("request failed"), { code: 230011 });
     replyMock.mockRejectedValue(sdkError);
@@ -143,6 +165,26 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
     expect(replyMock).toHaveBeenCalledTimes(1);
     expect(createMock).toHaveBeenCalledTimes(1);
     expect(result.messageId).toBe("om_axios_fallback");
+  });
+
+  it("falls back to create when card reply throws an unsupported-target error", async () => {
+    const sdkError = new Error("cannot reply to this message type");
+    replyMock.mockRejectedValue(sdkError);
+    createMock.mockResolvedValue({
+      code: 0,
+      data: { message_id: "om_card_unsupported_fallback" },
+    });
+
+    const result = await sendCardFeishu({
+      cfg: {} as never,
+      to: "user:ou_target",
+      card: { schema: "2.0" },
+      replyToMessageId: "om_parent",
+    });
+
+    expect(replyMock).toHaveBeenCalledTimes(1);
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(result.messageId).toBe("om_card_unsupported_fallback");
   });
 
   it("re-throws non-withdrawn thrown errors for text messages", async () => {

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -11,16 +11,39 @@ import type { FeishuSendResult } from "./types.js";
 
 const WITHDRAWN_REPLY_ERROR_CODES = new Set([230011, 231003]);
 
+const REPLY_TARGET_UNAVAILABLE_HINTS = [
+  "withdrawn",
+  "not found",
+  "message is not found",
+  "message was withdrawn",
+  "cannot reply",
+  "can not reply",
+  "not support reply",
+  "unsupported reply",
+  "reply target",
+  "不支持回复",
+  "无法回复",
+  "消息已撤回",
+  "消息不存在",
+] as const;
+
+function isReplyTargetUnavailableMessage(message: string | undefined): boolean {
+  const normalized = message?.toLowerCase() ?? "";
+  if (!normalized) {
+    return false;
+  }
+  return REPLY_TARGET_UNAVAILABLE_HINTS.some((hint) => normalized.includes(hint));
+}
+
 function shouldFallbackFromReplyTarget(response: { code?: number; msg?: string }): boolean {
   if (response.code !== undefined && WITHDRAWN_REPLY_ERROR_CODES.has(response.code)) {
     return true;
   }
-  const msg = response.msg?.toLowerCase() ?? "";
-  return msg.includes("withdrawn") || msg.includes("not found");
+  return isReplyTargetUnavailableMessage(response.msg);
 }
 
-/** Check whether a thrown error indicates a withdrawn/not-found reply target. */
-function isWithdrawnReplyError(err: unknown): boolean {
+/** Check whether a thrown error indicates the reply target is unavailable/unsupported. */
+function isReplyTargetUnavailableError(err: unknown): boolean {
   if (typeof err !== "object" || err === null) {
     return false;
   }
@@ -29,12 +52,28 @@ function isWithdrawnReplyError(err: unknown): boolean {
   if (typeof code === "number" && WITHDRAWN_REPLY_ERROR_CODES.has(code)) {
     return true;
   }
+  if (isReplyTargetUnavailableMessage((err as { message?: string; msg?: string }).msg)) {
+    return true;
+  }
+  if (isReplyTargetUnavailableMessage((err as { message?: string; msg?: string }).message)) {
+    return true;
+  }
   // AxiosError shape: err.response.data.code
-  const response = (err as { response?: { data?: { code?: number; msg?: string } } }).response;
+  const response = (
+    err as {
+      response?: { data?: { code?: number; msg?: string; message?: string } };
+    }
+  ).response;
   if (
     typeof response?.data?.code === "number" &&
     WITHDRAWN_REPLY_ERROR_CODES.has(response.data.code)
   ) {
+    return true;
+  }
+  if (isReplyTargetUnavailableMessage(response?.data?.msg)) {
+    return true;
+  }
+  if (isReplyTargetUnavailableMessage(response?.data?.message)) {
     return true;
   }
   return false;
@@ -308,7 +347,7 @@ export async function sendMessageFeishu(
         },
       });
     } catch (err) {
-      if (!isWithdrawnReplyError(err)) {
+      if (!isReplyTargetUnavailableError(err)) {
         throw err;
       }
       return sendFallbackDirect(client, directParams, "Feishu send failed");
@@ -352,7 +391,7 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
         },
       });
     } catch (err) {
-      if (!isWithdrawnReplyError(err)) {
+      if (!isReplyTargetUnavailableError(err)) {
         throw err;
       }
       return sendFallbackDirect(client, directParams, "Feishu card send failed");


### PR DESCRIPTION
## Summary
- broaden Feishu reply fallback detection so reply-target incompatibility errors also fall back to direct `message.create`
- keep existing withdrawn/not-found handling, while adding message-based detection for unsupported reply targets
- add regression coverage for both response and thrown-error paths

Fixes #35556

## Testing
- pnpm vitest run extensions/feishu/src/send.reply-fallback.test.ts
- pnpm vitest run extensions/feishu/src/outbound.test.ts extensions/feishu/src/send.test.ts
