### PR TITLE
fix(tools): guard malformed text blocks in tool results to prevent session crash loop

### DIFF
--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  estimateMessageCharsCached,
+  createMessageCharEstimateCache,
+  getToolResultText,
+} from "./tool-result-char-estimator.js";
+
+describe("tool-result-char-estimator", () => {
+  describe("malformed text blocks", () => {
+    it("does not crash on {type:'text'} with no text property", () => {
+      const cache = createMessageCharEstimateCache();
+      const msg = {
+        role: "toolResult" as const,
+        toolCallId: "call_1",
+        toolName: "test",
+        content: [{ type: "text" }],
+        isError: false,
+      };
+      // Should not throw — previously crashed with
+      // "Cannot read properties of undefined (reading 'length')"
+      const chars = estimateMessageCharsCached(msg as never, cache);
+      expect(chars).toBeGreaterThanOrEqual(0);
+    });
+
+    it("getToolResultText skips blocks with missing text property", () => {
+      const msg = {
+        role: "toolResult" as const,
+        toolCallId: "call_1",
+        toolName: "test",
+        content: [{ type: "text" }, { type: "text", text: "hello" }],
+        isError: false,
+      };
+      const text = getToolResultText(msg as never);
+      expect(text).toBe("hello");
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
@@ -7,7 +7,12 @@ const IMAGE_CHAR_ESTIMATE = 8_000;
 export type MessageCharEstimateCache = WeakMap<AgentMessage, number>;
 
 function isTextBlock(block: unknown): block is { type: "text"; text: string } {
-  return !!block && typeof block === "object" && (block as { type?: unknown }).type === "text";
+  return (
+    !!block &&
+    typeof block === "object" &&
+    (block as { type?: unknown }).type === "text" &&
+    typeof (block as { text?: unknown }).text === "string"
+  );
 }
 
 function isImageBlock(block: unknown): boolean {

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -18,6 +18,36 @@ const GUARD_TRUNCATION_SUFFIX =
   "Use offset/limit parameters or request specific sections for large content.]";
 
 /**
+ * Sanitize content blocks in a tool result message so that every `{type:"text"}`
+ * block has a valid `text` string.  Plugin tool handlers that return `undefined`
+ * can produce `{type:"text"}` without a `text` property; if persisted, these
+ * crash the context-truncation pipeline on every subsequent message.
+ */
+function sanitizeToolResultContent(msg: AgentMessage): AgentMessage {
+  if ((msg as { role?: string }).role !== "toolResult") {
+    return msg;
+  }
+  const content = (msg as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return msg;
+  }
+  let changed = false;
+  const fixed = content.map((block) => {
+    if (
+      block &&
+      typeof block === "object" &&
+      (block as { type?: unknown }).type === "text" &&
+      typeof (block as { text?: unknown }).text !== "string"
+    ) {
+      changed = true;
+      return { ...block, text: "" };
+    }
+    return block;
+  });
+  return changed ? { ...msg, content: fixed } : msg;
+}
+
+/**
  * Truncate oversized text content blocks in a tool result message.
  * Returns the original message if under the limit, or a new message with
  * truncated text blocks otherwise.
@@ -26,7 +56,7 @@ function capToolResultSize(msg: AgentMessage): AgentMessage {
   if ((msg as { role?: string }).role !== "toolResult") {
     return msg;
   }
-  return truncateToolResultMessage(msg, HARD_MAX_TOOL_RESULT_CHARS, {
+  return truncateToolResultMessage(sanitizeToolResultContent(msg), HARD_MAX_TOOL_RESULT_CHARS, {
     suffix: GUARD_TRUNCATION_SUFFIX,
     minKeepChars: 2_000,
   });


### PR DESCRIPTION
## Problem

A plugin tool handler returning `undefined`/`void` produces a malformed content block `{type: "text"}` (no `text` property). This crashes the context truncation pipeline on every subsequent message (`block.text.length` on `undefined`), locking the session into an unrecoverable crash loop with no self-service recovery.

## Fix

**1. `isTextBlock()` type guard** (`tool-result-char-estimator.ts`):
Now verifies `typeof block.text === 'string'` in addition to checking `block.type === 'text'`. Malformed blocks are treated as unknown content (estimated via `JSON.stringify`) instead of crashing.

**2. `sanitizeToolResultContent()`** (`session-tool-result-guard.ts`):
New sanitization step before persistence that normalizes any `{type: "text"}` block missing a `text` property to `{type: "text", text: ""}`, preventing future crash loops from corrupted JSONL.

## Tests

Added `tool-result-char-estimator.test.ts` covering:
- `estimateMessageCharsCached` no longer crashes on `{type: 'text'}` blocks
- `getToolResultText` correctly skips malformed blocks

Closes #34979