### PR TITLE
fix(feishu): harden streaming card error handling to prevent stale session state

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -168,11 +168,17 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     streamText =
       mode === "delta" ? `${streamText}${nextText}` : mergeStreamingText(streamText, nextText);
     partialUpdateQueue = partialUpdateQueue.then(async () => {
-      if (streamingStartPromise) {
-        await streamingStartPromise;
-      }
-      if (streaming?.isActive()) {
-        await streaming.update(streamText);
+      try {
+        if (streamingStartPromise) {
+          await streamingStartPromise;
+        }
+        if (streaming?.isActive()) {
+          await streaming.update(streamText);
+        }
+      } catch (err) {
+        params.runtime.error?.(
+          `feishu[${account.accountId}] streaming update failed: ${String(err)}`,
+        );
       }
     });
   };
@@ -207,21 +213,26 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   };
 
   const closeStreaming = async () => {
-    if (streamingStartPromise) {
-      await streamingStartPromise;
-    }
-    await partialUpdateQueue;
-    if (streaming?.isActive()) {
-      let text = streamText;
-      if (mentionTargets?.length) {
-        text = buildMentionedCardContent(mentionTargets, text);
+    try {
+      if (streamingStartPromise) {
+        await streamingStartPromise;
       }
-      await streaming.close(text);
+      await partialUpdateQueue;
+      if (streaming?.isActive()) {
+        let text = streamText;
+        if (mentionTargets?.length) {
+          text = buildMentionedCardContent(mentionTargets, text);
+        }
+        await streaming.close(text);
+      }
+    } catch (err) {
+      params.runtime.error?.(`feishu[${account.accountId}] streaming close failed: ${String(err)}`);
+    } finally {
+      streaming = null;
+      streamingStartPromise = null;
+      streamText = "";
+      lastPartial = "";
     }
-    streaming = null;
-    streamingStartPromise = null;
-    streamText = "";
-    lastPartial = "";
   };
 
   const { dispatcher, replyOptions, markDispatchIdle } =

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -267,12 +267,19 @@ export class FeishuStreamingSession {
     }
     const apiBase = resolveApiBase(this.creds.domain);
     this.state.sequence += 1;
+    let token: string;
+    try {
+      token = await getToken(this.creds);
+    } catch (error) {
+      onError?.(error);
+      return;
+    }
     await fetchWithSsrFGuard({
       url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/content/content`,
       init: {
         method: "PUT",
         headers: {
-          Authorization: `Bearer ${await getToken(this.creds)}`,
+          Authorization: `Bearer ${token}`,
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
@@ -341,12 +348,19 @@ export class FeishuStreamingSession {
 
     // Close streaming mode
     this.state.sequence += 1;
+    let closeToken: string;
+    try {
+      closeToken = await getToken(this.creds);
+    } catch (e) {
+      this.log?.(`Close token failed: ${String(e)}`);
+      return;
+    }
     await fetchWithSsrFGuard({
       url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/settings`,
       init: {
         method: "PATCH",
         headers: {
-          Authorization: `Bearer ${await getToken(this.creds)}`,
+          Authorization: `Bearer ${closeToken}`,
           "Content-Type": "application/json; charset=utf-8",
         },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary

- Problem: After sending a card message (streaming or markdown card), subsequent normal text messages silently fail. Restarting the Gateway temporarily fixes the issue but it quickly reproduces.
- Why it matters: This renders the Feishu channel unreliable for any user whose agent responses alternate between card-formatted and plain-text content.
- What changed: Added defensive error handling in three locations to prevent unhandled errors from corrupting the streaming card pipeline state.
- What did NOT change (scope boundary): Normal card/text sending logic, streaming card API calls, and the Feishu SDK client are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35556

## User-visible / Behavior Changes

- Streaming card failures no longer poison subsequent message delivery for the same dispatcher or session.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 15.7.4
- Runtime: Node.js 22+

### Steps

1. Configure Feishu channel with default settings (renderMode auto)
2. Trigger an agent response that produces markdown (code block/table) → delivered as card
3. Immediately trigger a plain-text agent response
4. Observe whether the plain text is delivered

### Expected

- Both messages arrive on the Feishu client

### Actual

- Before: Plain text message after card silently fails; Gateway restart temporarily fixes
- After: Plain text message delivered normally; any streaming card errors are logged and cleaned up

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: streaming card create → update → close lifecycle, token failure during update, queue error propagation, dispatcher cleanup after error
- Edge cases checked: getToken failure mid-update (previously unhandled), partialUpdateQueue rejection chain, close() after failed start()
- What you did **not** verify: Live Feishu API card streaming (tested via unit tests with mocked SDK)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert changes in `reply-dispatcher.ts` and `streaming-card.ts`
- Files/config to restore: `extensions/feishu/src/reply-dispatcher.ts`, `extensions/feishu/src/streaming-card.ts`

## Risks and Mitigations

- Risk: Swallowed errors in the streaming pipeline could mask underlying API issues.
  - Mitigation: All caught errors are logged via `params.runtime.error` / `this.log`, so they appear in Gateway logs for debugging. The cleanup (`finally` block) ensures state is always reset regardless.

