### PR TITLE
fix(agents ): recognize Gemini 3.1 models for google provider in fallback routing

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -27,12 +27,14 @@ const ZAI_GLM5_MODEL_ID = "glm-5";
 const ZAI_GLM5_TEMPLATE_MODEL_IDS = ["glm-4.7"] as const;
 
 // gemini-3.1-pro-preview / gemini-3.1-flash-preview are not yet in pi-ai's built-in
-// google-gemini-cli catalog. Clone the gemini-3-pro/flash-preview template so users
-// don't get "Unknown model" errors when Google releases a new minor version.
+// google-gemini-cli / google provider catalogs. Clone the gemini-3-pro/flash-preview
+// template so users don't get "Unknown model" errors when Google releases new
+// minor-version models.
 const GEMINI_3_1_PRO_PREFIX = "gemini-3.1-pro";
 const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";
 const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3-pro-preview"] as const;
 const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview"] as const;
+const GOOGLE_PROVIDER_IDS = new Set(["google-gemini-cli", "google"]);
 
 function resolveOpenAIGpt54ForwardCompatModel(
   provider: string,
@@ -241,15 +243,17 @@ function resolveAnthropicSonnet46ForwardCompatModel(
   });
 }
 
-// gemini-3.1-pro-preview / gemini-3.1-flash-preview are not present in pi-ai's built-in
-// google-gemini-cli catalog yet. Clone the nearest gemini-3 template so users don't get
-// "Unknown model" errors when Google Gemini CLI gains new minor-version models.
-function resolveGoogleGeminiCli31ForwardCompatModel(
+// Gemini 3.1 series models (pro / flash / flash-lite) are not yet present in pi-ai's
+// built-in google-gemini-cli or google provider catalogs.  Clone the nearest gemini-3
+// template so users don't get "Unknown model" errors when Google releases new
+// minor-version models.  Both the google-gemini-cli and google providers are supported.
+function resolveGoogle31ForwardCompatModel(
   provider: string,
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
-  if (normalizeProviderId(provider) !== "google-gemini-cli") {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (!GOOGLE_PROVIDER_IDS.has(normalizedProvider)) {
     return undefined;
   }
   const trimmed = modelId.trim();
@@ -265,7 +269,7 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
   }
 
   return cloneFirstTemplateModel({
-    normalizedProvider: "google-gemini-cli",
+    normalizedProvider,
     trimmedModelId: trimmed,
     templateIds: [...templateIds],
     modelRegistry,
@@ -326,6 +330,6 @@ export function resolveForwardCompatModel(
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveZaiGlm5ForwardCompatModel(provider, modelId, modelRegistry) ??
-    resolveGoogleGeminiCli31ForwardCompatModel(provider, modelId, modelRegistry)
+    resolveGoogle31ForwardCompatModel(provider, modelId, modelRegistry)
   );
 }

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -11,6 +11,7 @@ import {
   GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
   GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
   makeModel,
+  mockDiscoveredModel,
   mockGoogleGeminiCliFlashTemplateModel,
   mockGoogleGeminiCliProTemplateModel,
   mockOpenAICodexTemplateModel,
@@ -93,5 +94,53 @@ describe("pi embedded model e2e smoke", () => {
     const result = resolveModel("google-gemini-cli", "gemini-4-unknown", "/tmp/agent");
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: google-gemini-cli/gemini-4-unknown");
+  });
+
+  it("builds a google forward-compat fallback for gemini-3.1-pro-preview", () => {
+    mockDiscoveredModel({
+      provider: "google",
+      modelId: "gemini-3-pro-preview",
+      templateModel: {
+        ...GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+        provider: "google",
+        api: "google",
+      },
+    });
+
+    const result = resolveModel("google", "gemini-3.1-pro-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "gemini-3.1-pro-preview",
+      name: "gemini-3.1-pro-preview",
+      provider: "google",
+      reasoning: true,
+    });
+  });
+
+  it("builds a google forward-compat fallback for gemini-3.1-flash-lite-preview", () => {
+    mockDiscoveredModel({
+      provider: "google",
+      modelId: "gemini-3-flash-preview",
+      templateModel: {
+        ...GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
+        provider: "google",
+        api: "google",
+      },
+    });
+
+    const result = resolveModel("google", "gemini-3.1-flash-lite-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "gemini-3.1-flash-lite-preview",
+      name: "gemini-3.1-flash-lite-preview",
+      provider: "google",
+      reasoning: true,
+    });
+  });
+
+  it("keeps unknown-model errors for unrecognized google model IDs", () => {
+    const result = resolveModel("google", "gemini-4-unknown", "/tmp/agent");
+    expect(result.model).toBeUndefined();
+    expect(result.error).toBe("Unknown model: google/gemini-4-unknown");
   });
 });


### PR DESCRIPTION
**Fixes:** #36111

## Summary

This PR resolves a `FailoverError: Unknown model` regression that occurs when Gemini 3.1 series models (e.g., `google/gemini-3.1-pro-preview`, `google/gemini-3.1-flash-lite-preview`) are configured in the `fallbacks` array using the `google` provider. The existing forward-compatibility resolver only recognized the `google-gemini-cli` provider, causing failover attempts to fail for the plain `google` provider.

This fix enhances the forward-compatibility logic to correctly identify and handle Gemini 3.1 models for both `google-gemini-cli` and `google` providers. It also improves code clarity and maintainability by updating function names and comments to reflect the expanded provider support.

## Root Cause

The `resolveGoogleGeminiCli31ForwardCompatModel` function was hardcoded to only check for the `google-gemini-cli` provider. When a model from the `google` provider was used in a fallback scenario, this check would fail, and the model would not be resolved, leading to an "Unknown model" error.

## Solution

1.  **Generalize Provider Check**: A new `Set` named `GOOGLE_PROVIDER_IDS` is introduced, containing both `google-gemini-cli` and `google`.
2.  **Update Resolver Logic**: The resolver function now checks if the `normalizedProvider` is present in the `GOOGLE_PROVIDER_IDS` set, instead of a direct string comparison to `google-gemini-cli`.
3.  **Use Normalized Provider**: The `cloneFirstTemplateModel` function is now called with the actual `normalizedProvider` variable, ensuring the correct provider context is used when cloning the template model.
4.  **Improve Code Quality**: 
    *   The function `resolveGoogleGeminiCli31ForwardCompatModel` has been renamed to `resolveGoogle31ForwardCompatModel` to more accurately reflect its purpose.
    *   Code comments have been updated to clarify that both providers are supported, improving future maintainability.
5.  **Add Test Coverage**: New end-to-end tests have been added to `model.forward-compat.test.ts` to verify the fix for the `google` provider with both `gemini-3.1-pro-preview` and `gemini-3.1-flash-lite-preview` models, ensuring the issue is resolved and preventing future regressions.

## Changed Files

- `src/agents/model-forward-compat.ts`
- `src/agents/pi-embedded-runner/model.forward-compat.test.ts`

