### PR TITLE
Tools: honor default agent workspace roots in message tool sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
+- Tools/message media roots: resolve default agent identity for `message` tool sends even without an explicit session key so outbound local media validation includes agent-scoped workspace roots (including `agents.defaults.workspace`) instead of only global defaults. (#36185) Thanks @ravz.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -111,6 +111,28 @@ describe("message tool agent routing", () => {
     expect(call?.agentId).toBe("alpha");
     expect(call?.sessionKey).toBe("agent:alpha:main");
   });
+
+  it("falls back to default agentId when session key is missing", async () => {
+    mockSendResult();
+
+    const tool = createMessageTool({
+      config: {
+        agents: {
+          list: [{ id: "alpha" }, { id: "beta", default: true }],
+        },
+      } as never,
+    });
+
+    await tool.execute("1", {
+      action: "send",
+      target: "telegram:123",
+      message: "hi",
+    });
+
+    const call = mocks.runMessageAction.mock.calls[0]?.[0];
+    expect(call?.agentId).toBe("beta");
+    expect(call?.sessionKey).toBeUndefined();
+  });
 });
 
 describe("message tool path passthrough", () => {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -728,6 +728,12 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
               skipCrossContextDecoration: true,
             }
           : undefined;
+      // Preserve agent-scoped outbound policies (for example media local roots)
+      // even when the tool runs without an explicit session key.
+      const resolvedAgentId = resolveSessionAgentId({
+        sessionKey: options?.agentSessionKey,
+        config: cfg,
+      });
 
       const result = await runMessageAction({
         cfg,
@@ -738,9 +744,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         gateway,
         toolContext,
         sessionKey: options?.agentSessionKey,
-        agentId: options?.agentSessionKey
-          ? resolveSessionAgentId({ sessionKey: options.agentSessionKey, config: cfg })
-          : undefined,
+        agentId: resolvedAgentId,
         sandboxRoot: options?.sandboxRoot,
         abortSignal: signal,
       });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `message` tool calls without an explicit session key forwarded no `agentId`, so outbound media validation only used global local roots.
- Why it matters: users configuring `agents.defaults.workspace` could not send local files from that workspace via `message` tool (`path-not-allowed`).
- What changed: `createMessageTool` now always resolves an agent identity (session agent when present, otherwise default agent) and forwards it to `runMessageAction`.
- What did NOT change (scope boundary): no changes to attachment loaders, channel adapters, or sandbox-path validation semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36185
- Related #

## User-visible / Behavior Changes

- `message` tool invocations without `agentSessionKey` now inherit default-agent scoped outbound media roots.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: n/a
- Integration/channel (if any): outbound messaging tool path
- Relevant config (redacted): `agents.list` with default agent + `agents.defaults.workspace`

### Steps

1. Run `message` tool send call without `agentSessionKey`.
2. Inspect `runMessageAction` call payload.
3. Confirm resolved `agentId` equals default agent id.

### Expected

- Default agent id is forwarded so agent-scoped local roots are applied.

### Actual

- Verified by regression test: call now includes `agentId: "beta"` when no session key is present.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added regression test in `src/agents/tools/message-tool.test.ts` for no-session-key path.
  - Confirmed session-key path behavior remains unchanged (`agent:alpha:main` -> `alpha`).
- Edge cases checked:
  - Default agent resolution uses config default marker when multiple agents are present.
- What you did **not** verify:
  - End-to-end send against a live channel runtime.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Tools: default message tool agent scope for media roots`.
- Files/config to restore: `src/agents/tools/message-tool.ts` and `src/agents/tools/message-tool.test.ts`.
- Known bad symptoms reviewers should watch for: unexpected default-agent routing/account binding changes when no session key is present.

## Risks and Mitigations

- Risk: default-agent resolution in no-session-key calls could alter behavior for callers that relied on implicit `undefined` agent scope.
  - Mitigation: change is limited to message tool callsite and covered by focused regression tests for both session and no-session paths.
