### PR TITLE
browser: remove deprecated --disable-blink-features=AutomationControlled flag

### DIFF
--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -266,9 +266,6 @@ export async function launchOpenClawChrome(
       args.push("--disable-dev-shm-usage");
     }
 
-    // Stealth: hide navigator.webdriver from automation detection (#80)
-    args.push("--disable-blink-features=AutomationControlled");
-
     // Append user-configured extra arguments (e.g., stealth flags, window size)
     if (resolved.extraArgs.length > 0) {
       args.push(...resolved.extraArgs);


### PR DESCRIPTION
## Summary

Remove the deprecated `--disable-blink-features=AutomationControlled` Chrome launch flag that causes an "unsupported command line switch" warning banner in Chrome 130+.

## Root Cause

Chromium removed the `AutomationControlled` blink feature flag ([chromium issue 40537366](https://issues.chromium.org/issues/40537366)). Passing it now triggers a visible warning bar in the browser window.

## Fix

Remove the flag from the default Chrome launch args in `src/browser/chrome.ts`. Users who still need custom stealth flags can pass them via `browser.extraArgs` in config.

Fixes #35721