### PR TITLE
fix(feishu): normalize legacy groupPolicy allowall to open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/group-policy backward compatibility: normalize legacy `groupPolicy: "allowall"` values to `open`, so existing Feishu group configs keep accepting group messages without forced allowlist rewrites. (#36312)
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -24,6 +24,20 @@ describe("FeishuConfigSchema webhook validation", () => {
     expect(result.accounts?.main?.requireMention).toBeUndefined();
   });
 
+  it("normalizes legacy groupPolicy=allowall to open", () => {
+    const result = FeishuConfigSchema.parse({
+      groupPolicy: "allowall",
+      accounts: {
+        main: {
+          groupPolicy: "ALLOWALL",
+        },
+      },
+    });
+
+    expect(result.groupPolicy).toBe("open");
+    expect(result.accounts?.main?.groupPolicy).toBe("open");
+  });
+
   it("rejects top-level webhook mode without verificationToken", () => {
     const result = FeishuConfigSchema.safeParse({
       connectionMode: "webhook",

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -4,7 +4,20 @@ export { z };
 import { buildSecretInputSchema, hasConfiguredSecretInput } from "./secret-input.js";
 
 const DmPolicySchema = z.enum(["open", "pairing", "allowlist"]);
-const GroupPolicySchema = z.enum(["open", "allowlist", "disabled"]);
+const GroupPolicySchema = z.preprocess(
+  (value) => {
+    if (typeof value !== "string") {
+      return value;
+    }
+    const normalized = value.trim().toLowerCase();
+    // Backward compatibility: legacy configs used "allowall" for open group policy.
+    if (normalized === "allowall") {
+      return "open";
+    }
+    return normalized;
+  },
+  z.enum(["open", "allowlist", "disabled"]),
+);
 const FeishuDomainSchema = z.union([
   z.enum(["feishu", "lark"]),
   z.string().url().startsWith("https://"),


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Feishu configs using legacy `groupPolicy: "allowall"` were no longer treated as open-group mode.
- Why it matters: Existing deployments with legacy config values silently fell back to allowlist behavior and dropped group messages.
- What changed: Added config-schema normalization so `allowall` (case-insensitive) is mapped to `open` for Feishu group policy.
- What did NOT change (scope boundary): Group access logic, mention rules, and allowlist matching behavior were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36312
- Related #31425

## User-visible / Behavior Changes

Feishu users with legacy `groupPolicy: "allowall"` now get the intended open-group behavior without manually rewriting config to `open`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): `channels.feishu.groupPolicy: "allowall"`

### Steps

1. Parse Feishu config with top-level `groupPolicy: "allowall"`.
2. Parse Feishu config with account-level `groupPolicy: "ALLOWALL"`.
3. Verify normalized values.

### Expected

- Both legacy values normalize to `open`.

### Actual

- After this patch, schema parse returns `open` for both top-level and account-level legacy values.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added regression test covering top-level and account-level `allowall` normalization.
  - Confirmed existing Feishu config-schema tests still pass.
- Edge cases checked:
  - Case-insensitive input (`ALLOWALL`) is normalized.
- What you did **not** verify:
  - Live Feishu webhook end-to-end behavior against a real tenant.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `extensions/feishu/src/config-schema.ts`.
- Known bad symptoms reviewers should watch for: legacy `allowall` values failing schema parse or behaving as allowlist.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Normalization could accidentally coerce unrelated custom strings if expanded incorrectly in future edits.
  - Mitigation: Mapping is narrowly scoped to exact `allowall`; all other values remain validated by enum.
