### PR TITLE
fix(cli): include openclaw.mjs in service refresh entrypoint candidates

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -100,6 +100,7 @@ function resolveGatewayInstallEntrypointCandidates(root?: string): string[] {
     return [];
   }
   return [
+    path.join(root, "openclaw.mjs"),
     path.join(root, "dist", "entry.js"),
     path.join(root, "dist", "entry.mjs"),
     path.join(root, "dist", "index.js"),


### PR DESCRIPTION
## Summary

- **Problem:** After `openclaw update` on macOS, the LaunchAgent plist retains the old `OPENCLAW_SERVICE_VERSION` env var. `refreshGatewayServiceEnv` tries to run `gateway install --force` from the updated package, but the entrypoint candidate list only looks in `dist/` (`entry.js`, `entry.mjs`, `index.js`, `index.mjs`) and misses `openclaw.mjs` (the actual bin entry point at the package root). When no candidate is found, it falls back to `runDaemonInstall` in the current (pre-update) process, which still has the old `VERSION` loaded at module import time — writing a stale version to the plist.
- **Why it matters:** Users see the old version in the Control UI dashboard and `openclaw status` after upgrading, causing confusion and unnecessary troubleshooting. The workaround (`openclaw gateway install --force`) is non-obvious.
- **What changed:** Added `path.join(root, "openclaw.mjs")` as the first candidate in `resolveGatewayInstallEntrypointCandidates`, so the updated binary is used for plist regeneration.
- **What did NOT change:** The fallback to `runDaemonInstall` (still present as a last resort). The plist generation logic. The version resolution priority chain.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #34901

## User-visible / Behavior Changes

- After `openclaw update` on macOS, the LaunchAgent plist is now regenerated with the correct `OPENCLAW_SERVICE_VERSION`, so the Control UI and `openclaw status` show the updated version immediately.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon)
- Runtime: Node.js 22
- Integration/channel: LaunchAgent service management

### Steps

1. Install OpenClaw via npm/Homebrew
2. Run `openclaw update` to upgrade to a new version
3. Check `openclaw status` or Control UI for the reported version

### Expected

- Version matches the updated binary

### Actual

- Before fix: Version shows old version from stale plist
- After fix: Plist is regenerated with new version via `openclaw.mjs` entry point

## Evidence

The fix adds `openclaw.mjs` (the `package.json` bin entry) as the first candidate:

```typescript
return [
  path.join(root, "openclaw.mjs"),     // actual bin entry point
  path.join(root, "dist", "entry.js"),
  path.join(root, "dist", "entry.mjs"),
  path.join(root, "dist", "index.js"),
  path.join(root, "dist", "index.mjs"),
];
```

This ensures `refreshGatewayServiceEnv` runs the updated binary (which has the new `VERSION`) for `gateway install --force`, regenerating the plist with the correct `OPENCLAW_SERVICE_VERSION`.

TypeScript compiles cleanly.

## Human Verification (required)

- Verified scenarios: TypeScript compilation, traced the `refreshGatewayServiceEnv` → `resolveGatewayInstallEntrypointCandidates` → subprocess flow
- Edge cases checked: No `openclaw.mjs` found (falls through to existing `dist/` candidates), all candidates missing (falls back to `runDaemonInstall` as before)
- What I did **not** verify: Live macOS update with LaunchAgent (no macOS LaunchAgent test environment)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove the `openclaw.mjs` candidate line
- Files/config to restore: `src/cli/update-cli/update-command.ts`
- Known bad symptoms: N/A — worst case is fallback to existing behavior (stale plist)

## Risks and Mitigations

None — the change adds one more candidate to a search list. If the file doesn't exist, the search continues to the next candidate.

