### PR TITLE
Fix: Gemini 3.1 fallback model validation

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -17,6 +17,8 @@ const ANTHROPIC_SONNET_TEMPLATE_MODEL_IDS = ["claude-sonnet-4-5", "claude-sonnet
 const ZAI_GLM5_MODEL_ID = "glm-5";
 const ZAI_GLM5_TEMPLATE_MODEL_IDS = ["glm-4.7"] as const;
 
+const GEMINI_3_1_COMPATIBLE_PROVIDERS = new Set(["google", "google-gemini-cli"]);
+
 // gemini-3.1-pro-preview / gemini-3.1-flash-preview are not yet in pi-ai's built-in
 // google-gemini-cli catalog. Clone the gemini-3-pro/flash-preview template so users
 // don't get "Unknown model" errors when Google releases a new minor version.
@@ -176,7 +178,8 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
-  if (normalizeProviderId(provider) !== "google-gemini-cli") {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (!GEMINI_3_1_COMPATIBLE_PROVIDERS.has(normalizedProvider)) {
     return undefined;
   }
   const trimmed = modelId.trim();
@@ -191,13 +194,28 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
     return undefined;
   }
 
-  return cloneFirstTemplateModel({
-    normalizedProvider: "google-gemini-cli",
-    trimmedModelId: trimmed,
-    templateIds: [...templateIds],
-    modelRegistry,
-    patch: { reasoning: true },
-  });
+  const templateProviders =
+    normalizedProvider === "google"
+      ? ["google", "google-gemini-cli"]
+      : ["google-gemini-cli", "google"];
+
+  for (const templateProvider of templateProviders) {
+    for (const templateId of templateIds) {
+      const template = modelRegistry.find(templateProvider, templateId) as Model<Api> | null;
+      if (!template) {
+        continue;
+      }
+      return normalizeModelCompat({
+        ...template,
+        provider: normalizedProvider,
+        id: trimmed,
+        name: trimmed,
+        reasoning: true,
+      } as Model<Api>);
+    }
+  }
+
+  return undefined;
 }
 
 // Z.ai's GLM-5 may not be present in pi-ai's built-in model catalog yet.

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -11,6 +11,7 @@ import {
   GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
   GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
   makeModel,
+  mockDiscoveredModel,
   mockGoogleGeminiCliFlashTemplateModel,
   mockGoogleGeminiCliProTemplateModel,
   mockOpenAICodexTemplateModel,
@@ -77,6 +78,26 @@ describe("pi embedded model e2e smoke", () => {
       ...GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
       id: "gemini-3.1-flash-preview",
       name: "gemini-3.1-flash-preview",
+      reasoning: true,
+    });
+  });
+
+  it("builds a google forward-compat fallback for gemini-3.1-pro-preview", () => {
+    mockDiscoveredModel({
+      provider: "google",
+      modelId: "gemini-3-pro-preview",
+      templateModel: {
+        ...GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+        provider: "google",
+      },
+    });
+
+    const result = resolveModel("google", "gemini-3.1-pro-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "google",
+      id: "gemini-3.1-pro-preview",
+      name: "gemini-3.1-pro-preview",
       reasoning: true,
     });
   });


### PR DESCRIPTION
## Summary
- Extend Gemini 3.1 forward-compat resolution to handle both `google` and `google-gemini-cli` provider aliases.
- Resolve fallback templates across provider variants so `google/gemini-3.1-*` does not fail as `Unknown model` during fallback routing.
- Add regression coverage in `src/agents/pi-embedded-runner/model.forward-compat.test.ts`.

## Security Impact
No direct security boundary changes.

## Repro+Verification
- Reproduce: trigger model fallback with Gemini 3.1 model IDs under mixed provider aliases (`google` / `google-gemini-cli`).
- Before fix: fallback routing can fail with `Unknown model`.
- After fix: fallback model resolution works across provider aliases.

## Testing
- `pnpm test src/agents/pi-embedded-runner/model.forward-compat.test.ts src/agents/model-fallback.test.ts`

## AI Assisted
- Yes (Codex-assisted implementation).

## Fixes
- Fixes #36111
