### PR TITLE
fix(feishu): flush dropped block text on idle for block-only turns

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -591,4 +591,45 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       }),
     );
   });
+
+  it("flushes dropped block text on idle when no final was delivered", async () => {
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    options.onReplyStart?.();
+    await options.deliver({ text: "block-only reasoning output" }, { kind: "block" });
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+
+    await options.onIdle?.();
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "block-only reasoning output" }),
+    );
+  });
+
+  it("does not flush block text when final was delivered", async () => {
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    options.onReplyStart?.();
+    await options.deliver({ text: "block chunk" }, { kind: "block" });
+    await options.deliver({ text: "final answer" }, { kind: "final" });
+
+    sendMessageFeishuMock.mockClear();
+    await options.onIdle?.();
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -146,6 +146,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const deliveredFinalTexts = new Set<string>();
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
+  let droppedBlockText = "";
+  let sawFinal = false;
   type StreamTextUpdateMode = "snapshot" | "delta";
 
   const queueStreamingUpdate = (
@@ -231,6 +233,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
       onReplyStart: () => {
         deliveredFinalTexts.clear();
+        droppedBlockText = "";
+        sawFinal = false;
         if (streamingEnabled && renderMode === "card") {
           startStreaming();
         }
@@ -246,6 +250,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               : [];
         const hasText = Boolean(text.trim());
         const hasMedia = mediaList.length > 0;
+        if (info?.kind === "final") {
+          sawFinal = true;
+        }
         const skipTextForDuplicateFinal =
           info?.kind === "final" && hasText && deliveredFinalTexts.has(text);
         const shouldDeliverText = hasText && !skipTextForDuplicateFinal;
@@ -258,9 +265,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
 
           if (info?.kind === "block") {
-            // Drop internal block chunks unless we can safely consume them as
-            // streaming-card fallback content.
             if (!(streamingEnabled && useCard)) {
+              droppedBlockText = text;
               return;
             }
             startStreaming();
@@ -370,6 +376,44 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       },
       onIdle: async () => {
         await closeStreaming();
+        if (!sawFinal && droppedBlockText.trim()) {
+          const fallbackText = droppedBlockText;
+          droppedBlockText = "";
+          const useCard =
+            renderMode === "card" || (renderMode === "auto" && shouldUseCard(fallbackText));
+          if (useCard) {
+            for (const chunk of core.channel.text.chunkTextWithMode(
+              fallbackText,
+              textChunkLimit,
+              chunkMode,
+            )) {
+              await sendMarkdownCardFeishu({
+                cfg,
+                to: chatId,
+                text: chunk,
+                replyToMessageId: sendReplyToMessageId,
+                replyInThread: effectiveReplyInThread,
+                accountId,
+              });
+            }
+          } else {
+            const converted = core.channel.text.convertMarkdownTables(fallbackText, tableMode);
+            for (const chunk of core.channel.text.chunkTextWithMode(
+              converted,
+              textChunkLimit,
+              chunkMode,
+            )) {
+              await sendMessageFeishu({
+                cfg,
+                to: chatId,
+                text: chunk,
+                replyToMessageId: sendReplyToMessageId,
+                replyInThread: effectiveReplyInThread,
+                accountId,
+              });
+            }
+          }
+        }
         typingCallbacks.onIdle?.();
       },
       onCleanup: () => {


### PR DESCRIPTION
## Summary

- **Problem:** When a turn emits only `block` payloads (e.g. tool-call-only responses with reasoning text) and no `final` payload, the Feishu reply dispatcher drops all block chunks when `!(streamingEnabled && useCard)`, resulting in `queuedFinal=false, replies=0` and silent message loss.
- **Why it matters:** Users receive no reply at all for block-only turns in non-streaming/non-card mode.
- **What changed:** `extensions/feishu/src/reply-dispatcher.ts` — buffer the last dropped block text in `droppedBlockText` and flush it as a regular message in `onIdle` when no `final` payload was delivered during the turn. `extensions/feishu/src/reply-dispatcher.test.ts` — 2 new tests for the fallback behavior.
- **What did NOT change:** Streaming+card block handling path (already works); final payload delivery path; media delivery path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36033

## User-visible / Behavior Changes

- Block-only turns now deliver the last block text as a fallback message instead of dropping it silently.
- Turns with both block and final payloads are unaffected (final delivery suppresses the fallback).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+
- Integration/channel: Feishu (non-streaming or raw render mode)

### Steps

1. Configure a Feishu channel with `streaming: false` or `renderMode: "raw"`
2. Send a prompt that triggers a tool-call-only response with reasoning text
3. Observe whether the user receives a reply

### Expected

- User receives the reasoning/block text as a message

### Actual

- Before fix: `replies=0`, user receives nothing
- After fix: Block text flushed on idle as a regular message

## Evidence

```
 ✓ extensions/feishu/src/reply-dispatcher.test.ts (23 tests) 8ms
   ✓ flushes dropped block text on idle when no final was delivered
   ✓ does not flush block text when final was delivered
```

## Human Verification (required)

- Verified scenarios: All 23 Feishu dispatcher tests pass (including 2 new); TypeScript compiles cleanly
- Edge cases checked: Buffer reset on `onReplyStart` prevents stale text; `sawFinal` flag prevents double delivery when final exists; empty block text is not flushed; card vs plain text routing in fallback
- What I did **not** verify: Live Feishu channel test with block-only model response

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; block payloads return to being silently dropped
- Files/config to restore: None
- Known bad symptoms: None expected

## Risks and Mitigations

- If block text contains intermediate reasoning that shouldn't be shown to users, this could expose it — mitigated by the fact that the dispatch pipeline already filters block payloads through `normalizeReplyPayloadInternal` before they reach the dispatcher

