### PR TITLE
Fix: register TUI as CLI mode for deliver routing

### DIFF
--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -6,7 +6,7 @@ import {
   resolveExplicitGatewayAuth,
 } from "../gateway/call.js";
 import { GatewayClient } from "../gateway/client.js";
-import { GATEWAY_CLIENT_CAPS } from "../gateway/protocol/client-info.js";
+import { GATEWAY_CLIENT_CAPS, GATEWAY_CLIENT_MODES } from "../gateway/protocol/client-info.js";
 import {
   type HelloOk,
   PROTOCOL_VERSION,
@@ -14,7 +14,7 @@ import {
   type SessionsPatchResult,
   type SessionsPatchParams,
 } from "../gateway/protocol/index.js";
-import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import { GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { VERSION } from "../version.js";
 import type { ResponseUsageMode, SessionInfo, SessionScope } from "./tui-types.js";
 
@@ -128,7 +128,7 @@ export class GatewayChatClient {
       clientDisplayName: "openclaw-tui",
       clientVersion: VERSION,
       platform: process.platform,
-      mode: GATEWAY_CLIENT_MODES.UI,
+      mode: GATEWAY_CLIENT_MODES.CLI,
       caps: [GATEWAY_CLIENT_CAPS.TOOL_EVENTS],
       instanceId: randomUUID(),
       minProtocol: PROTOCOL_VERSION,


### PR DESCRIPTION
## Summary
- Register OpenClaw TUI as CLI mode for `--deliver` flows.
- Preserve route inheritance on configured main sessions instead of forcing UI-mode behavior that defaults to webchat routing.

## Security Impact
No direct security boundary changes.

## Repro+Verification
- Reproduce: run `openclaw tui --deliver` with configured main-session external routing metadata.
- Before fix: TUI is registered as UI mode, so `chat.send` disables route inheritance and can fall back to webchat.
- After fix: TUI is registered as CLI mode, so `--deliver` inherits external routing metadata correctly.

## Testing
- Covered by PR CI checks.

## AI Assisted
- Yes (Codex-assisted implementation).

## Fixes
- Fixes #36088
