### PR TITLE
fix(agents): default tool_choice for openai-responses tool payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
+- Agents/OpenAI Responses tool-choice defaulting: when outgoing payloads include `tools` but no explicit `tool_choice`, default to `tool_choice: "auto"` for `openai-responses` requests so stream-simple custom provider paths keep tool-call eligibility. (#36057)
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1045,6 +1045,42 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload.store).toBe(true);
   });
 
+  it("defaults tool_choice=auto for OpenAI Responses payloads with tools when unset", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: {
+        api: "openai-responses",
+        provider: "sub2api-gpt",
+        id: "gpt-5.3-codex",
+        baseUrl: "https://proxy.example.com/v1",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        tools: [{ type: "function", name: "exec", parameters: { type: "object" } }],
+        tool_choice: null,
+      },
+    });
+    expect(payload.tool_choice).toBe("auto");
+  });
+
+  it("preserves explicit tool_choice for OpenAI Responses payloads", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: {
+        api: "openai-responses",
+        provider: "sub2api-gpt",
+        id: "gpt-5.3-codex",
+        baseUrl: "https://proxy.example.com/v1",
+      } as unknown as Model<"openai-responses">,
+      payload: {
+        tools: [{ type: "function", name: "exec", parameters: { type: "object" } }],
+        tool_choice: "none",
+      },
+    });
+    expect(payload.tool_choice).toBe("none");
+  });
+
   it("does not force store for OpenAI Responses routed through non-OpenAI base URLs", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "openai",

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -283,7 +283,9 @@ function createOpenAIResponsesContextManagementWrapper(
   return (model, context, options) => {
     const forceStore = shouldForceResponsesStore(model);
     const useServerCompaction = shouldEnableOpenAIResponsesServerCompaction(model, extraParams);
-    if (!forceStore && !useServerCompaction) {
+    const normalizeToolChoice =
+      typeof model.api === "string" && OPENAI_RESPONSES_APIS.has(model.api);
+    if (!forceStore && !useServerCompaction && !normalizeToolChoice) {
       return underlying(model, context, options);
     }
 
@@ -298,6 +300,14 @@ function createOpenAIResponsesContextManagementWrapper(
           const payloadObj = payload as Record<string, unknown>;
           if (forceStore) {
             payloadObj.store = true;
+          }
+          if (
+            normalizeToolChoice &&
+            Array.isArray(payloadObj.tools) &&
+            payloadObj.tools.length > 0 &&
+            payloadObj.tool_choice == null
+          ) {
+            payloadObj.tool_choice = "auto";
           }
           if (useServerCompaction && payloadObj.context_management === undefined) {
             payloadObj.context_management = [


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openai-responses` payloads on stream-simple paths could carry `tools` with missing/null `tool_choice`, causing no tool-call eligibility on custom providers.
- Why it matters: tool-required tasks can silently degrade to text-only completions.
- What changed: in the OpenAI Responses payload wrapper, default `tool_choice` to `"auto"` only when `tools` are present and `tool_choice` is unset/null; explicit `tool_choice` values remain untouched.
- What did NOT change (scope boundary): no overrides when `tool_choice` is already set; no behavior change for non-`openai-responses` APIs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36057
- Related #34241

## User-visible / Behavior Changes

- For `openai-responses` requests with non-empty `tools` and missing/null `tool_choice`, payload now defaults to `tool_choice: "auto"`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: `openai-responses` (including custom provider path)
- Integration/channel (if any): agent stream payload mutation path
- Relevant config (redacted): provider/model params for `openai-responses`

### Steps

1. Build an `openai-responses` payload with non-empty `tools` and `tool_choice: null`.
2. Run through `applyExtraParamsToAgent` wrapper path.
3. Inspect final payload in `onPayload` callback.

### Expected

- `tool_choice` is `"auto"` only when `tools` are present and tool choice is unset.
- Explicit `tool_choice` (for example `"none"`) is preserved.

### Actual

- Matches expected after this change.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: new regression tests for unset/null `tool_choice` defaulting and explicit `tool_choice` preservation.
- Edge cases checked: only applies to `openai-responses`; wrapper no-op for other APIs remains unchanged.
- What you did **not** verify: live upstream packet capture against a custom provider endpoint.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Agents: default tool_choice for openai-responses tools`.
- Files/config to restore: `src/agents/pi-embedded-runner/extra-params.ts`, `src/agents/pi-embedded-runner-extraparams.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: unexpected non-auto `tool_choice` behavior on `openai-responses` payloads with tools.

## Risks and Mitigations

- Risk: providers that intentionally relied on null `tool_choice` with tools could observe behavior change.
  - Mitigation: only unset/null values are normalized, and explicit values are preserved.
