### PR TITLE
fix(daemon): refresh Windows gateway service version on restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
+- Windows/scheduled-task restart metadata: refresh `OPENCLAW_SERVICE_VERSION` in `gateway.cmd` on `openclaw gateway restart` so the Instances page reports the current npm-updated service version without manual script edits. (#36301) Thanks @pshotts.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.

--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -3,7 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { installScheduledTask, readScheduledTaskCommand } from "./schtasks.js";
+import { VERSION } from "../version.js";
+import {
+  installScheduledTask,
+  readScheduledTaskCommand,
+  resolveTaskScriptPath,
+  restartScheduledTask,
+} from "./schtasks.js";
 
 const schtasksCalls: string[][] = [];
 
@@ -131,6 +137,55 @@ describe("installScheduledTask", () => {
           environment: {},
         }),
       ).rejects.toThrow(/Task description cannot contain CR or LF/);
+    });
+  });
+});
+
+describe("restartScheduledTask", () => {
+  async function withUserProfileDir(
+    run: (tmpDir: string, env: Record<string, string>) => Promise<void>,
+  ) {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-schtasks-restart-"));
+    const env = {
+      USERPROFILE: tmpDir,
+      OPENCLAW_PROFILE: "default",
+    };
+    try {
+      await run(tmpDir, env);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  }
+
+  it("refreshes OPENCLAW_SERVICE_VERSION in gateway.cmd before restarting task", async () => {
+    await withUserProfileDir(async (_tmpDir, env) => {
+      const scriptPath = resolveTaskScriptPath(env);
+      await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+      await fs.writeFile(
+        scriptPath,
+        [
+          "@echo off",
+          "rem OpenClaw Gateway",
+          "set OPENCLAW_SERVICE_VERSION=2026.2.26",
+          "set NODE_ENV=production",
+          "node gateway.js --port 18789",
+        ].join("\r\n"),
+        "utf8",
+      );
+
+      await restartScheduledTask({
+        env,
+        stdout: new PassThrough(),
+      });
+
+      const script = await fs.readFile(scriptPath, "utf8");
+      expect(script).toContain(`set "OPENCLAW_SERVICE_VERSION=${VERSION}"`);
+      expect(script).not.toContain("set OPENCLAW_SERVICE_VERSION=2026.2.26");
+      expect(schtasksCalls).toEqual([
+        ["/Query"],
+        ["/End", "/TN", "OpenClaw Gateway"],
+        ["/Run", "/TN", "OpenClaw Gateway"],
+      ]);
     });
   });
 });

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { VERSION } from "../version.js";
 import { parseCmdScriptCommandLine, quoteCmdScriptArg } from "./cmd-argv.js";
 import { assertNoCmdLineBreak, parseCmdSetAssignment, renderCmdSetAssignment } from "./cmd-set.js";
 import { resolveGatewayServiceDescription, resolveGatewayWindowsTaskName } from "./constants.js";
@@ -310,12 +311,56 @@ export async function stopScheduledTask({ stdout, env }: GatewayServiceControlAr
   stdout.write(`${formatLine("Stopped Scheduled Task", taskName)}\n`);
 }
 
+async function refreshScheduledTaskScriptVersion(
+  env: GatewayServiceEnv,
+  serviceVersion: string,
+): Promise<void> {
+  const scriptPath = resolveTaskScriptPath(env);
+  let content: string;
+  try {
+    content = await fs.readFile(scriptPath, "utf8");
+  } catch {
+    return;
+  }
+  const newline = content.includes("\r\n") ? "\r\n" : "\n";
+  const lines = content.split(/\r?\n/);
+  const renderedVersionLine = renderCmdSetAssignment("OPENCLAW_SERVICE_VERSION", serviceVersion);
+  let replaced = false;
+  const nextLines = lines.map((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || !trimmed.toLowerCase().startsWith("set ")) {
+      return line;
+    }
+    const assignment = parseCmdSetAssignment(trimmed.slice(4));
+    if (!assignment || assignment.key.toUpperCase() !== "OPENCLAW_SERVICE_VERSION") {
+      return line;
+    }
+    replaced = true;
+    return renderedVersionLine;
+  });
+  if (!replaced) {
+    const insertAt = nextLines.findIndex((line) => {
+      const trimmed = line.trim().toLowerCase();
+      return trimmed.length > 0 && !trimmed.startsWith("@echo") && !trimmed.startsWith("rem ");
+    });
+    nextLines.splice(insertAt === -1 ? nextLines.length : insertAt, 0, renderedVersionLine);
+  }
+  const rewritten = nextLines.join(newline);
+  if (rewritten === content) {
+    return;
+  }
+  const normalized = rewritten.endsWith(newline) ? rewritten : `${rewritten}${newline}`;
+  await fs.writeFile(scriptPath, normalized, "utf8");
+}
+
 export async function restartScheduledTask({
   stdout,
   env,
 }: GatewayServiceControlArgs): Promise<void> {
   await assertSchtasksAvailable();
-  const taskName = resolveTaskName(env ?? (process.env as GatewayServiceEnv));
+  const resolvedEnv = env ?? (process.env as GatewayServiceEnv);
+  const taskName = resolveTaskName(resolvedEnv);
+  await refreshScheduledTaskScriptVersion(resolvedEnv, VERSION);
   await execSchtasks(["/End", "/TN", taskName]);
   const res = await execSchtasks(["/Run", "/TN", taskName]);
   if (res.code !== 0) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: on Windows scheduled-task installs, `openclaw gateway restart` did not refresh `gateway.cmd`, so stale `OPENCLAW_SERVICE_VERSION` could persist after npm global upgrades.
- Why it matters: the Instances page could report an outdated gateway/service version even after a successful update.
- What changed: before restarting the Scheduled Task, refresh `OPENCLAW_SERVICE_VERSION` inside `gateway.cmd` to the current runtime `VERSION`.
- What did NOT change (scope boundary): no changes to task creation flow, task name resolution, or non-Windows daemon backends.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36301
- Related #32655

## User-visible / Behavior Changes

- On Windows, running `openclaw gateway restart` now updates `~/.openclaw/gateway.cmd` service version metadata so status/Instances version display matches the updated runtime version.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (unit tests covering Windows Scheduled Task script behavior)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): daemon/scheduled-task control path
- Relevant config (redacted): default profile + `gateway.cmd` fixture

### Steps

1. Create a `gateway.cmd` fixture with stale `OPENCLAW_SERVICE_VERSION`.
2. Run `restartScheduledTask`.
3. Read back script content and inspect `schtasks` call sequence.

### Expected

- Script version line is rewritten to current `VERSION`.
- Restart still performs `/End` + `/Run` task control flow.

### Actual

- Matches expected after this change.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added test `refreshes OPENCLAW_SERVICE_VERSION in gateway.cmd before restarting task`.
- Edge cases checked: existing stale unquoted `set OPENCLAW_SERVICE_VERSION=...` line is normalized to quoted assignment with current version.
- What you did **not** verify: manual end-to-end run on a real Windows host.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Daemon: refresh gateway.cmd service version on restart`.
- Files/config to restore: `src/daemon/schtasks.ts`, `src/daemon/schtasks.install.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: failed Scheduled Task restart due malformed rewritten `gateway.cmd`.

## Risks and Mitigations

- Risk: script rewrite could alter formatting unexpectedly for custom-edited task scripts.
  - Mitigation: only `OPENCLAW_SERVICE_VERSION` assignment is targeted/replaced or inserted; command/start-stop flow remains unchanged and covered by tests.
