### PR TITLE
perf(media): short-circuit oversized responses via Content-Length

### DIFF
--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -64,6 +64,36 @@ describe("fetchWithGuard", () => {
     expect(canceled).toBe(true);
     expect(release).toHaveBeenCalledTimes(1);
   });
+
+  it("rejects oversized payloads from content-length before reading the stream", async () => {
+    const stream = new ReadableStream<Uint8Array>({});
+    const getReaderSpy = vi.spyOn(stream, "getReader");
+
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(stream, {
+        status: 200,
+        headers: {
+          "content-type": "application/octet-stream",
+          "content-length": "7",
+        },
+      }),
+      release,
+      finalUrl: "https://example.com/file.bin",
+    });
+
+    await expect(
+      fetchWithGuard({
+        url: "https://example.com/file.bin",
+        maxBytes: 6,
+        timeoutMs: 1000,
+        maxRedirects: 0,
+      }),
+    ).rejects.toThrow("Content too large");
+
+    expect(getReaderSpy).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("base64 size guards", () => {

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -10,6 +10,14 @@ export async function readResponseWithLimit(
     ((params: { size: number; maxBytes: number }) =>
       new Error(`Content too large: ${params.size} bytes (limit: ${params.maxBytes} bytes)`));
 
+  const contentLength = res.headers.get("content-length");
+  if (contentLength) {
+    const size = Number(contentLength);
+    if (Number.isFinite(size) && size > maxBytes) {
+      throw onOverflow({ size, maxBytes, res });
+    }
+  }
+
   const body = res.body;
   if (!body || typeof body.getReader !== "function") {
     const fallback = Buffer.from(await res.arrayBuffer());


### PR DESCRIPTION
## Summary
- short-circuit `readResponseWithLimit` when `Content-Length` already exceeds `maxBytes`
- avoid opening a stream reader for guaranteed-overflow payloads
- add regression coverage in `input-files.fetch-guard.test.ts` to assert no stream read happens

## Why
This reduces unnecessary stream work and memory pressure on media fetch paths when servers provide an oversized `Content-Length` header.

## Risk
Low: behavior for missing/invalid `Content-Length` is unchanged, and existing overflow signaling remains intact.
