### PR TITLE
fix(cron): persist payload.fallbacks on cron.update

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -694,6 +694,9 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   if (typeof patch.bestEffortDeliver === "boolean") {
     next.bestEffortDeliver = patch.bestEffortDeliver;
   }
+  if (Array.isArray(patch.fallbacks)) {
+    next.fallbacks = patch.fallbacks;
+  }
   return next;
 }
 
@@ -762,6 +765,7 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     channel: patch.channel,
     to: patch.to,
     bestEffortDeliver: patch.bestEffortDeliver,
+    fallbacks: patch.fallbacks,
   };
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** `payload.fallbacks` (per-job fallback model array) is accepted by the gateway schema and consumed at runtime by `runWithModelFallback`, but silently dropped when updating a cron job via the `cron.update` API. This is the same class of bug as #31425 (`lightContext` not persisted).
- **Why it matters:** Users configuring per-job fallback models via the API lose them on the next update — the job silently reverts to agent-level fallbacks.
- **What changed:** Added `fallbacks` handling to both `mergeCronPayload` (Array.isArray guard) and `buildPayloadFromPatch` (included in return object) in `src/cron/service/jobs.ts`.
- **What did NOT change:** No changes to the gateway schema, type definitions, runtime model resolution, or any other file. The `CronAgentTurnPayloadFields.fallbacks` type was already correctly defined.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36263

## User-visible / Behavior Changes

- `payload.fallbacks` is now persisted when creating or updating cron jobs via the API
- Existing cron jobs without `fallbacks` are unaffected

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22
- Integration/channel: Cron system

### Steps

1. Create a cron job with `payload.kind: "agentTurn"` and `payload.model: "some-model"`
2. Update it via API/CLI with `payload.fallbacks: ["anthropic/claude-sonnet-4-6"]`
3. Check the stored job in `~/.openclaw/cron/jobs.json`

### Expected

- `fallbacks` field is present in the stored payload

### Actual

- Before fix: `fallbacks` field is silently dropped
- After fix: `fallbacks` field is persisted

## Evidence

The fix follows the exact same pattern as the `lightContext` fix (#31425):

**`mergeCronPayload`** — copy field from patch when present:
```typescript
if (Array.isArray(patch.fallbacks)) {
  next.fallbacks = patch.fallbacks;
}
```

**`buildPayloadFromPatch`** — include in return object:
```typescript
fallbacks: patch.fallbacks,
```

TypeScript compiles cleanly. All 31 existing cron service tests pass.

## Human Verification (required)

- Verified scenarios: TypeScript compilation, all 31 cron service tests pass, code review of both functions
- Edge cases checked: `fallbacks: []` (clears existing fallbacks), `fallbacks: undefined` (preserves existing), patch without `fallbacks` (no change)
- What I did **not** verify: End-to-end test with live cron job update (no running gateway in dev)

## Compatibility / Migration

- Backward compatible? `Yes — no behavior change for jobs without fallbacks`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove the two added lines
- Files/config to restore: `src/cron/service/jobs.ts`
- Known bad symptoms: N/A — the fix only adds persistence for an already-accepted field

## Risks and Mitigations

None — the fix adds two lines following an established pattern for the same class of bug.

