### PR TITLE
fix(memory): enable WAL journal mode for SQLite memory index

### DIFF
--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -258,7 +258,10 @@ export abstract class MemoryManagerSyncOps {
     const dir = path.dirname(dbPath);
     ensureDir(dir);
     const { DatabaseSync } = requireNodeSqlite();
-    return new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    const db = new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    db.exec("PRAGMA journal_mode = WAL");
+    db.exec("PRAGMA synchronous = NORMAL");
+    return db;
   }
 
   private seedEmbeddingCache(sourceDb: DatabaseSync): void {


### PR DESCRIPTION
## Summary

- **Problem:** Memory index SQLite database uses the default `journal_mode=delete`, which can corrupt the DB when the gateway receives SIGTERM during writes (journal removed before write completion). Users see `database disk image is malformed` and must manually `rm + openclaw memory index` to recover.
- **Why it matters:** Data loss in memory index requires manual recovery and re-indexing.
- **What changed:** `src/memory/manager-sync-ops.ts` — `openDatabaseAtPath()` now sets `PRAGMA journal_mode = WAL` and `PRAGMA synchronous = NORMAL` immediately after opening the database connection.
- **What did NOT change:** Read-only QMD manager path (`qmd-manager.ts`) is unmodified — read-only connections automatically benefit from WAL. File swap logic (`moveIndexFiles`, `removeIndexFiles`) already handles `-wal`/`-shm` suffixes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36035

## User-visible / Behavior Changes

- Memory index database now uses WAL journal mode, which is crash-safe under SIGTERM.
- Write throughput improves slightly with `synchronous=NORMAL`.
- Two additional files (`-wal`, `-shm`) may appear alongside the `.sqlite` file (already handled by existing cleanup logic).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+
- Integration/channel: N/A (memory subsystem)

### Steps

1. Start gateway with memory indexing enabled
2. Send several messages to build memory index
3. Kill gateway with SIGTERM during active write
4. Restart gateway and check memory search

### Expected

- Memory index intact after SIGTERM during writes

### Actual

- Before fix: `database disk image is malformed` if SIGTERM hits during journal delete phase
- After fix: WAL ensures atomic commits; database remains consistent

## Evidence

```typescript
// src/memory/manager-sync-ops.ts — openDatabaseAtPath()
const db = new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
db.exec("PRAGMA journal_mode = WAL");
db.exec("PRAGMA synchronous = NORMAL");
return db;
```

Existing WAL file handling already in place:
```typescript
// moveIndexFiles() and removeIndexFiles()
const suffixes = ["", "-wal", "-shm"];
```

## Human Verification (required)

- Verified scenarios: TypeScript compilation passes (`npx tsc --noEmit`), existing test suite passes
- Edge cases checked: Read-only QMD path inherits WAL from writer; reindex swap already handles `-wal`/`-shm` files
- What I did **not** verify: Manual SIGTERM-during-write crash test (requires persistent storage setup)

## Compatibility / Migration

- Backward compatible? `Yes` — SQLite transparently migrates from `delete` to `WAL` on first `PRAGMA journal_mode = WAL`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; database reverts to `delete` mode on next open
- Files/config to restore: None
- Known bad symptoms: None expected

## Risks and Mitigations

- WAL mode creates `-wal` and `-shm` sidecar files — already handled by `moveIndexFiles()` and `removeIndexFiles()`
- `synchronous=NORMAL` trades a small durability window (OS crash, not process crash) for better write throughput — acceptable for a memory index that can be rebuilt

