### PR TITLE
fix(telegram): add setStatus health monitoring to track lastEventAt/lastInboundAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/health monitoring: thread `setStatus` callback through `monitorTelegramProvider` → `createTelegramBot`/`startTelegramWebhook` and call it on every inbound update so `lastEventAt` and `lastInboundAt` timestamps are correctly updated, fixing the always-`null` health snapshot for Telegram channels. (#32850)
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -499,6 +499,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         webhookPath: account.config.webhookPath,
         webhookHost: account.config.webhookHost,
         webhookPort: account.config.webhookPort,
+        setStatus: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
       });
     },
     logoutAccount: async ({ accountId, cfg }) => {

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -16,6 +16,7 @@ import {
   getReadChannelAllowFromStoreMock,
   getOnHandler,
   listSkillCommandsForAgents,
+  middlewareUseSpy,
   onSpy,
   replySpy,
   sendMessageSpy,
@@ -1754,5 +1755,47 @@ describe("createTelegramBot", () => {
     };
     const sessionKey = eventOptions.sessionKey ?? "";
     expect(sessionKey).not.toContain(":topic:");
+  });
+
+  describe("setStatus health tracking", () => {
+    it("calls setStatus with lastEventAt and lastInboundAt on each inbound update", async () => {
+      const setStatus = vi.fn();
+      createTelegramBot({ token: "tok", setStatus });
+
+      // The setStatus middleware is registered after the raw-update-logger middleware.
+      // Find it by calling each registered bot.use() middleware until one triggers setStatus.
+      const middlewareCalls = middlewareUseSpy.mock.calls;
+      let statusMiddleware:
+        | ((ctx: unknown, next: () => Promise<void>) => Promise<void>)
+        | undefined;
+      for (const [fn] of middlewareCalls) {
+        const next = vi.fn(async () => {});
+        await (fn as (ctx: unknown, next: () => Promise<void>) => Promise<void>)({}, next);
+        if (setStatus.mock.calls.length > 0) {
+          statusMiddleware = fn as typeof statusMiddleware;
+          break;
+        }
+        setStatus.mockClear();
+      }
+
+      expect(statusMiddleware).toBeDefined();
+      expect(setStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lastEventAt: expect.any(Number),
+          lastInboundAt: expect.any(Number),
+        }),
+      );
+    });
+
+    it("does not register setStatus middleware when setStatus is not provided", () => {
+      createTelegramBot({ token: "tok" });
+
+      const countBefore = middlewareUseSpy.mock.calls.length;
+      middlewareUseSpy.mockClear();
+      createTelegramBot({ token: "tok", setStatus: undefined });
+
+      // Call count should be identical whether setStatus is provided or not (undefined === skipped)
+      expect(middlewareUseSpy.mock.calls.length).toBe(countBefore);
+    });
   });
 });

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -56,6 +56,8 @@ export type TelegramBotOptions = {
     mediaGroupFlushMs?: number;
     textFragmentGapMs?: number;
   };
+  /** Callback to update the channel account status snapshot (e.g. lastEventAt, lastInboundAt). */
+  setStatus?: (next: Record<string, unknown>) => void;
 };
 
 export { getTelegramSequentialKey };
@@ -205,6 +207,19 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     }
     await next();
   });
+
+  // Track inbound events for channel health monitoring (lastEventAt / lastInboundAt).
+  if (opts.setStatus) {
+    const trackEvent = opts.setStatus;
+    bot.use(async (_ctx, next) => {
+      try {
+        trackEvent({ lastEventAt: Date.now(), lastInboundAt: Date.now() });
+      } catch {
+        // never let status tracking crash the update pipeline
+      }
+      await next();
+    });
+  }
 
   const historyLimit = Math.max(
     0,

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -30,6 +30,8 @@ export type MonitorTelegramOpts = {
   webhookHost?: string;
   proxyFetch?: typeof fetch;
   webhookUrl?: string;
+  /** Callback to update the channel account status snapshot (e.g. lastEventAt, lastInboundAt). */
+  setStatus?: (next: Record<string, unknown>) => void;
 };
 
 export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
@@ -172,6 +174,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         fetch: proxyFetch,
         abortSignal: opts.abortSignal,
         publicUrl: opts.webhookUrl,
+        setStatus: opts.setStatus,
       });
       await waitForAbortSignal(opts.abortSignal);
       return;
@@ -220,6 +223,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
           proxyFetch,
           config: cfg,
           accountId: account.accountId,
+          setStatus: opts.setStatus,
           updateOffset: {
             lastUpdateId,
             onUpdateId: persistUpdateId,

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -87,6 +87,8 @@ export async function startTelegramWebhook(opts: {
   abortSignal?: AbortSignal;
   healthPath?: string;
   publicUrl?: string;
+  /** Callback to update the channel account status snapshot (e.g. lastEventAt, lastInboundAt). */
+  setStatus?: (next: Record<string, unknown>) => void;
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
@@ -107,6 +109,7 @@ export async function startTelegramWebhook(opts: {
     proxyFetch: opts.fetch,
     config: opts.config,
     accountId: opts.accountId,
+    setStatus: opts.setStatus,
   });
   await initializeTelegramWebhookBot({
     bot,


### PR DESCRIPTION
## Summary

Fixes #32850 — Telegram's health monitoring timestamps (`lastEventAt`, `lastInboundAt`) remained `null` indefinitely even when messages were actively received, making it impossible to distinguish a healthy-but-quiet channel from a broken one.

- Add `setStatus?: (next: Record<string, unknown>) => void` to `MonitorTelegramOpts`, `TelegramBotOptions`, and `startTelegramWebhook` opts, following the established Slack/Discord pattern
- Register a grammY middleware in `createTelegramBot` that calls `setStatus({ lastEventAt, lastInboundAt })` on every inbound update (with try/catch so status tracking can never crash the update pipeline)
- Thread `setStatus` from polling and webhook paths in `monitor.ts` down into `createTelegramBot` / `startTelegramWebhook`
- Pass the callback from the Telegram extension's `startAccount` via `ctx.setStatus({ accountId, ...patch })`

## Test plan

- [ ] New unit test: verifies `setStatus` middleware fires with `lastEventAt`/`lastInboundAt` on each inbound update
- [ ] New unit test: verifies no extra middleware is registered when `setStatus` is not provided
- [ ] `pnpm test` passes (pre-existing unrelated failure in `bot.test.ts`: "blocks native DM commands for unpaired users" — confirmed failing on `main` before this PR)
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)