### PR TITLE
fix(onboard): use explicit Claude Sonnet default instead of openrouter/auto

### DIFF
--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -657,7 +657,7 @@ describe("applyAuthChoice", () => {
         expectEnvPrompt: true,
         expectedTextCalls: 0,
         expectedKey: "sk-openrouter-test",
-        expectedModel: "openrouter/auto",
+        expectedModel: "openrouter/anthropic/claude-sonnet-4-6",
       },
       {
         authChoice: "ai-gateway-api-key",

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -330,7 +330,7 @@ export async function setVeniceApiKey(
 
 export const ZAI_DEFAULT_MODEL_REF = "zai/glm-5";
 export const XIAOMI_DEFAULT_MODEL_REF = "xiaomi/mimo-v2-flash";
-export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
+export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/anthropic/claude-sonnet-4-6";
 export const HUGGINGFACE_DEFAULT_MODEL_REF = "huggingface/deepseek-ai/DeepSeek-R1";
 export const TOGETHER_DEFAULT_MODEL_REF = "together/moonshotai/Kimi-K2.5";
 export const LITELLM_DEFAULT_MODEL_REF = "litellm/claude-opus-4-6";


### PR DESCRIPTION
## Summary

- **Problem:** OpenRouter onboarding defaults to `openrouter/auto`, a routing directive that delegates model selection to OpenRouter's API at runtime. This frequently routes to non-Claude models (e.g., Gemini), causing inconsistent behavior and user confusion.
- **Why it matters:** Users expect a predictable default model after onboarding. Auto-routing undermines this by silently changing the model behind the scenes.
- **What changed:** Changed `OPENROUTER_DEFAULT_MODEL_REF` from `openrouter/auto` to `openrouter/anthropic/claude-sonnet-4-6`. Updated the corresponding test assertion.
- **What did NOT change:** The `HIDDEN_ROUTER_MODELS` set (still hides `openrouter/auto` from manual model picker), config application logic, or any other provider defaults.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35842

## User-visible / Behavior Changes

- New OpenRouter onboarding defaults to `anthropic/claude-sonnet-4-6` instead of `auto`.
- Existing configs with `openrouter/auto` are unaffected — only new onboarding flows use the new default.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: CLI onboarding

### Steps

1. Run `openclaw auth` and select OpenRouter
2. Complete the API key flow

### Expected

- Default model is set to `openrouter/anthropic/claude-sonnet-4-6`

### Actual

- Before fix: Default model is `openrouter/auto` (unpredictable routing)
- After fix: Default model is `openrouter/anthropic/claude-sonnet-4-6` (stable)

## Evidence

Two files changed:

```diff
// src/commands/onboard-auth.credentials.ts
-export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
+export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/anthropic/claude-sonnet-4-6";

// src/commands/auth-choice.test.ts
-        expectedModel: "openrouter/auto",
+        expectedModel: "openrouter/anthropic/claude-sonnet-4-6",
```

TypeScript check passes.

## Human Verification (required)

- Verified scenarios: TypeScript compilation, code review of all `OPENROUTER_DEFAULT_MODEL_REF` references
- Edge cases checked: Existing configs with `openrouter/auto` (unaffected), `HIDDEN_ROUTER_MODELS` still hides `openrouter/auto` from picker
- What I did **not** verify: Full onboarding flow end-to-end

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the constant; `openrouter/auto` returns as default
- Files/config to restore: `src/commands/onboard-auth.credentials.ts`
- Known bad symptoms: None — the new default is a standard, well-supported model

## Risks and Mitigations

None — this aligns OpenRouter onboarding with other providers that all use explicit model defaults.

