### PR TITLE
fix(gateway): skip internal-channel label in deriveSessionOrigin

### DIFF
--- a/src/config/sessions/metadata.internal-label.test.ts
+++ b/src/config/sessions/metadata.internal-label.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../channels/dock.js", () => ({
+  getChannelDock: vi.fn(() => null),
+}));
+
+vi.mock("../../channels/plugins/index.js", () => ({
+  normalizeChannelId: vi.fn((id: string) => id),
+}));
+
+vi.mock("../../utils/message-channel.js", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+  };
+});
+
+import type { MsgContext } from "../../auto-reply/templating.js";
+import { deriveSessionOrigin, deriveSessionMetaPatch } from "./metadata.js";
+
+function buildCtx(overrides: Partial<MsgContext>): MsgContext {
+  return {
+    Provider: "webchat",
+    Surface: "webchat",
+    ChatType: "direct",
+    ...overrides,
+  } as MsgContext;
+}
+
+describe("deriveSessionOrigin skips label for internal channels", () => {
+  it("does not use client displayName as label when originating from webchat", () => {
+    const ctx = buildCtx({
+      OriginatingChannel: "webchat",
+      SenderName: "openclaw-tui",
+      ChatType: "direct",
+    });
+
+    const origin = deriveSessionOrigin(ctx);
+
+    expect(origin?.label).toBeUndefined();
+    expect(origin?.provider).toBe("webchat");
+  });
+
+  it("preserves label for external channels (telegram)", () => {
+    const ctx = buildCtx({
+      OriginatingChannel: "telegram",
+      Provider: "telegram",
+      Surface: "telegram",
+      SenderName: "John",
+      ChatType: "direct",
+    });
+
+    const origin = deriveSessionOrigin(ctx);
+
+    expect(origin?.label).toBe("John");
+    expect(origin?.provider).toBe("telegram");
+  });
+
+  it("preserves label for discord channels", () => {
+    const ctx = buildCtx({
+      OriginatingChannel: "discord",
+      Provider: "discord",
+      Surface: "discord",
+      SenderName: "Alice",
+      ChatType: "direct",
+    });
+
+    const origin = deriveSessionOrigin(ctx);
+
+    expect(origin?.label).toBe("Alice");
+    expect(origin?.provider).toBe("discord");
+  });
+
+  it("mergeOrigin does not overwrite existing label with internal channel label", () => {
+    const existingEntry = {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+      origin: {
+        label: "John",
+        provider: "telegram",
+      },
+    };
+
+    const ctx = buildCtx({
+      OriginatingChannel: "webchat",
+      SenderName: "openclaw-tui",
+      ChatType: "direct",
+    });
+
+    const patch = deriveSessionMetaPatch({
+      ctx,
+      sessionKey: "agent:main:telegram:direct:12345",
+      existing: existingEntry,
+    });
+
+    expect(patch?.origin?.label).toBe("John");
+  });
+
+  it("allows external channel to update existing label via merge", () => {
+    const existingEntry = {
+      sessionId: "s1",
+      updatedAt: Date.now(),
+      origin: {
+        label: "John",
+        provider: "telegram",
+      },
+    };
+
+    const ctx = buildCtx({
+      OriginatingChannel: "telegram",
+      Provider: "telegram",
+      Surface: "telegram",
+      SenderName: "John Doe",
+      ChatType: "direct",
+    });
+
+    const patch = deriveSessionMetaPatch({
+      ctx,
+      sessionKey: "agent:main:telegram:direct:12345",
+      existing: existingEntry,
+    });
+
+    expect(patch?.origin?.label).toBe("John Doe");
+  });
+});

--- a/src/config/sessions/metadata.ts
+++ b/src/config/sessions/metadata.ts
@@ -3,7 +3,7 @@ import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveConversationLabel } from "../../channels/conversation-label.js";
 import { getChannelDock } from "../../channels/dock.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
-import { normalizeMessageChannel } from "../../utils/message-channel.js";
+import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { buildGroupDisplayName, resolveGroupSessionKey } from "./group.js";
 import type { GroupKeyResolution, SessionEntry, SessionOrigin } from "./types.js";
 
@@ -43,12 +43,18 @@ const mergeOrigin = (
 };
 
 export function deriveSessionOrigin(ctx: MsgContext): SessionOrigin | undefined {
-  const label = resolveConversationLabel(ctx)?.trim();
   const providerRaw =
     (typeof ctx.OriginatingChannel === "string" && ctx.OriginatingChannel) ||
     ctx.Surface ||
     ctx.Provider;
   const provider = normalizeMessageChannel(providerRaw);
+
+  // When the message originates from an internal channel (webchat/TUI),
+  // the conversation label resolves to the client's displayName (e.g.
+  // "openclaw-tui").  Using that as origin.label would overwrite the
+  // session's real channel-based identity (e.g. "John" from Telegram).
+  const label =
+    provider === INTERNAL_MESSAGE_CHANNEL ? undefined : resolveConversationLabel(ctx)?.trim();
   const surface = ctx.Surface?.trim().toLowerCase();
   const chatType = normalizeChatType(ctx.ChatType) ?? undefined;
   const from = ctx.From?.trim();


### PR DESCRIPTION
## Summary

- Problem: When TUI or webchat sends a message to a channel-scoped session (e.g. `agent:main:telegram:direct:12345`), `deriveSessionOrigin` resolves the conversation label from `ctx.SenderName`, returning the TUI client's displayName ("openclaw-tui"). `mergeOrigin` then overwrites the session's real label (e.g. "John" from Telegram), causing ALL sessions in the Control UI to show "openclaw-tui".
- Why it matters: The Control UI sessions list becomes unusable — every session shows the same TUI client name instead of the actual user identity from each channel.
- What changed: `deriveSessionOrigin` now skips `resolveConversationLabel` when the originating channel is `INTERNAL_MESSAGE_CHANNEL` ("webchat"), so the client's displayName is not used as the session's `origin.label`.
- What did NOT change (scope boundary): `resolveConversationLabel`, `mergeOrigin`, group session handling, TUI client info, and `chat.send` are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33534

## User-visible / Behavior Changes

- Control UI sessions list now correctly shows each session's channel-specific displayName (e.g. Telegram user name) instead of "openclaw-tui" for all sessions.
- TUI/webchat messages to channel-scoped sessions no longer overwrite the session's origin label.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Configure a Telegram channel with a paired account.
2. Have at least one Telegram DM session active.
3. Connect via TUI: `openclaw tui`.
4. Open Control UI → Sessions.

### Expected

- Telegram session shows the Telegram user's name (e.g. "John").
- Main session shows "openclaw-tui".

### Actual

- Before: Both sessions show "openclaw-tui".
- After: Telegram session shows "John"; main session shows "openclaw-tui".

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

5 vitest unit tests in `metadata.internal-label.test.ts`:
- Internal channel (webchat) does not set origin label
- External channel (telegram) preserves label
- External channel (discord) preserves label
- mergeOrigin does not overwrite existing label with internal channel label
- External channel can still update existing label via merge

## Human Verification (required)

- Verified scenarios: TUI sending to main session; TUI sending to Telegram session; Telegram user sending directly.
- Edge cases checked: Internal channel with no SenderName; external channel label update via merge.
- What you did **not** verify: Multi-agent setups; group session label derivation (separate code path).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit. Internal channel messages will resume overwriting session labels.
- Files/config to restore: `src/config/sessions/metadata.ts`

## Risks and Mitigations

- Risk: Main session (`agent:main:main`) won't get a label from the TUI client anymore when it's the first message.
  - Mitigation: The main session already shows "openclaw-tui" via `clientDisplayName` in the session listing fallback chain; the `origin.label` is the last resort in `displayName` resolution, so this has no visible impact on main sessions.