### PR TITLE
fix(gateway): create transcript for chat.inject when missing

### DIFF
--- a/src/gateway/server-methods/chat.inject.missing-transcript.test.ts
+++ b/src/gateway/server-methods/chat.inject.missing-transcript.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { chatHandlers } from "./chat.js";
+import { createMockSessionEntry, createTranscriptFixtureSync } from "./chat.test-helpers.js";
+import type { GatewayRequestContext } from "./types.js";
+
+// Note: chat.directive-tags.test.ts defines its own createChatContext() helper.
+// We keep a tiny local one here to avoid cross-test imports.
+function createChatContext(): Pick<
+  GatewayRequestContext,
+  "broadcast" | "nodeSendToSession" | "agentRunSeq" | "logGateway"
+> {
+  return {
+    broadcast: vi.fn() as unknown as GatewayRequestContext["broadcast"],
+    nodeSendToSession: vi.fn() as unknown as GatewayRequestContext["nodeSendToSession"],
+    agentRunSeq: new Map<string, number>(),
+    logGateway: {
+      warn: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as GatewayRequestContext["logGateway"],
+  };
+}
+
+describe("gateway chat.inject", () => {
+  it("creates transcript file when missing", async () => {
+    const { dir, transcriptPath } = createTranscriptFixtureSync({
+      prefix: "openclaw-chat-inject-missing-transcript-",
+      sessionId: "sess-missing",
+    });
+
+    try {
+      // Remove the transcript file but keep a session entry pointing at it.
+      fs.rmSync(transcriptPath, { force: true });
+      expect(fs.existsSync(transcriptPath)).toBe(false);
+
+      const mock = createMockSessionEntry({
+        transcriptPath,
+        sessionId: "sess-missing",
+        canonicalKey: "main",
+        cfg: {},
+      });
+
+      // Patch loadSessionEntry() used by chat.inject.
+      const sessionUtils = await import("../session-utils.js");
+      const loadSpy = vi.spyOn(sessionUtils, "loadSessionEntry").mockReturnValue({
+        cfg: mock.cfg as never,
+        storePath: mock.storePath,
+        entry: mock.entry as never,
+        canonicalKey: mock.canonicalKey,
+      });
+
+      const respond = vi.fn();
+      const context = createChatContext();
+
+      await chatHandlers["chat.inject"]({
+        params: { sessionKey: "main", message: "hello" },
+        respond,
+        req: {} as never,
+        client: null as never,
+        isWebchatConnect: () => false,
+        context: context as GatewayRequestContext,
+      });
+
+      const [ok, payload] = respond.mock.calls.at(-1) ?? [];
+      expect(ok).toBe(true);
+      expect(payload).toMatchObject({ ok: true });
+
+      expect(fs.existsSync(transcriptPath)).toBe(true);
+      const lines = fs
+        .readFileSync(transcriptPath, "utf-8")
+        .split(/\r?\n/)
+        .filter(Boolean);
+      expect(lines.length).toBeGreaterThanOrEqual(2);
+      const last = JSON.parse(lines.at(-1) as string) as Record<string, unknown>;
+      expect(last.type).toBe("message");
+
+      loadSpy.mockRestore();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1142,7 +1142,9 @@ export const chatHandlers: GatewayRequestHandlers = {
       storePath,
       sessionFile: entry?.sessionFile,
       agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
-      createIfMissing: false,
+      // If a session entry points at a transcriptPath but the file doesn't exist yet
+      // (common for ACP oneshot/run sessions), ensure we create it rather than hard-fail.
+      createIfMissing: true,
     });
     if (!appended.ok || !appended.messageId || !appended.message) {
       respond(


### PR DESCRIPTION
Closes #36170

### What
- chat.inject now uses `createIfMissing: true` when appending to a session transcript, so sessions that point to a transcriptPath but don't have the file yet (common for ACP oneshot/run) won't hard-fail.

### Tests
- Added a vitest that deletes the transcript file and verifies chat.inject recreates it and appends a message.

Test command:
- `vitest run --config vitest.gateway.config.ts src/gateway/server-methods/chat.inject.missing-transcript.test.ts`