### PR TITLE
fix: recognize Gemini 3.1 models under google provider for fallback routing

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -244,12 +244,15 @@ function resolveAnthropicSonnet46ForwardCompatModel(
 // gemini-3.1-pro-preview / gemini-3.1-flash-preview are not present in pi-ai's built-in
 // google-gemini-cli catalog yet. Clone the nearest gemini-3 template so users don't get
 // "Unknown model" errors when Google Gemini CLI gains new minor-version models.
+const GOOGLE_PROVIDER_IDS = new Set(["google-gemini-cli", "google"]);
+
 function resolveGoogleGeminiCli31ForwardCompatModel(
   provider: string,
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
-  if (normalizeProviderId(provider) !== "google-gemini-cli") {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (!GOOGLE_PROVIDER_IDS.has(normalizedProvider)) {
     return undefined;
   }
   const trimmed = modelId.trim();
@@ -265,7 +268,7 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
   }
 
   return cloneFirstTemplateModel({
-    normalizedProvider: "google-gemini-cli",
+    normalizedProvider,
     trimmedModelId: trimmed,
     templateIds: [...templateIds],
     modelRegistry,

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -11,6 +11,7 @@ import {
   GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
   GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
   makeModel,
+  mockDiscoveredModel,
   mockGoogleGeminiCliFlashTemplateModel,
   mockGoogleGeminiCliProTemplateModel,
   mockOpenAICodexTemplateModel,
@@ -93,5 +94,47 @@ describe("pi embedded model e2e smoke", () => {
     const result = resolveModel("google-gemini-cli", "gemini-4-unknown", "/tmp/agent");
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: google-gemini-cli/gemini-4-unknown");
+  });
+
+  it("builds a google forward-compat fallback for gemini-3.1-pro-preview", () => {
+    mockDiscoveredModel({
+      provider: "google",
+      modelId: "gemini-3-pro-preview",
+      templateModel: {
+        ...GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+        provider: "google",
+        api: "google",
+      },
+    });
+
+    const result = resolveModel("google", "gemini-3.1-pro-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "gemini-3.1-pro-preview",
+      name: "gemini-3.1-pro-preview",
+      provider: "google",
+      reasoning: true,
+    });
+  });
+
+  it("builds a google forward-compat fallback for gemini-3.1-flash-lite-preview", () => {
+    mockDiscoveredModel({
+      provider: "google",
+      modelId: "gemini-3-flash-preview",
+      templateModel: {
+        ...GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
+        provider: "google",
+        api: "google",
+      },
+    });
+
+    const result = resolveModel("google", "gemini-3.1-flash-lite-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "gemini-3.1-flash-lite-preview",
+      name: "gemini-3.1-flash-lite-preview",
+      provider: "google",
+      reasoning: true,
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fix `FailoverError: Unknown model: google/gemini-3.1-flash-lite-preview` when Gemini 3.1 series models are used in the fallbacks array with the `google` provider.

Fixes #36111

## Problem

The forward-compat resolver (`resolveGoogleGeminiCli31ForwardCompatModel`) only matched the `google-gemini-cli` provider. Users configuring `google/gemini-3.1-pro-preview` or `google/gemini-3.1-flash-lite-preview` as fallback models received "Unknown model" errors during failover, even though the same models worked fine as primary.

## Solution

Accept both `google-gemini-cli` and `google` as valid provider IDs, and use the actual normalized provider (not hardcoded `google-gemini-cli`) when cloning the template model.

### Changes
- `src/agents/model-forward-compat.ts` — Added `GOOGLE_PROVIDER_IDS` set, updated provider check and `normalizedProvider` usage
- `src/agents/pi-embedded-runner/model.forward-compat.test.ts` — Added 2 tests for `google` provider (pro + flash-lite)

### Tests
- 8/8 forward-compat tests pass ✅
- TypeScript check clean ✅