### PR TITLE
feat(gateway): make stale-socket detection threshold configurable

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -97,6 +97,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Explicit gateway-level tool denylist to block risky tools even if lower-level policies allow them. Use deny rules for emergency response and defense-in-depth hardening.",
   "gateway.channelHealthCheckMinutes":
     "Interval in minutes for automatic channel health probing and status updates. Use lower intervals for faster detection, or higher intervals to reduce periodic probe noise.",
+  "gateway.staleEventThresholdMinutes":
+    "Duration in minutes a connected channel can be idle (no application events) before the health monitor flags it as a stale socket and restarts it. Increase for low-traffic channels that are falsely detected as dead. Default: 30.",
   "gateway.tailscale":
     "Tailscale integration settings for Serve/Funnel exposure and lifecycle handling on gateway start/exit. Keep off unless your deployment intentionally relies on Tailscale ingress.",
   "gateway.tailscale.mode":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -84,6 +84,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.tools.allow": "Gateway Tool Allowlist",
   "gateway.tools.deny": "Gateway Tool Denylist",
   "gateway.channelHealthCheckMinutes": "Gateway Channel Health Check Interval (min)",
+  "gateway.staleEventThresholdMinutes": "Gateway Stale Socket Detection Threshold (min)",
   "gateway.tailscale": "Gateway Tailscale",
   "gateway.tailscale.mode": "Gateway Tailscale Mode",
   "gateway.tailscale.resetOnExit": "Gateway Tailscale Reset on Exit",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -364,4 +364,11 @@ export type GatewayConfig = {
    * Set to 0 to disable. Default: 5.
    */
   channelHealthCheckMinutes?: number;
+  /**
+   * Stale-socket detection threshold in minutes.
+   * A connected channel with no events for this long is flagged as stale-socket
+   * and restarted by the health monitor. Set higher for low-traffic channels.
+   * Default: 30.
+   */
+  staleEventThresholdMinutes?: number;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -653,6 +653,7 @@ export const OpenClawSchema = z
           .strict()
           .optional(),
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
+        staleEventThresholdMinutes: z.number().int().min(1).optional(),
         tailscale: z
           .object({
             mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -41,6 +41,11 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     kind: "hot",
     actions: ["restart-health-monitor"],
   },
+  {
+    prefix: "gateway.staleEventThresholdMinutes",
+    kind: "hot",
+    actions: ["restart-health-monitor"],
+  },
   // Stuck-session warning threshold is read by the diagnostics heartbeat loop.
   { prefix: "diagnostics.stuckSessionWarnMs", kind: "none" },
   { prefix: "hooks.gmail", kind: "hot", actions: ["restart-gmail-watcher"] },

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -47,7 +47,7 @@ export function createGatewayReloadHandlers(params: {
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
   logCron: { error: (msg: string) => void };
   logReload: { info: (msg: string) => void; warn: (msg: string) => void };
-  createHealthMonitor: (checkIntervalMs: number) => ChannelHealthMonitor;
+  createHealthMonitor: (checkIntervalMs: number, staleEventThresholdMs?: number) => ChannelHealthMonitor;
 }) {
   const applyHotReload = async (
     plan: GatewayReloadPlan,
@@ -97,8 +97,14 @@ export function createGatewayReloadHandlers(params: {
     if (plan.restartHealthMonitor) {
       state.channelHealthMonitor?.stop();
       const minutes = nextConfig.gateway?.channelHealthCheckMinutes;
+      const staleMinutes = nextConfig.gateway?.staleEventThresholdMinutes;
       nextState.channelHealthMonitor =
-        minutes === 0 ? null : params.createHealthMonitor((minutes ?? 5) * 60_000);
+        minutes === 0
+          ? null
+          : params.createHealthMonitor(
+              (minutes ?? 5) * 60_000,
+              staleMinutes != null ? staleMinutes * 60_000 : undefined,
+            );
     }
 
     if (plan.restartGmailWatcher) {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -691,12 +691,15 @@ export async function startGatewayServer(
     : startHeartbeatRunner({ cfg: cfgAtStart });
 
   const healthCheckMinutes = cfgAtStart.gateway?.channelHealthCheckMinutes;
+  const staleThresholdMinutes = cfgAtStart.gateway?.staleEventThresholdMinutes;
   const healthCheckDisabled = healthCheckMinutes === 0;
   let channelHealthMonitor = healthCheckDisabled
     ? null
     : startChannelHealthMonitor({
         channelManager,
         checkIntervalMs: (healthCheckMinutes ?? 5) * 60_000,
+        staleEventThresholdMs:
+          staleThresholdMinutes != null ? staleThresholdMinutes * 60_000 : undefined,
       });
 
   if (!minimalTestGateway) {
@@ -906,8 +909,8 @@ export async function startGatewayServer(
           logChannels,
           logCron,
           logReload,
-          createHealthMonitor: (checkIntervalMs: number) =>
-            startChannelHealthMonitor({ channelManager, checkIntervalMs }),
+          createHealthMonitor: (checkIntervalMs: number, staleEventThresholdMs?: number) =>
+            startChannelHealthMonitor({ channelManager, checkIntervalMs, staleEventThresholdMs }),
         });
 
         return startGatewayConfigReloader({


### PR DESCRIPTION
## Summary

- **Problem:** The channel health monitor hardcodes a 30-minute stale-socket detection window (`DEFAULT_STALE_EVENT_THRESHOLD_MS`). Low-traffic channels (e.g. Feishu during off-peak hours) are falsely flagged as dead, causing destructive WebSocket restart cycles that drop messages arriving during the ~1s restart window.
- **Why it matters:** Operators have no way to tune this threshold without patching dist files. The only alternative is `channelHealthCheckMinutes: 0`, which disables the entire health monitor — losing detection of genuinely dead connections.
- **What changed:** Added `gateway.staleEventThresholdMinutes` to the config schema (Zod + TypeScript type), wired it through gateway startup and hot-reload to the existing `staleEventThresholdMs` parameter that `startChannelHealthMonitor` already accepts but no caller previously passed. Added config labels, help text, and a hot-reload rule so the threshold can be changed without restart.
- **What did NOT change:** The default behavior is unchanged (30 minutes when unset). No changes to `evaluateChannelHealth`, `resolveChannelRestartReason`, or any channel provider code. The health monitor's restart logic is unmodified.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35532

## User-visible / Behavior Changes

- New config option: `gateway.staleEventThresholdMinutes` (integer >= 1, optional, default 30).
- Hot-reloadable: changing the value restarts the health monitor with the new threshold, no gateway restart needed.
- Example config:
  ```json
  {
    "gateway": {
      "channelHealthCheckMinutes": 5,
      "staleEventThresholdMinutes": 60
    }
  }
  ```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 26.3 (arm64)
- Runtime: Node.js 22
- Integration/channel: Any channel with health monitoring (Feishu, Telegram, Discord, etc.)

### Steps

1. Set `gateway.staleEventThresholdMinutes: 60` in `openclaw.json`
2. Start the gateway
3. Observe that idle channels are not flagged as stale-socket until 60 minutes of inactivity

### Expected

- Channel survives 30+ minutes of idle without being restarted

### Actual

- Before fix: channel is restarted after 30 minutes of idle (hardcoded)
- After fix: channel is restarted after 60 minutes of idle (configurable)

## Evidence

TypeScript compiles cleanly. All related tests pass:

```
 ✓ src/gateway/channel-health-policy.test.ts (7 tests) 2ms
 ✓ src/gateway/config-reload.test.ts (22 tests) 7ms
 ✓ src/config/config-misc.test.ts (29 tests) 40ms
   Tests  58 passed (58)
```

Files changed (7): `zod-schema.ts`, `types.gateway.ts`, `schema.labels.ts`, `schema.help.ts`, `server.impl.ts`, `server-reload-handlers.ts`, `config-reload-plan.ts`.

## Human Verification (required)

- Verified scenarios: Config validates with `staleEventThresholdMinutes: 60`; value flows through gateway startup to `startChannelHealthMonitor`; hot-reload picks up changes and restarts the health monitor with the new threshold.
- Edge cases checked: Omitting the field uses the existing 30-minute default; `min(1)` prevents setting to 0 (use `channelHealthCheckMinutes: 0` to disable the monitor entirely); hot-reload with `channelHealthCheckMinutes: 0` disables the monitor regardless of `staleEventThresholdMinutes`.
- What I did **not** verify: Live multi-channel setup with actual stale-socket detection at configured threshold (requires running gateway + multiple channel connections + extended idle period).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` (new optional field, existing behavior unchanged)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `staleEventThresholdMinutes` from config; the 30-minute default is restored.
- Files/config to restore: Revert this commit.
- Known bad symptoms: None expected — the parameter is already supported by `startChannelHealthMonitor`; this change just exposes it to config.

## Risks and Mitigations

- Risk: Setting a very high threshold could delay detection of genuinely dead connections. Mitigation: The `channelHealthCheckMinutes` interval still runs and checks other health indicators (not-running, disconnected); stale-socket is just one of several detection paths. The `min(1)` constraint prevents setting to 0.

