### PR TITLE
Docs: explain existing Chrome remote-debugging CDP setup

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -152,6 +152,51 @@ OpenClaw preserves the auth when calling `/json/*` endpoints and when connecting
 to the CDP WebSocket. Prefer environment variables or secrets managers for
 tokens instead of committing them to config files.
 
+## Connect to an existing Chrome instance
+
+Use this when you want OpenClaw to control a Chrome profile that is already
+running with your logged-in sessions, without relying on extension tab attach.
+
+1. Start Chrome with remote debugging enabled (loopback only):
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-address=127.0.0.1 \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/path/to/chrome-user-data
+```
+
+2. Point a browser profile at that CDP endpoint:
+
+```json5
+{
+  browser: {
+    enabled: true,
+    defaultProfile: "existing-chrome",
+    profiles: {
+      "existing-chrome": {
+        cdpUrl: "http://127.0.0.1:9222",
+        color: "#4285F4",
+      },
+    },
+  },
+}
+```
+
+3. Restart Gateway, then verify:
+
+```bash
+openclaw browser --browser-profile existing-chrome status
+openclaw browser --browser-profile existing-chrome tabs
+```
+
+Notes:
+
+- Remote CDP profiles are attach-only (`start/stop/reset` are disabled).
+- No extension click is required for this path.
+- `chrome` is a built-in extension-relay profile name. If you intentionally set
+  `profiles.chrome`, your config overrides the built-in relay profile.
+
 ## Node browser proxy (zero-config default)
 
 If you run a **node host** on the machine that has your browser, OpenClaw can


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: docs covered managed browser and extension relay, but missed a direct guide for attaching to an already-running Chrome instance via remote debugging.
- Why it matters: users running OpenClaw as a background service need a no-extension-attach path that keeps their existing browser session.
- What changed: added a new `Connect to an existing Chrome instance` section to browser docs with launch command, config snippet, verification commands, and profile-name behavior notes.
- What did NOT change (scope boundary): no runtime/code changes; docs only.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36150
- Related #36147

## User-visible / Behavior Changes

- New browser docs section with a copy-paste path for `--remote-debugging-port` based direct CDP attach.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: n/a
- Integration/channel (if any): browser docs
- Relevant config (redacted): browser profile with `cdpUrl`

### Steps

1. Open updated browser docs.
2. Follow the new `Connect to an existing Chrome instance` section.
3. Validate examples and notes align with current browser profile behavior.

### Expected

- Users can configure direct CDP attach to existing Chrome without ambiguity.

### Actual

- Section includes launch flags, profile config, verification commands, and `profiles.chrome` override note.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reviewed docs flow end-to-end from launch command -> config -> verification commands.
  - Confirmed docs wording matches runtime behavior where configured `profiles.chrome` overrides built-in relay profile.
- Edge cases checked:
  - Notes call out attach-only behavior for remote CDP profiles.
- What you did **not** verify:
  - Live browser session against a real remote-debugging Chrome process.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this docs commit.
- Files/config to restore: `docs/tools/browser.md`.
- Known bad symptoms reviewers should watch for: none (docs-only).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: docs examples could drift from runtime behavior in future browser-profile refactors.
  - Mitigation: section uses stable config keys already documented in browser config reference.
