### PR TITLE
feat(hooks): workspace events subscription hook

### DIFF
--- a/docs/automation/workspace-events.md
+++ b/docs/automation/workspace-events.md
@@ -1,0 +1,144 @@
+---
+summary: "Google Workspace Events subscription hooks wired into OpenClaw webhooks via gws"
+read_when:
+  - Wiring Workspace Events (Calendar, Drive, Chat) triggers to OpenClaw
+  - Setting up workspace event subscriptions for agent wake
+title: "Workspace Events"
+---
+
+# Google Workspace Events -> OpenClaw
+
+Subscribe to real-time Google Workspace changes (Calendar updates, Drive file edits,
+Chat messages, etc.) and forward them as hook events to your OpenClaw agent.
+
+Uses `gws events +subscribe` (pull-based Pub/Sub, NDJSON on stdout).
+
+## Prerequisites
+
+- `gcloud` installed and logged in ([install guide](https://docs.cloud.google.com/sdk/docs/install-sdk)).
+- `gws` installed and authorized: `npm i -g @googleworkspace/cli && gws auth login`.
+- OpenClaw hooks enabled (see [Webhooks](/automation/webhook)).
+- A GCP project with the Workspace Events API and Pub/Sub API enabled.
+
+## Quick start
+
+### 1. Setup
+
+```bash
+openclaw webhooks events setup \
+  --target '//chat.googleapis.com/spaces/SPACE_ID' \
+  --event-types 'google.workspace.chat.message.v1.created' \
+  --project my-gcp-project
+```
+
+This writes `hooks.workspaceEvents` config and adds the `"workspace-events"` preset.
+
+### 2. Run
+
+```bash
+openclaw webhooks events run
+```
+
+Or let the gateway start it automatically on boot (if `hooks.workspaceEvents.target` is configured).
+
+## Configuration
+
+```json5
+{
+  hooks: {
+    enabled: true,
+    token: "OPENCLAW_HOOK_TOKEN",
+    presets: ["workspace-events"],
+    workspaceEvents: {
+      project: "my-gcp-project",
+      target: "//chat.googleapis.com/spaces/SPACE_ID",
+      eventTypes: ["google.workspace.chat.message.v1.created"],
+      // Optional:
+      // subscription: "existing-sub-name",
+      // hookUrl: "http://127.0.0.1:18789/hooks/workspace-events",
+      // pollInterval: 5,
+      // maxMessages: 10,
+      // cleanup: false,
+      // model: "provider/model",
+      // thinking: "low",
+    },
+  },
+}
+```
+
+### Config fields
+
+| Field                        | Type     | Default    | Description                                                    |
+| ---------------------------- | -------- | ---------- | -------------------------------------------------------------- |
+| `project`                    | string   | (required) | GCP project ID                                                 |
+| `target`                     | string   | (required) | Workspace resource URI (e.g. `//chat.googleapis.com/spaces/X`) |
+| `eventTypes`                 | string[] | (required) | Event types to subscribe to                                    |
+| `subscription`               | string   | (auto)     | Reuse an existing Pub/Sub subscription                         |
+| `hookUrl`                    | string   | auto       | Override the hook POST URL                                     |
+| `pollInterval`               | number   | 5          | Pub/Sub poll interval in seconds                               |
+| `maxMessages`                | number   | 10         | Max messages per poll batch                                    |
+| `cleanup`                    | boolean  | false      | Delete Pub/Sub resources on process exit                       |
+| `model`                      | string   | (default)  | Model override for hook processing                             |
+| `thinking`                   | string   | (default)  | Thinking level override                                        |
+| `allowUnsafeExternalContent` | boolean  | false      | Disable external content safety wrapping                       |
+
+## Event types
+
+Common event types:
+
+- `google.workspace.chat.message.v1.created` - New Chat message
+- `google.workspace.chat.message.v1.updated` - Chat message edited
+- `google.workspace.chat.membership.v1.created` - New Chat space member
+- `google.workspace.calendar.event.v1.created` - New Calendar event
+- `google.workspace.calendar.event.v1.updated` - Calendar event updated
+- `google.workspace.drive.file.v1.updated` - Drive file updated
+
+Multiple types can be specified as a comma-separated list in the CLI or as an array in config.
+
+## Hook payload
+
+Each event is forwarded as:
+
+```json
+{
+  "events": [
+    {
+      "type": "google.workspace.chat.message.v1.created",
+      "source": "//chat.googleapis.com/spaces/X",
+      "time": "2026-02-13T10:00:00Z",
+      "resourceType": "chat.message",
+      "summary": "chat.message created from //chat.googleapis.com/spaces/X",
+      "data": { ... }
+    }
+  ]
+}
+```
+
+## Environment variables
+
+| Variable                          | Effect                                                           |
+| --------------------------------- | ---------------------------------------------------------------- |
+| `OPENCLAW_SKIP_WS_EVENTS_WATCHER` | Set to `1` to prevent the gateway from auto-starting the watcher |
+
+## Custom mappings
+
+Override the default preset mapping to deliver events to a specific channel:
+
+```json5
+{
+  hooks: {
+    presets: ["workspace-events"],
+    mappings: [
+      {
+        match: { path: "workspace-events" },
+        action: "agent",
+        name: "Workspace Event",
+        deliver: true,
+        channel: "slack",
+        sessionKey: "hook:ws-event:{{events[0].type}}:{{events[0].time}}",
+        messageTemplate: "Workspace event: {{events[0].summary}}\nData: {{events[0].data}}",
+      },
+    ],
+  },
+}
+```

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -627,7 +627,20 @@ export function resolveHooksGmailModel(params: {
   cfg: OpenClawConfig;
   defaultProvider: string;
 }): ModelRef | null {
-  const hooksModel = params.cfg.hooks?.gmail?.model;
+  return resolveHooksModel(params.cfg.hooks?.gmail?.model, params);
+}
+
+export function resolveHooksWsEventsModel(params: {
+  cfg: OpenClawConfig;
+  defaultProvider: string;
+}): ModelRef | null {
+  return resolveHooksModel(params.cfg.hooks?.workspaceEvents?.model, params);
+}
+
+function resolveHooksModel(
+  hooksModel: string | undefined,
+  params: { cfg: OpenClawConfig; defaultProvider: string },
+): ModelRef | null {
   if (!hooksModel?.trim()) {
     return null;
   }

--- a/src/cli/webhooks-cli.ts
+++ b/src/cli/webhooks-cli.ts
@@ -16,6 +16,16 @@ import {
   DEFAULT_GMAIL_SUBSCRIPTION,
   DEFAULT_GMAIL_TOPIC,
 } from "../hooks/gmail.js";
+import {
+  type WsEventsRunOptions,
+  type WsEventsSetupOptions,
+  runWsEventsService,
+  runWsEventsSetup,
+} from "../hooks/ws-events-ops.js";
+import {
+  DEFAULT_WS_EVENTS_MAX_MESSAGES,
+  DEFAULT_WS_EVENTS_POLL_INTERVAL,
+} from "../hooks/ws-events.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
@@ -97,6 +107,63 @@ export function registerWebhooksCli(program: Command) {
       try {
         const parsed = parseGmailRunOptions(opts);
         await runGmailService(parsed);
+      } catch (err) {
+        defaultRuntime.error(danger(String(err)));
+        defaultRuntime.exit(1);
+      }
+    });
+
+  const events = webhooks.command("events").description("Google Workspace Events hooks (via gws)");
+
+  events
+    .command("setup")
+    .description("Configure workspace events subscription + OpenClaw hooks")
+    .requiredOption(
+      "--target <uri>",
+      "Workspace resource URI (e.g. //chat.googleapis.com/spaces/X)",
+    )
+    .requiredOption(
+      "--event-types <types>",
+      "Comma-separated event types (e.g. google.workspace.chat.message.v1.created)",
+    )
+    .requiredOption("--project <id>", "GCP project id")
+    .option("--subscription <name>", "Reuse existing Pub/Sub subscription")
+    .option("--hook-url <url>", "OpenClaw hook URL")
+    .option("--hook-token <token>", "OpenClaw hook token")
+    .option(
+      "--poll-interval <n>",
+      "Poll interval in seconds",
+      String(DEFAULT_WS_EVENTS_POLL_INTERVAL),
+    )
+    .option("--max-messages <n>", "Max messages per poll", String(DEFAULT_WS_EVENTS_MAX_MESSAGES))
+    .option("--cleanup", "Delete Pub/Sub resources on exit", false)
+    .option("--json", "Output JSON summary", false)
+    .action(async (opts) => {
+      try {
+        const parsed = parseWsEventsSetupOptions(opts);
+        await runWsEventsSetup(parsed);
+      } catch (err) {
+        defaultRuntime.error(danger(String(err)));
+        defaultRuntime.exit(1);
+      }
+    });
+
+  events
+    .command("run")
+    .description("Run workspace events subscription service")
+    .option("--target <uri>", "Workspace resource URI")
+    .option("--event-types <types>", "Comma-separated event types")
+    .option("--project <id>", "GCP project id")
+    .option("--subscription <name>", "Reuse existing Pub/Sub subscription")
+    .option("--hook-url <url>", "OpenClaw hook URL")
+    .option("--hook-token <token>", "OpenClaw hook token")
+    .option("--poll-interval <n>", "Poll interval in seconds")
+    .option("--max-messages <n>", "Max messages per poll")
+    .option("--cleanup", "Delete Pub/Sub resources on exit")
+    .action(async (opts) => {
+      try {
+        const parsed = parseWsEventsRunOptions(opts);
+        await runWsEventsService(parsed);
       } catch (err) {
         defaultRuntime.error(danger(String(err)));
         defaultRuntime.exit(1);
@@ -194,4 +261,56 @@ function booleanOption(value: unknown): boolean | undefined {
     return undefined;
   }
   return Boolean(value);
+}
+
+function parseEventTypes(raw: unknown): string[] {
+  if (typeof raw !== "string") {
+    return [];
+  }
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function parseWsEventsSetupOptions(raw: Record<string, unknown>): WsEventsSetupOptions {
+  const target = stringOption(raw.target);
+  if (!target) {
+    throw new Error("--target is required");
+  }
+  const eventTypes = parseEventTypes(raw.eventTypes);
+  if (eventTypes.length === 0) {
+    throw new Error("--event-types is required (comma-separated)");
+  }
+  const project = stringOption(raw.project);
+  if (!project) {
+    throw new Error("--project is required");
+  }
+  return {
+    target,
+    eventTypes,
+    project,
+    subscription: stringOption(raw.subscription),
+    hookUrl: stringOption(raw.hookUrl),
+    hookToken: stringOption(raw.hookToken),
+    pollInterval: numberOption(raw.pollInterval),
+    maxMessages: numberOption(raw.maxMessages),
+    cleanup: booleanOption(raw.cleanup),
+    json: Boolean(raw.json),
+  };
+}
+
+function parseWsEventsRunOptions(raw: Record<string, unknown>): WsEventsRunOptions {
+  const eventTypes = raw.eventTypes ? parseEventTypes(raw.eventTypes) : undefined;
+  return {
+    target: stringOption(raw.target),
+    eventTypes,
+    project: stringOption(raw.project),
+    subscription: stringOption(raw.subscription),
+    hookUrl: stringOption(raw.hookUrl),
+    hookToken: stringOption(raw.hookToken),
+    pollInterval: numberOption(raw.pollInterval),
+    maxMessages: numberOption(raw.maxMessages),
+    cleanup: booleanOption(raw.cleanup),
+  };
 }

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -72,6 +72,23 @@ export type HooksGmailConfig = {
   thinking?: "off" | "minimal" | "low" | "medium" | "high";
 };
 
+export type HooksWorkspaceEventsConfig = {
+  project?: string;
+  target?: string;
+  eventTypes?: string[];
+  subscription?: string;
+  hookUrl?: string;
+  pollInterval?: number;
+  maxMessages?: number;
+  cleanup?: boolean;
+  /** Optional model override for workspace events hook processing. */
+  model?: string;
+  /** Optional thinking level override for workspace events hook processing. */
+  thinking?: "off" | "minimal" | "low" | "medium" | "high";
+  /** DANGEROUS: Disable external content safety wrapping for workspace events hooks. */
+  allowUnsafeExternalContent?: boolean;
+};
+
 export type InternalHookHandlerConfig = {
   /** Event key to listen for (e.g., 'command:new', 'message:received', 'message:transcribed', 'session:start') */
   event: string;
@@ -136,6 +153,7 @@ export type HooksConfig = {
   transformsDir?: string;
   mappings?: HookMappingConfig[];
   gmail?: HooksGmailConfig;
+  workspaceEvents?: HooksWorkspaceEventsConfig;
   /** Internal agent event hooks */
   internal?: InternalHooksConfig;
 };

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -159,3 +159,28 @@ export const HooksGmailSchema = z
   })
   .strict()
   .optional();
+
+export const HooksWorkspaceEventsSchema = z
+  .object({
+    project: z.string().optional(),
+    target: z.string().optional(),
+    eventTypes: z.array(z.string()).optional(),
+    subscription: z.string().optional(),
+    hookUrl: z.string().optional(),
+    pollInterval: z.number().int().positive().optional(),
+    maxMessages: z.number().int().positive().optional(),
+    cleanup: z.boolean().optional(),
+    model: z.string().optional(),
+    thinking: z
+      .union([
+        z.literal("off"),
+        z.literal("minimal"),
+        z.literal("low"),
+        z.literal("medium"),
+        z.literal("high"),
+      ])
+      .optional(),
+    allowUnsafeExternalContent: z.boolean().optional(),
+  })
+  .strict()
+  .optional();

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -10,7 +10,12 @@ import {
   SecretInputSchema,
   SecretsConfigSchema,
 } from "./zod-schema.core.js";
-import { HookMappingSchema, HooksGmailSchema, InternalHooksSchema } from "./zod-schema.hooks.js";
+import {
+  HookMappingSchema,
+  HooksGmailSchema,
+  HooksWorkspaceEventsSchema,
+  InternalHooksSchema,
+} from "./zod-schema.hooks.js";
 import { InstallRecordShape } from "./zod-schema.installs.js";
 import { ChannelsSchema } from "./zod-schema.providers.js";
 import { sensitive } from "./zod-schema.sensitive.js";
@@ -569,6 +574,7 @@ export const OpenClawSchema = z
         transformsDir: z.string().optional(),
         mappings: z.array(HookMappingSchema).optional(),
         gmail: HooksGmailSchema,
+        workspaceEvents: HooksWorkspaceEventsSchema,
         internal: InternalHooksSchema,
       })
       .strict()

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -10,6 +10,7 @@ export type GatewayReloadPlan = {
   hotReasons: string[];
   reloadHooks: boolean;
   restartGmailWatcher: boolean;
+  restartWsEventsWatcher: boolean;
   restartBrowserControl: boolean;
   restartCron: boolean;
   restartHeartbeat: boolean;
@@ -27,6 +28,7 @@ type ReloadRule = {
 type ReloadAction =
   | "reload-hooks"
   | "restart-gmail-watcher"
+  | "restart-ws-events-watcher"
   | "restart-browser-control"
   | "restart-cron"
   | "restart-heartbeat"
@@ -44,6 +46,7 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
   // Stuck-session warning threshold is read by the diagnostics heartbeat loop.
   { prefix: "diagnostics.stuckSessionWarnMs", kind: "none" },
   { prefix: "hooks.gmail", kind: "hot", actions: ["restart-gmail-watcher"] },
+  { prefix: "hooks.workspaceEvents", kind: "hot", actions: ["restart-ws-events-watcher"] },
   { prefix: "hooks", kind: "hot", actions: ["reload-hooks"] },
   {
     prefix: "agents.defaults.heartbeat",
@@ -147,6 +150,7 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
     hotReasons: [],
     reloadHooks: false,
     restartGmailWatcher: false,
+    restartWsEventsWatcher: false,
     restartBrowserControl: false,
     restartCron: false,
     restartHeartbeat: false,
@@ -167,6 +171,9 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
         break;
       case "restart-gmail-watcher":
         plan.restartGmailWatcher = true;
+        break;
+      case "restart-ws-events-watcher":
+        plan.restartWsEventsWatcher = true;
         break;
       case "restart-browser-control":
         plan.restartBrowserControl = true;
@@ -208,6 +215,9 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
   }
 
   if (plan.restartGmailWatcher) {
+    plan.reloadHooks = true;
+  }
+  if (plan.restartWsEventsWatcher) {
     plan.reloadHooks = true;
   }
 

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -77,6 +77,18 @@ const hookPresetMappings: Record<string, HookMappingConfig[]> = {
         "New email from {{messages[0].from}}\nSubject: {{messages[0].subject}}\n{{messages[0].snippet}}\n{{messages[0].body}}",
     },
   ],
+  "workspace-events": [
+    {
+      id: "workspace-events",
+      match: { path: "workspace-events" },
+      action: "agent",
+      wakeMode: "now",
+      name: "Workspace Event",
+      sessionKey: "hook:ws-event:{{events[0].type}}:{{events[0].time}}",
+      messageTemplate:
+        "Google Workspace event:\nType: {{events[0].type}}\nSource: {{events[0].source}}\nTime: {{events[0].time}}\n{{events[0].summary}}",
+    },
+  ],
 };
 
 const transformCache = new Map<string, HookTransformFn>();
@@ -109,6 +121,7 @@ export function resolveHookMappings(
 ): HookMappingResolved[] {
   const presets = hooks?.presets ?? [];
   const gmailAllowUnsafe = hooks?.gmail?.allowUnsafeExternalContent;
+  const wsEventsAllowUnsafe = hooks?.workspaceEvents?.allowUnsafeExternalContent;
   const mappings: HookMappingConfig[] = [];
   if (hooks?.mappings) {
     mappings.push(...hooks.mappings);
@@ -123,6 +136,15 @@ export function resolveHookMappings(
         ...presetMappings.map((mapping) => ({
           ...mapping,
           allowUnsafeExternalContent: gmailAllowUnsafe,
+        })),
+      );
+      continue;
+    }
+    if (preset === "workspace-events" && typeof wsEventsAllowUnsafe === "boolean") {
+      mappings.push(
+        ...presetMappings.map((mapping) => ({
+          ...mapping,
+          allowUnsafeExternalContent: wsEventsAllowUnsafe,
         })),
       );
       continue;

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -3,6 +3,7 @@ import type { WebSocketServer } from "ws";
 import type { CanvasHostHandler, CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
+import { stopWsEventsWatcher } from "../hooks/ws-events-watcher.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 
@@ -70,6 +71,7 @@ export function createGatewayCloseHandler(params: {
       await params.pluginServices.stop().catch(() => {});
     }
     await stopGmailWatcher();
+    await stopWsEventsWatcher();
     params.cron.stop();
     params.heartbeatRunner.stop();
     try {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -6,6 +6,8 @@ import { isRestartEnabled } from "../config/commands.js";
 import type { loadConfig } from "../config/config.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
+import { startWsEventsWatcherWithLogs } from "../hooks/ws-events-watcher-lifecycle.js";
+import { stopWsEventsWatcher } from "../hooks/ws-events-watcher.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import { resetDirectoryCache } from "../infra/outbound/target-resolver.js";
@@ -108,6 +110,18 @@ export function createGatewayReloadHandlers(params: {
         log: params.logHooks,
         onSkipped: () =>
           params.logHooks.info("skipping gmail watcher restart (OPENCLAW_SKIP_GMAIL_WATCHER=1)"),
+      });
+    }
+
+    if (plan.restartWsEventsWatcher) {
+      await stopWsEventsWatcher().catch(() => {});
+      await startWsEventsWatcherWithLogs({
+        cfg: nextConfig,
+        log: params.logHooks,
+        onSkipped: () =>
+          params.logHooks.info(
+            "skipping ws-events watcher restart (OPENCLAW_SKIP_WS_EVENTS_WATCHER=1)",
+          ),
       });
     }
 

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -19,6 +19,7 @@ import {
   triggerInternalHook,
 } from "../hooks/internal-hooks.js";
 import { loadInternalHooks } from "../hooks/loader.js";
+import { startWsEventsWatcherWithLogs } from "../hooks/ws-events-watcher-lifecycle.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { loadOpenClawPlugins } from "../plugins/loader.js";
 import { type PluginServicesHandle, startPluginServices } from "../plugins/services.js";
@@ -71,6 +72,12 @@ export async function startGatewaySidecars(params: {
 
   // Start Gmail watcher if configured (hooks.gmail.account).
   await startGmailWatcherWithLogs({
+    cfg: params.cfg,
+    log: params.logHooks,
+  });
+
+  // Start workspace events watcher if configured (hooks.workspaceEvents.target).
+  await startWsEventsWatcherWithLogs({
     cfg: params.cfg,
     log: params.logHooks,
   });

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -6,6 +6,7 @@ import {
   getModelRefStatus,
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
+  resolveHooksWsEventsModel,
 } from "../agents/model-selection.js";
 import { resolveAgentSessionDirs } from "../agents/session-dirs.js";
 import { cleanStaleLockFiles } from "../agents/session-write-lock.js";
@@ -110,6 +111,39 @@ export async function startGatewaySidecars(params: {
       if (!status.inCatalog) {
         params.logHooks.warn(
           `hooks.gmail.model "${status.key}" not in the model catalog (may fail at runtime)`,
+        );
+      }
+    }
+  }
+
+  // Validate hooks.workspaceEvents.model if configured.
+  if (params.cfg.hooks?.workspaceEvents?.model) {
+    const wsEventsModelRef = resolveHooksWsEventsModel({
+      cfg: params.cfg,
+      defaultProvider: DEFAULT_PROVIDER,
+    });
+    if (wsEventsModelRef) {
+      const { provider: defaultProvider, model: defaultModel } = resolveConfiguredModelRef({
+        cfg: params.cfg,
+        defaultProvider: DEFAULT_PROVIDER,
+        defaultModel: DEFAULT_MODEL,
+      });
+      const catalog = await loadModelCatalog({ config: params.cfg });
+      const status = getModelRefStatus({
+        cfg: params.cfg,
+        catalog,
+        ref: wsEventsModelRef,
+        defaultProvider,
+        defaultModel,
+      });
+      if (!status.allowed) {
+        params.logHooks.warn(
+          `hooks.workspaceEvents.model "${status.key}" not in agents.defaults.models allowlist (will use primary instead)`,
+        );
+      }
+      if (!status.inCatalog) {
+        params.logHooks.warn(
+          `hooks.workspaceEvents.model "${status.key}" not in the model catalog (may fail at runtime)`,
         );
       }
     }

--- a/src/hooks/gmail-setup-utils.ts
+++ b/src/hooks/gmail-setup-utils.ts
@@ -165,11 +165,27 @@ async function runGcloudCommand(
   });
 }
 
-export async function ensureDependency(bin: string, brewArgs: string[]) {
+export async function ensureDependency(
+  bin: string,
+  installArgs: string[],
+  installMethod: "brew" | "npm" = "brew",
+) {
   if (bin === "gcloud" && ensureGcloudOnPath()) {
     return;
   }
   if (hasBinary(bin)) {
+    return;
+  }
+  if (installMethod === "npm") {
+    const result = await runCommandWithTimeout(["npm", "install", "-g", ...installArgs], {
+      timeoutMs: 600_000,
+    });
+    if (result.code !== 0) {
+      throw new Error(`npm install failed for ${bin}: ${result.stderr || result.stdout}`);
+    }
+    if (!hasBinary(bin)) {
+      throw new Error(`${bin} still not available after npm install`);
+    }
     return;
   }
   if (process.platform !== "darwin") {
@@ -179,7 +195,7 @@ export async function ensureDependency(bin: string, brewArgs: string[]) {
     throw new Error("Homebrew not installed (install brew and retry)");
   }
   const brewEnv = bin === "gcloud" ? await gcloudEnv() : undefined;
-  const result = await runCommandWithTimeout(["brew", "install", ...brewArgs], {
+  const result = await runCommandWithTimeout(["brew", "install", ...installArgs], {
     timeoutMs: 600_000,
     env: brewEnv,
   });

--- a/src/hooks/ws-events-bridge.test.ts
+++ b/src/hooks/ws-events-bridge.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildEventSummary,
+  createWsEventsNdjsonLineHandler,
+  extractResourceType,
+  transformCloudEvent,
+} from "./ws-events-bridge.js";
+
+describe("extractResourceType", () => {
+  it("extracts resource type from standard event type", () => {
+    expect(extractResourceType("google.workspace.chat.message.v1.created")).toBe("chat.message");
+  });
+
+  it("handles drive event types", () => {
+    expect(extractResourceType("google.workspace.drive.file.v1.updated")).toBe("drive.file");
+  });
+
+  it("handles calendar event types", () => {
+    expect(extractResourceType("google.workspace.calendar.event.v1.created")).toBe(
+      "calendar.event",
+    );
+  });
+
+  it("returns original if no prefix match", () => {
+    expect(extractResourceType("custom.event.type")).toBe("custom.event.type");
+  });
+
+  it("handles empty string", () => {
+    expect(extractResourceType("")).toBe("");
+  });
+});
+
+describe("buildEventSummary", () => {
+  it("builds human-readable summary", () => {
+    expect(
+      buildEventSummary(
+        "google.workspace.chat.message.v1.created",
+        "//chat.googleapis.com/spaces/X",
+      ),
+    ).toBe("chat.message created from //chat.googleapis.com/spaces/X");
+  });
+});
+
+describe("transformCloudEvent", () => {
+  it("transforms a full CloudEvent", () => {
+    const event = {
+      type: "google.workspace.chat.message.v1.created",
+      source: "//chat.googleapis.com/spaces/X",
+      time: "2026-02-13T10:00:00Z",
+      data: { message: { text: "hello" } },
+    };
+    const result = transformCloudEvent(event);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]).toEqual({
+      type: "google.workspace.chat.message.v1.created",
+      source: "//chat.googleapis.com/spaces/X",
+      time: "2026-02-13T10:00:00Z",
+      resourceType: "chat.message",
+      summary: "chat.message created from //chat.googleapis.com/spaces/X",
+      data: { message: { text: "hello" } },
+    });
+  });
+
+  it("handles missing fields gracefully", () => {
+    const result = transformCloudEvent({});
+    expect(result.events[0]).toEqual({
+      type: "",
+      source: "",
+      time: "",
+      resourceType: "",
+      summary: "  from ",
+      data: {},
+    });
+  });
+
+  it("handles non-object data", () => {
+    const result = transformCloudEvent({ type: "test", data: "string-data" });
+    expect(result.events[0]?.data).toEqual({});
+  });
+
+  it("handles null data", () => {
+    const result = transformCloudEvent({ type: "test", data: null });
+    expect(result.events[0]?.data).toEqual({});
+  });
+});
+
+describe("createWsEventsNdjsonLineHandler", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("parses JSON line, transforms, and POSTs", () => {
+    const handler = createWsEventsNdjsonLineHandler({
+      hookUrl: "http://localhost/hooks/workspace-events",
+      hookToken: "tok",
+    });
+
+    const line = JSON.stringify({
+      type: "google.workspace.chat.message.v1.created",
+      source: "//chat.googleapis.com/spaces/X",
+      time: "2026-02-13T10:00:00Z",
+      data: { message: { text: "hello" } },
+    });
+
+    handler(line);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = vi.mocked(globalThis.fetch).mock.calls[0] ?? [];
+    expect(url).toBe("http://localhost/hooks/workspace-events");
+    const body = JSON.parse((opts as RequestInit).body as string) as Record<string, unknown>;
+    const events = body.events as Array<Record<string, unknown>>;
+    expect(events[0]?.type).toBe("google.workspace.chat.message.v1.created");
+    expect(events[0]?.resourceType).toBe("chat.message");
+  });
+
+  it("ignores empty lines", () => {
+    const handler = createWsEventsNdjsonLineHandler({
+      hookUrl: "http://localhost/hooks/workspace-events",
+      hookToken: "tok",
+    });
+
+    handler("");
+    handler("   ");
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-JSON lines", () => {
+    const handler = createWsEventsNdjsonLineHandler({
+      hookUrl: "http://localhost/hooks/workspace-events",
+      hookToken: "tok",
+    });
+
+    handler("not json at all");
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/ws-events-bridge.test.ts
+++ b/src/hooks/ws-events-bridge.test.ts
@@ -68,7 +68,7 @@ describe("transformCloudEvent", () => {
       source: "",
       time: "",
       resourceType: "",
-      summary: "  from ",
+      summary: " unknown from ",
       data: {},
     });
   });

--- a/src/hooks/ws-events-bridge.ts
+++ b/src/hooks/ws-events-bridge.ts
@@ -1,0 +1,127 @@
+/**
+ * Workspace Events Bridge
+ *
+ * Transforms gws events +subscribe NDJSON output (CloudEvent JSON)
+ * into the hook payload format expected by the workspace-events preset.
+ */
+
+import { createSubsystemLogger, type SubsystemLogger } from "../logging/subsystem.js";
+
+export type WsEventsHookEvent = {
+  type: string;
+  source: string;
+  time: string;
+  resourceType: string;
+  summary: string;
+  data: Record<string, unknown>;
+};
+
+export type WsEventsHookPayload = {
+  events: WsEventsHookEvent[];
+};
+
+/**
+ * Extract a human-readable resource type from the event type string.
+ * e.g. "google.workspace.chat.message.v1.created" → "chat.message"
+ */
+export function extractResourceType(eventType: string): string {
+  const stripped = eventType.replace(/^google\.workspace\./, "");
+  const withoutVersion = stripped.replace(/\.v\d+\.\w+$/, "");
+  return withoutVersion || eventType;
+}
+
+/**
+ * Build a human-readable summary from a CloudEvent.
+ */
+export function buildEventSummary(eventType: string, source: string): string {
+  const action = eventType.split(".").pop() ?? "unknown";
+  const resource = extractResourceType(eventType);
+  return `${resource} ${action} from ${source}`;
+}
+
+/**
+ * Transform a raw CloudEvent object (from gws events +subscribe) into
+ * the hook payload format expected by the workspace-events preset.
+ */
+export function transformCloudEvent(event: Record<string, unknown>): WsEventsHookPayload {
+  const type = typeof event.type === "string" ? event.type : "";
+  const source = typeof event.source === "string" ? event.source : "";
+  const time = typeof event.time === "string" ? event.time : "";
+  const data =
+    event.data !== null && typeof event.data === "object" && !Array.isArray(event.data)
+      ? (event.data as Record<string, unknown>)
+      : {};
+
+  return {
+    events: [
+      {
+        type,
+        source,
+        time,
+        resourceType: extractResourceType(type),
+        summary: buildEventSummary(type, source),
+        data,
+      },
+    ],
+  };
+}
+
+/**
+ * POST a hook payload to the OpenClaw hook URL.
+ */
+async function postToHookUrl(
+  payload: WsEventsHookPayload,
+  hookUrl: string,
+  hookToken: string,
+): Promise<void> {
+  const response = await fetch(hookUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${hookToken}`,
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error(`Hook POST failed: ${response.status} ${response.statusText}`);
+  }
+}
+
+export type WsEventsNdjsonLineHandlerConfig = {
+  hookUrl: string;
+  hookToken: string;
+};
+
+/**
+ * Create a callback that processes a single NDJSON line from gws stdout,
+ * transforms it into a hook payload, and POSTs it.
+ */
+export function createWsEventsNdjsonLineHandler(
+  cfg: WsEventsNdjsonLineHandlerConfig,
+  log?: SubsystemLogger,
+): (line: string) => void {
+  const logger = log ?? createSubsystemLogger("ws-events-bridge");
+
+  return (line: string) => {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return;
+    }
+    let event: Record<string, unknown>;
+    try {
+      event = JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      logger.warn(`ignoring non-JSON line: ${trimmed.slice(0, 120)}`);
+      return;
+    }
+
+    const payload = transformCloudEvent(event);
+
+    const eventType = payload.events[0]?.type ?? "?";
+    logger.info(`forwarding event ${eventType} to ${cfg.hookUrl}`);
+
+    void postToHookUrl(payload, cfg.hookUrl, cfg.hookToken).catch((err) => {
+      logger.error(`failed to forward event ${eventType}: ${String(err)}`);
+    });
+  };
+}

--- a/src/hooks/ws-events-bridge.ts
+++ b/src/hooks/ws-events-bridge.ts
@@ -34,7 +34,7 @@ export function extractResourceType(eventType: string): string {
  * Build a human-readable summary from a CloudEvent.
  */
 export function buildEventSummary(eventType: string, source: string): string {
-  const action = eventType.split(".").pop() ?? "unknown";
+  const action = eventType.split(".").pop() || "unknown";
   const resource = extractResourceType(eventType);
   return `${resource} ${action} from ${source}`;
 }

--- a/src/hooks/ws-events-ops.ts
+++ b/src/hooks/ws-events-ops.ts
@@ -1,0 +1,180 @@
+import { formatCliCommand } from "../cli/command-format.js";
+import {
+  type OpenClawConfig,
+  CONFIG_PATH,
+  loadConfig,
+  readConfigFileSnapshot,
+  resolveGatewayPort,
+  validateConfigObjectWithPlugins,
+  writeConfigFile,
+} from "../config/config.js";
+import { defaultRuntime } from "../runtime.js";
+import { displayPath } from "../utils.js";
+import { ensureDependency, ensureGcloudAuth, runGcloud } from "./gmail-setup-utils.js";
+import { generateHookToken, mergeHookPresets, normalizeHooksPath } from "./gmail.js";
+import { spawnGwsEventsSubscribe } from "./ws-events-watcher.js";
+import {
+  buildDefaultWsEventsHookUrl,
+  buildGwsEventsSubscribeArgs,
+  resolveWsEventsHookRuntimeConfig,
+  type WsEventsHookOverrides,
+} from "./ws-events.js";
+
+export type WsEventsSetupOptions = {
+  target: string;
+  eventTypes: string[];
+  project: string;
+  subscription?: string;
+  hookUrl?: string;
+  hookToken?: string;
+  pollInterval?: number;
+  maxMessages?: number;
+  cleanup?: boolean;
+  json?: boolean;
+};
+
+export type WsEventsRunOptions = {
+  target?: string;
+  eventTypes?: string[];
+  project?: string;
+  subscription?: string;
+  hookUrl?: string;
+  hookToken?: string;
+  pollInterval?: number;
+  maxMessages?: number;
+  cleanup?: boolean;
+};
+
+export async function runWsEventsSetup(opts: WsEventsSetupOptions) {
+  await ensureDependency("gws", ["@googleworkspace/cli"], "npm");
+  await ensureDependency("gcloud", ["--cask", "gcloud-cli"]);
+  await ensureGcloudAuth();
+
+  // Validate project exists
+  await runGcloud(["projects", "describe", opts.project, "--quiet"]);
+
+  const configSnapshot = await readConfigFileSnapshot();
+  if (!configSnapshot.valid) {
+    throw new Error(`Config invalid: ${CONFIG_PATH}`);
+  }
+
+  const baseConfig = configSnapshot.config;
+  const hooksPath = normalizeHooksPath(baseConfig.hooks?.path);
+  const hookToken = opts.hookToken ?? baseConfig.hooks?.token ?? generateHookToken();
+  const hookUrl =
+    opts.hookUrl ??
+    baseConfig.hooks?.workspaceEvents?.hookUrl ??
+    buildDefaultWsEventsHookUrl(hooksPath, resolveGatewayPort(baseConfig));
+
+  const nextConfig: OpenClawConfig = {
+    ...baseConfig,
+    hooks: {
+      ...baseConfig.hooks,
+      enabled: true,
+      path: hooksPath,
+      token: hookToken,
+      presets: mergeHookPresets(baseConfig.hooks?.presets, "workspace-events"),
+      workspaceEvents: {
+        ...baseConfig.hooks?.workspaceEvents,
+        project: opts.project,
+        target: opts.target,
+        eventTypes: opts.eventTypes,
+        ...(opts.subscription ? { subscription: opts.subscription } : {}),
+        hookUrl,
+        ...(opts.pollInterval !== undefined ? { pollInterval: opts.pollInterval } : {}),
+        ...(opts.maxMessages !== undefined ? { maxMessages: opts.maxMessages } : {}),
+        ...(opts.cleanup !== undefined ? { cleanup: opts.cleanup } : {}),
+      },
+    },
+  };
+
+  const validated = validateConfigObjectWithPlugins(nextConfig);
+  if (!validated.ok) {
+    throw new Error(`Config validation failed: ${validated.issues[0]?.message ?? "invalid"}`);
+  }
+  await writeConfigFile(validated.config);
+
+  const summary: Record<string, unknown> = {
+    project: opts.project,
+    target: opts.target,
+    eventTypes: opts.eventTypes,
+    hookUrl,
+    hookToken,
+  };
+  if (opts.subscription) {
+    summary.subscription = opts.subscription;
+  }
+
+  if (opts.json) {
+    defaultRuntime.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+
+  defaultRuntime.log("Workspace events hooks configured:");
+  defaultRuntime.log(`- project: ${opts.project}`);
+  defaultRuntime.log(`- target: ${opts.target}`);
+  defaultRuntime.log(`- event types: ${opts.eventTypes.join(", ")}`);
+  defaultRuntime.log(`- hook url: ${hookUrl}`);
+  defaultRuntime.log(`- config: ${displayPath(CONFIG_PATH)}`);
+  defaultRuntime.log(`Next: ${formatCliCommand("openclaw webhooks events run")}`);
+}
+
+export async function runWsEventsService(opts: WsEventsRunOptions) {
+  await ensureDependency("gws", ["@googleworkspace/cli"], "npm");
+
+  const config = loadConfig();
+  const overrides: WsEventsHookOverrides = {
+    project: opts.project,
+    target: opts.target,
+    eventTypes: opts.eventTypes,
+    subscription: opts.subscription,
+    hookToken: opts.hookToken,
+    hookUrl: opts.hookUrl,
+    pollInterval: opts.pollInterval,
+    maxMessages: opts.maxMessages,
+    cleanup: opts.cleanup,
+  };
+
+  const resolved = resolveWsEventsHookRuntimeConfig(config, overrides);
+  if (!resolved.ok) {
+    throw new Error(resolved.error);
+  }
+
+  const runtimeConfig = resolved.value;
+  const args = buildGwsEventsSubscribeArgs(runtimeConfig);
+  defaultRuntime.log(`Starting gws ${args.join(" ")}`);
+
+  let shuttingDown = false;
+  let child = spawnGwsEventsSubscribe(runtimeConfig);
+
+  const detachSignals = () => {
+    process.off("SIGINT", shutdown);
+    process.off("SIGTERM", shutdown);
+  };
+
+  const shutdown = () => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    detachSignals();
+    child.kill("SIGTERM");
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  child.on("exit", () => {
+    if (shuttingDown) {
+      detachSignals();
+      return;
+    }
+    defaultRuntime.log("gws events +subscribe exited; restarting in 2s");
+    setTimeout(() => {
+      if (shuttingDown) {
+        return;
+      }
+      child = spawnGwsEventsSubscribe(runtimeConfig);
+    }, 2000);
+  });
+}

--- a/src/hooks/ws-events-ops.ts
+++ b/src/hooks/ws-events-ops.ts
@@ -1,3 +1,4 @@
+import type { ChildProcess } from "node:child_process";
 import { formatCliCommand } from "../cli/command-format.js";
 import {
   type OpenClawConfig,
@@ -164,17 +165,21 @@ export async function runWsEventsService(opts: WsEventsRunOptions) {
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
 
-  child.on("exit", () => {
-    if (shuttingDown) {
-      detachSignals();
-      return;
-    }
-    defaultRuntime.log("gws events +subscribe exited; restarting in 2s");
-    setTimeout(() => {
+  function attachExitHandler(proc: ChildProcess) {
+    proc.on("exit", () => {
       if (shuttingDown) {
+        detachSignals();
         return;
       }
-      child = spawnGwsEventsSubscribe(runtimeConfig);
-    }, 2000);
-  });
+      defaultRuntime.log("gws events +subscribe exited; restarting in 2s");
+      setTimeout(() => {
+        if (shuttingDown) {
+          return;
+        }
+        child = spawnGwsEventsSubscribe(runtimeConfig);
+        attachExitHandler(child);
+      }, 2000);
+    });
+  }
+  attachExitHandler(child);
 }

--- a/src/hooks/ws-events-watcher-lifecycle.ts
+++ b/src/hooks/ws-events-watcher-lifecycle.ts
@@ -1,0 +1,37 @@
+import type { OpenClawConfig } from "../config/config.js";
+import { isTruthyEnvValue } from "../infra/env.js";
+import { startWsEventsWatcher } from "./ws-events-watcher.js";
+
+export type WsEventsWatcherLog = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+export async function startWsEventsWatcherWithLogs(params: {
+  cfg: OpenClawConfig;
+  log: WsEventsWatcherLog;
+  onSkipped?: () => void;
+}) {
+  if (isTruthyEnvValue(process.env.OPENCLAW_SKIP_WS_EVENTS_WATCHER)) {
+    params.onSkipped?.();
+    return;
+  }
+
+  try {
+    const result = startWsEventsWatcher(params.cfg);
+    if (result.started) {
+      params.log.info("workspace events watcher started");
+      return;
+    }
+    if (
+      result.reason &&
+      result.reason !== "hooks not enabled" &&
+      result.reason !== "no workspace events target configured"
+    ) {
+      params.log.warn(`workspace events watcher not started: ${result.reason}`);
+    }
+  } catch (err) {
+    params.log.error(`workspace events watcher failed to start: ${String(err)}`);
+  }
+}

--- a/src/hooks/ws-events-watcher.ts
+++ b/src/hooks/ws-events-watcher.ts
@@ -1,0 +1,166 @@
+/**
+ * Workspace Events Watcher Service
+ *
+ * Automatically starts the gws events +subscribe process when the gateway starts,
+ * if hooks.workspaceEvents is configured with a target.
+ */
+
+import { type ChildProcess, spawn } from "node:child_process";
+import { hasBinary } from "../agents/skills.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { createWsEventsNdjsonLineHandler } from "./ws-events-bridge.js";
+import {
+  buildGwsEventsSubscribeArgs,
+  resolveWsEventsHookRuntimeConfig,
+  type WsEventsHookRuntimeConfig,
+} from "./ws-events.js";
+
+const log = createSubsystemLogger("ws-events-watcher");
+
+let watcherProcess: ChildProcess | null = null;
+let shuttingDown = false;
+let currentConfig: WsEventsHookRuntimeConfig | null = null;
+
+function isGwsAvailable(): boolean {
+  return hasBinary("gws");
+}
+
+/**
+ * Spawn the gws events +subscribe process (NDJSON on stdout).
+ */
+export function spawnGwsEventsSubscribe(cfg: WsEventsHookRuntimeConfig): ChildProcess {
+  const args = buildGwsEventsSubscribeArgs(cfg);
+  log.info(`starting gws ${args.join(" ")}`);
+
+  const child = spawn("gws", args, {
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: false,
+  });
+
+  const handleLine = createWsEventsNdjsonLineHandler(
+    {
+      hookUrl: cfg.hookUrl,
+      hookToken: cfg.hookToken,
+    },
+    log,
+  );
+
+  // Buffer partial lines from stdout (NDJSON may arrive in chunks)
+  let buffer = "";
+  child.stdout?.on("data", (data: Buffer) => {
+    buffer += data.toString();
+    const lines = buffer.split("\n");
+    // Keep last (possibly incomplete) segment in the buffer
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      handleLine(line);
+    }
+  });
+
+  child.stderr?.on("data", (data: Buffer) => {
+    const line = data.toString().trim();
+    if (line) {
+      log.warn(`[gws] ${line}`);
+    }
+  });
+
+  child.on("error", (err) => {
+    log.error(`gws process error: ${String(err)}`);
+  });
+
+  child.on("exit", (code, signal) => {
+    // Flush remaining buffer
+    if (buffer.trim()) {
+      handleLine(buffer);
+      buffer = "";
+    }
+    if (shuttingDown) {
+      return;
+    }
+    log.warn(`gws exited (code=${code}, signal=${signal}); restarting in 5s`);
+    watcherProcess = null;
+    setTimeout(() => {
+      if (shuttingDown || !currentConfig) {
+        return;
+      }
+      watcherProcess = spawnGwsEventsSubscribe(currentConfig);
+    }, 5000);
+  });
+
+  return child;
+}
+
+export type WsEventsWatcherStartResult = {
+  started: boolean;
+  reason?: string;
+};
+
+/**
+ * Start the workspace events watcher service.
+ * Called automatically by the gateway if hooks.workspaceEvents is configured.
+ */
+export function startWsEventsWatcher(cfg: OpenClawConfig): WsEventsWatcherStartResult {
+  if (!cfg.hooks?.enabled) {
+    return { started: false, reason: "hooks not enabled" };
+  }
+
+  if (!cfg.hooks?.workspaceEvents?.target) {
+    return { started: false, reason: "no workspace events target configured" };
+  }
+
+  if (!isGwsAvailable()) {
+    return { started: false, reason: "gws binary not found" };
+  }
+
+  const resolved = resolveWsEventsHookRuntimeConfig(cfg, {});
+  if (!resolved.ok) {
+    return { started: false, reason: resolved.error };
+  }
+
+  const runtimeConfig = resolved.value;
+  currentConfig = runtimeConfig;
+
+  shuttingDown = false;
+  watcherProcess = spawnGwsEventsSubscribe(runtimeConfig);
+  log.info(`workspace events watcher started for ${runtimeConfig.target}`);
+  return { started: true };
+}
+
+/**
+ * Stop the workspace events watcher service.
+ */
+export async function stopWsEventsWatcher(): Promise<void> {
+  shuttingDown = true;
+
+  if (watcherProcess) {
+    log.info("stopping workspace events watcher");
+    watcherProcess.kill("SIGTERM");
+
+    await new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => {
+        if (watcherProcess) {
+          watcherProcess.kill("SIGKILL");
+        }
+        resolve();
+      }, 3000);
+
+      watcherProcess?.on("exit", () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+
+    watcherProcess = null;
+  }
+
+  currentConfig = null;
+  log.info("workspace events watcher stopped");
+}
+
+/**
+ * Check if the workspace events watcher is running.
+ */
+export function isWsEventsWatcherRunning(): boolean {
+  return watcherProcess !== null && !shuttingDown;
+}

--- a/src/hooks/ws-events.test.ts
+++ b/src/hooks/ws-events.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from "vitest";
+import { type OpenClawConfig, DEFAULT_GATEWAY_PORT } from "../config/config.js";
+import {
+  buildDefaultWsEventsHookUrl,
+  buildGwsEventsSubscribeArgs,
+  DEFAULT_WS_EVENTS_MAX_MESSAGES,
+  DEFAULT_WS_EVENTS_POLL_INTERVAL,
+  resolveWsEventsHookRuntimeConfig,
+} from "./ws-events.js";
+
+const baseConfig = {
+  hooks: {
+    token: "hook-token",
+    workspaceEvents: {
+      project: "my-project",
+      target: "//chat.googleapis.com/spaces/ABC",
+      eventTypes: ["google.workspace.chat.message.v1.created"],
+    },
+  },
+} satisfies OpenClawConfig;
+
+describe("ws-events hook config", () => {
+  it("builds default hook url", () => {
+    expect(buildDefaultWsEventsHookUrl("/hooks", DEFAULT_GATEWAY_PORT)).toBe(
+      `http://127.0.0.1:${DEFAULT_GATEWAY_PORT}/hooks/workspace-events`,
+    );
+  });
+
+  it("resolves runtime config with defaults", () => {
+    const result = resolveWsEventsHookRuntimeConfig(baseConfig, {});
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.project).toBe("my-project");
+      expect(result.value.target).toBe("//chat.googleapis.com/spaces/ABC");
+      expect(result.value.eventTypes).toEqual(["google.workspace.chat.message.v1.created"]);
+      expect(result.value.pollInterval).toBe(DEFAULT_WS_EVENTS_POLL_INTERVAL);
+      expect(result.value.maxMessages).toBe(DEFAULT_WS_EVENTS_MAX_MESSAGES);
+      expect(result.value.cleanup).toBe(false);
+      expect(result.value.hookUrl).toBe(
+        `http://127.0.0.1:${DEFAULT_GATEWAY_PORT}/hooks/workspace-events`,
+      );
+    }
+  });
+
+  it("fails without hook token", () => {
+    const result = resolveWsEventsHookRuntimeConfig(
+      {
+        hooks: {
+          workspaceEvents: {
+            project: "my-project",
+            target: "//chat.googleapis.com/spaces/ABC",
+            eventTypes: ["google.workspace.chat.message.v1.created"],
+          },
+        },
+      },
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("hooks.token");
+    }
+  });
+
+  it("fails without project", () => {
+    const result = resolveWsEventsHookRuntimeConfig(
+      {
+        hooks: {
+          token: "hook-token",
+          workspaceEvents: {
+            target: "//chat.googleapis.com/spaces/ABC",
+            eventTypes: ["google.workspace.chat.message.v1.created"],
+          },
+        },
+      },
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("project");
+    }
+  });
+
+  it("fails without target", () => {
+    const result = resolveWsEventsHookRuntimeConfig(
+      {
+        hooks: {
+          token: "hook-token",
+          workspaceEvents: {
+            project: "my-project",
+            eventTypes: ["google.workspace.chat.message.v1.created"],
+          },
+        },
+      },
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("target");
+    }
+  });
+
+  it("fails without event types", () => {
+    const result = resolveWsEventsHookRuntimeConfig(
+      {
+        hooks: {
+          token: "hook-token",
+          workspaceEvents: {
+            project: "my-project",
+            target: "//chat.googleapis.com/spaces/ABC",
+          },
+        },
+      },
+      {},
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("eventTypes");
+    }
+  });
+
+  it("applies overrides", () => {
+    const result = resolveWsEventsHookRuntimeConfig(baseConfig, {
+      project: "override-project",
+      target: "//drive.googleapis.com/files/X",
+      eventTypes: ["google.workspace.drive.file.v1.updated"],
+      subscription: "my-sub",
+      pollInterval: 10,
+      maxMessages: 5,
+      cleanup: true,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.project).toBe("override-project");
+      expect(result.value.target).toBe("//drive.googleapis.com/files/X");
+      expect(result.value.eventTypes).toEqual(["google.workspace.drive.file.v1.updated"]);
+      expect(result.value.subscription).toBe("my-sub");
+      expect(result.value.pollInterval).toBe(10);
+      expect(result.value.maxMessages).toBe(5);
+      expect(result.value.cleanup).toBe(true);
+    }
+  });
+});
+
+describe("buildGwsEventsSubscribeArgs", () => {
+  it("builds basic args", () => {
+    const args = buildGwsEventsSubscribeArgs({
+      target: "//chat.googleapis.com/spaces/ABC",
+      eventTypes: ["google.workspace.chat.message.v1.created"],
+      project: "my-project",
+      pollInterval: DEFAULT_WS_EVENTS_POLL_INTERVAL,
+      maxMessages: DEFAULT_WS_EVENTS_MAX_MESSAGES,
+      cleanup: false,
+    });
+    expect(args).toEqual([
+      "events",
+      "+subscribe",
+      "--target",
+      "//chat.googleapis.com/spaces/ABC",
+      "--event-types",
+      "google.workspace.chat.message.v1.created",
+      "--project",
+      "my-project",
+    ]);
+  });
+
+  it("includes subscription when set", () => {
+    const args = buildGwsEventsSubscribeArgs({
+      target: "//chat.googleapis.com/spaces/ABC",
+      eventTypes: ["google.workspace.chat.message.v1.created"],
+      project: "my-project",
+      subscription: "my-sub",
+      pollInterval: DEFAULT_WS_EVENTS_POLL_INTERVAL,
+      maxMessages: DEFAULT_WS_EVENTS_MAX_MESSAGES,
+      cleanup: false,
+    });
+    expect(args).toContain("--subscription");
+    expect(args).toContain("my-sub");
+  });
+
+  it("includes non-default poll interval", () => {
+    const args = buildGwsEventsSubscribeArgs({
+      target: "//chat.googleapis.com/spaces/ABC",
+      eventTypes: ["google.workspace.chat.message.v1.created"],
+      project: "my-project",
+      pollInterval: 10,
+      maxMessages: DEFAULT_WS_EVENTS_MAX_MESSAGES,
+      cleanup: false,
+    });
+    expect(args).toContain("--poll-interval");
+    expect(args).toContain("10");
+  });
+
+  it("includes non-default max messages", () => {
+    const args = buildGwsEventsSubscribeArgs({
+      target: "//chat.googleapis.com/spaces/ABC",
+      eventTypes: ["google.workspace.chat.message.v1.created"],
+      project: "my-project",
+      pollInterval: DEFAULT_WS_EVENTS_POLL_INTERVAL,
+      maxMessages: 20,
+      cleanup: false,
+    });
+    expect(args).toContain("--max-messages");
+    expect(args).toContain("20");
+  });
+
+  it("includes cleanup flag", () => {
+    const args = buildGwsEventsSubscribeArgs({
+      target: "//chat.googleapis.com/spaces/ABC",
+      eventTypes: ["google.workspace.chat.message.v1.created"],
+      project: "my-project",
+      pollInterval: DEFAULT_WS_EVENTS_POLL_INTERVAL,
+      maxMessages: DEFAULT_WS_EVENTS_MAX_MESSAGES,
+      cleanup: true,
+    });
+    expect(args).toContain("--cleanup");
+  });
+
+  it("joins multiple event types with comma", () => {
+    const args = buildGwsEventsSubscribeArgs({
+      target: "//chat.googleapis.com/spaces/ABC",
+      eventTypes: [
+        "google.workspace.chat.message.v1.created",
+        "google.workspace.chat.message.v1.updated",
+      ],
+      project: "my-project",
+      pollInterval: DEFAULT_WS_EVENTS_POLL_INTERVAL,
+      maxMessages: DEFAULT_WS_EVENTS_MAX_MESSAGES,
+      cleanup: false,
+    });
+    const idx = args.indexOf("--event-types");
+    expect(args[idx + 1]).toBe(
+      "google.workspace.chat.message.v1.created,google.workspace.chat.message.v1.updated",
+    );
+  });
+});

--- a/src/hooks/ws-events.ts
+++ b/src/hooks/ws-events.ts
@@ -1,0 +1,134 @@
+import { type OpenClawConfig, DEFAULT_GATEWAY_PORT, resolveGatewayPort } from "../config/config.js";
+import { normalizeHooksPath } from "./gmail.js";
+
+export const DEFAULT_WS_EVENTS_POLL_INTERVAL = 5;
+export const DEFAULT_WS_EVENTS_MAX_MESSAGES = 10;
+
+export type WsEventsHookRuntimeConfig = {
+  project: string;
+  target: string;
+  eventTypes: string[];
+  subscription?: string;
+  hookToken: string;
+  hookUrl: string;
+  pollInterval: number;
+  maxMessages: number;
+  cleanup: boolean;
+};
+
+export type WsEventsHookOverrides = {
+  project?: string;
+  target?: string;
+  eventTypes?: string[];
+  subscription?: string;
+  hookToken?: string;
+  hookUrl?: string;
+  pollInterval?: number;
+  maxMessages?: number;
+  cleanup?: boolean;
+};
+
+export function buildDefaultWsEventsHookUrl(
+  hooksPath?: string,
+  port: number = DEFAULT_GATEWAY_PORT,
+): string {
+  const basePath = normalizeHooksPath(hooksPath);
+  return `http://127.0.0.1:${port}${basePath}/workspace-events`;
+}
+
+export function resolveWsEventsHookRuntimeConfig(
+  cfg: OpenClawConfig,
+  overrides: WsEventsHookOverrides,
+): { ok: true; value: WsEventsHookRuntimeConfig } | { ok: false; error: string } {
+  const hooks = cfg.hooks;
+  const wsEvents = hooks?.workspaceEvents;
+
+  const hookToken = overrides.hookToken ?? hooks?.token ?? "";
+  if (!hookToken) {
+    return { ok: false, error: "hooks.token missing (needed for workspace events hook)" };
+  }
+
+  const project = overrides.project ?? wsEvents?.project ?? "";
+  if (!project) {
+    return { ok: false, error: "workspace events project required" };
+  }
+
+  const target = overrides.target ?? wsEvents?.target ?? "";
+  if (!target) {
+    return { ok: false, error: "workspace events target required" };
+  }
+
+  const eventTypes = overrides.eventTypes ?? wsEvents?.eventTypes ?? [];
+  if (eventTypes.length === 0) {
+    return { ok: false, error: "workspace events eventTypes required (at least one)" };
+  }
+
+  const subscription = overrides.subscription ?? wsEvents?.subscription;
+
+  const hookUrl =
+    overrides.hookUrl ??
+    wsEvents?.hookUrl ??
+    buildDefaultWsEventsHookUrl(hooks?.path, resolveGatewayPort(cfg));
+
+  const pollIntervalRaw = overrides.pollInterval ?? wsEvents?.pollInterval;
+  const pollInterval =
+    typeof pollIntervalRaw === "number" && Number.isFinite(pollIntervalRaw) && pollIntervalRaw > 0
+      ? Math.floor(pollIntervalRaw)
+      : DEFAULT_WS_EVENTS_POLL_INTERVAL;
+
+  const maxMessagesRaw = overrides.maxMessages ?? wsEvents?.maxMessages;
+  const maxMessages =
+    typeof maxMessagesRaw === "number" && Number.isFinite(maxMessagesRaw) && maxMessagesRaw > 0
+      ? Math.floor(maxMessagesRaw)
+      : DEFAULT_WS_EVENTS_MAX_MESSAGES;
+
+  const cleanup = overrides.cleanup ?? wsEvents?.cleanup ?? false;
+
+  return {
+    ok: true,
+    value: {
+      project,
+      target,
+      eventTypes,
+      subscription,
+      hookToken,
+      hookUrl,
+      pollInterval,
+      maxMessages,
+      cleanup,
+    },
+  };
+}
+
+export function buildGwsEventsSubscribeArgs(
+  cfg: Pick<
+    WsEventsHookRuntimeConfig,
+    | "target"
+    | "eventTypes"
+    | "project"
+    | "subscription"
+    | "pollInterval"
+    | "maxMessages"
+    | "cleanup"
+  >,
+): string[] {
+  const args = ["events", "+subscribe", "--target", cfg.target];
+
+  args.push("--event-types", cfg.eventTypes.join(","));
+  args.push("--project", cfg.project);
+
+  if (cfg.subscription) {
+    args.push("--subscription", cfg.subscription);
+  }
+  if (cfg.pollInterval !== DEFAULT_WS_EVENTS_POLL_INTERVAL) {
+    args.push("--poll-interval", String(cfg.pollInterval));
+  }
+  if (cfg.maxMessages !== DEFAULT_WS_EVENTS_MAX_MESSAGES) {
+    args.push("--max-messages", String(cfg.maxMessages));
+  }
+  if (cfg.cleanup) {
+    args.push("--cleanup");
+  }
+
+  return args;
+}


### PR DESCRIPTION
## Summary

- Adds Google Workspace Events subscription hook via `gws events +subscribe`, giving agents real-time awareness of Calendar changes, Drive file updates, Chat messages, etc.
- Follows the Gmail gws pattern exactly: config → runtime resolver → arg builder → bridge (NDJSON→hook POST) → watcher (spawn + restart) → lifecycle wrapper → gateway startup/reload
- Adds `openclaw webhooks events setup` and `openclaw webhooks events run` CLI commands

## Changes

**New files (8):**
- `src/hooks/ws-events.ts` — runtime config types, resolver, arg builder
- `src/hooks/ws-events-bridge.ts` — CloudEvent NDJSON → hook payload transform
- `src/hooks/ws-events-watcher.ts` — process lifecycle (spawn, restart, stop)
- `src/hooks/ws-events-watcher-lifecycle.ts` — thin wrapper with env skip + logging
- `src/hooks/ws-events-ops.ts` — setup + run command implementations
- `src/hooks/ws-events.test.ts` — 13 tests for config resolver + arg builder
- `src/hooks/ws-events-bridge.test.ts` — 13 tests for CloudEvent transform + NDJSON handler
- `docs/automation/workspace-events.md` — documentation

**Modified files (8):**
- `src/config/types.hooks.ts` — `HooksWorkspaceEventsConfig` type
- `src/config/zod-schema.hooks.ts` — `HooksWorkspaceEventsSchema`
- `src/config/zod-schema.ts` — wire schema into parent hooks object
- `src/gateway/hooks-mapping.ts` — `"workspace-events"` preset + allowUnsafeExternalContent
- `src/gateway/config-reload-plan.ts` — `restartWsEventsWatcher` plan field + reload rule
- `src/gateway/server-startup.ts` — start watcher on boot
- `src/gateway/server-reload-handlers.ts` — handle watcher restart on config change
- `src/cli/webhooks-cli.ts` — `events setup` + `events run` subcommands

## Dependencies

- Depends on #35506 (gws/06-gmail-hooks-gws) for `postToHookUrl`, `ensureDependency("gws", ...)`, and the NDJSON bridge pattern

## Test plan

- [x] `pnpm build` — no type errors
- [x] `pnpm check` — lint/format clean
- [x] 26/26 workspace events tests pass
- [x] 41/41 existing Gmail tests still pass
- [x] 21/21 hooks-mapping tests still pass
- [ ] Manual: `openclaw webhooks events setup --target '//chat.googleapis.com/spaces/X' --event-types 'google.workspace.chat.message.v1.created' --project P`

🤖 Generated with [Claude Code](https://claude.com/claude-code)