### PR TITLE
fix: allow chat.inject to create missing transcript file

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1142,7 +1142,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       storePath,
       sessionFile: entry?.sessionFile,
       agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
-      createIfMissing: false,
+      createIfMissing: true,
     });
     if (!appended.ok || !appended.messageId || !appended.message) {
       respond(

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1135,13 +1135,21 @@ export const chatHandlers: GatewayRequestHandlers = {
       return;
     }
 
+    // Reload entry before append to avoid writing into a stale transcript path
+    // when concurrent session mutations (for example sessions.reset) rotate ids/files.
+    const latest = loadSessionEntry(rawSessionKey);
+    const latestSessionId = latest.entry?.sessionId ?? sessionId;
+    const latestStorePath = latest.storePath ?? storePath;
+    const latestSessionFile = latest.entry?.sessionFile ?? entry?.sessionFile;
+    const latestCfg = latest.cfg ?? cfg;
+
     const appended = appendAssistantTranscriptMessage({
       message: p.message,
       label: p.label,
-      sessionId,
-      storePath,
-      sessionFile: entry?.sessionFile,
-      agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
+      sessionId: latestSessionId,
+      storePath: latestStorePath,
+      sessionFile: latestSessionFile,
+      agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: latestCfg }),
       createIfMissing: true,
     });
     if (!appended.ok || !appended.messageId || !appended.message) {


### PR DESCRIPTION
## Summary
- make `chat.inject` pass `createIfMissing: true` when appending transcript entries
- this prevents ENOENT hard-failure when session metadata points to a transcript path that does not exist yet

## Testing
- `pnpm vitest run src/gateway/server-methods/chat.inject.parentid.test.ts src/gateway/server-methods/chat.directive-tags.test.ts`

Fixes openclaw/openclaw#36170