### PR TITLE
fix(message-tool): use agent-scoped media roots for path validation

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -114,6 +114,7 @@ export function createOpenClawTools(options?: {
     : createMessageTool({
         agentAccountId: options?.agentAccountId,
         agentSessionKey: options?.agentSessionKey,
+        agentId: options?.requesterAgentIdOverride,
         config: options?.config,
         currentChannelId: options?.currentChannelId,
         currentChannelProvider: options?.agentChannel,

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -463,6 +463,8 @@ const MessageToolSchema = buildMessageToolSchemaFromActions(AllMessageActions, {
 type MessageToolOptions = {
   agentAccountId?: string;
   agentSessionKey?: string;
+  /** Explicit agent ID — used to resolve agent-scoped media roots when agentSessionKey is unavailable. */
+  agentId?: string;
   config?: OpenClawConfig;
   currentChannelId?: string;
   currentChannelProvider?: string;
@@ -740,7 +742,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         sessionKey: options?.agentSessionKey,
         agentId: options?.agentSessionKey
           ? resolveSessionAgentId({ sessionKey: options.agentSessionKey, config: cfg })
-          : undefined,
+          : options?.agentId,
         sandboxRoot: options?.sandboxRoot,
         abortSignal: signal,
       });


### PR DESCRIPTION
## Summary

- **Problem:** The message tool resolved `agentId` only from `agentSessionKey`, leaving it `undefined` for cron/hook sessions that lack a session key. This caused `getAgentScopedMediaLocalRoots(cfg, undefined)` to return only default roots (e.g. `~/.openclaw/media`), rejecting files under the agent's configured workspace directory with `LocalMediaAccessError: path-not-allowed`.
- **Why it matters:** Agents cannot send files from their own workspace via the message tool, forcing a manual workaround of copying files to `~/.openclaw/media/outbound/`.
- **What changed:** Added an `agentId` field to `MessageToolOptions` and threaded `requesterAgentIdOverride` (already available in `createOpenClawTools`) into the message tool creation. When `agentSessionKey` is unavailable, this explicit `agentId` is forwarded to `runMessageAction`, which passes it to `getAgentScopedMediaLocalRoots` to include the agent's workspace in the allowed media roots.
- **What did NOT change:** The `getAgentScopedMediaLocalRoots` function, the `runMessageAction` function, or any media path validation logic. The fix only ensures the existing agent-scoped path is reachable.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36185

## User-visible / Behavior Changes

- Files under the agent's configured workspace directory (e.g. `/home/user/clawd/`) are now accepted by the message tool's media path validation, instead of being rejected with `path-not-allowed`.

## Security Impact (required)

- New permissions/capabilities? `No` — the agent workspace was already an allowed root in `getAgentScopedMediaLocalRoots`; this fix just ensures it's actually used.
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: WhatsApp (or any channel using the message tool)

### Steps

1. Configure `agents.defaults.workspace` to a custom path (e.g. `/home/user/clawd`)
2. Place a file in that workspace
3. Use the message tool to send the file as an attachment

### Expected

- File is accepted and sent

### Actual

- Before fix: `LocalMediaAccessError: path-not-allowed`
- After fix: File is accepted (workspace is included in allowed roots)

## Evidence

Two files changed:

**`src/agents/tools/message-tool.ts`:** Added `agentId?: string` to `MessageToolOptions` and used it as fallback when `agentSessionKey` is unavailable.

**`src/agents/openclaw-tools.ts`:** Passed `requesterAgentIdOverride` as `agentId` when creating the message tool.

TypeScript check passes (`npx tsc --noEmit` — only pre-existing errors in `extensions/diffs` and `extensions/tlon`).

## Human Verification (required)

- Verified scenarios: TypeScript compilation, code review of `runMessageAction` resolution chain
- Edge cases checked: `agentSessionKey` present (uses session-based resolution as before), both `agentSessionKey` and `agentId` absent (falls through to undefined as before), `requesterAgentIdOverride` set (used as fallback)
- What I did **not** verify: End-to-end test with actual file sending from agent workspace

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the two-file change; the original behavior (default roots only) returns
- Files/config to restore: `src/agents/tools/message-tool.ts`, `src/agents/openclaw-tools.ts`
- Known bad symptoms: None expected — the `agentId` only widens the allowed media roots to include the agent's own workspace

## Risks and Mitigations

None — this aligns the message tool with the existing behavior of other code paths that already use `getAgentScopedMediaLocalRoots` with a resolved `agentId`.

