### PR TITLE
fix(tui): prioritize configured local gateway token over env fallback

### DIFF
--- a/extensions/mattermost/src/group-mentions.test.ts
+++ b/extensions/mattermost/src/group-mentions.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it } from "vitest";
 import { resolveMattermostGroupRequireMention } from "./group-mentions.js";
 

--- a/extensions/mattermost/src/group-mentions.ts
+++ b/extensions/mattermost/src/group-mentions.ts
@@ -1,4 +1,7 @@
-import { resolveChannelGroupRequireMention, type ChannelGroupContext } from "openclaw/plugin-sdk";
+import {
+  resolveChannelGroupRequireMention,
+  type ChannelGroupContext,
+} from "openclaw/plugin-sdk/mattermost";
 import { resolveMattermostAccount } from "./mattermost/accounts.js";
 
 export function resolveMattermostGroupRequireMention(

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it, vi } from "vitest";
 import { resolveMattermostAccount } from "./accounts.js";
 import {

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -49,6 +49,7 @@ export {
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "../config/runtime-group-policy.js";
+export { resolveChannelGroupRequireMention } from "../config/group-policy.js";
 export type { BlockStreamingCoalesceConfig, DmPolicy, GroupPolicy } from "../config/types.js";
 export type { SecretInput } from "../config/types.secrets.js";
 export {

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -83,7 +83,7 @@ describe("resolveGatewayConnection", () => {
     expect(result.url).toBe("ws://127.0.0.1:18800");
   });
 
-  it("uses OPENCLAW_GATEWAY_TOKEN for local mode", () => {
+  it("uses OPENCLAW_GATEWAY_TOKEN for local mode when config token is missing", () => {
     loadConfig.mockReturnValue({ gateway: { mode: "local" } });
 
     withEnv({ OPENCLAW_GATEWAY_TOKEN: "env-token" }, () => {
@@ -92,11 +92,13 @@ describe("resolveGatewayConnection", () => {
     });
   });
 
-  it("falls back to config auth token when env token is missing", () => {
+  it("prefers config auth token over env token in local mode", () => {
     loadConfig.mockReturnValue({ gateway: { mode: "local", auth: { token: "config-token" } } });
 
-    const result = resolveGatewayConnection({});
-    expect(result.token).toBe("config-token");
+    withEnv({ OPENCLAW_GATEWAY_TOKEN: "env-token" }, () => {
+      const result = resolveGatewayConnection({});
+      expect(result.token).toBe("config-token");
+    });
   });
 
   it("prefers OPENCLAW_GATEWAY_PASSWORD over remote password fallback", () => {

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -261,10 +261,9 @@ export function resolveGatewayConnection(opts: GatewayConnectionOptions) {
         ? typeof remote?.token === "string" && remote.token.trim().length > 0
           ? remote.token.trim()
           : undefined
-        : process.env.OPENCLAW_GATEWAY_TOKEN?.trim() ||
-          (typeof authToken === "string" && authToken.trim().length > 0
+        : (typeof authToken === "string" && authToken.trim().length > 0
             ? authToken.trim()
-            : undefined)
+            : undefined) || process.env.OPENCLAW_GATEWAY_TOKEN?.trim()
       : undefined);
 
   const password =


### PR DESCRIPTION
Problem: Fresh installs can hit `token_mismatch` on TUI websocket auth, then fail runs with `HTTP 401: Invalid Authentication` when a stale `OPENCLAW_GATEWAY_TOKEN` exists in shell env.
Root cause: `resolveGatewayConnection()` preferred `OPENCLAW_GATEWAY_TOKEN` over `gateway.auth.token` in local mode.
Fix: Prefer configured `gateway.auth.token` first in local mode; fall back to `OPENCLAW_GATEWAY_TOKEN` only when config token is missing.
Testing: `pnpm exec vitest run src/tui/gateway-chat.test.ts`.

Closes #36270
