### PR TITLE
fix(agents): use max instead of min for context window cache across providers

### DIFF
--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -8,17 +8,17 @@ import {
 import { createSessionManagerRuntimeRegistry } from "./pi-extensions/session-manager-runtime-registry.js";
 
 describe("applyDiscoveredContextWindows", () => {
-  it("keeps the smallest context window when duplicate model ids are discovered", () => {
+  it("keeps the largest context window when duplicate model ids are discovered", () => {
     const cache = new Map<string, number>();
     applyDiscoveredContextWindows({
       cache,
       models: [
-        { id: "claude-sonnet-4-5", contextWindow: 1_000_000 },
         { id: "claude-sonnet-4-5", contextWindow: 200_000 },
+        { id: "claude-sonnet-4-5", contextWindow: 1_000_000 },
       ],
     });
 
-    expect(cache.get("claude-sonnet-4-5")).toBe(200_000);
+    expect(cache.get("claude-sonnet-4-5")).toBe(1_000_000);
   });
 });
 

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -42,8 +42,11 @@ export function applyDiscoveredContextWindows(params: {
     }
     const existing = params.cache.get(model.id);
     // When multiple providers expose the same model id with different limits,
-    // prefer the smaller window so token budgeting is fail-safe (no overestimation).
-    if (existing === undefined || contextWindow < existing) {
+    // prefer the larger window.  Runtime token budgeting already resolves the
+    // correct limit from the active provider; the cache is only used for
+    // display (/status) where showing the smaller cross-provider minimum is
+    // misleading (e.g. gemini-3.1-pro shows 128k instead of 1024k).
+    if (existing === undefined || contextWindow > existing) {
       params.cache.set(model.id, contextWindow);
     }
   }


### PR DESCRIPTION
## Summary

- **Problem:** The context window discovery cache uses `model.id` as the key. When multiple providers expose the same model ID with different context limits (e.g., `gemini-3.1-pro-preview`: 128k via `github-copilot`, 1024k via `google-gemini-cli`), the minimum value was stored, causing `/status` to show `0/128k` instead of `0/1024k`.
- **Why it matters:** Users see a misleadingly small context window for their active model, causing confusion about available capacity.
- **What changed:** Switched the cache population strategy from MIN to MAX. When multiple providers expose the same model ID, the largest context window is now cached.
- **What did NOT change:** Runtime token budgeting is unaffected — `pi-embedded-runner/model.ts` resolves contextWindow from the active provider config independently. The `applyConfiguredContextWindows` override still takes precedence over discovered values.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35976

## User-visible / Behavior Changes

- `/status` now shows the correct (largest) context window for models available under multiple providers.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: any

### Steps

1. Configure `google-gemini-cli/gemini-3.1-pro-preview` as primary model
2. Run `/status`

### Expected

- Context line shows `0/1024k` (the google-gemini-cli limit)

### Actual

- Before fix: `0/128k` (the github-copilot limit, minimum across providers)
- After fix: `0/1024k` (maximum across providers)

## Evidence

All 8 context tests pass. Test updated to verify MAX behavior.

## Human Verification (required)

- Verified scenarios: TypeScript compilation, all context tests pass, cache behavior verified
- Edge cases checked: Single provider model IDs unaffected; `applyConfiguredContextWindows` still overrides; zero/negative windows still skipped
- What I did **not** verify: End-to-end `/status` display with real multi-provider setup

## Compatibility / Migration

- Backward compatible? `Yes` — display-only change, no runtime impact
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Change `>` back to `<` in `context.ts`
- Files/config to restore: `src/agents/context.ts`
- Known bad symptoms: If a model's true limit is smaller than what another provider reports, `/status` would show an overly optimistic number (display only, no runtime effect)

## Risks and Mitigations

- **Risk:** MAX could show a context window larger than what the active provider supports. **Mitigation:** The cache is display-only; runtime token budgeting uses the active provider's config. Users can always set explicit `contextWindow` in their model config to override.

