### PR TITLE
feat(slack): per-channel replyToMode config override

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -293,7 +293,30 @@ Reply threading controls:
 
 - `channels.slack.replyToMode`: `off|first|all` (default `off`)
 - `channels.slack.replyToModeByChatType`: per `direct|group|channel`
+- per-channel override: `channels.slack.channels.<id|name>.replyToMode`
 - legacy fallback for direct chats: `channels.slack.dm.replyToMode`
+
+Per-channel `replyToMode` takes highest priority, then falls through the account-level resolution chain:
+
+```json5
+{
+  channels: {
+    slack: {
+      replyToMode: "off", // account default
+      channels: {
+        "#support": {
+          allow: true,
+          replyToMode: "all", // thread all replies in #support
+        },
+        "#general": {
+          allow: true,
+          replyToMode: "first", // thread only first reply in #general
+        },
+      },
+    },
+  },
+}
+```
 
 Manual reply tags are supported:
 

--- a/extensions/slack/src/monitor/channel-config.test.ts
+++ b/extensions/slack/src/monitor/channel-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { SlackChannelSchema } from "../../config/zod-schema.providers-core.js";
 import { resolveSlackChannelConfig } from "./channel-config.js";
 
 describe("resolveSlackChannelConfig replyToMode fields", () => {
@@ -35,5 +36,21 @@ describe("resolveSlackChannelConfig replyToMode fields", () => {
       channels: { C123: { allow: true } },
     });
     expect(result?.replyToMode).toBeUndefined();
+  });
+});
+
+describe("SlackChannelSchema replyToMode field", () => {
+  it("accepts valid replyToMode values", () => {
+    for (const value of ["off", "first", "all"] as const) {
+      const result = SlackChannelSchema.safeParse({ replyToMode: value });
+      expect(result.success, `expected "${value}" to be valid`).toBe(true);
+    }
+  });
+
+  it("rejects invalid replyToMode values", () => {
+    for (const value of ["invalid", true, 123]) {
+      const result = SlackChannelSchema.safeParse({ replyToMode: value });
+      expect(result.success, `expected ${JSON.stringify(value)} to be invalid`).toBe(false);
+    }
   });
 });

--- a/extensions/slack/src/monitor/channel-config.test.ts
+++ b/extensions/slack/src/monitor/channel-config.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { resolveSlackChannelConfig } from "./channel-config.js";
+
+describe("resolveSlackChannelConfig replyToMode fields", () => {
+  it("returns replyToMode from exact channel match", () => {
+    const result = resolveSlackChannelConfig({
+      channelId: "C123",
+      channels: { C123: { allow: true, replyToMode: "all" } },
+    });
+    expect(result?.replyToMode).toBe("all");
+  });
+
+  it("uses wildcard replyToMode as fallback", () => {
+    const result = resolveSlackChannelConfig({
+      channelId: "C999",
+      channels: { "*": { allow: true, replyToMode: "first" } },
+    });
+    expect(result?.replyToMode).toBe("first");
+  });
+
+  it("channel-specific replyToMode overrides wildcard", () => {
+    const result = resolveSlackChannelConfig({
+      channelId: "C123",
+      channels: {
+        "*": { allow: true, replyToMode: "first" },
+        C123: { allow: true, replyToMode: "all" },
+      },
+    });
+    expect(result?.replyToMode).toBe("all");
+  });
+
+  it("returns undefined when replyToMode is not set", () => {
+    const result = resolveSlackChannelConfig({
+      channelId: "C123",
+      channels: { C123: { allow: true } },
+    });
+    expect(result?.replyToMode).toBeUndefined();
+  });
+});

--- a/extensions/slack/src/monitor/channel-config.ts
+++ b/extensions/slack/src/monitor/channel-config.ts
@@ -5,6 +5,7 @@ import {
   type ChannelMatchSource,
 } from "../../../../src/channels/channel-config.js";
 import type { SlackReactionNotificationMode } from "../../../../src/config/config.js";
+import type { ReplyToMode } from "../../../../src/config/types.base.js";
 import type { SlackMessageEvent } from "../types.js";
 import { allowListMatches, normalizeAllowListLower, normalizeSlackSlug } from "./allow-list.js";
 
@@ -17,7 +18,7 @@ export type SlackChannelConfigResolved = {
   systemPrompt?: string;
   matchKey?: string;
   matchSource?: ChannelMatchSource;
-  replyToMode?: "off" | "first" | "all";
+  replyToMode?: ReplyToMode;
 };
 
 export type SlackChannelConfigEntry = {
@@ -28,7 +29,7 @@ export type SlackChannelConfigEntry = {
   users?: Array<string | number>;
   skills?: string[];
   systemPrompt?: string;
-  replyToMode?: "off" | "first" | "all";
+  replyToMode?: ReplyToMode;
 };
 
 export type SlackChannelConfigEntries = Record<string, SlackChannelConfigEntry>;

--- a/extensions/slack/src/monitor/channel-config.ts
+++ b/extensions/slack/src/monitor/channel-config.ts
@@ -17,6 +17,7 @@ export type SlackChannelConfigResolved = {
   systemPrompt?: string;
   matchKey?: string;
   matchSource?: ChannelMatchSource;
+  replyToMode?: "off" | "first" | "all";
 };
 
 export type SlackChannelConfigEntry = {
@@ -27,6 +28,7 @@ export type SlackChannelConfigEntry = {
   users?: Array<string | number>;
   skills?: string[];
   systemPrompt?: string;
+  replyToMode?: "off" | "first" | "all";
 };
 
 export type SlackChannelConfigEntries = Record<string, SlackChannelConfigEntry>;
@@ -145,6 +147,7 @@ export function resolveSlackChannelConfig(params: {
   const users = firstDefined(resolved.users, fallback?.users);
   const skills = firstDefined(resolved.skills, fallback?.skills);
   const systemPrompt = firstDefined(resolved.systemPrompt, fallback?.systemPrompt);
+  const replyToMode = firstDefined(resolved.replyToMode, fallback?.replyToMode);
   const result: SlackChannelConfigResolved = {
     allowed,
     requireMention,
@@ -152,6 +155,7 @@ export function resolveSlackChannelConfig(params: {
     users,
     skills,
     systemPrompt,
+    replyToMode,
   };
   return applyChannelMatchMeta(result, match);
 }

--- a/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { SlackChannelSchema } from "../../../config/zod-schema.providers-core.js";
 import { isSlackStreamingEnabled, resolveSlackStreamingThreadHint } from "./dispatch.js";
 
 describe("slack native streaming defaults", () => {
@@ -44,21 +43,5 @@ describe("slack native streaming thread hint", () => {
         messageTs: "1000.3",
       }),
     ).toBe("2000.1");
-  });
-});
-
-describe("SlackChannelSchema replyToMode field", () => {
-  it("accepts valid replyToMode values", () => {
-    for (const value of ["off", "first", "all"] as const) {
-      const result = SlackChannelSchema.safeParse({ replyToMode: value });
-      expect(result.success, `expected "${value}" to be valid`).toBe(true);
-    }
-  });
-
-  it("rejects invalid replyToMode values", () => {
-    for (const value of ["invalid", true, 123]) {
-      const result = SlackChannelSchema.safeParse({ replyToMode: value });
-      expect(result.success, `expected ${JSON.stringify(value)} to be invalid`).toBe(false);
-    }
   });
 });

--- a/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { SlackChannelSchema } from "../../../config/zod-schema.providers-core.js";
 import { isSlackStreamingEnabled, resolveSlackStreamingThreadHint } from "./dispatch.js";
 
 describe("slack native streaming defaults", () => {
@@ -43,5 +44,21 @@ describe("slack native streaming thread hint", () => {
         messageTs: "1000.3",
       }),
     ).toBe("2000.1");
+  });
+});
+
+describe("SlackChannelSchema replyToMode field", () => {
+  it("accepts valid replyToMode values", () => {
+    for (const value of ["off", "first", "all"] as const) {
+      const result = SlackChannelSchema.safeParse({ replyToMode: value });
+      expect(result.success, `expected "${value}" to be valid`).toBe(true);
+    }
+  });
+
+  it("rejects invalid replyToMode values", () => {
+    for (const value of ["invalid", true, 123]) {
+      const result = SlackChannelSchema.safeParse({ replyToMode: value });
+      expect(result.success, `expected ${JSON.stringify(value)} to be invalid`).toBe(false);
+    }
   });
 });

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -416,6 +416,90 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared!.ctxPayload.MessageThreadId).toBeUndefined();
   });
 
+  it("per-channel replyToMode overrides account-level replyToMode", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: { slack: { enabled: true, replyToMode: "off", groupPolicy: "open" } },
+      } as OpenClawConfig,
+      defaultRequireMention: false,
+      channelsConfig: { C123: { replyToMode: "all" } } as never,
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount({ replyToMode: "off" }),
+      createSlackMessage({ channel: "C123", channel_type: "channel" }),
+    );
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.replyToMode).toBe("all");
+  });
+
+  it("per-channel replyToMode overrides replyToModeByChatType", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: { slack: { enabled: true, replyToMode: "off", groupPolicy: "open" } },
+      } as OpenClawConfig,
+      defaultRequireMention: false,
+      channelsConfig: { C123: { replyToMode: "first" } } as never,
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount({ replyToMode: "off", replyToModeByChatType: { channel: "all" } }),
+      createSlackMessage({ channel: "C123", channel_type: "channel" }),
+    );
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.replyToMode).toBe("first");
+  });
+
+  it("falls through to account-level when per-channel replyToMode is unset", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+      } as OpenClawConfig,
+      defaultRequireMention: false,
+      replyToMode: "all",
+      channelsConfig: { C123: {} } as never,
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount({ replyToMode: "all" }),
+      createSlackMessage({ channel: "C123", channel_type: "channel" }),
+    );
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.replyToMode).toBe("all");
+  });
+
+  it("DM channelConfig is null so per-channel replyToMode does not apply", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: { slack: { enabled: true, replyToMode: "all" } },
+      } as OpenClawConfig,
+      replyToMode: "all",
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
+
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount({ replyToMode: "all" }),
+      createSlackMessage({}),
+    );
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.replyToMode).toBe("all");
+  });
+
   it("marks first thread turn and injects thread history for a new thread session", async () => {
     const { storePath } = makeTmpStorePath();
     const replies = vi

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -261,8 +261,10 @@ function resolveSlackRoutingContext(params: {
   isGroupDm: boolean;
   isRoom: boolean;
   isRoomish: boolean;
+  channelConfig: ReturnType<typeof resolveSlackChannelConfig> | null;
 }): SlackRoutingContext {
-  const { ctx, account, message, isDirectMessage, isGroupDm, isRoom, isRoomish } = params;
+  const { ctx, account, message, isDirectMessage, isGroupDm, isRoom, isRoomish, channelConfig } =
+    params;
   const route = resolveAgentRoute({
     cfg: ctx.cfg,
     channel: "slack",
@@ -353,6 +355,7 @@ export async function prepareSlackMessage(params: {
     isGroupDm,
     isRoom,
     isRoomish,
+    channelConfig,
   });
   const {
     route,

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -275,7 +275,8 @@ function resolveSlackRoutingContext(params: {
   });
 
   const chatType = isDirectMessage ? "direct" : isGroupDm ? "group" : "channel";
-  const replyToMode = resolveSlackReplyToMode(account, chatType);
+  const accountReplyToMode = resolveSlackReplyToMode(account, chatType);
+  const replyToMode = channelConfig?.replyToMode ?? accountReplyToMode;
   const threadContext = resolveSlackThreadContext({ message, replyToMode });
   const threadTs = threadContext.incomingThreadTs;
   const isThreadReply = threadContext.isThreadReply;

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -45,6 +45,8 @@ export type SlackChannelConfig = {
   skills?: string[];
   /** Optional system prompt for this channel. */
   systemPrompt?: string;
+  /** Per-channel reply threading override (overrides account-level replyToMode). */
+  replyToMode?: ReplyToMode;
 };
 
 export type SlackReactionNotificationMode = "off" | "own" | "all" | "allowlist";

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -820,6 +820,7 @@ export const SlackChannelSchema = z
     users: z.array(z.union([z.string(), z.number()])).optional(),
     skills: z.array(z.string()).optional(),
     systemPrompt: z.string().optional(),
+    replyToMode: ReplyToModeSchema.optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

Closes #31130

- Add `replyToMode` field to `SlackChannelConfig` type and Zod schema
- Add resolution in `resolveSlackChannelConfig()` with `firstDefined()` fallback
- Apply per-channel override in `prepare.ts` before the account-level resolution chain
- DMs unaffected (`channelConfig` is null for DMs, so override is skipped)

Resolution priority:
1. Per-channel `replyToMode` (new)
2. `replyToModeByChatType`
3. `dm.replyToMode` (legacy)
4. Account-level `replyToMode`
5. `"off"` (default)

## Test plan

- [x] `resolveSlackChannelConfig` returns `replyToMode` from exact channel match
- [x] Wildcard `replyToMode` used as fallback
- [x] Channel-specific overrides wildcard
- [x] `undefined` when not set
- [x] Per-channel overrides account-level `replyToMode`
- [x] Per-channel overrides `replyToModeByChatType`
- [x] Falls through when per-channel unset
- [x] DM `channelConfig` is null — account defaults apply
- [x] Zod schema accepts valid values, rejects invalid
- [x] `pnpm build` passes
- [x] `pnpm check` passes
- [x] Deployed and tested on live gateways

🤖 Generated with [Claude Code](https://claude.com/claude-code)