### PR TITLE
Feishu: use session delivery context for sessions_send announce target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/sessions_send announce targeting: prefer `sessions.list` lookup for announce target resolution so group-session sends reuse canonical `to`/`accountId` delivery context instead of fragile session-key derivation, reducing announce 400 failures in multi-account group setups. (#36247, #36248)
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -9,6 +9,12 @@ vi.mock("./probe.js", () => ({
 
 import { feishuPlugin } from "./channel.js";
 
+describe("feishuPlugin metadata", () => {
+  it("prefers session lookup for announce target resolution", () => {
+    expect(feishuPlugin.meta.preferSessionLookupForAnnounceTarget).toBe(true);
+  });
+});
+
 describe("feishuPlugin.status.probeAccount", () => {
   it("uses current account credentials for multi-account config", async () => {
     const cfg = {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -36,6 +36,7 @@ const meta: ChannelMeta = {
   blurb: "飞书/Lark enterprise messaging.",
   aliases: ["lark"],
   order: 70,
+  preferSessionLookupForAnnounceTarget: true,
 };
 
 const secretInputJsonSchema = {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `sessions_send` announce delivery in Feishu group scenarios could derive announce target from session keys that do not carry canonical delivery context (`to`/`accountId`), leading to 400 send failures.
- Why it matters: in multi-account/multi-agent group setups, missing canonical target metadata can break announce sends and degrade inter-agent messaging reliability.
- What changed: set Feishu channel metadata `preferSessionLookupForAnnounceTarget: true` so announce target resolution prefers `sessions.list` delivery context hydration.
- What changed: added regression coverage asserting Feishu plugin metadata opts into session-lookup announce targeting.
- What did NOT change (scope boundary): no changes to Feishu send payload format, no retry policy changes, no gateway protocol/schema changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36247
- Related #36248

## User-visible / Behavior Changes

- Feishu `sessions_send` announce delivery now prefers canonical session delivery context (including accountId) when resolving announce targets, reducing invalid-target send failures in multi-account group chats.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS arm64
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Feishu plugin announce target metadata
- Relevant config (redacted): multi-account Feishu channel config

### Steps

1. Enable Feishu channel plugin and inspect channel metadata used by announce target resolver.
2. Verify Feishu plugin sets `preferSessionLookupForAnnounceTarget=true`.
3. Run sessions tool tests to confirm announce target resolution behavior remains green.

### Expected

- Feishu announce target resolution uses `sessions.list` hydration path (canonical `to`/`accountId`) instead of relying on session-key derivation.

### Actual

- Metadata now opts in to session lookup; targeted tests pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

- `pnpm test extensions/feishu/src/channel.test.ts`
- `pnpm test src/agents/tools/sessions.test.ts`
- `pnpm exec oxfmt --check extensions/feishu/src/channel.ts extensions/feishu/src/channel.test.ts CHANGELOG.md`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Feishu plugin metadata includes announce-target session lookup preference; sessions tool suite still passes with unchanged resolver logic.
- Edge cases checked: no behavior changes for existing non-Feishu routing logic in the sessions test suite.
- What you did **not** verify: live Feishu tenant/group reproduction against real API credentials.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `extensions/feishu/src/channel.ts`, `extensions/feishu/src/channel.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: Feishu announce targets unexpectedly bypassing session delivery context.

## Risks and Mitigations

- Risk: session-list hydration may return stale delivery context in edge recovery windows.
  - Mitigation: resolver already has fallback behavior; this change only toggles Feishu onto the same hydration-first strategy already used by other channels.
