### PR TITLE
Config: accept channels.discord.agentComponents in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
+- Config/Discord schema parity: accept `channels.discord.agentComponents` in strict config validation so valid component-control settings no longer fail with unknown-key errors. (#35564)
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.
 - Agents/xAI tool-call argument decoding: decode HTML-entity encoded xAI/Grok tool-call argument values (`&amp;`, `&quot;`, `&lt;`, `&gt;`, numeric entities) before tool execution so commands with shell operators and quotes no longer fail with parse errors. (#35276) Thanks @Sid-Qin.

--- a/src/config/config.discord.test.ts
+++ b/src/config/config.discord.test.ts
@@ -30,6 +30,9 @@ describe("config discord", () => {
               stickerUploads: false,
               channels: true,
             },
+            agentComponents: {
+              enabled: true,
+            },
             guilds: {
               "123": {
                 slug: "friends-of-openclaw",
@@ -52,6 +55,7 @@ describe("config discord", () => {
         expect(cfg.channels?.discord?.actions?.emojiUploads).toBe(true);
         expect(cfg.channels?.discord?.actions?.stickerUploads).toBe(false);
         expect(cfg.channels?.discord?.actions?.channels).toBe(true);
+        expect(cfg.channels?.discord?.agentComponents?.enabled).toBe(true);
         expect(cfg.channels?.discord?.guilds?.["123"]?.slug).toBe("friends-of-openclaw");
         expect(cfg.channels?.discord?.guilds?.["123"]?.channels?.general?.allow).toBe(true);
       },

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -474,6 +474,12 @@ export const DiscordAccountSchema = z
       })
       .strict()
       .optional(),
+    agentComponents: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
     ui: DiscordUiSchema,
     slashCommand: z
       .object({


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: strict Discord schema did not include `agentComponents`, despite type/runtime support.
- Why it matters: valid `channels.discord.agentComponents.enabled` configs fail validation.
- What changed: added `agentComponents` object to `DiscordAccountSchema` and covered it in config load regression test.
- What did NOT change (scope boundary): no runtime behavior changes in Discord component dispatch.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35564
- Related #35564

## User-visible / Behavior Changes

- Configs with `channels.discord.agentComponents.enabled` now validate successfully.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Discord config schema
- Relevant config (redacted): `channels.discord.agentComponents.enabled: true`

### Steps

1. Set `channels.discord.agentComponents.enabled` in config.
2. Validate/load config.
3. Confirm schema accepts and typed value is present.

### Expected

- Validation passes with `agentComponents` present.

### Actual

- Verified successful after schema fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm vitest run src/config/config.discord.test.ts`
  - `pnpm oxfmt --check src/config/zod-schema.providers-core.ts src/config/config.discord.test.ts CHANGELOG.md`
  - `pnpm oxlint src/config/zod-schema.providers-core.ts src/config/config.discord.test.ts`
- Edge cases checked:
  - Existing Discord config fields (`actions`, `guilds`) still load as before.
- What you did **not** verify:
  - Live Discord runtime behavior (schema-only fix).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/config/zod-schema.providers-core.ts`
  - `src/config/config.discord.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected validation behavior in Discord config parsing.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Expanded schema surface may mask typo concerns if object became loose.
  - Mitigation:
    - Kept `agentComponents` object strict and narrow (`enabled` only).
