### PR TITLE
fix(gateway): persist loopback device identity for gateway calls

### DIFF
--- a/src/gateway/call.device-identity-path.test.ts
+++ b/src/gateway/call.device-identity-path.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { resolveDeviceIdentityPathFromConfig } from "./call.js";
+
+describe("resolveDeviceIdentityPathFromConfig", () => {
+  it("derives a stable identity path from config path", () => {
+    expect(resolveDeviceIdentityPathFromConfig("/data/.openclaw/openclaw.json")).toBe(
+      "/data/.openclaw/identity/device.json",
+    );
+  });
+
+  it("returns undefined when config path is missing", () => {
+    expect(resolveDeviceIdentityPathFromConfig(undefined)).toBeUndefined();
+    expect(resolveDeviceIdentityPathFromConfig("   ")).toBeUndefined();
+  });
+});

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   loadConfig,
@@ -291,6 +292,14 @@ function resolveGatewayCallContext(opts: CallGatewayBaseOptions): ResolvedGatewa
     remoteUrl,
     explicitAuth,
   };
+}
+
+export function resolveDeviceIdentityPathFromConfig(configPath?: string): string | undefined {
+  const trimmed = configPath?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return path.join(path.dirname(trimmed), "identity", "device.json");
 }
 
 function ensureRemoteModeUrlConfigured(context: ResolvedGatewayCallContext): void {
@@ -634,7 +643,9 @@ async function executeGatewayRequestWithScopes<T>(params: {
       mode: opts.mode ?? GATEWAY_CLIENT_MODES.CLI,
       role: "operator",
       scopes,
-      deviceIdentity: loadOrCreateDeviceIdentity(),
+      deviceIdentity: loadOrCreateDeviceIdentity(
+        resolveDeviceIdentityPathFromConfig(params.connectionDetails.configPath),
+      ),
       minProtocol: opts.minProtocol ?? PROTOCOL_VERSION,
       maxProtocol: opts.maxProtocol ?? PROTOCOL_VERSION,
       onHelloOk: async (hello) => {


### PR DESCRIPTION
Problem: loopback gateway calls can fail with "pairing required" because the caller appears as a new device repeatedly in some deployments.

Root cause: gateway call connections used default device identity resolution only; when runtime contexts resolve HOME/state differently, identity persistence becomes unstable.

Fix: derive the device identity file path from the resolved config directory and reuse that identity for gateway calls, with safe fallback when config path is unavailable.

Testing:
- pnpm vitest run src/gateway/call.device-identity-path.test.ts src/infra/device-pairing.test.ts

AI-assisted: yes (implemented with assistant support, verified locally).