### PR TITLE
fix(skill-creator): expand description to cover edit/refactor tasks

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Create or update AgentSkills. Use when designing, structuring, or packaging skills with scripts, references, and assets.
+description: Create, update, or refactor AgentSkills. Use when creating a new skill from scratch, editing or improving an existing SKILL.md, restructuring a skill's layout (splitting content, adding reference files, reorganizing scripts/assets), or validating a skill against the AgentSkills spec.
 ---
 
 # Skill Creator


### PR DESCRIPTION
## Summary

- The `skill-creator` skill description only mentioned "designing, structuring, or packaging" — words that imply blank-slate creation
- When an agent is mid-task **refactoring** or **editing** an existing skill, it skips `skill-creator` entirely because the description doesn't match its current context
- This caused agents to place reference files in wrong directories and add invalid frontmatter (as documented in the issue)

## Root Cause

The trigger description `"Create or update AgentSkills. Use when designing, structuring, or packaging skills..."` lacks explicit edit/refactor vocabulary. Agents pattern-match skill descriptions against their current task frame — if the frame is "I am fixing/splitting/restructuring", none of the existing trigger words fire.

## Change

`skills/skill-creator/SKILL.md` — one-line description update:

**Before:**
> Create or update AgentSkills. Use when designing, structuring, or packaging skills with scripts, references, and assets.

**After:**
> Create, update, or refactor AgentSkills. Use when creating a new skill from scratch, editing or improving an existing SKILL.md, restructuring a skill's layout (splitting content, adding reference files, reorganizing scripts/assets), or validating a skill against the AgentSkills spec.

## Test plan

- [ ] Ask an agent to refactor/split an existing `SKILL.md` — verify `skill-creator` is now loaded
- [ ] Ask an agent to create a new skill — verify `skill-creator` still triggers as before
- [ ] Ask an agent to validate a skill layout — verify `skill-creator` triggers

Fixes #36039