### PR TITLE
fix(cron): write store and run-log files with 0o600 permissions

### DIFF
--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -125,7 +125,7 @@ async function pruneIfNeeded(filePath: string, opts: { maxBytes: number; keepLin
   const kept = lines.slice(Math.max(0, lines.length - opts.keepLines));
   const { randomBytes } = await import("node:crypto");
   const tmp = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.writeFile(tmp, `${kept.join("\n")}\n`, "utf-8");
+  await fs.writeFile(tmp, `${kept.join("\n")}\n`, { encoding: "utf-8", mode: 0o600 });
   await fs.rename(tmp, filePath);
 }
 
@@ -139,8 +139,11 @@ export async function appendCronRunLog(
   const next = prev
     .catch(() => undefined)
     .then(async () => {
-      await fs.mkdir(path.dirname(resolved), { recursive: true });
-      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, "utf-8");
+      await fs.mkdir(path.dirname(resolved), { recursive: true, mode: 0o700 });
+      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, {
+        encoding: "utf-8",
+        mode: 0o600,
+      });
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,
         keepLines: opts?.keepLines ?? DEFAULT_CRON_RUN_LOG_KEEP_LINES,

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -61,7 +61,7 @@ export async function saveCronStore(
   store: CronStoreFile,
   opts?: SaveCronStoreOptions,
 ) {
-  await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.promises.mkdir(path.dirname(storePath), { recursive: true, mode: 0o700 });
   const json = JSON.stringify(store, null, 2);
   const cached = serializedStoreCache.get(storePath);
   if (cached === json) {
@@ -83,10 +83,11 @@ export async function saveCronStore(
     return;
   }
   const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.promises.writeFile(tmp, json, "utf-8");
+  await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: 0o600 });
   if (previous !== null && !opts?.skipBackup) {
     try {
       await fs.promises.copyFile(storePath, `${storePath}.bak`);
+      await fs.promises.chmod(`${storePath}.bak`, 0o600);
     } catch {
       // best-effort
     }


### PR DESCRIPTION
## Summary

Cron job files (`jobs.json`, `jobs.json.bak`, `runs/*.jsonl`) and their parent directories were created with default umask permissions (0644/0755) instead of restrictive permissions.

## Changes

- **`store.ts`**: `writeFile` with `mode: 0o600`, `chmod` `.bak` after `copyFile`, `mkdir` with `mode: 0o700`
- **`run-log.ts`**: `appendFile` and `writeFile` with `mode: 0o600`, `mkdir` with `mode: 0o700`

## Context

While the parent `~/.openclaw/cron/` directory is typically 0o700, this hardens file permissions for defense-in-depth — consistent with how other sensitive files (device identity, exec approvals) are already handled in the codebase.

Minimal, low-risk change. All existing cron tests pass.

Fixes #35881