### PR TITLE
fix(gateway): use atomic write for restart sentinel file

### DIFF
--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveStateDir } from "../config/paths.js";
+import { writeJsonAtomic } from "./json-files.js";
 
 export type RestartSentinelLog = {
   stdoutTail?: string | null;
@@ -67,9 +68,8 @@ export async function writeRestartSentinel(
   env: NodeJS.ProcessEnv = process.env,
 ) {
   const filePath = resolveRestartSentinelPath(env);
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
   const data: RestartSentinel = { version: 1, payload };
-  await fs.writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+  await writeJsonAtomic(filePath, data, { trailingNewline: true });
   return filePath;
 }
 


### PR DESCRIPTION
**Problem:** `writeRestartSentinel()` uses raw `fs.writeFile` which can leave a corrupted/partial sentinel file if the process crashes mid-write — exactly the scenario when sentinels are written (during gateway restart or update).

**Fix:** Switch to `writeJsonAtomic()` (write-to-temp + rename), ensuring the sentinel is always either complete or absent. Also inherits the 0o600 permission default from `writeJsonAtomic`.

One-line change, zero risk.