### PR TITLE
fix: propagate mediaLocalRoots in Slack send action chain

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -44,6 +44,37 @@ describe("slackPlugin actions", () => {
       }),
       {},
       undefined,
+      { mediaLocalRoots: undefined },
+    );
+  });
+
+  it("forwards mediaLocalRoots for send action handler", async () => {
+    handleSlackActionMock.mockResolvedValueOnce({ ok: true });
+    const handleAction = slackPlugin.actions?.handleAction;
+    expect(handleAction).toBeDefined();
+
+    await handleAction!({
+      action: "send",
+      channel: "slack",
+      accountId: "default",
+      cfg: {},
+      mediaLocalRoots: ["/tmp/workspace"],
+      params: {
+        to: "C123",
+        media: "/tmp/workspace/report.pdf",
+      },
+    });
+
+    expect(handleSlackActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sendMessage",
+        to: "C123",
+        mediaUrl: "/tmp/workspace/report.pdf",
+        mediaLocalRoots: ["/tmp/workspace"],
+      }),
+      {},
+      undefined,
+      { mediaLocalRoots: ["/tmp/workspace"] },
     );
   });
 });

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -277,8 +277,10 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
         providerId: meta.id,
         ctx,
         includeReadThreadId: true,
-        invoke: async (action, cfg, toolContext) =>
-          await getSlackRuntime().channel.slack.handleSlackAction(action, cfg, toolContext),
+        invoke: async (action, cfg, toolContext, messageContext) =>
+          await getSlackRuntime().channel.slack.handleSlackAction(action, cfg, toolContext, {
+            mediaLocalRoots: messageContext?.mediaLocalRoots ?? ctx.mediaLocalRoots,
+          }),
       }),
   },
   setup: {

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -52,6 +52,10 @@ export type SlackActionContext = {
   hasRepliedRef?: { value: boolean };
 };
 
+export type SlackActionMessageContext = {
+  mediaLocalRoots?: readonly string[];
+};
+
 /**
  * Resolve threadTs for a Slack message based on context and replyToMode.
  * - "all": always inject threadTs
@@ -104,6 +108,7 @@ export async function handleSlackAction(
   params: Record<string, unknown>,
   cfg: OpenClawConfig,
   context?: SlackActionContext,
+  messageContext?: SlackActionMessageContext,
 ): Promise<AgentToolResult<unknown>> {
   const resolveChannelId = () =>
     resolveSlackChannelId(
@@ -209,6 +214,7 @@ export async function handleSlackAction(
         const result = await sendSlackMessage(to, content ?? "", {
           ...writeOpts,
           mediaUrl: mediaUrl ?? undefined,
+          mediaLocalRoots: messageContext?.mediaLocalRoots,
           threadTs: threadTs ?? undefined,
           blocks,
         });

--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -7,6 +7,7 @@ type SlackActionInvoke = (
   action: Record<string, unknown>,
   cfg: ChannelMessageActionContext["cfg"],
   toolContext?: ChannelMessageActionContext["toolContext"],
+  messageContext?: { mediaLocalRoots?: readonly string[] },
 ) => Promise<AgentToolResult<unknown>>;
 
 function readSlackBlocksParam(actionParams: Record<string, unknown>) {
@@ -55,9 +56,11 @@ export async function handleSlackMessageAction(params: {
         blocks,
         accountId,
         threadTs: threadId ?? replyTo ?? undefined,
+        mediaLocalRoots: ctx.mediaLocalRoots,
       },
       cfg,
       ctx.toolContext,
+      { mediaLocalRoots: ctx.mediaLocalRoots },
     );
   }
 

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -159,6 +159,7 @@ export async function sendSlackMessage(
   content: string,
   opts: SlackActionClientOpts & {
     mediaUrl?: string;
+    mediaLocalRoots?: readonly string[];
     threadTs?: string;
     blocks?: (Block | KnownBlock)[];
   } = {},
@@ -167,6 +168,7 @@ export async function sendSlackMessage(
     accountId: opts.accountId,
     token: opts.token,
     mediaUrl: opts.mediaUrl,
+    mediaLocalRoots: opts.mediaLocalRoots,
     client: opts.client,
     threadTs: opts.threadTs,
     blocks: opts.blocks,


### PR DESCRIPTION
## Summary
- forward trusted `mediaLocalRoots` from Slack channel action context into `handleSlackAction`
- include `mediaLocalRoots` in plugin-sdk Slack `send` invoke payload
- plumb `mediaLocalRoots` through Slack tool action -> `sendSlackMessage` -> `sendMessageSlack`
- add Slack extension action test coverage for `mediaLocalRoots` forwarding

## Testing
- pnpm -s vitest extensions/slack/src/channel.test.ts src/agents/tools/slack-actions.test.ts

Fixes openclaw/openclaw#36477
