### PR TITLE
fix(agents): forward remapped sandbox paths to file tools

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -417,6 +417,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
     ...tool,
     execute: async (toolCallId, args, signal, onUpdate) => {
       const normalized = normalizeToolParams(args);
+      let argsForExecute = normalized ?? args;
       const record =
         normalized ??
         (args && typeof args === "object" ? (args as Record<string, unknown>) : undefined);
@@ -428,8 +429,11 @@ export function wrapToolWorkspaceRootGuardWithOptions(
           containerWorkdir: options?.containerWorkdir,
         });
         await assertSandboxPath({ filePath: sandboxPath, cwd: root, root });
+        if (sandboxPath !== filePath && record && typeof record === "object") {
+          argsForExecute = { ...record, path: sandboxPath };
+        }
       }
-      return tool.execute(toolCallId, normalized ?? args, signal, onUpdate);
+      return tool.execute(toolCallId, argsForExecute, signal, onUpdate);
     },
   };
 }

--- a/src/agents/pi-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/pi-tools.read.workspace-root-guard.test.ts
@@ -32,7 +32,7 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
   });
 
   it("maps container workspace paths to host workspace root", async () => {
-    const { tool } = createToolHarness();
+    const { execute, tool } = createToolHarness();
     const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
       containerWorkdir: "/workspace",
     });
@@ -44,6 +44,12 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
       cwd: root,
       root,
     });
+    expect(execute).toHaveBeenCalledWith(
+      "tc1",
+      { path: path.resolve(root, "docs", "readme.md") },
+      undefined,
+      undefined,
+    );
   });
 
   it("maps file:// container workspace paths to host workspace root", async () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: sandbox file-tool workspace guard validates remapped host paths but still executes the underlying tool with the original container path string.
- Why it matters: this mismatch can make read/write/edit behavior diverge from guard validation and break inbound media access flows that use `/workspace/...` style paths.
- What changed: after remapping container workdir paths (for example `/workspace/...`) to host workspace paths, the wrapper now forwards the remapped `path` to the underlying tool execution.
- What did NOT change (scope boundary): no changes to sandbox mount rules, permission checks, or fs-bridge path safety policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36507
- Related #36501

## User-visible / Behavior Changes

Sandboxed file tools now use the same remapped workspace-root path for both validation and execution when users/agents pass container-style `/workspace/...` paths.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.4.1
- Runtime/container: Node.js v22.22.0
- Model/provider: N/A
- Integration/channel (if any): sandboxed read/write/edit path guard
- Relevant config (redacted): `tools.fs.workspaceOnly=true`, sandbox container workdir `/workspace`

### Steps

1. Wrap a file tool with `wrapToolWorkspaceRootGuardWithOptions(..., { containerWorkdir: "/workspace" })`.
2. Execute with `path: "/workspace/docs/readme.md"`.
3. Inspect forwarded args to the underlying tool.

### Expected

- Underlying tool receives host-remapped path (`<workspaceRoot>/docs/readme.md`).

### Actual

- Before fix, underlying tool received original container path (`/workspace/docs/readme.md`) even though validation used the remapped host path.
- After fix, forwarded path matches the remapped host path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: new regression assertion in workspace-root-guard test fails before fix and passes after; sandbox workspace-only suite remains green.
- Edge cases checked: file:// and @-prefixed path mapping tests still pass.
- What you did **not** verify: end-to-end Slack upload in a live Docker deployment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `b00817fee0`.
- Files/config to restore: `src/agents/pi-tools.read.ts`, `src/agents/pi-tools.read.workspace-root-guard.test.ts`.
- Known bad symptoms reviewers should watch for: read/write/edit tool receives unexpected absolute host path in sandbox wrappers.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: wrappers now mutate forwarded `path` when remapping applies.
  - Mitigation: mutation is scoped to file tools already guarded by workspace policy; existing path-mapping tests continue to pass.
