### PR TITLE
fix(gateway): normalize hook transform model overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/hooks transform model override normalization: accept trimmed string model overrides from hook transforms and ignore invalid non-string `model` values instead of clobbering configured mapping models. (#36326)
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -182,6 +182,84 @@ describe("hooks mapping", () => {
     }
   });
 
+  it("applies model override from transform result", async () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xform-model-"));
+    const transformsRoot = path.join(configDir, "hooks", "transforms");
+    fs.mkdirSync(transformsRoot, { recursive: true });
+    const modPath = path.join(transformsRoot, "model-transform.mjs");
+    fs.writeFileSync(
+      modPath,
+      'export default () => ({ model: "openai/gpt-4.1-mini", message: "Transform model override" });',
+    );
+
+    const mappings = resolveHookMappings(
+      {
+        mappings: [
+          {
+            match: { path: "model-override" },
+            action: "agent",
+            messageTemplate: "Base message",
+            model: "anthropic/claude-sonnet-4-6",
+            transform: { module: "model-transform.mjs" },
+          },
+        ],
+      },
+      { configDir },
+    );
+
+    const result = await applyHookMappings(mappings, {
+      payload: {},
+      headers: {},
+      url: new URL("http://127.0.0.1:18789/hooks/model-override"),
+      path: "model-override",
+    });
+
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.action?.kind === "agent") {
+      expect(result.action.message).toBe("Transform model override");
+      expect(result.action.model).toBe("openai/gpt-4.1-mini");
+    }
+  });
+
+  it("keeps base model when transform returns non-string model override", async () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-xform-model-type-"));
+    const transformsRoot = path.join(configDir, "hooks", "transforms");
+    fs.mkdirSync(transformsRoot, { recursive: true });
+    const modPath = path.join(transformsRoot, "model-type-transform.mjs");
+    fs.writeFileSync(
+      modPath,
+      'export default () => ({ model: { id: "openai/gpt-4.1-mini" }, message: "Invalid type override" });',
+    );
+
+    const mappings = resolveHookMappings(
+      {
+        mappings: [
+          {
+            match: { path: "model-type" },
+            action: "agent",
+            messageTemplate: "Base message",
+            model: "anthropic/claude-sonnet-4-6",
+            transform: { module: "model-type-transform.mjs" },
+          },
+        ],
+      },
+      { configDir },
+    );
+
+    const result = await applyHookMappings(mappings, {
+      payload: {},
+      headers: {},
+      url: new URL("http://127.0.0.1:18789/hooks/model-type"),
+      path: "model-type",
+    });
+
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.action?.kind === "agent") {
+      expect(result.action.message).toBe("Invalid type override");
+      expect(result.action.model).toBe("anthropic/claude-sonnet-4-6");
+    }
+  });
+
   it("rejects transform module traversal outside transformsDir", () => {
     const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-traversal-"));
     const transformsRoot = path.join(configDir, "hooks", "transforms");

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -292,6 +292,7 @@ function mergeAction(
     typeof override.message === "string" ? override.message : (baseAgent?.message ?? "");
   const wakeMode =
     override.wakeMode === "next-heartbeat" ? "next-heartbeat" : (baseAgent?.wakeMode ?? "now");
+  const overrideModel = normalizeTransformOptionalString(override.model);
   return validateAction({
     kind: "agent",
     message,
@@ -306,7 +307,7 @@ function mergeAction(
         : baseAgent?.allowUnsafeExternalContent,
     channel: override.channel ?? baseAgent?.channel,
     to: override.to ?? baseAgent?.to,
-    model: override.model ?? baseAgent?.model,
+    model: overrideModel ?? baseAgent?.model,
     thinking: override.thinking ?? baseAgent?.thinking,
     timeoutSeconds: override.timeoutSeconds ?? baseAgent?.timeoutSeconds,
   });
@@ -439,6 +440,18 @@ function renderOptional(value: string | undefined, ctx: HookMappingContext) {
   }
   const rendered = renderTemplate(value, ctx).trim();
   return rendered ? rendered : undefined;
+}
+
+function normalizeTransformOptionalString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  if (Object.prototype.toString.call(value) === "[object String]") {
+    const trimmed = String(value).trim();
+    return trimmed ? trimmed : undefined;
+  }
+  return undefined;
 }
 
 function renderTemplate(template: string, ctx: HookMappingContext) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Hook transform outputs are not schema-validated at runtime, so non-string `model` overrides can silently clobber a valid mapping model and lead to default-model fallback behavior.
- Why it matters: This can look like transform-specified model overrides being ignored, especially in dynamic hook-transform pipelines.
- What changed: Added normalization for transform `model` values (trimmed strings only), and fall back to mapping-level model when transform `model` is invalid/non-string.
- What did NOT change (scope boundary): Delivery, session routing, and other transform fields were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36326
- Related #15692

## User-visible / Behavior Changes

Hook transforms now only override `action.model` when `model` is a valid string; invalid typed values no longer wipe out a valid mapping model.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A (unit test)
- Integration/channel (if any): hooks mapping
- Relevant config (redacted): hook mapping with transform module overriding `model`

### Steps

1. Configure a hook mapping with base model and transform module.
2. Return `model` from transform as a valid string and verify override is applied.
3. Return `model` from transform as non-string (object) and verify base mapping model remains.

### Expected

- String transform model overrides mapping model.
- Invalid non-string transform model does not clobber mapping model.

### Actual

- After this fix, behavior matches expected in both paths.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added transform model override test (string) and transform invalid model fallback test (non-string).
  - Re-ran `src/gateway/hooks-mapping.test.ts`.
- Edge cases checked:
  - Boxed-string style values normalize correctly via string coercion path.
- What you did **not** verify:
  - Full gateway live run with external hook caller and model registry auth constraints.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/gateway/hooks-mapping.ts`.
- Known bad symptoms reviewers should watch for: transform model overrides not applied when valid strings are returned.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: More permissive string normalization could mask malformed transform output shape.
  - Mitigation: Only the `model` field is normalized; non-string values still do not override and tests cover both valid/invalid cases.
