### PR TITLE
fix(agents): surface model catalog warning in sessions_spawn when override model is not in catalog

### DIFF
--- a/src/agents/subagent-spawn.model-warning.test.ts
+++ b/src/agents/subagent-spawn.model-warning.test.ts
@@ -1,0 +1,175 @@
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resetSubagentRegistryForTests } from "./subagent-registry.js";
+
+const callGatewayMock = vi.fn();
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => ({
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: { defaults: { workspace: os.tmpdir() } },
+    }),
+  };
+});
+
+vi.mock("./subagent-registry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./subagent-registry.js")>();
+  return {
+    ...actual,
+    countActiveRunsForSession: () => 0,
+    registerSubagentRun: () => {},
+  };
+});
+
+vi.mock("./subagent-announce.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./subagent-announce.js")>();
+  return {
+    ...actual,
+    buildSubagentSystemPrompt: () => "system-prompt",
+  };
+});
+
+vi.mock("./agent-scope.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./agent-scope.js")>();
+  return {
+    ...actual,
+    resolveAgentWorkspaceDir: () => path.join(os.tmpdir(), "agent-workspace"),
+  };
+});
+
+vi.mock("./subagent-depth.js", () => ({
+  getSubagentDepthFromSessionStore: () => 0,
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => ({ hasHooks: () => false }),
+}));
+
+const loadModelCatalogMock = vi.fn();
+vi.mock("./model-catalog.js", () => ({
+  loadModelCatalog: (...args: unknown[]) => loadModelCatalogMock(...args),
+}));
+
+import { splitModelRef, spawnSubagentDirect } from "./subagent-spawn.js";
+
+function setupGatewayMock() {
+  callGatewayMock.mockImplementation(async (opts: { method?: string; params?: unknown }) => {
+    if (opts.method === "sessions.patch") {
+      return { ok: true };
+    }
+    if (opts.method === "sessions.delete") {
+      return { ok: true };
+    }
+    if (opts.method === "agent") {
+      return { runId: "run-1" };
+    }
+    return {};
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetSubagentRegistryForTests();
+  loadModelCatalogMock.mockResolvedValue([
+    { provider: "anthropic", id: "claude-sonnet-4-5" },
+    { provider: "xai", id: "grok-4-1-fast" },
+  ]);
+});
+
+describe("splitModelRef", () => {
+  it("parses provider/model from a slash-separated ref", () => {
+    expect(splitModelRef("google/gemini-3.1-flash-lite-preview")).toEqual({
+      provider: "google",
+      model: "gemini-3.1-flash-lite-preview",
+    });
+  });
+
+  it("parses xai/grok-4-1-fast", () => {
+    expect(splitModelRef("xai/grok-4-1-fast")).toEqual({
+      provider: "xai",
+      model: "grok-4-1-fast",
+    });
+  });
+
+  it("returns model only when no slash is present", () => {
+    expect(splitModelRef("gemini")).toEqual({
+      provider: undefined,
+      model: "gemini",
+    });
+  });
+
+  it("returns undefined fields for empty/undefined input", () => {
+    expect(splitModelRef(undefined)).toEqual({ provider: undefined, model: undefined });
+    expect(splitModelRef("")).toEqual({ provider: undefined, model: undefined });
+    expect(splitModelRef("  ")).toEqual({ provider: undefined, model: undefined });
+  });
+});
+
+describe("spawnSubagentDirect model warning", () => {
+  it("sets modelWarning when model override is not in catalog", async () => {
+    setupGatewayMock();
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "test task",
+        model: "google/gemini-3.1-flash-lite-preview",
+      },
+      {
+        agentSessionKey: "agent:main:session:test",
+        agentChannel: "tui",
+        requesterAgentIdOverride: "main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.modelApplied).toBe(true);
+    expect(result.modelWarning).toBeDefined();
+    expect(result.modelWarning).toContain("not in the runtime model catalog");
+  });
+
+  it("does not set modelWarning when model is in catalog", async () => {
+    setupGatewayMock();
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "test task",
+        model: "xai/grok-4-1-fast",
+      },
+      {
+        agentSessionKey: "agent:main:session:test",
+        agentChannel: "tui",
+        requesterAgentIdOverride: "main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.modelApplied).toBe(true);
+    expect(result.modelWarning).toBeUndefined();
+  });
+
+  it("does not set modelWarning when no model override is provided", async () => {
+    setupGatewayMock();
+
+    const result = await spawnSubagentDirect(
+      {
+        task: "test task",
+      },
+      {
+        agentSessionKey: "agent:main:session:test",
+        agentChannel: "tui",
+        requesterAgentIdOverride: "main",
+      },
+    );
+
+    expect(result.status).toBe("accepted");
+    expect(result.modelWarning).toBeUndefined();
+  });
+});

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -15,6 +15,7 @@ import {
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { resolveAgentConfig, resolveAgentWorkspaceDir } from "./agent-scope.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
+import { loadModelCatalog, type ModelCatalogEntry } from "./model-catalog.js";
 import { resolveSubagentSpawnModelSelection } from "./model-selection.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
 import { buildSubagentSystemPrompt } from "./subagent-announce.js";
@@ -99,6 +100,7 @@ export type SpawnSubagentResult = {
   mode?: SpawnSubagentMode;
   note?: string;
   modelApplied?: boolean;
+  modelWarning?: string;
   error?: string;
   attachments?: {
     count: number;
@@ -432,6 +434,7 @@ export async function spawnSubagentDirect(
     };
   }
 
+  let modelWarning: string | undefined;
   if (resolvedModel) {
     const modelPatchError = await patchChildSession({ model: resolvedModel });
     if (modelPatchError) {
@@ -442,6 +445,25 @@ export async function spawnSubagentDirect(
       };
     }
     modelApplied = true;
+
+    if (modelOverride) {
+      const { provider: mProvider, model: mModel } = splitModelRef(resolvedModel);
+      if (mProvider && mModel) {
+        try {
+          const catalog = await loadModelCatalog({ config: cfg });
+          const inCatalog = catalog.some(
+            (e: ModelCatalogEntry) =>
+              e.provider.toLowerCase() === mProvider.toLowerCase() &&
+              e.id.toLowerCase() === mModel.toLowerCase(),
+          );
+          if (!inCatalog) {
+            modelWarning = `Model "${resolvedModel}" was applied to the session but is not in the runtime model catalog. The agent may fall back to the default model at runtime.`;
+          }
+        } catch {
+          // Best-effort catalog check; do not block spawn on catalog load failure.
+        }
+      }
+    }
   }
   if (thinkingOverride !== undefined) {
     const thinkingPatchError = await patchChildSession({
@@ -875,6 +897,7 @@ export async function spawnSubagentDirect(
     mode: spawnMode,
     note,
     modelApplied: resolvedModel ? modelApplied : undefined,
+    modelWarning,
     attachments: attachmentsReceipt,
   };
 }


### PR DESCRIPTION
## Summary

- Problem: `sessions_spawn` returns `modelApplied: true` when the session patch succeeds, but the model may not exist in the runtime model catalog. The agent silently falls back to the default model at runtime (e.g., Sonnet instead of Gemini), and the caller has no indication. `modelApplied: true` is actively misleading — it means "session store was updated" not "model will actually be used."
- Why it matters: Users running multi-model pipelines (e.g., cost-optimized Guardian workflows using Gemini 3.1 Flash Lite at $1.50/MTok) unknowingly run on Sonnet ($15/MTok) — a 10x cost increase with zero visibility.
- What changed: After `sessions.patch` succeeds with a model override, a catalog lookup validates whether the model exists. If not, a `modelWarning` field is added to the spawn result explaining that runtime fallback may occur.
- What did NOT change (scope boundary): `modelApplied` semantics are preserved (still reflects session-patch success). No changes to model resolution, fallback routing, or gateway API. The underlying model resolution for Gemini 3.1 is addressed separately in #36173.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36134
- Related: #36173 (fixes underlying Gemini 3.1 forward-compat resolution)

## User-visible / Behavior Changes

`sessions_spawn` result now includes an optional `modelWarning` field when the overridden model is not found in the runtime model catalog. Example:

```json
{
  "status": "accepted",
  "modelApplied": true,
  "modelWarning": "Model \"google/gemini-3.1-flash-lite-preview\" was applied to the session but is not in the runtime model catalog. The agent may fall back to the default model at runtime."
}
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Configure OpenClaw with anthropic and google auth profiles
2. Call `sessions_spawn({ task: "Identify yourself", model: "google/gemini-3.1-flash-lite-preview" })`
3. Check spawn result

### Expected

- `modelWarning` field present when model is not in catalog

### Actual

- Before: `modelApplied: true`, no warning, silent fallback to Anthropic
- After: `modelApplied: true`, `modelWarning: "Model ... not in the runtime model catalog ..."`, caller has visibility

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

7 vitest unit tests covering:
- Model not in catalog → `modelWarning` set
- Model in catalog → no warning
- No model override → no warning
- `splitModelRef` edge cases (slash parsing, empty input)

## Human Verification (required)

- Verified scenarios: Catalog miss detection, catalog hit (no warning), no model override path.
- Edge cases checked: Empty/undefined model refs, bare model names without provider prefix.
- What you did **not** verify: Live multi-agent pipeline with actual Gemini 3.1 API (requires production credentials and Google auth).

## Compatibility / Migration

- Backward compatible? Yes — `modelWarning` is a new optional field; existing consumers ignore it.
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit. `modelWarning` field disappears from spawn results.
- Files/config to restore: `src/agents/subagent-spawn.ts`

## Risks and Mitigations

- Risk: `loadModelCatalog` call adds latency to spawn flow.
  - Mitigation: The catalog is cached at module scope after first load. The check is wrapped in try/catch so catalog load failures do not block spawn.
- Risk: Forward-compat models (resolved at runtime but not in catalog) trigger false positive warnings.
  - Mitigation: The warning is informational, not blocking. Once #36173 is merged, Gemini 3.1 models resolve via forward-compat and the catalog miss warning serves as a useful signal for other unrecognized models.