### PR TITLE
fix(feishu): accept legacy groupPolicy allowall

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -650,6 +650,49 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
   });
 
+  it("treats legacy groupPolicy allowall as open", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groupPolicy: "allowall",
+          groupAllowFrom: [],
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as unknown as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-anyone",
+        },
+      },
+      message: {
+        message_id: "msg-legacy-allowall",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ChatType: "group",
+        SenderId: "ou-anyone",
+      }),
+    );
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+
   it("prefers per-group allowFrom over global groupSenderAllowFrom", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -995,9 +995,12 @@ export async function handleFeishuMessage(params: {
       return;
     }
     const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
+    const rawGroupPolicy = feishuCfg?.groupPolicy as string | undefined;
+    const normalizedGroupPolicy =
+      rawGroupPolicy === "allowall" ? "open" : (feishuCfg?.groupPolicy ?? undefined);
     const { groupPolicy, providerMissingFallbackApplied } = resolveOpenProviderRuntimeGroupPolicy({
       providerConfigPresent: cfg.channels?.feishu !== undefined,
-      groupPolicy: feishuCfg?.groupPolicy,
+      groupPolicy: normalizedGroupPolicy,
       defaultGroupPolicy,
     });
     warnMissingProviderGroupPolicyFallbackOnce({


### PR DESCRIPTION
## Summary

Feishu still treated legacy `groupPolicy: "allowall"` as an allowlist-like mode, so group messages were dropped when `groupAllowFrom` was empty. This normalizes the legacy value to `open` at runtime.

## Changes

- Normalize `channels.feishu.groupPolicy = "allowall"` to `"open"` before group policy resolution in `extensions/feishu/src/bot.ts`
- Add regression test to ensure legacy `allowall` accepts group messages even when `groupAllowFrom` is empty

## Testing

- Added/updated test: `extensions/feishu/src/bot.test.ts`
- Could not run tests in this environment because project test tooling dependencies (`pnpm`/`vitest`) are unavailable in this runner

Fixes openclaw/openclaw#36312