### PR TITLE
fix(gateway): create transcript file on chat.inject when missing

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1142,7 +1142,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       storePath,
       sessionFile: entry?.sessionFile,
       agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
-      createIfMissing: false,
+      createIfMissing: true,
     });
     if (!appended.ok || !appended.messageId || !appended.message) {
       respond(


### PR DESCRIPTION
## Summary

`chat.inject` called `appendAssistantTranscriptMessage` with `createIfMissing: false`, causing a hard `"transcript file not found"` error when the transcript file did not yet exist on disk. This commonly affects ACP oneshot/run sessions where the transcript is not pre-created.

## Fix

Change `createIfMissing: false` → `createIfMissing: true` on line 1145 of `src/gateway/server-methods/chat.ts`, consistent with other callers (`chat.send` on line 492, line 1025).

## Impact

- Fixes: transcript persistence for ACP sessions, `chat.history` / `sessions_history` returning empty
- Risk: Minimal — other code paths already use `createIfMissing: true`

Closes #36170