### PR TITLE
Config: add missing Discord autoThread channel typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
+- Config/Discord type parity: add missing `autoThread` to `DiscordGuildChannelConfig` typings so channel config types match runtime/schema behavior and no longer require local shadow typings. (#35607)
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.
 - Agents/xAI tool-call argument decoding: decode HTML-entity encoded xAI/Grok tool-call argument values (`&amp;`, `&quot;`, `&lt;`, `&gt;`, numeric entities) before tool execution so commands with shell operators and quotes no longer fail with parse errors. (#35276) Thanks @Sid-Qin.

--- a/src/config/config.discord.test.ts
+++ b/src/config/config.discord.test.ts
@@ -36,7 +36,7 @@ describe("config discord", () => {
                 requireMention: false,
                 users: ["steipete"],
                 channels: {
-                  general: { allow: true },
+                  general: { allow: true, autoThread: true },
                 },
               },
             },
@@ -54,6 +54,7 @@ describe("config discord", () => {
         expect(cfg.channels?.discord?.actions?.channels).toBe(true);
         expect(cfg.channels?.discord?.guilds?.["123"]?.slug).toBe("friends-of-openclaw");
         expect(cfg.channels?.discord?.guilds?.["123"]?.channels?.general?.allow).toBe(true);
+        expect(cfg.channels?.discord?.guilds?.["123"]?.channels?.general?.autoThread).toBe(true);
       },
     );
   });

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -52,6 +52,8 @@ export type DiscordGuildChannelConfig = {
   systemPrompt?: string;
   /** If false, omit thread starter context for this channel (default: true). */
   includeThreadStarter?: boolean;
+  /** If true, auto-create thread responses for guild channel messages (default: false). */
+  autoThread?: boolean;
 };
 
 export type DiscordReactionNotificationMode = "off" | "own" | "all" | "allowlist";


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `DiscordGuildChannelConfig` type missed `autoThread`, while schema/runtime already support it.
- Why it matters: type/schema drift forces local shadow typings and weakens type safety.
- What changed: added `autoThread?: boolean` to canonical config type and asserted it in config loading test.
- What did NOT change (scope boundary): no runtime Discord logic change; typing parity only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35607
- Related #35607

## User-visible / Behavior Changes

- No direct runtime behavior change; improves config type parity and developer-facing type safety.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Discord config typing
- Relevant config (redacted): `channels.discord.guilds.*.channels.*.autoThread: true`

### Steps

1. Load Discord config containing `autoThread` channel override.
2. Verify load path returns typed `autoThread` value.
3. Run targeted test suite.

### Expected

- `autoThread` is available on canonical typed channel config.

### Actual

- Verified through typed config load assertions.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm vitest run src/config/config.discord.test.ts`
  - `pnpm oxfmt --check src/config/types.discord.ts src/config/config.discord.test.ts CHANGELOG.md`
  - `pnpm oxlint src/config/types.discord.ts src/config/config.discord.test.ts`
- Edge cases checked:
  - Existing `allow` channel config behavior unchanged.
- What you did **not** verify:
  - End-to-end Discord thread creation behavior (already covered elsewhere; no runtime changes here).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/config/types.discord.ts`
  - `src/config/config.discord.test.ts`
- Known bad symptoms reviewers should watch for:
  - Type-check failures around Discord channel config shape.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Narrow type-level drift could reappear in future schema-only edits.
  - Mitigation:
    - Added typed config assertion in existing Discord config tests.
