### PR TITLE
fix: TUI messages routed as webchat (closes #364 instead of tui31)

### DIFF
--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -3,7 +3,7 @@ import { getChannelDock, listChannelDocks } from "../channels/dock.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 import { normalizeAnyChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../utils/message-channel.js";
+import { isInternalMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 import type { MsgContext } from "./templating.js";
 
 export type CommandAuthorization = {
@@ -21,7 +21,7 @@ function resolveProviderFromContext(ctx: MsgContext, cfg: OpenClawConfig): Chann
     normalizeMessageChannel(ctx.Provider) ??
     normalizeMessageChannel(ctx.Surface) ??
     normalizeMessageChannel(ctx.OriginatingChannel);
-  if (explicitMessageChannel === INTERNAL_MESSAGE_CHANNEL) {
+  if (isInternalMessageChannel(explicitMessageChannel)) {
     return undefined;
   }
   const direct =
@@ -37,7 +37,7 @@ function resolveProviderFromContext(ctx: MsgContext, cfg: OpenClawConfig): Chann
     .flatMap((value) => value.split(":").map((part) => part.trim()));
   for (const candidate of candidates) {
     const normalizedCandidateChannel = normalizeMessageChannel(candidate);
-    if (normalizedCandidateChannel === INTERNAL_MESSAGE_CHANNEL) {
+    if (isInternalMessageChannel(normalizedCandidateChannel)) {
       return undefined;
     }
     const normalized =

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -19,7 +19,7 @@ import {
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
-import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
+import { isInternalMessageChannel, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { getReplyFromConfig } from "../reply.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
@@ -165,7 +165,6 @@ export async function dispatchReplyFromConfig(params: {
   }
 
   const sessionStoreEntry = resolveSessionStoreEntry(ctx, cfg);
-  const acpDispatchSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
   const inboundAudio = isInboundAudioContext(ctx);
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
   const hookRunner = getGlobalHookRunner();
@@ -219,7 +218,7 @@ export async function dispatchReplyFromConfig(params: {
     isRoutableChannel(originatingChannel) && originatingTo && originatingChannel !== currentSurface,
   );
   const shouldSuppressTyping =
-    shouldRouteToOriginating || originatingChannel === INTERNAL_MESSAGE_CHANNEL;
+    shouldRouteToOriginating || isInternalMessageChannel(originatingChannel);
   const ttsChannel = shouldRouteToOriginating ? originatingChannel : currentSurface;
 
   /**
@@ -329,7 +328,7 @@ export async function dispatchReplyFromConfig(params: {
       ctx,
       cfg,
       dispatcher,
-      sessionKey: acpDispatchSessionKey,
+      sessionKey,
       inboundAudio,
       sessionTtsAuto,
       ttsChannel,
@@ -434,32 +433,6 @@ export async function dispatchReplyFromConfig(params: {
       },
       cfg,
     );
-
-    if (ctx.AcpDispatchTailAfterReset === true) {
-      // Command handling prepared a trailing prompt after ACP in-place reset.
-      // Route that tail through ACP now (same turn) instead of embedded dispatch.
-      ctx.AcpDispatchTailAfterReset = false;
-      const acpTailDispatch = await tryDispatchAcpReply({
-        ctx,
-        cfg,
-        dispatcher,
-        sessionKey: acpDispatchSessionKey,
-        inboundAudio,
-        sessionTtsAuto,
-        ttsChannel,
-        shouldRouteToOriginating,
-        originatingChannel,
-        originatingTo,
-        shouldSendToolSummaries,
-        bypassForCommand: false,
-        onReplyStart: params.replyOptions?.onReplyStart,
-        recordProcessed,
-        markIdle,
-      });
-      if (acpTailDispatch) {
-        return acpTailDispatch;
-      }
-    }
 
     const replies = replyResult ? (Array.isArray(replyResult) ? replyResult : [replyResult]) : [];
 

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -12,7 +12,11 @@ import { resolveEffectiveMessagesConfig } from "../../agents/identity.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
-import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
+import {
+  InternalMessageChannel,
+  isInternalMessageChannel,
+  normalizeMessageChannel,
+} from "../../utils/message-channel.js";
 import type { OriginatingChannelType } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
@@ -112,10 +116,10 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
     return { ok: true };
   }
 
-  if (channel === INTERNAL_MESSAGE_CHANNEL) {
+  if (isInternalMessageChannel(channel)) {
     return {
       ok: false,
-      error: "Webchat routing not supported for queued replies",
+      error: "Internal routing channel not supported for queued replies",
     };
   }
 
@@ -183,8 +187,8 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
  */
 export function isRoutableChannel(
   channel: OriginatingChannelType | undefined,
-): channel is Exclude<OriginatingChannelType, typeof INTERNAL_MESSAGE_CHANNEL> {
-  if (!channel || channel === INTERNAL_MESSAGE_CHANNEL) {
+): channel is Exclude<OriginatingChannelType, InternalMessageChannel> {
+  if (!channel || isInternalMessageChannel(channel)) {
     return false;
   }
   return normalizeChannelId(channel) !== null;

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -7,8 +7,8 @@ import {
   normalizeDeliveryContext,
 } from "../../utils/delivery-context.js";
 import {
-  INTERNAL_MESSAGE_CHANNEL,
   isDeliverableMessageChannel,
+  isInternalMessageChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import type { MsgContext } from "../templating.js";
@@ -40,7 +40,7 @@ function isMainSessionKey(sessionKey?: string): boolean {
 
 function isExternalRoutingChannel(channel?: string): channel is string {
   return Boolean(
-    channel && channel !== INTERNAL_MESSAGE_CHANNEL && isDeliverableMessageChannel(channel),
+    channel && !isInternalMessageChannel(channel) && isDeliverableMessageChannel(channel),
   );
 }
 
@@ -50,7 +50,7 @@ export function resolveLastChannelRaw(params: {
   sessionKey?: string;
 }): string | undefined {
   const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
-  if (originatingChannel === INTERNAL_MESSAGE_CHANNEL && isMainSessionKey(params.sessionKey)) {
+  if (isInternalMessageChannel(originatingChannel) && isMainSessionKey(params.sessionKey)) {
     return params.originatingChannelRaw;
   }
   const persistedChannel = normalizeMessageChannel(params.persistedLastChannel);
@@ -77,7 +77,7 @@ export function resolveLastToRaw(params: {
   sessionKey?: string;
 }): string | undefined {
   const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
-  if (originatingChannel === INTERNAL_MESSAGE_CHANNEL && isMainSessionKey(params.sessionKey)) {
+  if (isInternalMessageChannel(originatingChannel) && isMainSessionKey(params.sessionKey)) {
     return params.originatingToRaw || params.toRaw;
   }
   const persistedChannel = normalizeMessageChannel(params.persistedLastChannel);

--- a/src/auto-reply/reply/typing-policy.ts
+++ b/src/auto-reply/reply/typing-policy.ts
@@ -1,4 +1,4 @@
-import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
+import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import type { TypingPolicy } from "../types.js";
 
 export type ResolveRunTypingPolicyParams = {
@@ -19,7 +19,7 @@ export function resolveRunTypingPolicy(
 ): ResolvedRunTypingPolicy {
   const typingPolicy = params.isHeartbeat
     ? "heartbeat"
-    : params.originatingChannel === INTERNAL_MESSAGE_CHANNEL
+    : isInternalMessageChannel(params.originatingChannel)
       ? "internal_webchat"
       : params.systemEvent
         ? "system_event"

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -10,7 +10,6 @@ import type { GatewayRequestContext } from "./types.js";
 const mockState = vi.hoisted(() => ({
   transcriptPath: "",
   sessionId: "sess-1",
-  mainSessionKey: "main",
   finalText: "[[reply_to_current]]",
   triggerAgentRunStart: false,
   agentRunId: "run-agent-1",
@@ -32,11 +31,7 @@ vi.mock("../session-utils.js", async (importOriginal) => {
   return {
     ...original,
     loadSessionEntry: (rawKey: string) => ({
-      cfg: {
-        session: {
-          mainKey: mockState.mainSessionKey,
-        },
-      },
+      cfg: {},
       storePath: path.join(path.dirname(mockState.transcriptPath), "sessions.json"),
       entry: {
         sessionId: mockState.sessionId,
@@ -153,25 +148,15 @@ async function runNonStreamingChatSend(params: {
   idempotencyKey: string;
   message?: string;
   sessionKey?: string;
-  deliver?: boolean;
   client?: unknown;
   expectBroadcast?: boolean;
 }) {
-  const sendParams: {
-    sessionKey: string;
-    message: string;
-    idempotencyKey: string;
-    deliver?: boolean;
-  } = {
-    sessionKey: params.sessionKey ?? "main",
-    message: params.message ?? "hello",
-    idempotencyKey: params.idempotencyKey,
-  };
-  if (typeof params.deliver === "boolean") {
-    sendParams.deliver = params.deliver;
-  }
   await chatHandlers["chat.send"]({
-    params: sendParams,
+    params: {
+      sessionKey: params.sessionKey ?? "main",
+      message: params.message ?? "hello",
+      idempotencyKey: params.idempotencyKey,
+    },
     respond: params.respond as unknown as Parameters<
       (typeof chatHandlers)["chat.send"]
     >[0]["respond"],
@@ -205,7 +190,6 @@ async function runNonStreamingChatSend(params: {
 describe("chat directive tag stripping for non-streaming final payloads", () => {
   afterEach(() => {
     mockState.finalText = "[[reply_to_current]]";
-    mockState.mainSessionKey = "main";
     mockState.triggerAgentRunStart = false;
     mockState.agentRunId = "run-agent-1";
     mockState.sessionEntry = {};
@@ -385,7 +369,6 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-origin-routing",
       sessionKey: "agent:main:telegram:direct:6812765697",
-      deliver: true,
       expectBroadcast: false,
     });
 
@@ -420,7 +403,6 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-feishu-origin-routing",
       sessionKey: "agent:main:feishu:direct:ou_feishu_direct_123",
-      deliver: true,
       expectBroadcast: false,
     });
 
@@ -454,7 +436,6 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-per-account-channel-peer-routing",
       sessionKey: "agent:main:telegram:account-a:direct:6812765697",
-      deliver: true,
       expectBroadcast: false,
     });
 
@@ -488,7 +469,6 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-legacy-channel-peer-routing",
       sessionKey: "agent:main:telegram:6812765697",
-      deliver: true,
       expectBroadcast: false,
     });
 
@@ -524,7 +504,6 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       respond,
       idempotencyKey: "idem-legacy-thread-channel-peer-routing",
       sessionKey: "agent:main:telegram:6812765697:thread:42",
-      deliver: true,
       expectBroadcast: false,
     });
 
@@ -534,6 +513,37 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         OriginatingTo: "telegram:6812765697",
         AccountId: "default",
         MessageThreadId: "42",
+      }),
+    );
+  });
+
+  it("chat.send maps UI clients to internal tui channel identity", async () => {
+    createTranscriptFixture("openclaw-chat-send-ui-channel-identity-");
+    mockState.finalText = "ok";
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-ui-channel-identity",
+      client: {
+        connId: "conn-ui",
+        connect: {
+          mode: GATEWAY_CLIENT_MODES.UI,
+          client: {
+            id: "gateway-client",
+          },
+        },
+      },
+      expectBroadcast: false,
+    });
+
+    expect(mockState.lastDispatchCtx).toEqual(
+      expect.objectContaining({
+        Provider: "tui",
+        Surface: "tui",
+        OriginatingChannel: "tui",
       }),
     );
   });
@@ -571,90 +581,6 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
   });
 
-  it("chat.send does not inherit external delivery context for UI clients on main sessions", async () => {
-    createTranscriptFixture("openclaw-chat-send-main-ui-routes-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      deliveryContext: {
-        channel: "whatsapp",
-        to: "whatsapp:+8613800138000",
-        accountId: "default",
-      },
-      lastChannel: "whatsapp",
-      lastTo: "whatsapp:+8613800138000",
-      lastAccountId: "default",
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-main-ui-routes",
-      client: {
-        connect: {
-          client: {
-            mode: GATEWAY_CLIENT_MODES.UI,
-            id: "openclaw-tui",
-          },
-        },
-      } as unknown,
-      sessionKey: "agent:main:main",
-      expectBroadcast: false,
-    });
-
-    expect(mockState.lastDispatchCtx).toEqual(
-      expect.objectContaining({
-        OriginatingChannel: "webchat",
-        OriginatingTo: undefined,
-        AccountId: undefined,
-      }),
-    );
-  });
-
-  it("chat.send inherits external delivery context for CLI clients on configured main sessions", async () => {
-    createTranscriptFixture("openclaw-chat-send-config-main-cli-routes-");
-    mockState.mainSessionKey = "work";
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      deliveryContext: {
-        channel: "whatsapp",
-        to: "whatsapp:+8613800138000",
-        accountId: "default",
-      },
-      lastChannel: "whatsapp",
-      lastTo: "whatsapp:+8613800138000",
-      lastAccountId: "default",
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-config-main-cli-routes",
-      client: {
-        connect: {
-          client: {
-            mode: GATEWAY_CLIENT_MODES.CLI,
-            id: "cli",
-          },
-        },
-      } as unknown,
-      sessionKey: "agent:main:work",
-      deliver: true,
-      expectBroadcast: false,
-    });
-
-    expect(mockState.lastDispatchCtx).toEqual(
-      expect.objectContaining({
-        OriginatingChannel: "whatsapp",
-        OriginatingTo: "whatsapp:+8613800138000",
-        AccountId: "default",
-      }),
-    );
-  });
-
   it("chat.send does not inherit external delivery context for non-channel custom sessions", async () => {
     createTranscriptFixture("openclaw-chat-send-custom-no-cross-route-");
     mockState.finalText = "ok";
@@ -678,40 +604,6 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       // Keep a second custom scope token so legacy-shape detection is exercised.
       // "agent:main:work" only yields one rest token and does not hit that path.
       sessionKey: "agent:main:work:ticket-123",
-      expectBroadcast: false,
-    });
-
-    expect(mockState.lastDispatchCtx).toEqual(
-      expect.objectContaining({
-        OriginatingChannel: "webchat",
-        OriginatingTo: undefined,
-        AccountId: undefined,
-      }),
-    );
-  });
-
-  it("chat.send keeps replies on the internal surface when deliver is not enabled", async () => {
-    createTranscriptFixture("openclaw-chat-send-no-deliver-internal-surface-");
-    mockState.finalText = "ok";
-    mockState.sessionEntry = {
-      deliveryContext: {
-        channel: "discord",
-        to: "user:1234567890",
-        accountId: "default",
-      },
-      lastChannel: "discord",
-      lastTo: "user:1234567890",
-      lastAccountId: "default",
-    };
-    const respond = vi.fn();
-    const context = createChatContext();
-
-    await runNonStreamingChatSend({
-      context,
-      respond,
-      idempotencyKey: "idem-no-deliver-internal-surface",
-      sessionKey: "agent:main:discord:direct:1234567890",
-      deliver: false,
       expectBroadcast: false,
     });
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -18,9 +18,9 @@ import {
   stripInlineDirectiveTagsFromMessageForDisplay,
 } from "../../utils/directive-tags.js";
 import {
-  INTERNAL_MESSAGE_CHANNEL,
-  isWebchatClient,
+  isInternalMessageChannel,
   normalizeMessageChannel,
+  resolveInboundMessageChannel,
 } from "../../utils/message-channel.js";
 import {
   abortChatRunById,
@@ -32,11 +32,7 @@ import {
 } from "../chat-abort.js";
 import { type ChatImageContent, parseMessageWithAttachments } from "../chat-attachments.js";
 import { stripEnvelopeFromMessage, stripEnvelopeFromMessages } from "../chat-sanitize.js";
-import {
-  GATEWAY_CLIENT_CAPS,
-  GATEWAY_CLIENT_MODES,
-  hasGatewayClientCap,
-} from "../protocol/client-info.js";
+import { GATEWAY_CLIENT_CAPS, hasGatewayClientCap } from "../protocol/client-info.js";
 import {
   ErrorCodes,
   errorShape,
@@ -864,7 +860,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       );
       const commandBody = injectThinking ? `/think ${p.thinking} ${parsedMessage}` : parsedMessage;
       const clientInfo = client?.connect?.client;
-      const shouldDeliverExternally = p.deliver === true;
+      const inboundInternalChannel = resolveInboundMessageChannel(client?.connect);
       const routeChannelCandidate = normalizeMessageChannel(
         entry?.deliveryContext?.channel ?? entry?.lastChannel,
       );
@@ -876,12 +872,11 @@ export const chatHandlers: GatewayRequestHandlers = {
       const sessionScopeParts = (parsedSessionKey?.rest ?? sessionKey).split(":").filter(Boolean);
       const sessionScopeHead = sessionScopeParts[0];
       const sessionChannelHint = normalizeMessageChannel(sessionScopeHead);
-      const normalizedSessionScopeHead = (sessionScopeHead ?? "").trim().toLowerCase();
       const sessionPeerShapeCandidates = [sessionScopeParts[1], sessionScopeParts[2]]
         .map((part) => (part ?? "").trim().toLowerCase())
         .filter(Boolean);
       const isChannelAgnosticSessionScope = CHANNEL_AGNOSTIC_SESSION_SCOPES.has(
-        normalizedSessionScopeHead,
+        (sessionScopeHead ?? "").trim().toLowerCase(),
       );
       const isChannelScopedSession = sessionPeerShapeCandidates.some((part) =>
         CHANNEL_SCOPED_SESSION_SHAPES.has(part),
@@ -890,32 +885,24 @@ export const chatHandlers: GatewayRequestHandlers = {
         !isChannelScopedSession &&
         typeof sessionScopeParts[1] === "string" &&
         sessionChannelHint === routeChannelCandidate;
-      const clientMode = client?.connect?.client?.mode;
-      const isFromWebchatClient =
-        isWebchatClient(client?.connect?.client) || clientMode === GATEWAY_CLIENT_MODES.UI;
-      const configuredMainKey = (cfg.session?.mainKey ?? "main").trim().toLowerCase();
-      const isConfiguredMainSessionScope =
-        normalizedSessionScopeHead.length > 0 && normalizedSessionScopeHead === configuredMainKey;
-      // Channel-agnostic session scopes (main, direct:<peer>, etc.) can leak
-      // stale routes across surfaces. Allow configured main sessions from
-      // non-Webchat/UI clients (e.g., CLI, backend) to keep the last external route.
+      // Only inherit prior external route metadata for channel-scoped sessions.
+      // Channel-agnostic sessions (main, direct:<peer>, etc.) can otherwise
+      // leak stale routes across surfaces.
       const canInheritDeliverableRoute = Boolean(
         sessionChannelHint &&
-        sessionChannelHint !== INTERNAL_MESSAGE_CHANNEL &&
-        ((!isChannelAgnosticSessionScope &&
-          (isChannelScopedSession || hasLegacyChannelPeerShape)) ||
-          (isConfiguredMainSessionScope && client?.connect !== undefined && !isFromWebchatClient)),
+        !isInternalMessageChannel(sessionChannelHint) &&
+        !isChannelAgnosticSessionScope &&
+        (isChannelScopedSession || hasLegacyChannelPeerShape),
       );
       const hasDeliverableRoute =
-        shouldDeliverExternally &&
         canInheritDeliverableRoute &&
         routeChannelCandidate &&
-        routeChannelCandidate !== INTERNAL_MESSAGE_CHANNEL &&
+        !isInternalMessageChannel(routeChannelCandidate) &&
         typeof routeToCandidate === "string" &&
         routeToCandidate.trim().length > 0;
       const originatingChannel = hasDeliverableRoute
         ? routeChannelCandidate
-        : INTERNAL_MESSAGE_CHANNEL;
+        : inboundInternalChannel;
       const originatingTo = hasDeliverableRoute ? routeToCandidate : undefined;
       const accountId = hasDeliverableRoute ? routeAccountIdCandidate : undefined;
       const messageThreadId = hasDeliverableRoute ? routeThreadIdCandidate : undefined;
@@ -931,8 +918,8 @@ export const chatHandlers: GatewayRequestHandlers = {
         RawBody: parsedMessage,
         CommandBody: commandBody,
         SessionKey: sessionKey,
-        Provider: INTERNAL_MESSAGE_CHANNEL,
-        Surface: INTERNAL_MESSAGE_CHANNEL,
+        Provider: inboundInternalChannel,
+        Surface: inboundInternalChannel,
         OriginatingChannel: originatingChannel,
         OriginatingTo: originatingTo,
         AccountId: accountId,
@@ -953,7 +940,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
         cfg,
         agentId,
-        channel: INTERNAL_MESSAGE_CHANNEL,
+        channel: inboundInternalChannel,
       });
       const finalReplyParts: string[] = [];
       const dispatcher = createReplyDispatcher({

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -15,7 +15,12 @@ import {
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 
 export const INTERNAL_MESSAGE_CHANNEL = "webchat" as const;
-export type InternalMessageChannel = typeof INTERNAL_MESSAGE_CHANNEL;
+export const TUI_MESSAGE_CHANNEL = "tui" as const;
+export type InternalMessageChannel = typeof INTERNAL_MESSAGE_CHANNEL | typeof TUI_MESSAGE_CHANNEL;
+const INTERNAL_MESSAGE_CHANNELS = new Set<InternalMessageChannel>([
+  INTERNAL_MESSAGE_CHANNEL,
+  TUI_MESSAGE_CHANNEL,
+]);
 
 const MARKDOWN_CAPABLE_CHANNELS = new Set<string>([
   "slack",
@@ -23,7 +28,7 @@ const MARKDOWN_CAPABLE_CHANNELS = new Set<string>([
   "signal",
   "discord",
   "googlechat",
-  "tui",
+  TUI_MESSAGE_CHANNEL,
   INTERNAL_MESSAGE_CHANNEL,
 ]);
 
@@ -34,6 +39,7 @@ export { normalizeGatewayClientName, normalizeGatewayClientMode };
 type GatewayClientInfoLike = {
   mode?: string | null;
   id?: string | null;
+  displayName?: string | null;
 };
 
 export function isGatewayCliClient(client?: GatewayClientInfoLike | null): boolean {
@@ -41,7 +47,15 @@ export function isGatewayCliClient(client?: GatewayClientInfoLike | null): boole
 }
 
 export function isInternalMessageChannel(raw?: string | null): raw is InternalMessageChannel {
-  return normalizeMessageChannel(raw) === INTERNAL_MESSAGE_CHANNEL;
+  const normalized = normalizeMessageChannel(raw);
+  return normalized != null && INTERNAL_MESSAGE_CHANNELS.has(normalized as InternalMessageChannel);
+}
+
+export function resolveInboundMessageChannel(
+  client?: GatewayClientInfoLike | null,
+): InternalMessageChannel {
+  const mode = normalizeGatewayClientMode(client?.mode);
+  return mode === GATEWAY_CLIENT_MODES.UI ? TUI_MESSAGE_CHANNEL : INTERNAL_MESSAGE_CHANNEL;
 }
 
 export function isWebchatClient(client?: GatewayClientInfoLike | null): boolean {
@@ -57,8 +71,8 @@ export function normalizeMessageChannel(raw?: string | null): string | undefined
   if (!normalized) {
     return undefined;
   }
-  if (normalized === INTERNAL_MESSAGE_CHANNEL) {
-    return INTERNAL_MESSAGE_CHANNEL;
+  if (INTERNAL_MESSAGE_CHANNELS.has(normalized as InternalMessageChannel)) {
+    return normalized as InternalMessageChannel;
   }
   const builtIn = normalizeChatChannelId(normalized);
   if (builtIn) {
@@ -101,7 +115,7 @@ export type GatewayMessageChannel = DeliverableMessageChannel | InternalMessageC
 
 export const listGatewayMessageChannels = (): GatewayMessageChannel[] => [
   ...listDeliverableMessageChannels(),
-  INTERNAL_MESSAGE_CHANNEL,
+  ...INTERNAL_MESSAGE_CHANNELS,
 ];
 
 export const listGatewayAgentChannelAliases = (): string[] =>


### PR DESCRIPTION
## Summary

- Problem: TUI messages were being routed as 'webchat' causing replies to not be delivered to TUI in real-time
- Why it matters: Users on TUI couldn't receive real-time replies; messages were going to webchat instead
- What changed: Added dedicated internal TUI channel identity, UI clients now map to 'tui' channel instead of 'webchat'
- What did NOT change: Webchat behavior remains unchanged

## Validation

- [ ] `pnpm build`
- [ ] `pnpm check`
- [ ] `pnpm test`

## AI Assistance

- [x] AI-assisted
- [ ] Testing level noted (untested / lightly tested / fully tested)
- [ ] I understand what this code does