### PR TITLE
fix(gateway): keep mode=ui agent runs on webchat origin

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -457,6 +457,53 @@ describe("gateway agent handler", () => {
     expect(callArgs.runContext?.messageChannel).toBe("webchat");
   });
 
+  it("treats mode=ui gateway clients as internal webchat origin for main sessions", async () => {
+    mockMainSessionEntry({
+      sessionId: "existing-session-id",
+      lastChannel: "telegram",
+      lastTo: "12345",
+    });
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        "agent:main:main": buildExistingMainStoreEntry({
+          lastChannel: "telegram",
+          lastTo: "12345",
+        }),
+      };
+      return await updater(store);
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "tui turn",
+        sessionKey: "agent:main:main",
+        idempotencyKey: "test-ui-mode-origin-channel",
+      },
+      {
+        reqId: "ui-mode-origin-1",
+        client: {
+          connect: {
+            client: { id: "gateway-client", mode: "ui" },
+          },
+        } as AgentHandlerArgs["client"],
+      },
+    );
+
+    await vi.waitFor(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      channel?: string;
+      messageChannel?: string;
+      runContext?: { messageChannel?: string };
+    };
+    expect(callArgs.channel).toBe("telegram");
+    expect(callArgs.messageChannel).toBe("webchat");
+    expect(callArgs.runContext?.messageChannel).toBe("webchat");
+  });
+
   it("handles missing cliSessionIds gracefully", async () => {
     mockMainSessionEntry({});
 

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -33,7 +33,11 @@ import { resolveAssistantIdentity } from "../assistant-identity.js";
 import { parseMessageWithAttachments } from "../chat-attachments.js";
 import { resolveAssistantAvatarUrl } from "../control-ui-shared.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
-import { GATEWAY_CLIENT_CAPS, hasGatewayClientCap } from "../protocol/client-info.js";
+import {
+  GATEWAY_CLIENT_CAPS,
+  GATEWAY_CLIENT_MODES,
+  hasGatewayClientCap,
+} from "../protocol/client-info.js";
 import {
   ErrorCodes,
   errorShape,
@@ -585,9 +589,10 @@ export const agentHandlers: GatewayRequestHandlers = {
       normalizedTurnSource && isGatewayMessageChannel(normalizedTurnSource)
         ? normalizedTurnSource
         : undefined;
+    const isUiModeClient = client?.connect?.client?.mode === GATEWAY_CLIENT_MODES.UI;
     const originMessageChannel =
       turnSourceMessageChannel ??
-      (client?.connect && isWebchatConnect(client.connect)
+      (client?.connect && (isWebchatConnect(client.connect) || isUiModeClient)
         ? INTERNAL_MESSAGE_CHANNEL
         : resolvedChannel);
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `agent.run` only treated `webchat` connects as internal source; `mode=ui` clients (for example TUI gateway client) could inherit stale external main-session routes.
- Why it matters: main-session turns from UI clients could be routed as if they originated from Telegram/other external channels, causing cross-channel delivery noise.
- What changed: treat `mode=ui` clients as internal webchat-origin when deriving `messageChannel`/`runContext.messageChannel` for `agentCommandFromIngress`.
- What did NOT change (scope boundary): delivery-plan resolution, explicit `--channel/--reply-channel`, and non-UI client behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35789
- Related #35859
- Related #35860

## User-visible / Behavior Changes

- UI-mode gateway clients now keep turn origin as `webchat` even when the main session has a remembered external route.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: n/a (routing unit test)
- Integration/channel (if any): Gateway agent handler
- Relevant config (redacted): main session with persisted `lastChannel=telegram`

### Steps

1. Seed main session with persisted external route (`telegram`).
2. Run `agent` with UI-mode client metadata (`id=gateway-client`, `mode=ui`).
3. Inspect downstream `agentCommandFromIngress` arguments.

### Expected

- `messageChannel` and `runContext.messageChannel` are `webchat` for UI-mode turns.

### Actual

- Before this patch, those fields could resolve to the stale external channel route.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added and ran a regression test for `mode=ui` client in `src/gateway/server-methods/agent.test.ts`.
- Edge cases checked: existing webchat-client route preservation test remains covered and passing.
- What you did **not** verify: end-to-end manual channel delivery on a live Telegram+TUI setup.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `gateway: treat UI-mode clients as webchat origin`.
- Files/config to restore: `src/gateway/server-methods/agent.ts`
- Known bad symptoms reviewers should watch for: UI-mode runs unexpectedly using external `messageChannel` again.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Some non-webchat UI-mode integrations may have relied on external origin fallback.
  - Mitigation: behavior change is narrowly scoped; explicit channel/reply-channel still takes precedence and regression tests cover the intended main-session case.
