### PR TITLE
chore(subagents): add warning when subagent_ended hook emission fails

### DIFF
--- a/src/agents/subagent-registry-completion.test.ts
+++ b/src/agents/subagent-registry-completion.test.ts
@@ -7,8 +7,16 @@ const lifecycleMocks = vi.hoisted(() => ({
   runSubagentEnded: vi.fn(async () => {}),
 }));
 
+const loggerMocks = vi.hoisted(() => ({
+  logWarn: vi.fn(),
+}));
+
 vi.mock("../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: () => lifecycleMocks.getGlobalHookRunner(),
+}));
+
+vi.mock("../logger.js", () => ({
+  logWarn: (...args: unknown[]) => loggerMocks.logWarn(...args),
 }));
 
 import { emitSubagentEndedHookOnce } from "./subagent-registry-completion.js";
@@ -44,6 +52,7 @@ describe("emitSubagentEndedHookOnce", () => {
   beforeEach(() => {
     lifecycleMocks.getGlobalHookRunner.mockClear();
     lifecycleMocks.runSubagentEnded.mockClear();
+    loggerMocks.logWarn.mockClear();
   });
 
   it("records ended hook marker even when no subagent_ended hooks are registered", async () => {
@@ -122,5 +131,9 @@ describe("emitSubagentEndedHookOnce", () => {
     expect(params.persist).not.toHaveBeenCalled();
     expect(inFlightRunIds.has(entry.runId)).toBe(false);
     expect(entry.endedHookEmittedAt).toBeUndefined();
+    expect(loggerMocks.logWarn).toHaveBeenCalledTimes(1);
+    expect(loggerMocks.logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("failed to emit subagent_ended hook for run run-1: Error: boom"),
+    );
   });
 });

--- a/src/agents/subagent-registry-completion.ts
+++ b/src/agents/subagent-registry-completion.ts
@@ -1,3 +1,4 @@
+import { logWarn } from "../logger.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { SubagentRunOutcome } from "./subagent-announce.js";
 import {
@@ -88,7 +89,8 @@ export async function emitSubagentEndedHookOnce(params: {
     params.entry.endedHookEmittedAt = Date.now();
     params.persist();
     return true;
-  } catch {
+  } catch (err) {
+    logWarn(`[subagents] failed to emit subagent_ended hook for run ${runId}: ${String(err)}`);
     return false;
   } finally {
     params.inFlightRunIds.delete(runId);


### PR DESCRIPTION
## Summary
- add warning-level observability when `emitSubagentEndedHookOnce` catches hook runner errors
- keep existing behavior unchanged by still returning `false` on failure
- extend unit test coverage to assert warning emission for thrown hook execution

## Why
Hook emission failures were silently swallowed, making intermittent delivery/debugging issues difficult to trace. Logging the failure with run id provides actionable diagnostics without changing control flow.

## Risk
Low: only failure-path logging changed; successful paths, persistence, and in-flight cleanup semantics remain unchanged.

## Validation
- `pnpm exec vitest run src/agents/subagent-registry-completion.test.ts`
