### PR TITLE
fix(mattermost): replace monolithic plugin-sdk imports

### DIFF
--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -49,6 +49,7 @@ export {
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "../config/runtime-group-policy.js";
+export { resolveChannelGroupRequireMention } from "../config/group-policy.js";
 export type { BlockStreamingCoalesceConfig, DmPolicy, GroupPolicy } from "../config/types.js";
 export type { SecretInput } from "../config/types.secrets.js";
 export {


### PR DESCRIPTION
## Root cause
Mattermost extension test/source files imported from the monolithic openclaw/plugin-sdk entrypoint. The CI guard (lint:plugins:no-monolithic-plugin-sdk-entry-imports) rejects bundled plugin source imports from that path.

## Fix
Replaced those imports with the channel-scoped entrypoint openclaw/plugin-sdk/mattermost in:
- extensions/mattermost/src/group-mentions.test.ts
- extensions/mattermost/src/group-mentions.ts
- extensions/mattermost/src/mattermost/monitor.test.ts

## Validation
Attempted local validation, but this checkout does not have dependencies installed (
ode_modules missing), so lint/tests could not run here:
- 
px pnpm lint:plugins:no-monolithic-plugin-sdk-entry-imports → failed: missing 	sx
- 
px vitest run ... --config vitest.extensions.config.ts → failed: missing itest

Changes are limited to import path updates only.