### PR TITLE
fix(models): support google provider in Gemini 3.1 forward compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
+- Models/Gemini 3.1 fallback recognition: extend forward-compat matching for `gemini-3.1-*` to the `google` provider (not only `google-gemini-cli`) so configured Google fallbacks like `google/gemini-3.1-pro-preview` and `google/gemini-3.1-flash-lite-preview` no longer fail as unknown models. (#36111)
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -24,6 +24,7 @@ const GEMINI_3_1_PRO_PREFIX = "gemini-3.1-pro";
 const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";
 const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3-pro-preview"] as const;
 const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview"] as const;
+const GEMINI_3_1_ELIGIBLE_PROVIDERS = new Set(["google-gemini-cli", "google"]);
 
 function cloneFirstTemplateModel(params: {
   normalizedProvider: string;
@@ -176,7 +177,8 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
-  if (normalizeProviderId(provider) !== "google-gemini-cli") {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (!GEMINI_3_1_ELIGIBLE_PROVIDERS.has(normalizedProvider)) {
     return undefined;
   }
   const trimmed = modelId.trim();
@@ -192,7 +194,7 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
   }
 
   return cloneFirstTemplateModel({
-    normalizedProvider: "google-gemini-cli",
+    normalizedProvider,
     trimmedModelId: trimmed,
     templateIds: [...templateIds],
     modelRegistry,

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -11,6 +11,7 @@ import {
   GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
   GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
   makeModel,
+  mockDiscoveredModel,
   mockGoogleGeminiCliFlashTemplateModel,
   mockGoogleGeminiCliProTemplateModel,
   mockOpenAICodexTemplateModel,
@@ -77,6 +78,48 @@ describe("pi embedded model e2e smoke", () => {
       ...GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
       id: "gemini-3.1-flash-preview",
       name: "gemini-3.1-flash-preview",
+      reasoning: true,
+    });
+  });
+
+  it("builds a google-provider forward-compat fallback for gemini-3.1-pro-preview", () => {
+    mockDiscoveredModel({
+      provider: "google",
+      modelId: "gemini-3-pro-preview",
+      templateModel: {
+        ...GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+        provider: "google",
+      },
+    });
+
+    const result = resolveModel("google", "gemini-3.1-pro-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      ...GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+      provider: "google",
+      id: "gemini-3.1-pro-preview",
+      name: "gemini-3.1-pro-preview",
+      reasoning: true,
+    });
+  });
+
+  it("builds a google-provider forward-compat fallback for gemini-3.1-flash-lite-preview", () => {
+    mockDiscoveredModel({
+      provider: "google",
+      modelId: "gemini-3-flash-preview",
+      templateModel: {
+        ...GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
+        provider: "google",
+      },
+    });
+
+    const result = resolveModel("google", "gemini-3.1-flash-lite-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      ...GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
+      provider: "google",
+      id: "gemini-3.1-flash-lite-preview",
+      name: "gemini-3.1-flash-lite-preview",
       reasoning: true,
     });
   });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `gemini-3.1-*` forward-compat fallback matching only handled `google-gemini-cli`, so `google/gemini-3.1-*` fallback models could fail as `Unknown model`.
- Why it matters: configured Google fallback models silently stop failover and reduce resilience on provider errors/rate limits.
- What changed: extend Gemini 3.1 forward-compat eligibility to both `google-gemini-cli` and `google` providers while reusing existing template-clone logic.
- What did NOT change (scope boundary): no changes to non-Google forward-compat providers; no changes to primary model resolution behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36111
- Related #36013

## User-visible / Behavior Changes

- `google/gemini-3.1-pro-preview` and `google/gemini-3.1-flash-lite-preview` can now resolve through forward-compat fallback templates instead of failing with unknown-model errors.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: Google provider model resolution path
- Integration/channel (if any): model forward-compat resolver
- Relevant config (redacted): fallback model refs under `agents.defaults.model.fallbacks`

### Steps

1. Resolve model `google/gemini-3.1-pro-preview` with only Gemini 3 template models available.
2. Resolve model `google/gemini-3.1-flash-lite-preview` under same conditions.
3. Validate no `Unknown model` errors and verify cloned template fields.

### Expected

- Both 3.1 fallback models resolve successfully for provider `google`.

### Actual

- Matches expected after this change.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added `model.forward-compat` tests for `google/gemini-3.1-pro-preview` and `google/gemini-3.1-flash-lite-preview`.
- Edge cases checked: existing `google-gemini-cli` behavior remains covered and unchanged.
- What you did **not** verify: live Google provider request execution against real credentials.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Models: forward-compat Gemini 3.1 for google provider`.
- Files/config to restore: `src/agents/model-forward-compat.ts`, `src/agents/pi-embedded-runner/model.forward-compat.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: `google/gemini-3.1-*` fallback model refs reverting to unknown-model failures.

## Risks and Mitigations

- Risk: broadening provider eligibility could apply fallback cloning where providers have divergent Gemini model semantics.
  - Mitigation: scope remains to `gemini-3.1-*` patterns and existing provider-specific template IDs; test coverage added for both targeted ids.
