### PR TITLE
perf(config-eval): bound hasBinary lookup cache

### DIFF
--- a/src/shared/config-eval.test.ts
+++ b/src/shared/config-eval.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { evaluateRuntimeEligibility } from "./config-eval.js";
+import fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { evaluateRuntimeEligibility, hasBinary } from "./config-eval.js";
 
 describe("evaluateRuntimeEligibility", () => {
   it("rejects entries when required OS does not match local or remote", () => {
@@ -49,5 +50,53 @@ describe("evaluateRuntimeEligibility", () => {
       isConfigPathTruthy: (path) => path === "browser.enabled",
     });
     expect(result).toBe(true);
+  });
+});
+
+describe("hasBinary", () => {
+  const originalPath = process.env.PATH;
+  const originalPathext = process.env.PATHEXT;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.PATH = `/tmp/config-eval-bin-${Date.now()}`;
+    process.env.PATHEXT = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env.PATH = originalPath;
+    if (originalPathext === undefined) {
+      delete process.env.PATHEXT;
+    } else {
+      process.env.PATHEXT = originalPathext;
+    }
+  });
+
+  it("reuses cached lookup results for the same binary", () => {
+    const accessSpy = vi.spyOn(fs, "accessSync").mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    expect(hasBinary("cache-hit-bin")).toBe(false);
+    expect(hasBinary("cache-hit-bin")).toBe(false);
+    expect(accessSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts oldest entries once the cache cap is exceeded", () => {
+    const accessSpy = vi.spyOn(fs, "accessSync").mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+
+    for (let i = 0; i < 300; i += 1) {
+      expect(hasBinary(`bin-${i}`)).toBe(false);
+    }
+
+    const callsAfterWarmup = accessSpy.mock.calls.length;
+    expect(hasBinary("bin-0")).toBe(false);
+    expect(accessSpy).toHaveBeenCalledTimes(callsAfterWarmup + 1);
+
+    expect(hasBinary("bin-299")).toBe(false);
+    expect(accessSpy).toHaveBeenCalledTimes(callsAfterWarmup + 1);
   });
 });

--- a/src/shared/config-eval.ts
+++ b/src/shared/config-eval.ts
@@ -147,7 +147,19 @@ function windowsPathExtensions(): string[] {
 
 let cachedHasBinaryPath: string | undefined;
 let cachedHasBinaryPathExt: string | undefined;
+const HAS_BINARY_CACHE_MAX = 256;
 const hasBinaryCache = new Map<string, boolean>();
+
+function setHasBinaryCache(bin: string, exists: boolean): void {
+  hasBinaryCache.set(bin, exists);
+  if (hasBinaryCache.size <= HAS_BINARY_CACHE_MAX) {
+    return;
+  }
+  const oldest = hasBinaryCache.keys().next();
+  if (!oldest.done) {
+    hasBinaryCache.delete(oldest.value);
+  }
+}
 
 export function hasBinary(bin: string): boolean {
   const pathEnv = process.env.PATH ?? "";
@@ -168,13 +180,13 @@ export function hasBinary(bin: string): boolean {
       const candidate = path.join(part, bin + ext);
       try {
         fs.accessSync(candidate, fs.constants.X_OK);
-        hasBinaryCache.set(bin, true);
+        setHasBinaryCache(bin, true);
         return true;
       } catch {
         // keep scanning
       }
     }
   }
-  hasBinaryCache.set(bin, false);
+  setHasBinaryCache(bin, false);
   return false;
 }


### PR DESCRIPTION
## Summary
- cap `hasBinary` memoization to 256 entries with FIFO eviction
- keep cache invalidation when `PATH`/`PATHEXT` changes
- add focused tests for cache-hit reuse and oldest-entry eviction

## Why
`hasBinary` is used during runtime eligibility checks and previously cached every queried binary name without a bound. In long-lived processes with highly variable bin names, that map could grow unbounded.

## Impact
- preserves fast repeated lookups
- keeps memory use bounded
- no behavior change for positive/negative lookup semantics

## Risk
Low. Evicted entries are safely recomputed on demand.

## Validation
- `pnpm vitest run --config vitest.unit.config.ts src/shared/config-eval.test.ts`
- `pnpm oxfmt --check src/shared/config-eval.ts src/shared/config-eval.test.ts`
