### PR TITLE
fix(telegram): compare provider+model when marking selected model in keyboard

### DIFF
--- a/src/telegram/model-buttons.test.ts
+++ b/src/telegram/model-buttons.test.ts
@@ -294,6 +294,31 @@ describe("buildModelsKeyboard", () => {
     }
   });
 
+  it("does not mark model as selected when it belongs to a different provider", () => {
+    const result = buildModelsKeyboard({
+      provider: "openrouter",
+      models: ["claude-opus-4-6", "gpt-4.1"],
+      currentModel: "anthropic/claude-opus-4-6",
+      currentPage: 1,
+      totalPages: 1,
+    });
+    // Neither model should have ✓ because the current provider is "anthropic", not "openrouter"
+    expect(result[0]?.[0]?.text).toBe("claude-opus-4-6");
+    expect(result[1]?.[0]?.text).toBe("gpt-4.1");
+  });
+
+  it("marks model as selected only for the matching provider", () => {
+    const result = buildModelsKeyboard({
+      provider: "anthropic",
+      models: ["claude-opus-4-6", "claude-sonnet-4"],
+      currentModel: "anthropic/claude-opus-4-6",
+      currentPage: 1,
+      totalPages: 1,
+    });
+    expect(result[0]?.[0]?.text).toBe("claude-opus-4-6 ✓");
+    expect(result[1]?.[0]?.text).toBe("claude-sonnet-4");
+  });
+
   it("uses compact selection callback when provider/model callback exceeds 64 bytes", () => {
     const model = "us.anthropic.claude-3-5-sonnet-20240620-v1:0";
     const result = buildModelsKeyboard({

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -195,9 +195,14 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
   const pageModels = models.slice(startIndex, endIndex);
 
   // Model buttons - one per row
-  const currentModelId = currentModel?.includes("/")
-    ? currentModel.split("/").slice(1).join("/")
-    : currentModel;
+  const parsedCurrentModel = currentModel?.includes("/")
+    ? (() => {
+        const idx = currentModel.indexOf("/");
+        return { provider: currentModel.slice(0, idx), model: currentModel.slice(idx + 1) };
+      })()
+    : currentModel
+      ? { provider: undefined as string | undefined, model: currentModel }
+      : null;
 
   for (const model of pageModels) {
     const callbackData = buildModelSelectionCallbackData({ provider, model });
@@ -206,7 +211,9 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
       continue;
     }
 
-    const isCurrentModel = model === currentModelId;
+    const isCurrentModel = parsedCurrentModel
+      ? parsedCurrentModel.provider === provider && model === parsedCurrentModel.model
+      : false;
     const displayText = truncateModelId(model, 38);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
 


### PR DESCRIPTION
## Summary

- Problem: When multiple providers expose a model with the same ID (e.g. `claude-opus-4-6` from `anthropic`, `openrouter`, `nexus-d`), the Telegram model list keyboard marks ALL entries with ✓ instead of just the one that was actually selected.
- Why it matters: Users cannot tell which provider is active because every instance of the same model ID appears selected.
- What changed: `buildModelsKeyboard` in `model-buttons.ts` now parses the full `provider/modelId` reference and compares both the provider and model components when deciding which button gets the ✓ indicator.
- What did NOT change (scope boundary): Discord model picker and Control UI already compare by full `provider/model` — no changes needed there. No changes to model selection logic or session persistence.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35476

## User-visible / Behavior Changes

Telegram `/models` keyboard now correctly shows ✓ only on the model entry whose provider matches the active session model. Previously all providers sharing the same model ID would show ✓.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Configure multiple providers with the same model ID (e.g. `claude-opus-4-6` on `anthropic` and `openrouter`)
2. Select one via `/model anthropic/claude-opus-4-6`
3. Open `/models openrouter`

### Expected

- Only `anthropic`'s `claude-opus-4-6` shows ✓; `openrouter`'s does not

### Actual

- Before: Both `anthropic/claude-opus-4-6` and `openrouter/claude-opus-4-6` showed ✓
- After: Only the active provider's entry shows ✓

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test cases in `src/telegram/model-buttons.test.ts`:
- `does not mark model as selected when it belongs to a different provider` — passes
- `marks model as selected only for the matching provider` — passes

## Human Verification (required)

- Verified scenarios: Same model ID on different providers; single-provider model; no current model set; model with no provider prefix
- Edge cases checked: `currentModel` without provider prefix (treated as `{ provider: undefined, model }` — no false match when viewing any provider page)
- What you did **not** verify: Live Telegram bot interaction

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/telegram/model-buttons.ts`

## Risks and Mitigations

- Risk: When `currentModel` has no provider prefix (legacy sessions), no model will show ✓ on any provider page.
  - Mitigation: This is more correct than the old behavior (which showed ✓ on every provider). The session will get a full `provider/model` ref on the next model switch.