### PR TITLE
Gateway: make chat.inject create missing transcript files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/chat.inject transcript persistence: auto-create missing transcript files before append so `chat.inject` no longer fails with `transcript file not found` on sessions whose transcript path exists in metadata but file is absent. (related to #36170)
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -93,6 +93,13 @@ function createTranscriptFixture(prefix: string) {
   mockState.transcriptPath = transcriptPath;
 }
 
+function createMissingTranscriptFixture(prefix: string) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const realDir = fs.realpathSync(dir);
+  const transcriptPath = path.join(realDir, "sess.jsonl");
+  mockState.transcriptPath = transcriptPath;
+}
+
 function extractFirstTextBlock(payload: unknown): string | undefined {
   if (!payload || typeof payload !== "object") {
     return undefined;
@@ -301,6 +308,28 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       }),
     );
     expect(extractFirstTextBlock(chatCall?.[1])).toBe("");
+  });
+
+  it("chat.inject creates missing transcript files before appending", async () => {
+    createMissingTranscriptFixture("openclaw-chat-inject-create-missing-");
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await chatHandlers["chat.inject"]({
+      params: { sessionKey: "main", message: "hello" },
+      respond,
+      req: {} as never,
+      client: null as never,
+      isWebchatConnect: () => false,
+      context: context as GatewayRequestContext,
+    });
+
+    const [ok, payload] = respond.mock.calls.at(-1) ?? [];
+    expect(ok).toBe(true);
+    expect(payload).toMatchObject({ ok: true, messageId: expect.any(String) });
+    expect(fs.existsSync(mockState.transcriptPath)).toBe(true);
+    const lines = fs.readFileSync(mockState.transcriptPath, "utf-8").split(/\r?\n/).filter(Boolean);
+    expect(lines.length).toBeGreaterThanOrEqual(2);
   });
 
   it("chat.send non-streaming final keeps message defined for directive-only assistant text", async () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1142,7 +1142,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       storePath,
       sessionFile: entry?.sessionFile,
       agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
-      createIfMissing: false,
+      createIfMissing: true,
     });
     if (!appended.ok || !appended.messageId || !appended.message) {
       respond(


### PR DESCRIPTION
## Summary

- Problem: `chat.inject` failed with `transcript file not found` when session metadata had a transcript path but the file was missing on disk.
- Why it matters: injected messages could not be persisted, breaking transcript continuity and downstream `chat.history` visibility.
- What changed: `chat.inject` now calls transcript append with `createIfMissing: true`, and regression coverage verifies missing transcript files are created before append.
- What did NOT change (scope boundary): no changes to `chat.send` flow, transcript schema, or routing/broadcast semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36170
- Related #36170

## User-visible / Behavior Changes

- `chat.inject` no longer hard-fails when transcript file is missing but transcript path is resolvable; it creates the transcript file and appends successfully.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev
- Model/provider: n/a
- Integration/channel (if any): Gateway RPC handler tests
- Relevant config (redacted): mocked session store path

### Steps

1. Prepare `chat.inject` session metadata with `sessionFile` path but no transcript file on disk.
2. Call `chat.inject` with a message.
3. Verify response success and transcript file creation with appended message entries.

### Expected

- `chat.inject` returns success and transcript file is created automatically.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/gateway/server-methods/chat.directive-tags.test.ts src/gateway/server-methods/chat.inject.parentid.test.ts`
  - `pnpm exec oxfmt --check CHANGELOG.md src/gateway/server-methods/chat.ts src/gateway/server-methods/chat.directive-tags.test.ts`
  - `pnpm exec oxlint src/gateway/server-methods/chat.ts src/gateway/server-methods/chat.directive-tags.test.ts`
- Edge cases checked:
  - Missing transcript file path under macOS `/var` -> `/private/var` symlink path normalization.
- What you did **not** verify:
  - Live gateway runtime behavior with real ACP backends.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/gateway/server-methods/chat.ts`
  - `src/gateway/server-methods/chat.directive-tags.test.ts`
- Known bad symptoms reviewers should watch for:
  - duplicate transcript headers or malformed first-line session entries on inject writes.

## Risks and Mitigations

- Risk:
  - Creating a missing transcript could mask broken upstream session bootstrap in edge setups.
  - Mitigation:
    - Behavior is intentionally best-effort for persistence continuity and covered by explicit regression test.
