### PR TITLE
test(voice): add local continuous voice smoke harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -324,6 +324,7 @@
     "test:perf:hotspots": "node scripts/test-hotspots.mjs",
     "test:sectriage": "pnpm exec vitest run --config vitest.gateway.config.ts && vitest run --config vitest.unit.config.ts --exclude src/daemon/launchd.integration.test.ts --exclude src/process/exec.test.ts",
     "test:ui": "pnpm lint:ui:no-raw-window-open && pnpm --dir ui test",
+    "test:voice:continuous:local": "bash scripts/test-continuous-voice-local.sh",
     "test:voicecall:closedloop": "vitest run extensions/voice-call/src/manager.test.ts extensions/voice-call/src/media-stream.test.ts src/plugins/voice-call.plugin.test.ts --maxWorkers=1",
     "test:watch": "vitest",
     "tui": "node scripts/run-node.mjs tui",

--- a/scripts/test-continuous-voice-local.sh
+++ b/scripts/test-continuous-voice-local.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Local continuous-voice verification harness.
+# Focus: talk/voice configuration + closed-loop voice-call path.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[voice-smoke] running talk config + closed-loop voice tests"
+pnpm exec vitest run \
+  src/config/talk.normalize.test.ts \
+  src/config/config.talk-api-key-fallback.test.ts \
+  src/gateway/server.talk-config.test.ts \
+  src/gateway/server.models-voicewake-misc.test.ts \
+  --maxWorkers=1
+
+echo "[voice-smoke] running voice call closed-loop tests"
+pnpm run -s test:voicecall:closedloop
+
+echo "[voice-smoke] PASS"


### PR DESCRIPTION
## Summary
- add a dedicated `scripts/test-continuous-voice-local.sh` harness for continuous voice validation
- run talk config + voice call closed-loop suites in one command
- expose the harness via `pnpm test:voice:continuous:local`

## Why
This makes it easy to run the exact self-test flow for local continuous voice work before/after changes.

## Validation
- `pnpm run -s test:voice:continuous:local`
  - 4 talk/config test files passed (21 tests)
  - 3 voice-call closed-loop files passed (25 tests)
