### PR TITLE
fix(chat.inject): improve error message for missing transcript file

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -416,7 +416,7 @@ function appendAssistantTranscriptMessage(params: {
 
   if (!fs.existsSync(transcriptPath)) {
     if (!params.createIfMissing) {
-      return { ok: false, error: "transcript file not found" };
+      return { ok: false, error: "transcript file not found (session exists but file missing)" };
     }
     const ensured = ensureTranscriptFile({
       transcriptPath,


### PR DESCRIPTION
## Summary
- Bug: chat.inject returns "transcript file not found" when transcriptPath exists in session metadata but file is missing on disk
- Fix: Improve error message to be more descriptive

## Change Type
- [x] Bug fix

## Linked Issue
- Related #36170

## Testing
- TypeScript compilation passed