### PR TITLE
fix(feishu): add timeout guard for hanging send requests

### DIFF
--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const resolveFeishuSendTargetMock = vi.hoisted(() => vi.fn());
 const resolveMarkdownTableModeMock = vi.hoisted(() => vi.fn(() => "preserve"));
@@ -24,8 +24,10 @@ import { sendCardFeishu, sendMessageFeishu } from "./send.js";
 describe("Feishu reply fallback for withdrawn/deleted targets", () => {
   const replyMock = vi.fn();
   const createMock = vi.fn();
+  const previousTimeoutEnv = process.env.OPENCLAW_FEISHU_SEND_TIMEOUT_MS;
 
   beforeEach(() => {
+    process.env.OPENCLAW_FEISHU_SEND_TIMEOUT_MS = "50";
     vi.clearAllMocks();
     resolveFeishuSendTargetMock.mockReturnValue({
       client: {
@@ -39,6 +41,15 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
       receiveId: "ou_target",
       receiveIdType: "open_id",
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (previousTimeoutEnv === undefined) {
+      delete process.env.OPENCLAW_FEISHU_SEND_TIMEOUT_MS;
+      return;
+    }
+    process.env.OPENCLAW_FEISHU_SEND_TIMEOUT_MS = previousTimeoutEnv;
   });
 
   it("falls back to create for withdrawn post replies", async () => {
@@ -175,5 +186,22 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
     ).rejects.toThrow("permission denied");
 
     expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("fails fast when Feishu create hangs", async () => {
+    vi.useFakeTimers();
+    createMock.mockImplementation(() => new Promise(() => {}));
+
+    const sendPromise = sendMessageFeishu({
+      cfg: {} as never,
+      to: "user:ou_target",
+      text: "hello",
+    }).catch((error: unknown) => error);
+
+    await vi.advanceTimersByTimeAsync(60);
+
+    const error = await sendPromise;
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("Feishu message create timed out");
   });
 });

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -16,7 +16,7 @@ const DEFAULT_FEISHU_SEND_TIMEOUT_MS = 20_000;
 function resolveFeishuSendTimeoutMs(): number {
   const raw = process.env.OPENCLAW_FEISHU_SEND_TIMEOUT_MS;
   if (!raw) return DEFAULT_FEISHU_SEND_TIMEOUT_MS;
-  const parsed = Number.parseInt(raw, 10);
+  const parsed = Number(raw);
   if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_FEISHU_SEND_TIMEOUT_MS;
   return parsed;
 }

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -1,5 +1,6 @@
 import type { ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
+import { raceWithTimeoutAndAbort } from "./async.js";
 import { createFeishuClient } from "./client.js";
 import type { MentionTarget } from "./mention.js";
 import { buildMentionedMessage, buildMentionedCardContent } from "./mention.js";
@@ -10,6 +11,27 @@ import { resolveFeishuSendTarget } from "./send-target.js";
 import type { FeishuSendResult } from "./types.js";
 
 const WITHDRAWN_REPLY_ERROR_CODES = new Set([230011, 231003]);
+const DEFAULT_FEISHU_SEND_TIMEOUT_MS = 20_000;
+
+function resolveFeishuSendTimeoutMs(): number {
+  const raw = process.env.OPENCLAW_FEISHU_SEND_TIMEOUT_MS;
+  if (!raw) return DEFAULT_FEISHU_SEND_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_FEISHU_SEND_TIMEOUT_MS;
+  return parsed;
+}
+
+async function withFeishuSendTimeout<T>(promise: Promise<T>, operationLabel: string): Promise<T> {
+  const timeoutMs = resolveFeishuSendTimeoutMs();
+  const result = await raceWithTimeoutAndAbort(promise, { timeoutMs });
+  if (result.status === "timeout") {
+    throw new Error(`${operationLabel} timed out after ${timeoutMs}ms`);
+  }
+  if (result.status === "aborted") {
+    throw new Error(`${operationLabel} aborted`);
+  }
+  return result.value;
+}
 
 function shouldFallbackFromReplyTarget(response: { code?: number; msg?: string }): boolean {
   if (response.code !== undefined && WITHDRAWN_REPLY_ERROR_CODES.has(response.code)) {
@@ -62,14 +84,17 @@ async function sendFallbackDirect(
   },
   errorPrefix: string,
 ): Promise<FeishuSendResult> {
-  const response = await client.im.message.create({
-    params: { receive_id_type: params.receiveIdType },
-    data: {
-      receive_id: params.receiveId,
-      content: params.content,
-      msg_type: params.msgType,
-    },
-  });
+  const response = await withFeishuSendTimeout(
+    client.im.message.create({
+      params: { receive_id_type: params.receiveIdType },
+      data: {
+        receive_id: params.receiveId,
+        content: params.content,
+        msg_type: params.msgType,
+      },
+    }),
+    "Feishu message create",
+  );
   assertFeishuMessageApiSuccess(response, errorPrefix);
   return toFeishuSendResult(response, params.receiveId);
 }
@@ -299,14 +324,17 @@ export async function sendMessageFeishu(
   if (replyToMessageId) {
     let response: { code?: number; msg?: string; data?: { message_id?: string } };
     try {
-      response = await client.im.message.reply({
-        path: { message_id: replyToMessageId },
-        data: {
-          content,
-          msg_type: msgType,
-          ...(replyInThread ? { reply_in_thread: true } : {}),
-        },
-      });
+      response = await withFeishuSendTimeout(
+        client.im.message.reply({
+          path: { message_id: replyToMessageId },
+          data: {
+            content,
+            msg_type: msgType,
+            ...(replyInThread ? { reply_in_thread: true } : {}),
+          },
+        }),
+        "Feishu message reply",
+      );
     } catch (err) {
       if (!isWithdrawnReplyError(err)) {
         throw err;
@@ -343,14 +371,17 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
   if (replyToMessageId) {
     let response: { code?: number; msg?: string; data?: { message_id?: string } };
     try {
-      response = await client.im.message.reply({
-        path: { message_id: replyToMessageId },
-        data: {
-          content,
-          msg_type: "interactive",
-          ...(replyInThread ? { reply_in_thread: true } : {}),
-        },
-      });
+      response = await withFeishuSendTimeout(
+        client.im.message.reply({
+          path: { message_id: replyToMessageId },
+          data: {
+            content,
+            msg_type: "interactive",
+            ...(replyInThread ? { reply_in_thread: true } : {}),
+          },
+        }),
+        "Feishu card reply",
+      );
     } catch (err) {
       if (!isWithdrawnReplyError(err)) {
         throw err;


### PR DESCRIPTION
Problem: Feishu send/reply calls can hang indefinitely on network stalls, leaving per-chat send chains unresolved and causing queue deadlocks in affected chats.\n\nRoot cause: sendMessageFeishu/sendCardFeishu awaited SDK promises directly without any timeout guard, so a hanging request never settled.\n\nFix: wrap Feishu message create/reply operations with raceWithTimeoutAndAbort and enforce a bounded timeout (default 20s, override via OPENCLAW_FEISHU_SEND_TIMEOUT_MS). Return explicit timeout errors so queues can fail-fast and continue processing.\n\nTesting: added regression test in extensions/feishu/src/send.reply-fallback.test.ts ("fails fast when Feishu create hangs") and ran:\n- pnpm vitest run extensions/feishu/src/send.reply-fallback.test.ts