### PR TITLE
gateway: keep webchat-origin agent turns on internal channel

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -409,7 +409,7 @@ describe("gateway agent handler", () => {
     expect(callArgs.bestEffortDeliver).toBe(false);
   });
 
-  it("keeps origin messageChannel as webchat while delivery channel uses last session channel", async () => {
+  it("keeps webchat-origin turns on internal channel when delivery is not requested", async () => {
     mockMainSessionEntry({
       sessionId: "existing-session-id",
       lastChannel: "telegram",
@@ -452,7 +452,7 @@ describe("gateway agent handler", () => {
       messageChannel?: string;
       runContext?: { messageChannel?: string };
     };
-    expect(callArgs.channel).toBe("telegram");
+    expect(callArgs.channel).toBe("webchat");
     expect(callArgs.messageChannel).toBe("webchat");
     expect(callArgs.runContext?.messageChannel).toBe("webchat");
   });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -536,6 +536,32 @@ export const agentHandlers: GatewayRequestHandlers = {
     let resolvedAccountId = deliveryPlan.resolvedAccountId;
     let resolvedTo = deliveryPlan.resolvedTo;
     let effectivePlan = deliveryPlan;
+    const isWebchatOriginRequest = Boolean(client?.connect && isWebchatConnect(client.connect));
+    const hasExplicitRouteHints = Boolean(
+      (typeof request.replyChannel === "string" && request.replyChannel.trim()) ||
+      (typeof request.channel === "string" && request.channel.trim()) ||
+      explicitTo ||
+      (typeof request.replyAccountId === "string" && request.replyAccountId.trim()) ||
+      (typeof request.accountId === "string" && request.accountId.trim()) ||
+      explicitThreadId,
+    );
+
+    // Keep webchat-origin turns internal by default. Otherwise a stale external
+    // last-route on main sessions can leak replies across channels.
+    if (!wantsDelivery && isWebchatOriginRequest && !hasExplicitRouteHints) {
+      resolvedChannel = INTERNAL_MESSAGE_CHANNEL;
+      deliveryTargetMode = undefined;
+      resolvedAccountId = undefined;
+      resolvedTo = undefined;
+      effectivePlan = {
+        ...deliveryPlan,
+        resolvedChannel,
+        resolvedTo: undefined,
+        resolvedAccountId: undefined,
+        resolvedThreadId: undefined,
+        deliveryTargetMode: undefined,
+      };
+    }
 
     if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
       const cfgResolved = cfgForAgent ?? cfg;
@@ -587,9 +613,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         : undefined;
     const originMessageChannel =
       turnSourceMessageChannel ??
-      (client?.connect && isWebchatConnect(client.connect)
-        ? INTERNAL_MESSAGE_CHANNEL
-        : resolvedChannel);
+      (isWebchatOriginRequest ? INTERNAL_MESSAGE_CHANNEL : resolvedChannel);
 
     const deliver = request.deliver === true && resolvedChannel !== INTERNAL_MESSAGE_CHANNEL;
 
@@ -610,7 +634,7 @@ export const agentHandlers: GatewayRequestHandlers = {
     });
     respond(true, accepted, undefined, { runId });
 
-    const resolvedThreadId = explicitThreadId ?? deliveryPlan.resolvedThreadId;
+    const resolvedThreadId = explicitThreadId ?? effectivePlan.resolvedThreadId;
 
     void agentCommandFromIngress(
       {


### PR DESCRIPTION
## Summary
- keep WebChat-origin `agent` runs on internal `webchat` routing when delivery is not requested and no explicit route hints are provided
- clear inherited external routing fields on that path to avoid stale main-session cross-channel leakage
- update the gateway agent handler test to assert internal-channel behavior for WebChat turns

Fixes #33522

## Testing
- pnpm test src/gateway/server-methods/agent.test.ts
- pnpm test src/gateway/server.agent.gateway-server-agent-a.test.ts
