### PR TITLE
Fix: allow insecure cert flags for dangerous private-network policy

### DIFF
--- a/src/browser/chrome.launch-args.test.ts
+++ b/src/browser/chrome.launch-args.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedBrowserConfig } from "./config.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
 
@@ -57,7 +58,7 @@ function createMockChromeProcess() {
   return child;
 }
 
-function makeResolvedConfig() {
+function makeResolvedConfig(): ResolvedBrowserConfig {
   return {
     enabled: true,
     evaluateEnabled: false,

--- a/src/browser/chrome.launch-args.test.ts
+++ b/src/browser/chrome.launch-args.test.ts
@@ -1,0 +1,140 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+vi.mock("node:fs", () => {
+  const existsSync = vi.fn(() => true);
+  const mkdirSync = vi.fn();
+  return { existsSync, mkdirSync, default: { existsSync, mkdirSync } };
+});
+
+vi.mock("../infra/ports.js", () => ({
+  ensurePortAvailable: vi.fn(async () => {}),
+}));
+
+vi.mock("./chrome.executables.js", () => ({
+  resolveBrowserExecutableForPlatform: vi.fn(() => ({
+    kind: "chromium",
+    path: "/usr/bin/chromium",
+  })),
+}));
+
+vi.mock("./chrome.profile-decoration.js", () => ({
+  decorateOpenClawProfile: vi.fn(),
+  ensureProfileCleanExit: vi.fn(),
+  isProfileDecorated: vi.fn(() => false),
+}));
+
+vi.mock("./cdp.helpers.js", () => ({
+  appendCdpPath: (url: string) => `${url}/json/version`,
+  fetchCdpChecked: async () => ({
+    json: async () => ({ Browser: "Chrome" }),
+  }),
+  openCdpWebSocket: vi.fn(),
+}));
+
+import { launchOpenClawChrome } from "./chrome.js";
+
+type MockChildProcess = {
+  pid: number;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+  exitCode: number | null;
+};
+
+function createMockChromeProcess() {
+  const child = {
+    pid: 1234,
+    stderr: new EventEmitter(),
+    kill: vi.fn(),
+    exitCode: null,
+  } as MockChildProcess;
+  return child;
+}
+
+function makeResolvedConfig() {
+  return {
+    enabled: true,
+    evaluateEnabled: false,
+    controlPort: 18791,
+    cdpPortRangeStart: 18800,
+    cdpPortRangeEnd: 18810,
+    cdpProtocol: "http",
+    cdpHost: "127.0.0.1",
+    cdpIsLoopback: true,
+    remoteCdpTimeoutMs: 1500,
+    remoteCdpHandshakeTimeoutMs: 3000,
+    color: "#00AA00",
+    executablePath: "/usr/bin/chromium",
+    headless: false,
+    noSandbox: false,
+    attachOnly: false,
+    ssrfPolicy: { dangerouslyAllowPrivateNetwork: false },
+    defaultProfile: "openclaw",
+    profiles: {},
+    extraArgs: [],
+  };
+}
+
+function makeProfile() {
+  return {
+    name: "openclaw",
+    cdpPort: 18800,
+    cdpUrl: "http://127.0.0.1:18800",
+    cdpHost: "127.0.0.1",
+    cdpIsLoopback: true,
+    color: "#00AA00",
+    driver: "openclaw" as const,
+    attachOnly: false,
+  };
+}
+
+beforeEach(() => {
+  spawnMock.mockReset();
+  spawnMock.mockImplementation(() => createMockChromeProcess());
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("launchOpenClawChrome", () => {
+  it("adds certificate-related flags when dangerous private-network policy is enabled", async () => {
+    const resolved = makeResolvedConfig();
+    resolved.ssrfPolicy = { dangerouslyAllowPrivateNetwork: true };
+
+    await launchOpenClawChrome(resolved, makeProfile());
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(args).toContain("--ignore-certificate-errors");
+    expect(args).toContain("--allow-insecure-localhost");
+  });
+
+  it("omits certificate-related flags when dangerous private-network policy is disabled", async () => {
+    const resolved = makeResolvedConfig();
+
+    await launchOpenClawChrome(resolved, makeProfile());
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(args).not.toContain("--ignore-certificate-errors");
+    expect(args).not.toContain("--allow-insecure-localhost");
+  });
+
+  it("adds --disable-setuid-sandbox when noSandbox is true", async () => {
+    const resolved = makeResolvedConfig();
+    resolved.noSandbox = true;
+
+    await launchOpenClawChrome(resolved, makeProfile());
+
+    const [, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(args).toContain("--disable-setuid-sandbox");
+    expect(args).toContain("--no-sandbox");
+  });
+});

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -2,6 +2,7 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { isPrivateNetworkAllowedByPolicy } from "../infra/net/ssrf.js";
 import { ensurePortAvailable } from "../infra/ports.js";
 import { rawDataToString } from "../infra/ws.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -257,6 +258,10 @@ export async function launchOpenClawChrome(
       // Best-effort; older Chromes may ignore.
       args.push("--headless=new");
       args.push("--disable-gpu");
+    }
+    if (isPrivateNetworkAllowedByPolicy(resolved.ssrfPolicy)) {
+      args.push("--ignore-certificate-errors");
+      args.push("--allow-insecure-localhost");
     }
     if (resolved.noSandbox) {
       args.push("--no-sandbox");


### PR DESCRIPTION
## Summary
- Fix issue #35858 by allowing insecure certificate flags when dangerous private-network SSRF policy is explicitly enabled.
- Align browser behavior with the configured dangerous policy mode.

## Security Impact
- This change is gated behind an explicit dangerous/private-network policy toggle.

## Repro+Verification
- Enable dangerous private-network SSRF policy and run browser flow with self-signed/private cert endpoints.
- Before: cert validation blocked intended dangerous-mode behavior.
- After: policy-consistent bypass flags are applied.

## Testing
- Validated via browser policy path exercised in PR checks.

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35858
