### PR TITLE
media: add observability hook for swallowed reader cleanup errors

### DIFF
--- a/src/media/read-response-with-limit.test.ts
+++ b/src/media/read-response-with-limit.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { readResponseWithLimit } from "./read-response-with-limit.js";
+
+type ReaderChunk = ReadableStreamReadResult<Uint8Array>;
+
+function createResponseWithReader(reader: {
+  read: () => Promise<ReaderChunk>;
+  cancel: () => Promise<void>;
+  releaseLock: () => void;
+}): Response {
+  return {
+    body: {
+      getReader: () => reader,
+    },
+    headers: new Headers(),
+    url: "https://example.com/file.bin",
+  } as unknown as Response;
+}
+
+describe("readResponseWithLimit internal error hooks", () => {
+  it("reports reader.cancel failures during overflow handling", async () => {
+    const onInternalError = vi.fn();
+    let readCalls = 0;
+    const reader = {
+      read: vi.fn(async () => {
+        readCalls += 1;
+        if (readCalls === 1) {
+          return { done: false, value: new Uint8Array([1, 2, 3]) };
+        }
+        return { done: false, value: new Uint8Array([4, 5, 6]) };
+      }),
+      cancel: vi.fn(async () => {
+        throw new Error("cancel failed");
+      }),
+      releaseLock: vi.fn(() => {}),
+    };
+
+    await expect(
+      readResponseWithLimit(createResponseWithReader(reader), 5, { onInternalError }),
+    ).rejects.toThrow("Content too large");
+
+    expect(reader.cancel).toHaveBeenCalledTimes(1);
+    expect(onInternalError).toHaveBeenCalledTimes(1);
+    expect(onInternalError.mock.calls[0]?.[0]).toMatchObject({
+      phase: "reader.cancel",
+      res: expect.objectContaining({ url: "https://example.com/file.bin" }),
+    });
+  });
+
+  it("reports reader.releaseLock failures after successful reads", async () => {
+    const onInternalError = vi.fn();
+    const reader = {
+      read: vi
+        .fn<() => Promise<ReaderChunk>>()
+        .mockResolvedValueOnce({ done: false, value: new Uint8Array([7, 8]) })
+        .mockResolvedValueOnce({ done: true, value: undefined }),
+      cancel: vi.fn(async () => {}),
+      releaseLock: vi.fn(() => {
+        throw new Error("release failed");
+      }),
+    };
+
+    const output = await readResponseWithLimit(createResponseWithReader(reader), 10, {
+      onInternalError,
+    });
+
+    expect(output).toEqual(Buffer.from([7, 8]));
+    expect(onInternalError).toHaveBeenCalledTimes(1);
+    expect(onInternalError.mock.calls[0]?.[0]).toMatchObject({
+      phase: "reader.releaseLock",
+      res: expect.objectContaining({ url: "https://example.com/file.bin" }),
+    });
+  });
+});

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -3,12 +3,18 @@ export async function readResponseWithLimit(
   maxBytes: number,
   opts?: {
     onOverflow?: (params: { size: number; maxBytes: number; res: Response }) => Error;
+    onInternalError?: (params: {
+      phase: "reader.cancel" | "reader.releaseLock";
+      error: unknown;
+      res: Response;
+    }) => void;
   },
 ): Promise<Buffer> {
   const onOverflow =
     opts?.onOverflow ??
     ((params: { size: number; maxBytes: number }) =>
       new Error(`Content too large: ${params.size} bytes (limit: ${params.maxBytes} bytes)`));
+  const onInternalError = opts?.onInternalError;
 
   const body = res.body;
   if (!body || typeof body.getReader !== "function") {
@@ -33,7 +39,9 @@ export async function readResponseWithLimit(
         if (total > maxBytes) {
           try {
             await reader.cancel();
-          } catch {}
+          } catch (error) {
+            onInternalError?.({ phase: "reader.cancel", error, res });
+          }
           throw onOverflow({ size: total, maxBytes, res });
         }
         chunks.push(value);
@@ -42,7 +50,9 @@ export async function readResponseWithLimit(
   } finally {
     try {
       reader.releaseLock();
-    } catch {}
+    } catch (error) {
+      onInternalError?.({ phase: "reader.releaseLock", error, res });
+    }
   }
 
   return Buffer.concat(


### PR DESCRIPTION
## Summary
- add an optional onInternalError callback to readResponseWithLimit
- report failures from swallowed reader.cancel() and reader.releaseLock() catch paths with phase + response context
- add focused unit tests for both error-reporting paths

## Why
readResponseWithLimit intentionally keeps stream cleanup failures non-fatal, but this currently hides useful diagnostics. The new hook preserves behavior while making silent catch paths observable for callers that need telemetry.

## Risk
Low. The callback is optional and only executes inside existing catch blocks; default behavior is unchanged.
