### PR TITLE
perf(channels): cache unresolved registry lookups in channel loader

### DIFF
--- a/src/channels/plugins/registry-loader.test.ts
+++ b/src/channels/plugins/registry-loader.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry, type PluginRegistry } from "../../plugins/registry.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createChannelRegistryLoader } from "./registry-loader.js";
+
+function createRegistryWithChannelIds(ids: string[]): PluginRegistry {
+  const registry = createEmptyPluginRegistry();
+  registry.channels = ids.map((id) => ({
+    pluginId: `plugin-${id}`,
+    plugin: { id } as never,
+    source: `test-${id}`,
+  }));
+  return registry;
+}
+
+describe("createChannelRegistryLoader", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(createEmptyPluginRegistry(), "test-reset");
+  });
+
+  it("caches misses so repeated unknown ids avoid repeated scans", async () => {
+    const registry = createRegistryWithChannelIds(["telegram"]);
+    const findSpy = vi.spyOn(registry.channels, "find");
+    setActivePluginRegistry(registry, "test-miss-cache");
+
+    const loader = createChannelRegistryLoader(() => "resolved");
+    await expect(loader("missing")).resolves.toBeUndefined();
+    await expect(loader("missing")).resolves.toBeUndefined();
+
+    expect(findSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches undefined resolver results to avoid repeat resolution", async () => {
+    const registry = createRegistryWithChannelIds(["telegram"]);
+    setActivePluginRegistry(registry, "test-undefined-cache");
+
+    let resolveCalls = 0;
+    const loader = createChannelRegistryLoader(() => {
+      resolveCalls += 1;
+      return undefined;
+    });
+
+    await expect(loader("telegram")).resolves.toBeUndefined();
+    await expect(loader("telegram")).resolves.toBeUndefined();
+
+    expect(resolveCalls).toBe(1);
+  });
+
+  it("caches falsy resolved values", async () => {
+    const registry = createRegistryWithChannelIds(["telegram"]);
+    setActivePluginRegistry(registry, "test-falsy-cache");
+
+    let resolveCalls = 0;
+    const loader = createChannelRegistryLoader(() => {
+      resolveCalls += 1;
+      return "";
+    });
+
+    await expect(loader("telegram")).resolves.toBe("");
+    await expect(loader("telegram")).resolves.toBe("");
+
+    expect(resolveCalls).toBe(1);
+  });
+
+  it("invalidates cached misses when registry instance changes", async () => {
+    const firstRegistry = createRegistryWithChannelIds(["telegram"]);
+    setActivePluginRegistry(firstRegistry, "test-registry-a");
+
+    const loader = createChannelRegistryLoader((entry) => `${entry.plugin.id}-value`);
+    await expect(loader("discord")).resolves.toBeUndefined();
+
+    const secondRegistry = createRegistryWithChannelIds(["discord"]);
+    setActivePluginRegistry(secondRegistry, "test-registry-b");
+
+    await expect(loader("discord")).resolves.toBe("discord-value");
+  });
+});

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -6,10 +6,12 @@ type ChannelRegistryValueResolver<TValue> = (
   entry: PluginChannelRegistration,
 ) => TValue | undefined;
 
+const MISSING = Symbol("missing");
+
 export function createChannelRegistryLoader<TValue>(
   resolveValue: ChannelRegistryValueResolver<TValue>,
 ): (id: ChannelId) => Promise<TValue | undefined> {
-  const cache = new Map<ChannelId, TValue>();
+  const cache = new Map<ChannelId, TValue | typeof MISSING>();
   let lastRegistry: PluginRegistry | null = null;
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
@@ -18,18 +20,20 @@ export function createChannelRegistryLoader<TValue>(
       cache.clear();
       lastRegistry = registry;
     }
-    const cached = cache.get(id);
-    if (cached) {
-      return cached;
+
+    if (cache.has(id)) {
+      const cached = cache.get(id);
+      return cached === MISSING ? undefined : cached;
     }
+
     const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
     if (!pluginEntry) {
+      cache.set(id, MISSING);
       return undefined;
     }
+
     const resolved = resolveValue(pluginEntry);
-    if (resolved) {
-      cache.set(id, resolved);
-    }
+    cache.set(id, resolved === undefined ? MISSING : resolved);
     return resolved;
   };
 }


### PR DESCRIPTION
## Summary
- cache unresolved channel IDs in `createChannelRegistryLoader` to avoid repeated registry scans
- cache `undefined` resolver outcomes and preserve falsy resolved values (e.g. empty strings)
- keep cache invalidation tied to active registry identity changes
- add focused tests for miss memoization, undefined/falsy caching, and invalidation

## Validation
- `pnpm -s vitest run src/channels/plugins/registry-loader.test.ts`
- `pnpm -s oxlint --type-aware src/channels/plugins/registry-loader.ts src/channels/plugins/registry-loader.test.ts`
