### PR TITLE
feat(reminder-guard): expand follow-up promise detection with CN and EN patterns

### DIFF
--- a/src/auto-reply/reply/agent-runner-reminder-guard.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.ts
@@ -5,8 +5,13 @@ export const UNSCHEDULED_REMINDER_NOTE =
   "Note: I did not schedule a reminder in this turn, so this will not trigger automatically.";
 
 const REMINDER_COMMITMENT_PATTERNS: RegExp[] = [
-  /\b(?:i\s*['’]?ll|i will)\s+(?:make sure to\s+)?(?:remember|remind|ping|follow up|follow-up|check back|circle back)\b/i,
-  /\b(?:i\s*['’]?ll|i will)\s+(?:set|create|schedule)\s+(?:a\s+)?reminder\b/i,
+  /\b(?:i\s*['\u2019]?ll|i will)\s+(?:make sure to\s+)?(?:remember|remind|ping|follow up|follow-up|check back|circle back)\b/i,
+  /\b(?:i\s*['\u2019]?ll|i will)\s+(?:set|create|schedule)\s+(?:a\s+)?reminder\b/i,
+  /\b(?:i\s*['\u2019]?ll|i will)\s+(?:let you know|update you|notify you|get back to you|message you)\b/i,
+  /\b(?:i\s*['\u2019]?ll|i will)\s+(?:ping|buzz|reach out to)\s+you\b/i,
+  /(?:稍后|之后|晚[点些]|回头|待会[儿]?|一会[儿]?|过[一会]*)(?:.*?)(?:提醒|通知|告[诉知]|同步|更新|汇报|反馈)/u,
+  /(?:完成|做完|搞定|结束|处理好)(?:.*?)(?:后|之后|了)(?:.*?)(?:通知|告[诉知]|提醒|同步|更新|汇报)/u,
+  /(?:到时候|届时)(?:.*?)(?:告[诉知]|通知|提醒|同步|更新)/u,
 ];
 
 export function hasUnbackedReminderCommitment(text: string): boolean {


### PR DESCRIPTION
## Summary

- **Problem:** The reminder-guard only matched a narrow set of English follow-up promise phrases (`remind`, `follow up`, `check back`, `circle back`). Common Chinese phrases (e.g., "稍后同步进度", "完成后通知", "到时候告诉你") and additional English variants (e.g., "I'll let you know when done", "I'll update you", "I'll ping you") were not detected, so users never received the "no reminder scheduled" hint.
- **Why it matters:** Users interpret agent follow-up promises as real scheduled actions. Without the guard hint, they wait indefinitely for a message that will never arrive.
- **What changed:** Added 5 new regex patterns to `REMINDER_COMMITMENT_PATTERNS` in `agent-runner-reminder-guard.ts`:
  - 2 new English patterns covering `let you know / update you / notify you / get back to you / message you / ping you / buzz you / reach out to you`
  - 3 Chinese patterns covering temporal promises (`稍后/回头/晚点` + action), completion-based promises (`完成后/搞定后` + notification), and time-reference promises (`到时候/届时` + notification)
- **What did NOT change:** The existing 2 English patterns, the `UNSCHEDULED_REMINDER_NOTE` text, the cron job suppression logic, or the `appendUnscheduledReminderNote` flow.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35462

## User-visible / Behavior Changes

- When the agent says phrases like "稍后同步进度", "完成后通知你", "到时候告诉你", "I'll let you know when done", "I'll update you in 30 minutes", or "I'll ping you later", the reminder guard now appends: "Note: I did not schedule a reminder in this turn, so this will not trigger automatically."

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: any

### Steps

1. Ask the agent to do something and it responds with "完成后通知你" or "I'll let you know when done"
2. Observe the response

### Expected

- After fix: Response includes "Note: I did not schedule a reminder..."

### Actual

- Before fix: No hint appended for these phrases
- After fix: Hint is appended

## Evidence

New patterns added:

```typescript
// EN: follow-up promises
/(?:i\s*['’]?ll|i will)\s+(?:let you know|update you|notify you|get back to you|message you)/i,
/(?:i\s*['’]?ll|i will)\s+(?:ping|buzz|reach out to)\s+you/i,

// CN: temporal follow-up promises
/(?:稍后|之后|晚[点些]|回头|待会[儿]?|一会[儿]?|过[一会]*)(?:.*?)(?:提醒|通知|告[诉知]|同步|更新|汇报|反馈)/u,
/(?:完成|做完|搞定|结束|处理好)(?:.*?)(?:后|之后|了)(?:.*?)(?:通知|告[诉知]|提醒|同步|更新|汇报)/u,
/(?:到时候|届时)(?:.*?)(?:告[诉知]|通知|提醒|同步|更新)/u,
```

TypeScript check passes.

## Human Verification (required)

- Verified scenarios: TypeScript compilation, manual regex testing against sample phrases
- Edge cases checked: Existing patterns still match, `UNSCHEDULED_REMINDER_NOTE` in text prevents double-match, empty text returns false
- What I did **not** verify: False positive rate on real conversation transcripts

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the file; original 2 patterns return
- Files/config to restore: `src/auto-reply/reply/agent-runner-reminder-guard.ts`
- Known bad symptoms: If patterns are too broad, the note may appear on non-promise text — but patterns are conservative and require specific verb+action combinations

## Risks and Mitigations

- Risk: Chinese regex may match in edge cases where the agent is quoting/explaining rather than promising. Mitigation: Patterns require specific temporal + action combinations that are unlikely in non-promise contexts.

