### PR TITLE
chore(gateway): ignore `.test.ts` changes in `gateway:watch`

### DIFF
--- a/scripts/watch-node.d.mts
+++ b/scripts/watch-node.d.mts
@@ -4,8 +4,20 @@ export function runWatchMain(params?: {
     args: string[],
     options: unknown,
   ) => {
+    kill?: (signal?: NodeJS.Signals | number) => void;
     on: (event: "exit", cb: (code: number | null, signal: string | null) => void) => void;
   };
+  createWatcher?: (
+    paths: string[],
+    options: {
+      ignoreInitial: boolean;
+      ignored: (watchPath: string) => boolean;
+    },
+  ) => {
+    on: (event: "add" | "change" | "unlink" | "error", cb: (arg?: unknown) => void) => void;
+    close?: () => Promise<void> | void;
+  };
+  watchPaths?: string[];
   process?: NodeJS.Process;
   cwd?: string;
   args?: string[];

--- a/scripts/watch-node.mjs
+++ b/scripts/watch-node.mjs
@@ -99,6 +99,10 @@ export async function runWatchMain(params = {}) {
     watcher.on("change", requestRestart);
     watcher.on("unlink", requestRestart);
     watcher.on("error", () => {
+      shuttingDown = true;
+      if (watchProcess && typeof watchProcess.kill === "function") {
+        watchProcess.kill(WATCH_RESTART_SIGNAL);
+      }
       settle(1);
     });
 

--- a/scripts/watch-node.mjs
+++ b/scripts/watch-node.mjs
@@ -2,16 +2,17 @@
 import { spawn } from "node:child_process";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
+import chokidar from "chokidar";
 import { runNodeWatchedPaths } from "./run-node.mjs";
 
 const WATCH_NODE_RUNNER = "scripts/run-node.mjs";
+const WATCH_RESTART_SIGNAL = "SIGTERM";
 
-const buildWatchArgs = (args) => [
-  ...runNodeWatchedPaths.flatMap((watchPath) => ["--watch-path", watchPath]),
-  "--watch-preserve-output",
-  WATCH_NODE_RUNNER,
-  ...args,
-];
+const buildRunnerArgs = (args) => [WATCH_NODE_RUNNER, ...args];
+
+const normalizePath = (filePath) => String(filePath ?? "").replaceAll("\\", "/");
+
+const isIgnoredWatchPath = (filePath) => normalizePath(filePath).endsWith(".test.ts");
 
 export async function runWatchMain(params = {}) {
   const deps = {
@@ -21,6 +22,9 @@ export async function runWatchMain(params = {}) {
     args: params.args ?? process.argv.slice(2),
     env: params.env ? { ...params.env } : { ...process.env },
     now: params.now ?? Date.now,
+    createWatcher:
+      params.createWatcher ?? ((watchPaths, options) => chokidar.watch(watchPaths, options)),
+    watchPaths: params.watchPaths ?? runNodeWatchedPaths,
   };
 
   const childEnv = { ...deps.env };
@@ -31,54 +35,92 @@ export async function runWatchMain(params = {}) {
     childEnv.OPENCLAW_WATCH_COMMAND = deps.args.join(" ");
   }
 
-  const watchProcess = deps.spawn(deps.process.execPath, buildWatchArgs(deps.args), {
-    cwd: deps.cwd,
-    env: childEnv,
-    stdio: "inherit",
-  });
-
-  let settled = false;
-  let onSigInt;
-  let onSigTerm;
-
-  const settle = (resolve, code) => {
-    if (settled) {
-      return;
-    }
-    settled = true;
-    if (onSigInt) {
-      deps.process.off("SIGINT", onSigInt);
-    }
-    if (onSigTerm) {
-      deps.process.off("SIGTERM", onSigTerm);
-    }
-    resolve(code);
-  };
-
   return await new Promise((resolve) => {
-    onSigInt = () => {
-      if (typeof watchProcess.kill === "function") {
-        watchProcess.kill("SIGTERM");
+    let settled = false;
+    let shuttingDown = false;
+    let restartRequested = false;
+    let watchProcess = null;
+    let onSigInt;
+    let onSigTerm;
+
+    const watcher = deps.createWatcher(deps.watchPaths, {
+      ignoreInitial: true,
+      ignored: (watchPath) => isIgnoredWatchPath(watchPath),
+    });
+
+    const settle = (code) => {
+      if (settled) {
+        return;
       }
-      settle(resolve, 130);
+      settled = true;
+      if (onSigInt) {
+        deps.process.off("SIGINT", onSigInt);
+      }
+      if (onSigTerm) {
+        deps.process.off("SIGTERM", onSigTerm);
+      }
+      watcher.close?.().catch?.(() => {});
+      resolve(code);
+    };
+
+    const startRunner = () => {
+      watchProcess = deps.spawn(deps.process.execPath, buildRunnerArgs(deps.args), {
+        cwd: deps.cwd,
+        env: childEnv,
+        stdio: "inherit",
+      });
+      watchProcess.on("exit", () => {
+        watchProcess = null;
+        if (shuttingDown) {
+          return;
+        }
+        if (restartRequested) {
+          restartRequested = false;
+          startRunner();
+        }
+      });
+    };
+
+    const requestRestart = (changedPath) => {
+      if (shuttingDown || isIgnoredWatchPath(changedPath)) {
+        return;
+      }
+      if (!watchProcess) {
+        startRunner();
+        return;
+      }
+      restartRequested = true;
+      if (typeof watchProcess.kill === "function") {
+        watchProcess.kill(WATCH_RESTART_SIGNAL);
+      }
+    };
+
+    watcher.on("add", requestRestart);
+    watcher.on("change", requestRestart);
+    watcher.on("unlink", requestRestart);
+    watcher.on("error", () => {
+      settle(1);
+    });
+
+    startRunner();
+
+    onSigInt = () => {
+      shuttingDown = true;
+      if (watchProcess && typeof watchProcess.kill === "function") {
+        watchProcess.kill(WATCH_RESTART_SIGNAL);
+      }
+      settle(130);
     };
     onSigTerm = () => {
-      if (typeof watchProcess.kill === "function") {
-        watchProcess.kill("SIGTERM");
+      shuttingDown = true;
+      if (watchProcess && typeof watchProcess.kill === "function") {
+        watchProcess.kill(WATCH_RESTART_SIGNAL);
       }
-      settle(resolve, 143);
+      settle(143);
     };
 
     deps.process.on("SIGINT", onSigInt);
     deps.process.on("SIGTERM", onSigTerm);
-
-    watchProcess.on("exit", (code, signal) => {
-      if (signal) {
-        settle(resolve, 1);
-        return;
-      }
-      settle(resolve, code ?? 1);
-    });
   });
 }
 

--- a/scripts/watch-node.mjs
+++ b/scripts/watch-node.mjs
@@ -12,7 +12,14 @@ const buildRunnerArgs = (args) => [WATCH_NODE_RUNNER, ...args];
 
 const normalizePath = (filePath) => String(filePath ?? "").replaceAll("\\", "/");
 
-const isIgnoredWatchPath = (filePath) => normalizePath(filePath).endsWith(".test.ts");
+const isIgnoredWatchPath = (filePath) => {
+  const normalizedPath = normalizePath(filePath);
+  return (
+    normalizedPath.endsWith(".test.ts") ||
+    normalizedPath.endsWith(".test.tsx") ||
+    normalizedPath.endsWith("test-helpers.ts")
+  );
+};
 
 export async function runWatchMain(params = {}) {
   const deps = {

--- a/src/infra/watch-node.test.ts
+++ b/src/infra/watch-node.test.ts
@@ -46,6 +46,8 @@ describe("watch-node script", () => {
     expect(watchPaths).toEqual(runNodeWatchedPaths);
     expect(watchOptions.ignoreInitial).toBe(true);
     expect(watchOptions.ignored("src/infra/watch-node.test.ts")).toBe(true);
+    expect(watchOptions.ignored("src/infra/watch-node.test.tsx")).toBe(true);
+    expect(watchOptions.ignored("src/infra/watch-node-test-helpers.ts")).toBe(true);
     expect(watchOptions.ignored("src/infra/watch-node.ts")).toBe(false);
     expect(watchOptions.ignored("tsconfig.json")).toBe(false);
 
@@ -111,7 +113,7 @@ describe("watch-node script", () => {
     expect(fakeProcess.listenerCount("SIGTERM")).toBe(0);
   });
 
-  it("ignores .test.ts changes and restarts on non-test source changes", async () => {
+  it("ignores test-only changes and restarts on non-test source changes", async () => {
     const childA = Object.assign(new EventEmitter(), {
       kill: vi.fn(function () {
         queueMicrotask(() => childA.emit("exit", 0, null));
@@ -135,6 +137,16 @@ describe("watch-node script", () => {
     });
 
     watcher.emit("change", "src/infra/watch-node.test.ts");
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(childA.kill).not.toHaveBeenCalled();
+
+    watcher.emit("change", "src/infra/watch-node.test.tsx");
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(childA.kill).not.toHaveBeenCalled();
+
+    watcher.emit("change", "src/infra/watch-node-test-helpers.ts");
     await new Promise((resolve) => setImmediate(resolve));
     expect(spawn).toHaveBeenCalledTimes(1);
     expect(childA.kill).not.toHaveBeenCalled();

--- a/src/infra/watch-node.test.ts
+++ b/src/infra/watch-node.test.ts
@@ -146,4 +146,22 @@ describe("watch-node script", () => {
     const exitCode = await runPromise;
     expect(exitCode).toBe(130);
   });
+
+  it("kills child and exits when watcher emits an error", async () => {
+    const { child, spawn, watcher, createWatcher, fakeProcess } = createWatchHarness();
+
+    const runPromise = runWatchMain({
+      args: ["gateway", "--force"],
+      createWatcher,
+      process: fakeProcess,
+      spawn,
+    });
+
+    watcher.emit("error", new Error("watch failed"));
+    const exitCode = await runPromise;
+
+    expect(exitCode).toBe(1);
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(watcher.close).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/infra/watch-node.test.ts
+++ b/src/infra/watch-node.test.ts
@@ -11,40 +11,46 @@ const createFakeProcess = () =>
 
 const createWatchHarness = () => {
   const child = Object.assign(new EventEmitter(), {
-    kill: vi.fn(),
+    kill: vi.fn(() => {}),
   });
   const spawn = vi.fn(() => child);
+  const watcher = Object.assign(new EventEmitter(), {
+    close: vi.fn(async () => {}),
+  });
+  const createWatcher = vi.fn(() => watcher);
   const fakeProcess = createFakeProcess();
-  return { child, spawn, fakeProcess };
+  return { child, spawn, watcher, createWatcher, fakeProcess };
 };
 
 describe("watch-node script", () => {
-  it("wires node watch to run-node with watched source/config paths", async () => {
-    const { child, spawn, fakeProcess } = createWatchHarness();
+  it("wires chokidar watch to run-node with watched source/config paths", async () => {
+    const { child, spawn, watcher, createWatcher, fakeProcess } = createWatchHarness();
 
     const runPromise = runWatchMain({
       args: ["gateway", "--force"],
       cwd: "/tmp/openclaw",
+      createWatcher,
       env: { PATH: "/usr/bin" },
       now: () => 1700000000000,
       process: fakeProcess,
       spawn,
     });
 
-    queueMicrotask(() => child.emit("exit", 0, null));
-    const exitCode = await runPromise;
+    expect(createWatcher).toHaveBeenCalledTimes(1);
+    const [watchPaths, watchOptions] = createWatcher.mock.calls[0] as [
+      string[],
+      { ignoreInitial: boolean; ignored: (watchPath: string) => boolean },
+    ];
+    expect(watchPaths).toEqual(runNodeWatchedPaths);
+    expect(watchOptions.ignoreInitial).toBe(true);
+    expect(watchOptions.ignored("src/infra/watch-node.test.ts")).toBe(true);
+    expect(watchOptions.ignored("src/infra/watch-node.ts")).toBe(false);
+    expect(watchOptions.ignored("tsconfig.json")).toBe(false);
 
-    expect(exitCode).toBe(0);
     expect(spawn).toHaveBeenCalledTimes(1);
     expect(spawn).toHaveBeenCalledWith(
       "/usr/local/bin/node",
-      [
-        ...runNodeWatchedPaths.flatMap((watchPath) => ["--watch-path", watchPath]),
-        "--watch-preserve-output",
-        "scripts/run-node.mjs",
-        "gateway",
-        "--force",
-      ],
+      ["scripts/run-node.mjs", "gateway", "--force"],
       expect.objectContaining({
         cwd: "/tmp/openclaw",
         stdio: "inherit",
@@ -56,13 +62,19 @@ describe("watch-node script", () => {
         }),
       }),
     );
+    fakeProcess.emit("SIGINT");
+    const exitCode = await runPromise;
+    expect(exitCode).toBe(130);
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(watcher.close).toHaveBeenCalledTimes(1);
   });
 
   it("terminates child on SIGINT and returns shell interrupt code", async () => {
-    const { child, spawn, fakeProcess } = createWatchHarness();
+    const { child, spawn, watcher, createWatcher, fakeProcess } = createWatchHarness();
 
     const runPromise = runWatchMain({
       args: ["gateway", "--force"],
+      createWatcher,
       process: fakeProcess,
       spawn,
     });
@@ -72,15 +84,17 @@ describe("watch-node script", () => {
 
     expect(exitCode).toBe(130);
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(watcher.close).toHaveBeenCalledTimes(1);
     expect(fakeProcess.listenerCount("SIGINT")).toBe(0);
     expect(fakeProcess.listenerCount("SIGTERM")).toBe(0);
   });
 
   it("terminates child on SIGTERM and returns shell terminate code", async () => {
-    const { child, spawn, fakeProcess } = createWatchHarness();
+    const { child, spawn, watcher, createWatcher, fakeProcess } = createWatchHarness();
 
     const runPromise = runWatchMain({
       args: ["gateway", "--force"],
+      createWatcher,
       process: fakeProcess,
       spawn,
     });
@@ -90,7 +104,46 @@ describe("watch-node script", () => {
 
     expect(exitCode).toBe(143);
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(watcher.close).toHaveBeenCalledTimes(1);
     expect(fakeProcess.listenerCount("SIGINT")).toBe(0);
     expect(fakeProcess.listenerCount("SIGTERM")).toBe(0);
+  });
+
+  it("ignores .test.ts changes and restarts on non-test source changes", async () => {
+    const childA = Object.assign(new EventEmitter(), {
+      kill: vi.fn(function () {
+        queueMicrotask(() => childA.emit("exit", 0, null));
+      }),
+    });
+    const childB = Object.assign(new EventEmitter(), {
+      kill: vi.fn(() => {}),
+    });
+    const spawn = vi.fn().mockReturnValueOnce(childA).mockReturnValueOnce(childB);
+    const watcher = Object.assign(new EventEmitter(), {
+      close: vi.fn(async () => {}),
+    });
+    const createWatcher = vi.fn(() => watcher);
+    const fakeProcess = createFakeProcess();
+
+    const runPromise = runWatchMain({
+      args: ["gateway", "--force"],
+      createWatcher,
+      process: fakeProcess,
+      spawn,
+    });
+
+    watcher.emit("change", "src/infra/watch-node.test.ts");
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(childA.kill).not.toHaveBeenCalled();
+
+    watcher.emit("change", "src/infra/watch-node.ts");
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(childA.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(spawn).toHaveBeenCalledTimes(2);
+
+    fakeProcess.emit("SIGINT");
+    const exitCode = await runPromise;
+    expect(exitCode).toBe(130);
   });
 });

--- a/src/infra/watch-node.test.ts
+++ b/src/infra/watch-node.test.ts
@@ -37,7 +37,9 @@ describe("watch-node script", () => {
     });
 
     expect(createWatcher).toHaveBeenCalledTimes(1);
-    const [watchPaths, watchOptions] = createWatcher.mock.calls[0] as [
+    const firstWatcherCall = createWatcher.mock.calls[0];
+    expect(firstWatcherCall).toBeDefined();
+    const [watchPaths, watchOptions] = firstWatcherCall as unknown as [
       string[],
       { ignoreInitial: boolean; ignored: (watchPath: string) => boolean },
     ];


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `pnpm gateway:watch` restarted the gateway for any watched workspace change, including `*.test.ts` edits.
- Why it matters: test-file churn interrupts gateway dev loops even when runtime code/config did not change; agents often update tests after making code changes - this can be disruptive if a developer has already started testing the logic change on the gateway and the gateway suddenly restarts because a `.test.ts` file was updated.
- What changed: replaced Node `--watch-path` restart control with a chokidar watcher over the same watch roots (`src`, `tsconfig.json`, `package.json`) and ignored `*.test.ts` restart events.
- What changed: added tests for ignore behavior, restart behavior, signal shutdown, and watcher-error cleanup.
- What did NOT change (scope boundary): no gateway runtime feature/config behavior changed; no docs/config format/API changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- No user-visible changes
- Developer-visible changes:
  - `pnpm gateway:watch` no longer restarts when `src/**/*.test.ts` files change.
  - It still restarts for non-test source changes and watched config files (`tsconfig.json`, `package.json`).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Start watcher: `pnpm gateway:watch`.
2. Edit a test file under `src` (for example `*.test.ts`).
3. Edit a non-test source file under `src`.
4. (Automated) Run `pnpm exec vitest run src/infra/watch-node.test.ts`.

### Expected

- Step 2: no gateway restart.
- Step 3: gateway restarts.
- Unit tests pass.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: edited non-test file, observed restart, edited test file, observed no restart.
- Edge cases checked: none.
- What you did **not** verify: not able to verify the cleanup of the gateway on an error in the watcher - not sure how to cause that.

https://github.com/user-attachments/assets/a30fb90c-6da2-4ed6-9290-d445020c3ff5


## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits `7e17b8311` and `cec160c81`.
- Files/config to restore: `scripts/watch-node.mjs`, `scripts/watch-node.d.mts`, `src/infra/watch-node.test.ts`.
- Known bad symptoms reviewers should watch for: gateway not restarting on non-test edits, or lingering child process after watcher errors.

## Risks and Mitigations

- Risk: ignore pattern is intentionally narrow and only excludes `.test.ts`.
  - Mitigation: kept watch roots unchanged and added targeted tests to guard regressions.
- Risk: watcher lifecycle could leave child process running on internal watcher failure.
  - Mitigation: explicit child kill on watcher error + test coverage.
