### PR TITLE
docs(browser): document existing Chrome remote-debugging setup

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -152,6 +152,48 @@ OpenClaw preserves the auth when calling `/json/*` endpoints and when connecting
 to the CDP WebSocket. Prefer environment variables or secrets managers for
 tokens instead of committing them to config files.
 
+## Attach to an existing Chrome instance (remote debugging port)
+
+If you want OpenClaw to use an already-running Chrome session (with your
+existing logins/cookies), run Chrome with remote debugging enabled and point a
+browser profile to that CDP endpoint.
+
+1. Start Chrome with a remote debugging port:
+
+```bash
+# macOS (example)
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.openclaw/chrome-remote-profile"
+```
+
+2. Configure a profile that uses that `cdpUrl`:
+
+```json5
+{
+  browser: {
+    defaultProfile: "chrome-live",
+    profiles: {
+      "chrome-live": {
+        cdpUrl: "http://127.0.0.1:9222",
+        color: "#4285F4",
+      },
+    },
+  },
+}
+```
+
+3. Restart the gateway, then use the profile with browser tools/CLI.
+
+Notes:
+
+- This is a direct CDP attach flow (no extension tab attach required).
+- If you want to keep the profile name `chrome`, define `browser.profiles.chrome`
+  in config; explicit profile config overrides the built-in extension relay
+  profile target.
+- Treat this profile as sensitive because OpenClaw can act with whatever
+  accounts are signed into that browser session.
+
 ## Node browser proxy (zero-config default)
 
 If you run a **node host** on the machine that has your browser, OpenClaw can


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: docs did not clearly explain how to attach OpenClaw browser control to an already-running Chrome instance via `--remote-debugging-port`.
- Why it matters: users running background services or wanting to reuse existing Chrome sessions had to reverse-engineer profile overrides.
- What changed: added a new browser docs section with launch command, config example (`browser.profiles.<name>.cdpUrl`), and behavior notes.
- What did NOT change (scope boundary): no code/runtime behavior changes; docs-only patch.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36150

## User-visible / Behavior Changes

- Browser docs now include explicit instructions for connecting to an existing Chrome instance over CDP.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: n/a (docs update)
- Runtime/container: n/a
- Model/provider: n/a
- Integration/channel (if any): Browser docs
- Relevant config (redacted): `browser.profiles.<name>.cdpUrl`

### Steps

1. Open `docs/tools/browser.md`.
2. Find the new “Attach to an existing Chrome instance (remote debugging port)” section.
3. Confirm it includes launch + config + profile override notes.

### Expected

- Users can follow one documented path without trial-and-error.

### Actual

- Previously this workflow was undocumented/implicit.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: checked rendered markdown section content and consistency with existing browser profile docs language.
- Edge cases checked: documented `browser.profiles.chrome` override note to avoid extension-relay confusion.
- What you did **not** verify: live browser attach against a running Chrome process.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert docs commit.
- Files/config to restore: `docs/tools/browser.md`
- Known bad symptoms reviewers should watch for: none (docs-only).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: example command could be interpreted as recommended for all setups.
  - Mitigation: scoped language and notes clarify this is an optional attach flow.
