### PR TITLE
cron: keep cron store and run logs private

### DIFF
--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -12,6 +12,8 @@ import {
   resolveCronRunLogPath,
 } from "./run-log.js";
 
+const isPosix = process.platform !== "win32";
+
 describe("cron run log", () => {
   it("resolves prune options from config with defaults", () => {
     expect(resolveCronRunLogPruneOptions()).toEqual({
@@ -92,6 +94,22 @@ describe("cron run log", () => {
       expect(lines.length).toBe(3);
       const last = JSON.parse(lines[2] ?? "{}") as { ts?: number };
       expect(last.ts).toBe(1009);
+    });
+  });
+
+  it.skipIf(!isPosix)("creates private run-log files and runs dir", async () => {
+    await withRunLogDir("openclaw-cron-log-mode-", async (dir) => {
+      const logPath = path.join(dir, "runs", "job-1.jsonl");
+
+      await appendCronRunLog(logPath, {
+        ts: 1,
+        jobId: "job-1",
+        action: "finished",
+        status: "ok",
+      });
+
+      expect((await fs.stat(path.dirname(logPath))).mode & 0o777).toBe(0o700);
+      expect((await fs.stat(logPath)).mode & 0o777).toBe(0o600);
     });
   });
 

--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -113,6 +113,26 @@ describe("cron run log", () => {
     });
   });
 
+  it.skipIf(!isPosix)("rejects symlinked run-log paths", async () => {
+    await withRunLogDir("openclaw-cron-log-symlink-", async (dir) => {
+      const runsDir = path.join(dir, "runs");
+      const targetPath = path.join(dir, "target.jsonl");
+      const logPath = path.join(runsDir, "job-1.jsonl");
+      await fs.mkdir(runsDir, { recursive: true });
+      await fs.writeFile(targetPath, "", "utf-8");
+      await fs.symlink(targetPath, logPath);
+
+      await expect(
+        appendCronRunLog(logPath, {
+          ts: 1,
+          jobId: "job-1",
+          action: "finished",
+          status: "ok",
+        }),
+      ).rejects.toThrow(/symlink/i);
+    });
+  });
+
   it("reads newest entries and filters by jobId", async () => {
     await withRunLogDir("openclaw-cron-log-read-", async (dir) => {
       const logPathA = path.join(dir, "runs", "a.jsonl");

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -1,3 +1,4 @@
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { parseByteSize } from "../cli/parse-bytes.js";
@@ -55,11 +56,67 @@ const CRON_RUN_LOG_FILE_MODE = 0o600;
 
 async function ensureCronRunsDir(dirPath: string) {
   await fs.mkdir(dirPath, { recursive: true, mode: CRON_RUNS_DIR_MODE });
-  await fs.chmod(dirPath, CRON_RUNS_DIR_MODE).catch(() => undefined);
+  const stat = await fs.lstat(dirPath);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`cron runs dir must be a real directory: ${dirPath}`);
+  }
+  await ensurePrivateMode(dirPath, CRON_RUNS_DIR_MODE);
 }
 
 async function ensureCronRunLogFileMode(filePath: string) {
-  await fs.chmod(filePath, CRON_RUN_LOG_FILE_MODE).catch(() => undefined);
+  await ensurePrivateMode(filePath, CRON_RUN_LOG_FILE_MODE);
+}
+
+async function ensurePrivateMode(filePath: string, mode: number) {
+  try {
+    await fs.chmod(filePath, mode);
+    return;
+  } catch (err) {
+    if (process.platform !== "win32") {
+      const stat = await fs.stat(filePath).catch(() => null);
+      if (stat && (stat.mode & 0o077) !== 0) {
+        throw err;
+      }
+    }
+  }
+}
+
+async function assertNotSymlink(filePath: string) {
+  const stat = await fs.lstat(filePath).catch((err: unknown) => {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  });
+  if (stat?.isSymbolicLink()) {
+    throw new Error(`refusing to use symlink for cron run log: ${filePath}`);
+  }
+}
+
+async function appendCronRunLogEntry(filePath: string, entry: CronRunLogEntry) {
+  await assertNotSymlink(filePath);
+  const flags =
+    process.platform === "win32"
+      ? fsConstants.O_APPEND | fsConstants.O_CREAT | fsConstants.O_WRONLY
+      : fsConstants.O_APPEND | fsConstants.O_CREAT | fsConstants.O_WRONLY | fsConstants.O_NOFOLLOW;
+  const handle = await fs.open(filePath, flags, CRON_RUN_LOG_FILE_MODE);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      throw new Error(`cron run log must be a regular file: ${filePath}`);
+    }
+    await handle.appendFile(`${JSON.stringify(entry)}\n`, "utf-8");
+    await handle.chmod(CRON_RUN_LOG_FILE_MODE).catch(async (err) => {
+      if (process.platform !== "win32") {
+        const nextStat = await handle.stat().catch(() => null);
+        if (nextStat && (nextStat.mode & 0o077) !== 0) {
+          throw err;
+        }
+      }
+    });
+  } finally {
+    await handle.close();
+  }
 }
 
 function assertSafeCronRunLogJobId(jobId: string): string {
@@ -156,8 +213,7 @@ export async function appendCronRunLog(
     .catch(() => undefined)
     .then(async () => {
       await ensureCronRunsDir(path.dirname(resolved));
-      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, "utf-8");
-      await ensureCronRunLogFileMode(resolved);
+      await appendCronRunLogEntry(resolved, entry);
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,
         keepLines: opts?.keepLines ?? DEFAULT_CRON_RUN_LOG_KEEP_LINES,

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -50,6 +50,18 @@ type ReadCronRunLogAllPageOptions = Omit<ReadCronRunLogPageOptions, "jobId"> & {
   jobNameById?: Record<string, string>;
 };
 
+const CRON_RUNS_DIR_MODE = 0o700;
+const CRON_RUN_LOG_FILE_MODE = 0o600;
+
+async function ensureCronRunsDir(dirPath: string) {
+  await fs.mkdir(dirPath, { recursive: true, mode: CRON_RUNS_DIR_MODE });
+  await fs.chmod(dirPath, CRON_RUNS_DIR_MODE).catch(() => undefined);
+}
+
+async function ensureCronRunLogFileMode(filePath: string) {
+  await fs.chmod(filePath, CRON_RUN_LOG_FILE_MODE).catch(() => undefined);
+}
+
 function assertSafeCronRunLogJobId(jobId: string): string {
   const trimmed = jobId.trim();
   if (!trimmed) {
@@ -125,8 +137,12 @@ async function pruneIfNeeded(filePath: string, opts: { maxBytes: number; keepLin
   const kept = lines.slice(Math.max(0, lines.length - opts.keepLines));
   const { randomBytes } = await import("node:crypto");
   const tmp = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.writeFile(tmp, `${kept.join("\n")}\n`, "utf-8");
+  await fs.writeFile(tmp, `${kept.join("\n")}\n`, {
+    encoding: "utf-8",
+    mode: CRON_RUN_LOG_FILE_MODE,
+  });
   await fs.rename(tmp, filePath);
+  await ensureCronRunLogFileMode(filePath);
 }
 
 export async function appendCronRunLog(
@@ -139,8 +155,9 @@ export async function appendCronRunLog(
   const next = prev
     .catch(() => undefined)
     .then(async () => {
-      await fs.mkdir(path.dirname(resolved), { recursive: true });
+      await ensureCronRunsDir(path.dirname(resolved));
       await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, "utf-8");
+      await ensureCronRunLogFileMode(resolved);
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? DEFAULT_CRON_RUN_LOG_MAX_BYTES,
         keepLines: opts?.keepLines ?? DEFAULT_CRON_RUN_LOG_KEEP_LINES,

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -6,6 +6,11 @@ import { loadCronStore, resolveCronStorePath, saveCronStore } from "./store.js";
 import type { CronStoreFile } from "./types.js";
 
 const { makeStorePath } = createCronStoreHarness({ prefix: "openclaw-cron-store-" });
+const isPosix = process.platform !== "win32";
+
+async function getModeBits(filePath: string) {
+  return (await fs.stat(filePath)).mode & 0o777;
+}
 
 function makeStore(jobId: string, enabled: boolean): CronStoreFile {
   const now = Date.now();
@@ -78,6 +83,19 @@ describe("cron store", () => {
     const backupRaw = await fs.readFile(`${store.storePath}.bak`, "utf-8");
     expect(JSON.parse(currentRaw)).toEqual(second);
     expect(JSON.parse(backupRaw)).toEqual(first);
+  });
+
+  it.skipIf(!isPosix)("writes cron store + backup with private permissions", async () => {
+    const store = await makeStorePath();
+    const first = makeStore("job-1", true);
+    const second = makeStore("job-2", false);
+
+    await saveCronStore(store.storePath, first);
+    await saveCronStore(store.storePath, second);
+
+    expect(await getModeBits(path.dirname(store.storePath))).toBe(0o700);
+    expect(await getModeBits(store.storePath)).toBe(0o600);
+    expect(await getModeBits(`${store.storePath}.bak`)).toBe(0o600);
   });
 });
 

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -97,6 +97,23 @@ describe("cron store", () => {
     expect(await getModeBits(store.storePath)).toBe(0o600);
     expect(await getModeBits(`${store.storePath}.bak`)).toBe(0o600);
   });
+
+  it.skipIf(!isPosix)("rejects symlinked backup path", async () => {
+    const store = await makeStorePath();
+    const first = makeStore("job-1", true);
+    const second = makeStore("job-2", false);
+    const symlinkTarget = path.join(path.dirname(store.storePath), "leak.txt");
+
+    await saveCronStore(store.storePath, first);
+    await fs.writeFile(symlinkTarget, "leak", "utf-8");
+    await fs.symlink(symlinkTarget, `${store.storePath}.bak`);
+
+    await saveCronStore(store.storePath, second);
+
+    expect(await fs.readFile(symlinkTarget, "utf-8")).toBe("leak");
+    expect((await fs.lstat(`${store.storePath}.bak`)).isSymbolicLink()).toBe(true);
+    expect(JSON.parse(await fs.readFile(store.storePath, "utf-8"))).toEqual(second);
+  });
 });
 
 describe("saveCronStore", () => {

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -9,6 +9,17 @@ import type { CronStoreFile } from "./types.js";
 export const DEFAULT_CRON_DIR = path.join(CONFIG_DIR, "cron");
 export const DEFAULT_CRON_STORE_PATH = path.join(DEFAULT_CRON_DIR, "jobs.json");
 const serializedStoreCache = new Map<string, string>();
+const CRON_DIR_MODE = 0o700;
+const CRON_FILE_MODE = 0o600;
+
+async function ensureCronDir(dirPath: string) {
+  await fs.promises.mkdir(dirPath, { recursive: true, mode: CRON_DIR_MODE });
+  await fs.promises.chmod(dirPath, CRON_DIR_MODE).catch(() => undefined);
+}
+
+async function ensureCronFileMode(filePath: string) {
+  await fs.promises.chmod(filePath, CRON_FILE_MODE).catch(() => undefined);
+}
 
 export function resolveCronStorePath(storePath?: string) {
   if (storePath?.trim()) {
@@ -61,7 +72,7 @@ export async function saveCronStore(
   store: CronStoreFile,
   opts?: SaveCronStoreOptions,
 ) {
-  await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
+  await ensureCronDir(path.dirname(storePath));
   const json = JSON.stringify(store, null, 2);
   const cached = serializedStoreCache.get(storePath);
   if (cached === json) {
@@ -83,15 +94,17 @@ export async function saveCronStore(
     return;
   }
   const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.promises.writeFile(tmp, json, "utf-8");
+  await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: CRON_FILE_MODE });
   if (previous !== null && !opts?.skipBackup) {
     try {
       await fs.promises.copyFile(storePath, `${storePath}.bak`);
+      await ensureCronFileMode(`${storePath}.bak`);
     } catch {
       // best-effort
     }
   }
   await renameWithRetry(tmp, storePath);
+  await ensureCronFileMode(storePath);
   serializedStoreCache.set(storePath, json);
 }
 
@@ -112,6 +125,7 @@ async function renameWithRetry(src: string, dest: string): Promise<void> {
       // Windows doesn't reliably support atomic replace via rename when dest exists.
       if (code === "EPERM" || code === "EEXIST") {
         await fs.promises.copyFile(src, dest);
+        await ensureCronFileMode(dest);
         await fs.promises.unlink(src).catch(() => {});
         return;
       }

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -14,11 +14,51 @@ const CRON_FILE_MODE = 0o600;
 
 async function ensureCronDir(dirPath: string) {
   await fs.promises.mkdir(dirPath, { recursive: true, mode: CRON_DIR_MODE });
-  await fs.promises.chmod(dirPath, CRON_DIR_MODE).catch(() => undefined);
+  const stat = await fs.promises.lstat(dirPath);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`cron dir must be a real directory: ${dirPath}`);
+  }
+  await ensureCronFileMode(dirPath, CRON_DIR_MODE);
 }
 
-async function ensureCronFileMode(filePath: string) {
-  await fs.promises.chmod(filePath, CRON_FILE_MODE).catch(() => undefined);
+async function ensureCronFileMode(filePath: string, mode = CRON_FILE_MODE) {
+  try {
+    await fs.promises.chmod(filePath, mode);
+    return;
+  } catch (err) {
+    if (process.platform !== "win32") {
+      const stat = await fs.promises.stat(filePath).catch(() => null);
+      if (stat && (stat.mode & 0o077) !== 0) {
+        throw err;
+      }
+    }
+  }
+}
+
+async function assertNotSymlink(filePath: string) {
+  const stat = await fs.promises.lstat(filePath).catch((err: unknown) => {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  });
+  if (stat?.isSymbolicLink()) {
+    throw new Error(`refusing to use symlink for cron file: ${filePath}`);
+  }
+}
+
+async function writeCronFile(filePath: string, contents: string) {
+  await assertNotSymlink(filePath);
+  const tmp = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
+  await fs.promises.writeFile(tmp, contents, { encoding: "utf-8", mode: CRON_FILE_MODE });
+  await fs.promises.rename(tmp, filePath);
+}
+
+async function copyCronFile(sourcePath: string, destPath: string) {
+  const contents = await fs.promises.readFile(sourcePath, "utf-8");
+  await assertNotSymlink(destPath);
+  await fs.promises.writeFile(destPath, contents, { encoding: "utf-8", mode: CRON_FILE_MODE });
+  await ensureCronFileMode(destPath);
 }
 
 export function resolveCronStorePath(storePath?: string) {
@@ -93,28 +133,27 @@ export async function saveCronStore(
     serializedStoreCache.set(storePath, json);
     return;
   }
-  const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: CRON_FILE_MODE });
   if (previous !== null && !opts?.skipBackup) {
     try {
-      await fs.promises.copyFile(storePath, `${storePath}.bak`);
-      await ensureCronFileMode(`${storePath}.bak`);
+      await writeCronFile(`${storePath}.bak`, previous);
     } catch {
       // best-effort
     }
   }
-  await renameWithRetry(tmp, storePath);
-  await ensureCronFileMode(storePath);
+  await writeCronFileWithRetry(storePath, json);
   serializedStoreCache.set(storePath, json);
 }
 
 const RENAME_MAX_RETRIES = 3;
 const RENAME_BASE_DELAY_MS = 50;
 
-async function renameWithRetry(src: string, dest: string): Promise<void> {
+async function writeCronFileWithRetry(dest: string, contents: string): Promise<void> {
+  const tmp = `${dest}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
+  await fs.promises.writeFile(tmp, contents, { encoding: "utf-8", mode: CRON_FILE_MODE });
   for (let attempt = 0; attempt <= RENAME_MAX_RETRIES; attempt++) {
     try {
-      await fs.promises.rename(src, dest);
+      await assertNotSymlink(dest);
+      await fs.promises.rename(tmp, dest);
       return;
     } catch (err) {
       const code = (err as { code?: string }).code;
@@ -124,9 +163,9 @@ async function renameWithRetry(src: string, dest: string): Promise<void> {
       }
       // Windows doesn't reliably support atomic replace via rename when dest exists.
       if (code === "EPERM" || code === "EEXIST") {
-        await fs.promises.copyFile(src, dest);
-        await ensureCronFileMode(dest);
-        await fs.promises.unlink(src).catch(() => {});
+        await assertNotSymlink(dest);
+        await copyCronFile(tmp, dest);
+        await fs.promises.unlink(tmp).catch(() => {});
         return;
       }
       throw err;


### PR DESCRIPTION
## Summary

- Problem: cron store writes (`jobs.json`, `jobs.json.bak`) and cron run logs (`cron/runs/*.jsonl`) were created with process-default permissions (`0644`), and `cron/runs/` was created as `0755`.
- Why it matters: cron payloads can contain delivery targets and message content; these files should stay private even if the parent `~/.openclaw/cron` directory already limits access.
- What changed: cron store and run-log writers now force `0700` on cron directories and `0600` on store, backup, tmp, and run-log files; added regression tests that assert those modes on POSIX.
- What did NOT change (scope boundary): no cron scheduling, retry, payload, or delivery behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35881
- Related #

## User-visible / Behavior Changes

- Cron store backups and per-job run logs are now recreated with private permissions (`0600`), and the `cron/runs` directory is forced to `0700` on write.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux/macOS POSIX filesystem behavior
- Runtime/container: local node test runtime
- Model/provider: n/a
- Integration/channel (if any): cron
- Relevant config (redacted): default cron store path semantics

### Steps

1. Create a cron store or run-log file using the existing cron writers.
2. Inspect mode bits with `stat`/`fs.stat`.
3. Trigger a rewrite so `jobs.json.bak` or `runs/<job>.jsonl` is recreated.

### Expected

- `jobs.json`, `jobs.json.bak`, and `runs/*.jsonl` are `0600`.
- `cron/runs/` is `0700`.

### Actual

- Files were created as `0644` and `cron/runs/` as `0755`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced default Node file creation mode locally with a minimal `fs.writeFile` script (`644`).
  - Verified `saveCronStore` now writes the store and backup with `0600` and keeps the cron dir at `0700`.
  - Verified `appendCronRunLog` now creates `runs/` as `0700` and log files as `0600`.
- Edge cases checked:
  - Backup copy path.
  - Atomic tmp-file rewrite path used by store saves and run-log pruning.
  - Windows fallback copy path still preserves private file mode best-effort.
- What you did **not** verify:
  - Full end-to-end cron execution on Windows filesystem ACLs.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR to restore the previous default write mode behavior.
- Files/config to restore: `src/cron/store.ts`, `src/cron/run-log.ts`
- Known bad symptoms reviewers should watch for: cron store/run-log writes failing on unusual filesystems that reject chmod after create/rename.

## Risks and Mitigations

- Risk: some filesystems may reject chmod after create/rename.
  - Mitigation: mode enforcement is best-effort (`catch(() => undefined)`), so cron writes still complete even if chmod is unsupported.
