### PR TITLE
fix(config): pass top-level env.vars into sandbox docker environment

### DIFF
--- a/src/agents/sandbox/config.test.ts
+++ b/src/agents/sandbox/config.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { resolveSandboxDockerConfig } from "./config.js";
+
+describe("resolveSandboxDockerConfig", () => {
+  it("merges configEnvVars into sandbox docker env", () => {
+    const result = resolveSandboxDockerConfig({
+      scope: "agent",
+      configEnvVars: { SUPADATA_API_KEY: "sk-test", MY_VAR: "hello" },
+    });
+    expect(result.env).toEqual({
+      LANG: "C.UTF-8",
+      SUPADATA_API_KEY: "sk-test",
+      MY_VAR: "hello",
+    });
+  });
+
+  it("globalDocker.env overrides configEnvVars", () => {
+    const result = resolveSandboxDockerConfig({
+      scope: "agent",
+      configEnvVars: { SUPADATA_API_KEY: "from-config" },
+      globalDocker: { env: { SUPADATA_API_KEY: "from-global-docker", OTHER: "val" } },
+    });
+    expect(result.env?.SUPADATA_API_KEY).toBe("from-global-docker");
+    expect(result.env?.OTHER).toBe("val");
+  });
+
+  it("agentDocker.env overrides both configEnvVars and globalDocker.env", () => {
+    const result = resolveSandboxDockerConfig({
+      scope: "agent",
+      configEnvVars: { SUPADATA_API_KEY: "from-config" },
+      globalDocker: { env: { SUPADATA_API_KEY: "from-global" } },
+      agentDocker: { env: { SUPADATA_API_KEY: "from-agent" } },
+    });
+    expect(result.env?.SUPADATA_API_KEY).toBe("from-agent");
+  });
+
+  it("works without configEnvVars (backwards compatible)", () => {
+    const result = resolveSandboxDockerConfig({
+      scope: "agent",
+    });
+    expect(result.env).toEqual({ LANG: "C.UTF-8" });
+  });
+
+  it("preserves LANG default when configEnvVars provided", () => {
+    const result = resolveSandboxDockerConfig({
+      scope: "agent",
+      configEnvVars: { FOO: "bar" },
+    });
+    expect(result.env?.LANG).toBe("C.UTF-8");
+    expect(result.env?.FOO).toBe("bar");
+  });
+});

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../../config/config.js";
+import { collectConfigRuntimeEnvVars } from "../../config/env-vars.js";
 import { resolveAgentConfig } from "../agent-scope.js";
 import {
   DEFAULT_SANDBOX_BROWSER_AUTOSTART_TIMEOUT_MS,
@@ -77,13 +78,15 @@ export function resolveSandboxDockerConfig(params: {
   scope: SandboxScope;
   globalDocker?: Partial<SandboxDockerConfig>;
   agentDocker?: Partial<SandboxDockerConfig>;
+  configEnvVars?: Record<string, string>;
 }): SandboxDockerConfig {
   const agentDocker = params.scope === "shared" ? undefined : params.agentDocker;
   const globalDocker = params.globalDocker;
+  const configVars = params.configEnvVars ?? {};
 
   const env = agentDocker?.env
-    ? { ...(globalDocker?.env ?? { LANG: "C.UTF-8" }), ...agentDocker.env }
-    : (globalDocker?.env ?? { LANG: "C.UTF-8" });
+    ? { LANG: "C.UTF-8", ...configVars, ...globalDocker?.env, ...agentDocker.env }
+    : { LANG: "C.UTF-8", ...configVars, ...globalDocker?.env };
 
   const ulimits = agentDocker?.ulimits
     ? { ...globalDocker?.ulimits, ...agentDocker.ulimits }
@@ -197,6 +200,7 @@ export function resolveSandboxConfigForAgent(
       scope,
       globalDocker: agent?.docker,
       agentDocker: agentSandbox?.docker,
+      configEnvVars: collectConfigRuntimeEnvVars(cfg),
     }),
     browser: resolveSandboxBrowserConfig({
       scope,


### PR DESCRIPTION
## Summary

Global `env.vars` from the top-level config block are not passed into Docker sandbox containers, causing tools and skills that rely on external API keys (e.g. `SUPADATA_API_KEY`) to fail when the session runs in sandbox mode. Switching to Anthropic/OpenAI (which run in-process) makes the same tools work because `process.env` inherits the config env vars.

## Changes

### `src/agents/sandbox/config.ts`
- Added `configEnvVars?: Record<string, string>` parameter to `resolveSandboxDockerConfig`
- Merged `configEnvVars` as a base layer in the env precedence chain: `LANG default → config.env.vars → globalDocker.env → agentDocker.env`
- Updated `resolveSandboxConfigForAgent` to call `collectConfigRuntimeEnvVars(cfg)` and pass the result to the docker config resolver
- Added import for `collectConfigRuntimeEnvVars`

### `src/agents/sandbox/config.test.ts` (new)
- 5 tests covering env merge precedence, override behavior, and backwards compatibility

## Why

`resolveSandboxDockerConfig` builds the container environment only from `agents.defaults.sandbox.docker.env` and per-agent overrides. It never includes `config.env.vars`, which is where users define API keys for skills and external services. The `applyConfigEnvVars()` call in `loadConfig()` writes these to `process.env`, so in-process tool execution inherits them — but containerized execution does not.

## Test Plan

- [x] 5 new vitest tests pass (merge, override precedence, backwards compatibility)
- [x] Existing `config-hash.test.ts` still passes (9 tests)
- [ ] Define `SUPADATA_API_KEY` in `env.vars`, use Ollama model with sandbox mode — verify tool receives the key
- [ ] Verify `globalDocker.env` and `agentDocker.env` can still override `env.vars`

## Security Impact

- Does this change handle user input? **No** (configuration values only)
- Does this change affect authentication or authorization? **No**
- Does this change modify data storage or retrieval? **No**
- Does this change affect network communications? **No** (env vars are passed into container, not over network)
- Does this introduce new dependencies? **No** (reuses existing `collectConfigRuntimeEnvVars`)

## Human Verification

1. Set `env.vars.MY_TEST_KEY: "hello"` in openclaw config
2. Enable sandbox mode for an agent
3. Run a tool that reads `$MY_TEST_KEY` — should print "hello"
4. Set `agents.defaults.sandbox.docker.env.MY_TEST_KEY: "override"` — should print "override"

## Failure Recovery

Revert this commit. Only effect is sandbox containers stop receiving `env.vars` (pre-existing behavior).

## Risks and Mitigations

- **Risk**: Exposing config env vars to containers could leak secrets if sandbox isolation is compromised → **Mitigated**: `collectConfigRuntimeEnvVars` already filters dangerous host env var names via `isDangerousHostEnvVarName`; only user-declared vars are passed
- **Risk**: More specific `globalDocker.env` or `agentDocker.env` could be unintentionally overridden → **Mitigated**: Precedence chain puts `configEnvVars` as the lowest layer; docker-level env always wins