### PR TITLE
fix(ui): recognize enum-based SecretInput unions in config schema analysis

### DIFF
--- a/ui/src/ui/views/config-form.analyze.test.ts
+++ b/ui/src/ui/views/config-form.analyze.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { analyzeConfigSchema } from "./config-form.analyze.ts";
+
+describe("analyzeConfigSchema", () => {
+  it("supports SecretInput unions when source uses enum values", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        accounts: {
+          type: "object",
+          additionalProperties: {
+            type: "object",
+            properties: {
+              appSecret: {
+                oneOf: [
+                  { type: "string" },
+                  {
+                    type: "object",
+                    required: ["source", "provider", "id"],
+                    additionalProperties: false,
+                    properties: {
+                      source: { type: "string", enum: ["env", "file", "exec"] },
+                      provider: { type: "string" },
+                      id: { type: "string" },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const analysis = analyzeConfigSchema(schema);
+    expect(analysis.unsupportedPaths).not.toContain("accounts");
+    expect(analysis.unsupportedPaths).not.toContain("accounts.*.appSecret");
+  });
+});

--- a/ui/src/ui/views/config-form.analyze.ts
+++ b/ui/src/ui/views/config-form.analyze.ts
@@ -129,8 +129,13 @@ function isSecretRefVariant(entry: JsonSchema): boolean {
   if (!source || !provider || !id) {
     return false;
   }
+  const hasStringConstSource = typeof source.const === "string";
+  const hasStringEnumSource =
+    Array.isArray(source.enum) &&
+    source.enum.length > 0 &&
+    source.enum.every((item) => typeof item === "string");
   return (
-    typeof source.const === "string" &&
+    (hasStringConstSource || hasStringEnumSource) &&
     schemaType(provider) === "string" &&
     schemaType(id) === "string"
   );
@@ -155,7 +160,10 @@ function normalizeSecretInputUnion(
     return null;
   }
   const nonString = remaining.filter((_, index) => index !== stringIndex);
-  if (nonString.length !== 1 || !isSecretRefUnion(nonString[0])) {
+  if (
+    nonString.length !== 1 ||
+    (!isSecretRefUnion(nonString[0]) && !isSecretRefVariant(nonString[0]))
+  ) {
     return null;
   }
   return normalizeSchemaNode(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: config-form schema analysis treated some SecretInput unions as unsupported when the object variant used `source: { enum: [...] }` (instead of `const`-based variants).
- Why it matters: Control Panel showed "Unsupported schema node. Use Raw mode." for nested map fields like Feishu `accounts.*.appSecret`.
- What changed: expanded SecretInput detection to accept enum-based `source` fields and direct string-or-object SecretInput unions.
- What did NOT change (scope boundary): no renderer/layout changes and no config schema changes in channels/plugins.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36498
- Related #36501

## User-visible / Behavior Changes

Control Panel schema analysis no longer flags Feishu-style `accounts.*.appSecret` SecretInput unions as unsupported when `source` is declared with enum values.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.4.1
- Runtime/container: Node.js v22.22.0
- Model/provider: N/A
- Integration/channel (if any): Control Panel config schema analyzer
- Relevant config (redacted): Feishu-style `accounts` map with `appSecret` SecretInput schema

### Steps

1. Analyze a schema where `accounts` is an `additionalProperties` map and `appSecret` is `oneOf: [string, object]`.
2. In object variant, set `source` as `type: string, enum: ["env","file","exec"]`.
3. Run `analyzeConfigSchema`.

### Expected

- `accounts` and `accounts.*.appSecret` are supported (not listed in `unsupportedPaths`).

### Actual

- Before fix, analyzer marked `accounts` unsupported.
- After fix, unsupported paths are clear for this SecretInput shape.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduction via direct analyzer run against Feishu channel schema (`unsupportedPaths` dropped from 3 to 0 for the affected paths).
- Edge cases checked: existing const-based SecretInput union behavior retained; analyzer-only unit test for enum-based variant added.
- What you did **not** verify: full browser-rendered Control Panel flow in a live gateway session.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `ae20cfff83`.
- Files/config to restore: `ui/src/ui/views/config-form.analyze.ts`, `ui/src/ui/views/config-form.analyze.test.ts`.
- Known bad symptoms reviewers should watch for: analyzer misclassifying non-secret unions as supported.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: broader SecretInput recognition could accept an unintended schema shape.
  - Mitigation: checks still require object shape with `source`, `provider`, and `id` all typed as strings.
