### PR TITLE
fix(chat.inject): create transcript file if missing (#36170)

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1142,7 +1142,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       storePath,
       sessionFile: entry?.sessionFile,
       agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
-      createIfMissing: false,
+      createIfMissing: true,
     });
     if (!appended.ok || !appended.messageId || !appended.message) {
       respond(


### PR DESCRIPTION
fix(chat.inject): create transcript file if missing.\n\n- Change createIfMissing from false to true in chat.inject RPC\n- Allows chat.inject to work when transcript file doesn't exist