### PR TITLE
fix(agents): honour explicit contextWindow/maxTokens overrides in model merge

### DIFF
--- a/src/agents/models-config.honours-explicit-context-window.test.ts
+++ b/src/agents/models-config.honours-explicit-context-window.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  installModelsConfigTestHooks,
+  withModelsTempHome as withTempHome,
+} from "./models-config.e2e-harness.js";
+import { ensureOpenClawModelsJson } from "./models-config.js";
+import { readGeneratedModelsJson } from "./models-config.test-utils.js";
+
+installModelsConfigTestHooks();
+
+type ModelEntry = {
+  id: string;
+  contextWindow?: number;
+  maxTokens?: number;
+};
+
+type ModelsJson = {
+  providers: Record<string, { models?: ModelEntry[] }>;
+};
+
+const MINIMAX_ENV_KEY = "MINIMAX_API_KEY";
+const MINIMAX_MODEL_ID = "MiniMax-M2.5";
+const MINIMAX_TEST_KEY = "sk-minimax-test";
+
+const baseMinimaxProvider = {
+  baseUrl: "https://api.minimax.io/anthropic",
+  api: "anthropic-messages",
+} as const;
+
+async function withMinimaxApiKey(run: () => Promise<void>) {
+  const prev = process.env[MINIMAX_ENV_KEY];
+  process.env[MINIMAX_ENV_KEY] = MINIMAX_TEST_KEY;
+  try {
+    await run();
+  } finally {
+    if (prev === undefined) {
+      delete process.env[MINIMAX_ENV_KEY];
+    } else {
+      process.env[MINIMAX_ENV_KEY] = prev;
+    }
+  }
+}
+
+async function generateAndReadMinimaxModel(cfg: OpenClawConfig): Promise<ModelEntry | undefined> {
+  await ensureOpenClawModelsJson(cfg);
+  const parsed = await readGeneratedModelsJson<ModelsJson>();
+  return parsed.providers.minimax?.models?.find((model) => model.id === MINIMAX_MODEL_ID);
+}
+
+describe("models-config: explicit contextWindow override (#35436)", () => {
+  it("honours user contextWindow when smaller than built-in catalog value", async () => {
+    await withTempHome(async () => {
+      await withMinimaxApiKey(async () => {
+        const cfg: OpenClawConfig = {
+          models: {
+            providers: {
+              minimax: {
+                ...baseMinimaxProvider,
+                models: [
+                  {
+                    id: MINIMAX_MODEL_ID,
+                    name: "MiniMax M2.5",
+                    reasoning: true,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 4096,
+                    maxTokens: 2048,
+                  },
+                ],
+              },
+            },
+          },
+        };
+
+        const model = await generateAndReadMinimaxModel(cfg);
+        expect(model).toBeDefined();
+        expect(model?.contextWindow).toBe(4096);
+        expect(model?.maxTokens).toBe(2048);
+      });
+    });
+  });
+
+  it("honours user contextWindow when larger than built-in catalog value", async () => {
+    await withTempHome(async () => {
+      await withMinimaxApiKey(async () => {
+        const cfg: OpenClawConfig = {
+          models: {
+            providers: {
+              minimax: {
+                ...baseMinimaxProvider,
+                models: [
+                  {
+                    id: MINIMAX_MODEL_ID,
+                    name: "MiniMax M2.5",
+                    reasoning: true,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 500000,
+                    maxTokens: 16384,
+                  },
+                ],
+              },
+            },
+          },
+        };
+
+        const model = await generateAndReadMinimaxModel(cfg);
+        expect(model).toBeDefined();
+        expect(model?.contextWindow).toBe(500000);
+        expect(model?.maxTokens).toBe(16384);
+      });
+    });
+  });
+});

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -16,10 +16,17 @@ type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 
 const DEFAULT_MODE: NonNullable<ModelsConfig["mode"]> = "merge";
 
-function resolvePreferredTokenLimit(explicitValue: number, implicitValue: number): number {
-  // Keep catalog refresh behavior for stale low values while preserving
-  // intentional larger user overrides (for example Ollama >128k contexts).
-  return explicitValue > implicitValue ? explicitValue : implicitValue;
+function resolvePreferredTokenLimit(explicitValue: number, _implicitValue: number): number {
+  // Honour user-configured values unconditionally.  The previous
+  // max(explicit, implicit) logic prevented stale catalog entries from
+  // capping discovery values, but it also overrode intentional user limits
+  // — e.g. a user setting contextWindow:4096 for an Ollama model would be
+  // silently replaced by the 262144 value returned by /api/show, making
+  // the model unusable on low-RAM machines (#35436).
+  //
+  // Models that appear only in the implicit catalog (no user config entry)
+  // are unaffected — they keep their discovery values.
+  return explicitValue;
 }
 
 function mergeProviderModels(implicit: ProviderConfig, explicit: ProviderConfig): ProviderConfig {


### PR DESCRIPTION
## Summary

When a user explicitly configures `contextWindow` or `maxTokens` for an Ollama model in their OpenClaw config, the values are silently overridden by the larger values returned by Ollama's `/api/show` endpoint. For example, setting `contextWindow: 4096` for `qwen3:4b` is replaced by the discovery value of 262144, causing Ollama to request 36GB of memory for a 2.5GB model.

## Changes

### `src/agents/models-config.ts`
- Modified `resolvePreferredTokenLimit` to always return the explicit (user-configured) value instead of `max(explicit, implicit)`
- Models that only exist in the implicit catalog (no user config entry) still use their discovery values
- Users who want the provider-reported context window can simply omit `contextWindow` from their config

### `src/agents/models-config.honours-explicit-context-window.test.ts` (new)
- Tests verifying that user-configured contextWindow is preserved when smaller than the built-in catalog value
- Tests verifying that user-configured contextWindow is preserved when larger than the built-in catalog value

## Why

`resolvePreferredTokenLimit` previously used `max(explicit, implicit)` to prevent stale built-in catalog values from capping provider-discovery results. While well-intentioned, this logic also overrode intentional user limits. The Ollama use case is particularly impactful: a user with 16GB RAM explicitly sets `contextWindow: 4096` to keep memory usage low, but the merge takes 262144 from `/api/show`, making the model completely unusable.

## Test Plan

- [x] 2 new vitest tests pass (smaller-than-catalog and larger-than-catalog contextWindow preserved)
- [x] Existing `models-config.preserves-explicit-reasoning-override.test.ts` still passes
- [ ] Configure an Ollama model with `contextWindow: 4096` — verify Ollama receives `num_ctx: 4096`
- [ ] Verify models without explicit contextWindow config use discovery values

## Security Impact

- Does this change handle user input? **No** (configuration values only)
- Does this change affect authentication or authorization? **No**
- Does this change modify data storage or retrieval? **No**
- Does this change affect network communications? **No** (only affects `num_ctx` parameter sent to Ollama)
- Does this introduce new dependencies? **No**

## Human Verification

1. Set `contextWindow: 4096` for an Ollama model in config
2. Start agent — verify Ollama logs show `KvSize` matching 4096, not 262144
3. Remove `contextWindow` from config — verify discovery value is used

## Failure Recovery

Revert this commit. Only effect is `max(explicit, implicit)` returns as the merge strategy (pre-existing behavior).

## Risks and Mitigations

- **Risk**: Users with outdated low contextWindow in config may not benefit from catalog updates → **Mitigated**: This only affects models the user explicitly listed in their config; if a user configured a model, their values should be respected. Users can remove or update stale entries.
- **Risk**: Default contextWindow (200000 from applyDefaults) is used instead of discovery value when user doesn't set contextWindow → **Mitigated**: 200000 is a generous default suitable for most use cases; models not in user config keep discovery values.