### PR TITLE
Control UI: avoid active-run final history replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/daemon lifecycle in containers: when no system service is loaded, `openclaw gateway stop` and `openclaw gateway restart` now attempt port-based gateway PID signaling (`SIGTERM`/`SIGUSR1`) instead of exiting early as not-loaded. (related to #36137)
+- Queue/followup collect metadata: include trusted queued-message `message_id` metadata in `[Queued messages while agent was busy]` prompts so agents can use original provider message ids for native reply APIs instead of placeholder ids from untrusted context blocks. (#36212)
+- Control UI/chat final-event reload gating: skip automatic `chat.history` reload when a `final` event belongs to the currently active run, preventing in-progress fallback/compaction transitions from replacing already-rendered chat messages mid-read. (#36221)
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -283,9 +283,10 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
       payload.sessionKey,
     );
   }
+  const activeRunId = host.chatRunId;
   const state = handleChatEvent(host as unknown as OpenClawApp, payload);
   handleTerminalChatEvent(host, payload, state);
-  if (state === "final" && shouldReloadHistoryForFinalEvent(payload)) {
+  if (state === "final" && shouldReloadHistoryForFinalEvent(payload, { activeRunId })) {
     void loadChatHistory(host as unknown as OpenClawApp);
   }
 }

--- a/ui/src/ui/chat-event-reload.test.ts
+++ b/ui/src/ui/chat-event-reload.test.ts
@@ -23,6 +23,19 @@ describe("shouldReloadHistoryForFinalEvent", () => {
     ).toBe(true);
   });
 
+  it("returns false for active-run final events without payload message", () => {
+    expect(
+      shouldReloadHistoryForFinalEvent(
+        {
+          runId: "run-1",
+          sessionKey: "main",
+          state: "final",
+        },
+        { activeRunId: "run-1" },
+      ),
+    ).toBe(false);
+  });
+
   it("returns false when final event includes assistant payload", () => {
     expect(
       shouldReloadHistoryForFinalEvent({

--- a/ui/src/ui/chat-event-reload.ts
+++ b/ui/src/ui/chat-event-reload.ts
@@ -1,7 +1,17 @@
 import type { ChatEventPayload } from "./controllers/chat.ts";
 
-export function shouldReloadHistoryForFinalEvent(payload?: ChatEventPayload): boolean {
+type ChatEventReloadOptions = {
+  activeRunId?: string | null;
+};
+
+export function shouldReloadHistoryForFinalEvent(
+  payload?: ChatEventPayload,
+  options?: ChatEventReloadOptions,
+): boolean {
   if (!payload || payload.state !== "final") {
+    return false;
+  }
+  if (options?.activeRunId && payload.runId === options.activeRunId) {
     return false;
   }
   if (!payload.message || typeof payload.message !== "object") {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Control UI can reload `chat.history` on `chat` `final` events that belong to the active run, which can replace already-rendered messages during fallback/compaction transitions.
- Why it matters: users can see messages disappear/replace mid-read when context fallback is happening.
- What changed: capture active `chatRunId` before handling the event, and skip `chat.history` reloads for `final` events from that same active run.
- What did NOT change (scope boundary): reload behavior for non-active-run `final` events (for example out-of-band/sub-agent style events) is preserved.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36221
- Related #1909

## User-visible / Behavior Changes

- Control UI no longer auto-refreshes chat history for `final` events from the currently active run.
- This avoids mid-read replacement of already-rendered messages during fallback/compaction transitions.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev
- Model/provider: N/A (UI event handling)
- Integration/channel (if any): Control UI
- Relevant config (redacted): default

### Steps

1. Start Control UI and trigger a chat run that can enter fallback/compaction behavior.
2. Receive `chat` `final` events while current run is active.
3. Observe chat timeline rendering continuity.

### Expected

- Existing rendered messages stay visible; no forced history replacement for active-run final events.

### Actual

- With this patch, active-run final events do not trigger history reload; rendered messages remain stable.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm --dir ui exec vitest run src/ui/chat-event-reload.test.ts src/ui/app-gateway.node.test.ts`
  - `pnpm exec oxfmt --check CHANGELOG.md ui/src/ui/chat-event-reload.ts ui/src/ui/chat-event-reload.test.ts ui/src/ui/app-gateway.ts`
- Edge cases checked:
  - final event without payload for non-active runs still reloads.
  - final event with assistant payload still does not reload.
- What you did **not** verify:
  - Full end-to-end browser reproduction against live fallback model switches.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `Control UI: gate final-event history reloads`.
- Files/config to restore:
  - `ui/src/ui/app-gateway.ts`
  - `ui/src/ui/chat-event-reload.ts`
- Known bad symptoms reviewers should watch for:
  - Missing out-of-band message visibility when non-active-run `final` events occur.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Non-active-run detection relies on `runId` matching; malformed run IDs could skip intended reloads.
  - Mitigation:
    - Kept fallback behavior unchanged for all non-matching runs and added focused unit coverage.
