### PR TITLE
fix(agents): avoid stall when embedded run state lags behind terminal lifecycle outcome

### DIFF
--- a/src/agents/subagent-announce.settle-race.test.ts
+++ b/src/agents/subagent-announce.settle-race.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type GatewayCall = {
+  method?: string;
+  timeoutMs?: number;
+  expectFinal?: boolean;
+  params?: Record<string, unknown>;
+};
+
+const gatewayCalls: GatewayCall[] = [];
+let sessionStore: Record<string, Record<string, unknown>> = {};
+let configOverride: ReturnType<(typeof import("../config/config.js"))["loadConfig"]> = {
+  session: {
+    mainKey: "main",
+    scope: "per-sender",
+  },
+};
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: vi.fn(async (request: GatewayCall) => {
+    gatewayCalls.push(request);
+    if (request.method === "chat.history") {
+      return { messages: [] };
+    }
+    return {};
+  }),
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => configOverride,
+  };
+});
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => sessionStore),
+  resolveAgentIdFromSessionKey: () => "main",
+  resolveStorePath: () => "/tmp/sessions-main.json",
+  resolveMainSessionKey: () => "agent:main:main",
+}));
+
+vi.mock("./subagent-depth.js", () => ({
+  getSubagentDepthFromSessionStore: () => 0,
+}));
+
+let embeddedRunActive = true;
+let waitForEndResult = false;
+
+vi.mock("./pi-embedded.js", () => ({
+  isEmbeddedPiRunActive: () => embeddedRunActive,
+  queueEmbeddedPiMessage: () => false,
+  waitForEmbeddedPiRunEnd: async () => waitForEndResult,
+}));
+
+vi.mock("./subagent-registry.js", () => ({
+  countActiveDescendantRuns: () => 0,
+  countPendingDescendantRuns: () => 0,
+  isSubagentSessionRunActive: () => true,
+  resolveRequesterForChildSession: () => null,
+}));
+
+import { runSubagentAnnounceFlow } from "./subagent-announce.js";
+
+type AnnounceFlowParams = Parameters<typeof runSubagentAnnounceFlow>[0];
+
+const baseParams = {
+  childSessionKey: "agent:main:subagent:worker",
+  requesterSessionKey: "agent:main:main",
+  requesterDisplayKey: "main",
+  task: "test task",
+  timeoutMs: 1_000,
+  cleanup: "keep",
+  roundOneReply: "done",
+  waitForCompletion: false,
+} satisfies Omit<AnnounceFlowParams, "childRunId">;
+
+beforeEach(() => {
+  gatewayCalls.length = 0;
+  sessionStore = {
+    "agent:main:main": { sessionId: "sid-main" },
+    "agent:main:subagent:worker": { sessionId: "sid-worker" },
+  };
+  configOverride = { session: { mainKey: "main", scope: "per-sender" } };
+  embeddedRunActive = true;
+  waitForEndResult = false;
+});
+
+describe("subagent announce settle race (#36081)", () => {
+  it("proceeds with announce when embedded run is still active but outcome is terminal", async () => {
+    embeddedRunActive = true;
+    waitForEndResult = false;
+
+    const result = await runSubagentAnnounceFlow({
+      ...baseParams,
+      childRunId: "run-with-outcome",
+      outcome: { status: "ok" },
+    });
+
+    expect(result).toBe(true);
+    const agentCalls = gatewayCalls.filter((c) => c.method === "agent");
+    expect(agentCalls.length).toBeGreaterThan(0);
+  });
+
+  it("proceeds with announce when outcome is error (terminal)", async () => {
+    embeddedRunActive = true;
+    waitForEndResult = false;
+
+    const result = await runSubagentAnnounceFlow({
+      ...baseParams,
+      childRunId: "run-with-error-outcome",
+      outcome: { status: "error", error: "test error" },
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("defers when embedded run is active and no terminal outcome", async () => {
+    embeddedRunActive = true;
+    waitForEndResult = false;
+
+    const result = await runSubagentAnnounceFlow({
+      ...baseParams,
+      childRunId: "run-no-outcome",
+      outcome: undefined,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("defers when embedded run is active with unknown outcome", async () => {
+    embeddedRunActive = true;
+    waitForEndResult = false;
+
+    const result = await runSubagentAnnounceFlow({
+      ...baseParams,
+      childRunId: "run-unknown-outcome",
+      outcome: { status: "unknown" },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("proceeds normally when waitForEmbeddedPiRunEnd settles", async () => {
+    embeddedRunActive = false;
+    waitForEndResult = true;
+
+    const result = await runSubagentAnnounceFlow({
+      ...baseParams,
+      childRunId: "run-settled",
+      outcome: { status: "ok" },
+    });
+
+    expect(result).toBe(true);
+  });
+});

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1150,11 +1150,17 @@ export async function runSubagentAnnounceFlow(params: {
     if (childSessionId && isEmbeddedPiRunActive(childSessionId)) {
       const settled = await waitForEmbeddedPiRunEnd(childSessionId, settleTimeoutMs);
       if (!settled && isEmbeddedPiRunActive(childSessionId)) {
-        // The child run is still active (e.g., compaction retry still in progress).
-        // Defer announcement so we don't report stale/partial output.
-        // Keep the child session so output is not lost while the run is still active.
-        shouldDeleteChildSession = false;
-        return false;
+        // The embedded run state hasn't cleared yet. However, if we already
+        // have a terminal outcome from the lifecycle event or agent.wait,
+        // the run is logically complete — the embedded state just lags behind.
+        // Proceed with the announce instead of deferring, which avoids the
+        // intermittent stall where the parent never gets woken up (#36081).
+        const hasTerminalOutcome =
+          outcome?.status === "ok" || outcome?.status === "error" || outcome?.status === "timeout";
+        if (!hasTerminalOutcome) {
+          shouldDeleteChildSession = false;
+          return false;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Problem: When a mode="run" sub-agent completes, the lifecycle "end" event fires before `clearActiveEmbeddedRun` runs in the `finally` block of `attempt.ts`. If `waitForEmbeddedPiRunEnd` times out while the embedded state is still active, `runSubagentAnnounceFlow` returns `false` and defers the announce. In narrow timing windows, the retry may not trigger or may arrive too late, causing the parent session to stall indefinitely — the sub-agent completes but the parent never receives the auto-announce turn.
- Why it matters: Multi-agent pipelines (e.g., orchestrator → web scout → guardian → orchestrator) intermittently stall, with 50-75% failure rate observed across independent machines. The parent sits idle with no error or timeout indication.
- What changed: When the registry already has a terminal outcome (`ok`, `error`, or `timeout`) from the lifecycle event or `agent.wait`, proceed with the announce instead of deferring. The embedded run state lagging behind is a cleanup detail, not an indicator that output is incomplete.
- What did NOT change (scope boundary): No changes to the settle-wait mechanism, lifecycle event emission, embedded run cleanup, or retry/defer logic. The defer path is preserved for cases where no terminal outcome is available.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36081

## User-visible / Behavior Changes

Sub-agent completion events now reliably wake the parent session for a new turn, even when the embedded run state hasn't fully cleared. Previously, 50-75% of mode="run" completions would stall the parent.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 12.7.4 / Darwin
- Runtime: Node.js 22+

### Steps

1. Spawn a sub-agent with `sessions_spawn({ task: "...", mode: "run" })`
2. Wait for sub-agent to complete
3. Observe parent session for auto-announce turn

### Expected

- Parent session receives auto-announce turn with sub-agent output

### Actual

- Before: Parent stalls ~50-75% of the time when lifecycle fires before embedded run state clears
- After: Parent reliably receives the announce when a terminal outcome exists

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

5 vitest unit tests covering:
- Terminal outcome `ok` proceeds despite active embedded run
- Terminal outcome `error` proceeds
- No outcome defers (preserves existing behavior)
- `unknown` outcome defers
- Normal settled path proceeds

## Human Verification (required)

- Verified scenarios: All 5 settle-race paths tested. Existing 3 timeout tests continue to pass unchanged.
- Edge cases checked: No outcome (defers), unknown outcome (defers), error outcome (proceeds), embedded run already settled (proceeds normally).
- What you did **not** verify: Live multi-agent pipeline across multiple machines. The race condition is inherently intermittent and depends on kernel scheduling and async task ordering.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit. The settle-wait behavior returns to always deferring when embedded run is active.
- Files/config to restore: `src/agents/subagent-announce.ts`

## Risks and Mitigations

- Risk: Proceeding with announce while embedded run state is still active could theoretically produce a slightly stale or truncated output snapshot.
  - Mitigation: The terminal outcome from lifecycle/agent.wait confirms the run has fully produced its output. The embedded state lingering is a cleanup artifact (e.g., compaction retry), not an output production phase. The existing `readLatestSubagentOutput` + retry mechanism handles reading the final output.