### PR TITLE
fix(gateway): allow TUI --deliver routing on main sessions

### DIFF
--- a/extensions/mattermost/src/group-mentions.test.ts
+++ b/extensions/mattermost/src/group-mentions.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it } from "vitest";
 import { resolveMattermostGroupRequireMention } from "./group-mentions.js";
 

--- a/extensions/mattermost/src/group-mentions.ts
+++ b/extensions/mattermost/src/group-mentions.ts
@@ -1,4 +1,5 @@
-import { resolveChannelGroupRequireMention, type ChannelGroupContext } from "openclaw/plugin-sdk";
+import { resolveChannelGroupRequireMention } from "openclaw/plugin-sdk/compat";
+import type { ChannelGroupContext } from "openclaw/plugin-sdk/mattermost";
 import { resolveMattermostAccount } from "./mattermost/accounts.js";
 
 export function resolveMattermostGroupRequireMention(

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it, vi } from "vitest";
 import { resolveMattermostAccount } from "./accounts.js";
 import {

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MsgContext } from "../../auto-reply/templating.js";
-import { GATEWAY_CLIENT_CAPS, GATEWAY_CLIENT_MODES } from "../protocol/client-info.js";
+import {
+  GATEWAY_CLIENT_CAPS,
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+} from "../protocol/client-info.js";
 import type { GatewayRequestContext } from "./types.js";
 
 const mockState = vi.hoisted(() => ({
@@ -608,6 +612,50 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         OriginatingChannel: "webchat",
         OriginatingTo: undefined,
         AccountId: undefined,
+      }),
+    );
+  });
+
+  it("chat.send allows TUI deliver on configured main sessions", async () => {
+    createTranscriptFixture("openclaw-chat-send-main-tui-routes-");
+    mockState.mainSessionKey = "main";
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "telegram",
+        to: "telegram:6812765697",
+        accountId: "default",
+      },
+      lastChannel: "telegram",
+      lastTo: "telegram:6812765697",
+      lastAccountId: "default",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-main-tui-routes",
+      client: {
+        connect: {
+          client: {
+            mode: GATEWAY_CLIENT_MODES.UI,
+            id: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+            displayName: "openclaw-tui",
+          },
+        },
+      } as unknown,
+      sessionKey: "agent:main:main",
+      deliver: true,
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        OriginatingChannel: "telegram",
+        OriginatingTo: "telegram:6812765697",
+        AccountId: "default",
       }),
     );
   });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -34,8 +34,10 @@ import { type ChatImageContent, parseMessageWithAttachments } from "../chat-atta
 import { stripEnvelopeFromMessage, stripEnvelopeFromMessages } from "../chat-sanitize.js";
 import {
   GATEWAY_CLIENT_CAPS,
+  GATEWAY_CLIENT_NAMES,
   GATEWAY_CLIENT_MODES,
   hasGatewayClientCap,
+  normalizeGatewayClientName,
 } from "../protocol/client-info.js";
 import {
   ErrorCodes,
@@ -891,14 +893,20 @@ export const chatHandlers: GatewayRequestHandlers = {
         typeof sessionScopeParts[1] === "string" &&
         sessionChannelHint === routeChannelCandidate;
       const clientMode = client?.connect?.client?.mode;
+      const clientId = normalizeGatewayClientName(clientInfo?.id);
+      const isTuiClient =
+        clientId === GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT &&
+        (clientInfo?.displayName ?? "").trim().toLowerCase() === "openclaw-tui";
       const isFromWebchatClient =
-        isWebchatClient(client?.connect?.client) || clientMode === GATEWAY_CLIENT_MODES.UI;
+        isWebchatClient(client?.connect?.client) ||
+        (clientMode === GATEWAY_CLIENT_MODES.UI && !isTuiClient);
       const configuredMainKey = (cfg.session?.mainKey ?? "main").trim().toLowerCase();
       const isConfiguredMainSessionScope =
         normalizedSessionScopeHead.length > 0 && normalizedSessionScopeHead === configuredMainKey;
       // Channel-agnostic session scopes (main, direct:<peer>, etc.) can leak
       // stale routes across surfaces. Allow configured main sessions from
-      // non-Webchat/UI clients (e.g., CLI, backend) to keep the last external route.
+      // non-Webchat clients (including TUI, CLI, backend) to keep the last
+      // external route.
       const canInheritDeliverableRoute = Boolean(
         sessionChannelHint &&
         sessionChannelHint !== INTERNAL_MESSAGE_CHANNEL &&


### PR DESCRIPTION
## Summary
- treat `openclaw-tui` (`gateway-client` in `mode=ui`) as a non-webchat surface for configured main-session route inheritance
- keep webchat/control UI behavior unchanged
- add a regression test proving TUI `--deliver` on `agent:main:main` keeps external routing metadata

## Testing
- `pnpm test src/gateway/server-methods/chat.directive-tags.test.ts`
- `pnpm test src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts`

Fixes #36088
