### PR TITLE
Browser: remove unsupported AutomationControlled launch flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
+- Browser/launch flags: remove the unsupported Chromium switch `--disable-blink-features=AutomationControlled` from OpenClaw-managed launches to avoid persistent startup warnings on newer Chrome builds. (#35721)
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.
 - Agents/xAI tool-call argument decoding: decode HTML-entity encoded xAI/Grok tool-call argument values (`&amp;`, `&quot;`, `&lt;`, `&gt;`, numeric entities) before tool execution so commands with shell operators and quotes no longer fail with parse errors. (#35276) Thanks @Sid-Qin.

--- a/src/browser/chrome.test.ts
+++ b/src/browser/chrome.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import {
+  buildOpenClawChromeLaunchArgs,
   decorateOpenClawProfile,
   ensureProfileCleanExit,
   findChromeExecutableMac,
@@ -16,6 +17,7 @@ import {
   resolveBrowserExecutableForPlatform,
   stopOpenClawChrome,
 } from "./chrome.js";
+import type { ResolvedBrowserConfig } from "./config.js";
 import {
   DEFAULT_OPENCLAW_BROWSER_COLOR,
   DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
@@ -256,6 +258,48 @@ describe("browser chrome helpers", () => {
     const exists = vi.spyOn(fs, "existsSync").mockReturnValue(false);
     expect(findChromeExecutableWindows()).toBeNull();
     exists.mockRestore();
+  });
+
+  it("builds launch args without unsupported AutomationControlled switch", () => {
+    const resolved = {
+      headless: false,
+      noSandbox: false,
+      extraArgs: [],
+    } satisfies Pick<ResolvedBrowserConfig, "headless" | "noSandbox" | "extraArgs">;
+
+    const args = buildOpenClawChromeLaunchArgs({
+      cdpPort: 9222,
+      userDataDir: "/tmp/openclaw-profile",
+      resolved,
+      platform: "darwin",
+    });
+
+    expect(args).toContain("--remote-debugging-port=9222");
+    expect(args).not.toContain("--disable-blink-features=AutomationControlled");
+  });
+
+  it("includes headless, sandbox, linux, and custom extra args when enabled", () => {
+    const resolved = {
+      headless: true,
+      noSandbox: true,
+      extraArgs: ["--window-size=1200,900", "--proxy-server=http://127.0.0.1:7890"],
+    } satisfies Pick<ResolvedBrowserConfig, "headless" | "noSandbox" | "extraArgs">;
+
+    const args = buildOpenClawChromeLaunchArgs({
+      cdpPort: 9333,
+      userDataDir: "/tmp/openclaw-profile",
+      resolved,
+      platform: "linux",
+    });
+
+    expect(args).toContain("--headless=new");
+    expect(args).toContain("--disable-gpu");
+    expect(args).toContain("--no-sandbox");
+    expect(args).toContain("--disable-setuid-sandbox");
+    expect(args).toContain("--disable-dev-shm-usage");
+    expect(args).toContain("--window-size=1200,900");
+    expect(args).toContain("--proxy-server=http://127.0.0.1:7890");
+    expect(args.at(-1)).toBe("about:blank");
   });
 
   it("resolves Windows executables without LOCALAPPDATA", () => {

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -74,6 +74,49 @@ export function resolveOpenClawUserDataDir(profileName = DEFAULT_OPENCLAW_BROWSE
   return path.join(CONFIG_DIR, "browser", profileName, "user-data");
 }
 
+export function buildOpenClawChromeLaunchArgs(params: {
+  cdpPort: number;
+  userDataDir: string;
+  resolved: Pick<ResolvedBrowserConfig, "headless" | "noSandbox" | "extraArgs">;
+  platform?: NodeJS.Platform;
+}): string[] {
+  const args: string[] = [
+    `--remote-debugging-port=${params.cdpPort}`,
+    `--user-data-dir=${params.userDataDir}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--disable-sync",
+    "--disable-background-networking",
+    "--disable-component-update",
+    "--disable-features=Translate,MediaRouter",
+    "--disable-session-crashed-bubble",
+    "--hide-crash-restore-bubble",
+    "--password-store=basic",
+  ];
+
+  if (params.resolved.headless) {
+    // Best-effort; older Chromes may ignore.
+    args.push("--headless=new");
+    args.push("--disable-gpu");
+  }
+  if (params.resolved.noSandbox) {
+    args.push("--no-sandbox");
+    args.push("--disable-setuid-sandbox");
+  }
+  if ((params.platform ?? process.platform) === "linux") {
+    args.push("--disable-dev-shm-usage");
+  }
+
+  // Append user-configured extra arguments (e.g., window size, proxy settings).
+  if (params.resolved.extraArgs.length > 0) {
+    args.push(...params.resolved.extraArgs);
+  }
+
+  // Always open a blank tab to ensure a target exists.
+  args.push("about:blank");
+  return args;
+}
+
 function cdpUrlForPort(cdpPort: number) {
   return `http://127.0.0.1:${cdpPort}`;
 }
@@ -239,43 +282,11 @@ export async function launchOpenClawChrome(
 
   // First launch to create preference files if missing, then decorate and relaunch.
   const spawnOnce = () => {
-    const args: string[] = [
-      `--remote-debugging-port=${profile.cdpPort}`,
-      `--user-data-dir=${userDataDir}`,
-      "--no-first-run",
-      "--no-default-browser-check",
-      "--disable-sync",
-      "--disable-background-networking",
-      "--disable-component-update",
-      "--disable-features=Translate,MediaRouter",
-      "--disable-session-crashed-bubble",
-      "--hide-crash-restore-bubble",
-      "--password-store=basic",
-    ];
-
-    if (resolved.headless) {
-      // Best-effort; older Chromes may ignore.
-      args.push("--headless=new");
-      args.push("--disable-gpu");
-    }
-    if (resolved.noSandbox) {
-      args.push("--no-sandbox");
-      args.push("--disable-setuid-sandbox");
-    }
-    if (process.platform === "linux") {
-      args.push("--disable-dev-shm-usage");
-    }
-
-    // Stealth: hide navigator.webdriver from automation detection (#80)
-    args.push("--disable-blink-features=AutomationControlled");
-
-    // Append user-configured extra arguments (e.g., stealth flags, window size)
-    if (resolved.extraArgs.length > 0) {
-      args.push(...resolved.extraArgs);
-    }
-
-    // Always open a blank tab to ensure a target exists.
-    args.push("about:blank");
+    const args = buildOpenClawChromeLaunchArgs({
+      cdpPort: profile.cdpPort,
+      userDataDir,
+      resolved,
+    });
 
     return spawn(exe.path, args, {
       stdio: "pipe",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenClaw-managed Chrome launches included `--disable-blink-features=AutomationControlled`, which shows unsupported-switch warnings on newer Chrome versions.
- Why it matters: users see noisy warning banners even though automation works.
- What changed: extracted Chrome launch-arg builder, removed the unsupported switch, and added unit tests for launch-arg composition.
- What did NOT change (scope boundary): no CDP/runtime protocol behavior changes beyond launch args.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35721
- Related #35721

## User-visible / Behavior Changes

- Chrome startup warning for unsupported `AutomationControlled` switch is removed.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): browser launch path
- Relevant config (redacted): default browser profile

### Steps

1. Build launch args for OpenClaw Chrome profile.
2. Verify unsupported AutomationControlled flag is absent.
3. Verify required headless/sandbox/linux/extra args are preserved.

### Expected

- No unsupported switch in launch args.

### Actual

- Verified absent, with other launch args preserved.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm vitest run src/browser/chrome.test.ts`
  - `pnpm oxfmt --check src/browser/chrome.ts src/browser/chrome.test.ts CHANGELOG.md`
  - `pnpm oxlint src/browser/chrome.ts src/browser/chrome.test.ts`
- Edge cases checked:
  - Headless/noSandbox/linux-specific args and custom `extraArgs` are still emitted.
- What you did **not** verify:
  - Manual browser launch UI observation on every OS variant.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/browser/chrome.ts`
  - `src/browser/chrome.test.ts`
- Known bad symptoms reviewers should watch for:
  - Missing expected launch args in browser startup flows.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Launch-arg regression from refactor extraction.
  - Mitigation:
    - Added direct unit coverage for baseline and option-heavy arg sets.
