### PR TITLE
fix(telegram): render markdown tables as code by default

### DIFF
--- a/src/config/markdown-tables.defaults.test.ts
+++ b/src/config/markdown-tables.defaults.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { resolveMarkdownTableMode } from "./markdown-tables.ts";
+
+describe("resolveMarkdownTableMode - defaults", () => {
+  it("defaults telegram to code mode (Telegram does not support markdown tables)", () => {
+    expect(resolveMarkdownTableMode({ cfg: undefined, channel: "telegram" })).toBe("code");
+  });
+
+  it("defaults whatsapp to bullets", () => {
+    expect(resolveMarkdownTableMode({ cfg: undefined, channel: "whatsapp" })).toBe("bullets");
+  });
+
+  it("defaults signal to bullets", () => {
+    expect(resolveMarkdownTableMode({ cfg: undefined, channel: "signal" })).toBe("bullets");
+  });
+});

--- a/src/config/markdown-tables.ts
+++ b/src/config/markdown-tables.ts
@@ -17,6 +17,8 @@ type MarkdownConfigSection = MarkdownConfigEntry & {
 const DEFAULT_TABLE_MODES = new Map<string, MarkdownTableMode>([
   ["signal", "bullets"],
   ["whatsapp", "bullets"],
+  // Telegram renders markdown tables as raw pipes/dashes; prefer code blocks.
+  ["telegram", "code"],
 ]);
 
 const isMarkdownTableMode = (value: unknown): value is MarkdownTableMode =>


### PR DESCRIPTION
Closes #36323

Telegram does not support GitHub-flavored markdown tables. Default table conversion for the Telegram channel to "code" mode so tables render as preformatted code blocks instead of raw pipes/dashes.

Adds a unit test covering channel defaults.