### PR TITLE
fix(agents): guard context pruning text block access for user messages

### DIFF
--- a/src/agents/pi-extensions/context-pruning/pruner.test.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.test.ts
@@ -94,6 +94,27 @@ describe("pruneContextMessages", () => {
     ).not.toThrow();
   });
 
+  it("does not crash on user message with malformed text block (missing text string)", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "user",
+        content: [
+          { type: "text" } as unknown as { type: "text"; text: string },
+          { type: "text", text: "valid part" },
+        ],
+        timestamp: Date.now(),
+      },
+      makeAssistant([{ type: "text", text: "reply" }]),
+    ];
+    expect(() =>
+      pruneContextMessages({
+        messages,
+        settings: DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        ctx: CONTEXT_WINDOW_1M,
+      }),
+    ).not.toThrow();
+  });
+
   it("handles well-formed thinking blocks correctly", () => {
     const messages: AgentMessage[] = [
       makeUser("hello"),

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -16,7 +16,7 @@ function asText(text: string): TextContent {
 function collectTextSegments(content: ReadonlyArray<TextContent | ImageContent>): string[] {
   const parts: string[] = [];
   for (const block of content) {
-    if (block.type === "text") {
+    if (block.type === "text" && typeof block.text === "string") {
       parts.push(block.text);
     }
   }
@@ -99,7 +99,7 @@ function hasImageBlocks(content: ReadonlyArray<TextContent | ImageContent>): boo
 function estimateTextAndImageChars(content: ReadonlyArray<TextContent | ImageContent>): number {
   let chars = 0;
   for (const block of content) {
-    if (block.type === "text") {
+    if (block.type === "text" && typeof block.text === "string") {
       chars += block.text.length;
     }
     if (block.type === "image") {


### PR DESCRIPTION
Follows the same pattern as #35146 (guard context pruning against malformed thinking blocks).

`collectTextSegments` and `estimateTextAndImageChars` in the context pruner accessed `block.text` without verifying it is a string. For assistant messages this was already guarded in `estimateMessageChars`, but the user-message path through these shared helpers was not.

A malformed user content block like `{type:'text'}` (missing `text` field) would cause a `TypeError` crash during context pruning, potentially creating a session crash loop.

Adds `typeof block.text === 'string'` guards consistent with the existing assistant-message path. Regression test included.

2 files, +23/-2. 5 tests pass.

---

AI-assisted PR (Claude via OpenClaw agent). I understand what this code does.