### PR TITLE
fix(pairing): harden path normalization against directory traversal

### DIFF
--- a/src/pairing/pairing-store.test.ts
+++ b/src/pairing/pairing-store.test.ts
@@ -494,3 +494,56 @@ describe("pairing store", () => {
     });
   });
 });
+
+describe("path traversal protection", () => {
+  it("rejects channel IDs containing traversal sequences", async () => {
+    await withTempStateDir(async () => {
+      await expect(
+        listChannelPairingRequests("../../etc" as "telegram"),
+      ).rejects.toThrow();
+    });
+  });
+
+  it("rejects channel IDs with encoded separators", async () => {
+    await withTempStateDir(async () => {
+      await expect(
+        listChannelPairingRequests("foo/bar" as "telegram"),
+      ).rejects.toThrow();
+    });
+  });
+
+  it("rejects channel IDs with backslash separators", async () => {
+    await withTempStateDir(async () => {
+      await expect(
+        listChannelPairingRequests("foo\\bar" as "telegram"),
+      ).rejects.toThrow();
+    });
+  });
+
+  it("rejects absolute path injection in channel ID", async () => {
+    await withTempStateDir(async () => {
+      await expect(
+        listChannelPairingRequests("/tmp/evil" as "telegram"),
+      ).rejects.toThrow();
+    });
+  });
+
+  it("rejects traversal in account ID via allowFrom operations", async () => {
+    await withTempStateDir(async () => {
+      await expect(
+        addChannelAllowFromStoreEntry({
+          channel: "telegram",
+          entry: "12345",
+          accountId: "../../etc/passwd",
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  it("accepts valid channel IDs without error", async () => {
+    await withTempStateDir(async () => {
+      const requests = await listChannelPairingRequests("telegram");
+      expect(requests).toEqual([]);
+    });
+  });
+});

--- a/src/pairing/pairing-store.ts
+++ b/src/pairing/pairing-store.ts
@@ -65,15 +65,31 @@ function safeChannelKey(channel: PairingChannel): string {
   if (!raw) {
     throw new Error("invalid pairing channel");
   }
-  const safe = raw.replace(/[\\/:*?"<>|]/g, "_").replace(/\.\./g, "_");
-  if (!safe || safe === "_") {
+  if (/[\\/:*?"<>|]/.test(raw) || /\.\./.test(raw)) {
+    throw new Error("invalid pairing channel: contains path separator or traversal sequence");
+  }
+  if (!raw || raw === "_") {
     throw new Error("invalid pairing channel");
   }
-  return safe;
+  return raw;
+}
+
+function assertWithinRoot(resolved: string, root: string): void {
+  const normalizedResolved = path.resolve(resolved);
+  const normalizedRoot = path.resolve(root);
+  if (
+    !normalizedResolved.startsWith(normalizedRoot + path.sep) &&
+    normalizedResolved !== normalizedRoot
+  ) {
+    throw new Error("pairing store path escapes root directory");
+  }
 }
 
 function resolvePairingPath(channel: PairingChannel, env: NodeJS.ProcessEnv = process.env): string {
-  return path.join(resolveCredentialsDir(env), `${safeChannelKey(channel)}-pairing.json`);
+  const root = resolveCredentialsDir(env);
+  const resolved = path.join(root, `${safeChannelKey(channel)}-pairing.json`);
+  assertWithinRoot(resolved, root);
+  return resolved;
 }
 
 function safeAccountKey(accountId: string): string {
@@ -81,11 +97,13 @@ function safeAccountKey(accountId: string): string {
   if (!raw) {
     throw new Error("invalid pairing account id");
   }
-  const safe = raw.replace(/[\\/:*?"<>|]/g, "_").replace(/\.\./g, "_");
-  if (!safe || safe === "_") {
+  if (/[\\/:*?"<>|]/.test(raw) || /\.\./.test(raw)) {
+    throw new Error("invalid pairing account id: contains path separator or traversal sequence");
+  }
+  if (!raw || raw === "_") {
     throw new Error("invalid pairing account id");
   }
-  return safe;
+  return raw;
 }
 
 function resolveAllowFromPath(
@@ -93,15 +111,14 @@ function resolveAllowFromPath(
   env: NodeJS.ProcessEnv = process.env,
   accountId?: string,
 ): string {
+  const root = resolveCredentialsDir(env);
   const base = safeChannelKey(channel);
   const normalizedAccountId = typeof accountId === "string" ? accountId.trim() : "";
-  if (!normalizedAccountId) {
-    return path.join(resolveCredentialsDir(env), `${base}-allowFrom.json`);
-  }
-  return path.join(
-    resolveCredentialsDir(env),
-    `${base}-${safeAccountKey(normalizedAccountId)}-allowFrom.json`,
-  );
+  const resolved = normalizedAccountId
+    ? path.join(root, `${base}-${safeAccountKey(normalizedAccountId)}-allowFrom.json`)
+    : path.join(root, `${base}-allowFrom.json`);
+  assertWithinRoot(resolved, root);
+  return resolved;
 }
 
 async function readJsonFile<T>(


### PR DESCRIPTION
## Summary

- **Problem:** `safeChannelKey` and `safeAccountKey` silently sanitized traversal patterns (`../`, `\`, `/`) instead of rejecting them. No defense-in-depth check verified resolved paths stayed within the credentials root.
- **Why it matters:** A bug in sanitization (or future refactor) could allow path inputs to escape the intended storage root, enabling out-of-root reads/writes.
- **What changed:** (1) `safeChannelKey` and `safeAccountKey` now throw on inputs containing path separators or `..` sequences instead of silently replacing them. (2) A new `assertWithinRoot` check validates the final resolved path against the credentials root after `path.join`.
- **What did NOT change:** Valid channel IDs and account IDs continue to work unchanged. The credentials root resolution logic (`resolveCredentialsDir`, `resolveOAuthDir`) is untouched.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36552

## User-visible / Behavior Changes

- Channel IDs or account IDs containing `..`, `/`, `\`, or other path-special characters now cause an explicit error instead of being silently sanitized.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `Yes - narrows valid inputs to prevent path traversal`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22
- Integration/channel: Any (pairing store is channel-agnostic)

### Steps

1. Call `listChannelPairingRequests("../../etc")` or `addChannelAllowFromStoreEntry({ channel: "telegram", entry: "123", accountId: "../../etc/passwd" })`
2. Observe behavior

### Expected

- Operation throws with a clear error message about invalid input

### Actual

- Before fix: Input silently sanitized, `..` replaced with `_`, operation succeeds with mangled filename
- After fix: Throws `"invalid pairing channel: contains path separator or traversal sequence"`

## Evidence

```
 src/pairing/pairing-store.test.ts | 53 ++++++++++++++++++++++++++++++++++++
 src/pairing/pairing-store.ts      | 45 ++++++++++++++++++++++-----------
 2 files changed, 84 insertions(+), 14 deletions(-)
```

All 23 tests pass, including 6 new regression tests covering `..`, `/`, `\`, absolute paths, account ID traversal, and valid channel acceptance.

## Human Verification (required)

- Verified scenarios: traversal via `..`, forward slash, backslash, absolute path, account ID traversal, valid channel ID acceptance
- Edge cases checked: empty input, `_`-only input, mixed traversal patterns
- What I did **not** verify: Unicode lookalike separators (e.g. full-width `/`), env-controlled root override paths

## Compatibility / Migration

- Backward compatible? `Yes — only malformed/malicious inputs are rejected; valid channel/account IDs are unaffected`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit to restore silent sanitization behavior
- Files/config to restore: `src/pairing/pairing-store.ts`
- Known bad symptoms: Operations that previously succeeded with silently sanitized channel/account IDs would now throw

## Risks and Mitigations

- Risk: If any legitimate channel ID contains characters like `:` or `/` (unlikely given channel IDs are typically simple slugs), it would be rejected
- Mitigation: All standard channel IDs (telegram, discord, slack, etc.) are simple lowercase alpha strings and are unaffected

