### PR TITLE
Fix: parse Anthropic content_block streaming events

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -313,6 +313,32 @@ describe("resolveModel", () => {
     });
   });
 
+  it("builds an anthropic forward-compat fallback for claude-opus-4-6-thinking", () => {
+    mockDiscoveredModel({
+      provider: "anthropic",
+      modelId: "claude-opus-4-5",
+      templateModel: buildForwardCompatTemplate({
+        id: "claude-opus-4-5",
+        name: "Claude Opus 4.5",
+        provider: "anthropic",
+        api: "anthropic-messages",
+        baseUrl: "https://api.anthropic.com",
+      }),
+    });
+
+    expectResolvedForwardCompatFallback({
+      provider: "anthropic",
+      id: "claude-opus-4-6-thinking",
+      expectedModel: {
+        provider: "anthropic",
+        id: "claude-opus-4-6-thinking",
+        api: "anthropic-messages",
+        baseUrl: "https://api.anthropic.com",
+        reasoning: true,
+      },
+    });
+  });
+
   it("builds an anthropic forward-compat fallback for claude-sonnet-4-6", () => {
     mockDiscoveredModel({
       provider: "anthropic",

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -18,6 +18,82 @@ import {
   promoteThinkingTagsToBlocks,
 } from "./pi-embedded-utils.js";
 
+type ContentBlockStreamUpdate = {
+  evtType: "text_delta" | "text_start" | "thinking_delta" | "thinking_start";
+  delta: string;
+  content: string;
+  blockKind: "text" | "thinking";
+};
+
+function normalizeBlockKind(type: string): "text" | "thinking" | undefined {
+  const normalized = type.toLowerCase();
+  if (normalized === "text" || normalized === "text_delta") {
+    return "text";
+  }
+  if (normalized === "thinking" || normalized === "thinking_delta") {
+    return "thinking";
+  }
+  return undefined;
+}
+
+function resolveContentBlockUpdate(
+  assistantRecord: Record<string, unknown> | undefined,
+): ContentBlockStreamUpdate | null {
+  const eventType = typeof assistantRecord?.type === "string" ? assistantRecord.type : "";
+  if (eventType === "content_block_delta") {
+    const deltaRecord = assistantRecord?.delta;
+    if (typeof deltaRecord !== "object" || deltaRecord === null) {
+      return null;
+    }
+    const record = deltaRecord as Record<string, unknown>;
+    const blockKind = normalizeBlockKind(typeof record.type === "string" ? record.type : "");
+    if (!blockKind) {
+      return null;
+    }
+    const delta =
+      typeof record.text === "string"
+        ? record.text
+        : blockKind === "thinking" && typeof record.thinking === "string"
+          ? record.thinking
+          : "";
+    if (!delta) {
+      return null;
+    }
+    return {
+      evtType: blockKind === "text" ? "text_delta" : "thinking_delta",
+      delta,
+      content: "",
+      blockKind,
+    };
+  }
+
+  if (eventType !== "content_block_start") {
+    return null;
+  }
+
+  const blockRecord = assistantRecord?.content_block;
+  if (typeof blockRecord !== "object" || blockRecord === null) {
+    return null;
+  }
+  const record = blockRecord as Record<string, unknown>;
+  const blockKind = normalizeBlockKind(typeof record.type === "string" ? record.type : "");
+  if (!blockKind) {
+    return null;
+  }
+  const content =
+    typeof record.text === "string"
+      ? record.text
+      : blockKind === "thinking" && typeof record.thinking === "string"
+        ? record.thinking
+        : "";
+  return {
+    evtType: blockKind === "text" ? "text_start" : "thinking_start",
+    delta: "",
+    content,
+    blockKind,
+  };
+}
+
 const stripTrailingDirective = (text: string): string => {
   const openIndex = text.lastIndexOf("[[");
   if (openIndex < 0) {
@@ -91,7 +167,10 @@ export function handleMessageUpdate(
     assistantEvent && typeof assistantEvent === "object"
       ? (assistantEvent as Record<string, unknown>)
       : undefined;
-  const evtType = typeof assistantRecord?.type === "string" ? assistantRecord.type : "";
+  const contentBlockUpdate = resolveContentBlockUpdate(assistantRecord);
+  const evtType =
+    contentBlockUpdate?.evtType ??
+    (typeof assistantRecord?.type === "string" ? assistantRecord.type : "");
 
   if (evtType === "thinking_start" || evtType === "thinking_delta" || evtType === "thinking_end") {
     if (evtType === "thinking_start" || evtType === "thinking_delta") {
@@ -100,19 +179,29 @@ export function handleMessageUpdate(
     const thinkingDelta = typeof assistantRecord?.delta === "string" ? assistantRecord.delta : "";
     const thinkingContent =
       typeof assistantRecord?.content === "string" ? assistantRecord.content : "";
+    const inferredContent =
+      !thinkingContent && contentBlockUpdate?.blockKind === "thinking"
+        ? contentBlockUpdate.content
+        : "";
+    const inferredDelta =
+      !thinkingDelta && contentBlockUpdate?.blockKind === "thinking"
+        ? contentBlockUpdate.delta
+        : "";
     appendRawStream({
       ts: Date.now(),
       event: "assistant_thinking_stream",
       runId: ctx.params.runId,
       sessionId: (ctx.params.session as { id?: string }).id,
       evtType,
-      delta: thinkingDelta,
-      content: thinkingContent,
+      delta: thinkingDelta || inferredDelta,
+      content: thinkingContent || inferredContent,
     });
     if (ctx.state.streamReasoning) {
       // Prefer full partial-message thinking when available; fall back to event payloads.
       const partialThinking = extractAssistantThinking(msg);
-      ctx.emitReasoningStream(partialThinking || thinkingContent || thinkingDelta);
+      ctx.emitReasoningStream(
+        partialThinking || thinkingContent || thinkingDelta || inferredContent || inferredDelta,
+      );
     }
     if (evtType === "thinking_end") {
       if (!ctx.state.reasoningStreamOpen) {
@@ -127,8 +216,18 @@ export function handleMessageUpdate(
     return;
   }
 
-  const delta = typeof assistantRecord?.delta === "string" ? assistantRecord.delta : "";
-  const content = typeof assistantRecord?.content === "string" ? assistantRecord.content : "";
+  const delta =
+    contentBlockUpdate?.blockKind === "text"
+      ? contentBlockUpdate.delta
+      : typeof assistantRecord?.delta === "string"
+        ? assistantRecord.delta
+        : "";
+  const content =
+    contentBlockUpdate?.blockKind === "text"
+      ? contentBlockUpdate.content
+      : typeof assistantRecord?.content === "string"
+        ? assistantRecord.content
+        : "";
 
   appendRawStream({
     ts: Date.now(),

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -12,15 +12,19 @@ import {
 import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
 
 describe("subscribeEmbeddedPiSession", () => {
-  function createAgentEventHarness(options?: { runId?: string; sessionKey?: string }) {
+  function createAgentEventHarness(
+    options?: Partial<
+      Omit<Parameters<typeof subscribeEmbeddedPiSession>[0], "session" | "onAgentEvent">
+    >,
+  ) {
     const { session, emit } = createStubSessionHarness();
     const onAgentEvent = vi.fn();
 
     subscribeEmbeddedPiSession({
       session,
       runId: options?.runId ?? "run",
+      ...options,
       onAgentEvent,
-      sessionKey: options?.sessionKey,
     });
 
     return { emit, onAgentEvent };
@@ -59,6 +63,42 @@ describe("subscribeEmbeddedPiSession", () => {
       assistantMessageEvent: {
         type: "text_delta",
         delta,
+      },
+    });
+  }
+
+  function emitContentBlockTextDelta(
+    emit: (evt: unknown) => void,
+    delta: string,
+    message: Record<string, unknown> = { role: "assistant" },
+  ) {
+    emit({
+      type: "message_update",
+      message,
+      assistantMessageEvent: {
+        type: "content_block_delta",
+        delta: {
+          type: "text",
+          text: delta,
+        },
+      },
+    });
+  }
+
+  function emitContentBlockThinkingDelta(
+    emit: (evt: unknown) => void,
+    delta: string,
+    message: Record<string, unknown> = { role: "assistant" },
+  ) {
+    emit({
+      type: "message_update",
+      message,
+      assistantMessageEvent: {
+        type: "content_block_delta",
+        delta: {
+          type: "thinking",
+          thinking: delta,
+        },
       },
     });
   }
@@ -227,6 +267,39 @@ describe("subscribeEmbeddedPiSession", () => {
       .filter((value): value is string => typeof value === "string");
     expect(streamTexts.at(-1)).toBe("Reasoning:\n_Checking files done_");
     expect(onReasoningEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("streams assistant text from content_block_delta events", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitContentBlockTextDelta(emit, "Hello");
+    emitContentBlockTextDelta(emit, " world");
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toHaveLength(2);
+    expect(payloads[0]).toMatchObject({ text: "Hello", delta: "Hello" });
+    expect(payloads[1]).toMatchObject({ text: "Hello world", delta: " world" });
+  });
+
+  it("streams both content_block thinking and text blocks during streaming", () => {
+    const onReasoningStream = vi.fn();
+    const { emit, onAgentEvent } = createAgentEventHarness({
+      onReasoningStream,
+      reasoningMode: "stream",
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitContentBlockThinkingDelta(emit, "Checking...");
+    emitContentBlockTextDelta(emit, "Final answer");
+
+    const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
+    expect(payloads).toEqual([{ text: "Final answer", delta: "Final answer" }]);
+
+    const reasoningTexts = onReasoningStream.mock.calls
+      .map((call) => call[0]?.text)
+      .filter((value): value is string => typeof value === "string");
+    expect(reasoningTexts.at(-1)).toBe("Reasoning:\n_Checking..._");
   });
 
   it("emits reasoning end once when native and tagged reasoning end overlap", () => {


### PR DESCRIPTION
## Summary
- Fix issue #35975: parse Anthropic-style `content_block_*` streaming events from third-party relays.
- Support both thinking and text content blocks in streaming pipeline.
- Prevent final assistant output from being dropped when relays emit block-delimited streams.

## Security Impact
- N/A

## Repro+Verification
- Stream responses through a third-party relay emitting `content_block_*` events.
- Before: valid streams could produce no final output.
- After: content blocks are parsed/normalized and final output is emitted correctly.

## Testing
- Added regression coverage for `claude-opus-4-6-thinking` forward-compat and content-block streaming behavior.

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35975
