### PR TITLE
mattermost: short-circuit explicit group mention overrides

### DIFF
--- a/extensions/mattermost/src/group-mentions.test.ts
+++ b/extensions/mattermost/src/group-mentions.test.ts
@@ -43,4 +43,26 @@ describe("resolveMattermostGroupRequireMention", () => {
     });
     expect(requireMention).toBe(false);
   });
+
+  it("does not resolve account secrets when runtime override is explicit", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          botToken: {
+            source: "env",
+            provider: "MISSING_PROVIDER",
+            id: "MISSING_ID",
+          },
+        },
+      },
+    };
+
+    const requireMention = resolveMattermostGroupRequireMention({
+      cfg,
+      accountId: "default",
+      requireMentionOverride: false,
+    });
+
+    expect(requireMention).toBe(false);
+  });
 });

--- a/extensions/mattermost/src/group-mentions.ts
+++ b/extensions/mattermost/src/group-mentions.ts
@@ -5,14 +5,13 @@ import { resolveMattermostAccount } from "./mattermost/accounts.js";
 export function resolveMattermostGroupRequireMention(
   params: ChannelGroupContext & { requireMentionOverride?: boolean },
 ): boolean | undefined {
-  const account = resolveMattermostAccount({
-    cfg: params.cfg,
-    accountId: params.accountId,
-  });
   const requireMentionOverride =
     typeof params.requireMentionOverride === "boolean"
       ? params.requireMentionOverride
-      : account.requireMention;
+      : resolveMattermostAccount({
+          cfg: params.cfg,
+          accountId: params.accountId,
+        }).requireMention;
   return resolveChannelGroupRequireMention({
     cfg: params.cfg,
     channel: "mattermost",


### PR DESCRIPTION
## Summary
- skip Mattermost account resolution when `requireMentionOverride` is explicitly provided at runtime
- keep existing precedence (explicit override still wins)
- add regression coverage to ensure unresolved account secrets are not touched in explicit-override flows

## Why
`resolveMattermostGroupRequireMention` runs on message handling paths. When a caller already provides an explicit override, resolving account config is unnecessary work and can trigger unrelated secret-resolution failures.

## Impact
- reduces avoidable work on the hot path
- improves robustness for runtime override flows with unresolved secret refs in config

## Risk
Low. Behavior only changes when `requireMentionOverride` is already explicitly passed; fallback behavior is unchanged.
