### PR TITLE
Fix: guard Discord gateway reconnect-attempt failures

### DIFF
--- a/src/discord/monitor/gateway-plugin.ts
+++ b/src/discord/monitor/gateway-plugin.ts
@@ -7,6 +7,34 @@ import type { DiscordAccountConfig } from "../../config/types.js";
 import { danger } from "../../globals.js";
 import type { RuntimeEnv } from "../../runtime.js";
 
+type GatewayPluginLike = GatewayPlugin & {
+  handleReconnectionAttempt?: (...args: unknown[]) => unknown;
+  emitter?: {
+    emit: (event: "error", value: unknown) => void;
+  };
+};
+
+function withSafeReconnectionHandling(
+  plugin: GatewayPluginLike,
+  runtime: RuntimeEnv,
+): GatewayPlugin {
+  const originalHandleReconnectionAttempt = plugin.handleReconnectionAttempt;
+  if (typeof originalHandleReconnectionAttempt !== "function") {
+    return plugin;
+  }
+
+  plugin.handleReconnectionAttempt = async (...args: unknown[]) => {
+    try {
+      return await Promise.resolve(originalHandleReconnectionAttempt.apply(plugin, args));
+    } catch (error) {
+      runtime.error?.(`discord: gateway reconnect handler failed: ${String(error)}`);
+      plugin.emitter?.emit("error", error);
+    }
+  };
+
+  return plugin;
+}
+
 export function resolveDiscordGatewayIntents(
   intentsConfig?: import("../../config/types.discord.js").DiscordIntentsConfig,
 ): number {
@@ -40,7 +68,7 @@ export function createDiscordGatewayPlugin(params: {
   };
 
   if (!proxy) {
-    return new GatewayPlugin(options);
+    return withSafeReconnectionHandling(new GatewayPlugin(options), params.runtime);
   }
 
   try {
@@ -79,9 +107,9 @@ export function createDiscordGatewayPlugin(params: {
       }
     }
 
-    return new ProxyGatewayPlugin();
+    return withSafeReconnectionHandling(new ProxyGatewayPlugin(), params.runtime);
   } catch (err) {
     params.runtime.error?.(danger(`discord: invalid gateway proxy: ${String(err)}`));
-    return new GatewayPlugin(options);
+    return withSafeReconnectionHandling(new GatewayPlugin(options), params.runtime);
   }
 }

--- a/src/discord/monitor/provider.proxy.test.ts
+++ b/src/discord/monitor/provider.proxy.test.ts
@@ -32,6 +32,7 @@ const {
   } as const;
 
   class GatewayPlugin {
+    emitter = { emit: vi.fn() };
     options: unknown;
     gatewayInfo: unknown;
     constructor(options?: unknown, gatewayInfo?: unknown) {
@@ -40,6 +41,9 @@ const {
     }
     async registerClient(client: unknown) {
       baseRegisterClientSpy(client);
+    }
+    handleReconnectionAttempt() {
+      throw new Error("max reconnect attempts reached");
     }
   }
 
@@ -193,5 +197,23 @@ describe("createDiscordGatewayPlugin", () => {
       }),
     );
     expect(baseRegisterClientSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles reconnect attempt failures without throwing", async () => {
+    const runtime = createRuntime();
+
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: {},
+      runtime,
+    });
+
+    const pluginWithReconnector = plugin as unknown as {
+      handleReconnectionAttempt: () => Promise<void>;
+      emitter: { emit: ReturnType<typeof vi.fn> };
+    };
+
+    await expect(pluginWithReconnector.handleReconnectionAttempt()).resolves.toBeUndefined();
+    expect(runtime.error).toHaveBeenCalled();
+    expect(pluginWithReconnector.emitter.emit).toHaveBeenCalledWith("error", expect.any(Error));
   });
 });


### PR DESCRIPTION
## Summary
Guard Discord gateway reconnect-attempt handling so max-attempt exceptions are caught and do not crash the reconnect flow.

## Security Impact
No direct security boundary changes.

## Repro+Verification
- Reproduce: trigger repeated Discord gateway reconnect failures until reconnect-attempt limits are hit.
- Before fix: uncaught reconnect-attempt errors can bubble and break gateway recovery.
- After fix: reconnect-attempt failures are handled gracefully and recovery continues.

## Testing
- Covered by PR CI checks.

## AI Assisted
- Yes (Codex-assisted implementation).

## Fixes
- Fixes #36055
