### PR TITLE
Auth: add configurable rate-limit cooldown sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - Slack/DM typing feedback: add `channels.slack.typingReaction` so Socket Mode DMs can show reaction-based processing status even when Slack native assistant typing is unavailable. (#19816) Thanks @dalefrieswthat.
 - Cron/job snapshot persistence: skip backup during normalization persistence in `ensureLoaded` so `jobs.json.bak` keeps the pre-edit snapshot for recovery, while preserving backup creation on explicit user-driven writes. (#35234) Thanks @0xsline.
 - TTS/OpenAI-compatible endpoints: add `messages.tts.openai.baseUrl` config support with config-over-env precedence, endpoint-aware directive validation, and OpenAI TTS request routing to the resolved base URL. (#34321) thanks @RealKai42.
+- Auth/cooldown tuning: add `auth.cooldowns.rateLimitBackoffMs` to customize per-step `rate_limit` profile cooldown windows (ms), while keeping the existing default progression (1m, 5m, 25m, 60m). (#36119)
 
 ### Fixes
 

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore, ProfileUsageStats } from "./types.js";
 import {
+  calculateRateLimitCooldownMs,
   clearAuthProfileCooldown,
   clearExpiredCooldowns,
   isProfileInCooldown,
@@ -50,6 +51,22 @@ describe("resolveProfileUnusableUntil", () => {
   it("returns the latest active timestamp", () => {
     expect(resolveProfileUnusableUntil({ cooldownUntil: 100, disabledUntil: 200 })).toBe(200);
     expect(resolveProfileUnusableUntil({ cooldownUntil: 300 })).toBe(300);
+  });
+});
+
+describe("calculateRateLimitCooldownMs", () => {
+  it("uses default rate-limit cooldown sequence and caps at the last value", () => {
+    expect(calculateRateLimitCooldownMs(1)).toBe(60_000);
+    expect(calculateRateLimitCooldownMs(2)).toBe(300_000);
+    expect(calculateRateLimitCooldownMs(3)).toBe(1_500_000);
+    expect(calculateRateLimitCooldownMs(4)).toBe(3_600_000);
+    expect(calculateRateLimitCooldownMs(9)).toBe(3_600_000);
+  });
+
+  it("uses custom sequence when provided", () => {
+    expect(calculateRateLimitCooldownMs(1, [15_000, 45_000, 90_000])).toBe(15_000);
+    expect(calculateRateLimitCooldownMs(2, [15_000, 45_000, 90_000])).toBe(45_000);
+    expect(calculateRateLimitCooldownMs(5, [15_000, 45_000, 90_000])).toBe(90_000);
   });
 });
 
@@ -509,6 +526,13 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
     store: ReturnType<typeof makeStore>;
     now: number;
     reason: "rate_limit" | "billing" | "auth_permanent";
+    cfg?: {
+      auth?: {
+        cooldowns?: {
+          rateLimitBackoffMs?: number[];
+        };
+      };
+    };
   }): Promise<void> {
     vi.useFakeTimers();
     vi.setSystemTime(params.now);
@@ -517,6 +541,7 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
         store: params.store,
         profileId: "anthropic:default",
         reason: params.reason,
+        cfg: params.cfg,
       });
     } finally {
       vi.useRealTimers();
@@ -635,4 +660,31 @@ describe("markAuthProfileFailure — active windows do not extend on retry", () 
       expect(testCase.readUntil(stats)).toBe(testCase.expectedUntil(now));
     });
   }
+
+  it("uses configured rate-limit cooldown sequence for recomputed cooldown windows", async () => {
+    const now = 1_000_000;
+    const store = makeStore({
+      "anthropic:default": {
+        cooldownUntil: now - 60_000,
+        errorCount: 3,
+        lastFailureAt: now - 60_000,
+      },
+    });
+
+    await markFailureAt({
+      store,
+      now,
+      reason: "rate_limit",
+      cfg: {
+        auth: {
+          cooldowns: {
+            rateLimitBackoffMs: [45_000, 90_000],
+          },
+        },
+      },
+    });
+
+    const stats = store.usageStats?.["anthropic:default"];
+    expect(stats?.cooldownUntil).toBe(now + 90_000);
+  });
 });

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -274,10 +274,44 @@ export function calculateAuthProfileCooldownMs(errorCount: number): number {
   );
 }
 
+const DEFAULT_RATE_LIMIT_BACKOFF_MS = [60_000, 300_000, 1_500_000, 3_600_000] as const;
+
+function normalizeRateLimitBackoffSequence(input: unknown): number[] | undefined {
+  if (!Array.isArray(input)) {
+    return undefined;
+  }
+  const normalized = input
+    .map((entry) => {
+      if (typeof entry !== "number" || !Number.isFinite(entry) || entry <= 0) {
+        return null;
+      }
+      return Math.trunc(entry);
+    })
+    .filter((entry): entry is number => entry !== null);
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export function calculateRateLimitCooldownMs(
+  errorCount: number,
+  sequenceMs: readonly number[] = DEFAULT_RATE_LIMIT_BACKOFF_MS,
+): number {
+  const normalized = Math.max(1, errorCount);
+  if (!Array.isArray(sequenceMs) || sequenceMs.length === 0) {
+    return calculateAuthProfileCooldownMs(normalized);
+  }
+  const index = Math.min(normalized - 1, sequenceMs.length - 1);
+  const selected = sequenceMs[index];
+  if (typeof selected !== "number" || !Number.isFinite(selected) || selected <= 0) {
+    return calculateAuthProfileCooldownMs(normalized);
+  }
+  return Math.trunc(selected);
+}
+
 type ResolvedAuthCooldownConfig = {
   billingBackoffMs: number;
   billingMaxMs: number;
   failureWindowMs: number;
+  rateLimitBackoffMs: readonly number[];
 };
 
 function resolveAuthCooldownConfig(params: {
@@ -321,6 +355,9 @@ function resolveAuthCooldownConfig(params: {
     billingBackoffMs: billingBackoffHours * 60 * 60 * 1000,
     billingMaxMs: billingMaxHours * 60 * 60 * 1000,
     failureWindowMs: failureWindowHours * 60 * 60 * 1000,
+    rateLimitBackoffMs:
+      normalizeRateLimitBackoffSequence(cooldowns?.rateLimitBackoffMs) ??
+      DEFAULT_RATE_LIMIT_BACKOFF_MS,
   };
 }
 
@@ -426,7 +463,10 @@ function computeNextProfileUsageStats(params: {
     });
     updatedStats.disabledReason = params.reason;
   } else {
-    const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount);
+    const backoffMs =
+      params.reason === "rate_limit"
+        ? calculateRateLimitCooldownMs(nextErrorCount, params.cfgResolved.rateLimitBackoffMs)
+        : calculateAuthProfileCooldownMs(nextErrorCount);
     // Keep active cooldown windows immutable so retries within the window
     // cannot push recovery further out.
     updatedStats.cooldownUntil = keepActiveWindowOrRecompute({

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -722,6 +722,8 @@ export const FIELD_HELP: Record<string, string> = {
   "auth.cooldowns.billingBackoffHoursByProvider":
     "Optional per-provider overrides for billing backoff (hours).",
   "auth.cooldowns.billingMaxHours": "Cap (hours) for billing backoff (default: 24).",
+  "auth.cooldowns.rateLimitBackoffMs":
+    "Optional rate-limit cooldown sequence in milliseconds (for example [60000,300000,1500000,3600000]). Each `rate_limit` failure advances the index; the last value is reused after the sequence ends.",
   "auth.cooldowns.failureWindowHours": "Failure window (hours) for backoff counters (default: 24).",
   "agents.defaults.workspace":
     "Default workspace path exposed to agent runtime tools for filesystem context and repo-aware behavior. Set this explicitly when running from wrappers so path resolution stays deterministic.",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -411,6 +411,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "auth.cooldowns.billingBackoffHours": "Billing Backoff (hours)",
   "auth.cooldowns.billingBackoffHoursByProvider": "Billing Backoff Overrides",
   "auth.cooldowns.billingMaxHours": "Billing Backoff Cap (hours)",
+  "auth.cooldowns.rateLimitBackoffMs": "Rate-limit Backoff (ms)",
   "auth.cooldowns.failureWindowHours": "Failover Window (hours)",
   "agents.defaults.models": "Models",
   "agents.defaults.model.primary": "Primary Model",

--- a/src/config/types.auth.ts
+++ b/src/config/types.auth.ts
@@ -21,6 +21,12 @@ export type AuthConfig = {
     /** Billing backoff cap (hours). Default: 24. */
     billingMaxHours?: number;
     /**
+     * Rate-limit cooldown sequence in milliseconds.
+     * Example: `[60000, 300000, 1500000, 3600000]` (1m, 5m, 25m, 60m).
+     * The last value is reused for subsequent failures.
+     */
+    rateLimitBackoffMs?: number[];
+    /**
      * Failure window for backoff counters (hours). If no failures occur within
      * this window, counters reset. Default: 24.
      */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -357,6 +357,7 @@ export const OpenClawSchema = z
             billingBackoffHours: z.number().positive().optional(),
             billingBackoffHoursByProvider: z.record(z.string(), z.number().positive()).optional(),
             billingMaxHours: z.number().positive().optional(),
+            rateLimitBackoffMs: z.array(z.number().positive()).min(1).optional(),
             failureWindowHours: z.number().positive().optional(),
           })
           .strict()


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: auth profile cooldown timing for `rate_limit` failures is fixed in code (1m/5m/25m/60m), so operators cannot tune behavior for high-concurrency multi-agent workloads.
- Why it matters: some deployments need faster or slower cooldown ramps depending on provider/token-bucket refill patterns.
- What changed: added `auth.cooldowns.rateLimitBackoffMs` config to define per-step cooldown durations for `rate_limit` failures.
- What did NOT change (scope boundary): default cooldown progression remains unchanged; billing/permanent-auth cooldown logic and profile-rotation behavior are untouched.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36119
- Related #36229

## User-visible / Behavior Changes

- New config key: `auth.cooldowns.rateLimitBackoffMs` (array of positive ms values).
- Example: `[60000, 300000, 1500000, 3600000]` (1m, 5m, 25m, 60m).
- For `rate_limit` failures, cooldown uses indexed step by error count and reuses the last value once the array is exhausted.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev
- Model/provider: auth profile cooldown path
- Integration/channel (if any): N/A
- Relevant config (redacted): `auth.cooldowns.rateLimitBackoffMs`

### Steps

1. Configure `auth.cooldowns.rateLimitBackoffMs` with a custom sequence.
2. Trigger `markAuthProfileFailure(... reason: "rate_limit")` through retry/failure paths.
3. Verify `cooldownUntil` matches configured step and caps at final step.

### Expected

- Rate-limit cooldown windows follow configured sequence.
- Non-rate-limit cooldown behavior remains unchanged.

### Actual

- Verified by unit tests and config schema/help quality checks.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/agents/auth-profiles/usage.test.ts src/config/schema.help.quality.test.ts src/config/config-misc.test.ts`
  - `pnpm exec oxfmt --check CHANGELOG.md src/agents/auth-profiles/usage.ts src/agents/auth-profiles/usage.test.ts src/config/types.auth.ts src/config/zod-schema.ts src/config/schema.labels.ts src/config/schema.help.ts`
  - `pnpm exec oxlint src/agents/auth-profiles/usage.ts src/agents/auth-profiles/usage.test.ts src/config/types.auth.ts src/config/zod-schema.ts src/config/schema.labels.ts src/config/schema.help.ts`
- Edge cases checked:
  - custom sequence caps at final value
  - invalid/empty custom sequence falls back to default progression
- What you did **not** verify:
  - Live multi-profile Anthropic load test in a production gateway.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Optional`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Remove `auth.cooldowns.rateLimitBackoffMs` from config or revert this commit.
- Files/config to restore:
  - `src/agents/auth-profiles/usage.ts`
  - `src/config/types.auth.ts`
  - `src/config/zod-schema.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected `rate_limit` cooldown durations not matching configured steps.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Misconfigured sequences (too short/too long) can unintentionally over- or under-throttle profile reuse.
  - Mitigation:
    - schema validation requires positive values; fallback defaults remain in place when custom sequence is absent/invalid.
