### PR TITLE
fix(feishu): support groupPolicy "allowall" (#36312)

### DIFF
--- a/extensions/feishu/src/policy.ts
+++ b/extensions/feishu/src/policy.ts
@@ -92,7 +92,7 @@ export function resolveFeishuGroupToolPolicy(
 }
 
 export function isFeishuGroupAllowed(params: {
-  groupPolicy: "open" | "allowlist" | "disabled";
+  groupPolicy: "open" | "allowlist" | "allowall" | "disabled";
   allowFrom: Array<string | number>;
   senderId: string;
   senderIds?: Array<string | null | undefined>;
@@ -102,7 +102,7 @@ export function isFeishuGroupAllowed(params: {
   if (groupPolicy === "disabled") {
     return false;
   }
-  if (groupPolicy === "open") {
+  if (groupPolicy === "open" || groupPolicy === "allowall") {
     return true;
   }
   return resolveFeishuAllowlistMatch(params).allowed;


### PR DESCRIPTION
Fixes #36312 - groupPolicy "allowall" not working

## Problem
- Config: `groupPolicy: "allowall"` + `allowFrom: []`
- Result: Groups rejected (log shows "not in groupAllowFrom")

## Root Cause
- `isFeishuGroupAllowed()` missing "allowall" case
- Falls through to `resolveFeishuAllowlistMatch()`

## Fix
- Add `|| groupPolicy === "allowall"` check
- +1 line to type, +1 line to condition

## Testing
- "allowall" → ✅ bypasses allowFrom
- "open" → ✅ still works
- "allowlist" → ✅ checks allowFrom
