### PR TITLE
fix(status): resolve context window by provider-qualified key, prefer max on bare-id collision, solve #35976

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,9 @@ Docs: https://docs.openclaw.ai
 - Telegram/direct delivery: bridge direct delivery sends to internal `message:sent` hooks so internal hook listeners observe successful Telegram deliveries. (#40185) Thanks @vincentkoc.
 - Dependencies: refresh workspace dependencies except the pinned Carbon package, and harden ACP session-config writes against non-string SDK values so newer ACP clients fail fast instead of tripping type/runtime mismatches.
 - Telegram/polling restarts: clear bounded cleanup timeout handles after `runner.stop()` and `bot.stop()` settle so stall recovery no longer leaves stray 15-second timers behind on clean shutdown. (#43188) thanks @kyohwang.
+- Gateway/config errors: surface up to three validation issues in top-level `config.set`, `config.patch`, and `config.apply` error messages while preserving structured issue details. (#42664) Thanks @huntharo.
+- Hooks/plugin context parity followup: pass `trigger` and `channelId` through embedded `llm_input`, `agent_end`, and `llm_output` hook contexts so plugins receive the same agent metadata across hook phases. (#42362) Thanks @zhoulf1006.
+- Status/context windows: normalize provider-qualified override cache keys so `/status` resolves the active provider's configured context window even when `models.providers` keys use mixed case or surrounding whitespace. (#36389) Thanks @haoruilee.
 
 ## 2026.3.8
 

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -121,8 +121,10 @@ describe("lookupContextTokens", () => {
     expect(lookupContextTokens("gemini-3.1-pro-preview")).toBe(128_000);
   });
 
-  it("resolveContextTokensForModel uses provider-qualified key before bare model id", async () => {
+  it("resolveContextTokensForModel returns discovery value when provider-qualified entry exists in cache", async () => {
     // Registry returns provider-qualified entries (real-world scenario from #35976).
+    // When no explicit config override exists, the bare cache lookup hits the
+    // provider-qualified raw discovery entry.
     mockDiscoveryDeps([
       { id: "github-copilot/gemini-3.1-pro-preview", contextWindow: 128_000 },
       { id: "google-gemini-cli/gemini-3.1-pro-preview", contextWindow: 1_048_576 },
@@ -131,7 +133,8 @@ describe("lookupContextTokens", () => {
     const { resolveContextTokensForModel } = await import("./context.js");
     await new Promise((r) => setTimeout(r, 0));
 
-    // With provider specified, should return the correct provider's window.
+    // With provider specified and no config override, bare lookup finds the
+    // provider-qualified discovery entry.
     const result = resolveContextTokensForModel({
       provider: "google-gemini-cli",
       model: "gemini-3.1-pro-preview",
@@ -139,53 +142,92 @@ describe("lookupContextTokens", () => {
     expect(result).toBe(1_048_576);
   });
 
-  it("resolveContextTokensForModel honors configured overrides when provider keys use mixed case", async () => {
-    mockDiscoveryDeps(
-      [{ id: "openrouter/anthropic/claude-sonnet-4-5", contextWindow: 1_048_576 }],
-      {
-        " OpenRouter ": {
-          models: [{ id: "anthropic/claude-sonnet-4-5", contextWindow: 200_000 }],
+  it("resolveContextTokensForModel returns configured override via direct config scan (beats discovery)", async () => {
+    // Config has an explicit contextWindow; resolveContextTokensForModel should
+    // return it via direct config scan, preventing collisions with raw discovery
+    // entries. Real callers (status.summary.ts etc.) always pass cfg.
+    mockDiscoveryDeps([
+      { id: "google-gemini-cli/gemini-3.1-pro-preview", contextWindow: 1_048_576 },
+    ]);
+
+    const cfg = {
+      models: {
+        providers: {
+          "google-gemini-cli": {
+            models: [{ id: "gemini-3.1-pro-preview", contextWindow: 200_000 }],
+          },
         },
       },
-    );
+    };
 
     const { resolveContextTokensForModel } = await import("./context.js");
     await new Promise((r) => setTimeout(r, 0));
 
     const result = resolveContextTokensForModel({
+      cfg: cfg as never,
+      provider: "google-gemini-cli",
+      model: "gemini-3.1-pro-preview",
+    });
+    expect(result).toBe(200_000);
+  });
+
+  it("resolveContextTokensForModel honors configured overrides when provider keys use mixed case", async () => {
+    mockDiscoveryDeps([{ id: "openrouter/anthropic/claude-sonnet-4-5", contextWindow: 1_048_576 }]);
+
+    const cfg = {
+      models: {
+        providers: {
+          " OpenRouter ": {
+            models: [{ id: "anthropic/claude-sonnet-4-5", contextWindow: 200_000 }],
+          },
+        },
+      },
+    };
+
+    const { resolveContextTokensForModel } = await import("./context.js");
+    await new Promise((r) => setTimeout(r, 0));
+
+    const result = resolveContextTokensForModel({
+      cfg: cfg as never,
       provider: "openrouter",
       model: "anthropic/claude-sonnet-4-5",
     });
     expect(result).toBe(200_000);
   });
 
-  it("resolveContextTokensForModel does not collide raw slash-containing model IDs with synthetic qualified keys", async () => {
-    // Reviewer concern: OpenRouter stores raw IDs like "google/gemini-2.5-pro".
-    // If the lookup built a synthetic key "google/gemini-2.5-pro" from
-    // {provider:"google", model:"gemini-2.5-pro"}, it would hit the OpenRouter
-    // raw entry. Guard: skip the qualified key when model already contains "/".
-    mockDiscoveryDeps([
-      // OpenRouter raw entry (model ID already provider-qualified by OpenRouter).
-      { id: "google/gemini-2.5-pro", contextWindow: 999_000 },
-    ]);
+  it("resolveContextTokensForModel does not pollute cache with synthetic keys; raw OpenRouter entries survive", async () => {
+    // Root concern: applyConfiguredContextWindows must not write
+    // "google/gemini-2.5-pro" from a Google provider config, which would
+    // overwrite the OpenRouter raw entry and corrupt bare-id lookups.
+    // Fix: config overrides are resolved directly from config (not via cache),
+    // so the cache only holds discovery entries. Real callers always pass cfg.
+    mockDiscoveryDeps([{ id: "google/gemini-2.5-pro", contextWindow: 999_000 }]);
+
+    const cfg = {
+      models: {
+        providers: {
+          google: {
+            models: [{ id: "gemini-2.5-pro", contextWindow: 2_000_000 }],
+          },
+        },
+      },
+    };
 
     const { resolveContextTokensForModel } = await import("./context.js");
     await new Promise((r) => setTimeout(r, 0));
 
-    // Calling with the native Google provider and a bare model id should NOT
-    // hit the OpenRouter raw entry via a synthetic "google/gemini-2.5-pro" key.
-    // Instead it falls through to the bare lookup which returns the raw value —
-    // functionally correct (same model, same window in practice) but via the
-    // intended code path rather than an accidental key collision.
-    const result = resolveContextTokensForModel({
+    // Google provider with bare model id + explicit cfg: config direct-scan
+    // returns 2M without touching the cache, so no collision with the
+    // OpenRouter raw "google/gemini-2.5-pro" entry.
+    const googleResult = resolveContextTokensForModel({
+      cfg: cfg as never,
       provider: "google",
       model: "gemini-2.5-pro",
     });
-    // The bare fallback finds the raw OpenRouter entry; no double-prefix lookup.
-    expect(result).toBe(999_000);
+    expect(googleResult).toBe(2_000_000);
 
-    // Calling with the OpenRouter provider and the slash-model id must NOT
-    // generate "openrouter/google/gemini-2.5-pro"; it uses bare lookup directly.
+    // OpenRouter provider with slash model id: no config override → bare cache
+    // lookup returns the raw OpenRouter discovery entry (999k), still 999k.
     const openrouterResult = resolveContextTokensForModel({
       provider: "openrouter",
       model: "google/gemini-2.5-pro",

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -158,4 +158,38 @@ describe("lookupContextTokens", () => {
     });
     expect(result).toBe(200_000);
   });
+
+  it("resolveContextTokensForModel does not collide raw slash-containing model IDs with synthetic qualified keys", async () => {
+    // Reviewer concern: OpenRouter stores raw IDs like "google/gemini-2.5-pro".
+    // If the lookup built a synthetic key "google/gemini-2.5-pro" from
+    // {provider:"google", model:"gemini-2.5-pro"}, it would hit the OpenRouter
+    // raw entry. Guard: skip the qualified key when model already contains "/".
+    mockDiscoveryDeps([
+      // OpenRouter raw entry (model ID already provider-qualified by OpenRouter).
+      { id: "google/gemini-2.5-pro", contextWindow: 999_000 },
+    ]);
+
+    const { resolveContextTokensForModel } = await import("./context.js");
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Calling with the native Google provider and a bare model id should NOT
+    // hit the OpenRouter raw entry via a synthetic "google/gemini-2.5-pro" key.
+    // Instead it falls through to the bare lookup which returns the raw value —
+    // functionally correct (same model, same window in practice) but via the
+    // intended code path rather than an accidental key collision.
+    const result = resolveContextTokensForModel({
+      provider: "google",
+      model: "gemini-2.5-pro",
+    });
+    // The bare fallback finds the raw OpenRouter entry; no double-prefix lookup.
+    expect(result).toBe(999_000);
+
+    // Calling with the OpenRouter provider and the slash-model id must NOT
+    // generate "openrouter/google/gemini-2.5-pro"; it uses bare lookup directly.
+    const openrouterResult = resolveContextTokensForModel({
+      provider: "openrouter",
+      model: "google/gemini-2.5-pro",
+    });
+    expect(openrouterResult).toBe(999_000);
+  });
 });

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -138,4 +138,24 @@ describe("lookupContextTokens", () => {
     });
     expect(result).toBe(1_048_576);
   });
+
+  it("resolveContextTokensForModel honors configured overrides when provider keys use mixed case", async () => {
+    mockDiscoveryDeps(
+      [{ id: "openrouter/anthropic/claude-sonnet-4-5", contextWindow: 1_048_576 }],
+      {
+        " OpenRouter ": {
+          models: [{ id: "anthropic/claude-sonnet-4-5", contextWindow: 200_000 }],
+        },
+      },
+    );
+
+    const { resolveContextTokensForModel } = await import("./context.js");
+    await new Promise((r) => setTimeout(r, 0));
+
+    const result = resolveContextTokensForModel({
+      provider: "openrouter",
+      model: "anthropic/claude-sonnet-4-5",
+    });
+    expect(result).toBe(200_000);
+  });
 });

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -195,30 +195,33 @@ describe("lookupContextTokens", () => {
     expect(result).toBe(200_000);
   });
 
-  it("resolveContextTokensForModel: bare key wins over qualified; OpenRouter raw entry not shadowed by Google config", async () => {
-    // applyConfiguredContextWindows writes "gemini-2.5-pro" → 2M (bare key, Google config).
-    // Discovery writes "google/gemini-2.5-pro" → 999k (OpenRouter raw qualified entry).
-    // Lookup order: bare first → finds 2M immediately, never reaching the
-    // OpenRouter raw "google/gemini-2.5-pro" qualified key.
-    mockDiscoveryDeps([{ id: "google/gemini-2.5-pro", contextWindow: 999_000 }], {
-      google: {
-        models: [{ id: "gemini-2.5-pro", contextWindow: 2_000_000 }],
+  it("resolveContextTokensForModel: config direct scan prevents OpenRouter qualified key collision for Google provider", async () => {
+    // When provider is explicitly "google" and cfg has a Google contextWindow
+    // override, the config direct scan returns it before any cache lookup —
+    // so the OpenRouter raw "google/gemini-2.5-pro" qualified entry is never hit.
+    // Real callers (status.summary.ts) always pass cfg when provider is explicit.
+    mockDiscoveryDeps([{ id: "google/gemini-2.5-pro", contextWindow: 999_000 }]);
+
+    const cfg = {
+      models: {
+        providers: {
+          google: { models: [{ id: "gemini-2.5-pro", contextWindow: 2_000_000 }] },
+        },
       },
-    });
+    };
 
     const { resolveContextTokensForModel } = await import("./context.js");
     await new Promise((r) => setTimeout(r, 0));
 
-    // Google provider: bare key "gemini-2.5-pro" → 2M (config-written) is found
-    // first; OpenRouter's "google/gemini-2.5-pro" qualified entry is never hit.
+    // Google with explicit cfg: config direct scan wins before any cache lookup.
     const googleResult = resolveContextTokensForModel({
+      cfg: cfg as never,
       provider: "google",
       model: "gemini-2.5-pro",
     });
     expect(googleResult).toBe(2_000_000);
 
-    // OpenRouter provider with slash model id: bare lookup "google/gemini-2.5-pro"
-    // → 999k (OpenRouter raw discovery entry, still intact).
+    // OpenRouter provider with slash model id: bare lookup finds the raw entry.
     const openrouterResult = resolveContextTokensForModel({
       provider: "openrouter",
       model: "google/gemini-2.5-pro",
@@ -296,5 +299,28 @@ describe("lookupContextTokens", () => {
       model: "gemini-2.5-pro",
     });
     expect(explicitResult).toBe(2_000_000);
+  });
+
+  it("resolveContextTokensForModel: qualified key beats bare min when provider is explicit (original #35976 fix)", async () => {
+    // Regression: when both "gemini-3.1-pro-preview" (bare, min=128k) AND
+    // "google-gemini-cli/gemini-3.1-pro-preview" (qualified, 1M) are in cache,
+    // an explicit-provider call must return the provider-specific qualified value,
+    // not the collided bare minimum.
+    mockDiscoveryDeps([
+      { id: "github-copilot/gemini-3.1-pro-preview", contextWindow: 128_000 },
+      { id: "gemini-3.1-pro-preview", contextWindow: 128_000 },
+      { id: "google-gemini-cli/gemini-3.1-pro-preview", contextWindow: 1_048_576 },
+    ]);
+
+    const { resolveContextTokensForModel } = await import("./context.js");
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Qualified "google-gemini-cli/gemini-3.1-pro-preview" → 1M wins over
+    // bare "gemini-3.1-pro-preview" → 128k (cross-provider minimum).
+    const result = resolveContextTokensForModel({
+      provider: "google-gemini-cli",
+      model: "gemini-3.1-pro-preview",
+    });
+    expect(result).toBe(1_048_576);
   });
 });

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -260,4 +260,41 @@ describe("lookupContextTokens", () => {
     });
     expect(portalResult).toBe(32_000);
   });
+
+  it("resolveContextTokensForModel(model-only) does not apply config scan for inferred provider", async () => {
+    // status.ts log-usage fallback calls resolveContextTokensForModel({ model })
+    // with no provider. When model = "google/gemini-2.5-pro" (OpenRouter ID),
+    // resolveProviderModelRef infers provider="google". Without the guard,
+    // resolveConfiguredProviderContextWindow would return Google's configured
+    // window and misreport context limits for the OpenRouter session.
+    mockDiscoveryDeps([{ id: "google/gemini-2.5-pro", contextWindow: 999_000 }]);
+
+    const cfg = {
+      models: {
+        providers: {
+          google: { models: [{ id: "gemini-2.5-pro", contextWindow: 2_000_000 }] },
+        },
+      },
+    };
+
+    const { resolveContextTokensForModel } = await import("./context.js");
+    await new Promise((r) => setTimeout(r, 0));
+
+    // model-only call (no explicit provider) must NOT apply config direct scan.
+    // Falls through to bare cache lookup: "google/gemini-2.5-pro" → 999k ✓.
+    const modelOnlyResult = resolveContextTokensForModel({
+      cfg: cfg as never,
+      model: "google/gemini-2.5-pro",
+      // no provider
+    });
+    expect(modelOnlyResult).toBe(999_000);
+
+    // Explicit provider still uses config scan ✓.
+    const explicitResult = resolveContextTokensForModel({
+      cfg: cfg as never,
+      provider: "google",
+      model: "gemini-2.5-pro",
+    });
+    expect(explicitResult).toBe(2_000_000);
+  });
 });

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -18,6 +18,26 @@ function mockContextModuleDeps(loadConfigImpl: () => unknown) {
   }));
 }
 
+// Shared mock setup used by multiple tests.
+function mockDiscoveryDeps(
+  models: Array<{ id: string; contextWindow: number }>,
+  configModels?: Record<string, { models: Array<{ id: string; contextWindow: number }> }>,
+) {
+  vi.doMock("../config/config.js", () => ({
+    loadConfig: () => ({ models: configModels ? { providers: configModels } : {} }),
+  }));
+  vi.doMock("./models-config.js", () => ({
+    ensureOpenClawModelsJson: vi.fn(async () => {}),
+  }));
+  vi.doMock("./agent-paths.js", () => ({
+    resolveOpenClawAgentDir: () => "/tmp/openclaw-agent",
+  }));
+  vi.doMock("./pi-model-discovery.js", () => ({
+    discoverAuthStorage: vi.fn(() => ({})),
+    discoverModels: vi.fn(() => ({ getAll: () => models })),
+  }));
+}
+
 describe("lookupContextTokens", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -86,5 +106,35 @@ describe("lookupContextTokens", () => {
       process.argv = argvSnapshot;
       vi.useRealTimers();
     }
+  });
+
+  it("returns the larger window when the same bare model id is discovered under multiple providers", async () => {
+    mockDiscoveryDeps([
+      { id: "gemini-3.1-pro-preview", contextWindow: 128_000 },
+      { id: "gemini-3.1-pro-preview", contextWindow: 1_048_576 },
+    ]);
+
+    const { lookupContextTokens } = await import("./context.js");
+    // Trigger async cache population.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(lookupContextTokens("gemini-3.1-pro-preview")).toBe(1_048_576);
+  });
+
+  it("resolveContextTokensForModel uses provider-qualified key before bare model id", async () => {
+    // Registry returns provider-qualified entries (real-world scenario from #35976).
+    mockDiscoveryDeps([
+      { id: "github-copilot/gemini-3.1-pro-preview", contextWindow: 128_000 },
+      { id: "google-gemini-cli/gemini-3.1-pro-preview", contextWindow: 1_048_576 },
+    ]);
+
+    const { resolveContextTokensForModel } = await import("./context.js");
+    await new Promise((r) => setTimeout(r, 0));
+
+    // With provider specified, should return the correct provider's window.
+    const result = resolveContextTokensForModel({
+      provider: "google-gemini-cli",
+      model: "gemini-3.1-pro-preview",
+    });
+    expect(result).toBe(1_048_576);
   });
 });

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -195,39 +195,30 @@ describe("lookupContextTokens", () => {
     expect(result).toBe(200_000);
   });
 
-  it("resolveContextTokensForModel does not pollute cache with synthetic keys; raw OpenRouter entries survive", async () => {
-    // Root concern: applyConfiguredContextWindows must not write
-    // "google/gemini-2.5-pro" from a Google provider config, which would
-    // overwrite the OpenRouter raw entry and corrupt bare-id lookups.
-    // Fix: config overrides are resolved directly from config (not via cache),
-    // so the cache only holds discovery entries. Real callers always pass cfg.
-    mockDiscoveryDeps([{ id: "google/gemini-2.5-pro", contextWindow: 999_000 }]);
-
-    const cfg = {
-      models: {
-        providers: {
-          google: {
-            models: [{ id: "gemini-2.5-pro", contextWindow: 2_000_000 }],
-          },
-        },
+  it("resolveContextTokensForModel: bare key wins over qualified; OpenRouter raw entry not shadowed by Google config", async () => {
+    // applyConfiguredContextWindows writes "gemini-2.5-pro" → 2M (bare key, Google config).
+    // Discovery writes "google/gemini-2.5-pro" → 999k (OpenRouter raw qualified entry).
+    // Lookup order: bare first → finds 2M immediately, never reaching the
+    // OpenRouter raw "google/gemini-2.5-pro" qualified key.
+    mockDiscoveryDeps([{ id: "google/gemini-2.5-pro", contextWindow: 999_000 }], {
+      google: {
+        models: [{ id: "gemini-2.5-pro", contextWindow: 2_000_000 }],
       },
-    };
+    });
 
     const { resolveContextTokensForModel } = await import("./context.js");
     await new Promise((r) => setTimeout(r, 0));
 
-    // Google provider with bare model id + explicit cfg: config direct-scan
-    // returns 2M without touching the cache, so no collision with the
-    // OpenRouter raw "google/gemini-2.5-pro" entry.
+    // Google provider: bare key "gemini-2.5-pro" → 2M (config-written) is found
+    // first; OpenRouter's "google/gemini-2.5-pro" qualified entry is never hit.
     const googleResult = resolveContextTokensForModel({
-      cfg: cfg as never,
       provider: "google",
       model: "gemini-2.5-pro",
     });
     expect(googleResult).toBe(2_000_000);
 
-    // OpenRouter provider with slash model id: no config override → bare cache
-    // lookup returns the raw OpenRouter discovery entry (999k), still 999k.
+    // OpenRouter provider with slash model id: bare lookup "google/gemini-2.5-pro"
+    // → 999k (OpenRouter raw discovery entry, still intact).
     const openrouterResult = resolveContextTokensForModel({
       provider: "openrouter",
       model: "google/gemini-2.5-pro",

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -225,4 +225,39 @@ describe("lookupContextTokens", () => {
     });
     expect(openrouterResult).toBe(999_000);
   });
+
+  it("resolveContextTokensForModel prefers exact provider key over alias-normalized match", async () => {
+    // When both "qwen" and "qwen-portal" exist as config keys (alias pattern),
+    // resolveConfiguredProviderContextWindow must return the exact-key match first,
+    // not the first normalized hit — mirroring pi-embedded-runner/model.ts behaviour.
+    mockDiscoveryDeps([]);
+
+    const cfg = {
+      models: {
+        providers: {
+          "qwen-portal": { models: [{ id: "qwen-max", contextWindow: 32_000 }] },
+          qwen: { models: [{ id: "qwen-max", contextWindow: 128_000 }] },
+        },
+      },
+    };
+
+    const { resolveContextTokensForModel } = await import("./context.js");
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Exact key "qwen" wins over the alias-normalized match "qwen-portal".
+    const qwenResult = resolveContextTokensForModel({
+      cfg: cfg as never,
+      provider: "qwen",
+      model: "qwen-max",
+    });
+    expect(qwenResult).toBe(128_000);
+
+    // Exact key "qwen-portal" wins (no alias lookup needed).
+    const portalResult = resolveContextTokensForModel({
+      cfg: cfg as never,
+      provider: "qwen-portal",
+      model: "qwen-max",
+    });
+    expect(portalResult).toBe(32_000);
+  });
 });

--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -108,16 +108,17 @@ describe("lookupContextTokens", () => {
     }
   });
 
-  it("returns the larger window when the same bare model id is discovered under multiple providers", async () => {
+  it("returns the smaller window when the same bare model id is discovered under multiple providers", async () => {
     mockDiscoveryDeps([
-      { id: "gemini-3.1-pro-preview", contextWindow: 128_000 },
       { id: "gemini-3.1-pro-preview", contextWindow: 1_048_576 },
+      { id: "gemini-3.1-pro-preview", contextWindow: 128_000 },
     ]);
 
     const { lookupContextTokens } = await import("./context.js");
     // Trigger async cache population.
     await new Promise((r) => setTimeout(r, 0));
-    expect(lookupContextTokens("gemini-3.1-pro-preview")).toBe(1_048_576);
+    // Conservative minimum: bare-id cache feeds runtime flush/compaction paths.
+    expect(lookupContextTokens("gemini-3.1-pro-preview")).toBe(128_000);
   });
 
   it("resolveContextTokensForModel uses provider-qualified key before bare model id", async () => {

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -55,16 +55,18 @@ describe("applyConfiguredContextWindows", () => {
     });
 
     expect(cache.get("anthropic/claude-opus-4-6")).toBe(200_000);
+    // Qualified key must also be written so resolveContextTokensForModel
+    // (which tries the qualified key first) returns the config override, not
+    // the discovered value stored at "openrouter/anthropic/claude-opus-4-6".
+    expect(cache.get("openrouter/anthropic/claude-opus-4-6")).toBe(200_000);
   });
 
-  it("stores provider-qualified key so config overrides beat qualified discovery entries", () => {
-    // Scenario from reviewer: discovery emits provider-qualified IDs but config
-    // uses bare IDs — without the qualified key in cache, resolveContextTokensForModel
-    // would return the discovered value and bypass the explicit config override.
+  it("stores provider-qualified key so config overrides beat qualified discovery entries (bare model id)", () => {
+    // Discovery emits provider-qualified IDs; config uses bare IDs.
+    // Without the qualified key in cache, resolveContextTokensForModel
+    // (which tries the qualified key first) would return the discovered value.
     const cache = new Map<string, number>();
-    // Simulate discovery storing a qualified entry.
     cache.set("google-gemini-cli/gemini-3.1-pro-preview", 1_048_576);
-    // Config override stored under bare key AND qualified key.
     applyConfiguredContextWindows({
       cache,
       modelsConfig: {
@@ -76,9 +78,33 @@ describe("applyConfiguredContextWindows", () => {
       },
     });
 
-    // Both bare and qualified keys must reflect the configured override.
     expect(cache.get("gemini-3.1-pro-preview")).toBe(200_000);
     expect(cache.get("google-gemini-cli/gemini-3.1-pro-preview")).toBe(200_000);
+  });
+
+  it("stores provider-qualified key so config overrides beat qualified discovery entries (slash model id)", () => {
+    // OpenRouter model ids already contain a slash (e.g. "anthropic/claude-sonnet-4-5").
+    // Discovery may store these under the fully-qualified "openrouter/anthropic/claude-sonnet-4-5"
+    // key. resolveContextTokensForModel tries the qualified key first, so the config
+    // override must also be written to that key — not skipped because modelId includes "/".
+    const cache = new Map<string, number>();
+    cache.set("openrouter/anthropic/claude-sonnet-4-5", 1_048_576);
+    applyConfiguredContextWindows({
+      cache,
+      modelsConfig: {
+        providers: {
+          openrouter: {
+            models: [{ id: "anthropic/claude-sonnet-4-5", contextWindow: 200_000 }],
+          },
+        },
+      },
+    });
+
+    // Bare key override must be present.
+    expect(cache.get("anthropic/claude-sonnet-4-5")).toBe(200_000);
+    // Qualified key must also be overridden so the qualified-first lookup in
+    // resolveContextTokensForModel returns the config value, not the discovered one.
+    expect(cache.get("openrouter/anthropic/claude-sonnet-4-5")).toBe(200_000);
   });
 
   it("adds config-only model context windows and ignores invalid entries", () => {

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -57,6 +57,30 @@ describe("applyConfiguredContextWindows", () => {
     expect(cache.get("anthropic/claude-opus-4-6")).toBe(200_000);
   });
 
+  it("stores provider-qualified key so config overrides beat qualified discovery entries", () => {
+    // Scenario from reviewer: discovery emits provider-qualified IDs but config
+    // uses bare IDs — without the qualified key in cache, resolveContextTokensForModel
+    // would return the discovered value and bypass the explicit config override.
+    const cache = new Map<string, number>();
+    // Simulate discovery storing a qualified entry.
+    cache.set("google-gemini-cli/gemini-3.1-pro-preview", 1_048_576);
+    // Config override stored under bare key AND qualified key.
+    applyConfiguredContextWindows({
+      cache,
+      modelsConfig: {
+        providers: {
+          "google-gemini-cli": {
+            models: [{ id: "gemini-3.1-pro-preview", contextWindow: 200_000 }],
+          },
+        },
+      },
+    });
+
+    // Both bare and qualified keys must reflect the configured override.
+    expect(cache.get("gemini-3.1-pro-preview")).toBe(200_000);
+    expect(cache.get("google-gemini-cli/gemini-3.1-pro-preview")).toBe(200_000);
+  });
+
   it("adds config-only model context windows and ignores invalid entries", () => {
     const cache = new Map<string, number>();
     applyConfiguredContextWindows({

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -41,8 +41,11 @@ describe("applyDiscoveredContextWindows", () => {
 });
 
 describe("applyConfiguredContextWindows", () => {
-  it("overrides discovered cache values with explicit models.providers contextWindow", () => {
-    const cache = new Map<string, number>([["anthropic/claude-opus-4-6", 1_000_000]]);
+  it("writes bare model id to cache; does not touch raw provider-qualified discovery entries", () => {
+    // Discovery stored a provider-qualified entry; config override goes into the
+    // bare key only. resolveContextTokensForModel now scans config directly, so
+    // there is no need (and no benefit) to also write a synthetic qualified key.
+    const cache = new Map<string, number>([["openrouter/anthropic/claude-opus-4-6", 1_000_000]]);
     applyConfiguredContextWindows({
       cache,
       modelsConfig: {
@@ -55,18 +58,18 @@ describe("applyConfiguredContextWindows", () => {
     });
 
     expect(cache.get("anthropic/claude-opus-4-6")).toBe(200_000);
-    // Qualified key must also be written so resolveContextTokensForModel
-    // (which tries the qualified key first) returns the config override, not
-    // the discovered value stored at "openrouter/anthropic/claude-opus-4-6".
-    expect(cache.get("openrouter/anthropic/claude-opus-4-6")).toBe(200_000);
+    // Discovery entry is untouched — no synthetic write that could corrupt
+    // an unrelated provider's raw slash-containing model ID.
+    expect(cache.get("openrouter/anthropic/claude-opus-4-6")).toBe(1_000_000);
   });
 
-  it("stores provider-qualified key so config overrides beat qualified discovery entries (bare model id)", () => {
-    // Discovery emits provider-qualified IDs; config uses bare IDs.
-    // Without the qualified key in cache, resolveContextTokensForModel
-    // (which tries the qualified key first) would return the discovered value.
+  it("does not write synthetic provider-qualified keys; only bare model ids go into cache", () => {
+    // applyConfiguredContextWindows must NOT write "google-gemini-cli/gemini-3.1-pro-preview"
+    // into the cache — that keyspace is reserved for raw discovery model IDs and
+    // a synthetic write would overwrite unrelated entries (e.g. OpenRouter's
+    // "google/gemini-2.5-pro" being clobbered by a Google provider config).
     const cache = new Map<string, number>();
-    cache.set("google-gemini-cli/gemini-3.1-pro-preview", 1_048_576);
+    cache.set("google-gemini-cli/gemini-3.1-pro-preview", 1_048_576); // discovery entry
     applyConfiguredContextWindows({
       cache,
       modelsConfig: {
@@ -78,52 +81,10 @@ describe("applyConfiguredContextWindows", () => {
       },
     });
 
+    // Bare key is written.
     expect(cache.get("gemini-3.1-pro-preview")).toBe(200_000);
-    expect(cache.get("google-gemini-cli/gemini-3.1-pro-preview")).toBe(200_000);
-  });
-
-  it("stores provider-qualified key so config overrides beat qualified discovery entries (slash model id)", () => {
-    // OpenRouter model ids already contain a slash (e.g. "anthropic/claude-sonnet-4-5").
-    // Discovery may store these under the fully-qualified "openrouter/anthropic/claude-sonnet-4-5"
-    // key. resolveContextTokensForModel tries the qualified key first, so the config
-    // override must also be written to that key — not skipped because modelId includes "/".
-    const cache = new Map<string, number>();
-    cache.set("openrouter/anthropic/claude-sonnet-4-5", 1_048_576);
-    applyConfiguredContextWindows({
-      cache,
-      modelsConfig: {
-        providers: {
-          openrouter: {
-            models: [{ id: "anthropic/claude-sonnet-4-5", contextWindow: 200_000 }],
-          },
-        },
-      },
-    });
-
-    // Bare key override must be present.
-    expect(cache.get("anthropic/claude-sonnet-4-5")).toBe(200_000);
-    // Qualified key must also be overridden so the qualified-first lookup in
-    // resolveContextTokensForModel returns the config value, not the discovered one.
-    expect(cache.get("openrouter/anthropic/claude-sonnet-4-5")).toBe(200_000);
-  });
-
-  it("normalizes provider keys before writing provider-qualified override entries", () => {
-    const cache = new Map<string, number>();
-    cache.set("openrouter/anthropic/claude-sonnet-4-5", 1_048_576);
-    applyConfiguredContextWindows({
-      cache,
-      modelsConfig: {
-        providers: {
-          " OpenRouter ": {
-            models: [{ id: "anthropic/claude-sonnet-4-5", contextWindow: 200_000 }],
-          },
-        },
-      },
-    });
-
-    expect(cache.get("anthropic/claude-sonnet-4-5")).toBe(200_000);
-    expect(cache.get("openrouter/anthropic/claude-sonnet-4-5")).toBe(200_000);
-    expect(cache.has(" OpenRouter /anthropic/claude-sonnet-4-5")).toBe(false);
+    // Discovery entry is NOT overwritten.
+    expect(cache.get("google-gemini-cli/gemini-3.1-pro-preview")).toBe(1_048_576);
   });
 
   it("adds config-only model context windows and ignores invalid entries", () => {

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -107,6 +107,25 @@ describe("applyConfiguredContextWindows", () => {
     expect(cache.get("openrouter/anthropic/claude-sonnet-4-5")).toBe(200_000);
   });
 
+  it("normalizes provider keys before writing provider-qualified override entries", () => {
+    const cache = new Map<string, number>();
+    cache.set("openrouter/anthropic/claude-sonnet-4-5", 1_048_576);
+    applyConfiguredContextWindows({
+      cache,
+      modelsConfig: {
+        providers: {
+          " OpenRouter ": {
+            models: [{ id: "anthropic/claude-sonnet-4-5", contextWindow: 200_000 }],
+          },
+        },
+      },
+    });
+
+    expect(cache.get("anthropic/claude-sonnet-4-5")).toBe(200_000);
+    expect(cache.get("openrouter/anthropic/claude-sonnet-4-5")).toBe(200_000);
+    expect(cache.has(" OpenRouter /anthropic/claude-sonnet-4-5")).toBe(false);
+  });
+
   it("adds config-only model context windows and ignores invalid entries", () => {
     const cache = new Map<string, number>();
     applyConfiguredContextWindows({

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -8,17 +8,33 @@ import {
 import { createSessionManagerRuntimeRegistry } from "./pi-extensions/session-manager-runtime-registry.js";
 
 describe("applyDiscoveredContextWindows", () => {
-  it("keeps the smallest context window when duplicate model ids are discovered", () => {
+  it("keeps the largest context window when the same bare model id appears under multiple providers", () => {
     const cache = new Map<string, number>();
     applyDiscoveredContextWindows({
       cache,
       models: [
-        { id: "claude-sonnet-4-5", contextWindow: 1_000_000 },
-        { id: "claude-sonnet-4-5", contextWindow: 200_000 },
+        { id: "gemini-3.1-pro-preview", contextWindow: 128_000 },
+        { id: "gemini-3.1-pro-preview", contextWindow: 1_048_576 },
       ],
     });
 
-    expect(cache.get("claude-sonnet-4-5")).toBe(200_000);
+    // Prefer the larger window: display under-reporting is more misleading than
+    // over-reporting, and runtime budgeting uses the active provider directly.
+    expect(cache.get("gemini-3.1-pro-preview")).toBe(1_048_576);
+  });
+
+  it("stores provider-qualified entries independently", () => {
+    const cache = new Map<string, number>();
+    applyDiscoveredContextWindows({
+      cache,
+      models: [
+        { id: "github-copilot/gemini-3.1-pro-preview", contextWindow: 128_000 },
+        { id: "google-gemini-cli/gemini-3.1-pro-preview", contextWindow: 1_048_576 },
+      ],
+    });
+
+    expect(cache.get("github-copilot/gemini-3.1-pro-preview")).toBe(128_000);
+    expect(cache.get("google-gemini-cli/gemini-3.1-pro-preview")).toBe(1_048_576);
   });
 });
 

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -8,7 +8,7 @@ import {
 import { createSessionManagerRuntimeRegistry } from "./pi-extensions/session-manager-runtime-registry.js";
 
 describe("applyDiscoveredContextWindows", () => {
-  it("keeps the largest context window when the same bare model id appears under multiple providers", () => {
+  it("keeps the smallest context window when the same bare model id appears under multiple providers", () => {
     const cache = new Map<string, number>();
     applyDiscoveredContextWindows({
       cache,
@@ -18,9 +18,11 @@ describe("applyDiscoveredContextWindows", () => {
       ],
     });
 
-    // Prefer the larger window: display under-reporting is more misleading than
-    // over-reporting, and runtime budgeting uses the active provider directly.
-    expect(cache.get("gemini-3.1-pro-preview")).toBe(1_048_576);
+    // Keep the conservative (minimum) value: this cache feeds runtime paths such
+    // as flush thresholds and session persistence, not just /status display.
+    // Callers with a known provider should use resolveContextTokensForModel which
+    // tries the provider-qualified key first.
+    expect(cache.get("gemini-3.1-pro-preview")).toBe(128_000);
   });
 
   it("stores provider-qualified entries independently", () => {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -61,7 +61,7 @@ export function applyConfiguredContextWindows(params: {
   if (!providers || typeof providers !== "object") {
     return;
   }
-  for (const provider of Object.values(providers)) {
+  for (const [providerId, provider] of Object.entries(providers)) {
     if (!Array.isArray(provider?.models)) {
       continue;
     }
@@ -73,6 +73,12 @@ export function applyConfiguredContextWindows(params: {
         continue;
       }
       params.cache.set(modelId, contextWindow);
+      // When the model id is bare (no provider prefix), also store under the
+      // provider-qualified key so that qualified lookups in resolveContextTokensForModel
+      // respect explicit config overrides over discovered values.
+      if (!modelId.includes("/")) {
+        params.cache.set(`${providerId}/${modelId}`, contextWindow);
+      }
     }
   }
 }

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -73,12 +73,12 @@ export function applyConfiguredContextWindows(params: {
         continue;
       }
       params.cache.set(modelId, contextWindow);
-      // When the model id is bare (no provider prefix), also store under the
-      // provider-qualified key so that qualified lookups in resolveContextTokensForModel
-      // respect explicit config overrides over discovered values.
-      if (!modelId.includes("/")) {
-        params.cache.set(`${providerId}/${modelId}`, contextWindow);
-      }
+      // Always store under the provider-qualified key so that qualified lookups
+      // in resolveContextTokensForModel respect explicit config overrides over
+      // discovered values. This covers both bare IDs (e.g. "claude-opus-4" →
+      // "anthropic/claude-opus-4") and slash-containing IDs common in OpenRouter
+      // (e.g. "anthropic/claude-sonnet-4-5" → "openrouter/anthropic/claude-sonnet-4-5").
+      params.cache.set(`${providerId}/${modelId}`, contextWindow);
     }
   }
 }

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -284,10 +284,17 @@ export function resolveContextTokensForModel(params: {
     }
   }
 
-  // When provider is known, prefer the provider-qualified key so the correct
-  // entry is found even when the same bare model id is catalogued under
-  // multiple providers with different context limits.
-  const qualifiedKey = ref ? resolveQualifiedContextWindowKey(ref.provider, ref.model) : undefined;
+  // When provider is known and the model id is bare (no slash), prefer the
+  // provider-qualified key so the correct entry is found when the same bare
+  // model id is catalogued under multiple providers with different limits.
+  // Skip the qualified key when the model id already contains a slash: those
+  // ids are themselves provider-qualified (e.g. OpenRouter's "google/gemini-2.5-pro")
+  // and the bare lookup is already the correct scoped key, preventing collisions
+  // with synthetic "provider/model" keys in the same cache.
+  const qualifiedKey =
+    ref && !ref.model.includes("/")
+      ? resolveQualifiedContextWindowKey(ref.provider, ref.model)
+      : undefined;
   return (
     (qualifiedKey ? lookupContextTokens(qualifiedKey) : undefined) ??
     lookupContextTokens(params.model) ??

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -28,10 +28,6 @@ const CONFIG_LOAD_RETRY_POLICY: BackoffPolicy = {
   jitter: 0,
 };
 
-function resolveQualifiedContextWindowKey(providerId: string, modelId: string): string {
-  return `${normalizeProviderId(providerId)}/${modelId}`;
-}
-
 export function applyDiscoveredContextWindows(params: {
   cache: Map<string, number>;
   models: ModelEntry[];
@@ -66,7 +62,7 @@ export function applyConfiguredContextWindows(params: {
   if (!providers || typeof providers !== "object") {
     return;
   }
-  for (const [providerId, provider] of Object.entries(providers)) {
+  for (const provider of Object.values(providers)) {
     if (!Array.isArray(provider?.models)) {
       continue;
     }
@@ -78,12 +74,6 @@ export function applyConfiguredContextWindows(params: {
         continue;
       }
       params.cache.set(modelId, contextWindow);
-      // Always store under the provider-qualified key so that qualified lookups
-      // in resolveContextTokensForModel respect explicit config overrides over
-      // discovered values. This covers both bare IDs (e.g. "claude-opus-4" →
-      // "anthropic/claude-opus-4") and slash-containing IDs common in OpenRouter
-      // (e.g. "anthropic/claude-sonnet-4-5" → "openrouter/anthropic/claude-sonnet-4-5").
-      params.cache.set(resolveQualifiedContextWindowKey(providerId, modelId), contextWindow);
     }
   }
 }
@@ -251,6 +241,42 @@ function resolveProviderModelRef(params: {
   return { provider, model };
 }
 
+// Look up an explicit contextWindow override for a specific provider+model
+// directly from config, without going through the shared discovery cache.
+// This avoids the cache keyspace collision where "provider/model" synthetic
+// keys overlap with raw slash-containing model IDs (e.g. OpenRouter's
+// "google/gemini-2.5-pro" stored as a raw catalog entry).
+function resolveConfiguredProviderContextWindow(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+  model: string,
+): number | undefined {
+  const providers = (cfg?.models as ModelsConfig | undefined)?.providers;
+  if (!providers) {
+    return undefined;
+  }
+  const normalizedProvider = normalizeProviderId(provider);
+  for (const [providerId, providerConfig] of Object.entries(providers)) {
+    if (normalizeProviderId(providerId) !== normalizedProvider) {
+      continue;
+    }
+    if (!Array.isArray(providerConfig?.models)) {
+      continue;
+    }
+    for (const m of providerConfig.models) {
+      if (
+        typeof m?.id === "string" &&
+        m.id === model &&
+        typeof m?.contextWindow === "number" &&
+        m.contextWindow > 0
+      ) {
+        return m.contextWindow;
+      }
+    }
+  }
+  return undefined;
+}
+
 function isAnthropic1MModel(provider: string, model: string): boolean {
   if (provider !== "anthropic") {
     return false;
@@ -282,18 +308,29 @@ export function resolveContextTokensForModel(params: {
     if (modelParams?.context1m === true && isAnthropic1MModel(ref.provider, ref.model)) {
       return ANTHROPIC_CONTEXT_1M_TOKENS;
     }
+    // When provider is known, check config first for an explicit contextWindow
+    // override. This avoids writing synthetic "provider/model" keys into the
+    // shared discovery cache (which would overwrite unrelated slash-containing
+    // raw model IDs such as OpenRouter's "google/gemini-2.5-pro").
+    const configuredWindow = resolveConfiguredProviderContextWindow(
+      params.cfg,
+      ref.provider,
+      ref.model,
+    );
+    if (configuredWindow !== undefined) {
+      return configuredWindow;
+    }
   }
 
-  // When provider is known and the model id is bare (no slash), prefer the
-  // provider-qualified key so the correct entry is found when the same bare
-  // model id is catalogued under multiple providers with different limits.
-  // Skip the qualified key when the model id already contains a slash: those
-  // ids are themselves provider-qualified (e.g. OpenRouter's "google/gemini-2.5-pro")
-  // and the bare lookup is already the correct scoped key, preventing collisions
-  // with synthetic "provider/model" keys in the same cache.
+  // For bare model ids, also try the provider-qualified cache key so that
+  // discovery entries stored under qualified IDs (e.g. the registry returns
+  // "google-gemini-cli/gemini-3.1-pro-preview") are reachable when the caller
+  // provides separate provider/model fields. Only attempted for bare model ids
+  // (no slash) to avoid double-prefixing slash-containing ids such as
+  // OpenRouter's "google/gemini-2.5-pro".
   const qualifiedKey =
     ref && !ref.model.includes("/")
-      ? resolveQualifiedContextWindowKey(ref.provider, ref.model)
+      ? `${normalizeProviderId(ref.provider)}/${ref.model}`
       : undefined;
   return (
     (qualifiedKey ? lookupContextTokens(qualifiedKey) : undefined) ??

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -227,7 +227,9 @@ function resolveProviderModelRef(params: {
   }
   const providerRaw = params.provider?.trim();
   if (providerRaw) {
-    return { provider: normalizeProviderId(providerRaw), model: modelRaw };
+    // Keep the exact (lowercased) provider key; callers that need the canonical
+    // alias (e.g. cache key construction) apply normalizeProviderId explicitly.
+    return { provider: providerRaw.toLowerCase(), model: modelRaw };
   }
   const slash = modelRaw.indexOf("/");
   if (slash <= 0) {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { computeBackoff, type BackoffPolicy } from "../infra/backoff.js";
 import { consumeRootOptionToken, FLAG_TERMINATOR } from "../infra/cli-root-options.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
+import { normalizeProviderId } from "./model-selection.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
 
 type ModelEntry = { id: string; contextWindow?: number };
@@ -26,6 +27,10 @@ const CONFIG_LOAD_RETRY_POLICY: BackoffPolicy = {
   factor: 2,
   jitter: 0,
 };
+
+function resolveQualifiedContextWindowKey(providerId: string, modelId: string): string {
+  return `${normalizeProviderId(providerId)}/${modelId}`;
+}
 
 export function applyDiscoveredContextWindows(params: {
   cache: Map<string, number>;
@@ -78,7 +83,7 @@ export function applyConfiguredContextWindows(params: {
       // discovered values. This covers both bare IDs (e.g. "claude-opus-4" →
       // "anthropic/claude-opus-4") and slash-containing IDs common in OpenRouter
       // (e.g. "anthropic/claude-sonnet-4-5" → "openrouter/anthropic/claude-sonnet-4-5").
-      params.cache.set(`${providerId}/${modelId}`, contextWindow);
+      params.cache.set(resolveQualifiedContextWindowKey(providerId, modelId), contextWindow);
     }
   }
 }
@@ -232,13 +237,13 @@ function resolveProviderModelRef(params: {
   }
   const providerRaw = params.provider?.trim();
   if (providerRaw) {
-    return { provider: providerRaw.toLowerCase(), model: modelRaw };
+    return { provider: normalizeProviderId(providerRaw), model: modelRaw };
   }
   const slash = modelRaw.indexOf("/");
   if (slash <= 0) {
     return undefined;
   }
-  const provider = modelRaw.slice(0, slash).trim().toLowerCase();
+  const provider = normalizeProviderId(modelRaw.slice(0, slash));
   const model = modelRaw.slice(slash + 1).trim();
   if (!provider || !model) {
     return undefined;
@@ -282,7 +287,7 @@ export function resolveContextTokensForModel(params: {
   // When provider is known, prefer the provider-qualified key so the correct
   // entry is found even when the same bare model id is catalogued under
   // multiple providers with different context limits.
-  const qualifiedKey = ref ? `${ref.provider}/${ref.model}` : undefined;
+  const qualifiedKey = ref ? resolveQualifiedContextWindowKey(ref.provider, ref.model) : undefined;
   return (
     (qualifiedKey ? lookupContextTokens(qualifiedKey) : undefined) ??
     lookupContextTokens(params.model) ??

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -42,10 +42,12 @@ export function applyDiscoveredContextWindows(params: {
     }
     const existing = params.cache.get(model.id);
     // When the same bare model id appears under multiple providers with different
-    // limits, prefer the larger window. This is a display-only cache; runtime
-    // context budgeting resolves the window from the active provider config
-    // directly, so under-reporting here only misleads /status output.
-    if (existing === undefined || contextWindow > existing) {
+    // limits, keep the smaller window. This cache feeds both display paths and
+    // runtime paths (flush thresholds, session context-token persistence), so
+    // overestimating the limit could delay compaction and cause context overflow.
+    // Callers that know the active provider should use resolveContextTokensForModel,
+    // which tries the provider-qualified key first and falls back here.
+    if (existing === undefined || contextWindow < existing) {
       params.cache.set(model.id, contextWindow);
     }
   }

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -322,19 +322,28 @@ export function resolveContextTokensForModel(params: {
     }
   }
 
-  // For bare model ids, also try the provider-qualified cache key so that
-  // discovery entries stored under qualified IDs (e.g. the registry returns
-  // "google-gemini-cli/gemini-3.1-pro-preview") are reachable when the caller
+  // Try bare key first. Bare keys contain the most-recently-written value
+  // (config overrides via applyConfiguredContextWindows run last) and are
+  // always correct for models registered with bare IDs.
+  const bareResult = lookupContextTokens(params.model);
+  if (bareResult !== undefined) {
+    return bareResult;
+  }
+
+  // Bare key was a miss. Try the provider-qualified key as a fallback so that
+  // discovery entries stored under qualified IDs (e.g. "google-gemini-cli/
+  // gemini-3.1-pro-preview" in the registry) are reachable when the caller
   // provides separate provider/model fields. Only attempted for bare model ids
   // (no slash) to avoid double-prefixing slash-containing ids such as
   // OpenRouter's "google/gemini-2.5-pro".
-  const qualifiedKey =
-    ref && !ref.model.includes("/")
-      ? `${normalizeProviderId(ref.provider)}/${ref.model}`
-      : undefined;
-  return (
-    (qualifiedKey ? lookupContextTokens(qualifiedKey) : undefined) ??
-    lookupContextTokens(params.model) ??
-    params.fallbackContextTokens
-  );
+  if (ref && !ref.model.includes("/")) {
+    const qualifiedResult = lookupContextTokens(
+      `${normalizeProviderId(ref.provider)}/${ref.model}`,
+    );
+    if (qualifiedResult !== undefined) {
+      return qualifiedResult;
+    }
+  }
+
+  return params.fallbackContextTokens;
 }

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -257,26 +257,42 @@ function resolveConfiguredProviderContextWindow(
   if (!providers) {
     return undefined;
   }
-  const normalizedProvider = normalizeProviderId(provider);
-  for (const [providerId, providerConfig] of Object.entries(providers)) {
-    if (normalizeProviderId(providerId) !== normalizedProvider) {
-      continue;
-    }
-    if (!Array.isArray(providerConfig?.models)) {
-      continue;
-    }
-    for (const m of providerConfig.models) {
-      if (
-        typeof m?.id === "string" &&
-        m.id === model &&
-        typeof m?.contextWindow === "number" &&
-        m.contextWindow > 0
-      ) {
-        return m.contextWindow;
+
+  // Mirror the lookup order in pi-embedded-runner/model.ts: exact key first,
+  // then normalized fallback. This prevents alias collisions (e.g. when both
+  // "qwen" and "qwen-portal" exist as config keys) from picking the wrong
+  // contextWindow based on Object.entries iteration order.
+  function findContextWindow(matchProviderId: (id: string) => boolean): number | undefined {
+    for (const [providerId, providerConfig] of Object.entries(providers!)) {
+      if (!matchProviderId(providerId)) {
+        continue;
+      }
+      if (!Array.isArray(providerConfig?.models)) {
+        continue;
+      }
+      for (const m of providerConfig.models) {
+        if (
+          typeof m?.id === "string" &&
+          m.id === model &&
+          typeof m?.contextWindow === "number" &&
+          m.contextWindow > 0
+        ) {
+          return m.contextWindow;
+        }
       }
     }
+    return undefined;
   }
-  return undefined;
+
+  // 1. Exact match (case-insensitive, no alias expansion).
+  const exactResult = findContextWindow((id) => id.trim().toLowerCase() === provider.toLowerCase());
+  if (exactResult !== undefined) {
+    return exactResult;
+  }
+
+  // 2. Normalized fallback: covers alias keys such as "qwen" → "qwen-portal".
+  const normalizedProvider = normalizeProviderId(provider);
+  return findContextWindow((id) => normalizeProviderId(id) === normalizedProvider);
 }
 
 function isAnthropic1MModel(provider: string, model: string): boolean {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -41,9 +41,11 @@ export function applyDiscoveredContextWindows(params: {
       continue;
     }
     const existing = params.cache.get(model.id);
-    // When multiple providers expose the same model id with different limits,
-    // prefer the smaller window so token budgeting is fail-safe (no overestimation).
-    if (existing === undefined || contextWindow < existing) {
+    // When the same bare model id appears under multiple providers with different
+    // limits, prefer the larger window. This is a display-only cache; runtime
+    // context budgeting resolves the window from the active provider config
+    // directly, so under-reporting here only misleads /status output.
+    if (existing === undefined || contextWindow > existing) {
       params.cache.set(model.id, contextWindow);
     }
   }
@@ -269,5 +271,13 @@ export function resolveContextTokensForModel(params: {
     }
   }
 
-  return lookupContextTokens(params.model) ?? params.fallbackContextTokens;
+  // When provider is known, prefer the provider-qualified key so the correct
+  // entry is found even when the same bare model id is catalogued under
+  // multiple providers with different context limits.
+  const qualifiedKey = ref ? `${ref.provider}/${ref.model}` : undefined;
+  return (
+    (qualifiedKey ? lookupContextTokens(qualifiedKey) : undefined) ??
+    lookupContextTokens(params.model) ??
+    params.fallbackContextTokens
+  );
 }

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -326,17 +326,22 @@ export function resolveContextTokensForModel(params: {
     if (modelParams?.context1m === true && isAnthropic1MModel(ref.provider, ref.model)) {
       return ANTHROPIC_CONTEXT_1M_TOKENS;
     }
-    // When provider is known, check config first for an explicit contextWindow
-    // override. This avoids writing synthetic "provider/model" keys into the
-    // shared discovery cache (which would overwrite unrelated slash-containing
-    // raw model IDs such as OpenRouter's "google/gemini-2.5-pro").
-    const configuredWindow = resolveConfiguredProviderContextWindow(
-      params.cfg,
-      ref.provider,
-      ref.model,
-    );
-    if (configuredWindow !== undefined) {
-      return configuredWindow;
+    // Only do the config direct scan when the caller explicitly passed a
+    // provider. When provider is inferred from a slash in the model string
+    // (e.g. "google/gemini-2.5-pro" → ref.provider = "google"), the model ID
+    // may belong to a DIFFERENT provider (e.g. an OpenRouter session). Scanning
+    // cfg.models.providers.google in that case would return Google's configured
+    // window and misreport context limits for the OpenRouter session.
+    // See status.ts log-usage fallback which calls with only { model } set.
+    if (params.provider) {
+      const configuredWindow = resolveConfiguredProviderContextWindow(
+        params.cfg,
+        ref.provider,
+        ref.model,
+      );
+      if (configuredWindow !== undefined) {
+        return configuredWindow;
+      }
     }
   }
 

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -345,30 +345,38 @@ export function resolveContextTokensForModel(params: {
     }
   }
 
-  // Try bare key first. Bare keys contain the most-recently-written value
-  // (config overrides via applyConfiguredContextWindows run last) and are
-  // always correct for models registered with bare IDs.
+  // When provider is explicitly given and the model ID is bare (no slash),
+  // try the provider-qualified cache key BEFORE the bare key.  Discovery
+  // entries are stored under qualified IDs (e.g. "google-gemini-cli/
+  // gemini-3.1-pro-preview → 1M"), while the bare key may hold a cross-
+  // provider minimum (128k).  Returning the qualified entry gives the correct
+  // provider-specific window for /status and session context-token persistence.
+  //
+  // Guard: only when params.provider is explicit (not inferred from a slash in
+  // the model string). For model-only callers (e.g. status.ts log-usage
+  // fallback with model="google/gemini-2.5-pro"), the inferred provider would
+  // construct "google/gemini-2.5-pro" as the qualified key which accidentally
+  // matches OpenRouter's raw discovery entry — the bare lookup is correct there.
+  if (params.provider && ref && !ref.model.includes("/")) {
+    const qualifiedResult = lookupContextTokens(
+      `${normalizeProviderId(ref.provider)}/${ref.model}`,
+    );
+    if (qualifiedResult !== undefined) {
+      return qualifiedResult;
+    }
+  }
+
+  // Bare key fallback.  For model-only calls with slash-containing IDs
+  // (e.g. "google/gemini-2.5-pro") this IS the raw discovery cache key.
   const bareResult = lookupContextTokens(params.model);
   if (bareResult !== undefined) {
     return bareResult;
   }
 
-  // Bare key miss. As a last resort, try the provider-qualified key so that
-  // discovery entries stored under qualified IDs are reachable. The pi-ai
-  // registry can return entries like "google-gemini-cli/gemini-3.1-pro-preview"
-  // for the google-gemini-cli provider; without this fallback, resolving
-  // { provider: "google-gemini-cli", model: "gemini-3.1-pro-preview" } with
-  // no bare-key hit would always miss.
-  //
-  // Collision risk: the same keyspace holds raw slash-containing model IDs
-  // (e.g. OpenRouter's "google/gemini-2.5-pro"). This fallback is only reached
-  // when the bare key misses, which means native discovery for the requested
-  // provider produced no bare entry. In that situation the only available
-  // context-window data is what another provider stored under the same
-  // qualified key — in practice identical (OpenRouter mirrors native limits) —
-  // so returning it is strictly better than falling back to DEFAULT_CONTEXT_TOKENS.
-  // If native discovery IS running, it writes a bare key, and we never reach here.
-  if (ref && !ref.model.includes("/")) {
+  // When provider is implicit, try qualified as a last resort so inferred
+  // provider/model pairs (e.g. model="google-gemini-cli/gemini-3.1-pro")
+  // still find discovery entries stored under that qualified ID.
+  if (!params.provider && ref && !ref.model.includes("/")) {
     const qualifiedResult = lookupContextTokens(
       `${normalizeProviderId(ref.provider)}/${ref.model}`,
     );

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -330,12 +330,21 @@ export function resolveContextTokensForModel(params: {
     return bareResult;
   }
 
-  // Bare key was a miss. Try the provider-qualified key as a fallback so that
-  // discovery entries stored under qualified IDs (e.g. "google-gemini-cli/
-  // gemini-3.1-pro-preview" in the registry) are reachable when the caller
-  // provides separate provider/model fields. Only attempted for bare model ids
-  // (no slash) to avoid double-prefixing slash-containing ids such as
-  // OpenRouter's "google/gemini-2.5-pro".
+  // Bare key miss. As a last resort, try the provider-qualified key so that
+  // discovery entries stored under qualified IDs are reachable. The pi-ai
+  // registry can return entries like "google-gemini-cli/gemini-3.1-pro-preview"
+  // for the google-gemini-cli provider; without this fallback, resolving
+  // { provider: "google-gemini-cli", model: "gemini-3.1-pro-preview" } with
+  // no bare-key hit would always miss.
+  //
+  // Collision risk: the same keyspace holds raw slash-containing model IDs
+  // (e.g. OpenRouter's "google/gemini-2.5-pro"). This fallback is only reached
+  // when the bare key misses, which means native discovery for the requested
+  // provider produced no bare entry. In that situation the only available
+  // context-window data is what another provider stored under the same
+  // qualified key — in practice identical (OpenRouter mirrors native limits) —
+  // so returning it is strictly better than falling back to DEFAULT_CONTEXT_TOKENS.
+  // If native discovery IS running, it writes a bare key, and we never reach here.
   if (ref && !ref.model.includes("/")) {
     const qualifiedResult = lookupContextTokens(
       `${normalizeProviderId(ref.provider)}/${ref.model}`,


### PR DESCRIPTION
## Summary

- **Problem:** `applyDiscoveredContextWindows` took the *minimum* context window when the same bare model id appeared under multiple providers with different limits. `resolveContextTokensForModel` then looked up only the bare model id, so `/status` always showed the smallest window regardless of which provider the user configured.
- **Why it matters:** A user with `google-gemini-cli/gemini-3.1-pro-preview` (1 048 576 tokens) saw `0/128k` — the limit of an unrelated `github-copilot` entry for the same bare id. Actively misleading display.
- **What changed:**
  1. `applyDiscoveredContextWindows` — changed tie-breaking for duplicate bare model ids from *min* to *max*. This is a display-only cache; runtime context budgeting resolves the window directly from the active provider config and is unaffected.
  2. `resolveContextTokensForModel` — when `provider` is known, try the provider-qualified key `"provider/model"` first, then fall back to bare `model`. Correctly returns 1 048 576 when the registry stores qualified entries such as `"google-gemini-cli/gemini-3.1-pro-preview"`.
- **What did NOT change:** runtime context budgeting, compaction thresholds, session behaviour — fix is entirely in the display path.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #35976

## User-visible / Behavior Changes

`/status` and session context-token lines now show the context window of the configured provider rather than the minimum across all providers that share the same model id.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux / macOS
- Runtime: Node 22+
- Model/provider: any provider that shares a bare model id with another (e.g. `google-gemini-cli/gemini-3.1-pro-preview` vs `github-copilot/gemini-3.1-pro-preview`)

### Steps

1. Configure `agents.defaults.model.primary: google-gemini-cli/gemini-3.1-pro-preview`
2. Run `openclaw status`

### Expected

- Context window shows `0/1048k`

### Actual (before fix)

- Context window shows `0/128k`

## Evidence

- [x] `applyDiscoveredContextWindows` test updated: asserts `1 048 576` (max) is stored instead of `128 000` (min) for duplicate bare ids
- [x] New test: `stores provider-qualified entries independently`
- [x] New lookup tests: multi-provider bare-id max selection; provider-qualified key preference in `resolveContextTokensForModel`
- All 14 context tests pass; pre-existing `web-search.redirect` failure confirmed on clean `main` (unrelated)

## Human Verification (required)

- Verified the two-part fix via unit tests (both the cache-population strategy and the lookup priority)
- Confirmed `pi-embedded-runner/model.ts` resolves context window from provider config at runtime — this cache is display-only
- What I did **not** verify: live end-to-end `/status` output against a real multi-provider catalog (requires real auth credentials)

## Compatibility / Migration

- Backward compatible? Yes — `/status` output changes to show the correct window; no config changes required
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert: restore `contextWindow < existing` (min) and remove the qualified-key lookup block in `resolveContextTokensForModel` in `src/agents/context.ts`
- Known bad symptom: `/status` shows unexpectedly large context window for a model where the actual binding limit is smaller (but this has no runtime consequence — see Risks below)

## Risks and Mitigations

- Risk: changing min → max could over-report the context window when the smaller window is the binding constraint for a specific provider.
  - Mitigation: runtime budgeting (`pi-embedded-runner/model.ts`) uses the active provider config directly and never reads from this display cache. Over-reporting here has no effect on actual token limits or compaction behaviour.