### PR TITLE
fix(gateway): auto-create transcript file for chat.inject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
+- Gateway/chat.inject transcript resilience: create missing transcript files on `chat.inject` writes (instead of hard-failing with `transcript file not found`) so ACP and other sessions with missing transcript files can recover and persist injected messages. (#36170) Thanks @See-Cat.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -303,6 +303,41 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(extractFirstTextBlock(chatCall?.[1])).toBe("");
   });
 
+  it("chat.inject creates transcript file when session metadata points to a missing file", async () => {
+    createTranscriptFixture("openclaw-chat-inject-missing-transcript-");
+    fs.rmSync(mockState.transcriptPath, { force: true });
+    expect(fs.existsSync(mockState.transcriptPath)).toBe(false);
+
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await chatHandlers["chat.inject"]({
+      params: { sessionKey: "main", message: "hello from inject" },
+      respond,
+      req: {} as never,
+      client: null as never,
+      isWebchatConnect: () => false,
+      context: context as GatewayRequestContext,
+    });
+
+    expect(respond).toHaveBeenCalled();
+    const [ok, payload, error] = respond.mock.calls.at(-1) ?? [];
+    expect(ok).toBe(true);
+    expect(error).toBeUndefined();
+    expect(payload).toMatchObject({ ok: true, messageId: expect.any(String) });
+    const transcriptDir = path.dirname(mockState.transcriptPath);
+    const createdJsonl = fs
+      .readdirSync(transcriptDir)
+      .filter((entry) => entry.endsWith(".jsonl"))
+      .map((entry) => path.join(transcriptDir, entry));
+    expect(createdJsonl.length).toBeGreaterThan(0);
+
+    const lines = fs.readFileSync(createdJsonl[0], "utf-8").split(/\r?\n/).filter(Boolean);
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    const last = JSON.parse(lines.at(-1) as string) as Record<string, unknown>;
+    expect(last.type).toBe("message");
+  });
+
   it("chat.send non-streaming final keeps message defined for directive-only assistant text", async () => {
     createTranscriptFixture("openclaw-chat-send-directive-only-");
     mockState.finalText = "[[reply_to_current]]";

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1142,7 +1142,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       storePath,
       sessionFile: entry?.sessionFile,
       agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
-      createIfMissing: false,
+      createIfMissing: true,
     });
     if (!appended.ok || !appended.messageId || !appended.message) {
       respond(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `chat.inject` failed with `transcript file not found` when session metadata had a valid transcript path but the file itself was missing.
- Why it matters: injected messages could not be persisted, which broke `chat.history`/session history continuity for affected sessions.
- What changed: switched `chat.inject` transcript append path to `createIfMissing: true` and added regression coverage for missing transcript files.
- What did NOT change (scope boundary): no changes to normal inject flow when transcript file already exists; no changes to `chat.send` behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36170
- Related #27508

## User-visible / Behavior Changes

- `chat.inject` now auto-creates the session transcript file when it is missing and proceeds with message injection.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): gateway chat RPC
- Relevant config (redacted): default local test config

### Steps

1. Create a session fixture and remove the underlying transcript file while keeping metadata (`sessionFile`) present.
2. Call `chat.inject` with `sessionKey` + message.
3. Inspect response and resulting transcript files.

### Expected

- `chat.inject` succeeds.
- A transcript file is created and the injected message is appended.

### Actual

- Matches expected after this change.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: new test `chat.inject creates transcript file when session metadata points to a missing file` passes.
- Edge cases checked: transcript file is absent before call, then created with a message entry after inject.
- What you did **not** verify: live ACP gateway run on a real external environment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Gateway: create transcript file for chat.inject`.
- Files/config to restore: `src/gateway/server-methods/chat.ts`, `src/gateway/server-methods/chat.directive-tags.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: `chat.inject` unexpectedly failing on missing transcript files.

## Risks and Mitigations

- Risk: creating transcripts on inject could use a normalized path that differs from stale session metadata path.
  - Mitigation: regression test validates successful creation + appended message in the resolved session directory.
