### PR TITLE
Mattermost: switch plugin-sdk imports to scoped subpaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,8 @@ Docs: https://docs.openclaw.ai
 - LINE cleanup/test follow-ups: fold cleanup/test learnings into the synthesis review path while keeping runtime changes focused on regression fixes. (from #17630, #17289) Thanks @Clawborn and @davidahmann.
 - Mattermost/interactive buttons: add interactive button send/callback support with directory-based channel/user target resolution, and harden callbacks via account-scoped HMAC verification plus sender-scoped DM routing. (#19957) thanks @tonydehnke.
 
+- Mattermost/plugin SDK import policy: replace remaining monolithic `openclaw/plugin-sdk` imports in Mattermost mention-gating paths/tests with scoped subpaths (`openclaw/plugin-sdk/compat` and `openclaw/plugin-sdk/mattermost`) so `pnpm check` passes `lint:plugins:no-monolithic-plugin-sdk-entry-imports` on baseline. (#36480) Thanks @Takhoffman.
+
 ## 2026.3.2
 
 ### Changes

--- a/extensions/mattermost/src/group-mentions.test.ts
+++ b/extensions/mattermost/src/group-mentions.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it } from "vitest";
 import { resolveMattermostGroupRequireMention } from "./group-mentions.js";
 

--- a/extensions/mattermost/src/group-mentions.ts
+++ b/extensions/mattermost/src/group-mentions.ts
@@ -1,4 +1,5 @@
-import { resolveChannelGroupRequireMention, type ChannelGroupContext } from "openclaw/plugin-sdk";
+import { resolveChannelGroupRequireMention } from "openclaw/plugin-sdk/compat";
+import type { ChannelGroupContext } from "openclaw/plugin-sdk/mattermost";
 import { resolveMattermostAccount } from "./mattermost/accounts.js";
 
 export function resolveMattermostGroupRequireMention(

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/mattermost";
 import { describe, expect, it, vi } from "vitest";
 import { resolveMattermostAccount } from "./accounts.js";
 import {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `pnpm check` failed at `lint:plugins:no-monolithic-plugin-sdk-entry-imports` because Mattermost extension files imported from monolithic `openclaw/plugin-sdk`.
- Why it matters: bundled plugin sources must use scoped plugin-sdk subpath imports to satisfy lint policy and keep extension boundaries explicit.
- What changed: replaced root `openclaw/plugin-sdk` imports with scoped subpaths in 3 Mattermost files:
  - `resolveChannelGroupRequireMention` -> `openclaw/plugin-sdk/compat`
  - `ChannelGroupContext` and `OpenClawConfig` -> `openclaw/plugin-sdk/mattermost`
- What did NOT change (scope boundary): no runtime logic changes, no config/schema changes, no non-Mattermost files modified in this commit.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A
- Related: N/A

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/Bun toolchain via pnpm
- Model/provider: N/A
- Integration/channel (if any): Mattermost extension
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm vitest run extensions/mattermost/src/group-mentions.test.ts extensions/mattermost/src/mattermost/monitor.test.ts`
2. Run `pnpm check`
3. Confirm `lint:plugins:no-monolithic-plugin-sdk-entry-imports` passes.

### Expected

- Targeted Mattermost tests pass.
- `pnpm check` succeeds, including the monolithic plugin-sdk import lint check.

### Actual

- Tests passed: 2 files, 6 tests.
- `pnpm check` passed and reported:
  - `OK: bundled plugin source files use scoped plugin-sdk subpaths (740 checked).`

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification snippets:

- `pnpm vitest run ...`:
  - `Test Files  2 passed (2)`
  - `Tests  6 passed (6)`

- `pnpm check`:
  - `lint:plugins:no-monolithic-plugin-sdk-entry-imports`
  - `OK: bundled plugin source files use scoped plugin-sdk subpaths (740 checked).`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Scoped imports compile and tests for Mattermost mention behavior still pass.
  - Full `pnpm check` passes with lint rule no longer failing.
- Edge cases checked:
  - Import split uses `/compat` only for `resolveChannelGroupRequireMention`, `/mattermost` for Mattermost-specific types.
  - No root `openclaw/plugin-sdk` imports remain in the 3 changed files.
- What you did **not** verify:
  - Full repository test suite beyond the requested targeted tests and `pnpm check`.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `98b3472ae`.
- Files/config to restore:
  - `extensions/mattermost/src/group-mentions.ts`
  - `extensions/mattermost/src/group-mentions.test.ts`
  - `extensions/mattermost/src/mattermost/monitor.test.ts`
- Known bad symptoms reviewers should watch for:
  - Type/import resolution errors in Mattermost extension build/tests.
  - Regression in mention-gating tests.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: wrong scoped subpath for `resolveChannelGroupRequireMention` could cause import/runtime break.
  - Mitigation: selected `openclaw/plugin-sdk/compat` (which re-exports root), and validated with targeted tests + `pnpm check`.
- Risk: accidental behavior change in mention gate defaults.
  - Mitigation: no logic edits; import-only change; existing tests passed.
