### PR TITLE
fix(cron): create cron dirs with 0700 and files with 0600 permissions

### DIFF
--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -139,8 +139,8 @@ export async function appendCronRunLog(
   const next = prev
     .catch(() => undefined)
     .then(async () => {
-      await fs.mkdir(path.dirname(resolved), { recursive: true });
-      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, "utf-8");
+      await fs.mkdir(path.dirname(resolved), { recursive: true, mode: 0o700 });
+      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, { encoding: "utf-8", mode: 0o600 });
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,
         keepLines: opts?.keepLines ?? DEFAULT_CRON_RUN_LOG_KEEP_LINES,

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -125,7 +125,7 @@ async function pruneIfNeeded(filePath: string, opts: { maxBytes: number; keepLin
   const kept = lines.slice(Math.max(0, lines.length - opts.keepLines));
   const { randomBytes } = await import("node:crypto");
   const tmp = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.writeFile(tmp, `${kept.join("\n")}\n`, "utf-8");
+  await fs.writeFile(tmp, `${kept.join("\n")}\n`, { encoding: "utf-8", mode: 0o600 });
   await fs.rename(tmp, filePath);
 }
 

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -140,7 +140,10 @@ export async function appendCronRunLog(
     .catch(() => undefined)
     .then(async () => {
       await fs.mkdir(path.dirname(resolved), { recursive: true, mode: 0o700 });
-      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, { encoding: "utf-8", mode: 0o600 });
+      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, {
+        encoding: "utf-8",
+        mode: 0o600,
+      });
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,
         keepLines: opts?.keepLines ?? DEFAULT_CRON_RUN_LOG_KEEP_LINES,

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -86,7 +86,8 @@ export async function saveCronStore(
   await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: 0o600 });
   if (previous !== null && !opts?.skipBackup) {
     try {
-      await fs.promises.copyFile(storePath, `${storePath}.bak`);
+      const bakContent = await fs.promises.readFile(storePath);
+      await fs.promises.writeFile(`${storePath}.bak`, bakContent, { mode: 0o600 });
     } catch {
       // best-effort
     }

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -61,7 +61,7 @@ export async function saveCronStore(
   store: CronStoreFile,
   opts?: SaveCronStoreOptions,
 ) {
-  await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.promises.mkdir(path.dirname(storePath), { recursive: true, mode: 0o700 });
   const json = JSON.stringify(store, null, 2);
   const cached = serializedStoreCache.get(storePath);
   if (cached === json) {
@@ -83,7 +83,7 @@ export async function saveCronStore(
     return;
   }
   const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.promises.writeFile(tmp, json, "utf-8");
+  await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: 0o600 });
   if (previous !== null && !opts?.skipBackup) {
     try {
       await fs.promises.copyFile(storePath, `${storePath}.bak`);


### PR DESCRIPTION
## Summary

- Cron job files (`jobs.json`, `jobs.json.bak`, `runs/*.jsonl`) were created with default `0644` permissions, exposing cron schedules and message content to other users on shared systems
- The `runs/` directory was created with `0755` (world-readable)
- Fix: pass `mode: 0o700` to `mkdir` calls and `mode: 0o600` to `writeFile`/`appendFile` calls in `src/cron/store.ts` and `src/cron/run-log.ts`

## Details

The parent directory `~/.openclaw/cron/` is already `0700`, so in practice files were not accessible. This is a defense-in-depth fix to ensure files are private from the moment of creation, regardless of parent directory state.

## Files changed

- `src/cron/store.ts`: `mkdir` → `mode: 0o700`, `writeFile` → `mode: 0o600`
- `src/cron/run-log.ts`: `mkdir` → `mode: 0o700`, `appendFile` → `mode: 0o600`

## Test plan

- [ ] Create a cron job and verify `jobs.json`, `jobs.json.bak` are created with `0600`
- [ ] Verify `runs/` directory is created with `0700`
- [ ] Verify `runs/*.jsonl` files are created with `0600`
- [ ] Verify cron jobs still execute normally

Fixes #35881