### PR TITLE
Optimize channel registry loader cache behavior

### DIFF
--- a/src/channels/plugins/registry-loader.test.ts
+++ b/src/channels/plugins/registry-loader.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { createChannelRegistryLoader } from "./registry-loader.js";
+import type { ChannelId } from "./types.js";
+
+const emptyRegistry = createTestRegistry([]);
+
+describe("createChannelRegistryLoader", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(emptyRegistry);
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(emptyRegistry);
+  });
+
+  it("caches missing channel ids to avoid repeated registry scans", async () => {
+    const registry = createTestRegistry([
+      {
+        pluginId: "msteams",
+        plugin: { id: "msteams" },
+        source: "test",
+      },
+    ]);
+    const findSpy = vi.spyOn(registry.channels, "find");
+    setActivePluginRegistry(registry);
+
+    const load = createChannelRegistryLoader(() => "ok");
+
+    expect(await load("telegram" as ChannelId)).toBeUndefined();
+    expect(await load("telegram" as ChannelId)).toBeUndefined();
+    expect(findSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches undefined resolver results", async () => {
+    const registry = createTestRegistry([
+      {
+        pluginId: "slack",
+        plugin: { id: "slack" },
+        source: "test",
+      },
+    ]);
+    setActivePluginRegistry(registry);
+
+    const resolveValue = vi.fn(() => undefined);
+    const load = createChannelRegistryLoader(resolveValue);
+
+    expect(await load("slack" as ChannelId)).toBeUndefined();
+    expect(await load("slack" as ChannelId)).toBeUndefined();
+    expect(resolveValue).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches falsy resolved values", async () => {
+    const registry = createTestRegistry([
+      {
+        pluginId: "slack",
+        plugin: { id: "slack" },
+        source: "test",
+      },
+    ]);
+    setActivePluginRegistry(registry);
+
+    const resolveValue = vi.fn(() => 0);
+    const load = createChannelRegistryLoader<number>(resolveValue);
+
+    expect(await load("slack" as ChannelId)).toBe(0);
+    expect(await load("slack" as ChannelId)).toBe(0);
+    expect(resolveValue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -9,7 +9,8 @@ type ChannelRegistryValueResolver<TValue> = (
 export function createChannelRegistryLoader<TValue>(
   resolveValue: ChannelRegistryValueResolver<TValue>,
 ): (id: ChannelId) => Promise<TValue | undefined> {
-  const cache = new Map<ChannelId, TValue>();
+  const CACHE_MISS = Symbol("channel-registry-cache-miss");
+  const cache = new Map<ChannelId, TValue | typeof CACHE_MISS>();
   let lastRegistry: PluginRegistry | null = null;
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
@@ -18,18 +19,17 @@ export function createChannelRegistryLoader<TValue>(
       cache.clear();
       lastRegistry = registry;
     }
-    const cached = cache.get(id);
-    if (cached) {
-      return cached;
+    if (cache.has(id)) {
+      const cached = cache.get(id);
+      return cached === CACHE_MISS ? undefined : cached;
     }
     const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
     if (!pluginEntry) {
+      cache.set(id, CACHE_MISS);
       return undefined;
     }
     const resolved = resolveValue(pluginEntry);
-    if (resolved) {
-      cache.set(id, resolved);
-    }
+    cache.set(id, resolved === undefined ? CACHE_MISS : resolved);
     return resolved;
   };
 }


### PR DESCRIPTION
## Summary
- cache channel lookup misses in `createChannelRegistryLoader` to avoid repeated registry scans
- cache `undefined` resolver results and other falsy resolved values
- add focused tests covering miss caching, undefined-result caching, and falsy-value caching

## Why
The loader previously only cached truthy values, so repeated lookups for missing channels or undefined/falsy resolver outputs re-scanned the registry every time.

## Risk
Low. The change is localized to cache bookkeeping and keeps existing registry-change invalidation behavior intact.

## Validation
- `pnpm vitest src/channels/plugins/registry-loader.test.ts`
- `pnpm vitest src/channels/plugins/plugins-core.test.ts`
