### PR TITLE
fix(agents): preserve thinking block signatures for Anthropic providers

### DIFF
--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -123,7 +123,7 @@ export function resolveTranscriptPolicy(params: {
       (!isOpenAi && sanitizeToolCallIds) || requiresOpenAiCompatibleToolIdSanitization,
     toolCallIdMode,
     repairToolUseResultPairing,
-    preserveSignatures: false,
+    preserveSignatures: isAnthropic || isCopilotClaude,
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     sanitizeThinkingSignatures: false,
     dropThinkingBlocks,


### PR DESCRIPTION
## Summary

- **Problem:** The transcript sanitization pipeline strips `thinkingSignature` fields from content blocks when `preserveSignatures` is `false` (the previous hardcoded default for all providers). After auto-compaction retains messages, the stripped signatures cause Anthropic to reject all subsequent API calls with "thinking/redacted_thinking blocks cannot be modified", making the session unrecoverable.
- **Why it matters:** Users with `thinking: high` on long sessions inevitably hit this — the session becomes permanently broken with no recovery path except manual clearing (losing all context).
- **What changed:** In `resolveTranscriptPolicy()`, changed `preserveSignatures` from unconditional `false` to `isAnthropic || isCopilotClaude`, so thinking block signatures are preserved for Anthropic providers (including Copilot Claude endpoints).
- **What did NOT change:** Behavior for Google/Gemini providers (signatures are still stripped via `stripThoughtSignatures` for format compatibility), OpenAI providers, `sanitizeThinkingSignatures` behavior, compaction logic, or any other sanitization rules.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36229

## User-visible / Behavior Changes

- Long-running sessions with `thinking: high` on Anthropic models no longer break after auto-compaction.
- Thinking block signatures are preserved exactly as returned by the API.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: any

### Steps

1. Configure a session with `thinking: high` and `anthropic/claude-opus-4-6`
2. Use the session until context approaches ~80% (compaction threshold)
3. Auto-compaction triggers

### Expected

- Session continues working normally after compaction

### Actual

- Before fix: "thinking/redacted_thinking blocks cannot be modified" on every subsequent turn
- After fix: Thinking block signatures are preserved, session continues

## Evidence

One-line change in `transcript-policy.ts`:

```diff
-    preserveSignatures: false,
+    preserveSignatures: isAnthropic || isCopilotClaude,
```

The `preserveSignatures` flag controls whether `stripThoughtSignatures` is called in `images.ts` line 124:

```typescript
const strippedContent = options?.preserveSignatures
  ? content // Keep signatures for Anthropic
  : stripThoughtSignatures(content, options?.sanitizeThoughtSignatures);
```

All 10 existing transcript-policy tests pass.

## Human Verification (required)

- Verified scenarios: TypeScript compilation, all 10 transcript-policy tests pass
- Edge cases checked: Google/Gemini providers (signatures still stripped for format compatibility), Copilot Claude (also preserves — same Anthropic API backend), non-Anthropic providers (unchanged)
- What I did **not** verify: End-to-end test with actual long-running thinking session and compaction

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single-line change; signatures go back to being stripped for all providers
- Files/config to restore: `src/agents/transcript-policy.ts`
- Known bad symptoms: If an Anthropic API change requires signature stripping, this would need reversal — but currently signatures must be preserved

## Risks and Mitigations

- Risk: Preserved signatures may increase token count slightly for Anthropic sessions. Mitigation: Signatures are small relative to thinking content; the alternative (session corruption) is far worse.

