### PR TITLE
Fix: allow Control UI device token bypass when device auth is disabled

### DIFF
--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -347,6 +347,44 @@ export function registerControlUiAndPairingSuite(): void {
     }
   });
 
+  test("allows webchat-ui client with stale device identity when device auth is disabled", async () => {
+    testState.gatewayControlUi = { dangerouslyDisableDeviceAuth: true };
+    testState.gatewayAuth = { mode: "token", token: "secret" };
+    const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
+    try {
+      await withGatewayServer(async ({ port }) => {
+        const ws = await openWs(port, { origin: originForPort(port) });
+        const challengeNonce = await readConnectChallengeNonce(ws);
+        expect(challengeNonce).toBeTruthy();
+        const { device } = await createSignedDevice({
+          token: "secret",
+          scopes: [],
+          clientId: GATEWAY_CLIENT_NAMES.WEBCHAT_UI,
+          clientMode: GATEWAY_CLIENT_MODES.WEBCHAT,
+          signedAtMs: Date.now() - 60 * 60 * 1000,
+          nonce: String(challengeNonce),
+        });
+        const res = await connectReq(ws, {
+          token: "secret",
+          scopes: ["operator.read"],
+          device,
+          client: {
+            ...CONTROL_UI_CLIENT,
+            id: GATEWAY_CLIENT_NAMES.WEBCHAT_UI,
+          },
+        });
+        expect(res.ok).toBe(true);
+        expect((res.payload as { auth?: unknown } | undefined)?.auth).toBeUndefined();
+        const health = await rpcReq(ws, "health");
+        expect(health.ok).toBe(true);
+        ws.close();
+      });
+    } finally {
+      restoreGatewayToken(prevToken);
+    }
+  });
+
   test("device token auth matrix", async () => {
     const { server, ws, port, prevToken } = await startServerWithClient("secret");
     const { deviceToken, deviceIdentityPath } = await ensurePairedDeviceTokenForCurrentIdentity(ws);

--- a/src/gateway/server/ws-connection/auth-messages.ts
+++ b/src/gateway/server/ws-connection/auth-messages.ts
@@ -12,7 +12,8 @@ export function formatGatewayAuthFailureMessage(params: {
 }): string {
   const { authMode, authProvided, reason, client } = params;
   const isCli = isGatewayCliClient(client);
-  const isControlUi = client?.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
+  const isControlUi =
+    client?.id === GATEWAY_CLIENT_IDS.CONTROL_UI || client?.id === GATEWAY_CLIENT_IDS.WEBCHAT_UI;
   const isWebchat = isWebchatClient(client);
   const uiHint = "open the dashboard URL and paste the token in Control UI settings";
   const tokenHint = isCli

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -494,7 +494,9 @@ export function attachGatewayWsMessageHandler(params: {
         connectParams.role = role;
         connectParams.scopes = scopes;
 
-        const isControlUi = connectParams.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI;
+        const isControlUi =
+          connectParams.client.id === GATEWAY_CLIENT_IDS.CONTROL_UI ||
+          connectParams.client.id === GATEWAY_CLIENT_IDS.WEBCHAT_UI;
         const isWebchat = isWebchatConnect(connectParams);
         if (enforceOriginCheckForAnyClient || isControlUi || isWebchat) {
           const hostHeaderOriginFallbackEnabled =


### PR DESCRIPTION
## Summary
- Fix issue #35944: Control UI bypass path did not consistently include `webchat-ui` in device-auth handling.
- Expand client detection and auth-failure hint logic for Control UI equivalent clients.
- Add regression coverage for stale device identity with `dangerouslyDisableDeviceAuth=true`.

## Security Impact
- N/A

## Repro+Verification
- Enable `gateway.controlUi.dangerouslyDisableDeviceAuth=true` and connect via Control UI/webchat-ui path.
- Before: device-token mismatch path could still block expected bypass behavior.
- After: bypass logic is honored for Control UI-equivalent client path.

## Testing
- `pnpm test -- src/gateway/server.auth.control-ui.test.ts`
- `pnpm exec vitest run src/gateway/server.auth.modes.test.ts`

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35944
