### PR TITLE
fix(llm-task): add type field to input and schema tool parameters

### DIFF
--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -74,9 +74,17 @@ export function createLlmTaskTool(api: OpenClawPluginApi) {
       "Run a generic JSON-only LLM task and return schema-validated JSON. Designed for orchestration from Lobster workflows via openclaw.invoke.",
     parameters: Type.Object({
       prompt: Type.String({ description: "Task instruction for the LLM." }),
-      input: Type.Optional(Type.Unknown({ description: "Optional input payload for the task." })),
+      input: Type.Optional(
+        Type.Unsafe<Record<string, unknown>>({
+          type: "object",
+          description: "Optional input payload for the task.",
+        }),
+      ),
       schema: Type.Optional(
-        Type.Unknown({ description: "Optional JSON Schema to validate the returned JSON." }),
+        Type.Unsafe<Record<string, unknown>>({
+          type: "object",
+          description: "Optional JSON Schema to validate the returned JSON.",
+        }),
       ),
       provider: Type.Optional(
         Type.String({ description: "Provider override (e.g. openai-codex, anthropic)." }),


### PR DESCRIPTION
## Summary

- **Problem:** The `llm-task` tool's `input` and `schema` parameters use `Type.Unknown()` from TypeBox, which produces JSON Schemas without a `type` field (e.g. `{"description":"..."}` only). llama.cpp's OpenAI-compatible endpoint requires every parameter to have a `type` field for JSON schema-to-grammar conversion, causing a 400 error on every request when `llm-task` is in the tool set.
- **Why it matters:** Any agent using local LLM backends (llama.cpp / llama-server) with `llm-task` enabled is completely broken — the error surfaces as HTTP 502 through TensorZero.
- **What changed:** `extensions/llm-task/src/llm-task-tool.ts` — switched `input` and `schema` from `Type.Unknown()` to `Type.Unsafe<Record<string, unknown>>({ type: "object", description: "..." })`, producing schemas with an explicit `type: "object"` field.
- **What did NOT change:** Other tool parameters (`prompt`, `provider`, `model`, etc.) already had explicit types. Runtime behavior is unchanged — both parameters still accept arbitrary JSON objects.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35443

## User-visible / Behavior Changes

- `llm-task` tool now works with llama.cpp and other strict JSON Schema consumers that require a `type` field on every parameter definition.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+
- Integration/channel: Any agent using local LLM (llama.cpp)

### Steps

1. Enable `llm-task` tool on an agent using llama.cpp backend
2. Send any message

### Expected

- Tool definitions accepted, agent responds normally

### Actual

- Before fix: `400 "Unrecognized schema: {"description":"..."}"` on every request
- After fix: Tool definitions include `type: "object"`, llama.cpp accepts them

## Evidence

```
 ✓ extensions/llm-task/src/llm-task-tool.test.ts (8 tests) 21ms
   All 8 existing tests pass.
```

## Human Verification (required)

- Verified scenarios: All 8 llm-task tests pass, TypeScript compiles cleanly
- Edge cases checked: `Type.Unsafe` preserves runtime behavior; `type: "object"` is the correct JSON Schema type for arbitrary key-value payloads
- What I did **not** verify: Live llama.cpp endpoint test

## Compatibility / Migration

- Backward compatible? `Yes` — adding `type: "object"` is a strictly more constrained schema
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: None
- Known bad symptoms: None expected

## Risks and Mitigations

- Changing from `Type.Unknown()` (accepts any JSON type) to `type: "object"` means callers must pass objects, not strings/arrays/numbers for these parameters — this matches the documented usage (input is a payload object, schema is a JSON Schema object)

