### PR TITLE
Fix: pass session key for direct agent message:sent hooks

### DIFF
--- a/src/commands/agent.delivery.test.ts
+++ b/src/commands/agent.delivery.test.ts
@@ -260,6 +260,31 @@ describe("deliverAgentCommandResult", () => {
     );
   });
 
+  it("passes session key from opts to mirror when delivering direct agent responses", async () => {
+    await runDelivery({
+      opts: {
+        message: "hello",
+        deliver: true,
+        channel: "whatsapp",
+        to: "+15551234567",
+        sessionKey: "agent:main:main",
+      },
+      outboundSession: {
+        agentId: "main",
+      },
+      resultText: "ok",
+    });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mirror: expect.objectContaining({
+          sessionKey: "agent:main:main",
+          agentId: "main",
+        }),
+      }),
+    );
+  });
+
   it("prefixes nested agent outputs with context", async () => {
     const runtime = createRuntime();
     await runDelivery({

--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -212,6 +212,17 @@ export async function deliverAgentCommandResult(params: {
     }
     runtime.log(output);
   };
+  const mirrorPayloadText = deliveryPayloads
+    .map((payload) => payload.text)
+    .filter(Boolean)
+    .join("\n");
+  const mirrorPayloadMedia = [
+    ...new Set(
+      deliveryPayloads.flatMap((payload) =>
+        (payload.mediaUrls ?? []).filter((url): url is string => url.trim().length > 0),
+      ),
+    ),
+  ];
   if (!deliver) {
     for (const payload of deliveryPayloads) {
       logPayload(payload);
@@ -232,6 +243,15 @@ export async function deliverAgentCommandResult(params: {
         onError: (err) => logDeliveryError(err),
         onPayload: logPayload,
         deps: createOutboundSendDeps(deps),
+        mirror:
+          effectiveSessionKey && effectiveSessionKey.trim()
+            ? {
+                sessionKey: effectiveSessionKey,
+                agentId: outboundSession?.agentId,
+                text: mirrorPayloadText || undefined,
+                mediaUrls: mirrorPayloadMedia.length ? mirrorPayloadMedia : undefined,
+              }
+            : undefined,
       });
     }
   }


### PR DESCRIPTION
## Summary
- Propagate effective session key for direct agent deliveries so outbound mirror metadata includes the session key required by `message:sent` hooks.
- Use outbound session context (or command session fallback) to prevent hook skips on direct responses.
- Add regression coverage for direct-delivery hook invocation with session-key propagation.

## Security Impact
- N/A (event metadata propagation only)

## Repro+Verification
- Reproduced direct agent responses where `message:sent` hooks did not fire because session key metadata was missing.
- Verified direct responses now include session key metadata and hooks execute as expected.
- Confirmed existing outbound delivery flow remains intact.

## Testing
- `pnpm test src/commands/agent.delivery.test.ts src/infra/outbound/deliver.test.ts`

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35557