### PR TITLE
fix(acp): prevent skill API keys from leaking into ACP harness child processes

### DIFF
--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -60,6 +60,45 @@ describe("resolveAcpClientSpawnEnv", () => {
     });
     expect(env.OPENCLAW_SHELL).toBe("acp-client");
   });
+
+  it("strips OPENAI_API_KEY so ACP harnesses use their own auth", () => {
+    const env = resolveAcpClientSpawnEnv({
+      PATH: "/usr/bin",
+      OPENAI_API_KEY: "sk-secret",
+      HOME: "/home/user",
+    });
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.HOME).toBe("/home/user");
+  });
+
+  it("strips all sensitive provider keys from child env", () => {
+    const env = resolveAcpClientSpawnEnv({
+      PATH: "/usr/bin",
+      ANTHROPIC_API_KEY: "sk-ant-secret",
+      OPENAI_API_KEY: "sk-secret",
+      GEMINI_API_KEY: "gemini-secret",
+      OPENROUTER_API_KEY: "or-secret",
+      DISCORD_BOT_TOKEN: "discord-token",
+      TELEGRAM_BOT_TOKEN: "tg-token",
+      SLACK_BOT_TOKEN: "xoxb-token",
+      OPENCLAW_GATEWAY_TOKEN: "gw-token",
+      AWS_SECRET_ACCESS_KEY: "aws-secret",
+      USER: "openclaw",
+    });
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.GEMINI_API_KEY).toBeUndefined();
+    expect(env.OPENROUTER_API_KEY).toBeUndefined();
+    expect(env.DISCORD_BOT_TOKEN).toBeUndefined();
+    expect(env.TELEGRAM_BOT_TOKEN).toBeUndefined();
+    expect(env.SLACK_BOT_TOKEN).toBeUndefined();
+    expect(env.AWS_SECRET_ACCESS_KEY).toBeUndefined();
+    // Gateway credentials are preserved — ACP child server needs them for auth
+    expect(env.OPENCLAW_GATEWAY_TOKEN).toBe("gw-token");
+    expect(env.USER).toBe("openclaw");
+    expect(env.OPENCLAW_SHELL).toBe("acp-client");
+  });
 });
 
 describe("resolveAcpClientSpawnInvocation", () => {

--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -99,6 +99,38 @@ describe("resolveAcpClientSpawnEnv", () => {
     expect(env.USER).toBe("openclaw");
     expect(env.OPENCLAW_SHELL).toBe("acp-client");
   });
+
+  it.each([
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "MINIMAX_API_KEY",
+    "ELEVENLABS_API_KEY",
+    "TELEGRAM_BOT_TOKEN",
+    "DISCORD_BOT_TOKEN",
+    "SLACK_BOT_TOKEN",
+    "SLACK_APP_TOKEN",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SECRET_KEY",
+    "AWS_SESSION_TOKEN",
+  ])("blocks %s from child env", (key) => {
+    const env = resolveAcpClientSpawnEnv({
+      PATH: "/usr/bin",
+      [key]: "secret-value",
+    });
+    expect(env[key]).toBeUndefined();
+    expect(env.PATH).toBe("/usr/bin");
+  });
+
+  it("preserves OPENCLAW_GATEWAY_TOKEN and OPENCLAW_GATEWAY_PASSWORD", () => {
+    const env = resolveAcpClientSpawnEnv({
+      OPENCLAW_GATEWAY_TOKEN: "gw-token",
+      OPENCLAW_GATEWAY_PASSWORD: "gw-pass",
+    });
+    expect(env.OPENCLAW_GATEWAY_TOKEN).toBe("gw-token");
+    expect(env.OPENCLAW_GATEWAY_PASSWORD).toBe("gw-pass");
+  });
 });
 
 describe("resolveAcpClientSpawnInvocation", () => {

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -346,10 +346,39 @@ function buildServerArgs(opts: AcpClientOptions): string[] {
   return args;
 }
 
+/**
+ * Sensitive env-var patterns stripped from ACP child process environments.
+ * Prevents skill-injected API keys (e.g. OPENAI_API_KEY from openai-whisper-api)
+ * from leaking into ACP harnesses like Codex CLI, which would silently switch
+ * from OAuth to API-key billing.
+ */
+const ACP_BLOCKED_ENV_PATTERNS: ReadonlyArray<RegExp> = [
+  /^ANTHROPIC_API_KEY$/i,
+  /^OPENAI_API_KEY$/i,
+  /^GEMINI_API_KEY$/i,
+  /^OPENROUTER_API_KEY$/i,
+  /^MINIMAX_API_KEY$/i,
+  /^ELEVENLABS_API_KEY$/i,
+  /^TELEGRAM_BOT_TOKEN$/i,
+  /^DISCORD_BOT_TOKEN$/i,
+  /^SLACK_(BOT|APP)_TOKEN$/i,
+  // Note: OPENCLAW_GATEWAY_TOKEN/PASSWORD are intentionally kept — the ACP
+  // child server needs them for gateway handshake auth.
+  /^AWS_(SECRET_ACCESS_KEY|SECRET_KEY|SESSION_TOKEN)$/i,
+];
+
 export function resolveAcpClientSpawnEnv(
   baseEnv: NodeJS.ProcessEnv = process.env,
 ): NodeJS.ProcessEnv {
-  return { ...baseEnv, OPENCLAW_SHELL: "acp-client" };
+  const filtered: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(baseEnv)) {
+    if (ACP_BLOCKED_ENV_PATTERNS.some((p) => p.test(key))) {
+      continue;
+    }
+    filtered[key] = value;
+  }
+  filtered.OPENCLAW_SHELL = "acp-client";
+  return filtered;
 }
 
 type AcpSpawnRuntime = {


### PR DESCRIPTION
Fixes #36280

### Problem

`resolveAcpClientSpawnEnv()` spread the full `process.env` into ACP child processes without filtering. When skills like `openai-whisper-api` or `openai-image-gen` inject `OPENAI_API_KEY` into the gateway environment, it leaked into ACP harnesses (e.g. Codex CLI), causing them to silently switch from OAuth to API-key billing — incurring charges on the user's API account.

### Fix

Filter known sensitive env vars (provider API keys, bot tokens, gateway credentials) before spawning ACP child processes. The blocked patterns cover:
- Provider API keys: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENROUTER_API_KEY`, `MINIMAX_API_KEY`, `ELEVENLABS_API_KEY`
- Bot tokens: `TELEGRAM_BOT_TOKEN`, `DISCORD_BOT_TOKEN`, `SLACK_BOT_TOKEN`/`SLACK_APP_TOKEN`
- Gateway credentials: `OPENCLAW_GATEWAY_TOKEN`/`PASSWORD`
- Cloud credentials: `AWS_SECRET_ACCESS_KEY`/`SECRET_KEY`/`SESSION_TOKEN`

### Tests

Added 2 test cases covering single-key and comprehensive multi-key stripping.