### PR TITLE
Fix sessions_spawn Google/Gemini model routing

### DIFF
--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -204,6 +204,49 @@ export function inferUniqueProviderFromConfiguredModels(params: {
   return providers.values().next().value;
 }
 
+function inferProviderFromModelHint(params: {
+  cfg: OpenClawConfig;
+  model: string;
+}): string | undefined {
+  const inferredProvider = inferUniqueProviderFromConfiguredModels({
+    cfg: params.cfg,
+    model: params.model,
+  });
+  if (inferredProvider) {
+    return inferredProvider;
+  }
+  const lower = params.model.toLowerCase();
+  if (lower === "gemini" || lower.startsWith("gemini-")) {
+    return "google";
+  }
+  return undefined;
+}
+
+function normalizeSubagentSpawnModelSelection(params: {
+  cfg: OpenClawConfig;
+  model: string;
+  defaultProvider: string;
+}): string {
+  const trimmed = params.model.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  if (trimmed.includes("/")) {
+    const parsed = parseModelRef(trimmed, params.defaultProvider);
+    if (!parsed) {
+      return trimmed;
+    }
+    return `${parsed.provider}/${parsed.model}`;
+  }
+  const inferredProvider = inferProviderFromModelHint({
+    cfg: params.cfg,
+    model: trimmed,
+  });
+  const selectedProvider = normalizeProviderId(inferredProvider ?? params.defaultProvider);
+  const selectedModel = normalizeProviderModelId(selectedProvider, trimmed);
+  return `${selectedProvider}/${selectedModel}`;
+}
+
 export function resolveAllowlistModelKey(raw: string, defaultProvider: string): string | null {
   const parsed = parseModelRef(raw, defaultProvider);
   if (!parsed) {
@@ -371,13 +414,38 @@ export function resolveSubagentSpawnModelSelection(params: {
     cfg: params.cfg,
     agentId: params.agentId,
   });
+  const resolvedModelOverride = params.modelOverride
+    ? normalizeSubagentSpawnModelSelection({
+        cfg: params.cfg,
+        model: normalizeModelSelection(params.modelOverride) ?? "",
+        defaultProvider: runtimeDefault.provider,
+      })
+    : undefined;
+  const resolvedConfiguredModel = resolveSubagentConfiguredModelSelection({
+    cfg: params.cfg,
+    agentId: params.agentId,
+  });
+  const normalizedConfiguredModel = resolvedConfiguredModel
+    ? normalizeSubagentSpawnModelSelection({
+        cfg: params.cfg,
+        model: resolvedConfiguredModel,
+        defaultProvider: runtimeDefault.provider,
+      })
+    : undefined;
+  const normalizedPrimaryModel = resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model)
+    ? normalizeSubagentSpawnModelSelection({
+        cfg: params.cfg,
+        model:
+          normalizeModelSelection(
+            resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model),
+          ) ?? "",
+        defaultProvider: runtimeDefault.provider,
+      })
+    : undefined;
   return (
-    normalizeModelSelection(params.modelOverride) ??
-    resolveSubagentConfiguredModelSelection({
-      cfg: params.cfg,
-      agentId: params.agentId,
-    }) ??
-    normalizeModelSelection(resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model)) ??
+    resolvedModelOverride ??
+    normalizedConfiguredModel ??
+    normalizedPrimaryModel ??
     `${runtimeDefault.provider}/${runtimeDefault.model}`
   );
 }

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
@@ -134,7 +134,7 @@ describe("openclaw-tools: subagents (sessions_spawn model + thinking)", () => {
     );
     expect(patchCall?.params).toMatchObject({
       key: expect.stringContaining("subagent:"),
-      model: "claude-haiku-4-5",
+      model: "anthropic/claude-haiku-4-5",
     });
   });
 
@@ -252,7 +252,7 @@ describe("openclaw-tools: subagents (sessions_spawn model + thinking)", () => {
       acceptedAtBase: 4000,
       patch: async (request) => {
         const model = (request.params as { model?: unknown } | undefined)?.model;
-        if (model === "bad-model") {
+        if (model === "anthropic/bad-model" || model === "bad-model") {
           throw new Error("invalid model: bad-model");
         }
         return { ok: true };
@@ -271,9 +271,40 @@ describe("openclaw-tools: subagents (sessions_spawn model + thinking)", () => {
     });
     expect(result.details).toMatchObject({
       status: "error",
+      modelApplied: false,
     });
     expect(String((result.details as { error?: string }).error ?? "")).toContain("invalid model");
     expect(calls.some((call) => call.method === "agent")).toBe(false);
+  });
+
+  it("sessions_spawn maps bare Gemini model names to the Google provider", async () => {
+    const calls: GatewayCall[] = [];
+    mockLongRunningSpawnFlow({
+      calls,
+      acceptedAtBase: 4500,
+    });
+
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "main",
+      agentChannel: "discord",
+    });
+
+    const result = await tool.execute("call-gemini", {
+      task: "do thing",
+      model: "gemini-2.5-flash",
+      runTimeoutSeconds: 1,
+    });
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      modelApplied: true,
+    });
+
+    const patchCall = calls.find(
+      (call) => call.method === "sessions.patch" && (call.params as { model?: string })?.model,
+    );
+    expect(patchCall?.params).toMatchObject({
+      model: "google/gemini-2.5-flash",
+    });
   });
 
   it("sessions_spawn supports legacy timeoutSeconds alias", async () => {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -437,6 +437,7 @@ export async function spawnSubagentDirect(
     if (modelPatchError) {
       return {
         status: "error",
+        modelApplied: false,
         error: modelPatchError,
         childSessionKey,
       };


### PR DESCRIPTION
Fixes #36134 by resolving sessions_spawn model routing for bare Gemini model names and surfacing unavailable model overrides.

Changes:
- Update subagent model resolution to infer provider for unqualified model names in spawn flow (including Google Gemini patterns) and normalize configured/bare overrides before patch.
- Keep bare configured/per-agent defaults consistent with spawn model inference so Gemini values are normalized to google/gemini-style provider refs.
- Return `modelApplied: false` on sessions.patch model patch failures so unavailable overrides are not reported as successfully applied.

Tests:
- `pnpm test src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts`
- `pnpm test src/agents/model-selection.test.ts`
