### PR TITLE
perf(channels): cache registry misses with bounded loader cache

### DIFF
--- a/src/channels/plugins/registry-loader.test.ts
+++ b/src/channels/plugins/registry-loader.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getActivePluginRegistry, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import {
+  CHANNEL_REGISTRY_LOADER_CACHE_MAX,
+  createChannelRegistryLoader,
+} from "./registry-loader.js";
+import type { ChannelPlugin } from "./types.js";
+
+const emptyRegistry = createTestRegistry([]);
+
+let previousRegistry: ReturnType<typeof getActivePluginRegistry> = null;
+
+function createPlugin(id: string): ChannelPlugin {
+  return {
+    id,
+    meta: {
+      id,
+      label: id,
+      selectionLabel: id,
+      docsPath: `/channels/${id}`,
+      blurb: "test plugin",
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: {
+      listAccountIds: () => [],
+      resolveAccount: () => ({}),
+    },
+  };
+}
+
+describe("createChannelRegistryLoader", () => {
+  beforeEach(() => {
+    previousRegistry = getActivePluginRegistry();
+    setActivePluginRegistry(emptyRegistry);
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(previousRegistry ?? emptyRegistry);
+  });
+
+  it("caches plugin misses and undefined resolver results", async () => {
+    const registry = createTestRegistry([
+      {
+        pluginId: "slack",
+        plugin: createPlugin("slack"),
+        source: "test",
+      },
+    ]);
+    const findSpy = vi.spyOn(registry.channels, "find");
+    setActivePluginRegistry(registry);
+
+    const resolveSpy = vi.fn((entry) => entry.plugin.outbound);
+    const loadOutbound = createChannelRegistryLoader(resolveSpy);
+
+    await expect(loadOutbound("slack")).resolves.toBeUndefined();
+    await expect(loadOutbound("slack")).resolves.toBeUndefined();
+    await expect(loadOutbound("missing")).resolves.toBeUndefined();
+    await expect(loadOutbound("missing")).resolves.toBeUndefined();
+
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+    expect(findSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds cache growth with FIFO eviction", async () => {
+    const registry = createTestRegistry([]);
+    const findSpy = vi.spyOn(registry.channels, "find");
+    setActivePluginRegistry(registry);
+
+    const loadPlugin = createChannelRegistryLoader((entry) => entry.plugin);
+    for (let i = 0; i <= CHANNEL_REGISTRY_LOADER_CACHE_MAX; i += 1) {
+      await loadPlugin(`missing-${i}`);
+    }
+    await loadPlugin("missing-0");
+
+    expect(findSpy).toHaveBeenCalledTimes(CHANNEL_REGISTRY_LOADER_CACHE_MAX + 2);
+  });
+});

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -6,10 +6,31 @@ type ChannelRegistryValueResolver<TValue> = (
   entry: PluginChannelRegistration,
 ) => TValue | undefined;
 
+export const CHANNEL_REGISTRY_LOADER_CACHE_MAX = 512;
+
+const CHANNEL_REGISTRY_MISS = Symbol("channel-registry-miss");
+
+type ChannelRegistryCacheValue<TValue> = TValue | typeof CHANNEL_REGISTRY_MISS;
+
+function setChannelRegistryCacheValue<TValue>(
+  cache: Map<ChannelId, ChannelRegistryCacheValue<TValue>>,
+  key: ChannelId,
+  value: ChannelRegistryCacheValue<TValue>,
+): void {
+  cache.set(key, value);
+  if (cache.size <= CHANNEL_REGISTRY_LOADER_CACHE_MAX) {
+    return;
+  }
+  const oldest = cache.keys().next();
+  if (!oldest.done) {
+    cache.delete(oldest.value);
+  }
+}
+
 export function createChannelRegistryLoader<TValue>(
   resolveValue: ChannelRegistryValueResolver<TValue>,
 ): (id: ChannelId) => Promise<TValue | undefined> {
-  const cache = new Map<ChannelId, TValue>();
+  const cache = new Map<ChannelId, ChannelRegistryCacheValue<TValue>>();
   let lastRegistry: PluginRegistry | null = null;
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
@@ -18,18 +39,20 @@ export function createChannelRegistryLoader<TValue>(
       cache.clear();
       lastRegistry = registry;
     }
-    const cached = cache.get(id);
-    if (cached) {
+    if (cache.has(id)) {
+      const cached = cache.get(id);
+      if (cached === CHANNEL_REGISTRY_MISS) {
+        return undefined;
+      }
       return cached;
     }
     const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
-    if (!pluginEntry) {
-      return undefined;
-    }
-    const resolved = resolveValue(pluginEntry);
-    if (resolved) {
-      cache.set(id, resolved);
-    }
+    const resolved = pluginEntry ? resolveValue(pluginEntry) : undefined;
+    setChannelRegistryCacheValue(
+      cache,
+      id,
+      resolved === undefined ? CHANNEL_REGISTRY_MISS : resolved,
+    );
     return resolved;
   };
 }


### PR DESCRIPTION
## Summary
- cache unresolved channel IDs in createChannelRegistryLoader instead of rescanning registry on every miss
- cache resolveValue(...) returning undefined (for example outbound-less plugins) to avoid repeated hot-path Array.find scans
- cap loader cache size to 512 entries with FIFO eviction to prevent unbounded growth

## Why
loadChannelPlugin and loadChannelOutboundAdapter both use this loader in runtime paths. Before this change, misses and undefined-resolve cases were never cached, so repeated lookups could trigger repeated O(n) scans and unbounded key growth under noisy IDs.

## Validation
- pnpm vitest run src/channels/plugins/registry-loader.test.ts
- pnpm exec oxfmt --check src/channels/plugins/registry-loader.ts src/channels/plugins/registry-loader.test.ts

## Risk
Low. Successful-hit behavior is unchanged, cache still invalidates when active registry changes, and tests cover miss caching plus FIFO eviction.