### PR TITLE
fix(heartbeat): prevent node notification wake from overriding configured heartbeat.session

### DIFF
--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -492,7 +492,9 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         contextKey: `notification:${key}`,
       });
       if (queued) {
-        requestHeartbeatNow({ reason: "notifications-event", sessionKey });
+        requestHeartbeatNow(
+          scopedHeartbeatWakeOptions(sessionKey, { reason: "notifications-event" }),
+        );
       }
       return;
     }


### PR DESCRIPTION
## Summary

- **Problem:** Node notification events (`notifications.changed`) passed a synthetic `sessionKey` (`node-<nodeId>`) directly to `requestHeartbeatNow`. This caused `resolveHeartbeatSession` to use the forced key instead of the user-configured `heartbeat.session`, making heartbeat runs execute in a node-scoped session (`agent:main:node-<nodeId>`) rather than the intended fixed session.
- **Why it matters:** Users who configure `heartbeat.session` to a specific session key expect heartbeat to always run in that session. Node notification events silently hijacking the session routing breaks this expectation and pollutes node-scoped sessions.
- **What changed:** Replaced `requestHeartbeatNow({ reason: "notifications-event", sessionKey })` with `requestHeartbeatNow(scopedHeartbeatWakeOptions(sessionKey, { reason: "notifications-event" }))` in the `notifications.changed` handler. `scopedHeartbeatWakeOptions` already handles this correctly for exec events — it omits `sessionKey` from wake options when the key is a synthetic non-agent key (e.g., `node-*`), allowing `resolveHeartbeatSession` to fall through to the configured `heartbeat.session`.
- **What did NOT change:** Exec event handling (already uses `scopedHeartbeatWakeOptions`), `resolveHeartbeatSession` logic, system event enqueueing, or any other node event handlers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35310

## User-visible / Behavior Changes

- When `heartbeat.session` is configured, node notification events no longer override it with `node-<nodeId>`.
- Heartbeat runs triggered by notifications now use the configured session (or main session if unconfigured).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js gateway
- Integration/channel: Node-paired device (Android/iOS)

### Steps

1. Configure `heartbeat.session` to a fixed session key
2. Pair a node device
3. Receive a notification on the device

### Expected

- Heartbeat runs in the configured session

### Actual

- Before fix: Heartbeat runs in `agent:main:node-<nodeId>` (wrong session)
- After fix: Heartbeat runs in the configured session

## Evidence

One-line change in `server-node-events.ts`:

```diff
-        requestHeartbeatNow({ reason: "notifications-event", sessionKey });
+        requestHeartbeatNow(
+          scopedHeartbeatWakeOptions(sessionKey, { reason: "notifications-event" }),
+        );
```

This aligns notification wake behavior with the existing exec event wake behavior (line 580) which already uses `scopedHeartbeatWakeOptions`.

TypeScript check passes.

## Human Verification (required)

- Verified scenarios: TypeScript compilation, code review of `scopedHeartbeatWakeOptions` behavior, comparison with exec event handler (same pattern)
- Edge cases checked: Real session keys from payload (still passed through correctly by `scopedHeartbeatWakeOptions`), synthetic `node-*` keys (omitted, letting `heartbeat.session` take over)
- What I did **not** verify: End-to-end test with paired node device

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single-line change; notification wakes go back to forcing the synthetic key
- Files/config to restore: `src/gateway/server-node-events.ts`
- Known bad symptoms: None — the fix aligns with the existing pattern used by exec events

## Risks and Mitigations

- Risk: If a notification event payload provides a valid explicit `sessionKey`, `scopedHeartbeatWakeOptions` will still pass it through. No change for explicit keys.

