### PR TITLE
fix(skills): broaden skill-creator trigger description for edit/refactor tasks

### DIFF
--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Create or update AgentSkills. Use when designing, structuring, or packaging skills with scripts, references, and assets.
+description: Create, edit, refactor, or validate AgentSkills. Use when creating a new skill from scratch, editing or improving an existing SKILL.md, restructuring a skill's layout (splitting content, adding reference files, reorganizing scripts or assets), packaging a skill for distribution, or validating a skill against the AgentSkills spec. If you are about to write to any SKILL.md file or create/move files within a skill directory, follow this guide.
 ---
 
 # Skill Creator


### PR DESCRIPTION
## Summary

- **Problem:** The `skill-creator` built-in skill has a narrow description ("Create or update AgentSkills. Use when designing, structuring, or packaging skills") that fails to trigger when agents are editing, refactoring, or restructuring existing skills. The words "designing" and "packaging" read as blank-slate creation activities, so agents doing mid-task refactoring (e.g., splitting `SKILL.md` into `SKILL.md` + `references/REFERENCE.md`) skip the skill entirely.
- **Why it matters:** Without the skill-creator guidance, agents make spec violations: placing reference files in the wrong directory, adding invalid frontmatter to non-skill files, and using incorrect file references. These errors are all caught by the skill-creator guidance but only if it triggers.
- **What changed:** Rewrote the YAML `description` field to explicitly cover editing, refactoring, restructuring, validating, and packaging — and added a concrete filesystem heuristic ("if you are about to write to any SKILL.md file or create/move files within a skill directory, follow this guide").
- **What did NOT change:** The SKILL.md body content. The skill name. Any other skill files.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36039

## User-visible / Behavior Changes

- The `skill-creator` skill now triggers more reliably for edit, refactor, restructure, and validate tasks — not just new-skill creation
- Agents working on existing skills will automatically load the skill-creator guidance, reducing spec violations

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Any
- Integration/channel: Agent skill system

### Steps

1. Ask an agent to refactor an existing skill (e.g., split `SKILL.md` into procedures + reference file)
2. Check if the skill-creator guidance is loaded

### Expected

- Skill-creator triggers and guides the agent

### Actual

- Before fix: Skill-creator does not trigger for refactoring tasks
- After fix: Skill-creator triggers for editing, refactoring, restructuring, and validating

## Evidence

**Before:**
```
description: Create or update AgentSkills. Use when designing, structuring, or packaging skills with scripts, references, and assets.
```

**After:**
```
description: Create, edit, refactor, or validate AgentSkills. Use when creating a new skill from scratch, editing or improving an existing SKILL.md, restructuring a skill's layout (splitting content, adding reference files, reorganizing scripts or assets), packaging a skill for distribution, or validating a skill against the AgentSkills spec. If you are about to write to any SKILL.md file or create/move files within a skill directory, follow this guide.
```

## Human Verification (required)

- Verified scenarios: Description now includes all action types mentioned in the issue (edit, refactor, restructure, validate, package, create)
- Edge cases checked: Description includes the concrete filesystem heuristic suggested by the issue reporter
- What I did **not** verify: Live agent triggering test (requires running agent session)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Restore the original description string
- Files/config to restore: `skills/skill-creator/SKILL.md`
- Known bad symptoms: N/A — broader description may trigger slightly more often, which is the intended behavior

## Risks and Mitigations

- **Risk:** Slightly more frequent triggering for unrelated tasks. **Mitigation:** The description is specific about when to trigger (SKILL.md files, skill directories) and the body content is only loaded after triggering.

