### PR TITLE
perf(thread-ownership): cap mention bypass cache size

### DIFF
--- a/extensions/thread-ownership/index.test.ts
+++ b/extensions/thread-ownership/index.test.ts
@@ -142,6 +142,52 @@ describe("thread-ownership plugin", () => {
       expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 
+    it("bounds mention cache and evicts oldest tracked thread", async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ owner: "test-agent" }), { status: 200 }),
+      );
+
+      const channelId = "CCAP";
+      await hooks.message_received(
+        {
+          content: "Hey @TestBot oldest",
+          metadata: { threadTs: "cap-oldest", channelId },
+        },
+        { channelId: "slack", conversationId: channelId },
+      );
+
+      for (let i = 0; i < 1000; i += 1) {
+        await hooks.message_received(
+          {
+            content: "Hey @TestBot fill",
+            metadata: { threadTs: `cap-${i}`, channelId },
+          },
+          { channelId: "slack", conversationId: channelId },
+        );
+      }
+
+      await hooks.message_sending(
+        {
+          content: "Should require ownership check after eviction",
+          metadata: { threadTs: "cap-oldest", channelId },
+          to: channelId,
+        },
+        { channelId: "slack", conversationId: channelId },
+      );
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+      vi.mocked(globalThis.fetch).mockClear();
+      await hooks.message_sending(
+        {
+          content: "Newest tracked thread should still bypass ownership check",
+          metadata: { threadTs: "cap-999", channelId },
+          to: channelId,
+        },
+        { channelId: "slack", conversationId: channelId },
+      );
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
     it("ignores @-mentions on non-slack channels", async () => {
       // Use a unique thread key so module-level state from other tests doesn't interfere.
       await hooks.message_received(

--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -11,13 +11,28 @@ type AgentEntry = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[num
 // Entries expire after 5 minutes.
 const mentionedThreads = new Map<string, number>();
 const MENTION_TTL_MS = 5 * 60 * 1000;
+const MAX_TRACKED_MENTIONS = 1000;
 
-function cleanExpiredMentions(): void {
-  const now = Date.now();
+function cleanExpiredMentions(now = Date.now()): void {
   for (const [key, ts] of mentionedThreads) {
     if (now - ts > MENTION_TTL_MS) {
       mentionedThreads.delete(key);
     }
+  }
+}
+
+function trackMention(key: string, now = Date.now()): void {
+  cleanExpiredMentions(now);
+  if (mentionedThreads.has(key)) {
+    mentionedThreads.delete(key);
+  }
+  mentionedThreads.set(key, now);
+  while (mentionedThreads.size > MAX_TRACKED_MENTIONS) {
+    const oldestKey = mentionedThreads.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    mentionedThreads.delete(oldestKey);
   }
 }
 
@@ -75,8 +90,7 @@ export default function register(api: OpenClawPluginApi) {
       (botUserId && text.includes(`<@${botUserId}>`));
 
     if (mentioned) {
-      cleanExpiredMentions();
-      mentionedThreads.set(`${channelId}:${threadTs}`, Date.now());
+      trackMention(`${channelId}:${threadTs}`);
     }
   });
 


### PR DESCRIPTION
## Summary\n- add a hard cap to the in-memory mention-bypass cache in the thread-ownership plugin\n- refresh insertion order for repeated mentions so active threads stay resident\n- add a focused test that verifies oldest-entry eviction once the cache limit is exceeded\n\n## Why\nThe mention bypass cache was only time-based (5 minute TTL). Under high mention volume, entries could spike before expiration and grow memory usage unnecessarily.\n\n## Risk\nLow. The change only bounds the cache size and keeps existing bypass semantics for recent mentions.