### PR TITLE
fix: refresh allowlist caches when source arrays mutate in place

### DIFF
--- a/src/channels/allowlist-match.test.ts
+++ b/src/channels/allowlist-match.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveAllowlistMatchByCandidates,
+  resolveAllowlistMatchSimple,
+} from "./allowlist-match.js";
+
+describe("resolveAllowlistMatchByCandidates", () => {
+  it("refreshes cached allowList sets when an array is mutated in-place", () => {
+    const allowList = ["alice"];
+
+    expect(
+      resolveAllowlistMatchByCandidates({
+        allowList,
+        candidates: [{ value: "alice", source: "id" }],
+      }),
+    ).toEqual({
+      allowed: true,
+      matchKey: "alice",
+      matchSource: "id",
+    });
+
+    allowList[0] = "bob";
+
+    expect(
+      resolveAllowlistMatchByCandidates({
+        allowList,
+        candidates: [{ value: "alice", source: "id" }],
+      }),
+    ).toEqual({ allowed: false });
+
+    expect(
+      resolveAllowlistMatchByCandidates({
+        allowList,
+        candidates: [{ value: "bob", source: "id" }],
+      }),
+    ).toEqual({
+      allowed: true,
+      matchKey: "bob",
+      matchSource: "id",
+    });
+  });
+});
+
+describe("resolveAllowlistMatchSimple", () => {
+  it("refreshes cached normalized sets when allowFrom mutates with same length", () => {
+    const allowFrom: Array<string | number> = ["alice"];
+
+    expect(
+      resolveAllowlistMatchSimple({
+        allowFrom,
+        senderId: "alice",
+      }),
+    ).toEqual({
+      allowed: true,
+      matchKey: "alice",
+      matchSource: "id",
+    });
+
+    allowFrom[0] = "bob";
+
+    expect(
+      resolveAllowlistMatchSimple({
+        allowFrom,
+        senderId: "alice",
+      }),
+    ).toEqual({ allowed: false });
+
+    expect(
+      resolveAllowlistMatchSimple({
+        allowFrom,
+        senderId: "bob",
+      }),
+    ).toEqual({
+      allowed: true,
+      matchKey: "bob",
+      matchSource: "id",
+    });
+  });
+});

--- a/src/channels/allowlist-match.ts
+++ b/src/channels/allowlist-match.ts
@@ -18,14 +18,20 @@ export type AllowlistMatch<TSource extends string = AllowlistMatchSource> = {
 
 type CachedAllowListSet = {
   size: number;
+  signature: string;
+  set: Set<string>;
+};
+
+type CachedSimpleAllowFrom = {
+  normalized: string[];
+  size: number;
+  signature: string;
+  wildcard: boolean;
   set: Set<string>;
 };
 
 const ALLOWLIST_SET_CACHE = new WeakMap<string[], CachedAllowListSet>();
-const SIMPLE_ALLOWLIST_CACHE = new WeakMap<
-  Array<string | number>,
-  { normalized: string[]; size: number; wildcard: boolean; set: Set<string> }
->();
+const SIMPLE_ALLOWLIST_CACHE = new WeakMap<Array<string | number>, CachedSimpleAllowFrom>();
 
 export function formatAllowlistMatchMeta(
   match?: { matchKey?: string; matchSource?: string } | null,
@@ -81,32 +87,39 @@ export function resolveAllowlistMatchSimple(params: {
   return { allowed: false };
 }
 
+function buildArrayCacheSignature(values: ReadonlyArray<string | number>): string {
+  let signature = `${values.length}:`;
+  for (const value of values) {
+    const normalized = String(value);
+    signature += `${normalized.length}:${normalized};`;
+  }
+  return signature;
+}
+
 function resolveAllowListSet(allowList: string[]): Set<string> {
+  const signature = buildArrayCacheSignature(allowList);
   const cached = ALLOWLIST_SET_CACHE.get(allowList);
-  if (cached && cached.size === allowList.length) {
+  if (cached && cached.size === allowList.length && cached.signature === signature) {
     return cached.set;
   }
   const set = new Set(allowList);
-  ALLOWLIST_SET_CACHE.set(allowList, { size: allowList.length, set });
+  ALLOWLIST_SET_CACHE.set(allowList, { size: allowList.length, signature, set });
   return set;
 }
 
-function resolveSimpleAllowFrom(allowFrom: Array<string | number>): {
-  normalized: string[];
-  size: number;
-  wildcard: boolean;
-  set: Set<string>;
-} {
+function resolveSimpleAllowFrom(allowFrom: Array<string | number>): CachedSimpleAllowFrom {
+  const signature = buildArrayCacheSignature(allowFrom);
   const cached = SIMPLE_ALLOWLIST_CACHE.get(allowFrom);
-  if (cached && cached.size === allowFrom.length) {
+  if (cached && cached.size === allowFrom.length && cached.signature === signature) {
     return cached;
   }
 
   const normalized = allowFrom.map((entry) => String(entry).trim().toLowerCase()).filter(Boolean);
   const set = new Set(normalized);
-  const built = {
+  const built: CachedSimpleAllowFrom = {
     normalized,
     size: allowFrom.length,
+    signature,
     wildcard: set.has("*"),
     set,
   };


### PR DESCRIPTION
## Summary
- make allowlist cache reuse mutation-aware by tracking a lightweight content signature
- keep WeakMap identity caching, but invalidate when array contents change without length changes
- add targeted tests covering both `resolveAllowlistMatchByCandidates` and `resolveAllowlistMatchSimple`

## Why
Allowlist caches were previously validated by array identity + length. If a caller reused the same array object and replaced entries in place, stale sets could be returned.

## Validation
- `pnpm vitest run src/channels/allowlist-match.test.ts`
