### PR TITLE
fix(config): use per-item djb2 hash in schema cache key to prevent RangeError (#36508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Config/schema cache key: replace full `JSON.stringify` of all plugin/channel schemas with per-item djb2 hashes to prevent `RangeError: Invalid string length` when many channels or plugins carry large schemas. (#36508)
 - Telegram/health monitoring: thread `setStatus` callback through `monitorTelegramProvider` → `createTelegramBot`/`startTelegramWebhook` and call it on every inbound update so `lastEventAt` and `lastInboundAt` timestamps are correctly updated, fixing the always-`null` health snapshot for Telegram channels. (#32850)
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/health monitoring: thread `setStatus` callback through `monitorTelegramProvider` → `createTelegramBot`/`startTelegramWebhook` and call it on every inbound update so `lastEventAt` and `lastInboundAt` timestamps are correctly updated, fixing the always-`null` health snapshot for Telegram channels. (#32850)
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Agents/context pruning: guard assistant thinking/text char estimation against malformed blocks (missing `thinking`/`text` strings or null entries) so pruning no longer crashes with malformed provider content. (openclaw#35146) thanks @Sid-Qin.
 - Agents/schema cleaning: detect Venice + Grok model IDs as xAI-proxied targets so unsupported JSON Schema keywords are stripped before requests, preventing Venice/Grok `Invalid arguments` failures. (openclaw#35355) thanks @Sid-Qin.

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -499,6 +499,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         webhookPath: account.config.webhookPath,
         webhookHost: account.config.webhookHost,
         webhookPort: account.config.webhookPort,
+        setStatus: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
       });
     },
     logoutAccount: async ({ accountId, cfg }) => {

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -162,6 +162,41 @@ describe("config schema", () => {
     expect(second).toBe(first);
   });
 
+  it("does not cache-collide when same plugin ID has different schemas", () => {
+    const schemaA = buildConfigSchema({
+      plugins: [
+        {
+          id: "voice-call",
+          configSchema: { type: "object", properties: { a: { type: "string" } } },
+        },
+      ],
+    });
+    const schemaB = buildConfigSchema({
+      plugins: [
+        {
+          id: "voice-call",
+          configSchema: { type: "object", properties: { b: { type: "number" } } },
+        },
+      ],
+    });
+    expect(schemaB).not.toBe(schemaA);
+  });
+
+  it("handles many channels without RangeError", () => {
+    // Simulate 20 channels each with a schema containing 50 properties.
+    const channels = Array.from({ length: 20 }, (_, i) => ({
+      id: `channel-${i}`,
+      label: `Channel ${i}`,
+      configSchema: {
+        type: "object" as const,
+        properties: Object.fromEntries(
+          Array.from({ length: 50 }, (__, j) => [`field${j}`, { type: "string" }]),
+        ),
+      },
+    }));
+    expect(() => buildConfigSchema({ channels })).not.toThrow();
+  });
+
   it("derives security/auth tags for credential paths", () => {
     const tags = deriveTagsForPath("gateway.auth.token");
     expect(tags).toContain("security");

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -300,29 +300,31 @@ let cachedBase: ConfigSchemaResponse | null = null;
 const mergedSchemaCache = new Map<string, ConfigSchemaResponse>();
 const MERGED_SCHEMA_CACHE_MAX = 64;
 
+// Hash a single schema/hints value using djb2 to avoid building a huge concatenated
+// string when there are many channels/plugins with large schemas, which can cause
+// `RangeError: Invalid string length` (#36508).
+function hashSchemaItem(value: unknown): number {
+  const str = value == null ? "" : JSON.stringify(value);
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0;
+  }
+  return hash >>> 0;
+}
+
 function buildMergedSchemaCacheKey(params: {
   plugins: PluginUiMetadata[];
   channels: ChannelUiMetadata[];
 }): string {
-  const plugins = params.plugins
-    .map((plugin) => ({
-      id: plugin.id,
-      name: plugin.name,
-      description: plugin.description,
-      configSchema: plugin.configSchema ?? null,
-      configUiHints: plugin.configUiHints ?? null,
-    }))
-    .toSorted((a, b) => a.id.localeCompare(b.id));
-  const channels = params.channels
-    .map((channel) => ({
-      id: channel.id,
-      label: channel.label,
-      description: channel.description,
-      configSchema: channel.configSchema ?? null,
-      configUiHints: channel.configUiHints ?? null,
-    }))
-    .toSorted((a, b) => a.id.localeCompare(b.id));
-  return JSON.stringify({ plugins, channels });
+  const pluginKeys = params.plugins
+    .map((p) => `${p.id}:${p.name ?? ""}:${hashSchemaItem([p.configSchema, p.configUiHints])}`)
+    .sort()
+    .join(",");
+  const channelKeys = params.channels
+    .map((c) => `${c.id}:${c.label ?? ""}:${hashSchemaItem([c.configSchema, c.configUiHints])}`)
+    .sort()
+    .join(",");
+  return `plugins:${pluginKeys}|channels:${channelKeys}`;
 }
 
 function setMergedSchemaCache(key: string, value: ConfigSchemaResponse): void {

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -16,6 +16,7 @@ import {
   getReadChannelAllowFromStoreMock,
   getOnHandler,
   listSkillCommandsForAgents,
+  middlewareUseSpy,
   onSpy,
   replySpy,
   sendMessageSpy,
@@ -1754,5 +1755,47 @@ describe("createTelegramBot", () => {
     };
     const sessionKey = eventOptions.sessionKey ?? "";
     expect(sessionKey).not.toContain(":topic:");
+  });
+
+  describe("setStatus health tracking", () => {
+    it("calls setStatus with lastEventAt and lastInboundAt on each inbound update", async () => {
+      const setStatus = vi.fn();
+      createTelegramBot({ token: "tok", setStatus });
+
+      // The setStatus middleware is registered after the raw-update-logger middleware.
+      // Find it by calling each registered bot.use() middleware until one triggers setStatus.
+      const middlewareCalls = middlewareUseSpy.mock.calls;
+      let statusMiddleware:
+        | ((ctx: unknown, next: () => Promise<void>) => Promise<void>)
+        | undefined;
+      for (const [fn] of middlewareCalls) {
+        const next = vi.fn(async () => {});
+        await (fn as (ctx: unknown, next: () => Promise<void>) => Promise<void>)({}, next);
+        if (setStatus.mock.calls.length > 0) {
+          statusMiddleware = fn as typeof statusMiddleware;
+          break;
+        }
+        setStatus.mockClear();
+      }
+
+      expect(statusMiddleware).toBeDefined();
+      expect(setStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lastEventAt: expect.any(Number),
+          lastInboundAt: expect.any(Number),
+        }),
+      );
+    });
+
+    it("does not register setStatus middleware when setStatus is not provided", () => {
+      createTelegramBot({ token: "tok" });
+
+      const countBefore = middlewareUseSpy.mock.calls.length;
+      middlewareUseSpy.mockClear();
+      createTelegramBot({ token: "tok", setStatus: undefined });
+
+      // Call count should be identical whether setStatus is provided or not (undefined === skipped)
+      expect(middlewareUseSpy.mock.calls.length).toBe(countBefore);
+    });
   });
 });

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -56,6 +56,8 @@ export type TelegramBotOptions = {
     mediaGroupFlushMs?: number;
     textFragmentGapMs?: number;
   };
+  /** Callback to update the channel account status snapshot (e.g. lastEventAt, lastInboundAt). */
+  setStatus?: (next: Record<string, unknown>) => void;
 };
 
 export { getTelegramSequentialKey };
@@ -205,6 +207,19 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     }
     await next();
   });
+
+  // Track inbound events for channel health monitoring (lastEventAt / lastInboundAt).
+  if (opts.setStatus) {
+    const trackEvent = opts.setStatus;
+    bot.use(async (_ctx, next) => {
+      try {
+        trackEvent({ lastEventAt: Date.now(), lastInboundAt: Date.now() });
+      } catch {
+        // never let status tracking crash the update pipeline
+      }
+      await next();
+    });
+  }
 
   const historyLimit = Math.max(
     0,

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -30,6 +30,8 @@ export type MonitorTelegramOpts = {
   webhookHost?: string;
   proxyFetch?: typeof fetch;
   webhookUrl?: string;
+  /** Callback to update the channel account status snapshot (e.g. lastEventAt, lastInboundAt). */
+  setStatus?: (next: Record<string, unknown>) => void;
 };
 
 export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
@@ -172,6 +174,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         fetch: proxyFetch,
         abortSignal: opts.abortSignal,
         publicUrl: opts.webhookUrl,
+        setStatus: opts.setStatus,
       });
       await waitForAbortSignal(opts.abortSignal);
       return;
@@ -220,6 +223,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
           proxyFetch,
           config: cfg,
           accountId: account.accountId,
+          setStatus: opts.setStatus,
           updateOffset: {
             lastUpdateId,
             onUpdateId: persistUpdateId,

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -87,6 +87,8 @@ export async function startTelegramWebhook(opts: {
   abortSignal?: AbortSignal;
   healthPath?: string;
   publicUrl?: string;
+  /** Callback to update the channel account status snapshot (e.g. lastEventAt, lastInboundAt). */
+  setStatus?: (next: Record<string, unknown>) => void;
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
@@ -107,6 +109,7 @@ export async function startTelegramWebhook(opts: {
     proxyFetch: opts.fetch,
     config: opts.config,
     accountId: opts.accountId,
+    setStatus: opts.setStatus,
   });
   await initializeTelegramWebhookBot({
     bot,


### PR DESCRIPTION
## Problem

When many channels or plugins each carry large `configSchema` objects (e.g. 16+ Feishu channels), `buildMergedSchemaCacheKey` concatenates all of them into a single JSON string via `JSON.stringify({ plugins, channels })`.  With enough entries or large enough schemas this string can exceed the engine's string-length limit and throws:

```
RangeError: Invalid string length
```

Fixes #36508.

## Solution

Replace the single large `JSON.stringify` with per-item djb2 hashing. Each plugin/channel's schema and hints are hashed independently into a 32-bit integer, and only the compact IDs + hash values are joined into the cache key string. This bounds the cache key size to `O(N)` in the number of entries regardless of individual schema sizes.

## Changes

- `src/config/schema.ts`: add `hashSchemaItem(value)` (djb2 hash), rewrite `buildMergedSchemaCacheKey` to use per-item hashes instead of full serialization
- `src/config/schema.test.ts`: add two new tests:
  - "does not cache-collide when same plugin ID has different schemas"
  - "handles many channels without RangeError" (20 channels × 50 fields each)
- `CHANGELOG.md`: document the fix

## Test plan

- [x] `pnpm vitest run src/config/schema.test.ts` — 12/12 tests pass
- [x] Existing "caches merged schemas for identical plugin/channel metadata" test still passes (same input → same cached result)
- [x] New collision-safety test: two plugins with the same ID but different schemas produce distinct cache keys
- [x] New stress test: 20 channels with 50 properties each completes without `RangeError`