### PR TITLE
fix(discord): align doctor/skills-status Discord token detection with runtime checks

### DIFF
--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
+import { isDiscordTokenConfigured } from "../discord/token.js";
 import { evaluateEntryRequirementsForCurrentPlatform } from "../shared/entry-status.js";
 import type { RequirementConfigCheck, Requirements } from "../shared/requirements.js";
 import { CONFIG_DIR } from "../utils.js";
@@ -185,7 +186,12 @@ function buildSkillStatus(
       skillConfig?.env?.[envName] ||
       (skillConfig?.apiKey && entry.metadata?.primaryEnv === envName),
     );
-  const isConfigSatisfied = (pathStr: string) => isConfigPathTruthy(config, pathStr);
+  const isConfigSatisfied = (pathStr: string) => {
+    if (pathStr === "channels.discord.token") {
+      return isDiscordTokenConfigured(config);
+    }
+    return isConfigPathTruthy(config, pathStr);
+  };
   const bundled =
     bundledNames && bundledNames.size > 0
       ? bundledNames.has(entry.skill.name)

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig, SkillConfig } from "../../config/config.js";
+import { isDiscordTokenConfigured } from "../../discord/token.js";
 import {
   evaluateRuntimeEligibility,
   hasBinary,
@@ -97,6 +98,11 @@ export function shouldIncludeSkill(params: {
         skillConfig?.env?.[envName] ||
         (skillConfig?.apiKey && entry.metadata?.primaryEnv === envName),
       ),
-    isConfigPathTruthy: (configPath) => isConfigPathTruthy(config, configPath),
+    isConfigPathTruthy: (configPath) => {
+      if (configPath === "channels.discord.token") {
+        return isDiscordTokenConfigured(config);
+      }
+      return isConfigPathTruthy(config, configPath);
+    },
   });
 }

--- a/src/discord/token.test.ts
+++ b/src/discord/token.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveDiscordToken } from "./token.js";
+import { isDiscordTokenConfigured, resolveDiscordToken } from "./token.js";
 
 describe("resolveDiscordToken", () => {
   afterEach(() => {
@@ -103,5 +103,44 @@ describe("resolveDiscordToken", () => {
     expect(() => resolveDiscordToken(cfg)).toThrow(
       /channels\.discord\.token: unresolved SecretRef/i,
     );
+  });
+});
+
+describe("isDiscordTokenConfigured", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns true when channels.discord.token is set", () => {
+    const cfg = {
+      channels: { discord: { token: "bot-token" } },
+    } as OpenClawConfig;
+    expect(isDiscordTokenConfigured(cfg)).toBe(true);
+  });
+
+  it("returns true when DISCORD_BOT_TOKEN env is set", () => {
+    vi.stubEnv("DISCORD_BOT_TOKEN", "env-token");
+    const cfg = { channels: { discord: {} } } as OpenClawConfig;
+    expect(isDiscordTokenConfigured(cfg)).toBe(true);
+  });
+
+  it("returns true when an account token is configured", () => {
+    const cfg = {
+      channels: {
+        discord: {
+          accounts: { work: { token: "account-token" } },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    expect(isDiscordTokenConfigured(cfg)).toBe(true);
+  });
+
+  it("returns false when no token source is available", () => {
+    const cfg = { channels: { discord: {} } } as OpenClawConfig;
+    expect(isDiscordTokenConfigured(cfg)).toBe(false);
+  });
+
+  it("returns false when config is undefined", () => {
+    expect(isDiscordTokenConfigured(undefined)).toBe(false);
   });
 });

--- a/src/discord/token.ts
+++ b/src/discord/token.ts
@@ -69,3 +69,33 @@ export function resolveDiscordToken(
 
   return { token: "", source: "none" };
 }
+
+/**
+ * Returns true when any Discord token source is configured (config, accounts, or env).
+ * Shared helper for consistent credential detection across doctor, skills-status,
+ * and security audit paths.
+ */
+export function isDiscordTokenConfigured(cfg?: OpenClawConfig): boolean {
+  const discordCfg = cfg?.channels?.discord;
+  if (normalizeDiscordToken(discordCfg?.token ?? undefined, "channels.discord.token")) {
+    return true;
+  }
+  const accounts = discordCfg?.accounts;
+  if (accounts && typeof accounts === "object" && !Array.isArray(accounts)) {
+    for (const account of Object.values(accounts)) {
+      if (
+        account &&
+        normalizeDiscordToken(
+          (account as { token?: unknown }).token ?? undefined,
+          "channels.discord.accounts.*.token",
+        )
+      ) {
+        return true;
+      }
+    }
+  }
+  if (normalizeDiscordToken(process.env.DISCORD_BOT_TOKEN, "DISCORD_BOT_TOKEN")) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

- **Problem:** Skills eligibility (used by doctor/status) only checked `channels.discord.token` to determine if Discord was configured, while runtime security checks (`audit-extra.async.ts`) also checked `channels.discord.accounts.*.token` and `DISCORD_BOT_TOKEN` env var. This caused false "Discord not configured" reports when tokens were provided via accounts or env.
- **Why it matters:** Operators setting up Discord via env var or multi-account config saw the Discord skill marked as ineligible in status/doctor output, despite Discord working correctly at runtime.
- **What changed:** (1) Added `isDiscordTokenConfigured(cfg)` shared helper in `src/discord/token.ts` that checks all three token sources (config, accounts, env). (2) Updated `isConfigSatisfied` callbacks in `skills-status.ts` and `skills/config.ts` to use this helper for `channels.discord.token` path checks.
- **What did NOT change:** Runtime security audit logic, Discord plugin `isConfigured`, non-Discord config path checks. The `resolveDiscordToken` function is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36550

## User-visible / Behavior Changes

- Discord skill now correctly shows as "configured" in status/doctor output when credentials are provided via `DISCORD_BOT_TOKEN` env var or `channels.discord.accounts.*.token`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22
- Integration/channel: Discord

### Steps

1. Set `DISCORD_BOT_TOKEN` env var (without `channels.discord.token` in config)
2. Run `/status` or `doctor`
3. Check Discord skill eligibility

### Expected

- Discord skill shows as configured/eligible

### Actual

- Before fix: Discord skill shows as not configured (missing `channels.discord.token`)
- After fix: Discord skill shows as configured (detected via env var)

## Evidence

```
 src/agents/skills-status.ts |  8 +++++-
 src/agents/skills/config.ts |  8 +++++-
 src/discord/token.test.ts   | 41 +++++++++++++++++++++++++++++++++-
 src/discord/token.ts        | 30 +++++++++++++++++++++++++
 4 files changed, 84 insertions(+), 3 deletions(-)
```

All 12 tests pass in `token.test.ts` (7 existing + 5 new), including coverage for config token, env token, accounts token, no token, and undefined config scenarios. Skills-status test also passes.

## Human Verification (required)

- Verified scenarios: config token, env token, account token, no token, undefined config
- Edge cases checked: non-default account tokens, empty token strings, account object that is an array (ignored)
- What I did **not** verify: Live doctor output with multi-account Discord setup

## Compatibility / Migration

- Backward compatible? `Yes — only expands what counts as "configured", no behavior removed`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit to restore original `isConfigPathTruthy`-only check
- Files/config to restore: `src/agents/skills-status.ts`, `src/agents/skills/config.ts`, `src/discord/token.ts`
- Known bad symptoms: Discord skill might show as "configured" when it shouldn't (unlikely since all token sources are also checked at runtime)

## Risks and Mitigations

None — this aligns the status/doctor detection with the runtime security audit, which is the ground truth for whether Discord is usable.

