### PR TITLE
fix(agents): surface error detail in subagent failure announcements

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -923,7 +923,44 @@ describe("subagent announce formatting", () => {
       expect(msg).toContain(testCase.expectedHeader);
       expect(msg).toContain(testCase.replyText);
       expect(msg).not.toContain(testCase.excludedHeader);
+      if (testCase.outcome.status === "error" && testCase.outcome.error) {
+        expect(msg).toContain(`Reason: ${testCase.outcome.error}`);
+      }
     }
+  });
+
+  it("includes error detail in failure header when subagent has no findings", async () => {
+    sendSpy.mockClear();
+    sessionStore = {
+      "agent:main:subagent:test": {
+        sessionId: "child-session-error-no-findings",
+      },
+      "agent:main:main": {
+        sessionId: "requester-session-error-no-findings",
+      },
+    };
+    chatHistoryMock.mockResolvedValueOnce({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "(no output)" }] }],
+    });
+    readLatestAssistantReplyMock.mockResolvedValue("");
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-error-no-findings",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
+      ...defaultOutcomeAnnounce,
+      outcome: { status: "error", error: "⚠️ API rate limit reached. Please try again later." },
+      expectsCompletionMessage: true,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    const msg = typeof (call?.params?.message) === "string" ? call.params.message as string : "";
+    expect(msg).toContain("❌ Subagent main failed");
+    expect(msg).toContain("Reason: ⚠️ API rate limit reached. Please try again later.");
   });
 
   it("routes manual completion direct-send using requester thread hints", async () => {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -97,9 +97,12 @@ function buildCompletionDeliveryMessage(params: {
   }
   const header = (() => {
     if (params.outcome?.status === "error") {
-      return params.spawnMode === "session"
-        ? `❌ Subagent ${params.subagentName} failed this task (session remains active)`
-        : `❌ Subagent ${params.subagentName} failed`;
+      const base =
+        params.spawnMode === "session"
+          ? `❌ Subagent ${params.subagentName} failed this task (session remains active)`
+          : `❌ Subagent ${params.subagentName} failed`;
+      const detail = params.outcome.error?.trim();
+      return detail ? `${base}\n\nReason: ${detail}` : base;
     }
     if (params.outcome?.status === "timeout") {
       return params.spawnMode === "session"


### PR DESCRIPTION
## Summary

- **Problem:** When a subagent fails (e.g. provider 429 rate limit, auth error, context overflow), the parent agent only sees `"❌ Subagent X failed"` with no actionable information about what went wrong.
- **Why it matters:** Operators cannot distinguish recoverable errors (rate limit — retry later) from configuration issues (auth — fix API key) or capacity limits (context overflow — reduce history) without inspecting server logs. This increases support load and delays recovery.
- **What changed:** `buildCompletionDeliveryMessage` now appends `outcome.error` as a `"Reason: ..."` line to the failure header. The error string is already sanitized by `formatAssistantErrorText` upstream and contains provider name, error type, and recovery hints.
- **What did NOT change:** Timeout and success message formatting, cron job completion handling, internal lifecycle event logging, error propagation chain.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36518

## User-visible / Behavior Changes

Before:
```
❌ Subagent main failed
```

After:
```
❌ Subagent main failed

Reason: ⚠️ API rate limit reached. Please try again later.
```

The error detail is only shown when `outcome.error` is present. When no error detail is available, the message is unchanged.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: any (subagent spawning)

### Steps

1. Spawn a subagent that hits a provider rate limit (e.g. Anthropic 429)
2. Wait for the subagent to fail
3. Observe the failure announcement in the parent session

### Expected

- Failure message includes error reason (e.g. rate limit, auth error)

### Actual

- Before fix: generic "Subagent X failed" with no detail
- After fix: "Subagent X failed" followed by "Reason: ⚠️ API rate limit reached..."

## Evidence

Existing tests pass. Updated e2e test verifies:
1. Error detail is included in the failure header (`Reason: boom`)
2. No-findings case still includes error detail (`Reason: ⚠️ API rate limit reached...`)

## Human Verification (required)

- Verified scenarios: error with findings, error without findings, timeout (unchanged), success (unchanged)
- Edge cases checked: empty error string (no "Reason:" appended), whitespace-only error (no "Reason:" appended)
- What I did **not** verify: end-to-end with live provider rate limit

## Compatibility / Migration

- Backward compatible? `Yes` — message format is additive; no existing parsers expect exact failure text
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit
- Files/config to restore: `src/agents/subagent-announce.ts`
- Known bad symptoms: if `outcome.error` contains very long strings, the message could be verbose (unlikely — upstream already truncates)

## Risks and Mitigations

- Risk: `outcome.error` could theoretically contain markdown or formatting that looks odd in some channels. Mitigation: `formatAssistantErrorText` upstream already produces clean, user-friendly text.

