### PR TITLE
fix(mattermost): use scoped plugin-sdk imports (#19957 regression)

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -162,6 +162,41 @@ describe("config schema", () => {
     expect(second).toBe(first);
   });
 
+  it("does not cache-collide when same plugin ID has different schemas", () => {
+    const schemaA = buildConfigSchema({
+      plugins: [
+        {
+          id: "voice-call",
+          configSchema: { type: "object", properties: { a: { type: "string" } } },
+        },
+      ],
+    });
+    const schemaB = buildConfigSchema({
+      plugins: [
+        {
+          id: "voice-call",
+          configSchema: { type: "object", properties: { b: { type: "number" } } },
+        },
+      ],
+    });
+    expect(schemaB).not.toBe(schemaA);
+  });
+
+  it("handles many channels without RangeError", () => {
+    // Simulate 20 channels each with a schema containing 50 properties.
+    const channels = Array.from({ length: 20 }, (_, i) => ({
+      id: `channel-${i}`,
+      label: `Channel ${i}`,
+      configSchema: {
+        type: "object" as const,
+        properties: Object.fromEntries(
+          Array.from({ length: 50 }, (__, j) => [`field${j}`, { type: "string" }]),
+        ),
+      },
+    }));
+    expect(() => buildConfigSchema({ channels })).not.toThrow();
+  });
+
   it("derives security/auth tags for credential paths", () => {
     const tags = deriveTagsForPath("gateway.auth.token");
     expect(tags).toContain("security");

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -49,6 +49,7 @@ export {
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "../config/runtime-group-policy.js";
+export { resolveChannelGroupRequireMention } from "../config/group-policy.js";
 export type { BlockStreamingCoalesceConfig, DmPolicy, GroupPolicy } from "../config/types.js";
 export type { SecretInput } from "../config/types.secrets.js";
 export {


### PR DESCRIPTION
## Summary

The `feat(mattermost): add interactive buttons support` PR (#19957) introduced imports from the monolithic `openclaw/plugin-sdk` entry in three mattermost extension files, which fails the `lint:plugins:no-monolithic-plugin-sdk-entry-imports` check and causes `check` CI failures on all PRs based on this version of main.

**Changes:**
- `extensions/mattermost/src/group-mentions.ts`: `openclaw/plugin-sdk` → `openclaw/plugin-sdk/mattermost`
- `extensions/mattermost/src/group-mentions.test.ts`: same
- `extensions/mattermost/src/mattermost/monitor.test.ts`: same
- `src/plugin-sdk/mattermost.ts`: export `resolveChannelGroupRequireMention` from `../config/group-policy.js` (required by `group-mentions.ts`)

## Test plan

- [x] `node --import tsx scripts/check-no-monolithic-plugin-sdk-entry-imports.ts` passes (740 files checked)
- [x] `pnpm format:fix` applied