### PR TITLE
fix(browser): auto-detect proxy env vars and pass --proxy-server to Chrome

### DIFF
--- a/src/browser/chrome.proxy-arg.test.ts
+++ b/src/browser/chrome.proxy-arg.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { resolveProxyArg } from "./chrome.js";
+
+describe("resolveProxyArg (#35346)", () => {
+  it("returns --proxy-server from HTTPS_PROXY", () => {
+    expect(resolveProxyArg([], { HTTPS_PROXY: "http://proxy:8080" })).toBe(
+      "--proxy-server=http://proxy:8080",
+    );
+  });
+
+  it("prefers HTTPS_PROXY over HTTP_PROXY", () => {
+    expect(
+      resolveProxyArg([], {
+        HTTPS_PROXY: "http://secure:8443",
+        HTTP_PROXY: "http://plain:8080",
+      }),
+    ).toBe("--proxy-server=http://secure:8443");
+  });
+
+  it("falls back to http_proxy (lowercase)", () => {
+    expect(resolveProxyArg([], { http_proxy: "socks5://proxy:1080" })).toBe(
+      "--proxy-server=socks5://proxy:1080",
+    );
+  });
+
+  it("falls back to ALL_PROXY", () => {
+    expect(resolveProxyArg([], { ALL_PROXY: "http://all:3128" })).toBe(
+      "--proxy-server=http://all:3128",
+    );
+  });
+
+  it("returns undefined when no proxy env vars set", () => {
+    expect(resolveProxyArg([], {})).toBeUndefined();
+  });
+
+  it("returns undefined when user already has --proxy-server in extraArgs", () => {
+    expect(
+      resolveProxyArg(["--proxy-server=http://custom:9090"], {
+        HTTPS_PROXY: "http://proxy:8080",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when user has --proxy-server= prefix in extraArgs", () => {
+    expect(
+      resolveProxyArg(["--proxy-server=socks5://custom:1080"], {
+        HTTP_PROXY: "http://proxy:8080",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -70,6 +70,29 @@ function resolveBrowserExecutable(resolved: ResolvedBrowserConfig): BrowserExecu
   return resolveBrowserExecutableForPlatform(resolved, process.platform);
 }
 
+/**
+ * Detect proxy env vars and return a `--proxy-server=<url>` Chrome arg,
+ * or undefined when no proxy is configured or the user already supplied one.
+ *
+ * @internal Exported for testing.
+ */
+export function resolveProxyArg(
+  extraArgs: string[],
+  env: Record<string, string | undefined> = process.env,
+): string | undefined {
+  if (extraArgs.some((a) => a.startsWith("--proxy-server"))) {
+    return undefined;
+  }
+  const proxyUrl =
+    env.HTTPS_PROXY ||
+    env.https_proxy ||
+    env.HTTP_PROXY ||
+    env.http_proxy ||
+    env.ALL_PROXY ||
+    env.all_proxy;
+  return proxyUrl ? `--proxy-server=${proxyUrl}` : undefined;
+}
+
 export function resolveOpenClawUserDataDir(profileName = DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME) {
   return path.join(CONFIG_DIR, "browser", profileName, "user-data");
 }
@@ -268,6 +291,14 @@ export async function launchOpenClawChrome(
 
     // Stealth: hide navigator.webdriver from automation detection (#80)
     args.push("--disable-blink-features=AutomationControlled");
+
+    // Chromium does not honor HTTP_PROXY/HTTPS_PROXY env vars; it needs
+    // an explicit --proxy-server flag. Auto-inject it unless the user
+    // already specified one via extraArgs.
+    const proxyArg = resolveProxyArg(resolved.extraArgs);
+    if (proxyArg) {
+      args.push(proxyArg);
+    }
 
     // Append user-configured extra arguments (e.g., stealth flags, window size)
     if (resolved.extraArgs.length > 0) {


### PR DESCRIPTION
## Summary

- Problem: Chromium does not honor `HTTP_PROXY` / `HTTPS_PROXY` environment variables. Users behind corporate proxies see `ERR_CONNECTION_RESET` because the spawned Chrome process attempts a direct connection. The env vars are passed via `process.env` spread but Chromium ignores them.
- Why it matters: Any user behind an HTTP/SOCKS proxy cannot use the browser feature at all — every page load fails with a connection reset.
- What changed: Added `resolveProxyArg()` that detects `HTTPS_PROXY`, `HTTP_PROXY`, and `ALL_PROXY` (both cases) and automatically appends `--proxy-server=<url>` to Chrome launch args. Skips injection when the user already supplies `--proxy-server` via `browser.extraArgs`.
- What did NOT change (scope boundary): No changes to CDP connection logic, browser profile management, or any other launch flags. The proxy arg is only added to the Chrome process args.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35346

## User-visible / Behavior Changes

Browser automatically uses the system proxy when `HTTPS_PROXY`, `HTTP_PROXY`, or `ALL_PROXY` environment variables are set.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (Chrome uses the proxy that was already intended by the user's env)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux / macOS / Windows
- Runtime: Node.js 22+

### Steps

1. Set `HTTPS_PROXY=http://proxy:8080`
2. Launch OpenClaw with browser enabled
3. Navigate to any page

### Expected

- Page loads through the proxy

### Actual

- Before: `ERR_CONNECTION_RESET` on every page
- After: Page loads through the configured proxy

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

7 vitest unit tests for `resolveProxyArg`: HTTPS_PROXY, HTTP_PROXY, ALL_PROXY, lowercase variants, priority order, no proxy, explicit --proxy-server skip.

## Human Verification (required)

- Verified scenarios: HTTPS_PROXY set, HTTP_PROXY fallback, ALL_PROXY fallback, no proxy env, user-supplied --proxy-server
- Edge cases checked: Mixed case env vars, SOCKS5 proxy URL, empty proxy string
- What you did **not** verify: End-to-end with a real corporate proxy

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the commit, or set `browser.extraArgs: ["--proxy-server=direct://"]` to override
- Files/config to restore: `src/browser/chrome.ts`

## Risks and Mitigations

- Risk: A user with proxy env vars set but not wanting Chrome to use them could see unexpected behavior.
  - Mitigation: Users can override with `browser.extraArgs: ["--proxy-server=direct://"]` or `--no-proxy-server`. The proxy detection follows the same precedence as curl/wget.

