### PR TITLE
fix(tools): allow sandbox read tool to resolve /workspace inbound paths

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -359,7 +359,9 @@ function mapContainerPathToWorkspaceRoot(params: {
   root: string;
   containerWorkdir?: string;
 }): string {
-  const containerWorkdir = params.containerWorkdir?.trim();
+  const inferredWorkdir =
+    path.basename(path.resolve(params.root)) === "workspace" ? "/workspace" : undefined;
+  const containerWorkdir = params.containerWorkdir?.trim() || inferredWorkdir;
   if (!containerWorkdir) {
     return params.filePath;
   }

--- a/src/agents/pi-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/pi-tools.read.workspace-root-guard.test.ts
@@ -26,6 +26,7 @@ function createToolHarness() {
 
 describe("wrapToolWorkspaceRootGuardWithOptions", () => {
   const root = "/tmp/root";
+  const sandboxWorkspaceRoot = "/tmp/session/workspace";
 
   beforeEach(() => {
     mocks.assertSandboxPath.mockClear();
@@ -103,6 +104,19 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
       filePath: "/workspace-two/secret.txt",
       cwd: root,
       root,
+    });
+  });
+
+  it("infers /workspace mapping when containerWorkdir is missing", async () => {
+    const { tool } = createToolHarness();
+    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, sandboxWorkspaceRoot);
+
+    await wrapped.execute("tc4", { path: "/workspace/media/inbound/upload.csv" });
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
+      filePath: path.resolve(sandboxWorkspaceRoot, "media", "inbound", "upload.csv"),
+      cwd: sandboxWorkspaceRoot,
+      root: sandboxWorkspaceRoot,
     });
   });
 });

--- a/src/agents/pi-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/pi-tools.read.workspace-root-guard.test.ts
@@ -119,4 +119,17 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
       root: sandboxWorkspaceRoot,
     });
   });
+
+  it("infers /workspace mapping for file:// inbound paths", async () => {
+    const { tool } = createToolHarness();
+    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, sandboxWorkspaceRoot);
+
+    await wrapped.execute("tc5", { path: "file:///workspace/media/inbound/upload.csv" });
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
+      filePath: path.resolve(sandboxWorkspaceRoot, "media", "inbound", "upload.csv"),
+      cwd: sandboxWorkspaceRoot,
+      root: sandboxWorkspaceRoot,
+    });
+  });
 });


### PR DESCRIPTION
Problem: Sandbox agents can fail to read Slack-uploaded files under `/workspace/media/inbound/*` with the read tool.
Root cause: Workspace guard only remapped container paths when `containerWorkdir` was explicitly set; when unset, `/workspace/...` stayed unmapped and failed root validation.
Fix: Infer `/workspace` mapping when sandbox root basename is `workspace`, preserve explicit `containerWorkdir` behavior, and add regression coverage for `/workspace/media/inbound/*` (including `file://` path form).
Testing: `pnpm exec vitest run src/agents/pi-tools.read.workspace-root-guard.test.ts` (7 passed).

Closes #36507
