### PR TITLE
feat: add agents.defaults.systemPromptFile config option

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -15,6 +15,7 @@ import { resolveDefaultModelForAgent } from "../model-selection.js";
 import { resolveOwnerDisplaySetting } from "../owner-display.js";
 import type { EmbeddedContextFile } from "../pi-embedded-helpers.js";
 import { detectRuntimeShell } from "../shell-utils.js";
+import { readSystemPromptFile } from "../system-prompt-file.js";
 import { buildSystemPromptParams } from "../system-prompt-params.js";
 import { buildAgentSystemPrompt } from "../system-prompt.js";
 export { buildCliSupervisorScopeKey, resolveCliNoOutputTimeoutMs } from "./reliability.js";
@@ -74,10 +75,15 @@ export function buildSystemPrompt(params: {
   });
   const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
   const ownerDisplay = resolveOwnerDisplaySetting(params.config);
+  const systemPromptFileContent = readSystemPromptFile(
+    params.config?.agents?.defaults?.systemPromptFile,
+  );
+  const extraSystemPrompt =
+    [systemPromptFileContent, params.extraSystemPrompt].filter(Boolean).join("\n\n") || undefined;
   return buildAgentSystemPrompt({
     workspaceDir: params.workspaceDir,
     defaultThinkLevel: params.defaultThinkLevel,
-    extraSystemPrompt: params.extraSystemPrompt,
+    extraSystemPrompt,
     ownerNumbers: params.ownerNumbers,
     ownerDisplay: ownerDisplay.ownerDisplay,
     ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -80,6 +80,7 @@ import {
   applySkillEnvOverridesFromSnapshot,
   resolveSkillsPromptForRun,
 } from "../../skills.js";
+import { readSystemPromptFile } from "../../system-prompt-file.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../../tool-call-id.js";
@@ -925,11 +926,17 @@ export async function runEmbeddedAttempt(
     const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
     const ownerDisplay = resolveOwnerDisplaySetting(params.config);
 
+    const systemPromptFileContent = readSystemPromptFile(
+      params.config?.agents?.defaults?.systemPromptFile,
+    );
+    const extraSystemPromptWithFile =
+      [systemPromptFileContent, params.extraSystemPrompt].filter(Boolean).join("\n\n") || undefined;
+
     const appendPrompt = buildEmbeddedSystemPrompt({
       workspaceDir: effectiveWorkspace,
       defaultThinkLevel: params.thinkLevel,
       reasoningLevel: params.reasoningLevel ?? "off",
-      extraSystemPrompt: params.extraSystemPrompt,
+      extraSystemPrompt: extraSystemPromptWithFile,
       ownerNumbers: params.ownerNumbers,
       ownerDisplay: ownerDisplay.ownerDisplay,
       ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,

--- a/src/agents/system-prompt-file.test.ts
+++ b/src/agents/system-prompt-file.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readSystemPromptFile } from "./system-prompt-file.js";
+
+describe("readSystemPromptFile", () => {
+  const tmpFiles: string[] = [];
+
+  function writeTmp(content: string): string {
+    const filePath = path.join(os.tmpdir(), `system-prompt-test-${Date.now()}-${Math.random()}.md`);
+    fs.writeFileSync(filePath, content, "utf-8");
+    tmpFiles.push(filePath);
+    return filePath;
+  }
+
+  afterEach(() => {
+    for (const f of tmpFiles) {
+      try {
+        fs.unlinkSync(f);
+      } catch {}
+    }
+    tmpFiles.length = 0;
+  });
+
+  it("returns undefined when filePath is undefined", () => {
+    expect(readSystemPromptFile(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when filePath is empty string", () => {
+    expect(readSystemPromptFile("")).toBeUndefined();
+  });
+
+  it("returns file contents when file exists", () => {
+    const filePath = writeTmp("You are a helpful assistant.");
+    expect(readSystemPromptFile(filePath)).toBe("You are a helpful assistant.");
+  });
+
+  it("trims whitespace from file contents", () => {
+    const filePath = writeTmp("  \n  Be concise.  \n  ");
+    expect(readSystemPromptFile(filePath)).toBe("Be concise.");
+  });
+
+  it("returns undefined for empty file", () => {
+    const filePath = writeTmp("");
+    expect(readSystemPromptFile(filePath)).toBeUndefined();
+  });
+
+  it("returns undefined for whitespace-only file", () => {
+    const filePath = writeTmp("   \n\n   ");
+    expect(readSystemPromptFile(filePath)).toBeUndefined();
+  });
+
+  it("returns undefined when file does not exist", () => {
+    expect(readSystemPromptFile("/nonexistent/path/prompt.md")).toBeUndefined();
+  });
+
+  it("handles multiline content", () => {
+    const content = "# Instructions\n\nBe polite.\nDo not share secrets.";
+    const filePath = writeTmp(content);
+    expect(readSystemPromptFile(filePath)).toBe(content);
+  });
+});

--- a/src/agents/system-prompt-file.ts
+++ b/src/agents/system-prompt-file.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { logVerbose } from "../globals.js";
 
 /**
  * Read the contents of a systemPromptFile config value.
@@ -11,7 +12,8 @@ export function readSystemPromptFile(filePath: string | undefined): string | und
   try {
     const content = fs.readFileSync(filePath, "utf-8").trim();
     return content || undefined;
-  } catch {
+  } catch (err: unknown) {
+    logVerbose(`systemPromptFile: could not read "${filePath}": ${String(err)}`);
     return undefined;
   }
 }

--- a/src/agents/system-prompt-file.ts
+++ b/src/agents/system-prompt-file.ts
@@ -1,0 +1,17 @@
+import fs from "node:fs";
+
+/**
+ * Read the contents of a systemPromptFile config value.
+ * Returns the trimmed file contents, or undefined if not configured / unreadable.
+ */
+export function readSystemPromptFile(filePath: string | undefined): string | undefined {
+  if (!filePath) {
+    return undefined;
+  }
+  try {
+    const content = fs.readFileSync(filePath, "utf-8").trim();
+    return content || undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -268,7 +268,7 @@ export async function runPreparedReply(
   const inboundMetaPrompt = buildInboundMetaSystemPrompt(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },
   );
-  const systemPromptFileContent = readSystemPromptFile(agentCfg?.systemPromptFile) ?? "";
+  const systemPromptFileContent = readSystemPromptFile(agentCfg?.systemPromptFile);
   const extraSystemPromptParts = [
     systemPromptFileContent,
     inboundMetaPrompt,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -7,7 +7,6 @@ import {
   isEmbeddedPiRunStreaming,
   resolveEmbeddedSessionLane,
 } from "../../agents/pi-embedded.js";
-import { readSystemPromptFile } from "../../agents/system-prompt-file.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   resolveGroupSessionKey,
@@ -268,9 +267,7 @@ export async function runPreparedReply(
   const inboundMetaPrompt = buildInboundMetaSystemPrompt(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },
   );
-  const systemPromptFileContent = readSystemPromptFile(agentCfg?.systemPromptFile);
   const extraSystemPromptParts = [
-    systemPromptFileContent,
     inboundMetaPrompt,
     groupChatContext,
     groupIntro,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -7,6 +7,7 @@ import {
   isEmbeddedPiRunStreaming,
   resolveEmbeddedSessionLane,
 } from "../../agents/pi-embedded.js";
+import { readSystemPromptFile } from "../../agents/system-prompt-file.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   resolveGroupSessionKey,
@@ -267,7 +268,9 @@ export async function runPreparedReply(
   const inboundMetaPrompt = buildInboundMetaSystemPrompt(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },
   );
+  const systemPromptFileContent = readSystemPromptFile(agentCfg?.systemPromptFile) ?? "";
   const extraSystemPromptParts = [
+    systemPromptFileContent,
     inboundMetaPrompt,
     groupChatContext,
     groupIntro,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -136,6 +136,8 @@ export type AgentDefaultsConfig = {
   repoRoot?: string;
   /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */
   skipBootstrap?: boolean;
+  /** Absolute path to a file whose contents are injected into the system prompt for all sessions. */
+  systemPromptFile?: string;
   /** Max chars for injected bootstrap files before truncation (default: 20000). */
   bootstrapMaxChars?: number;
   /** Max total chars across all injected bootstrap files (default: 150000). */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -38,6 +38,7 @@ export const AgentDefaultsSchema = z
     workspace: z.string().optional(),
     repoRoot: z.string().optional(),
     skipBootstrap: z.boolean().optional(),
+    systemPromptFile: z.string().optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),
     bootstrapTotalMaxChars: z.number().int().positive().optional(),
     bootstrapPromptTruncationWarning: z


### PR DESCRIPTION
## Summary

- Problem: No way to inject a custom system prompt from config that the agent cannot modify. Workspace bootstrap files (AGENTS.md, etc.) are agent-editable. Channel-level `systemPrompt` only applies to group sessions.
- Why it matters: Operators running always-on agents need to enforce behavioral instructions that survive agent self-modification.
- What changed: New `agents.defaults.systemPromptFile` config field. Reads an external file at the given path and injects its contents into the system prompt for all sessions via `extraSystemPrompt`.
- What did NOT change: Existing bootstrap file injection, channel-level `systemPrompt`, or `extraSystemPrompt` API parameter behavior.

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #36190

- Closes #36190

## User-visible / Behavior Changes

New optional config field `agents.defaults.systemPromptFile` (string, file path). When set, the file contents are injected into the system prompt for all session types.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No` — file is read by the gateway process from a path the operator configures. No new path traversal surface (operator already controls config).

## Repro + Verification

### Environment

- OS: Amazon Linux 2023 (ARM)
- Runtime/container: Node.js 24
- Model/provider: Any
- Integration/channel: All

### Steps

1. Create `/etc/openclaw/system-prompt.md` with behavioral instructions
2. Add to config: `"agents": { "defaults": { "systemPromptFile": "/etc/openclaw/system-prompt.md" } }`
3. Start a new session on any channel

### Expected

File contents appear in the system prompt (visible in session logs / debug output)

### Actual

File contents are injected into the "Group Chat Context" section of the system prompt

## Evidence

- [x] Failing test/log before + passing after — 8 new unit tests for `readSystemPromptFile()`

## Human Verification (required)

- Verified scenarios: Config set with valid file, config unset, nonexistent file path
- Edge cases checked: Empty file, whitespace-only file, multiline content (all covered by unit tests)
- What I did **not** verify: Production deployment with live agent sessions

## Compatibility / Migration

- Backward compatible? `Yes` — omitting the field preserves current behavior
- Config/env changes? New optional config field
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `systemPromptFile` from config, restart gateway
- Files/config to restore: None
- Known bad symptoms: If file path is wrong, no injection occurs (fail-open with silent skip)

## Risks and Mitigations

- Risk: Operator misconfigures path, expects injection but nothing happens (fail-open)
  - Mitigation: Logged via `logVerbose` when file is unreadable. Could add startup validation in a follow-up.

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)