### PR TITLE
fix(plugins): deduplicate repeated "duplicate plugin id" warnings across config reloads

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -4,7 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { PluginCandidate } from "./discovery.js";
-import { loadPluginManifestRegistry } from "./manifest-registry.js";
+import {
+  clearPluginManifestRegistryCache,
+  loadPluginManifestRegistry,
+} from "./manifest-registry.js";
 
 const tempDirs: string[] = [];
 
@@ -116,6 +119,7 @@ function expectUnsafeWorkspaceManifestRejected(params: {
 }
 
 afterEach(() => {
+  clearPluginManifestRegistryCache();
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (!dir) {
@@ -234,6 +238,32 @@ describe("loadPluginManifestRegistry", () => {
     expect(countDuplicateWarnings(registry)).toBe(0);
     expect(registry.plugins.length).toBe(1);
     expect(registry.plugins[0]?.origin).toBe("config");
+  });
+
+  it("emits duplicate warning only once across repeated loads for the same plugin", () => {
+    clearPluginManifestRegistryCache();
+
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    const manifest = { id: "dedup-plugin", configSchema: { type: "object" } };
+    writeManifest(dirA, manifest);
+    writeManifest(dirB, manifest);
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "dedup-plugin",
+        rootDir: dirA,
+        origin: "bundled",
+      }),
+      createPluginCandidate({
+        idHint: "dedup-plugin",
+        rootDir: dirB,
+        origin: "global",
+      }),
+    ];
+
+    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
+    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
   });
 
   it("rejects manifest paths that escape plugin root via symlink", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -49,8 +49,11 @@ const registryCache = new Map<string, { expiresAt: number; registry: PluginManif
 // Keep a short cache window to collapse bursty reloads during startup flows.
 const DEFAULT_MANIFEST_CACHE_MS = 1000;
 
+const emittedDuplicateWarnings = new Set<string>();
+
 export function clearPluginManifestRegistryCache(): void {
   registryCache.clear();
+  emittedDuplicateWarnings.clear();
 }
 
 function resolveManifestCacheMs(env: NodeJS.ProcessEnv): number {
@@ -229,12 +232,16 @@ export function loadPluginManifestRegistry(params: {
         }
         continue;
       }
-      diagnostics.push({
-        level: "warn",
-        pluginId: manifest.id,
-        source: candidate.source,
-        message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
-      });
+      const dupKey = `${manifest.id}::${candidate.source}`;
+      if (!emittedDuplicateWarnings.has(dupKey)) {
+        emittedDuplicateWarnings.add(dupKey);
+        diagnostics.push({
+          level: "warn",
+          pluginId: manifest.id,
+          source: candidate.source,
+          message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
+        });
+      }
     } else {
       seenIds.set(manifest.id, { candidate, recordIndex: records.length });
     }


### PR DESCRIPTION
## Summary

- Problem: When a plugin ID is registered from two distinct directories (e.g. the bundled `feishu` and a user-installed copy in `~/.openclaw/extensions/feishu`), the "duplicate plugin id detected" warning is emitted on every config validation cycle (~every 1 second), flooding the gateway logs with identical messages.
- Why it matters: The log noise makes it impossible to find real issues in the gateway logs. Users report logs refreshing every second with nothing but duplicate plugin warnings.
- What changed: Added a process-wide `Set` that tracks emitted duplicate warnings by `pluginId::source`. The first occurrence is still surfaced; subsequent identical warnings from cache-expired reloads are suppressed. The Set is cleared alongside the registry cache via `clearPluginManifestRegistryCache()`.
- What did NOT change (scope boundary): The duplicate detection logic itself is unchanged. Truly distinct duplicates still produce a warning on first encounter. No changes to plugin loading order, precedence, or config validation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35656

## User-visible / Behavior Changes

Gateway logs no longer flood with repeated "duplicate plugin id detected" warnings every second. The warning appears once on startup, then is suppressed for subsequent config reloads unless the duplicate configuration changes.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu / macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Install OpenClaw with a bundled Feishu plugin
2. Also place a copy of the Feishu plugin in `~/.openclaw/extensions/feishu/`
3. Start the gateway: `openclaw gateway start`
4. Watch logs: `openclaw logs --follow`

### Expected

- "duplicate plugin id detected" warning appears once at startup

### Actual

- Before: Warning floods logs every ~1 second
- After: Warning appears once, then is suppressed

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test in `src/plugins/manifest-registry.test.ts`:
- `emits duplicate warning only once across repeated loads for the same plugin` — first load returns 1 warning, second load returns 0

## Human Verification (required)

- Verified scenarios: Repeated loads with same duplicate; single load still emits warning; clearing cache resets the dedup set
- Edge cases checked: Different plugin IDs don't interfere; afterEach cleanup resets state between tests
- What you did **not** verify: Live gateway with multiple Feishu plugin installations

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; duplicate warnings return to every-cycle behavior
- Files/config to restore: `src/plugins/manifest-registry.ts`

## Risks and Mitigations

- Risk: If a user resolves the duplicate (removes one copy), the warning from the previous configuration may remain suppressed until the next process restart or cache clear.
  - Mitigation: `clearPluginManifestRegistryCache()` clears the dedup set, and the Set is keyed by `pluginId::source` — if the source path changes, a new key is used and the new warning is emitted.