### PR TITLE
fix(slack): propagate mediaLocalRoots through send action path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/mediaLocalRoots propagation: forward agent-scoped media roots through the Slack send action path so local file uploads from agent workspace directories pass `assertLocalMediaAllowed` instead of failing with `path-not-allowed`. (#36477)
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -194,6 +194,11 @@ export async function handleSlackAction(
           allowEmpty: true,
         });
         const mediaUrl = readStringParam(params, "mediaUrl");
+        // mediaLocalRoots is forwarded from the agent's outbound context so local
+        // file paths under the agent workspace pass assertLocalMediaAllowed. (#36477)
+        const mediaLocalRoots = Array.isArray(params.mediaLocalRoots)
+          ? (params.mediaLocalRoots as readonly string[])
+          : undefined;
         const blocks = readSlackBlocksParam(params);
         if (!content && !mediaUrl && !blocks) {
           throw new Error("Slack sendMessage requires content, blocks, or mediaUrl.");
@@ -209,6 +214,7 @@ export async function handleSlackAction(
         const result = await sendSlackMessage(to, content ?? "", {
           ...writeOpts,
           mediaUrl: mediaUrl ?? undefined,
+          mediaLocalRoots,
           threadTs: threadTs ?? undefined,
           blocks,
         });

--- a/src/plugin-sdk/slack-message-actions.test.ts
+++ b/src/plugin-sdk/slack-message-actions.test.ts
@@ -64,4 +64,34 @@ describe("handleSlackMessageAction", () => {
       expect.any(Object),
     );
   });
+
+  it("propagates mediaLocalRoots from ctx to sendMessage so agent workspace files are allowed (#36477)", async () => {
+    const invoke = createInvokeSpy();
+    const mediaLocalRoots = ["/home/admin/clawd-agents/potty"] as const;
+
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "send",
+        cfg: {},
+        params: {
+          to: "channel:C1",
+          message: "hi",
+          media: "/home/admin/clawd-agents/potty/output/report.pdf",
+        },
+        mediaLocalRoots,
+      } as never,
+      invoke: invoke as never,
+    });
+
+    expect(invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sendMessage",
+        to: "channel:C1",
+        mediaLocalRoots,
+      }),
+      expect.any(Object),
+      undefined,
+    );
+  });
 });

--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -52,6 +52,9 @@ export async function handleSlackMessageAction(params: {
         to,
         content: content ?? "",
         mediaUrl: mediaUrl ?? undefined,
+        // Propagate agent-scoped media roots so local file uploads are
+        // permitted from the agent workspace directory. (#36477)
+        mediaLocalRoots: ctx.mediaLocalRoots,
         blocks,
         accountId,
         threadTs: threadId ?? replyTo ?? undefined,


### PR DESCRIPTION
## Summary

- `src/plugin-sdk/slack-message-actions.ts`: add `mediaLocalRoots: ctx.mediaLocalRoots` to the `sendMessage` action payload in the `"send"` branch of `handleSlackMessageAction`
- `src/agents/tools/slack-actions.ts`: read `params.mediaLocalRoots` (forwarded through the action payload) and pass it as `mediaLocalRoots` to `sendSlackMessage()`

## Root cause

The CVE fix in v2026.3.2 added `assertLocalMediaAllowed` enforcement requiring local file paths to be under explicitly allowed roots. Feishu was patched (#27884) to propagate `mediaLocalRoots`, but the Slack send path was not updated. Three places dropped `mediaLocalRoots`:

1. `handleSlackMessageAction` (plugin-sdk): didn't include `ctx.mediaLocalRoots` in the `sendMessage` action payload
2. `handleSlackAction` (agents/tools): didn't read `mediaLocalRoots` from params or pass it to `sendSlackMessage`

`sendMessageSlack` and `uploadSlackFile` already accept and use `mediaLocalRoots` correctly — the fix is purely propagating the value upstream.

Note: the `extensions/slack/src/channel.ts` invoke callback doesn't need updating since `handleSlackMessageAction` now includes `mediaLocalRoots` in the action object that flows to `handleSlackAction`.

## Test plan

- [x] Added test in `src/plugin-sdk/slack-message-actions.test.ts` verifying `mediaLocalRoots` is forwarded in the `sendMessage` action payload
- [x] All 38 tests pass: `pnpm test src/plugin-sdk/slack-message-actions.test.ts src/agents/tools/slack-actions.test.ts`

Fixes #36477