### PR TITLE
perf(media): avoid redundant stream chunk buffer conversion

### DIFF
--- a/src/media/read-response-with-limit.test.ts
+++ b/src/media/read-response-with-limit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { readResponseWithLimit } from "./read-response-with-limit.js";
+
+describe("readResponseWithLimit", () => {
+  it("concatenates streamed Uint8Array chunks with non-zero offsets", async () => {
+    const backing = new Uint8Array([0, 65, 66, 67, 0, 68, 69, 70, 0]);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(backing.subarray(1, 4));
+        controller.enqueue(backing.subarray(5, 8));
+        controller.close();
+      },
+    });
+
+    const buffer = await readResponseWithLimit(new Response(stream), 16);
+    expect(buffer).toEqual(Buffer.from("ABCDEF"));
+  });
+
+  it("calls onOverflow and cancels the reader when maxBytes is exceeded", async () => {
+    let canceled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.enqueue(new Uint8Array([4, 5, 6]));
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    const res = new Response(stream);
+    const overflowError = new Error("custom overflow");
+    const onOverflow = vi.fn(() => overflowError);
+
+    await expect(readResponseWithLimit(res, 4, { onOverflow })).rejects.toBe(overflowError);
+
+    expect(onOverflow).toHaveBeenCalledWith(expect.objectContaining({ size: 6, maxBytes: 4, res }));
+    expect(canceled).toBe(true);
+  });
+});

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -45,8 +45,5 @@ export async function readResponseWithLimit(
     } catch {}
   }
 
-  return Buffer.concat(
-    chunks.map((chunk) => Buffer.from(chunk)),
-    total,
-  );
+  return Buffer.concat(chunks, total);
 }


### PR DESCRIPTION
## Summary
- remove the extra Uint8Array->Buffer conversion before Buffer.concat in src/media/read-response-with-limit.ts
- add focused tests for chunk concatenation (including non-zero byte offsets)
- add focused tests for overflow callback and reader cancel behavior

## Why
Buffer.concat already accepts Uint8Array arrays. Pre-converting each chunk created avoidable allocation and extra work on a streaming hot path.

## Risk
Low: behavior is unchanged; targeted tests cover data correctness and overflow semantics.

## Validation
- pnpm vitest run src/media/read-response-with-limit.test.ts
- pnpm oxlint src/media/read-response-with-limit.ts src/media/read-response-with-limit.test.ts
