### PR TITLE
Docs: add existing Chrome remote-debugging setup

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -152,6 +152,50 @@ OpenClaw preserves the auth when calling `/json/*` endpoints and when connecting
 to the CDP WebSocket. Prefer environment variables or secrets managers for
 tokens instead of committing them to config files.
 
+### Attach to an existing Chrome instance (`--remote-debugging-port`)
+
+Use this when you want OpenClaw to control your already-running Chrome profile
+(for example, to reuse existing logins) without using the extension attach flow.
+
+1. Start Chrome with a loopback-only debugging port:
+
+```bash
+# macOS
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.openclaw/browser/existing-chrome"
+```
+
+2. Point a browser profile at that CDP endpoint and set `attachOnly: true`:
+
+```json5
+{
+  browser: {
+    attachOnly: true,
+    profiles: {
+      existingChrome: {
+        cdpUrl: "http://127.0.0.1:9222",
+        color: "#4285F4",
+      },
+    },
+  },
+}
+```
+
+3. Use that profile when calling browser tools:
+
+```bash
+openclaw browser --browser-profile existingChrome tabs
+```
+
+Notes:
+
+- Keep CDP bound to loopback (`127.0.0.1`) unless you have strong network
+  controls.
+- The built-in `chrome` profile is reserved for extension relay by default.
+  Use a custom profile name (recommended), or explicitly override `profiles.chrome`
+  if you want `chrome` to point at your own CDP endpoint.
+
 ## Node browser proxy (zero-config default)
 
 If you run a **node host** on the machine that has your browser, OpenClaw can


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: browser docs did not provide a clear primary-path recipe for attaching OpenClaw to an already-running Chrome instance launched with `--remote-debugging-port`.
- Why it matters: users wanting to reuse existing Chrome sessions (without extension tab attach flow) lacked a concise, copy-pasteable setup.
- What changed: added a dedicated section in `docs/tools/browser.md` with launch command, config snippet (`attachOnly: true` + custom profile `cdpUrl`), usage command, and safety notes.
- What did NOT change (scope boundary): no runtime behavior, no schema/CLI changes, no channel/plugin code touched.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36150
- Related #36224

## User-visible / Behavior Changes

- Documentation now includes an explicit "existing Chrome via remote debugging port" setup path in the main browser tools guide.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS arm64
- Runtime/container: docs-only change
- Model/provider: N/A
- Integration/channel (if any): Browser docs
- Relevant config (redacted): N/A

### Steps

1. Open `docs/tools/browser.md`.
2. Follow the new "Attach to an existing Chrome instance" section.
3. Validate formatting and command/config consistency.

### Expected

- Users can configure and use an existing Chrome CDP target without guessing profile naming/attach-only behavior.

### Actual

- New section provides end-to-end steps and caveats (custom profile vs overriding built-in `chrome`).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

- `pnpm exec oxfmt --check docs/tools/browser.md`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: section is discoverable under remote CDP context, includes launch/config/use flow, and aligns with existing profile semantics in the same doc.
- Edge cases checked: warns about built-in `chrome` extension-relay profile and recommends custom profile name; loopback safety note included.
- What you did **not** verify: live Chrome attach on a running gateway instance.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `docs/tools/browser.md`.
- Known bad symptoms reviewers should watch for: documentation ambiguity between extension relay profile and remote CDP profile naming.

## Risks and Mitigations

- Risk: users may still point `cdpUrl` to a non-loopback endpoint without protections.
  - Mitigation: explicit loopback/security note added in the new section.
