### PR TITLE
fix: handle D-Bus connection failure in container environments

### DIFF
--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -159,7 +159,9 @@ function isSystemctlMissing(detail: string): boolean {
     normalized.includes("not found") ||
     normalized.includes("no such file or directory") ||
     normalized.includes("spawn systemctl enoent") ||
-    normalized.includes("spawn systemctl eacces")
+    normalized.includes("spawn systemctl eacces") ||
+    normalized.includes("failed to connect") ||
+    normalized.includes("dbus_session_bus_address")
   );
 }
 


### PR DESCRIPTION
## Summary
- Detect 'failed to connect' and 'dbus_session_bus_address' errors in `isSystemctlMissing()` to prevent throwing exceptions when `systemctl --user` cannot connect to the D-Bus session bus in containers

## Problem
When running in a container environment without proper D-Bus session bus configuration, `systemctl --user is-enabled` fails with:
```
Failed to connect to user scope bus via local transport: $DBUS_SESSION_BUS_ADDRESS and $XDG_RUNTIME_DIR not defined
```

This error was not being caught by the existing `isSystemctlMissing()` check, causing the gateway service check to fail with an unhandled error.

## Solution
Add detection for "failed to connect" and "dbus_session_bus_address" strings in the error output, so these container-environment errors are treated as systemctl being unavailable (returning false) instead of throwing an exception.