### PR TITLE
Feishu: support requester_open_id fallback for doc create grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/doc create requester grants: support explicit `requester_open_id` fallback for `feishu_doc` create outside trusted Feishu message contexts, while keeping trusted sender identity authoritative when available. (related to #36109)
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -43,6 +43,12 @@ export const FeishuDocSchema = Type.Union([
     action: Type.Literal("create"),
     title: Type.String({ description: "Document title" }),
     folder_token: Type.Optional(Type.String({ description: "Target folder token (optional)" })),
+    requester_open_id: Type.Optional(
+      Type.String({
+        description:
+          "Requester open_id for edit-grant fallback outside trusted Feishu message context. Ignored when trusted sender context exists.",
+      }),
+    ),
     grant_to_requester: Type.Optional(
       Type.Boolean({
         description:

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -326,6 +326,53 @@ describe("feishu_doc image fetch hardening", () => {
     );
   });
 
+  it("create allows explicit requester_open_id outside Feishu channel context", async () => {
+    const feishuDocTool = resolveFeishuDocTool({
+      messageChannel: "webchat",
+    });
+
+    const result = await feishuDocTool.execute("tool-call", {
+      action: "create",
+      title: "Demo",
+      requester_open_id: "ou_manual_456",
+    });
+
+    expect(result.details.requester_permission_added).toBe(true);
+    expect(result.details.requester_open_id).toBe("ou_manual_456");
+    expect(permissionMemberCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          member_id: "ou_manual_456",
+          perm: "edit",
+        }),
+      }),
+    );
+  });
+
+  it("create ignores explicit requester_open_id when trusted Feishu requester is present", async () => {
+    const feishuDocTool = resolveFeishuDocTool({
+      messageChannel: "feishu",
+      requesterSenderId: "ou_123",
+    });
+
+    const result = await feishuDocTool.execute("tool-call", {
+      action: "create",
+      title: "Demo",
+      requester_open_id: "ou_manual_456",
+    });
+
+    expect(result.details.requester_permission_added).toBe(true);
+    expect(result.details.requester_open_id).toBe("ou_123");
+    expect(permissionMemberCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          member_id: "ou_123",
+          perm: "edit",
+        }),
+      }),
+    );
+  });
+
   it("create skips requester grant when trusted requester identity is unavailable", async () => {
     const feishuDocTool = resolveFeishuDocTool({
       messageChannel: "feishu",

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -1308,13 +1308,17 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                       api.logger,
                     ),
                   );
-                case "create":
+                case "create": {
+                  // Keep trusted sender identity authoritative on Feishu, but allow
+                  // explicit requester_open_id as a fallback for non-Feishu contexts.
+                  const requestedRequesterOpenId = p.requester_open_id?.trim() || undefined;
                   return json(
                     await createDoc(client, p.title, p.folder_token, {
                       grantToRequester: p.grant_to_requester,
-                      requesterOpenId: trustedRequesterOpenId,
+                      requesterOpenId: trustedRequesterOpenId ?? requestedRequesterOpenId,
                     }),
                   );
+                }
                 case "list_blocks":
                   return json(await listBlocks(client, p.doc_token));
                 case "get_block":


### PR DESCRIPTION
## Summary

- Problem: `feishu_doc` create grant logic only used trusted Feishu sender context; when create is triggered outside Feishu channel context, `grant_to_requester` could not resolve an identity and silently skipped the grant.
- Why it matters: users can create docs from non-Feishu contexts (for example webchat/agent orchestrations) and still expect edit access handoff.
- What changed: added optional `requester_open_id` on `feishu_doc` create; runtime now prefers trusted Feishu sender identity when present, otherwise falls back to explicit `requester_open_id`.
- What did NOT change (scope boundary): permission scope/role remains `edit`; no changes to Feishu auth/account routing; no separate share API added.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36109
- Related #36109

## User-visible / Behavior Changes

- `feishu_doc` `action: "create"` now accepts `requester_open_id`.
- If channel is trusted Feishu context, trusted `requesterSenderId` stays authoritative.
- If not in trusted Feishu context, explicit `requester_open_id` can be used for requester permission grant.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Surface change is limited to one optional tool input (`requester_open_id`) on existing create flow.
  - Mitigation: trusted Feishu sender remains authoritative when available, preventing spoofed override in trusted channel context.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev
- Model/provider: n/a
- Integration/channel (if any): Feishu extension tool tests
- Relevant config (redacted): default test config

### Steps

1. Execute `feishu_doc` create in non-Feishu context with `grant_to_requester` default and `requester_open_id` provided.
2. Execute `feishu_doc` create in trusted Feishu context with both trusted sender and explicit `requester_open_id`.
3. Check permission member payload target ID and returned details.

### Expected

- Step 1 grants to explicit `requester_open_id`.
- Step 2 grants to trusted sender ID and ignores explicit override.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test extensions/feishu/src/docx.test.ts` (includes new cases for fallback + trusted precedence).
  - `pnpm exec oxfmt --check CHANGELOG.md extensions/feishu/src/doc-schema.ts extensions/feishu/src/docx.ts extensions/feishu/src/docx.test.ts`.
- Edge cases checked:
  - trusted sender present + explicit param present -> trusted sender wins.
  - explicit opt-out (`grant_to_requester: false`) behavior remains unchanged (existing test).
- What you did **not** verify:
  - Live Feishu API interaction with real tenant credentials.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Set `grant_to_requester: false` in create calls, or revert this PR.
- Files/config to restore:
  - `extensions/feishu/src/doc-schema.ts`
  - `extensions/feishu/src/docx.ts`
- Known bad symptoms reviewers should watch for:
  - create unexpectedly granting to wrong open_id in trusted Feishu context.

## Risks and Mitigations

- Risk:
  - Caller in non-Feishu context may pass an unintended `requester_open_id`.
  - Mitigation:
    - trusted Feishu sender cannot be overridden when present; behavior is explicit and opt-in via parameter.
