### PR TITLE
Media: surface swallowed stream cleanup errors via callback

### DIFF
--- a/src/media/read-response-with-limit.test.ts
+++ b/src/media/read-response-with-limit.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { readResponseWithLimit } from "./read-response-with-limit.js";
+
+type ReaderLike = {
+  read: () => Promise<ReadableStreamReadResult<Uint8Array>>;
+  cancel: () => Promise<void>;
+  releaseLock: () => void;
+};
+
+function createResponse(reader: ReaderLike): Response {
+  return {
+    body: {
+      getReader: () => reader,
+    } as unknown as ReadableStream<Uint8Array>,
+  } as unknown as Response;
+}
+
+describe("readResponseWithLimit", () => {
+  it("reports reader cancel errors via onCleanupError before overflow", async () => {
+    const read = vi
+      .fn<ReaderLike["read"]>()
+      .mockResolvedValueOnce({ done: false, value: new Uint8Array([1, 2, 3]) })
+      .mockResolvedValueOnce({ done: false, value: new Uint8Array([4, 5, 6]) });
+    const cancel = vi.fn<ReaderLike["cancel"]>(async () => {
+      throw new Error("cancel failed");
+    });
+    const releaseLock = vi.fn<ReaderLike["releaseLock"]>();
+    const reader = { read, cancel, releaseLock };
+    const response = createResponse(reader);
+    const onCleanupError = vi.fn();
+
+    await expect(
+      readResponseWithLimit(response, 4, {
+        onCleanupError,
+      }),
+    ).rejects.toThrow("Content too large");
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    expect(onCleanupError).toHaveBeenCalledTimes(1);
+    expect(onCleanupError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: "cancel",
+        res: response,
+      }),
+    );
+  });
+
+  it("reports releaseLock errors via onCleanupError after successful reads", async () => {
+    const read = vi
+      .fn<ReaderLike["read"]>()
+      .mockResolvedValueOnce({ done: false, value: new Uint8Array([7, 8, 9]) })
+      .mockResolvedValueOnce({ done: true, value: undefined });
+    const cancel = vi.fn<ReaderLike["cancel"]>(async () => {});
+    const releaseLock = vi.fn<ReaderLike["releaseLock"]>(() => {
+      throw new Error("releaseLock failed");
+    });
+    const reader = { read, cancel, releaseLock };
+    const response = createResponse(reader);
+    const onCleanupError = vi.fn();
+
+    const result = await readResponseWithLimit(response, 16, { onCleanupError });
+
+    expect(result).toEqual(Buffer.from([7, 8, 9]));
+    expect(cancel).not.toHaveBeenCalled();
+    expect(onCleanupError).toHaveBeenCalledTimes(1);
+    expect(onCleanupError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: "releaseLock",
+        res: response,
+      }),
+    );
+  });
+});

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -3,12 +3,18 @@ export async function readResponseWithLimit(
   maxBytes: number,
   opts?: {
     onOverflow?: (params: { size: number; maxBytes: number; res: Response }) => Error;
+    onCleanupError?: (params: {
+      phase: "cancel" | "releaseLock";
+      error: unknown;
+      res: Response;
+    }) => void;
   },
 ): Promise<Buffer> {
   const onOverflow =
     opts?.onOverflow ??
     ((params: { size: number; maxBytes: number }) =>
       new Error(`Content too large: ${params.size} bytes (limit: ${params.maxBytes} bytes)`));
+  const onCleanupError = opts?.onCleanupError;
 
   const body = res.body;
   if (!body || typeof body.getReader !== "function") {
@@ -33,7 +39,9 @@ export async function readResponseWithLimit(
         if (total > maxBytes) {
           try {
             await reader.cancel();
-          } catch {}
+          } catch (error) {
+            onCleanupError?.({ phase: "cancel", error, res });
+          }
           throw onOverflow({ size: total, maxBytes, res });
         }
         chunks.push(value);
@@ -42,7 +50,9 @@ export async function readResponseWithLimit(
   } finally {
     try {
       reader.releaseLock();
-    } catch {}
+    } catch (error) {
+      onCleanupError?.({ phase: "releaseLock", error, res });
+    }
   }
 
   return Buffer.concat(


### PR DESCRIPTION
## Summary
- add an optional onCleanupError callback to readResponseWithLimit so internal cancel/releaseLock failures are observable instead of silently swallowed
- keep cleanup failures non-fatal and preserve existing overflow/read behavior
- add focused tests for overflow+cancel failure and releaseLock failure paths

## Why
These paths currently use empty catch blocks, which hide diagnostics when stream cleanup fails.

## Impact
Low risk: existing runtime behavior is unchanged unless a caller opts into the callback.

## Validation
- pnpm test src/media/fetch.test.ts src/media/read-response-with-limit.test.ts
