### PR TITLE
fix(feishu): add HTTP timeout to prevent per-chat queue deadlocks

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -12,6 +12,17 @@ const httpsProxyAgentCtorMock = vi.hoisted(() =>
   }),
 );
 
+const mockBaseHttpInstance = vi.hoisted(() => ({
+  request: vi.fn().mockResolvedValue({}),
+  get: vi.fn().mockResolvedValue({}),
+  post: vi.fn().mockResolvedValue({}),
+  put: vi.fn().mockResolvedValue({}),
+  patch: vi.fn().mockResolvedValue({}),
+  delete: vi.fn().mockResolvedValue({}),
+  head: vi.fn().mockResolvedValue({}),
+  options: vi.fn().mockResolvedValue({}),
+}));
+
 vi.mock("@larksuiteoapi/node-sdk", () => ({
   AppType: { SelfBuild: "self" },
   Domain: { Feishu: "https://open.feishu.cn", Lark: "https://open.larksuite.com" },
@@ -19,13 +30,20 @@ vi.mock("@larksuiteoapi/node-sdk", () => ({
   Client: vi.fn(),
   WSClient: wsClientCtorMock,
   EventDispatcher: vi.fn(),
+  defaultHttpInstance: mockBaseHttpInstance,
 }));
 
 vi.mock("https-proxy-agent", () => ({
   HttpsProxyAgent: httpsProxyAgentCtorMock,
 }));
 
-import { createFeishuWSClient } from "./client.js";
+import { Client as LarkClient } from "@larksuiteoapi/node-sdk";
+import {
+  createFeishuClient,
+  createFeishuWSClient,
+  clearClientCache,
+  FEISHU_HTTP_TIMEOUT_MS,
+} from "./client.js";
 
 const proxyEnvKeys = ["https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY"] as const;
 type ProxyEnvKey = (typeof proxyEnvKeys)[number];
@@ -66,6 +84,59 @@ afterEach(() => {
       process.env[key] = value;
     }
   }
+});
+
+describe("createFeishuClient HTTP timeout", () => {
+  beforeEach(() => {
+    clearClientCache();
+  });
+
+  it("passes a custom httpInstance with default timeout to Lark.Client", () => {
+    createFeishuClient({ appId: "app_1", appSecret: "secret_1", accountId: "timeout-test" });
+
+    const calls = (LarkClient as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const lastCall = calls[calls.length - 1][0] as { httpInstance?: unknown };
+    expect(lastCall.httpInstance).toBeDefined();
+  });
+
+  it("injects default timeout into HTTP request options", async () => {
+    createFeishuClient({ appId: "app_2", appSecret: "secret_2", accountId: "timeout-inject" });
+
+    const calls = (LarkClient as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const lastCall = calls[calls.length - 1][0] as {
+      httpInstance: { post: (...args: unknown[]) => Promise<unknown> };
+    };
+    const httpInstance = lastCall.httpInstance;
+
+    await httpInstance.post(
+      "https://example.com/api",
+      { data: 1 },
+      { headers: { "X-Custom": "yes" } },
+    );
+
+    expect(mockBaseHttpInstance.post).toHaveBeenCalledWith(
+      "https://example.com/api",
+      { data: 1 },
+      expect.objectContaining({ timeout: FEISHU_HTTP_TIMEOUT_MS, headers: { "X-Custom": "yes" } }),
+    );
+  });
+
+  it("allows explicit timeout override per-request", async () => {
+    createFeishuClient({ appId: "app_3", appSecret: "secret_3", accountId: "timeout-override" });
+
+    const calls = (LarkClient as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const lastCall = calls[calls.length - 1][0] as {
+      httpInstance: { get: (...args: unknown[]) => Promise<unknown> };
+    };
+    const httpInstance = lastCall.httpInstance;
+
+    await httpInstance.get("https://example.com/api", { timeout: 5_000 });
+
+    expect(mockBaseHttpInstance.get).toHaveBeenCalledWith(
+      "https://example.com/api",
+      expect.objectContaining({ timeout: 5_000 }),
+    );
+  });
 });
 
 describe("createFeishuWSClient proxy handling", () => {

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -2,6 +2,9 @@ import * as Lark from "@larksuiteoapi/node-sdk";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import type { FeishuDomain, ResolvedFeishuAccount } from "./types.js";
 
+/** Default HTTP timeout for Feishu API requests (30 seconds). */
+export const FEISHU_HTTP_TIMEOUT_MS = 30_000;
+
 function getWsProxyAgent(): HttpsProxyAgent<string> | undefined {
   const proxyUrl =
     process.env.https_proxy ||
@@ -29,6 +32,30 @@ function resolveDomain(domain: FeishuDomain | undefined): Lark.Domain | string {
     return Lark.Domain.Feishu;
   }
   return domain.replace(/\/+$/, ""); // Custom URL for private deployment
+}
+
+/**
+ * Create an HTTP instance that delegates to the Lark SDK's default instance
+ * but injects a default request timeout to prevent indefinite hangs
+ * (e.g. when the Feishu API is slow, causing per-chat queue deadlocks).
+ */
+function createTimeoutHttpInstance(): Lark.HttpInstance {
+  const base: Lark.HttpInstance = Lark.defaultHttpInstance as unknown as Lark.HttpInstance;
+
+  function injectTimeout<D>(opts?: Lark.HttpRequestOptions<D>): Lark.HttpRequestOptions<D> {
+    return { timeout: FEISHU_HTTP_TIMEOUT_MS, ...opts } as Lark.HttpRequestOptions<D>;
+  }
+
+  return {
+    request: (opts) => base.request(injectTimeout(opts)),
+    get: (url, opts) => base.get(url, injectTimeout(opts)),
+    post: (url, data, opts) => base.post(url, data, injectTimeout(opts)),
+    put: (url, data, opts) => base.put(url, data, injectTimeout(opts)),
+    patch: (url, data, opts) => base.patch(url, data, injectTimeout(opts)),
+    delete: (url, opts) => base.delete(url, injectTimeout(opts)),
+    head: (url, opts) => base.head(url, injectTimeout(opts)),
+    options: (url, opts) => base.options(url, injectTimeout(opts)),
+  };
 }
 
 /**
@@ -64,12 +91,13 @@ export function createFeishuClient(creds: FeishuClientCredentials): Lark.Client 
     return cached.client;
   }
 
-  // Create new client
+  // Create new client with timeout-aware HTTP instance
   const client = new Lark.Client({
     appId,
     appSecret,
     appType: Lark.AppType.SelfBuild,
     domain: resolveDomain(domain),
+    httpInstance: createTimeoutHttpInstance(),
   });
 
   // Cache it


### PR DESCRIPTION
## Summary

- Problem: The Feishu plugin's Lark SDK HTTP client has no request timeout configured. When the Feishu API hangs or responds slowly, the `sendChain` never settles, causing the per-chat queue for that `chatId` to remain in a processing state forever, blocking all subsequent messages in that thread.
- Why it matters: A single slow API response creates a **permanent per-chat deadlock** — the affected group chat becomes completely unresponsive until the gateway is manually restarted.
- What changed: Introduced a timeout-aware `httpInstance` wrapper (30s default) that is passed to the Lark SDK `Client` constructor. This injects a default timeout into **all** Feishu HTTP requests (send, reply, edit, get, card update, etc.) at the client level, so any hung API call will fail with a timeout error rather than blocking indefinitely.
- What did NOT change (scope boundary): No changes to the Lark SDK itself, the message queue logic, the retry/fallback behavior in `send.ts`, or any other Feishu plugin files. The existing withdrawn-message reply fallback and all other error handling paths remain untouched.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #36412

## User-visible / Behavior Changes

When the Feishu API hangs, the HTTP request now fails with a timeout error after 30 seconds instead of hanging indefinitely. The per-chat message queue can then settle and process the next message. Individual API calls can still override the default timeout if needed.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — existing calls now have a timeout, no new endpoints
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps
1. Configure a Feishu channel
2. Simulate a scenario where the Feishu API endpoint hangs (e.g., network partition, slow response)
3. Observe that after 30s the request times out and the queue unblocks

### Expected
- The HTTP request times out after 30 seconds
- The sendChain settles (rejects)
- Subsequent messages in the same chat are processed normally

### Actual (before fix)
- The HTTP request hangs indefinitely
- The sendChain never settles
- All subsequent messages in that chat are blocked forever

## Evidence

- [x] Failing test/log before + passing after
- Added 3 unit tests verifying:
  1. Custom `httpInstance` is passed to `Lark.Client`
  2. Default timeout (30s) is injected into HTTP request options
  3. Explicit per-request timeout can override the default

## Human Verification (required)

- Verified scenarios: All 8 existing + 3 new client tests pass (`pnpm vitest run extensions/feishu/src/client.test.ts`)
- Edge cases checked: Explicit timeout override works correctly; existing proxy and cache behavior unchanged
- What you did **not** verify: Live Feishu API testing with actual hung connections (requires production-like environment)

## Compatibility / Migration

- Backward compatible? Yes — the 30s default is generous; normal Feishu API responses complete in <5s
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; the Lark SDK falls back to its default no-timeout httpInstance
- Files/config to restore: `extensions/feishu/src/client.ts`
- Known bad symptoms reviewers should watch for: If timeout is too aggressive, legitimate slow responses (large file uploads) may fail — increase `FEISHU_HTTP_TIMEOUT_MS` if needed

## Risks and Mitigations

- Risk: 30s timeout could be too short for very large message payloads or slow network conditions
  - Mitigation: The timeout is configurable per-request (explicit `timeout` in request options overrides the default); 30s is well above the typical <2s Feishu API response time