### PR TITLE
fix(feishu): normalize @bot-prefixed group slash commands

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -69,10 +69,15 @@ function createRuntimeEnv(): RuntimeEnv {
   } as RuntimeEnv;
 }
 
-async function dispatchMessage(params: { cfg: ClawdbotConfig; event: FeishuMessageEvent }) {
+async function dispatchMessage(params: {
+  cfg: ClawdbotConfig;
+  event: FeishuMessageEvent;
+  botOpenId?: string;
+}) {
   await handleFeishuMessage({
     cfg: params.cfg,
     event: params.event,
+    botOpenId: params.botOpenId,
     runtime: createRuntimeEnv(),
   });
 }
@@ -565,6 +570,57 @@ describe("handleFeishuMessage command authorization", () => {
         ChatType: "group",
         CommandAuthorized: true,
         SenderId: "ou-admin",
+      }),
+    );
+  });
+
+  it("normalizes leading bot mention into slash CommandBody for group commands", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(true);
+    mockResolveCommandAuthorizedFromAuthorizers.mockReturnValue(true);
+
+    const cfg: ClawdbotConfig = {
+      commands: { useAccessGroups: true },
+      channels: {
+        feishu: {
+          allowFrom: ["ou-admin"],
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-admin",
+        },
+      },
+      message: {
+        message_id: "msg-group-command-mention-prefix",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "@_bot_1 /model" }),
+        mentions: [
+          {
+            key: "@_bot_1",
+            name: "OpenClaw",
+            id: { open_id: "ou-bot" },
+          },
+        ],
+      },
+    };
+
+    await dispatchMessage({ cfg, event, botOpenId: "ou-bot" });
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ChatType: "group",
+        RawBody: '<at user_id="ou-bot">OpenClaw</at> /model',
+        CommandBody: "/model",
       }),
     );
   });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -503,6 +503,30 @@ function normalizeMentions(
   return result;
 }
 
+function normalizeFeishuCommandBody(params: {
+  text: string;
+  isGroup: boolean;
+  botOpenId?: string;
+}): string {
+  const trimmed = params.text.trimStart();
+  if (!params.isGroup) {
+    return trimmed;
+  }
+
+  const botOpenId = params.botOpenId?.trim();
+  if (!botOpenId) {
+    return trimmed;
+  }
+
+  const escapedBotOpenId = botOpenId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const leadingBotMentionPattern = new RegExp(
+    `^(?:<at\\s+user_id="${escapedBotOpenId}">[^<]*</at>\\s*)+`,
+    "i",
+  );
+  const stripped = trimmed.replace(leadingBotMentionPattern, "").trimStart();
+  return stripped.startsWith("/") ? stripped : trimmed;
+}
+
 /**
  * Parse media keys from message content based on message type.
  */
@@ -1297,6 +1321,11 @@ export async function handleFeishuMessage(params: {
             timestamp: entry.timestamp,
           }))
         : undefined;
+    const normalizedCommandBody = normalizeFeishuCommandBody({
+      text: ctx.content,
+      isGroup,
+      botOpenId,
+    });
 
     // --- Shared context builder for dispatch ---
     const buildCtxPayloadForAgent = (
@@ -1311,7 +1340,7 @@ export async function handleFeishuMessage(params: {
         ReplyToId: ctx.parentId,
         RootMessageId: ctx.rootId,
         RawBody: ctx.content,
-        CommandBody: ctx.content,
+        CommandBody: normalizedCommandBody,
         From: feishuFrom,
         To: feishuTo,
         SessionKey: agentSessionKey,


### PR DESCRIPTION
## Summary
- normalize Feishu `CommandBody` for group messages when they start with bot mention tags (for example `<at ...> /model`)
- strip only leading bot mention tags and only when the remaining body is a slash command
- keep `RawBody`/`BodyForAgent` unchanged so conversational context still includes mention semantics

## Testing
- pnpm test -- extensions/feishu/src/bot.test.ts extensions/feishu/src/bot.stripBotMention.test.ts

Fixes #35994
