### PR TITLE
Improve auth error observability for failed profile resolution

### DIFF
--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -333,4 +333,57 @@ describe("getApiKeyForModel", () => {
       },
     );
   });
+
+  it("reports the first profile resolution error when profile refresh throws", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-error-"));
+    const agentDir = path.join(tempDir, "agent");
+    await fs.mkdir(agentDir, { recursive: true, mode: 0o700 });
+
+    const expired = Date.now() - 60_000;
+    const store = {
+      version: 1,
+      profiles: {
+        "chutes:default": {
+          type: "oauth",
+          provider: "chutes",
+          access: "expired-access",
+          expires: expired,
+        },
+      },
+    } as never;
+    await fs.writeFile(
+      path.join(agentDir, "auth-profiles.json"),
+      `${JSON.stringify(store)}\n`,
+      "utf8",
+    );
+
+    try {
+      await withEnvAsync(
+        {
+          CHUTES_OAUTH_TOKEN: undefined,
+          CHUTES_API_KEY: undefined,
+          CHUTES_CLIENT_ID: undefined,
+        },
+        async () => {
+          let error: unknown = null;
+          try {
+            await resolveApiKeyForProvider({
+              provider: "chutes",
+              store,
+              agentDir,
+            });
+          } catch (err) {
+            error = err;
+          }
+
+          const message = String(error);
+          expect(message).toContain('No API key found for provider "chutes".');
+          expect(message).toContain("Last auth profile error (chutes:default)");
+          expect(message).toContain("missing refresh token");
+        },
+      );
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -77,6 +77,11 @@ function resolveEnvSourceLabel(params: {
   return `${prefix}${params.label}`;
 }
 
+function summarizeProfileResolutionError(error: unknown): string {
+  const text = error instanceof Error ? error.message : String(error);
+  return text.replace(/\s+/g, " ").trim();
+}
+
 export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): string | undefined {
   if (env[AWS_BEARER_ENV]?.trim()) {
     return AWS_BEARER_ENV;
@@ -173,6 +178,7 @@ export async function resolveApiKeyForProvider(params: {
     provider,
     preferredProfile,
   });
+  let profileResolutionError: { profileId: string; message: string } | null = null;
   for (const candidate of order) {
     try {
       const resolved = await resolveApiKeyForProfile({
@@ -190,7 +196,14 @@ export async function resolveApiKeyForProvider(params: {
           mode: mode === "oauth" ? "oauth" : mode === "token" ? "token" : "api-key",
         };
       }
-    } catch {}
+    } catch (error) {
+      if (!profileResolutionError) {
+        profileResolutionError = {
+          profileId: candidate,
+          message: summarizeProfileResolutionError(error),
+        };
+      }
+    }
   }
 
   const envResolved = resolveEnvApiKey(provider);
@@ -223,12 +236,15 @@ export async function resolveApiKeyForProvider(params: {
 
   const authStorePath = resolveAuthStorePathForDisplay(params.agentDir);
   const resolvedAgentDir = path.dirname(authStorePath);
+  const profileErrorHint = profileResolutionError
+    ? ` Last auth profile error (${profileResolutionError.profileId}): ${profileResolutionError.message}`
+    : "";
   throw new Error(
     [
       `No API key found for provider "${provider}".`,
       `Auth store: ${authStorePath} (agentDir: ${resolvedAgentDir}).`,
       `Configure auth for this agent (${formatCliCommand("openclaw agents add <id>")}) or copy auth-profiles.json from the main agentDir.`,
-    ].join(" "),
+    ].join(" ") + profileErrorHint,
   );
 }
 


### PR DESCRIPTION
## Summary
- keep existing auth fallback behavior in `resolveApiKeyForProvider`
- record the first exception thrown while resolving ordered auth profiles
- append that compact profile error context to the final missing-key error
- add a regression test for oauth refresh failures (missing Chutes refresh token)

## Why
When profile resolution failed due to refresh/config issues, the loop swallowed exceptions and surfaced only a generic "No API key found" error. This made auth debugging harder than necessary.

## Risk
Low: behavior only changes in failure messaging. Successful resolution/fallback precedence remains unchanged.

## Validation
- `pnpm vitest src/agents/model-auth.profiles.test.ts src/agents/model-auth.test.ts`
