### PR TITLE
fix(security): classify Russian SYSTEM account as trusted

### DIFF
--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -492,6 +492,10 @@ Successfully processed 1 files`;
       expectTrustedOnly([aclEntry({ principal: "AUTORIDAD NT\\SYSTEM" })]);
     });
 
+    it("classifies Russian SYSTEM (NT AUTHORITY\\СИСТЕМА) as trusted", () => {
+      expectTrustedOnly([aclEntry({ principal: "NT AUTHORITY\\СИСТЕМА" })]);
+    });
+
     it("French Windows full scenario: user + Système only → no untrusted", () => {
       const entries: WindowsAclEntry[] = [
         aclEntry({ principal: "MYPC\\Pierre" }),

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -33,11 +33,12 @@ const TRUSTED_BASE = new Set([
   "system",
   "builtin\\administrators",
   "creator owner",
-  // Localized SYSTEM account names (French, German, Spanish, Portuguese)
+  // Localized SYSTEM account names (French, German, Spanish, Portuguese, Russian)
   "autorite nt\\système",
   "nt-autorität\\system",
   "autoridad nt\\system",
   "autoridade nt\\system",
+  "nt authority\\система",
 ]);
 const WORLD_SUFFIXES = ["\\users", "\\authenticated users"];
 const TRUSTED_SUFFIXES = ["\\administrators", "\\system", "\\système"];


### PR DESCRIPTION
## Problem
On Russian Windows systems, the SYSTEM account is displayed as NT AUTHORITY\СИСТЕМА instead of NT AUTHORITY\SYSTEM. The security audit code classifies this as an untrusted principal, causing false positive perms_writable errors.

## Solution
Add the Russian localized SYSTEM account name to the TRUSTED_BASE set.

## Changes
- src/security/windows-acl.ts: Add nt authority\система to TRUSTED_BASE
- src/security/windows-acl.test.ts: Add test for Russian SYSTEM classification

Fixes #35834

---

AI-assisted PR - Testing: untested (CI will verify)