### PR TITLE
fix(telegram): keep topic slash commands scoped when forum flag is absent

### DIFF
--- a/src/telegram/bot-native-commands.session-meta.test.ts
+++ b/src/telegram/bot-native-commands.session-meta.test.ts
@@ -102,6 +102,24 @@ function buildStatusTopicCommandContext() {
   };
 }
 
+function buildStatusTopicCommandContextWithoutForumFlag() {
+  return {
+    match: "",
+    message: {
+      message_id: 3,
+      date: Math.floor(Date.now() / 1000),
+      chat: {
+        id: -1001234567890,
+        type: "supergroup" as const,
+        title: "OpenClaw",
+      },
+      is_topic_message: true,
+      message_thread_id: 42,
+      from: { id: 200, username: "bob" },
+    },
+  };
+}
+
 function registerAndResolveStatusHandler(params: {
   cfg: OpenClawConfig;
   allowFrom?: string[];
@@ -265,6 +283,47 @@ describe("registerTelegramNativeCommands — session metadata", () => {
       >
     )[0]?.[0];
     expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe(boundSessionKey);
+  });
+
+  it("routes topic commands when is_topic_message is set without chat.is_forum", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "topic-agent" }, { id: "group-agent" }],
+      },
+      bindings: [
+        {
+          agentId: "topic-agent",
+          match: {
+            channel: "telegram",
+            accountId: "default",
+            peer: { kind: "group", id: "-1001234567890:topic:42" },
+          },
+        },
+        {
+          agentId: "group-agent",
+          match: {
+            channel: "telegram",
+            accountId: "default",
+            peer: { kind: "group", id: "-1001234567890" },
+          },
+        },
+      ],
+    };
+    const { handler } = registerAndResolveStatusHandler({
+      cfg,
+      allowFrom: ["200"],
+      groupAllowFrom: ["200"],
+    });
+    await handler(buildStatusTopicCommandContextWithoutForumFlag());
+
+    const dispatchCall = (
+      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
+        [{ ctx?: { CommandTargetSessionKey?: string } }]
+      >
+    )[0]?.[0];
+    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toContain(
+      "agent:topic-agent:telegram:group:-1001234567890:topic:42",
+    );
   });
 
   it("aborts native command dispatch when configured ACP topic binding cannot initialize", async () => {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -141,6 +141,14 @@ type RegisterTelegramNativeCommandsParams = {
   opts: { token: string };
 };
 
+function isTelegramForumCommandMessage(msg: NonNullable<TelegramNativeCommandContext["message"]>) {
+  if ((msg.chat as { is_forum?: boolean }).is_forum === true) {
+    return true;
+  }
+  // Some topic updates omit chat.is_forum but still mark topic messages explicitly.
+  return (msg as { is_topic_message?: boolean }).is_topic_message === true;
+}
+
 async function resolveTelegramCommandAuth(params: {
   msg: NonNullable<TelegramNativeCommandContext["message"]>;
   bot: Bot;
@@ -173,7 +181,7 @@ async function resolveTelegramCommandAuth(params: {
   const chatId = msg.chat.id;
   const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
   const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
-  const isForum = (msg.chat as { is_forum?: boolean }).is_forum === true;
+  const isForum = isTelegramForumCommandMessage(msg);
   const threadSpec = resolveTelegramThreadSpec({
     isGroup,
     isForum,


### PR DESCRIPTION
## Summary
- detect Telegram topic native-command messages using either `chat.is_forum` or `message.is_topic_message`
- preserve topic thread scoping for `/new` and `/reset` route resolution when `chat.is_forum` is omitted
- add regression coverage for topic routing with missing `chat.is_forum`

## Testing
- pnpm test -- src/telegram/bot-native-commands.test.ts src/telegram/bot-native-commands.session-meta.test.ts

Fixes #35963
