### PR TITLE
fix(discord): return error reply for unauthorized slash commands instead of silent timeout

### DIFF
--- a/src/auto-reply/reply/command-gates.ts
+++ b/src/auto-reply/reply/command-gates.ts
@@ -14,7 +14,12 @@ export function rejectUnauthorizedCommand(
   logVerbose(
     `Ignoring ${commandLabel} from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
   );
-  return { shouldContinue: false };
+  return {
+    shouldContinue: false,
+    reply: {
+      text: `⚠️ You are not authorized to use ${commandLabel}.`,
+    },
+  };
 }
 
 export function buildDisabledCommandReply(params: {

--- a/src/auto-reply/reply/commands-compact.ts
+++ b/src/auto-reply/reply/commands-compact.ts
@@ -55,7 +55,10 @@ export const handleCompactCommand: CommandHandler = async (params) => {
     logVerbose(
       `Ignoring /compact from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
     );
-    return { shouldContinue: false };
+    return {
+      shouldContinue: false,
+      reply: { text: "⚠️ You are not authorized to use /compact." },
+    };
   }
   if (!params.sessionEntry?.sessionId) {
     return {

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -401,7 +401,8 @@ describe("/compact command", () => {
       true,
     );
 
-    expect(result).toEqual({ shouldContinue: false });
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("not authorized");
     expect(vi.mocked(compactEmbeddedPiSession)).not.toHaveBeenCalled();
   });
 
@@ -488,7 +489,8 @@ describe("abort trigger command", () => {
       },
     });
 
-    expect(result).toEqual({ shouldContinue: false });
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("not authorized");
     expect(sessionStore[params.sessionKey]?.abortedLastRun).toBe(false);
     expect(vi.mocked(abortEmbeddedPiRun)).not.toHaveBeenCalled();
   });
@@ -812,7 +814,8 @@ describe("/models command", () => {
         senderId: "unauthorized",
       },
     });
-    expect(result).toEqual({ shouldContinue: false });
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("not authorized");
   });
 
   it("lists providers on telegram (buttons)", async () => {


### PR DESCRIPTION
## Summary

- Problem: When `commands.allowFrom` is configured, unauthorized Discord slash command users see "The application did not respond" after a timeout. The command is ACKed (deferred) immediately, but `rejectUnauthorizedCommand()` returns `{ shouldContinue: false }` with no reply, so Discord never receives a follow-up message.
- Why it matters: Users have no idea their command was rejected due to authorization — they only see a confusing timeout message.
- What changed: `rejectUnauthorizedCommand()` in `command-gates.ts` and the inline auth check in `commands-compact.ts` now include a `reply` with an error message so a visible response is always sent.
- What did NOT change (scope boundary): The authorization logic itself is unchanged. Only the return shape adds a `reply` field. No changes to Discord interaction handling or session management.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34776

## User-visible / Behavior Changes

Unauthorized users now see a clear "You are not authorized to use /command" error message instead of a silent timeout when using Discord slash commands restricted by `commands.allowFrom`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Configure `commands.allowFrom` to restrict command access to specific users
2. Have an unauthorized user invoke a Discord native slash command (e.g. `/status`)

### Expected

- Unauthorized users receive "You are not authorized to use /status" immediately

### Actual

- Before: "The application did not respond" timeout after several minutes
- After: Immediate "⚠️ You are not authorized to use /status." error message

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Updated test assertions in `commands.test.ts`:
- `rejects unauthorized /compact commands` — now asserts `reply.text` contains "not authorized"
- `rejects unauthorized natural-language abort triggers` — now asserts `reply.text` contains "not authorized"
- `rejects unauthorized /models commands` — now asserts `reply.text` contains "not authorized"

## Human Verification (required)

- Verified scenarios: `/compact`, `/models`, abort triggers — all return error reply when unauthorized
- Edge cases checked: Authorized users still get `null` (pass-through); disabled commands still use their own reply
- What you did **not** verify: Live Discord bot interaction with deferred interactions

## Compatibility / Migration

- Backward compatible? Yes — the return shape gains a `reply` field where there was none
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; unauthorized commands will return to silent timeout behavior
- Files/config to restore: `src/auto-reply/reply/command-gates.ts`, `src/auto-reply/reply/commands-compact.ts`

## Risks and Mitigations

- Risk: Downstream command handlers that check for `result.reply === undefined` to detect "no response" may behave differently.
  - Mitigation: The `shouldContinue: false` contract is preserved; reply is additive. The Discord handler already has a no-reply fallback path that would benefit from receiving a reply.