### PR TITLE
fix(synology-chat): propagate delivery failure from dispatch callback

### DIFF
--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -45,6 +45,9 @@ vi.mock("zod", () => ({
 
 const { createSynologyChatPlugin } = await import("./channel.js");
 const { registerPluginHttpRoute } = await import("openclaw/plugin-sdk/synology-chat");
+const { sendMessage: sendMessageMock } = await import("./client.js");
+const { createWebhookHandler: createWebhookHandlerMock } = await import("./webhook-handler.js");
+const { getSynologyRuntime: getSynologyRuntimeMock } = await import("./runtime.js");
 
 describe("createSynologyChatPlugin", () => {
   it("returns a plugin object with all required sections", () => {
@@ -397,6 +400,82 @@ describe("createSynologyChatPlugin", () => {
       expect(registerMock).not.toHaveBeenCalled();
       abortController.abort();
       await result;
+    });
+
+    it("dispatch deliver throws when sendMessage fails", async () => {
+      // Capture the outer deliver function passed to createWebhookHandler
+      let outerDeliver: ((msg: any) => Promise<any>) | undefined;
+      vi.mocked(createWebhookHandlerMock).mockImplementation((opts: any) => {
+        outerDeliver = opts.deliver;
+        return vi.fn();
+      });
+
+      // Mock runtime so dispatchReplyWithBufferedBlockDispatcher invokes the inner deliver
+      vi.mocked(getSynologyRuntimeMock).mockReturnValue({
+        config: { loadConfig: vi.fn().mockResolvedValue({}) },
+        channel: {
+          reply: {
+            finalizeInboundContext: vi.fn((ctx: any) => ctx),
+            dispatchReplyWithBufferedBlockDispatcher: vi.fn(async (opts: any) => {
+              await opts.dispatcherOptions.deliver({ text: "chunk" });
+              return { counts: {} };
+            }),
+          },
+        },
+      } as any);
+
+      // Make sendMessage return false (all retries exhausted)
+      vi.mocked(sendMessageMock).mockResolvedValue(false);
+
+      const plugin = createSynologyChatPlugin();
+      const abortController = new AbortController();
+      const ctx = {
+        cfg: {
+          channels: {
+            "synology-chat": {
+              enabled: true,
+              token: "t",
+              incomingUrl: "https://nas/incoming",
+              webhookPath: "/webhook/synology",
+              dmPolicy: "open",
+            },
+          },
+        },
+        accountId: "default",
+        log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+        abortSignal: abortController.signal,
+      };
+
+      const startPromise = plugin.gateway.startAccount(ctx);
+      await new Promise((r) => setTimeout(r, 10));
+      expect(outerDeliver).toBeDefined();
+
+      await expect(
+        outerDeliver!({
+          body: "test",
+          from: "user1",
+          chatUserId: 4,
+          sessionKey: "default:synology-chat:user1",
+          chatType: "direct",
+          senderName: "Tester",
+        }),
+      ).rejects.toThrow("Failed to deliver message chunk");
+
+      // Restore mocks for subsequent tests
+      vi.mocked(sendMessageMock).mockResolvedValue(true);
+      vi.mocked(createWebhookHandlerMock).mockImplementation(() => vi.fn());
+      vi.mocked(getSynologyRuntimeMock).mockReturnValue({
+        config: { loadConfig: vi.fn().mockResolvedValue({}) },
+        channel: {
+          reply: {
+            dispatchReplyWithBufferedBlockDispatcher: vi.fn().mockResolvedValue({ counts: {} }),
+          },
+        },
+      } as any);
+      vi.mocked(registerPluginHttpRoute).mockClear();
+
+      abortController.abort();
+      await startPromise;
     });
 
     it("deregisters stale route before re-registering same account/path", async () => {

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -293,12 +293,15 @@ export function createSynologyChatPlugin() {
                 deliver: async (payload: { text?: string; body?: string }) => {
                   const text = payload?.text ?? payload?.body;
                   if (text) {
-                    await sendMessage(
+                    const ok = await sendMessage(
                       account.incomingUrl,
                       text,
                       sendUserId,
                       account.allowInsecureSsl,
                     );
+                    if (!ok) {
+                      throw new Error("Failed to deliver message chunk to Synology Chat");
+                    }
                   }
                 },
                 onReplyStart: () => {


### PR DESCRIPTION
## Summary

- Problem: The `deliver` callback inside `dispatchReplyWithBufferedBlockDispatcher` silently discards `sendMessage` failures. When `sendMessage` returns `false` (after exhausting retries), the callback does not throw, so the SDK considers delivery successful and skips the chunk.
- Why it matters: Long agent responses are split into chunks; any silently dropped chunk causes permanent message loss. Users report receiving truncated replies with large sections missing (e.g. lines 164–549 of a response vanish).
- What changed: The dispatcher's `deliver` callback now checks `sendMessage`'s return value and throws on failure, matching the existing `outbound.sendText` error-propagation pattern.
- What did NOT change (scope boundary): `sendMessage` retry logic (3 attempts, exponential backoff), `outbound.sendText`/`sendMedia` paths, webhook handler, rate limiter, chunking limit.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #36439

## User-visible / Behavior Changes

When Synology Chat's incoming webhook API rejects a message chunk (after 3 retry attempts), the error now surfaces instead of being swallowed. This means:
- The SDK can detect the failure and log it appropriately
- Users see an error indication instead of silently missing content

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Integration/channel: Synology Chat

### Steps

1. Configure Synology Chat channel
2. Send a message that triggers a long agent response (>2000 chars, multiple chunks)
3. Simulate Synology Chat API returning non-200 for some chunks (e.g. NAS temporarily unreachable)

### Expected

- Error is propagated to the SDK; failed chunks are detectable

### Actual (before fix)

- `sendMessage` returns `false`, callback silently succeeds, chunks permanently lost

## Evidence

- [x] Failing test/log before + passing after

New test `dispatch deliver throws when sendMessage fails` verifies the callback throws when `sendMessage` returns false. All 25 tests pass.

## Human Verification (required)

- Verified scenarios: sendMessage returning false → deliver callback now throws; sendMessage returning true → no behavior change
- Edge cases checked: empty text payload (no sendMessage call, no throw); the `outbound.sendText` path already had this pattern — confirmed consistent
- What you did **not** verify: live Synology NAS environment (no hardware available); interaction with SDK's retry/fallback behavior on deliver throw

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert single commit; the deliver callback returns to fire-and-forget behavior
- Files/config to restore: `extensions/synology-chat/src/channel.ts`
- Known bad symptoms reviewers should watch for: If the SDK does not gracefully handle deliver throws, agent responses could fail entirely instead of partially. However, the SDK's `dispatchReplyWithBufferedBlockDispatcher` is designed to handle deliver errors.

## Risks and Mitigations

- Risk: If the Synology Chat API is intermittently slow (not failing), this change could surface transient errors more aggressively.
  - Mitigation: `sendMessage` already retries 3 times with exponential backoff before returning false, so only persistent failures trigger the throw.