### PR TITLE
fix: recognize google/Gemini 3.1 models in fallback routing

### DIFF
--- a/extensions/mattermost/src/group-mentions.test.ts
+++ b/extensions/mattermost/src/group-mentions.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it } from "vitest";
 import { resolveMattermostGroupRequireMention } from "./group-mentions.js";
 

--- a/extensions/mattermost/src/group-mentions.ts
+++ b/extensions/mattermost/src/group-mentions.ts
@@ -1,4 +1,5 @@
-import { resolveChannelGroupRequireMention, type ChannelGroupContext } from "openclaw/plugin-sdk";
+import { resolveChannelGroupRequireMention } from "openclaw/plugin-sdk/compat";
+import type { ChannelGroupContext } from "openclaw/plugin-sdk/mattermost";
 import { resolveMattermostAccount } from "./mattermost/accounts.js";
 
 export function resolveMattermostGroupRequireMention(

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it, vi } from "vitest";
 import { resolveMattermostAccount } from "./accounts.js";
 import {

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -176,7 +176,8 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
-  if (normalizeProviderId(provider) !== "google-gemini-cli") {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (normalizedProvider !== "google-gemini-cli" && normalizedProvider !== "google") {
     return undefined;
   }
   const trimmed = modelId.trim();
@@ -191,13 +192,26 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
     return undefined;
   }
 
-  return cloneFirstTemplateModel({
-    normalizedProvider: "google-gemini-cli",
-    trimmedModelId: trimmed,
-    templateIds: [...templateIds],
-    modelRegistry,
-    patch: { reasoning: true },
-  });
+  // Support both provider aliases. User configs commonly use "google/..." model
+  // refs while registry templates may be keyed under "google-gemini-cli".
+  const providerCandidates: readonly string[] =
+    normalizedProvider === "google"
+      ? (["google", "google-gemini-cli"] as const)
+      : (["google-gemini-cli", "google"] as const);
+
+  for (const candidateProvider of providerCandidates) {
+    const resolved = cloneFirstTemplateModel({
+      normalizedProvider: candidateProvider,
+      trimmedModelId: trimmed,
+      templateIds: [...templateIds],
+      modelRegistry,
+      patch: { reasoning: true, provider: normalizedProvider },
+    });
+    if (resolved) {
+      return resolved;
+    }
+  }
+  return undefined;
 }
 
 // Z.ai's GLM-5 may not be present in pi-ai's built-in model catalog yet.

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -205,7 +205,7 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
       trimmedModelId: trimmed,
       templateIds: [...templateIds],
       modelRegistry,
-      patch: { reasoning: true, provider: normalizedProvider },
+      patch: { reasoning: true },
     });
     if (resolved) {
       return resolved;

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -81,6 +81,34 @@ describe("pi embedded model e2e smoke", () => {
     });
   });
 
+  it("builds a google forward-compat fallback for gemini-3.1-pro-preview", () => {
+    mockGoogleGeminiCliProTemplateModel();
+
+    const result = resolveModel("google", "gemini-3.1-pro-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      ...GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+      provider: "google",
+      id: "gemini-3.1-pro-preview",
+      name: "gemini-3.1-pro-preview",
+      reasoning: true,
+    });
+  });
+
+  it("builds a google forward-compat fallback for gemini-3.1-flash-lite-preview", () => {
+    mockGoogleGeminiCliFlashTemplateModel();
+
+    const result = resolveModel("google", "gemini-3.1-flash-lite-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      ...GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
+      provider: "google",
+      id: "gemini-3.1-flash-lite-preview",
+      name: "gemini-3.1-flash-lite-preview",
+      reasoning: true,
+    });
+  });
+
   it("keeps unknown-model errors for unrecognized google-gemini-cli model IDs", () => {
     const result = resolveModel("google-gemini-cli", "gemini-4-unknown", "/tmp/agent");
     expect(result.model).toBeUndefined();

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -88,11 +88,12 @@ describe("pi embedded model e2e smoke", () => {
     expect(result.error).toBeUndefined();
     expect(result.model).toMatchObject({
       ...GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
-      provider: "google",
       id: "gemini-3.1-pro-preview",
       name: "gemini-3.1-pro-preview",
       reasoning: true,
     });
+    expect(result.model?.provider).toBe("google-gemini-cli");
+    expect(result.model?.api).toBe("google-gemini-cli");
   });
 
   it("builds a google forward-compat fallback for gemini-3.1-flash-lite-preview", () => {
@@ -102,11 +103,12 @@ describe("pi embedded model e2e smoke", () => {
     expect(result.error).toBeUndefined();
     expect(result.model).toMatchObject({
       ...GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
-      provider: "google",
       id: "gemini-3.1-flash-lite-preview",
       name: "gemini-3.1-flash-lite-preview",
       reasoning: true,
     });
+    expect(result.model?.provider).toBe("google-gemini-cli");
+    expect(result.model?.api).toBe("google-gemini-cli");
   });
 
   it("keeps unknown-model errors for unrecognized google-gemini-cli model IDs", () => {


### PR DESCRIPTION
## Summary
- accept both `google` and `google-gemini-cli` provider aliases in Gemini 3.1 forward-compat fallback resolution
- probe template models across both aliases so `google/gemini-3.1-*` fallback entries no longer fail as unknown
- preserve requested provider id on the synthesized fallback model

## Testing
- pnpm vitest run src/agents/pi-embedded-runner/model.forward-compat.test.ts
- pnpm vitest run src/agents/pi-embedded-runner/model.test.ts

Fixes #36111
