### PR TITLE
fix(ui): keep WebChat compose visible above iOS keyboard (#36488)

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -141,13 +141,13 @@
 /* Chat compose - sticky at bottom */
 .chat-compose {
   position: sticky;
-  bottom: 0;
+  bottom: var(--chat-viewport-keyboard-inset, 0px);
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
   gap: 12px;
   margin-top: auto; /* Push to bottom of flex container */
-  padding: 12px 4px 4px;
+  padding: 12px 4px calc(4px + env(safe-area-inset-bottom, 0px));
   background: linear-gradient(to bottom, transparent, var(--bg) 20%);
   z-index: 10;
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -9,6 +9,7 @@
   --shell-topbar-height: 56px;
   --shell-focus-duration: 200ms;
   --shell-focus-ease: var(--ease-out);
+  --chat-viewport-keyboard-inset: 0px;
   height: 100vh;
   display: grid;
   grid-template-columns: var(--shell-nav-width) minmax(0, 1fr);

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -9,7 +9,6 @@
   --shell-topbar-height: 56px;
   --shell-focus-duration: 200ms;
   --shell-focus-ease: var(--ease-out);
-  --chat-viewport-keyboard-inset: 0px;
   height: 100vh;
   display: grid;
   grid-template-columns: var(--shell-nav-width) minmax(0, 1fr);

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -18,6 +18,7 @@ import {
 } from "./app-settings.ts";
 import { loadControlUiBootstrapConfig } from "./controllers/control-ui-bootstrap.ts";
 import type { Tab } from "./navigation.ts";
+import { attachVisualViewportKeyboardInset } from "./visual-viewport.ts";
 
 type LifecycleHost = {
   basePath: string;
@@ -40,6 +41,7 @@ type LifecycleHost = {
   logsEntries: unknown[];
   popStateHandler: () => void;
   topbarObserver: ResizeObserver | null;
+  visualViewportCleanup: (() => void) | null;
 };
 
 export function handleConnected(host: LifecycleHost) {
@@ -50,6 +52,8 @@ export function handleConnected(host: LifecycleHost) {
   syncTabWithLocation(host as unknown as Parameters<typeof syncTabWithLocation>[0], true);
   syncThemeWithSettings(host as unknown as Parameters<typeof syncThemeWithSettings>[0]);
   attachThemeListener(host as unknown as Parameters<typeof attachThemeListener>[0]);
+  host.visualViewportCleanup?.();
+  host.visualViewportCleanup = attachVisualViewportKeyboardInset();
   window.addEventListener("popstate", host.popStateHandler);
   void bootstrapReady.finally(() => {
     if (host.connectGeneration !== connectGeneration) {
@@ -80,6 +84,8 @@ export function handleDisconnected(host: LifecycleHost) {
   host.client = null;
   host.connected = false;
   detachThemeListener(host as unknown as Parameters<typeof detachThemeListener>[0]);
+  host.visualViewportCleanup?.();
+  host.visualViewportCleanup = null;
   host.topbarObserver?.disconnect();
   host.topbarObserver = null;
 }

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -395,6 +395,7 @@ export class OpenClawApp extends LitElement {
   private themeMedia: MediaQueryList | null = null;
   private themeMediaHandler: ((event: MediaQueryListEvent) => void) | null = null;
   private topbarObserver: ResizeObserver | null = null;
+  private visualViewportCleanup: (() => void) | null = null;
 
   createRenderRoot() {
     return this;

--- a/ui/src/ui/visual-viewport.test.ts
+++ b/ui/src/ui/visual-viewport.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  attachVisualViewportKeyboardInset,
+  CHAT_KEYBOARD_INSET_CSS_VAR,
+  computeVisualViewportKeyboardInset,
+} from "./visual-viewport.ts";
+
+function createListenerStore() {
+  return new Map<string, Set<() => void>>();
+}
+
+function fireListener(store: Map<string, Set<() => void>>, type: string) {
+  for (const listener of store.get(type) ?? []) {
+    listener();
+  }
+}
+
+describe("computeVisualViewportKeyboardInset", () => {
+  it("ignores small visual viewport changes from browser chrome", () => {
+    expect(
+      computeVisualViewportKeyboardInset({
+        windowInnerHeight: 844,
+        viewportHeight: 800,
+        viewportOffsetTop: 0,
+      }),
+    ).toBe(0);
+  });
+
+  it("returns the keyboard overlap when the visual viewport shrinks substantially", () => {
+    expect(
+      computeVisualViewportKeyboardInset({
+        windowInnerHeight: 844,
+        viewportHeight: 512,
+        viewportOffsetTop: 0,
+      }),
+    ).toBe(332);
+  });
+
+  it("accounts for shifted visual viewports on iOS", () => {
+    expect(
+      computeVisualViewportKeyboardInset({
+        windowInnerHeight: 844,
+        viewportHeight: 512,
+        viewportOffsetTop: 24,
+      }),
+    ).toBe(308);
+  });
+});
+
+describe("attachVisualViewportKeyboardInset", () => {
+  it("updates and clears the chat keyboard inset CSS variable", () => {
+    const root = document.createElement("div");
+    const viewportListeners = createListenerStore();
+    const windowListeners = createListenerStore();
+    const viewport = {
+      height: 844,
+      offsetTop: 0,
+      addEventListener: vi.fn((type: "resize" | "scroll", listener: () => void) => {
+        const set = viewportListeners.get(type) ?? new Set<() => void>();
+        set.add(listener);
+        viewportListeners.set(type, set);
+      }),
+      removeEventListener: vi.fn((type: "resize" | "scroll", listener: () => void) => {
+        viewportListeners.get(type)?.delete(listener);
+      }),
+    };
+    const win = {
+      innerHeight: 844,
+      visualViewport: viewport,
+      addEventListener: vi.fn((type: "resize", listener: () => void) => {
+        const set = windowListeners.get(type) ?? new Set<() => void>();
+        set.add(listener);
+        windowListeners.set(type, set);
+      }),
+      removeEventListener: vi.fn((type: "resize", listener: () => void) => {
+        windowListeners.get(type)?.delete(listener);
+      }),
+    };
+
+    const cleanup = attachVisualViewportKeyboardInset({ root, win });
+
+    expect(root.style.getPropertyValue(CHAT_KEYBOARD_INSET_CSS_VAR)).toBe("0px");
+
+    viewport.height = 500;
+    fireListener(viewportListeners, "resize");
+    expect(root.style.getPropertyValue(CHAT_KEYBOARD_INSET_CSS_VAR)).toBe("344px");
+
+    cleanup();
+
+    expect(root.style.getPropertyValue(CHAT_KEYBOARD_INSET_CSS_VAR)).toBe("");
+    expect(viewport.removeEventListener).toHaveBeenCalledTimes(2);
+    expect(win.removeEventListener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/ui/visual-viewport.test.ts
+++ b/ui/src/ui/visual-viewport.test.ts
@@ -91,4 +91,36 @@ describe("attachVisualViewportKeyboardInset", () => {
     expect(viewport.removeEventListener).toHaveBeenCalledTimes(2);
     expect(win.removeEventListener).toHaveBeenCalledTimes(1);
   });
+
+  it("defaults the CSS variable to document.documentElement", () => {
+    const viewportListeners = createListenerStore();
+    const viewport = {
+      height: 844,
+      offsetTop: 0,
+      addEventListener: vi.fn((type: "resize" | "scroll", listener: () => void) => {
+        const set = viewportListeners.get(type) ?? new Set<() => void>();
+        set.add(listener);
+        viewportListeners.set(type, set);
+      }),
+      removeEventListener: vi.fn((type: "resize" | "scroll", listener: () => void) => {
+        viewportListeners.get(type)?.delete(listener);
+      }),
+    };
+    const win = {
+      innerHeight: 844,
+      visualViewport: viewport,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    };
+
+    const cleanup = attachVisualViewportKeyboardInset({ win });
+
+    viewport.height = 500;
+    fireListener(viewportListeners, "resize");
+    expect(document.documentElement.style.getPropertyValue(CHAT_KEYBOARD_INSET_CSS_VAR)).toBe(
+      "344px",
+    );
+
+    cleanup();
+  });
 });

--- a/ui/src/ui/visual-viewport.ts
+++ b/ui/src/ui/visual-viewport.ts
@@ -1,0 +1,67 @@
+const KEYBOARD_INSET_CUTOFF_PX = 80;
+
+export const CHAT_KEYBOARD_INSET_CSS_VAR = "--chat-viewport-keyboard-inset";
+
+export function computeVisualViewportKeyboardInset(params: {
+  windowInnerHeight: number;
+  viewportHeight: number;
+  viewportOffsetTop?: number;
+}): number {
+  const rawInset =
+    params.windowInnerHeight - (params.viewportHeight + (params.viewportOffsetTop ?? 0));
+  const roundedInset = Math.max(0, Math.round(rawInset));
+  return roundedInset >= KEYBOARD_INSET_CUTOFF_PX ? roundedInset : 0;
+}
+
+type VisualViewportLike = {
+  height: number;
+  offsetTop: number;
+  addEventListener: (type: "resize" | "scroll", listener: () => void) => void;
+  removeEventListener: (type: "resize" | "scroll", listener: () => void) => void;
+};
+
+type WindowLike = {
+  innerHeight: number;
+  visualViewport?: VisualViewportLike;
+  addEventListener: (type: "resize", listener: () => void) => void;
+  removeEventListener: (type: "resize", listener: () => void) => void;
+};
+
+export function attachVisualViewportKeyboardInset(params?: {
+  root?: HTMLElement;
+  win?: WindowLike;
+}): () => void {
+  const root = params?.root ?? document.documentElement;
+  const win = params?.win ?? window;
+  const viewport = win.visualViewport;
+
+  const updateInset = () => {
+    const inset = viewport
+      ? computeVisualViewportKeyboardInset({
+          windowInnerHeight: win.innerHeight,
+          viewportHeight: viewport.height,
+          viewportOffsetTop: viewport.offsetTop,
+        })
+      : 0;
+    root.style.setProperty(CHAT_KEYBOARD_INSET_CSS_VAR, `${inset}px`);
+  };
+
+  updateInset();
+
+  if (!viewport) {
+    return () => {
+      root.style.removeProperty(CHAT_KEYBOARD_INSET_CSS_VAR);
+    };
+  }
+
+  viewport.addEventListener("resize", updateInset);
+  viewport.addEventListener("scroll", updateInset);
+  win.addEventListener("resize", updateInset);
+
+  return () => {
+    viewport.removeEventListener("resize", updateInset);
+    viewport.removeEventListener("scroll", updateInset);
+    win.removeEventListener("resize", updateInset);
+    root.style.removeProperty(CHAT_KEYBOARD_INSET_CSS_VAR);
+  };
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: on iOS, the WebChat compose bar stays pinned to the layout viewport bottom, so the virtual keyboard covers the message field when it opens.
- Why it matters: chat becomes hard to use on iPhone/iPad because users cannot see the text area while composing.
- What changed: added a small `visualViewport` helper that computes keyboard overlap, writes it to a CSS variable, and offsets the sticky compose bar by that inset.
- What did NOT change (scope boundary): no message send logic, no non-chat layout changes, no native iOS app code, and no broader viewport refactor.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36488
- Related #36584

## User-visible / Behavior Changes

- On iOS WebChat, focusing the message field now lifts the sticky compose bar above the virtual keyboard instead of leaving it hidden behind the keyboard.
- Small visual viewport shifts from browser chrome are ignored, so the compose bar does not jump for minor Safari UI changes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: iOS Safari/WebView (reported), macOS for code/test verification
- Runtime/container: browser UI
- Model/provider: n/a
- Integration/channel (if any): WebChat / Control UI
- Relevant config (redacted): default WebChat UI with chat focus mode path

### Steps

1. Open WebChat on iOS (Safari or the OpenClaw iOS app WebView).
2. Navigate to chat and tap the compose textarea.
3. Let the iOS virtual keyboard open.

### Expected

- The compose textarea stays visible above the keyboard while typing.

### Actual

- The sticky compose bar remains at the layout viewport bottom, so the keyboard covers the textarea.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: inspected current WebChat layout/sticky compose path; verified the new helper computes keyboard overlap from `visualViewport`; verified the CSS variable is written/cleared correctly in `src/ui/visual-viewport.test.ts`.
- Edge cases checked: small viewport deltas under 80px are ignored so browser chrome changes do not move the compose bar; safe-area bottom padding is preserved.
- What you did **not** verify: I did not run this on a physical iOS device in this environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or remove the `attachVisualViewportKeyboardInset()` wiring and `--chat-viewport-keyboard-inset` CSS usage.
- Files/config to restore: `ui/src/ui/app-lifecycle.ts`, `ui/src/ui/visual-viewport.ts`, `ui/src/styles/chat/layout.css`, `ui/src/styles/layout.css`
- Known bad symptoms reviewers should watch for: compose bar floating too high after keyboard close, or unexpected movement on non-iOS browsers.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: some mobile browsers may report transient `visualViewport` changes unrelated to the keyboard.
  - Mitigation: ignore inset deltas below 80px and clear the CSS variable on teardown.
