### PR TITLE
Fix iMessage replies mirrored into control UI

### DIFF
--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -415,6 +415,22 @@ describe("routeReply", () => {
       }),
     );
   });
+
+  it("does not mirror imessage replies by default", async () => {
+    mocks.deliverOutboundPayloads.mockResolvedValue([]);
+    await routeReply({
+      payload: { text: "hi" },
+      channel: "imessage",
+      to: "imessage:+15551234567",
+      sessionKey: "agent:main:main",
+      cfg: {} as never,
+    });
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mirror: undefined,
+      }),
+    );
+  });
 });
 
 const emptyRegistry = createRegistry([]);

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -152,7 +152,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       session: outboundSession,
       abortSignal,
       mirror:
-        params.mirror !== false && params.sessionKey
+        params.mirror !== false && params.sessionKey && normalizedChannel !== "imessage"
           ? {
               sessionKey: params.sessionKey,
               agentId: resolvedAgentId,


### PR DESCRIPTION
Fix issue #36000 by disabling default transcript mirroring for iMessage routed replies in routeReply and adding regression coverage.