### PR TITLE
fix(skills): prevent skill apiKey env vars from leaking to ACP harness child processes

### DIFF
--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -10,6 +10,17 @@ import {
 } from "./client.js";
 import { extractAttachmentsFromPrompt, extractTextFromPrompt } from "./event-mapper.js";
 
+vi.mock("../agents/skills/env-overrides.js", () => {
+  const keys = new Set<string>();
+  return {
+    getActiveSkillEnvKeys: () => keys,
+    __setActiveSkillEnvKeysForTest: (newKeys: string[]) => {
+      keys.clear();
+      for (const k of newKeys) keys.add(k);
+    },
+  };
+});
+
 function makePermissionRequest(
   overrides: Partial<RequestPermissionRequest> = {},
 ): RequestPermissionRequest {
@@ -59,6 +70,30 @@ describe("resolveAcpClientSpawnEnv", () => {
       OPENCLAW_SHELL: "wrong",
     });
     expect(env.OPENCLAW_SHELL).toBe("acp-client");
+  });
+
+  it("strips env vars injected by active skill overrides", async () => {
+    const mod = await import("../agents/skills/env-overrides.js");
+    const setKeys = (mod as Record<string, unknown>).__setActiveSkillEnvKeysForTest as (
+      keys: string[],
+    ) => void;
+    setKeys(["OPENAI_API_KEY", "CUSTOM_SKILL_TOKEN"]);
+
+    const env = resolveAcpClientSpawnEnv({
+      PATH: "/usr/bin",
+      OPENAI_API_KEY: "sk-proj-leaked",
+      CUSTOM_SKILL_TOKEN: "secret",
+      HOME: "/home/user",
+    });
+
+    expect(env.PATH).toBe("/usr/bin");
+    expect(env.HOME).toBe("/home/user");
+    expect(env.OPENCLAW_SHELL).toBe("acp-client");
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.CUSTOM_SKILL_TOKEN).toBeUndefined();
+
+    // Clean up
+    setKeys([]);
   });
 });
 

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -14,6 +14,7 @@ import {
   type SessionNotification,
 } from "@agentclientprotocol/sdk";
 import { isKnownCoreToolId } from "../agents/tool-catalog.js";
+import { getActiveSkillEnvKeys } from "../agents/skills/env-overrides.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import {
   materializeWindowsSpawnProgram,
@@ -349,7 +350,16 @@ function buildServerArgs(opts: AcpClientOptions): string[] {
 export function resolveAcpClientSpawnEnv(
   baseEnv: NodeJS.ProcessEnv = process.env,
 ): NodeJS.ProcessEnv {
-  return { ...baseEnv, OPENCLAW_SHELL: "acp-client" };
+  // Strip env vars injected by skill overrides so ACP harnesses (e.g. Codex CLI)
+  // inherit a clean environment and use their own auth instead of leaked skill keys.
+  const skillKeys = getActiveSkillEnvKeys();
+  const cleaned: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(baseEnv)) {
+    if (!skillKeys.has(key)) {
+      cleaned[key] = value;
+    }
+  }
+  return { ...cleaned, OPENCLAW_SHELL: "acp-client" };
 }
 
 type AcpSpawnRuntime = {

--- a/src/agents/auth-profiles/credential-state.ts
+++ b/src/agents/auth-profiles/credential-state.ts
@@ -39,7 +39,11 @@ export function evaluateStoredCredentialEligibility(params: {
   const credential = params.credential;
 
   if (credential.type === "api_key") {
-    const hasKey = hasConfiguredSecretString(credential.key);
+    // Support both 'key' (canonical) and 'apiKey' (legacy/alias) field names
+    const legacyApiKey = (credential as Record<string, unknown>).apiKey;
+    const keyValue =
+      credential.key ?? (typeof legacyApiKey === "string" ? legacyApiKey : undefined);
+    const hasKey = hasConfiguredSecretString(keyValue);
     const hasKeyRef = hasConfiguredSecretRef(credential.keyRef);
     if (!hasKey && !hasKeyRef) {
       return { eligible: false, reasonCode: "missing_credential" };

--- a/src/agents/auth-profiles/oauth.test.ts
+++ b/src/agents/auth-profiles/oauth.test.ts
@@ -394,3 +394,56 @@ describe("resolveApiKeyForProfile secret refs", () => {
     }
   });
 });
+
+describe("resolveApiKeyForProfile with legacy apiKey field (#34654)", () => {
+  it("resolves api_key credentials using apiKey field", async () => {
+    const profileId = "google:default";
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [profileId]: {
+          type: "api_key",
+          provider: "google",
+          apiKey: "AIzaSy...",
+        } as AuthProfileStore["profiles"][string],
+      },
+    };
+
+    const result = await resolveApiKeyForProfile({
+      store,
+      profileId,
+    });
+
+    expect(result).toEqual({
+      apiKey: "AIzaSy...",
+      provider: "google",
+      email: undefined,
+    });
+  });
+
+  it("prefers canonical key field over apiKey alias", async () => {
+    const profileId = "anthropic:default";
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [profileId]: {
+          type: "api_key",
+          provider: "anthropic",
+          key: "sk-ant-canonical",
+          apiKey: "sk-ant-alias",
+        } as AuthProfileStore["profiles"][string],
+      },
+    };
+
+    const result = await resolveApiKeyForProfile({
+      store,
+      profileId,
+    });
+
+    expect(result).toEqual({
+      apiKey: "sk-ant-canonical",
+      provider: "anthropic",
+      email: undefined,
+    });
+  });
+});

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -310,10 +310,13 @@ export async function resolveApiKeyForProfile(
   const refDefaults = configForRefResolution.secrets?.defaults;
 
   if (cred.type === "api_key") {
+    // Support both 'key' (canonical) and 'apiKey' (legacy/alias) field names
+    const legacyApiKey = (cred as Record<string, unknown>).apiKey;
+    const keyValue = cred.key ?? (typeof legacyApiKey === "string" ? legacyApiKey : undefined);
     const key = await resolveProfileSecretString({
       profileId,
       provider: cred.provider,
-      value: cred.key,
+      value: keyValue,
       valueRef: cred.keyRef,
       refDefaults,
       configForRefResolution,

--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -22,4 +22,36 @@ describe("resolveAuthProfileOrder", () => {
 
     expect(order).toEqual(["volcengine:default"]);
   });
+
+  it("resolves api_key profiles using both apiKey and key fields (#34654)", () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "google:default": {
+          type: "api_key",
+          provider: "google",
+          apiKey: "AIzaSy...",
+        } as AuthProfileStore["profiles"][string],
+        "anthropic:default": {
+          type: "api_key",
+          provider: "anthropic",
+          key: "sk-ant-...",
+        },
+      },
+    };
+
+    const order = resolveAuthProfileOrder({
+      store,
+      provider: "google",
+    });
+
+    expect(order).toEqual(["google:default"]);
+
+    const anthropicOrder = resolveAuthProfileOrder({
+      store,
+      provider: "anthropic",
+    });
+
+    expect(anthropicOrder).toEqual(["anthropic:default"]);
+  });
 });

--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -104,7 +104,23 @@ describe("buildAssistantMessage", () => {
     expect(result.usage.totalTokens).toBe(15);
   });
 
-  it("falls back to reasoning when content is empty", () => {
+  it("falls back to thinking when content is empty", () => {
+    const response = {
+      model: "kimi-k2.5",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content: "",
+        thinking: "Thinking output",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, modelInfo);
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toEqual([{ type: "text", text: "Thinking output" }]);
+  });
+
+  it("falls back to reasoning when content and thinking are empty", () => {
     const response = {
       model: "qwen3:32b",
       created_at: "2026-01-01T00:00:00Z",
@@ -118,6 +134,22 @@ describe("buildAssistantMessage", () => {
     const result = buildAssistantMessage(response, modelInfo);
     expect(result.stopReason).toBe("stop");
     expect(result.content).toEqual([{ type: "text", text: "Reasoning output" }]);
+  });
+
+  it("prefers thinking over reasoning when both present", () => {
+    const response = {
+      model: "test-model",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content: "",
+        thinking: "Thinking output",
+        reasoning: "Reasoning output",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, modelInfo);
+    expect(result.content).toEqual([{ type: "text", text: "Thinking output" }]);
   });
 
   it("builds response with tool calls", () => {
@@ -361,7 +393,28 @@ describe("createOllamaStreamFn", () => {
     );
   });
 
-  it("accumulates reasoning chunks when content is empty", async () => {
+  it("accumulates thinking chunks when content is empty", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":"thinking"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":" output"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":2}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
+        const events = await collectStreamEvents(stream);
+
+        const doneEvent = events.at(-1);
+        if (!doneEvent || doneEvent.type !== "done") {
+          throw new Error("Expected done event");
+        }
+
+        expect(doneEvent.message.content).toEqual([{ type: "text", text: "thinking output" }]);
+      },
+    );
+  });
+
+  it("accumulates reasoning chunks when content is empty (backward compatibility)", async () => {
     await withMockNdjsonFetch(
       [
         '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","reasoning":"reasoned"},"done":false}',

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -185,6 +185,7 @@ interface OllamaChatResponse {
   message: {
     role: "assistant";
     content: string;
+    thinking?: string;
     reasoning?: string;
     tool_calls?: OllamaToolCall[];
   };
@@ -323,10 +324,10 @@ export function buildAssistantMessage(
 ): AssistantMessage {
   const content: (TextContent | ToolCall)[] = [];
 
-  // Qwen 3 (and potentially other reasoning models) may return their final
-  // answer in a `reasoning` field with an empty `content`. Fall back to
-  // `reasoning` so the response isn't silently dropped.
-  const text = response.message.content || response.message.reasoning || "";
+  // Ollama API uses `thinking` for reasoning/thinking models (kimi-k2.5, glm-5, etc.).
+  // Some models may also use `reasoning`. Check both fields so responses aren't silently dropped.
+  const text =
+    response.message.content || response.message.thinking || response.message.reasoning || "";
   if (text) {
     content.push({ type: "text", text });
   }
@@ -470,8 +471,11 @@ export function createOllamaStreamFn(baseUrl: string): StreamFn {
         for await (const chunk of parseNdjsonStream(reader)) {
           if (chunk.message?.content) {
             accumulatedContent += chunk.message.content;
+          } else if (chunk.message?.thinking) {
+            // Ollama API uses `thinking` for reasoning/thinking models
+            accumulatedContent += chunk.message.thinking;
           } else if (chunk.message?.reasoning) {
-            // Qwen 3 reasoning mode: content may be empty, output in reasoning
+            // Fall back to `reasoning` for backward compatibility
             accumulatedContent += chunk.message.reasoning;
           }
 

--- a/src/agents/pi-embedded-subscribe.multi-segment-text.test.ts
+++ b/src/agents/pi-embedded-subscribe.multi-segment-text.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import {
+  createStubSessionHarness,
+  emitAssistantTextDelta,
+  emitAssistantTextEnd,
+} from "./pi-embedded-subscribe.e2e-harness.js";
+import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
+
+describe("subscribeEmbeddedPiSession - multi-segment text across tool calls", () => {
+  it("includes all text segments across tool call boundaries in assistantTexts", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      reasoningMode: "off",
+    });
+
+    // First assistant message with text before tool call
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "Let me check that. " });
+    emitAssistantTextEnd({ emit, content: "Let me check that. " });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Let me check that. " }],
+      },
+    });
+
+    // Tool call happens (simulated by tool_use message)
+    emit({
+      type: "message_start",
+      message: { role: "assistant" },
+    });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "tool_1",
+            name: "Read",
+            input: { file_path: "test.txt" },
+          },
+        ],
+      },
+    });
+
+    // Tool result
+    emit({
+      type: "message_start",
+      message: { role: "user" },
+    });
+    emit({
+      type: "message_end",
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tool_1",
+            content: "File contents here",
+          },
+        ],
+      },
+    });
+
+    // Second assistant message with text after tool call
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "The file contains important data." });
+    emitAssistantTextEnd({ emit, content: "The file contains important data." });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "The file contains important data." }],
+      },
+    });
+
+    // Both text segments should be present
+    expect(subscription.assistantTexts).toEqual([
+      "Let me check that.",
+      "The file contains important data.",
+    ]);
+  });
+
+  it("includes all text segments when reasoning mode is on without block replies", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      reasoningMode: "on",
+      // No onBlockReply - this triggers the problematic code path
+    });
+
+    // First assistant message with text before tool call
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "Let me check that. " });
+    emitAssistantTextEnd({ emit, content: "Let me check that. " });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Let me check that. " }],
+      },
+    });
+
+    // Tool call
+    emit({
+      type: "message_start",
+      message: { role: "assistant" },
+    });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "tool_1",
+            name: "Read",
+            input: { file_path: "test.txt" },
+          },
+        ],
+      },
+    });
+
+    // Tool result
+    emit({
+      type: "message_start",
+      message: { role: "user" },
+    });
+    emit({
+      type: "message_end",
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tool_1",
+            content: "File contents here",
+          },
+        ],
+      },
+    });
+
+    // Second assistant message with text after tool call
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "The file contains important data." });
+    emitAssistantTextEnd({ emit, content: "The file contains important data." });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "The file contains important data." }],
+      },
+    });
+
+    // Should keep the final consolidated text, not discard pre-tool-call text
+    expect(subscription.assistantTexts.length).toBeGreaterThan(0);
+    const allText = subscription.assistantTexts.join(" ");
+    expect(allText).toContain("Let me check that");
+    expect(allText).toContain("The file contains important data");
+  });
+});

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -172,6 +172,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // the final text even when interim streaming was enabled.
     if (state.includeReasoning && text && !params.onBlockReply) {
       if (assistantTexts.length > state.assistantTextBaseline) {
+        // Consolidate streaming chunks from this message into a single final text.
+        // IMPORTANT: Only replace chunks from the CURRENT message (from assistantTextBaseline onwards),
+        // preserving any text from previous assistant message segments (before tool calls).
         assistantTexts.splice(
           state.assistantTextBaseline,
           assistantTexts.length - state.assistantTextBaseline,
@@ -179,6 +182,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
         );
         rememberAssistantText(text);
       } else {
+        // No chunks were added during streaming, so append the final text.
         pushAssistantText(text);
       }
       state.suppressBlockChunks = true;

--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -12,6 +12,7 @@ import {
   buildWorkspaceSkillSnapshot,
   loadWorkspaceSkillEntries,
 } from "./skills.js";
+import { getActiveSkillEnvKeys } from "./skills/env-overrides.js";
 
 const fixtureSuite = createFixtureSuite("openclaw-skills-suite-");
 let tempHome: TempHomeEnv | null = null;
@@ -259,6 +260,33 @@ describe("applySkillEnvOverrides", () => {
       } finally {
         restore();
         expect(process.env.ENV_KEY).toBeUndefined();
+      }
+    });
+  });
+
+  it("tracks active skill env keys and clears them on revert", async () => {
+    const workspaceDir = await makeWorkspace();
+    const skillDir = path.join(workspaceDir, "skills", "tracked-skill");
+    await writeSkill({
+      dir: skillDir,
+      name: "tracked-skill",
+      description: "Tracked env",
+      metadata: '{"openclaw":{"requires":{"env":["TRACKED_KEY"]},"primaryEnv":"TRACKED_KEY"}}',
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, resolveTestSkillDirs(workspaceDir));
+
+    withClearedEnv(["TRACKED_KEY"], () => {
+      const restore = applySkillEnvOverrides({
+        skills: entries,
+        config: { skills: { entries: { "tracked-skill": { apiKey: "tracked-val" } } } },
+      });
+
+      try {
+        expect(getActiveSkillEnvKeys().has("TRACKED_KEY")).toBe(true);
+      } finally {
+        restore();
+        expect(getActiveSkillEnvKeys().has("TRACKED_KEY")).toBe(false);
       }
     });
   });

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -9,6 +9,16 @@ import type { SkillEntry, SkillSnapshot } from "./types.js";
 
 const log = createSubsystemLogger("env-overrides");
 
+// Track env keys that were injected by skill overrides so ACP harnesses
+// (and other child-process spawn points) can strip them before spawning.
+// Keys are added when overrides are applied and removed when reverted.
+const activeSkillEnvKeys = new Set<string>();
+
+/** Returns the set of env var keys currently injected by skill overrides. */
+export function getActiveSkillEnvKeys(): ReadonlySet<string> {
+  return activeSkillEnvKeys;
+}
+
 type EnvUpdate = { key: string; prev: string | undefined };
 type SkillConfig = NonNullable<ReturnType<typeof resolveSkillConfig>>;
 
@@ -135,6 +145,7 @@ function applySkillConfigEnvOverrides(params: {
     }
     updates.push({ key: envKey, prev: process.env[envKey] });
     process.env[envKey] = envValue;
+    activeSkillEnvKeys.add(envKey);
   }
 }
 
@@ -146,6 +157,7 @@ function createEnvReverter(updates: EnvUpdate[]) {
       } else {
         process.env[update.key] = update.prev;
       }
+      activeSkillEnvKeys.delete(update.key);
     }
   };
 }


### PR DESCRIPTION
## Summary

Closes #36280

Skill `apiKey` entries (e.g. `openai-image-gen`, `openai-whisper-api`) were exported as env vars like `OPENAI_API_KEY` into `process.env` and inherited by **all** child processes, including ACP harnesses like Codex CLI. This caused Codex to silently switch from free OAuth auth to paid API billing.

**Root cause:** `applySkillConfigEnvOverrides` sets skill API keys on `process.env`, and `resolveAcpClientSpawnEnv` spreads the entire `process.env` into ACP child process environments without filtering.

**Fix:**
- Track which env keys are actively injected by skill overrides in a module-level `Set` (`activeSkillEnvKeys`)
- Export `getActiveSkillEnvKeys()` so consumers can query the set
- In `resolveAcpClientSpawnEnv`, strip all active skill-injected keys before building the ACP spawn environment
- Keys are automatically removed from the tracking set when the reverter is called

## Changes

- `src/agents/skills/env-overrides.ts`: Added `activeSkillEnvKeys` tracking set + `getActiveSkillEnvKeys()` export; keys added on apply, removed on revert
- `src/acp/client.ts`: `resolveAcpClientSpawnEnv` now filters out active skill env keys before spreading into child env
- `src/acp/client.test.ts`: Added test for skill env key stripping
- `src/agents/skills.test.ts`: Added test verifying tracking set lifecycle (add on apply, clear on revert)

## Test plan

- [x] `pnpm test -- src/acp/client.test.ts` — 32 tests pass including new stripping test
- [x] `pnpm test -- src/agents/skills.test.ts` — 13 tests pass including new tracking test
- [x] `pnpm tsgo` — no type errors