### PR TITLE
fix(config): hash merged schema cache key to prevent RangeError with many channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/compaction safeguard pre-check: skip embedded compaction before entering the Pi SDK when a session has no real conversation messages, avoiding unnecessary LLM API calls on idle sessions. (#36451) thanks @Sid-Qin.
+- Config/schema cache key stability: build merged schema cache keys with incremental hashing to avoid large single-string serialization and prevent `RangeError: Invalid string length` on high-cardinality plugin/channel metadata. (#36603) Thanks @powermaster888.
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Sessions/daily reset transcript archival: archive prior transcript files during stale-session scheduled/daily resets by capturing the previous session entry before rollover, preventing orphaned transcript files on disk. (#35493) Thanks @byungsker.
 - Feishu/group slash command detection: normalize group mention wrappers before command-authorization probing so mention-prefixed commands (for example `@Bot/model` and `@Bot /reset`) are recognized as gateway commands instead of being forwarded to the agent. (#35994) Thanks @liuxiaopai-ai.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -323,10 +323,24 @@ function buildMergedSchemaCacheKey(params: {
       configUiHints: channel.configUiHints ?? null,
     }))
     .toSorted((a, b) => a.id.localeCompare(b.id));
-  // Hash the serialized key to avoid RangeError with many plugins/channels
-  // (JSON.stringify can exceed V8 string limits with 16+ channel schemas).
-  const raw = JSON.stringify({ plugins, channels });
-  return crypto.createHash("sha256").update(raw).digest("hex");
+  // Build the hash incrementally so we never materialize one giant JSON string.
+  const hash = crypto.createHash("sha256");
+  hash.update('{"plugins":[');
+  plugins.forEach((plugin, index) => {
+    if (index > 0) {
+      hash.update(",");
+    }
+    hash.update(JSON.stringify(plugin));
+  });
+  hash.update('],"channels":[');
+  channels.forEach((channel, index) => {
+    if (index > 0) {
+      hash.update(",");
+    }
+    hash.update(JSON.stringify(channel));
+  });
+  hash.update("]}");
+  return hash.digest("hex");
 }
 
 function setMergedSchemaCache(key: string, value: ConfigSchemaResponse): void {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { CHANNEL_IDS } from "../channels/registry.js";
 import { VERSION } from "../version.js";
 import type { ConfigUiHint, ConfigUiHints } from "./schema.hints.js";
@@ -322,7 +323,10 @@ function buildMergedSchemaCacheKey(params: {
       configUiHints: channel.configUiHints ?? null,
     }))
     .toSorted((a, b) => a.id.localeCompare(b.id));
-  return JSON.stringify({ plugins, channels });
+  // Hash the serialized key to avoid RangeError with many plugins/channels
+  // (JSON.stringify can exceed V8 string limits with 16+ channel schemas).
+  const raw = JSON.stringify({ plugins, channels });
+  return crypto.createHash("sha256").update(raw).digest("hex");
 }
 
 function setMergedSchemaCache(key: string, value: ConfigSchemaResponse): void {


### PR DESCRIPTION
## Summary

- `buildMergedSchemaCacheKey` serialized full plugin/channel metadata (including `configSchema` objects) via `JSON.stringify` and used the raw string as a `Map` key
- With 16+ Feishu channel accounts, each carrying a full config schema, the serialized string can exceed V8's string length limit, causing `RangeError: Invalid string length`
- Replace raw JSON string with SHA-256 hash (constant-size key regardless of channel count)

## Before / After

**Before:** `JSON.stringify({ plugins, channels })` used directly as cache key → crash with many channels  
**After:** `crypto.createHash("sha256").update(raw).digest("hex")` → fixed-length 64-char hex key

## Test plan

- [x] All `src/config/schema*.test.ts` pass (37 tests)
- [x] `pnpm check` passes
- Cache behavior unchanged — same inputs produce same hash, different inputs produce different hashes

Fixes #36508

🤖 Generated with [Claude Code](https://claude.com/claude-code)