### PR TITLE
fix(auth): reduce gemini oauth cooldown after transient failures

### DIFF
--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore, ProfileUsageStats } from "./types.js";
 import {
+  calculateAuthProfileCooldownMs,
   clearAuthProfileCooldown,
   clearExpiredCooldowns,
   isProfileInCooldown,
@@ -40,6 +41,27 @@ function expectProfileErrorStateCleared(
   expect(stats?.errorCount).toBe(0);
   expect(stats?.failureCounts).toBeUndefined();
 }
+
+describe("calculateAuthProfileCooldownMs", () => {
+  it("uses shorter first backoff for google-gemini-cli oauth-style failures", () => {
+    const googleTimeout = calculateAuthProfileCooldownMs(1, {
+      providerId: "google-gemini-cli",
+      reason: "timeout",
+    });
+    const googleAuth = calculateAuthProfileCooldownMs(1, {
+      providerId: "google-gemini-cli",
+      reason: "auth",
+    });
+    const defaultBackoff = calculateAuthProfileCooldownMs(1, {
+      providerId: "anthropic",
+      reason: "timeout",
+    });
+
+    expect(googleTimeout).toBe(10_000);
+    expect(googleAuth).toBe(10_000);
+    expect(defaultBackoff).toBe(60_000);
+  });
+});
 
 describe("resolveProfileUnusableUntil", () => {
   it("returns null when both values are missing or invalid", () => {

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -62,7 +62,7 @@ describe("calculateAuthProfileCooldownMs", () => {
     expect(defaultBackoff).toBe(60_000);
   });
 
-  it("applies full exponential backoff progression for google-gemini-cli oauth failures", () => {
+  it("applies exponential backoff for google-gemini-cli oauth failures and reaches max cooldown", () => {
     expect(
       calculateAuthProfileCooldownMs(1, {
         providerId: "google-gemini-cli",
@@ -92,7 +92,13 @@ describe("calculateAuthProfileCooldownMs", () => {
         providerId: "google-gemini-cli",
         reason: "auth",
       }),
-    ).toBe(1_250_000);
+    ).toBe(3_600_000);
+    expect(
+      calculateAuthProfileCooldownMs(7, {
+        providerId: "google-gemini-cli",
+        reason: "auth",
+      }),
+    ).toBe(3_600_000);
   });
 
   it("keeps default cooldown for google-gemini-cli non-oauth failures", () => {

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -61,6 +61,58 @@ describe("calculateAuthProfileCooldownMs", () => {
     expect(googleAuth).toBe(10_000);
     expect(defaultBackoff).toBe(60_000);
   });
+
+  it("applies full exponential backoff progression for google-gemini-cli oauth failures", () => {
+    expect(
+      calculateAuthProfileCooldownMs(1, {
+        providerId: "google-gemini-cli",
+        reason: "auth",
+      }),
+    ).toBe(10_000);
+    expect(
+      calculateAuthProfileCooldownMs(2, {
+        providerId: "google-gemini-cli",
+        reason: "auth",
+      }),
+    ).toBe(50_000);
+    expect(
+      calculateAuthProfileCooldownMs(3, {
+        providerId: "google-gemini-cli",
+        reason: "timeout",
+      }),
+    ).toBe(250_000);
+    expect(
+      calculateAuthProfileCooldownMs(4, {
+        providerId: "google-gemini-cli",
+        reason: "timeout",
+      }),
+    ).toBe(1_250_000);
+    expect(
+      calculateAuthProfileCooldownMs(5, {
+        providerId: "google-gemini-cli",
+        reason: "auth",
+      }),
+    ).toBe(1_250_000);
+  });
+
+  it("keeps default cooldown for google-gemini-cli non-oauth failures", () => {
+    expect(
+      calculateAuthProfileCooldownMs(1, {
+        providerId: "google-gemini-cli",
+        reason: "rate_limit",
+      }),
+    ).toBe(60_000);
+    expect(
+      calculateAuthProfileCooldownMs(1, {
+        providerId: "google-gemini-cli",
+        reason: "unknown",
+      }),
+    ).toBe(60_000);
+  });
+
+  it("remains backward compatible when called without options", () => {
+    expect(calculateAuthProfileCooldownMs(1)).toBe(60_000);
+  });
 });
 
 describe("resolveProfileUnusableUntil", () => {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -266,11 +266,24 @@ export async function markAuthProfileUsed(params: {
   saveAuthProfileStore(store, agentDir);
 }
 
-export function calculateAuthProfileCooldownMs(errorCount: number): number {
+const DEFAULT_PROFILE_COOLDOWN_BASE_MS = 60 * 1000;
+const GOOGLE_GEMINI_OAUTH_COOLDOWN_BASE_MS = 10 * 1000;
+
+export function calculateAuthProfileCooldownMs(
+  errorCount: number,
+  options?: { reason?: AuthProfileFailureReason; providerId?: string },
+): number {
   const normalized = Math.max(1, errorCount);
+  const providerId = normalizeProviderId(options?.providerId ?? "");
+  const isGoogleGeminiCli = providerId === "google-gemini-cli";
+  const isOauthLikeFailure = options?.reason === "auth" || options?.reason === "timeout";
+  const baseMs =
+    isGoogleGeminiCli && isOauthLikeFailure
+      ? GOOGLE_GEMINI_OAUTH_COOLDOWN_BASE_MS
+      : DEFAULT_PROFILE_COOLDOWN_BASE_MS;
   return Math.min(
     60 * 60 * 1000, // 1 hour max
-    60 * 1000 * 5 ** Math.min(normalized - 1, 3),
+    baseMs * 5 ** Math.min(normalized - 1, 3),
   );
 }
 
@@ -390,6 +403,7 @@ function computeNextProfileUsageStats(params: {
   existing: ProfileUsageStats;
   now: number;
   reason: AuthProfileFailureReason;
+  providerId?: string;
   cfgResolved: ResolvedAuthCooldownConfig;
 }): ProfileUsageStats {
   const windowMs = params.cfgResolved.failureWindowMs;
@@ -426,7 +440,10 @@ function computeNextProfileUsageStats(params: {
     });
     updatedStats.disabledReason = params.reason;
   } else {
-    const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount);
+    const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount, {
+      reason: params.reason,
+      providerId: params.providerId,
+    });
     // Keep active cooldown windows immutable so retries within the window
     // cannot push recovery further out.
     updatedStats.cooldownUntil = keepActiveWindowOrRecompute({
@@ -475,6 +492,7 @@ export async function markAuthProfileFailure(params: {
           existing: existing ?? {},
           now,
           reason,
+          providerId: providerKey,
           cfgResolved,
         }),
       );
@@ -501,6 +519,7 @@ export async function markAuthProfileFailure(params: {
       existing: existing ?? {},
       now,
       reason,
+      providerId: providerKey,
       cfgResolved,
     }),
   );

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -283,7 +283,7 @@ export function calculateAuthProfileCooldownMs(
       : DEFAULT_PROFILE_COOLDOWN_BASE_MS;
   return Math.min(
     60 * 60 * 1000, // 1 hour max
-    baseMs * 5 ** Math.min(normalized - 1, 3),
+    baseMs * 5 ** Math.max(normalized - 1, 0),
   );
 }
 


### PR DESCRIPTION
Problem: google-gemini-cli OAuth sessions can appear to hang around ~60s after transient auth/timeout failures because profile cooldown backoff starts at 60s, delaying retry/profile rotation in multi-step tool flows.\n\nRoot cause: auth profile cooldown used a provider-agnostic base (60s) for all non-billing failures, including transient OAuth/auth timeout cases for google-gemini-cli.\n\nFix: make cooldown calculation provider/reason-aware. For google-gemini-cli transient oauth-like failures (reason=auth or timeout), start backoff at 10s (still exponential with existing cap) while preserving default behavior for other providers/reasons.\n\nTesting:\n- added usage test coverage for provider-aware cooldown behavior\n- pnpm vitest run src/agents/auth-profiles/usage.test.ts