### PR TITLE
fix: prevent Feishu send queue deadlock on hung API calls

### DIFF
--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -176,4 +176,37 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
 
     expect(createMock).not.toHaveBeenCalled();
   });
+
+  it("times out hung reply requests so queue can continue", async () => {
+    vi.useFakeTimers();
+    replyMock.mockImplementation(() => new Promise(() => {}));
+
+    const promise = sendMessageFeishu({
+      cfg: {} as never,
+      to: "user:ou_target",
+      text: "hello",
+      replyToMessageId: "om_parent",
+    });
+    const assertion = expect(promise).rejects.toThrow("Feishu reply timed out");
+
+    await vi.advanceTimersByTimeAsync(20_001);
+    await assertion;
+    vi.useRealTimers();
+  });
+
+  it("times out hung direct send requests", async () => {
+    vi.useFakeTimers();
+    createMock.mockImplementation(() => new Promise(() => {}));
+
+    const promise = sendMessageFeishu({
+      cfg: {} as never,
+      to: "user:ou_target",
+      text: "hello",
+    });
+    const assertion = expect(promise).rejects.toThrow("Feishu send timed out");
+
+    await vi.advanceTimersByTimeAsync(20_001);
+    await assertion;
+    vi.useRealTimers();
+  });
 });

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -1,5 +1,6 @@
 import type { ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
+import { raceWithTimeoutAndAbort } from "./async.js";
 import { createFeishuClient } from "./client.js";
 import type { MentionTarget } from "./mention.js";
 import { buildMentionedMessage, buildMentionedCardContent } from "./mention.js";
@@ -10,6 +11,20 @@ import { resolveFeishuSendTarget } from "./send-target.js";
 import type { FeishuSendResult } from "./types.js";
 
 const WITHDRAWN_REPLY_ERROR_CODES = new Set([230011, 231003]);
+const FEISHU_SEND_REQUEST_TIMEOUT_MS = 20_000;
+
+async function withSendTimeout<T>(promise: Promise<T>, operation: string): Promise<T> {
+  const result = await raceWithTimeoutAndAbort(promise, {
+    timeoutMs: FEISHU_SEND_REQUEST_TIMEOUT_MS,
+  });
+  if (result.status === "timeout") {
+    throw new Error(`${operation} timed out after ${FEISHU_SEND_REQUEST_TIMEOUT_MS}ms`);
+  }
+  if (result.status === "aborted") {
+    throw new Error(`${operation} aborted`);
+  }
+  return result.value;
+}
 
 function shouldFallbackFromReplyTarget(response: { code?: number; msg?: string }): boolean {
   if (response.code !== undefined && WITHDRAWN_REPLY_ERROR_CODES.has(response.code)) {
@@ -62,14 +77,17 @@ async function sendFallbackDirect(
   },
   errorPrefix: string,
 ): Promise<FeishuSendResult> {
-  const response = await client.im.message.create({
-    params: { receive_id_type: params.receiveIdType },
-    data: {
-      receive_id: params.receiveId,
-      content: params.content,
-      msg_type: params.msgType,
-    },
-  });
+  const response = await withSendTimeout(
+    client.im.message.create({
+      params: { receive_id_type: params.receiveIdType },
+      data: {
+        receive_id: params.receiveId,
+        content: params.content,
+        msg_type: params.msgType,
+      },
+    }),
+    "Feishu send",
+  );
   assertFeishuMessageApiSuccess(response, errorPrefix);
   return toFeishuSendResult(response, params.receiveId);
 }
@@ -299,14 +317,17 @@ export async function sendMessageFeishu(
   if (replyToMessageId) {
     let response: { code?: number; msg?: string; data?: { message_id?: string } };
     try {
-      response = await client.im.message.reply({
-        path: { message_id: replyToMessageId },
-        data: {
-          content,
-          msg_type: msgType,
-          ...(replyInThread ? { reply_in_thread: true } : {}),
-        },
-      });
+      response = await withSendTimeout(
+        client.im.message.reply({
+          path: { message_id: replyToMessageId },
+          data: {
+            content,
+            msg_type: msgType,
+            ...(replyInThread ? { reply_in_thread: true } : {}),
+          },
+        }),
+        "Feishu reply",
+      );
     } catch (err) {
       if (!isWithdrawnReplyError(err)) {
         throw err;
@@ -343,14 +364,17 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
   if (replyToMessageId) {
     let response: { code?: number; msg?: string; data?: { message_id?: string } };
     try {
-      response = await client.im.message.reply({
-        path: { message_id: replyToMessageId },
-        data: {
-          content,
-          msg_type: "interactive",
-          ...(replyInThread ? { reply_in_thread: true } : {}),
-        },
-      });
+      response = await withSendTimeout(
+        client.im.message.reply({
+          path: { message_id: replyToMessageId },
+          data: {
+            content,
+            msg_type: "interactive",
+            ...(replyInThread ? { reply_in_thread: true } : {}),
+          },
+        }),
+        "Feishu card reply",
+      );
     } catch (err) {
       if (!isWithdrawnReplyError(err)) {
         throw err;


### PR DESCRIPTION
## Summary
- add a hard timeout wrapper around Feishu message send/reply API calls
- make hung `reply` / `create` requests fail with explicit timeout errors so the per-chat send chain can settle
- keep existing withdrawn-message fallback behavior intact

## Testing
- pnpm vitest run extensions/feishu/src/send.reply-fallback.test.ts
- added timeout coverage for both hung reply and hung direct send paths

Fixes openclaw/openclaw#36412
