### PR TITLE
fix(matrix): retry on M_LIMIT_EXCEEDED to prevent message loss

### DIFF
--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -1,4 +1,4 @@
-import { resolveMatrixRoomId, sendMessageMatrix } from "../send.js";
+import { resolveMatrixRoomId, sendMessageMatrix, sendWithRateLimitRetry } from "../send.js";
 import { resolveActionClient } from "./client.js";
 import { resolveMatrixActionLimit } from "./limits.js";
 import { summarizeMatrixRawEvent } from "./summary.js";
@@ -56,7 +56,9 @@ export async function editMatrixMessage(
         event_id: messageId,
       },
     };
-    const eventId = await client.sendMessage(resolvedRoom, payload);
+    const eventId = await sendWithRateLimitRetry(() =>
+      client.sendMessage(resolvedRoom, payload),
+    );
     return { eventId: eventId ?? null };
   } finally {
     if (stopOnDone) {

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -324,3 +324,42 @@ describe("resolveMediaMaxBytes cfg threading", () => {
     expect(runtimeLoadConfigMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("sendWithRateLimitRetry", () => {
+  it("retries on M_LIMIT_EXCEEDED and succeeds", async () => {
+    const { sendWithRateLimitRetry } = await import("./send.js");
+    let attempt = 0;
+    const fn = async () => {
+      attempt++;
+      if (attempt === 1) {
+        const err: Record<string, unknown> = new Error("rate limited");
+        err.errcode = "M_LIMIT_EXCEEDED";
+        err.retry_after_ms = 10;
+        throw err;
+      }
+      return "ok";
+    };
+    const result = await sendWithRateLimitRetry(fn);
+    expect(result).toBe("ok");
+    expect(attempt).toBe(2);
+  });
+
+  it("throws non-rate-limit errors immediately", async () => {
+    const { sendWithRateLimitRetry } = await import("./send.js");
+    const fn = async () => {
+      throw new Error("network down");
+    };
+    await expect(sendWithRateLimitRetry(fn)).rejects.toThrow("network down");
+  });
+
+  it("throws after max retries", async () => {
+    const { sendWithRateLimitRetry } = await import("./send.js");
+    const fn = async () => {
+      const err: Record<string, unknown> = new Error("rate limited");
+      err.errcode = "M_LIMIT_EXCEEDED";
+      err.retry_after_ms = 10;
+      throw err;
+    };
+    await expect(sendWithRateLimitRetry(fn)).rejects.toThrow("rate limited");
+  });
+});

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -29,7 +29,49 @@ import {
 } from "./send/types.js";
 
 const MATRIX_TEXT_LIMIT = 4000;
+const MATRIX_RATE_LIMIT_MAX_RETRIES = 3;
+const MATRIX_RATE_LIMIT_DEFAULT_DELAY_MS = 2000;
 const getCore = () => getMatrixRuntime();
+
+function isMatrixRateLimited(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as Record<string, unknown>;
+  const code =
+    (typeof e.errcode === "string" ? e.errcode : undefined) ??
+    (e.body && typeof e.body === "object"
+      ? (e.body as Record<string, unknown>).errcode
+      : undefined);
+  if (code === "M_LIMIT_EXCEEDED") return true;
+  const msg = typeof e.message === "string" ? e.message : "";
+  return msg.includes("M_LIMIT_EXCEEDED");
+}
+
+function extractRetryAfterMs(err: unknown): number {
+  if (!err || typeof err !== "object") return MATRIX_RATE_LIMIT_DEFAULT_DELAY_MS;
+  const e = err as Record<string, unknown>;
+  const ms =
+    (typeof e.retry_after_ms === "number" ? e.retry_after_ms : undefined) ??
+    (e.body && typeof e.body === "object"
+      ? (e.body as Record<string, unknown>).retry_after_ms
+      : undefined);
+  return typeof ms === "number" && Number.isFinite(ms) && ms > 0
+    ? ms
+    : MATRIX_RATE_LIMIT_DEFAULT_DELAY_MS;
+}
+
+export async function sendWithRateLimitRetry<T>(fn: () => Promise<T>): Promise<T> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= MATRIX_RATE_LIMIT_MAX_RETRIES || !isMatrixRateLimited(err)) {
+        throw err;
+      }
+      const delayMs = extractRetryAfterMs(err);
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+}
 
 export type { MatrixSendOpts, MatrixSendResult } from "./send/types.js";
 export { resolveMatrixRoomId } from "./send/targets.js";
@@ -75,9 +117,10 @@ export async function sendMessageMatrix(
         ? buildThreadRelation(threadId, opts.replyToId)
         : buildReplyRelation(opts.replyToId);
       const sendContent = async (content: MatrixOutboundContent) => {
-        // @vector-im/matrix-bot-sdk uses sendMessage differently
-        const eventId = await client.sendMessage(roomId, content);
-        return eventId;
+        return sendWithRateLimitRetry(async () => {
+          const eventId = await client.sendMessage(roomId, content);
+          return eventId;
+        });
       };
 
       let lastMessageId = "";
@@ -182,8 +225,9 @@ export async function sendPollMatrix(
     const pollPayload = threadId
       ? { ...pollContent, "m.relates_to": buildThreadRelation(threadId) }
       : pollContent;
-    // @vector-im/matrix-bot-sdk sendEvent returns eventId string directly
-    const eventId = await client.sendEvent(roomId, M_POLL_START, pollPayload);
+    const eventId = await sendWithRateLimitRetry(() =>
+      client.sendEvent(roomId, M_POLL_START, pollPayload),
+    );
 
     return {
       eventId: eventId ?? "unknown",
@@ -258,7 +302,9 @@ export async function reactMatrixMessage(
         key: emoji,
       },
     };
-    await resolved.sendEvent(resolvedRoom, EventType.Reaction, reaction);
+    await sendWithRateLimitRetry(() =>
+      resolved.sendEvent(resolvedRoom, EventType.Reaction, reaction),
+    );
   } finally {
     if (stopOnDone) {
       resolved.stop();


### PR DESCRIPTION
## Summary

- **Problem:** When Synapse returns `M_LIMIT_EXCEEDED` with `retry_after_ms`, the Matrix extension does not retry — the message is permanently lost and the user never receives a reply.
- **Why it matters:** Rate limiting under load causes silent message drops with no recovery path.
- **What changed:** Added `sendWithRateLimitRetry()` in `extensions/matrix/src/matrix/send.ts` that detects `M_LIMIT_EXCEEDED` (via `errcode` or error body), waits the server-specified `retry_after_ms` (default 2s), and retries up to 3 times. Applied to all outbound Matrix API calls: `sendMessage` (text/media), `sendEvent` (polls, reactions), and message edits in `actions/messages.ts`.
- **What did NOT change:** `redactEvent` (deletes) and read receipt paths — these are not user-facing content and rate limiting there is less critical.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36027

## User-visible / Behavior Changes

- Matrix messages are now retried (up to 3 times) when the homeserver returns `M_LIMIT_EXCEEDED`, preventing silent message loss.
- Retry delay respects the server's `retry_after_ms` hint.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (retries existing calls)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+
- Integration/channel: Matrix (Synapse homeserver)

### Steps

1. Configure Matrix channel with a Synapse homeserver
2. Send rapid messages to trigger rate limiting
3. Observe M_LIMIT_EXCEEDED errors

### Expected

- Messages are retried after the server-specified delay and eventually delivered

### Actual

- Before fix: Messages permanently lost on M_LIMIT_EXCEEDED
- After fix: Automatic retry with delay, messages delivered

## Evidence

```
 ✓ extensions/matrix/src/matrix/send.test.ts (12 tests) 1149ms
   ✓ sendWithRateLimitRetry > retries on M_LIMIT_EXCEEDED and succeeds
   ✓ sendWithRateLimitRetry > throws non-rate-limit errors immediately
   ✓ sendWithRateLimitRetry > throws after max retries
```

Reference implementations: MSTeams `extractRetryAfterMs()` (`extensions/msteams/src/errors.ts`), Telegram `createTelegramRetryRunner` (`src/telegram/send.ts`), Discord retry on 429 (`src/discord/api.ts`).

## Human Verification (required)

- Verified scenarios: All 12 matrix send tests pass (including 3 new retry tests), TypeScript compiles cleanly
- Edge cases checked: Non-rate-limit errors throw immediately; retry count capped at 3; `retry_after_ms` from both top-level and nested body; missing `retry_after_ms` uses 2s default
- What I did **not** verify: Live Synapse rate limiting test (requires homeserver under load)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: None
- Known bad symptoms: None expected — on failure, behavior reverts to immediate throw (pre-fix)

## Risks and Mitigations

- Retry loop adds up to ~6s delay in worst case (3 retries × 2s) — acceptable for preventing message loss
- If `retry_after_ms` is very large (e.g. 60s), the retry will block for that duration — capped by the 3-attempt limit

