### PR TITLE
Fix: Normalize OpenRouter Perplexity auth and add compatibility headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Gemini PDF URL construction: avoid `/v1beta/v1beta` duplication when baseUrl already includes `/v1beta`, fixing 404 errors for Gemini native PDF analysis in subagent paths. (#34312)
 - Agents/Nodes media outputs: add dedicated `photos_latest` action handling, block media-returning `nodes invoke` commands, keep metadata-only `camera.list` invoke allowed, and normalize empty `photos_latest` results to a consistent response shape to prevent base64 context bloat. (#34332) Thanks @obviyus.
 - TUI/session-key canonicalization: normalize `openclaw tui --session` values to lowercase so uppercase session names no longer drop real-time streaming updates due to gateway/TUI key mismatches. (#33866, #34013) thanks @lynnzc.
 - Outbound/send config threading: pass resolved SecretRef config through outbound adapters and helper send paths so send flows do not reload unresolved runtime config. (#33987) Thanks @joshavant.

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -141,7 +141,9 @@ export async function geminiAnalyzePdf(params: {
     /\/+$/,
     "",
   );
-  const url = `${baseUrl}/v1beta/models/${encodeURIComponent(params.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
+  // Avoid /v1beta/v1beta duplication if baseUrl already includes /v1beta
+  const versionedBase = baseUrl.includes("/v1beta") ? baseUrl : `${baseUrl}/v1beta`;
+  const url = `${versionedBase}/models/${encodeURIComponent(params.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
 
   const res = await fetch(url, {
     method: "POST",

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -628,6 +628,28 @@ describe("native PDF provider API calls", () => {
     expect(body.contents[0].parts[1].text).toBe("Summarize this");
   });
 
+  it("geminiAnalyzePdf avoids /v1beta/v1beta duplication when baseUrl already includes /v1beta", async () => {
+    const { geminiAnalyzePdf } = await import("./pdf-native-providers.js");
+    const fetchMock = mockFetchResponse({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: "ok" }] } }],
+      }),
+    });
+
+    // baseUrl already includes /v1beta - should NOT duplicate
+    await geminiAnalyzePdf(
+      makeGeminiAnalyzeParams({
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+      }),
+    );
+
+    const [url] = fetchMock.mock.calls[0];
+    // Should have single /v1beta, not /v1beta/v1beta
+    expect(url).toContain("/v1beta/models/");
+    expect(url).not.toContain("/v1beta/v1beta/");
+  });
+
   it("geminiAnalyzePdf throws on API error", async () => {
     const { geminiAnalyzePdf } = await import("./pdf-native-providers.js");
     mockFetchResponse({

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -15,6 +15,9 @@ const {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  resolvePerplexityBaseUrl,
+  resolvePerplexityApiKey,
+  resolvePerplexityModel,
 } = __testing;
 
 describe("web_search brave language param normalization", () => {
@@ -269,5 +272,66 @@ describe("extractKimiCitations", () => {
         ],
       }).toSorted(),
     ).toEqual(["https://example.com/a", "https://example.com/b", "https://example.com/c"]);
+  });
+});
+
+describe("web_search perplexity config resolution", () => {
+  it("normalizes Bearer-prefixed config API key for Perplexity/OpenRouter", () => {
+    const configKey = resolvePerplexityApiKey({ apiKey: "Bearer sk-or-config-key" });
+    expect(configKey).toEqual({
+      apiKey: "sk-or-config-key",
+      source: "config",
+    });
+  });
+
+  it("normalizes Bearer-prefixed PERPLEXITY_API_KEY from env", () => {
+    withEnv({ PERPLEXITY_API_KEY: "Bearer pplx-env-key" }, () => {
+      const envKey = resolvePerplexityApiKey({});
+      expect(envKey).toEqual({
+        apiKey: "pplx-env-key",
+        source: "perplexity_env",
+      });
+    });
+  });
+
+  it("normalizes Bearer-prefixed OPENROUTER_API_KEY from env", () => {
+    withEnv({ OPENROUTER_API_KEY: "Bearer sk-or-env-key" }, () => {
+      const envKey = resolvePerplexityApiKey({});
+      expect(envKey).toEqual({
+        apiKey: "sk-or-env-key",
+        source: "openrouter_env",
+      });
+      expect(resolvePerplexityBaseUrl({}, envKey.source, envKey.apiKey)).toBe(
+        "https://openrouter.ai/api/v1",
+      );
+    });
+  });
+
+  it("defaults Perplexity base URL based on OpenRouter key", () => {
+    const keyInfo = resolvePerplexityApiKey({
+      apiKey: "sk-or-abc123",
+    });
+    expect(resolvePerplexityBaseUrl({}, keyInfo.source, keyInfo.apiKey)).toBe(
+      "https://openrouter.ai/api/v1",
+    );
+  });
+
+  it("defaults Perplexity base URL to direct endpoint when Perplexity key is set", () => {
+    const keyInfo = resolvePerplexityApiKey({
+      apiKey: "pplx-abc123",
+    });
+    expect(resolvePerplexityBaseUrl({}, keyInfo.source, keyInfo.apiKey)).toBe(
+      "https://api.perplexity.ai",
+    );
+  });
+
+  it("defaults Perplexity model to sonar-pro", () => {
+    expect(resolvePerplexityModel({})).toBe("perplexity/sonar-pro");
+  });
+
+  it("allows overriding Perplexity model in config", () => {
+    expect(resolvePerplexityModel({ model: "perplexity/sonar-reasoning" })).toBe(
+      "perplexity/sonar-reasoning",
+    );
   });
 });

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -26,7 +26,10 @@ const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
 const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
-const PERPLEXITY_SEARCH_ENDPOINT = "https://api.perplexity.ai/search";
+const PERPLEXITY_API_BASE_URL = "https://api.perplexity.ai";
+const OPENROUTER_API_ENDPOINT = "https://openrouter.ai/api/v1";
+const OPENROUTER_PERPLEXITY_MODEL = "perplexity/sonar-pro";
+const OPENROUTER_KEY_PREFIX = "sk-or-";
 
 const XAI_API_ENDPOINT = "https://api.x.ai/v1/responses";
 const DEFAULT_GROK_MODEL = "grok-4-1-fast";
@@ -189,9 +192,11 @@ type BraveSearchResponse = {
 
 type PerplexityConfig = {
   apiKey?: string;
+  baseUrl?: string;
+  model?: string;
 };
 
-type PerplexityApiKeySource = "config" | "perplexity_env" | "none";
+type PerplexityApiKeySource = "config" | "perplexity_env" | "openrouter_env" | "none";
 
 type GrokConfig = {
   apiKey?: string;
@@ -387,7 +392,7 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
     return {
       error: "missing_perplexity_api_key",
       message:
-        "web_search (perplexity) needs an API key. Set PERPLEXITY_API_KEY in the Gateway environment, or configure tools.web.search.perplexity.apiKey.",
+        "web_search (perplexity) needs an API key. Set PERPLEXITY_API_KEY or OPENROUTER_API_KEY in the Gateway environment, or configure tools.web.search.perplexity.apiKey.",
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
@@ -505,17 +510,80 @@ function resolvePerplexityApiKey(perplexity?: PerplexityConfig): {
   apiKey?: string;
   source: PerplexityApiKeySource;
 } {
-  const fromConfig = normalizeApiKey(perplexity?.apiKey);
+  const fromConfig = normalizeApiKey(resolveOpenRouterApiKey(perplexity?.apiKey));
   if (fromConfig) {
     return { apiKey: fromConfig, source: "config" };
   }
 
-  const fromEnvPerplexity = normalizeApiKey(process.env.PERPLEXITY_API_KEY);
+  const fromEnvPerplexity = normalizeApiKey(
+    resolveOpenRouterApiKey(process.env.PERPLEXITY_API_KEY),
+  );
   if (fromEnvPerplexity) {
     return { apiKey: fromEnvPerplexity, source: "perplexity_env" };
   }
 
+  const fromEnvOpenrouter = normalizeApiKey(
+    resolveOpenRouterApiKey(process.env.OPENROUTER_API_KEY),
+  );
+  if (fromEnvOpenrouter) {
+    return { apiKey: fromEnvOpenrouter, source: "openrouter_env" };
+  }
+
   return { apiKey: undefined, source: "none" };
+}
+
+function isOpenRouterApiKey(apiKey: string): boolean {
+  return apiKey.startsWith(OPENROUTER_KEY_PREFIX);
+}
+
+function resolveOpenRouterApiKey(value: unknown): string {
+  return normalizeSecretInput(value).replace(/^bearer\s+/i, "");
+}
+
+function normalizePerplexityBaseUrl(baseUrl?: string): string | undefined {
+  const fromConfig = normalizeSecretInput(baseUrl);
+  if (!fromConfig) {
+    return undefined;
+  }
+  return fromConfig
+    .trim()
+    .replace(/\/$/, "")
+    .replace(/\/search\/?$/i, "")
+    .replace(/\/chat\/completions\/?$/i, "");
+}
+
+function isOpenRouterPerplexityEndpoint(baseUrl: string): boolean {
+  try {
+    const normalized = new URL(baseUrl);
+    return normalized.hostname === "openrouter.ai" && normalized.pathname.startsWith("/api/v1");
+  } catch {
+    return /openrouter\.ai\/api\/v1/i.test(baseUrl);
+  }
+}
+
+function resolvePerplexityBaseUrl(
+  perplexity: PerplexityConfig,
+  source: PerplexityApiKeySource,
+  apiKey?: string,
+): string {
+  const configured = normalizePerplexityBaseUrl(perplexity.baseUrl);
+  if (configured) {
+    return configured;
+  }
+
+  const isOpenRouterMode =
+    source === "openrouter_env" || (typeof apiKey === "string" && isOpenRouterApiKey(apiKey));
+  return isOpenRouterMode ? OPENROUTER_API_ENDPOINT : PERPLEXITY_API_BASE_URL;
+}
+
+function resolvePerplexityModel(perplexity?: PerplexityConfig): string {
+  const fromConfig =
+    perplexity && typeof perplexity.model === "string" ? perplexity.model.trim() : "";
+  return fromConfig || OPENROUTER_PERPLEXITY_MODEL;
+}
+
+function isOpenRouterPerplexityMode(baseUrl: string, apiKey: string): boolean {
+  return isOpenRouterPerplexityEndpoint(baseUrl) || isOpenRouterApiKey(apiKey);
 }
 
 function normalizeApiKey(key: unknown): string {
@@ -855,6 +923,14 @@ async function throwWebSearchApiError(res: Response, providerLabel: string): Pro
   throw new Error(`${providerLabel} API error (${res.status}): ${detail || res.statusText}`);
 }
 
+type PerplexitySearchResult = {
+  title: string;
+  url: string;
+  description: string;
+  published?: string;
+  siteName?: string;
+};
+
 async function runPerplexitySearchApi(params: {
   query: string;
   apiKey: string;
@@ -868,9 +944,16 @@ async function runPerplexitySearchApi(params: {
   searchBeforeDate?: string;
   maxTokens?: number;
   maxTokensPerPage?: number;
-}): Promise<
-  Array<{ title: string; url: string; description: string; published?: string; siteName?: string }>
-> {
+  baseUrl?: string;
+  model?: string;
+}): Promise<PerplexitySearchResult[]> {
+  const baseUrl = normalizePerplexityBaseUrl(params.baseUrl) ?? PERPLEXITY_API_BASE_URL;
+  const useOpenRouterMode = isOpenRouterPerplexityMode(baseUrl, params.apiKey);
+
+  if (useOpenRouterMode) {
+    return runPerplexityOpenRouterSearchApi(params, baseUrl);
+  }
+
   const body: Record<string, unknown> = {
     query: params.query,
     max_results: params.count,
@@ -903,7 +986,7 @@ async function runPerplexitySearchApi(params: {
 
   return withTrustedWebSearchEndpoint(
     {
-      url: PERPLEXITY_SEARCH_ENDPOINT,
+      url: `${baseUrl}/search`,
       timeoutSeconds: params.timeoutSeconds,
       init: {
         method: "POST",
@@ -911,6 +994,7 @@ async function runPerplexitySearchApi(params: {
           "Content-Type": "application/json",
           Accept: "application/json",
           Authorization: `Bearer ${params.apiKey}`,
+          "x-api-key": params.apiKey,
           "HTTP-Referer": "https://openclaw.ai",
           "X-Title": "OpenClaw Web Search",
         },
@@ -937,6 +1021,113 @@ async function runPerplexitySearchApi(params: {
           siteName: resolveSiteName(url) || undefined,
         };
       });
+    },
+  );
+}
+
+function extractOpenRouterCitations(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const values = value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry) => entry.length > 0);
+  return [...new Set(values)];
+}
+
+function extractPerplexityOpenRouterResponseText(data: Record<string, unknown>): string {
+  const choices = Array.isArray(data.choices) ? data.choices : [];
+  const firstChoice = choices[0] as Record<string, unknown> | undefined;
+  const message = firstChoice?.message;
+  if (message && typeof (message as Record<string, unknown>).content === "string") {
+    return ((message as Record<string, unknown>).content as string).trim();
+  }
+  return "Search completed but returned no text.";
+}
+
+function parseOpenRouterUrlsFromText(value: string, maxResults: number): string[] {
+  const urlRegex = /https?:\/\/[^\s"'`<>]+/g;
+  const urls = (value.match(urlRegex) ?? []).filter(Boolean).map((u) => u.replace(/[\])}]$/, ""));
+  const unique = [...new Set(urls)];
+  return maxResults > 0 ? unique.slice(0, maxResults) : unique;
+}
+
+async function runPerplexityOpenRouterSearchApi(
+  params: {
+    apiKey: string;
+    count: number;
+    timeoutSeconds: number;
+    query: string;
+    model?: string;
+  },
+  baseUrl: string,
+): Promise<PerplexitySearchResult[]> {
+  const body: Record<string, unknown> = {
+    model: params.model || OPENROUTER_PERPLEXITY_MODEL,
+    messages: [
+      {
+        role: "user",
+        content: `Search the web for: ${params.query}`,
+      },
+    ],
+    max_tokens: 2048,
+  };
+
+  return withTrustedWebSearchEndpoint(
+    {
+      url: `${baseUrl}/chat/completions`,
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          Authorization: `Bearer ${params.apiKey}`,
+          "x-api-key": params.apiKey,
+          "HTTP-Referer": "https://openclaw.ai",
+          "X-Title": "OpenClaw Web Search",
+        },
+        body: JSON.stringify(body),
+      },
+    },
+    async (res) => {
+      if (!res.ok) {
+        return await throwWebSearchApiError(res, "Perplexity Search");
+      }
+
+      const raw = (await res.json()) as Record<string, unknown>;
+      const text = extractPerplexityOpenRouterResponseText(raw);
+      const rawChoice = Array.isArray(raw.choices) ? raw.choices[0] : undefined;
+      const rawMessage =
+        rawChoice && typeof rawChoice === "object" && !Array.isArray(rawChoice)
+          ? (rawChoice as Record<string, unknown>).message
+          : undefined;
+      const rawCitations =
+        extractOpenRouterCitations(raw.citations) ??
+        extractOpenRouterCitations(
+          rawMessage && typeof rawMessage === "object" && !Array.isArray(rawMessage)
+            ? (rawMessage as Record<string, unknown>).citations
+            : undefined,
+        );
+      const urls =
+        rawCitations.length > 0 ? rawCitations : parseOpenRouterUrlsFromText(text, params.count);
+      const resultEntries =
+        urls.length > 0
+          ? urls.map((url) => ({
+              title: resolveSiteName(url) || "Search Result",
+              url,
+              description: wrapWebContent(text, "web_search"),
+            }))
+          : [
+              {
+                title: "Search Result",
+                url: "",
+                description: wrapWebContent(text, "web_search"),
+              },
+            ];
+      return resultEntries
+        .slice(0, params.count)
+        .map((entry) => ({ ...entry, description: entry.description || "No results" }));
     },
   );
 }
@@ -1169,6 +1360,8 @@ async function runWebSearch(params: {
   grokModel?: string;
   grokInlineCitations?: boolean;
   geminiModel?: string;
+  perplexityBaseUrl?: string;
+  perplexityModel?: string;
   kimiBaseUrl?: string;
   kimiModel?: string;
 }): Promise<Record<string, unknown>> {
@@ -1179,7 +1372,9 @@ async function runWebSearch(params: {
         ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
         : params.provider === "kimi"
           ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
-          : "";
+          : params.provider === "perplexity"
+            ? `${params.perplexityBaseUrl || PERPLEXITY_API_BASE_URL}:${params.perplexityModel || OPENROUTER_PERPLEXITY_MODEL}`
+            : "";
   const cacheKey = normalizeCacheKey(
     `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}`,
   );
@@ -1204,6 +1399,8 @@ async function runWebSearch(params: {
       searchBeforeDate: params.dateBefore ? isoToPerplexityDate(params.dateBefore) : undefined,
       maxTokens: params.maxTokens,
       maxTokensPerPage: params.maxTokensPerPage,
+      baseUrl: params.perplexityBaseUrl,
+      model: params.perplexityModel,
     });
 
     const payload = {
@@ -1421,6 +1618,12 @@ export function createWebSearchTool(options?: {
     execute: async (_toolCallId, args) => {
       const perplexityAuth =
         provider === "perplexity" ? resolvePerplexityApiKey(perplexityConfig) : undefined;
+      const perplexityBaseUrl =
+        provider === "perplexity" && perplexityAuth?.apiKey
+          ? resolvePerplexityBaseUrl(perplexityConfig, perplexityAuth.source, perplexityAuth.apiKey)
+          : undefined;
+      const perplexityModel =
+        provider === "perplexity" ? resolvePerplexityModel(perplexityConfig) : undefined;
       const apiKey =
         provider === "perplexity"
           ? perplexityAuth?.apiKey
@@ -1594,6 +1797,8 @@ export function createWebSearchTool(options?: {
         grokModel: resolveGrokModel(grokConfig),
         grokInlineCitations: resolveGrokInlineCitations(grokConfig),
         geminiModel: resolveGeminiModel(geminiConfig),
+        perplexityBaseUrl,
+        perplexityModel,
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
       });
@@ -1619,5 +1824,8 @@ export const __testing = {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  resolvePerplexityModel,
+  resolvePerplexityBaseUrl,
+  resolvePerplexityApiKey,
   resolveRedirectUrl: resolveCitationRedirectUrl,
 } as const;

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -15,7 +15,11 @@ function installMockFetch(payload: unknown) {
   return mockFetch;
 }
 
-function createPerplexitySearchTool(perplexityConfig?: { apiKey?: string }) {
+function createPerplexitySearchTool(perplexityConfig?: {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+}) {
   return createWebSearchTool({
     config: {
       tools: {
@@ -288,6 +292,41 @@ describe("web_search perplexity Search API", () => {
       | Record<string, string>
       | undefined;
     expect(headers?.Authorization).toBe("Bearer pplx-config");
+  });
+
+  it("uses OpenRouter chat/completions when OPENROUTER_API_KEY is used", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "Bearer sk-or-test");
+    const mockFetch = installMockFetch({
+      choices: [
+        {
+          message: {
+            content: "Result from Perplexity via OpenRouter. See https://example.com/openrouter",
+          },
+        },
+      ],
+      citations: ["https://example.com/openrouter"],
+    });
+    const tool = createPerplexitySearchTool({
+      baseUrl: "https://openrouter.ai/api/v1",
+      model: "perplexity/sonar-pro",
+    });
+    const result = await tool?.execute?.("call-1", { query: "test" });
+
+    expect(mockFetch).toHaveBeenCalled();
+    expect(mockFetch.mock.calls[0]?.[0]).toBe("https://openrouter.ai/api/v1/chat/completions");
+    const request = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(request?.method).toBe("POST");
+    const requestHeaders = request?.headers as Record<string, string> | undefined;
+    expect(requestHeaders?.Authorization).toBe("Bearer sk-or-test");
+    expect(requestHeaders?.["x-api-key"]).toBe("sk-or-test");
+    const body = parseFirstRequestBody(mockFetch);
+    expect(body.model).toBe("perplexity/sonar-pro");
+    expect(result?.details).toMatchObject({
+      provider: "perplexity",
+      results: expect.arrayContaining([
+        expect.objectContaining({ url: "https://example.com/openrouter" }),
+      ]),
+    });
   });
 
   it("passes freshness filter to Perplexity Search API", async () => {

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -94,6 +94,11 @@ describe("web search provider auto-detection", () => {
     expect(resolveSearchProvider({})).toBe("perplexity");
   });
 
+  it("auto-detects perplexity when only OPENROUTER_API_KEY is set", () => {
+    process.env.OPENROUTER_API_KEY = "sk-or-test-key";
+    expect(resolveSearchProvider({})).toBe("perplexity");
+  });
+
   it("auto-detects grok when only XAI_API_KEY is set", () => {
     process.env.XAI_API_KEY = "test-xai-key";
     expect(resolveSearchProvider({})).toBe("grok");

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -278,8 +278,6 @@ export const ToolsWebSearchSchema = z
     perplexity: z
       .object({
         apiKey: SecretInputSchema.optional().register(sensitive),
-        // Legacy Sonar/OpenRouter fields — kept for backward compatibility
-        // so existing configs don't fail validation. Ignored at runtime.
         baseUrl: z.string().optional(),
         model: z.string().optional(),
       })


### PR DESCRIPTION
## Summary
- Normalize Perplexity auth resolution so Bearer-prefixed values are accepted and reused consistently.
- Allow `OPENROUTER_API_KEY` to be used for the Perplexity provider and auto-detect it as Perplexity-capable.
- Route Perplexity requests through OpenRouter-compatible endpoints when using OpenRouter keys, while preserving direct Perplexity behavior for `pplx-*` keys.
- Add OpenRouter-compatible header support (`Authorization` + `x-api-key`) and normalize endpoint/model handling so the Perplexity tool works under both providers.
- Extend tests for key normalization, endpoint/model resolution, header usage, and provider auto-detection.

## Security Impact
- Uses existing secret-normalization helpers (`normalizeSecretInput`) and avoids logging API keys.
- Sends keys only in standard Authorization headers and `x-api-key` (required by some providers) for outbound requests.
- No new credential persistence or external secret flow is introduced; existing secret storage behavior is unchanged.

## Repro+Verification
- Repro: configure the Perplexity web-search tool with `OPENROUTER_API_KEY=Bearer sk-or-...` and trigger a Perplexity web search.
- Verification: request now uses OpenRouter-compatible chat/completions flow and no longer receives 401 from Perplexity key-prefix handling.
- Legacy `PERPLEXITY_API_KEY` / direct `api.perplexity.ai` path still works when a `pplx-*` style key is provided.

## Testing
- Added/updated unit tests in:
  - `src/agents/tools/web-search.test.ts`
  - `src/agents/tools/web-tools.enabled-defaults.test.ts`
  - `src/config/config.web-search-provider.test.ts`
- Covered scenarios include Bearer prefix normalization, OpenRouter endpoint routing, header presence, and auto-provider detection.

## AI Assisted
- AI-assisted implementation and test suggestions were used to identify edge-case handling for bearer stripping, endpoint/model defaults, and OpenRouter-compatible response parsing.

## Fixes
- Fixes #36182
