### PR TITLE
fix(discord): suppress Max reconnect attempts crash during teardown

### DIFF
--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -2,6 +2,7 @@ import type { Client } from "@buape/carbon";
 import type { GatewayPlugin } from "@buape/carbon/gateway";
 import { createArmableStallWatchdog } from "../../channels/transport/stall-watchdog.js";
 import { danger } from "../../globals.js";
+import { registerUnhandledRejectionHandler } from "../../infra/unhandled-rejections.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { attachDiscordGatewayLogging } from "../gateway-logging.js";
 import { getDiscordGatewayEmitter, waitForDiscordGatewayStop } from "../monitor.gateway.js";
@@ -97,8 +98,19 @@ export async function runDiscordGatewayLifecycle(params: {
       return;
     }
     gatewayEmitter?.once("error", () => {});
+    // Suppress "Max reconnect attempts (0) reached" thrown as an unhandled
+    // rejection by @buape/carbon when we force-disconnect with maxAttempts: 0.
+    // The error is expected and harmless during intentional teardown (#36055).
+    const unregister = registerUnhandledRejectionHandler((reason) => {
+      if (reason instanceof Error && reason.message.includes("Max reconnect attempts")) {
+        return true;
+      }
+      return false;
+    });
     gateway.options.reconnect = { maxAttempts: 0 };
     gateway.disconnect();
+    // Clean up handler after a short delay to cover async rejection.
+    setTimeout(unregister, 5000);
   };
 
   if (params.abortSignal?.aborted) {


### PR DESCRIPTION
Fixes #36055

When the Discord gateway is intentionally disconnected (abort signal, config reload), we set `maxAttempts: 0` and call `disconnect()`. The `@buape/carbon` library then throws `Max reconnect attempts (0) reached after code 1006` as an unhandled rejection, which crashes the entire gateway process via the global `process.exit(1)` handler.

This registers a temporary `registerUnhandledRejectionHandler` callback that suppresses this specific error during intentional teardown. The handler auto-cleans after 5 seconds to avoid suppressing legitimate reconnect failures.

1 file, +12/-0. 540 Discord tests pass.

---

AI-assisted PR (Claude via OpenClaw agent). I understand what this code does.