### PR TITLE
Fix: relax Linux systemctl availability and enabled checks

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const execFileMock = vi.hoisted(() => vi.fn());
@@ -30,21 +33,24 @@ describe("systemd availability", () => {
 
   it("returns false when systemd user bus is unavailable", async () => {
     execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
-      const err = new Error("Failed to connect to bus") as Error & {
+      expect(_args).toEqual(["--user", "--version"]);
+      const err = new Error("permission denied") as Error & {
         stderr?: string;
         code?: number;
       };
-      err.stderr = "Failed to connect to bus";
+      err.stderr = "permission denied";
       err.code = 1;
       cb(err, "", "");
     });
-    await expect(isSystemdUserServiceAvailable()).resolves.toBe(false);
+    await expect(isSystemdUserServiceAvailable({ SUDO_USER: "root", USER: "root" })).resolves.toBe(
+      false,
+    );
   });
 
   it("falls back to machine user scope when --user bus is unavailable", async () => {
     execFileMock
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["--user", "status"]);
+        expect(args).toEqual(["--user", "--version"]);
         const err = new Error(
           "Failed to connect to user scope bus via local transport",
         ) as Error & {
@@ -57,7 +63,7 @@ describe("systemd availability", () => {
         cb(err, "", "");
       })
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        expect(args).toEqual(["--machine", "debian@", "--user", "status"]);
+        expect(args).toEqual(["--machine", "debian@", "--user", "--version"]);
         cb(null, "", "");
       });
 
@@ -102,12 +108,12 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
-  it("throws when systemctl is-enabled fails for non-state errors", async () => {
+  it("returns false when systemctl is-enabled fails for non-state errors", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock
       .mockImplementationOnce((_cmd, args, _opts, cb) => {
         expect(args).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
-        const err = new Error("Failed to connect to bus") as Error & { code?: number };
+        const err = new Error("permission denied") as Error & { code?: number };
         err.code = 1;
         cb(err, "", "Failed to connect to bus");
       })
@@ -118,10 +124,64 @@ describe("isSystemdServiceEnabled", () => {
         const err = new Error("permission denied") as Error & { code?: number };
         err.code = 1;
         cb(err, "", "permission denied");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual([
+          "--user",
+          "show",
+          "openclaw-gateway.service",
+          "-p",
+          "UnitFileState",
+          "--value",
+        ]);
+        const err = new Error("failed to connect to bus") as Error & { code?: number };
+        err.code = 1;
+        cb(err, "", "permission denied");
       });
-    await expect(isSystemdServiceEnabled({ env: {} })).rejects.toThrow(
-      "systemctl is-enabled unavailable: permission denied",
-    );
+    const result = await isSystemdServiceEnabled({ env: { SUDO_USER: "root", USER: "root" } });
+    expect(result).toBe(false);
+  });
+
+  it("falls back to filesystem marker when is-enabled is unusable", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-service-"));
+    const unitDir = path.join(tmpDir, ".config", "systemd", "user");
+    const wantsDir = path.join(unitDir, "default.target.wants");
+    const unitPath = path.join(unitDir, "openclaw-gateway.service");
+    const enabledMarkerPath = path.join(wantsDir, "openclaw-gateway.service");
+    try {
+      await fs.mkdir(wantsDir, { recursive: true });
+      await fs.writeFile(unitPath, "[Unit]\n");
+      await fs.writeFile(enabledMarkerPath, "");
+
+      execFileMock
+        .mockImplementationOnce((_cmd, args, _opts, cb) => {
+          expect(args).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
+          const err = new Error("permission denied") as Error & { code?: number };
+          err.code = 1;
+          cb(err, "", "permission denied");
+        })
+        .mockImplementationOnce((_cmd, args, _opts, cb) => {
+          expect(args).toEqual([
+            "--user",
+            "show",
+            "openclaw-gateway.service",
+            "-p",
+            "UnitFileState",
+            "--value",
+          ]);
+          const err = new Error("permission denied") as Error & { code?: number };
+          err.code = 1;
+          cb(err, "", "permission denied");
+        });
+
+      const result = await isSystemdServiceEnabled({
+        env: { HOME: tmpDir, SUDO_USER: "root", USER: "root" },
+      });
+      expect(result).toBe(true);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("returns false when systemctl is-enabled exits with code 4 (not-found)", async () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -183,6 +183,13 @@ function resolveSystemctlDirectUserScopeArgs(): string[] {
   return ["--user"];
 }
 
+function resolveGatewayServiceEnv(env?: GatewayServiceEnv): GatewayServiceEnv {
+  if (!env || Object.keys(env).length === 0) {
+    return process.env as GatewayServiceEnv;
+  }
+  return { ...process.env, ...env };
+}
+
 function resolveSystemctlMachineScopeUser(env: GatewayServiceEnv): string | null {
   const sudoUser = env.SUDO_USER?.trim();
   if (sudoUser && sudoUser !== "root") {
@@ -252,7 +259,8 @@ async function execSystemctlUser(
 export async function isSystemdUserServiceAvailable(
   env: GatewayServiceEnv = process.env as GatewayServiceEnv,
 ): Promise<boolean> {
-  const res = await execSystemctlUser(env, ["status"]);
+  const resolvedEnv = resolveGatewayServiceEnv(env);
+  const res = await execSystemctlUser(resolvedEnv, ["--version"]);
   if (res.code === 0) {
     return true;
   }
@@ -276,6 +284,72 @@ export async function isSystemdUserServiceAvailable(
     return false;
   }
   return false;
+}
+
+function isUnitFileStateEnabled(state: string): boolean | null {
+  const normalized = state.toLowerCase();
+  if (normalized === "enabled" || normalized === "enabled-runtime") {
+    return true;
+  }
+  if (normalized === "disabled" || normalized === "masked") {
+    return false;
+  }
+  return null;
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isSystemdServiceEnabledByFilesystem(
+  env: GatewayServiceEnv,
+  unitName: string,
+): Promise<boolean | null> {
+  const serviceName = unitName.endsWith(".service")
+    ? unitName.slice(0, -".service".length)
+    : unitName;
+  const unitPath = resolveSystemdUnitPathForName(env, serviceName);
+  if (!(await pathExists(unitPath))) {
+    return null;
+  }
+
+  const unitDir = path.posix.dirname(unitPath);
+  const enabled = await pathExists(path.posix.join(unitDir, "default.target.wants", unitName));
+  if (enabled) {
+    return true;
+  }
+  return false;
+}
+
+async function isSystemdServiceEnabledByUnitFileState(
+  env: GatewayServiceEnv,
+  unitName: string,
+): Promise<boolean | null> {
+  const state = await execSystemctlUser(env, ["show", unitName, "-p", "UnitFileState", "--value"]);
+  if (state.code !== 0) {
+    return null;
+  }
+  const normalized = `${state.stdout} ${state.stderr}`.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  return isUnitFileStateEnabled(normalized);
+}
+
+async function fallbackSystemdServiceEnabled(
+  env: GatewayServiceEnv,
+  unitName: string,
+): Promise<boolean | null> {
+  const commandState = await isSystemdServiceEnabledByUnitFileState(env, unitName);
+  if (commandState !== null) {
+    return commandState;
+  }
+  return isSystemdServiceEnabledByFilesystem(env, unitName);
 }
 
 async function assertSystemdAvailable(env: GatewayServiceEnv = process.env as GatewayServiceEnv) {
@@ -422,7 +496,7 @@ export async function restartSystemdService({
 }
 
 export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Promise<boolean> {
-  const env = args.env ?? process.env;
+  const env = resolveGatewayServiceEnv(args.env);
   const serviceName = resolveSystemdServiceName(args.env ?? {});
   const unitName = `${serviceName}.service`;
   const res = await execSystemctlUser(env, ["is-enabled", unitName]);
@@ -433,7 +507,11 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
   if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
     return false;
   }
-  throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());
+  const fallbackEnabled = await fallbackSystemdServiceEnabled(env, unitName);
+  if (fallbackEnabled !== null) {
+    return fallbackEnabled;
+  }
+  return false;
 }
 
 export async function readSystemdServiceRuntime(


### PR DESCRIPTION
## Summary
- Fix issue #36008: onboarding/systemd checks failed on environments where `systemctl --user is-enabled` is unreliable.
- Treat `systemctl --user --version` as sufficient availability signal.
- Add tolerant fallback detection for service-enabled state using unit metadata/filesystem markers.

## Security Impact
- N/A

## Repro+Verification
- Run onboarding/systemd checks on Ubuntu 24.04 user-service setups with unreliable `is-enabled` behavior.
- Before: setup failed with `systemctl is-enabled unavailable`.
- After: checks complete while preserving disabled/missing-unit outcomes.

## Testing
- Validated by affected daemon/systemd test and PR checks.

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #36008
