### PR TITLE
fix(agents): skip compaction API call when session has no real messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/compaction safeguard pre-check: skip embedded compaction before entering the Pi SDK when a session has no real conversation messages, avoiding unnecessary LLM API calls on idle sessions. (#36451) thanks @Sid-Qin.
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Feishu/group slash command detection: normalize group mention wrappers before command-authorization probing so mention-prefixed commands (for example `@Bot/model` and `@Bot /reset`) are recognized as gateway commands instead of being forwarded to the agent. (#35994) Thanks @liuxiaopai-ai.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -132,6 +132,10 @@ type CompactionMessageMetrics = {
   contributors: Array<{ role: string; chars: number; tool?: string }>;
 };
 
+function hasRealConversationContent(msg: AgentMessage): boolean {
+  return msg.role === "user" || msg.role === "assistant" || msg.role === "toolResult";
+}
+
 function createCompactionDiagId(): string {
   return `cmp-${Date.now().toString(36)}-${generateSecureToken(4)}`;
 }
@@ -661,6 +665,17 @@ export async function compactEmbeddedPiSessionDirect(
           log.debug(
             `[compaction-diag] contributors diagId=${diagId} top=${JSON.stringify(preMetrics.contributors)}`,
           );
+        }
+
+        if (!session.messages.some(hasRealConversationContent)) {
+          log.info(
+            `[compaction] skipping — no real conversation messages (sessionKey=${params.sessionKey ?? params.sessionId})`,
+          );
+          return {
+            ok: true,
+            compacted: false,
+            reason: "no real conversation messages",
+          };
         }
 
         const compactStartedAt = Date.now();


### PR DESCRIPTION
## Summary

- **Problem:** With `compaction.mode: "safeguard"`, the compaction timer fires every ~30 minutes on all active sessions including idle cron sessions. The safeguard extension correctly cancels compaction when there are no real conversation messages, but the cancellation happens inside the Pi SDK's `session_before_compact` event — after the SDK has already initiated an LLM API call (~33k prompt tokens).
- **Why it matters:** Wastes ~48 unnecessary API calls/day on a typical setup with multiple idle sessions. Each call costs ~33k prompt tokens.
- **What changed:** Added a local pre-check in `compactEmbeddedPiSessionDirect` that bails out before calling `session.compact()` when no user/assistant/toolResult messages exist.
- **What did NOT change:** The safeguard extension still provides the same check as a second layer. Sessions with real messages compact normally.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34935

## User-visible / Behavior Changes

- Idle cron sessions no longer trigger unnecessary LLM API calls for compaction.
- Gateway logs show `[compaction] skipping — no real conversation messages` instead of the safeguard cancellation message.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes — eliminates unnecessary outbound LLM API calls for empty sessions`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22
- Integration/channel: Any with compaction.mode: "safeguard"

### Steps

1. Configure any agent with `compaction.mode: "safeguard"` and a remote LLM provider
2. Set up one or more isolated cron jobs
3. Leave the system running idle between scheduled jobs
4. Observe gateway logs

### Expected

- No LLM API calls for empty sessions; log shows `[compaction] skipping`

### Actual

- Before fix: LLM API calls fire every ~30 minutes, safeguard cancels after round-trip
- After fix: Pre-check prevents the API call entirely

## Evidence

```
 src/agents/pi-embedded-runner/compact.ts | 15 +++++++++++++++
 1 file changed, 15 insertions(+)
```

Added `hasRealConversationContent()` helper (mirrors the check in `compaction-safeguard.ts`) and early-exit before `session.compact()`.

## Human Verification (required)

- Verified scenarios: Empty session skips compaction, sessions with real messages still compact
- Edge cases checked: System-only messages (no user/assistant/toolResult), mixed message types
- What I did **not** verify: Long-running production deployment with multiple idle sessions

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/agents/pi-embedded-runner/compact.ts`
- Known bad symptoms: Only effect would be unnecessary API calls return for empty sessions (pre-existing behavior)

## Risks and Mitigations

- **Risk:** Overly aggressive skip could prevent compaction on sessions that need it → **Mitigated:** Check uses the exact same criteria as the safeguard extension (`user`, `assistant`, `toolResult` roles)
- **Risk:** Race condition if messages arrive between check and compact call → **Mitigated:** Compaction runs under a session lock; new messages cannot be added during the check