### PR TITLE
fix(cron): restrict file permissions to 0o600 and directory permissions to 0o700

### DIFF
--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -66,6 +66,38 @@ describe("cron run log", () => {
     );
   });
 
+  const isWindows = process.platform === "win32";
+
+  it.skipIf(isWindows)("creates run log file with owner-only permissions (0o600)", async () => {
+    await withRunLogDir("openclaw-cron-log-perm-", async (dir) => {
+      const logPath = path.join(dir, "runs", "job-perm.jsonl");
+      await appendCronRunLog(logPath, {
+        ts: 1,
+        jobId: "job-perm",
+        action: "finished",
+        status: "ok",
+      });
+      const stat = await fs.stat(logPath);
+      // eslint-disable-next-line no-bitwise
+      expect(stat.mode & 0o777).toBe(0o600);
+    });
+  });
+
+  it.skipIf(isWindows)("creates runs directory with owner-only permissions (0o700)", async () => {
+    await withRunLogDir("openclaw-cron-log-dirperm-", async (dir) => {
+      const logPath = path.join(dir, "runs", "job-dirperm.jsonl");
+      await appendCronRunLog(logPath, {
+        ts: 1,
+        jobId: "job-dirperm",
+        action: "finished",
+        status: "ok",
+      });
+      const stat = await fs.stat(path.dirname(logPath));
+      // eslint-disable-next-line no-bitwise
+      expect(stat.mode & 0o777).toBe(0o700);
+    });
+  });
+
   it("appends JSONL and prunes by line count", async () => {
     await withRunLogDir("openclaw-cron-log-", async (dir) => {
       const logPath = path.join(dir, "runs", "job-1.jsonl");

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -140,10 +140,12 @@ export async function appendCronRunLog(
     .catch(() => undefined)
     .then(async () => {
       await fs.mkdir(path.dirname(resolved), { recursive: true, mode: 0o700 });
+      await fs.chmod(path.dirname(resolved), 0o700).catch(() => {});
       await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, {
         encoding: "utf-8",
         mode: 0o600,
       });
+      await fs.chmod(resolved, 0o600).catch(() => {});
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,
         keepLines: opts?.keepLines ?? DEFAULT_CRON_RUN_LOG_KEEP_LINES,

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -125,7 +125,7 @@ async function pruneIfNeeded(filePath: string, opts: { maxBytes: number; keepLin
   const kept = lines.slice(Math.max(0, lines.length - opts.keepLines));
   const { randomBytes } = await import("node:crypto");
   const tmp = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.writeFile(tmp, `${kept.join("\n")}\n`, "utf-8");
+  await fs.writeFile(tmp, `${kept.join("\n")}\n`, { encoding: "utf-8", mode: 0o600 });
   await fs.rename(tmp, filePath);
 }
 
@@ -139,8 +139,11 @@ export async function appendCronRunLog(
   const next = prev
     .catch(() => undefined)
     .then(async () => {
-      await fs.mkdir(path.dirname(resolved), { recursive: true });
-      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, "utf-8");
+      await fs.mkdir(path.dirname(resolved), { recursive: true, mode: 0o700 });
+      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, {
+        encoding: "utf-8",
+        mode: 0o600,
+      });
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,
         keepLines: opts?.keepLines ?? DEFAULT_CRON_RUN_LOG_KEEP_LINES,

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -84,6 +84,35 @@ describe("cron store", () => {
 describe("saveCronStore", () => {
   const dummyStore: CronStoreFile = { version: 1, jobs: [] };
 
+  const isWindows = process.platform === "win32";
+
+  it.skipIf(isWindows)("creates store file with owner-only permissions (0o600)", async () => {
+    const { storePath } = await makeStorePath();
+    await saveCronStore(storePath, dummyStore);
+    const stat = await fs.stat(storePath);
+    // eslint-disable-next-line no-bitwise
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it.skipIf(isWindows)("creates backup file with owner-only permissions (0o600)", async () => {
+    const { storePath } = await makeStorePath();
+    const first = makeStore("perm-1", true);
+    const second = makeStore("perm-2", false);
+    await saveCronStore(storePath, first);
+    await saveCronStore(storePath, second);
+    const stat = await fs.stat(`${storePath}.bak`);
+    // eslint-disable-next-line no-bitwise
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it.skipIf(isWindows)("creates parent directory with owner-only permissions (0o700)", async () => {
+    const { storePath } = await makeStorePath();
+    await saveCronStore(storePath, dummyStore);
+    const stat = await fs.stat(path.dirname(storePath));
+    // eslint-disable-next-line no-bitwise
+    expect(stat.mode & 0o777).toBe(0o700);
+  });
+
   it("persists and round-trips a store file", async () => {
     const { storePath } = await makeStorePath();
     await saveCronStore(storePath, dummyStore);

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -61,7 +61,7 @@ export async function saveCronStore(
   store: CronStoreFile,
   opts?: SaveCronStoreOptions,
 ) {
-  await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.promises.mkdir(path.dirname(storePath), { recursive: true, mode: 0o700 });
   const json = JSON.stringify(store, null, 2);
   const cached = serializedStoreCache.get(storePath);
   if (cached === json) {
@@ -83,10 +83,11 @@ export async function saveCronStore(
     return;
   }
   const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.promises.writeFile(tmp, json, "utf-8");
+  await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: 0o600 });
   if (previous !== null && !opts?.skipBackup) {
     try {
       await fs.promises.copyFile(storePath, `${storePath}.bak`);
+      await fs.promises.chmod(`${storePath}.bak`, 0o600);
     } catch {
       // best-effort
     }
@@ -112,6 +113,7 @@ async function renameWithRetry(src: string, dest: string): Promise<void> {
       // Windows doesn't reliably support atomic replace via rename when dest exists.
       if (code === "EPERM" || code === "EEXIST") {
         await fs.promises.copyFile(src, dest);
+        await fs.promises.chmod(dest, 0o600).catch(() => {});
         await fs.promises.unlink(src).catch(() => {});
         return;
       }

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -62,6 +62,7 @@ export async function saveCronStore(
   opts?: SaveCronStoreOptions,
 ) {
   await fs.promises.mkdir(path.dirname(storePath), { recursive: true, mode: 0o700 });
+  await fs.promises.chmod(path.dirname(storePath), 0o700).catch(() => {});
   const json = JSON.stringify(store, null, 2);
   const cached = serializedStoreCache.get(storePath);
   if (cached === json) {
@@ -86,8 +87,8 @@ export async function saveCronStore(
   await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: 0o600 });
   if (previous !== null && !opts?.skipBackup) {
     try {
-      await fs.promises.copyFile(storePath, `${storePath}.bak`);
-      await fs.promises.chmod(`${storePath}.bak`, 0o600);
+      const bakContent = await fs.promises.readFile(storePath);
+      await fs.promises.writeFile(`${storePath}.bak`, bakContent, { mode: 0o600 });
     } catch {
       // best-effort
     }


### PR DESCRIPTION
Fixes #35881

## Root Cause

`fs.promises.writeFile` and `fs.appendFile` use Node's default file creation mode (subject to process umask, typically `0o644`). `fs.promises.mkdir` defaults to `0o755`. Cron store files (`jobs.json`, `.bak`) and run-log files (`runs/*.jsonl`) were world-readable; the `runs/` directory was world-traversable.

## Solution

- Pass `{ mode: 0o600 }` to all `writeFile` / `appendFile` calls in `store.ts` and `run-log.ts`
- Pass `{ mode: 0o700 }` to all `mkdir` calls for cron directories
- Apply `chmod(0o600)` after `copyFile` for `.bak` backup and Windows-fallback rename paths (`copyFile` does not preserve the source file mode)

## Files Changed

| File | Change |
|------|--------|
| `src/cron/store.ts` | `writeFile` mode, `mkdir` mode, `chmod` after `copyFile` |
| `src/cron/run-log.ts` | `writeFile` / `appendFile` mode, `mkdir` mode |
| `src/cron/store.test.ts` | 3 permission verification tests |
| `src/cron/run-log.test.ts` | 2 permission verification tests |