### PR TITLE
fix(slack): propagate mediaLocalRoots through send pipeline (#36477)

### DIFF
--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -278,7 +278,10 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
         ctx,
         includeReadThreadId: true,
         invoke: async (action, cfg, toolContext) =>
-          await getSlackRuntime().channel.slack.handleSlackAction(action, cfg, toolContext),
+          await getSlackRuntime().channel.slack.handleSlackAction(action, cfg, {
+            ...toolContext,
+            mediaLocalRoots: ctx.mediaLocalRoots,
+          }),
       }),
   },
   setup: {

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -211,6 +211,7 @@ export async function handleSlackAction(
           mediaUrl: mediaUrl ?? undefined,
           threadTs: threadTs ?? undefined,
           blocks,
+          mediaLocalRoots: context?.mediaLocalRoots,
         });
 
         if (threadTs && result.channelId && account.accountId) {

--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -57,7 +57,10 @@ export async function handleSlackMessageAction(params: {
         threadTs: threadId ?? replyTo ?? undefined,
       },
       cfg,
-      ctx.toolContext,
+      {
+        ...ctx.toolContext,
+        mediaLocalRoots: ctx.mediaLocalRoots,
+      },
     );
   }
 

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -161,6 +161,7 @@ export async function sendSlackMessage(
     mediaUrl?: string;
     threadTs?: string;
     blocks?: (Block | KnownBlock)[];
+    mediaLocalRoots?: readonly string[];
   } = {},
 ) {
   return await sendMessageSlack(to, content, {
@@ -170,6 +171,7 @@ export async function sendSlackMessage(
     client: opts.client,
     threadTs: opts.threadTs,
     blocks: opts.blocks,
+    mediaLocalRoots: opts.mediaLocalRoots,
   });
 }
 


### PR DESCRIPTION
Fixes #36477 - Slack plugin missing mediaLocalRoots propagation

## Problem
- Local file uploads fail: `LocalMediaAccessError("path-not-allowed")`
- Agent workspace files blocked even with proper workspace config
- CVE fix in 2026.3.2 added enforcement, Feishu patched but Slack missed

## Root Cause
4 layers drop mediaLocalRoots:
1. `channel.ts` invoke callback
2. `slack-message-actions.ts` handleSlackMessageAction
3. `slack-actions.ts` handleSlackAction  
4. `slack-actions.ts` sendSlackMessage → sendMessageSlack

## Fix
Propagate `ctx.mediaLocalRoots` through all 4 layers to `sendMessageSlack`

## Changes
- channel.ts: +3 lines
- slack-message-actions.ts: +4 lines
- slack-actions.ts (handleSlackAction): +1 line
- slack-actions.ts (sendSlackMessage): +2 lines
Total: +10 lines, -2 lines

## Testing
- Workspace files ✅
- Default dirs ✅
- Blocked paths ✅
