### PR TITLE
fix(telegram): retry once on transient media group photo fetch failure

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -350,14 +350,19 @@ export const registerTelegramHandlers = ({
         let media;
         try {
           media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
-        } catch (mediaErr) {
-          if (!isRecoverableMediaGroupError(mediaErr)) {
-            throw mediaErr;
+        } catch (firstErr) {
+          if (!isRecoverableMediaGroupError(firstErr)) {
+            throw firstErr;
           }
-          runtime.log?.(
-            warn(`media group: skipping photo that failed to fetch: ${String(mediaErr)}`),
-          );
-          continue;
+          try {
+            await new Promise((r) => setTimeout(r, 500));
+            media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+          } catch (retryErr) {
+            runtime.log?.(
+              warn(`media group: skipping photo after retry: ${String(retryErr)}`),
+            );
+            continue;
+          }
         }
         if (media) {
           allMedia.push({


### PR DESCRIPTION
## Summary

- **Problem:** When multiple photos are sent at once in a Telegram media group, intermittent `TypeError: fetch failed` errors cause individual photos to be silently skipped. This is triggered by Node.js 25 undici IPv6/IPv4 race conditions when concurrent fetches hit `api.telegram.org`.
- **Why it matters:** Users lose photos from media groups with no way to recover them. The error is transient — a second attempt almost always succeeds.
- **What changed:** Added a single retry with 500ms backoff in `processMediaGroup` before skipping a photo. On the first recoverable fetch failure, the code waits 500ms and retries `resolveMedia` once. Only if the retry also fails does it log and skip.
- **What did NOT change:** Non-recoverable errors still propagate immediately. Single photo messages are unaffected (different code path). The `isRecoverableMediaGroupError` guard is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36010

## User-visible / Behavior Changes

- Media group photos that previously failed on transient network errors now succeed on retry, reducing the "skipping photo" warning frequency.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (same endpoint, one additional attempt)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 25+ (undici)
- Integration/channel: Telegram

### Steps

1. Send a media group (3+ photos) in a Telegram chat monitored by OpenClaw
2. Under Node.js 25 with IPv6 enabled, some fetches intermittently fail

### Expected

- All photos downloaded successfully (retry absorbs transient failure)

### Actual

- Before fix: 1 of N photos silently skipped with `MediaFetchError`
- After fix: Retry succeeds; photo included in media group

## Evidence

TypeScript compiles cleanly. The retry adds at most 500ms latency per failed photo, bounded to one attempt.

## Human Verification (required)

- Verified scenarios: TypeScript compilation, code path analysis
- Edge cases checked: Non-recoverable errors still throw; retry only fires for `isRecoverableMediaGroupError`; single photos unaffected
- What I did **not** verify: End-to-end test with real Telegram media group on Node.js 25 (requires IPv6 race condition)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single file change in `bot-handlers.ts`
- Files/config to restore: `src/telegram/bot-handlers.ts`
- Known bad symptoms: If retry logic had a bug, worst case is the same behavior as before (photo skipped)

## Risks and Mitigations

- **Risk:** 500ms delay per failed photo could slow media group processing. **Mitigation:** Only triggers on failure (rare), and 500ms is well within user tolerance for photo downloads. The delay is not applied to successful fetches.

