### PR TITLE
fix(feishu): add HTTP timeout to prevent queue deadlock (#36412)

### DIFF
--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -65,11 +65,19 @@ export function createFeishuClient(creds: FeishuClientCredentials): Lark.Client 
   }
 
   // Create new client
+  // Bug fix for #36412: Add HTTP timeout to prevent queue deadlock.
+  // When Feishu API hangs (slow response, stuck TCP connection), the sendChain
+  // never settles, causing the per-chat queue to remain in processing state forever.
+  // This blocks all subsequent messages for that chatId until gateway restart.
+  const httpInstance = Lark.newHTTPInstance();
+  httpInstance.defaults.timeout = 30000; // 30 seconds (reasonable timeout for chat messages)
+  
   const client = new Lark.Client({
     appId,
     appSecret,
     appType: Lark.AppType.SelfBuild,
     domain: resolveDomain(domain),
+    httpInstance,
   });
 
   // Cache it


### PR DESCRIPTION
Fixes #36412 - Feishu plugin HTTP timeout missing, causing permanent per-chat queue deadlock.

## Problem
- Feishu API hang → sendChain never settles → queue blocked forever
- Only gateway restart recovers
- High severity, per-chat impact

## Fix
- Add 30s HTTP timeout to Lark.Client
- Uses `newHTTPInstance()` + `httpInstance.defaults.timeout`
- Queue auto-recovers after timeout

## Testing
- Normal: No impact
- Slow (< 30s): Works
- Hung (> 30s): Timeout, queue unblocked ✅

+8 lines
