### PR TITLE
fix(feishu): detect group @mentions by stable ID

### DIFF
--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -76,6 +76,14 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     expect(ctx.mentionedBot).toBe(true);
   });
 
+  it("returns mentionedBot=true when bot mention name differs from configured botName", () => {
+    const event = makeEvent("group", [
+      { key: "@_user_1", name: "OpenClaw Bot (Alias)", id: { open_id: BOT_OPEN_ID } },
+    ]);
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID, "OpenClaw Bot");
+    expect(ctx.mentionedBot).toBe(true);
+  });
+
   it("returns mentionedBot=false when only other users are mentioned", () => {
     const event = makeEvent("group", [
       { key: "@_user_1", name: "Alice", id: { open_id: "ou_alice" } },

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -450,24 +450,15 @@ function formatSubMessageContent(content: string, contentType: string): string {
   }
 }
 
-function checkBotMentioned(
-  event: FeishuMessageEvent,
-  botOpenId?: string,
-  botName?: string,
-): boolean {
+function checkBotMentioned(event: FeishuMessageEvent, botOpenId?: string): boolean {
   if (!botOpenId) return false;
   // Check for @all (@_all in Feishu) — treat as mentioning every bot
   const rawContent = event.message.content ?? "";
   if (rawContent.includes("@_all")) return true;
   const mentions = event.message.mentions ?? [];
   if (mentions.length > 0) {
-    return mentions.some((m) => {
-      if (m.id.open_id !== botOpenId) return false;
-      // Guard against Feishu WS open_id remapping in multi-app groups:
-      // if botName is known and mention name differs, this is a false positive.
-      if (botName && m.name && m.name !== botName) return false;
-      return true;
-    });
+    // Rely on Feishu mention IDs; display names can vary by alias/context.
+    return mentions.some((m) => m.id.open_id === botOpenId);
   }
   // Post (rich text) messages may have empty message.mentions when they contain docs/paste
   if (event.message.message_type === "post") {
@@ -768,10 +759,10 @@ export function buildBroadcastSessionKey(
 export function parseFeishuMessageEvent(
   event: FeishuMessageEvent,
   botOpenId?: string,
-  botName?: string,
+  _botName?: string,
 ): FeishuMessageContext {
   const rawContent = parseMessageContent(event.message.content, event.message.message_type);
-  const mentionedBot = checkBotMentioned(event, botOpenId, botName);
+  const mentionedBot = checkBotMentioned(event, botOpenId);
   const hasAnyMention = (event.message.mentions?.length ?? 0) > 0;
   // In p2p, the bot mention is a pure addressing prefix with no semantic value;
   // strip it so slash commands like @Bot /help still have a leading /.


### PR DESCRIPTION
## Summary
- remove strict bot display-name equality from Feishu mention detection
- keep mention detection anchored on `mentions[].id.open_id`, which stays stable when display names/aliases vary
- add regression coverage for `@mention` where mention name differs from configured bot name

## Why
Feishu group messages can carry alias/display-name variants for bot mentions. Requiring an exact name match caused valid mentions to be treated as non-mentions, so group messages were dropped.

## Testing
- `pnpm vitest run extensions/feishu/src/bot.checkBotMentioned.test.ts`
- `pnpm vitest run extensions/feishu/src/bot.test.ts`

Fixes #36317
