### PR TITLE
daemon/systemd: accept is-enabled code 1 with not-found

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -138,6 +138,21 @@ describe("isSystemdServiceEnabled", () => {
     const result = await isSystemdServiceEnabled({ env: {} });
     expect(result).toBe(false);
   });
+
+  it("returns false when systemctl is-enabled exits with code 1 (not-found)", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      // On some distros/systemd versions, `systemctl --user is-enabled <unit>`
+      // exits with code 1 (not 4) and prints "not-found" when the unit doesn't exist.
+      const err = new Error(
+        "Command failed: systemctl --user is-enabled openclaw-gateway.service",
+      ) as Error & { code?: number };
+      err.code = 1;
+      cb(err, "not-found\n", "");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
 });
 
 describe("systemd runtime parsing", () => {


### PR DESCRIPTION
Fixes regression where `systemctl --user is-enabled <unit>` may exit with code 1 and output `not-found` when the unit is missing; treat this as a valid "not enabled" state.

Closes #36008.