### PR TITLE
fix(whatsapp): surface actionable allowFrom policy error instead of misleading format hint (#35580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
+- Gateway/device pairing loopback: restore pre-regression pairing bypass for loopback-bound gateways (`gateway.bind = "loopback"`) so non-browser operator connections authenticated with the shared gateway credential skip device pairing, fixing Docker deployments where internal proxy layers can make `isLocalClient` false. (#35763)
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.
 - Skills/native command deduplication: centralize skill command dedupe by canonical `skillName` in `listSkillCommandsForAgents` so duplicate suffixed variants (for example `_2`) are no longer surfaced across interfaces outside Discord. (#27521) thanks @shivama205.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
+- WhatsApp/allowFrom error clarity: replace misleading "requires target <E.164|group JID>" error with a clear "not listed in the configured WhatsApp allowFrom policy" message when a valid target is blocked by the allowFrom list, so users can distinguish format errors from policy rejections. (#35580)
 - Gateway/device pairing loopback: restore pre-regression pairing bypass for loopback-bound gateways (`gateway.bind = "loopback"`) so non-browser operator connections authenticated with the shared gateway credential skip device pairing, fixing Docker deployments where internal proxy layers can make `isLocalClient` false. (#35763)
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -289,6 +289,57 @@ describe("sendMessageMatrix cfg threading", () => {
   });
 });
 
+describe("sendMessageMatrix rate-limit retry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runtimeLoadConfigMock.mockReset();
+    runtimeLoadConfigMock.mockReturnValue({});
+    setMatrixRuntime(runtimeStub);
+  });
+
+  it("retries once after M_LIMIT_EXCEEDED and succeeds", async () => {
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce({ body: { errcode: "M_LIMIT_EXCEEDED", retry_after_ms: 1 } })
+      .mockResolvedValue("evt-retry");
+    const client = {
+      sendMessage,
+      getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
+    } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient;
+
+    const result = await sendMessageMatrix("!room:example", "hello", { client });
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(result.messageId).toBe("evt-retry");
+  });
+
+  it("propagates error when retry also fails", async () => {
+    const rateLimitErr = { body: { errcode: "M_LIMIT_EXCEEDED", retry_after_ms: 1 } };
+    const sendMessage = vi.fn().mockRejectedValue(rateLimitErr);
+    const client = {
+      sendMessage,
+      getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
+    } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient;
+
+    await expect(sendMessageMatrix("!room:example", "hello", { client })).rejects.toBe(
+      rateLimitErr,
+    );
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry on non-rate-limit errors", async () => {
+    const otherErr = new Error("M_FORBIDDEN");
+    const sendMessage = vi.fn().mockRejectedValue(otherErr);
+    const client = {
+      sendMessage,
+      getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
+    } as unknown as import("@vector-im/matrix-bot-sdk").MatrixClient;
+
+    await expect(sendMessageMatrix("!room:example", "hello", { client })).rejects.toBe(otherErr);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("resolveMediaMaxBytes cfg threading", () => {
   beforeEach(() => {
     runtimeLoadConfigMock.mockReset();

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -75,9 +75,22 @@ export async function sendMessageMatrix(
         ? buildThreadRelation(threadId, opts.replyToId)
         : buildReplyRelation(opts.replyToId);
       const sendContent = async (content: MatrixOutboundContent) => {
-        // @vector-im/matrix-bot-sdk uses sendMessage differently
-        const eventId = await client.sendMessage(roomId, content);
-        return eventId;
+        // @vector-im/matrix-bot-sdk uses sendMessage differently.
+        // On M_LIMIT_EXCEEDED, honor retry_after_ms and retry once (issue #36027).
+        try {
+          return await client.sendMessage(roomId, content);
+        } catch (err) {
+          const body = (err as { body?: { errcode?: string; retry_after_ms?: unknown } }).body;
+          if (body?.errcode !== "M_LIMIT_EXCEEDED") {
+            throw err;
+          }
+          const retryAfterMs =
+            typeof body.retry_after_ms === "number" && body.retry_after_ms > 0
+              ? Math.min(body.retry_after_ms, 30_000)
+              : 2_000;
+          await new Promise<void>((resolve) => setTimeout(resolve, retryAfterMs));
+          return await client.sendMessage(roomId, content);
+        }
       };
 
       let lastMessageId = "";

--- a/skills/skill-creator/SKILL.md
+++ b/skills/skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-creator
-description: Create or update AgentSkills. Use when designing, structuring, or packaging skills with scripts, references, and assets.
+description: Create, update, or refactor AgentSkills. Use when creating a new skill from scratch, editing or improving an existing SKILL.md, restructuring a skill's layout (splitting content, adding reference files, reorganizing scripts/assets), or validating a skill against the AgentSkills spec.
 ---
 
 # Skill Creator

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -278,6 +278,58 @@ describe("resolveModel", () => {
     expect(result.model?.reasoning).toBe(true);
   });
 
+  it("prefers configured provider api metadata over discovered registry model", () => {
+    mockDiscoveredModel({
+      provider: "onehub",
+      modelId: "glm-5",
+      templateModel: {
+        id: "glm-5",
+        name: "GLM-5 (cached)",
+        provider: "onehub",
+        api: "anthropic-messages",
+        baseUrl: "https://old-provider.example.com/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 8192,
+        maxTokens: 2048,
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          onehub: {
+            baseUrl: "http://new-provider.example.com/v1",
+            api: "openai-completions",
+            models: [
+              {
+                ...makeModel("glm-5"),
+                api: "openai-completions",
+                reasoning: true,
+                contextWindow: 198000,
+                maxTokens: 16000,
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("onehub", "glm-5", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "onehub",
+      id: "glm-5",
+      api: "openai-completions",
+      baseUrl: "http://new-provider.example.com/v1",
+      reasoning: true,
+      contextWindow: 198000,
+      maxTokens: 16000,
+    });
+  });
+
   it("builds an openai-codex fallback for gpt-5.3-codex", () => {
     mockOpenAICodexTemplateModel();
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -41,7 +41,12 @@ function applyConfiguredProviderOverrides(params: {
     return discoveredModel;
   }
   const configuredModel = providerConfig.models?.find((candidate) => candidate.id === modelId);
-  if (!configuredModel && !providerConfig.baseUrl && !providerConfig.api && !providerConfig.headers) {
+  if (
+    !configuredModel &&
+    !providerConfig.baseUrl &&
+    !providerConfig.api &&
+    !providerConfig.headers
+  ) {
     return discoveredModel;
   }
   return {
@@ -56,9 +61,9 @@ function applyConfiguredProviderOverrides(params: {
     headers:
       providerConfig.headers || configuredModel?.headers
         ? {
-            ...(discoveredModel.headers ?? {}),
-            ...(providerConfig.headers ?? {}),
-            ...(configuredModel?.headers ?? {}),
+            ...discoveredModel.headers,
+            ...providerConfig.headers,
+            ...configuredModel?.headers,
           }
         : discoveredModel.headers,
     compat: configuredModel?.compat ?? discoveredModel.compat,

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -7,7 +7,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { buildModelAliasLines } from "../model-alias-lines.js";
 import { normalizeModelCompat } from "../model-compat.js";
 import { resolveForwardCompatModel } from "../model-forward-compat.js";
-import { normalizeProviderId } from "../model-selection.js";
+import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
 import { discoverAuthStorage, discoverModels } from "../pi-model-discovery.js";
 
 type InlineModelEntry = ModelDefinitionConfig & {
@@ -23,6 +23,47 @@ type InlineProviderConfig = {
 };
 
 export { buildModelAliasLines };
+
+function resolveConfiguredProviderConfig(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+): InlineProviderConfig | undefined {
+  return findNormalizedProviderValue(cfg?.models?.providers, provider);
+}
+
+function applyConfiguredProviderOverrides(params: {
+  discoveredModel: Model<Api>;
+  providerConfig?: InlineProviderConfig;
+  modelId: string;
+}): Model<Api> {
+  const { discoveredModel, providerConfig, modelId } = params;
+  if (!providerConfig) {
+    return discoveredModel;
+  }
+  const configuredModel = providerConfig.models?.find((candidate) => candidate.id === modelId);
+  if (!configuredModel && !providerConfig.baseUrl && !providerConfig.api && !providerConfig.headers) {
+    return discoveredModel;
+  }
+  return {
+    ...discoveredModel,
+    api: configuredModel?.api ?? providerConfig.api ?? discoveredModel.api,
+    baseUrl: providerConfig.baseUrl ?? discoveredModel.baseUrl,
+    reasoning: configuredModel?.reasoning ?? discoveredModel.reasoning,
+    input: configuredModel?.input ?? discoveredModel.input,
+    cost: configuredModel?.cost ?? discoveredModel.cost,
+    contextWindow: configuredModel?.contextWindow ?? discoveredModel.contextWindow,
+    maxTokens: configuredModel?.maxTokens ?? discoveredModel.maxTokens,
+    headers:
+      providerConfig.headers || configuredModel?.headers
+        ? {
+            ...(discoveredModel.headers ?? {}),
+            ...(providerConfig.headers ?? {}),
+            ...(configuredModel?.headers ?? {}),
+          }
+        : discoveredModel.headers,
+    compat: configuredModel?.compat ?? discoveredModel.compat,
+  };
+}
 
 export function buildInlineProviderModels(
   providers: Record<string, InlineProviderConfig>,
@@ -59,6 +100,7 @@ export function resolveModel(
   const resolvedAgentDir = agentDir ?? resolveOpenClawAgentDir();
   const authStorage = discoverAuthStorage(resolvedAgentDir);
   const modelRegistry = discoverModels(authStorage, resolvedAgentDir);
+  const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
   const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
 
   if (!model) {
@@ -100,7 +142,7 @@ export function resolveModel(
       } as Model<Api>);
       return { model: fallbackModel, authStorage, modelRegistry };
     }
-    const providerCfg = providers[provider];
+    const providerCfg = providerConfig;
     if (providerCfg || modelId.startsWith("mock-")) {
       const configuredModel = providerCfg?.models?.find((candidate) => candidate.id === modelId);
       const fallbackModel: Model<Api> = normalizeModelCompat({
@@ -133,21 +175,17 @@ export function resolveModel(
       modelRegistry,
     };
   }
-  const providerOverride = cfg?.models?.providers?.[provider] as InlineProviderConfig | undefined;
-  if (providerOverride?.baseUrl || providerOverride?.headers) {
-    const overridden: Model<Api> & { headers?: Record<string, string> } = { ...model };
-    if (providerOverride.baseUrl) {
-      overridden.baseUrl = providerOverride.baseUrl;
-    }
-    if (providerOverride.headers) {
-      overridden.headers = {
-        ...(model as Model<Api> & { headers?: Record<string, string> }).headers,
-        ...providerOverride.headers,
-      };
-    }
-    return { model: normalizeModelCompat(overridden), authStorage, modelRegistry };
-  }
-  return { model: normalizeModelCompat(model), authStorage, modelRegistry };
+  return {
+    model: normalizeModelCompat(
+      applyConfiguredProviderOverrides({
+        discoveredModel: model,
+        providerConfig,
+        modelId,
+      }),
+    ),
+    authStorage,
+    modelRegistry,
+  };
 }
 
 /**

--- a/src/config/legacy.rules.ts
+++ b/src/config/legacy.rules.ts
@@ -131,6 +131,11 @@ export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
     message: "routing.queue was moved; use messages.queue instead (auto-migrated on load).",
   },
   {
+    path: ["messages", "queue", "byProvider"],
+    message:
+      "messages.queue.byProvider was renamed; use messages.queue.byChannel instead (auto-migrated on load).",
+  },
+  {
     path: ["routing", "transcribeAudio"],
     message:
       "routing.transcribeAudio was moved; use tools.media.audio.models instead (auto-migrated on load).",

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -313,6 +313,58 @@ export function validateConfigObjectRawWithPlugins(raw: unknown):
   return validateConfigObjectWithPluginsBase(raw, { applyDefaults: false });
 }
 
+/**
+ * Strip Zod-identified unrecognized keys from a raw config object.
+ * Returns the stripped config and a list of warnings for the removed keys.
+ * Used to allow gateway startup when config has stale/unknown keys from older versions.
+ */
+function stripUnrecognizedKeysFromRaw(raw: unknown): {
+  stripped: unknown;
+  warnings: ConfigValidationIssue[];
+} {
+  const probe = OpenClawSchema.safeParse(raw);
+  if (probe.success) {
+    return { stripped: raw, warnings: [] };
+  }
+  const unrecognizedIssues = probe.error.issues.filter((iss) => iss.code === "unrecognized_keys");
+  if (unrecognizedIssues.length === 0) {
+    return { stripped: raw, warnings: [] };
+  }
+  // Deep-clone the raw config and delete each unrecognized key.
+  const next = JSON.parse(JSON.stringify(raw)) as Record<string, unknown>;
+  const warnings: ConfigValidationIssue[] = [];
+  for (const issue of unrecognizedIssues) {
+    const path = issue.path.filter(
+      (seg): seg is string | number => typeof seg === "string" || typeof seg === "number",
+    );
+    let target: unknown = next;
+    for (const seg of path) {
+      if (!target || typeof target !== "object" || Array.isArray(target)) {
+        target = null;
+        break;
+      }
+      target = (target as Record<string | number, unknown>)[seg];
+    }
+    if (!target || typeof target !== "object" || Array.isArray(target)) {
+      continue;
+    }
+    const record = target as Record<string, unknown>;
+    const keys: PropertyKey[] = (issue as unknown as { keys?: PropertyKey[] }).keys ?? [];
+    for (const key of keys) {
+      if (typeof key !== "string" || !(key in record)) {
+        continue;
+      }
+      const fullPath = path.length > 0 ? `${path.join(".")}.${key}` : key;
+      delete record[key];
+      warnings.push({
+        path: fullPath,
+        message: `Unknown config key "${fullPath}" ignored. Remove it to suppress this warning.`,
+      });
+    }
+  }
+  return { stripped: next, warnings };
+}
+
 function validateConfigObjectWithPluginsBase(
   raw: unknown,
   opts: { applyDefaults: boolean },
@@ -327,14 +379,28 @@ function validateConfigObjectWithPluginsBase(
       issues: ConfigValidationIssue[];
       warnings: ConfigValidationIssue[];
     } {
-  const base = opts.applyDefaults ? validateConfigObject(raw) : validateConfigObjectRaw(raw);
+  // Check for legacy config issues first — these must be errors, not silently stripped.
+  // Only strip truly unknown keys (not legacy ones) to allow startup with stale config
+  // from older versions that had keys removed (issue #35957).
+  const legacyIssues = findLegacyConfigIssues(raw);
+  if (legacyIssues.length > 0) {
+    return {
+      ok: false,
+      issues: legacyIssues.map((iss) => ({ path: iss.path, message: iss.message })),
+      warnings: [],
+    };
+  }
+  const { stripped: strippedRaw, warnings: unknownKeyWarnings } = stripUnrecognizedKeysFromRaw(raw);
+  const base = opts.applyDefaults
+    ? validateConfigObject(strippedRaw)
+    : validateConfigObjectRaw(strippedRaw);
   if (!base.ok) {
-    return { ok: false, issues: base.issues, warnings: [] };
+    return { ok: false, issues: base.issues, warnings: unknownKeyWarnings };
   }
 
   const config = base.config;
   const issues: ConfigValidationIssue[] = [];
-  const warnings: ConfigValidationIssue[] = [];
+  const warnings: ConfigValidationIssue[] = [...unknownKeyWarnings];
   const hasExplicitPluginsConfig =
     isRecord(raw) && Object.prototype.hasOwnProperty.call(raw, "plugins");
 

--- a/src/discord/monitor/preflight-audio.ts
+++ b/src/discord/monitor/preflight-audio.ts
@@ -61,16 +61,27 @@ export async function resolveDiscordPreflightAudioMentionContext(params: {
         .map((att) => att.url)
         .filter((url): url is string => typeof url === "string" && url.length > 0);
       if (audioUrls.length > 0) {
-        transcript = await transcribeFirstAudio({
-          ctx: {
-            MediaUrls: audioUrls,
-            MediaTypes: audioAttachments
-              .map((att) => att.content_type)
-              .filter((contentType): contentType is string => Boolean(contentType)),
-          },
+        const transcriptCtx = {
+          MediaUrls: audioUrls,
+          MediaTypes: audioAttachments
+            .map((att) => att.content_type)
+            .filter((contentType): contentType is string => Boolean(contentType)),
+        };
+        const transcriptionPromise = transcribeFirstAudio({
+          ctx: transcriptCtx,
           cfg: params.cfg,
           agentDir: undefined,
         });
+        // Race against abort so a slow transcription does not hold up the
+        // channel queue when the listener has already timed out (issue #36017).
+        if (params.abortSignal && !params.abortSignal.aborted) {
+          const abortPromise = new Promise<undefined>((resolve) => {
+            params.abortSignal!.addEventListener("abort", () => resolve(undefined), { once: true });
+          });
+          transcript = await Promise.race([transcriptionPromise, abortPromise]);
+        } else {
+          transcript = await transcriptionPromise;
+        }
         if (params.abortSignal?.aborted) {
           transcript = undefined;
         }

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -129,4 +129,20 @@ describe("resolveChannelRestartReason", () => {
     );
     expect(reason).toBe("gave-up");
   });
+
+  it("maps disconnected evaluation to disconnected (not stuck)", () => {
+    const reason = resolveChannelRestartReason(
+      { running: true, connected: false },
+      { healthy: false, reason: "disconnected" },
+    );
+    expect(reason).toBe("disconnected");
+  });
+
+  it("maps stuck evaluation to stuck", () => {
+    const reason = resolveChannelRestartReason(
+      { running: true, busy: true, activeRuns: 1 },
+      { healthy: false, reason: "stuck" },
+    );
+    expect(reason).toBe("stuck");
+  });
 });

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -32,7 +32,12 @@ export type ChannelHealthPolicy = {
   channelConnectGraceMs: number;
 };
 
-export type ChannelRestartReason = "gave-up" | "stopped" | "stale-socket" | "stuck";
+export type ChannelRestartReason =
+  | "gave-up"
+  | "stopped"
+  | "disconnected"
+  | "stale-socket"
+  | "stuck";
 
 function isManagedAccount(snapshot: ChannelHealthSnapshot): boolean {
   return snapshot.enabled !== false && snapshot.configured !== false;
@@ -115,6 +120,9 @@ export function resolveChannelRestartReason(
   }
   if (evaluation.reason === "not-running") {
     return snapshot.reconnectAttempts && snapshot.reconnectAttempts >= 10 ? "gave-up" : "stopped";
+  }
+  if (evaluation.reason === "disconnected") {
+    return "disconnected";
   }
   return "stuck";
 }

--- a/src/gateway/server.auth.browser-hardening.test.ts
+++ b/src/gateway/server.auth.browser-hardening.test.ts
@@ -176,4 +176,84 @@ describe("gateway auth browser hardening", () => {
       }
     });
   });
+
+  // #35763: loopback-bound gateway pairing bypass for Docker deployments.
+  // When gateway.bind = "loopback", all connections must originate locally.
+  // Internal proxy layers in Docker can make isLocalClient=false, so we test
+  // the bypass using x-forwarded-for to simulate that condition.
+  test("skips device pairing for non-browser operator on loopback-bound gateway when isLocalClient is false (Docker scenario)", async () => {
+    testState.gatewayAuth = { mode: "token", token: "secret" };
+    // default bind is "loopback"; set explicitly to document the expectation
+    testState.gatewayBind = "loopback";
+    await withGatewayServer(async ({ port }) => {
+      // x-forwarded-for (without a trusted proxy) makes isLocalClient=false
+      const ws = await openWs(port, { "x-forwarded-for": "10.0.0.2" });
+      try {
+        const res = await connectReq(ws, {
+          token: "secret",
+          client: TEST_OPERATOR_CLIENT,
+          deviceIdentityPath: path.join(
+            os.tmpdir(),
+            `openclaw-loopback-bypass-${randomUUID()}.json`,
+          ),
+        });
+        // skipPairingForLoopbackBoundSharedAuth=true → pairing check bypassed
+        expect(res.ok).toBe(true);
+      } finally {
+        ws.close();
+      }
+    });
+  });
+
+  test("still requires device pairing for browser clients on loopback-bound gateway when isLocalClient is false", async () => {
+    testState.gatewayAuth = { mode: "token", token: "secret" };
+    testState.gatewayBind = "loopback";
+    await withGatewayServer(async ({ port }) => {
+      // browser Origin + x-forwarded-for → hasBrowserOriginHeader=true AND isLocalClient=false
+      const ws = await openWs(port, {
+        "x-forwarded-for": "10.0.0.2",
+        origin: originForPort(port),
+      });
+      try {
+        const res = await connectReq(ws, {
+          token: "secret",
+          client: TEST_OPERATOR_CLIENT,
+          deviceIdentityPath: path.join(
+            os.tmpdir(),
+            `openclaw-loopback-browser-${randomUUID()}.json`,
+          ),
+        });
+        // skipPairingForLoopbackBoundSharedAuth=false (hasBrowserOriginHeader blocks it)
+        // shouldAllowSilentLocalPairing=false (isLocalClient=false)
+        // → pairing required
+        expect(res.ok).toBe(false);
+        expect(res.error?.message ?? "").toContain("pairing required");
+      } finally {
+        ws.close();
+      }
+    });
+  });
+
+  test("still requires device pairing on non-loopback-bound gateway when isLocalClient is false", async () => {
+    testState.gatewayAuth = { mode: "token", token: "secret" };
+    testState.gatewayBind = "lan";
+    await withGatewayServer(async ({ port }) => {
+      // x-forwarded-for makes isLocalClient=false; non-loopback bind disables bypass
+      const ws = await openWs(port, { "x-forwarded-for": "10.0.0.2" });
+      try {
+        const res = await connectReq(ws, {
+          token: "secret",
+          client: TEST_OPERATOR_CLIENT,
+          deviceIdentityPath: path.join(os.tmpdir(), `openclaw-lan-bypass-${randomUUID()}.json`),
+        });
+        // skipPairingForLoopbackBoundSharedAuth=false (bind != loopback)
+        // shouldAllowSilentLocalPairing=false (isLocalClient=false)
+        // → pairing required
+        expect(res.ok).toBe(false);
+        expect(res.error?.message ?? "").toContain("pairing required");
+      } finally {
+        ws.close();
+      }
+    });
+  });
 });

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -753,14 +753,33 @@ export function attachGatewayWsMessageHandler(params: {
           authOk,
           authMethod,
         });
+        // When the gateway is loopback-bound, all incoming connections must originate
+        // from the local host (no external network access is possible). Operator
+        // connections authenticated with the shared gateway credential (token/password)
+        // skip device pairing in this configuration — the bind restriction already
+        // provides the locality guarantee, and the gateway token is the primary auth
+        // factor. This restores the pre-#8d1481cb4 behaviour for Docker deployments
+        // where the loopback detection heuristic may not fire correctly due to internal
+        // proxy layers. (#35763)
+        const usesSharedSecretAuth = authMethod === "token" || authMethod === "password";
+        const skipPairingForLoopbackBoundSharedAuth =
+          (configSnapshot.gateway?.bind ?? "loopback") === "loopback" &&
+          role === "operator" &&
+          sharedAuthOk &&
+          usesSharedSecretAuth &&
+          !hasBrowserOriginHeader &&
+          !isControlUi &&
+          !isWebchat;
         const skipPairing =
+          skipPairingForLoopbackBoundSharedAuth ||
           shouldSkipBackendSelfPairing({
             connectParams,
             isLocalClient,
             hasBrowserOriginHeader,
             sharedAuthOk,
             authMethod,
-          }) || shouldSkipControlUiPairing(controlUiAuthPolicy, sharedAuthOk, trustedProxyAuthOk);
+          }) ||
+          shouldSkipControlUiPairing(controlUiAuthPolicy, sharedAuthOk, trustedProxyAuthOk);
         if (device && devicePublicKey && !skipPairing) {
           const formatAuditList = (items: string[] | undefined): string => {
             if (!items || items.length === 0) {

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -258,7 +258,10 @@ export abstract class MemoryManagerSyncOps {
     const dir = path.dirname(dbPath);
     ensureDir(dir);
     const { DatabaseSync } = requireNodeSqlite();
-    return new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    const db = new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    // WAL mode is crash-safe and survives SIGTERM/SIGKILL mid-write (issue #36035).
+    db.exec("PRAGMA journal_mode = WAL");
+    return db;
   }
 
   private seedEmbeddingCache(sourceDb: DatabaseSync): void {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -24,6 +24,7 @@ import type {
   TelegramTopicConfig,
 } from "../config/types.js";
 import { danger, logVerbose, warn } from "../globals.js";
+import { retryAsync } from "../infra/retry.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { MediaFetchError } from "../media/fetch.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
@@ -349,7 +350,20 @@ export const registerTelegramHandlers = ({
       for (const { ctx } of entry.messages) {
         let media;
         try {
-          media = await resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch);
+          // Retry once on recoverable errors (e.g. intermittent IPv6/IPv4 races on Node 25).
+          media = await retryAsync(
+            () => resolveMedia(ctx, mediaMaxBytes, opts.token, opts.proxyFetch),
+            {
+              attempts: 2,
+              minDelayMs: 500,
+              maxDelayMs: 500,
+              shouldRetry: (err) => isRecoverableMediaGroupError(err),
+              onRetry: ({ err }) =>
+                runtime.log?.(
+                  warn(`media group: retrying photo fetch after error: ${String(err)}`),
+                ),
+            },
+          );
         } catch (mediaErr) {
           if (!isRecoverableMediaGroupError(mediaErr)) {
             throw mediaErr;

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -2076,7 +2076,8 @@ describe("createTelegramBot", () => {
     let fetchCallIndex = 0;
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
       fetchCallIndex++;
-      if (fetchCallIndex === 2) {
+      // Fail calls 2 and 3 (photo 2's initial attempt and its retry) so the photo is skipped.
+      if (fetchCallIndex === 2 || fetchCallIndex === 3) {
         throw new Error("MediaFetchError: Failed to fetch media");
       }
       return new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {

--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -139,6 +139,21 @@ describe("resolveWhatsAppOutboundTarget", () => {
       expectDeniedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "implicit" });
     });
 
+    it("allowFrom denial error references the target and allowFrom policy, not format hint", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
+      const result = resolveWhatsAppOutboundTarget({
+        to: PRIMARY_TARGET,
+        allowFrom: [SECONDARY_TARGET],
+        mode: "implicit",
+      });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain("allowFrom");
+        expect(result.error.message).toContain(PRIMARY_TARGET);
+        expect(result.error.message).not.toContain("E.164");
+      }
+    });
+
     it("handles mixed numeric and string allowList entries", () => {
       vi.mocked(normalize.normalizeWhatsAppTarget)
         .mockReturnValueOnce("+11234567890") // for 'to' param

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -41,7 +41,9 @@ export function resolveWhatsAppOutboundTarget(params: {
     }
     return {
       ok: false,
-      error: missingTargetError("WhatsApp", "<E.164|group JID>"),
+      error: new Error(
+        `Target "${trimmed}" is not listed in the configured WhatsApp allowFrom policy.`,
+      ),
     };
   }
 


### PR DESCRIPTION
## Summary

Fixes #35580.

When a valid WhatsApp target (proper E.164 or group JID) is blocked by the `allowFrom` policy, the error previously said `Delivering to WhatsApp requires target <E.164|group JID>` — the same generic format error shown when the phone number is actually malformed. This made it impossible to distinguish between a formatting mistake and a policy configuration problem.

**Fix:** When the target passes format validation but is not in the `allowFrom` list, return a specific error: `Target "+1..." is not listed in the configured WhatsApp allowFrom policy.`

The three distinct error cases are now:
- **No target provided** (empty/null/undefined): `Delivering to WhatsApp requires target <E.164|group JID>` (unchanged)
- **Invalid format** (fails normalization): `Delivering to WhatsApp requires target <E.164|group JID>` (unchanged)
- **allowFrom policy rejection** (valid format, not in list): `Target "+1..." is not listed in the configured WhatsApp allowFrom policy.` (**new**)

## Test plan

- [x] `allowFrom denial error references the target and allowFrom policy, not format hint` — new test verifying the error contains "allowFrom" and the target number, not "E.164"
- [x] All 22 tests in `resolve-outbound-target.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)