### PR TITLE
Discord: mirror component sends into session transcripts

### DIFF
--- a/extensions/mattermost/src/group-mentions.test.ts
+++ b/extensions/mattermost/src/group-mentions.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it } from "vitest";
 import { resolveMattermostGroupRequireMention } from "./group-mentions.js";
 

--- a/extensions/mattermost/src/group-mentions.ts
+++ b/extensions/mattermost/src/group-mentions.ts
@@ -1,4 +1,5 @@
-import { resolveChannelGroupRequireMention, type ChannelGroupContext } from "openclaw/plugin-sdk";
+import { resolveChannelGroupRequireMention } from "openclaw/plugin-sdk/compat";
+import type { ChannelGroupContext } from "openclaw/plugin-sdk/mattermost";
 import { resolveMattermostAccount } from "./mattermost/accounts.js";
 
 export function resolveMattermostGroupRequireMention(

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it, vi } from "vitest";
 import { resolveMattermostAccount } from "./accounts.js";
 import {

--- a/src/agents/tools/discord-actions-messaging.ts
+++ b/src/agents/tools/discord-actions-messaging.ts
@@ -295,6 +295,7 @@ export async function handleDiscordMessagingAction(
           agentId: agentId ?? undefined,
           mediaUrl: mediaUrl ?? undefined,
           filename: filename ?? undefined,
+          mirrorTranscript: sessionKey ? false : undefined,
         });
         return jsonResult({ ok: true, result, components: true });
       }

--- a/src/agents/tools/discord-actions.test.ts
+++ b/src/agents/tools/discord-actions.test.ts
@@ -35,6 +35,7 @@ const discordSendMocks = vi.hoisted(() => ({
   removeOwnReactionsDiscord: vi.fn(async () => ({ removed: ["👍"] })),
   removeReactionDiscord: vi.fn(async () => ({})),
   searchMessagesDiscord: vi.fn(async () => ({})),
+  sendDiscordComponentMessage: vi.fn(async () => ({})),
   sendMessageDiscord: vi.fn(async () => ({})),
   sendPollDiscord: vi.fn(async () => ({})),
   sendStickerDiscord: vi.fn(async () => ({})),
@@ -60,6 +61,7 @@ const {
   removeOwnReactionsDiscord,
   removeReactionDiscord,
   searchMessagesDiscord,
+  sendDiscordComponentMessage,
   sendMessageDiscord,
   sendVoiceMessageDiscord,
   setChannelPermissionDiscord,
@@ -282,6 +284,35 @@ describe("handleDiscordMessagingAction", () => {
       expect.objectContaining({
         mediaUrl: "/tmp/image.png",
         mediaLocalRoots: ["/tmp/agent-root"],
+      }),
+    );
+  });
+
+  it("disables component transcript mirroring when outbound routing injected a session key", async () => {
+    sendDiscordComponentMessage.mockClear();
+
+    await handleDiscordMessagingAction(
+      "sendMessage",
+      {
+        to: "channel:123",
+        components: {
+          blocks: [{ type: "actions", buttons: [{ label: "Tap" }] }],
+        },
+        __sessionKey: "agent:main:discord:channel:123",
+        __agentId: "main",
+      },
+      enableAllActions,
+    );
+
+    expect(sendDiscordComponentMessage).toHaveBeenCalledWith(
+      "channel:123",
+      expect.objectContaining({
+        blocks: [{ type: "actions", buttons: [{ label: "Tap" }] }],
+      }),
+      expect.objectContaining({
+        sessionKey: "agent:main:discord:channel:123",
+        agentId: "main",
+        mirrorTranscript: false,
       }),
     );
   });

--- a/src/discord/send.components.test.ts
+++ b/src/discord/send.components.test.ts
@@ -1,5 +1,6 @@
 import { ChannelType } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { appendAssistantMessageToSessionTranscript } from "../config/sessions.js";
 import { registerDiscordComponentEntries } from "./components-registry.js";
 import { sendDiscordComponentMessage } from "./send.components.js";
 import { makeDiscordRest } from "./send.test-harness.js";
@@ -18,8 +19,16 @@ vi.mock("./components-registry.js", () => ({
   registerDiscordComponentEntries: vi.fn(),
 }));
 
+vi.mock("../config/sessions.js", () => ({
+  appendAssistantMessageToSessionTranscript: vi.fn(async () => ({
+    ok: true as const,
+    sessionFile: "session.jsonl",
+  })),
+}));
+
 describe("sendDiscordComponentMessage", () => {
   const registerMock = vi.mocked(registerDiscordComponentEntries);
+  const appendTranscriptMock = vi.mocked(appendAssistantMessageToSessionTranscript);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -49,5 +58,13 @@ describe("sendDiscordComponentMessage", () => {
     expect(registerMock).toHaveBeenCalledTimes(1);
     const args = registerMock.mock.calls[0]?.[0];
     expect(args?.entries[0]?.sessionKey).toBe("agent:main:discord:channel:dm-1");
+    expect(appendTranscriptMock).toHaveBeenCalledTimes(1);
+    expect(appendTranscriptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:discord:channel:dm-1",
+        agentId: "main",
+        text: expect.stringContaining("Tap"),
+      }),
+    );
   });
 });

--- a/src/discord/send.components.test.ts
+++ b/src/discord/send.components.test.ts
@@ -5,6 +5,11 @@ import { registerDiscordComponentEntries } from "./components-registry.js";
 import { sendDiscordComponentMessage } from "./send.components.js";
 import { makeDiscordRest } from "./send.test-harness.js";
 
+vi.mock("../web/media.js", async () => {
+  const { discordWebMediaMockFactory } = await import("./send.test-harness.js");
+  return discordWebMediaMockFactory();
+});
+
 const loadConfigMock = vi.hoisted(() => vi.fn(() => ({ session: { dmScope: "main" } })));
 
 vi.mock("../config/config.js", async () => {
@@ -66,5 +71,39 @@ describe("sendDiscordComponentMessage", () => {
         text: expect.stringContaining("Tap"),
       }),
     );
+  });
+
+  it("preserves transcript mirror text when media is attached", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({
+      type: ChannelType.DM,
+      recipients: [{ id: "user-1" }],
+    });
+    postMock.mockResolvedValueOnce({ id: "msg1", channel_id: "dm-1" });
+
+    await sendDiscordComponentMessage(
+      "channel:dm-1",
+      {
+        text: "Pick an option",
+        blocks: [{ type: "actions", buttons: [{ label: "Tap" }] }],
+      },
+      {
+        rest,
+        token: "t",
+        sessionKey: "agent:main:discord:channel:dm-1",
+        agentId: "main",
+        mediaUrl: "https://example.test/photo.jpg",
+      },
+    );
+
+    expect(appendTranscriptMock).toHaveBeenCalledTimes(1);
+    expect(appendTranscriptMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:discord:channel:dm-1",
+        agentId: "main",
+        text: expect.stringContaining("Pick an option"),
+      }),
+    );
+    expect(appendTranscriptMock.mock.calls[0]?.[0]?.mediaUrls).toBeUndefined();
   });
 });

--- a/src/discord/send.components.test.ts
+++ b/src/discord/send.components.test.ts
@@ -106,4 +106,30 @@ describe("sendDiscordComponentMessage", () => {
     );
     expect(appendTranscriptMock.mock.calls[0]?.[0]?.mediaUrls).toBeUndefined();
   });
+
+  it("skips transcript mirroring when delegated to the outbound layer", async () => {
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({
+      type: ChannelType.DM,
+      recipients: [{ id: "user-1" }],
+    });
+    postMock.mockResolvedValueOnce({ id: "msg1", channel_id: "dm-1" });
+
+    await sendDiscordComponentMessage(
+      "channel:dm-1",
+      {
+        text: "Pick an option",
+        blocks: [{ type: "actions", buttons: [{ label: "Tap" }] }],
+      },
+      {
+        rest,
+        token: "t",
+        sessionKey: "agent:main:discord:channel:dm-1",
+        agentId: "main",
+        mirrorTranscript: false,
+      },
+    );
+
+    expect(appendTranscriptMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/discord/send.components.ts
+++ b/src/discord/send.components.ts
@@ -6,6 +6,7 @@ import {
 } from "@buape/carbon";
 import { ChannelType, Routes } from "discord-api-types/v10";
 import { loadConfig, type OpenClawConfig } from "../config/config.js";
+import { appendAssistantMessageToSessionTranscript } from "../config/sessions.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
 import { loadWebMedia } from "../web/media.js";
 import { resolveDiscordAccount } from "./accounts.js";
@@ -14,6 +15,7 @@ import {
   buildDiscordComponentMessage,
   buildDiscordComponentMessageFlags,
   resolveDiscordComponentAttachmentName,
+  type DiscordComponentBuildResult,
   type DiscordComponentMessageSpec,
 } from "./components.js";
 import {
@@ -38,6 +40,52 @@ function extractComponentAttachmentNames(spec: DiscordComponentMessageSpec): str
     }
   }
   return names;
+}
+
+function buildComponentTranscriptMirrorText(
+  spec: DiscordComponentMessageSpec,
+  buildResult: DiscordComponentBuildResult,
+): string | undefined {
+  const lines: string[] = [];
+  const text = spec.text?.trim();
+  if (text) {
+    lines.push(text);
+  }
+
+  const buttonLabels: string[] = [];
+  const selectLabels: string[] = [];
+  const modalTriggerLabels: string[] = [];
+  for (const entry of buildResult.entries) {
+    const label = entry.label?.trim();
+    if (!label) {
+      continue;
+    }
+    if (entry.kind === "button") {
+      buttonLabels.push(label);
+    } else if (entry.kind === "select") {
+      selectLabels.push(label);
+    } else if (entry.kind === "modal-trigger") {
+      modalTriggerLabels.push(label);
+    }
+  }
+  if (buttonLabels.length > 0) {
+    lines.push(`Buttons: ${buttonLabels.join(", ")}`);
+  }
+  if (selectLabels.length > 0) {
+    lines.push(`Select menus: ${selectLabels.join(", ")}`);
+  }
+  if (modalTriggerLabels.length > 0) {
+    lines.push(`Modal triggers: ${modalTriggerLabels.join(", ")}`);
+  }
+
+  const modalTitles = buildResult.modals
+    .map((modal) => modal.title?.trim())
+    .filter((value): value is string => Boolean(value));
+  if (modalTitles.length > 0) {
+    lines.push(`Modals: ${modalTitles.join(", ")}`);
+  }
+
+  return lines.length > 0 ? lines.join("\n") : undefined;
 }
 
 type DiscordComponentSendOpts = {
@@ -144,6 +192,23 @@ export async function sendDiscordComponentMessage(
     modals: buildResult.modals,
     messageId: result.id,
   });
+
+  const sessionKey = opts.sessionKey?.trim();
+  if (sessionKey) {
+    const transcriptText = buildComponentTranscriptMirrorText(spec, buildResult);
+    if (transcriptText) {
+      try {
+        await appendAssistantMessageToSessionTranscript({
+          agentId: opts.agentId,
+          sessionKey,
+          text: transcriptText,
+          mediaUrls: opts.mediaUrl ? [opts.mediaUrl] : undefined,
+        });
+      } catch {
+        // Outbound delivery already succeeded; transcript mirroring is best-effort.
+      }
+    }
+  }
 
   recordChannelActivity({
     channel: "discord",

--- a/src/discord/send.components.ts
+++ b/src/discord/send.components.ts
@@ -202,7 +202,6 @@ export async function sendDiscordComponentMessage(
           agentId: opts.agentId,
           sessionKey,
           text: transcriptText,
-          mediaUrls: opts.mediaUrl ? [opts.mediaUrl] : undefined,
         });
       } catch {
         // Outbound delivery already succeeded; transcript mirroring is best-effort.

--- a/src/discord/send.components.ts
+++ b/src/discord/send.components.ts
@@ -100,6 +100,7 @@ type DiscordComponentSendOpts = {
   mediaUrl?: string;
   mediaLocalRoots?: readonly string[];
   filename?: string;
+  mirrorTranscript?: boolean;
 };
 
 export async function sendDiscordComponentMessage(
@@ -194,7 +195,7 @@ export async function sendDiscordComponentMessage(
   });
 
   const sessionKey = opts.sessionKey?.trim();
-  if (sessionKey) {
+  if (sessionKey && opts.mirrorTranscript !== false) {
     const transcriptText = buildComponentTranscriptMirrorText(spec, buildResult);
     if (transcriptText) {
       try {


### PR DESCRIPTION
## Summary
- mirror Discord component sends into the session transcript from `sendDiscordComponentMessage`
- include lightweight component context in mirror text (buttons/select menus/modal triggers/titles)
- keep mirroring best-effort so send success is not blocked by transcript write failures
- add a unit test that verifies transcript mirroring is called for component sends

## Testing
- `pnpm test src/discord/send.components.test.ts`

Fixes #21649
