### PR TITLE
feat: add sessions_yield tool for cooperative turn-ending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Docs/Kubernetes: Add a starter K8s install path with raw manifests, Kind setup, and deployment docs. Thanks @sallyom @dzianisv @egkristi
+- Agents/subagents: add `sessions_yield` so orchestrators can end the current turn immediately, skip queued tool work, and carry a hidden follow-up payload into the next session turn. (#36537) thanks @jriff
 
 ### Fixes
 

--- a/scripts/bundle-a2ui.sh
+++ b/scripts/bundle-a2ui.sh
@@ -32,13 +32,13 @@ INPUT_PATHS=(
 )
 
 compute_hash() {
-  ROOT_DIR="$ROOT_DIR" node --input-type=module - "${INPUT_PATHS[@]}" <<'NODE'
+  ROOT_DIR="$ROOT_DIR" node --input-type=module --eval '
 import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 
 const rootDir = process.env.ROOT_DIR ?? process.cwd();
-const inputs = process.argv.slice(2);
+const inputs = process.argv.slice(1);
 const files = [];
 
 async function walk(entryPath) {
@@ -73,7 +73,7 @@ for (const filePath of files) {
 }
 
 process.stdout.write(hash.digest("hex"));
-NODE
+' "${INPUT_PATHS[@]}"
 }
 
 current_hash="$(compute_hash)"

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -79,7 +79,7 @@ export function createOpenClawTools(
      */
     spawnWorkspaceDir?: string;
     /** Callback invoked when sessions_yield tool is called. */
-    onYield?: () => void;
+    onYield?: (message: string) => Promise<void> | void;
   } & SpawnedToolContext,
 ): AnyAgentTool[] {
   const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir);

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -78,6 +78,8 @@ export function createOpenClawTools(
      * subagents inherit the real workspace path instead of the sandbox copy.
      */
     spawnWorkspaceDir?: string;
+    /** Callback invoked when sessions_yield tool is called. */
+    onYield?: (message: string) => void;
   } & SpawnedToolContext,
 ): AnyAgentTool[] {
   const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir);
@@ -184,6 +186,7 @@ export function createOpenClawTools(
     }),
     createSessionsYieldTool({
       sessionId: options?.sessionId,
+      onYield: options?.onYield,
     }),
     createSessionsSpawnTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -79,7 +79,7 @@ export function createOpenClawTools(
      */
     spawnWorkspaceDir?: string;
     /** Callback invoked when sessions_yield tool is called. */
-    onYield?: (message: string) => void;
+    onYield?: () => void;
   } & SpawnedToolContext,
 ): AnyAgentTool[] {
   const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir);

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -21,6 +21,7 @@ import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
 import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
 import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
+import { createSessionsYieldTool } from "./tools/sessions-yield-tool.js";
 import { createSubagentsTool } from "./tools/subagents-tool.js";
 import { createTtsTool } from "./tools/tts-tool.js";
 import { createWebFetchTool, createWebSearchTool } from "./tools/web-tools.js";
@@ -180,6 +181,9 @@ export function createOpenClawTools(
       agentSessionKey: options?.agentSessionKey,
       agentChannel: options?.agentChannel,
       sandboxed: options?.sandboxed,
+    }),
+    createSessionsYieldTool({
+      sessionId: options?.sessionId,
     }),
     createSessionsSpawnTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -276,7 +276,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = { model: "deepseek/deepseek-r1" };
-      options?.onPayload?.(payload, model);
+      options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -308,7 +308,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = {};
-      options?.onPayload?.(payload, model);
+      options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -332,7 +332,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = { reasoning_effort: "high" };
-      options?.onPayload?.(payload, model);
+      options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -357,7 +357,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = { reasoning: { max_tokens: 256 } };
-      options?.onPayload?.(payload, model);
+      options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -381,7 +381,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = { reasoning_effort: "medium" };
-      options?.onPayload?.(payload, model);
+      options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -588,7 +588,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = { thinking: "off" };
-      options?.onPayload?.(payload, model);
+      options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -619,7 +619,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = { thinking: "off" };
-      options?.onPayload?.(payload, model);
+      options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -650,7 +650,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = {};
-      options?.onPayload?.(payload, model);
+      options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -674,7 +674,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = { tool_choice: "required" };
-      options?.onPayload?.(payload, model);
+      options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -699,7 +699,7 @@ describe("applyExtraParamsToAgent", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
       const payload: Record<string, unknown> = {};
-      options?.onPayload?.(payload, model);
+      options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -749,7 +749,7 @@ describe("applyExtraParamsToAgent", () => {
         ],
         tool_choice: { type: "tool", name: "read" },
       };
-      options?.onPayload?.(payload, model);
+      options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -793,7 +793,7 @@ describe("applyExtraParamsToAgent", () => {
           },
         ],
       };
-      options?.onPayload?.(payload, model);
+      options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -832,7 +832,7 @@ describe("applyExtraParamsToAgent", () => {
           },
         ],
       };
-      options?.onPayload?.(payload, model);
+      options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -896,7 +896,7 @@ describe("applyExtraParamsToAgent", () => {
           },
         },
       };
-      options?.onPayload?.(payload, model);
+      options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };
@@ -943,7 +943,7 @@ describe("applyExtraParamsToAgent", () => {
           },
         },
       };
-      options?.onPayload?.(payload, model);
+      options?.onPayload?.(payload, _model);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
     };

--- a/src/agents/pi-embedded-runner.sessions-yield.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.sessions-yield.e2e.test.ts
@@ -34,6 +34,9 @@ function createMockUsage(input: number, output: number) {
 
 // Track call sequence to return tool_use first, then stop.
 let streamCallCount = 0;
+// When true, the first LLM response includes two tool calls: sessions_yield + read.
+// This tests that the abort prevents the second tool from executing.
+let multiToolMode = false;
 
 vi.mock("@mariozechner/pi-coding-agent", async () => {
   return await vi.importActual<typeof import("@mariozechner/pi-coding-agent")>(
@@ -44,23 +47,39 @@ vi.mock("@mariozechner/pi-coding-agent", async () => {
 vi.mock("@mariozechner/pi-ai", async () => {
   const actual = await vi.importActual<typeof import("@mariozechner/pi-ai")>("@mariozechner/pi-ai");
 
-  const buildToolUseMessage = (model: { api: string; provider: string; id: string }) => ({
-    role: "assistant" as const,
-    content: [
+  const buildToolUseMessage = (model: { api: string; provider: string; id: string }) => {
+    const toolCalls: Array<{
+      type: "toolCall";
+      id: string;
+      name: string;
+      arguments: Record<string, unknown>;
+    }> = [
       {
         type: "toolCall" as const,
         id: "tc-yield-e2e-1",
         name: "sessions_yield",
         arguments: { message: "Yielding turn." },
       },
-    ],
-    stopReason: "toolUse" as const,
-    api: model.api,
-    provider: model.provider,
-    model: model.id,
-    usage: createMockUsage(1, 1),
-    timestamp: Date.now(),
-  });
+    ];
+    if (multiToolMode) {
+      toolCalls.push({
+        type: "toolCall" as const,
+        id: "tc-post-yield-2",
+        name: "read",
+        arguments: { file_path: "/etc/hostname" },
+      });
+    }
+    return {
+      role: "assistant" as const,
+      content: toolCalls,
+      stopReason: "toolUse" as const,
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: createMockUsage(1, 1),
+      timestamp: Date.now(),
+    };
+  };
 
   const buildStopMessage = (model: { api: string; provider: string; id: string }) => ({
     role: "assistant" as const,
@@ -221,6 +240,81 @@ describe("sessions_yield e2e", () => {
         (c) => c.type === "toolCall" && c.name === "sessions_yield",
       );
       expect(toolCall).toBeDefined();
+    },
+  );
+
+  it(
+    "abort prevents subsequent tool calls from executing after yield",
+    { timeout: 15_000 },
+    async () => {
+      // Enable multi-tool mode: LLM returns [sessions_yield, read] in one response.
+      // The abort should fire after yield, preventing read from executing.
+      streamCallCount = 0;
+      multiToolMode = true;
+
+      const sessionId = "yield-e2e-abort";
+      const sessionFile = path.join(workspaceDir, "session-yield-abort.jsonl");
+      const cfg = makeConfig(["mock-yield-abort"]);
+
+      const result = await runEmbeddedPiAgent({
+        sessionId,
+        sessionKey: "agent:test:yield-abort",
+        sessionFile,
+        workspaceDir,
+        config: cfg,
+        prompt: "Yield and then read a file.",
+        provider: "openai",
+        model: "mock-yield-abort",
+        timeoutMs: 10_000,
+        agentDir,
+        runId: "run-yield-abort-1",
+        enqueue: immediateEnqueue,
+      });
+
+      // Reset for other tests
+      multiToolMode = false;
+
+      // 1. Run completed with end_turn despite the second tool call
+      expect(result.meta.stopReason).toBe("end_turn");
+
+      // 2. Session is idle
+      expect(isEmbeddedPiRunActive(sessionId)).toBe(false);
+
+      // 3. LLM was only called ONCE — abort prevented the post-tool model call
+      expect(streamCallCount).toBe(1);
+
+      // 4. Transcript should contain sessions_yield but NOT a successful read result
+      const messages = await readSessionMessages(sessionFile);
+      const allContent = messages.flatMap((m) =>
+        Array.isArray(m?.content) ? (m.content as Array<{ type?: string; name?: string }>) : [],
+      );
+      const yieldCall = allContent.find(
+        (c) => c.type === "toolCall" && c.name === "sessions_yield",
+      );
+      expect(yieldCall).toBeDefined();
+
+      // The read tool call should be in the assistant message (LLM requested it),
+      // but its result should NOT show a successful file read.
+      const readCall = allContent.find((c) => c.type === "toolCall" && c.name === "read");
+      expect(readCall).toBeDefined(); // LLM asked for it...
+
+      // ...but the file was never actually read (no tool result with file contents)
+      const toolResults = messages.filter((m) => m?.role === "toolResult");
+      const readResult = toolResults.find((tr) => {
+        const content = tr?.content;
+        if (typeof content === "string") {
+          return content.includes("/etc/hostname");
+        }
+        if (Array.isArray(content)) {
+          return (content as Array<{ text?: string }>).some((c) =>
+            c.text?.includes("/etc/hostname"),
+          );
+        }
+        return false;
+      });
+      // If the read tool ran, its result would reference the file path.
+      // The abort should have prevented it from executing.
+      expect(readResult).toBeUndefined();
     },
   );
 });

--- a/src/agents/pi-embedded-runner.sessions-yield.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.sessions-yield.e2e.test.ts
@@ -1,0 +1,195 @@
+/**
+ * End-to-end test proving that when sessions_yield is called:
+ * 1. The attempt completes with yieldDetected
+ * 2. The run exits with stopReason "end_turn" and no pendingToolCalls
+ * 3. The parent session is idle (clearActiveEmbeddedRun has run)
+ *
+ * This exercises the full path: mock LLM → agent loop → tool execution → callback → attempt result → run result.
+ * Follows the same pattern as pi-embedded-runner.e2e.test.ts.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import "./test-helpers/fast-coding-tools.js";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { isEmbeddedPiRunActive, queueEmbeddedPiMessage } from "./pi-embedded-runner/runs.js";
+
+function createMockUsage(input: number, output: number) {
+  return {
+    input,
+    output,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: input + output,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    },
+  };
+}
+
+// Track call sequence to return tool_use first, then stop.
+let streamCallCount = 0;
+
+vi.mock("@mariozechner/pi-coding-agent", async () => {
+  return await vi.importActual<typeof import("@mariozechner/pi-coding-agent")>(
+    "@mariozechner/pi-coding-agent",
+  );
+});
+
+vi.mock("@mariozechner/pi-ai", async () => {
+  const actual = await vi.importActual<typeof import("@mariozechner/pi-ai")>("@mariozechner/pi-ai");
+
+  const buildToolUseMessage = (model: { api: string; provider: string; id: string }) => ({
+    role: "assistant" as const,
+    content: [
+      {
+        type: "toolCall" as const,
+        id: "tc-yield-e2e-1",
+        name: "sessions_yield",
+        arguments: { message: "Yielding turn." },
+      },
+    ],
+    stopReason: "toolUse" as const,
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: createMockUsage(1, 1),
+    timestamp: Date.now(),
+  });
+
+  const buildStopMessage = (model: { api: string; provider: string; id: string }) => ({
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text: "Acknowledged." }],
+    stopReason: "stop" as const,
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: createMockUsage(1, 1),
+    timestamp: Date.now(),
+  });
+
+  return {
+    ...actual,
+    complete: async (model: { api: string; provider: string; id: string }) => {
+      streamCallCount++;
+      return streamCallCount === 1 ? buildToolUseMessage(model) : buildStopMessage(model);
+    },
+    completeSimple: async (model: { api: string; provider: string; id: string }) => {
+      streamCallCount++;
+      return streamCallCount === 1 ? buildToolUseMessage(model) : buildStopMessage(model);
+    },
+    streamSimple: (model: { api: string; provider: string; id: string }) => {
+      streamCallCount++;
+      const isFirstCall = streamCallCount === 1;
+      const message = isFirstCall ? buildToolUseMessage(model) : buildStopMessage(model);
+      const stream = actual.createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        stream.push({
+          type: "done",
+          reason: isFirstCall ? "toolUse" : "stop",
+          message,
+        });
+        stream.end();
+      });
+      return stream;
+    },
+  };
+});
+
+let runEmbeddedPiAgent: typeof import("./pi-embedded-runner/run.js").runEmbeddedPiAgent;
+let tempRoot: string | undefined;
+let agentDir: string;
+let workspaceDir: string;
+
+beforeAll(async () => {
+  vi.useRealTimers();
+  streamCallCount = 0;
+  ({ runEmbeddedPiAgent } = await import("./pi-embedded-runner/run.js"));
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-yield-e2e-"));
+  agentDir = path.join(tempRoot, "agent");
+  workspaceDir = path.join(tempRoot, "workspace");
+  await fs.mkdir(agentDir, { recursive: true });
+  await fs.mkdir(workspaceDir, { recursive: true });
+}, 180_000);
+
+afterAll(async () => {
+  if (!tempRoot) {
+    return;
+  }
+  await fs.rm(tempRoot, { recursive: true, force: true });
+  tempRoot = undefined;
+});
+
+const makeConfig = (modelIds: string[]) =>
+  ({
+    models: {
+      providers: {
+        openai: {
+          api: "openai-responses",
+          apiKey: "sk-test",
+          baseUrl: "https://example.com",
+          models: modelIds.map((id) => ({
+            id,
+            name: `Mock ${id}`,
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 16_000,
+            maxTokens: 2048,
+          })),
+        },
+      },
+    },
+  }) satisfies OpenClawConfig;
+
+const immediateEnqueue = async <T>(task: () => Promise<T>) => task();
+
+describe("sessions_yield e2e", () => {
+  it(
+    "parent session is idle after yield — full path through attempt",
+    { timeout: 15_000 },
+    async () => {
+      // Reset call counter so first call returns tool_use
+      streamCallCount = 0;
+
+      const sessionId = "yield-e2e-parent";
+      const sessionFile = path.join(workspaceDir, "session-yield-e2e.jsonl");
+      const cfg = makeConfig(["mock-yield"]);
+
+      const result = await runEmbeddedPiAgent({
+        sessionId,
+        sessionKey: "agent:test:yield-e2e",
+        sessionFile,
+        workspaceDir,
+        config: cfg,
+        prompt: "Spawn subagent and yield.",
+        provider: "openai",
+        model: "mock-yield",
+        timeoutMs: 10_000,
+        agentDir,
+        runId: "run-yield-e2e-1",
+        enqueue: immediateEnqueue,
+      });
+
+      // 1. Run completed with end_turn (yield causes clean exit)
+      expect(result.meta.stopReason).toBe("end_turn");
+
+      // 2. No pending tool calls (yield is NOT a client tool call)
+      expect(result.meta.pendingToolCalls).toBeUndefined();
+
+      // 3. Parent session is IDLE — clearActiveEmbeddedRun ran in finally block
+      expect(isEmbeddedPiRunActive(sessionId)).toBe(false);
+
+      // 4. Steer would fail — session not in ACTIVE_EMBEDDED_RUNS
+      expect(queueEmbeddedPiMessage(sessionId, "subagent result")).toBe(false);
+
+      // 5. The mock LLM was called twice (tool_use + stop)
+      expect(streamCallCount).toBe(2);
+    },
+  );
+});

--- a/src/agents/pi-embedded-runner.sessions-yield.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.sessions-yield.e2e.test.ts
@@ -32,11 +32,10 @@ function createMockUsage(input: number, output: number) {
   };
 }
 
-// Track call sequence to return tool_use first, then stop.
 let streamCallCount = 0;
-// When true, the first LLM response includes two tool calls: sessions_yield + read.
-// This tests that the abort prevents the second tool from executing.
 let multiToolMode = false;
+let responsePlan: Array<"toolUse" | "stop"> = [];
+let observedContexts: Array<Array<{ role?: string; content?: unknown }>> = [];
 
 vi.mock("@mariozechner/pi-coding-agent", async () => {
   return await vi.importActual<typeof import("@mariozechner/pi-coding-agent")>(
@@ -96,21 +95,27 @@ vi.mock("@mariozechner/pi-ai", async () => {
     ...actual,
     complete: async (model: { api: string; provider: string; id: string }) => {
       streamCallCount++;
-      return streamCallCount === 1 ? buildToolUseMessage(model) : buildStopMessage(model);
+      const next = responsePlan.shift() ?? "stop";
+      return next === "toolUse" ? buildToolUseMessage(model) : buildStopMessage(model);
     },
     completeSimple: async (model: { api: string; provider: string; id: string }) => {
       streamCallCount++;
-      return streamCallCount === 1 ? buildToolUseMessage(model) : buildStopMessage(model);
+      const next = responsePlan.shift() ?? "stop";
+      return next === "toolUse" ? buildToolUseMessage(model) : buildStopMessage(model);
     },
-    streamSimple: (model: { api: string; provider: string; id: string }) => {
+    streamSimple: (
+      model: { api: string; provider: string; id: string },
+      context: { messages?: Array<{ role?: string; content?: unknown }> },
+    ) => {
       streamCallCount++;
-      const isFirstCall = streamCallCount === 1;
-      const message = isFirstCall ? buildToolUseMessage(model) : buildStopMessage(model);
+      observedContexts.push((context.messages ?? []).map((message) => ({ ...message })));
+      const next = responsePlan.shift() ?? "stop";
+      const message = next === "toolUse" ? buildToolUseMessage(model) : buildStopMessage(model);
       const stream = actual.createAssistantMessageEventStream();
       queueMicrotask(() => {
         stream.push({
           type: "done",
-          reason: isFirstCall ? "toolUse" : "stop",
+          reason: next === "toolUse" ? "toolUse" : "stop",
           message,
         });
         stream.end();
@@ -128,6 +133,8 @@ let workspaceDir: string;
 beforeAll(async () => {
   vi.useRealTimers();
   streamCallCount = 0;
+  responsePlan = [];
+  observedContexts = [];
   ({ runEmbeddedPiAgent } = await import("./pi-embedded-runner/run.js"));
   tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-yield-e2e-"));
   agentDir = path.join(tempRoot, "agent");
@@ -181,13 +188,20 @@ const readSessionMessages = async (sessionFile: string) => {
     .map((entry) => entry.message) as Array<{ role?: string; content?: unknown }>;
 };
 
+const readSessionEntries = async (sessionFile: string) =>
+  (await fs.readFile(sessionFile, "utf-8"))
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+
 describe("sessions_yield e2e", () => {
   it(
-    "parent session is idle after yield — full path through attempt",
+    "parent session is idle after yield and preserves the follow-up payload",
     { timeout: 15_000 },
     async () => {
-      // Reset call counter so first call returns tool_use
       streamCallCount = 0;
+      responsePlan = ["toolUse"];
+      observedContexts = [];
 
       const sessionId = "yield-e2e-parent";
       const sessionFile = path.join(workspaceDir, "session-yield-e2e.jsonl");
@@ -220,19 +234,15 @@ describe("sessions_yield e2e", () => {
       // 4. Steer would fail — session not in ACTIVE_EMBEDDED_RUNS
       expect(queueEmbeddedPiMessage(sessionId, "subagent result")).toBe(false);
 
-      // 5. The mock LLM was called twice (tool_use + stop)
-      expect(streamCallCount).toBe(2);
+      // 5. The yield stops at tool time — there is no second provider call.
+      expect(streamCallCount).toBe(1);
 
-      // 6. Session transcript contains the yield tool call and result
+      // 6. Session transcript contains only the original assistant tool call.
       const messages = await readSessionMessages(sessionFile);
       const roles = messages.map((m) => m?.role);
-      // Expect: user → assistant (tool_use) → [tool_result] → assistant (stop)
-      // The session file records user + assistant messages; tool results may be
-      // embedded as a separate role.
       expect(roles).toContain("user");
-      expect(roles.filter((r) => r === "assistant").length).toBeGreaterThanOrEqual(2);
+      expect(roles.filter((r) => r === "assistant")).toHaveLength(1);
 
-      // The first assistant message should contain the sessions_yield tool call
       const firstAssistant = messages.find((m) => m?.role === "assistant");
       const content = firstAssistant?.content;
       expect(Array.isArray(content)).toBe(true);
@@ -240,6 +250,46 @@ describe("sessions_yield e2e", () => {
         (c) => c.type === "toolCall" && c.name === "sessions_yield",
       );
       expect(toolCall).toBeDefined();
+
+      const entries = await readSessionEntries(sessionFile);
+      const yieldContext = entries.find(
+        (entry) =>
+          entry.type === "custom_message" && entry.customType === "openclaw.sessions_yield",
+      );
+      expect(yieldContext).toMatchObject({
+        content: expect.stringContaining("Yielding turn."),
+      });
+
+      streamCallCount = 0;
+      responsePlan = ["stop"];
+      observedContexts = [];
+      await runEmbeddedPiAgent({
+        sessionId,
+        sessionKey: "agent:test:yield-e2e",
+        sessionFile,
+        workspaceDir,
+        config: cfg,
+        prompt: "Subagent finished with the requested result.",
+        provider: "openai",
+        model: "mock-yield",
+        timeoutMs: 10_000,
+        agentDir,
+        runId: "run-yield-e2e-2",
+        enqueue: immediateEnqueue,
+      });
+
+      const resumeContext = observedContexts[0] ?? [];
+      const resumeTexts = resumeContext.flatMap((message) =>
+        Array.isArray(message.content)
+          ? (message.content as Array<{ type?: string; text?: string }>)
+              .filter((part) => part.type === "text" && typeof part.text === "string")
+              .map((part) => part.text ?? "")
+          : [],
+      );
+      expect(resumeTexts.some((text) => text.includes("Yielding turn."))).toBe(true);
+      expect(
+        resumeTexts.some((text) => text.includes("Subagent finished with the requested result.")),
+      ).toBe(true);
     },
   );
 
@@ -247,10 +297,10 @@ describe("sessions_yield e2e", () => {
     "abort prevents subsequent tool calls from executing after yield",
     { timeout: 15_000 },
     async () => {
-      // Enable multi-tool mode: LLM returns [sessions_yield, read] in one response.
-      // The abort should fire after yield, preventing read from executing.
       streamCallCount = 0;
       multiToolMode = true;
+      responsePlan = ["toolUse"];
+      observedContexts = [];
 
       const sessionId = "yield-e2e-abort";
       const sessionFile = path.join(workspaceDir, "session-yield-abort.jsonl");
@@ -274,13 +324,13 @@ describe("sessions_yield e2e", () => {
       // Reset for other tests
       multiToolMode = false;
 
-      // 1. Run completed with end_turn despite the second tool call
+      // 1. Run completed with end_turn despite the extra queued tool call
       expect(result.meta.stopReason).toBe("end_turn");
 
       // 2. Session is idle
       expect(isEmbeddedPiRunActive(sessionId)).toBe(false);
 
-      // 3. LLM was only called ONCE — abort prevented the post-tool model call
+      // 3. The yield prevented a post-tool provider call.
       expect(streamCallCount).toBe(1);
 
       // 4. Transcript should contain sessions_yield but NOT a successful read result

--- a/src/agents/pi-embedded-runner.sessions-yield.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.sessions-yield.e2e.test.ts
@@ -149,6 +149,19 @@ const makeConfig = (modelIds: string[]) =>
 
 const immediateEnqueue = async <T>(task: () => Promise<T>) => task();
 
+const readSessionMessages = async (sessionFile: string) => {
+  const raw = await fs.readFile(sessionFile, "utf-8");
+  return raw
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map(
+      (line) =>
+        JSON.parse(line) as { type?: string; message?: { role?: string; content?: unknown } },
+    )
+    .filter((entry) => entry.type === "message")
+    .map((entry) => entry.message) as Array<{ role?: string; content?: unknown }>;
+};
+
 describe("sessions_yield e2e", () => {
   it(
     "parent session is idle after yield — full path through attempt",
@@ -190,6 +203,24 @@ describe("sessions_yield e2e", () => {
 
       // 5. The mock LLM was called twice (tool_use + stop)
       expect(streamCallCount).toBe(2);
+
+      // 6. Session transcript contains the yield tool call and result
+      const messages = await readSessionMessages(sessionFile);
+      const roles = messages.map((m) => m?.role);
+      // Expect: user → assistant (tool_use) → [tool_result] → assistant (stop)
+      // The session file records user + assistant messages; tool results may be
+      // embedded as a separate role.
+      expect(roles).toContain("user");
+      expect(roles.filter((r) => r === "assistant").length).toBeGreaterThanOrEqual(2);
+
+      // The first assistant message should contain the sessions_yield tool call
+      const firstAssistant = messages.find((m) => m?.role === "assistant");
+      const content = firstAssistant?.content;
+      expect(Array.isArray(content)).toBe(true);
+      const toolCall = (content as Array<{ type?: string; name?: string }>).find(
+        (c) => c.type === "toolCall" && c.name === "sessions_yield",
+      );
+      expect(toolCall).toBeDefined();
     },
   );
 });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1574,7 +1574,9 @@ export async function runEmbeddedPiAgent(
               // ACP bridge) can distinguish end_turn from max_tokens.
               stopReason: attempt.clientToolCall
                 ? "tool_calls"
-                : (lastAssistant?.stopReason as string | undefined),
+                : attempt.yieldDetected
+                  ? "end_turn"
+                  : (lastAssistant?.stopReason as string | undefined),
               pendingToolCalls: attempt.clientToolCall
                 ? [
                     {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1125,6 +1125,7 @@ export async function runEmbeddedAttempt(
     let yieldDetected = false;
     // Late-binding reference so onYield can abort the session (declared after tool creation)
     let abortSessionForYield: (() => void) | null = null;
+    let yieldAbortSettled: Promise<void> | null = null;
     // Check if the model supports native image input
     const modelHasVision = params.model.input?.includes("image") ?? false;
     const toolsRaw = params.disableTools
@@ -1485,7 +1486,7 @@ export async function runEmbeddedAttempt(
       }
       const activeSession = session;
       abortSessionForYield = () => {
-        void activeSession.abort();
+        yieldAbortSettled = Promise.resolve(activeSession.abort());
       };
       removeToolResultContextGuard = installToolResultContextGuard({
         agent: activeSession.agent,
@@ -2098,6 +2099,11 @@ export async function runEmbeddedAttempt(
             err.cause === "sessions_yield";
           if (yieldAborted) {
             aborted = false;
+            // Ensure the session abort has fully settled before proceeding.
+            if (yieldAbortSettled) {
+              // eslint-disable-next-line @typescript-eslint/await-thenable -- abort() returns Promise<void> per AgentSession.d.ts
+              await yieldAbortSettled;
+            }
           } else {
             promptError = err;
             promptErrorSource = "prompt";

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -256,18 +256,7 @@ async function persistSessionsYieldContextMessage(
 function stripSessionsYieldArtifacts(activeSession: {
   messages: AgentMessage[];
   agent: { replaceMessages: (messages: AgentMessage[]) => void };
-  sessionManager?: {
-    fileEntries?: Array<{
-      type?: string;
-      id?: string;
-      parentId?: string | null;
-      message?: { role?: string; stopReason?: string };
-      customType?: string;
-    }>;
-    byId?: Map<string, { id: string }>;
-    leafId?: string | null;
-    _rewriteFile?: () => void;
-  };
+  sessionManager?: unknown;
 }) {
   const strippedMessages = activeSession.messages.slice();
   while (strippedMessages.length > 0) {
@@ -292,7 +281,20 @@ function stripSessionsYieldArtifacts(activeSession: {
     activeSession.agent.replaceMessages(strippedMessages);
   }
 
-  const sessionManager = activeSession.sessionManager;
+  const sessionManager = activeSession.sessionManager as
+    | {
+        fileEntries?: Array<{
+          type?: string;
+          id?: string;
+          parentId?: string | null;
+          message?: { role?: string; stopReason?: string };
+          customType?: string;
+        }>;
+        byId?: Map<string, { id: string }>;
+        leafId?: string | null;
+        _rewriteFile?: () => void;
+      }
+    | undefined;
   const fileEntries = sessionManager?.fileEntries;
   const byId = sessionManager?.byId;
   if (!fileEntries || !byId) {
@@ -1848,7 +1850,9 @@ export async function runEmbeddedAttempt(
       activeSession.agent.streamFn = (model, context, options) => {
         const signal = runAbortController.signal as AbortSignal & { reason?: unknown };
         if (yieldDetected && signal.aborted && signal.reason === "sessions_yield") {
-          return createYieldAbortedResponse(model) as Awaited<ReturnType<typeof innerStreamFn>>;
+          return createYieldAbortedResponse(model) as unknown as Awaited<
+            ReturnType<typeof innerStreamFn>
+          >;
         }
         return innerStreamFn(model, context, options);
       };

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1758,6 +1758,7 @@ export async function runEmbeddedAttempt(
       }
 
       let aborted = Boolean(params.abortSignal?.aborted);
+      let yieldAborted = false;
       let timedOut = false;
       let timedOutDuringCompaction = false;
       const getAbortReason = (signal: AbortSignal): unknown =>
@@ -2087,8 +2088,15 @@ export async function runEmbeddedAttempt(
             await abortable(activeSession.prompt(effectivePrompt));
           }
         } catch (err) {
-          // Yield-triggered abort is intentional — treat as clean stop, not error
-          if (yieldDetected && isRunnerAbortError(err)) {
+          // Yield-triggered abort is intentional — treat as clean stop, not error.
+          // Check the abort reason to distinguish from external aborts (timeout, user cancel)
+          // that may race after yieldDetected is set.
+          yieldAborted =
+            yieldDetected &&
+            isRunnerAbortError(err) &&
+            err instanceof Error &&
+            err.cause === "sessions_yield";
+          if (yieldAborted) {
             aborted = false;
           } else {
             promptError = err;
@@ -2122,7 +2130,7 @@ export async function runEmbeddedAttempt(
 
           // Skip compaction wait when yield aborted the run — the signal is
           // already tripped and abortable() would immediately reject.
-          const compactionRetryWait = yieldDetected
+          const compactionRetryWait = yieldAborted
             ? { timedOut: false }
             : await waitForCompactionRetryWithAggregateTimeout({
                 waitForCompactionRetry,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -148,6 +148,184 @@ type PromptBuildHookRunner = {
   ) => Promise<PluginHookBeforeAgentStartResult | undefined>;
 };
 
+const SESSIONS_YIELD_INTERRUPT_CUSTOM_TYPE = "openclaw.sessions_yield_interrupt";
+const SESSIONS_YIELD_CONTEXT_CUSTOM_TYPE = "openclaw.sessions_yield";
+
+// Persist a hidden context reminder so the next turn knows why the runner stopped.
+function buildSessionsYieldContextMessage(message: string): string {
+  return `${message}\n\n[Context: The previous turn ended intentionally via sessions_yield while waiting for a follow-up event.]`;
+}
+
+// Return a synthetic aborted response so pi-agent-core unwinds without a real provider call.
+function createYieldAbortedResponse(model: { api?: string; provider?: string; id?: string }): {
+  [Symbol.asyncIterator]: () => AsyncGenerator<never, void, unknown>;
+  result: () => Promise<{
+    role: "assistant";
+    content: Array<{ type: "text"; text: string }>;
+    stopReason: "aborted";
+    api: string;
+    provider: string;
+    model: string;
+    usage: {
+      input: number;
+      output: number;
+      cacheRead: number;
+      cacheWrite: number;
+      totalTokens: number;
+      cost: {
+        input: number;
+        output: number;
+        cacheRead: number;
+        cacheWrite: number;
+        total: number;
+      };
+    };
+    timestamp: number;
+  }>;
+} {
+  const message = {
+    role: "assistant" as const,
+    content: [{ type: "text" as const, text: "" }],
+    stopReason: "aborted" as const,
+    api: model.api ?? "",
+    provider: model.provider ?? "",
+    model: model.id ?? "",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    timestamp: Date.now(),
+  };
+  return {
+    async *[Symbol.asyncIterator]() {},
+    result: async () => message,
+  };
+}
+
+// Queue a hidden steering message so pi-agent-core skips any remaining tool calls.
+function queueSessionsYieldInterruptMessage(activeSession: {
+  agent: { steer: (message: AgentMessage) => void };
+}) {
+  activeSession.agent.steer({
+    role: "custom",
+    customType: SESSIONS_YIELD_INTERRUPT_CUSTOM_TYPE,
+    content: "[sessions_yield interrupt]",
+    display: false,
+    details: { source: "sessions_yield" },
+    timestamp: Date.now(),
+  });
+}
+
+// Append the caller-provided yield payload as a hidden session message once the run is idle.
+async function persistSessionsYieldContextMessage(
+  activeSession: {
+    sendCustomMessage: (
+      message: {
+        customType: string;
+        content: string;
+        display: boolean;
+        details?: Record<string, unknown>;
+      },
+      options?: { triggerTurn?: boolean },
+    ) => Promise<void>;
+  },
+  message: string,
+) {
+  await activeSession.sendCustomMessage(
+    {
+      customType: SESSIONS_YIELD_CONTEXT_CUSTOM_TYPE,
+      content: buildSessionsYieldContextMessage(message),
+      display: false,
+      details: { source: "sessions_yield", message },
+    },
+    { triggerTurn: false },
+  );
+}
+
+// Remove the synthetic yield interrupt + aborted assistant entry from the live transcript.
+function stripSessionsYieldArtifacts(activeSession: {
+  messages: AgentMessage[];
+  agent: { replaceMessages: (messages: AgentMessage[]) => void };
+  sessionManager?: {
+    fileEntries?: Array<{
+      type?: string;
+      id?: string;
+      parentId?: string | null;
+      message?: { role?: string; stopReason?: string };
+      customType?: string;
+    }>;
+    byId?: Map<string, { id: string }>;
+    leafId?: string | null;
+    _rewriteFile?: () => void;
+  };
+}) {
+  const strippedMessages = activeSession.messages.slice();
+  while (strippedMessages.length > 0) {
+    const last = strippedMessages.at(-1) as
+      | AgentMessage
+      | { role?: string; customType?: string; stopReason?: string };
+    if (last?.role === "assistant" && "stopReason" in last && last.stopReason === "aborted") {
+      strippedMessages.pop();
+      continue;
+    }
+    if (
+      last?.role === "custom" &&
+      "customType" in last &&
+      last.customType === SESSIONS_YIELD_INTERRUPT_CUSTOM_TYPE
+    ) {
+      strippedMessages.pop();
+      continue;
+    }
+    break;
+  }
+  if (strippedMessages.length !== activeSession.messages.length) {
+    activeSession.agent.replaceMessages(strippedMessages);
+  }
+
+  const sessionManager = activeSession.sessionManager;
+  const fileEntries = sessionManager?.fileEntries;
+  const byId = sessionManager?.byId;
+  if (!fileEntries || !byId) {
+    return;
+  }
+
+  let changed = false;
+  while (fileEntries.length > 1) {
+    const last = fileEntries.at(-1);
+    if (!last || last.type === "session") {
+      break;
+    }
+    const isYieldAbortAssistant =
+      last.type === "message" &&
+      last.message?.role === "assistant" &&
+      last.message?.stopReason === "aborted";
+    const isYieldInterruptMessage =
+      last.type === "custom_message" && last.customType === SESSIONS_YIELD_INTERRUPT_CUSTOM_TYPE;
+    if (!isYieldAbortAssistant && !isYieldInterruptMessage) {
+      break;
+    }
+    fileEntries.pop();
+    if (last.id) {
+      byId.delete(last.id);
+    }
+    sessionManager.leafId = last.parentId ?? null;
+    changed = true;
+  }
+  if (changed) {
+    sessionManager._rewriteFile?.();
+  }
+}
+
 export function isOllamaCompatProvider(model: {
   provider?: string;
   baseUrl?: string;
@@ -1123,8 +1301,10 @@ export async function runEmbeddedAttempt(
     });
     // Track sessions_yield tool invocation (callback pattern, like clientToolCallDetected)
     let yieldDetected = false;
+    let yieldMessage: string | null = null;
     // Late-binding reference so onYield can abort the session (declared after tool creation)
     let abortSessionForYield: (() => void) | null = null;
+    let queueYieldInterruptForSession: (() => void) | null = null;
     let yieldAbortSettled: Promise<void> | null = null;
     // Check if the model supports native image input
     const modelHasVision = params.model.input?.includes("image") ?? false;
@@ -1170,8 +1350,10 @@ export async function runEmbeddedAttempt(
           requireExplicitMessageTarget:
             params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
           disableMessageTool: params.disableMessageTool,
-          onYield: () => {
+          onYield: (message) => {
             yieldDetected = true;
+            yieldMessage = message;
+            queueYieldInterruptForSession?.();
             runAbortController.abort("sessions_yield");
             abortSessionForYield?.();
           },
@@ -1488,6 +1670,9 @@ export async function runEmbeddedAttempt(
       abortSessionForYield = () => {
         yieldAbortSettled = Promise.resolve(activeSession.abort());
       };
+      queueYieldInterruptForSession = () => {
+        queueSessionsYieldInterruptMessage(activeSession);
+      };
       removeToolResultContextGuard = installToolResultContextGuard({
         agent: activeSession.agent,
         contextWindowTokens: Math.max(
@@ -1658,6 +1843,15 @@ export async function runEmbeddedAttempt(
           return inner(model, nextContext as typeof context, options);
         };
       }
+
+      const innerStreamFn = activeSession.agent.streamFn;
+      activeSession.agent.streamFn = (model, context, options) => {
+        const signal = runAbortController.signal as AbortSignal & { reason?: unknown };
+        if (yieldDetected && signal.aborted && signal.reason === "sessions_yield") {
+          return createYieldAbortedResponse(model) as Awaited<ReturnType<typeof innerStreamFn>>;
+        }
+        return innerStreamFn(model, context, options);
+      };
 
       // Some models emit tool names with surrounding whitespace (e.g. " read ").
       // pi-agent-core dispatches tool calls with exact string matching, so normalize
@@ -2103,6 +2297,10 @@ export async function runEmbeddedAttempt(
             if (yieldAbortSettled) {
               // eslint-disable-next-line @typescript-eslint/await-thenable -- abort() returns Promise<void> per AgentSession.d.ts
               await yieldAbortSettled;
+            }
+            stripSessionsYieldArtifacts(activeSession);
+            if (yieldMessage) {
+              await persistSessionsYieldContextMessage(activeSession, yieldMessage);
             }
           } else {
             promptError = err;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1123,6 +1123,8 @@ export async function runEmbeddedAttempt(
     });
     // Track sessions_yield tool invocation (callback pattern, like clientToolCallDetected)
     let yieldDetected = false;
+    // Late-binding reference so onYield can abort the session (declared after tool creation)
+    let abortSessionForYield: (() => void) | null = null;
     // Check if the model supports native image input
     const modelHasVision = params.model.input?.includes("image") ?? false;
     const toolsRaw = params.disableTools
@@ -1169,6 +1171,8 @@ export async function runEmbeddedAttempt(
           disableMessageTool: params.disableMessageTool,
           onYield: () => {
             yieldDetected = true;
+            runAbortController.abort("sessions_yield");
+            abortSessionForYield?.();
           },
         });
     const toolsEnabled = supportsModelTools(params.model);
@@ -1480,6 +1484,9 @@ export async function runEmbeddedAttempt(
         throw new Error("Embedded agent session missing");
       }
       const activeSession = session;
+      abortSessionForYield = () => {
+        void activeSession.abort();
+      };
       removeToolResultContextGuard = installToolResultContextGuard({
         agent: activeSession.agent,
         contextWindowTokens: Math.max(
@@ -2080,8 +2087,13 @@ export async function runEmbeddedAttempt(
             await abortable(activeSession.prompt(effectivePrompt));
           }
         } catch (err) {
-          promptError = err;
-          promptErrorSource = "prompt";
+          // Yield-triggered abort is intentional — treat as clean stop, not error
+          if (yieldDetected && isRunnerAbortError(err)) {
+            aborted = false;
+          } else {
+            promptError = err;
+            promptErrorSource = "prompt";
+          }
         } finally {
           log.debug(
             `embedded run prompt end: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - promptStartedAt}`,
@@ -2108,12 +2120,16 @@ export async function runEmbeddedAttempt(
             await params.onBlockReplyFlush();
           }
 
-          const compactionRetryWait = await waitForCompactionRetryWithAggregateTimeout({
-            waitForCompactionRetry,
-            abortable,
-            aggregateTimeoutMs: COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS,
-            isCompactionStillInFlight: isCompactionInFlight,
-          });
+          // Skip compaction wait when yield aborted the run — the signal is
+          // already tripped and abortable() would immediately reject.
+          const compactionRetryWait = yieldDetected
+            ? { timedOut: false }
+            : await waitForCompactionRetryWithAggregateTimeout({
+                waitForCompactionRetry,
+                abortable,
+                aggregateTimeoutMs: COMPACTION_RETRY_AGGREGATE_TIMEOUT_MS,
+                isCompactionStillInFlight: isCompactionInFlight,
+              });
           if (compactionRetryWait.timedOut) {
             timedOutDuringCompaction = true;
             if (!isProbeSession) {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1121,6 +1121,8 @@ export async function runEmbeddedAttempt(
       config: params.config,
       sessionAgentId,
     });
+    // Track sessions_yield tool invocation (callback pattern, like clientToolCallDetected)
+    let yieldDetected = false;
     // Check if the model supports native image input
     const modelHasVision = params.model.input?.includes("image") ?? false;
     const toolsRaw = params.disableTools
@@ -1165,6 +1167,9 @@ export async function runEmbeddedAttempt(
           requireExplicitMessageTarget:
             params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
           disableMessageTool: params.disableMessageTool,
+          onYield: () => {
+            yieldDetected = true;
+          },
         });
     const toolsEnabled = supportsModelTools(params.model);
     const tools = sanitizeToolsForGoogle({
@@ -2365,6 +2370,7 @@ export async function runEmbeddedAttempt(
         compactionCount: getCompactionCount(),
         // Client tool call detected (OpenResponses hosted tools)
         clientToolCall: clientToolCallDetected ?? undefined,
+        yieldDetected: yieldDetected || undefined,
       };
     } finally {
       // Always tear down the session (and release the lock) before we leave this attempt.

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -64,4 +64,6 @@ export type EmbeddedRunAttemptResult = {
   compactionCount?: number;
   /** Client tool call detected (OpenResponses hosted tools). */
   clientToolCall?: { name: string; params: Record<string, unknown> };
+  /** True when sessions_yield tool was called during this attempt. */
+  yieldDetected?: boolean;
 };

--- a/src/agents/pi-embedded-runner/sessions-yield.orchestration.test.ts
+++ b/src/agents/pi-embedded-runner/sessions-yield.orchestration.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Integration test proving that sessions_yield produces a clean end_turn exit
+ * with no pending tool calls, so the parent session is idle when subagent
+ * results arrive.
+ */
+import "./run.overflow-compaction.mocks.shared.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runEmbeddedPiAgent } from "./run.js";
+import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
+import { mockedGlobalHookRunner } from "./run.overflow-compaction.mocks.shared.js";
+import {
+  mockedRunEmbeddedAttempt,
+  overflowBaseRunParams,
+} from "./run.overflow-compaction.shared-test.js";
+import { isEmbeddedPiRunActive, queueEmbeddedPiMessage } from "./runs.js";
+
+describe("sessions_yield orchestration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGlobalHookRunner.hasHooks.mockImplementation(() => false);
+  });
+
+  it("parent session is idle after yield — end_turn, no pendingToolCalls", async () => {
+    const sessionId = "yield-parent-session";
+
+    // Simulate an attempt where sessions_yield was called
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: null,
+        sessionIdUsed: sessionId,
+        yieldDetected: true,
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      sessionId,
+      runId: "run-yield-orchestration",
+    });
+
+    // 1. Run completed with end_turn (yield causes clean exit)
+    expect(result.meta.stopReason).toBe("end_turn");
+
+    // 2. No pending tool calls (yield is NOT a client tool call)
+    expect(result.meta.pendingToolCalls).toBeUndefined();
+
+    // 3. Parent session is IDLE (not in ACTIVE_EMBEDDED_RUNS)
+    expect(isEmbeddedPiRunActive(sessionId)).toBe(false);
+
+    // 4. Steer would fail (message delivery must take direct path, not steer)
+    expect(queueEmbeddedPiMessage(sessionId, "subagent result")).toBe(false);
+  });
+
+  it("clientToolCall takes precedence over yieldDetected", async () => {
+    // Edge case: both flags set (shouldn't happen, but clientToolCall wins)
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: null,
+        yieldDetected: true,
+        clientToolCall: { name: "hosted_tool", params: { arg: "value" } },
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-yield-vs-client-tool",
+    });
+
+    // clientToolCall wins — tool_calls stopReason, pendingToolCalls populated
+    expect(result.meta.stopReason).toBe("tool_calls");
+    expect(result.meta.pendingToolCalls).toHaveLength(1);
+    expect(result.meta.pendingToolCalls![0].name).toBe("hosted_tool");
+  });
+
+  it("normal attempt without yield has no stopReason override", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-no-yield",
+    });
+
+    // Neither clientToolCall nor yieldDetected → stopReason is undefined
+    expect(result.meta.stopReason).toBeUndefined();
+    expect(result.meta.pendingToolCalls).toBeUndefined();
+  });
+});

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -268,7 +268,7 @@ export function createOpenClawCodingTools(options?: {
   /** Whether the sender is an owner (required for owner-only tools). */
   senderIsOwner?: boolean;
   /** Callback invoked when sessions_yield tool is called. */
-  onYield?: () => void;
+  onYield?: (message: string) => Promise<void> | void;
 }): AnyAgentTool[] {
   const execToolName = "exec";
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -268,7 +268,7 @@ export function createOpenClawCodingTools(options?: {
   /** Whether the sender is an owner (required for owner-only tools). */
   senderIsOwner?: boolean;
   /** Callback invoked when sessions_yield tool is called. */
-  onYield?: (message: string) => void;
+  onYield?: () => void;
 }): AnyAgentTool[] {
   const execToolName = "exec";
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -267,6 +267,8 @@ export function createOpenClawCodingTools(options?: {
   disableMessageTool?: boolean;
   /** Whether the sender is an owner (required for owner-only tools). */
   senderIsOwner?: boolean;
+  /** Callback invoked when sessions_yield tool is called. */
+  onYield?: (message: string) => void;
 }): AnyAgentTool[] {
   const execToolName = "exec";
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;
@@ -530,6 +532,7 @@ export function createOpenClawCodingTools(options?: {
       requesterSenderId: options?.senderId,
       senderIsOwner: options?.senderIsOwner,
       sessionId: options?.sessionId,
+      onYield: options?.onYield,
     }),
   ];
   const toolsForMemoryFlush =

--- a/src/agents/pi-tools.workspace-only-false.test.ts
+++ b/src/agents/pi-tools.workspace-only-false.test.ts
@@ -7,10 +7,13 @@ vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
   const original = await importOriginal<typeof import("@mariozechner/pi-ai")>();
   return {
     ...original,
-    getOAuthApiKey: () => undefined,
-    getOAuthProviders: () => [],
   };
 });
+
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: () => undefined,
+  getOAuthProviders: () => [],
+}));
 
 import { createOpenClawCodingTools } from "./pi-tools.js";
 

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -22,6 +22,7 @@ export const DEFAULT_TOOL_ALLOW = [
   "sessions_history",
   "sessions_send",
   "sessions_spawn",
+  "sessions_yield",
   "subagents",
   "session_status",
 ] as const;

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -146,6 +146,14 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     includeInOpenClawGroup: true,
   },
   {
+    id: "sessions_yield",
+    label: "sessions_yield",
+    description: "End turn to receive sub-agent results",
+    sectionId: "sessions",
+    profiles: ["coding"],
+    includeInOpenClawGroup: true,
+  },
+  {
     id: "subagents",
     label: "subagents",
     description: "Manage sub-agents",

--- a/src/agents/tools/sessions-yield-tool.test.ts
+++ b/src/agents/tools/sessions-yield-tool.test.ts
@@ -32,7 +32,7 @@ describe("sessions_yield tool", () => {
     const result = await tool.execute("call-1", {});
     expect(result.details).toMatchObject({
       status: "error",
-      error: "Session not active or not streaming",
+      error: "Session not active, not streaming, or compacting",
     });
   });
 

--- a/src/agents/tools/sessions-yield-tool.test.ts
+++ b/src/agents/tools/sessions-yield-tool.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => {
+  const queueEmbeddedPiMessageMock = vi.fn();
+  return { queueEmbeddedPiMessageMock };
+});
+
+vi.mock("../pi-embedded.js", () => ({
+  queueEmbeddedPiMessage: (...args: unknown[]) => hoisted.queueEmbeddedPiMessageMock(...args),
+}));
+
+const { createSessionsYieldTool } = await import("./sessions-yield-tool.js");
+
+describe("sessions_yield tool", () => {
+  beforeEach(() => {
+    hoisted.queueEmbeddedPiMessageMock.mockReset();
+  });
+
+  it("returns error when no sessionId is provided", async () => {
+    const tool = createSessionsYieldTool();
+    const result = await tool.execute("call-1", {});
+    expect(result.details).toMatchObject({
+      status: "error",
+      error: "No session context",
+    });
+    expect(hoisted.queueEmbeddedPiMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("returns error when session is not active", async () => {
+    hoisted.queueEmbeddedPiMessageMock.mockReturnValue(false);
+    const tool = createSessionsYieldTool({ sessionId: "test-session" });
+    const result = await tool.execute("call-1", {});
+    expect(result.details).toMatchObject({
+      status: "error",
+      error: "Session not active or not streaming",
+    });
+  });
+
+  it("yields successfully with default message", async () => {
+    hoisted.queueEmbeddedPiMessageMock.mockReturnValue(true);
+    const tool = createSessionsYieldTool({ sessionId: "test-session" });
+    const result = await tool.execute("call-1", {});
+    expect(result.details).toMatchObject({ status: "yielded" });
+    expect(hoisted.queueEmbeddedPiMessageMock).toHaveBeenCalledWith(
+      "test-session",
+      expect.stringContaining("Turn yielded."),
+    );
+  });
+
+  it("yields with custom message", async () => {
+    hoisted.queueEmbeddedPiMessageMock.mockReturnValue(true);
+    const tool = createSessionsYieldTool({ sessionId: "test-session" });
+    const result = await tool.execute("call-1", { message: "Waiting for fact-checker" });
+    expect(result.details).toMatchObject({ status: "yielded" });
+    expect(hoisted.queueEmbeddedPiMessageMock).toHaveBeenCalledWith(
+      "test-session",
+      expect.stringContaining("Waiting for fact-checker"),
+    );
+  });
+
+  it("includes system directive in steer text", async () => {
+    hoisted.queueEmbeddedPiMessageMock.mockReturnValue(true);
+    const tool = createSessionsYieldTool({ sessionId: "test-session" });
+    await tool.execute("call-1", { message: "Waiting" });
+    const steerText = hoisted.queueEmbeddedPiMessageMock.mock.calls[0][1];
+    expect(steerText).toContain("[SYSTEM]");
+    expect(steerText).toContain("Do NOT call any tools");
+  });
+});

--- a/src/agents/tools/sessions-yield-tool.test.ts
+++ b/src/agents/tools/sessions-yield-tool.test.ts
@@ -32,9 +32,12 @@ describe("sessions_yield tool", () => {
     expect(onYield).toHaveBeenCalledOnce();
   });
 
-  it("succeeds without onYield callback", async () => {
+  it("returns error without onYield callback", async () => {
     const tool = createSessionsYieldTool({ sessionId: "test-session" });
     const result = await tool.execute("call-1", {});
-    expect(result.details).toMatchObject({ status: "yielded", message: "Turn yielded." });
+    expect(result.details).toMatchObject({
+      status: "error",
+      error: "Yield not supported in this context",
+    });
   });
 });

--- a/src/agents/tools/sessions-yield-tool.test.ts
+++ b/src/agents/tools/sessions-yield-tool.test.ts
@@ -19,9 +19,10 @@ describe("sessions_yield tool", () => {
     const result = await tool.execute("call-1", {});
     expect(result.details).toMatchObject({ status: "yielded", message: "Turn yielded." });
     expect(onYield).toHaveBeenCalledOnce();
+    expect(onYield).toHaveBeenCalledWith("Turn yielded.");
   });
 
-  it("custom message appears in result but callback takes no args", async () => {
+  it("passes the custom message through the yield callback", async () => {
     const onYield = vi.fn();
     const tool = createSessionsYieldTool({ sessionId: "test-session", onYield });
     const result = await tool.execute("call-1", { message: "Waiting for fact-checker" });
@@ -30,6 +31,7 @@ describe("sessions_yield tool", () => {
       message: "Waiting for fact-checker",
     });
     expect(onYield).toHaveBeenCalledOnce();
+    expect(onYield).toHaveBeenCalledWith("Waiting for fact-checker");
   });
 
   it("returns error without onYield callback", async () => {

--- a/src/agents/tools/sessions-yield-tool.test.ts
+++ b/src/agents/tools/sessions-yield-tool.test.ts
@@ -1,69 +1,40 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const hoisted = vi.hoisted(() => {
-  const queueEmbeddedPiMessageMock = vi.fn();
-  return { queueEmbeddedPiMessageMock };
-});
-
-vi.mock("../pi-embedded.js", () => ({
-  queueEmbeddedPiMessage: (...args: unknown[]) => hoisted.queueEmbeddedPiMessageMock(...args),
-}));
-
-const { createSessionsYieldTool } = await import("./sessions-yield-tool.js");
+import { describe, expect, it, vi } from "vitest";
+import { createSessionsYieldTool } from "./sessions-yield-tool.js";
 
 describe("sessions_yield tool", () => {
-  beforeEach(() => {
-    hoisted.queueEmbeddedPiMessageMock.mockReset();
-  });
-
   it("returns error when no sessionId is provided", async () => {
-    const tool = createSessionsYieldTool();
+    const onYield = vi.fn();
+    const tool = createSessionsYieldTool({ onYield });
     const result = await tool.execute("call-1", {});
     expect(result.details).toMatchObject({
       status: "error",
       error: "No session context",
     });
-    expect(hoisted.queueEmbeddedPiMessageMock).not.toHaveBeenCalled();
+    expect(onYield).not.toHaveBeenCalled();
   });
 
-  it("returns error when session is not active", async () => {
-    hoisted.queueEmbeddedPiMessageMock.mockReturnValue(false);
-    const tool = createSessionsYieldTool({ sessionId: "test-session" });
+  it("invokes onYield callback with default message", async () => {
+    const onYield = vi.fn();
+    const tool = createSessionsYieldTool({ sessionId: "test-session", onYield });
     const result = await tool.execute("call-1", {});
-    expect(result.details).toMatchObject({
-      status: "error",
-      error: "Session not active, not streaming, or compacting",
-    });
+    expect(result.details).toMatchObject({ status: "yielded", message: "Turn yielded." });
+    expect(onYield).toHaveBeenCalledWith("Turn yielded.");
   });
 
-  it("yields successfully with default message", async () => {
-    hoisted.queueEmbeddedPiMessageMock.mockReturnValue(true);
-    const tool = createSessionsYieldTool({ sessionId: "test-session" });
-    const result = await tool.execute("call-1", {});
-    expect(result.details).toMatchObject({ status: "yielded" });
-    expect(hoisted.queueEmbeddedPiMessageMock).toHaveBeenCalledWith(
-      "test-session",
-      expect.stringContaining("Turn yielded."),
-    );
-  });
-
-  it("yields with custom message", async () => {
-    hoisted.queueEmbeddedPiMessageMock.mockReturnValue(true);
-    const tool = createSessionsYieldTool({ sessionId: "test-session" });
+  it("passes custom message to onYield callback", async () => {
+    const onYield = vi.fn();
+    const tool = createSessionsYieldTool({ sessionId: "test-session", onYield });
     const result = await tool.execute("call-1", { message: "Waiting for fact-checker" });
-    expect(result.details).toMatchObject({ status: "yielded" });
-    expect(hoisted.queueEmbeddedPiMessageMock).toHaveBeenCalledWith(
-      "test-session",
-      expect.stringContaining("Waiting for fact-checker"),
-    );
+    expect(result.details).toMatchObject({
+      status: "yielded",
+      message: "Waiting for fact-checker",
+    });
+    expect(onYield).toHaveBeenCalledWith("Waiting for fact-checker");
   });
 
-  it("includes system directive in steer text", async () => {
-    hoisted.queueEmbeddedPiMessageMock.mockReturnValue(true);
+  it("succeeds without onYield callback", async () => {
     const tool = createSessionsYieldTool({ sessionId: "test-session" });
-    await tool.execute("call-1", { message: "Waiting" });
-    const steerText = hoisted.queueEmbeddedPiMessageMock.mock.calls[0][1];
-    expect(steerText).toContain("[SYSTEM]");
-    expect(steerText).toContain("Do NOT call any tools");
+    const result = await tool.execute("call-1", {});
+    expect(result.details).toMatchObject({ status: "yielded", message: "Turn yielded." });
   });
 });

--- a/src/agents/tools/sessions-yield-tool.test.ts
+++ b/src/agents/tools/sessions-yield-tool.test.ts
@@ -18,10 +18,10 @@ describe("sessions_yield tool", () => {
     const tool = createSessionsYieldTool({ sessionId: "test-session", onYield });
     const result = await tool.execute("call-1", {});
     expect(result.details).toMatchObject({ status: "yielded", message: "Turn yielded." });
-    expect(onYield).toHaveBeenCalledWith("Turn yielded.");
+    expect(onYield).toHaveBeenCalledOnce();
   });
 
-  it("passes custom message to onYield callback", async () => {
+  it("custom message appears in result but callback takes no args", async () => {
     const onYield = vi.fn();
     const tool = createSessionsYieldTool({ sessionId: "test-session", onYield });
     const result = await tool.execute("call-1", { message: "Waiting for fact-checker" });
@@ -29,7 +29,7 @@ describe("sessions_yield tool", () => {
       status: "yielded",
       message: "Waiting for fact-checker",
     });
-    expect(onYield).toHaveBeenCalledWith("Waiting for fact-checker");
+    expect(onYield).toHaveBeenCalledOnce();
   });
 
   it("succeeds without onYield callback", async () => {

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -27,7 +27,10 @@ export function createSessionsYieldTool(opts?: { sessionId?: string }): AnyAgent
       ].join("\n\n");
       const steered = queueEmbeddedPiMessage(sessionId, steerText);
       if (!steered) {
-        return jsonResult({ status: "error", error: "Session not active or not streaming" });
+        return jsonResult({
+          status: "error",
+          error: "Session not active, not streaming, or compacting",
+        });
       }
       return jsonResult({ status: "yielded" });
     },

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -1,0 +1,35 @@
+import { Type } from "@sinclair/typebox";
+import { queueEmbeddedPiMessage } from "../pi-embedded.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readStringParam } from "./common.js";
+
+const SessionsYieldToolSchema = Type.Object({
+  message: Type.Optional(Type.String()),
+});
+
+export function createSessionsYieldTool(opts?: { sessionId?: string }): AnyAgentTool {
+  return {
+    label: "Yield",
+    name: "sessions_yield",
+    description:
+      "End your current turn. Use after spawning subagents to receive their results as the next message.",
+    parameters: SessionsYieldToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const userMessage = readStringParam(params, "message") || "Turn yielded.";
+      const sessionId = opts?.sessionId;
+      if (!sessionId) {
+        return jsonResult({ status: "error", error: "No session context" });
+      }
+      const steerText = [
+        userMessage,
+        "[SYSTEM] Your turn was yielded. The subagent result will arrive as the NEXT message. Do NOT call any tools — just reply with a brief acknowledgment.",
+      ].join("\n\n");
+      const steered = queueEmbeddedPiMessage(sessionId, steerText);
+      if (!steered) {
+        return jsonResult({ status: "error", error: "Session not active or not streaming" });
+      }
+      return jsonResult({ status: "yielded" });
+    },
+  };
+}

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -8,7 +8,7 @@ const SessionsYieldToolSchema = Type.Object({
 
 export function createSessionsYieldTool(opts?: {
   sessionId?: string;
-  onYield?: () => void;
+  onYield?: (message: string) => Promise<void> | void;
 }): AnyAgentTool {
   return {
     label: "Yield",
@@ -25,7 +25,7 @@ export function createSessionsYieldTool(opts?: {
       if (!opts?.onYield) {
         return jsonResult({ status: "error", error: "Yield not supported in this context" });
       }
-      opts.onYield();
+      await opts.onYield(message);
       return jsonResult({ status: "yielded", message });
     },
   };

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -22,7 +22,10 @@ export function createSessionsYieldTool(opts?: {
       if (!opts?.sessionId) {
         return jsonResult({ status: "error", error: "No session context" });
       }
-      opts.onYield?.();
+      if (!opts?.onYield) {
+        return jsonResult({ status: "error", error: "Yield not supported in this context" });
+      }
+      opts.onYield();
       return jsonResult({ status: "yielded", message });
     },
   };

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -8,7 +8,7 @@ const SessionsYieldToolSchema = Type.Object({
 
 export function createSessionsYieldTool(opts?: {
   sessionId?: string;
-  onYield?: (message: string) => void;
+  onYield?: () => void;
 }): AnyAgentTool {
   return {
     label: "Yield",
@@ -22,7 +22,7 @@ export function createSessionsYieldTool(opts?: {
       if (!opts?.sessionId) {
         return jsonResult({ status: "error", error: "No session context" });
       }
-      opts.onYield?.(message);
+      opts.onYield?.();
       return jsonResult({ status: "yielded", message });
     },
   };

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -1,5 +1,4 @@
 import { Type } from "@sinclair/typebox";
-import { queueEmbeddedPiMessage } from "../pi-embedded.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";
 
@@ -7,7 +6,10 @@ const SessionsYieldToolSchema = Type.Object({
   message: Type.Optional(Type.String()),
 });
 
-export function createSessionsYieldTool(opts?: { sessionId?: string }): AnyAgentTool {
+export function createSessionsYieldTool(opts?: {
+  sessionId?: string;
+  onYield?: (message: string) => void;
+}): AnyAgentTool {
   return {
     label: "Yield",
     name: "sessions_yield",
@@ -16,23 +18,12 @@ export function createSessionsYieldTool(opts?: { sessionId?: string }): AnyAgent
     parameters: SessionsYieldToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
-      const userMessage = readStringParam(params, "message") || "Turn yielded.";
-      const sessionId = opts?.sessionId;
-      if (!sessionId) {
+      const message = readStringParam(params, "message") || "Turn yielded.";
+      if (!opts?.sessionId) {
         return jsonResult({ status: "error", error: "No session context" });
       }
-      const steerText = [
-        userMessage,
-        "[SYSTEM] Your turn was yielded. The subagent result will arrive as the NEXT message. Do NOT call any tools — just reply with a brief acknowledgment.",
-      ].join("\n\n");
-      const steered = queueEmbeddedPiMessage(sessionId, steerText);
-      if (!steered) {
-        return jsonResult({
-          status: "error",
-          error: "Session not active, not streaming, or compacting",
-        });
-      }
-      return jsonResult({ status: "yielded" });
+      opts.onYield?.(message);
+      return jsonResult({ status: "yielded", message });
     },
   };
 }

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -69,7 +69,12 @@ export type TelegramBotOptions = {
 
 export { getTelegramSequentialKey };
 
-function readRequestUrl(input: RequestInfo | URL): string | null {
+type TelegramFetchInput = Parameters<NonNullable<ApiClientOptions["fetch"]>>[0];
+type TelegramFetchInit = Parameters<NonNullable<ApiClientOptions["fetch"]>>[1];
+type GlobalFetchInput = Parameters<typeof globalThis.fetch>[0];
+type GlobalFetchInit = Parameters<typeof globalThis.fetch>[1];
+
+function readRequestUrl(input: TelegramFetchInput): string | null {
   if (typeof input === "string") {
     return input;
   }
@@ -83,7 +88,7 @@ function readRequestUrl(input: RequestInfo | URL): string | null {
   return null;
 }
 
-function extractTelegramApiMethod(input: RequestInfo | URL): string | null {
+function extractTelegramApiMethod(input: TelegramFetchInput): string | null {
   const url = readRequestUrl(input);
   if (!url) {
     return null;
@@ -150,7 +155,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     // Use manual event forwarding instead of AbortSignal.any() to avoid the cross-realm
     // AbortSignal issue in Node.js (grammY's signal may come from a different module context,
     // causing "signals[0] must be an instance of AbortSignal" errors).
-    finalFetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    finalFetch = ((input: TelegramFetchInput, init?: TelegramFetchInit) => {
       const controller = new AbortController();
       const abortWith = (signal: AbortSignal) => controller.abort(signal.reason);
       const onShutdown = () => abortWith(shutdownSignal);
@@ -162,13 +167,16 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       }
       if (init?.signal) {
         if (init.signal.aborted) {
-          abortWith(init.signal);
+          abortWith(init.signal as unknown as AbortSignal);
         } else {
           onRequestAbort = () => abortWith(init.signal as AbortSignal);
-          init.signal.addEventListener("abort", onRequestAbort, { once: true });
+          init.signal.addEventListener("abort", onRequestAbort);
         }
       }
-      return callFetch(input, { ...init, signal: controller.signal }).finally(() => {
+      return callFetch(input as GlobalFetchInput, {
+        ...(init as GlobalFetchInit),
+        signal: controller.signal,
+      }).finally(() => {
         shutdownSignal.removeEventListener("abort", onShutdown);
         if (init?.signal && onRequestAbort) {
           init.signal.removeEventListener("abort", onRequestAbort);
@@ -178,7 +186,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   }
   if (finalFetch) {
     const baseFetch = finalFetch;
-    finalFetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    finalFetch = ((input: TelegramFetchInput, init?: TelegramFetchInit) => {
       return Promise.resolve(baseFetch(input, init)).catch((err: unknown) => {
         try {
           tagTelegramNetworkError(err, {

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -12,11 +12,13 @@ vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
   return {
     ...original,
     completeSimple: vi.fn(),
-    // Some auth helpers import oauth provider metadata at module load time.
-    getOAuthProviders: () => [],
-    getOAuthApiKey: vi.fn(async () => null),
   };
 });
+
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthProviders: () => [],
+  getOAuthApiKey: vi.fn(async () => null),
+}));
 
 vi.mock("../agents/pi-embedded-runner/model.js", () => ({
   resolveModel: vi.fn((provider: string, modelId: string) => ({


### PR DESCRIPTION
## Summary

Agents orchestrating subagents via `sessions_spawn` have no way to voluntarily end their turn while waiting for results. The auto-announce mechanism delivers subagent results as follow-up messages, but only after the calling agent's turn ends. Models that keep making tool calls (polling with `sessions_history`, calling `subagents list`) block delivery indefinitely.

`sessions_yield` uses the existing steer mechanism (`queueEmbeddedPiMessage`) to end the current turn. The subagent result then arrives as the next message via auto-announce.

## Problem

The spawn → poll → read-history pattern is wasteful and unreliable:
- Models burn tokens polling `sessions_history` or `subagents list` in a loop
- Some models (especially via OpenRouter) never stop making tool calls, so auto-announce can never deliver
- The pattern requires explicit instructions in agent configs to "not poll" — which models frequently ignore

Related issues:
- #19506 — Feature Request: `sessions_spawn_and_wait` for reliable subagent execution
- #36081 — `mode="run"` sub-agent completions fail to trigger parent session turn
- #22673 — Subagent completion direct-delivery breaks manager-first orchestration
- #27758 — `ANNOUNCE_EXPIRY_MS` too short for long-running subagents (yield avoids the expiry problem entirely since the parent is idle)

## Solution

New tool: `sessions_yield({ message?: string })`

- Injects a steer into the calling session via `queueEmbeddedPiMessage`
- The steer ends the current turn; remaining queued tool calls are skipped
- The `message` text (plus a system directive) becomes the next user message
- Auto-announce then delivers the subagent result as a follow-up

Typical flow:
```
sessions_spawn({ agentId: "fact-checker", task: "..." })
sessions_yield({ message: "Waiting for fact-checker" })
// turn ends → subagent result arrives as next message → agent continues
```

Leverages `sessionId` already threaded through the tool context (#32273).

This is a lighter-weight alternative to #19506's `sessions_spawn_and_wait` — instead of blocking the tool call, the agent cooperatively ends its turn. No changes to the agent loop or spawn machinery required.

For #36081 and #22673, `sessions_yield` gives the parent a reliable way to receive completions: the parent is guaranteed to be idle when the subagent finishes, so announce delivery always succeeds.

For #27758, `sessions_yield` sidesteps the expiry problem entirely — since the parent's turn has ended, direct delivery succeeds immediately without needing to wait or retry.

## Changes

- `src/agents/tools/sessions-yield-tool.ts` — new tool implementation
- `src/agents/tools/sessions-yield-tool.test.ts` — 5 unit tests
- `src/agents/openclaw-tools.ts` — import and register the tool

## Testing

- Unit tests cover: no sessionId, inactive session, default message, custom message, system directive presence
- Tested in production with multi-agent orchestration (spawn → yield → auto-announce) across Anthropic and OpenRouter models

---
Related: #36081, #26741, #19506, #22673, #27758.