### PR TITLE
fix(whatsapp): auto-populate participant for group reactions from inbound context

### DIFF
--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -253,7 +253,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       return Array.from(actions);
     },
     supportsAction: ({ action }) => action === "react",
-    handleAction: async ({ action, params, cfg, accountId }) => {
+    handleAction: async ({ action, params, cfg, accountId, requesterSenderId }) => {
       if (action !== "react") {
         throw new Error(`Action ${action} is not supported for provider ${meta.id}.`);
       }
@@ -262,15 +262,20 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       });
       const emoji = readStringParam(params, "emoji", { allowEmpty: true });
       const remove = typeof params.remove === "boolean" ? params.remove : undefined;
+      const chatJid =
+        readStringParam(params, "chatJid") ?? readStringParam(params, "to", { required: true });
+      const isGroup = chatJid.endsWith("@g.us");
+      const participant =
+        readStringParam(params, "participant") ??
+        (isGroup && requesterSenderId?.trim() ? requesterSenderId.trim() : undefined);
       return await getWhatsAppRuntime().channel.whatsapp.handleWhatsAppAction(
         {
           action: "react",
-          chatJid:
-            readStringParam(params, "chatJid") ?? readStringParam(params, "to", { required: true }),
+          chatJid,
           messageId,
           emoji,
           remove,
-          participant: readStringParam(params, "participant"),
+          participant,
           accountId: accountId ?? undefined,
           fromMe: typeof params.fromMe === "boolean" ? params.fromMe : undefined,
         },

--- a/src/agents/tools/whatsapp-actions.ts
+++ b/src/agents/tools/whatsapp-actions.ts
@@ -7,6 +7,7 @@ import { resolveAuthorizedWhatsAppOutboundTarget } from "./whatsapp-target-auth.
 export async function handleWhatsAppAction(
   params: Record<string, unknown>,
   cfg: OpenClawConfig,
+  options?: { requesterSenderId?: string },
 ): Promise<AgentToolResult<unknown>> {
   const action = readStringParam(params, "action", { required: true });
   const isActionEnabled = createActionGate(cfg.channels?.whatsapp?.actions);
@@ -20,7 +21,12 @@ export async function handleWhatsAppAction(
     const { emoji, remove, isEmpty } = readReactionParams(params, {
       removeErrorMessage: "Emoji is required to remove a WhatsApp reaction.",
     });
-    const participant = readStringParam(params, "participant");
+    const isGroup = chatJid.endsWith("@g.us");
+    const participant =
+      readStringParam(params, "participant") ??
+      (isGroup && options?.requesterSenderId?.trim()
+        ? options.requesterSenderId.trim()
+        : undefined);
     const accountId = readStringParam(params, "accountId");
     const fromMeRaw = params.fromMe;
     const fromMe = typeof fromMeRaw === "boolean" ? fromMeRaw : undefined;


### PR DESCRIPTION
## Summary

- **Problem:** WhatsApp group reactions silently fail when the `participant` field is omitted. The Baileys message key requires `{remoteJid, id, fromMe, participant}` for group messages, but agents have no natural way to provide the sender's JID. The tool returns `{ok: true}` but the reaction never appears.
- **Why it matters:** Users see successful tool output but no actual reaction, creating a confusing UX with no indication of failure.
- **What changed:** Auto-populate `participant` from `requesterSenderId` (the trusted inbound sender JID, already available in `ChannelMessageActionContext`) when the target is a group JID (`@g.us`) and no explicit `participant` was provided. Applied in both the WhatsApp extension plugin (`extensions/whatsapp/src/channel.ts`) and the core action handler (`src/agents/tools/whatsapp-actions.ts`).
- **What did NOT change:** DM reactions (no `participant` needed), explicit `participant` from params (still takes priority), the Baileys key construction, or any other action type.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36090

## User-visible / Behavior Changes

- WhatsApp group reactions now work automatically — the agent no longer needs to know or supply the sender's JID for reactions.
- DM reactions are unaffected (no `participant` required).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: WhatsApp

### Steps

1. Configure a WhatsApp channel with a group chat
2. Receive a message from a group participant
3. Agent reacts via the message tool with `action=react` targeting the group JID

### Expected

- Reaction appears on the message

### Actual

- Before fix: Tool returns `{ok: true}` but reaction silently fails (incomplete Baileys key)
- After fix: `participant` is auto-populated from inbound context, reaction appears

## Evidence

The fix mirrors the existing ack-reaction path (`src/web/auto-reply/monitor/ack-reaction.ts`) which correctly uses `params.msg.senderJid`:

```typescript
// ack-reaction.ts (existing, correct):
sendReactionWhatsApp(params.msg.chatId, params.msg.id, emoji, {
  participant: params.msg.senderJid,  // ← always set for groups
});
```

Two files changed:
- `extensions/whatsapp/src/channel.ts`: Destructure `requesterSenderId` from context, auto-populate `participant` for group JIDs
- `src/agents/tools/whatsapp-actions.ts`: Accept optional `requesterSenderId` in new `options` parameter, same auto-populate logic

All 7 existing WhatsApp action tests pass.

## Human Verification (required)

- Verified scenarios: TypeScript compilation, all 7 existing tests pass, code review of ack-reaction reference path
- Edge cases checked: DM reactions (no `participant` needed, no change), explicit `participant` in params (takes priority), `requesterSenderId` is undefined (falls through, same as before), non-group JID with `requesterSenderId` (ignored)
- What I did **not** verify: End-to-end test with actual WhatsApp group reaction

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the two-file change; reactions go back to requiring explicit `participant`
- Files/config to restore: `src/agents/tools/whatsapp-actions.ts`, `extensions/whatsapp/src/channel.ts`
- Known bad symptoms: If `requesterSenderId` is wrong, reactions would target the wrong participant — but this field is server-injected and trusted

## Risks and Mitigations

- Risk: `requesterSenderId` might not always be the correct participant for multi-message scenarios. Mitigation: Only used as fallback when `participant` is not explicitly provided; explicit param always takes priority.

