### PR TITLE
fix(feishu): add HTTP timeout to prevent queue deadlocks

### DIFF
--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@larksuiteoapi/node-sdk": "^1.59.0",
     "@sinclair/typebox": "0.34.48",
+    "axios": "^1.13.0",
     "https-proxy-agent": "^7.0.6",
     "zod": "^4.3.6"
   },

--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -6,9 +6,19 @@ const wsClientCtorMock = vi.hoisted(() =>
     return { connected: true };
   }),
 );
+const clientCtorMock = vi.hoisted(() =>
+  vi.fn(function clientCtor() {
+    return { im: {} };
+  }),
+);
 const httpsProxyAgentCtorMock = vi.hoisted(() =>
   vi.fn(function httpsProxyAgentCtor(proxyUrl: string) {
     return { proxyUrl };
+  }),
+);
+const axiosCreateMock = vi.hoisted(() =>
+  vi.fn(function axiosCreate(config: { timeout?: number }) {
+    return { defaults: { timeout: config?.timeout } };
   }),
 );
 
@@ -16,7 +26,7 @@ vi.mock("@larksuiteoapi/node-sdk", () => ({
   AppType: { SelfBuild: "self" },
   Domain: { Feishu: "https://open.feishu.cn", Lark: "https://open.larksuite.com" },
   LoggerLevel: { info: "info" },
-  Client: vi.fn(),
+  Client: clientCtorMock,
   WSClient: wsClientCtorMock,
   EventDispatcher: vi.fn(),
 }));
@@ -25,7 +35,18 @@ vi.mock("https-proxy-agent", () => ({
   HttpsProxyAgent: httpsProxyAgentCtorMock,
 }));
 
-import { createFeishuWSClient } from "./client.js";
+vi.mock("axios", () => ({
+  default: {
+    create: axiosCreateMock,
+  },
+}));
+
+import {
+  createFeishuClient,
+  createFeishuWSClient,
+  clearClientCache,
+  FEISHU_HTTP_TIMEOUT_MS,
+} from "./client.js";
 
 const proxyEnvKeys = ["https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY"] as const;
 type ProxyEnvKey = (typeof proxyEnvKeys)[number];
@@ -48,6 +69,13 @@ function firstWsClientOptions(): { agent?: unknown } {
   return calls[0]?.[0] ?? {};
 }
 
+function firstClientOptions(): { httpInstance?: unknown } {
+  const calls = clientCtorMock.mock.calls as unknown as Array<
+    [options: { httpInstance?: unknown }]
+  >;
+  return calls[0]?.[0] ?? {};
+}
+
 beforeEach(() => {
   priorProxyEnv = {};
   for (const key of proxyEnvKeys) {
@@ -55,6 +83,7 @@ beforeEach(() => {
     delete process.env[key];
   }
   vi.clearAllMocks();
+  clearClientCache();
 });
 
 afterEach(() => {
@@ -66,6 +95,37 @@ afterEach(() => {
       process.env[key] = value;
     }
   }
+});
+
+describe("createFeishuClient HTTP timeout", () => {
+  it("creates an axios instance with 30s timeout to prevent queue deadlocks", () => {
+    createFeishuClient({
+      accountId: "test",
+      appId: "app_123",
+      appSecret: "secret_123",
+    });
+
+    expect(axiosCreateMock).toHaveBeenCalledTimes(1);
+    expect(axiosCreateMock).toHaveBeenCalledWith({
+      timeout: 30_000,
+    });
+  });
+
+  it("exports the timeout constant for documentation", () => {
+    expect(FEISHU_HTTP_TIMEOUT_MS).toBe(30_000);
+  });
+
+  it("passes the axios instance to Lark Client as httpInstance", () => {
+    createFeishuClient({
+      accountId: "test",
+      appId: "app_123",
+      appSecret: "secret_123",
+    });
+
+    const options = firstClientOptions();
+    expect(options.httpInstance).toBeDefined();
+    expect(options.httpInstance).toEqual({ defaults: { timeout: 30_000 } });
+  });
 });
 
 describe("createFeishuWSClient proxy handling", () => {

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -1,6 +1,14 @@
 import * as Lark from "@larksuiteoapi/node-sdk";
+import axios from "axios";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import type { FeishuDomain, ResolvedFeishuAccount } from "./types.js";
+
+/**
+ * Default HTTP timeout for Feishu API requests in milliseconds.
+ * Prevents queue deadlocks when the Feishu API hangs or responds slowly.
+ * @see https://github.com/openclaw/openclaw/issues/36412
+ */
+export const FEISHU_HTTP_TIMEOUT_MS = 30_000;
 
 function getWsProxyAgent(): HttpsProxyAgent<string> | undefined {
   const proxyUrl =
@@ -10,6 +18,16 @@ function getWsProxyAgent(): HttpsProxyAgent<string> | undefined {
     process.env.HTTP_PROXY;
   if (!proxyUrl) return undefined;
   return new HttpsProxyAgent(proxyUrl);
+}
+
+/**
+ * Create an axios instance with timeout configured.
+ * This prevents queue deadlocks when Feishu API requests hang.
+ */
+function createHttpInstance(): ReturnType<typeof axios.create> {
+  return axios.create({
+    timeout: FEISHU_HTTP_TIMEOUT_MS,
+  });
 }
 
 // Multi-account client cache
@@ -64,12 +82,13 @@ export function createFeishuClient(creds: FeishuClientCredentials): Lark.Client 
     return cached.client;
   }
 
-  // Create new client
+  // Create new client with timeout-configured HTTP instance
   const client = new Lark.Client({
     appId,
     appSecret,
     appType: Lark.AppType.SelfBuild,
     domain: resolveDomain(domain),
+    httpInstance: createHttpInstance(),
   });
 
   // Cache it

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,9 @@ importers:
       '@sinclair/typebox':
         specifier: 0.34.48
         version: 0.34.48
+      axios:
+        specifier: ^1.13.0
+        version: 1.13.5
       https-proxy-agent:
         specifier: ^7.0.6
         version: 7.0.6


### PR DESCRIPTION
## Problem

Fixes #36412

The Feishu plugin's `sendMessageFeishu` lacks an explicit HTTP timeout. When a Feishu API request hangs or responds slowly, the `sendChain` never settles, causing the per-chat queue for that specific `chatId` to remain in a processing state forever, blocking all subsequent messages.

**Impact:**
- Silent failure where the bot appears "alive" but ignores all messages in affected channels
- Only a manual gateway restart clears the in-memory Promise queue
- Affects all users utilizing the Feishu/Lark adapter

## Root Cause

- The Lark SDK `Client` was created without timeout configuration
- Axios requests could hang indefinitely
- Per-chat queue serialization meant one hung request blocked the entire queue for that `chatId`

## Fix

- Create axios instance with 30s timeout (`FEISHU_HTTP_TIMEOUT_MS`)
- Pass it to Lark SDK Client via `httpInstance` option
- Export the timeout constant for documentation

## Testing

- Added 3 unit tests verifying timeout configuration
- All 324 existing Feishu plugin tests pass

## Technical Details

```typescript
// client.ts - key change
export const FEISHU_HTTP_TIMEOUT_MS = 30_000;

function createHttpInstance(): ReturnType<typeof axios.create> {
  return axios.create({
    timeout: FEISHU_HTTP_TIMEOUT_MS,
  });
}

const client = new Lark.Client({
  // ...
  httpInstance: createHttpInstance(),
});
```

cc @greptile-apps please review