### PR TITLE
fix(agents): guard null stream result after LLM timeout

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -340,6 +340,27 @@ export function resolveOllamaBaseUrlForRun(params: {
   return OLLAMA_NATIVE_BASE_URL;
 }
 
+/**
+ * When the LLM request times out or the stream ends without a result, the
+ * underlying EventStream resolves with `undefined`.  Downstream code
+ * (pi-agent-core) expects a valid AssistantMessage object and will call
+ * Object.keys / Object.entries on it — throwing "Cannot convert undefined or
+ * null to object" if it is null.  Return a minimal error-typed message instead.
+ */
+function toTimeoutFallbackMessage(): ReturnType<ReturnType<typeof streamSimple>["result"]> extends Promise<infer R> ? R : never {
+  return {
+    role: "assistant",
+    content: [],
+    stopReason: "error",
+    errorMessage: "LLM request timed out or returned no result.",
+    usage: { input: 0, output: 0 },
+    api: "",
+    provider: "",
+    model: "",
+    timestamp: Date.now(),
+  } as never;
+}
+
 function trimWhitespaceFromToolCallNamesInMessage(
   message: unknown,
   allowedToolNames?: Set<string>,
@@ -374,6 +395,9 @@ function wrapStreamTrimToolCallNames(
   const originalResult = stream.result.bind(stream);
   stream.result = async () => {
     const message = await originalResult();
+    if (message == null) {
+      return toTimeoutFallbackMessage();
+    }
     trimWhitespaceFromToolCallNamesInMessage(message, allowedToolNames);
     return message;
   };
@@ -485,6 +509,9 @@ function wrapStreamDecodeXaiToolCallArguments(
   const originalResult = stream.result.bind(stream);
   stream.result = async () => {
     const message = await originalResult();
+    if (message == null) {
+      return toTimeoutFallbackMessage();
+    }
     decodeXaiToolCallArgumentsInMessage(message);
     return message;
   };


### PR DESCRIPTION
## Summary

- **Problem:** After a 10-minute LLM timeout, the stream result resolves with `undefined`. The stream result wrappers (`wrapStreamTrimToolCallNames`, `wrapStreamDecodeXaiToolCallArguments`) pass this `null`/`undefined` through to pi-agent-core, which calls `Object.keys()` on it and throws `Cannot convert undefined or null to object`.
- **Why it matters:** Unhandled crash with a cryptic JS error instead of a clear timeout message.
- **What changed:** `src/agents/pi-embedded-runner/run/attempt.ts` — added null checks in both stream result wrappers and a `toTimeoutFallbackMessage()` helper that returns a minimal `AssistantMessage` with `stopReason: "error"` and a clear error message.
- **What did NOT change:** The underlying stream/timeout behavior in pi-ai; only the result wrapper layer is guarded.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35827

## User-visible / Behavior Changes

- LLM timeout now produces a clear error message (`LLM request timed out or returned no result.`) instead of crashing with `Cannot convert undefined or null to object`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+
- Integration/channel: Any channel that uses embedded agent

### Steps

1. Configure an LLM with a slow or unreachable endpoint
2. Send a message that triggers a 10-minute timeout
3. Observe the error message

### Expected

- Clear error: "LLM request timed out or returned no result."

### Actual

- Before fix: `Cannot convert undefined or null to object` crash
- After fix: Graceful error with `stopReason: "error"` in the AssistantMessage

## Evidence

```typescript
// wrapStreamTrimToolCallNames — before:
stream.result = async () => {
  const message = await originalResult();
  trimWhitespaceFromToolCallNamesInMessage(message, allowedToolNames);
  return message;  // null if timeout → crash downstream
};

// after:
stream.result = async () => {
  const message = await originalResult();
  if (message == null) {
    return toTimeoutFallbackMessage();
  }
  trimWhitespaceFromToolCallNamesInMessage(message, allowedToolNames);
  return message;
};
```

Same guard added to `wrapStreamDecodeXaiToolCallArguments`.

## Human Verification (required)

- Verified scenarios: TypeScript compilation passes, both wrappers guarded
- Edge cases checked: `null` and `undefined` both handled via `== null`; fallback message has all required AssistantMessage fields
- What I did **not** verify: End-to-end timeout test (requires slow LLM endpoint)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: None
- Known bad symptoms: None expected

## Risks and Mitigations

- The fallback message uses empty strings for `api`/`provider`/`model` since the actual values are unknown after timeout — this is safe because the error stopReason prevents further processing of these fields

