### PR TITLE
feat(telegram): bound sticker cache growth

### DIFF
--- a/src/telegram/sticker-cache.test.ts
+++ b/src/telegram/sticker-cache.test.ts
@@ -34,6 +34,7 @@ describe("sticker-cache", () => {
     if (fs.existsSync(TEST_CACHE_FILE)) {
       fs.unlinkSync(TEST_CACHE_FILE);
     }
+    vi.unstubAllEnvs();
   });
 
   describe("getCachedSticker", () => {
@@ -112,6 +113,58 @@ describe("sticker-cache", () => {
       const result = getCachedSticker("unique789");
       expect(result?.description).toBe("Updated description");
       expect(result?.fileId).toBe("file789-new");
+    });
+  });
+
+  describe("cache bounds", () => {
+    it("keeps only the newest entries when max cache size is exceeded", () => {
+      vi.stubEnv("OPENCLAW_TELEGRAM_STICKER_CACHE_MAX", "3");
+
+      cacheSticker({
+        fileId: "s1",
+        fileUniqueId: "unique-1",
+        description: "Sticker 1",
+        cachedAt: "2026-01-26T10:00:00.000Z",
+      });
+      cacheSticker({
+        fileId: "s2",
+        fileUniqueId: "unique-2",
+        description: "Sticker 2",
+        cachedAt: "2026-01-26T11:00:00.000Z",
+      });
+      cacheSticker({
+        fileId: "s3",
+        fileUniqueId: "unique-3",
+        description: "Sticker 3",
+        cachedAt: "2026-01-26T12:00:00.000Z",
+      });
+      cacheSticker({
+        fileId: "s4",
+        fileUniqueId: "unique-4",
+        description: "Sticker 4",
+        cachedAt: "2026-01-26T13:00:00.000Z",
+      });
+
+      expect(getCachedSticker("unique-1")).toBeNull();
+      expect(getCachedSticker("unique-2")).not.toBeNull();
+      expect(getCachedSticker("unique-3")).not.toBeNull();
+      expect(getCachedSticker("unique-4")).not.toBeNull();
+      expect(getCacheStats().count).toBe(3);
+    });
+
+    it("falls back to default max entries when env is invalid", () => {
+      vi.stubEnv("OPENCLAW_TELEGRAM_STICKER_CACHE_MAX", "invalid");
+
+      for (let i = 0; i < 5; i += 1) {
+        cacheSticker({
+          fileId: `sticker-${i}`,
+          fileUniqueId: `unique-${i}`,
+          description: `Sticker ${i}`,
+          cachedAt: `2026-01-26T1${i}:00:00.000Z`,
+        });
+      }
+
+      expect(getCacheStats().count).toBe(5);
     });
   });
 

--- a/src/telegram/sticker-cache.ts
+++ b/src/telegram/sticker-cache.ts
@@ -16,6 +16,7 @@ import { resolveAutoImageModel } from "../media-understanding/runner.js";
 
 const CACHE_FILE = path.join(STATE_DIR, "telegram", "sticker-cache.json");
 const CACHE_VERSION = 1;
+const DEFAULT_STICKER_CACHE_MAX_ENTRIES = 1000;
 
 export interface CachedSticker {
   fileId: string;
@@ -49,6 +50,48 @@ function saveCache(cache: StickerCache): void {
   saveJsonFile(CACHE_FILE, cache);
 }
 
+function resolveStickerCacheMaxEntries(): number {
+  const raw = process.env.OPENCLAW_TELEGRAM_STICKER_CACHE_MAX?.trim();
+  if (!raw) {
+    return DEFAULT_STICKER_CACHE_MAX_ENTRIES;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_STICKER_CACHE_MAX_ENTRIES;
+  }
+  return parsed;
+}
+
+function cachedAtTimestamp(value: string): number {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function pruneStickerCache(cache: StickerCache, maxEntries: number): void {
+  const stickers = Object.values(cache.stickers);
+  if (stickers.length <= maxEntries) {
+    return;
+  }
+  const keep = new Set(
+    stickers
+      .toSorted((a, b) => {
+        const timeDiff = cachedAtTimestamp(a.cachedAt) - cachedAtTimestamp(b.cachedAt);
+        if (timeDiff !== 0) {
+          return timeDiff;
+        }
+        return a.fileUniqueId.localeCompare(b.fileUniqueId);
+      })
+      .slice(-maxEntries)
+      .map((sticker) => sticker.fileUniqueId),
+  );
+
+  for (const fileUniqueId of Object.keys(cache.stickers)) {
+    if (!keep.has(fileUniqueId)) {
+      delete cache.stickers[fileUniqueId];
+    }
+  }
+}
+
 /**
  * Get a cached sticker by its unique ID.
  */
@@ -63,6 +106,7 @@ export function getCachedSticker(fileUniqueId: string): CachedSticker | null {
 export function cacheSticker(sticker: CachedSticker): void {
   const cache = loadCache();
   cache.stickers[sticker.fileUniqueId] = sticker;
+  pruneStickerCache(cache, resolveStickerCacheMaxEntries());
   saveCache(cache);
 }
 


### PR DESCRIPTION
## Summary
- add a bounded sticker cache size in `cacheSticker` to prevent unbounded state growth
- keep the newest entries when pruning by `cachedAt` (with deterministic tie-breaker)
- allow operator override via `OPENCLAW_TELEGRAM_STICKER_CACHE_MAX`
- add tests for pruning behavior and invalid env fallback

## Why
Telegram sticker caches can grow indefinitely on long-lived bots. This keeps cache files predictable and avoids slowdowns from oversized state.

## Risk
Low. Scope is limited to sticker cache persistence and validated with focused channel tests.

## Validation
- `pnpm oxfmt --check src/telegram/sticker-cache.ts src/telegram/sticker-cache.test.ts`
- `pnpm vitest run --config vitest.channels.config.ts src/telegram/sticker-cache.test.ts`
