### PR TITLE
fix(config): use SHA256 hash for schema cache key (fixes #36508)

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { CHANNEL_IDS } from "../channels/registry.js";
 import { VERSION } from "../version.js";
 import type { ConfigUiHint, ConfigUiHints } from "./schema.hints.js";
@@ -322,7 +323,10 @@ function buildMergedSchemaCacheKey(params: {
       configUiHints: channel.configUiHints ?? null,
     }))
     .toSorted((a, b) => a.id.localeCompare(b.id));
-  return JSON.stringify({ plugins, channels });
+  const keyHash = createHash("sha256");
+  const payload = JSON.stringify({ plugins, channels });
+  keyHash.update(payload);
+  return keyHash.digest("hex");
 }
 
 function setMergedSchemaCache(key: string, value: ConfigSchemaResponse): void {


### PR DESCRIPTION
## Summary

Fixes issue #36508: RangeError in config.get RPC with Multiple Channels.

## Problem

The `buildMergedSchemaCacheKey()` function serializes complete plugin/channel config schemas as cache key, causing `RangeError: Invalid string length` when 16+ channels are configured.

## Solution

Use SHA-256 hash instead of full JSON.stringify for the cache key, maintaining cache effectiveness while avoiding string length limits.

## Changes

- Added `createHash` import from `node:crypto`
- Replaced `JSON.stringify({ plugins, channels })` return with SHA-256 hex digest
