### PR TITLE
fix(gateway): bind lan to :: for dual-stack IPv4+IPv6 support

### DIFF
--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -227,7 +227,7 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
         bind === "loopback"
           ? "127.0.0.1"
           : bind === "lan"
-            ? "0.0.0.0"
+            ? "::"
             : bind === "custom"
               ? toOptionString(cfg.gateway?.customBindHost)
               : undefined;

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -328,7 +328,7 @@ export type GatewayConfig = {
   /**
    * Bind address policy for the Gateway WebSocket + Control UI HTTP server.
    * - auto: Loopback (127.0.0.1) if available, else 0.0.0.0 (fallback to all interfaces)
-   * - lan: 0.0.0.0 (all interfaces, no fallback)
+   * - lan: :: (dual-stack, all interfaces, no fallback)
    * - loopback: 127.0.0.1 (local-only)
    * - tailnet: Tailnet IPv4 if available (100.64.0.0/10), else loopback
    * - custom: User-specified IP, fallback to 0.0.0.0 if unavailable (requires customBindHost)

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -211,7 +211,7 @@ export function isLocalGatewayAddress(ip: string | undefined): boolean {
  *
  * Modes:
  * - loopback: 127.0.0.1 (rarely fails, but handled gracefully)
- * - lan: always 0.0.0.0 (no fallback)
+ * - lan: :: (dual-stack IPv4+IPv6, no fallback)
  * - tailnet: Tailnet IPv4 if available, else loopback
  * - auto: Loopback if available, else 0.0.0.0
  * - custom: User-specified IP, fallback to 0.0.0.0 if unavailable
@@ -244,7 +244,7 @@ export async function resolveGatewayBindHost(
   }
 
   if (mode === "lan") {
-    return "0.0.0.0";
+    return "::";
   }
 
   if (mode === "custom") {

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -30,7 +30,7 @@ describe("resolveGatewayRuntimeConfig", () => {
             controlUi: { allowedOrigins: ["https://control.example.com"] },
           },
         },
-        expectedBindHost: "0.0.0.0",
+        expectedBindHost: "::",
       },
       {
         name: "loopback binding with 127.0.0.1 proxy",
@@ -135,7 +135,7 @@ describe("resolveGatewayRuntimeConfig", () => {
           },
         },
         expectedAuthMode: "token",
-        expectedBindHost: "0.0.0.0",
+        expectedBindHost: "::",
       },
       {
         name: "loopback binding with explicit none auth",
@@ -228,7 +228,7 @@ describe("resolveGatewayRuntimeConfig", () => {
         },
         port: 18789,
       });
-      expect(result.bindHost).toBe("0.0.0.0");
+      expect(result.bindHost).toBe("::");
     });
   });
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -182,7 +182,7 @@ export type GatewayServerOptions = {
   /**
    * Bind address policy for the Gateway WebSocket/HTTP server.
    * - loopback: 127.0.0.1
-   * - lan: 0.0.0.0
+   * - lan: :: (dual-stack)
    * - tailnet: bind only to the Tailscale IPv4 address (100.64.0.0/10)
    * - auto: prefer loopback, else LAN
    */


### PR DESCRIPTION
## Summary

- **Problem:** `--bind lan` uses `0.0.0.0` (IPv4 only). Container platforms like Railway route through IPv6 proxies, causing a 502 "Application failed to respond" error because the gateway is unreachable over IPv6.
- **Why it matters:** Any user deploying OpenClaw on IPv6-only or dual-stack container platforms (Railway, Fly.io, etc.) cannot use `--bind lan` without a workaround.
- **What changed:** Changed the `lan` bind address from `0.0.0.0` to `::` (dual-stack) in `resolveGatewayBindHost`, the CLI port-probe host, type/doc comments, and test expectations. On Linux and macOS, `::` enables IPv4-mapped IPv6, accepting both IPv4 and IPv6 connections on the same socket.
- **What did NOT change:** Other bind modes (`loopback`, `tailnet`, `auto`, `custom`). Auth validation logic (non-loopback bind still requires auth token/password). Legacy migration rules (already map both `0.0.0.0` and `::` to `lan`).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #34633

## User-visible / Behavior Changes

- `--bind lan` now listens on `::` (dual-stack) instead of `0.0.0.0` (IPv4 only)
- Both IPv4 and IPv6 clients can now reach the gateway when using `--bind lan`

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No — same listen scope (all interfaces), just dual-stack instead of IPv4-only`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22
- Integration/channel: Gateway HTTP server

### Steps

1. Deploy OpenClaw to a dual-stack container platform (e.g. Railway)
2. Start gateway with `--bind lan`
3. Access the gateway via IPv6

### Expected

- Gateway responds on both IPv4 and IPv6

### Actual

- Before fix: Gateway only listens on IPv4, IPv6 connections get 502
- After fix: Gateway listens on dual-stack `::`, both IPv4 and IPv6 work

## Evidence

Files changed (5 files, +8/-8 lines):

| File | Change |
|------|--------|
| `src/gateway/net.ts` | `lan` return: `0.0.0.0` → `::`, doc comment updated |
| `src/cli/gateway-cli/run.ts` | bind-probe host for `lan`: `0.0.0.0` → `::` |
| `src/config/types.gateway.ts` | `lan` description updated |
| `src/gateway/server.impl.ts` | `lan` comment updated |
| `src/gateway/server-runtime-config.test.ts` | 3 test expectations: `0.0.0.0` → `::` |

TypeScript compiles cleanly. All 19 gateway runtime config tests pass.

Legacy config migration (`src/config/legacy.migrations.part-1.ts`) already maps both `0.0.0.0` and `::` to `lan`, so existing configs will work. `formatHost` in `server-startup-log.ts` already formats `::` correctly as `[::]` in URLs.

## Human Verification (required)

- Verified scenarios: TypeScript compilation, all 19 runtime config tests pass, legacy migration already handles `::`, `formatHost` already supports `::`, auth validation unchanged for non-loopback hosts
- Edge cases checked: `isLoopbackHost` correctly returns false for `::`, auth still required for `lan` bind, `resolveGatewayListenHosts` returns `["::""]` for non-loopback hosts (no expansion needed)
- What I did **not** verify: Live dual-stack listen on a container platform (no Railway/Fly.io environment available)

## Compatibility / Migration

- Backward compatible? `Yes — dual-stack :: accepts all connections that 0.0.0.0 did, plus IPv6`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Change `::` back to `0.0.0.0` in `src/gateway/net.ts` and `src/cli/gateway-cli/run.ts`
- Files/config to restore: 2 source files + 1 test file
- Known bad symptoms: On rare systems where `::` doesn't support dual-stack (e.g. `net.ipv6.bindv6only=1` on Linux), IPv4 clients would fail. Users can work around with `--bind custom` and `customBindHost: "0.0.0.0"`.

## Risks and Mitigations

- **Risk:** Systems with `net.ipv6.bindv6only=1` sysctl would lose IPv4 connectivity. **Mitigation:** This sysctl is disabled by default on all major Linux distros, Docker, and container runtimes. Users who explicitly enable it already understand IPv6 networking.

