### PR TITLE
fix: device pairing required on loopback for backend clients

### DIFF
--- a/src/gateway/server/ws-connection/auth-context.ts
+++ b/src/gateway/server/ws-connection/auth-context.ts
@@ -136,10 +136,14 @@ export async function resolveConnectAuthState(params: {
   // Trusted-proxy auth is semantically shared: the proxy vouches for identity,
   // no per-device credential needed. Include it so operator connections
   // can skip device identity via roleCanSkipDeviceIdentity().
+  // Also include successful token/password auth from the primary authResult
+  // so that backend clients (gateway-client/backend mode) can skip device pairing
+  // on loopback when using shared secret auth.
   const sharedAuthOk =
     (sharedAuthResult?.ok === true &&
       (sharedAuthResult.method === "token" || sharedAuthResult.method === "password")) ||
-    (authResult.ok && authResult.method === "trusted-proxy");
+    (authResult.ok && authResult.method === "trusted-proxy") ||
+    (authResult.ok && (authResult.method === "token" || authResult.method === "password"));
 
   return {
     authResult,


### PR DESCRIPTION
Fixes #35763

## Problem

Docker deployments with `gateway.bind = loopback` and `gateway.auth.mode = token` required device pairing for every tool call, despite the docs stating that loopback connections should be auto-approved.

## Root Cause

The `sharedAuthOk` calculation in `resolveConnectAuthState` was missing the case where the primary `authResult` succeeded with token/password authentication. This caused backend clients (gateway-client/backend mode) to require device pairing even on loopback connections with valid shared secret authentication.

## Fix

Added an additional condition to `sharedAuthOk` to include successful token/password auth from the primary `authResult`. This ensures that:

1. When `authResult.ok` is true and the method is `token` or `password`, `sharedAuthOk` is also true
2. The `shouldSkipBackendSelfPairing` check can correctly skip pairing for local backend clients using shared secret auth

## Testing

All existing tests pass, including:
- `connect-policy.test.ts` (4 tests)
- `auth-context.test.ts` (5 tests)

## Impact

This fix enables Docker deployments with loopback binding to work correctly without requiring manual device approval for every tool call.