### PR TITLE
fix(skill-creator): broaden description to trigger on edit/refactor tasks (#36039)

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: skill-creator
-description: Create or update AgentSkills. Use when designing, structuring, or packaging skills with scripts, references, and assets.
+description: Create, edit, or refactor AgentSkills. Use when creating a new skill, editing an existing SKILL.md, restructuring a skill's layout (splitting content, adding reference files, reorganizing scripts or assets), or validating a skill against the AgentSkills spec.
 ---
 
 # Skill Creator
 
-This skill provides guidance for creating effective skills.
+> **Trigger check:** If you are about to write to any `SKILL.md` file, create or move files within a skill directory, or restructure a skill's layout — you are doing skill authoring. Follow this guide.
+
+This skill provides guidance for creating and maintaining effective skills.
 
 ## About Skills
 


### PR DESCRIPTION
## Summary

Fixes #36039 — The skill-creator skill's description only triggers on creation tasks, not on editing/refactoring existing skills.

## Problem

The current description (`Create or update AgentSkills. Use when designing, structuring, or packaging skills with scripts, references, and assets.`) uses creation-oriented language that doesn't match when an agent is mid-task refactoring an existing skill. This leads to agents skipping the skill entirely and making spec violations (wrong directory layout, invalid frontmatter, incorrect file references).

## Fix

1. **Broadened description** to explicitly cover editing, refactoring, restructuring, and validation
2. **Added trigger heuristic** near the top of the skill body — a blockquote that helps agents recognize when they're doing skill authoring even if their primary frame is the object-level task

## Changed File

- `skills/skill-creator/SKILL.md` — Updated description + added trigger check note