### PR TITLE
perf(media): avoid extra copies in readResponseWithLimit

### DIFF
--- a/src/media/read-response-with-limit.test.ts
+++ b/src/media/read-response-with-limit.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { readResponseWithLimit } from "./read-response-with-limit.js";
+
+type MockReader = {
+  read: () => Promise<ReadableStreamReadResult<Uint8Array>>;
+  cancel: () => Promise<void>;
+  releaseLock: () => void;
+};
+
+function makeResponse(reader: MockReader): Response {
+  return {
+    body: {
+      getReader: () => reader,
+    },
+    arrayBuffer: async () => new ArrayBuffer(0),
+  } as unknown as Response;
+}
+
+describe("readResponseWithLimit", () => {
+  it("concatenates streamed chunks without per-chunk Buffer.from conversions", async () => {
+    const reader: MockReader = {
+      read: vi
+        .fn<MockReader["read"]>()
+        .mockResolvedValueOnce({ done: false, value: new Uint8Array([1, 2]) })
+        .mockResolvedValueOnce({ done: false, value: new Uint8Array([3, 4]) })
+        .mockResolvedValueOnce({ done: true, value: undefined }),
+      cancel: vi.fn<MockReader["cancel"]>().mockResolvedValue(undefined),
+      releaseLock: vi.fn<MockReader["releaseLock"]>(),
+    };
+
+    const fromSpy = vi.spyOn(Buffer, "from");
+    const buffer = await readResponseWithLimit(makeResponse(reader), 16);
+
+    expect(Array.from(buffer)).toEqual([1, 2, 3, 4]);
+    expect(fromSpy).toHaveBeenCalledTimes(0);
+    expect(reader.releaseLock).toHaveBeenCalledTimes(1);
+
+    fromSpy.mockRestore();
+  });
+
+  it("cancels stream and throws when payload exceeds maxBytes", async () => {
+    const reader: MockReader = {
+      read: vi
+        .fn<MockReader["read"]>()
+        .mockResolvedValueOnce({ done: false, value: new Uint8Array([1, 2, 3]) })
+        .mockResolvedValueOnce({ done: false, value: new Uint8Array([4]) }),
+      cancel: vi.fn<MockReader["cancel"]>().mockResolvedValue(undefined),
+      releaseLock: vi.fn<MockReader["releaseLock"]>(),
+    };
+
+    await expect(readResponseWithLimit(makeResponse(reader), 3)).rejects.toThrow(
+      "Content too large",
+    );
+
+    expect(reader.cancel).toHaveBeenCalledTimes(1);
+    expect(reader.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("still throws overflow when cancel/releaseLock fail", async () => {
+    const reader: MockReader = {
+      read: vi
+        .fn<MockReader["read"]>()
+        .mockResolvedValueOnce({ done: false, value: new Uint8Array([1, 2]) })
+        .mockResolvedValueOnce({ done: false, value: new Uint8Array([3]) }),
+      cancel: vi.fn<MockReader["cancel"]>().mockRejectedValue(new Error("cancel failed")),
+      releaseLock: vi.fn<MockReader["releaseLock"]>().mockImplementation(() => {
+        throw new Error("release failed");
+      }),
+    };
+
+    await expect(readResponseWithLimit(makeResponse(reader), 2)).rejects.toThrow(
+      "Content too large",
+    );
+
+    expect(reader.cancel).toHaveBeenCalledTimes(1);
+    expect(reader.releaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to arrayBuffer when reader is unavailable", async () => {
+    const res = {
+      body: null,
+      arrayBuffer: vi.fn(async () => Uint8Array.from([9, 8, 7]).buffer),
+    } as unknown as Response;
+
+    const buffer = await readResponseWithLimit(res, 3);
+    expect(buffer).toEqual(Buffer.from([9, 8, 7]));
+
+    await expect(readResponseWithLimit(res, 2)).rejects.toThrow("Content too large");
+  });
+});

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -1,3 +1,17 @@
+function concatUint8Chunks(chunks: readonly Uint8Array[], total: number): Buffer {
+  if (total === 0) {
+    return Buffer.alloc(0);
+  }
+
+  const out = Buffer.allocUnsafe(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
 export async function readResponseWithLimit(
   res: Response,
   maxBytes: number,
@@ -45,8 +59,5 @@ export async function readResponseWithLimit(
     } catch {}
   }
 
-  return Buffer.concat(
-    chunks.map((chunk) => Buffer.from(chunk)),
-    total,
-  );
+  return concatUint8Chunks(chunks, total);
 }


### PR DESCRIPTION
## Summary
- replace per-chunk `Buffer.from(...)` + `Buffer.concat(...)` with a single preallocated output buffer in `readResponseWithLimit`
- keep overflow, cancel, and `releaseLock` semantics unchanged
- add focused unit tests for streamed reads, overflow cancellation, cleanup error tolerance, and `arrayBuffer` fallback

## Why
`readResponseWithLimit` sits on media fetch/input paths and previously copied streamed bytes twice. This change reduces allocation pressure and copy overhead on large streamed payloads.

## Risk
Low: behavior is unchanged at the API level and covered by targeted tests.
