### PR TITLE
Perf: prune expired web cache entries before FIFO eviction

### DIFF
--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { writeCache } from "./web-shared.js";
+
+type CacheEntry = {
+  value: string;
+  expiresAt: number;
+  insertedAt: number;
+};
+
+const MAX_CACHE_ENTRIES = 100;
+const TTL_MS = 60_000;
+
+function buildCache(expiredLast = false): Map<string, CacheEntry> {
+  const now = Date.now();
+  const cache = new Map<string, CacheEntry>();
+  for (let i = 0; i < MAX_CACHE_ENTRIES; i += 1) {
+    cache.set(`key-${i}`, {
+      value: `value-${i}`,
+      expiresAt: now + TTL_MS,
+      insertedAt: now + i,
+    });
+  }
+  if (expiredLast) {
+    cache.set("key-99", {
+      value: "value-99",
+      expiresAt: now - 1,
+      insertedAt: now + 99,
+    });
+  }
+  return cache;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("writeCache", () => {
+  it("prunes expired entries before size-based eviction", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    const cache = buildCache(true);
+    writeCache(cache, "key-new", "value-new", TTL_MS);
+
+    expect(cache.has("key-99")).toBe(false);
+    expect(cache.has("key-0")).toBe(true);
+    expect(cache.has("key-new")).toBe(true);
+    expect(cache.size).toBe(MAX_CACHE_ENTRIES);
+  });
+
+  it("evicts the oldest entry when full without expired entries", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    const cache = buildCache(false);
+    writeCache(cache, "key-new", "value-new", TTL_MS);
+
+    expect(cache.has("key-0")).toBe(false);
+    expect(cache.has("key-1")).toBe(true);
+    expect(cache.has("key-new")).toBe(true);
+    expect(cache.size).toBe(MAX_CACHE_ENTRIES);
+  });
+});

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -8,6 +8,14 @@ export const DEFAULT_TIMEOUT_SECONDS = 30;
 export const DEFAULT_CACHE_TTL_MINUTES = 15;
 const DEFAULT_CACHE_MAX_ENTRIES = 100;
 
+function pruneExpiredEntries<T>(cache: Map<string, CacheEntry<T>>, now: number): void {
+  for (const [entryKey, entry] of cache) {
+    if (now > entry.expiresAt) {
+      cache.delete(entryKey);
+    }
+  }
+}
+
 export function resolveTimeoutSeconds(value: unknown, fallback: number): number {
   const parsed = typeof value === "number" && Number.isFinite(value) ? value : fallback;
   return Math.max(1, Math.floor(parsed));
@@ -47,6 +55,8 @@ export function writeCache<T>(
   if (ttlMs <= 0) {
     return;
   }
+  const now = Date.now();
+  pruneExpiredEntries(cache, now);
   if (cache.size >= DEFAULT_CACHE_MAX_ENTRIES) {
     const oldest = cache.keys().next();
     if (!oldest.done) {
@@ -55,8 +65,8 @@ export function writeCache<T>(
   }
   cache.set(key, {
     value,
-    expiresAt: Date.now() + ttlMs,
-    insertedAt: Date.now(),
+    expiresAt: now + ttlMs,
+    insertedAt: now,
   });
 }
 


### PR DESCRIPTION
## Summary
- prune expired entries in web tool cache before size-based FIFO eviction
- keep existing fallback eviction when cache is full and no expired entries
- add focused unit tests for both paths

## Why
When cache reaches capacity with stale entries, the old behavior could evict a still-valid oldest item while retaining expired data.

## Risk
Low: helper-local change in `writeCache` plus targeted tests.

## Validation
- `pnpm vitest run src/agents/tools/web-shared.test.ts`
- `pnpm exec oxfmt --check src/agents/tools/web-shared.ts src/agents/tools/web-shared.test.ts`
