### PR TITLE
fix(telegram): thread setStatus into long-polling for health-monitor watchdog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
+- Browser/chrome-extension: remove stray top-level `nonce` from the extension's gateway connect params; the field is not allowed by the connect schema (`additionalProperties: false`) and caused handshake rejection with `unexpected property 'nonce'` for all extension connections. (#35405)
 - Agents/openai-responses tool_choice: inject `tool_choice: "auto"` on the openai-responses payload path when tools are present but no explicit tool_choice is set, so custom providers (e.g. `api: openai-responses` with a non-openai provider) no longer silently produce text-only output when tool execution is required. (#36057)
 - Cron/update fallbacks persistence: persist `payload.fallbacks` in `cron.update` same-kind merge and kind-change rebuilds so fallback model lists are no longer silently dropped when updating cron jobs. (#36263)
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
+- Cron/update fallbacks persistence: persist `payload.fallbacks` in `cron.update` same-kind merge and kind-change rebuilds so fallback model lists are no longer silently dropped when updating cron jobs. (#36263)
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
+- Agents/openai-responses tool_choice: inject `tool_choice: "auto"` on the openai-responses payload path when tools are present but no explicit tool_choice is set, so custom providers (e.g. `api: openai-responses` with a non-openai provider) no longer silently produce text-only output when tool execution is required. (#36057)
 - Cron/update fallbacks persistence: persist `payload.fallbacks` in `cron.update` same-kind merge and kind-change rebuilds so fallback model lists are no longer silently dropped when updating cron jobs. (#36263)
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
+- Control UI/Core Files: re-fetch active file content (with `force: true`) when the Refresh button is clicked so external edits (e.g. CLI writes) become visible immediately without a full page reload. (#35428)
 - Browser/chrome-extension: remove stray top-level `nonce` from the extension's gateway connect params; the field is not allowed by the connect schema (`additionalProperties: false`) and caused handshake rejection with `unexpected property 'nonce'` for all extension connections. (#35405)
 - Agents/openai-responses tool_choice: inject `tool_choice: "auto"` on the openai-responses payload path when tools are present but no explicit tool_choice is set, so custom providers (e.g. `api: openai-responses` with a non-openai provider) no longer silently produce text-only output when tool execution is required. (#36057)
 - Cron/update fallbacks persistence: persist `payload.fallbacks` in `cron.update` same-kind merge and kind-change rebuilds so fallback model lists are no longer silently dropped when updating cron jobs. (#36263)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
+
+- # iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
+- Telegram/health-monitor: thread `setStatus` into Telegram long-polling (and webhook) so the channel health monitor can detect and recover stale/silent Telegram connections the same way it already does for Slack, WhatsApp, and Discord. (#36259)
+  > > > > > > > a1d6f9f68 (fix(telegram): thread setStatus into long-polling for health-monitor watchdog (#36259))
 - Security/skill env leak: strip skill-injected env vars (e.g. `OPENAI_API_KEY` from `openai-image-gen`) from exec child process environments so ACP harnesses and unrelated tools that have their own auth (e.g. Codex CLI via OAuth) no longer inherit skill API keys and silently switch to API billing. (#36280)
 - Control UI/Core Files: re-fetch active file content (with `force: true`) when the Refresh button is clicked so external edits (e.g. CLI writes) become visible immediately without a full page reload. (#35428)
 - Browser/chrome-extension: remove stray top-level `nonce` from the extension's gateway connect params; the field is not allowed by the connect schema (`additionalProperties: false`) and caused handshake rejection with `unexpected property 'nonce'` for all extension connections. (#35405)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
+- Security/skill env leak: strip skill-injected env vars (e.g. `OPENAI_API_KEY` from `openai-image-gen`) from exec child process environments so ACP harnesses and unrelated tools that have their own auth (e.g. Codex CLI via OAuth) no longer inherit skill API keys and silently switch to API billing. (#36280)
 - Control UI/Core Files: re-fetch active file content (with `force: true`) when the Refresh button is clicked so external edits (e.g. CLI writes) become visible immediately without a full page reload. (#35428)
 - Browser/chrome-extension: remove stray top-level `nonce` from the extension's gateway connect params; the field is not allowed by the connect schema (`additionalProperties: false`) and caused handshake rejection with `unexpected property 'nonce'` for all extension connections. (#35405)
 - Agents/openai-responses tool_choice: inject `tool_choice: "auto"` on the openai-responses payload path when tools are present but no explicit tool_choice is set, so custom providers (e.g. `api: openai-responses` with a non-openai provider) no longer silently produce text-only output when tool execution is required. (#36057)

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -336,9 +336,8 @@ function sendToRelay(payload) {
   ws.send(JSON.stringify(payload))
 }
 
-function ensureGatewayHandshakeStarted(payload) {
+function ensureGatewayHandshakeStarted() {
   if (relayConnectRequestId) return
-  const nonce = typeof payload?.nonce === 'string' ? payload.nonce.trim() : ''
   relayConnectRequestId = `ext-connect-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`
   sendToRelay({
     type: 'req',
@@ -357,7 +356,6 @@ function ensureGatewayHandshakeStarted(payload) {
       scopes: ['operator.read', 'operator.write'],
       caps: [],
       commands: [],
-      nonce: nonce || undefined,
       auth: relayGatewayToken ? { token: relayGatewayToken } : undefined,
     },
   })
@@ -406,7 +404,7 @@ async function onRelayMessage(text) {
 
   if (msg && msg.type === 'event' && msg.event === 'connect.challenge') {
     try {
-      ensureGatewayHandshakeStarted(msg.payload)
+      ensureGatewayHandshakeStarted()
     } catch (err) {
       console.warn('gateway connect handshake start failed', err instanceof Error ? err.message : String(err))
       relayConnectRequestId = null

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -289,6 +289,57 @@ describe("sendMessageMatrix cfg threading", () => {
   });
 });
 
+describe("sendMessageMatrix rate-limit retry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runtimeLoadConfigMock.mockReset();
+    runtimeLoadConfigMock.mockReturnValue({});
+    setMatrixRuntime(runtimeStub);
+  });
+
+  it("retries once after M_LIMIT_EXCEEDED and succeeds", async () => {
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce({ body: { errcode: "M_LIMIT_EXCEEDED", retry_after_ms: 1 } })
+      .mockResolvedValue("evt-retry");
+    const client = {
+      sendMessage,
+      getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
+    } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient;
+
+    const result = await sendMessageMatrix("!room:example", "hello", { client });
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(result.messageId).toBe("evt-retry");
+  });
+
+  it("propagates error when retry also fails", async () => {
+    const rateLimitErr = { body: { errcode: "M_LIMIT_EXCEEDED", retry_after_ms: 1 } };
+    const sendMessage = vi.fn().mockRejectedValue(rateLimitErr);
+    const client = {
+      sendMessage,
+      getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
+    } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient;
+
+    await expect(sendMessageMatrix("!room:example", "hello", { client })).rejects.toBe(
+      rateLimitErr,
+    );
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry on non-rate-limit errors", async () => {
+    const otherErr = new Error("M_FORBIDDEN");
+    const sendMessage = vi.fn().mockRejectedValue(otherErr);
+    const client = {
+      sendMessage,
+      getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
+    } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient;
+
+    await expect(sendMessageMatrix("!room:example", "hello", { client })).rejects.toBe(otherErr);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("resolveMediaMaxBytes cfg threading", () => {
   beforeEach(() => {
     runtimeLoadConfigMock.mockReset();

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -75,9 +75,22 @@ export async function sendMessageMatrix(
         ? buildThreadRelation(threadId, opts.replyToId)
         : buildReplyRelation(opts.replyToId);
       const sendContent = async (content: MatrixOutboundContent) => {
-        // @vector-im/matrix-bot-sdk uses sendMessage differently
-        const eventId = await client.sendMessage(roomId, content);
-        return eventId;
+        // @vector-im/matrix-bot-sdk uses sendMessage differently.
+        // On M_LIMIT_EXCEEDED, honor retry_after_ms and retry once (issue #36027).
+        try {
+          return await client.sendMessage(roomId, content);
+        } catch (err) {
+          const body = (err as { body?: { errcode?: string; retry_after_ms?: unknown } }).body;
+          if (body?.errcode !== "M_LIMIT_EXCEEDED") {
+            throw err;
+          }
+          const retryAfterMs =
+            typeof body.retry_after_ms === "number" && body.retry_after_ms > 0
+              ? Math.min(body.retry_after_ms, 30_000)
+              : 2_000;
+          await new Promise<void>((resolve) => setTimeout(resolve, retryAfterMs));
+          return await client.sendMessage(roomId, content);
+        }
       };
 
       let lastMessageId = "";

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -499,6 +499,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         webhookPath: account.config.webhookPath,
         webhookHost: account.config.webhookHost,
         webhookPort: account.config.webhookPort,
+        setStatus: ctx.setStatus as (next: Record<string, unknown>) => void,
       });
     },
     logoutAccount: async ({ accountId, cfg }) => {

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Create or update AgentSkills. Use when designing, structuring, or packaging skills with scripts, references, and assets.
+description: Create, update, or refactor AgentSkills. Use when creating a new skill from scratch, editing or improving an existing SKILL.md, restructuring a skill's layout (splitting content, adding reference files, reorganizing scripts/assets), or validating a skill against the AgentSkills spec.
 ---
 
 # Skill Creator

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -8,9 +8,14 @@ vi.mock("../infra/system-events.js", () => ({
   enqueueSystemEvent: vi.fn(),
 }));
 
+const mockSkillInjectedKeys = new Set<string>();
+vi.mock("./skills/env-overrides.js", () => ({
+  getActiveSkillInjectedEnvKeys: () => mockSkillInjectedKeys,
+}));
+
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
-import { emitExecSystemEvent } from "./bash-tools.exec-runtime.js";
+import { emitExecSystemEvent, sanitizeHostBaseEnv } from "./bash-tools.exec-runtime.js";
 
 const requestHeartbeatNowMock = vi.mocked(requestHeartbeatNow);
 const enqueueSystemEventMock = vi.mocked(enqueueSystemEvent);
@@ -60,5 +65,50 @@ describe("emitExecSystemEvent", () => {
 
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("sanitizeHostBaseEnv: skill-injected key stripping (#36280)", () => {
+  beforeEach(() => {
+    mockSkillInjectedKeys.clear();
+  });
+
+  it("strips env vars that are currently injected by skill overrides", () => {
+    mockSkillInjectedKeys.add("OPENAI_API_KEY");
+
+    const result = sanitizeHostBaseEnv({
+      PATH: "/usr/bin",
+      OPENAI_API_KEY: "sk-injected-by-skill",
+      HOME: "/home/user",
+    });
+
+    expect(result).not.toHaveProperty("OPENAI_API_KEY");
+    expect(result.HOME).toBe("/home/user");
+    expect(result.PATH).toBe("/usr/bin");
+  });
+
+  it("passes through env vars that are not skill-injected", () => {
+    // No skill keys in the set.
+    const result = sanitizeHostBaseEnv({
+      PATH: "/usr/bin",
+      SOME_USER_KEY: "value",
+      HOME: "/home/user",
+    });
+
+    expect(result.SOME_USER_KEY).toBe("value");
+    expect(result.HOME).toBe("/home/user");
+  });
+
+  it("does not strip skill-injected keys once the set is cleared (reverter called)", () => {
+    mockSkillInjectedKeys.add("OPENAI_API_KEY");
+    mockSkillInjectedKeys.clear(); // simulates reverter being called
+
+    const result = sanitizeHostBaseEnv({
+      PATH: "/usr/bin",
+      OPENAI_API_KEY: "user-provided-key",
+    });
+
+    // After revert, user-provided key should pass through.
+    expect(result.OPENAI_API_KEY).toBe("user-provided-key");
   });
 });

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -29,10 +29,14 @@ import {
 } from "./bash-tools.shared.js";
 import { buildCursorPositionResponse, stripDsrRequests } from "./pty-dsr.js";
 import { getShellConfig, sanitizeBinaryOutput } from "./shell-utils.js";
+import { getActiveSkillInjectedEnvKeys } from "./skills/env-overrides.js";
 
 // Sanitize inherited host env before merge so dangerous variables from process.env
-// are not propagated into non-sandboxed executions.
+// are not propagated into non-sandboxed executions. Also strips env vars that
+// were injected by skill env overrides so skill API keys (e.g. OPENAI_API_KEY
+// from openai-image-gen) do not leak into unrelated child processes. (#36280)
 export function sanitizeHostBaseEnv(env: Record<string, string>): Record<string, string> {
+  const skillInjectedKeys = getActiveSkillInjectedEnvKeys();
   const sanitized: Record<string, string> = {};
   for (const [key, value] of Object.entries(env)) {
     const upperKey = key.toUpperCase();
@@ -41,6 +45,11 @@ export function sanitizeHostBaseEnv(env: Record<string, string>): Record<string,
       continue;
     }
     if (isDangerousHostEnvVarName(upperKey)) {
+      continue;
+    }
+    // Strip env vars that are currently injected by skill env overrides so they
+    // don't leak to unrelated exec child processes via inherited environment.
+    if (skillInjectedKeys.has(key)) {
       continue;
     }
     sanitized[key] = value;

--- a/src/agents/pi-embedded-runner/extra-params.openai-responses-tool-choice.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openai-responses-tool-choice.test.ts
@@ -1,0 +1,122 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+// Mock streamSimple for testing
+vi.mock("@mariozechner/pi-ai", () => ({
+  streamSimple: vi.fn(() => ({
+    push: vi.fn(),
+    result: vi.fn(),
+  })),
+}));
+
+type ToolChoiceCase = {
+  applyProvider: string;
+  applyModelId: string;
+  model: Model<"openai-responses">;
+  initialPayload?: Record<string, unknown>;
+};
+
+function runToolChoiceCase(params: ToolChoiceCase) {
+  const payload: Record<string, unknown> = {
+    model: params.model.id,
+    ...params.initialPayload,
+  };
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    options?.onPayload?.(payload);
+    return {} as ReturnType<StreamFn>;
+  };
+  const agent = { streamFn: baseStreamFn };
+
+  applyExtraParamsToAgent(agent, undefined, params.applyProvider, params.applyModelId);
+
+  const context: Context = { messages: [] };
+  void agent.streamFn?.(params.model, context, {});
+
+  return payload;
+}
+
+describe("extra-params: openai-responses tool_choice injection (#36057)", () => {
+  it("injects tool_choice=auto for custom openai-responses provider when tools present and tool_choice absent", () => {
+    const payload = runToolChoiceCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: {
+        api: "openai-responses",
+        provider: "sub2api-gpt",
+        id: "gpt-5.3-codex",
+      } as Model<"openai-responses">,
+      initialPayload: {
+        tools: [{ type: "function", name: "exec" }],
+      },
+    });
+
+    expect(payload.tool_choice).toBe("auto");
+  });
+
+  it("does not inject tool_choice when tools array is empty", () => {
+    const payload = runToolChoiceCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: {
+        api: "openai-responses",
+        provider: "sub2api-gpt",
+        id: "gpt-5.3-codex",
+      } as Model<"openai-responses">,
+      initialPayload: { tools: [] },
+    });
+
+    expect(payload).not.toHaveProperty("tool_choice");
+  });
+
+  it("does not inject tool_choice when tools are absent", () => {
+    const payload = runToolChoiceCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: {
+        api: "openai-responses",
+        provider: "sub2api-gpt",
+        id: "gpt-5.3-codex",
+      } as Model<"openai-responses">,
+      initialPayload: {},
+    });
+
+    expect(payload).not.toHaveProperty("tool_choice");
+  });
+
+  it("preserves explicit tool_choice when already set", () => {
+    const payload = runToolChoiceCase({
+      applyProvider: "sub2api-gpt",
+      applyModelId: "gpt-5.3-codex",
+      model: {
+        api: "openai-responses",
+        provider: "sub2api-gpt",
+        id: "gpt-5.3-codex",
+      } as Model<"openai-responses">,
+      initialPayload: {
+        tools: [{ type: "function", name: "exec" }],
+        tool_choice: "required",
+      },
+    });
+
+    expect(payload.tool_choice).toBe("required");
+  });
+
+  it("does not inject tool_choice for non-openai-responses api", () => {
+    const payload = runToolChoiceCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      model: {
+        api: "openai-completions",
+        provider: "openai",
+        id: "gpt-5",
+      } as unknown as Model<"openai-responses">,
+      initialPayload: {
+        tools: [{ type: "function", name: "exec" }],
+      },
+    });
+
+    expect(payload).not.toHaveProperty("tool_choice");
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -283,7 +283,13 @@ function createOpenAIResponsesContextManagementWrapper(
   return (model, context, options) => {
     const forceStore = shouldForceResponsesStore(model);
     const useServerCompaction = shouldEnableOpenAIResponsesServerCompaction(model, extraParams);
-    if (!forceStore && !useServerCompaction) {
+    // Inject tool_choice: "auto" for any openai-responses model that has tools
+    // in the payload but no explicit tool_choice. Custom providers using
+    // api: "openai-responses" don't always get a default from the upstream
+    // library and may silently produce text-only output when tool_choice is
+    // absent. (#36057)
+    const isResponsesApi = typeof model.api === "string" && OPENAI_RESPONSES_APIS.has(model.api);
+    if (!forceStore && !useServerCompaction && !isResponsesApi) {
       return underlying(model, context, options);
     }
 
@@ -306,6 +312,16 @@ function createOpenAIResponsesContextManagementWrapper(
                 compact_threshold: compactThreshold,
               },
             ];
+          }
+          // Ensure tool_choice is set when tools are present so custom
+          // openai-responses providers don't silently fall back to text-only.
+          if (
+            isResponsesApi &&
+            Array.isArray(payloadObj.tools) &&
+            payloadObj.tools.length > 0 &&
+            payloadObj.tool_choice == null
+          ) {
+            payloadObj.tool_choice = "auto";
           }
         }
         originalOnPayload?.(payload);

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -278,6 +278,58 @@ describe("resolveModel", () => {
     expect(result.model?.reasoning).toBe(true);
   });
 
+  it("prefers configured provider api metadata over discovered registry model", () => {
+    mockDiscoveredModel({
+      provider: "onehub",
+      modelId: "glm-5",
+      templateModel: {
+        id: "glm-5",
+        name: "GLM-5 (cached)",
+        provider: "onehub",
+        api: "anthropic-messages",
+        baseUrl: "https://old-provider.example.com/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 8192,
+        maxTokens: 2048,
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          onehub: {
+            baseUrl: "http://new-provider.example.com/v1",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("glm-5"),
+                api: "openai-completions",
+                reasoning: true,
+                contextWindow: 198000,
+                maxTokens: 16000,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("onehub", "glm-5", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "onehub",
+      id: "glm-5",
+      api: "openai-completions",
+      baseUrl: "http://new-provider.example.com/v1",
+      reasoning: true,
+      contextWindow: 198000,
+      maxTokens: 16000,
+    });
+  });
+
   it("builds an openai-codex fallback for gpt-5.3-codex", () => {
     mockOpenAICodexTemplateModel();
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -41,7 +41,12 @@ function applyConfiguredProviderOverrides(params: {
     return discoveredModel;
   }
   const configuredModel = providerConfig.models?.find((candidate) => candidate.id === modelId);
-  if (!configuredModel && !providerConfig.baseUrl && !providerConfig.api && !providerConfig.headers) {
+  if (
+    !configuredModel &&
+    !providerConfig.baseUrl &&
+    !providerConfig.api &&
+    !providerConfig.headers
+  ) {
     return discoveredModel;
   }
   return {
@@ -56,9 +61,9 @@ function applyConfiguredProviderOverrides(params: {
     headers:
       providerConfig.headers || configuredModel?.headers
         ? {
-            ...(discoveredModel.headers ?? {}),
-            ...(providerConfig.headers ?? {}),
-            ...(configuredModel?.headers ?? {}),
+            ...discoveredModel.headers,
+            ...providerConfig.headers,
+            ...configuredModel?.headers,
           }
         : discoveredModel.headers,
     compat: configuredModel?.compat ?? discoveredModel.compat,

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -7,7 +7,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { buildModelAliasLines } from "../model-alias-lines.js";
 import { normalizeModelCompat } from "../model-compat.js";
 import { resolveForwardCompatModel } from "../model-forward-compat.js";
-import { normalizeProviderId } from "../model-selection.js";
+import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
 import { discoverAuthStorage, discoverModels } from "../pi-model-discovery.js";
 
 type InlineModelEntry = ModelDefinitionConfig & {
@@ -23,6 +23,47 @@ type InlineProviderConfig = {
 };
 
 export { buildModelAliasLines };
+
+function resolveConfiguredProviderConfig(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+): InlineProviderConfig | undefined {
+  return findNormalizedProviderValue(cfg?.models?.providers, provider);
+}
+
+function applyConfiguredProviderOverrides(params: {
+  discoveredModel: Model<Api>;
+  providerConfig?: InlineProviderConfig;
+  modelId: string;
+}): Model<Api> {
+  const { discoveredModel, providerConfig, modelId } = params;
+  if (!providerConfig) {
+    return discoveredModel;
+  }
+  const configuredModel = providerConfig.models?.find((candidate) => candidate.id === modelId);
+  if (!configuredModel && !providerConfig.baseUrl && !providerConfig.api && !providerConfig.headers) {
+    return discoveredModel;
+  }
+  return {
+    ...discoveredModel,
+    api: configuredModel?.api ?? providerConfig.api ?? discoveredModel.api,
+    baseUrl: providerConfig.baseUrl ?? discoveredModel.baseUrl,
+    reasoning: configuredModel?.reasoning ?? discoveredModel.reasoning,
+    input: configuredModel?.input ?? discoveredModel.input,
+    cost: configuredModel?.cost ?? discoveredModel.cost,
+    contextWindow: configuredModel?.contextWindow ?? discoveredModel.contextWindow,
+    maxTokens: configuredModel?.maxTokens ?? discoveredModel.maxTokens,
+    headers:
+      providerConfig.headers || configuredModel?.headers
+        ? {
+            ...(discoveredModel.headers ?? {}),
+            ...(providerConfig.headers ?? {}),
+            ...(configuredModel?.headers ?? {}),
+          }
+        : discoveredModel.headers,
+    compat: configuredModel?.compat ?? discoveredModel.compat,
+  };
+}
 
 export function buildInlineProviderModels(
   providers: Record<string, InlineProviderConfig>,
@@ -59,6 +100,7 @@ export function resolveModel(
   const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
   const authStorage = discoverAuthStorage(resolvedAgentDir);
   const modelRegistry = discoverModels(authStorage, resolvedAgentDir);
+  const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
   const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
 
   if (!model) {
@@ -100,7 +142,7 @@ export function resolveModel(
       } as Model<Api>);
       return { model: fallbackModel, authStorage, modelRegistry };
     }
-    const providerCfg = providers[provider];
+    const providerCfg = providerConfig;
     if (providerCfg || modelId.startsWith("mock-")) {
       const configuredModel = providerCfg?.models?.find((candidate) => candidate.id === modelId);
       const fallbackModel: Model<Api> = normalizeModelCompat({
@@ -133,21 +175,17 @@ export function resolveModel(
       modelRegistry,
     };
   }
-  const providerOverride = cfg?.models?.providers?.[provider] as InlineProviderConfig | undefined;
-  if (providerOverride?.baseUrl || providerOverride?.headers) {
-    const overridden: Model<Api> & { headers?: Record<string, string> } = { ...model };
-    if (providerOverride.baseUrl) {
-      overridden.baseUrl = providerOverride.baseUrl;
-    }
-    if (providerOverride.headers) {
-      overridden.headers = {
-        ...(model as Model<Api> & { headers?: Record<string, string> }).headers,
-        ...providerOverride.headers,
-      };
-    }
-    return { model: normalizeModelCompat(overridden), authStorage, modelRegistry };
-  }
-  return { model: normalizeModelCompat(model), authStorage, modelRegistry };
+  return {
+    model: normalizeModelCompat(
+      applyConfiguredProviderOverrides({
+        discoveredModel: model,
+        providerConfig,
+        modelId,
+      }),
+    ),
+    authStorage,
+    modelRegistry,
+  };
 }
 
 /**

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -10,6 +10,15 @@ import type { SkillEntry, SkillSnapshot } from "./types.js";
 const log = createSubsystemLogger("env-overrides");
 
 type EnvUpdate = { key: string; prev: string | undefined };
+
+// Tracks env keys that are currently injected by skill env overrides so that
+// exec child processes can strip them and avoid leaking skill API keys to
+// unrelated tools (e.g. ACP harnesses that have their own auth). (#36280)
+const activeSkillInjectedKeys = new Set<string>();
+
+export function getActiveSkillInjectedEnvKeys(): ReadonlySet<string> {
+  return activeSkillInjectedKeys;
+}
 type SkillConfig = NonNullable<ReturnType<typeof resolveSkillConfig>>;
 
 type SanitizedSkillEnvOverrides = {
@@ -135,6 +144,7 @@ function applySkillConfigEnvOverrides(params: {
     }
     updates.push({ key: envKey, prev: process.env[envKey] });
     process.env[envKey] = envValue;
+    activeSkillInjectedKeys.add(envKey);
   }
 }
 
@@ -146,6 +156,7 @@ function createEnvReverter(updates: EnvUpdate[]) {
       } else {
         process.env[update.key] = update.prev;
       }
+      activeSkillInjectedKeys.delete(update.key);
     }
   };
 }

--- a/src/config/legacy.rules.ts
+++ b/src/config/legacy.rules.ts
@@ -131,6 +131,11 @@ export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
     message: "routing.queue was moved; use messages.queue instead (auto-migrated on load).",
   },
   {
+    path: ["messages", "queue", "byProvider"],
+    message:
+      "messages.queue.byProvider was renamed; use messages.queue.byChannel instead (auto-migrated on load).",
+  },
+  {
     path: ["routing", "transcribeAudio"],
     message:
       "routing.transcribeAudio was moved; use tools.media.audio.models instead (auto-migrated on load).",

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -313,6 +313,58 @@ export function validateConfigObjectRawWithPlugins(raw: unknown):
   return validateConfigObjectWithPluginsBase(raw, { applyDefaults: false });
 }
 
+/**
+ * Strip Zod-identified unrecognized keys from a raw config object.
+ * Returns the stripped config and a list of warnings for the removed keys.
+ * Used to allow gateway startup when config has stale/unknown keys from older versions.
+ */
+function stripUnrecognizedKeysFromRaw(raw: unknown): {
+  stripped: unknown;
+  warnings: ConfigValidationIssue[];
+} {
+  const probe = OpenClawSchema.safeParse(raw);
+  if (probe.success) {
+    return { stripped: raw, warnings: [] };
+  }
+  const unrecognizedIssues = probe.error.issues.filter((iss) => iss.code === "unrecognized_keys");
+  if (unrecognizedIssues.length === 0) {
+    return { stripped: raw, warnings: [] };
+  }
+  // Deep-clone the raw config and delete each unrecognized key.
+  const next = JSON.parse(JSON.stringify(raw)) as Record<string, unknown>;
+  const warnings: ConfigValidationIssue[] = [];
+  for (const issue of unrecognizedIssues) {
+    const path = issue.path.filter(
+      (seg): seg is string | number => typeof seg === "string" || typeof seg === "number",
+    );
+    let target: unknown = next;
+    for (const seg of path) {
+      if (!target || typeof target !== "object" || Array.isArray(target)) {
+        target = null;
+        break;
+      }
+      target = (target as Record<string | number, unknown>)[seg];
+    }
+    if (!target || typeof target !== "object" || Array.isArray(target)) {
+      continue;
+    }
+    const record = target as Record<string, unknown>;
+    const keys: PropertyKey[] = (issue as unknown as { keys?: PropertyKey[] }).keys ?? [];
+    for (const key of keys) {
+      if (typeof key !== "string" || !(key in record)) {
+        continue;
+      }
+      const fullPath = path.length > 0 ? `${path.join(".")}.${key}` : key;
+      delete record[key];
+      warnings.push({
+        path: fullPath,
+        message: `Unknown config key "${fullPath}" ignored. Remove it to suppress this warning.`,
+      });
+    }
+  }
+  return { stripped: next, warnings };
+}
+
 function validateConfigObjectWithPluginsBase(
   raw: unknown,
   opts: { applyDefaults: boolean },
@@ -327,14 +379,28 @@ function validateConfigObjectWithPluginsBase(
       issues: ConfigValidationIssue[];
       warnings: ConfigValidationIssue[];
     } {
-  const base = opts.applyDefaults ? validateConfigObject(raw) : validateConfigObjectRaw(raw);
+  // Check for legacy config issues first — these must be errors, not silently stripped.
+  // Only strip truly unknown keys (not legacy ones) to allow startup with stale config
+  // from older versions that had keys removed (issue #35957).
+  const legacyIssues = findLegacyConfigIssues(raw);
+  if (legacyIssues.length > 0) {
+    return {
+      ok: false,
+      issues: legacyIssues.map((iss) => ({ path: iss.path, message: iss.message })),
+      warnings: [],
+    };
+  }
+  const { stripped: strippedRaw, warnings: unknownKeyWarnings } = stripUnrecognizedKeysFromRaw(raw);
+  const base = opts.applyDefaults
+    ? validateConfigObject(strippedRaw)
+    : validateConfigObjectRaw(strippedRaw);
   if (!base.ok) {
-    return { ok: false, issues: base.issues, warnings: [] };
+    return { ok: false, issues: base.issues, warnings: unknownKeyWarnings };
   }
 
   const config = base.config;
   const issues: ConfigValidationIssue[] = [];
-  const warnings: ConfigValidationIssue[] = [];
+  const warnings: ConfigValidationIssue[] = [...unknownKeyWarnings];
   const hasExplicitPluginsConfig =
     isRecord(raw) && Object.prototype.hasOwnProperty.call(raw, "plugins");
 

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -76,6 +76,25 @@ describe("Cron issue regressions", () => {
       expect(patched.payload.message).toBe("hi");
     }
 
+    // Regression: cron.update should persist payload.fallbacks (issue #36263).
+    const withFallbacks = await cron.update(unsafeToggle.id, {
+      payload: { kind: "agentTurn", fallbacks: ["gpt-4o", "claude-haiku-4-5-20251001"] },
+    });
+    expect(withFallbacks.payload.kind).toBe("agentTurn");
+    if (withFallbacks.payload.kind === "agentTurn") {
+      expect(withFallbacks.payload.fallbacks).toEqual(["gpt-4o", "claude-haiku-4-5-20251001"]);
+      // Other fields must be preserved across a same-kind merge.
+      expect(withFallbacks.payload.message).toBe("hi");
+    }
+
+    // Clearing fallbacks by passing an empty array should also be persisted.
+    const cleared = await cron.update(unsafeToggle.id, {
+      payload: { kind: "agentTurn", fallbacks: [] },
+    });
+    if (cleared.payload.kind === "agentTurn") {
+      expect(cleared.payload.fallbacks).toEqual([]);
+    }
+
     cron.stop();
   });
 

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -694,6 +694,9 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   if (typeof patch.bestEffortDeliver === "boolean") {
     next.bestEffortDeliver = patch.bestEffortDeliver;
   }
+  if (Array.isArray(patch.fallbacks)) {
+    next.fallbacks = patch.fallbacks;
+  }
   return next;
 }
 
@@ -762,6 +765,7 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     channel: patch.channel,
     to: patch.to,
     bestEffortDeliver: patch.bestEffortDeliver,
+    fallbacks: Array.isArray(patch.fallbacks) ? patch.fallbacks : undefined,
   };
 }
 

--- a/src/discord/monitor/preflight-audio.ts
+++ b/src/discord/monitor/preflight-audio.ts
@@ -61,16 +61,27 @@ export async function resolveDiscordPreflightAudioMentionContext(params: {
         .map((att) => att.url)
         .filter((url): url is string => typeof url === "string" && url.length > 0);
       if (audioUrls.length > 0) {
-        transcript = await transcribeFirstAudio({
-          ctx: {
-            MediaUrls: audioUrls,
-            MediaTypes: audioAttachments
-              .map((att) => att.content_type)
-              .filter((contentType): contentType is string => Boolean(contentType)),
-          },
+        const transcriptCtx = {
+          MediaUrls: audioUrls,
+          MediaTypes: audioAttachments
+            .map((att) => att.content_type)
+            .filter((contentType): contentType is string => Boolean(contentType)),
+        };
+        const transcriptionPromise = transcribeFirstAudio({
+          ctx: transcriptCtx,
           cfg: params.cfg,
           agentDir: undefined,
         });
+        // Race against abort so a slow transcription does not hold up the
+        // channel queue when the listener has already timed out (issue #36017).
+        if (params.abortSignal && !params.abortSignal.aborted) {
+          const abortPromise = new Promise<undefined>((resolve) => {
+            params.abortSignal!.addEventListener("abort", () => resolve(undefined), { once: true });
+          });
+          transcript = await Promise.race([transcriptionPromise, abortPromise]);
+        } else {
+          transcript = await transcriptionPromise;
+        }
         if (params.abortSignal?.aborted) {
           transcript = undefined;
         }

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -129,4 +129,20 @@ describe("resolveChannelRestartReason", () => {
     );
     expect(reason).toBe("gave-up");
   });
+
+  it("maps disconnected evaluation to disconnected (not stuck)", () => {
+    const reason = resolveChannelRestartReason(
+      { running: true, connected: false },
+      { healthy: false, reason: "disconnected" },
+    );
+    expect(reason).toBe("disconnected");
+  });
+
+  it("maps stuck evaluation to stuck", () => {
+    const reason = resolveChannelRestartReason(
+      { running: true, busy: true, activeRuns: 1 },
+      { healthy: false, reason: "stuck" },
+    );
+    expect(reason).toBe("stuck");
+  });
 });

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -32,7 +32,12 @@ export type ChannelHealthPolicy = {
   channelConnectGraceMs: number;
 };
 
-export type ChannelRestartReason = "gave-up" | "stopped" | "stale-socket" | "stuck";
+export type ChannelRestartReason =
+  | "gave-up"
+  | "stopped"
+  | "disconnected"
+  | "stale-socket"
+  | "stuck";
 
 function isManagedAccount(snapshot: ChannelHealthSnapshot): boolean {
   return snapshot.enabled !== false && snapshot.configured !== false;
@@ -115,6 +120,9 @@ export function resolveChannelRestartReason(
   }
   if (evaluation.reason === "not-running") {
     return snapshot.reconnectAttempts && snapshot.reconnectAttempts >= 10 ? "gave-up" : "stopped";
+  }
+  if (evaluation.reason === "disconnected") {
+    return "disconnected";
   }
   return "stuck";
 }

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -258,7 +258,10 @@ export abstract class MemoryManagerSyncOps {
     const dir = path.dirname(dbPath);
     ensureDir(dir);
     const { DatabaseSync } = requireNodeSqlite();
-    return new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    const db = new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    // WAL mode is crash-safe and survives SIGTERM/SIGKILL mid-write (issue #36035).
+    db.exec("PRAGMA journal_mode = WAL");
+    return db;
   }
 
   private seedEmbeddingCache(sourceDb: DatabaseSync): void {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -24,6 +24,7 @@ import type {
   TelegramTopicConfig,
 } from "../config/types.js";
 import { danger, logVerbose, warn } from "../globals.js";
+import { retryAsync } from "../infra/retry.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { MediaFetchError } from "../media/fetch.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
@@ -349,7 +350,20 @@ export const registerTelegramHandlers = ({
       for (const { ctx } of entry.messages) {
         let media;
         try {
-          media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+          // Retry once on recoverable errors (e.g. intermittent IPv6/IPv4 races on Node 25).
+          media = await retryAsync(
+            () => resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch),
+            {
+              attempts: 2,
+              minDelayMs: 500,
+              maxDelayMs: 500,
+              shouldRetry: (err) => isRecoverableMediaGroupError(err),
+              onRetry: ({ err }) =>
+                runtime.log?.(
+                  warn(`media group: retrying photo fetch after error: ${String(err)}`),
+                ),
+            },
+          );
         } catch (mediaErr) {
           if (!isRecoverableMediaGroupError(mediaErr)) {
             throw mediaErr;

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -2076,7 +2076,8 @@ describe("createTelegramBot", () => {
     let fetchCallIndex = 0;
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
       fetchCallIndex++;
-      if (fetchCallIndex === 2) {
+      // Fail calls 2 and 3 (photo 2's initial attempt and its retry) so the photo is skipped.
+      if (fetchCallIndex === 2 || fetchCallIndex === 3) {
         throw new Error("MediaFetchError: Failed to fetch media");
       }
       return new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -56,6 +56,8 @@ export type TelegramBotOptions = {
     mediaGroupFlushMs?: number;
     textFragmentGapMs?: number;
   };
+  /** Callback to update the channel account status snapshot (e.g. lastEventAt). */
+  setStatus?: (next: Record<string, unknown>) => void;
 };
 
 export { getTelegramSequentialKey };
@@ -163,6 +165,16 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       }
     }
   });
+
+  // Track event liveness: update lastEventAt on every inbound update so the
+  // health monitor can detect long-polling sessions that have gone silent. (#36259)
+  if (opts.setStatus) {
+    const trackEvent = opts.setStatus;
+    bot.use(async (ctx, next) => {
+      trackEvent({ lastEventAt: Date.now(), lastInboundAt: Date.now() });
+      await next();
+    });
+  }
 
   bot.use(sequentialize(getTelegramSequentialKey));
 

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -63,6 +63,10 @@ const { createdBotStops } = vi.hoisted(() => ({
   createdBotStops: [] as Array<ReturnType<typeof vi.fn<() => void>>>,
 }));
 
+const { capturedBotSetStatus } = vi.hoisted(() => ({
+  capturedBotSetStatus: [] as Array<((next: Record<string, unknown>) => void) | undefined>,
+}));
+
 const { computeBackoff, sleepWithAbort } = vi.hoisted(() => ({
   computeBackoff: vi.fn(() => 0),
   sleepWithAbort: vi.fn(async () => undefined),
@@ -135,7 +139,8 @@ vi.mock("../config/config.js", async (importOriginal) => {
 });
 
 vi.mock("./bot.js", () => ({
-  createTelegramBot: () => {
+  createTelegramBot: (opts: { setStatus?: (next: Record<string, unknown>) => void }) => {
+    capturedBotSetStatus.push(opts?.setStatus);
     const nextError = createTelegramBotErrors.shift();
     if (nextError) {
       throw nextError;
@@ -210,6 +215,7 @@ describe("monitorTelegramProvider (grammY)", () => {
     resetUnhandledRejection();
     createTelegramBotErrors.length = 0;
     createdBotStops.length = 0;
+    capturedBotSetStatus.length = 0;
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
@@ -488,5 +494,31 @@ describe("monitorTelegramProvider (grammY)", () => {
       }),
     );
     expect(runSpy).not.toHaveBeenCalled();
+  });
+
+  it("passes setStatus callback to createTelegramBot for polling (#36259)", async () => {
+    const setStatus = vi.fn();
+    await monitorWithAutoAbort({ setStatus });
+
+    expect(capturedBotSetStatus[0]).toBe(setStatus);
+  });
+
+  it("does not pass setStatus when not provided", async () => {
+    await monitorWithAutoAbort();
+
+    expect(capturedBotSetStatus[0]).toBeUndefined();
+  });
+
+  it("passes setStatus to startTelegramWebhook for webhook mode (#36259)", async () => {
+    const setStatus = vi.fn();
+    await monitorTelegramProvider({
+      token: "tok",
+      useWebhook: true,
+      webhookUrl: "https://example.test/telegram",
+      webhookSecret: "secret",
+      setStatus,
+    });
+
+    expect(startTelegramWebhookSpy).toHaveBeenCalledWith(expect.objectContaining({ setStatus }));
   });
 });

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -30,6 +30,8 @@ export type MonitorTelegramOpts = {
   webhookHost?: string;
   proxyFetch?: typeof fetch;
   webhookUrl?: string;
+  /** Callback to update the channel account status snapshot (e.g. lastEventAt). */
+  setStatus?: (next: Record<string, unknown>) => void;
 };
 
 export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
@@ -172,6 +174,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         fetch: proxyFetch,
         abortSignal: opts.abortSignal,
         publicUrl: opts.webhookUrl,
+        setStatus: opts.setStatus,
       });
       await waitForAbortSignal(opts.abortSignal);
       return;
@@ -224,6 +227,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
             lastUpdateId,
             onUpdateId: persistUpdateId,
           },
+          setStatus: opts.setStatus,
         });
       } catch (err) {
         const shouldRetry = await waitBeforeRetryOnRecoverableSetupError(

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -87,6 +87,8 @@ export async function startTelegramWebhook(opts: {
   abortSignal?: AbortSignal;
   healthPath?: string;
   publicUrl?: string;
+  /** Callback to update the channel account status snapshot (e.g. lastEventAt). */
+  setStatus?: (next: Record<string, unknown>) => void;
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
@@ -107,6 +109,7 @@ export async function startTelegramWebhook(opts: {
     proxyFetch: opts.fetch,
     config: opts.config,
     accountId: opts.accountId,
+    setStatus: opts.setStatus,
   });
   await initializeTelegramWebhookBot({
     bot,

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -639,7 +639,18 @@ export function renderApp(state: AppViewState) {
                     void state.loadCron();
                   }
                 },
-                onLoadFiles: (agentId) => loadAgentFiles(state, agentId),
+                onLoadFiles: async (agentId) => {
+                  const active = state.agentFileActive;
+                  await loadAgentFiles(state, agentId);
+                  // Re-fetch the active file so external edits (e.g. CLI writes)
+                  // become visible after the user clicks Refresh. (#35428)
+                  if (active && resolvedAgentId === agentId) {
+                    await loadAgentFileContent(state, agentId, active, {
+                      force: true,
+                      preserveDraft: false,
+                    });
+                  }
+                },
                 onSelectFile: (name) => {
                   state.agentFileActive = name;
                   if (!resolvedAgentId) {


### PR DESCRIPTION
## Summary

Fixes #36259.

The channel health monitor already detects and auto-recovers stale/half-dead connections for Slack, WhatsApp, and Discord by checking `lastEventAt` in the channel runtime snapshot. Telegram was the only built-in channel missing this watchdog because `monitorTelegramProvider` never called `setStatus` to update `lastEventAt`.

- Add `setStatus?: (next: Record<string, unknown>) => void` to `MonitorTelegramOpts` (mirrors the Slack provider opts pattern)
- Add `setStatus` to `TelegramBotOptions` and wire a bot middleware that calls `setStatus({ lastEventAt, lastInboundAt })` on every inbound update
- Pass `setStatus` through to `startTelegramWebhook` for webhook mode consistency
- Pass `ctx.setStatus` from the Telegram extension's `gateway.startAccount` (same pattern as the Slack extension)

## Test plan

- [x] New tests in `monitor.test.ts` verify `setStatus` is passed to `createTelegramBot` (polling) and to `startTelegramWebhook` (webhook mode)
- [x] All 17 Telegram monitor tests pass
- [x] `pnpm build` succeeds with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)