### PR TITLE
fix(cli): stop browser control service when agent command exits

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -945,6 +945,12 @@ async function agentCommandInternal(
     });
   } finally {
     clearAgentRunContext(runId);
+    try {
+      const { stopBrowserControlService } = await import("../browser/control-service.js");
+      await stopBrowserControlService();
+    } catch {
+      // Browser control service may not have been started
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

When running `openclaw agent --local` with a prompt that invokes the Browser tool, the CLI process never exits after the agent completes its response. Chrome and Playwright handles remain open, keeping the Node.js event loop alive. Users must Ctrl+C to terminate.

## Changes

### `src/commands/agent.ts`
- Added a call to `stopBrowserControlService()` in the `finally` block of `agentCommandInternal`
- Uses dynamic `import()` so the browser module is only loaded if it was already imported during the agent run
- The function is safe to call when no browser was started (early-returns on `null` state)

## Why

`stopBrowserControlService()` (defined in `src/browser/control-service.ts`) stops Chrome child processes via `stopKnownBrowserProfiles()` and closes Playwright CDP connections via `closePlaywrightBrowserConnection()`. This function was only called from the gateway shutdown path (`src/gateway/server-browser.ts`), never from the `agent --local` CLI path. After the agent run finishes, Chrome and Playwright handles keep the process alive indefinitely.

## Test Plan

- [x] Code review of the single-line addition
- [ ] Run `openclaw agent --local --message "Open browser and visit https://example.com"` — verify process exits after answer
- [ ] Run `openclaw agent --local --message "Hello"` — verify process still exits normally (no browser used)
- [ ] Run gateway mode — verify browser cleanup is unaffected (gateway uses its own shutdown lifecycle)

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication or authorization? **No**
- Does this change modify data storage or retrieval? **No**
- Does this change affect network communications? **No**
- Does this introduce new dependencies? **No**

## Human Verification

1. Start `openclaw agent --local` with a browser prompt — after the response, the shell prompt should return within a few seconds
2. Without this fix, the process hangs indefinitely after the response

## Failure Recovery

Revert this single commit. The only effect is that the CLI will hang again after browser tool usage (pre-existing behavior).

## Risks and Mitigations

- **Risk**: `stopBrowserControlService()` could throw if Playwright module fails to import → **Mitigated**: wrapped in try/catch that swallows errors
- **Risk**: Dynamic import could load the browser module unnecessarily → **Mitigated**: `stopBrowserControlService()` early-returns when `state` is null, so no heavy work is done if browser was never started