### PR TITLE
fix(agents): surface slow google-gemini-cli OAuth prompt stalls

### DIFF
--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -1,5 +1,7 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { Type } from "@sinclair/typebox";
 import Ajv from "ajv";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/llm-task";
@@ -10,6 +12,64 @@ import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/llm-task";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/llm-task";
 
 type RunEmbeddedPiAgentFn = (params: Record<string, unknown>) => Promise<unknown>;
+let openClawRootCache: string | null = null;
+
+function findPackageRoot(startDir: string, name: string): string | null {
+  let dir = startDir;
+  for (;;) {
+    const pkgPath = path.join(dir, "package.json");
+    try {
+      if (fsSync.existsSync(pkgPath)) {
+        const raw = fsSync.readFileSync(pkgPath, "utf8");
+        const pkg = JSON.parse(raw) as { name?: string };
+        if (pkg.name === name) {
+          return dir;
+        }
+      }
+    } catch {
+      // ignore parse/read errors and keep walking
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+}
+
+function resolveOpenClawRoot(): string {
+  if (openClawRootCache) {
+    return openClawRootCache;
+  }
+  const override = process.env.OPENCLAW_ROOT?.trim();
+  if (override) {
+    openClawRootCache = override;
+    return override;
+  }
+
+  const candidates = new Set<string>();
+  if (process.argv[1]) {
+    candidates.add(path.dirname(process.argv[1]));
+  }
+  candidates.add(process.cwd());
+  try {
+    const urlPath = fileURLToPath(import.meta.url);
+    candidates.add(path.dirname(urlPath));
+  } catch {
+    // ignore
+  }
+
+  for (const start of candidates) {
+    const found = findPackageRoot(start, "openclaw");
+    if (found) {
+      openClawRootCache = found;
+      return found;
+    }
+  }
+  const fallback = process.cwd();
+  openClawRootCache = fallback;
+  return fallback;
+}
 
 async function loadRunEmbeddedPiAgent(): Promise<RunEmbeddedPiAgentFn> {
   // Source checkout (tests/dev)
@@ -25,11 +85,17 @@ async function loadRunEmbeddedPiAgent(): Promise<RunEmbeddedPiAgentFn> {
   }
 
   // Bundled install (built)
-  const mod = await import("../../../src/agents/pi-embedded-runner.js");
-  if (typeof mod.runEmbeddedPiAgent !== "function") {
+  // NOTE: there is no src/ tree in a packaged install. Prefer a stable internal entrypoint.
+  const distExtensionApi = pathToFileURL(
+    path.join(resolveOpenClawRoot(), "dist", "extensionAPI.js"),
+  ).href;
+  const mod = (await import(distExtensionApi)) as { runEmbeddedPiAgent?: unknown };
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const fn = (mod as any).runEmbeddedPiAgent;
+  if (typeof fn !== "function") {
     throw new Error("Internal error: runEmbeddedPiAgent not available");
   }
-  return mod.runEmbeddedPiAgent as RunEmbeddedPiAgentFn;
+  return fn as RunEmbeddedPiAgentFn;
 }
 
 function stripCodeFences(s: string): string {

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -9,7 +9,15 @@ export type ResolvedMemorySearchConfig = {
   enabled: boolean;
   sources: Array<"memory" | "sessions">;
   extraPaths: string[];
-  provider: "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama" | "auto";
+  provider:
+    | "openai"
+    | "local"
+    | "gemini"
+    | "voyage"
+    | "mistral"
+    | "ollama"
+    | "siliconflow"
+    | "auto";
   remote?: {
     baseUrl?: string;
     apiKey?: string;
@@ -25,7 +33,15 @@ export type ResolvedMemorySearchConfig = {
   experimental: {
     sessionMemory: boolean;
   };
-  fallback: "openai" | "gemini" | "local" | "voyage" | "mistral" | "ollama" | "none";
+  fallback:
+    | "openai"
+    | "gemini"
+    | "local"
+    | "voyage"
+    | "mistral"
+    | "ollama"
+    | "siliconflow"
+    | "none";
   model: string;
   local: {
     modelPath?: string;
@@ -156,6 +172,7 @@ function mergeConfig(
     provider === "gemini" ||
     provider === "voyage" ||
     provider === "mistral" ||
+    provider === "siliconflow" ||
     provider === "ollama" ||
     provider === "auto";
   const batch = {
@@ -190,7 +207,9 @@ function mergeConfig(
             ? DEFAULT_MISTRAL_MODEL
             : provider === "ollama"
               ? DEFAULT_OLLAMA_MODEL
-              : undefined;
+              : provider === "siliconflow"
+                ? DEFAULT_OPENAI_MODEL
+                : undefined;
   const model = overrides?.model ?? defaults?.model ?? modelDefault ?? "";
   const local = {
     modelPath: overrides?.local?.modelPath ?? defaults?.local?.modelPath,

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../../../config/config.js";
 import {
   isOllamaCompatProvider,
   resolveAttemptFsWorkspaceOnly,
+  shouldWarnGoogleGeminiCliOAuthPromptLatency,
   resolveOllamaBaseUrlForRun,
   resolveOllamaCompatNumCtxEnabled,
   resolvePromptBuildHookResult,
@@ -121,6 +122,48 @@ describe("resolveAttemptFsWorkspaceOnly", () => {
       resolveAttemptFsWorkspaceOnly({
         config: cfg,
         sessionAgentId: "main",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldWarnGoogleGeminiCliOAuthPromptLatency", () => {
+  it("returns true for slow google-gemini-cli oauth prompt steps", () => {
+    expect(
+      shouldWarnGoogleGeminiCliOAuthPromptLatency({
+        provider: "google-gemini-cli",
+        modelAuthMode: "oauth",
+        durationMs: 60_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for non-oauth auth modes", () => {
+    expect(
+      shouldWarnGoogleGeminiCliOAuthPromptLatency({
+        provider: "google-gemini-cli",
+        modelAuthMode: "api-key",
+        durationMs: 60_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false below the slow prompt threshold", () => {
+    expect(
+      shouldWarnGoogleGeminiCliOAuthPromptLatency({
+        provider: "google-gemini-cli",
+        modelAuthMode: "oauth",
+        durationMs: 39_999,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for other providers", () => {
+    expect(
+      shouldWarnGoogleGeminiCliOAuthPromptLatency({
+        provider: "google",
+        modelAuthMode: "oauth",
+        durationMs: 60_000,
       }),
     ).toBe(false);
   });

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -45,7 +45,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { resolveOpenClawDocsPath } from "../../docs-path.js";
 import { isTimeoutError } from "../../failover-error.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
-import { resolveModelAuthMode } from "../../model-auth.js";
+import { resolveModelAuthMode, type ModelAuthMode } from "../../model-auth.js";
 import { normalizeProviderId, resolveDefaultModelForAgent } from "../../model-selection.js";
 import { createOllamaStreamFn, OLLAMA_NATIVE_BASE_URL } from "../../ollama-stream.js";
 import { createOpenAIWebSocketStreamFn, releaseWsSession } from "../../openai-ws-stream.js";
@@ -590,6 +590,25 @@ export function resolveAttemptFsWorkspaceOnly(params: {
   });
 }
 
+const GOOGLE_GEMINI_CLI_OAUTH_SLOW_PROMPT_WARN_MS = 40_000;
+
+export function shouldWarnGoogleGeminiCliOAuthPromptLatency(params: {
+  provider: string;
+  modelAuthMode: ModelAuthMode | undefined;
+  durationMs: number;
+}): boolean {
+  if (
+    !Number.isFinite(params.durationMs) ||
+    params.durationMs < GOOGLE_GEMINI_CLI_OAUTH_SLOW_PROMPT_WARN_MS
+  ) {
+    return false;
+  }
+  if (normalizeProviderId(params.provider) !== "google-gemini-cli") {
+    return false;
+  }
+  return params.modelAuthMode === "oauth";
+}
+
 function summarizeMessagePayload(msg: AgentMessage): { textChars: number; imageBlocks: number } {
   const content = (msg as { content?: unknown }).content;
   if (typeof content === "string") {
@@ -749,6 +768,7 @@ export async function runEmbeddedAttempt(
       config: params.config,
       sessionAgentId,
     });
+    const modelAuthMode = resolveModelAuthMode(params.model.provider, params.config);
     // Check if the model supports native image input
     const modelHasVision = params.model.input?.includes("image") ?? false;
     const toolsRaw = params.disableTools
@@ -783,7 +803,7 @@ export async function runEmbeddedAttempt(
           modelProvider: params.model.provider,
           modelId: params.modelId,
           modelContextWindowTokens: params.model.contextWindow,
-          modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
+          modelAuthMode,
           currentChannelId: params.currentChannelId,
           currentThreadTs: params.currentThreadTs,
           currentMessageId: params.currentMessageId,
@@ -1632,9 +1652,23 @@ export async function runEmbeddedAttempt(
           promptError = err;
           promptErrorSource = "prompt";
         } finally {
+          const promptDurationMs = Date.now() - promptStartedAt;
           log.debug(
-            `embedded run prompt end: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - promptStartedAt}`,
+            `embedded run prompt end: runId=${params.runId} sessionId=${params.sessionId} durationMs=${promptDurationMs}`,
           );
+          if (
+            shouldWarnGoogleGeminiCliOAuthPromptLatency({
+              provider: params.provider,
+              modelAuthMode,
+              durationMs: promptDurationMs,
+            })
+          ) {
+            log.warn(
+              `[gemini-oauth-latency] slow prompt step detected: runId=${params.runId} sessionId=${params.sessionId} ` +
+                `provider=${params.provider}/${params.modelId} durationMs=${promptDurationMs} ` +
+                `possibleCause=upstream rate-limit backoff (HTTP 429).`,
+            );
+          }
         }
 
         // Capture snapshot before compaction wait so we have complete messages if timeout occurs

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -258,7 +258,7 @@ describe("noteMemorySearchHealth", () => {
     expect(note).toHaveBeenCalledTimes(1);
     const providerCalls = resolveApiKeyForProvider.mock.calls as Array<[{ provider: string }]>;
     const providersChecked = providerCalls.map(([arg]) => arg.provider);
-    expect(providersChecked).toEqual(["openai", "google", "voyage", "mistral"]);
+    expect(providersChecked).toEqual(["openai", "google", "voyage", "mistral", "siliconflow"]);
   });
 });
 

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -117,7 +117,7 @@ export async function noteMemorySearchHealth(
   if (hasLocalEmbeddings(resolved.local)) {
     return;
   }
-  for (const provider of ["openai", "gemini", "voyage", "mistral"] as const) {
+  for (const provider of ["openai", "gemini", "voyage", "mistral", "siliconflow"] as const) {
     if (hasRemoteApiKey || (await hasApiKeyForProvider(provider, cfg, agentDir))) {
       return;
     }
@@ -186,7 +186,7 @@ function hasLocalEmbeddings(local: { modelPath?: string }, useDefaultFallback = 
 }
 
 async function hasApiKeyForProvider(
-  provider: "openai" | "gemini" | "voyage" | "mistral" | "ollama",
+  provider: "openai" | "gemini" | "voyage" | "mistral" | "ollama" | "siliconflow",
   cfg: OpenClawConfig,
   agentDir: string,
 ): Promise<boolean> {

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -324,7 +324,15 @@ export type MemorySearchConfig = {
     sessionMemory?: boolean;
   };
   /** Embedding provider mode. */
-  provider?: "openai" | "gemini" | "local" | "voyage" | "mistral" | "ollama";
+  provider?:
+    | "openai"
+    | "gemini"
+    | "local"
+    | "voyage"
+    | "mistral"
+    | "ollama"
+    | "siliconflow"
+    | "auto";
   remote?: {
     baseUrl?: string;
     apiKey?: string;
@@ -343,7 +351,15 @@ export type MemorySearchConfig = {
     };
   };
   /** Fallback behavior when embeddings fail. */
-  fallback?: "openai" | "gemini" | "local" | "voyage" | "mistral" | "ollama" | "none";
+  fallback?:
+    | "openai"
+    | "gemini"
+    | "local"
+    | "voyage"
+    | "mistral"
+    | "ollama"
+    | "siliconflow"
+    | "none";
   /** Embedding model id (remote) or alias (local). */
   model?: string;
   /** Local embedding settings (node-llama-cpp). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -561,6 +561,8 @@ export const MemorySearchSchema = z
         z.literal("voyage"),
         z.literal("mistral"),
         z.literal("ollama"),
+        z.literal("siliconflow"),
+        z.literal("auto"),
       ])
       .optional(),
     remote: z
@@ -589,6 +591,7 @@ export const MemorySearchSchema = z
         z.literal("voyage"),
         z.literal("mistral"),
         z.literal("ollama"),
+        z.literal("siliconflow"),
         z.literal("none"),
       ])
       .optional(),

--- a/src/memory/embeddings-remote-client.ts
+++ b/src/memory/embeddings-remote-client.ts
@@ -4,7 +4,7 @@ import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import type { EmbeddingProviderOptions } from "./embeddings.js";
 import { buildRemoteBaseUrlPolicy } from "./remote-http.js";
 
-export type RemoteEmbeddingProviderId = "openai" | "voyage" | "mistral";
+export type RemoteEmbeddingProviderId = "openai" | "voyage" | "mistral" | "siliconflow";
 
 export async function resolveRemoteEmbeddingBearerClient(params: {
   provider: RemoteEmbeddingProviderId;

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -36,14 +36,27 @@ export type EmbeddingProvider = {
   embedBatch: (texts: string[]) => Promise<number[][]>;
 };
 
-export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama";
+export type EmbeddingProviderId =
+  | "openai"
+  | "local"
+  | "gemini"
+  | "voyage"
+  | "mistral"
+  | "ollama"
+  | "siliconflow";
 export type EmbeddingProviderRequest = EmbeddingProviderId | "auto";
 export type EmbeddingProviderFallback = EmbeddingProviderId | "none";
 
 // Remote providers considered for auto-selection when provider === "auto".
 // Ollama is intentionally excluded here so that "auto" mode does not
 // implicitly assume a local Ollama instance is available.
-const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "voyage", "mistral"] as const;
+const REMOTE_EMBEDDING_PROVIDER_IDS = [
+  "openai",
+  "gemini",
+  "voyage",
+  "mistral",
+  "siliconflow",
+] as const;
 
 export type EmbeddingProviderResult = {
   provider: EmbeddingProvider | null;
@@ -188,6 +201,10 @@ export async function createEmbeddingProvider(
     if (id === "mistral") {
       const { provider, client } = await createMistralEmbeddingProvider(options);
       return { provider, mistral: client };
+    }
+    if (id === "siliconflow") {
+      const { provider, client } = await createOpenAiEmbeddingProvider(options);
+      return { provider: { ...provider, id: "siliconflow" }, openAi: client };
     }
     const { provider, client } = await createOpenAiEmbeddingProvider(options);
     return { provider, openAi: client };

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -93,7 +93,14 @@ export abstract class MemoryManagerSyncOps {
   protected abstract readonly workspaceDir: string;
   protected abstract readonly settings: ResolvedMemorySearchConfig;
   protected provider: EmbeddingProvider | null = null;
-  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama";
+  protected fallbackFrom?:
+    | "openai"
+    | "local"
+    | "gemini"
+    | "voyage"
+    | "mistral"
+    | "ollama"
+    | "siliconflow";
   protected openAi?: OpenAiEmbeddingClient;
   protected gemini?: GeminiEmbeddingClient;
   protected voyage?: VoyageEmbeddingClient;
@@ -970,7 +977,8 @@ export abstract class MemoryManagerSyncOps {
       | "local"
       | "voyage"
       | "mistral"
-      | "ollama";
+      | "ollama"
+      | "siliconflow";
 
     const fallbackModel =
       fallback === "gemini"
@@ -983,7 +991,9 @@ export abstract class MemoryManagerSyncOps {
               ? DEFAULT_MISTRAL_EMBEDDING_MODEL
               : fallback === "ollama"
                 ? DEFAULT_OLLAMA_EMBEDDING_MODEL
-                : this.settings.model;
+                : fallback === "siliconflow"
+                  ? DEFAULT_OPENAI_EMBEDDING_MODEL
+                  : this.settings.model;
 
     const fallbackResult = await createEmbeddingProvider({
       config: this.cfg,

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -56,8 +56,16 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     | "voyage"
     | "mistral"
     | "ollama"
+    | "siliconflow"
     | "auto";
-  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama";
+  protected fallbackFrom?:
+    | "openai"
+    | "local"
+    | "gemini"
+    | "voyage"
+    | "mistral"
+    | "ollama"
+    | "siliconflow";
   protected fallbackReason?: string;
   private readonly providerUnavailableReason?: string;
   protected openAi?: OpenAiEmbeddingClient;

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -111,4 +111,168 @@ describe("tui session actions", () => {
     expect(updateFooter).toHaveBeenCalledTimes(2);
     expect(requestRender).toHaveBeenCalledTimes(2);
   });
+
+  it("keeps patched model selection when a refresh returns an older snapshot", async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: {},
+      sessions: [
+        {
+          key: "agent:main:main",
+          model: "old-model",
+          modelProvider: "ollama",
+          updatedAt: 100,
+        },
+      ],
+    });
+
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: false,
+      sessionInfo: {
+        model: "old-model",
+        modelProvider: "ollama",
+        updatedAt: 100,
+      },
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { applySessionInfoFromPatch, refreshSessionInfo } = createSessionActions({
+      client: { listSessions } as unknown as GatewayChatClient,
+      chatLog: { addSystem: vi.fn() } as unknown as import("./components/chat-log.js").ChatLog,
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn(),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus: vi.fn(),
+    });
+
+    applySessionInfoFromPatch({
+      ok: true,
+      path: "/tmp/sessions.json",
+      key: "agent:main:main",
+      resolved: {
+        modelProvider: "openai",
+        model: "new-model",
+      },
+      entry: {
+        sessionId: "session-1",
+        model: "new-model",
+        modelProvider: "openai",
+        updatedAt: 200,
+      },
+    });
+
+    expect(state.sessionInfo.model).toBe("new-model");
+    expect(state.sessionInfo.modelProvider).toBe("openai");
+
+    await refreshSessionInfo();
+
+    expect(state.sessionInfo.model).toBe("new-model");
+    expect(state.sessionInfo.modelProvider).toBe("openai");
+    expect(state.sessionInfo.updatedAt).toBe(200);
+  });
+
+  it("accepts older session snapshots after switching session keys", async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: {},
+      sessions: [
+        {
+          key: "agent:main:other",
+          model: "session-model",
+          modelProvider: "openai",
+          updatedAt: 50,
+        },
+      ],
+    });
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-2",
+      messages: [],
+    });
+
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: true,
+      sessionInfo: {
+        model: "previous-model",
+        modelProvider: "anthropic",
+        updatedAt: 500,
+      },
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { setSession } = createSessionActions({
+      client: {
+        listSessions,
+        loadHistory,
+      } as unknown as GatewayChatClient,
+      chatLog: {
+        addSystem: vi.fn(),
+        clearAll: vi.fn(),
+      } as unknown as import("./components/chat-log.js").ChatLog,
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn((raw?: string) => raw ?? "agent:main:main"),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus: vi.fn(),
+    });
+
+    await setSession("agent:main:other");
+
+    expect(loadHistory).toHaveBeenCalledWith({
+      sessionKey: "agent:main:other",
+      limit: 200,
+    });
+    expect(state.currentSessionKey).toBe("agent:main:other");
+    expect(state.sessionInfo.model).toBe("session-model");
+    expect(state.sessionInfo.modelProvider).toBe("openai");
+    expect(state.sessionInfo.updatedAt).toBe(50);
+  });
 });


### PR DESCRIPTION
## Summary
- add a focused latency warning gate for `google-gemini-cli` when auth mode resolves to OAuth and a single prompt step takes >= 40s
- log a clear warning after each slow step in `runEmbeddedAttempt` with a likely cause hint (`HTTP 429` upstream backoff)
- add unit tests for the new warning gate behavior

## Why
Issue #36399 reports repeated ~60s stalls during multi-step tool chains on the OAuth adapter. This change keeps runtime behavior unchanged, but makes the stall diagnosable in logs so users and maintainers can distinguish silent upstream throttling/backoff from local deadlock.

## Testing
- pnpm test src/agents/pi-embedded-runner/run/attempt.test.ts

Fixes #36399
