### PR TITLE
Fix: tolerate browser-relay tab attach relay-forward failures

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -492,26 +492,46 @@ async function attachTab(tabId, opts = {}) {
 
   tabs.set(tabId, { state: 'connected', sessionId, targetId, attachOrder })
   tabBySession.set(sessionId, tabId)
+
+  let attachedToRelay = false
+  if (!opts.skipAttachedEvent) {
+    try {
+      sendToRelay({
+        method: 'forwardCDPEvent',
+        params: {
+          method: 'Target.attachedToTarget',
+          params: {
+            sessionId,
+            targetInfo: { ...targetInfo, attached: true },
+            waitingForDebugger: false,
+          },
+        },
+      })
+      attachedToRelay = true
+    } catch (err) {
+      setBadge(tabId, 'connecting')
+      void chrome.action.setTitle({
+        tabId,
+        title: 'OpenClaw Browser Relay: attached, waiting for relay reconnect…',
+      })
+      console.warn(
+        'attached to tab, but relay forward failed',
+        err instanceof Error ? err.message : String(err),
+      )
+    }
+  }
+
+  if (opts.skipAttachedEvent || !attachedToRelay) {
+    await persistState()
+    return { sessionId, targetId }
+  }
+
+  setBadge(tabId, 'on')
   void chrome.action.setTitle({
     tabId,
     title: 'OpenClaw Browser Relay: attached (click to detach)',
   })
 
-  if (!opts.skipAttachedEvent) {
-    sendToRelay({
-      method: 'forwardCDPEvent',
-      params: {
-        method: 'Target.attachedToTarget',
-        params: {
-          sessionId,
-          targetInfo: { ...targetInfo, attached: true },
-          waitingForDebugger: false,
-        },
-      },
-    })
-  }
-
-  setBadge(tabId, 'on')
   await persistState()
 
   return { sessionId, targetId }


### PR DESCRIPTION
## Summary
- Fix issue #35851: Browser Relay showed `!` / "Relay not running" after tab attach when relay-forwarding failed transiently.
- Keep local attach state after successful tab attach.
- Guard `Target.attachedToTarget` forwarding with `try/catch` and keep reconnect state instead of flipping to a hard-down UI state.

## Security Impact
- N/A

## Repro+Verification
- Attach a normal tab while relay forwarding is transiently unavailable.
- Before: badge/title incorrectly switched to "Relay not running".
- After: badge remains in reconnect/connecting state and recovers when relay is back.

## Testing
- `pnpm test src/browser/extension-relay.test.ts src/browser/chrome-extension-background-utils.test.ts src/browser/chrome-extension-options-validation.test.ts`

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35851
