### PR TITLE
Fix: remove unsupported AutomationControlled Chrome switch

### DIFF
--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -266,8 +266,7 @@ export async function launchOpenClawChrome(
       args.push("--disable-dev-shm-usage");
     }
 
-    // Stealth: hide navigator.webdriver from automation detection (#80)
-    args.push("--disable-blink-features=AutomationControlled");
+    // Removed unsupported Blink feature switch for newer Chrome versions.
 
     // Append user-configured extra arguments (e.g., stealth flags, window size)
     if (resolved.extraArgs.length > 0) {


### PR DESCRIPTION
## Summary
Remove the hard-coded `--disable-blink-features=AutomationControlled` flag from local Chrome startup.

## Security Impact
No direct security boundary changes.

## Repro+Verification
- Reproduce: start local Chrome with the previous hard-coded launch flags.
- Before fix: recent Chrome versions emit startup warnings for unsupported `AutomationControlled` handling.
- After fix: warning is avoided while preserving user-configurable `extraArgs` behavior.

## Testing
- Covered by PR CI checks.

## AI Assisted
- Yes (Codex-assisted implementation).

## Fixes
- Fixes #35721
