### PR TITLE
feat(cli): add --session-key option to openclaw agent command

### DIFF
--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -26,6 +26,7 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
     .requiredOption("-m, --message <text>", "Message body for the agent")
     .option("-t, --to <number>", "Recipient number in E.164 used to derive the session key")
     .option("--session-id <id>", "Use an explicit session id")
+    .option("--session-key <key>", "Use an explicit session key (overrides --to routing)")
     .option("--agent <id>", "Agent id (overrides routing bindings)")
     .option("--thinking <level>", "Thinking level: off | minimal | low | medium | high")
     .option("--verbose <on|off>", "Persist agent verbose level for the session")
@@ -58,6 +59,10 @@ ${formatHelpExamples([
   [
     'openclaw agent --session-id 1234 --message "Summarize inbox" --thinking medium',
     "Target a session with explicit thinking level.",
+  ],
+  [
+    'openclaw agent --agent dev --session-key "agent:dev:telegram:group:-100123456789" --message "Start implementation" --deliver --channel telegram',
+    "Target a specific agent group-chat session.",
   ],
   [
     'openclaw agent --to +15555550123 --message "Trace logs" --verbose on --json',

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -37,6 +37,7 @@ export type AgentCliOpts = {
   agent?: string;
   to?: string;
   sessionId?: string;
+  sessionKey?: string;
   thinking?: string;
   verbose?: string;
   json?: boolean;
@@ -89,8 +90,10 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
   if (!body) {
     throw new Error("Message (--message) is required");
   }
-  if (!opts.to && !opts.sessionId && !opts.agent) {
-    throw new Error("Pass --to <E.164>, --session-id, or --agent to choose a session");
+  if (!opts.to && !opts.sessionId && !opts.sessionKey && !opts.agent) {
+    throw new Error(
+      "Pass --to <E.164>, --session-id, --session-key, or --agent to choose a session",
+    );
   }
 
   const cfg = loadConfig();
@@ -115,6 +118,7 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
     agentId,
     to: opts.to,
     sessionId: opts.sessionId,
+    sessionKey: opts.sessionKey,
   }).sessionKey;
 
   const channel = normalizeMessageChannel(opts.channel);


### PR DESCRIPTION
## Summary

- **Problem:** The `openclaw agent` CLI has no way to target a specific session by its full key. `--to` derives a key from the default agent (ignoring `--agent`), `--session-id` treats the message as a continue, and there is no direct override path for scripts or multi-agent group-chat coordination.
- **Why it matters:** External systems (MCP servers, CI pipelines, cron scripts) that need to dispatch a message into a specific agent's group-chat session have no reliable CLI path. This blocks multi-agent collaboration workflows.
- **What changed:** Added `--session-key <key>` CLI option to `register.agent.ts` and wired it through `AgentCliOpts` and `resolveSessionKeyForRequest` in `agent-via-gateway.ts`. The RPC layer (`server-methods/agent.ts`) and session resolution (`agent/session.ts`) already accept `sessionKey` — this change just exposes the existing capability through the CLI.
- **What did NOT change:** No changes to the RPC layer, session resolution logic, gateway protocol schema, or any channel/delivery code. The `--local` embedded path also receives the new option via `localOpts` spread.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36401

## User-visible / Behavior Changes

- New CLI option: `openclaw agent --session-key "agent:dev:telegram:group:-100123456789" -m "message"` routes the message to the exact session key.
- The session selector validation now accepts `--session-key` as a valid alternative to `--to`, `--session-id`, or `--agent`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.3 (arm64)
- Runtime: Node.js 22
- Integration/channel: CLI

### Steps

1. Run `openclaw agent --session-key "agent:main:telegram:group:-100xxx" -m "test" --deliver --channel telegram`
2. Verify the message is routed to the specified session key

### Expected

- Message is dispatched to the exact session key provided

### Actual

- Before fix: `--session-key` option does not exist; must use `--to` (wrong key derivation) or `--session-id` (continue semantics)
- After fix: `--session-key` routes to the specified session

## Evidence

TypeScript compiles cleanly. The change is pure wiring — `resolveSessionKeyForRequest` already handles `sessionKey` at line 46–53 of `agent/session.ts`, and `callGateway` params already forward `sessionKey` at line 138 of `agent-via-gateway.ts`.

## Human Verification (required)

- Verified scenarios: TypeScript compilation passes; `AgentCliOpts` type now includes `sessionKey`; `resolveSessionKeyForRequest` receives the new field; session selector validation accepts `--session-key` as sufficient.
- Edge cases checked: `--session-key` combined with `--to` (sessionKey takes priority in `resolveSessionKeyForRequest`); `--session-key` without `--agent` (works, key is used directly); empty/whitespace `--session-key` (trimmed to empty, falls through to normal resolution).
- What I did **not** verify: Live multi-agent group-chat dispatch (requires running gateway + configured agents + Telegram group).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; the `--session-key` option is removed.
- Files/config to restore: `src/cli/program/register.agent.ts`, `src/commands/agent-via-gateway.ts`
- Known bad symptoms: None expected — existing behavior is unchanged when `--session-key` is not provided.

## Risks and Mitigations

None. This is pure CLI wiring that exposes an existing, already-tested capability (`resolveSessionKeyForRequest` with `sessionKey` + RPC `sessionKey` param).

