### PR TITLE
Add opt-in warnings for invalid external plugin catalog JSON

### DIFF
--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -58,6 +58,7 @@ const DEFAULT_CATALOG_PATHS = [
 ];
 
 const ENV_CATALOG_PATHS = ["OPENCLAW_PLUGIN_CATALOG_PATHS", "OPENCLAW_MPM_CATALOG_PATHS"];
+const WARN_INVALID_CATALOG_ENV = "OPENCLAW_PLUGIN_CATALOG_WARN_INVALID";
 
 type ManifestKey = typeof MANIFEST_KEY;
 
@@ -100,9 +101,25 @@ function resolveExternalCatalogPaths(options: CatalogOptions): string[] {
   return DEFAULT_CATALOG_PATHS;
 }
 
+function shouldWarnOnInvalidCatalogFile(env: NodeJS.ProcessEnv): boolean {
+  const raw = env[WARN_INVALID_CATALOG_ENV]?.trim().toLowerCase();
+  if (!raw) {
+    return false;
+  }
+  return raw !== "0" && raw !== "false" && raw !== "off";
+}
+
+function formatCatalogLoadError(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim();
+  }
+  return String(error);
+}
+
 function loadExternalCatalogEntries(options: CatalogOptions): ExternalCatalogEntry[] {
   const paths = resolveExternalCatalogPaths(options);
   const entries: ExternalCatalogEntry[] = [];
+  const warnOnInvalidCatalog = shouldWarnOnInvalidCatalogFile(process.env);
   for (const rawPath of paths) {
     const resolved = resolveUserPath(rawPath);
     if (!fs.existsSync(resolved)) {
@@ -111,8 +128,13 @@ function loadExternalCatalogEntries(options: CatalogOptions): ExternalCatalogEnt
     try {
       const payload = JSON.parse(fs.readFileSync(resolved, "utf-8")) as unknown;
       entries.push(...parseCatalogEntries(payload));
-    } catch {
+    } catch (err) {
       // Ignore invalid catalog files.
+      if (warnOnInvalidCatalog) {
+        console.warn(
+          `[plugins/catalog] ignored invalid catalog file: ${resolved} (${formatCatalogLoadError(err)})`,
+        );
+      }
     }
   }
   return entries;

--- a/src/channels/plugins/plugins-core.test.ts
+++ b/src/channels/plugins/plugins-core.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { DiscordProbe } from "../../discord/probe.js";
 import type { DiscordTokenResolution } from "../../discord/token.js";
@@ -143,6 +143,31 @@ describe("channel plugin catalog", () => {
       (entry) => entry.id,
     );
     expect(ids).toContain("demo-channel");
+  });
+
+  it("warns when external catalog JSON is invalid and warning env is enabled", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-catalog-invalid-"));
+    const catalogPath = path.join(dir, "catalog.json");
+    fs.writeFileSync(catalogPath, "{bad json", "utf-8");
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const previous = process.env.OPENCLAW_PLUGIN_CATALOG_WARN_INVALID;
+    process.env.OPENCLAW_PLUGIN_CATALOG_WARN_INVALID = "1";
+    try {
+      const ids = listChannelPluginCatalogEntries({ catalogPaths: [catalogPath] }).map(
+        (entry) => entry.id,
+      );
+      expect(ids).toContain("msteams");
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("ignored invalid catalog file"));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(catalogPath));
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_PLUGIN_CATALOG_WARN_INVALID;
+      } else {
+        process.env.OPENCLAW_PLUGIN_CATALOG_WARN_INVALID = previous;
+      }
+      warnSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary\n- add an opt-in warning path for malformed external plugin catalog files\n- keep default behavior unchanged (invalid files are still ignored silently unless explicitly enabled)\n- add unit coverage for the new warning behavior\n\n## Why\nInvalid external catalog files were silently skipped, which made troubleshooting harder when users provided custom catalog paths.\n\n## Impact\nWhen  is set, OpenClaw now emits a warning with the resolved file path and parse error. Default behavior remains unchanged.\n\n## Risk\nLow risk: this is gated behind an environment variable and only affects logging on parse failures.