### PR TITLE
Fix: prevent Control UI crash when markdown parse recurses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/markdown renderer resilience: catch markdown parse failures (including recursive-parser edge cases) and fall back to escaped preformatted text so chat history still renders instead of crashing the page. (#36213)
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { marked } from "marked";
+import { describe, expect, it, vi } from "vitest";
 import { toSanitizedMarkdownHtml } from "./markdown.ts";
 
 describe("toSanitizedMarkdownHtml", () => {
@@ -81,5 +82,17 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).toContain("Col2");
     // Pipes from table delimiters must not appear as raw text
     expect(html).not.toContain("|------|");
+  });
+
+  it("falls back to escaped text when marked.parse throws", () => {
+    const parseSpy = vi.spyOn(marked, "parse").mockImplementationOnce(() => {
+      throw new Error("too much recursion");
+    });
+    const html = toSanitizedMarkdownHtml("plain <script>alert(1)</script> **text**");
+    expect(html).toContain("<pre");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).toContain("**text**");
+    expect(html).not.toContain("<script>");
+    expect(parseSpy).toHaveBeenCalledOnce();
   });
 });

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -85,6 +85,10 @@ function installHooks() {
   });
 }
 
+function renderEscapedPre(value: string): string {
+  return `<pre class="code-block">${escapeHtml(value)}</pre>`;
+}
+
 export function toSanitizedMarkdownHtml(markdown: string): string {
   const input = markdown.trim();
   if (!input) {
@@ -101,20 +105,27 @@ export function toSanitizedMarkdownHtml(markdown: string): string {
   const suffix = truncated.truncated
     ? `\n\n… truncated (${truncated.total} chars, showing first ${truncated.text.length}).`
     : "";
+  const renderInput = `${truncated.text}${suffix}`;
   if (truncated.text.length > MARKDOWN_PARSE_LIMIT) {
-    const escaped = escapeHtml(`${truncated.text}${suffix}`);
-    const html = `<pre class="code-block">${escaped}</pre>`;
+    const html = renderEscapedPre(renderInput);
     const sanitized = DOMPurify.sanitize(html, sanitizeOptions);
     if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
       setCachedMarkdown(input, sanitized);
     }
     return sanitized;
   }
-  const rendered = marked.parse(`${truncated.text}${suffix}`, {
-    renderer: htmlEscapeRenderer,
-    gfm: true,
-    breaks: true,
-  }) as string;
+  let rendered: string;
+  try {
+    rendered = marked.parse(renderInput, {
+      renderer: htmlEscapeRenderer,
+      gfm: true,
+      breaks: true,
+    }) as string;
+  } catch {
+    // Marked can throw on malformed recursive markdown edge-cases.
+    // Fallback to escaped preformatted text so the UI remains usable.
+    rendered = renderEscapedPre(renderInput);
+  }
   const sanitized = DOMPurify.sanitize(rendered, sanitizeOptions);
   if (input.length <= MARKDOWN_CACHE_MAX_CHARS) {
     setCachedMarkdown(input, sanitized);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Control UI markdown rendering could crash the page when `marked.parse` hit recursive parser edge-cases (`InternalError: too much recursion`).
- Why it matters: a single malformed/edge chat history entry could prevent Control UI from rendering at all.
- What changed: wrapped markdown parsing in a guarded fallback; on parser exceptions we now render escaped `<pre>` content instead of crashing.
- What changed: added regression test that forces `marked.parse` to throw and verifies escaped fallback output.
- What did NOT change (scope boundary): no markdown syntax behavior changes on successful parse, no sanitization policy changes, no channel/gateway logic touched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36213
- Related #36213

## User-visible / Behavior Changes

- Control UI no longer hard-crashes when markdown parser recursion errors occur for history content; affected messages render as escaped preformatted text fallback.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS arm64
- Runtime/container: Node 22 + pnpm workspace (`ui` package tests)
- Model/provider: N/A
- Integration/channel (if any): Control UI browser markdown rendering path
- Relevant config (redacted): N/A

### Steps

1. In `ui/src/ui/markdown.ts`, simulate `marked.parse` throwing (recursion-like parse failure).
2. Render markdown content through `toSanitizedMarkdownHtml(...)`.
3. Verify output is escaped `<pre>` content and no raw script tag is emitted.

### Expected

- UI should keep rendering with safe fallback output instead of crashing.

### Actual

- Verified via regression test: fallback `<pre>` output is returned and unsafe HTML remains escaped.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

- `pnpm --dir ui exec vitest run src/ui/markdown.test.ts`
- `pnpm exec oxfmt --check ui/src/ui/markdown.ts ui/src/ui/markdown.test.ts CHANGELOG.md`
- `pnpm exec oxlint ui/src/ui/markdown.ts ui/src/ui/markdown.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: normal markdown rendering still passes existing tests; forced parser-error path returns escaped fallback HTML.
- Edge cases checked: unsafe HTML in fallback path remains escaped (`<script>` rendered as text), not executable.
- What you did **not** verify: browser manual click-through on a live crashing history payload (no deterministic real-world repro payload provided in issue).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `ui/src/ui/markdown.ts`, `ui/src/ui/markdown.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: unexpected increase in `<pre class="code-block">` rendering for markdown that should parse normally.

## Risks and Mitigations

- Risk: broad catch could hide parser regressions by falling back silently.
  - Mitigation: fallback is intentionally scoped to parse exceptions only; successful parse path remains unchanged and regression test covers fallback contract.
