### PR TITLE
fix(agents): default tool_choice to auto for openai-responses on streamSimple path

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.openai-responses-tool-choice.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openai-responses-tool-choice.test.ts
@@ -1,0 +1,167 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+vi.mock("@mariozechner/pi-ai", () => ({
+  streamSimple: vi.fn(() => ({
+    push: vi.fn(),
+    result: vi.fn(),
+  })),
+}));
+
+type ToolChoiceCase = {
+  applyProvider: string;
+  applyModelId: string;
+  model: Model<"openai-responses">;
+  payload?: Record<string, unknown>;
+  cfg?: Parameters<typeof applyExtraParamsToAgent>[1];
+  options?: SimpleStreamOptions;
+};
+
+function runToolChoiceCase(params: ToolChoiceCase) {
+  const payload: Record<string, unknown> = {
+    model: params.model.id,
+    input: [],
+    ...params.payload,
+  };
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    options?.onPayload?.(payload);
+    return {} as ReturnType<StreamFn>;
+  };
+  const agent = { streamFn: baseStreamFn };
+
+  applyExtraParamsToAgent(agent, params.cfg, params.applyProvider, params.applyModelId);
+
+  const context: Context = { messages: [] };
+  void agent.streamFn?.(params.model, context, params.options ?? {});
+
+  return payload;
+}
+
+const customResponsesModel = {
+  api: "openai-responses",
+  provider: "sub2api-gpt",
+  id: "gpt-5.3-codex",
+} as Model<"openai-responses">;
+
+const openaiResponsesModel = {
+  api: "openai-responses",
+  provider: "openai",
+  id: "gpt-5",
+} as Model<"openai-responses">;
+
+const openaiCompletionsModel = {
+  api: "openai-completions",
+  provider: "openai",
+  id: "gpt-5",
+} as Model<"openai-completions">;
+
+describe("extra-params: openai-responses tool_choice default (#36057)", () => {
+  it("injects tool_choice='auto' when tools present but tool_choice null (custom provider)", () => {
+    const payload = runToolChoiceCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: customResponsesModel,
+      payload: {
+        tools: [{ type: "function", name: "exec" }],
+        tool_choice: null,
+      },
+    });
+
+    expect(payload.tool_choice).toBe("auto");
+  });
+
+  it("injects tool_choice='auto' when tools present and tool_choice undefined", () => {
+    const payload = runToolChoiceCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: customResponsesModel,
+      payload: {
+        tools: [{ type: "function", name: "exec" }],
+      },
+    });
+
+    expect(payload.tool_choice).toBe("auto");
+  });
+
+  it("preserves explicit tool_choice='required'", () => {
+    const payload = runToolChoiceCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: customResponsesModel,
+      payload: {
+        tools: [{ type: "function", name: "exec" }],
+        tool_choice: "required",
+      },
+    });
+
+    expect(payload.tool_choice).toBe("required");
+  });
+
+  it("preserves explicit tool_choice='none'", () => {
+    const payload = runToolChoiceCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: customResponsesModel,
+      payload: {
+        tools: [{ type: "function", name: "exec" }],
+        tool_choice: "none",
+      },
+    });
+
+    expect(payload.tool_choice).toBe("none");
+  });
+
+  it("does not inject tool_choice when tools array is empty", () => {
+    const payload = runToolChoiceCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: customResponsesModel,
+      payload: {
+        tools: [],
+      },
+    });
+
+    expect(payload.tool_choice).toBeUndefined();
+  });
+
+  it("does not inject tool_choice when no tools field", () => {
+    const payload = runToolChoiceCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: customResponsesModel,
+      payload: {},
+    });
+
+    expect(payload.tool_choice).toBeUndefined();
+  });
+
+  it("injects tool_choice for direct openai provider too", () => {
+    const payload = runToolChoiceCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      model: openaiResponsesModel,
+      payload: {
+        tools: [{ type: "function", name: "exec" }],
+        tool_choice: null,
+      },
+    });
+
+    expect(payload.tool_choice).toBe("auto");
+  });
+
+  it("does not inject tool_choice for non-responses API", () => {
+    const payload = runToolChoiceCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      model: openaiCompletionsModel as unknown as Model<"openai-responses">,
+      payload: {
+        tools: [{ type: "function", name: "exec" }],
+        tool_choice: null,
+      },
+    });
+
+    expect(payload.tool_choice).toBeNull();
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -314,6 +314,40 @@ function createOpenAIResponsesContextManagementWrapper(
   };
 }
 
+/**
+ * Default `tool_choice` to `"auto"` for OpenAI Responses API requests that
+ * include tools but omit an explicit tool_choice.  Custom (non-OpenAI)
+ * providers route through `streamSimple` which never injects this field,
+ * causing the model to ignore tools and return text-only completions.
+ */
+function createOpenAIResponsesToolChoiceDefaultWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (typeof model.api !== "string" || !OPENAI_RESPONSES_APIS.has(model.api)) {
+      return underlying(model, context, options);
+    }
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          const payloadObj = payload as Record<string, unknown>;
+          if (
+            Array.isArray(payloadObj.tools) &&
+            payloadObj.tools.length > 0 &&
+            payloadObj.tool_choice == null
+          ) {
+            payloadObj.tool_choice = "auto";
+          }
+        }
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}
+
 function createCodexDefaultTransportWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) =>
@@ -964,4 +998,9 @@ export function applyExtraParamsToAgent(
   // Force `store=true` for direct OpenAI Responses models and auto-enable
   // server-side compaction for compatible OpenAI Responses payloads.
   agent.streamFn = createOpenAIResponsesContextManagementWrapper(agent.streamFn, merged);
+
+  // Default tool_choice to "auto" for OpenAI Responses API when tools are
+  // present but tool_choice is null/undefined.  Custom providers that route
+  // through streamSimple never set this field, causing silent tool failures.
+  agent.streamFn = createOpenAIResponsesToolChoiceDefaultWrapper(agent.streamFn);
 }


### PR DESCRIPTION
## Summary

- Problem: Custom providers using `api: openai-responses` route through `streamSimple` instead of the OpenAI WebSocket transport. On this path `tool_choice` is never injected, causing the model to silently ignore tools and return text-only completions.
- Why it matters: Users of third-party OpenAI-compatible services (e.g. sub2api, one-api) that rely on the Responses API cannot use tool calling at all.
- What changed: Added `createOpenAIResponsesToolChoiceDefaultWrapper` that defaults `tool_choice` to `"auto"` in the request payload when tools are present but `tool_choice` is `null`/`undefined`, applied after the context management wrapper in `applyExtraParamsToAgent`.
- What did NOT change (scope boundary): The OpenAI WebSocket path (which already handles `tool_choice`) is unchanged. Explicit `tool_choice` values (e.g. `"required"`, `"none"`) are never overridden.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36057

## User-visible / Behavior Changes

Custom openai-responses providers now correctly invoke tools instead of silently returning text-only responses.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+

### Steps

1. Configure a custom provider with `api: openai-responses` and a non-OpenAI baseUrl
2. Send a message that should trigger tool use
3. Observe tool calls in the response

### Expected

- Agent makes tool calls as expected

### Actual

- Before: Agent returns text-only, tools are ignored
- After: Agent correctly calls tools with `tool_choice: "auto"`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

8 vitest unit tests covering: null tool_choice, undefined tool_choice, explicit tool_choice preserved, empty tools, no tools, direct OpenAI provider, non-responses API.

## Human Verification (required)

- Verified scenarios: Custom openai-responses provider with tools, direct OpenAI provider, explicit tool_choice values
- Edge cases checked: Empty tools array, missing tools field, tool_choice="none", tool_choice="required"
- What you did **not** verify: End-to-end with a real third-party API endpoint

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single commit; the wrapper is additive and independent
- Files/config to restore: `src/agents/pi-embedded-runner/extra-params.ts`

## Risks and Mitigations

- Risk: A provider that intentionally omits tool_choice to use server-default behavior would now receive `tool_choice: "auto"` explicitly.
  - Mitigation: `"auto"` is the documented default for OpenAI Responses API, so explicit injection matches the server default.

