### PR TITLE
feat(session): add /resume command to list and restore previous sessions

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -90,6 +90,7 @@ Current source-of-truth:
 Built-in commands available today:
 
 - `/new [model]` starts a new session; `/reset` is the reset alias.
+- `/resume [id|#]` resumes a previous session; omit arg to list recent sessions, provide 8-char session ID or list index to switch.
 - `/compact [instructions]` compacts the session context. See [/concepts/compaction](/concepts/compaction).
 - `/stop` aborts the current run.
 - `/session idle <duration|off>` and `/session max-age <duration|off>` manage thread-binding expiry.

--- a/src/auto-reply/command-status-builders.ts
+++ b/src/auto-reply/command-status-builders.ts
@@ -55,7 +55,7 @@ export function buildHelpMessage(cfg?: OpenClawConfig): string {
   const lines = ["ℹ️ Help", ""];
 
   lines.push("Session");
-  lines.push("  /new  |  /reset  |  /compact [instructions]  |  /stop");
+  lines.push("  /new  |  /reset  |  /resume [id|#]  |  /compact [instructions]  |  /stop");
   lines.push("");
 
   const optionParts = ["/think <level>", "/model <id>", "/fast status|on|off", "/verbose on|off"];

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -625,6 +625,21 @@ export function buildBuiltinChatCommands(): ChatCommandDefinition[] {
       category: "session",
     }),
     defineChatCommand({
+      key: "resume",
+      nativeName: "resume",
+      description: "Resume a previous session by ID, or list recent sessions.",
+      textAlias: "/resume",
+      acceptsArgs: true,
+      category: "session",
+      args: [
+        {
+          name: "session-id",
+          description: "8-char session ID or list index to resume (omit to list recent sessions)",
+          type: "string",
+        },
+      ],
+    }),
+    defineChatCommand({
       key: "compact",
       nativeName: "compact",
       description: "Compact the session context.",

--- a/src/auto-reply/reply/commands-handlers.runtime.ts
+++ b/src/auto-reply/reply/commands-handlers.runtime.ts
@@ -17,6 +17,7 @@ import { handleMcpCommand } from "./commands-mcp.js";
 import { handleModelsCommand } from "./commands-models.js";
 import { handlePluginCommand } from "./commands-plugin.js";
 import { handlePluginsCommand } from "./commands-plugins.js";
+import { handleResumeCommand } from "./commands-session-resume.js";
 import {
   handleAbortTrigger,
   handleActivationCommand,
@@ -64,6 +65,7 @@ export function loadCommandHandlers(): CommandHandler[] {
     handleModelsCommand,
     handleStopCommand,
     handleCompactCommand,
+    handleResumeCommand,
     handleAbortTrigger,
   ];
 }

--- a/src/auto-reply/reply/commands-session-resume.test.ts
+++ b/src/auto-reply/reply/commands-session-resume.test.ts
@@ -1,0 +1,613 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry, SessionHistoryEntry } from "../../config/sessions.js";
+import * as sessions from "../../config/sessions.js";
+import * as sessionUtilsFs from "../../gateway/session-utils.fs.js";
+import { handleResumeCommand } from "./commands-session-resume.js";
+import type { HandleCommandsParams } from "./commands-types.js";
+
+// ---------- shared mutable state for file-system mocks ----------
+const fsMockState = vi.hoisted(() => ({
+  existsSyncResults: [] as boolean[],
+  readdirResult: [] as string[],
+  readdirByDir: null as Map<string, string[]> | null,
+  renameArgs: null as [string, string] | null,
+  renameError: null as (Error & { code?: string }) | null,
+  copyFileArgs: null as [string, string] | null,
+  copyFileError: null as Error | null,
+  unlinkArgs: null as string | null,
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  const wrapped = {
+    ...actual,
+    existsSync: vi.fn((_p: unknown) => {
+      return fsMockState.existsSyncResults.shift() ?? false;
+    }),
+  };
+  return { ...wrapped, default: wrapped };
+});
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  const wrapped = {
+    ...actual,
+    readdir: vi.fn(
+      async (dir: unknown) =>
+        fsMockState.readdirByDir?.get(dir as string) ?? fsMockState.readdirResult,
+    ),
+    rename: vi.fn(async (from: unknown, to: unknown) => {
+      if (fsMockState.renameError) {
+        const err = fsMockState.renameError;
+        fsMockState.renameError = null;
+        throw err;
+      }
+      fsMockState.renameArgs = [from as string, to as string];
+    }),
+    copyFile: vi.fn(async (from: unknown, to: unknown) => {
+      if (fsMockState.copyFileError) {
+        const err = fsMockState.copyFileError;
+        fsMockState.copyFileError = null;
+        throw err;
+      }
+      fsMockState.copyFileArgs = [from as string, to as string];
+    }),
+    unlink: vi.fn(async (p: unknown) => {
+      fsMockState.unlinkArgs = p as string;
+    }),
+  };
+  return { ...wrapped, default: wrapped };
+});
+
+// ---------- sessions + session-utils mocks ----------
+// Mock the barrel (not submodules) so that the source file's barrel imports
+// resolve to the mock functions. Mocking only a submodule does not update the
+// barrel's ESM live re-export bindings used by commands-session-resume.ts.
+vi.mock("../../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/sessions.js")>();
+  return {
+    ...actual,
+    updateSessionStore: vi.fn(),
+    parseSessionArchiveTimestamp: vi.fn((filename: string, reason: string) => {
+      const re = new RegExp(`\\.${reason}\\.(\\d+)$`);
+      const m = filename.match(re);
+      return m ? Number(m[1]) : null;
+    }),
+  };
+});
+
+vi.mock("../../gateway/session-utils.fs.js", () => ({
+  resolveSessionTranscriptCandidates: vi.fn(() => [] as string[]),
+  resolveSessionEntryLabel: vi.fn(() => undefined),
+}));
+
+// ---------- helpers ----------
+function makeParams(
+  commandText: string,
+  history: SessionHistoryEntry[] = [],
+  storePath = "/tmp/fake/sessions.json",
+): HandleCommandsParams {
+  return {
+    command: {
+      surface: "telegram",
+      channel: "telegram",
+      ownerList: ["owner"],
+      senderIsOwner: true,
+      isAuthorizedSender: true,
+      senderId: "owner",
+      rawBodyNormalized: commandText,
+      commandBodyNormalized: commandText,
+    },
+    ctx: {} as HandleCommandsParams["ctx"],
+    cfg: {} as HandleCommandsParams["cfg"],
+    directives: {} as HandleCommandsParams["directives"],
+    elevated: { enabled: false, allowed: false, failures: [] },
+    sessionKey: "telegram:owner",
+    storePath,
+    agentId: "main",
+    sessionEntry: {
+      sessionId: "current-session-uuid",
+      updatedAt: Date.now(),
+      systemSent: true,
+      history,
+    } as SessionEntry,
+    workspaceDir: "/tmp",
+    defaultGroupActivation: () => "always",
+    resolvedVerboseLevel: "normal" as HandleCommandsParams["resolvedVerboseLevel"],
+    resolvedReasoningLevel: "normal" as HandleCommandsParams["resolvedReasoningLevel"],
+    provider: "anthropic",
+    model: "claude-sonnet-4-6",
+    contextTokens: 0,
+    isGroup: false,
+  } as unknown as HandleCommandsParams;
+}
+
+const sampleHistory: SessionHistoryEntry[] = [
+  {
+    sessionId: "aaaabbbbccccdddd",
+    sessionFile: "/tmp/fake/aaaabbbbccccdddd.jsonl",
+    updatedAt: new Date("2026-01-15T10:00:00Z").getTime(),
+    label: "chat about TypeScript",
+    systemSent: true,
+  },
+  {
+    sessionId: "11112222333344445",
+    sessionFile: "/tmp/fake/11112222333344445.jsonl",
+    updatedAt: new Date("2026-01-14T08:30:00Z").getTime(),
+    systemSent: false,
+  },
+];
+
+// ---------- tests ----------
+describe("handleResumeCommand", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    fsMockState.existsSyncResults = [];
+    fsMockState.readdirResult = [];
+    fsMockState.readdirByDir = null;
+    fsMockState.renameArgs = null;
+    fsMockState.renameError = null;
+    fsMockState.copyFileArgs = null;
+    fsMockState.copyFileError = null;
+    fsMockState.unlinkArgs = null;
+  });
+
+  it("returns null for non-resume commands", async () => {
+    const result = await handleResumeCommand(makeParams("/new"), true);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when text commands are disabled", async () => {
+    const result = await handleResumeCommand(makeParams("/resume"), false);
+    expect(result).toBeNull();
+  });
+
+  it("blocks unauthorized senders", async () => {
+    const params = makeParams("/resume");
+    params.command.isAuthorizedSender = false;
+    const result = await handleResumeCommand(params, true);
+    expect(result).toEqual({ shouldContinue: false });
+  });
+
+  describe("list mode (no argument)", () => {
+    it("returns 'no previous sessions' when history is empty", async () => {
+      const result = await handleResumeCommand(makeParams("/resume", []), true);
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain("No previous sessions");
+    });
+
+    it("lists history entries with date, id prefix, and label", async () => {
+      const result = await handleResumeCommand(makeParams("/resume", sampleHistory), true);
+      expect(result?.shouldContinue).toBe(false);
+      const text = result?.reply?.text ?? "";
+      expect(text).toContain("aaaabbb");
+      expect(text).toMatch(/Jan(uary)? 15/); // dateFallback: older than 7d shows short date
+      expect(text).toContain("chat about TypeScript");
+      expect(text).toContain("/resume <id or #>");
+    });
+
+    it("limits display to 10 entries", async () => {
+      const bigHistory: SessionHistoryEntry[] = Array.from({ length: 15 }, (_, i) => ({
+        sessionId: `session-${String(i).padStart(4, "0")}-uuid-longid`,
+        updatedAt: Date.now() - i * 1000,
+      }));
+      const result = await handleResumeCommand(makeParams("/resume", bigHistory), true);
+      const text = result?.reply?.text ?? "";
+      const matches = text.match(/^\d+\./gm);
+      expect(matches?.length).toBe(10);
+    });
+  });
+
+  describe("resume mode (with argument)", () => {
+    it("returns not-found when prefix doesn't match any history entry", async () => {
+      const result = await handleResumeCommand(makeParams("/resume xxxxxxxx", sampleHistory), true);
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain("Session not found");
+    });
+
+    it("returns transcript-not-found when no file can be restored", async () => {
+      // existsSync returns false (default), readdir returns empty (default)
+      const result = await handleResumeCommand(makeParams("/resume aaaabbbb", sampleHistory), true);
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain("not found on disk");
+    });
+
+    it("restores session when transcript exists at known candidate path", async () => {
+      vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+        "/tmp/fake/aaaabbbbccccdddd.jsonl",
+      ]);
+      // First existsSync call returns true (candidate found)
+      fsMockState.existsSyncResults = [true];
+      vi.mocked(sessions.updateSessionStore).mockResolvedValueOnce(undefined);
+
+      const result = await handleResumeCommand(makeParams("/resume aaaabbbb", sampleHistory), true);
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain("Resumed session");
+      expect(result?.reply?.text).toContain("aaaabbb");
+      expect(vi.mocked(sessions.updateSessionStore)).toHaveBeenCalledOnce();
+    });
+
+    it("reports not-found when transcript is in external candidate dir but copyFile fails", async () => {
+      const externalCand = "/external/sessions/aaaabbbbccccdddd.jsonl";
+      vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+        externalCand,
+      ]);
+      // Candidate exists but is outside sessionsDir (/tmp/fake)
+      fsMockState.existsSyncResults = [true];
+      fsMockState.copyFileError = Object.assign(new Error("EACCES"), { code: "EACCES" });
+
+      const result = await handleResumeCommand(makeParams("/resume aaaabbbb", sampleHistory), true);
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain("not found on disk");
+      expect(vi.mocked(sessions.updateSessionStore)).not.toHaveBeenCalled();
+    });
+
+    it("restores from archive when transcript is missing but .reset.* file exists", async () => {
+      const archiveTs = 1700000000000;
+      fsMockState.readdirResult = [`aaaabbbbccccdddd.jsonl.reset.${archiveTs}`];
+      vi.mocked(sessions.parseSessionArchiveTimestamp).mockReturnValueOnce(archiveTs);
+      vi.mocked(sessions.updateSessionStore).mockResolvedValueOnce(undefined);
+
+      const result = await handleResumeCommand(makeParams("/resume aaaabbbb", sampleHistory), true);
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain("Resumed session");
+      expect(fsMockState.renameArgs).toEqual([
+        path.join("/tmp/fake", `aaaabbbbccccdddd.jsonl.reset.${archiveTs}`),
+        path.join("/tmp/fake", "aaaabbbbccccdddd.jsonl"),
+      ]);
+    });
+
+    it("restores topic/thread session archive using original filename as prefix", async () => {
+      const archiveTs = 1700000000000;
+      const topicHistory: SessionHistoryEntry[] = [
+        {
+          sessionId: "aaaabbbbccccdddd",
+          sessionFile: "/tmp/fake/aaaabbbbccccdddd-topic-42.jsonl",
+          updatedAt: new Date("2026-01-15T10:00:00Z").getTime(),
+          systemSent: true,
+        },
+      ];
+      fsMockState.readdirResult = [`aaaabbbbccccdddd-topic-42.jsonl.reset.${archiveTs}`];
+      vi.mocked(sessions.parseSessionArchiveTimestamp).mockReturnValueOnce(archiveTs);
+      vi.mocked(sessions.updateSessionStore).mockResolvedValueOnce(undefined);
+
+      const result = await handleResumeCommand(makeParams("/resume aaaabbbb", topicHistory), true);
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain("Resumed session");
+      expect(fsMockState.renameArgs).toEqual([
+        path.join("/tmp/fake", `aaaabbbbccccdddd-topic-42.jsonl.reset.${archiveTs}`),
+        path.join("/tmp/fake", "aaaabbbbccccdddd-topic-42.jsonl"),
+      ]);
+    });
+
+    it("finds archive in a candidate directory other than sessionsDir (e.g. legacy sessions dir)", async () => {
+      const archiveTs = 1700000000000;
+      const legacyDir = "/home/legacy/sessions";
+      vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+        "/tmp/fake/aaaabbbbccccdddd.jsonl",
+        `${legacyDir}/aaaabbbbccccdddd.jsonl`,
+      ]);
+      // Both live candidates missing
+      fsMockState.existsSyncResults = [false, false];
+      // Archive only in the legacy dir
+      fsMockState.readdirByDir = new Map([
+        ["/tmp/fake", []],
+        [legacyDir, [`aaaabbbbccccdddd.jsonl.reset.${archiveTs}`]],
+      ]);
+      vi.mocked(sessions.parseSessionArchiveTimestamp).mockReturnValueOnce(archiveTs);
+      vi.mocked(sessions.updateSessionStore).mockResolvedValueOnce(undefined);
+
+      const result = await handleResumeCommand(makeParams("/resume aaaabbbb", sampleHistory), true);
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain("Resumed session");
+      // Archive from legacy dir should be restored to primary sessionsDir (/tmp/fake)
+      expect(fsMockState.renameArgs).toEqual([
+        path.join(legacyDir, `aaaabbbbccccdddd.jsonl.reset.${archiveTs}`),
+        path.join("/tmp/fake", "aaaabbbbccccdddd.jsonl"),
+      ]);
+    });
+
+    it("uses copyFile+unlink when cross-device rename (EXDEV) occurs, restoring to primary dir", async () => {
+      const archiveTs = 1700000000000;
+      const legacyDir = "/home/legacy/sessions";
+      vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+        "/tmp/fake/aaaabbbbccccdddd.jsonl",
+        `${legacyDir}/aaaabbbbccccdddd.jsonl`,
+      ]);
+      fsMockState.existsSyncResults = [false, false];
+      fsMockState.readdirByDir = new Map([
+        ["/tmp/fake", []],
+        [legacyDir, [`aaaabbbbccccdddd.jsonl.reset.${archiveTs}`]],
+      ]);
+      vi.mocked(sessions.parseSessionArchiveTimestamp).mockReturnValueOnce(archiveTs);
+      fsMockState.renameError = Object.assign(new Error("EXDEV"), { code: "EXDEV" });
+      vi.mocked(sessions.updateSessionStore).mockResolvedValueOnce(undefined);
+
+      const result = await handleResumeCommand(makeParams("/resume aaaabbbb", sampleHistory), true);
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain("Resumed session");
+      // copyFile: archive → primary dir (not legacy dir)
+      expect(fsMockState.copyFileArgs).toEqual([
+        path.join(legacyDir, `aaaabbbbccccdddd.jsonl.reset.${archiveTs}`),
+        path.join("/tmp/fake", "aaaabbbbccccdddd.jsonl"),
+      ]);
+      // archive removed after successful copy
+      expect(fsMockState.unlinkArgs).toBe(
+        path.join(legacyDir, `aaaabbbbccccdddd.jsonl.reset.${archiveTs}`),
+      );
+      // rename was NOT called a second time (no in-place fallback)
+      expect(fsMockState.renameArgs).toBeNull();
+    });
+
+    it("probes entry.sessionFile directly when candidates normalize it away (e.g. legacy topic transcript)", async () => {
+      // candidates only returns the normalized path (no topic suffix) — file doesn't exist there
+      vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+        "/tmp/fake/aaaabbbbccccdddd.jsonl",
+      ]);
+      const legacyTopicHistory: SessionHistoryEntry[] = [
+        {
+          sessionId: "aaaabbbbccccdddd",
+          sessionFile: "/legacy/sessions/aaaabbbbccccdddd-topic-42.jsonl",
+          updatedAt: new Date("2026-01-15T10:00:00Z").getTime(),
+          systemSent: true,
+        },
+      ];
+      // first existsSync → normalized candidate (false), second → raw sessionFile (true)
+      fsMockState.existsSyncResults = [false, true];
+
+      // Use storePath="" (falsy) so updateSessionStore is not called, avoiding the
+      // pre-existing barrel-mock issue. The test exercises transcript discovery only.
+      const result = await handleResumeCommand(
+        makeParams("/resume aaaabbbb", legacyTopicHistory, ""),
+        true,
+      );
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain("Resumed session");
+      // No sessionsDir (storePath falsy) → raw path returned directly without copying
+      expect(fsMockState.copyFileArgs).toBeNull();
+    });
+
+    it("prefers entry.sessionFile over normalized candidate in sessionsDir when raw path exists outside candidates (placeholder bug)", async () => {
+      // Simulate: normalized candidate exists in primary sessions dir (but is a placeholder),
+      // while entry.sessionFile points to the real transcript outside the candidates list.
+      vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+        "/tmp/fake/aaaabbbbccccdddd.jsonl",
+      ]);
+      const legacyTopicHistory: SessionHistoryEntry[] = [
+        {
+          sessionId: "aaaabbbbccccdddd",
+          sessionFile: "/legacy/sessions/aaaabbbbccccdddd-topic-42.jsonl",
+          updatedAt: new Date("2026-01-15T10:00:00Z").getTime(),
+          systemSent: true,
+        },
+      ];
+      // First existsSync → normalized candidate (true, the placeholder exists),
+      // second existsSync → raw sessionFile (true, the real transcript exists).
+      fsMockState.existsSyncResults = [true, true];
+      vi.mocked(sessions.updateSessionStore).mockResolvedValueOnce(undefined);
+
+      const result = await handleResumeCommand(
+        makeParams("/resume aaaabbbb", legacyTopicHistory),
+        true,
+      );
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain("Resumed session");
+      // Raw path (external) should be copied into primary sessionsDir, not the placeholder returned.
+      expect(fsMockState.copyFileArgs).toEqual([
+        "/legacy/sessions/aaaabbbbccccdddd-topic-42.jsonl",
+        path.join("/tmp/fake", "aaaabbbbccccdddd-topic-42.jsonl"),
+      ]);
+    });
+
+    it("falls back to normalized candidate when raw sessionFile copy fails (placeholder scenario)", async () => {
+      vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+        "/tmp/fake/aaaabbbbccccdddd.jsonl",
+      ]);
+      const legacyTopicHistory: SessionHistoryEntry[] = [
+        {
+          sessionId: "aaaabbbbccccdddd",
+          sessionFile: "/legacy/sessions/aaaabbbbccccdddd-topic-42.jsonl",
+          updatedAt: new Date("2026-01-15T10:00:00Z").getTime(),
+          systemSent: true,
+        },
+      ];
+      // Normalized candidate exists, raw path exists but copy will fail.
+      fsMockState.existsSyncResults = [true, true];
+      fsMockState.copyFileError = Object.assign(new Error("EACCES"), { code: "EACCES" });
+      vi.mocked(sessions.updateSessionStore).mockResolvedValueOnce(undefined);
+
+      const result = await handleResumeCommand(
+        makeParams("/resume aaaabbbb", legacyTopicHistory),
+        true,
+      );
+      // Should still succeed, falling back to the normalized candidate.
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain("Resumed session");
+    });
+
+    it("resolves session by numeric index (e.g. /resume 1)", async () => {
+      vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+        "/tmp/fake/aaaabbbbccccdddd.jsonl",
+      ]);
+      fsMockState.existsSyncResults = [true];
+      vi.mocked(sessions.updateSessionStore).mockResolvedValueOnce(undefined);
+
+      // history[0] is "aaaabbbbccccdddd", so /resume 1 should pick it
+      const result = await handleResumeCommand(makeParams("/resume 1", sampleHistory), true);
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain("Resumed session");
+      expect(result?.reply?.text).toContain("aaaabbb");
+    });
+
+    it("returns not-found for out-of-range numeric index", async () => {
+      const result = await handleResumeCommand(makeParams("/resume 99", sampleHistory), true);
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain("Session not found");
+    });
+
+    it("updates history: removes resumed entry and prepends current session", async () => {
+      vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+        "/tmp/fake/aaaabbbbccccdddd.jsonl",
+      ]);
+      fsMockState.existsSyncResults = [true];
+
+      let capturedStore: Record<string, SessionEntry> = {};
+      vi.mocked(sessions.updateSessionStore).mockImplementationOnce(async (_storePath, mutator) => {
+        capturedStore = {};
+        await mutator(capturedStore);
+        return undefined;
+      });
+
+      await handleResumeCommand(makeParams("/resume aaaabbbb", sampleHistory), true);
+
+      const updated = capturedStore["telegram:owner"];
+      expect(updated).toBeDefined();
+      // Resumed entry should NOT be in history
+      expect(updated?.history?.find((h) => h.sessionId === "aaaabbbbccccdddd")).toBeUndefined();
+      // Current session should be in history
+      expect(updated?.history?.find((h) => h.sessionId === "current-session-uuid")).toBeDefined();
+    });
+
+    it("clears compaction/flush counters so resumed session is not treated as already flushed", async () => {
+      vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+        "/tmp/fake/aaaabbbbccccdddd.jsonl",
+      ]);
+      fsMockState.existsSyncResults = [true];
+
+      let capturedStore: Record<string, SessionEntry> = {};
+      vi.mocked(sessions.updateSessionStore).mockImplementationOnce(async (_storePath, mutator) => {
+        // Seed existing entry with compaction state from the outgoing session
+        capturedStore = {
+          "telegram:owner": {
+            sessionId: "current-session-uuid",
+            updatedAt: Date.now(),
+            compactionCount: 3,
+            memoryFlushCompactionCount: 3,
+            memoryFlushAt: Date.now() - 1000,
+          } as SessionEntry,
+        };
+        await mutator(capturedStore);
+        return undefined;
+      });
+
+      await handleResumeCommand(makeParams("/resume aaaabbbb", sampleHistory), true);
+
+      const updated = capturedStore["telegram:owner"];
+      expect(updated?.compactionCount).toBe(0);
+      expect(updated?.memoryFlushCompactionCount).toBeUndefined();
+      expect(updated?.memoryFlushAt).toBeUndefined();
+    });
+
+    it("clears cache counters so /status does not show previous session cache usage", async () => {
+      vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+        "/tmp/fake/aaaabbbbccccdddd.jsonl",
+      ]);
+      fsMockState.existsSyncResults = [true];
+
+      let capturedStore: Record<string, SessionEntry> = {};
+      vi.mocked(sessions.updateSessionStore).mockImplementationOnce(async (_storePath, mutator) => {
+        capturedStore = {
+          "telegram:owner": {
+            sessionId: "current-session-uuid",
+            updatedAt: Date.now(),
+            cacheRead: 1234,
+            cacheWrite: 567,
+            inputTokens: 1000,
+            outputTokens: 500,
+          } as SessionEntry,
+        };
+        await mutator(capturedStore);
+        return undefined;
+      });
+
+      await handleResumeCommand(makeParams("/resume aaaabbbb", sampleHistory), true);
+
+      const updated = capturedStore["telegram:owner"];
+      expect(updated?.cacheRead).toBeUndefined();
+      expect(updated?.cacheWrite).toBeUndefined();
+      expect(updated?.inputTokens).toBeUndefined();
+      expect(updated?.outputTokens).toBeUndefined();
+    });
+
+    it("clears fallback notice state so resolveFallbackTransition does not emit spurious transitions", async () => {
+      vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+        "/tmp/fake/aaaabbbbccccdddd.jsonl",
+      ]);
+      fsMockState.existsSyncResults = [true];
+
+      let capturedStore: Record<string, SessionEntry> = {};
+      vi.mocked(sessions.updateSessionStore).mockImplementationOnce(async (_storePath, mutator) => {
+        capturedStore = {
+          "telegram:owner": {
+            sessionId: "current-session-uuid",
+            updatedAt: Date.now(),
+            fallbackNoticeSelectedModel: "claude-opus-4-6",
+            fallbackNoticeActiveModel: "claude-sonnet-4-6",
+            fallbackNoticeReason: "quota",
+          } as SessionEntry,
+        };
+        await mutator(capturedStore);
+        return undefined;
+      });
+
+      await handleResumeCommand(makeParams("/resume aaaabbbb", sampleHistory), true);
+
+      const updated = capturedStore["telegram:owner"];
+      expect(updated?.fallbackNoticeSelectedModel).toBeUndefined();
+      expect(updated?.fallbackNoticeActiveModel).toBeUndefined();
+      expect(updated?.fallbackNoticeReason).toBeUndefined();
+    });
+
+    it("clears abort cutoff fields so the first resumed message is not skipped by shouldSkipMessageByAbortCutoff", async () => {
+      vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+        "/tmp/fake/aaaabbbbccccdddd.jsonl",
+      ]);
+      fsMockState.existsSyncResults = [true];
+
+      let capturedStore: Record<string, SessionEntry> = {};
+      vi.mocked(sessions.updateSessionStore).mockImplementationOnce(async (_storePath, mutator) => {
+        capturedStore = {
+          "telegram:owner": {
+            sessionId: "current-session-uuid",
+            updatedAt: Date.now(),
+            abortCutoffMessageSid: "msg-sid-from-stop",
+            abortCutoffTimestamp: Date.now() - 5000,
+          } as SessionEntry,
+        };
+        await mutator(capturedStore);
+        return undefined;
+      });
+
+      await handleResumeCommand(makeParams("/resume aaaabbbb", sampleHistory), true);
+
+      const updated = capturedStore["telegram:owner"];
+      expect(updated?.abortCutoffMessageSid).toBeUndefined();
+      expect(updated?.abortCutoffTimestamp).toBeUndefined();
+    });
+
+    it("clears systemPromptReport so /context does not show the previous session's report", async () => {
+      vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+        "/tmp/fake/aaaabbbbccccdddd.jsonl",
+      ]);
+      fsMockState.existsSyncResults = [true];
+
+      let capturedStore: Record<string, SessionEntry> = {};
+      vi.mocked(sessions.updateSessionStore).mockImplementationOnce(async (_storePath, mutator) => {
+        capturedStore = {
+          "telegram:owner": {
+            sessionId: "current-session-uuid",
+            updatedAt: Date.now(),
+            systemPromptReport: { source: "run", generatedAt: Date.now() } as SessionEntry["systemPromptReport"],
+          } as SessionEntry,
+        };
+        await mutator(capturedStore);
+        return undefined;
+      });
+
+      await handleResumeCommand(makeParams("/resume aaaabbbb", sampleHistory), true);
+
+      expect(capturedStore["telegram:owner"]?.systemPromptReport).toBeUndefined();
+    });
+  });
+});

--- a/src/auto-reply/reply/commands-session-resume.ts
+++ b/src/auto-reply/reply/commands-session-resume.ts
@@ -1,0 +1,328 @@
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import path from "node:path";
+import {
+  MAX_SESSION_HISTORY,
+  parseSessionArchiveTimestamp,
+  updateSessionStore,
+} from "../../config/sessions.js";
+import type { SessionHistoryEntry } from "../../config/sessions.js";
+import {
+  resolveSessionEntryLabel,
+  resolveSessionTranscriptCandidates,
+} from "../../gateway/session-utils.fs.js";
+import { formatRelativeTimestamp } from "../../infra/format-time/format-relative.js";
+import type { CommandHandler } from "./commands-types.js";
+
+const MAX_HISTORY_DISPLAY = 10;
+
+async function restoreSessionTranscript(
+  entry: SessionHistoryEntry,
+  storePath: string | undefined,
+  agentId: string | undefined,
+): Promise<string | undefined> {
+  const sessionsDir = storePath ? path.dirname(storePath) : undefined;
+
+  // 1. Check if transcript already exists at known candidates.
+  // If found outside the primary sessions dir, copy it in so that
+  // initSessionState's resolveAndPersistSessionFile does not re-normalize
+  // sessionFile to a different (empty) path and drop the resumed context
+  // after one message.
+  const candidates = resolveSessionTranscriptCandidates(
+    entry.sessionId,
+    storePath,
+    entry.sessionFile,
+    agentId,
+  );
+  for (const cand of candidates) {
+    if (!fs.existsSync(cand)) {
+      continue;
+    }
+    if (!sessionsDir) {
+      return cand;
+    }
+    const candResolved = path.resolve(cand);
+    const dirResolved = path.resolve(sessionsDir);
+    const relative = path.relative(dirResolved, candResolved);
+    if (!relative.startsWith("..") && !path.isAbsolute(relative)) {
+      // Inside primary sessions dir — but probe entry.sessionFile raw path before
+      // accepting this as the authoritative transcript. resolveSessionTranscriptCandidates
+      // may have normalized it away (e.g. mapped a legacy topic path to the primary dir),
+      // so the raw path may not appear in candidates even when it still holds the real
+      // transcript on disk (e.g. migrated/legacy states where this normalized path is
+      // only a placeholder or partial stub).
+      if (entry.sessionFile) {
+        const rawPath = path.resolve(entry.sessionFile.trim());
+        if (rawPath && !candidates.includes(rawPath) && fs.existsSync(rawPath)) {
+          const rawRelative = path.relative(dirResolved, rawPath);
+          if (!rawRelative.startsWith("..") && !path.isAbsolute(rawRelative)) {
+            // Raw path is also inside sessionsDir.
+            return rawPath;
+          }
+          // External raw path: copy it in so the location stays stable across turns.
+          const targetPath = path.join(dirResolved, path.basename(rawPath));
+          try {
+            await fsPromises.mkdir(dirResolved, { recursive: true });
+            await fsPromises.copyFile(rawPath, targetPath);
+            return targetPath;
+          } catch {
+            // Copy failed — fall through to return the normalized candidate.
+          }
+        }
+      }
+      return cand;
+    }
+    // External candidate: copy into primary sessions dir so the path stays
+    // stable across turns. Mirror the cross-filesystem fallback used for
+    // archived restores below.
+    const targetPath = path.join(dirResolved, path.basename(cand));
+    try {
+      await fsPromises.mkdir(dirResolved, { recursive: true });
+      await fsPromises.copyFile(cand, targetPath);
+      return targetPath;
+    } catch {
+      // Copy failed — continue to next candidate or fall through to archive scan.
+      continue;
+    }
+  }
+
+  // 1.5. Probe entry.sessionFile directly — resolveSessionTranscriptCandidates normalizes
+  // this path (e.g. maps a legacy topic transcript to the primary sessions dir), so the
+  // raw path may not appear in candidates even when the file still exists on disk there.
+  if (entry.sessionFile) {
+    const raw = path.resolve(entry.sessionFile.trim());
+    if (raw && !candidates.includes(raw) && fs.existsSync(raw)) {
+      if (!sessionsDir) {
+        return raw;
+      }
+      const dirResolved = path.resolve(sessionsDir);
+      const relative = path.relative(dirResolved, raw);
+      if (!relative.startsWith("..") && !path.isAbsolute(relative)) {
+        return raw;
+      }
+      // External path: copy into sessionsDir so the location stays stable across turns.
+      const targetPath = path.join(dirResolved, path.basename(raw));
+      try {
+        await fsPromises.mkdir(dirResolved, { recursive: true });
+        await fsPromises.copyFile(raw, targetPath);
+        return targetPath;
+      } catch {
+        // Copy failed — fall through to archive scan.
+      }
+    }
+  }
+
+  // 2. Look for the newest .reset.* archive across all candidate directories.
+  // archiveSessionTranscripts uses resolveSessionTranscriptCandidates (which includes
+  // the legacy ~/.openclaw/sessions dir) so we must search the same set of directories.
+  // Use the original filename as prefix so topic/thread sessions (e.g. <id>-topic-<n>.jsonl)
+  // are found after archiving, not just the default <sessionId>.jsonl pattern.
+  const fileBasename = entry.sessionFile
+    ? path.basename(entry.sessionFile)
+    : `${entry.sessionId}.jsonl`;
+  const prefix = `${fileBasename}.reset.`;
+
+  // Always include sessionsDir; add extra dirs from candidates (e.g. legacy path).
+  // Also include the raw directory of entry.sessionFile: resolveSessionTranscriptCandidates
+  // may normalize that path away (e.g. remaps a legacy directory to sessionsDir), so its
+  // original directory never appears in candidates — but archives may still live there.
+  const rawSessionFileDir = entry.sessionFile
+    ? path.dirname(path.resolve(entry.sessionFile.trim()))
+    : undefined;
+  const searchDirs = Array.from(
+    new Set([
+      ...(sessionsDir ? [sessionsDir] : []),
+      ...candidates.map((c) => path.dirname(c)),
+      ...(rawSessionFileDir ? [rawSessionFileDir] : []),
+    ]),
+  );
+  if (searchDirs.length === 0) {
+    return undefined;
+  }
+
+  let bestArchive: { dir: string; file: string; ts: number } | undefined;
+  for (const dir of searchDirs) {
+    const files = await fsPromises.readdir(dir).catch(() => [] as string[]);
+    for (const f of files) {
+      if (!f.startsWith(prefix)) {
+        continue;
+      }
+      const ts = parseSessionArchiveTimestamp(f, "reset");
+      if (ts === null) {
+        continue;
+      }
+      if (!bestArchive || ts > bestArchive.ts) {
+        bestArchive = { dir, file: f, ts };
+      }
+    }
+  }
+
+  if (!bestArchive) {
+    return undefined;
+  }
+
+  const archivedPath = path.join(bestArchive.dir, bestArchive.file);
+  // Always restore to primaryDir so the file is in a location that initSessionState
+  // will not re-normalize away. On cross-filesystem moves (EXDEV), fall back to
+  // copyFile + unlink rather than in-place restore: an in-place restore would leave
+  // sessionFile pointing outside sessionsDir, causing initSessionState to create a
+  // new empty file in sessionsDir that shadows the restored transcript after one turn.
+  const primaryDir = sessionsDir ?? bestArchive.dir;
+  const restoredPath = path.join(primaryDir, fileBasename);
+  try {
+    await fsPromises.rename(archivedPath, restoredPath);
+    return restoredPath;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EXDEV" || primaryDir === bestArchive.dir) {
+      return undefined;
+    }
+  }
+  // Cross-filesystem: copy to primaryDir then remove the archive.
+  // If copy fails, leave the archive intact and report not-found rather than
+  // silently restoring to the wrong location.
+  try {
+    await fsPromises.copyFile(archivedPath, restoredPath);
+  } catch {
+    return undefined;
+  }
+  await fsPromises.unlink(archivedPath).catch(() => undefined);
+  return restoredPath;
+}
+
+export const handleResumeCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+  const normalized = params.command.commandBodyNormalized;
+  if (!/^\/resume(?:\s|$)/i.test(normalized)) {
+    return null;
+  }
+  if (!params.command.isAuthorizedSender) {
+    return { shouldContinue: false };
+  }
+
+  const target = normalized.slice("/resume".length).trim();
+  const history: SessionHistoryEntry[] = params.sessionEntry?.history ?? [];
+
+  // --- No argument: list recent sessions ---
+  if (!target) {
+    if (history.length === 0) {
+      return {
+        shouldContinue: false,
+        reply: { text: "No previous sessions found." },
+      };
+    }
+    const items = history.slice(0, MAX_HISTORY_DISPLAY);
+    const lines = items.map((entry, i) => {
+      const date = formatRelativeTimestamp(entry.updatedAt, { dateFallback: true });
+      const label = entry.label ? ` — ${entry.label}` : "";
+      return `${i + 1}. \`${entry.sessionId.slice(0, 8)}\` ${date}${label}`;
+    });
+    return {
+      shouldContinue: false,
+      reply: {
+        text: `Recent sessions:\n${lines.join("\n")}\n\nUse /resume <id or #> to switch.`,
+      },
+    };
+  }
+
+  // --- With argument: switch to target session ---
+  // Support numeric index (e.g. /resume 2 → history[1]) or exact 8-char session ID.
+  // Short all-digit string → index; 8-char string → ID. Decoupled from history size.
+  const numericIndex = target.length < 8 && /^\d+$/.test(target) ? Number(target) : NaN;
+  const match =
+    !Number.isNaN(numericIndex) && numericIndex >= 1 && numericIndex <= history.length
+      ? history[numericIndex - 1]
+      : history.find((h) => h.sessionId === target || h.sessionId.slice(0, 8) === target);
+  if (!match) {
+    return {
+      shouldContinue: false,
+      reply: {
+        text: `Session not found: \`${target}\`. Use /resume to list recent sessions.`,
+      },
+    };
+  }
+
+  const { storePath, agentId } = params;
+
+  const restoredFile = await restoreSessionTranscript(match, storePath, agentId);
+  if (!restoredFile) {
+    return {
+      shouldContinue: false,
+      reply: {
+        text: `Transcript for session \`${match.sessionId.slice(0, 8)}\` not found on disk.`,
+      },
+    };
+  }
+
+  // Build updated history: push current session in, remove the newly-resumed entry
+  const currentEntry = params.sessionEntry;
+  const updatedHistory: SessionHistoryEntry[] = [
+    ...(currentEntry
+      ? [
+          {
+            sessionId: currentEntry.sessionId,
+            sessionFile: currentEntry.sessionFile,
+            updatedAt: currentEntry.updatedAt,
+            label: resolveSessionEntryLabel(currentEntry, storePath, agentId),
+            systemSent: currentEntry.systemSent,
+          },
+        ]
+      : []),
+    ...history.filter((h) => h.sessionId !== match.sessionId),
+  ].slice(0, MAX_SESSION_HISTORY);
+
+  if (storePath) {
+    await updateSessionStore(storePath, (store) => {
+      const existing = store[params.sessionKey] ?? {};
+      store[params.sessionKey] = {
+        ...existing,
+        sessionId: match.sessionId,
+        sessionFile: restoredFile,
+        updatedAt: Date.now(),
+        systemSent: match.systemSent,
+        history: updatedHistory,
+        // Clear stale per-run metrics
+        totalTokens: undefined,
+        inputTokens: undefined,
+        outputTokens: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+        contextTokens: undefined,
+        estimatedCostUsd: undefined,
+        abortedLastRun: false,
+        // Clear abort cutoff: /stop on the outgoing session sets these fields and they
+        // must not carry over — shouldSkipMessageByAbortCutoff evaluates them on the
+        // next inbound message and would incorrectly drop the first resumed message when
+        // message ID/timestamp spaces differ across session-key switches.
+        abortCutoffMessageSid: undefined,
+        abortCutoffTimestamp: undefined,
+        // Clear compaction/flush state: these counters belong to the outgoing session
+        // and must not carry over — otherwise the resumed session may be treated as
+        // "already flushed" and skip needed memory flush behavior.
+        compactionCount: 0,
+        memoryFlushCompactionCount: undefined,
+        memoryFlushAt: undefined,
+        // Clear fallback notice state: the outgoing session's fallback context must not
+        // carry over — stale values cause resolveFallbackTransition to emit a spurious
+        // "fallback cleared" notice or suppress a notice that should fire for the resumed
+        // conversation.
+        fallbackNoticeSelectedModel: undefined,
+        fallbackNoticeActiveModel: undefined,
+        fallbackNoticeReason: undefined,
+        // Clear system prompt report: /context returns source="run" reports immediately
+        // without recomputing, so retaining the outgoing session's report would show the
+        // wrong session's context breakdown until the next model run.
+        systemPromptReport: undefined,
+      };
+    });
+  }
+
+  const shortId = match.sessionId.slice(0, 8);
+  return {
+    shouldContinue: false,
+    reply: {
+      text: `Resumed session \`${shortId}\`. Your next message will continue that conversation.`,
+    },
+  };
+};

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -2776,3 +2776,120 @@ describe("initSessionState internal channel routing preservation", () => {
     expect(result.sessionEntry.deliveryContext?.accountId).toBe("work");
   });
 });
+
+describe("initSessionState session history", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("appends expired session to history on daily reset", async () => {
+    vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
+    const root = await makeCaseDir("openclaw-history-daily-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:whatsapp:dm:hist1";
+    const expiredSessionId = "expired-daily-id";
+    const expiredSessionFile = path.join(root, `${expiredSessionId}.jsonl`);
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: expiredSessionId,
+        sessionFile: expiredSessionFile,
+        label: "old label",
+        updatedAt: new Date(2026, 0, 18, 3, 0, 0).getTime(),
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: { Body: "hello", SessionKey: sessionKey },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionEntry.history).toHaveLength(1);
+    expect(result.sessionEntry.history?.[0].sessionId).toBe(expiredSessionId);
+    expect(result.sessionEntry.history?.[0].label).toBe("old label");
+  });
+
+  it("appends expired session to history on idle timeout", async () => {
+    vi.setSystemTime(new Date(2026, 0, 18, 5, 30, 0));
+    const root = await makeCaseDir("openclaw-history-idle-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:whatsapp:dm:hist2";
+    const expiredSessionId = "expired-idle-id";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: expiredSessionId,
+        updatedAt: new Date(2026, 0, 18, 4, 0, 0).getTime(),
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath, reset: { mode: "daily", atHour: 4, idleMinutes: 30 } },
+    } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: { Body: "hello", SessionKey: sessionKey },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionEntry.history).toHaveLength(1);
+    expect(result.sessionEntry.history?.[0].sessionId).toBe(expiredSessionId);
+  });
+
+  it("appends session to history on explicit /new", async () => {
+    const root = await makeCaseDir("openclaw-history-new-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:telegram:dm:hist3";
+    const activeSessionId = "active-session-id";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: activeSessionId,
+        updatedAt: Date.now(),
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: { Body: "/new", CommandBody: "/new", SessionKey: sessionKey },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionEntry.history).toHaveLength(1);
+    expect(result.sessionEntry.history?.[0].sessionId).toBe(activeSessionId);
+  });
+
+  it("does not duplicate an entry already in history", async () => {
+    const root = await makeCaseDir("openclaw-history-dedup-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:telegram:dm:hist4";
+    const sessionId = "active-id";
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId,
+        updatedAt: Date.now(),
+        history: [{ sessionId, updatedAt: Date.now() - 1000 }],
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: { Body: "/new", CommandBody: "/new", SessionKey: sessionKey },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.sessionEntry.history).toHaveLength(1);
+    expect(result.sessionEntry.history?.[0].sessionId).toBe(sessionId);
+  });
+});

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -24,9 +24,12 @@ import {
   DEFAULT_RESET_TRIGGERS,
   type GroupKeyResolution,
   type SessionEntry,
+  MAX_SESSION_HISTORY,
+  type SessionHistoryEntry,
   type SessionScope,
 } from "../../config/sessions/types.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
+import { resolveSessionEntryLabel } from "../../gateway/session-utils.fs.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -212,6 +215,25 @@ function resolveBoundConversationSessionKey(params: {
   return binding.targetSessionKey;
 }
 
+function buildUpdatedHistory(
+  entry: SessionEntry,
+  storePath: string | undefined,
+  agentId: string | undefined,
+): SessionHistoryEntry[] {
+  const prev: SessionHistoryEntry[] = entry.history ?? [];
+  const newEntry: SessionHistoryEntry = {
+    sessionId: entry.sessionId,
+    sessionFile: entry.sessionFile,
+    updatedAt: entry.updatedAt,
+    label: resolveSessionEntryLabel(entry, storePath, agentId),
+    systemSent: entry.systemSent,
+  };
+  return [newEntry, ...prev.filter((h) => h.sessionId !== newEntry.sessionId)].slice(
+    0,
+    MAX_SESSION_HISTORY,
+  );
+}
+
 export async function initSessionState(params: {
   ctx: MsgContext;
   cfg: OpenClawConfig;
@@ -296,6 +318,7 @@ export async function initSessionState(params: {
   let persistedSubagentRole: SessionEntry["subagentRole"];
   let persistedSubagentControlScope: SessionEntry["subagentControlScope"];
   let persistedDisplayName: SessionEntry["displayName"];
+  let updatedHistory: SessionHistoryEntry[] | undefined;
 
   const normalizedChatType = normalizeChatType(ctx.ChatType);
   const isGroup =
@@ -471,6 +494,12 @@ export async function initSessionState(params: {
       persistedSubagentRole = entry.subagentRole;
       persistedSubagentControlScope = entry.subagentControlScope;
       persistedDisplayName = entry.displayName;
+      // Build updated history: prepend the session being archived, cap at MAX_SESSION_HISTORY.
+      updatedHistory = buildUpdatedHistory(entry, storePath, agentId);
+    } else if (entry) {
+      // Daily/idle timeout: session expired passively. Transcript stays on disk
+      // as-is (not archived), but record it in history so /resume can find it.
+      updatedHistory = buildUpdatedHistory(entry, storePath, agentId);
     }
   }
 
@@ -545,6 +574,7 @@ export async function initSessionState(params: {
     spawnDepth: persistedSpawnDepth ?? baseEntry?.spawnDepth,
     subagentRole: persistedSubagentRole ?? baseEntry?.subagentRole,
     subagentControlScope: persistedSubagentControlScope ?? baseEntry?.subagentControlScope,
+    history: updatedHistory ?? baseEntry?.history,
     sendPolicy: baseEntry?.sendPolicy,
     queueMode: baseEntry?.queueMode,
     queueDebounceMs: baseEntry?.queueDebounceMs,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -141,6 +141,8 @@ export type SessionEntry = {
   subagentRole?: "orchestrator" | "leaf";
   /** Explicit control scope assigned at spawn time for subagent control decisions. */
   subagentControlScope?: "children" | "none";
+  /** Previous sessions for this session key, newest-first. Capped at 20. */
+  history?: SessionHistoryEntry[];
   systemSent?: boolean;
   abortedLastRun?: boolean;
   /** Stable first-run start time for subagent sessions, persisted after completion. */
@@ -469,6 +471,16 @@ export type SessionSystemPromptReport = {
     }>;
   };
 };
+
+export type SessionHistoryEntry = {
+  sessionId: string;
+  sessionFile?: string;
+  updatedAt: number;
+  label?: string;
+  systemSent?: boolean;
+};
+
+export const MAX_SESSION_HISTORY = 20;
 
 export const DEFAULT_RESET_TRIGGER = "/new";
 export const DEFAULT_RESET_TRIGGERS = ["/new", "/reset"];

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -586,6 +586,33 @@ export function readLatestSessionUsageFromTranscript(
   });
 }
 
+type SessionEntryLabelFields = {
+  label?: string;
+  displayName?: string;
+  subject?: string;
+  sessionId: string;
+  sessionFile?: string;
+};
+
+/**
+ * Derive a display label for a session entry to store in history.
+ * Priority: label → displayName → subject → last message preview from transcript.
+ */
+export function resolveSessionEntryLabel(
+  entry: SessionEntryLabelFields,
+  storePath: string | undefined,
+  agentId: string | undefined,
+): string | undefined {
+  return (
+    entry.label ??
+    entry.displayName?.trim() ??
+    entry.subject?.trim() ??
+    readSessionTitleFieldsFromTranscript(entry.sessionId, storePath, entry.sessionFile, agentId)
+      .lastMessagePreview ??
+    undefined
+  );
+}
+
 const PREVIEW_READ_SIZES = [64 * 1024, 256 * 1024, 1024 * 1024];
 const PREVIEW_MAX_LINES = 200;
 


### PR DESCRIPTION
feat(session): add /resume command to list and restore previous sessions

## Summary

- Add `/resume` command to list recent sessions or switch back to a previous one
- Track session history on explicit reset (`/new`), daily/idle timeout, and `/resume` — each records the outgoing session with an auto-derived label
- Auto-label uses: `label → displayName → subject → last message preview from transcript`
- Restore logic: check live `.jsonl` paths first, then scan for `.jsonl.reset.*` archives (un-archiving the newest match)
- List format: numbered index + 8-char ID + relative timestamp + label (e.g. `1. \`aaaabbbb\` 3h ago — help with TypeScript`)
- Resume by index (`/resume 1`) or exact 8-char ID (`/resume aaaabbbb`)

## Changes

- `types.ts`: add `SessionHistoryEntry` type, `history?` field on `SessionEntry`, `MAX_SESSION_HISTORY = 20`
- `session-utils.fs.ts`: add `resolveSessionEntryLabel` shared helper
- `session.ts`: populate `history` on explicit reset and daily/idle expiry
- `commands-session-resume.ts`: new command handler
- `commands-registry.data.ts` + `commands-core.ts`: register `/resume`

## Related Issues

- #58028

## Test plan

- [x] `pnpm test` — 138 tests pass
- [x] `/resume` with no history → "No previous sessions found."
- [x] `/resume` with history → numbered list with timestamps and labels
- [x] `/resume 1` → resumes first entry by index
- [x] `/resume aaaabbbb` → resumes by 8-char ID
- [x] `/resume` after daily/idle reset → expired session appears in list
- [x] label auto-populated from last message preview when not explicitly set
