### PR TITLE
fix(feishu): remove unsupported media timeout payload fields

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -182,7 +182,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("uses image upload timeout override for image media", async () => {
+  it("uploads image media with the supported SDK request shape", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -192,7 +192,7 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(imageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        timeout: 120_000,
+        data: expect.objectContaining({ image_type: "message" }),
       }),
     );
     expect(messageCreateMock).toHaveBeenCalledWith(
@@ -320,7 +320,6 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(imageGetMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { image_key: imageKey },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toEqual(Buffer.from("image-data"));
@@ -512,7 +511,6 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_audio_msg", file_key: "file_key_audio" },
         params: { type: "file" },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);
@@ -532,7 +530,6 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_img_msg", file_key: "img_key_1" },
         params: { type: "image" },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -200,6 +200,12 @@ describe("sendMediaFeishu msg_type routing", () => {
         data: expect.objectContaining({ msg_type: "image" }),
       }),
     );
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "main",
+        httpTimeoutMs: 120_000,
+      }),
+    );
   });
 
   it("uses msg_type=media when replying with mp4", async () => {
@@ -320,6 +326,12 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(imageGetMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { image_key: imageKey },
+      }),
+    );
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "main",
+        httpTimeoutMs: 120_000,
       }),
     );
     expect(result.buffer).toEqual(Buffer.from("image-data"));

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -9,8 +9,6 @@ import { getFeishuRuntime } from "./runtime.js";
 import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
 
-const FEISHU_MEDIA_HTTP_TIMEOUT_MS = 120_000;
-
 export type DownloadImageResult = {
   buffer: Buffer;
   contentType?: string;

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -9,6 +9,8 @@ import { getFeishuRuntime } from "./runtime.js";
 import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
 
+const FEISHU_MEDIA_HTTP_TIMEOUT_MS = 120_000;
+
 export type DownloadImageResult = {
   buffer: Buffer;
   contentType?: string;
@@ -78,6 +80,11 @@ async function readFeishuResponseBuffer(params: {
   throw new Error(`${params.errorPrefix}: unexpected response format. Keys: [${types}]`);
 }
 
+function createFeishuMediaClient(account: ReturnType<typeof resolveFeishuAccount>) {
+  // Media uploads/downloads routinely take longer than the default API budget.
+  return createFeishuClient({ ...account, httpTimeoutMs: FEISHU_MEDIA_HTTP_TIMEOUT_MS });
+}
+
 /**
  * Download an image from Feishu using image_key.
  * Used for downloading images sent in messages.
@@ -97,10 +104,7 @@ export async function downloadImageFeishu(params: {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
   }
 
-  const client = createFeishuClient({
-    ...account,
-    httpTimeoutMs: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
-  });
+  const client = createFeishuMediaClient(account);
 
   const response = await client.im.image.get({
     path: { image_key: normalizedImageKey },
@@ -135,10 +139,7 @@ export async function downloadMessageResourceFeishu(params: {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
   }
 
-  const client = createFeishuClient({
-    ...account,
-    httpTimeoutMs: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
-  });
+  const client = createFeishuMediaClient(account);
 
   const response = await client.im.messageResource.get({
     path: { message_id: messageId, file_key: normalizedFileKey },
@@ -182,10 +183,7 @@ export async function uploadImageFeishu(params: {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
   }
 
-  const client = createFeishuClient({
-    ...account,
-    httpTimeoutMs: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
-  });
+  const client = createFeishuMediaClient(account);
 
   // SDK accepts Buffer directly or fs.ReadStream for file paths
   // Using Readable.from(buffer) causes issues with form-data library
@@ -252,10 +250,7 @@ export async function uploadFileFeishu(params: {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
   }
 
-  const client = createFeishuClient({
-    ...account,
-    httpTimeoutMs: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
-  });
+  const client = createFeishuMediaClient(account);
 
   // SDK accepts Buffer directly or fs.ReadStream for file paths
   // Using Readable.from(buffer) causes issues with form-data library


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `pnpm check` on `main` failed in `extensions/feishu/src/media.ts` because Feishu media SDK calls still passed a top-level `timeout` field that current SDK method typings reject.
- Why it matters: repo-wide checks stopped before completion, blocking Feishu changes and unrelated upstream work.
- What changed: removed unsupported per-call `timeout` payload fields from Feishu media helper calls and updated regression tests to assert the supported request shape.
- What did NOT change (scope boundary): no dependency changes, no Feishu timeout policy changes, and no send/download behavior changes beyond using the existing client-level timeout wrapper.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36581
- Related #36500

## User-visible / Behavior Changes

Users no longer hit a repo-wide typecheck failure from Feishu media helpers. Runtime Feishu media timeout behavior is unchanged because requests still go through the timeout-aware client HTTP wrapper.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Feishu extension
- Relevant config (redacted): default repo checkout; no special config required

### Steps

1. Check out current `main` before this patch.
2. Run `pnpm check`.
3. Observe `TS2353` errors in `extensions/feishu/src/media.ts` for unsupported `timeout` properties on `client.im.image.get`, `client.im.messageResource.get`, `client.im.image.create`, and `client.im.file.create` payloads.
4. Apply this patch and rerun the same commands.

### Expected

- Feishu media helpers use a request shape accepted by the current SDK typings.
- `pnpm check` completes successfully.

### Actual

- `pnpm check` failed early with `TS2353` because the method payloads still included unsupported `timeout` fields.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test extensions/feishu/src/media.test.ts extensions/feishu/src/client.test.ts`; ran `pnpm check`.
- Edge cases checked: confirmed download/upload test expectations still cover image and file resource calls after removing per-call timeout fields.
- What you did **not** verify: live Feishu API traffic against a real tenant.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `0e88e4cca8`.
- Files/config to restore: `extensions/feishu/src/media.ts`, `extensions/feishu/src/media.test.ts`.
- Known bad symptoms reviewers should watch for: Feishu media tests failing because SDK request payload expectations drift again.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: some SDK methods might previously have honored undocumented per-call timeout overrides.
  - Mitigation: the client already injects timeouts centrally via `createFeishuClient()`; this patch only removes fields the current SDK typings reject.
