### PR TITLE
fix(agents): strip constraint keywords from tool schemas for Ollama/llama.cpp

### DIFF
--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { normalizeToolParameters } from "./pi-tools.schema.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+
+function makeTool(parameters: Record<string, unknown>): AnyAgentTool {
+  return {
+    name: "test_tool",
+    description: "A test tool",
+    parameters,
+  } as unknown as AnyAgentTool;
+}
+
+describe("normalizeToolParameters strips constraint keywords for Ollama", () => {
+  const schemaWithConstraints = {
+    type: "object",
+    properties: {
+      label: { type: "string", minLength: 1, maxLength: 64, description: "Label" },
+      items: { type: "array", items: { type: "string" }, maxItems: 50 },
+    },
+    required: ["label"],
+  };
+
+  it("strips maxLength/minLength/maxItems for ollama provider", () => {
+    const result = normalizeToolParameters(makeTool(schemaWithConstraints), {
+      modelProvider: "ollama",
+    });
+    const params = result.parameters as {
+      properties: {
+        label: Record<string, unknown>;
+        items: Record<string, unknown>;
+      };
+    };
+    expect(params.properties.label.maxLength).toBeUndefined();
+    expect(params.properties.label.minLength).toBeUndefined();
+    expect(params.properties.items.maxItems).toBeUndefined();
+    expect(params.properties.label.type).toBe("string");
+    expect(params.properties.label.description).toBe("Label");
+  });
+
+  it("strips constraint keywords for llama provider", () => {
+    const result = normalizeToolParameters(makeTool(schemaWithConstraints), {
+      modelProvider: "llama",
+    });
+    const params = result.parameters as {
+      properties: { label: Record<string, unknown> };
+    };
+    expect(params.properties.label.maxLength).toBeUndefined();
+    expect(params.properties.label.minLength).toBeUndefined();
+  });
+
+  it("preserves constraint keywords for openai provider", () => {
+    const result = normalizeToolParameters(makeTool(schemaWithConstraints), {
+      modelProvider: "openai",
+    });
+    const params = result.parameters as {
+      properties: { label: Record<string, unknown> };
+    };
+    expect(params.properties.label.maxLength).toBe(64);
+    expect(params.properties.label.minLength).toBe(1);
+  });
+
+  it("preserves constraint keywords for anthropic provider", () => {
+    const result = normalizeToolParameters(makeTool(schemaWithConstraints), {
+      modelProvider: "anthropic",
+    });
+    const params = result.parameters as {
+      properties: { label: Record<string, unknown> };
+    };
+    expect(params.properties.label.maxLength).toBe(64);
+    expect(params.properties.label.minLength).toBe(1);
+  });
+});

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -89,12 +89,13 @@ export function normalizeToolParameters(
     options?.modelProvider?.toLowerCase().includes("gemini");
   const isAnthropicProvider = options?.modelProvider?.toLowerCase().includes("anthropic");
   const isXai = isXaiProvider(options?.modelProvider, options?.modelId);
+  const isOllamaLike = isOllamaLikeProvider(options?.modelProvider);
 
   function applyProviderCleaning(s: unknown): unknown {
     if (isGeminiProvider && !isAnthropicProvider) {
       return cleanSchemaForGemini(s);
     }
-    if (isXai) {
+    if (isXai || isOllamaLike) {
       return stripXaiUnsupportedKeywords(s);
     }
     return s;
@@ -196,6 +197,20 @@ export function normalizeToolParameters(
     // Merging properties preserves useful enums like `action` while keeping schemas portable.
     parameters: applyProviderCleaning(flattenedSchema),
   };
+}
+
+/**
+ * Ollama / llama.cpp converts JSON Schema → GBNF grammar at request time.
+ * Constraint keywords like maxLength and maxItems generate repetition rules
+ * ({0,N}) that exceed llama.cpp's sane defaults when N is large, causing a
+ * hard parse error.  Reuse the same stripping logic already applied for xAI.
+ */
+function isOllamaLikeProvider(modelProvider?: string): boolean {
+  if (!modelProvider) {
+    return false;
+  }
+  const lower = modelProvider.toLowerCase();
+  return lower.includes("ollama") || lower === "llama" || lower.includes("llama-server");
 }
 
 /**


### PR DESCRIPTION
## Summary

When using local LLMs via Ollama or llama.cpp, tool-calling requests fail with `"parse: error parsing grammar: number of repetitions exceeds sane defaults"`. This happens because JSON Schema constraint keywords (`maxLength`, `maxItems`, etc.) are converted into GBNF repetition rules `{0,N}` where N can be very large, exceeding llama.cpp's safety limits.

## Changes

### `src/agents/pi-tools.schema.ts`
- Added `isOllamaLikeProvider()` helper to detect Ollama, llama, and llama-server providers
- Extended `applyProviderCleaning()` to strip constraint keywords (via existing `stripXaiUnsupportedKeywords`) for Ollama-like providers, matching the existing xAI treatment

### `src/agents/pi-tools.schema.test.ts` (new)
- Tests verifying constraint keywords are stripped for `ollama` and `llama` providers
- Tests verifying constraint keywords are preserved for `openai` and `anthropic` providers

## Why

The `normalizeToolParameters` function already strips `minLength`, `maxLength`, `minItems`, `maxItems`, `minContains`, and `maxContains` for xAI (which also rejects them). Ollama/llama.cpp has the same problem — these keywords generate GBNF rules with repetition counts that overflow llama.cpp's internal limits. The fix reuses the existing stripping logic.

## Test Plan

- [x] 4 vitest unit tests pass (ollama stripped, llama stripped, openai preserved, anthropic preserved)
- [ ] Run `openclaw agent` with Ollama model that has tool schemas with `maxLength: 64` — verify no grammar parse error
- [ ] Run with Anthropic/OpenAI model — verify constraint keywords still present in schema

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication or authorization? **No**
- Does this change modify data storage or retrieval? **No**
- Does this change affect network communications? **No** (only modifies outbound schema payloads)
- Does this introduce new dependencies? **No**

## Human Verification

1. Configure an Ollama model with tool support (e.g. Qwen3)
2. Send a message that triggers tool use — should succeed without grammar errors
3. Verify Anthropic/OpenAI still receive full constraint keywords

## Failure Recovery

Revert this commit. Only effect is grammar errors return for Ollama users (pre-existing behavior).

## Risks and Mitigations

- **Risk**: Stripping constraints could allow Ollama to generate out-of-range values (e.g. strings > maxLength) → **Mitigated**: Tool handlers already validate inputs; constraints are hints for schema-aware LLMs, not hard enforcement
- **Risk**: False positive on provider detection → **Mitigated**: `isOllamaLikeProvider` only matches providers containing "ollama", exact "llama", or containing "llama-server"