### PR TITLE
perf(media): avoid second-pass chunk conversion in response reader

### DIFF
--- a/src/media/read-response-with-limit.test.ts
+++ b/src/media/read-response-with-limit.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { readResponseWithLimit } from "./read-response-with-limit.js";
+
+describe("readResponseWithLimit", () => {
+  it("concatenates streamed chunks in order", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.enqueue(new Uint8Array([4, 5]));
+        controller.close();
+      },
+    });
+
+    const res = new Response(stream, { status: 200 });
+    const output = await readResponseWithLimit(res, 10);
+
+    expect([...output]).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("cancels the reader when payload exceeds limit", async () => {
+    let canceled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3, 4]));
+        controller.enqueue(new Uint8Array([5, 6, 7, 8]));
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+
+    await expect(readResponseWithLimit(new Response(stream, { status: 200 }), 6)).rejects.toThrow(
+      "Content too large",
+    );
+
+    expect(canceled).toBe(true);
+  });
+});

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -20,7 +20,7 @@ export async function readResponseWithLimit(
   }
 
   const reader = body.getReader();
-  const chunks: Uint8Array[] = [];
+  const chunks: Buffer[] = [];
   let total = 0;
   try {
     while (true) {
@@ -29,14 +29,15 @@ export async function readResponseWithLimit(
         break;
       }
       if (value?.length) {
-        total += value.length;
+        const chunk = Buffer.from(value);
+        total += chunk.length;
         if (total > maxBytes) {
           try {
             await reader.cancel();
           } catch {}
           throw onOverflow({ size: total, maxBytes, res });
         }
-        chunks.push(value);
+        chunks.push(chunk);
       }
     }
   } finally {
@@ -45,8 +46,5 @@ export async function readResponseWithLimit(
     } catch {}
   }
 
-  return Buffer.concat(
-    chunks.map((chunk) => Buffer.from(chunk)),
-    total,
-  );
+  return Buffer.concat(chunks, total);
 }


### PR DESCRIPTION
## Summary\n- convert streamed chunks to `Buffer` once during read instead of converting in a second pass\n- pass the `Buffer[]` directly to `Buffer.concat` with the tracked total size\n- add focused tests for ordered chunk concatenation and overflow-triggered stream cancellation\n\n## Why\n`readResponseWithLimit` sits on the media fetch path. The previous implementation performed an extra full pass over chunks and temporary allocations right before concat.\n\n## Validation\n- `pnpm vitest run src/media/read-response-with-limit.test.ts src/media/fetch.test.ts`