### PR TITLE
fix(feishu): add 30s timeout to all send/reply/edit API calls

### DIFF
--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -9,6 +9,32 @@ import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result
 import { resolveFeishuSendTarget } from "./send-target.js";
 import type { FeishuSendResult } from "./types.js";
 
+/** Default HTTP-level timeout for Feishu API calls (ms). */
+const FEISHU_SEND_TIMEOUT_MS = 30_000;
+
+/**
+ * Race a promise against a timeout.  Prevents a hanging Feishu API call from
+ * permanently blocking the per-chat send queue (see #36412).
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number = FEISHU_SEND_TIMEOUT_MS): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`Feishu API request timed out after ${ms}ms`)),
+      ms,
+    );
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      },
+    );
+  });
+}
+
 const WITHDRAWN_REPLY_ERROR_CODES = new Set([230011, 231003]);
 
 function shouldFallbackFromReplyTarget(response: { code?: number; msg?: string }): boolean {
@@ -62,14 +88,16 @@ async function sendFallbackDirect(
   },
   errorPrefix: string,
 ): Promise<FeishuSendResult> {
-  const response = await client.im.message.create({
-    params: { receive_id_type: params.receiveIdType },
-    data: {
-      receive_id: params.receiveId,
-      content: params.content,
-      msg_type: params.msgType,
-    },
-  });
+  const response = await withTimeout(
+    client.im.message.create({
+      params: { receive_id_type: params.receiveIdType },
+      data: {
+        receive_id: params.receiveId,
+        content: params.content,
+        msg_type: params.msgType,
+      },
+    }),
+  );
   assertFeishuMessageApiSuccess(response, errorPrefix);
   return toFeishuSendResult(response, params.receiveId);
 }
@@ -175,9 +203,11 @@ export async function getMessageFeishu(params: {
   const client = createFeishuClient(account);
 
   try {
-    const response = (await client.im.message.get({
-      path: { message_id: messageId },
-    })) as {
+    const response = (await withTimeout(
+      client.im.message.get({
+        path: { message_id: messageId },
+      }),
+    )) as {
       code?: number;
       msg?: string;
       data?: {
@@ -299,14 +329,16 @@ export async function sendMessageFeishu(
   if (replyToMessageId) {
     let response: { code?: number; msg?: string; data?: { message_id?: string } };
     try {
-      response = await client.im.message.reply({
-        path: { message_id: replyToMessageId },
-        data: {
-          content,
-          msg_type: msgType,
-          ...(replyInThread ? { reply_in_thread: true } : {}),
-        },
-      });
+      response = await withTimeout(
+        client.im.message.reply({
+          path: { message_id: replyToMessageId },
+          data: {
+            content,
+            msg_type: msgType,
+            ...(replyInThread ? { reply_in_thread: true } : {}),
+          },
+        }),
+      );
     } catch (err) {
       if (!isWithdrawnReplyError(err)) {
         throw err;
@@ -343,14 +375,16 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
   if (replyToMessageId) {
     let response: { code?: number; msg?: string; data?: { message_id?: string } };
     try {
-      response = await client.im.message.reply({
-        path: { message_id: replyToMessageId },
-        data: {
-          content,
-          msg_type: "interactive",
-          ...(replyInThread ? { reply_in_thread: true } : {}),
-        },
-      });
+      response = await withTimeout(
+        client.im.message.reply({
+          path: { message_id: replyToMessageId },
+          data: {
+            content,
+            msg_type: "interactive",
+            ...(replyInThread ? { reply_in_thread: true } : {}),
+          },
+        }),
+      );
     } catch (err) {
       if (!isWithdrawnReplyError(err)) {
         throw err;
@@ -382,10 +416,12 @@ export async function updateCardFeishu(params: {
   const client = createFeishuClient(account);
   const content = JSON.stringify(card);
 
-  const response = await client.im.message.patch({
-    path: { message_id: messageId },
-    data: { content },
-  });
+  const response = await withTimeout(
+    client.im.message.patch({
+      path: { message_id: messageId },
+      data: { content },
+    }),
+  );
 
   if (response.code !== 0) {
     throw new Error(`Feishu card update failed: ${response.msg || `code ${response.code}`}`);
@@ -463,13 +499,15 @@ export async function editMessageFeishu(params: {
 
   const { content, msgType } = buildFeishuPostMessagePayload({ messageText });
 
-  const response = await client.im.message.update({
-    path: { message_id: messageId },
-    data: {
-      msg_type: msgType,
-      content,
-    },
-  });
+  const response = await withTimeout(
+    client.im.message.update({
+      path: { message_id: messageId },
+      data: {
+        msg_type: msgType,
+        content,
+      },
+    }),
+  );
 
   if (response.code !== 0) {
     throw new Error(`Feishu message edit failed: ${response.msg || `code ${response.code}`}`);

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveStateDir } from "../config/paths.js";
+import { writeJsonAtomic } from "./json-files.js";
 
 export type RestartSentinelLog = {
   stdoutTail?: string | null;
@@ -67,9 +68,8 @@ export async function writeRestartSentinel(
   env: NodeJS.ProcessEnv = process.env,
 ) {
   const filePath = resolveRestartSentinelPath(env);
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
   const data: RestartSentinel = { version: 1, payload };
-  await fs.writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+  await writeJsonAtomic(filePath, data, { trailingNewline: true });
   return filePath;
 }
 


### PR DESCRIPTION
## Summary

Adds a 30-second timeout to all Feishu Lark SDK API calls in `send.ts` (`create`, `get`, `reply`, `patch`, `update`).

## Problem

When the Feishu API hangs or responds slowly, the Promise from the SDK call never settles. Since message processing is serialized per `chatId`, a single stuck request permanently blocks all subsequent messages in that chat — a silent deadlock that only a gateway restart can fix.

## Fix

Wraps every SDK call with a `withTimeout()` helper using `Promise.race`. If the API doesn't respond within 30 seconds, the promise rejects with a clear error, allowing the per-chat queue to recover.

Closes #36412