### PR TITLE
fix(media): reject null-literal and empty buffers in saveMediaBuffer

### DIFF
--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -64,6 +64,23 @@ describe("media store", () => {
     });
   });
 
+  it("rejects empty buffer", async () => {
+    await withTempStore(async (store) => {
+      await expect(store.saveMediaBuffer(Buffer.alloc(0), "text/plain")).rejects.toThrow(
+        "non-empty Buffer",
+      );
+    });
+  });
+
+  it('rejects 4-byte "null" literal buffer', async () => {
+    await withTempStore(async (store) => {
+      const nullBuf = Buffer.from("null");
+      await expect(store.saveMediaBuffer(nullBuf, "application/pdf")).rejects.toThrow(
+        '"null" literal',
+      );
+    });
+  });
+
   it("copies local files and cleans old media", async () => {
     await withTempStore(async (store, home) => {
       const srcFile = path.join(home, "tmp-src.txt");

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -297,6 +297,8 @@ export async function saveMediaSource(
   }
 }
 
+const NULL_LITERAL = Buffer.from("null");
+
 export async function saveMediaBuffer(
   buffer: Buffer,
   contentType?: string,
@@ -304,6 +306,12 @@ export async function saveMediaBuffer(
   maxBytes = MAX_BYTES,
   originalFilename?: string,
 ): Promise<SavedMedia> {
+  if (!Buffer.isBuffer(buffer) || buffer.byteLength === 0) {
+    throw new Error("saveMediaBuffer requires a non-empty Buffer");
+  }
+  if (buffer.byteLength <= 4 && buffer.equals(NULL_LITERAL)) {
+    throw new Error('saveMediaBuffer received a 4-byte "null" literal instead of real content');
+  }
   if (buffer.byteLength > maxBytes) {
     throw new Error(`Media exceeds ${(maxBytes / (1024 * 1024)).toFixed(0)}MB limit`);
   }


### PR DESCRIPTION
## Summary

Discord PDF attachments are sporadically saved as 4-byte files containing the ASCII string `"null"` (hex `6e 75 6c 6c`) instead of actual PDF content. Downstream processors (e.g. pdfplumber) crash on these corrupt files, and no error is surfaced to the user or agent.

## Changes

### `src/media/store.ts`
- Added an empty-buffer guard that throws before writing zero-length files
- Added a "null" literal guard that detects and rejects 4-byte buffers containing exactly `"null"` — the signature of a CDN/proxy returning a JSON null body with HTTP 200

### `src/media/store.test.ts`
- Added test: rejects empty buffer with descriptive error
- Added test: rejects 4-byte "null" literal buffer with descriptive error

## Why

When Discord CDN (or an intermediate proxy) returns HTTP 200 with a body of `null` (JSON literal), the existing pipeline converts it to a `Buffer` and writes it to disk without validation. The resulting 4-byte file has a valid path and passes through the system as if it were a real PDF, only failing when a downstream tool tries to parse it.

## Test Plan

- [x] 20 vitest tests pass (18 existing + 2 new guard tests)
- [ ] Upload a PDF to Discord agent — verify normal PDFs still save correctly
- [ ] Simulate a null-body response — verify error is thrown and surfaced

## Security Impact

- Does this change handle user input? **No** (media buffers from Discord CDN)
- Does this change affect authentication or authorization? **No**
- Does this change modify data storage or retrieval? **Yes** — adds pre-write validation, but only rejects clearly invalid content
- Does this change affect network communications? **No**
- Does this introduce new dependencies? **No**

## Human Verification

1. Send a PDF to a Discord-connected agent — verify it saves and processes normally
2. Verify that a 4-byte "null" file is no longer silently written to `~/.openclaw/media/inbound/`

## Failure Recovery

Revert this commit. Only effect is that null-literal PDFs are silently saved again (pre-existing behavior).

## Risks and Mitigations

- **Risk**: Legitimate 4-byte files rejected → **Mitigated**: Only exact match against ASCII `"null"` is rejected; any other 4-byte content passes through. Real media files (images, PDFs, audio) are always larger than 4 bytes.
- **Risk**: Empty buffer check could reject valid zero-length responses → **Mitigated**: Zero-length media files are never valid; rejecting them surfaces the error early.