### PR TITLE
fix(gateway): route TUI messages with surface "tui" instead of "webchat"

### DIFF
--- a/src/gateway/protocol/client-info.ts
+++ b/src/gateway/protocol/client-info.ts
@@ -21,6 +21,7 @@ export type GatewayClientName = GatewayClientId;
 
 export const GATEWAY_CLIENT_MODES = {
   WEBCHAT: "webchat",
+  TUI: "tui",
   CLI: "cli",
   UI: "ui",
   BACKEND: "backend",

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -612,6 +612,81 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
   });
 
+  it("chat.send routes TUI client messages with surface=tui instead of webchat", async () => {
+    createTranscriptFixture("openclaw-chat-send-tui-surface-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {};
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-tui-surface",
+      client: {
+        connect: {
+          client: {
+            mode: GATEWAY_CLIENT_MODES.TUI,
+            id: "gateway-client",
+          },
+        },
+      } as unknown,
+      sessionKey: "agent:main:main",
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        Provider: "tui",
+        Surface: "tui",
+        OriginatingChannel: "tui",
+      }),
+    );
+  });
+
+  it("chat.send does not inherit external delivery context for TUI clients on main sessions", async () => {
+    createTranscriptFixture("openclaw-chat-send-main-tui-routes-");
+    mockState.finalText = "ok";
+    mockState.sessionEntry = {
+      deliveryContext: {
+        channel: "whatsapp",
+        to: "whatsapp:+8613800138000",
+        accountId: "default",
+      },
+      lastChannel: "whatsapp",
+      lastTo: "whatsapp:+8613800138000",
+      lastAccountId: "default",
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-main-tui-routes",
+      client: {
+        connect: {
+          client: {
+            mode: GATEWAY_CLIENT_MODES.TUI,
+            id: "gateway-client",
+          },
+        },
+      } as unknown,
+      sessionKey: "agent:main:main",
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        Provider: "tui",
+        Surface: "tui",
+        OriginatingChannel: "tui",
+        OriginatingTo: undefined,
+        AccountId: undefined,
+      }),
+    );
+  });
+
   it("chat.send inherits external delivery context for CLI clients on configured main sessions", async () => {
     createTranscriptFixture("openclaw-chat-send-config-main-cli-routes-");
     mockState.mainSessionKey = "work";

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -19,6 +19,7 @@ import {
 } from "../../utils/directive-tags.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
+  isTuiClient,
   isWebchatClient,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
@@ -891,6 +892,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         typeof sessionScopeParts[1] === "string" &&
         sessionChannelHint === routeChannelCandidate;
       const clientMode = client?.connect?.client?.mode;
+      const isFromTuiClient = isTuiClient(client?.connect?.client);
       const isFromWebchatClient =
         isWebchatClient(client?.connect?.client) || clientMode === GATEWAY_CLIENT_MODES.UI;
       const configuredMainKey = (cfg.session?.mainKey ?? "main").trim().toLowerCase();
@@ -904,7 +906,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         sessionChannelHint !== INTERNAL_MESSAGE_CHANNEL &&
         ((!isChannelAgnosticSessionScope &&
           (isChannelScopedSession || hasLegacyChannelPeerShape)) ||
-          (isConfiguredMainSessionScope && client?.connect !== undefined && !isFromWebchatClient)),
+          (isConfiguredMainSessionScope && client?.connect !== undefined && !isFromWebchatClient && !isFromTuiClient)),
       );
       const hasDeliverableRoute =
         shouldDeliverExternally &&
@@ -913,9 +915,10 @@ export const chatHandlers: GatewayRequestHandlers = {
         routeChannelCandidate !== INTERNAL_MESSAGE_CHANNEL &&
         typeof routeToCandidate === "string" &&
         routeToCandidate.trim().length > 0;
+      const internalSurface = isFromTuiClient ? "tui" : INTERNAL_MESSAGE_CHANNEL;
       const originatingChannel = hasDeliverableRoute
         ? routeChannelCandidate
-        : INTERNAL_MESSAGE_CHANNEL;
+        : internalSurface;
       const originatingTo = hasDeliverableRoute ? routeToCandidate : undefined;
       const accountId = hasDeliverableRoute ? routeAccountIdCandidate : undefined;
       const messageThreadId = hasDeliverableRoute ? routeThreadIdCandidate : undefined;
@@ -931,8 +934,8 @@ export const chatHandlers: GatewayRequestHandlers = {
         RawBody: parsedMessage,
         CommandBody: commandBody,
         SessionKey: sessionKey,
-        Provider: INTERNAL_MESSAGE_CHANNEL,
-        Surface: INTERNAL_MESSAGE_CHANNEL,
+        Provider: internalSurface,
+        Surface: internalSurface,
         OriginatingChannel: originatingChannel,
         OriginatingTo: originatingTo,
         AccountId: accountId,
@@ -953,7 +956,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
         cfg,
         agentId,
-        channel: INTERNAL_MESSAGE_CHANNEL,
+        channel: internalSurface,
       });
       const finalReplyParts: string[] = [];
       const dispatcher = createReplyDispatcher({

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -128,7 +128,7 @@ export class GatewayChatClient {
       clientDisplayName: "openclaw-tui",
       clientVersion: VERSION,
       platform: process.platform,
-      mode: GATEWAY_CLIENT_MODES.UI,
+      mode: GATEWAY_CLIENT_MODES.TUI,
       caps: [GATEWAY_CLIENT_CAPS.TOOL_EVENTS],
       instanceId: randomUUID(),
       minProtocol: PROTOCOL_VERSION,

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -52,6 +52,10 @@ export function isWebchatClient(client?: GatewayClientInfoLike | null): boolean 
   return normalizeGatewayClientName(client?.id) === GATEWAY_CLIENT_NAMES.WEBCHAT_UI;
 }
 
+export function isTuiClient(client?: GatewayClientInfoLike | null): boolean {
+  return normalizeGatewayClientMode(client?.mode) === GATEWAY_CLIENT_MODES.TUI;
+}
+
 export function normalizeMessageChannel(raw?: string | null): string | undefined {
   const normalized = raw?.trim().toLowerCase();
   if (!normalized) {


### PR DESCRIPTION
## Summary

- **Problem:** The TUI client identified itself with gateway mode `"ui"`, causing `chat.send` to classify it as a webchat client and hardcode `Provider`, `Surface`, and `OriginatingChannel` to `"webchat"`. This made TUI traffic indistinguishable from webchat in analytics, per-channel message config, and session routing metadata.
- **Why it matters:** Any downstream logic that branches on `Provider`/`Surface`/`OriginatingChannel` (e.g. per-channel `responsePrefix`, message formatting, analytics segmentation) cannot differentiate TUI from webchat, leading to incorrect behavior or misleading data.
- **What changed:**
  1. Added `TUI: "tui"` to `GATEWAY_CLIENT_MODES` (`src/gateway/protocol/client-info.ts`)
  2. Changed TUI's mode from `GATEWAY_CLIENT_MODES.UI` to `GATEWAY_CLIENT_MODES.TUI` (`src/tui/gateway-chat.ts`)
  3. Added `isTuiClient()` helper (`src/utils/message-channel.ts`)
  4. Updated `chat.send` to resolve `Provider`/`Surface`/`OriginatingChannel` to `"tui"` when the client is TUI, and prevent TUI from inheriting stale external delivery routes on shared main sessions (`src/gateway/server-methods/chat.ts`)
  5. Added two test cases verifying TUI surface routing and delivery context isolation (`src/gateway/server-methods/chat.directive-tags.test.ts`)
- **What did NOT change:** `agent` handler routing (TUI uses `chat.send`, not `agent`), webchat/UI behavior, CLI behavior, channel plugin registration.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36431

## User-visible / Behavior Changes

- `Provider`, `Surface`, and `OriginatingChannel` in `MsgContext` are now `"tui"` instead of `"webchat"` when messages originate from the TUI client.
- Per-channel message config (e.g. `responsePrefix`) can now target `"tui"` independently of `"webchat"`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js
- Integration/channel: TUI (gateway-client)

### Steps

1. Start the gateway and connect via TUI (`openclaw tui`)
2. Send any message
3. Inspect the `MsgContext` passed to `dispatchInboundMessage`

### Expected

- `Provider`, `Surface`, `OriginatingChannel` should all be `"tui"`

### Actual

- Before fix: all three were `"webchat"`
- After fix: all three are `"tui"`

## Evidence

All existing tests pass (29/29) plus 2 new test cases:
- `chat.send routes TUI client messages with surface=tui instead of webchat`
- `chat.send does not inherit external delivery context for TUI clients on main sessions`

```
 Test Files  2 passed (2)
      Tests  31 passed (31)
```

## Human Verification (required)

- Verified scenarios: TUI surface routing, TUI delivery context isolation, webchat/UI behavior unchanged, CLI behavior unchanged
- Edge cases checked: TUI on configured main session with stale external route (correctly blocked)
- What I did **not** verify: end-to-end TUI session with live gateway

## Compatibility / Migration

- Backward compatible? `Yes` — existing webchat and UI clients are unaffected; TUI only used `"ui"` internally
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit; TUI falls back to `"ui"` mode and `"webchat"` surface
- Files/config to restore: `src/tui/gateway-chat.ts` (mode), `src/gateway/protocol/client-info.ts` (modes enum)
- Known bad symptoms: if downstream code expects `Provider === "webchat"` for TUI, it would stop matching

## Risks and Mitigations

- Risk: downstream code or analytics pipelines that key on `Provider === "webchat"` to include TUI traffic will now miss it. Mitigation: `"tui"` was already recognized in `MARKDOWN_CAPABLE_CHANNELS`; the old behavior was a bug, not a contract.

