### PR TITLE
feishu: detect mention-prefixed group slash commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
+- Feishu/group slash command detection: normalize group mention wrappers before command-authorization probing so mention-prefixed commands (for example `@Bot/model` and `@Bot /reset`) are recognized as gateway commands instead of being forwarded to the agent. (#35994) Thanks @liuxiaopai-ai.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -521,6 +521,42 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("normalizes group mention-prefixed slash commands before command-auth probing", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(true);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-attacker",
+        },
+      },
+      message: {
+        message_id: "msg-group-mention-command-probe",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "@_user_1/model" }),
+        mentions: [{ key: "@_user_1", id: { open_id: "ou-bot" }, name: "Bot", tenant_key: "" }],
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockShouldComputeCommandAuthorized).toHaveBeenCalledWith("/model", cfg);
+  });
+
   it("falls back to top-level allowFrom for group command authorization", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(true);
     mockResolveCommandAuthorizedFromAuthorizers.mockReturnValue(true);

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -494,6 +494,17 @@ function normalizeMentions(
   return result;
 }
 
+function normalizeFeishuCommandProbeBody(text: string): string {
+  if (!text) {
+    return "";
+  }
+  return text
+    .replace(/<at\b[^>]*>[^<]*<\/at>/giu, " ")
+    .replace(/(^|\s)@[^/\s]+(?=\s|$|\/)/gu, "$1")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 /**
  * Parse media keys from message content based on message type.
  */
@@ -1069,8 +1080,9 @@ export async function handleFeishuMessage(params: {
       channel: "feishu",
       accountId: account.accountId,
     });
+    const commandProbeBody = isGroup ? normalizeFeishuCommandProbeBody(ctx.content) : ctx.content;
     const shouldComputeCommandAuthorized = core.channel.commands.shouldComputeCommandAuthorized(
-      ctx.content,
+      commandProbeBody,
       cfg,
     );
     const storeAllowFrom =


### PR DESCRIPTION
## Summary

- Problem: In Feishu group chats, mention-prefixed slash commands (especially compact forms like `@bot/model`) could fail command-auth probing and be forwarded to the agent as normal text.
- Why it matters: Gateway-level commands like `/model`, `/reset`, and `/new` should be intercepted reliably instead of silently falling through.
- What changed: Added Feishu-only command-probe normalization that strips mention wrappers (`<at ...>...</at>` and leading `@name` mention tokens) before `shouldComputeCommandAuthorized` runs.
- What did NOT change (scope boundary): Did not change user message body passed to agent, mention-forward behavior, or group routing/session logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35994
- Related #10965

## User-visible / Behavior Changes

- Feishu group messages with mention-prefixed slash commands now reliably enter command handling instead of being treated as ordinary chat content in the command-auth probe phase.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): `channels.feishu.groups.<group>.requireMention=false`

### Steps

1. Send a Feishu group message with mention-prefixed slash text (e.g. `@_user_1/model` via mention token normalization path).
2. Let `handleFeishuMessage` compute command authorization.
3. Observe the argument passed to `shouldComputeCommandAuthorized`.

### Expected

- Probe input is normalized to `/model`.

### Actual

- Verified by regression test and local run.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm vitest run extensions/feishu/src/bot.test.ts`
  - New test: `normalizes group mention-prefixed slash commands before command-auth probing`
- Edge cases checked:
  - Mention wrapper stripping keeps this change scoped to command-probe normalization only.
- What you did **not** verify:
  - Live Feishu end-to-end against real tenant traffic.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `extensions/feishu/src/bot.ts` and `extensions/feishu/src/bot.test.ts`.
- Known bad symptoms reviewers should watch for: unexpected command-auth probing mismatches in Feishu group messages.

## Risks and Mitigations

- Risk: Over-normalizing mention text in probe path could over-trigger command probing.
  - Mitigation: normalization is Feishu-only and only used for command-auth probing (not for final message body or routing).
