### PR TITLE
Config: accept channels.signal.accountUuid in strict schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
+- Config/Signal schema parity: accept `channels.signal.accountUuid` in strict config validation so loop-protection UUID settings no longer fail with unknown-key errors. (#35601)
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.
 - Agents/xAI tool-call argument decoding: decode HTML-entity encoded xAI/Grok tool-call argument values (`&amp;`, `&quot;`, `&lt;`, `&gt;`, numeric entities) before tool execution so commands with shell operators and quotes no longer fail with parse errors. (#35276) Thanks @Sid-Qin.

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -184,4 +184,18 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it("accepts channels.signal.accountUuid for loop protection", () => {
+    const res = validateConfigObject({
+      channels: {
+        signal: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          accountUuid: "00000000-0000-4000-8000-000000000000",
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -927,6 +927,7 @@ export const SignalAccountSchemaBase = z
     enabled: z.boolean().optional(),
     configWrites: z.boolean().optional(),
     account: z.string().optional(),
+    accountUuid: z.string().optional(),
     httpUrl: z.string().optional(),
     httpHost: z.string().optional(),
     httpPort: z.number().int().positive().optional(),


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `channels.signal.accountUuid` is present in runtime/types but missing from strict Signal config schema.
- Why it matters: valid loop-protection configs are rejected as unknown keys.
- What changed: added `accountUuid` to `SignalAccountSchemaBase` and added a regression test in `config.schema-regressions.test.ts`.
- What did NOT change (scope boundary): no runtime behavior changes in Signal message handling; schema acceptance only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35601
- Related #35577

## User-visible / Behavior Changes

- Configs that set `channels.signal.accountUuid` now validate successfully.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Signal config schema
- Relevant config (redacted): `channels.signal.accountUuid: <uuid>`

### Steps

1. Set `channels.signal.accountUuid` in config.
2. Validate config through `validateConfigObject` test path.
3. Confirm validation succeeds.

### Expected

- Signal config with `accountUuid` is accepted.

### Actual

- Verified accepted after fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm vitest run src/config/config.schema-regressions.test.ts`
  - `pnpm oxfmt --check src/config/zod-schema.providers-core.ts src/config/config.schema-regressions.test.ts CHANGELOG.md`
  - `pnpm oxlint src/config/zod-schema.providers-core.ts src/config/config.schema-regressions.test.ts`
- Edge cases checked:
  - Existing Signal schema keys remain unchanged; only additive optional key.
- What you did **not** verify:
  - End-to-end Signal transport runtime (not needed for schema-only fix).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/config/zod-schema.providers-core.ts`
  - `src/config/config.schema-regressions.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected validation acceptance/rejection changes for Signal config keys.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Over-accepting a misspelled field near `account`.
  - Mitigation:
    - Key is explicitly named `accountUuid` and covered by regression test.
