### PR TITLE
Agents: preserve Anthropic transcript signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/daemon lifecycle in containers: when no system service is loaded, `openclaw gateway stop` and `openclaw gateway restart` now attempt port-based gateway PID signaling (`SIGTERM`/`SIGUSR1`) instead of exiting early as not-loaded. (related to #36137)
+- Queue/followup collect metadata: include trusted queued-message `message_id` metadata in `[Queued messages while agent was busy]` prompts so agents can use original provider message ids for native reply APIs instead of placeholder ids from untrusted context blocks. (#36212)
+- Control UI/chat final-event reload gating: skip automatic `chat.history` reload when a `final` event belongs to the currently active run, preventing in-progress fallback/compaction transitions from replacing already-rendered chat messages mid-read. (#36221)
+- Agents/transcript signature preservation: keep `preserveSignatures` enabled for Anthropic-compatible transcript policy so thinking/redacted thinking blocks round-trip without signature mutation during history sanitization and compaction-adjacent turns. (#36229)
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -212,7 +212,11 @@ describe("sanitizeSessionHistory", () => {
     expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
       mockMessages,
       "session:history",
-      expect.objectContaining({ sanitizeMode: "full", sanitizeToolCallIds: true }),
+      expect.objectContaining({
+        sanitizeMode: "full",
+        sanitizeToolCallIds: true,
+        preserveSignatures: true,
+      }),
     );
   });
 

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -10,6 +10,7 @@ describe("resolveTranscriptPolicy", () => {
     });
     expect(policy.sanitizeToolCallIds).toBe(true);
     expect(policy.toolCallIdMode).toBe("strict");
+    expect(policy.preserveSignatures).toBe(true);
   });
 
   it("enables sanitizeToolCallIds for Google provider", () => {
@@ -23,6 +24,7 @@ describe("resolveTranscriptPolicy", () => {
       allowBase64Only: true,
       includeCamelCase: true,
     });
+    expect(policy.preserveSignatures).toBe(false);
   });
 
   it("enables sanitizeToolCallIds for Mistral provider", () => {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -123,7 +123,8 @@ export function resolveTranscriptPolicy(params: {
       (!isOpenAi && sanitizeToolCallIds) || requiresOpenAiCompatibleToolIdSanitization,
     toolCallIdMode,
     repairToolUseResultPairing,
-    preserveSignatures: false,
+    // Anthropic-style APIs require assistant thinking signatures to round-trip unchanged.
+    preserveSignatures: isAnthropic,
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     sanitizeThinkingSignatures: false,
     dropThinkingBlocks,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Anthropic-compatible runs sanitize retained transcript history with `preserveSignatures: false`, which can mutate/drop thinking signatures on assistant thinking blocks.
- Why it matters: signature mutation can make long-running sessions unrecoverable after compaction-adjacent turns (`thinking/redacted_thinking blocks cannot be modified`).
- What changed: enable `preserveSignatures` for Anthropic-compatible transcript policy and lock this with policy + sanitize-session-history tests.
- What did NOT change (scope boundary): Google/OpenAI/Mistral sanitization behavior and tool-call id policies remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36229
- Related #36221

## User-visible / Behavior Changes

- Anthropic-compatible sessions now preserve assistant thinking signatures in sanitized retained history.
- This prevents signature-corruption failures after compaction-adjacent long-session turns.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev
- Model/provider: anthropic policy path
- Integration/channel (if any): N/A
- Relevant config (redacted): default

### Steps

1. Resolve transcript policy for Anthropic-compatible provider/model.
2. Sanitize session history through runner path.
3. Verify sanitize options preserve signatures for Anthropic path.

### Expected

- Anthropic policy uses `preserveSignatures: true`.
- sanitize-session-history forwards `preserveSignatures: true` to message sanitizer.

### Actual

- Assertions now pass for both checks.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/agents/transcript-policy.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts`
  - `pnpm exec oxfmt --check CHANGELOG.md src/agents/transcript-policy.ts src/agents/transcript-policy.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts`
- Edge cases checked:
  - Google path still reports `preserveSignatures: false` in policy tests.
- What you did **not** verify:
  - Full live Anthropic end-to-end compaction replay against a production gateway.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `Agents: preserve Anthropic transcript signatures`.
- Files/config to restore:
  - `src/agents/transcript-policy.ts`
  - `src/agents/transcript-policy.test.ts`
  - `src/agents/pi-embedded-runner.sanitize-session-history.test.ts`
- Known bad symptoms reviewers should watch for:
  - Anthropic runs unexpectedly dropping thinking signatures again in sanitized history.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Preserving signatures in Anthropic path could preserve malformed signatures from previously corrupted history.
  - Mitigation:
    - Scope is limited to Anthropic-compatible policy branch with focused regression checks.
