### PR TITLE
Cron: keep hot stagger offsets in bounded cache

### DIFF
--- a/src/cron/service.jobs.top-of-hour-stagger.test.ts
+++ b/src/cron/service.jobs.top-of-hour-stagger.test.ts
@@ -1,8 +1,10 @@
 import crypto from "node:crypto";
-import { describe, expect, it, vi } from "vitest";
-import { computeJobNextRunAtMs } from "./service/jobs.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { clearStaggerOffsetCacheForTest, computeJobNextRunAtMs } from "./service/jobs.js";
 import { DEFAULT_TOP_OF_HOUR_STAGGER_MS } from "./stagger.js";
 import type { CronJob } from "./types.js";
+
+const STAGGER_OFFSET_CACHE_MAX = 4096;
 
 function stableOffsetMs(jobId: string, windowMs: number) {
   const digest = crypto.createHash("sha256").update(jobId).digest();
@@ -31,6 +33,10 @@ function createCronJob(params: {
 }
 
 describe("computeJobNextRunAtMs top-of-hour staggering", () => {
+  beforeEach(() => {
+    clearStaggerOffsetCacheForTest();
+  });
+
   it("applies deterministic 0..5m stagger for recurring top-of-hour schedules", () => {
     const now = Date.parse("2026-02-06T10:05:00.000Z");
     const job = createCronJob({ id: "hourly-job-a", expr: "0 * * * *", tz: "UTC" });
@@ -101,6 +107,30 @@ describe("computeJobNextRunAtMs top-of-hour staggering", () => {
 
     expect(second).toBe(first);
     expect(hashSpy).toHaveBeenCalledTimes(1);
+    hashSpy.mockRestore();
+  });
+
+  it("keeps recently used stagger offsets when cache hits capacity", () => {
+    const now = Date.parse("2026-02-06T10:05:00.000Z");
+    const expr = "0 * * * *";
+    const tz = "UTC";
+    const hot = createCronJob({ id: "hourly-job-hot", expr, tz });
+    const hashSpy = vi.spyOn(crypto, "createHash");
+
+    computeJobNextRunAtMs(hot, now);
+
+    for (let i = 0; i < STAGGER_OFFSET_CACHE_MAX - 1; i += 1) {
+      computeJobNextRunAtMs(createCronJob({ id: `hourly-job-fill-${i}`, expr, tz }), now);
+    }
+
+    // Mark the hot key as recently used before we overflow capacity.
+    computeJobNextRunAtMs(hot, now);
+    computeJobNextRunAtMs(createCronJob({ id: "hourly-job-overflow", expr, tz }), now);
+
+    hashSpy.mockClear();
+    computeJobNextRunAtMs(hot, now);
+
+    expect(hashSpy).toHaveBeenCalledTimes(0);
     hashSpy.mockRestore();
   });
 });

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -46,6 +46,9 @@ function resolveStableCronOffsetMs(jobId: string, staggerMs: number) {
   const cacheKey = `${staggerMs}:${jobId}`;
   const cached = staggerOffsetCache.get(cacheKey);
   if (cached !== undefined) {
+    // Refresh insertion order so eviction prefers stale entries.
+    staggerOffsetCache.delete(cacheKey);
+    staggerOffsetCache.set(cacheKey, cached);
     return cached;
   }
   const digest = crypto.createHash("sha256").update(jobId).digest();
@@ -58,6 +61,10 @@ function resolveStableCronOffsetMs(jobId: string, staggerMs: number) {
   }
   staggerOffsetCache.set(cacheKey, offset);
   return offset;
+}
+
+export function clearStaggerOffsetCacheForTest(): void {
+  staggerOffsetCache.clear();
 }
 
 function computeStaggeredCronNextRunAtMs(job: CronJob, nowMs: number) {


### PR DESCRIPTION
## Summary
- refresh stagger-offset cache entries on read so eviction drops stale entries first
- keep cache bounded as before (4096) while reducing re-hash churn for hot cron jobs
- add a regression test that fills cache to capacity and verifies a recently used key stays cached

## Why
The cache is bounded, but previous eviction order was insert-only FIFO. Under high churn, frequently used keys could be evicted and re-hashed immediately.

## Impact
- lower repeat hashing in long-running cron workloads with many unique job IDs
- no change to scheduling semantics or stagger values

## Risk
Low. Change is limited to cache bookkeeping and covered by targeted tests.
