### PR TITLE
fix(gateway): suppress hook fallback summary when deliver=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/hooks `deliver:false` semantics: suppress fallback main-session `Hook ...` system-event injection when hook mappings explicitly disable delivery, so hook runs can stay fully silent as configured. (#36325)
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/src/gateway/server/hooks.deliver-false-main-summary.test.ts
+++ b/src/gateway/server/hooks.deliver-false-main-summary.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HookAgentDispatchPayload } from "../hooks.js";
+
+const {
+  loadConfigMock,
+  resolveMainSessionKeyFromConfigMock,
+  runCronIsolatedAgentTurnMock,
+  requestHeartbeatNowMock,
+  enqueueSystemEventMock,
+  createHooksRequestHandlerMock,
+} = vi.hoisted(() => ({
+  loadConfigMock: vi.fn(() => ({})),
+  resolveMainSessionKeyFromConfigMock: vi.fn(() => "agent:main"),
+  runCronIsolatedAgentTurnMock: vi.fn(),
+  requestHeartbeatNowMock: vi.fn(),
+  enqueueSystemEventMock: vi.fn(),
+  createHooksRequestHandlerMock: vi.fn((deps) => deps),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: loadConfigMock,
+}));
+
+vi.mock("../../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/sessions.js")>();
+  return {
+    ...actual,
+    resolveMainSessionKeyFromConfig: resolveMainSessionKeyFromConfigMock,
+  };
+});
+
+vi.mock("../../cron/isolated-agent.js", () => ({
+  runCronIsolatedAgentTurn: runCronIsolatedAgentTurnMock,
+}));
+
+vi.mock("../../infra/heartbeat-wake.js", () => ({
+  requestHeartbeatNow: requestHeartbeatNowMock,
+}));
+
+vi.mock("../../infra/system-events.js", () => ({
+  enqueueSystemEvent: enqueueSystemEventMock,
+}));
+
+vi.mock("../server-http.js", () => ({
+  createHooksRequestHandler: createHooksRequestHandlerMock,
+}));
+
+import { createGatewayHooksRequestHandler } from "./hooks.js";
+
+type HooksHarness = {
+  dispatchAgentHook: (value: HookAgentDispatchPayload) => string;
+  dispatchWakeHook: (value: { text: string; mode: "now" | "next-heartbeat" }) => void;
+};
+
+function createHarness() {
+  return createGatewayHooksRequestHandler({
+    deps: {} as never,
+    getHooksConfig: () => null,
+    bindHost: "127.0.0.1",
+    port: 18789,
+    logHooks: {
+      warn: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+    } as never,
+  }) as unknown as HooksHarness;
+}
+
+function createPayload(overrides?: Partial<HookAgentDispatchPayload>): HookAgentDispatchPayload {
+  return {
+    message: "summarize recent alerts",
+    name: "alert-hook",
+    wakeMode: "now",
+    sessionKey: "hook:alerts",
+    deliver: true,
+    channel: "last",
+    ...overrides,
+  };
+}
+
+describe("createGatewayHooksRequestHandler deliver=false behavior", () => {
+  beforeEach(() => {
+    loadConfigMock.mockReset();
+    resolveMainSessionKeyFromConfigMock.mockReset();
+    runCronIsolatedAgentTurnMock.mockReset();
+    requestHeartbeatNowMock.mockReset();
+    enqueueSystemEventMock.mockReset();
+    createHooksRequestHandlerMock.mockReset();
+
+    loadConfigMock.mockReturnValue({});
+    resolveMainSessionKeyFromConfigMock.mockReturnValue("agent:main");
+    createHooksRequestHandlerMock.mockImplementation((deps) => deps);
+  });
+
+  it("does not inject fallback main-session summary when deliver=false", async () => {
+    runCronIsolatedAgentTurnMock.mockResolvedValue({
+      status: "ok",
+      summary: "done",
+      delivered: false,
+      deliveryAttempted: false,
+    });
+    const harness = createHarness();
+
+    harness.dispatchAgentHook(createPayload({ deliver: false }));
+
+    await vi.waitFor(() => {
+      expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(1);
+    });
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps fallback main-session summary behavior when delivery is enabled", async () => {
+    runCronIsolatedAgentTurnMock.mockResolvedValue({
+      status: "ok",
+      summary: "done",
+      delivered: false,
+      deliveryAttempted: false,
+    });
+    const harness = createHarness();
+
+    harness.dispatchAgentHook(createPayload({ deliver: true }));
+
+    await vi.waitFor(() => {
+      expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    });
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith("Hook alert-hook: done", {
+      sessionKey: "agent:main",
+    });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: expect.stringMatching(/^hook:/),
+      }),
+    );
+  });
+});

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -80,7 +80,7 @@ export function createGatewayHooksRequestHandler(params: {
         const summary = result.summary?.trim() || result.error?.trim() || result.status;
         const prefix =
           result.status === "ok" ? `Hook ${value.name}` : `Hook ${value.name} (${result.status})`;
-        if (!result.delivered) {
+        if (!result.delivered && value.deliver) {
           enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {
             sessionKey: mainSessionKey,
           });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Hook mappings configured with `deliver: false` still injected a fallback `Hook ...` system event into the main session.
- Why it matters: `deliver: false` is meant to keep hook runs silent; the fallback summary could leak hook outcomes back into unrelated main-session delivery flows.
- What changed: In `createGatewayHooksRequestHandler`, fallback summary enqueue now requires both `!result.delivered` and `value.deliver !== false`.
- What did NOT change (scope boundary): Hook execution, cron isolated-run behavior, and delivery plan resolution were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36325
- Related #15692

## User-visible / Behavior Changes

Hook mappings with `deliver: false` no longer post fallback `Hook ...` summary system events into the main session.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A (unit test)
- Integration/channel (if any): gateway hooks
- Relevant config (redacted): hooks mapping with `action: "agent"` and `deliver: false`

### Steps

1. Configure a hook mapping with `deliver: false`.
2. Trigger the hook and have the isolated run return `delivered: false`.
3. Observe whether a fallback `Hook ...` system event is injected into the main session.

### Expected

- No fallback main-session summary is injected when delivery is explicitly disabled.

### Actual

- After this change, fallback summary is suppressed when `deliver: false`; behavior remains unchanged when delivery is enabled.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - New regression test `does not inject fallback main-session summary when deliver=false` passes.
  - Control test `keeps fallback main-session summary behavior when delivery is enabled` passes.
- Edge cases checked:
  - `wakeMode: now` path does not request heartbeat when fallback summary is suppressed.
- What you did **not** verify:
  - Full end-to-end live hook delivery against external channels.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/gateway/server/hooks.ts`.
- Known bad symptoms reviewers should watch for: hook mappings with `deliver: false` unexpectedly posting fallback summaries.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Could suppress fallback summaries in paths where delivery was unintentionally disabled.
  - Mitigation: Change is gated strictly on explicit `value.deliver === false`; normal delivery-enabled behavior is covered by a control test.
