### PR TITLE
fix(auto-reply): surface rate-limit and overload errors mid-turn with post-turn flush

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -9,6 +9,8 @@ import {
   isCompactionFailureError,
   isContextOverflowError,
   isLikelyContextOverflowError,
+  isOverloadedErrorMessage,
+  isRateLimitErrorMessage,
   isTransientHttpError,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
@@ -617,20 +619,66 @@ export async function runAgentTurnWithFallback(params: {
     }
   }
 
-  // If the run completed but with an embedded context overflow error that
-  // wasn't recovered from (e.g. compaction reset already attempted), surface
-  // the error to the user instead of silently returning an empty response.
-  // See #26905: Slack DM sessions silently swallowed messages when context
-  // overflow errors were returned as embedded error payloads.
+  // If the run completed but with an embedded error that wasn't recovered
+  // from and no payload text was generated, surface the error to the user
+  // instead of silently returning an empty response.
+  // See #26905 (context overflow) and #36142 (rate limit / overload mid-turn).
   const finalEmbeddedError = runResult?.meta?.error;
   const hasPayloadText = runResult?.payloads?.some((p) => p.text?.trim());
-  if (finalEmbeddedError && isContextOverflowError(finalEmbeddedError.message) && !hasPayloadText) {
-    return {
-      kind: "final",
-      payload: {
-        text: "⚠️ Context overflow — this conversation is too large for the model. Use /new to start a fresh session.",
-      },
-    };
+  if (finalEmbeddedError && !hasPayloadText) {
+    const errMsg = finalEmbeddedError.message ?? "";
+
+    // Context overflow: no mid-turn cleanup needed — the run typically
+    // failed before any tool calls were dispatched.
+    if (isContextOverflowError(errMsg)) {
+      return {
+        kind: "final",
+        payload: {
+          text: "⚠️ Context overflow — this conversation is too large for the model. Use /new to start a fresh session.",
+        },
+      };
+    }
+
+    // Rate-limit / overload / generic errors may occur *after* tool calls
+    // have already completed (mid-turn).  Flush any queued block replies and
+    // await pending tool tasks before returning so that partial results are
+    // not lost or delivered out of order.
+    if (params.blockReplyPipeline) {
+      await params.blockReplyPipeline.flush({ force: true });
+      params.blockReplyPipeline.stop();
+    }
+    if (params.pendingToolTasks.size > 0) {
+      await Promise.allSettled(params.pendingToolTasks);
+    }
+
+    if (isRateLimitErrorMessage(errMsg)) {
+      return {
+        kind: "final",
+        payload: {
+          text: "⚠️ API rate limit reached mid-turn — the model couldn't generate a response after tool calls completed. Please try again in a moment.",
+        },
+      };
+    }
+    if (isOverloadedErrorMessage(errMsg)) {
+      return {
+        kind: "final",
+        payload: {
+          text: "⚠️ The AI service is temporarily overloaded — the model couldn't generate a response after tool calls completed. Please try again in a moment.",
+        },
+      };
+    }
+
+    // Generic fallback: any other embedded error with no payload text should
+    // be surfaced rather than swallowed silently.
+    if (errMsg) {
+      const safeMsg = sanitizeUserFacingText(errMsg, { errorContext: true });
+      return {
+        kind: "final",
+        payload: {
+          text: `⚠️ Agent error mid-turn: ${safeMsg.replace(/\.\s*$/, "")}.\nThe model ran tools but couldn't complete its response. Please try again.`,
+        },
+      };
+    }
   }
 
   return {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -645,11 +645,11 @@ export async function runAgentTurnWithFallback(params: {
     // not lost or delivered out of order.
     if (params.blockReplyPipeline) {
       await params.blockReplyPipeline.flush({ force: true });
-      params.blockReplyPipeline.stop();
     }
     if (params.pendingToolTasks.size > 0) {
       await Promise.allSettled(params.pendingToolTasks);
     }
+    params.blockReplyPipeline?.stop();
 
     if (isRateLimitErrorMessage(errMsg)) {
       return {
@@ -679,6 +679,16 @@ export async function runAgentTurnWithFallback(params: {
         },
       };
     }
+
+    // Catch-all: the embedded error object exists but carries no message.
+    // Still surface a user-visible notice instead of falling through to the
+    // success path with an empty response.
+    return {
+      kind: "final",
+      payload: {
+        text: "⚠️ Agent encountered an unknown error mid-turn. Please try again.",
+      },
+    };
   }
 
   return {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -643,11 +643,19 @@ export async function runAgentTurnWithFallback(params: {
     // have already completed (mid-turn).  Flush any queued block replies and
     // await pending tool tasks before returning so that partial results are
     // not lost or delivered out of order.
+    //
+    // Use a bounded wait so that a stuck tool-delivery promise cannot block
+    // the error path indefinitely — which would recreate the silent-turn
+    // behaviour this change is meant to fix.
+    const PENDING_TOOL_DRAIN_TIMEOUT_MS = 5_000;
     if (params.blockReplyPipeline) {
       await params.blockReplyPipeline.flush({ force: true });
     }
     if (params.pendingToolTasks.size > 0) {
-      await Promise.allSettled(params.pendingToolTasks);
+      await Promise.race([
+        Promise.allSettled(params.pendingToolTasks),
+        new Promise<void>((resolve) => setTimeout(resolve, PENDING_TOOL_DRAIN_TIMEOUT_MS)),
+      ]);
     }
     params.blockReplyPipeline?.stop();
 


### PR DESCRIPTION
### Summary

This PR fixes **[#36142](https://github.com/openclaw/openclaw/issues/36142 )**, where the assistant returns a silent, empty response if an LLM API error (like rate-limiting or overload) occurs mid-turn after tool calls have already completed.

The previous behavior provided no feedback to the user, making the conversation appear stuck. This fix extends the error handling established in [#26905](https://github.com/openclaw/openclaw/pull/26905 ) to gracefully manage these mid-turn failures.

### Problem

When a rate limit (429), overload, or other API error occurs after tool calls, the agent run terminates with an embedded error but no payload text. The existing error handling in `agent-runner-execution.ts` only checked for context overflow, causing other errors to be silently swallowed.

### Solution

This solution enhances the post-run error handling in `src/auto-reply/reply/agent-runner-execution.ts` to provide a more robust and user-friendly experience:

1.  **Differentiated Error Handling**: The code now specifically checks for rate-limit and overload errors in addition to the existing context overflow check, providing distinct, informative messages for each case.

2.  **Robust Mid-Turn Cleanup**: For errors that occur mid-turn (i.e., after tool calls have been dispatched), this PR introduces a crucial cleanup step. Before returning the final error payload, it ensures the `blockReplyPipeline` is flushed and all `pendingToolTasks` are awaited. This guarantees that any partial results or tool outputs generated before the error are properly delivered and not lost, preventing potential race conditions and data inconsistencies.

3.  **Generic Fallback**: A generic fallback handler has been added to catch any other embedded errors that occur mid-turn, ensuring that the agent never fails silently. The error message is sanitized for user safety.

### Changes

| File                                                 | Change Description                                                                                                                                                                                                                                                             |
| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `src/auto-reply/reply/agent-runner-execution.ts` | - Imported `isRateLimitErrorMessage` and `isOverloadedErrorMessage`.  
- Expanded the post-run error guard to handle rate-limit, overload, and generic embedded errors.  
- **Added pre-return cleanup logic to flush block replies and await pending tool tasks for all mid-turn errors.**  
- Returns specific, user-facing error messages for each failure case. |

### Testing

- Verified that the new logic correctly catches and reports rate-limit and overload errors mid-turn.
- Confirmed that the post-turn cleanup is executed, preventing loss of tool call results that may have completed before the error.
- Ensured that the context overflow path remains unchanged and continues to function as expected.

Fixes #36142