### PR TITLE
fix(imessage): fallback missing group sender from participants

### DIFF
--- a/extensions/mattermost/src/group-mentions.test.ts
+++ b/extensions/mattermost/src/group-mentions.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it } from "vitest";
 import { resolveMattermostGroupRequireMention } from "./group-mentions.js";
 

--- a/extensions/mattermost/src/group-mentions.ts
+++ b/extensions/mattermost/src/group-mentions.ts
@@ -1,4 +1,7 @@
-import { resolveChannelGroupRequireMention, type ChannelGroupContext } from "openclaw/plugin-sdk";
+import {
+  resolveChannelGroupRequireMention,
+  type ChannelGroupContext,
+} from "openclaw/plugin-sdk/mattermost";
 import { resolveMattermostAccount } from "./mattermost/accounts.js";
 
 export function resolveMattermostGroupRequireMention(

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it, vi } from "vitest";
 import { resolveMattermostAccount } from "./accounts.js";
 import {

--- a/src/imessage/monitor.gating.test.ts
+++ b/src/imessage/monitor.gating.test.ts
@@ -118,6 +118,23 @@ describe("imessage monitor gating + envelope builders", () => {
     expect(decision.reason).toBe("no mention");
   });
 
+  it("falls back to first group participant when sender is missing", () => {
+    const cfg = baseCfg();
+    const message: IMessagePayload = {
+      id: 2,
+      chat_id: 41,
+      sender: "",
+      is_from_me: false,
+      text: "@openclaw hello",
+      is_group: true,
+      participants: ["+15550003333", "+15550004444"],
+    };
+
+    const ctxPayload = buildDispatchContextPayload({ cfg, message });
+    expect(ctxPayload.SenderId).toBe("+15550003333");
+    expect(String(ctxPayload.Body ?? "")).toContain("+15550003333:");
+  });
+
   it("dispatches group messages with mention and builds a group envelope", () => {
     const cfg = baseCfg();
     const message: IMessagePayload = {

--- a/src/imessage/monitor/inbound-processing.ts
+++ b/src/imessage/monitor/inbound-processing.ts
@@ -104,10 +104,17 @@ export function resolveIMessageInboundDecision(params: {
 }): IMessageInboundDecision {
   const senderRaw = params.message.sender ?? "";
   const sender = senderRaw.trim();
-  if (!sender) {
+  const participantFallbackSender =
+    !sender && params.message.is_group
+      ? ((params.message.participants ?? [])
+          .map((value) => value?.trim() ?? "")
+          .find((value) => value.length > 0) ?? "")
+      : "";
+  const effectiveSender = sender || participantFallbackSender;
+  if (!effectiveSender) {
     return { kind: "drop", reason: "missing sender" };
   }
-  const senderNormalized = normalizeIMessageHandle(sender);
+  const senderNormalized = normalizeIMessageHandle(effectiveSender);
   if (params.message.is_from_me) {
     return { kind: "drop", reason: "from me" };
   }
@@ -153,7 +160,7 @@ export function resolveIMessageInboundDecision(params: {
     isSenderAllowed: (allowFrom) =>
       isAllowedIMessageSender({
         allowFrom,
-        sender,
+        sender: effectiveSender,
         chatId,
         chatGuid,
         chatIdentifier,
@@ -175,7 +182,7 @@ export function resolveIMessageInboundDecision(params: {
         return { kind: "drop", reason: "groupPolicy allowlist (empty groupAllowFrom)" };
       }
       if (accessDecision.reasonCode === DM_GROUP_ACCESS_REASON.GROUP_POLICY_NOT_ALLOWLISTED) {
-        params.logVerbose?.(`Blocked iMessage sender ${sender} (not in groupAllowFrom)`);
+        params.logVerbose?.(`Blocked iMessage sender ${effectiveSender} (not in groupAllowFrom)`);
         return { kind: "drop", reason: "not in groupAllowFrom" };
       }
       params.logVerbose?.(`Blocked iMessage group message (${accessDecision.reason})`);
@@ -187,7 +194,7 @@ export function resolveIMessageInboundDecision(params: {
     if (accessDecision.decision === "pairing") {
       return { kind: "pairing", senderId: senderNormalized };
     }
-    params.logVerbose?.(`Blocked iMessage sender ${sender} (dmPolicy=${params.dmPolicy})`);
+    params.logVerbose?.(`Blocked iMessage sender ${effectiveSender} (dmPolicy=${params.dmPolicy})`);
     return { kind: "drop", reason: "dmPolicy blocked" };
   }
 
@@ -222,7 +229,7 @@ export function resolveIMessageInboundDecision(params: {
       accountId: params.accountId,
       isGroup,
       chatId,
-      sender,
+      sender: effectiveSender,
     });
     if (
       params.echoCache.has(echoScope, {
@@ -260,7 +267,7 @@ export function resolveIMessageInboundDecision(params: {
     commandDmAllowFrom.length > 0
       ? isAllowedIMessageSender({
           allowFrom: commandDmAllowFrom,
-          sender,
+          sender: effectiveSender,
           chatId,
           chatGuid,
           chatIdentifier,
@@ -270,7 +277,7 @@ export function resolveIMessageInboundDecision(params: {
     effectiveGroupAllowFrom.length > 0
       ? isAllowedIMessageSender({
           allowFrom: effectiveGroupAllowFrom,
-          sender,
+          sender: effectiveSender,
           chatId,
           chatGuid,
           chatIdentifier,
@@ -293,7 +300,7 @@ export function resolveIMessageInboundDecision(params: {
         log: params.logVerbose,
         channel: "imessage",
         reason: "control command (unauthorized)",
-        target: sender,
+        target: effectiveSender,
       });
     }
     return { kind: "drop", reason: "control command (unauthorized)" };
@@ -328,7 +335,7 @@ export function resolveIMessageInboundDecision(params: {
     chatIdentifier,
     groupId,
     historyKey,
-    sender,
+    sender: effectiveSender,
     senderNormalized,
     route,
     bodyText,

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -49,6 +49,7 @@ export {
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "../config/runtime-group-policy.js";
+export { resolveChannelGroupRequireMention } from "../config/group-policy.js";
 export type { BlockStreamingCoalesceConfig, DmPolicy, GroupPolicy } from "../config/types.js";
 export type { SecretInput } from "../config/types.secrets.js";
 export {


### PR DESCRIPTION
Problem: Some iMessage group payloads can arrive without `sender`, which causes inbound dispatch to drop the message as "missing sender" and prevents member identity from being resolved.

Root cause: `resolveIMessageInboundDecision` treated `message.sender` as mandatory even for group payloads that include participant identities.

Fix: add a group-only fallback that derives `effectiveSender` from the first non-empty participant when `sender` is missing; keep direct-message behavior unchanged. Also add regression coverage.

Testing:
- pnpm vitest run src/imessage/monitor.gating.test.ts
- pnpm run lint
- pnpm run check (fails on existing unrelated main-branch issue: `lint:plugins:no-monolithic-plugin-sdk-entry-imports` in mattermost plugin files)

AI-assisted: yes (GPT). Testing: targeted local + lint run.
