### PR TITLE
fix(agents): Gemini 3.1 models not recognized with 'google' provider alias

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -176,9 +176,13 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
-  if (normalizeProviderId(provider) !== "google-gemini-cli") {
+  const normalized = normalizeProviderId(provider);
+  if (normalized !== "google-gemini-cli" && normalized !== "google") {
     return undefined;
   }
+  // Templates are registered under "google-gemini-cli" in the model registry,
+  // so always search there regardless of which alias the user specified.
+  const templateProvider = "google-gemini-cli";
   const trimmed = modelId.trim();
   const lower = trimmed.toLowerCase();
 
@@ -192,7 +196,7 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
   }
 
   return cloneFirstTemplateModel({
-    normalizedProvider: "google-gemini-cli",
+    normalizedProvider: templateProvider,
     trimmedModelId: trimmed,
     templateIds: [...templateIds],
     modelRegistry,

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -86,4 +86,28 @@ describe("pi embedded model e2e smoke", () => {
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: google-gemini-cli/gemini-4-unknown");
   });
+
+  it("builds a forward-compat fallback for google/gemini-3.1-flash-lite-preview", () => {
+    mockGoogleGeminiCliFlashTemplateModel();
+    const result = resolveModel("google", "gemini-3.1-flash-lite-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toBeDefined();
+    expect(result.model).toMatchObject({
+      id: "gemini-3.1-flash-lite-preview",
+      name: "gemini-3.1-flash-lite-preview",
+      reasoning: true,
+    });
+  });
+
+  it("builds a forward-compat fallback for google/gemini-3.1-pro-preview", () => {
+    mockGoogleGeminiCliProTemplateModel();
+    const result = resolveModel("google", "gemini-3.1-pro-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toBeDefined();
+    expect(result.model).toMatchObject({
+      id: "gemini-3.1-pro-preview",
+      name: "gemini-3.1-pro-preview",
+      reasoning: true,
+    });
+  });
 });


### PR DESCRIPTION
Fixes #36111
Fixes #36134

### Root Cause

`resolveGoogleGeminiCli31ForwardCompatModel` only accepted `google-gemini-cli` as the provider ID. Users specifying `google/gemini-3.1-flash-lite-preview` (using the common `google` alias) hit the provider guard and got either:
- `Unknown model` errors when used in fallback chains (#36111)
- Silent fallback to default Anthropic provider with misleading `modelApplied: true` (#36134)

### Fix

Accept both `google` and `google-gemini-cli` as valid providers. Templates are always searched under `google-gemini-cli` (where they are registered in the model registry), but the cloned model preserves the caller's original provider ID.

### Changes

- `src/agents/model-forward-compat.ts`: widen provider check, use `templateProvider` for registry lookup
- Added 2 tests for `google/gemini-3.1-flash-lite-preview` and `google/gemini-3.1-pro-preview`