### PR TITLE
fix(mattermost): log websocket close failures in error path

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -10,6 +10,7 @@ import { runWithReconnect } from "./reconnect.js";
 class FakeWebSocket implements MattermostWebSocketLike {
   public readonly sent: string[] = [];
   public closeCalls = 0;
+  public closeError: unknown = null;
   public terminateCalls = 0;
   private openListeners: Array<() => void> = [];
   private messageListeners: Array<(data: Buffer) => void | Promise<void>> = [];
@@ -42,6 +43,9 @@ class FakeWebSocket implements MattermostWebSocketLike {
 
   close(): void {
     this.closeCalls++;
+    if (this.closeError !== null) {
+      throw this.closeError;
+    }
   }
 
   terminate(): void {
@@ -104,6 +108,32 @@ describe("mattermost websocket monitor", () => {
     await expect(failure).rejects.toMatchObject({
       message: "websocket closed before open (code 1006)",
     });
+  });
+
+  it("logs close failures when websocket is already in an error path", async () => {
+    const socket = new FakeWebSocket();
+    socket.closeError = new Error("close failed");
+    const runtime = testRuntime();
+    const connectOnce = createMattermostConnectOnce({
+      wsUrl: "wss://example.invalid/api/v4/websocket",
+      botToken: "token",
+      runtime,
+      nextSeq: () => 1,
+      onPosted: async () => {},
+      webSocketFactory: () => socket,
+    });
+
+    queueMicrotask(() => {
+      socket.emitError(new Error("boom"));
+      socket.emitClose(1006, "connection refused");
+    });
+
+    const failure = connectOnce();
+    await expect(failure).rejects.toBeInstanceOf(WebSocketClosedBeforeOpenError);
+    expect(runtime.error).toHaveBeenCalledWith("mattermost websocket error: Error: boom");
+    expect(runtime.error).toHaveBeenCalledWith(
+      "mattermost websocket close() after error failed: Error: close failed",
+    );
   });
 
   it("retries when first attempt errors before open and next attempt succeeds", async () => {

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -201,7 +201,11 @@ export function createMattermostConnectOnce(
           });
           try {
             ws.close();
-          } catch {}
+          } catch (closeErr) {
+            opts.runtime.error?.(
+              `mattermost websocket close() after error failed: ${String(closeErr)}`,
+            );
+          }
         });
       });
     } finally {


### PR DESCRIPTION
## Summary
- add error logging when `ws.close()` throws inside the Mattermost websocket error handler
- keep existing control flow unchanged (logging-only behavior change)
- add a focused regression test for close-failure observability

## Why
`ws.close()` exceptions were swallowed, which made reconnect teardown issues hard to diagnose in production.

## Impact
When close fails in an already-failing websocket path, operators now get a concrete error message.

## Risk
Low. This only adds logging in an existing error branch and does not alter reconnect semantics.

## Validation
- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/mattermost/src/mattermost/monitor-websocket.test.ts`