### PR TITLE
fix(cron): keep tie-break direction consistent for descending sorts

### DIFF
--- a/src/cron/service.list-page-sort-guards.test.ts
+++ b/src/cron/service.list-page-sort-guards.test.ts
@@ -51,3 +51,39 @@ describe("cron listPage sort guards", () => {
     expect(page.jobs).toHaveLength(2);
   });
 });
+
+describe("cron listPage descending tie-breaker", () => {
+  it("uses id descending when names tie in desc order", async () => {
+    const jobs = [
+      createBaseJob({ id: "job-a", name: "same", updatedAtMs: 1, state: { nextRunAtMs: 1 } }),
+      createBaseJob({ id: "job-b", name: "same", updatedAtMs: 1, state: { nextRunAtMs: 1 } }),
+    ];
+    const state = createMockCronStateForJobs({ jobs });
+
+    const page = await listPage(state, { sortBy: "name", sortDir: "desc" });
+    expect(page.jobs.map((job) => job.id)).toEqual(["job-b", "job-a"]);
+  });
+
+  it("uses id descending when updatedAtMs ties in desc order", async () => {
+    const jobs = [
+      createBaseJob({ id: "job-a", name: "alpha", updatedAtMs: 42 }),
+      createBaseJob({ id: "job-b", name: "beta", updatedAtMs: 42 }),
+    ];
+    const state = createMockCronStateForJobs({ jobs });
+
+    const page = await listPage(state, { sortBy: "updatedAtMs", sortDir: "desc" });
+    expect(page.jobs.map((job) => job.id)).toEqual(["job-b", "job-a"]);
+  });
+
+  it("uses id descending when nextRunAtMs ties in desc order", async () => {
+    const nextRunAtMs = Date.parse("2026-02-27T15:30:00.000Z");
+    const jobs = [
+      createBaseJob({ id: "job-a", name: "alpha", state: { nextRunAtMs } }),
+      createBaseJob({ id: "job-b", name: "beta", state: { nextRunAtMs } }),
+    ];
+    const state = createMockCronStateForJobs({ jobs });
+
+    const page = await listPage(state, { sortBy: "nextRunAtMs", sortDir: "desc" });
+    expect(page.jobs.map((job) => job.id)).toEqual(["job-b", "job-a"]);
+  });
+});

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -187,7 +187,7 @@ function sortJobs(jobs: CronJob[], sortBy: CronJobsSortBy, sortDir: CronSortDir)
     }
     const aId = typeof a.id === "string" ? a.id : "";
     const bId = typeof b.id === "string" ? b.id : "";
-    return aId.localeCompare(bId);
+    return aId.localeCompare(bId) * dir;
   });
 }
 


### PR DESCRIPTION
## Summary
- apply sort direction to id tie-breaker in cron job sorting
- add regression tests for desc tie cases (name, updatedAtMs, nextRunAtMs)

## Input→Output behavior matrix
| sortBy | sortDir | tie condition | expected id order |
|---|---|---|---|
| name | desc | same name | job-b, job-a |
| updatedAtMs | desc | same timestamp | job-b, job-a |
| nextRunAtMs | desc | same next run | job-b, job-a |

## Validation
- pnpm -s vitest run src/cron/service.list-page-sort-guards.test.ts
- Result: 1 file, 5 tests passed

## Risk
- low: only affects deterministic tie-break ordering when primary values tie
- ascending behavior remains unchanged