### PR TITLE
fix(cron): create files with 600 permissions for defense-in-depth

### DIFF
--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -125,7 +125,7 @@ async function pruneIfNeeded(filePath: string, opts: { maxBytes: number; keepLin
   const kept = lines.slice(Math.max(0, lines.length - opts.keepLines));
   const { randomBytes } = await import("node:crypto");
   const tmp = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.writeFile(tmp, `${kept.join("\n")}\n`, "utf-8");
+  await fs.writeFile(tmp, `${kept.join("\n")}\n`, { encoding: "utf-8", mode: 0o600 });
   await fs.rename(tmp, filePath);
 }
 
@@ -139,8 +139,8 @@ export async function appendCronRunLog(
   const next = prev
     .catch(() => undefined)
     .then(async () => {
-      await fs.mkdir(path.dirname(resolved), { recursive: true });
-      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, "utf-8");
+      await fs.mkdir(path.dirname(resolved), { recursive: true, mode: 0o700 });
+      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, { encoding: "utf-8", mode: 0o600 });
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,
         keepLines: opts?.keepLines ?? DEFAULT_CRON_RUN_LOG_KEEP_LINES,

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -125,7 +125,11 @@ async function pruneIfNeeded(filePath: string, opts: { maxBytes: number; keepLin
   const kept = lines.slice(Math.max(0, lines.length - opts.keepLines));
   const { randomBytes } = await import("node:crypto");
   const tmp = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.writeFile(tmp, `${kept.join("\n")}\n`, { encoding: "utf-8", mode: 0o600 });
+  await fs.writeFile(
+    tmp,
+    `${kept.join("\n")}\n`,
+    { encoding: "utf-8", mode: 0o600 },
+  );
   await fs.rename(tmp, filePath);
 }
 
@@ -140,7 +144,11 @@ export async function appendCronRunLog(
     .catch(() => undefined)
     .then(async () => {
       await fs.mkdir(path.dirname(resolved), { recursive: true, mode: 0o700 });
-      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, { encoding: "utf-8", mode: 0o600 });
+      await fs.appendFile(
+        resolved,
+        `${JSON.stringify(entry)}\n`,
+        { encoding: "utf-8", mode: 0o600 },
+      );
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,
         keepLines: opts?.keepLines ?? DEFAULT_CRON_RUN_LOG_KEEP_LINES,

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -83,7 +83,7 @@ export async function saveCronStore(
     return;
   }
   const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.promises.writeFile(tmp, json, "utf-8");
+  await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: 0o600 });
   if (previous !== null && !opts?.skipBackup) {
     try {
       await fs.promises.copyFile(storePath, `${storePath}.bak`);


### PR DESCRIPTION
## Problem
Cron job files (jobs.json, jobs.json.bak, runs/*.jsonl) are created with 644 permissions instead of 600. The runs/ directory is 755 instead of 700.

This is a defense-in-depth issue - while parent directory permissions (700) provide protection, the files themselves should also be restricted.

## Solution
Set explicit file mode 0o600 when writing cron files and 0o700 when creating the runs/ directory.

## Changes
- src/cron/store.ts: writeFile with mode: 0o600
- src/cron/run-log.ts: mkdir with mode: 0o700, writeFile/appendFile with mode: 0o600

This follows the pattern used in src/infra/device-auth-store.ts which uses mode: 0o600 for sensitive files.

Fixes #35881

---

🤖 AI-assisted PR
- Testing: untested (CI will verify)
- I understand what this code does: ✅