### PR TITLE
fix: device pairing required on loopback for backend clients (#35763)

### DIFF
--- a/src/gateway/server/ws-connection/auth-context.ts
+++ b/src/gateway/server/ws-connection/auth-context.ts
@@ -136,10 +136,14 @@ export async function resolveConnectAuthState(params: {
   // Trusted-proxy auth is semantically shared: the proxy vouches for identity,
   // no per-device credential needed. Include it so operator connections
   // can skip device identity via roleCanSkipDeviceIdentity().
+  // Also include successful token/password auth from the primary authResult
+  // so that backend clients (gateway-client/backend mode) can skip device pairing
+  // on loopback when using shared secret auth.
   const sharedAuthOk =
     (sharedAuthResult?.ok === true &&
       (sharedAuthResult.method === "token" || sharedAuthResult.method === "password")) ||
-    (authResult.ok && authResult.method === "trusted-proxy");
+    (authResult.ok && authResult.method === "trusted-proxy") ||
+    (authResult.ok && (authResult.method === "token" || authResult.method === "password"));
 
   return {
     authResult,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -143,6 +143,7 @@ function shouldAllowSilentLocalPairing(params: {
 function shouldSkipBackendSelfPairing(params: {
   connectParams: ConnectParams;
   isLocalClient: boolean;
+  isLoopbackClientIp: boolean;
   hasBrowserOriginHeader: boolean;
   sharedAuthOk: boolean;
   authMethod: GatewayAuthResult["method"];
@@ -155,7 +156,7 @@ function shouldSkipBackendSelfPairing(params: {
   }
   const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
   return (
-    params.isLocalClient &&
+    (params.isLocalClient || params.isLoopbackClientIp) &&
     !params.hasBrowserOriginHeader &&
     params.sharedAuthOk &&
     usesSharedSecretAuth
@@ -757,6 +758,7 @@ export function attachGatewayWsMessageHandler(params: {
           shouldSkipBackendSelfPairing({
             connectParams,
             isLocalClient,
+            isLoopbackClientIp: isLoopbackAddress(clientIp),
             hasBrowserOriginHeader,
             sharedAuthOk,
             authMethod,


### PR DESCRIPTION
## Summary

Two complementary fixes for device pairing on loopback connections:

### 1. Relax isLocalClient check in shouldSkipBackendSelfPairing
- Add isLoopbackClientIp parameter to catch cases where isLocalClient is false but client IP is loopback
- This handles Docker environments where Host header or request metadata may differ from standard loopback detection

### 2. Fix sharedAuthOk calculation in resolveConnectAuthState
- Include successful token/password auth from primary authResult in sharedAuthOk calculation
- This ensures sharedAuthOk is true when the primary auth succeeds with shared secret auth
- Enables backend clients (gateway-client/backend mode) to skip device pairing on loopback

## Problem

In Docker deployments with gateway.bind = "loopback" and token-based auth:
- Every tool call generated a new device keypair in devices/pending.json
- Agent could not send outbound messages (WhatsApp/Telegram etc.)
- Error: "gateway closed (1008): pairing required"

## Root Cause

Two issues combined to cause this:
1. isLocalClient could be false in Docker even when connecting via 127.0.0.1
2. sharedAuthOk was false because it only checked sharedAuthResult, not the primary authResult

## Testing

- Build: ✅
- Unit tests: ✅ (connect-policy.test.ts)

Fixes #35763

---

*Complements existing PR #35775 with a more complete fix*