### PR TITLE
fix(agents): recognize Ollama context overflow error for auto-compaction

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -96,9 +96,11 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     lower.includes("context length exceeded") ||
     lower.includes("maximum context length") ||
     lower.includes("prompt is too long") ||
+    lower.includes("prompt too long") ||
     lower.includes("exceeds model context window") ||
     lower.includes("model token limit") ||
     (hasRequestSizeExceeds && hasContextWindow) ||
+    (lower.includes("exceeded") && hasContextWindow) ||
     lower.includes("context overflow:") ||
     lower.includes("exceed context limit") ||
     lower.includes("exceeds the model's maximum context") ||


### PR DESCRIPTION
## Summary

- **Problem:** Ollama returns `"prompt too long; exceeded max context length by N tokens"` on context overflow, but `isContextOverflowError()` did not recognize this pattern. The existing checks require either `"prompt is too long"` (with "is") or `"context length exceeded"` (reversed word order), neither of which matches Ollama's phrasing.
- **Why it matters:** Without recognition, auto-compaction never triggers. The session shows a cryptic API error and enters a broken state until the user manually starts a new conversation.
- **What changed:** Added two patterns to `isContextOverflowError()`:
  1. `"prompt too long"` — matches Ollama's error without requiring "is"
  2. `"exceeded" + context-window term` — catches "exceeded max context length" regardless of "max" vs "maximum" prefix
- **What did NOT change:** All existing overflow patterns, rate limit exclusions, and reasoning constraint exclusions remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34005

## User-visible / Behavior Changes

- Ollama context overflow now shows the helpful "Context overflow: prompt too large..." message instead of the raw API error.
- Auto-compaction can now trigger for Ollama models when context is exceeded.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: any (agent-level, Ollama provider)

### Steps

1. Configure an Ollama model with limited context window
2. Send enough messages to exceed the context limit
3. Observe error handling

### Expected

- "Context overflow: prompt too large for the model. Try /reset (or /new) to start a fresh session, or use a larger-context model."

### Actual

- Before fix: `run error: Ollama API error 400: {"error":"prompt too long; exceeded max context length by 4 tokens"}`
- After fix: Friendly error message + auto-compaction eligibility

## Evidence

TypeScript compiles cleanly. Pattern analysis:
- `"prompt too long; exceeded max context length by 4 tokens".includes("prompt too long")` → `true`
- `"prompt too long; exceeded max context length by 4 tokens".includes("context length")` → `true` (hasContextWindow)
- `"prompt too long; exceeded max context length by 4 tokens".includes("exceeded")` → `true`
- Both new patterns match.

## Human Verification (required)

- Verified scenarios: TypeScript compilation, substring pattern analysis against reported error string
- Edge cases checked: Existing rate limit exclusion still works (TPM errors still excluded); "exceeded" alone doesn't trigger without context-window term; existing patterns unchanged
- What I did **not** verify: End-to-end test with real Ollama model context overflow

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the two added lines in `errors.ts`
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts`
- Known bad symptoms: False positive context overflow detection could trigger unnecessary compaction

## Risks and Mitigations

- **Risk:** `"prompt too long"` is broader than `"prompt is too long"` and could match non-context errors. **Mitigation:** The function has guards for rate limits and reasoning constraints at the top, and the pattern is specific enough that false positives are unlikely.

