### PR TITLE
Fix: Control UI origin allowlist matching for canonical URLs

### DIFF
--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -49,6 +49,24 @@ describe("checkBrowserOrigin", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("accepts allowlisted origins with path", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "192.168.1.10:18789",
+      origin: "http://192.168.1.10:18789",
+      allowedOrigins: ["http://192.168.1.10:18789/"],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts scheme-less allowlist host values", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "192.168.1.10:18789",
+      origin: "http://192.168.1.10:18789",
+      allowedOrigins: ["192.168.1.10:18789"],
+    });
+    expect(result.ok).toBe(true);
+  });
+
   it("accepts wildcard allowedOrigins", () => {
     const result = checkBrowserOrigin({
       requestHost: "gateway.example.com:18789",

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -26,6 +26,25 @@ function parseOrigin(
   }
 }
 
+function normalizeAllowedOrigin(rawValue: string): string | null {
+  const value = rawValue.trim().toLowerCase();
+  if (value === "") {
+    return null;
+  }
+  if (value === "*") {
+    return "*";
+  }
+  try {
+    return new URL(value).origin;
+  } catch {
+    try {
+      return new URL(`http://${value}`).origin;
+    } catch {
+      return null;
+    }
+  }
+}
+
 export function checkBrowserOrigin(params: {
   requestHost?: string;
   origin?: string;
@@ -39,7 +58,9 @@ export function checkBrowserOrigin(params: {
   }
 
   const allowlist = new Set(
-    (params.allowedOrigins ?? []).map((value) => value.trim().toLowerCase()).filter(Boolean),
+    (params.allowedOrigins ?? [])
+      .map((value) => normalizeAllowedOrigin(value))
+      .filter((value): value is string => typeof value === "string" && value.length > 0),
   );
   if (allowlist.has("*") || allowlist.has(parsedOrigin.origin)) {
     return { ok: true, matchedBy: "allowlist" };


### PR DESCRIPTION
## Summary
Normalize Control UI `allowedOrigins` entries before matching request `Origin`, so canonical URL variants do not cause false negatives.

## Security Impact
Improves origin allowlist correctness and reduces accidental reject/accept mismatches caused by non-canonical origin entries.

## Repro+Verification
- Reproduce: configure `allowedOrigins` with URL-style values (for example with path suffixes like `http://192.168.x.x:18789/`).
- Before fix: path/scheme formatting variants could fail origin matching unexpectedly.
- After fix: canonical origin matching succeeds for equivalent origins; wildcard and host-header fallback behavior stay unchanged.

## Testing
- Added/updated unit coverage for origin canonicalization edge cases.
- Covered by PR CI checks.

## AI Assisted
- Yes (Codex-assisted implementation).

## Fixes
- Fixes #36056
