### PR TITLE
fix(sessions): clear contextTokens on model switch

### DIFF
--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -85,4 +85,42 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(entry.model).toBe("gpt-5.2");
     expect(entry.updatedAt).toBe(before);
   });
+
+  it("clears contextTokens when switching to a different model", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-ctx-1",
+      updatedAt: Date.now() - 5_000,
+      providerOverride: "anthropic",
+      modelOverride: "claude-sonnet-4-6",
+      contextTokens: 160_000,
+    };
+
+    const result = applyModelOverrideToSessionEntry({
+      entry,
+      selection: { provider: "openai", model: "gpt-5.2" },
+    });
+
+    expect(result.updated).toBe(true);
+    expect(entry.contextTokens).toBeUndefined();
+  });
+
+  it("preserves contextTokens when model selection is unchanged", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-ctx-2",
+      updatedAt: Date.now() - 5_000,
+      providerOverride: "openai",
+      modelOverride: "gpt-5.2",
+      modelProvider: "openai",
+      model: "gpt-5.2",
+      contextTokens: 198_000,
+    };
+
+    const result = applyModelOverrideToSessionEntry({
+      entry,
+      selection: { provider: "openai", model: "gpt-5.2" },
+    });
+
+    expect(result.updated).toBe(false);
+    expect(entry.contextTokens).toBe(198_000);
+  });
 });

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -97,5 +97,10 @@ export function applyModelOverrideToSessionEntry(params: {
     entry.updatedAt = Date.now();
   }
 
+  if (selectionUpdated && entry.contextTokens !== undefined) {
+    delete entry.contextTokens;
+    updated = true;
+  }
+
   return { updated };
 }


### PR DESCRIPTION
## Summary

When switching models in an existing session, `contextTokens` remained stuck at the previous model's value. For example, switching from a 198k model to 160k and back left the session permanently at 160k, causing premature compaction and incorrect context accounting.

The root cause is that `applyModelOverrideToSessionEntry` updates `providerOverride`/`modelOverride` but never touches `contextTokens`. This PR deletes `contextTokens` from the session entry whenever the model selection changes, forcing the agent runner to recalculate it from the new model's catalog entry on the next turn.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35372

## Changes

| File | What changed |
|------|-------------|
| `src/sessions/model-overrides.ts` | Delete `entry.contextTokens` when `selectionUpdated` is true |
| `src/sessions/model-overrides.test.ts` | Added 2 tests: contextTokens cleared on switch, preserved when unchanged |

## User-visible / Behavior Changes

- `/status` now reflects the correct context window after model switches.
- Compaction triggers at the correct threshold for the active model instead of using a stale lower value.
- Session store `contextTokens` field is cleared on model switch and repopulated on the next LLM call.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Start a session with Model A (e.g. `claude-opus-4-5`, 198k context).
2. Switch to Model B via `/model openai/gpt-4o` (160k context).
3. Switch back to Model A via `/model anthropic/claude-opus-4-5`.

### Expected

- `contextTokens` updates to 198k after step 3.

### Actual (before fix)

- `contextTokens` stays at 160k after step 3.

## Evidence

- [x] Failing test/log before + passing after

2 new vitest unit tests in `model-overrides.test.ts`:
- "clears contextTokens when switching to a different model"
- "preserves contextTokens when model selection is unchanged"

All 5 model-overrides tests pass.

## Human Verification (required)

- Verified scenarios: Model switch via `/model` clears stale `contextTokens`; re-selecting same model preserves `contextTokens`.
- Edge cases checked: No selection change (no-op); `contextTokens` already undefined (no-op).
- What you did **not** verify: End-to-end compaction behavior; multi-agent sessions.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit. Sessions will resume stale-contextTokens behavior.
- Files/config to restore: `src/sessions/model-overrides.ts`

## Risks and Mitigations

- Risk: Clearing `contextTokens` means the first turn after a model switch may briefly lack the value until the agent runner recalculates it.
  - Mitigation: The agent runner already has a fallback chain: `agentCfgContextTokens ?? lookupContextTokens(modelUsed) ?? activeSessionEntry?.contextTokens ?? DEFAULT`. The value is repopulated immediately after the first API call via `persistSessionUsageUpdate`.