### PR TITLE
fix(agents): resolve Gemini 3.1 forward-compat for all Google provider variants

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -168,15 +168,29 @@ function resolveAnthropicSonnet46ForwardCompatModel(
   });
 }
 
-// gemini-3.1-pro-preview / gemini-3.1-flash-preview are not present in pi-ai's built-in
-// google-gemini-cli catalog yet. Clone the nearest gemini-3 template so users don't get
-// "Unknown model" errors when Google Gemini CLI gains new minor-version models.
+// gemini-3.1-pro-preview / gemini-3.1-flash-preview / gemini-3.1-flash-lite-preview
+// are not present in pi-ai's built-in catalog for all Google provider variants.
+// Clone the nearest gemini-3 template so users don't get "Unknown model" errors
+// when Google releases new minor-version models.
+//
+// This must handle all Google provider variants ("google", "google-gemini-cli",
+// "google-vertex", "google-antigravity") so that model overrides via
+// sessions_spawn (which use the user-facing "google" provider) also resolve
+// correctly instead of silently falling back to the default provider (#36134).
+const GOOGLE_GEMINI_FORWARD_COMPAT_PROVIDERS = new Set([
+  "google",
+  "google-gemini-cli",
+  "google-vertex",
+  "google-antigravity",
+]);
+
 function resolveGoogleGeminiCli31ForwardCompatModel(
   provider: string,
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
-  if (normalizeProviderId(provider) !== "google-gemini-cli") {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (!GOOGLE_GEMINI_FORWARD_COMPAT_PROVIDERS.has(normalizedProvider)) {
     return undefined;
   }
   const trimmed = modelId.trim();
@@ -191,13 +205,30 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
     return undefined;
   }
 
-  return cloneFirstTemplateModel({
-    normalizedProvider: "google-gemini-cli",
-    trimmedModelId: trimmed,
-    templateIds: [...templateIds],
-    modelRegistry,
-    patch: { reasoning: true },
-  });
+  // Try the caller's provider first, then fall back to other Google variants.
+  // The template model may live under a different Google provider in the
+  // pi-ai built-in catalog (e.g. "google-gemini-cli") while the user
+  // specified the bare "google" provider via sessions_spawn (#36134).
+  const providersToTry = [
+    normalizedProvider,
+    ...Array.from(GOOGLE_GEMINI_FORWARD_COMPAT_PROVIDERS).filter((p) => p !== normalizedProvider),
+  ];
+  for (const candidateProvider of providersToTry) {
+    const result = cloneFirstTemplateModel({
+      normalizedProvider: candidateProvider,
+      trimmedModelId: trimmed,
+      templateIds: [...templateIds],
+      modelRegistry,
+      patch: { reasoning: true },
+    });
+    if (result) {
+      // Re-stamp the provider to match what the caller requested so the
+      // returned model routes through the correct auth/transport layer.
+      (result as { provider: string }).provider = normalizedProvider;
+      return result;
+    }
+  }
+  return undefined;
 }
 
 // Z.ai's GLM-5 may not be present in pi-ai's built-in model catalog yet.

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -86,4 +86,43 @@ describe("pi embedded model e2e smoke", () => {
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: google-gemini-cli/gemini-4-unknown");
   });
+
+  it("builds a forward-compat fallback for google/gemini-3.1-flash-lite-preview (#36134)", () => {
+    mockGoogleGeminiCliFlashTemplateModel();
+
+    const result = resolveModel("google", "gemini-3.1-flash-lite-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "gemini-3.1-flash-lite-preview",
+      name: "gemini-3.1-flash-lite-preview",
+      provider: "google",
+      reasoning: true,
+    });
+  });
+
+  it("builds a forward-compat fallback for google/gemini-3.1-pro-preview (#36134)", () => {
+    mockGoogleGeminiCliProTemplateModel();
+
+    const result = resolveModel("google", "gemini-3.1-pro-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "gemini-3.1-pro-preview",
+      name: "gemini-3.1-pro-preview",
+      provider: "google",
+      reasoning: true,
+    });
+  });
+
+  it("builds a forward-compat fallback for google-vertex/gemini-3.1-flash-preview (#36134)", () => {
+    mockGoogleGeminiCliFlashTemplateModel();
+
+    const result = resolveModel("google-vertex", "gemini-3.1-flash-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "gemini-3.1-flash-preview",
+      name: "gemini-3.1-flash-preview",
+      provider: "google-vertex",
+      reasoning: true,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #36134 — sessions_spawn silently falls back to Anthropic when targeting Google Gemini models.

## Root Cause

When `sessions_spawn` targets `google/gemini-3.1-flash-lite-preview`, the model override is stored with `providerOverride: "google"`. At runtime, `resolveModel()` can't find the model because:

1. pi-ai's built-in catalog doesn't have `gemini-3.1-flash-lite-preview` yet
2. The forward-compat fallback (`resolveGoogleGeminiCli31ForwardCompatModel`) only checked the `"google-gemini-cli"` provider — not `"google"`
3. Template models (e.g. `gemini-3-flash-preview`) exist under `"google-gemini-cli"` in the registry
4. `FailoverError` is thrown and silently caught by `runWithModelFallback`, falling back to Anthropic
5. `modelApplied: true` was already returned to the caller — misleading

## Fix

Expand `resolveGoogleGeminiCli31ForwardCompatModel` to accept all Google provider variants (`google`, `google-gemini-cli`, `google-vertex`, `google-antigravity`). When the template model lives under a different variant in the pi-ai catalog, try all variants and re-stamp the provider to match the caller's request.

## Tests

Added 3 new test cases covering:
- `google/gemini-3.1-flash-lite-preview` (the exact model from the bug report)
- `google/gemini-3.1-pro-preview`
- `google-vertex/gemini-3.1-flash-preview`

All existing tests continue to pass.