### PR TITLE
fix(status): align stale default account handling in channel summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
+- Status/channels account resolution: when a plugin default account ID is stale, prefer the first configured account for status summary evaluation so `openclaw status` channel rows stay consistent with `status --deep` and `health --json` link state. (#36267) Thanks @xmoxmo.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.

--- a/src/channels/plugins/helpers.test.ts
+++ b/src/channels/plugins/helpers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveChannelDefaultAccountId } from "./helpers.js";
+import type { ChannelPlugin } from "./types.js";
+
+describe("resolveChannelDefaultAccountId", () => {
+  it("falls back to the first configured account when plugin default is not listed", () => {
+    const plugin = {
+      id: "demo",
+      config: {
+        listAccountIds: () => ["Primary"],
+        defaultAccountId: () => "default",
+      },
+    } as unknown as ChannelPlugin;
+
+    const accountId = resolveChannelDefaultAccountId({
+      plugin,
+      cfg: {} as OpenClawConfig,
+    });
+
+    expect(accountId).toBe("Primary");
+  });
+
+  it("keeps plugin default when it matches a listed account", () => {
+    const plugin = {
+      id: "demo",
+      config: {
+        listAccountIds: () => ["default", "Primary"],
+        defaultAccountId: () => "default",
+      },
+    } as unknown as ChannelPlugin;
+
+    const accountId = resolveChannelDefaultAccountId({
+      plugin,
+      cfg: {} as OpenClawConfig,
+    });
+
+    expect(accountId).toBe("default");
+  });
+});

--- a/src/channels/plugins/helpers.ts
+++ b/src/channels/plugins/helpers.ts
@@ -10,7 +10,15 @@ export function resolveChannelDefaultAccountId<ResolvedAccount>(params: {
   accountIds?: string[];
 }): string {
   const accountIds = params.accountIds ?? params.plugin.config.listAccountIds(params.cfg);
-  return params.plugin.config.defaultAccountId?.(params.cfg) ?? accountIds[0] ?? DEFAULT_ACCOUNT_ID;
+  const configuredDefaultRaw = params.plugin.config.defaultAccountId?.(params.cfg);
+  const configuredDefault = configuredDefaultRaw?.trim() ? configuredDefaultRaw.trim() : null;
+  if (accountIds.length > 0) {
+    if (configuredDefault && accountIds.includes(configuredDefault)) {
+      return configuredDefault;
+    }
+    return accountIds[0];
+  }
+  return configuredDefault ?? DEFAULT_ACCOUNT_ID;
 }
 
 export function formatPairingApproveHint(channelId: string): string {

--- a/src/commands/status-all/channels.mattermost-token-summary.test.ts
+++ b/src/commands/status-all/channels.mattermost-token-summary.test.ts
@@ -93,6 +93,40 @@ function makeTokenPlugin(): ChannelPlugin {
   };
 }
 
+function makeMismatchedDefaultLinkPlugin(): ChannelPlugin {
+  return {
+    id: "bncr",
+    meta: {
+      id: "bncr",
+      label: "Bncr",
+      selectionLabel: "Bncr",
+      docsPath: "/channels/bncr",
+      blurb: "test",
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: {
+      listAccountIds: () => ["Primary"],
+      defaultAccountId: () => "default",
+      resolveAccount: (_cfg, accountId) => ({
+        name: accountId,
+        enabled: true,
+        token: "bncr-token",
+      }),
+      isConfigured: () => true,
+      isEnabled: () => true,
+    },
+    status: {
+      buildChannelSummary: ({ defaultAccountId }) => ({
+        linked: defaultAccountId === "Primary",
+        configured: true,
+      }),
+    },
+    actions: {
+      listActions: () => ["send"],
+    },
+  };
+}
+
 describe("buildChannelsTable - mattermost token summary", () => {
   it("does not require appToken for mattermost accounts", async () => {
     vi.mocked(listChannelPlugins).mockReturnValue([makeMattermostPlugin()]);
@@ -133,5 +167,18 @@ describe("buildChannelsTable - mattermost token summary", () => {
     expect(tokenRow).toBeDefined();
     expect(tokenRow?.state).toBe("ok");
     expect(tokenRow?.detail).toContain("token");
+  });
+
+  it("uses a real configured account when plugin default account id is stale", async () => {
+    vi.mocked(listChannelPlugins).mockReturnValue([makeMismatchedDefaultLinkPlugin()]);
+
+    const table = await buildChannelsTable({ channels: {} } as never, {
+      showSecrets: false,
+    });
+
+    const bncrRow = table.rows.find((row) => row.id === "bncr");
+    expect(bncrRow).toBeDefined();
+    expect(bncrRow?.state).toBe("ok");
+    expect(bncrRow?.detail).toContain("linked");
   });
 });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw status` top channel summary could show `SETUP/not linked` when a plugin default account id was stale (not present in configured account IDs), even though `status --deep` and `health --json` showed linked on the real account.
- Why it matters: operators get contradictory connectivity signals across status surfaces.
- What changed: normalized default-account resolution to prefer a listed account when configured account IDs exist; added regression coverage for stale-default cases and linked status evaluation.
- What did NOT change (scope boundary): no channel runtime behavior changes; this only affects account selection for status evaluation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36267
- Related #36263

## User-visible / Behavior Changes

- `openclaw status` channel rows now use a real configured account when plugin default account id is stale, so linked/setup output aligns with `status --deep` and `health --json`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): status summary + plugin account resolution
- Relevant config (redacted): test config with stale plugin default account id

### Steps

1. Configure a plugin with listed accounts (for example `Primary`) but a stale plugin default account id (`default`).
2. Run `openclaw status` channel table evaluation.
3. Compare with linked state from per-account status signals.

### Expected

- Status summary evaluates against a real configured account and reports linked/setup consistently.

### Actual

- Matches expected after this change.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: helper regression tests for stale vs valid defaults; status table regression test for stale default account id reports linked `ok`.
- Edge cases checked: empty/default mismatch fallback path and matching-default passthrough.
- What you did **not** verify: live Bncr runtime on a real gateway instance.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Status: honor configured account when default is stale`.
- Files/config to restore: `src/channels/plugins/helpers.ts`, `src/channels/plugins/helpers.test.ts`, `src/commands/status-all/channels.mattermost-token-summary.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: status rows regressing to `not linked` when deep/json indicate linked.

## Risks and Mitigations

- Risk: changing default-account fallback semantics could affect code paths expecting stale defaults.
  - Mitigation: fallback only applies when configured account IDs exist and stale default is not listed; matching defaults remain unchanged.
