### PR TITLE
fix(memory): enable WAL journal mode on SQLite index to prevent corruption on restart #36035 

### DIFF
--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -264,14 +264,23 @@ export abstract class MemoryManagerSyncOps {
     // failing immediately with SQLITE_BUSY.
     db.exec("PRAGMA busy_timeout = 5000");
     // WAL mode survives SIGTERM mid-write; default DELETE journal corrupts on crash.
-    // Read back the result to detect environments (e.g. network mounts) where WAL
-    // is silently unavailable — exec() would discard the return value and hide the failure.
-    const row = db.prepare("PRAGMA journal_mode = WAL").get() as
-      | { journal_mode: string }
-      | undefined;
-    if (row?.journal_mode !== "wal") {
+    // busy_timeout above already retries for 5 s on SQLITE_BUSY, but if the lock
+    // still cannot be acquired (e.g. two processes racing on a brand-new DB), we
+    // degrade gracefully rather than aborting manager construction entirely.
+    // Once a DB is in WAL mode the header persists it, so this becomes a no-op
+    // on every subsequent open and never needs a lock.
+    try {
+      const row = db.prepare("PRAGMA journal_mode = WAL").get() as
+        | { journal_mode: string }
+        | undefined;
+      if (row?.journal_mode !== "wal") {
+        log.warn(
+          `memory index: WAL mode unavailable (got ${row?.journal_mode ?? "unknown"}); database may be vulnerable to corruption on SIGTERM`,
+        );
+      }
+    } catch (err) {
       log.warn(
-        `memory index: WAL mode unavailable (got ${row?.journal_mode ?? "unknown"}); database may be vulnerable to corruption on SIGTERM`,
+        `memory index: could not enable WAL mode (${(err as Error).message}); database may be vulnerable to corruption on SIGTERM`,
       );
     }
     return db;

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -263,6 +263,17 @@ export abstract class MemoryManagerSyncOps {
     // Set it on every open so concurrent processes retry instead of
     // failing immediately with SQLITE_BUSY.
     db.exec("PRAGMA busy_timeout = 5000");
+    // WAL mode survives SIGTERM mid-write; default DELETE journal corrupts on crash.
+    // Read back the result to detect environments (e.g. network mounts) where WAL
+    // is silently unavailable — exec() would discard the return value and hide the failure.
+    const row = db.prepare("PRAGMA journal_mode = WAL").get() as
+      | { journal_mode: string }
+      | undefined;
+    if (row?.journal_mode !== "wal") {
+      log.warn(
+        `memory index: WAL mode unavailable (got ${row?.journal_mode ?? "unknown"}); database may be vulnerable to corruption on SIGTERM`,
+      );
+    }
     return db;
   }
 

--- a/src/memory/manager.wal-mode.test.ts
+++ b/src/memory/manager.wal-mode.test.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resetEmbeddingMocks } from "./embedding.test-mocks.js";
+import type { MemoryIndexManager } from "./index.js";
+import { getRequiredMemoryIndexManager } from "./test-manager-helpers.js";
+
+describe("memory manager WAL journal mode", () => {
+  let workspaceDir = "";
+  let indexPath = "";
+  let manager: MemoryIndexManager | null = null;
+
+  function createMemoryConfig(): OpenClawConfig {
+    return {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "mock-embed",
+            store: { path: indexPath },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+  }
+
+  beforeEach(async () => {
+    resetEmbeddingMocks();
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-wal-"));
+    indexPath = path.join(workspaceDir, "index.sqlite");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "Hello memory.");
+  });
+
+  afterEach(async () => {
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("opens the memory index database with WAL journal mode", async () => {
+    manager = await getRequiredMemoryIndexManager({
+      cfg: createMemoryConfig(),
+      agentId: "main",
+    });
+
+    const db = (manager as unknown as { db: DatabaseSync }).db;
+    const row = db.prepare("PRAGMA journal_mode").get() as { journal_mode: string };
+    expect(row.journal_mode).toBe("wal");
+  });
+});


### PR DESCRIPTION
## Summary

- **Problem:** The memory index SQLite database (`~/.openclaw/memory/main.sqlite`) is opened with the default `DELETE` journal mode. When the gateway receives SIGTERM mid-write (restart, update, config change), the journal is removed before the transaction completes, permanently corrupting the database.
- **Why it matters:** Users hit `"database disk image is malformed"` errors; memory search stops working until a manual `rm` + full reindex — and it recurs on every restart.
- **What changed:** Added `PRAGMA journal_mode = WAL` immediately after opening the SQLite connection in `openDatabaseAtPath`. WAL mode is crash-safe — partial writes are silently rolled back on next open.
- **What did NOT change:** No schema changes, no migration. The existing `-wal`/`-shm` suffix cleanup in `swapIndexFiles` already handles WAL sidecar files.

## Change Type

- [x] Bug fix

## Scope

- [x] Memory / storage

## Linked Issue/PR

- Closes #36035

## User-visible / Behavior Changes

Memory index SQLite now uses WAL journal mode by default. `-wal` and `-shm` sidecar files may appear alongside `main.sqlite`; this is normal.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence

- [x] New test `src/memory/manager.wal-mode.test.ts` asserts `PRAGMA journal_mode` returns `wal` after manager construction.
- All 235 memory tests pass (`pnpm test -- src/memory/`).

## Compatibility / Migration

- Backward compatible? Yes — existing databases are silently switched to WAL on next open.
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- Revert: remove `db.exec("PRAGMA journal_mode = WAL")` from `openDatabaseAtPath` in `src/memory/manager-sync-ops.ts`.

## Risks and Mitigations

- Risk: WAL mode leaves `-wal`/`-shm` sidecar files on disk.
  - Mitigation: `swapIndexFiles` already removes all three suffixes (`""`, `"-wal"`, `"-shm"`); no additional cleanup needed.