### PR TITLE
fix(agents): strip pipe-delimited suffix from tool call IDs for Codex API

### DIFF
--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -170,6 +170,16 @@ export function convertTools(tools: Context["tools"]): FunctionToolDefinition[] 
 }
 
 /**
+ * Strip the pipe-delimited `|fc_*` suffix from compound tool call IDs.
+ * The OpenAI Responses API produces compound IDs (e.g. `call_xxx|fc_xxx`)
+ * but the Codex API strictly requires `[a-zA-Z0-9_-]+`.
+ */
+function sanitizeToolCallId(id: string): string {
+  const pipeIdx = id.indexOf("|");
+  return pipeIdx > 0 ? id.slice(0, pipeIdx) : id;
+}
+
+/**
  * Convert the full pi-ai message history to an OpenAI `input` array.
  * Handles user messages, assistant text+tool-call messages, and tool results.
  */
@@ -219,15 +229,14 @@ export function convertMessagesToInputItems(messages: Message[]): InputItem[] {
               });
               textParts.length = 0;
             }
-            const callId = toNonEmptyString(block.id);
+            const rawCallId = toNonEmptyString(block.id);
             const toolName = toNonEmptyString(block.name);
-            if (!callId || !toolName) {
+            if (!rawCallId || !toolName) {
               continue;
             }
-            // Push function_call item
             items.push({
               type: "function_call",
-              call_id: callId,
+              call_id: sanitizeToolCallId(rawCallId),
               name: toolName,
               arguments:
                 typeof block.arguments === "string"
@@ -263,14 +272,14 @@ export function convertMessagesToInputItems(messages: Message[]): InputItem[] {
         content: unknown;
         isError: boolean;
       };
-      const callId = toNonEmptyString(tr.toolCallId) ?? toNonEmptyString(tr.toolUseId);
-      if (!callId) {
+      const rawCallId = toNonEmptyString(tr.toolCallId) ?? toNonEmptyString(tr.toolUseId);
+      if (!rawCallId) {
         continue;
       }
       const outputText = contentToText(tr.content);
       items.push({
         type: "function_call_output",
-        call_id: callId,
+        call_id: sanitizeToolCallId(rawCallId),
         output: outputText,
       });
       continue;


### PR DESCRIPTION
## Summary

- **Problem:** The OpenAI Responses API produces compound tool call IDs like `call_xxx|fc_xxx`. These get stored in session transcripts and replayed to the API. The Codex API strictly requires `call_id` to match `[a-zA-Z0-9_-]+` and rejects the pipe character, causing persistent 100% failure on all subsequent requests to that session (`string_pattern_mismatch` on `input[N].id`).
- **Why it matters:** Once a transcript contains a bad ID, every future request fails and the session is effectively bricked. Users must manually edit transcript files to recover.
- **What changed:** `src/agents/openai-ws-stream.ts` — added `sanitizeToolCallId()` that strips the `|fc_*` suffix from compound IDs before they're sent as `call_id` in `function_call` and `function_call_output` input items via `convertMessagesToInputItems()`.
- **What did NOT change:** Transcript storage format (IDs are still stored as compound); the sanitization happens at the API boundary only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35528

## User-visible / Behavior Changes

- Sessions using `openai-codex` provider no longer break when tool call IDs contain pipe characters.
- Existing broken sessions will self-heal on next request (the stored compound IDs are sanitized at the API boundary).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux WSL2
- Runtime: Node.js v22+
- Integration/channel: Any (openai-codex provider)

### Steps

1. Configure agent with `model: openai-codex/gpt-5.3-codex`
2. Have the agent invoke several tools
3. Continue the conversation

### Expected

- Subsequent requests succeed normally

### Actual

- Before fix: `string_pattern_mismatch` error on every request after tool calls
- After fix: pipe suffix stripped at API boundary, requests succeed

## Evidence

```
 ✓ src/agents/openai-ws-stream.test.ts (40 tests) 10ms
   All 40 existing tests pass after changes.
```

The fix applies to the same location where `call_id` is emitted to the API (`convertMessagesToInputItems`), ensuring no pipe characters reach the Codex validation layer.

## Human Verification (required)

- Verified scenarios: All 40 WS stream tests pass, TypeScript compiles cleanly
- Edge cases checked: IDs without pipe pass through unchanged; pipe at position 0 is kept (no callId prefix); both function_call and function_call_output sanitized
- What I did **not** verify: Live Codex API test (requires API key and gpt-5.3-codex access)

## Compatibility / Migration

- Backward compatible? `Yes` — the `call_xxx` prefix is the canonical ID for matching results to calls
- Config/env changes? `No`
- Migration needed? `No` — existing broken transcripts self-heal

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: None
- Known bad symptoms: None expected

## Risks and Mitigations

- The `fc_*` suffix is only needed for the Responses API's reasoning replay feature; `convertMessagesToInputItems` is used for the WebSocket/Codex path where it is not needed
- Standard OpenAI Responses API calls go through a different code path (`streamSimple`) and are unaffected

