### PR TITLE
fix(gateway): create transcript file on chat.inject when missing

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1142,7 +1142,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       storePath,
       sessionFile: entry?.sessionFile,
       agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
-      createIfMissing: false,
+      createIfMissing: true,
     });
     if (!appended.ok || !appended.messageId || !appended.message) {
       respond(


### PR DESCRIPTION
## Summary

- **Problem:** `chat.inject` fails with "transcript file not found" when the transcript file does not exist on disk, even though the session entry has a valid `transcriptPath`. This commonly happens with ACP oneshot/run sessions where the transcript file is not pre-created.
- **Why it matters:** Users cannot inject messages into sessions that lack a transcript file, breaking transcript persistence and making `chat.history` / `sessions_history` return empty. The workaround (manually `touch`ing the file) is unreasonable for production use.
- **What changed:** Changed `createIfMissing: false` to `createIfMissing: true` in the `chat.inject` handler so that `appendAssistantTranscriptMessage` delegates to the existing `ensureTranscriptFile` helper (which safely creates the directory and file) before appending.
- **What did NOT change:** The `appendAssistantTranscriptMessage` function itself, `ensureTranscriptFile` logic, or any other RPC handler. The abort/auto-reply paths already use `createIfMissing: true`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36170

## User-visible / Behavior Changes

- `chat.inject` now succeeds even when the transcript file does not exist on disk — the file is created automatically (matching the behavior of `chat.send`'s abort/auto-reply paths which already use `createIfMissing: true`).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS arm64
- Runtime: Node.js
- Integration/channel: gateway RPC (any client)

### Steps

1. Create an ACP oneshot/run session (the transcript file is not pre-created)
2. Call `chat.inject` with a valid `sessionKey`

### Expected

- The transcript file is created and the message is appended successfully

### Actual

- Before fix: Error `"failed to write transcript: transcript file not found"`
- After fix: File is created via `ensureTranscriptFile`, message is appended, success response returned

## Evidence

One-line change:

```diff
-      createIfMissing: false,
+      createIfMissing: true,
```

This aligns `chat.inject` with the existing behavior in the abort handler (line 492) and the auto-reply handler (line 1025), both of which already use `createIfMissing: true`.

TypeScript check passes (`npx tsc --noEmit` — only pre-existing errors in `extensions/diffs` and `extensions/tlon`). Existing test (`chat.inject.parentid.test.ts`) passes.

## Human Verification (required)

- Verified scenarios: TypeScript compilation, existing test suite, code review of all `createIfMissing` usage sites
- Edge cases checked: `transcriptPath` resolves to null (returns early with "path not resolved" before reaching `createIfMissing`), `ensureTranscriptFile` fails (returns error "failed to create transcript file")
- What I did **not** verify: End-to-end test with ACP oneshot session

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single-line change; the original behavior (hard error on missing file) returns
- Files/config to restore: `src/gateway/server-methods/chat.ts`
- Known bad symptoms: None expected — `ensureTranscriptFile` is already used safely in two other code paths

## Risks and Mitigations

None — this change makes `chat.inject` consistent with the other two callers that already use `createIfMissing: true`.

