### PR TITLE
Queue: preserve provider message_id metadata in collect prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Queue/followup collect metadata: include trusted queued-message `message_id` metadata in `[Queued messages while agent was busy]` prompts so agents can use original provider message ids for native reply APIs instead of placeholder ids from untrusted context blocks. (#36212)
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -63,6 +63,19 @@ function resolveCrossChannelKey(item: FollowupRun): { cross?: true; key?: string
   };
 }
 
+function buildQueuedMessageMetadataBlock(item: FollowupRun): string | undefined {
+  const messageId = item.messageId?.trim();
+  if (!messageId) {
+    return undefined;
+  }
+  return [
+    "Queued message metadata (trusted queue data):",
+    "```json",
+    JSON.stringify({ message_id: messageId }, null, 2),
+    "```",
+  ].join("\n");
+}
+
 export function scheduleFollowupDrain(
   key: string,
   runFollowup: (run: FollowupRun) => Promise<void>,
@@ -114,7 +127,11 @@ export function scheduleFollowupDrain(
             title: "[Queued messages while agent was busy]",
             items,
             summary,
-            renderItem: (item, idx) => `---\nQueued #${idx + 1}\n${item.prompt}`.trim(),
+            renderItem: (item, idx) =>
+              ["---", `Queued #${idx + 1}`, buildQueuedMessageMetadataBlock(item), item.prompt]
+                .filter(Boolean)
+                .join("\n")
+                .trim(),
           });
           await runFollowup({
             prompt,

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -690,6 +690,40 @@ describe("followup queue deduplication", () => {
     expect(calls[0]?.prompt).toContain("[Queued messages while agent was busy]");
   });
 
+  it("includes original provider message_id metadata in collect prompts", async () => {
+    const key = `test-collect-message-id-metadata-${Date.now()}`;
+    const done = createDeferred<void>();
+    let collectedPrompt = "";
+    const runFollowup = async (run: FollowupRun) => {
+      collectedPrompt = run.prompt;
+      done.resolve();
+    };
+    const settings: QueueSettings = {
+      mode: "collect",
+      debounceMs: 0,
+      cap: 50,
+      dropPolicy: "summarize",
+    };
+
+    enqueueFollowupRun(
+      key,
+      createRun({
+        prompt:
+          'Conversation info (untrusted metadata):\\n```json\\n{"message_id":"om_x_queue_placeholder"}\\n```',
+        messageId: "om_platform_original_123",
+        originatingChannel: "slack",
+        originatingTo: "channel:C123",
+      }),
+      settings,
+    );
+
+    scheduleFollowupDrain(key, runFollowup);
+    await done.promise;
+
+    expect(collectedPrompt).toContain("Queued message metadata (trusted queue data):");
+    expect(collectedPrompt).toContain('"message_id": "om_platform_original_123"');
+  });
+
   it("deduplicates exact prompt when routing matches and no message id", async () => {
     const key = `test-dedup-whatsapp-${Date.now()}`;
     const settings: QueueSettings = {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: collect-mode queued prompts (`[Queued messages while agent was busy]`) did not surface trusted provider message ids, so agents often used placeholder ids from untrusted context blocks.
- Why it matters: channel-native reply APIs (for example Feishu reply) need the original platform message id.
- What changed: collect prompt rendering now injects a trusted per-item metadata block containing `message_id` from the queued run metadata.
- What did NOT change (scope boundary): no routing changes, no queue dedupe policy changes, no channel adapter changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36212
- Related #

## User-visible / Behavior Changes

- Busy-queue collect prompts now include a trusted JSON block per queued item:
  - `{"message_id":"<original-provider-id>"}`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: n/a
- Integration/channel (if any): followup queue collect mode
- Relevant config (redacted): queue mode `collect`

### Steps

1. Enqueue followup runs while the agent is busy with collect mode.
2. Drain queue into `[Queued messages while agent was busy]` prompt.
3. Inspect rendered prompt sections per queued item.

### Expected

- Each queued item includes trusted original `message_id` metadata.

### Actual

- Prompt now contains `Queued message metadata (trusted queue data)` JSON block with `message_id`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added regression test `includes original provider message_id metadata in collect prompts`.
  - Confirmed existing queue dedupe + collect tests still pass.
- Edge cases checked:
  - Metadata block is omitted when queued item has no `messageId`.
- What you did **not** verify:
  - Live Feishu end-to-end reply API call against a production bot.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Queue: include original message_id in collect prompts`.
- Files/config to restore: `src/auto-reply/reply/queue/drain.ts`, related test file.
- Known bad symptoms reviewers should watch for: collect prompt formatting regressions.

## Risks and Mitigations

- Risk: prompt shape change could affect downstream prompt parsing assumptions.
  - Mitigation: change is additive, scoped to collect mode, and covered by targeted regression test.
