### PR TITLE
Media: short-circuit oversized responses by content-length

### DIFF
--- a/src/media/read-response-with-limit.test.ts
+++ b/src/media/read-response-with-limit.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { readResponseWithLimit } from "./read-response-with-limit.js";
+
+function makeStream(chunks: Uint8Array[], onPull?: () => void): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      onPull?.();
+      const next = chunks.shift();
+      if (!next) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(next);
+    },
+  });
+}
+
+describe("readResponseWithLimit", () => {
+  it("rejects immediately when content-length exceeds the limit", async () => {
+    let getReaderCalled = false;
+    let arrayBufferCalled = false;
+    const res = {
+      headers: new Headers({ "content-length": "5" }),
+      body: {
+        getReader() {
+          getReaderCalled = true;
+          throw new Error("getReader should not be called");
+        },
+      },
+      async arrayBuffer() {
+        arrayBufferCalled = true;
+        throw new Error("arrayBuffer should not be called");
+      },
+    } as unknown as Response;
+
+    await expect(readResponseWithLimit(res, 4)).rejects.toThrow(
+      "Content too large: 5 bytes (limit: 4 bytes)",
+    );
+    expect(getReaderCalled).toBe(false);
+    expect(arrayBufferCalled).toBe(false);
+  });
+
+  it("falls back to streamed counting when content-length is invalid", async () => {
+    const res = new Response(makeStream([new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])]), {
+      headers: { "content-length": "not-a-number" },
+    });
+
+    await expect(readResponseWithLimit(res, 4)).rejects.toThrow(
+      "Content too large: 6 bytes (limit: 4 bytes)",
+    );
+  });
+});

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -10,6 +10,14 @@ export async function readResponseWithLimit(
     ((params: { size: number; maxBytes: number }) =>
       new Error(`Content too large: ${params.size} bytes (limit: ${params.maxBytes} bytes)`));
 
+  const contentLengthHeader = res.headers.get("content-length");
+  if (contentLengthHeader) {
+    const contentLength = Number(contentLengthHeader);
+    if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+      throw onOverflow({ size: contentLength, maxBytes, res });
+    }
+  }
+
   const body = res.body;
   if (!body || typeof body.getReader !== "function") {
     const fallback = Buffer.from(await res.arrayBuffer());


### PR DESCRIPTION
## Summary
- add an early `content-length` bound check in `readResponseWithLimit` so oversized payloads fail before stream reads start
- keep existing streamed-size enforcement as a fallback when `content-length` is missing or invalid
- add focused tests for both the early-reject path and invalid-header fallback path

## Why
`readResponseWithLimit` is reused by multiple media fetch paths. Applying the size guard in one place reduces unnecessary read work and ensures consistent bounds handling across callers.

## Risk
Low. The change only short-circuits when the server reports a finite `content-length` above `maxBytes`; all existing runtime checks remain in place.

## Validation
- `pnpm test src/media/read-response-with-limit.test.ts src/media/fetch.test.ts`
