### PR TITLE
fix(daemon): handle generic systemctl is-enabled failures

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -138,6 +138,19 @@ describe("isSystemdServiceEnabled", () => {
     const result = await isSystemdServiceEnabled({ env: {} });
     expect(result).toBe(false);
   });
+
+  it("returns false when exec fallback only provides generic command-failed detail", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error(
+        "Command failed: systemctl --user is-enabled openclaw-gateway.service",
+      ) as Error & { code?: number };
+      err.code = 1;
+      cb(err, "", "");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
 });
 
 describe("systemd runtime parsing", () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -179,6 +179,18 @@ function isSystemdUnitNotEnabled(detail: string): boolean {
   );
 }
 
+function isGenericSystemctlIsEnabledFailure(detail: string, unitName: string): boolean {
+  if (!detail) {
+    return false;
+  }
+  const normalized = detail.toLowerCase();
+  return (
+    normalized.startsWith("command failed: systemctl ") &&
+    normalized.includes(" is-enabled ") &&
+    normalized.includes(unitName.toLowerCase())
+  );
+}
+
 function resolveSystemctlDirectUserScopeArgs(): string[] {
   return ["--user"];
 }
@@ -430,7 +442,11 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
     return true;
   }
   const detail = readSystemctlDetail(res);
-  if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
+  if (
+    isSystemctlMissing(detail) ||
+    isSystemdUnitNotEnabled(detail) ||
+    isGenericSystemctlIsEnabledFailure(detail, unitName)
+  ) {
     return false;
   }
   throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `isSystemdServiceEnabled()` can throw `systemctl is-enabled unavailable` when `execFile` only returns a generic `Command failed: systemctl --user is-enabled ...` message (no stdout/stderr detail).
- Why it matters: users on Ubuntu 24.04 reported setup/start flows failing hard even after enabling the unit, instead of being treated as "not enabled / unknown state".
- What changed: added a narrow matcher for generic `systemctl is-enabled` command-failed fallback strings and treat this case as `false` (not enabled) instead of throwing.
- What did NOT change (scope boundary): no changes to install/uninstall/restart commands, no new systemd calls, no behavior change for explicit permission/systemctl errors.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36008
- Related #

## User-visible / Behavior Changes

- Gateway systemd status checks no longer fail hard on generic `systemctl --user is-enabled` command-failed fallback output.
- In that scenario, OpenClaw now treats service state as "not enabled" (`false`) and continues normal control flow.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (reported), local tests on Linux
- Runtime/container: Node.js + Vitest
- Model/provider: N/A
- Integration/channel (if any): systemd user service
- Relevant config (redacted): default `openclaw-gateway.service`

### Steps

1. Make `execFileUtf8("systemctl", ["--user", "is-enabled", ...])` return code `1` with no stdout/stderr and only fallback error message `Command failed: systemctl --user is-enabled ...`.
2. Call `isSystemdServiceEnabled({ env: {} })`.
3. Observe result.

### Expected

- Returns `false` (service not enabled / unavailable state), no thrown exception for this generic fallback case.

### Actual

- Before fix: throws `systemctl is-enabled unavailable: Command failed: systemctl --user is-enabled ...`.
- After fix: returns `false`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added/ran regression test for generic `Command failed: systemctl --user is-enabled ...` fallback case in `src/daemon/systemd.test.ts`.
  - Ran systemd daemon tests and related daemon/respawn tests successfully.
- Edge cases checked:
  - Existing branches still pass: code `0` => `true`, `disabled/not-found` => `false`, permission-denied path still throws.
- What you did **not** verify:
  - Did not run on a real Ubuntu host with live `systemctl` in this PR; verification is via unit/integration tests.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `7b15e1245`.
- Files/config to restore:
  - `src/daemon/systemd.ts`
  - `src/daemon/systemd.test.ts`
- Known bad symptoms reviewers should watch for:
  - If matcher is too broad, genuine `is-enabled` failures may be hidden as `false`.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Generic matcher could accidentally classify unexpected errors as "not enabled".
  - Mitigation: matcher is narrow (`Command failed: systemctl`, contains `is-enabled`, contains exact unit name); explicit error paths remain unchanged and are covered by tests.
