### PR TITLE
fix(memory): use WAL journal mode for index database

### DIFF
--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -258,7 +258,11 @@ export abstract class MemoryManagerSyncOps {
     const dir = path.dirname(dbPath);
     ensureDir(dir);
     const { DatabaseSync } = requireNodeSqlite();
-    return new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    const db = new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    // WAL journal mode survives SIGTERM/SIGKILL mid-write; the default
+    // "delete" mode can leave a corrupted database on unclean shutdown.
+    db.exec("PRAGMA journal_mode=WAL");
+    return db;
   }
 
   private seedEmbeddingCache(sourceDb: DatabaseSync): void {

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -261,7 +261,10 @@ export abstract class MemoryManagerSyncOps {
     const db = new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
     // WAL journal mode survives SIGTERM/SIGKILL mid-write; the default
     // "delete" mode can leave a corrupted database on unclean shutdown.
-    db.exec("PRAGMA journal_mode=WAL");
+    const row = db.prepare("PRAGMA journal_mode=WAL").get() as { journal_mode: string } | undefined;
+    if (row?.journal_mode !== "wal") {
+      log.warn(`failed to enable WAL journal mode (got ${row?.journal_mode ?? "unknown"})`);
+    }
     return db;
   }
 

--- a/src/memory/manager.readonly-recovery.test.ts
+++ b/src/memory/manager.readonly-recovery.test.ts
@@ -86,6 +86,13 @@ describe("memory manager readonly recovery", () => {
     await fs.rm(workspaceDir, { recursive: true, force: true });
   });
 
+  it("opens database with WAL journal mode", async () => {
+    const currentManager = await createManager();
+    const db = (currentManager as unknown as { db: DatabaseSync }).db;
+    const row = db.prepare("PRAGMA journal_mode").get() as { journal_mode: string };
+    expect(row.journal_mode).toBe("wal");
+  });
+
   it("reopens sqlite and retries once when sync hits SQLITE_READONLY", async () => {
     await expectReadonlyRetry({
       firstError: new Error("attempt to write a readonly database"),


### PR DESCRIPTION
## Summary

- Problem: Memory index SQLite database uses `journal_mode=delete` (SQLite default), which can leave the database corrupted when the gateway receives SIGTERM mid-write (restart, update, config reload).
- Why it matters: Users hit "database disk image is malformed" errors and must manually `rm` + `openclaw memory index` to recover — memory search is completely broken until then.
- What changed: Added `PRAGMA journal_mode=WAL` when opening the memory index database. WAL mode is crash-safe and survives SIGTERM/SIGKILL mid-write.
- What did NOT change (scope boundary): No changes to query logic, embedding pipeline, schema migrations, or any other database pragma. The qmd-manager (read-only path) is untouched.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Closes #36035

## User-visible / Behavior Changes

- Memory index SQLite database now uses WAL journal mode instead of the default delete mode. This is transparent to users — no config change needed. The only visible effect is improved crash resilience.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any (reported on macOS arm64)
- Runtime/container: Node 22+
- Integration/channel: N/A (memory subsystem)

### Steps

1. Start gateway with memory indexing enabled
2. Trigger a memory sync (`openclaw memory index`)
3. Send SIGTERM to the gateway process mid-write
4. Restart gateway and attempt memory search

### Expected

- Database remains intact after unclean shutdown
- Memory search continues to work

### Actual (before fix)

- Database corruption: "database disk image is malformed"
- Memory search completely broken until manual `rm` + re-index

## Evidence

- [x] Failing test/log before + passing after
- New test verifies `PRAGMA journal_mode` returns `wal` after database open

## Human Verification (required)

- Verified scenarios: New test confirms WAL mode is set on freshly opened database; all existing readonly-recovery tests continue to pass
- Edge cases checked: WAL mode is idempotent — re-setting it on an already-WAL database is a no-op
- What you did **not** verify: Live SIGTERM crash recovery (requires manual process kill timing)

## Compatibility / Migration

- Backward compatible? Yes — SQLite transparently handles the journal mode switch; existing databases are upgraded in-place on first open
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single pragma line in `manager-sync-ops.ts`; database falls back to delete mode automatically
- Files/config to restore: `src/memory/manager-sync-ops.ts`
- Known bad symptoms reviewers should watch for: WAL mode creates `-wal` and `-shm` sidecar files next to the database; these are normal and managed by SQLite

## Risks and Mitigations

- Risk: WAL sidecar files (`-wal`, `-shm`) appear next to the database
  - Mitigation: This is standard SQLite WAL behavior; the files are automatically managed and cleaned up on clean shutdown