### PR TITLE
fix(feishu): accept groupPolicy "allowall" as alias for "open"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@ Docs: https://docs.openclaw.ai
 - LINE/status/config/webhook synthesis: fix status false positives from snapshot/config state and accept LINE webhook HEAD probes for compatibility. (from #10487, #25726, #27537, #27908, #31387) Thanks @BlueBirdBack, @stakeswky, @loiie45e, @puritysb, and @mcaxtr.
 - LINE cleanup/test follow-ups: fold cleanup/test learnings into the synthesis review path while keeping runtime changes focused on regression fixes. (from #17630, #17289) Thanks @Clawborn and @davidahmann.
 - Mattermost/interactive buttons: add interactive button send/callback support with directory-based channel/user target resolution, and harden callbacks via account-scoped HMAC verification plus sender-scoped DM routing. (#19957) thanks @tonydehnke.
+- Feishu/groupPolicy legacy alias compatibility: treat legacy `groupPolicy: "allowall"` as `open` in both schema parsing and runtime policy checks so intended open-group configs no longer silently drop group messages when `groupAllowFrom` is empty. (from #36358) Thanks @Sid-Qin.
 
 - Mattermost/plugin SDK import policy: replace remaining monolithic `openclaw/plugin-sdk` imports in Mattermost mention-gating paths/tests with scoped subpaths (`openclaw/plugin-sdk/compat` and `openclaw/plugin-sdk/mattermost`) so `pnpm check` passes `lint:plugins:no-monolithic-plugin-sdk-entry-imports` on baseline. (#36480) Thanks @Takhoffman.
 

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -24,6 +24,14 @@ describe("FeishuConfigSchema webhook validation", () => {
     expect(result.accounts?.main?.requireMention).toBeUndefined();
   });
 
+  it("normalizes legacy groupPolicy allowall to open", () => {
+    const result = FeishuConfigSchema.parse({
+      groupPolicy: "allowall",
+    });
+
+    expect(result.groupPolicy).toBe("open");
+  });
+
   it("rejects top-level webhook mode without verificationToken", () => {
     const result = FeishuConfigSchema.safeParse({
       connectionMode: "webhook",

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -4,7 +4,10 @@ export { z };
 import { buildSecretInputSchema, hasConfiguredSecretInput } from "./secret-input.js";
 
 const DmPolicySchema = z.enum(["open", "pairing", "allowlist"]);
-const GroupPolicySchema = z.enum(["open", "allowlist", "disabled"]);
+const GroupPolicySchema = z.union([
+  z.enum(["open", "allowlist", "disabled"]),
+  z.literal("allowall").transform(() => "open" as const),
+]);
 const FeishuDomainSchema = z.union([
   z.enum(["feishu", "lark"]),
   z.string().url().startsWith("https://"),

--- a/extensions/feishu/src/policy.test.ts
+++ b/extensions/feishu/src/policy.test.ts
@@ -110,5 +110,45 @@ describe("feishu policy", () => {
         }),
       ).toBe(true);
     });
+
+    it("allows group when groupPolicy is 'open'", () => {
+      expect(
+        isFeishuGroupAllowed({
+          groupPolicy: "open",
+          allowFrom: [],
+          senderId: "oc_group_999",
+        }),
+      ).toBe(true);
+    });
+
+    it("treats 'allowall' as equivalent to 'open'", () => {
+      expect(
+        isFeishuGroupAllowed({
+          groupPolicy: "allowall",
+          allowFrom: [],
+          senderId: "oc_group_999",
+        }),
+      ).toBe(true);
+    });
+
+    it("rejects group when groupPolicy is 'disabled'", () => {
+      expect(
+        isFeishuGroupAllowed({
+          groupPolicy: "disabled",
+          allowFrom: ["oc_group_999"],
+          senderId: "oc_group_999",
+        }),
+      ).toBe(false);
+    });
+
+    it("rejects group when groupPolicy is 'allowlist' and allowFrom is empty", () => {
+      expect(
+        isFeishuGroupAllowed({
+          groupPolicy: "allowlist",
+          allowFrom: [],
+          senderId: "oc_group_999",
+        }),
+      ).toBe(false);
+    });
   });
 });

--- a/extensions/feishu/src/policy.ts
+++ b/extensions/feishu/src/policy.ts
@@ -92,7 +92,7 @@ export function resolveFeishuGroupToolPolicy(
 }
 
 export function isFeishuGroupAllowed(params: {
-  groupPolicy: "open" | "allowlist" | "disabled" | (string & {});
+  groupPolicy: "open" | "allowlist" | "disabled" | "allowall";
   allowFrom: Array<string | number>;
   senderId: string;
   senderIds?: Array<string | null | undefined>;

--- a/extensions/feishu/src/policy.ts
+++ b/extensions/feishu/src/policy.ts
@@ -92,7 +92,7 @@ export function resolveFeishuGroupToolPolicy(
 }
 
 export function isFeishuGroupAllowed(params: {
-  groupPolicy: "open" | "allowlist" | "disabled";
+  groupPolicy: "open" | "allowlist" | "disabled" | (string & {});
   allowFrom: Array<string | number>;
   senderId: string;
   senderIds?: Array<string | null | undefined>;
@@ -102,7 +102,7 @@ export function isFeishuGroupAllowed(params: {
   if (groupPolicy === "disabled") {
     return false;
   }
-  if (groupPolicy === "open") {
+  if (groupPolicy === "open" || groupPolicy === "allowall") {
     return true;
   }
   return resolveFeishuAllowlistMatch(params).allowed;


### PR DESCRIPTION
## Summary

- Problem: When users configure `groupPolicy: "allowall"` in Feishu channel config, the Zod schema rejects the value and the runtime policy check in `isFeishuGroupAllowed` falls through to the allowlist path. With an empty `allowFrom` array, all group messages are silently dropped even though the user intended "allow all" semantics.
- Why it matters: Users see `group oc_xxx not in groupAllowFrom (groupPolicy=allowall)` in logs and their Feishu bot silently ignores all group messages despite intending to accept them.
- What changed: (1) `GroupPolicySchema` in `config-schema.ts` now accepts `"allowall"` and transforms it to `"open"` at parse time. (2) `isFeishuGroupAllowed` in `policy.ts` treats `"allowall"` the same as `"open"` at runtime as a safety net.
- What did NOT change (scope boundary): No changes to other channels, no changes to the core `GroupPolicy` type or `runtime-group-policy.ts`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36312

## User-visible / Behavior Changes

Feishu groups now correctly accept all messages when `groupPolicy: "allowall"` is configured, matching the intended semantics. Previously, all group messages were silently dropped.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Configure Feishu channel with `groupPolicy: "allowall"` and `allowFrom: []`
2. Add the bot to a Feishu group chat
3. Send a message in the group @mentioning the bot

### Expected

- Group messages are accepted and processed

### Actual

- Before: `group oc_xxx not in groupAllowFrom (groupPolicy=allowall)` — messages silently dropped
- After: Messages accepted and processed normally

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test cases in `extensions/feishu/src/policy.test.ts`:
- `treats 'allowall' as equivalent to 'open'` — passes
- `allows group when groupPolicy is 'open'` — passes
- `rejects group when groupPolicy is 'disabled'` — passes
- `rejects group when groupPolicy is 'allowlist' and allowFrom is empty` — passes

## Human Verification (required)

- Verified scenarios: `"allowall"` with empty allowFrom; `"open"` still works; `"disabled"` still blocks; `"allowlist"` with empty list still blocks
- Edge cases checked: Runtime `"allowall"` string that bypasses Zod transform
- What you did **not** verify: Full Feishu bot integration test with live webhook

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No — `"allowall"` is a new accepted value, existing `"open"`/`"allowlist"`/`"disabled"` configs are unchanged
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; users can use `groupPolicy: "open"` instead of `"allowall"`
- Files/config to restore: `extensions/feishu/src/config-schema.ts`, `extensions/feishu/src/policy.ts`

## Risks and Mitigations

- Risk: Users who accidentally set `"allowall"` when they meant `"allowlist"` will now accept all groups instead of getting a validation error.
  - Mitigation: The values are sufficiently distinct (`"allowall"` vs `"allowlist"`), and accepting all groups is a safer failure mode than silently dropping all messages.