### PR TITLE
Fix: cron isolated sessions run in sandboxed run session context

### DIFF
--- a/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
+++ b/src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts
@@ -402,7 +402,7 @@ describe("runCronIsolatedAgentTurn", () => {
         workspaceDir?: string;
         sessionFile?: string;
       };
-      expect(call?.sessionKey).toBe("agent:ops:cron:job-ops");
+      expect(call?.sessionKey).toMatch(/^agent:ops:cron:job-ops:run:/);
       expect(call?.workspaceDir).toBe(opsWorkspace);
       expect(call?.sessionFile).toContain(path.join("agents", "ops"));
     });
@@ -628,12 +628,18 @@ describe("runCronIsolatedAgentTurn", () => {
       const first = (await runPingTurn()).res;
 
       const second = (await runPingTurn()).res;
+      const calls = vi.mocked(runEmbeddedPiAgent).mock.calls;
+      const firstCall = calls[0]?.[0] as { sessionKey?: string } | undefined;
+      const secondCall = calls.at(-1)?.[0] as { sessionKey?: string } | undefined;
 
       expect(first.sessionId).toBeDefined();
       expect(second.sessionId).toBeDefined();
       expect(second.sessionId).not.toBe(first.sessionId);
       expect(first.sessionKey).toMatch(/^agent:main:cron:job-1:run:/);
       expect(second.sessionKey).toMatch(/^agent:main:cron:job-1:run:/);
+      expect(firstCall?.sessionKey).toMatch(/^agent:main:cron:job-1:run:/);
+      expect(secondCall?.sessionKey).toMatch(/^agent:main:cron:job-1:run:/);
+      expect(secondCall?.sessionKey).not.toBe(firstCall?.sessionKey);
       expect(second.sessionKey).not.toBe(first.sessionKey);
     });
   });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -478,7 +478,7 @@ export async function runCronIsolatedAgentTurn(params: {
             : getCliSessionId(cronSession.sessionEntry, providerOverride);
           const result = await runCliAgent({
             sessionId: cronSession.sessionEntry.sessionId,
-            sessionKey: agentSessionKey,
+            sessionKey: runSessionKey,
             agentId,
             sessionFile,
             workspaceDir,
@@ -500,7 +500,7 @@ export async function runCronIsolatedAgentTurn(params: {
         }
         const result = await runEmbeddedPiAgent({
           sessionId: cronSession.sessionEntry.sessionId,
-          sessionKey: agentSessionKey,
+          sessionKey: runSessionKey,
           agentId,
           trigger: "cron",
           messageChannel,


### PR DESCRIPTION

## Summary
- Fix issue #35636: cron isolated sessions run on gateway host instead of Docker sandbox
- Root cause: cron isolated execution was passing agentSessionKey instead of runSessionKey to runEmbeddedPiAgent
- Fixed by passing runSessionKey (the agent:...:run:<id> value) which aligns with sandbox/container keying

## Security Impact
- N/A

## Repro+Verification
- Configure agents.defaults.sandbox.mode: "all" with custom Docker image
- Add isolated cron job with --session isolated
- Verify Docker container is created for cron job execution
- Exec should run inside container with full output capture

## Testing
- pnpm test src/cron/isolated-agent.subagent-model.test.ts - passed
- pnpm test src/cron/isolated-agent.uses-last-non-empty-agent-text-as.test.ts - passed

## AI Assisted
- AI assisted (Codex)

## Fixes
- Fixes #35636
