### PR TITLE
failover: avoid false global rate-limit classification from generic cooling-down text

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -483,9 +483,7 @@ describe("classifyFailoverReason", () => {
     expect(
       classifyFailoverReason("model_cooldown: All credentials for model gpt-5 are cooling down"),
     ).toBe("rate_limit");
-    expect(classifyFailoverReason("all credentials for model x are cooling down")).toBe(
-      "rate_limit",
-    );
+    expect(classifyFailoverReason("all credentials for model x are cooling down")).toBeNull();
     expect(
       classifyFailoverReason(
         '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -3,8 +3,10 @@ type ErrorPattern = RegExp | string;
 const ERROR_PATTERNS = {
   rateLimit: [
     /rate[_ ]limit|too many requests|429/,
+    // Keep the explicit internal marker used by auth-profile fallback routing.
+    // Do not match generic "cooling down" text, which can appear in unrelated
+    // provider or runtime errors and causes false global rate-limit warnings.
     "model_cooldown",
-    "cooling down",
     "exceeded your current quota",
     "resource has been exhausted",
     "quota exceeded",


### PR DESCRIPTION
## Summary
- prevent false `rate_limit` classification for generic cooldown phrasing by removing the broad `"cooling down"` matcher
- keep explicit internal cooldown handling via `model_cooldown`
- update failover classification tests to lock this behavior

## Why
Issue #32828 reports provider-agnostic lockouts where users receive `API rate limit reached` even when upstream APIs are healthy. The broad `"cooling down"` token causes generic text like `all credentials for model x are cooling down` to be classified as `rate_limit`, which can surface misleading global rate-limit messaging.

## Changes
- `src/agents/pi-embedded-helpers/failover-matches.ts`
  - removed generic `"cooling down"` from `rateLimit` patterns
  - preserved `"model_cooldown"` marker with explanatory comment
- `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
  - assert generic `cooling down` text is no longer classified as `rate_limit`
  - keep explicit `model_cooldown:` classification as `rate_limit`

## Related triage
- related PR #32861: currently `CONFLICTING` / stale branch
- related PR #32972: closer scope, but currently `UNSTABLE` with failing required checks
- this PR is a clean, minimal branch on current `main` that implements the high-confidence classification fix with regression coverage

Fixes #32828
Related: #24839 #22294 #13623 #30030 #32861 #32972

## Validation
- `pnpm exec vitest run src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- `pnpm exec vitest run --config vitest.e2e.config.ts src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts`
- `pnpm check`
- `pnpm build`
