### PR TITLE
fix(tools): respect perplexity baseUrl and model config in web_search

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -26,7 +26,7 @@ const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
 const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
-const PERPLEXITY_SEARCH_ENDPOINT = "https://api.perplexity.ai/search";
+const DEFAULT_PERPLEXITY_BASE_URL = "https://api.perplexity.ai";
 
 const XAI_API_ENDPOINT = "https://api.x.ai/v1/responses";
 const DEFAULT_GROK_MODEL = "grok-4-1-fast";
@@ -189,6 +189,8 @@ type BraveSearchResponse = {
 
 type PerplexityConfig = {
   apiKey?: string;
+  baseUrl?: string;
+  model?: string;
 };
 
 type PerplexityApiKeySource = "config" | "perplexity_env" | "none";
@@ -516,6 +518,22 @@ function resolvePerplexityApiKey(perplexity?: PerplexityConfig): {
   }
 
   return { apiKey: undefined, source: "none" };
+}
+
+function resolvePerplexityBaseUrl(perplexity?: PerplexityConfig): string {
+  const fromConfig =
+    perplexity && "baseUrl" in perplexity && typeof perplexity.baseUrl === "string"
+      ? perplexity.baseUrl.trim()
+      : "";
+  return fromConfig || DEFAULT_PERPLEXITY_BASE_URL;
+}
+
+function resolvePerplexityModel(perplexity?: PerplexityConfig): string | undefined {
+  const fromConfig =
+    perplexity && "model" in perplexity && typeof perplexity.model === "string"
+      ? perplexity.model.trim()
+      : "";
+  return fromConfig || undefined;
 }
 
 function normalizeApiKey(key: unknown): string {
@@ -858,6 +876,8 @@ async function throwWebSearchApiError(res: Response, providerLabel: string): Pro
 async function runPerplexitySearchApi(params: {
   query: string;
   apiKey: string;
+  baseUrl: string;
+  model?: string;
   count: number;
   timeoutSeconds: number;
   country?: string;
@@ -871,11 +891,17 @@ async function runPerplexitySearchApi(params: {
 }): Promise<
   Array<{ title: string; url: string; description: string; published?: string; siteName?: string }>
 > {
+  const baseUrl = params.baseUrl.trim().replace(/\/$/, "");
+  const endpoint = `${baseUrl}/search`;
+
   const body: Record<string, unknown> = {
     query: params.query,
     max_results: params.count,
   };
 
+  if (params.model) {
+    body.model = params.model;
+  }
   if (params.country) {
     body.country = params.country;
   }
@@ -903,7 +929,7 @@ async function runPerplexitySearchApi(params: {
 
   return withTrustedWebSearchEndpoint(
     {
-      url: PERPLEXITY_SEARCH_ENDPOINT,
+      url: endpoint,
       timeoutSeconds: params.timeoutSeconds,
       init: {
         method: "POST",
@@ -1171,6 +1197,8 @@ async function runWebSearch(params: {
   geminiModel?: string;
   kimiBaseUrl?: string;
   kimiModel?: string;
+  perplexityBaseUrl?: string;
+  perplexityModel?: string;
 }): Promise<Record<string, unknown>> {
   const providerSpecificKey =
     params.provider === "grok"
@@ -1179,7 +1207,9 @@ async function runWebSearch(params: {
         ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
         : params.provider === "kimi"
           ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
-          : "";
+          : params.provider === "perplexity"
+            ? `${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? ""}`
+            : "";
   const cacheKey = normalizeCacheKey(
     `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}`,
   );
@@ -1194,6 +1224,8 @@ async function runWebSearch(params: {
     const results = await runPerplexitySearchApi({
       query: params.query,
       apiKey: params.apiKey,
+      baseUrl: params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL,
+      model: params.perplexityModel,
       count: params.count,
       timeoutSeconds: params.timeoutSeconds,
       country: params.country,
@@ -1596,6 +1628,8 @@ export function createWebSearchTool(options?: {
         geminiModel: resolveGeminiModel(geminiConfig),
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
+        perplexityBaseUrl: resolvePerplexityBaseUrl(perplexityConfig),
+        perplexityModel: resolvePerplexityModel(perplexityConfig),
       });
       return jsonResult(result);
     },
@@ -1619,5 +1653,7 @@ export const __testing = {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  resolvePerplexityBaseUrl,
+  resolvePerplexityModel,
   resolveRedirectUrl: resolveCitationRedirectUrl,
 } as const;


### PR DESCRIPTION
## Summary

- **Problem:** The Perplexity web search provider hardcodes its API endpoint to `https://api.perplexity.ai/search` and ignores the `baseUrl` and `model` fields that users configure in `tools.web.search.perplexity`. This causes 401 errors when users configure a custom proxy or alternative base URL, because the request is always sent to the native Perplexity endpoint with potentially mismatched API credentials.
- **Why it matters:** Users who proxy the Perplexity Search API through a relay or custom endpoint cannot use web search at all — every request fails with `Invalid API key` because it hits the wrong server.
- **What changed:** Added `baseUrl` and `model` to `PerplexityConfig`, created `resolvePerplexityBaseUrl` / `resolvePerplexityModel` helper functions (following the existing `KimiConfig` pattern), threaded both values through `runWebSearch` → `runPerplexitySearchApi`, and changed the endpoint construction from the hardcoded constant to `{baseUrl}/search`.
- **What did NOT change:** Default behavior when no `baseUrl` is configured (still uses `https://api.perplexity.ai`). No changes to other search providers. No changes to the Perplexity Search API request/response format. No changes to API key resolution logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36182

## User-visible / Behavior Changes

- Users can now set `tools.web.search.perplexity.baseUrl` to override the Perplexity Search API endpoint (e.g. for proxied deployments).
- Users can now set `tools.web.search.perplexity.model` to specify a Perplexity model variant in the search request body.
- No change for users who do not set these fields — the default endpoint `https://api.perplexity.ai/search` is used.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes — the Perplexity search endpoint URL can now be overridden via config. The request format and auth header handling are unchanged.`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22
- Integration/channel: Any (web_search tool)

### Steps

1. Configure `tools.web.search.perplexity.baseUrl` to a custom Perplexity API proxy endpoint
2. Configure `tools.web.search.perplexity.apiKey` with the key for that proxy
3. Ask the agent to search the web

### Expected

- Search request goes to `{baseUrl}/search` with the configured API key

### Actual

- Before fix: Request always sent to `https://api.perplexity.ai/search` regardless of `baseUrl` config, causing 401 with mismatched API keys
- After fix: Request sent to `{configured baseUrl}/search` with the correct API key

## Evidence

TypeScript compiles cleanly (`npx tsc --noEmit` — only pre-existing unrelated errors in `extensions/diffs` and `extensions/tlon`).

All 28 existing web-search tests pass:
```
✓ src/agents/tools/web-search.test.ts (28 tests) 4ms
Test Files  1 passed (1)
     Tests  28 passed (28)
```

The fix follows the exact same pattern as `KimiConfig` which already supports `baseUrl` and `model`:
```typescript
// KimiConfig (existing pattern)
type KimiConfig = { apiKey?: string; baseUrl?: string; model?: string; };

// PerplexityConfig (before)
type PerplexityConfig = { apiKey?: string; };

// PerplexityConfig (after — consistent with KimiConfig)
type PerplexityConfig = { apiKey?: string; baseUrl?: string; model?: string; };
```

## Human Verification (required)

- Verified scenarios: TypeScript compilation, all existing web-search tests, code review of the full call chain from config resolution through to HTTP request
- Edge cases checked: Trailing slash in baseUrl (stripped), empty/undefined baseUrl (defaults to native endpoint), empty/undefined model (omitted from request body)
- What I did **not** verify: End-to-end test with a live Perplexity API proxy (no access to one), behavior when baseUrl points to an incompatible API (e.g. OpenRouter chat completions — this would return a format error rather than 401, which is more actionable for the user)

## Compatibility / Migration

- Backward compatible? `Yes — no behavior change when baseUrl/model are not configured`
- Config/env changes? `No — new optional fields only`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `baseUrl` and `model` from `tools.web.search.perplexity` config — reverts to hardcoded endpoint behavior
- Files/config to restore: `src/agents/tools/web-search.ts`
- Known bad symptoms: If `baseUrl` points to an endpoint that doesn't support the `/search` format, users will get a non-401 error (e.g. 404 or format mismatch) which is more debuggable than the current silent 401

## Risks and Mitigations

- **Risk:** User sets `baseUrl` to an endpoint that doesn't implement the Perplexity Search API `/search` format (e.g. OpenRouter's chat completions API). **Mitigation:** The error will be a clear HTTP error from the target endpoint rather than a misleading 401 from the wrong server, making it easier to diagnose.

