### PR TITLE
fix(auto-reply): surface rate-limit and overload errors instead of silent empty response

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -9,6 +9,8 @@ import {
   isCompactionFailureError,
   isContextOverflowError,
   isLikelyContextOverflowError,
+  isOverloadedErrorMessage,
+  isRateLimitErrorMessage,
   isTransientHttpError,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
@@ -609,20 +611,38 @@ export async function runAgentTurnWithFallback(params: {
     }
   }
 
-  // If the run completed but with an embedded context overflow error that
-  // wasn't recovered from (e.g. compaction reset already attempted), surface
-  // the error to the user instead of silently returning an empty response.
-  // See #26905: Slack DM sessions silently swallowed messages when context
-  // overflow errors were returned as embedded error payloads.
+  // If the run completed but with an embedded error that wasn't recovered
+  // from and no payload text was generated, surface the error to the user
+  // instead of silently returning an empty response.
+  // See #26905 (context overflow) and #36142 (rate limit / overload mid-turn).
   const finalEmbeddedError = runResult?.meta?.error;
   const hasPayloadText = runResult?.payloads?.some((p) => p.text?.trim());
-  if (finalEmbeddedError && isContextOverflowError(finalEmbeddedError.message) && !hasPayloadText) {
-    return {
-      kind: "final",
-      payload: {
-        text: "⚠️ Context overflow — this conversation is too large for the model. Use /new to start a fresh session.",
-      },
-    };
+  if (finalEmbeddedError && !hasPayloadText) {
+    const errMsg = finalEmbeddedError.message ?? "";
+    if (isContextOverflowError(errMsg)) {
+      return {
+        kind: "final",
+        payload: {
+          text: "⚠️ Context overflow — this conversation is too large for the model. Use /new to start a fresh session.",
+        },
+      };
+    }
+    if (isRateLimitErrorMessage(errMsg)) {
+      return {
+        kind: "final",
+        payload: {
+          text: "⚠️ API rate limit reached mid-turn — the model couldn't generate a response after tool calls completed. Please try again in a moment.",
+        },
+      };
+    }
+    if (isOverloadedErrorMessage(errMsg)) {
+      return {
+        kind: "final",
+        payload: {
+          text: "⚠️ The AI service is temporarily overloaded. Please try again in a moment.",
+        },
+      };
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

- **Problem:** When an LLM rate limit or overload error occurs mid-turn (after tool calls have already executed), the run completes with an embedded error and empty payloads. The existing code only checks for context-overflow errors, so rate-limit and overload errors fall through to `kind: "success"` with no text — the user sees nothing.
- **Why it matters:** Users lose trust when the assistant silently swallows errors after visible tool execution. They have no indication to retry.
- **What changed:** Extended the embedded-error guard in `agent-runner-execution.ts` to also recognize `isRateLimitErrorMessage` and `isOverloadedErrorMessage` (both already exported from `pi-embedded-helpers`) and return informative user-facing messages.
- **What did NOT change:** Context-overflow handling, the `kind: "success"` return path (still used for genuine success), failover logic, or any other error classification.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36142

## User-visible / Behavior Changes

- When an LLM rate-limit error occurs mid-turn, the user now sees: "⚠️ API rate limit reached mid-turn — the model couldn't generate a response after tool calls completed. Please try again in a moment."
- When an LLM overload error occurs mid-turn, the user now sees: "⚠️ The AI service is temporarily overloaded. Please try again in a moment."
- Previously both cases returned an empty (silent) response.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: all channels (Slack, Telegram, Discord, etc.)

### Steps

1. Configure an LLM provider with low rate limits
2. Send a message that triggers tool calls
3. Ensure the rate limit is hit when the model tries to generate the final response after tool calls

### Expected

- User receives an informative error message explaining the rate limit

### Actual

- Before fix: User sees nothing (silent empty response)
- After fix: User sees "⚠️ API rate limit reached mid-turn — ..."

## Evidence

The fix extends the existing pattern from #26905 (context overflow):

```typescript
// Before: only context overflow was checked
if (finalEmbeddedError && isContextOverflowError(finalEmbeddedError.message) && !hasPayloadText) { ... }

// After: rate limit and overload are also surfaced
if (finalEmbeddedError && !hasPayloadText) {
  if (isContextOverflowError(errMsg)) { ... }
  if (isRateLimitErrorMessage(errMsg)) { ... }
  if (isOverloadedErrorMessage(errMsg)) { ... }
}
```

TypeScript check passes (`npx tsc --noEmit` — only pre-existing errors in `extensions/diffs` and `extensions/tlon`).

## Human Verification (required)

- Verified scenarios: TypeScript compilation, code review of all callers of `isRateLimitErrorMessage` and `isOverloadedErrorMessage`
- Edge cases checked: `finalEmbeddedError` is null/undefined (guard short-circuits), error message is empty string (no match, falls through to success as before), payloads DO have text (guard short-circuits, success returned as before)
- What I did **not** verify: End-to-end test with a real rate-limited provider

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single file change; the original behavior (silent empty response) returns
- Files/config to restore: `src/auto-reply/reply/agent-runner-execution.ts`
- Known bad symptoms: If the error classification functions have false positives, a genuine success with an embedded error could be intercepted — but this only triggers when `!hasPayloadText`, so any run that produced text is unaffected

## Risks and Mitigations

- Risk: An unknown embedded error type could still fall through silently. Mitigation: This PR handles the two most common transient error types; a catch-all can be added later if needed.

