### PR TITLE
Media: surface suppressed cleanup errors in response size guard

### DIFF
--- a/src/media/read-response-with-limit.test.ts
+++ b/src/media/read-response-with-limit.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { readResponseWithLimit } from "./read-response-with-limit.js";
+
+function createResponseFromReader(reader: {
+  read: () => Promise<ReadableStreamReadResult<Uint8Array>>;
+  cancel: () => Promise<void>;
+  releaseLock: () => void;
+}): Response {
+  return {
+    body: {
+      getReader: () => reader,
+    },
+    url: "https://example.com/test.bin",
+  } as unknown as Response;
+}
+
+describe("readResponseWithLimit", () => {
+  it("reports suppressed cleanup errors during overflow handling", async () => {
+    let readCount = 0;
+    const response = createResponseFromReader({
+      async read() {
+        readCount += 1;
+        if (readCount === 1) {
+          return { done: false, value: new Uint8Array([1, 2, 3]) };
+        }
+        if (readCount === 2) {
+          return { done: false, value: new Uint8Array([4, 5]) };
+        }
+        return { done: true, value: undefined };
+      },
+      async cancel() {
+        throw new Error("cancel failed");
+      },
+      releaseLock() {
+        throw new Error("release failed");
+      },
+    });
+    const suppressed: Array<{ phase: string; message: string }> = [];
+
+    await expect(
+      readResponseWithLimit(response, 4, {
+        onSuppressedError: ({ phase, error }) => {
+          suppressed.push({ phase, message: String(error) });
+        },
+      }),
+    ).rejects.toThrow("Content too large");
+
+    expect(suppressed).toEqual([
+      { phase: "cancel_after_overflow", message: "Error: cancel failed" },
+      { phase: "release_lock", message: "Error: release failed" },
+    ]);
+  });
+
+  it("keeps overflow behavior when error reporter throws", async () => {
+    let readCount = 0;
+    const response = createResponseFromReader({
+      async read() {
+        readCount += 1;
+        if (readCount === 1) {
+          return { done: false, value: new Uint8Array([1, 2, 3]) };
+        }
+        if (readCount === 2) {
+          return { done: false, value: new Uint8Array([4, 5]) };
+        }
+        return { done: true, value: undefined };
+      },
+      async cancel() {
+        throw new Error("cancel failed");
+      },
+      releaseLock() {
+        throw new Error("release failed");
+      },
+    });
+    const onSuppressedError = vi.fn(() => {
+      throw new Error("observer failed");
+    });
+
+    await expect(
+      readResponseWithLimit(response, 4, {
+        onSuppressedError,
+      }),
+    ).rejects.toThrow("Content too large");
+
+    expect(onSuppressedError).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -3,12 +3,25 @@ export async function readResponseWithLimit(
   maxBytes: number,
   opts?: {
     onOverflow?: (params: { size: number; maxBytes: number; res: Response }) => Error;
+    onSuppressedError?: (params: {
+      phase: "cancel_after_overflow" | "release_lock";
+      error: unknown;
+      res: Response;
+    }) => void;
   },
 ): Promise<Buffer> {
   const onOverflow =
     opts?.onOverflow ??
     ((params: { size: number; maxBytes: number }) =>
       new Error(`Content too large: ${params.size} bytes (limit: ${params.maxBytes} bytes)`));
+  const reportSuppressedError = (
+    phase: "cancel_after_overflow" | "release_lock",
+    error: unknown,
+  ) => {
+    try {
+      opts?.onSuppressedError?.({ phase, error, res });
+    } catch {}
+  };
 
   const body = res.body;
   if (!body || typeof body.getReader !== "function") {
@@ -33,7 +46,9 @@ export async function readResponseWithLimit(
         if (total > maxBytes) {
           try {
             await reader.cancel();
-          } catch {}
+          } catch (error) {
+            reportSuppressedError("cancel_after_overflow", error);
+          }
           throw onOverflow({ size: total, maxBytes, res });
         }
         chunks.push(value);
@@ -42,7 +57,9 @@ export async function readResponseWithLimit(
   } finally {
     try {
       reader.releaseLock();
-    } catch {}
+    } catch (error) {
+      reportSuppressedError("release_lock", error);
+    }
   }
 
   return Buffer.concat(


### PR DESCRIPTION
## Summary
- add an optional `onSuppressedError` callback to `readResponseWithLimit` for cleanup failures that were previously silently swallowed
- report suppressed errors for both overflow-triggered `reader.cancel()` and `reader.releaseLock()` cleanup
- add focused tests that verify callback reporting and confirm overflow behavior remains unchanged even if the observer throws

## Rationale
- Why: the helper currently uses silent `catch {}` around stream cleanup, which hides useful diagnostics when remote bodies/streams misbehave.
- Impact: no behavior change for existing callers; this is opt-in observability for debugging and telemetry.
- Risk: low. The callback is itself guarded with `try/catch`, so observer failures cannot alter overflow control flow.

## Validation
- `pnpm test src/media/read-response-with-limit.test.ts`
- `pnpm test src/media/fetch.test.ts`
- `pnpm lint src/media/read-response-with-limit.ts src/media/read-response-with-limit.test.ts`
- `pnpm format:check src/media/read-response-with-limit.ts src/media/read-response-with-limit.test.ts`
