### PR TITLE
fix(whatsapp): auto-populate participant for group reactions from requesterSenderId

### DIFF
--- a/extensions/whatsapp/src/channel.test.ts
+++ b/extensions/whatsapp/src/channel.test.ts
@@ -23,7 +23,7 @@ describe("whatsappPlugin.actions.handleAction react participant fallback", () =>
     installRuntime();
   });
 
-  it("uses requesterSenderId as participant fallback when param is omitted", async () => {
+  it("uses requesterSenderId as participant fallback for @s.whatsapp.net JIDs", async () => {
     await whatsappPlugin.actions!.handleAction!({
       channel: "whatsapp",
       action: "react",
@@ -39,6 +39,48 @@ describe("whatsappPlugin.actions.handleAction react participant fallback", () =>
     expect(handleWhatsAppAction).toHaveBeenCalledWith(
       expect.objectContaining({
         participant: "201006884440@s.whatsapp.net",
+      }),
+      enabledConfig,
+    );
+  });
+
+  it("uses requesterSenderId as participant fallback for @lid JIDs", async () => {
+    await whatsappPlugin.actions!.handleAction!({
+      channel: "whatsapp",
+      action: "react",
+      cfg: enabledConfig,
+      params: {
+        chatJid: "group123@g.us",
+        messageId: "msg1",
+        emoji: "✅",
+      },
+      requesterSenderId: "143134247891105@lid",
+    });
+
+    expect(handleWhatsAppAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        participant: "143134247891105@lid",
+      }),
+      enabledConfig,
+    );
+  });
+
+  it("ignores requesterSenderId from non-WhatsApp contexts", async () => {
+    await whatsappPlugin.actions!.handleAction!({
+      channel: "whatsapp",
+      action: "react",
+      cfg: enabledConfig,
+      params: {
+        chatJid: "group123@g.us",
+        messageId: "msg1",
+        emoji: "✅",
+      },
+      requesterSenderId: "discord-user-123",
+    });
+
+    expect(handleWhatsAppAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        participant: undefined,
       }),
       enabledConfig,
     );

--- a/extensions/whatsapp/src/channel.test.ts
+++ b/extensions/whatsapp/src/channel.test.ts
@@ -1,0 +1,88 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { whatsappPlugin } from "./channel.js";
+import { setWhatsAppRuntime } from "./runtime.js";
+
+const handleWhatsAppAction = vi.fn(async () => ({ type: "json", data: { ok: true } }));
+
+function installRuntime() {
+  setWhatsAppRuntime({
+    channel: {
+      whatsapp: { handleWhatsAppAction },
+    },
+  } as never);
+}
+
+const enabledConfig = {
+  channels: { whatsapp: { actions: { reactions: true } } },
+} as OpenClawConfig;
+
+describe("whatsappPlugin.actions.handleAction react participant fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    installRuntime();
+  });
+
+  it("uses requesterSenderId as participant fallback when param is omitted", async () => {
+    await whatsappPlugin.actions!.handleAction!({
+      channel: "whatsapp",
+      action: "react",
+      cfg: enabledConfig,
+      params: {
+        chatJid: "group123@g.us",
+        messageId: "msg1",
+        emoji: "✅",
+      },
+      requesterSenderId: "201006884440@s.whatsapp.net",
+    });
+
+    expect(handleWhatsAppAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        participant: "201006884440@s.whatsapp.net",
+      }),
+      enabledConfig,
+    );
+  });
+
+  it("prefers explicit participant param over requesterSenderId", async () => {
+    await whatsappPlugin.actions!.handleAction!({
+      channel: "whatsapp",
+      action: "react",
+      cfg: enabledConfig,
+      params: {
+        chatJid: "group123@g.us",
+        messageId: "msg1",
+        emoji: "✅",
+        participant: "explicit@s.whatsapp.net",
+      },
+      requesterSenderId: "fallback@s.whatsapp.net",
+    });
+
+    expect(handleWhatsAppAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        participant: "explicit@s.whatsapp.net",
+      }),
+      enabledConfig,
+    );
+  });
+
+  it("passes undefined participant when both param and requesterSenderId are absent", async () => {
+    await whatsappPlugin.actions!.handleAction!({
+      channel: "whatsapp",
+      action: "react",
+      cfg: enabledConfig,
+      params: {
+        chatJid: "123@s.whatsapp.net",
+        messageId: "msg1",
+        emoji: "✅",
+      },
+    });
+
+    expect(handleWhatsAppAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        participant: undefined,
+      }),
+      enabledConfig,
+    );
+  });
+});

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -274,10 +274,15 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
           messageId,
           emoji,
           remove,
-          // Fallback to requesterSenderId (the sender who triggered this agent turn).
+          // Fallback to requesterSenderId when it looks like a WhatsApp JID (@s.whatsapp.net or @lid).
           // Correct when reacting to the requester's own message (the common case).
           // For reactions to other participants' messages the model must supply participant explicitly.
-          participant: readStringParam(params, "participant") ?? requesterSenderId ?? undefined,
+          // Guard: only use the fallback for WhatsApp-origin sender IDs to avoid cross-channel pollution.
+          participant:
+            readStringParam(params, "participant") ??
+            (requesterSenderId && /\@(s\.whatsapp\.net|lid)$/.test(requesterSenderId)
+              ? requesterSenderId
+              : undefined),
           accountId: accountId ?? undefined,
           fromMe: typeof params.fromMe === "boolean" ? params.fromMe : undefined,
         },

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -274,6 +274,9 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
           messageId,
           emoji,
           remove,
+          // Fallback to requesterSenderId (the sender who triggered this agent turn).
+          // Correct when reacting to the requester's own message (the common case).
+          // For reactions to other participants' messages the model must supply participant explicitly.
           participant: readStringParam(params, "participant") ?? requesterSenderId ?? undefined,
           accountId: accountId ?? undefined,
           fromMe: typeof params.fromMe === "boolean" ? params.fromMe : undefined,

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -257,7 +257,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       return Array.from(actions);
     },
     supportsAction: ({ action }) => action === "react",
-    handleAction: async ({ action, params, cfg, accountId }) => {
+    handleAction: async ({ action, params, cfg, accountId, requesterSenderId }) => {
       if (action !== "react") {
         throw new Error(`Action ${action} is not supported for provider ${meta.id}.`);
       }
@@ -274,7 +274,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
           messageId,
           emoji,
           remove,
-          participant: readStringParam(params, "participant"),
+          participant: readStringParam(params, "participant") ?? requesterSenderId ?? undefined,
           accountId: accountId ?? undefined,
           fromMe: typeof params.fromMe === "boolean" ? params.fromMe : undefined,
         },


### PR DESCRIPTION
## Summary

- **Problem:** WhatsApp group reactions silently fail — the `message` tool returns `{ ok: true }` but the reaction never appears. Baileys requires the `participant` field (sender JID) in the message key for group messages, but the action handler never populates it unless the model explicitly provides it.
- **Why it matters:** Reactions are a core agent capability; silent failures erode trust and waste tool calls.
- **What changed:** `handleAction` in `extensions/whatsapp/src/channel.ts` now destructures `requesterSenderId` from the `ChannelMessageActionContext` and uses it as a fallback when `participant` is not in `params`. `requesterSenderId` is server-injected (trusted, not model-controlled) and already contains the sender's JID (e.g. `201006884440@s.whatsapp.net`).
- **What did NOT change:** DM reactions (no participant needed), explicit participant params (still take precedence), poll actions, outbound messaging.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #36090

## User-visible / Behavior Changes

Reactions in WhatsApp groups now work when the agent omits the `participant` field. The gateway auto-populates it from trusted inbound context.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

`requesterSenderId` is server-injected and trusted (never sourced from model/tool params). Using it as a fallback for `participant` does not expand any attack surface.

## Repro + Verification

### Environment

- OS: macOS
- Integration/channel: WhatsApp (Baileys)

### Steps

1. Agent is in a WhatsApp group chat
2. Someone sends a message
3. Agent calls `react` action with emoji but without `participant`

### Expected

- Reaction appears on the message

### Actual (before fix)

- `{ ok: true }` returned but reaction never appears

## Evidence

- [x] Existing tests pass (`pnpm test -- src/agents/tools/whatsapp-actions.test.ts` — 7/7)
- [x] Build passes (`pnpm build`)

## Human Verification (required)

- Verified scenarios: Build passes, existing WhatsApp action tests pass (7/7)
- Edge cases checked: DM reactions (no participant needed — `requesterSenderId` fallback is harmless), explicit participant param (takes precedence via `??` chain)
- What you did **not** verify: Live WhatsApp group reaction (requires linked device)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert single commit on `extensions/whatsapp/src/channel.ts`
- No config changes needed

## Risks and Mitigations

None — the fallback value (`requesterSenderId`) is already available in the context and is the same JID that `ack-reaction.ts` uses via `params.msg.senderJid`.