### PR TITLE
fix(discord): check response.ok before parsing gateway bot info

### DIFF
--- a/src/discord/monitor/gateway-plugin.ts
+++ b/src/discord/monitor/gateway-plugin.ts
@@ -63,6 +63,12 @@ export function createDiscordGatewayPlugin(params: {
               },
               dispatcher: fetchAgent,
             } as Record<string, unknown>);
+            if (!response.ok) {
+              const body = await response.text().catch(() => "");
+              throw new Error(
+                `Discord API returned ${response.status}: ${body.slice(0, 200) || response.statusText}`,
+              );
+            }
             this.gatewayInfo = (await response.json()) as APIGatewayBotInfo;
           } catch (error) {
             throw new Error(

--- a/src/discord/monitor/provider.proxy.test.ts
+++ b/src/discord/monitor/provider.proxy.test.ts
@@ -169,7 +169,9 @@ describe("createDiscordGatewayPlugin", () => {
   it("uses proxy fetch for gateway metadata lookup before registering", async () => {
     const runtime = createRuntime();
     undiciFetchMock.mockResolvedValue({
+      ok: true,
       json: async () => ({ url: "wss://gateway.discord.gg" }),
+      text: async () => "",
     } as Response);
     const plugin = createDiscordGatewayPlugin({
       discordConfig: { proxy: "http://proxy.test:8080" },


### PR DESCRIPTION
The Discord gateway plugin calls `/api/v10/gateway/bot` during `registerClient` but never checks `response.ok` before calling `response.json()`. When the API returns an error (401 invalid token, 403 forbidden, 429 rate limited), this either throws an unhelpful JSON parse error or silently casts an error body to `APIGatewayBotInfo`.

Now checks `response.ok` first and throws a descriptive error with the HTTP status and response body, making auth/permission failures immediately diagnosable.

2 files, +8/-0. All discord tests pass (540/540).

---

AI-assisted PR (Claude via OpenClaw agent). I understand what this code does.