### PR TITLE
docs(browser): document existing Chrome setup via remote-debugging port

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -250,7 +250,8 @@ If you want OpenClaw to control an already-running Chrome instance (for example 
 
 ```bash
 "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
-  --remote-debugging-port=9222 \
+  --remote-debugging-port=9223 \
+  --remote-debugging-address=127.0.0.1 \
   --user-data-dir="$HOME/.openclaw/browser/existing-chrome"
 ```
 
@@ -263,7 +264,7 @@ If you want OpenClaw to control an already-running Chrome instance (for example 
     defaultProfile: "existing-chrome",
     profiles: {
       "existing-chrome": {
-        cdpUrl: "http://127.0.0.1:9222",
+        cdpUrl: "http://127.0.0.1:9223",
         color: "#4285F4",
       },
     },
@@ -275,7 +276,7 @@ If you want OpenClaw to control an already-running Chrome instance (for example 
 
 Notes:
 
-- `attachOnly: true` tells OpenClaw not to launch its own local browser process.
+- `attachOnly: true` is global: OpenClaw will not launch its own local browser process for **any** profile. If you still want OpenClaw-managed profiles (for example `openclaw`), omit `attachOnly` and only set `profiles.existing-chrome.cdpUrl`.
 - If you prefer to keep the profile name `chrome`, you can override `profiles.chrome.cdpUrl` with your own CDP URL.
 - Keep the debugging endpoint on loopback (`127.0.0.1`) unless you have strong network controls in place.
 

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -242,6 +242,43 @@ Flow:
 
 If the Gateway runs elsewhere, run a node host on the browser machine so the Gateway can proxy browser actions.
 
+### Connect to an existing Chrome via `--remote-debugging-port` (no extension)
+
+If you want OpenClaw to control an already-running Chrome instance (for example to reuse existing login sessions) without clicking the extension button on each tab, run Chrome with a debugging port and point an OpenClaw profile at that CDP URL.
+
+1. Start Chrome with remote debugging enabled (example: macOS):
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.openclaw/browser/existing-chrome"
+```
+
+2. Add a CDP profile in `~/.openclaw/openclaw.json`:
+
+```json5
+{
+  browser: {
+    attachOnly: true,
+    defaultProfile: "existing-chrome",
+    profiles: {
+      "existing-chrome": {
+        cdpUrl: "http://127.0.0.1:9222",
+        color: "#4285F4",
+      },
+    },
+  },
+}
+```
+
+3. Restart the Gateway.
+
+Notes:
+
+- `attachOnly: true` tells OpenClaw not to launch its own local browser process.
+- If you prefer to keep the profile name `chrome`, you can override `profiles.chrome.cdpUrl` with your own CDP URL.
+- Keep the debugging endpoint on loopback (`127.0.0.1`) unless you have strong network controls in place.
+
 ### Sandboxed sessions
 
 If the agent session is sandboxed, the `browser` tool may default to `target="sandbox"` (sandbox browser).

--- a/docs/zh-CN/tools/browser.md
+++ b/docs/zh-CN/tools/browser.md
@@ -223,6 +223,43 @@ OpenClaw 还可以通过本地 CDP 中继 + Chrome 扩展驱动**你现有的 Ch
 
 如果 Gateway 网关在其他地方运行，请在浏览器所在机器上运行节点主机，以便 Gateway 网关可以代理浏览器操作。
 
+### 通过 `--remote-debugging-port` 连接已运行的 Chrome（无需扩展）
+
+如果你希望 OpenClaw 直接控制一个已运行的 Chrome 实例（例如复用已登录会话），并且不想为每个标签页手动点击扩展按钮，可以让 Chrome 开启调试端口，然后把 OpenClaw 配置到该 CDP 地址。
+
+1. 启动 Chrome 并开启远程调试端口（macOS 示例）：
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.openclaw/browser/existing-chrome"
+```
+
+2. 在 `~/.openclaw/openclaw.json` 中添加 CDP 配置文件：
+
+```json5
+{
+  browser: {
+    attachOnly: true,
+    defaultProfile: "existing-chrome",
+    profiles: {
+      "existing-chrome": {
+        cdpUrl: "http://127.0.0.1:9222",
+        color: "#4285F4",
+      },
+    },
+  },
+}
+```
+
+3. 重启 Gateway 网关。
+
+注意：
+
+- `attachOnly: true` 表示 OpenClaw 不会再自行启动本地浏览器进程。
+- 如果你希望继续使用 `chrome` 这个配置名，也可以直接覆盖 `profiles.chrome.cdpUrl`。
+- 除非你有严格的网络隔离控制，否则请将调试端点保持在 loopback（`127.0.0.1`）。
+
 ### 沙箱会话
 
 如果智能体会话是沙箱隔离的，`browser` 工具可能默认为 `target="sandbox"`（沙箱浏览器）。

--- a/docs/zh-CN/tools/browser.md
+++ b/docs/zh-CN/tools/browser.md
@@ -231,7 +231,8 @@ OpenClaw 还可以通过本地 CDP 中继 + Chrome 扩展驱动**你现有的 Ch
 
 ```bash
 "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
-  --remote-debugging-port=9222 \
+  --remote-debugging-port=9223 \
+  --remote-debugging-address=127.0.0.1 \
   --user-data-dir="$HOME/.openclaw/browser/existing-chrome"
 ```
 
@@ -244,7 +245,7 @@ OpenClaw 还可以通过本地 CDP 中继 + Chrome 扩展驱动**你现有的 Ch
     defaultProfile: "existing-chrome",
     profiles: {
       "existing-chrome": {
-        cdpUrl: "http://127.0.0.1:9222",
+        cdpUrl: "http://127.0.0.1:9223",
         color: "#4285F4",
       },
     },
@@ -256,7 +257,7 @@ OpenClaw 还可以通过本地 CDP 中继 + Chrome 扩展驱动**你现有的 Ch
 
 注意：
 
-- `attachOnly: true` 表示 OpenClaw 不会再自行启动本地浏览器进程。
+- `attachOnly: true` 是全局开关：OpenClaw 会对**所有**配置文件都停止自行启动本地浏览器进程。如果你仍然需要 OpenClaw 托管配置（例如 `openclaw`），请不要设置 `attachOnly`，只配置 `profiles.existing-chrome.cdpUrl`。
 - 如果你希望继续使用 `chrome` 这个配置名，也可以直接覆盖 `profiles.chrome.cdpUrl`。
 - 除非你有严格的网络隔离控制，否则请将调试端点保持在 loopback（`127.0.0.1`）。
 


### PR DESCRIPTION
## What changed
- Added a new docs subsection in `docs/tools/browser.md` that explains how to connect OpenClaw to an already-running Chrome instance via `--remote-debugging-port` (without relying on the extension relay attach flow).
- Added the same guidance in `docs/zh-CN/tools/browser.md`.
- Included a concrete config example using `attachOnly: true`, a custom `existing-chrome` profile, and `cdpUrl: "http://127.0.0.1:9222"`.
- Documented security guidance to keep the debug endpoint on loopback.

## Why
- Users asked for an explicit guide to control an existing Chrome profile (including existing login sessions) without per-tab extension attachment.
- The behavior is supported today but was not clearly documented in the browser guide.

## Testing
- ✅ `scripts/clone_and_test.sh openclaw/openclaw` (pass: 16 passed)

Closes #36150
