### PR TITLE
fix(agents): default tool_choice for openai-responses payload tools

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1059,6 +1059,58 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.store).toBe(false);
   });
 
+  it("defaults tool_choice to auto for OpenAI Responses payloads with tools", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: {
+        api: "openai-responses",
+        provider: "sub2api-gpt",
+        id: "gpt-5.3-codex",
+        baseUrl: "https://proxy.example.com/v1",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        tools: [{ type: "function", name: "exec" }],
+      },
+    });
+    expect(payload.tool_choice).toBe("auto");
+  });
+
+  it("preserves explicit tool_choice for OpenAI Responses payloads with tools", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: {
+        api: "openai-responses",
+        provider: "sub2api-gpt",
+        id: "gpt-5.3-codex",
+        baseUrl: "https://proxy.example.com/v1",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        tools: [{ type: "function", name: "exec" }],
+        tool_choice: "required",
+      },
+    });
+    expect(payload.tool_choice).toBe("required");
+  });
+
+  it("does not set tool_choice when OpenAI Responses payload has no tools", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: {
+        api: "openai-responses",
+        provider: "sub2api-gpt",
+        id: "gpt-5.3-codex",
+        baseUrl: "https://proxy.example.com/v1",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        tools: [],
+      },
+    });
+    expect(payload).not.toHaveProperty("tool_choice");
+  });
+
   it("does not force store for OpenAI Responses when baseUrl is empty", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "openai",

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -281,9 +281,10 @@ function createOpenAIResponsesContextManagementWrapper(
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
+    const shouldDefaultToolChoice = model.api === "openai-responses";
     const forceStore = shouldForceResponsesStore(model);
     const useServerCompaction = shouldEnableOpenAIResponsesServerCompaction(model, extraParams);
-    if (!forceStore && !useServerCompaction) {
+    if (!shouldDefaultToolChoice && !forceStore && !useServerCompaction) {
       return underlying(model, context, options);
     }
 
@@ -296,6 +297,14 @@ function createOpenAIResponsesContextManagementWrapper(
       onPayload: (payload) => {
         if (payload && typeof payload === "object") {
           const payloadObj = payload as Record<string, unknown>;
+          if (
+            shouldDefaultToolChoice &&
+            Array.isArray(payloadObj.tools) &&
+            payloadObj.tools.length > 0 &&
+            payloadObj.tool_choice == null
+          ) {
+            payloadObj.tool_choice = "auto";
+          }
           if (forceStore) {
             payloadObj.store = true;
           }


### PR DESCRIPTION
## Summary
This PR fixes a regression on the `openai-responses` HTTP stream path where requests could include non-empty `tools` but omit `tool_choice`, which can bias compatible upstream providers toward text-only output and prevent tool calls from being emitted.

## Root cause
`createOpenAIResponsesContextManagementWrapper` only wrapped payloads when one of these was true:
- force `store=true` for direct OpenAI Responses
- auto-inject `context_management` compaction

For non-OpenAI custom providers using `api: openai-responses`, neither condition is typically true, so payload mutation was skipped entirely and `tool_choice` could remain unset even when `tools` were present.

## Fix
- Keep the existing store/compaction behavior unchanged.
- Also activate the wrapper for `model.api === "openai-responses"`.
- In `onPayload`, default `tool_choice` to `"auto"` only when all of the following are true:
  - payload `tools` is an array
  - `tools.length > 0`
  - `tool_choice` is `null`/`undefined`
- Preserve any explicitly configured `tool_choice`.

## Validation
Targeted tests added in `src/agents/pi-embedded-runner-extraparams.test.ts`:
- defaults `tool_choice="auto"` when tools are present and `tool_choice` is unset
- preserves explicit `tool_choice`
- does not set `tool_choice` when tools are empty

Command run:
- `pnpm test src/agents/pi-embedded-runner-extraparams.test.ts`

Fixes #36057
