### PR TITLE
fix(cli): propagate config env vars to tool runtime

### DIFF
--- a/src/agents/cli-runner.test.ts
+++ b/src/agents/cli-runner.test.ts
@@ -107,6 +107,54 @@ describe("runCliAgent with process supervisor", () => {
     expect(input.scopeKey).toContain("thread-123");
   });
 
+  it("injects config.env vars into CLI runtime env", async () => {
+    const envKey = "OPENCLAW_TEST_TOOL_ENV_PROPAGATION";
+    const previous = process.env[envKey];
+    delete process.env[envKey];
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 30,
+        stdout: "ok",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    try {
+      await runCliAgent({
+        sessionId: "s1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        prompt: "hi",
+        provider: "codex-cli",
+        model: "gpt-5.2-codex",
+        timeoutMs: 1_000,
+        runId: "run-env-1",
+        config: {
+          env: {
+            vars: {
+              [envKey]: "from-config",
+            },
+          },
+        } satisfies OpenClawConfig,
+      });
+
+      const input = supervisorSpawnMock.mock.calls[0]?.[0] as { env?: Record<string, string> };
+      expect(input.env?.[envKey]).toBe("from-config");
+    } finally {
+      if (previous === undefined) {
+        delete process.env[envKey];
+      } else {
+        process.env[envKey] = previous;
+      }
+    }
+  });
+
   it("fails with timeout when no-output watchdog trips", async () => {
     supervisorSpawnMock.mockResolvedValueOnce(
       createManagedRun({

--- a/src/agents/cli-runner.test.ts
+++ b/src/agents/cli-runner.test.ts
@@ -146,6 +146,7 @@ describe("runCliAgent with process supervisor", () => {
 
       const input = supervisorSpawnMock.mock.calls[0]?.[0] as { env?: Record<string, string> };
       expect(input.env?.[envKey]).toBe("from-config");
+      expect(process.env[envKey]).toBeUndefined();
     } finally {
       if (previous === undefined) {
         delete process.env[envKey];

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -89,7 +89,6 @@ export async function runCliAgent(params: {
   }
   const workspaceDir = resolvedWorkspace;
 
-
   const backendResolved = resolveCliBackendConfig(params.provider, params.config);
   if (!backendResolved) {
     throw new Error(`Unknown CLI backend: ${params.provider}`);

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -2,6 +2,7 @@ import type { ImageContent } from "@mariozechner/pi-ai";
 import { resolveHeartbeatPrompt } from "../auto-reply/heartbeat.js";
 import type { ThinkLevel } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { applyConfigEnvVars } from "../config/env-vars.js";
 import { shouldLogVerbose } from "../globals.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
@@ -87,6 +88,10 @@ export async function runCliAgent(params: {
     );
   }
   const workspaceDir = resolvedWorkspace;
+
+  if (params.config) {
+    applyConfigEnvVars(params.config);
+  }
 
   const backendResolved = resolveCliBackendConfig(params.provider, params.config);
   if (!backendResolved) {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -2,7 +2,7 @@ import type { ImageContent } from "@mariozechner/pi-ai";
 import { resolveHeartbeatPrompt } from "../auto-reply/heartbeat.js";
 import type { ThinkLevel } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { applyConfigEnvVars } from "../config/env-vars.js";
+import { collectConfigRuntimeEnvVars } from "../config/env-vars.js";
 import { shouldLogVerbose } from "../globals.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
@@ -89,9 +89,6 @@ export async function runCliAgent(params: {
   }
   const workspaceDir = resolvedWorkspace;
 
-  if (params.config) {
-    applyConfigEnvVars(params.config);
-  }
 
   const backendResolved = resolveCliBackendConfig(params.provider, params.config);
   if (!backendResolved) {
@@ -291,7 +288,13 @@ export async function runCliAgent(params: {
         }
 
         const env = (() => {
-          const next = { ...process.env, ...backend.env };
+          const next: NodeJS.ProcessEnv = { ...process.env };
+          const configEnv = collectConfigRuntimeEnvVars(params.config);
+          for (const [key, value] of Object.entries(configEnv)) {
+            if (next[key]?.trim()) continue;
+            next[key] = value;
+          }
+          Object.assign(next, backend.env);
           for (const key of backend.clearEnv ?? []) {
             delete next[key];
           }

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -290,7 +290,9 @@ export async function runCliAgent(params: {
           const next: NodeJS.ProcessEnv = { ...process.env };
           const configEnv = collectConfigRuntimeEnvVars(params.config);
           for (const [key, value] of Object.entries(configEnv)) {
-            if (next[key]?.trim()) continue;
+            if (next[key]?.trim()) {
+              continue;
+            }
             next[key] = value;
           }
           Object.assign(next, backend.env);


### PR DESCRIPTION
Problem: tools/skills relying on config-level env vars (config.env / config.env.vars) fail under CLI backends because those vars are not guaranteed to be present in runtime process.env for the CLI execution path.\n\nRoot cause: runCliAgent constructed child env from process.env + backend overrides, but did not explicitly apply config env vars in this path when called with config objects that bypass full loadConfig() initialization.\n\nFix: apply config env vars at runCliAgent startup when config is provided, before resolving backend and spawning the CLI child process; add regression test asserting config.env vars are injected into supervisor spawn env.\n\nTesting:\n- pnpm vitest run src/agents/cli-runner.test.ts