### PR TITLE
fix(web-search): reject incompatible OpenRouter/proxy configs with clear error

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -15,6 +15,8 @@ const {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  resolvePerplexityApiKey,
+  detectIncompatiblePerplexityConfig,
 } = __testing;
 
 describe("web_search brave language param normalization", () => {
@@ -269,5 +271,108 @@ describe("extractKimiCitations", () => {
         ],
       }).toSorted(),
     ).toEqual(["https://example.com/a", "https://example.com/b", "https://example.com/c"]);
+  });
+});
+
+describe("web_search perplexity config resolution", () => {
+  it("normalizes Bearer-prefixed config API key", () => {
+    const result = resolvePerplexityApiKey({ apiKey: "Bearer pplx-config-key" });
+    expect(result).toEqual({ apiKey: "pplx-config-key", source: "config" });
+  });
+
+  it("normalizes Bearer-prefixed PERPLEXITY_API_KEY from env", () => {
+    withEnv({ PERPLEXITY_API_KEY: "Bearer pplx-env-key" }, () => {
+      const result = resolvePerplexityApiKey({});
+      expect(result).toEqual({ apiKey: "pplx-env-key", source: "perplexity_env" });
+    });
+  });
+
+  it("normalizes Bearer-prefixed OPENROUTER_API_KEY from env", () => {
+    withEnv({ OPENROUTER_API_KEY: "Bearer sk-or-env-key" }, () => {
+      const result = resolvePerplexityApiKey({});
+      expect(result).toEqual({ apiKey: "sk-or-env-key", source: "openrouter_env" });
+    });
+  });
+
+  it("prefers config apiKey over environment variables", () => {
+    withEnv({ PERPLEXITY_API_KEY: "pplx-env", OPENROUTER_API_KEY: "sk-or-env" }, () => {
+      const result = resolvePerplexityApiKey({ apiKey: "pplx-config" });
+      expect(result).toEqual({ apiKey: "pplx-config", source: "config" });
+    });
+  });
+
+  it("prefers PERPLEXITY_API_KEY over OPENROUTER_API_KEY when no baseUrl", () => {
+    withEnv({ PERPLEXITY_API_KEY: "pplx-env", OPENROUTER_API_KEY: "sk-or-env" }, () => {
+      const result = resolvePerplexityApiKey({});
+      expect(result).toEqual({ apiKey: "pplx-env", source: "perplexity_env" });
+    });
+  });
+
+  it("prefers OPENROUTER_API_KEY when baseUrl targets OpenRouter", () => {
+    withEnv({ PERPLEXITY_API_KEY: "pplx-env", OPENROUTER_API_KEY: "sk-or-env" }, () => {
+      const result = resolvePerplexityApiKey({
+        baseUrl: "https://openrouter.ai/api/v1",
+      });
+      expect(result).toEqual({ apiKey: "sk-or-env", source: "openrouter_env" });
+    });
+  });
+
+  it("returns none when baseUrl targets OpenRouter but only PERPLEXITY_API_KEY is set", () => {
+    withEnv({ PERPLEXITY_API_KEY: "pplx-env", OPENROUTER_API_KEY: undefined }, () => {
+      const result = resolvePerplexityApiKey({
+        baseUrl: "https://openrouter.ai/api/v1",
+      });
+      expect(result).toEqual({ apiKey: undefined, source: "none" });
+    });
+  });
+
+  it("returns none when no API key is available", () => {
+    withEnv({ PERPLEXITY_API_KEY: undefined, OPENROUTER_API_KEY: undefined }, () => {
+      const result = resolvePerplexityApiKey({});
+      expect(result).toEqual({ apiKey: undefined, source: "none" });
+    });
+  });
+});
+
+describe("detectIncompatiblePerplexityConfig", () => {
+  it("returns error when API key has OpenRouter prefix", () => {
+    const result = detectIncompatiblePerplexityConfig({}, "sk-or-abc123", "config");
+    expect(result).toBeDefined();
+    expect(result!.error).toBe("incompatible_perplexity_config");
+    expect(result!.message).toContain("sk-or-");
+  });
+
+  it("returns error when baseUrl targets non-Perplexity host", () => {
+    const result = detectIncompatiblePerplexityConfig(
+      { baseUrl: "https://openrouter.ai/api/v1" },
+      "pplx-abc123",
+      "config",
+    );
+    expect(result).toBeDefined();
+    expect(result!.error).toBe("incompatible_perplexity_config");
+    expect(result!.message).toContain("openrouter.ai");
+  });
+
+  it("returns error when key source is openrouter_env", () => {
+    const result = detectIncompatiblePerplexityConfig({}, "some-key", "openrouter_env");
+    expect(result).toBeDefined();
+    expect(result!.error).toBe("incompatible_perplexity_config");
+    expect(result!.message).toContain("OPENROUTER_API_KEY");
+  });
+
+  it("returns undefined for valid native Perplexity config", () => {
+    expect(detectIncompatiblePerplexityConfig({}, "pplx-abc123", "config")).toBeUndefined();
+    expect(detectIncompatiblePerplexityConfig({}, "pplx-abc123", "perplexity_env")).toBeUndefined();
+    expect(
+      detectIncompatiblePerplexityConfig(
+        { baseUrl: "https://api.perplexity.ai" },
+        "pplx-abc123",
+        "config",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when apiKey is undefined and source is none", () => {
+    expect(detectIncompatiblePerplexityConfig({}, undefined, "none")).toBeUndefined();
   });
 });

--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -287,10 +287,10 @@ describe("web_search perplexity config resolution", () => {
     });
   });
 
-  it("normalizes Bearer-prefixed OPENROUTER_API_KEY from env", () => {
+  it("ignores OPENROUTER_API_KEY when no baseUrl targets non-Perplexity host", () => {
     withEnv({ OPENROUTER_API_KEY: "Bearer sk-or-env-key" }, () => {
       const result = resolvePerplexityApiKey({});
-      expect(result).toEqual({ apiKey: "sk-or-env-key", source: "openrouter_env" });
+      expect(result).toEqual({ apiKey: undefined, source: "none" });
     });
   });
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -530,12 +530,14 @@ function resolvePerplexityApiKey(perplexity?: PerplexityConfig): {
     // Do NOT fall back to PERPLEXITY_API_KEY here — return "none" so the
     // caller surfaces a clear missing-key error instead of a cryptic 401.
   } else {
-    // Default priority: Perplexity key first
+    // Default priority: native Perplexity key only.  Do NOT fall back to
+    // OPENROUTER_API_KEY here — it would cause resolveSearchProvider to
+    // auto-select Perplexity, only for detectIncompatiblePerplexityConfig
+    // to reject it immediately.  In environments that set OPENROUTER_API_KEY
+    // globally alongside other provider keys (e.g. XAI_API_KEY), this would
+    // prevent the working provider from being selected.
     if (fromEnvPerplexity) {
       return { apiKey: fromEnvPerplexity, source: "perplexity_env" };
-    }
-    if (fromEnvOpenRouter) {
-      return { apiKey: fromEnvOpenRouter, source: "openrouter_env" };
     }
   }
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -189,9 +189,11 @@ type BraveSearchResponse = {
 
 type PerplexityConfig = {
   apiKey?: string;
+  baseUrl?: string;
+  model?: string;
 };
 
-type PerplexityApiKeySource = "config" | "perplexity_env" | "none";
+type PerplexityApiKeySource = "config" | "perplexity_env" | "openrouter_env" | "none";
 
 type GrokConfig = {
   apiKey?: string;
@@ -387,7 +389,7 @@ function missingSearchKeyPayload(provider: (typeof SEARCH_PROVIDERS)[number]) {
     return {
       error: "missing_perplexity_api_key",
       message:
-        "web_search (perplexity) needs an API key. Set PERPLEXITY_API_KEY in the Gateway environment, or configure tools.web.search.perplexity.apiKey.",
+        "web_search (perplexity) needs an API key. Set PERPLEXITY_API_KEY in the Gateway environment, or configure tools.web.search.perplexity.apiKey. Note: OpenRouter keys (sk-or-...) are not supported — the Perplexity Search API requires a native Perplexity API key from https://www.perplexity.ai/settings/api.",
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }
@@ -505,17 +507,69 @@ function resolvePerplexityApiKey(perplexity?: PerplexityConfig): {
   apiKey?: string;
   source: PerplexityApiKeySource;
 } {
-  const fromConfig = normalizeApiKey(perplexity?.apiKey);
+  const fromConfig = stripBearerPrefix(normalizeApiKey(perplexity?.apiKey));
   if (fromConfig) {
     return { apiKey: fromConfig, source: "config" };
   }
 
-  const fromEnvPerplexity = normalizeApiKey(process.env.PERPLEXITY_API_KEY);
-  if (fromEnvPerplexity) {
-    return { apiKey: fromEnvPerplexity, source: "perplexity_env" };
+  // When baseUrl explicitly targets a non-Perplexity host (e.g. OpenRouter),
+  // prefer the OpenRouter key so the request is authenticated correctly.
+  const baseUrlTargetsNonPerplexity = isNonPerplexityBaseUrl(perplexity?.baseUrl);
+
+  const fromEnvPerplexity = stripBearerPrefix(normalizeApiKey(process.env.PERPLEXITY_API_KEY));
+  const fromEnvOpenRouter = stripBearerPrefix(normalizeApiKey(process.env.OPENROUTER_API_KEY));
+
+  if (baseUrlTargetsNonPerplexity) {
+    // When baseUrl explicitly targets a non-Perplexity host, only accept the
+    // OpenRouter key.  Falling back to PERPLEXITY_API_KEY would send a
+    // Perplexity-issued key to a third-party host, which always results in a
+    // 401 and obscures the real configuration error.
+    if (fromEnvOpenRouter) {
+      return { apiKey: fromEnvOpenRouter, source: "openrouter_env" };
+    }
+    // Do NOT fall back to PERPLEXITY_API_KEY here — return "none" so the
+    // caller surfaces a clear missing-key error instead of a cryptic 401.
+  } else {
+    // Default priority: Perplexity key first
+    if (fromEnvPerplexity) {
+      return { apiKey: fromEnvPerplexity, source: "perplexity_env" };
+    }
+    if (fromEnvOpenRouter) {
+      return { apiKey: fromEnvOpenRouter, source: "openrouter_env" };
+    }
   }
 
   return { apiKey: undefined, source: "none" };
+}
+
+/**
+ * Check whether a baseUrl string points to a host other than api.perplexity.ai.
+ * Returns false for undefined/empty/invalid values so the default priority is used.
+ */
+function isNonPerplexityBaseUrl(baseUrl?: string): boolean {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  try {
+    return new URL(trimmed).hostname !== "api.perplexity.ai";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Strip a leading "Bearer " prefix that users sometimes accidentally include
+ * when copy-pasting API keys from documentation or curl examples.
+ */
+function stripBearerPrefix(value: string): string {
+  return value.replace(/^bearer\s+/i, "");
+}
+
+const OPENROUTER_KEY_PREFIX = "sk-or-";
+
+function isOpenRouterApiKey(apiKey: string): boolean {
+  return apiKey.startsWith(OPENROUTER_KEY_PREFIX);
 }
 
 function normalizeApiKey(key: unknown): string {
@@ -853,6 +907,46 @@ async function throwWebSearchApiError(res: Response, providerLabel: string): Pro
   const detailResult = await readResponseText(res, { maxBytes: 64_000 });
   const detail = detailResult.text;
   throw new Error(`${providerLabel} API error (${res.status}): ${detail || res.statusText}`);
+}
+
+/**
+ * Detect configurations that are incompatible with the Perplexity Search API
+ * and return a user-friendly error payload.  The Search API is only available
+ * at api.perplexity.ai with a native Perplexity API key; OpenRouter and other
+ * proxies expose the Sonar chat/completions endpoint which returns AI-
+ * synthesized summaries instead of structured search results.
+ */
+function detectIncompatiblePerplexityConfig(
+  config: PerplexityConfig,
+  apiKey: string | undefined,
+  source: PerplexityApiKeySource,
+): { error: string; message: string; docs: string } | undefined {
+  const hasOpenRouterKey = apiKey ? isOpenRouterApiKey(apiKey) : false;
+  const hasNonPerplexityBaseUrl = isNonPerplexityBaseUrl(config.baseUrl);
+
+  if (hasOpenRouterKey || hasNonPerplexityBaseUrl || source === "openrouter_env") {
+    const reasons: string[] = [];
+    if (hasOpenRouterKey) {
+      reasons.push(`the API key has an OpenRouter prefix (${OPENROUTER_KEY_PREFIX}...)`);
+    }
+    if (hasNonPerplexityBaseUrl) {
+      reasons.push(`baseUrl is set to a non-Perplexity host (${config.baseUrl})`);
+    }
+    if (!hasOpenRouterKey && source === "openrouter_env") {
+      reasons.push("the key was resolved from OPENROUTER_API_KEY");
+    }
+    return {
+      error: "incompatible_perplexity_config",
+      message:
+        `web_search (perplexity) cannot use this configuration because ${reasons.join(" and ")}. ` +
+        "The Perplexity Search API is only available at api.perplexity.ai and requires a native " +
+        "Perplexity API key. OpenRouter exposes Sonar via chat/completions which returns AI-" +
+        "synthesized summaries instead of structured search results. Please set PERPLEXITY_API_KEY " +
+        "to a native key from https://www.perplexity.ai/settings/api, or remove the custom baseUrl.",
+      docs: "https://docs.openclaw.ai/tools/web",
+    };
+  }
+  return undefined;
 }
 
 async function runPerplexitySearchApi(params: {
@@ -1421,6 +1515,22 @@ export function createWebSearchTool(options?: {
     execute: async (_toolCallId, args) => {
       const perplexityAuth =
         provider === "perplexity" ? resolvePerplexityApiKey(perplexityConfig) : undefined;
+
+      // Reject OpenRouter / non-Perplexity proxy configurations early with a
+      // clear, actionable error instead of letting the request fail with a
+      // cryptic 401 or an incompatible API format.  The Perplexity Search API
+      // is only available at api.perplexity.ai and requires a native key.
+      if (provider === "perplexity" && perplexityAuth) {
+        const incompatible = detectIncompatiblePerplexityConfig(
+          perplexityConfig,
+          perplexityAuth.apiKey,
+          perplexityAuth.source,
+        );
+        if (incompatible) {
+          return jsonResult(incompatible);
+        }
+      }
+
       const apiKey =
         provider === "perplexity"
           ? perplexityAuth?.apiKey
@@ -1619,5 +1729,7 @@ export const __testing = {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  resolvePerplexityApiKey,
+  detectIncompatiblePerplexityConfig,
   resolveRedirectUrl: resolveCitationRedirectUrl,
 } as const;

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -15,7 +15,11 @@ function installMockFetch(payload: unknown) {
   return mockFetch;
 }
 
-function createPerplexitySearchTool(perplexityConfig?: { apiKey?: string }) {
+function createPerplexitySearchTool(perplexityConfig?: {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+}) {
   return createWebSearchTool({
     config: {
       tools: {
@@ -368,6 +372,47 @@ describe("web_search perplexity Search API", () => {
     expect(body.search_recency_filter).toBe("month");
     expect(body.search_domain_filter).toEqual(["nature.com", ".gov"]);
     expect(body.search_language_filter).toEqual(["en"]);
+  });
+
+  it("rejects OpenRouter API key with clear error instead of calling API", async () => {
+    const mockFetch = installPerplexitySearchApiFetch([]);
+    const tool = createPerplexitySearchTool({ apiKey: "sk-or-openrouter-key" });
+    const result = await tool?.execute?.("call-1", { query: "test" });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result?.details).toMatchObject({
+      error: "incompatible_perplexity_config",
+    });
+    expect(result?.details?.message).toContain("sk-or-");
+    expect(result?.details?.message).toContain("api.perplexity.ai");
+  });
+
+  it("rejects non-Perplexity baseUrl with clear error", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "sk-or-test");
+    const mockFetch = installPerplexitySearchApiFetch([]);
+    const tool = createPerplexitySearchTool({
+      baseUrl: "https://openrouter.ai/api/v1",
+    });
+    const result = await tool?.execute?.("call-1", { query: "test" });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result?.details).toMatchObject({
+      error: "incompatible_perplexity_config",
+    });
+    expect(result?.details?.message).toContain("openrouter.ai");
+  });
+
+  it("rejects OPENROUTER_API_KEY env with clear error when no PERPLEXITY_API_KEY", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "sk-or-env-key");
+    vi.stubEnv("PERPLEXITY_API_KEY", "");
+    const mockFetch = installPerplexitySearchApiFetch([]);
+    const tool = createPerplexitySearchTool();
+    const result = await tool?.execute?.("call-1", { query: "test" });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result?.details).toMatchObject({
+      error: "incompatible_perplexity_config",
+    });
   });
 });
 

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -383,8 +383,8 @@ describe("web_search perplexity Search API", () => {
     expect(result?.details).toMatchObject({
       error: "incompatible_perplexity_config",
     });
-    expect(result?.details?.message).toContain("sk-or-");
-    expect(result?.details?.message).toContain("api.perplexity.ai");
+    expect((result?.details as Record<string, unknown>)?.message).toContain("sk-or-");
+    expect((result?.details as Record<string, unknown>)?.message).toContain("api.perplexity.ai");
   });
 
   it("rejects non-Perplexity baseUrl with clear error", async () => {
@@ -399,7 +399,7 @@ describe("web_search perplexity Search API", () => {
     expect(result?.details).toMatchObject({
       error: "incompatible_perplexity_config",
     });
-    expect(result?.details?.message).toContain("openrouter.ai");
+    expect((result?.details as Record<string, unknown>)?.message).toContain("openrouter.ai");
   });
 
   it("rejects OPENROUTER_API_KEY env with clear error when no PERPLEXITY_API_KEY", async () => {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -639,11 +639,11 @@ export const FIELD_HELP: Record<string, string> = {
     'Kimi base URL override (default: "https://api.moonshot.ai/v1").',
   "tools.web.search.kimi.model": 'Kimi model override (default: "moonshot-v1-128k").',
   "tools.web.search.perplexity.apiKey":
-    "Perplexity or OpenRouter API key (fallback: PERPLEXITY_API_KEY or OPENROUTER_API_KEY env var).",
+    "Native Perplexity API key (fallback: PERPLEXITY_API_KEY env var). OpenRouter keys are not supported.",
   "tools.web.search.perplexity.baseUrl":
-    "Perplexity base URL override (default: https://openrouter.ai/api/v1 or https://api.perplexity.ai).",
+    "Perplexity base URL override (default: https://api.perplexity.ai). Non-Perplexity hosts will be rejected at runtime.",
   "tools.web.search.perplexity.model":
-    'Perplexity model override (default: "perplexity/sonar-pro").',
+    "Reserved for future use. Currently ignored by the Perplexity Search API.",
   "tools.web.fetch.enabled": "Enable the web_fetch tool (lightweight HTTP fetch).",
   "tools.web.fetch.maxChars": "Max characters returned by web_fetch (truncated).",
   "tools.web.fetch.maxCharsCap":

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -278,8 +278,9 @@ export const ToolsWebSearchSchema = z
     perplexity: z
       .object({
         apiKey: SecretInputSchema.optional().register(sensitive),
-        // Legacy Sonar/OpenRouter fields — kept for backward compatibility
-        // so existing configs don't fail validation. Ignored at runtime.
+        // Custom base URL — accepted by the schema for backward compatibility
+        // but will be rejected at runtime if it points to a non-Perplexity host.
+        // The Perplexity Search API only works at api.perplexity.ai.
         baseUrl: z.string().optional(),
         model: z.string().optional(),
       })


### PR DESCRIPTION
## Summary

This PR addresses the `401 Unauthorized` error reported in #36182 when using the Perplexity provider with an OpenRouter API key.

Instead of silently falling back to a `chat/completions` path (which returns AI-synthesized summaries instead of structured search results), this PR **detects incompatible configurations and surfaces a clear, actionable error message** to the user.

This approach resolves the issue while respecting the design principle that `web_search` should consistently return structured search results.

## The Problem

The Perplexity provider currently uses the native Search API, which is only available at `api.perplexity.ai` with a native Perplexity API key. Users with existing configurations that rely on `OPENROUTER_API_KEY` or custom `baseUrl`s encounter a cryptic `401` error, since these keys are not accepted by the Perplexity Search API endpoint.

## Solution

This PR introduces robust detection for incompatible Perplexity configurations at the `createWebSearchTool` level. Specifically, it will now return a detailed error payload if:

1.  The API key has an OpenRouter prefix (`sk-or-...`).
2.  The `baseUrl` is set to a non-Perplexity host (e.g., `https://openrouter.ai/api/v1`).
3.  The API key is resolved from the `OPENROUTER_API_KEY` environment variable.

The error message clearly explains why the configuration is incompatible and guides the user to obtain a native Perplexity API key from `https://www.perplexity.ai/settings/api`.

### Key Changes

-   **`web-search.ts`**: 
    -   Added `detectIncompatiblePerplexityConfig()` to check for OpenRouter keys or non-Perplexity `baseUrl`s.
    -   The `execute` function in `createWebSearchTool` now calls this detection logic and returns an error early if the configuration is incompatible.
    -   Updated `missing_perplexity_api_key` error message to proactively state that OpenRouter keys are not supported.
-   **`zod-schema.agent-runtime.ts` & `schema.help.ts`**: Updated comments and help text to reflect that the Perplexity provider requires a native key and that `baseUrl` overrides pointing to non-Perplexity hosts will be rejected.
-   **Tests**: Added comprehensive unit and integration tests to verify that incompatible configurations are correctly detected and that the appropriate error message is returned to the user.

Fixes #36182
