### PR TITLE
fix(security): use icacls /sid for locale-independent Windows ACL audit

### DIFF
--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -244,6 +244,20 @@ Successfully processed 1 files`;
       expectTrustedOnly([aclEntry({ principal: "S-1-5-18" })]);
     });
 
+    it("classifies *S-1-5-18 (icacls /sid prefix form of SYSTEM) as trusted (refs #35834)", () => {
+      // icacls /sid output prefixes SIDs with *, e.g. *S-1-5-18 instead of
+      // S-1-5-18.  Without this fix the asterisk caused SID_RE to not match
+      // and the SYSTEM entry was misclassified as "group" (untrusted).
+      expectTrustedOnly([aclEntry({ principal: "*S-1-5-18" })]);
+    });
+
+    it("classifies *S-1-5-32-544 (icacls /sid Administrators) as trusted", () => {
+      const entries: WindowsAclEntry[] = [aclEntry({ principal: "*S-1-5-32-544" })];
+      const summary = summarizeWindowsAcl(entries);
+      expect(summary.trusted).toHaveLength(1);
+      expect(summary.untrustedGroup).toHaveLength(0);
+    });
+
     it("classifies BUILTIN\\Administrators SID (S-1-5-32-544) as trusted", () => {
       const entries: WindowsAclEntry[] = [aclEntry({ principal: "S-1-5-32-544" })];
       const summary = summarizeWindowsAcl(entries);
@@ -319,7 +333,30 @@ Successfully processed 1 files`;
         exec: mockExec,
       });
       expectInspectSuccess(result, 2);
-      expect(mockExec).toHaveBeenCalledWith("icacls", ["C:\\test\\file.txt"]);
+      // /sid is passed so that account names are printed as SIDs, making the
+      // audit locale-independent (fixes #35834).
+      expect(mockExec).toHaveBeenCalledWith("icacls", ["C:\\test\\file.txt", "/sid"]);
+    });
+
+    it("classifies *S-1-5-18 (SID form of SYSTEM from /sid) as trusted", async () => {
+      // When icacls is called with /sid it outputs *S-X-X-X instead of
+      // locale-dependent names like "NT AUTHORITY\\SYSTEM" or the Russian
+      // garbled equivalent.
+      const mockExec = vi.fn().mockResolvedValue({
+        stdout:
+          "C:\\test\\file.txt *S-1-5-21-111-222-333-1001:(F)\n                *S-1-5-18:(F)\n                *S-1-5-32-544:(F)",
+        stderr: "",
+      });
+
+      const result = await inspectWindowsAcl("C:\\test\\file.txt", {
+        exec: mockExec,
+        env: { USERSID: "S-1-5-21-111-222-333-1001" },
+      });
+      expectInspectSuccess(result, 3);
+      // All three entries (current user, SYSTEM, Administrators) must be trusted.
+      expect(result.trusted).toHaveLength(3);
+      expect(result.untrustedGroup).toHaveLength(0);
+      expect(result.untrustedWorld).toHaveLength(0);
     });
 
     it("returns error state on exec failure", async () => {

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -42,7 +42,9 @@ const TRUSTED_BASE = new Set([
 const WORLD_SUFFIXES = ["\\users", "\\authenticated users"];
 const TRUSTED_SUFFIXES = ["\\administrators", "\\system", "\\système"];
 
-const SID_RE = /^s-\d+-\d+(-\d+)+$/i;
+// Accept an optional leading * which icacls prefixes to SIDs when invoked with /sid
+// (e.g. *S-1-5-18 instead of S-1-5-18).
+const SID_RE = /^\*?s-\d+-\d+(-\d+)+$/i;
 const TRUSTED_SIDS = new Set([
   "s-1-5-18",
   "s-1-5-32-544",
@@ -91,7 +93,11 @@ function classifyPrincipal(
   const normalized = normalize(principal);
 
   if (SID_RE.test(normalized)) {
-    return TRUSTED_SIDS.has(normalized) || trustedPrincipals.has(normalized) ? "trusted" : "group";
+    // Strip the leading * that icacls /sid prefixes to SIDs before lookup.
+    const sid = normalized.startsWith("*") ? normalized.slice(1) : normalized;
+    return TRUSTED_SIDS.has(sid) || trustedPrincipals.has(sid) || trustedPrincipals.has(normalized)
+      ? "trusted"
+      : "group";
   }
 
   if (
@@ -249,7 +255,12 @@ export async function inspectWindowsAcl(
 ): Promise<WindowsAclSummary> {
   const exec = opts?.exec ?? runExec;
   try {
-    const { stdout, stderr } = await exec("icacls", [targetPath]);
+    // /sid outputs security identifiers (e.g. *S-1-5-18) instead of locale-
+    // dependent account names so the audit works correctly on non-English
+    // Windows (Russian, Chinese, etc.) where icacls prints Cyrillic / CJK
+    // characters that may be garbled when Node reads them in the wrong code
+    // page.  Fixes #35834.
+    const { stdout, stderr } = await exec("icacls", [targetPath, "/sid"]);
     const output = `${stdout}\n${stderr}`.trim();
     const entries = parseIcaclsOutput(output, targetPath);
     const { trusted, untrustedWorld, untrustedGroup } = summarizeWindowsAcl(entries, opts?.env);


### PR DESCRIPTION
Fixes #35834

## Problem

On non-English Windows (Russian, Chinese, etc.) `icacls` prints account names in the **system locale**. When Node.js reads the output in a different code page the strings are garbled:

```
acl=NT AUTHORITY\???????: (F)
```

`summarizeWindowsAcl` doesn't recognise this as the SYSTEM account, classifies it as an untrusted **group** entry, and raises a false-positive security alert:

```
• fs.config.perms_writable   (acl=NT AUTHORITY\???????:(F))
• fs.credentials_dir.perms_writable
```

## Root Cause

`inspectWindowsAcl` calls `icacls <path>` (no flags). On localised Windows the output is language-dependent; `TRUSTED_BASE` only covers French, German, Spanish, and Portuguese translations of SYSTEM.

## Fix

Three-part change in `src/security/windows-acl.ts`:

### 1. Pass `/sid` to `icacls`

```diff
- const { stdout, stderr } = await exec("icacls", [targetPath]);
+ const { stdout, stderr } = await exec("icacls", [targetPath, "/sid"]);
```

`/sid` makes icacls emit security identifiers (`*S-1-5-18`) instead of locale-dependent names. SIDs are ASCII-only and identical on every Windows language edition.

### 2. Accept `*` prefix in `SID_RE`

```diff
- const SID_RE = /^s-\d+-\d+(-\d+)+$/i;
+ const SID_RE = /^\*?s-\d+-\d+(-\d+)+$/i;
```

`icacls /sid` prefixes every SID with `*` (e.g. `*S-1-5-18`).

### 3. Strip `*` before TRUSTED_SIDS / per-user SID lookup

```diff
  if (SID_RE.test(normalized)) {
-   return TRUSTED_SIDS.has(normalized) || trustedPrincipals.has(normalized) ? "trusted" : "group";
+   const sid = normalized.startsWith("*") ? normalized.slice(1) : normalized;
+   return TRUSTED_SIDS.has(sid) || trustedPrincipals.has(sid) || trustedPrincipals.has(normalized)
+     ? "trusted"
+     : "group";
  }
```

## Tests

| New test | Covers |
|----------|--------|
| classifies `*S-1-5-18` as trusted | SYSTEM in `/sid` output |
| classifies `*S-1-5-32-544` as trusted | Administrators in `/sid` output |
| `inspectWindowsAcl` end-to-end with `/sid` format mock | user SID + SYSTEM + Admins all trusted |
| Updated call assertion | `icacls` invoked with `/sid` flag |
