### PR TITLE
Config: accept browser profile driver "openclaw"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
+- Config/browser profile driver schema: accept `browser.profiles.*.driver: "openclaw"` (while keeping legacy `"clawd"` compatibility) so modern profile configs no longer fail validation. (#35620)
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.
 - Agents/xAI tool-call argument decoding: decode HTML-entity encoded xAI/Grok tool-call argument values (`&amp;`, `&quot;`, `&lt;`, `&gt;`, numeric entities) before tool execution so commands with shell operators and quotes no longer fail with parse errors. (#35276) Thanks @Sid-Qin.

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -184,4 +184,20 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it('accepts browser profile driver "openclaw"', () => {
+    const res = validateConfigObject({
+      browser: {
+        profiles: {
+          default: {
+            cdpPort: 9222,
+            driver: "openclaw",
+            color: "#ff0000",
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -406,7 +406,7 @@ const ENUM_EXPECTATIONS: Record<string, string[]> = {
   "gateway.bind": ['"auto"', '"lan"', '"loopback"', '"custom"', '"tailnet"'],
   "gateway.auth.mode": ['"none"', '"token"', '"password"', '"trusted-proxy"'],
   "gateway.tailscale.mode": ['"off"', '"serve"', '"funnel"'],
-  "browser.profiles.*.driver": ['"clawd"', '"extension"'],
+  "browser.profiles.*.driver": ['"openclaw"', '"clawd"', '"extension"'],
   "discovery.mdns.mode": ['"off"', '"minimal"', '"full"'],
   "wizard.lastRunMode": ['"local"', '"remote"'],
   "diagnostics.otel.protocol": ['"http/protobuf"', '"grpc"'],

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -251,7 +251,7 @@ export const FIELD_HELP: Record<string, string> = {
   "browser.profiles.*.cdpUrl":
     "Per-profile CDP websocket URL used for explicit remote browser routing by profile name. Use this when profile connections terminate on remote hosts or tunnels.",
   "browser.profiles.*.driver":
-    'Per-profile browser driver mode: "clawd" or "extension" depending on connection/runtime strategy. Use the driver that matches your browser control stack to avoid protocol mismatches.',
+    'Per-profile browser driver mode: "openclaw" (legacy alias: "clawd") or "extension" depending on connection/runtime strategy. Use the driver that matches your browser control stack to avoid protocol mismatches.',
   "browser.profiles.*.attachOnly":
     "Per-profile attach-only override that skips local browser launch and only attaches to an existing CDP endpoint. Useful when one profile is externally managed but others are locally launched.",
   "browser.profiles.*.color":

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -309,7 +309,9 @@ export const OpenClawSchema = z
               .object({
                 cdpPort: z.number().int().min(1).max(65535).optional(),
                 cdpUrl: z.string().optional(),
-                driver: z.union([z.literal("clawd"), z.literal("extension")]).optional(),
+                driver: z
+                  .union([z.literal("openclaw"), z.literal("clawd"), z.literal("extension")])
+                  .optional(),
                 attachOnly: z.boolean().optional(),
                 color: HexColorSchema,
               })


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: browser profile schema allowed legacy `"clawd"` but rejected documented/default `"openclaw"` driver values.
- Why it matters: valid profile configs fail strict validation.
- What changed: schema now accepts `"openclaw"` and keeps `"clawd"` for backward compatibility; help + enum quality expectations updated; regression test added.
- What did NOT change (scope boundary): no runtime browser driver behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35620
- Related #35620

## User-visible / Behavior Changes

- `browser.profiles.*.driver: "openclaw"` now validates.
- Existing legacy `"clawd"` remains accepted.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): browser config schema
- Relevant config (redacted): `browser.profiles.default.driver: "openclaw"`

### Steps

1. Configure `browser.profiles.default.driver` as `"openclaw"`.
2. Run config validation.
3. Confirm schema accepts the profile.

### Expected

- Validation succeeds for `"openclaw"` driver.

### Actual

- Verified successful after fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm vitest run src/config/config.schema-regressions.test.ts src/config/schema.help.quality.test.ts`
  - `pnpm oxfmt --check src/config/zod-schema.ts src/config/schema.help.ts src/config/schema.help.quality.test.ts src/config/config.schema-regressions.test.ts CHANGELOG.md`
  - `pnpm oxlint src/config/zod-schema.ts src/config/schema.help.ts src/config/schema.help.quality.test.ts src/config/config.schema-regressions.test.ts`
- Edge cases checked:
  - Legacy `"clawd"` remains in accepted enum list.
- What you did **not** verify:
  - End-to-end browser launch behavior (schema/docs-only compatibility fix).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/config/zod-schema.ts`
  - `src/config/schema.help.ts`
  - `src/config/schema.help.quality.test.ts`
  - `src/config/config.schema-regressions.test.ts`
- Known bad symptoms reviewers should watch for:
  - Driver enum mismatch between schema and docs/tests.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Enum/docs drift could reappear in future edits.
  - Mitigation:
    - Added regression + enum quality test expectation updates in same change.
