### PR TITLE
fix: include archived transcripts in sessions usage statistics

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -442,4 +442,39 @@ example
     expect(lastPoint?.cumulativeTokens).toBe(165);
     expect(lastPoint?.cumulativeCost).toBeCloseTo(0.055, 8);
   });
+
+  it("includes reset-archived transcript shards in usage summary and discovery", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-reset-archives-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const nowIso = new Date("2026-03-01T10:00:00.000Z").toISOString();
+    const mainFile = path.join(sessionsDir, "sess-archived.jsonl");
+    const archivedFile = path.join(
+      sessionsDir,
+      "sess-archived.jsonl.reset.2026-03-01T09-00-00.000Z",
+    );
+
+    const mkAssistant = (tokens: number) =>
+      JSON.stringify({
+        type: "message",
+        timestamp: nowIso,
+        message: {
+          role: "assistant",
+          usage: { input: tokens, output: 0, totalTokens: tokens, cost: { total: tokens / 1000 } },
+        },
+      });
+
+    await fs.writeFile(mainFile, `${mkAssistant(10)}\n`, "utf-8");
+    await fs.writeFile(archivedFile, `${mkAssistant(30)}\n`, "utf-8");
+
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30 });
+      expect(summary.totals.totalTokens).toBe(40);
+
+      const discovered = await discoverAllSessions();
+      const archivedSession = discovered.find((s) => s.sessionId === "sess-archived");
+      expect(archivedSession).toBeTruthy();
+    });
+  });
 });

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -5,6 +5,7 @@ import type { NormalizedUsage, UsageLike } from "../agents/usage.js";
 import { normalizeUsage } from "../agents/usage.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { parseSessionArchiveTimestamp } from "../config/sessions/artifacts.js";
 import {
   resolveSessionFilePath,
   resolveSessionTranscriptsDirForAgent,
@@ -214,6 +215,15 @@ const applyCostTotal = (totals: CostUsageTotals, costTotal: number | undefined) 
   totals.totalCost += costTotal;
 };
 
+function isUsageTranscriptFileName(fileName: string): boolean {
+  if (fileName.endsWith(".jsonl")) {
+    return true;
+  }
+  return (
+    parseSessionArchiveTimestamp(fileName, "reset") !== null && fileName.includes(".jsonl.reset.")
+  );
+}
+
 async function* readJsonlRecords(filePath: string): AsyncGenerator<Record<string, unknown>> {
   const fileStream = fs.createReadStream(filePath, { encoding: "utf-8" });
   const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
@@ -318,7 +328,7 @@ export async function loadCostUsageSummary(params?: {
   const files = (
     await Promise.all(
       entries
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+        .filter((entry) => entry.isFile() && isUsageTranscriptFileName(entry.name))
         .map(async (entry) => {
           const filePath = path.join(sessionsDir, entry.name);
           const stats = await fs.promises.stat(filePath).catch(() => null);
@@ -393,7 +403,7 @@ export async function discoverAllSessions(params?: {
   const discovered: DiscoveredSession[] = [];
 
   for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+    if (!entry.isFile() || !isUsageTranscriptFileName(entry.name)) {
       continue;
     }
 
@@ -409,8 +419,15 @@ export async function discoverAllSessions(params?: {
     }
     // Do not exclude by endMs: a session can have activity in range even if it continued later.
 
-    // Extract session ID from filename (remove .jsonl)
-    const sessionId = entry.name.slice(0, -6);
+    // Extract session ID from filename (remove .jsonl or .jsonl.reset.<timestamp>)
+    const resetMarker = ".jsonl.reset.";
+    const resetIdx = entry.name.indexOf(resetMarker);
+    const sessionId =
+      resetIdx >= 0
+        ? entry.name.slice(0, resetIdx)
+        : entry.name.endsWith(".jsonl")
+          ? entry.name.slice(0, -6)
+          : entry.name;
 
     // Try to read first user message for label extraction
     let firstUserMessage: string | undefined;


### PR DESCRIPTION
Closes #27417

Problem: sessions usage excludes /new-archived transcripts
Fix: Reuse a shared transcript filename matcher to include both primary .jsonl and reset-archived .jsonl.reset.<timestamp> shards when scanning usage/discovery, and normalize discovered session IDs for reset archive filenames.