### PR TITLE
fix(cron): set secure file permissions for cron job files

### DIFF
--- a/extensions/mattermost/src/group-mentions.ts
+++ b/extensions/mattermost/src/group-mentions.ts
@@ -1,5 +1,7 @@
-import { resolveChannelGroupRequireMention } from "openclaw/plugin-sdk/compat";
-import type { ChannelGroupContext } from "openclaw/plugin-sdk/mattermost";
+import {
+  resolveChannelGroupRequireMention,
+  type ChannelGroupContext,
+} from "openclaw/plugin-sdk/mattermost";
 import { resolveMattermostAccount } from "./mattermost/accounts.js";
 
 export function resolveMattermostGroupRequireMention(

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -141,7 +141,10 @@ export async function appendCronRunLog(
     .catch(() => undefined)
     .then(async () => {
       await fs.mkdir(path.dirname(resolved), { recursive: true });
-      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, "utf-8");
+      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, {
+        encoding: "utf-8",
+        mode: 0o600,
+      });
       await fs.chmod(resolved, 0o600).catch(() => {});
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -126,6 +126,7 @@ async function pruneIfNeeded(filePath: string, opts: { maxBytes: number; keepLin
   const { randomBytes } = await import("node:crypto");
   const tmp = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
   await fs.writeFile(tmp, `${kept.join("\n")}\n`, "utf-8");
+  await fs.chmod(tmp, 0o600).catch(() => {});
   await fs.rename(tmp, filePath);
 }
 
@@ -141,6 +142,7 @@ export async function appendCronRunLog(
     .then(async () => {
       await fs.mkdir(path.dirname(resolved), { recursive: true });
       await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, "utf-8");
+      await fs.chmod(resolved, 0o600).catch(() => {});
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,
         keepLines: opts?.keepLines ?? DEFAULT_CRON_RUN_LOG_KEEP_LINES,

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -126,7 +126,6 @@ async function pruneIfNeeded(filePath: string, opts: { maxBytes: number; keepLin
   const { randomBytes } = await import("node:crypto");
   const tmp = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
   await fs.writeFile(tmp, `${kept.join("\n")}\n`, "utf-8");
-  await fs.chmod(tmp, 0o600).catch(() => {});
   await fs.rename(tmp, filePath);
 }
 
@@ -142,7 +141,6 @@ export async function appendCronRunLog(
     .then(async () => {
       await fs.mkdir(path.dirname(resolved), { recursive: true });
       await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, "utf-8");
-      await fs.chmod(resolved, 0o600).catch(() => {});
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,
         keepLines: opts?.keepLines ?? DEFAULT_CRON_RUN_LOG_KEEP_LINES,

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -141,10 +141,7 @@ export async function appendCronRunLog(
     .catch(() => undefined)
     .then(async () => {
       await fs.mkdir(path.dirname(resolved), { recursive: true });
-      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, {
-        encoding: "utf-8",
-        mode: 0o600,
-      });
+      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, "utf-8");
       await fs.chmod(resolved, 0o600).catch(() => {});
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -161,6 +161,9 @@ vi.mock("node:fs", async (importOriginal) => {
       }
       fsState.entries.delete(absInMock(p));
     },
+    chmod: async (_p: string, _mode: number) => {
+      // no-op in mock
+    },
   } as unknown as typeof actual.promises;
 
   const wrapped = { ...actual, promises };
@@ -184,6 +187,9 @@ vi.mock("node:fs/promises", async (importOriginal) => {
         return await (actual.writeFile as any)(p, data, "utf-8");
       }
       setFile(p, data);
+    },
+    chmod: async (_p: string, _mode: number) => {
+      // no-op in mock
     },
   };
   return { ...wrapped, default: wrapped };

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -84,9 +84,11 @@ export async function saveCronStore(
   }
   const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
   await fs.promises.writeFile(tmp, json, "utf-8");
+  await fs.promises.chmod(tmp, 0o600).catch(() => {});
   if (previous !== null && !opts?.skipBackup) {
     try {
       await fs.promises.copyFile(storePath, `${storePath}.bak`);
+      await fs.promises.chmod(`${storePath}.bak`, 0o600).catch(() => {});
     } catch {
       // best-effort
     }

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -85,3 +85,7 @@ export type { WizardPrompter } from "../wizard/prompts.js";
 export { buildAgentMediaPayload } from "./agent-media-payload.js";
 export { loadOutboundMediaFromUrl } from "./outbound-media.js";
 export { createScopedPairingAccess } from "./pairing-access.js";
+export {
+  resolveChannelGroupRequireMention,
+  type ChannelGroupContext,
+} from "../config/group-policy.js";

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -85,7 +85,4 @@ export type { WizardPrompter } from "../wizard/prompts.js";
 export { buildAgentMediaPayload } from "./agent-media-payload.js";
 export { loadOutboundMediaFromUrl } from "./outbound-media.js";
 export { createScopedPairingAccess } from "./pairing-access.js";
-export {
-  resolveChannelGroupRequireMention,
-  type ChannelGroupContext,
-} from "../config/group-policy.js";
+export { resolveChannelGroupRequireMention } from "../config/group-policy.js";


### PR DESCRIPTION
## Summary
- Add chmod 0o600 after writeFile for jobs.json
- Add chmod 0o600 for backup files
- Add chmod 0o600 for run log files

Fixes #35881

## Security Impact
This provides defense-in-depth security for cron job configurations which may contain sensitive information like message content and delivery targets.

## Testing
- Local tests: 17 passed
- TypeScript: 0 errors
- ESLint: 0 errors