### PR TITLE
fix(models): honor explicit kimi-coding baseUrl in merge mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/kimi-coding baseUrl precedence: in merge mode, respect explicit `models.providers["kimi-coding"].baseUrl` from config instead of reusing stale agent `models.json` baseUrl values, so custom `/coding` endpoints are honored. (#36353)
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -10,6 +10,7 @@ import {
   withModelsTempHome as withTempHome,
 } from "./models-config.e2e-harness.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
+import { buildKimiCodingProvider } from "./models-config.providers.js";
 import { readGeneratedModelsJson } from "./models-config.test-utils.js";
 
 installModelsConfigTestHooks();
@@ -230,6 +231,39 @@ describe("models-config", () => {
       });
       expect(parsed.providers.custom?.apiKey).toBe("CONFIG_KEY");
       expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
+    });
+  });
+
+  it("prefers explicit config baseUrl for kimi-coding in merge mode", async () => {
+    await withTempHome(async () => {
+      const kimiProvider = buildKimiCodingProvider();
+      await writeAgentModelsJson({
+        providers: {
+          "kimi-coding": {
+            ...kimiProvider,
+            baseUrl: "https://api.kimi.com",
+            apiKey: "AGENT_KEY",
+          },
+        },
+      });
+
+      await ensureOpenClawModelsJson({
+        models: {
+          mode: "merge",
+          providers: {
+            "kimi-coding": {
+              ...kimiProvider,
+              baseUrl: "https://api.kimi.com/coding",
+              apiKey: "CONFIG_KEY",
+            },
+          },
+        },
+      });
+
+      const parsed = await readGeneratedModelsJson<{
+        providers: Record<string, { apiKey?: string; baseUrl?: string }>;
+      }>();
+      expect(parsed.providers["kimi-coding"]?.baseUrl).toBe("https://api.kimi.com/coding");
     });
   });
 

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -162,7 +162,14 @@ function mergeWithExistingProviderSecrets(params: {
     if (typeof existing.apiKey === "string" && existing.apiKey) {
       preserved.apiKey = existing.apiKey;
     }
-    if (typeof existing.baseUrl === "string" && existing.baseUrl) {
+    // Kimi Coding users commonly override the endpoint path in config; prefer
+    // that explicit baseUrl over stale agent-side merged values.
+    const preservesAgentBaseUrl = !(
+      key === "kimi-coding" &&
+      typeof newEntry.baseUrl === "string" &&
+      newEntry.baseUrl.trim()
+    );
+    if (preservesAgentBaseUrl && typeof existing.baseUrl === "string" && existing.baseUrl) {
       preserved.baseUrl = existing.baseUrl;
     }
     mergedProviders[key] = { ...newEntry, ...preserved };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: In merge mode, existing agent `models.json` baseUrl values could override explicit config baseUrl for `kimi-coding`.
- Why it matters: Users configuring `models.providers["kimi-coding"].baseUrl` (for example `/coding` endpoint path) still hit stale/incorrect endpoints and got 404s.
- What changed: During merge-time provider secret/baseUrl preservation, `kimi-coding` now prefers the explicit config baseUrl when present.
- What did NOT change (scope boundary): API key precedence and merge behavior for other providers remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36353
- Related #22409

## User-visible / Behavior Changes

When `models.mode="merge"`, explicit `models.providers["kimi-coding"].baseUrl` in config is now honored even if agent `models.json` contains an older `kimi-coding` baseUrl.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: kimi-coding
- Integration/channel (if any): N/A
- Relevant config (redacted): `models.mode="merge"`, explicit `models.providers["kimi-coding"].baseUrl`

### Steps

1. Seed agent `models.json` with `providers["kimi-coding"].baseUrl` pointing to a stale endpoint.
2. Run `ensureOpenClawModelsJson` with merge mode and explicit config baseUrl for `kimi-coding`.
3. Inspect merged provider baseUrl in generated `models.json`.

### Expected

- Generated `providers["kimi-coding"].baseUrl` should match explicit config baseUrl.

### Actual

- After this fix, merge mode correctly keeps the explicit config baseUrl for `kimi-coding`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added regression test `prefers explicit config baseUrl for kimi-coding in merge mode`.
  - Re-ran full `models-config.fills-missing-provider-apikey-from-env-var` test file.
- Edge cases checked:
  - Existing non-empty agent values still preserve behavior outside this specific `kimi-coding` baseUrl override path.
- What you did **not** verify:
  - Live Kimi API request/response against a real production key.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/models-config.ts`.
- Known bad symptoms reviewers should watch for: explicit `kimi-coding` baseUrl being ignored in merge mode.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Provider-specific override logic could diverge from generic merge semantics.
  - Mitigation: Narrowly scoped to `kimi-coding` + explicit non-empty config baseUrl; regression test locks expected behavior.
