### PR TITLE
Bound session-store caches with LRU eviction

### DIFF
--- a/src/config/sessions.cache.test.ts
+++ b/src/config/sessions.cache.test.ts
@@ -8,6 +8,7 @@ import {
   type SessionEntry,
   saveSessionStore,
 } from "./sessions.js";
+import { SESSION_STORE_CACHE_MAX_ENTRIES } from "./sessions/store-cache.js";
 
 function createSessionEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
   return {
@@ -231,5 +232,41 @@ describe("Session Store Cache", () => {
     const loaded2 = loadSessionStore(storePath);
     expect(loaded2["session:2"]).toBeDefined();
     expect(loaded2["session:2"].displayName).toBe("Added");
+  });
+
+  it("should evict least-recently-used cache entries when cache exceeds the max size", async () => {
+    const allStorePaths = Array.from({ length: SESSION_STORE_CACHE_MAX_ENTRIES + 1 }, (_, index) =>
+      path.join(testDir, `sessions-${index}.json`),
+    );
+
+    for (const [index, filePath] of allStorePaths.entries()) {
+      const testStore = createSingleSessionStore(
+        createSessionEntry({ sessionId: `id-${index}`, displayName: `Session ${index}` }),
+        `session:${index}`,
+      );
+      await saveSessionStore(filePath, testStore);
+      const loaded = loadSessionStore(filePath);
+      expect(loaded[`session:${index}`]?.displayName).toBe(`Session ${index}`);
+    }
+
+    const oldestPath = allStorePaths[0];
+    const newestPath = allStorePaths[allStorePaths.length - 1];
+    expect(oldestPath).toBeDefined();
+    expect(newestPath).toBeDefined();
+
+    const readSpy = vi.spyOn(fs, "readFileSync");
+
+    const oldestReload = loadSessionStore(oldestPath);
+    expect(oldestReload["session:0"]?.displayName).toBe("Session 0");
+    expect(readSpy).toHaveBeenCalledTimes(1);
+
+    readSpy.mockClear();
+
+    const newestReload = loadSessionStore(newestPath);
+    expect(newestReload[`session:${SESSION_STORE_CACHE_MAX_ENTRIES}`]?.displayName).toBe(
+      `Session ${SESSION_STORE_CACHE_MAX_ENTRIES}`,
+    );
+    expect(readSpy).toHaveBeenCalledTimes(0);
+    readSpy.mockRestore();
   });
 });

--- a/src/config/sessions/store-cache.ts
+++ b/src/config/sessions/store-cache.ts
@@ -9,8 +9,46 @@ type SessionStoreCacheEntry = {
   serialized?: string;
 };
 
+export const SESSION_STORE_CACHE_MAX_ENTRIES = 64;
+
 const SESSION_STORE_CACHE = new Map<string, SessionStoreCacheEntry>();
 const SESSION_STORE_SERIALIZED_CACHE = new Map<string, string>();
+
+function setMostRecent<K, V>(map: Map<K, V>, key: K, value: V): void {
+  map.delete(key);
+  map.set(key, value);
+}
+
+function touchMostRecent<K, V>(map: Map<K, V>, key: K): V | undefined {
+  const value = map.get(key);
+  if (value === undefined) {
+    return undefined;
+  }
+  map.delete(key);
+  map.set(key, value);
+  return value;
+}
+
+function trimSessionStoreCacheBounds(): void {
+  while (SESSION_STORE_CACHE.size > SESSION_STORE_CACHE_MAX_ENTRIES) {
+    const oldestKey = SESSION_STORE_CACHE.keys().next().value;
+    if (oldestKey === undefined) {
+      break;
+    }
+    SESSION_STORE_CACHE.delete(oldestKey);
+    SESSION_STORE_SERIALIZED_CACHE.delete(oldestKey);
+  }
+}
+
+function trimSessionStoreSerializedCacheBounds(): void {
+  while (SESSION_STORE_SERIALIZED_CACHE.size > SESSION_STORE_CACHE_MAX_ENTRIES) {
+    const oldestKey = SESSION_STORE_SERIALIZED_CACHE.keys().next().value;
+    if (oldestKey === undefined) {
+      break;
+    }
+    SESSION_STORE_SERIALIZED_CACHE.delete(oldestKey);
+  }
+}
 
 export function clearSessionStoreCaches(): void {
   SESSION_STORE_CACHE.clear();
@@ -23,7 +61,7 @@ export function invalidateSessionStoreCache(storePath: string): void {
 }
 
 export function getSerializedSessionStore(storePath: string): string | undefined {
-  return SESSION_STORE_SERIALIZED_CACHE.get(storePath);
+  return touchMostRecent(SESSION_STORE_SERIALIZED_CACHE, storePath);
 }
 
 export function setSerializedSessionStore(storePath: string, serialized?: string): void {
@@ -31,7 +69,8 @@ export function setSerializedSessionStore(storePath: string, serialized?: string
     SESSION_STORE_SERIALIZED_CACHE.delete(storePath);
     return;
   }
-  SESSION_STORE_SERIALIZED_CACHE.set(storePath, serialized);
+  setMostRecent(SESSION_STORE_SERIALIZED_CACHE, storePath, serialized);
+  trimSessionStoreSerializedCacheBounds();
 }
 
 export function dropSessionStoreObjectCache(storePath: string): void {
@@ -57,6 +96,7 @@ export function readSessionStoreCache(params: {
     invalidateSessionStoreCache(params.storePath);
     return null;
   }
+  touchMostRecent(SESSION_STORE_CACHE, params.storePath);
   return structuredClone(cached.store);
 }
 
@@ -67,7 +107,7 @@ export function writeSessionStoreCache(params: {
   sizeBytes?: number;
   serialized?: string;
 }): void {
-  SESSION_STORE_CACHE.set(params.storePath, {
+  setMostRecent(SESSION_STORE_CACHE, params.storePath, {
     store: structuredClone(params.store),
     loadedAt: Date.now(),
     storePath: params.storePath,
@@ -75,7 +115,9 @@ export function writeSessionStoreCache(params: {
     sizeBytes: params.sizeBytes,
     serialized: params.serialized,
   });
+  trimSessionStoreCacheBounds();
   if (params.serialized !== undefined) {
-    SESSION_STORE_SERIALIZED_CACHE.set(params.storePath, params.serialized);
+    setMostRecent(SESSION_STORE_SERIALIZED_CACHE, params.storePath, params.serialized);
+    trimSessionStoreSerializedCacheBounds();
   }
 }


### PR DESCRIPTION
## Summary
- add a fixed 64-entry bound to session store object cache and serialized cache
- use recency updates on reads/writes so eviction drops least-recently-used entries
- evict paired serialized entries when object-cache entries are trimmed
- add a focused regression test proving oldest cache entries are evicted while newest remain hot

## Why
`src/config/sessions/store-cache.ts` used unbounded `Map`s keyed by `storePath`. In long-lived processes that touch many unique stores, this could keep growing and retain stale snapshots unnecessarily.

## Validation
- `pnpm vitest src/config/sessions.cache.test.ts`
