### PR TITLE
perf(channels): memoize registry misses with bounded loader cache

### DIFF
--- a/src/channels/plugins/plugins-core.test.ts
+++ b/src/channels/plugins/plugins-core.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { DiscordProbe } from "../../discord/probe.js";
 import type { DiscordTokenResolution } from "../../discord/token.js";
@@ -261,6 +261,30 @@ describe("channel plugin loader", () => {
     expect(await loadChannelOutboundAdapter("msteams")).toBe(msteamsOutbound);
     setActivePluginRegistry(registryWithMSTeamsV2);
     expect(await loadChannelOutboundAdapter("msteams")).toBe(msteamsOutboundV2);
+  });
+
+  it("memoizes missing plugin lookups within the active registry version", async () => {
+    const registry = createTestRegistry([
+      { pluginId: "msteams", plugin: msteamsPlugin, source: "test" },
+    ]);
+    setActivePluginRegistry(registry, "registry-miss-cache");
+
+    const findSpy = vi.spyOn(registry.channels, "find");
+    expect(await loadChannelPlugin("missing-plugin-id")).toBeUndefined();
+    expect(await loadChannelPlugin("missing-plugin-id")).toBeUndefined();
+    expect(findSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears cached misses when the registry is re-activated", async () => {
+    const registry = createTestRegistry([]);
+    setActivePluginRegistry(registry, "registry-miss-refresh");
+    expect(await loadChannelPlugin("slack")).toBeUndefined();
+
+    const slackPlugin: ChannelPlugin = createChannelTestPluginBase({ id: "slack", label: "Slack" });
+    registry.channels = [{ pluginId: "slack", plugin: slackPlugin, source: "test" }];
+    setActivePluginRegistry(registry, "registry-miss-refresh");
+
+    expect(await loadChannelPlugin("slack")).toBe(slackPlugin);
   });
 
   it("returns undefined when plugin has no outbound adapter", async () => {

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -1,5 +1,5 @@
-import type { PluginChannelRegistration, PluginRegistry } from "../../plugins/registry.js";
-import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import type { PluginChannelRegistration } from "../../plugins/registry.js";
+import { getActivePluginRegistry, getActivePluginRegistryVersion } from "../../plugins/runtime.js";
 import type { ChannelId } from "./types.js";
 
 type ChannelRegistryValueResolver<TValue> = (
@@ -9,27 +9,42 @@ type ChannelRegistryValueResolver<TValue> = (
 export function createChannelRegistryLoader<TValue>(
   resolveValue: ChannelRegistryValueResolver<TValue>,
 ): (id: ChannelId) => Promise<TValue | undefined> {
-  const cache = new Map<ChannelId, TValue>();
-  let lastRegistry: PluginRegistry | null = null;
+  const CACHE_MISS = Symbol("channel-registry-cache-miss");
+  const CACHE_MAX_ENTRIES = 256;
+  const cache = new Map<ChannelId, TValue | typeof CACHE_MISS>();
+  let lastRegistryVersion = -1;
+
+  const cacheSet = (id: ChannelId, value: TValue | typeof CACHE_MISS) => {
+    if (!cache.has(id) && cache.size >= CACHE_MAX_ENTRIES) {
+      const oldest = cache.keys().next().value;
+      if (oldest !== undefined) {
+        cache.delete(oldest);
+      }
+    }
+    cache.set(id, value);
+  };
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
-    const registry = getActivePluginRegistry();
-    if (registry !== lastRegistry) {
+    const registryVersion = getActivePluginRegistryVersion();
+    if (registryVersion !== lastRegistryVersion) {
       cache.clear();
-      lastRegistry = registry;
+      lastRegistryVersion = registryVersion;
     }
-    const cached = cache.get(id);
-    if (cached) {
-      return cached;
+
+    if (cache.has(id)) {
+      const cached = cache.get(id);
+      return cached === CACHE_MISS ? undefined : cached;
     }
+
+    const registry = getActivePluginRegistry();
     const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
     if (!pluginEntry) {
+      cacheSet(id, CACHE_MISS);
       return undefined;
     }
+
     const resolved = resolveValue(pluginEntry);
-    if (resolved) {
-      cache.set(id, resolved);
-    }
+    cacheSet(id, resolved === undefined ? CACHE_MISS : resolved);
     return resolved;
   };
 }


### PR DESCRIPTION
Summary:\n- Memoize missing channel and outbound lookups in the channel registry loader to avoid repeated linear scans.\n- Invalidate loader cache on plugin registry version changes, including same-object re-activation.\n- Cap loader cache at 256 entries to bound memory growth from noisy IDs.\n- Add targeted tests for miss memoization and re-activation invalidation.\n\nWhy:\nRepeated miss lookups previously re-scanned the active registry every time, which adds avoidable overhead on hot lookup paths.\n\nImpact:\nLower CPU overhead on repeated misses and bounded cache memory, with unchanged caller-facing semantics.\n\nRisk:\nLow. Misses still return undefined, and focused tests cover both memoization and cache refresh behavior.