### PR TITLE
fix(plugins): fallback plugin-sdk subpath aliases for production src runtime

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1124,6 +1124,23 @@ describe("loadOpenClawPlugins", () => {
     expect(resolved).toBe(srcFile);
   });
 
+  it("falls back to src plugin-sdk alias when running from src in production and dist alias is missing", () => {
+    const { root, srcFile, distFile } = createPluginSdkAliasFixture({
+      srcFile: "telegram.ts",
+      distFile: "telegram.js",
+    });
+    fs.rmSync(distFile);
+
+    const resolved = withEnv({ NODE_ENV: "production" }, () =>
+      __testing.resolvePluginSdkAliasFile({
+        srcFile: "telegram.ts",
+        distFile: "telegram.js",
+        modulePath: path.join(root, "src", "plugins", "loader.ts"),
+      }),
+    );
+    expect(resolved).toBe(srcFile);
+  });
+
   it("prefers dist root-alias shim when loader runs from dist", () => {
     const { root, distFile } = createPluginSdkAliasFixture({
       srcFile: "root-alias.cjs",

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -57,6 +57,7 @@ const resolvePluginSdkAliasFile = (params: {
     const isTest = process.env.VITEST || process.env.NODE_ENV === "test";
     const normalizedModulePath = modulePath.replace(/\\/g, "/");
     const isDistRuntime = normalizedModulePath.includes("/dist/");
+    const isSrcRuntime = normalizedModulePath.includes("/src/");
     let cursor = path.dirname(modulePath);
     for (let i = 0; i < 6; i += 1) {
       const srcCandidate = path.join(cursor, "src", "plugin-sdk", params.srcFile);
@@ -64,7 +65,7 @@ const resolvePluginSdkAliasFile = (params: {
       const orderedCandidates = isDistRuntime
         ? [distCandidate, srcCandidate]
         : isProduction
-          ? isTest
+          ? isTest || isSrcRuntime
             ? [distCandidate, srcCandidate]
             : [distCandidate]
           : [srcCandidate, distCandidate];


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: bundled channel plugins can fail to load in embedded/heartbeat runs when plugin-sdk subpath aliases are resolved from `src` runtime in production mode and the corresponding `dist/plugin-sdk/<subpath>.js` shim is missing.
- Why it matters: this can break channel delivery paths (for example Telegram heartbeat delivery) with module-resolution errors.
- What changed: `resolvePluginSdkAliasFile` now allows a `src` fallback for production mode only when the loader itself is running from `src`.
- What did NOT change (scope boundary): no changes to plugin loading order, manifest discovery, runtime registration, or non-plugin-sdk alias behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36425
- Related #36501

## User-visible / Behavior Changes

When OpenClaw runs from source in production mode and a plugin-sdk dist subpath alias is unavailable, plugin loading can now fall back to the corresponding `src/plugin-sdk/*.ts` alias instead of failing module resolution.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.4.1
- Runtime/container: Node.js v22.22.0
- Model/provider: N/A
- Integration/channel (if any): plugin loader / Telegram plugin-sdk alias path
- Relevant config (redacted): N/A

### Steps

1. Create plugin-sdk alias fixtures with `src/plugin-sdk/telegram.ts` present.
2. Remove `dist/plugin-sdk/telegram.js` in the fixture.
3. Resolve plugin-sdk alias with module path under `src/plugins/loader.ts` and `NODE_ENV=production`.

### Expected

- Resolver returns the src alias path so plugin subpath imports can still resolve.

### Actual

- Before fix, resolver returned `null` in this scenario, allowing downstream module-resolution failures.
- After fix, resolver returns the src alias path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: production + src runtime + missing dist subpath now resolves to src alias.
- Edge cases checked: existing alias preference tests for dist runtime and non-production src runtime remain green.
- What you did **not** verify: live heartbeat delivery in a real Telegram environment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `2bbca489a8`.
- Files/config to restore: `src/plugins/loader.ts`, `src/plugins/loader.test.ts`.
- Known bad symptoms reviewers should watch for: unexpected alias resolution preference changes in production dist-only installs.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: production src fallback could mask missing dist artifacts in source-based deployments.
  - Mitigation: fallback is only active when runtime module path is under `src`; dist runtime behavior stays unchanged.
