### PR TITLE
fix(feishu): detect group mentions when display name is decorated

### DIFF
--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -76,6 +76,22 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     expect(ctx.mentionedBot).toBe(true);
   });
 
+  it("accepts decorated mention display names when bot open_id matches", () => {
+    const event = makeEvent("group", [
+      { key: "@_user_1", name: "Bot（机器人）", id: { open_id: BOT_OPEN_ID } },
+    ]);
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID, "Bot");
+    expect(ctx.mentionedBot).toBe(true);
+  });
+
+  it("keeps name guard for clear mismatch when bot open_id matches", () => {
+    const event = makeEvent("group", [
+      { key: "@_user_1", name: "Other Bot", id: { open_id: BOT_OPEN_ID } },
+    ]);
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID, "Primary Bot");
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
   it("returns mentionedBot=false when only other users are mentioned", () => {
     const event = makeEvent("group", [
       { key: "@_user_1", name: "Alice", id: { open_id: "ou_alice" } },

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -450,6 +450,19 @@ function formatSubMessageContent(content: string, contentType: string): string {
   }
 }
 
+function normalizeMentionName(value?: string): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function mentionNameMatchesBotName(mentionName?: string, botName?: string): boolean {
+  const normalizedMention = normalizeMentionName(mentionName);
+  const normalizedBot = normalizeMentionName(botName);
+  if (!normalizedMention || !normalizedBot) return true;
+  if (normalizedMention === normalizedBot) return true;
+  // Feishu can include display-name decorations/suffixes in mentions depending on client locale.
+  return normalizedMention.includes(normalizedBot) || normalizedBot.includes(normalizedMention);
+}
+
 function checkBotMentioned(
   event: FeishuMessageEvent,
   botOpenId?: string,
@@ -463,10 +476,9 @@ function checkBotMentioned(
   if (mentions.length > 0) {
     return mentions.some((m) => {
       if (m.id.open_id !== botOpenId) return false;
-      // Guard against Feishu WS open_id remapping in multi-app groups:
-      // if botName is known and mention name differs, this is a false positive.
-      if (botName && m.name && m.name !== botName) return false;
-      return true;
+      // Guard against Feishu WS open_id remapping in multi-app groups, but keep
+      // mention detection resilient when Feishu decorates display names.
+      return mentionNameMatchesBotName(m.name, botName);
     });
   }
   // Post (rich text) messages may have empty message.mentions when they contain docs/paste


### PR DESCRIPTION
## Summary
Fixes a regression in Feishu group mention detection where valid mentions were dropped when Feishu decorated the bot display name (locale/client variants), even though the mention open_id matched the bot.

## Root cause
`checkBotMentioned` required an exact string match between `mention.name` and `botName`. In real group payloads this can differ (suffixes/decorations), producing false negatives and skipping mention-gated messages.

## Changes
- normalize mention/bot names before comparison
- allow substring match in either direction for decorated display names
- keep mismatch guard for clearly different names
- add regression tests for decorated-name match and clear mismatch behavior

## Testing
- `pnpm exec vitest run extensions/feishu/src/bot.checkBotMentioned.test.ts`
- `pnpm exec vitest run extensions/feishu/src/bot.test.ts -t "mention"`

Fixes #36317