### PR TITLE
fix(slack): propagate mediaLocalRoots for local uploads

### DIFF
--- a/src/agents/tools/slack-actions.test.ts
+++ b/src/agents/tools/slack-actions.test.ts
@@ -71,6 +71,7 @@ describe("handleSlackAction", () => {
   function expectLastSlackSend(content: string, threadTs?: string) {
     expect(sendSlackMessage).toHaveBeenLastCalledWith("channel:C123", content, {
       mediaUrl: undefined,
+      mediaLocalRoots: undefined,
       threadTs,
       blocks: undefined,
     });
@@ -191,7 +192,28 @@ describe("handleSlackAction", () => {
     );
     expect(sendSlackMessage).toHaveBeenCalledWith("channel:C123", "Hello thread", {
       mediaUrl: undefined,
+      mediaLocalRoots: undefined,
       threadTs: "1234567890.123456",
+      blocks: undefined,
+    });
+  });
+
+  it("passes mediaLocalRoots to sendSlackMessage for outbound media", async () => {
+    await handleSlackAction(
+      {
+        action: "sendMessage",
+        to: "channel:C123",
+        content: "caption",
+        mediaUrl: "/tmp/report.pdf",
+        mediaLocalRoots: ["/tmp"],
+      },
+      slackConfig(),
+    );
+
+    expect(sendSlackMessage).toHaveBeenCalledWith("channel:C123", "caption", {
+      mediaUrl: "/tmp/report.pdf",
+      mediaLocalRoots: ["/tmp"],
+      threadTs: undefined,
       blocks: undefined,
     });
   });
@@ -267,6 +289,7 @@ describe("handleSlackAction", () => {
     );
     expect(sendSlackMessage).toHaveBeenCalledWith("channel:C123", "", {
       mediaUrl: undefined,
+      mediaLocalRoots: undefined,
       threadTs: undefined,
       blocks: expectedBlocks,
     });
@@ -377,6 +400,7 @@ describe("handleSlackAction", () => {
     );
     expect(sendSlackMessage).toHaveBeenCalledWith("channel:C123", "Auto-threaded", {
       mediaUrl: undefined,
+      mediaLocalRoots: undefined,
       threadTs: "1111111111.111111",
       blocks: undefined,
     });
@@ -427,6 +451,7 @@ describe("handleSlackAction", () => {
     });
     expect(sendSlackMessage).toHaveBeenCalledWith("channel:C123", "No ref", {
       mediaUrl: undefined,
+      mediaLocalRoots: undefined,
       threadTs: undefined,
       blocks: undefined,
     });
@@ -450,6 +475,7 @@ describe("handleSlackAction", () => {
     );
     expect(sendSlackMessage).toHaveBeenCalledWith("channel:C123", "Off mode", {
       mediaUrl: undefined,
+      mediaLocalRoots: undefined,
       threadTs: undefined,
       blocks: undefined,
     });
@@ -473,6 +499,7 @@ describe("handleSlackAction", () => {
     );
     expect(sendSlackMessage).toHaveBeenCalledWith("channel:C999", "Different channel", {
       mediaUrl: undefined,
+      mediaLocalRoots: undefined,
       threadTs: undefined,
       blocks: undefined,
     });
@@ -497,6 +524,7 @@ describe("handleSlackAction", () => {
     );
     expect(sendSlackMessage).toHaveBeenCalledWith("channel:C123", "Explicit thread", {
       mediaUrl: undefined,
+      mediaLocalRoots: undefined,
       threadTs: "2222222222.222222",
       blocks: undefined,
     });
@@ -520,6 +548,7 @@ describe("handleSlackAction", () => {
     );
     expect(sendSlackMessage).toHaveBeenCalledWith("C123", "No prefix", {
       mediaUrl: undefined,
+      mediaLocalRoots: undefined,
       threadTs: "1111111111.111111",
       blocks: undefined,
     });

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -206,9 +206,13 @@ export async function handleSlackAction(
           to,
           context,
         );
+        const mediaLocalRoots = Array.isArray(params.mediaLocalRoots)
+          ? (params.mediaLocalRoots.filter((root) => typeof root === "string") as string[])
+          : undefined;
         const result = await sendSlackMessage(to, content ?? "", {
           ...writeOpts,
           mediaUrl: mediaUrl ?? undefined,
+          mediaLocalRoots,
           threadTs: threadTs ?? undefined,
           blocks,
         });

--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -52,6 +52,7 @@ export async function handleSlackMessageAction(params: {
         to,
         content: content ?? "",
         mediaUrl: mediaUrl ?? undefined,
+        mediaLocalRoots: ctx.mediaLocalRoots,
         blocks,
         accountId,
         threadTs: threadId ?? replyTo ?? undefined,

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -159,6 +159,7 @@ export async function sendSlackMessage(
   content: string,
   opts: SlackActionClientOpts & {
     mediaUrl?: string;
+    mediaLocalRoots?: readonly string[];
     threadTs?: string;
     blocks?: (Block | KnownBlock)[];
   } = {},
@@ -167,6 +168,7 @@ export async function sendSlackMessage(
     accountId: opts.accountId,
     token: opts.token,
     mediaUrl: opts.mediaUrl,
+    mediaLocalRoots: opts.mediaLocalRoots,
     client: opts.client,
     threadTs: opts.threadTs,
     blocks: opts.blocks,


### PR DESCRIPTION
Closes #36477

Slack local file uploads started failing after the outbound local media allowlist enforcement because the Slack message action path did not forward agent-scoped mediaLocalRoots to the Slack sender.

This change threads mediaLocalRoots through:
- plugin-sdk handleSlackMessageAction -> handleSlackAction params
- slack-actions tool handler -> sendSlackMessage -> sendMessageSlack

Adds a regression unit test to ensure mediaLocalRoots is passed for media sends.

Tests:
- pnpm -s vitest run src/agents/tools/slack-actions.test.ts
