### PR TITLE
Fix: stale-socket false positives in channel health monitor

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -494,9 +494,21 @@ describe("channel-health-monitor", () => {
       const manager = createSlackSnapshotManager(
         runningConnectedSlackAccount({
           lastStartAt: now - STALE_THRESHOLD - 60_000,
+          lastEventAt: now - STALE_THRESHOLD - 30_000,
         }),
       );
       await expectRestartedChannel(manager, "slack");
+    });
+
+    it("skips stale-socket restarts when only pre-lifecycle activity is known", async () => {
+      const now = Date.now();
+      const manager = createSlackSnapshotManager(
+        runningConnectedSlackAccount({
+          lastStartAt: now - STALE_THRESHOLD - 60_000,
+          lastEventAt: now - STALE_THRESHOLD - 120_000,
+        }),
+      );
+      await expectNoRestart(manager);
     });
 
     it("respects custom staleEventThresholdMs", async () => {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -105,8 +105,8 @@ describe("evaluateChannelHealth", () => {
         connected: true,
         enabled: true,
         configured: true,
-        lastStartAt: 0,
-        lastEventAt: null,
+        lastStartAt: 10_000,
+        lastEventAt: 40_000,
       },
       {
         now: 100_000,
@@ -115,6 +115,45 @@ describe("evaluateChannelHealth", () => {
       },
     );
     expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
+  });
+
+  it("ignores activity timestamps from prior lifecycle when determining stale sockets", () => {
+    const now = 100_000;
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: now - 40_000,
+        lastEventAt: now - 120_000,
+      },
+      {
+        now,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
+  it("does not flag stale when no lifecycle-safe activity is available", () => {
+    const now = 100_000;
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: now - 120_000,
+      },
+      {
+        now,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
   });
 });
 

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -3,11 +3,14 @@ export type ChannelHealthSnapshot = {
   connected?: boolean;
   enabled?: boolean;
   configured?: boolean;
+  lastMessageAt?: number | null;
   busy?: boolean;
   activeRuns?: number;
   lastRunActivityAt?: number | null;
   lastEventAt?: number | null;
   lastStartAt?: number | null;
+  lastInboundAt?: number | null;
+  lastOutboundAt?: number | null;
   reconnectAttempts?: number;
 };
 
@@ -39,6 +42,29 @@ function isManagedAccount(snapshot: ChannelHealthSnapshot): boolean {
 }
 
 const BUSY_ACTIVITY_STALE_THRESHOLD_MS = 25 * 60_000;
+
+function toTimestamp(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function latestActivityAt(snapshot: ChannelHealthSnapshot): number | null {
+  const candidates = [
+    toTimestamp(snapshot.lastEventAt),
+    toTimestamp(snapshot.lastInboundAt),
+    toTimestamp(snapshot.lastOutboundAt),
+    toTimestamp(snapshot.lastMessageAt),
+  ];
+  let latest: number | null = null;
+  for (const candidate of candidates) {
+    if (candidate == null) {
+      continue;
+    }
+    if (latest == null || candidate > latest) {
+      latest = candidate;
+    }
+  }
+  return latest;
+}
 
 export function evaluateChannelHealth(
   snapshot: ChannelHealthSnapshot,
@@ -83,8 +109,9 @@ export function evaluateChannelHealth(
       return { healthy: false, reason: "stuck" };
     }
   }
-  if (snapshot.lastStartAt != null) {
-    const upDuration = policy.now - snapshot.lastStartAt;
+  const currentStartAt = toTimestamp(snapshot.lastStartAt);
+  if (currentStartAt != null) {
+    const upDuration = policy.now - currentStartAt;
     if (upDuration < policy.channelConnectGraceMs) {
       return { healthy: true, reason: "startup-connect-grace" };
     }
@@ -92,15 +119,19 @@ export function evaluateChannelHealth(
   if (snapshot.connected === false) {
     return { healthy: false, reason: "disconnected" };
   }
-  if (snapshot.lastEventAt != null || snapshot.lastStartAt != null) {
-    const upSince = snapshot.lastStartAt ?? 0;
-    const upDuration = policy.now - upSince;
-    if (upDuration > policy.staleEventThresholdMs) {
-      const lastEvent = snapshot.lastEventAt ?? 0;
-      const eventAge = policy.now - lastEvent;
-      if (eventAge > policy.staleEventThresholdMs) {
-        return { healthy: false, reason: "stale-socket" };
-      }
+  const lastActivityAt = latestActivityAt(snapshot);
+  if (lastActivityAt == null) {
+    return { healthy: true, reason: "healthy" };
+  }
+  if (currentStartAt != null && lastActivityAt < currentStartAt) {
+    return { healthy: true, reason: "healthy" };
+  }
+  const upDuration =
+    currentStartAt == null ? Number.POSITIVE_INFINITY : policy.now - currentStartAt;
+  if (upDuration > policy.staleEventThresholdMs) {
+    const eventAge = policy.now - lastActivityAt;
+    if (eventAge > policy.staleEventThresholdMs) {
+      return { healthy: false, reason: "stale-socket" };
     }
   }
   return { healthy: true, reason: "healthy" };


### PR DESCRIPTION
## Summary
- Evaluate stale-socket status only from lifecycle-safe activity timestamps.
- Ignore activity timestamps older than current channel `startedAt` to avoid stale startup artifacts.
- Keep channels healthy when no safe per-cycle activity data is available instead of forcing stale-socket restarts.
- Add regression tests in `src/gateway/channel-health-policy.test.ts` and `src/gateway/channel-health-monitor.test.ts`.

## Security Impact
No direct security boundary changes.

## Repro+Verification
- Reproduce: restart gateway/channels with historical activity timestamps still present.
- Before fix: health monitor can classify active channels as stale-socket and restart them unnecessarily.
- After fix: stale-socket checks rely on lifecycle-safe activity only and avoid false positives.

## Testing
- `pnpm test src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts`

## AI Assisted
- Yes (Codex-assisted implementation).

## Fixes
- Fixes #34052
