### PR TITLE
fix(security): include Gemini, Grok, and Kimi in web search key audit

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -329,7 +329,17 @@ function resolveToolPolicies(params: {
 function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
   return Boolean(
-    search?.apiKey || search?.perplexity?.apiKey || env.BRAVE_API_KEY || env.PERPLEXITY_API_KEY,
+    search?.apiKey ||
+    search?.perplexity?.apiKey ||
+    search?.gemini?.apiKey ||
+    search?.grok?.apiKey ||
+    search?.kimi?.apiKey ||
+    env.BRAVE_API_KEY ||
+    env.PERPLEXITY_API_KEY ||
+    env.GEMINI_API_KEY ||
+    env.XAI_API_KEY ||
+    env.KIMI_API_KEY ||
+    env.MOONSHOT_API_KEY,
   );
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** `hasWebSearchKey` only checks Brave and Perplexity API keys, missing three other supported web search providers (Gemini, Grok, Kimi). Users who configure only one of these providers get false-negative audit results.
- **Why it matters:** `collectSmallModelRiskFindings` uses `isWebSearchEnabled` (which calls `hasWebSearchKey`) to determine if web search is available. With Gemini/Grok/Kimi-only configs, the audit incorrectly reports no web search capability.
- **What changed:** Extended `hasWebSearchKey` to check config keys for all 5 providers and their env var equivalents.
- **What did NOT change:** Audit logic, risk findings, or any other security audit function.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34509

## User-visible / Behavior Changes

- Security audit now correctly detects Gemini, Grok, and Kimi web search provider keys in addition to Brave and Perplexity.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22
- Integration/channel: Any

### Steps

1. Configure only `tools.web.search.gemini.apiKey` in openclaw config
2. Run security audit

### Expected

- Audit recognizes web search as available

### Actual

- Before fix: Audit reports no web search key found
- After fix: Audit correctly detects the Gemini key

## Evidence

```
 src/security/audit-extra.sync.ts | 12 +++++++++++-
 1 file changed, 11 insertions(+), 1 deletion(-)
```

`SEARCH_PROVIDERS` in `web-search.ts` defines 5 providers: `["brave", "perplexity", "grok", "gemini", "kimi"]`. The audit now checks all 5.

## Human Verification (required)

- Verified scenarios: Gemini-only config, Grok-only config, Kimi-only config, MOONSHOT_API_KEY env var
- Edge cases checked: Multiple providers configured simultaneously, existing Brave/Perplexity behavior unchanged
- What I did **not** verify: End-to-end audit output rendering in TUI

## Compatibility / Migration

- Backward compatible? `Yes — purely additive check`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/security/audit-extra.sync.ts`
- Known bad symptoms: Only effect would be audit false negatives return for Gemini/Grok/Kimi users

## Risks and Mitigations

- None. This is a purely additive check that cannot break existing behavior.