### PR TITLE
fix(gateway): suppress system event when hook deliver is false

### DIFF
--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -80,7 +80,7 @@ export function createGatewayHooksRequestHandler(params: {
         const summary = result.summary?.trim() || result.error?.trim() || result.status;
         const prefix =
           result.status === "ok" ? `Hook ${value.name}` : `Hook ${value.name} (${result.status})`;
-        if (!result.delivered) {
+        if (!result.delivered && value.deliver !== false) {
           enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {
             sessionKey: mainSessionKey,
           });


### PR DESCRIPTION
## Summary

- **Problem:** When a hook mapping sets `deliver: false`, the delivery announcement is correctly suppressed, but a system event (`Hook <name>: <summary>`) is still injected into the main session via `enqueueSystemEvent`. This happens because the guard at `src/gateway/server/hooks.ts` line 83 only checks `!result.delivered` — which is always true when delivery was never attempted — without checking whether delivery was explicitly disabled.
- **Why it matters:** The main session agent receives spurious hook completion events and may announce them to unrelated channels (e.g. posting triage summaries to a project coordination channel instead of keeping them silent as intended).
- **What changed:** Added `&& value.deliver !== false` to the guard condition, so hooks with delivery explicitly disabled also skip system event injection and the associated heartbeat wake.
- **What did NOT change:** Behavior when `deliver: true` or omitted (default). Error path in the catch block still always enqueues a system event for failed hooks. No changes to `resolveCronDeliveryPlan`, `dispatchAgentHook`, or any other file.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36325

## User-visible / Behavior Changes

- Hooks with `deliver: false` no longer inject `Hook <name>: <summary>` system events into the main session.
- Hooks with `deliver: false` no longer trigger `requestHeartbeatNow` after completion.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22
- Integration/channel: Any (hooks system)

### Steps

1. Configure a hook mapping with `deliver: false`
2. Trigger the hook
3. Check the main session for system events

### Expected

- No system event injected into main session

### Actual

- Before fix: `Hook <name>: <summary>` system event is injected into the main session
- After fix: No system event when `deliver: false`

## Evidence

The fix follows the data flow:

1. `resolveHookDeliver(raw)` in `src/gateway/hooks.ts` returns `false` when the mapping sets `deliver: false`
2. `value.deliver` is passed into `dispatchAgentHook` and is in scope at the guard
3. `resolveCronDeliveryPlan` in `src/cron/delivery.ts` correctly resolves to `{ mode: "none", requested: false }` when `deliver === false`
4. Delivery is never attempted → `result.delivered` is always `false`
5. **Before fix:** `!result.delivered` passes → system event fires
6. **After fix:** `!result.delivered && value.deliver !== false` fails → system event skipped

TypeScript compiles cleanly (only pre-existing unrelated errors in `extensions/diffs` and `extensions/tlon`).

## Human Verification (required)

- Verified scenarios: TypeScript compilation, traced the full `deliver: false` → `resolveCronDeliveryPlan` → `result.delivered` flow
- Edge cases checked: `deliver: true` (unchanged), `deliver` omitted (defaults to `true` via `resolveHookDeliver`, unchanged), error path (unchanged — errors always enqueue system event)
- What I did **not** verify: End-to-end test with live hook trigger (no hook infrastructure in dev)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove the `&& value.deliver !== false` condition
- Files/config to restore: `src/gateway/server/hooks.ts`
- Known bad symptoms: If reverted, hooks with `deliver: false` will resume injecting system events into main session

## Risks and Mitigations

None — the change is a single additional condition that narrows an existing guard.

