### PR TITLE
test(cron): add cross-channel announce fallback regression coverage

### DIFF
--- a/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
+++ b/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
@@ -192,6 +192,44 @@ async function runAnnounceFlowResult(bestEffort: boolean) {
   return outcome;
 }
 
+async function runSignalAnnounceFlowResult(bestEffort: boolean) {
+  let outcome:
+    | {
+        res: Awaited<ReturnType<typeof runCronIsolatedAgentTurn>>;
+        deps: CliDeps;
+      }
+    | undefined;
+  await withTempHome(async (home) => {
+    const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+    const deps = createCliDeps();
+    mockAgentPayloads([{ text: "hello from cron" }]);
+    vi.mocked(runSubagentAnnounceFlow).mockResolvedValueOnce(false);
+    const res = await runCronIsolatedAgentTurn({
+      cfg: makeCfg(home, storePath, {
+        channels: { signal: {} },
+      }),
+      deps,
+      job: {
+        ...makeJob({ kind: "agentTurn", message: "do it" }),
+        delivery: {
+          mode: "announce",
+          channel: "signal",
+          to: "+15551234567",
+          bestEffort,
+        },
+      },
+      message: "do it",
+      sessionKey: "cron:job-1",
+      lane: "cron",
+    });
+    outcome = { res, deps };
+  });
+  if (!outcome) {
+    throw new Error("signal announce flow did not produce an outcome");
+  }
+  return outcome;
+}
+
 async function assertExplicitTelegramTargetAnnounce(params: {
   home: string;
   storePath: string;
@@ -428,6 +466,15 @@ describe("runCronIsolatedAgentTurn", () => {
     expect(res.deliveryAttempted).toBe(true);
     expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
     expect(deps.sendMessageTelegram).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to direct delivery for signal when announce reports false and best-effort is enabled", async () => {
+    const { res, deps } = await runSignalAnnounceFlowResult(true);
+    expect(res.status).toBe("ok");
+    expect(res.delivered).toBe(true);
+    expect(res.deliveryAttempted).toBe(true);
+    expect(runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+    expect(deps.sendMessageSignal).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to direct delivery when announce flow throws and best-effort is disabled", async () => {

--- a/src/cron/isolated-agent.test-setup.ts
+++ b/src/cron/isolated-agent.test-setup.ts
@@ -2,6 +2,7 @@ import { vi } from "vitest";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { runSubagentAnnounceFlow } from "../agents/subagent-announce.js";
+import { signalOutbound } from "../channels/plugins/outbound/signal.js";
 import { telegramOutbound } from "../channels/plugins/outbound/telegram.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
@@ -18,6 +19,11 @@ export function setupIsolatedAgentTurnMocks(params?: { fast?: boolean }): void {
       {
         pluginId: "telegram",
         plugin: createOutboundTestPlugin({ id: "telegram", outbound: telegramOutbound }),
+        source: "test",
+      },
+      {
+        pluginId: "signal",
+        plugin: createOutboundTestPlugin({ id: "signal", outbound: signalOutbound }),
         source: "test",
       },
     ]),


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Cron announce fallback behavior was fixed in shared delivery logic, but regression coverage only asserted Telegram behavior.
- Why it matters: Without cross-channel coverage, the same fallback path could regress for other direct-delivery channels without detection.
- What changed: Added Signal outbound plugin registration in isolated-agent test setup and added a Signal-specific best-effort announce-failure fallback regression test.
- What did NOT change (scope boundary): No runtime delivery logic changed in this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #36177

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram and Signal cron delivery tests
- Relevant config (redacted): test harness config only

### Steps

1. Run cron announce fallback tests for isolated-agent delivery.
2. Trigger announce failure in best-effort mode.
3. Verify direct fallback happens for Telegram and Signal.

### Expected

- Delivery is marked delivered after direct fallback for both channels.

### Actual

- Tests pass for both channels with fallback behavior asserted.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Signal best-effort announce failure now has explicit fallback regression coverage, alongside existing Telegram coverage.
- Edge cases checked: forum-topic direct-delivery test still passes.
- What you did **not** verify: full codebase behavior outside covered tests.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/cron/isolated-agent.test-setup.ts`, `src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts`.
- Known bad symptoms reviewers should watch for: false negatives in cron fallback coverage for non-Telegram channels.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: test setup plugin registration changes could affect unrelated isolated-agent tests.
  - Mitigation: registration only extends existing test registry; targeted cron tests were rerun and passed.
