### PR TITLE
fix(agents): make reasoning level static in system prompt for cache stability

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -599,7 +599,7 @@ describe("buildAgentSystemPrompt", () => {
       reasoningLevel: "off",
     });
 
-    expect(prompt).toContain("Reasoning: off");
+    expect(prompt).toContain("Reasoning: configurable");
     expect(prompt).toContain("/reasoning");
     expect(prompt).toContain("/status shows Reasoning");
   });
@@ -671,6 +671,22 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("## Reactions");
     expect(prompt).toContain("Reactions are enabled for Telegram in MINIMAL mode.");
+  });
+});
+
+describe("system prompt cache stability", () => {
+  it("produces identical system prompt regardless of reasoning level", () => {
+    const base = { workspaceDir: "/tmp/openclaw" };
+    const promptOff = buildAgentSystemPrompt({ ...base, reasoningLevel: "off" });
+    const promptOn = buildAgentSystemPrompt({ ...base, reasoningLevel: "on" });
+    const promptStream = buildAgentSystemPrompt({ ...base, reasoningLevel: "stream" });
+
+    expect(promptOff).toBe(promptOn);
+    expect(promptOn).toBe(promptStream);
+    expect(promptOff).toContain("Reasoning: configurable");
+    expect(promptOff).not.toContain("Reasoning: off");
+    expect(promptOff).not.toContain("Reasoning: on");
+    expect(promptOff).not.toContain("Reasoning: stream");
   });
 });
 

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -360,7 +360,6 @@ export function buildAgentSystemPrompt(params: {
         "<final>Hey there! What would you like to do next?</final>",
       ].join(" ")
     : undefined;
-  const reasoningLevel = params.reasoningLevel ?? "off";
   const userTimezone = params.userTimezone?.trim();
   const skillsPrompt = params.skillsPrompt?.trim();
   const heartbeatPrompt = params.heartbeatPrompt?.trim();
@@ -678,7 +677,7 @@ export function buildAgentSystemPrompt(params: {
   lines.push(
     "## Runtime",
     buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities, params.defaultThinkLevel),
-    `Reasoning: ${reasoningLevel} (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.`,
+    "Reasoning: configurable (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.",
   );
 
   return lines.filter(Boolean).join("\n");


### PR DESCRIPTION
## Summary

- **Problem:** The system prompt interpolated the session's current reasoning level (`off`/`on`/`stream`) into the `## Runtime` footer. Every `/reasoning` toggle mutated the system prompt, invalidating prompt cache for all providers — cloud (`cache_read` miss → `cache_write`) and local (full KV re-prefill). On large contexts (100k+ tokens) this adds minutes of latency per turn for local inference.
- **Why it matters:** Prompt caching is critical for performance and cost. A single `/reasoning` toggle causes full re-processing of the entire context on the next turn. For cloud APIs this means paying full input token cost instead of cache-discounted cost. For local providers it means full KV prefill latency.
- **What changed:** Replaced dynamic `${reasoningLevel}` interpolation with static `"configurable"` label. Removed the unused `reasoningLevel` local variable.
- **What did NOT change:** Reasoning behavior (controlled via `reasoning_effort` in request parameters), `/status` command output (still shows current reasoning level), `buildRuntimeLine` (model/agent/host info), `reasoningLevel` param type (kept for backward compatibility).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36520

## User-visible / Behavior Changes

- System prompt no longer changes when `/reasoning` is toggled. Prompt cache remains stable across reasoning level changes.
- The model no longer sees the exact reasoning state in the system prompt. Reasoning behavior is unaffected since it's controlled via `reasoning_effort` request parameter.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: any

### Steps

1. Start a session and build up context
2. Toggle `/reasoning`
3. Send a new message

### Expected

- System prompt is identical before and after the toggle
- Prompt cache is reused (no re-prefill)

### Actual

- Before fix: system prompt changes (`Reasoning: off` → `Reasoning: on`), cache invalidated
- After fix: system prompt is stable (`Reasoning: configurable`), cache preserved

## Evidence

All 44 tests pass including new cache stability test:

```
 ✓ system prompt cache stability > produces identical system prompt regardless of reasoning level
 Test Files  1 passed (1)
      Tests  44 passed (44)
```

## Human Verification (required)

- Verified scenarios: reasoning off/on/stream produce identical system prompt, `/status` still shows current reasoning level, existing reasoning hint test updated
- Edge cases checked: `reasoningLevel` param omitted (defaults to undefined, prompt unchanged)
- What I did **not** verify: end-to-end cache hit measurement with live provider

## Compatibility / Migration

- Backward compatible? `Yes` — the `reasoningLevel` param type is preserved; callers can still pass it without error
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit
- Files/config to restore: `src/agents/system-prompt.ts`
- Known bad symptoms: model may not know current reasoning mode (but reasoning behavior is unaffected since it's controlled via request params)

## Risks and Mitigations

- Risk: model relies on the system prompt to know the current reasoning state. Mitigation: reasoning behavior is already controlled via `reasoning_effort` in request parameters, making the system prompt line purely informational. The `/status` command still shows the current state for human operators.

