### PR TITLE
perf(channels): memoize channel loader misses

### DIFF
--- a/src/channels/plugins/registry-loader.test.ts
+++ b/src/channels/plugins/registry-loader.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginChannelRegistration } from "../../plugins/registry.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createChannelRegistryLoader } from "./registry-loader.js";
+
+function channelEntry(id: string, outbound?: unknown): PluginChannelRegistration {
+  return {
+    pluginId: `plugin-${id}`,
+    plugin: { id, outbound } as PluginChannelRegistration["plugin"],
+    source: "test",
+  };
+}
+
+describe("createChannelRegistryLoader", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(createEmptyPluginRegistry(), "test-empty");
+  });
+
+  it("caches undefined resolver results", async () => {
+    const resolveValue = vi.fn((entry: PluginChannelRegistration) => entry.plugin.outbound);
+    const load = createChannelRegistryLoader(resolveValue);
+
+    const registry = createEmptyPluginRegistry();
+    registry.channels = [channelEntry("feishu")];
+    setActivePluginRegistry(registry, "test-undefined");
+
+    await expect(load("feishu")).resolves.toBeUndefined();
+    await expect(load("feishu")).resolves.toBeUndefined();
+    expect(resolveValue).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches misses for unknown channel ids", async () => {
+    const load = createChannelRegistryLoader(() => ({ ok: true }));
+
+    const registry = createEmptyPluginRegistry();
+    const channels = [channelEntry("telegram")];
+    const findSpy = vi.spyOn(channels, "find");
+    registry.channels = channels;
+    setActivePluginRegistry(registry, "test-miss");
+
+    await expect(load("missing-channel")).resolves.toBeUndefined();
+    await expect(load("missing-channel")).resolves.toBeUndefined();
+    expect(findSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates miss cache when registry changes", async () => {
+    const resolveValue = vi.fn((entry: PluginChannelRegistration) => entry.plugin.outbound);
+    const load = createChannelRegistryLoader(resolveValue);
+
+    const registryA = createEmptyPluginRegistry();
+    registryA.channels = [channelEntry("slack")];
+    setActivePluginRegistry(registryA, "test-a");
+
+    await expect(load("discord")).resolves.toBeUndefined();
+
+    const outboundAdapter = { send: vi.fn() };
+    const registryB = createEmptyPluginRegistry();
+    registryB.channels = [channelEntry("discord", outboundAdapter)];
+    setActivePluginRegistry(registryB, "test-b");
+
+    await expect(load("discord")).resolves.toBe(outboundAdapter);
+    expect(resolveValue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -9,7 +9,8 @@ type ChannelRegistryValueResolver<TValue> = (
 export function createChannelRegistryLoader<TValue>(
   resolveValue: ChannelRegistryValueResolver<TValue>,
 ): (id: ChannelId) => Promise<TValue | undefined> {
-  const cache = new Map<ChannelId, TValue>();
+  const CACHE_MISS = Symbol("channel-registry-loader-miss");
+  const cache = new Map<ChannelId, TValue | typeof CACHE_MISS>();
   let lastRegistry: PluginRegistry | null = null;
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
@@ -18,18 +19,17 @@ export function createChannelRegistryLoader<TValue>(
       cache.clear();
       lastRegistry = registry;
     }
-    const cached = cache.get(id);
-    if (cached) {
-      return cached;
+    if (cache.has(id)) {
+      const cached = cache.get(id);
+      return cached === CACHE_MISS ? undefined : cached;
     }
     const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
     if (!pluginEntry) {
+      cache.set(id, CACHE_MISS);
       return undefined;
     }
     const resolved = resolveValue(pluginEntry);
-    if (resolved) {
-      cache.set(id, resolved);
-    }
+    cache.set(id, resolved === undefined ? CACHE_MISS : resolved);
     return resolved;
   };
 }


### PR DESCRIPTION
## Summary
- add explicit miss sentinel caching in `createChannelRegistryLoader`
- switch to `cache.has()` so cached falsey/undefined results are handled correctly
- preserve existing cache invalidation when active plugin registry instance changes
- add focused tests for undefined-result caching, miss caching, and registry-change invalidation

## Why
`createChannelRegistryLoader` previously cached only truthy resolved values. For channels that intentionally resolve to `undefined` (for example, no outbound adapter) and for unknown channel ids, every lookup rescanned `registry.channels`. This is avoidable hot-path work.

## Validation
- `pnpm vitest src/channels/plugins/registry-loader.test.ts`
