### PR TITLE
fix(whatsapp): use fresh config for group gating and message processing

### DIFF
--- a/src/web/auto-reply/monitor/on-message.ts
+++ b/src/web/auto-reply/monitor/on-message.ts
@@ -40,7 +40,7 @@ export function createWebOnMessageHandler(params: {
     },
   ) =>
     processMessage({
-      cfg: params.cfg,
+      cfg: loadConfig(),
       msg,
       route,
       groupHistoryKey,
@@ -113,7 +113,7 @@ export function createWebOnMessageHandler(params: {
         OriginatingTo: conversationId,
       } satisfies MsgContext;
       updateLastRouteInBackground({
-        cfg: params.cfg,
+        cfg: loadConfig(),
         backgroundTasks: params.backgroundTasks,
         storeAgentId: route.agentId,
         sessionKey: route.sessionKey,
@@ -125,7 +125,7 @@ export function createWebOnMessageHandler(params: {
       });
 
       const gating = applyGroupGating({
-        cfg: params.cfg,
+        cfg: loadConfig(),
         msg,
         conversationId,
         groupHistoryKey,
@@ -153,7 +153,7 @@ export function createWebOnMessageHandler(params: {
     // Does not bypass group mention/activation gating above.
     if (
       await maybeBroadcastMessage({
-        cfg: params.cfg,
+        cfg: loadConfig(),
         msg,
         peerId,
         route,


### PR DESCRIPTION
Fixes #33974

`createWebOnMessageHandler` captured `params.cfg` at handler creation time, so all downstream calls used a stale config snapshot for the lifetime of the channel. Runtime config changes (toggling `requireMention`, updating group allowlists, changing group policy) were silently ignored until a full channel restart.

`resolveAgentRoute` already called `loadConfig()` per-message (line 68), confirming fresh config is the intended pattern. This PR applies the same pattern to the remaining 4 stale call sites:
- `processMessage`
- `updateLastRouteInBackground`
- `applyGroupGating`
- `maybeBroadcastMessage`

1 file, +4/-4. 72 tests pass.

---

AI-assisted PR (Claude via OpenClaw agent). I understand what this code does.