### PR TITLE
feat(security): grouped fix result summary (Config / Permissions / Needs manual review)

### DIFF
--- a/docs/cli/security.md
+++ b/docs/cli/security.md
@@ -55,6 +55,16 @@ If `--fix` and `--json` are combined, output includes both fix actions and final
 openclaw security audit --fix --json | jq '{fix: .fix.ok, summary: .report.summary}'
 ```
 
+## Fix output (with `--fix`)
+
+When you run `openclaw security audit --fix` without `--json`, the fix result is grouped into:
+
+- **Config changes** — config keys that were updated (e.g. `logging.redactSensitive`, group policy)
+- **Permissions** — state dir, config file, and credential/session file permission updates (chmod or icacls)
+- **Needs manual review** — any errors (e.g. config write or permission failure) that require you to fix manually
+
+Use this summary to see what was applied and what still needs attention.
+
 ## What `--fix` changes
 
 `--fix` applies safe, deterministic remediations:

--- a/src/cli/security-cli.ts
+++ b/src/cli/security-cli.ts
@@ -2,7 +2,7 @@ import type { Command } from "commander";
 import { loadConfig } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
 import { runSecurityAudit } from "../security/audit.js";
-import { fixSecurityFootguns } from "../security/fix.js";
+import { fixSecurityFootguns, formatSecurityFixResult } from "../security/fix.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { isRich, theme } from "../terminal/theme.js";
 import { shortenHomeInString, shortenHomePath } from "../utils.js";
@@ -88,38 +88,12 @@ export function registerSecurityCli(program: Command) {
         } else {
           lines.push("");
           lines.push(heading("FIX"));
-          for (const change of fixResult.changes) {
-            lines.push(muted(`  ${shortenHomeInString(change)}`));
-          }
-          for (const action of fixResult.actions) {
-            if (action.kind === "chmod") {
-              const mode = action.mode.toString(8).padStart(3, "0");
-              if (action.ok) {
-                lines.push(muted(`  chmod ${mode} ${shortenHomePath(action.path)}`));
-              } else if (action.skipped) {
-                lines.push(
-                  muted(`  skip chmod ${mode} ${shortenHomePath(action.path)} (${action.skipped})`),
-                );
-              } else if (action.error) {
-                lines.push(
-                  muted(`  chmod ${mode} ${shortenHomePath(action.path)} failed: ${action.error}`),
-                );
-              }
-              continue;
-            }
-            const command = shortenHomeInString(action.command);
-            if (action.ok) {
-              lines.push(muted(`  ${command}`));
-            } else if (action.skipped) {
-              lines.push(muted(`  skip ${command} (${action.skipped})`));
-            } else if (action.error) {
-              lines.push(muted(`  ${command} failed: ${action.error}`));
-            }
-          }
-          if (fixResult.errors.length > 0) {
-            for (const err of fixResult.errors) {
-              lines.push(muted(`  error: ${shortenHomeInString(err)}`));
-            }
+          const fixLines = formatSecurityFixResult(fixResult, {
+            shortenPath: shortenHomePath,
+            shortenInString: shortenHomeInString,
+          });
+          for (const line of fixLines) {
+            lines.push(line.startsWith("  ") ? muted(line) : heading(line));
           }
         }
       }

--- a/src/security/fix.test.ts
+++ b/src/security/fix.test.ts
@@ -268,7 +268,7 @@ describe("formatSecurityFixResult", () => {
       stateDir: "/home/u/.openclaw",
       configPath: "/home/u/.openclaw/openclaw.json",
       configWritten: true,
-      changes: ["logging.redactSensitive=off -> \"tools\""],
+      changes: ['logging.redactSensitive=off -> "tools"'],
       actions: [
         { kind: "chmod", path: "/home/u/.openclaw", mode: 0o700, ok: true },
         { kind: "chmod", path: "/home/u/.openclaw/openclaw.json", mode: 0o600, ok: true },

--- a/src/security/fix.test.ts
+++ b/src/security/fix.test.ts
@@ -2,7 +2,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { fixSecurityFootguns } from "./fix.js";
+import { fixSecurityFootguns, formatSecurityFixResult } from "./fix.js";
+import type { SecurityFixResult } from "./fix.js";
 
 const isWindows = process.platform === "win32";
 
@@ -254,5 +255,49 @@ describe("security fix", () => {
     expectPerms((await fs.stat(sessionsStorePath)).mode & 0o777, 0o600);
     expectPerms((await fs.stat(transcriptPath)).mode & 0o777, 0o600);
     expectPerms((await fs.stat(includePath)).mode & 0o777, 0o600);
+  });
+});
+
+describe("formatSecurityFixResult", () => {
+  const id = (s: string) => s;
+  const opts = { shortenPath: id, shortenInString: id };
+
+  it("groups config changes, permissions, and errors", () => {
+    const result: SecurityFixResult = {
+      ok: false,
+      stateDir: "/home/u/.openclaw",
+      configPath: "/home/u/.openclaw/openclaw.json",
+      configWritten: true,
+      changes: ["logging.redactSensitive=off -> \"tools\""],
+      actions: [
+        { kind: "chmod", path: "/home/u/.openclaw", mode: 0o700, ok: true },
+        { kind: "chmod", path: "/home/u/.openclaw/openclaw.json", mode: 0o600, ok: true },
+      ],
+      errors: ["writeConfigFile failed: EACCES"],
+    };
+    const lines = formatSecurityFixResult(result, opts);
+    expect(lines).toContain("Config changes");
+    expect(lines.some((l) => l.includes("logging.redactSensitive"))).toBe(true);
+    expect(lines).toContain("Permissions");
+    expect(lines.some((l) => l.includes("state dir (700)"))).toBe(true);
+    expect(lines.some((l) => l.includes("config file (600)"))).toBe(true);
+    expect(lines).toContain("Needs manual review");
+    expect(lines.some((l) => l.includes("writeConfigFile failed"))).toBe(true);
+  });
+
+  it("omits sections when empty", () => {
+    const result: SecurityFixResult = {
+      ok: true,
+      stateDir: "/s",
+      configPath: "/s/c.json",
+      configWritten: false,
+      changes: [],
+      actions: [{ kind: "chmod", path: "/s", mode: 0o700, ok: false, skipped: "already" }],
+      errors: [],
+    };
+    const lines = formatSecurityFixResult(result, opts);
+    expect(lines).not.toContain("Config changes");
+    expect(lines).toContain("Permissions");
+    expect(lines).not.toContain("Needs manual review");
   });
 });

--- a/src/security/fix.ts
+++ b/src/security/fix.ts
@@ -475,3 +475,84 @@ export async function fixSecurityFootguns(opts?: {
     errors,
   };
 }
+
+export type FormatSecurityFixResultOptions = {
+  shortenPath: (p: string) => string;
+  shortenInString: (s: string) => string;
+};
+
+/**
+ * Format a SecurityFixResult into human-readable lines grouped by category:
+ * Config changes, Permissions, and Needs manual review (errors).
+ * Use from CLI or doctor to present fix output consistently.
+ */
+export function formatSecurityFixResult(
+  result: SecurityFixResult,
+  opts: FormatSecurityFixResultOptions,
+): string[] {
+  const lines: string[] = [];
+  const { stateDir, configPath } = result;
+
+  if (result.changes.length > 0) {
+    lines.push("Config changes");
+    for (const c of result.changes) {
+      lines.push(`  ${opts.shortenInString(c)}`);
+    }
+  }
+
+  const permLabel = (action: SecurityFixAction): string => {
+    if (action.kind === "chmod") {
+      const mode = action.mode.toString(8).padStart(3, "0");
+      const pathNorm = action.path.replace(/\/+$/, "");
+      if (stateDir && pathNorm === stateDir.replace(/\/+$/, "")) {
+        return `state dir (${mode})`;
+      }
+      if (configPath && pathNorm === configPath.replace(/\/+$/, "")) {
+        return `config file (${mode})`;
+      }
+      return mode;
+    }
+    return "";
+  };
+
+  const hasPermOutput = result.actions.some(
+    (a) => a.ok || a.skipped !== undefined || a.error !== undefined,
+  );
+  if (hasPermOutput) {
+    lines.push("Permissions");
+    for (const action of result.actions) {
+      if (action.kind === "chmod") {
+        const mode = action.mode.toString(8).padStart(3, "0");
+        const label = permLabel(action);
+        const suffix = label !== mode ? ` ${label}` : "";
+        if (action.ok) {
+          lines.push(`  chmod ${mode}${suffix} ${opts.shortenPath(action.path)}`);
+        } else if (action.skipped) {
+          lines.push(
+            `  skip chmod ${mode} ${opts.shortenPath(action.path)} (${action.skipped})`,
+          );
+        } else if (action.error) {
+          lines.push(`  chmod ${mode} ${opts.shortenPath(action.path)} failed: ${action.error}`);
+        }
+        continue;
+      }
+      const command = opts.shortenInString(action.command);
+      if (action.ok) {
+        lines.push(`  ${command}`);
+      } else if (action.skipped) {
+        lines.push(`  skip ${command} (${action.skipped})`);
+      } else if (action.error) {
+        lines.push(`  ${command} failed: ${action.error}`);
+      }
+    }
+  }
+
+  if (result.errors.length > 0) {
+    lines.push("Needs manual review");
+    for (const err of result.errors) {
+      lines.push(`  ${opts.shortenInString(err)}`);
+    }
+  }
+
+  return lines;
+}

--- a/src/security/fix.ts
+++ b/src/security/fix.ts
@@ -529,10 +529,12 @@ export function formatSecurityFixResult(
           lines.push(`  chmod ${mode}${suffix} ${opts.shortenPath(action.path)}`);
         } else if (action.skipped) {
           lines.push(
-            `  skip chmod ${mode} ${opts.shortenPath(action.path)} (${action.skipped})`,
+            `  skip chmod ${mode}${suffix} ${opts.shortenPath(action.path)} (${action.skipped})`,
           );
         } else if (action.error) {
-          lines.push(`  chmod ${mode} ${opts.shortenPath(action.path)} failed: ${action.error}`);
+          lines.push(
+            `  chmod ${mode}${suffix} ${opts.shortenPath(action.path)} failed: ${action.error}`,
+          );
         }
         continue;
       }


### PR DESCRIPTION
## Summary

Improve the readability of `openclaw security audit --fix` by grouping the fix result into three sections and reusing a single formatter so CLI (and future doctor integration) can present the same structure.

## Changes

- **src/security/fix.ts**
  - Add `formatSecurityFixResult(result, opts)` that returns lines grouped as:
    - **Config changes** — list of config keys updated (e.g. `logging.redactSensitive`, group policy)
    - **Permissions** — chmod/icacls lines with optional labels for state dir (700) and config file (600)
    - **Needs manual review** — errors that require manual follow-up
  - Export `FormatSecurityFixResultOptions` for callers that need path shortening.

- **src/cli/security-cli.ts**
  - Use `formatSecurityFixResult()` for the fix block instead of inline loops; section titles are rendered as headings, detail lines as muted.

- **docs/cli/security.md**
  - Add a **Fix output (with `--fix`)** section describing the three groups and how to use the summary.

- **src/security/fix.test.ts**
  - Add tests for `formatSecurityFixResult`: grouping and labels (state dir / config file), and omission of empty sections.

## Testing

- `pnpm test src/security/fix.test.ts --run` — 7 tests passed.
- `pnpm format:docs:check` — passed.