### PR TITLE
test(cron): add webhook URL normalization tests

### DIFF
--- a/src/cron/webhook-url.test.ts
+++ b/src/cron/webhook-url.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { normalizeHttpWebhookUrl } from "./webhook-url.js";
+
+describe("normalizeHttpWebhookUrl", () => {
+  it("accepts valid http URLs", () => {
+    expect(normalizeHttpWebhookUrl("http://example.com/webhook")).toBe(
+      "http://example.com/webhook",
+    );
+  });
+
+  it("accepts valid https URLs", () => {
+    expect(normalizeHttpWebhookUrl("https://example.com/webhook")).toBe(
+      "https://example.com/webhook",
+    );
+  });
+
+  it("preserves query params and fragments", () => {
+    const url = "https://example.com/hook?key=abc&channel=test#ref";
+    expect(normalizeHttpWebhookUrl(url)).toBe(url);
+  });
+
+  it("rejects ftp protocol", () => {
+    expect(normalizeHttpWebhookUrl("ftp://example.com/file")).toBeNull();
+  });
+
+  it("rejects file protocol", () => {
+    expect(normalizeHttpWebhookUrl("file:///etc/passwd")).toBeNull();
+  });
+
+  it("rejects javascript protocol", () => {
+    expect(normalizeHttpWebhookUrl("javascript:alert(1)")).toBeNull();
+  });
+
+  it("rejects data protocol", () => {
+    expect(normalizeHttpWebhookUrl("data:text/html,<script>alert(1)</script>")).toBeNull();
+  });
+
+  it("rejects empty string", () => {
+    expect(normalizeHttpWebhookUrl("")).toBeNull();
+  });
+
+  it("rejects whitespace-only string", () => {
+    expect(normalizeHttpWebhookUrl("   ")).toBeNull();
+  });
+
+  it("rejects null and undefined", () => {
+    expect(normalizeHttpWebhookUrl(null)).toBeNull();
+    expect(normalizeHttpWebhookUrl(undefined)).toBeNull();
+  });
+
+  it("rejects non-string values", () => {
+    expect(normalizeHttpWebhookUrl(42)).toBeNull();
+    expect(normalizeHttpWebhookUrl(true)).toBeNull();
+    expect(normalizeHttpWebhookUrl({})).toBeNull();
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(normalizeHttpWebhookUrl("not-a-url")).toBeNull();
+    expect(normalizeHttpWebhookUrl("://missing-scheme")).toBeNull();
+  });
+
+  it("trims whitespace from valid URLs", () => {
+    expect(normalizeHttpWebhookUrl("  https://example.com/hook  ")).toBe(
+      "https://example.com/hook",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add missing test file for `src/cron/webhook-url.ts` (`normalizeHttpWebhookUrl`)
- 13 tests covering protocol validation, dangerous scheme rejection, and edge cases

## Motivation

`normalizeHttpWebhookUrl` is a security-sensitive function (validates webhook delivery targets) with zero test coverage. Tests verify:
- Only `http:` and `https:` protocols are accepted
- Dangerous schemes (`file:`, `javascript:`, `data:`, `ftp:`) are rejected
- Null, undefined, non-string, empty, whitespace-only, and malformed inputs are rejected
- Whitespace trimming works correctly

## Test plan

- [x] All 13 new tests pass
- [x] `pnpm check` passes

Ref #36551

🤖 Generated with [Claude Code](https://claude.com/claude-code)