### PR TITLE
telegram: wire polling activity into gateway health monitor

### DIFF
--- a/extensions/telegram/src/channel.test.ts
+++ b/extensions/telegram/src/channel.test.ts
@@ -137,18 +137,18 @@ describe("telegramPlugin duplicate token guard", () => {
       webhookPort: 9876,
     };
 
-    await telegramPlugin.gateway!.startAccount!(
-      createStartAccountCtx({
-        cfg,
-        accountId: "ops",
-        runtime: createRuntimeEnv(),
-      }),
-    );
+    const ctx = createStartAccountCtx({
+      cfg,
+      accountId: "ops",
+      runtime: createRuntimeEnv(),
+    });
+    await telegramPlugin.gateway!.startAccount!(ctx);
 
     expect(monitorTelegramProvider).toHaveBeenCalledWith(
       expect.objectContaining({
         useWebhook: true,
         webhookPort: 9876,
+        setStatus: ctx.setStatus,
       }),
     );
   });

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -492,6 +492,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         accountId: account.accountId,
         config: ctx.cfg,
         runtime: ctx.runtime,
+        setStatus: ctx.setStatus,
         abortSignal: ctx.abortSignal,
         useWebhook: Boolean(account.config.webhookUrl),
         webhookUrl: account.config.webhookUrl,

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -59,6 +59,15 @@ const { createTelegramBotErrors } = vi.hoisted(() => ({
   createTelegramBotErrors: [] as unknown[],
 }));
 
+const { createTelegramBotOptions } = vi.hoisted(() => ({
+  createTelegramBotOptions: [] as Array<{
+    updateOffset?: {
+      lastUpdateId?: number | null;
+      onUpdateId?: (updateId: number) => void | Promise<void>;
+    };
+  }>,
+}));
+
 const { createdBotStops } = vi.hoisted(() => ({
   createdBotStops: [] as Array<ReturnType<typeof vi.fn<() => void>>>,
 }));
@@ -69,6 +78,11 @@ const { computeBackoff, sleepWithAbort } = vi.hoisted(() => ({
 }));
 const { startTelegramWebhookSpy } = vi.hoisted(() => ({
   startTelegramWebhookSpy: vi.fn(async () => ({ server: { close: vi.fn() }, stop: vi.fn() })),
+}));
+
+const { readTelegramUpdateOffsetSpy, writeTelegramUpdateOffsetSpy } = vi.hoisted(() => ({
+  readTelegramUpdateOffsetSpy: vi.fn(async () => null),
+  writeTelegramUpdateOffsetSpy: vi.fn(async () => undefined),
 }));
 
 type RunnerStub = {
@@ -135,7 +149,13 @@ vi.mock("../config/config.js", async (importOriginal) => {
 });
 
 vi.mock("./bot.js", () => ({
-  createTelegramBot: () => {
+  createTelegramBot: (opts: {
+    updateOffset?: {
+      lastUpdateId?: number | null;
+      onUpdateId?: (updateId: number) => void | Promise<void>;
+    };
+  }) => {
+    createTelegramBotOptions.push(opts);
     const nextError = createTelegramBotErrors.shift();
     if (nextError) {
       throw nextError;
@@ -183,6 +203,11 @@ vi.mock("./webhook.js", () => ({
   startTelegramWebhook: startTelegramWebhookSpy,
 }));
 
+vi.mock("./update-offset-store.js", () => ({
+  readTelegramUpdateOffset: readTelegramUpdateOffsetSpy,
+  writeTelegramUpdateOffset: writeTelegramUpdateOffsetSpy,
+}));
+
 vi.mock("../auto-reply/reply.js", () => ({
   getReplyFromConfig: async (ctx: { Body?: string }) => ({
     text: `echo:${ctx.Body}`,
@@ -209,7 +234,10 @@ describe("monitorTelegramProvider (grammY)", () => {
     registerUnhandledRejectionHandlerMock.mockClear();
     resetUnhandledRejection();
     createTelegramBotErrors.length = 0;
+    createTelegramBotOptions.length = 0;
     createdBotStops.length = 0;
+    readTelegramUpdateOffsetSpy.mockReset().mockResolvedValue(null);
+    writeTelegramUpdateOffsetSpy.mockReset().mockResolvedValue(undefined);
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
@@ -256,6 +284,45 @@ describe("monitorTelegramProvider (grammY)", () => {
           retryInterval: "exponential",
         }),
       }),
+    );
+  });
+
+  it("pushes polling runtime status updates for health monitoring", async () => {
+    const setStatus = vi.fn();
+
+    await monitorWithAutoAbort({ setStatus });
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        mode: "polling",
+        connected: true,
+        lastConnectedAt: expect.any(Number),
+        lastEventAt: expect.any(Number),
+        lastError: null,
+      }),
+    );
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        connected: false,
+        lastEventAt: expect.any(Number),
+      }),
+    );
+
+    const offsetWriter = createTelegramBotOptions[0]?.updateOffset?.onUpdateId;
+    expect(offsetWriter).toBeTypeOf("function");
+    await offsetWriter?.(42);
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        lastInboundAt: expect.any(Number),
+        lastEventAt: expect.any(Number),
+      }),
+    );
+    expect(writeTelegramUpdateOffsetSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: "default", updateId: 42 }),
     );
   });
 

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -326,6 +326,41 @@ describe("monitorTelegramProvider (grammY)", () => {
     );
   });
 
+  it("pushes webhook inbound activity updates for health monitoring", async () => {
+    const abort = new AbortController();
+    const setStatus = vi.fn();
+    let onUpdateReceived: ((at?: number) => void) | undefined;
+    startTelegramWebhookSpy.mockImplementationOnce(
+      async (opts?: { onUpdateReceived?: typeof onUpdateReceived }) => {
+        onUpdateReceived = opts?.onUpdateReceived;
+        return { server: { close: vi.fn() }, stop: vi.fn() };
+      },
+    );
+
+    const monitor = monitorTelegramProvider({
+      token: "tok",
+      useWebhook: true,
+      webhookUrl: "https://example.test/telegram",
+      webhookSecret: "secret",
+      abortSignal: abort.signal,
+      setStatus,
+    });
+
+    await vi.waitFor(() => expect(startTelegramWebhookSpy).toHaveBeenCalledTimes(1));
+    onUpdateReceived?.(123);
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        lastInboundAt: 123,
+        lastEventAt: 123,
+      }),
+    );
+
+    abort.abort();
+    await monitor;
+  });
+
   it("requires mention in groups by default", async () => {
     Object.values(api).forEach((fn) => {
       fn?.mockReset?.();

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -1,4 +1,5 @@
 import { type RunOptions, run } from "@grammyjs/runner";
+import type { ChannelAccountSnapshot } from "../channels/plugins/types.js";
 import { resolveAgentMaxConcurrent } from "../config/agent-limits.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
@@ -30,6 +31,7 @@ export type MonitorTelegramOpts = {
   webhookHost?: string;
   proxyFetch?: typeof fetch;
   webhookUrl?: string;
+  setStatus?: (next: ChannelAccountSnapshot) => void;
 };
 
 export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
@@ -127,6 +129,18 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       cfg,
       accountId: opts.accountId,
     });
+    const setStatus = (next: ChannelAccountSnapshot) => {
+      opts.setStatus?.({
+        accountId: account.accountId,
+        ...next,
+      });
+    };
+    const markInboundActivity = (at = Date.now()) => {
+      setStatus({
+        lastInboundAt: at,
+        lastEventAt: at,
+      });
+    };
     const token = opts.token?.trim() || account.token;
     if (!token) {
       throw new Error(
@@ -146,6 +160,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         return;
       }
       lastUpdateId = updateId;
+      markInboundActivity();
       try {
         await writeTelegramUpdateOffset({
           accountId: account.accountId,
@@ -173,7 +188,19 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         abortSignal: opts.abortSignal,
         publicUrl: opts.webhookUrl,
       });
+      const connectedAt = Date.now();
+      setStatus({
+        mode: "webhook",
+        connected: true,
+        lastConnectedAt: connectedAt,
+        lastEventAt: connectedAt,
+        lastError: null,
+      });
       await waitForAbortSignal(opts.abortSignal);
+      setStatus({
+        connected: false,
+        lastEventAt: Date.now(),
+      });
       return;
     }
 
@@ -261,6 +288,14 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
     const runPollingCycle = async (bot: TelegramBot): Promise<"continue" | "exit"> => {
       const runner = run(bot, runnerOptions);
       activeRunner = runner;
+      const connectedAt = Date.now();
+      setStatus({
+        mode: "polling",
+        connected: true,
+        lastConnectedAt: connectedAt,
+        lastEventAt: connectedAt,
+        lastError: null,
+      });
       let stopPromise: Promise<void> | undefined;
       const stopRunner = () => {
         stopPromise ??= Promise.resolve(runner.stop())
@@ -314,6 +349,10 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         );
         return shouldRestart ? "continue" : "exit";
       } finally {
+        setStatus({
+          connected: false,
+          lastEventAt: Date.now(),
+        });
         opts.abortSignal?.removeEventListener("abort", stopOnAbort);
         await stopRunner();
         await stopBot();

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -34,6 +34,8 @@ export type MonitorTelegramOpts = {
   setStatus?: (next: ChannelAccountSnapshot) => void;
 };
 
+type ChannelAccountStatusPatch = Omit<ChannelAccountSnapshot, "accountId">;
+
 export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
   return {
     sink: {
@@ -129,7 +131,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       cfg,
       accountId: opts.accountId,
     });
-    const setStatus = (next: ChannelAccountSnapshot) => {
+    const setStatus = (next: ChannelAccountStatusPatch) => {
       opts.setStatus?.({
         accountId: account.accountId,
         ...next,
@@ -187,6 +189,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         fetch: proxyFetch,
         abortSignal: opts.abortSignal,
         publicUrl: opts.webhookUrl,
+        onUpdateReceived: markInboundActivity,
       });
       const connectedAt = Date.now();
       setStatus({

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -356,6 +356,7 @@ describe("startTelegramWebhook", () => {
   it("invokes webhook handler on matching path", async () => {
     handlerSpy.mockClear();
     createTelegramBotSpy.mockClear();
+    const onUpdateReceived = vi.fn();
     const cfg = { bindings: [] };
     await withStartedWebhook(
       {
@@ -363,6 +364,7 @@ describe("startTelegramWebhook", () => {
         accountId: "opie",
         config: cfg,
         path: TELEGRAM_WEBHOOK_PATH,
+        onUpdateReceived,
       },
       async ({ port }) => {
         expect(createTelegramBotSpy).toHaveBeenCalledWith(
@@ -379,6 +381,7 @@ describe("startTelegramWebhook", () => {
         });
         expect(response.status).toBe(200);
         expect(handlerSpy).toHaveBeenCalled();
+        expect(onUpdateReceived).toHaveBeenCalledTimes(1);
       },
     );
   });

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -386,6 +386,43 @@ describe("startTelegramWebhook", () => {
     );
   });
 
+  it("does not mark activity when webhook secret verification fails", async () => {
+    const onUpdateReceived = vi.fn();
+    webhookCallbackSpy.mockImplementationOnce(
+      () =>
+        vi.fn(
+          async (
+            _update: unknown,
+            _reply: (json: string) => Promise<void>,
+            secretHeader: string | undefined,
+            unauthorized: () => Promise<void>,
+          ) => {
+            if (secretHeader !== TELEGRAM_SECRET) {
+              await unauthorized();
+            }
+          },
+        ) as unknown as typeof handlerSpy,
+    );
+
+    await withStartedWebhook(
+      {
+        secret: TELEGRAM_SECRET,
+        path: TELEGRAM_WEBHOOK_PATH,
+        onUpdateReceived,
+      },
+      async ({ port }) => {
+        const payload = JSON.stringify({ update_id: 2, message: { text: "hello" } });
+        const response = await postWebhookJson({
+          url: webhookUrl(port, TELEGRAM_WEBHOOK_PATH),
+          payload,
+          secret: "wrong-secret",
+        });
+        expect(response.status).toBe(401);
+        expect(onUpdateReceived).not.toHaveBeenCalled();
+      },
+    );
+  });
+
   it("rejects startup when webhook secret is missing", async () => {
     await expect(
       startTelegramWebhook({

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -87,6 +87,7 @@ export async function startTelegramWebhook(opts: {
   abortSignal?: AbortSignal;
   healthPath?: string;
   publicUrl?: string;
+  onUpdateReceived?: (at?: number) => void;
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
@@ -168,6 +169,7 @@ export async function startTelegramWebhook(opts: {
         respondText(400, body.error);
         return;
       }
+      opts.onUpdateReceived?.(Date.now());
 
       let replied = false;
       const reply = async (json: string) => {

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -169,9 +169,8 @@ export async function startTelegramWebhook(opts: {
         respondText(400, body.error);
         return;
       }
-      opts.onUpdateReceived?.(Date.now());
-
       let replied = false;
+      let unauthorizedRequest = false;
       const reply = async (json: string) => {
         if (replied) {
           return;
@@ -187,6 +186,7 @@ export async function startTelegramWebhook(opts: {
         if (replied) {
           return;
         }
+        unauthorizedRequest = true;
         replied = true;
         respondText(401, "unauthorized");
       };
@@ -194,6 +194,9 @@ export async function startTelegramWebhook(opts: {
       const secretHeader = Array.isArray(secretHeaderRaw) ? secretHeaderRaw[0] : secretHeaderRaw;
 
       await handler(body.value, reply, secretHeader, unauthorized);
+      if (!unauthorizedRequest) {
+        opts.onUpdateReceived?.(Date.now());
+      }
       if (!replied) {
         respondText(200);
       }


### PR DESCRIPTION
## Summary
- forward `ctx.setStatus` from the Telegram channel gateway adapter into `monitorTelegramProvider`
- publish Telegram runtime health status during provider lifecycle (`connected`, `lastConnectedAt`, `lastEventAt`, `mode`)
- mark inbound activity when polling updates advance offset, so health monitor can detect real inactivity per account
- add focused tests for status propagation in Telegram monitor and extension channel startup wiring

## Testing
- pnpm test -- src/telegram/monitor.test.ts extensions/telegram/src/channel.test.ts

Fixes #36259
