### PR TITLE
perf: reduce allocations in joinPresentTextSegments

### DIFF
--- a/src/shared/text/join-segments.test.ts
+++ b/src/shared/text/join-segments.test.ts
@@ -23,4 +23,13 @@ describe("joinPresentTextSegments", () => {
   it("trims segments when requested", () => {
     expect(joinPresentTextSegments(["  A  ", "  B  "], { trim: true })).toBe("A\n\nB");
   });
+
+  it("uses custom separator and skips whitespace-only segments after trim", () => {
+    expect(
+      joinPresentTextSegments(["  keep  ", "   ", "next"], {
+        trim: true,
+        separator: " | ",
+      }),
+    ).toBe("keep | next");
+  });
 });

--- a/src/shared/text/join-segments.ts
+++ b/src/shared/text/join-segments.ts
@@ -19,7 +19,7 @@ export function joinPresentTextSegments(
 ): string | undefined {
   const separator = options?.separator ?? "\n\n";
   const trim = options?.trim ?? false;
-  const values: string[] = [];
+  let result: string | undefined;
   for (const segment of segments) {
     if (typeof segment !== "string") {
       continue;
@@ -28,7 +28,11 @@ export function joinPresentTextSegments(
     if (!normalized) {
       continue;
     }
-    values.push(normalized);
+    if (result === undefined) {
+      result = normalized;
+      continue;
+    }
+    result += `${separator}${normalized}`;
   }
-  return values.length > 0 ? values.join(separator) : undefined;
+  return result;
 }


### PR DESCRIPTION
## Summary
- switch joinPresentTextSegments to a single-pass string builder
- avoid intermediate array allocation + join() on every call
- add coverage for custom separator behavior with whitespace-only segments under trim: true

## Why
This helper is part of prompt/context assembly paths and can run frequently. Reducing temporary allocations is a low-risk hot-path optimization.

## Validation
- pnpm -s vitest run src/shared/text/join-segments.test.ts
- pnpm -s vitest run src/agents/pi-embedded-runner/run/attempt.test.ts src/plugins/hooks.phase-hooks.test.ts
