### PR TITLE
Fix: render TUI chat events for canonical session-key aliases

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -193,6 +193,23 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.startTool).toHaveBeenCalledWith("tc1", "exec", undefined);
   });
 
+  it("accepts chat events when canonical and legacy main session keys are equivalent", () => {
+    const { state, chatLog, handleChatEvent, tui } = createHandlersHarness({
+      state: { currentSessionKey: "agent:main:main", activeChatRunId: null },
+    });
+
+    handleChatEvent({
+      runId: "run-alias",
+      sessionKey: "main",
+      state: "delta",
+      message: { content: "hello" },
+    });
+
+    expect(state.activeChatRunId).toBe("run-alias");
+    expect(chatLog.updateAssistant).toHaveBeenCalledWith("hello", "run-alias");
+    expect(tui.requestRender).toHaveBeenCalled();
+  });
+
   it("clears run mapping when the session changes", () => {
     const { state, chatLog, tui, handleChatEvent, handleAgentEvent } = createHandlersHarness({
       state: { activeChatRunId: null },

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,3 +1,4 @@
+import { parseAgentSessionKey } from "../routing/session-key.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
@@ -87,6 +88,26 @@ export function createEventHandlers(context: EventHandlerContext) {
     pruneRunMap(sessionRuns);
   };
 
+  const isSessionMatch = (sessionKey: string) => {
+    const current = state.currentSessionKey.trim().toLowerCase();
+    const incoming = sessionKey.trim().toLowerCase();
+    if (current === incoming) {
+      return true;
+    }
+    const currentParsed = parseAgentSessionKey(current);
+    const incomingParsed = parseAgentSessionKey(incoming);
+    if (!currentParsed) {
+      return false;
+    }
+    if (incomingParsed) {
+      return (
+        incomingParsed.agentId === currentParsed.agentId &&
+        incomingParsed.rest === currentParsed.rest
+      );
+    }
+    return currentParsed.rest === incoming;
+  };
+
   const noteFinalizedRun = (runId: string) => {
     finalizedRuns.set(runId, Date.now());
     sessionRuns.delete(runId);
@@ -152,7 +173,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     const evt = payload as ChatEvent;
     syncSessionKey();
-    if (evt.sessionKey !== state.currentSessionKey) {
+    if (!isSessionMatch(evt.sessionKey)) {
       return;
     }
     if (finalizedRuns.has(evt.runId)) {


### PR DESCRIPTION
## Summary
- Normalize TUI chat-event session matching so canonical session-key aliases are treated as equivalent during render filtering.
- Keep active-run and stream handling unchanged while ensuring assistant events are rendered for alias-equivalent sessions.
- Add regression coverage for canonical vs legacy session-key alias matching in TUI event handlers.

## Security Impact
- N/A (no auth, permission, or trust-boundary changes)

## Repro+Verification
- Reproduced with events emitted under alias-equivalent session keys where UI previously dropped assistant messages.
- Verified assistant messages now render when session keys are canonical aliases of the same session.
- Confirmed no behavior change for non-matching sessions.

## Testing
- `pnpm test src/tui/tui-event-handlers.test.ts`

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35523