### PR TITLE
fix(feishu): strip bot mention in group context so slash commands are recognized

### DIFF
--- a/extensions/feishu/src/bot.stripBotMention.test.ts
+++ b/extensions/feishu/src/bot.stripBotMention.test.ts
@@ -37,7 +37,7 @@ describe("normalizeMentions (via parseFeishuMessageEvent)", () => {
     expect(ctx.content).toBe("hello");
   });
 
-  it("normalizes bot mention to <at> tag in group (semantic content)", () => {
+  it("strips bot mention in group so slash commands work (#35994)", () => {
     const ctx = parseFeishuMessageEvent(
       makeEvent(
         "@_bot_1 hello",
@@ -46,7 +46,19 @@ describe("normalizeMentions (via parseFeishuMessageEvent)", () => {
       ) as any,
       BOT_OPEN_ID,
     );
-    expect(ctx.content).toBe('<at user_id="ou_bot">Bot</at> hello');
+    expect(ctx.content).toBe("hello");
+  });
+
+  it("strips bot mention in group preserving slash command prefix (#35994)", () => {
+    const ctx = parseFeishuMessageEvent(
+      makeEvent(
+        "@_bot_1 /model",
+        [{ key: "@_bot_1", name: "Bot", id: { open_id: "ou_bot" } }],
+        "group",
+      ) as any,
+      BOT_OPEN_ID,
+    );
+    expect(ctx.content).toBe("/model");
   });
 
   it("strips bot mention but normalizes other mentions in p2p (mention-forward)", () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -773,14 +773,12 @@ export function parseFeishuMessageEvent(
   const rawContent = parseMessageContent(event.message.content, event.message.message_type);
   const mentionedBot = checkBotMentioned(event, botOpenId, botName);
   const hasAnyMention = (event.message.mentions?.length ?? 0) > 0;
-  // In p2p, the bot mention is a pure addressing prefix with no semantic value;
-  // strip it so slash commands like @Bot /help still have a leading /.
+  // Strip the bot's own mention so slash commands like @Bot /help retain
+  // the leading /. This applies in both p2p *and* group contexts — the
+  // mentionedBot flag already captures whether the bot was addressed, so
+  // keeping the mention tag in content only breaks command detection (#35994).
   // Non-bot mentions (e.g. mention-forward targets) are still normalized to <at> tags.
-  const content = normalizeMentions(
-    rawContent,
-    event.message.mentions,
-    event.message.chat_type === "p2p" ? botOpenId : undefined,
-  );
+  const content = normalizeMentions(rawContent, event.message.mentions, botOpenId);
   const senderOpenId = event.sender.sender_id.open_id?.trim();
   const senderUserId = event.sender.sender_id.user_id?.trim();
   const senderFallbackId = senderOpenId || senderUserId || "";


### PR DESCRIPTION
## Summary

- Problem: Slash commands (`/model`, `/reset`, `/new`) in Feishu group chats are not intercepted by the Gateway command parser. Commands are passed to the agent as regular messages.
- Why it matters: Any Feishu group using `@Bot /command` is unable to use system commands, forcing manual workarounds or DM-only command usage.
- What changed: `parseFeishuMessageEvent` now strips the bot's own mention in **both** p2p and group contexts (previously p2p only). The `mentionedBot` boolean already captures whether the bot was addressed, so the mention tag in `content` only served to break command detection.
- What did NOT change (scope boundary): Non-bot mentions are still normalized to `<at>` tags. Mention-forward detection, `requireMention` gating, and agent routing are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35994

## User-visible / Behavior Changes

- `@Bot /model`, `@Bot /reset`, `@Bot /new` now work in Feishu group chats (previously silently passed to agent as text).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Configure Feishu channel with `commands.text: true`
2. Add bot to a Feishu group chat
3. Send `@Bot /model` in the group

### Expected

- Command intercepted by Gateway, model info returned

### Actual

- Before: Command passed to agent as regular text
- After: Command correctly intercepted and processed

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: p2p mention strip (unchanged), group mention strip (new), group slash command detection, multi-mention normalization
- Edge cases checked: mention-forward with bot + other user, regex metacharacters in mention keys, dollar signs in display names
- What you did **not** verify: Live Feishu API integration (tested via unit tests with mock events)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single-line change in `parseFeishuMessageEvent` to restore `event.message.chat_type === "p2p" ? botOpenId : undefined`
- Files/config to restore: `extensions/feishu/src/bot.ts`

## Risks and Mitigations

- Risk: Group messages that previously included the bot mention in agent context will no longer include it.
  - Mitigation: The `mentionedBot` flag and `hasAnyMention` field already provide this information to downstream consumers. The mention tag was redundant noise in the agent body.

