### PR TITLE
fix(models): preserve kimi-coding baseUrl from explicit config

### DIFF
--- a/src/agents/models-config.providers.kimi-coding.test.ts
+++ b/src/agents/models-config.providers.kimi-coding.test.ts
@@ -21,6 +21,29 @@ describe("kimi-coding implicit provider (#22409)", () => {
     }
   });
 
+  it("should preserve explicit baseUrl for kimi-coding provider", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    const envSnapshot = captureEnv(["KIMI_API_KEY"]);
+    process.env.KIMI_API_KEY = "test-key";
+
+    try {
+      const providers = await resolveImplicitProviders({
+        agentDir,
+        explicitProviders: {
+          "kimi-coding": {
+            baseUrl: "https://api.kimi.com/custom/coding/",
+            api: "anthropic-messages",
+            models: [{ id: "k2p5", name: "Kimi for Coding" }],
+          },
+        },
+      });
+      expect(providers?.["kimi-coding"]).toBeDefined();
+      expect(providers?.["kimi-coding"]?.baseUrl).toBe("https://api.kimi.com/custom/coding/");
+    } finally {
+      envSnapshot.restore();
+    }
+  });
+
   it("should build kimi-coding provider with anthropic-messages API", () => {
     const provider = buildKimiCodingProvider();
     expect(provider.api).toBe("anthropic-messages");

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -955,7 +955,14 @@ export async function resolveImplicitProviders(params: {
     resolveEnvApiKeyVarName("kimi-coding") ??
     resolveApiKeyFromProfiles({ provider: "kimi-coding", store: authStore });
   if (kimiCodingKey) {
-    providers["kimi-coding"] = { ...buildKimiCodingProvider(), apiKey: kimiCodingKey };
+    // Preserve user-configured baseUrl when present so alternate Kimi endpoints
+    // (e.g. proxies or regional hosts) can be used with implicit provider setup.
+    const explicitKimiCoding = params.explicitProviders?.["kimi-coding"];
+    providers["kimi-coding"] = {
+      ...buildKimiCodingProvider(),
+      ...(explicitKimiCoding?.baseUrl ? { baseUrl: explicitKimiCoding.baseUrl } : {}),
+      apiKey: kimiCodingKey,
+    };
   }
 
   const syntheticKey =


### PR DESCRIPTION
Closes #36353

When kimi-coding is auto-added via env/profile API key, preserve an explicitly configured baseUrl (if present) instead of always using the catalog default.

Adds a regression test to ensure explicit baseUrl wins.