### PR TITLE
Agents: default openai-responses tool_choice to auto when tools are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/openai-responses tool-choice fallback: when Responses payloads include tools but omit `tool_choice`, default to `tool_choice: "auto"` in payload interception so custom OpenAI-compatible providers on HTTP stream paths keep tool-call execution enabled. (related to #36057)
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1073,6 +1073,60 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.store).toBe(false);
   });
 
+  it("defaults tool_choice to auto when OpenAI Responses payload has tools but no tool_choice", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: {
+        api: "openai-responses",
+        provider: "sub2api-gpt",
+        id: "gpt-5.3-codex",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+        tools: [{ type: "function", name: "exec" }],
+        tool_choice: null,
+      },
+    });
+    expect(payload.tool_choice).toBe("auto");
+  });
+
+  it("does not force tool_choice when OpenAI Responses payload has no tools", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: {
+        api: "openai-responses",
+        provider: "sub2api-gpt",
+        id: "gpt-5.3-codex",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+        tools: [],
+        tool_choice: null,
+      },
+    });
+    expect(payload.tool_choice).toBeNull();
+  });
+
+  it("preserves explicit OpenAI Responses tool_choice values", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: {
+        api: "openai-responses",
+        provider: "sub2api-gpt",
+        id: "gpt-5.3-codex",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        store: false,
+        tools: [{ type: "function", name: "exec" }],
+        tool_choice: "required",
+      },
+    });
+    expect(payload.tool_choice).toBe("required");
+  });
+
   it("does not force store for models that declare supportsStore=false", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "azure-openai-responses",

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -283,7 +283,10 @@ function createOpenAIResponsesContextManagementWrapper(
   return (model, context, options) => {
     const forceStore = shouldForceResponsesStore(model);
     const useServerCompaction = shouldEnableOpenAIResponsesServerCompaction(model, extraParams);
-    if (!forceStore && !useServerCompaction) {
+    const normalizeToolChoice = OPENAI_RESPONSES_APIS.has(
+      typeof model.api === "string" ? model.api : "",
+    );
+    if (!forceStore && !useServerCompaction && !normalizeToolChoice) {
       return underlying(model, context, options);
     }
 
@@ -306,6 +309,16 @@ function createOpenAIResponsesContextManagementWrapper(
                 compact_threshold: compactThreshold,
               },
             ];
+          }
+          // Ensure custom OpenAI Responses providers keep an effective tool choice
+          // when tools are present on the HTTP stream path.
+          if (
+            normalizeToolChoice &&
+            Array.isArray(payloadObj.tools) &&
+            payloadObj.tools.length > 0 &&
+            payloadObj.tool_choice == null
+          ) {
+            payloadObj.tool_choice = "auto";
           }
         }
         originalOnPayload?.(payload);


### PR DESCRIPTION
## Summary

- Problem: some `openai-responses` custom-provider runs could emit payloads with non-empty `tools` but missing/null `tool_choice` on HTTP stream paths.
- Why it matters: models may return text-only outputs and skip function/tool-call generation, silently breaking tool workflows.
- What changed: in the OpenAI Responses payload wrapper, when `tools` is non-empty and `tool_choice` is null/undefined, default to `tool_choice: "auto"`.
- What did NOT change (scope boundary): explicit `tool_choice` values are preserved; no changes to tool schema or model routing order.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36057
- Related #36057

## User-visible / Behavior Changes

- Custom OpenAI-compatible Responses providers are less likely to silently skip tool calls when tools are available and `tool_choice` would otherwise be omitted.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local unit tests
- Model/provider: openai-responses (mock payload interception)
- Integration/channel (if any): agent stream payload wrappers
- Relevant config (redacted): default test config

### Steps

1. Build an `openai-responses` payload with non-empty `tools` and null `tool_choice`.
2. Pass through `applyExtraParamsToAgent` stream wrapper path.
3. Inspect payload seen in `onPayload` callback.

### Expected

- `tool_choice` becomes `"auto"` only when tools are present and no explicit choice exists.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/agents/pi-embedded-runner-extraparams.test.ts`
  - `pnpm exec oxfmt --check CHANGELOG.md src/agents/pi-embedded-runner/extra-params.ts src/agents/pi-embedded-runner-extraparams.test.ts`
  - `pnpm exec oxlint src/agents/pi-embedded-runner/extra-params.ts src/agents/pi-embedded-runner-extraparams.test.ts`
- Edge cases checked:
  - `tools: []` does not force `tool_choice`.
  - Explicit `tool_choice` (`required`) is preserved.
- What you did **not** verify:
  - Live upstream capture against a real custom provider endpoint.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/agents/pi-embedded-runner/extra-params.ts`
  - `src/agents/pi-embedded-runner-extraparams.test.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected tool_choice overrides when caller explicitly sets custom tool_choice.

## Risks and Mitigations

- Risk:
  - payloads that intentionally rely on implicit provider defaults may now become explicit `auto`.
  - Mitigation:
    - change only applies when `tools` exist and `tool_choice` is absent/null; explicit caller values remain untouched.
