### PR TITLE
fix(ui): catch marked.js parse errors and fall back to escaped plain text

### DIFF
--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { toSanitizedMarkdownHtml } from "./markdown.ts";
 
 describe("toSanitizedMarkdownHtml", () => {
@@ -81,5 +81,28 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).toContain("Col2");
     // Pipes from table delimiters must not appear as raw text
     expect(html).not.toContain("|------|");
+  });
+
+  it("falls back to escaped plain text when marked throws (e.g. too much recursion, refs #36213)", async () => {
+    // Simulate the Firefox "InternalError: too much recursion" that certain chat
+    // content can trigger inside marked.js.  The UI must not crash — it should
+    // display the raw content as escaped text instead.
+    const { marked } = await import("marked");
+    const parseSpy = vi.spyOn(marked, "parse").mockImplementation(() => {
+      throw new Error("too much recursion");
+    });
+
+    const input = "Hello **world** <b>test</b>";
+    const html = toSanitizedMarkdownHtml(input);
+
+    // Raw content must be escaped (not rendered as HTML) and shown in a <pre>.
+    expect(html).toContain("<pre");
+    expect(html).toContain("Hello **world**");
+    // HTML special chars must be escaped to prevent XSS.
+    expect(html).toContain("&lt;b&gt;test&lt;/b&gt;");
+    // No unescaped tags from the input.
+    expect(html).not.toContain("<b>");
+
+    parseSpy.mockRestore();
   });
 });

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -110,11 +110,20 @@ export function toSanitizedMarkdownHtml(markdown: string): string {
     }
     return sanitized;
   }
-  const rendered = marked.parse(`${truncated.text}${suffix}`, {
-    renderer: htmlEscapeRenderer,
-    gfm: true,
-    breaks: true,
-  }) as string;
+  // Wrap in try/catch: certain message content can trigger infinite recursion
+  // in marked.js (Firefox: "InternalError: too much recursion").  Rather than
+  // crashing the entire Control UI we fall back to showing the raw content as
+  // escaped plain text so the session remains usable.  Fixes #36213.
+  let rendered: string;
+  try {
+    rendered = marked.parse(`${truncated.text}${suffix}`, {
+      renderer: htmlEscapeRenderer,
+      gfm: true,
+      breaks: true,
+    }) as string;
+  } catch {
+    rendered = `<pre class="code-block">${escapeHtml(`${truncated.text}${suffix}`)}</pre>`;
+  }
   const sanitized = DOMPurify.sanitize(rendered, sanitizeOptions);
   if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
     setCachedMarkdown(input, sanitized);


### PR DESCRIPTION
Fixes #36213

## Problem

Certain message content saved to session history can trigger infinite recursion inside `marked.js`. Firefox surfaces this as:

```
Uncaught (in promise) InternalError: too much recursion
    marked.js — parseMarkdown
```

The exception propagates up and crashes the entire Control UI render, leaving the page blank. The only recovery is `/new` or `/reset` to clear session history.

## Root Cause

`toSanitizedMarkdownHtml` calls `marked.parse(...)` without any error boundary. The `gfm: true` + `breaks: true` combination can occasionally enter a recursion loop on malformed or deeply nested chat content.

## Fix

Wrap the `marked.parse()` call in `try/catch`. On any exception, fall back to rendering the content as HTML-escaped plain text inside a `<pre>` block:

```typescript
let rendered: string;
try {
  rendered = marked.parse(input, { renderer: htmlEscapeRenderer, gfm: true, breaks: true }) as string;
} catch {
  rendered = `<pre class="code-block">${escapeHtml(input)}</pre>`;
}
```

This ensures:
- The Control UI **never crashes** due to a parser error
- The raw message content is still **visible and copyable**
- No XSS risk — `escapeHtml()` escapes all HTML special characters
- Normal markdown rendering is completely unaffected

## Test

The new test mocks `marked.parse` to throw `"too much recursion"` and asserts:
- Output wraps content in `<pre>`
- Raw text is preserved (`Hello **world**`)
- HTML tags are escaped (`&lt;b&gt;test&lt;/b&gt;`, not `<b>test</b>`)
