### PR TITLE
perf(channels): cache registry-loader misses and falsey values

### DIFF
--- a/src/channels/plugins/registry-loader.test.ts
+++ b/src/channels/plugins/registry-loader.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
+import { createChannelRegistryLoader } from "./registry-loader.js";
+import type { ChannelPlugin } from "./types.js";
+
+const emptyRegistry = createTestRegistry([]);
+
+const createPlugin = (id: ChannelPlugin["id"]): ChannelPlugin => ({
+  ...createChannelTestPluginBase({ id, label: String(id) }),
+});
+
+describe("createChannelRegistryLoader", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(emptyRegistry);
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(emptyRegistry);
+  });
+
+  it("caches undefined resolved values to avoid repeated resolver work", async () => {
+    const registry = createTestRegistry([
+      {
+        pluginId: "msteams",
+        plugin: createPlugin("msteams"),
+        source: "test",
+      },
+    ]);
+    setActivePluginRegistry(registry);
+
+    const resolveValue = vi.fn(() => undefined as string | undefined);
+    const load = createChannelRegistryLoader(resolveValue);
+
+    await expect(load("msteams")).resolves.toBeUndefined();
+    await expect(load("msteams")).resolves.toBeUndefined();
+
+    expect(resolveValue).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches falsey resolved values", async () => {
+    const registry = createTestRegistry([
+      {
+        pluginId: "msteams",
+        plugin: createPlugin("msteams"),
+        source: "test",
+      },
+    ]);
+    setActivePluginRegistry(registry);
+
+    const resolveValue = vi.fn(() => "");
+    const load = createChannelRegistryLoader(resolveValue);
+
+    await expect(load("msteams")).resolves.toBe("");
+    await expect(load("msteams")).resolves.toBe("");
+
+    expect(resolveValue).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches missing channel ids to avoid repeated registry scans", async () => {
+    const registry = createTestRegistry([
+      {
+        pluginId: "msteams",
+        plugin: createPlugin("msteams"),
+        source: "test",
+      },
+    ]);
+    setActivePluginRegistry(registry);
+
+    const findSpy = vi.spyOn(registry.channels, "find");
+    const resolveValue = vi.fn(() => "ok");
+    const load = createChannelRegistryLoader(resolveValue);
+
+    await expect(load("slack")).resolves.toBeUndefined();
+    await expect(load("slack")).resolves.toBeUndefined();
+
+    expect(findSpy).toHaveBeenCalledTimes(1);
+    expect(resolveValue).not.toHaveBeenCalled();
+  });
+});

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -6,10 +6,14 @@ type ChannelRegistryValueResolver<TValue> = (
   entry: PluginChannelRegistration,
 ) => TValue | undefined;
 
+const CACHE_MISS = Symbol("channel-registry-loader-cache-miss");
+
+type ChannelRegistryLoaderCacheValue<TValue> = TValue | typeof CACHE_MISS;
+
 export function createChannelRegistryLoader<TValue>(
   resolveValue: ChannelRegistryValueResolver<TValue>,
 ): (id: ChannelId) => Promise<TValue | undefined> {
-  const cache = new Map<ChannelId, TValue>();
+  const cache = new Map<ChannelId, ChannelRegistryLoaderCacheValue<TValue>>();
   let lastRegistry: PluginRegistry | null = null;
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
@@ -18,18 +22,20 @@ export function createChannelRegistryLoader<TValue>(
       cache.clear();
       lastRegistry = registry;
     }
+
     const cached = cache.get(id);
-    if (cached) {
-      return cached;
+    if (cached !== undefined) {
+      return cached === CACHE_MISS ? undefined : cached;
     }
+
     const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
     if (!pluginEntry) {
+      cache.set(id, CACHE_MISS);
       return undefined;
     }
+
     const resolved = resolveValue(pluginEntry);
-    if (resolved) {
-      cache.set(id, resolved);
-    }
+    cache.set(id, resolved === undefined ? CACHE_MISS : resolved);
     return resolved;
   };
 }


### PR DESCRIPTION
## Summary
- memoize channel-registry loader misses with an internal sentinel
- cache `undefined` and other falsey resolver outputs so repeated lookups do not rescan the plugin registry
- add targeted tests for undefined, falsey, and missing-id caching behavior

## Why
`createChannelRegistryLoader` only cached truthy values. On hot paths this caused repeated `Array.find` scans for missing channels or plugins whose resolved value is falsey/undefined.

## Risk
Low. Cache invalidation behavior is unchanged (cache clears when active registry reference changes). Tests cover the new caching semantics.
