### PR TITLE
discord: bound directory cache by account

### DIFF
--- a/src/discord/directory-cache.test.ts
+++ b/src/discord/directory-cache.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetDiscordDirectoryCacheForTest,
+  rememberDiscordDirectoryUser,
+  resolveDiscordDirectoryUserId,
+} from "./directory-cache.js";
+
+describe("discord directory cache account bounds", () => {
+  beforeEach(() => {
+    __resetDiscordDirectoryCacheForTest();
+  });
+
+  it("evicts the oldest account cache when the account cap is exceeded", () => {
+    for (let index = 0; index < 64; index += 1) {
+      rememberDiscordDirectoryUser({
+        accountId: `acct-${index}`,
+        userId: `${1000 + index}`,
+        handles: ["alice"],
+      });
+    }
+
+    expect(resolveDiscordDirectoryUserId({ accountId: "acct-0", handle: "alice" })).toBe("1000");
+
+    rememberDiscordDirectoryUser({
+      accountId: "acct-64",
+      userId: "1064",
+      handles: ["alice"],
+    });
+
+    expect(resolveDiscordDirectoryUserId({ accountId: "acct-0", handle: "alice" })).toBeUndefined();
+    expect(resolveDiscordDirectoryUserId({ accountId: "acct-64", handle: "alice" })).toBe("1064");
+  });
+
+  it("keeps recently touched accounts when evicting", () => {
+    for (let index = 0; index < 64; index += 1) {
+      rememberDiscordDirectoryUser({
+        accountId: `acct-${index}`,
+        userId: `${2000 + index}`,
+        handles: ["alice"],
+      });
+    }
+
+    rememberDiscordDirectoryUser({
+      accountId: "acct-0",
+      userId: "3000",
+      handles: ["bob"],
+    });
+
+    rememberDiscordDirectoryUser({
+      accountId: "acct-64",
+      userId: "3064",
+      handles: ["alice"],
+    });
+
+    expect(resolveDiscordDirectoryUserId({ accountId: "acct-0", handle: "bob" })).toBe("3000");
+    expect(resolveDiscordDirectoryUserId({ accountId: "acct-1", handle: "alice" })).toBeUndefined();
+  });
+});

--- a/src/discord/directory-cache.ts
+++ b/src/discord/directory-cache.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/account-id.js";
 
 const DISCORD_DIRECTORY_CACHE_MAX_ENTRIES = 4000;
+const DISCORD_DIRECTORY_CACHE_MAX_ACCOUNTS = 64;
 const DISCORD_DISCRIMINATOR_SUFFIX = /#\d{4}$/;
 
 const DIRECTORY_HANDLE_CACHE = new Map<string, Map<string, string>>();
@@ -32,14 +33,31 @@ function normalizeHandleKey(raw: string): string | null {
   return handle.toLowerCase();
 }
 
+function touchAccountCache(cacheKey: string, cache: Map<string, string>): void {
+  DIRECTORY_HANDLE_CACHE.delete(cacheKey);
+  DIRECTORY_HANDLE_CACHE.set(cacheKey, cache);
+}
+
+function enforceAccountCacheBound(): void {
+  if (DIRECTORY_HANDLE_CACHE.size <= DISCORD_DIRECTORY_CACHE_MAX_ACCOUNTS) {
+    return;
+  }
+  const oldest = DIRECTORY_HANDLE_CACHE.keys().next();
+  if (!oldest.done) {
+    DIRECTORY_HANDLE_CACHE.delete(oldest.value);
+  }
+}
+
 function ensureAccountCache(accountId?: string | null): Map<string, string> {
   const cacheKey = normalizeAccountCacheKey(accountId);
   const existing = DIRECTORY_HANDLE_CACHE.get(cacheKey);
   if (existing) {
+    touchAccountCache(cacheKey, existing);
     return existing;
   }
   const created = new Map<string, string>();
   DIRECTORY_HANDLE_CACHE.set(cacheKey, created);
+  enforceAccountCacheBound();
   return created;
 }
 


### PR DESCRIPTION
## Summary
- cap the top-level Discord directory cache to 64 account maps
- keep recently touched account caches hot by moving them to the back on writes
- add focused tests for account-cache eviction and recency behavior

## Why
`DIRECTORY_HANDLE_CACHE` already bounded entries within each account map, but the number of account maps had no limit. In long-running multi-account setups this could grow unbounded.

## Risk
Low. Evicted account caches only lose warm mention-lookup data and repopulate naturally from later directory observations.

## Validation
- `pnpm vitest src/discord/directory-cache.test.ts src/discord/mentions.test.ts`
