### PR TITLE
Fix: nested run completion routing for run-mode subagents

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -1884,11 +1884,11 @@ describe("subagent announce formatting", () => {
 
     expect(didAnnounce).toBe(true);
     const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
-    expect(call?.params?.sessionKey).toBe("agent:main:main");
-    expect(call?.params?.deliver).toBe(true);
-    expect(call?.params?.channel).toBe("whatsapp");
-    expect(call?.params?.to).toBe("+1555");
-    expect(call?.params?.accountId).toBe("acct-main");
+    expect(call?.params?.sessionKey).toBe("agent:main:subagent:orchestrator");
+    expect(call?.params?.deliver).toBe(false);
+    expect(call?.params?.channel).toBeUndefined();
+    expect(call?.params?.to).toBeUndefined();
+    expect(call?.params?.accountId).toBeUndefined();
   });
 
   it("keeps announce retryable when ended requester subagent has no fallback requester", async () => {
@@ -1904,12 +1904,12 @@ describe("subagent announce formatting", () => {
       cleanup: "delete",
     });
 
-    expect(didAnnounce).toBe(false);
+    expect(didAnnounce).toBe(true);
     expect(subagentRegistryMock.resolveRequesterForChildSession).toHaveBeenCalledWith(
       "agent:main:subagent:orchestrator",
     );
-    expect(agentSpy).not.toHaveBeenCalled();
-    expect(sessionsDeleteSpy).not.toHaveBeenCalled();
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    expect(sessionsDeleteSpy).toHaveBeenCalledTimes(1);
   });
 
   it("defers announce when child run stays active after settle timeout", async () => {
@@ -2021,9 +2021,9 @@ describe("subagent announce formatting", () => {
             outputTokens: 10,
           },
         },
-        expectedSessionKey: "agent:main:main",
-        expectedDeliver: true,
-        expectedChannel: "discord",
+        expectedSessionKey: "agent:main:subagent:newton",
+        expectedDeliver: false,
+        expectedChannel: undefined,
       },
       {
         name: "falls back when parent sessionId is blank",
@@ -2043,9 +2043,9 @@ describe("subagent announce formatting", () => {
             outputTokens: 10,
           },
         },
-        expectedSessionKey: "agent:main:main",
-        expectedDeliver: true,
-        expectedChannel: "discord",
+        expectedSessionKey: "agent:main:subagent:newton",
+        expectedDeliver: false,
+        expectedChannel: undefined,
       },
     ] as const;
 
@@ -2075,5 +2075,82 @@ describe("subagent announce formatting", () => {
       expect(call?.params?.deliver, testCase.name).toBe(testCase.expectedDeliver);
       expect(call?.params?.channel, testCase.name).toBe(testCase.expectedChannel);
     }
+  });
+
+  it("targets ended parent subagent session even if parent store entry is missing (#36081)", async () => {
+    subagentRegistryMock.isSubagentSessionRunActive.mockReturnValue(false);
+    subagentRegistryMock.resolveRequesterForChildSession.mockReturnValue({
+      requesterSessionKey: "agent:main:main",
+      requesterOrigin: { channel: "discord", to: "channel:main", accountId: "acct-main" },
+    });
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:newton:subagent:leaf",
+      childRunId: "run-birdie-missing-parent-entry",
+      requesterSessionKey: "agent:main:subagent:newton",
+      requesterDisplayKey: "subagent:newton",
+      ...defaultOutcomeAnnounce,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(subagentRegistryMock.isSubagentSessionRunActive).toHaveBeenCalledWith(
+      "agent:main:subagent:newton",
+    );
+    expect(subagentRegistryMock.resolveRequesterForChildSession).toHaveBeenCalledWith(
+      "agent:main:subagent:newton",
+    );
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(call?.params?.sessionKey).toBe("agent:main:subagent:newton");
+    expect(call?.params?.deliver).toBe(false);
+    expect(call?.params?.channel).toBeUndefined();
+    expect(call?.params?.to).toBeUndefined();
+  });
+
+  it("falls back to the grandparent only if parent injection fails (#36081)", async () => {
+    let attempt = 0;
+    agentSpy.mockImplementation(async () => {
+      attempt += 1;
+      if (attempt === 1) {
+        throw new Error("parent injection unavailable");
+      }
+      return { runId: "run-main", status: "ok" };
+    });
+    subagentRegistryMock.isSubagentSessionRunActive.mockReturnValue(false);
+    subagentRegistryMock.resolveRequesterForChildSession.mockReturnValue({
+      requesterSessionKey: "agent:main:main",
+      requesterOrigin: { channel: "discord", to: "channel:main", accountId: "acct-main" },
+    });
+    sessionStore = {
+      "agent:main:subagent:newton": {
+        sessionId: "newton-session-id",
+        inputTokens: 100,
+        outputTokens: 50,
+      },
+      "agent:main:main": {
+        sessionId: "main-session-id",
+        lastChannel: "discord",
+        lastTo: "channel:main",
+        lastAccountId: "acct-main",
+      },
+    };
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:newton:subagent:leaf",
+      childRunId: "run-birdie-parent-fails",
+      requesterSessionKey: "agent:main:subagent:newton",
+      requesterDisplayKey: "subagent:newton",
+      ...defaultOutcomeAnnounce,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).toHaveBeenCalledTimes(2);
+    const firstCall = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    const secondCall = agentSpy.mock.calls[1]?.[0] as { params?: Record<string, unknown> };
+    expect(firstCall?.params?.sessionKey).toBe("agent:main:subagent:newton");
+    expect(firstCall?.params?.deliver).toBe(false);
+    expect(secondCall?.params?.sessionKey).toBe("agent:main:main");
+    expect(secondCall?.params?.deliver).toBe(true);
+    expect(secondCall?.params?.channel).toBe("discord");
+    expect(secondCall?.params?.to).toBe("channel:main");
   });
 });

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1136,6 +1136,10 @@ export async function runSubagentAnnounceFlow(params: {
   try {
     let targetRequesterSessionKey = params.requesterSessionKey;
     let targetRequesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
+    let fallbackRequester: {
+      requesterSessionKey: string;
+      requesterOrigin?: DeliveryContext;
+    } | null = null;
     const childSessionId = (() => {
       const entry = loadSessionEntryByKey(params.childSessionKey);
       return typeof entry?.sessionId === "string" && entry.sessionId.trim()
@@ -1286,32 +1290,13 @@ export async function runSubagentAnnounceFlow(params: {
       const { isSubagentSessionRunActive, resolveRequesterForChildSession } =
         await loadSubagentRegistryRuntime();
       if (!isSubagentSessionRunActive(targetRequesterSessionKey)) {
-        // Parent run has ended. Check if parent SESSION still exists.
-        // If it does, the parent may be waiting for child results — inject there.
-        const parentSessionEntry = loadSessionEntryByKey(targetRequesterSessionKey);
-        const parentSessionAlive =
-          parentSessionEntry &&
-          typeof parentSessionEntry.sessionId === "string" &&
-          parentSessionEntry.sessionId.trim();
-
-        if (!parentSessionAlive) {
-          // Parent session is truly gone — fallback to grandparent
-          const fallback = resolveRequesterForChildSession(targetRequesterSessionKey);
-          if (!fallback?.requesterSessionKey) {
-            // Without a requester fallback we cannot safely deliver this nested
-            // completion. Keep cleanup retryable so a later registry restore can
-            // recover and re-announce instead of silently dropping the result.
-            shouldDeleteChildSession = false;
-            return false;
-          }
-          targetRequesterSessionKey = fallback.requesterSessionKey;
-          targetRequesterOrigin =
-            normalizeDeliveryContext(fallback.requesterOrigin) ?? targetRequesterOrigin;
-          requesterDepth = getSubagentDepthFromSessionStore(targetRequesterSessionKey);
-          requesterIsSubagent = requesterDepth >= 1;
+        const fallback = resolveRequesterForChildSession(targetRequesterSessionKey);
+        if (fallback?.requesterSessionKey) {
+          fallbackRequester = {
+            requesterSessionKey: fallback.requesterSessionKey,
+            requesterOrigin: normalizeDeliveryContext(fallback.requesterOrigin),
+          };
         }
-        // If parent session is alive (just has no active run), continue with parent
-        // as target. Injecting the announce will start a new agent turn for processing.
       }
     }
 
@@ -1365,57 +1350,78 @@ export async function runSubagentAnnounceFlow(params: {
       childSessionKey: params.childSessionKey,
       childRunId: params.childRunId,
     });
-    // Send to the requester session. For nested subagents this is an internal
-    // follow-up injection (deliver=false) so the orchestrator receives it.
-    let directOrigin = targetRequesterOrigin;
-    if (!requesterIsSubagent) {
-      const { entry } = loadRequesterSessionEntry(targetRequesterSessionKey);
-      directOrigin = resolveAnnounceOrigin(entry, targetRequesterOrigin);
-    }
-    const completionResolution =
-      expectsCompletionMessage && !requesterIsSubagent
-        ? await resolveSubagentCompletionOrigin({
-            childSessionKey: params.childSessionKey,
-            requesterSessionKey: targetRequesterSessionKey,
-            requesterOrigin: directOrigin,
-            childRunId: params.childRunId,
-            spawnMode: params.spawnMode,
-            expectsCompletionMessage,
-          })
-        : {
-            origin: targetRequesterOrigin,
-            routeMode: "fallback" as const,
-          };
-    const completionDirectOrigin = completionResolution.origin;
     // Use a deterministic idempotency key so the gateway dedup cache
     // catches duplicates if this announce is also queued by the gateway-
     // level message queue while the main session is busy (#17122).
     const directIdempotencyKey = buildAnnounceIdempotencyKey(announceId);
-    const delivery = await deliverSubagentAnnouncement({
-      requesterSessionKey: targetRequesterSessionKey,
-      announceId,
-      triggerMessage,
-      steerMessage,
-      completionMessage,
-      internalEvents,
-      summaryLine: taskLabel,
-      requesterOrigin:
-        expectsCompletionMessage && !requesterIsSubagent
-          ? completionDirectOrigin
-          : targetRequesterOrigin,
-      completionDirectOrigin,
-      directOrigin,
-      targetRequesterSessionKey,
-      requesterIsSubagent,
-      expectsCompletionMessage: expectsCompletionMessage,
-      bestEffortDeliver: params.bestEffortDeliver,
-      completionRouteMode: completionResolution.routeMode,
-      spawnMode: params.spawnMode,
-      announceType,
-      directIdempotencyKey,
-      currentRunId: params.childRunId,
-      signal: params.signal,
+
+    const deliverWithTarget = async (options: { sessionKey: string; origin?: DeliveryContext }) => {
+      const targetDepth = getSubagentDepthFromSessionStore(options.sessionKey);
+      const targetIsSubagent = targetDepth >= 1;
+      const targetTriggerMessage = buildAnnounceSteerMessage(internalEvents);
+      let targetDirectOrigin = options.origin;
+      if (!targetIsSubagent) {
+        const { entry } = loadRequesterSessionEntry(options.sessionKey);
+        targetDirectOrigin = resolveAnnounceOrigin(entry, options.origin);
+      }
+      const completionResolution =
+        expectsCompletionMessage && !targetIsSubagent
+          ? await resolveSubagentCompletionOrigin({
+              childSessionKey: params.childSessionKey,
+              requesterSessionKey: options.sessionKey,
+              requesterOrigin: targetDirectOrigin,
+              childRunId: params.childRunId,
+              spawnMode: params.spawnMode,
+              expectsCompletionMessage,
+            })
+          : {
+              origin: options.origin,
+              routeMode: "fallback" as const,
+            };
+      const completionDirectOrigin = completionResolution.origin;
+
+      return deliverSubagentAnnouncement({
+        requesterSessionKey: options.sessionKey,
+        announceId,
+        triggerMessage: targetTriggerMessage,
+        steerMessage,
+        completionMessage,
+        internalEvents,
+        summaryLine: taskLabel,
+        requesterOrigin:
+          expectsCompletionMessage && !targetIsSubagent ? completionDirectOrigin : options.origin,
+        completionDirectOrigin,
+        directOrigin: targetDirectOrigin,
+        targetRequesterSessionKey: options.sessionKey,
+        requesterIsSubagent: targetIsSubagent,
+        expectsCompletionMessage: expectsCompletionMessage,
+        bestEffortDeliver: params.bestEffortDeliver,
+        completionRouteMode: completionResolution.routeMode,
+        spawnMode: params.spawnMode,
+        announceType,
+        directIdempotencyKey,
+        currentRunId: params.childRunId,
+        signal: params.signal,
+      });
+    };
+
+    let delivery = await deliverWithTarget({
+      sessionKey: targetRequesterSessionKey,
+      origin: targetRequesterOrigin,
     });
+
+    if (!delivery.delivered && fallbackRequester && fallbackRequester.requesterSessionKey) {
+      if (fallbackRequester.requesterSessionKey !== targetRequesterSessionKey) {
+        const fallbackTargetSessionKey = fallbackRequester.requesterSessionKey;
+        const fallbackTargetOrigin = fallbackRequester.requesterOrigin ?? targetRequesterOrigin;
+        targetRequesterSessionKey = fallbackTargetSessionKey;
+        targetRequesterOrigin = fallbackTargetOrigin;
+        delivery = await deliverWithTarget({
+          sessionKey: fallbackTargetSessionKey,
+          origin: fallbackTargetOrigin,
+        });
+      }
+    }
     // Cron delivery state should only be marked as delivered when we have a
     // direct path result. Queue/steer means "accepted for later processing",
     // not a confirmed channel send, and can otherwise produce false positives.


### PR DESCRIPTION
## Summary
- Route nested run-mode subagent completions to the direct parent requester session first, even when the parent session store row is temporarily missing.
- Keep grandparent fallback only when parent delivery fails, preventing dropped auto-announcements caused by race conditions.
- Add regression coverage for nested run completion routing.

## Security Impact
No direct security boundary changes.

## Repro+Verification
- Reproduce: create nested run-mode subagent flows where parent session metadata may lag persistence.
- Before fix: completion announcements can skip parent and get lost or misrouted.
- After fix: parent receives completion first; grandparent is used only as fallback.

## Testing
- `pnpm vitest run --config vitest.e2e.config.ts src/agents/subagent-announce.format.e2e.test.ts`

## AI Assisted
- Yes (Codex-assisted implementation).

## Fixes
- Fixes #36081
