### PR TITLE
fix(models): default OpenAI Codex to gpt-5.4

### DIFF
--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -12,6 +12,7 @@ const ANTHROPIC_PREFIXES = [
 ];
 const OPENAI_MODELS = ["gpt-5.2", "gpt-5.0"];
 const CODEX_MODELS = [
+  "gpt-5.4",
   "gpt-5.2",
   "gpt-5.2-codex",
   "gpt-5.3-codex",

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -157,7 +157,7 @@ describe("getApiKeyForModel", () => {
           } catch (err) {
             error = err;
           }
-          expect(String(error)).toContain("openai-codex/gpt-5.3-codex");
+          expect(String(error)).toContain("openai-codex/gpt-5.4");
         },
       );
     } finally {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -216,7 +216,7 @@ export async function resolveApiKeyForProvider(params: {
     const hasCodex = listProfilesForProvider(store, "openai-codex").length > 0;
     if (hasCodex) {
       throw new Error(
-        'No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth. Use openai-codex/gpt-5.3-codex (OAuth) or set OPENAI_API_KEY to use openai/gpt-5.1-codex.',
+        'No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth. Use openai-codex/gpt-5.4 (OAuth) or set OPENAI_API_KEY to use openai/gpt-5.1-codex.',
       );
     }
   }

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -85,7 +85,7 @@ describe("loadModelCatalog", () => {
     }
   });
 
-  it("adds openai-codex/gpt-5.3-codex-spark when base gpt-5.3-codex exists", async () => {
+  it("adds openai-codex/gpt-5.4 and gpt-5.3-codex-spark when a codex template exists", async () => {
     mockPiDiscoveryModels([
       {
         id: "gpt-5.3-codex",
@@ -103,6 +103,15 @@ describe("loadModelCatalog", () => {
     ]);
 
     const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        provider: "openai-codex",
+        id: "gpt-5.4",
+      }),
+    );
+    const gpt54 = result.find((entry) => entry.id === "gpt-5.4");
+    expect(gpt54?.name).toBe("gpt-5.4");
+    expect(gpt54?.reasoning).toBe(true);
     expect(result).toContainEqual(
       expect.objectContaining({
         provider: "openai-codex",

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -33,17 +33,48 @@ const defaultImportPiSdk = () => import("./pi-model-discovery.js");
 let importPiSdk = defaultImportPiSdk;
 
 const CODEX_PROVIDER = "openai-codex";
+const OPENAI_CODEX_GPT54_MODEL_ID = "gpt-5.4";
 const OPENAI_CODEX_GPT53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_GPT53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
+const OPENAI_CODEX_TEMPLATE_MODEL_IDS = [
+  OPENAI_CODEX_GPT53_MODEL_ID,
+  "gpt-5.2-codex",
+  "gpt-5.2",
+  "gpt-5.1-codex",
+] as const;
 const NON_PI_NATIVE_MODEL_PROVIDERS = new Set(["kilocode"]);
 
-function applyOpenAICodexSparkFallback(models: ModelCatalogEntry[]): void {
-  const hasSpark = models.some(
-    (entry) =>
-      entry.provider === CODEX_PROVIDER &&
-      entry.id.toLowerCase() === OPENAI_CODEX_GPT53_SPARK_MODEL_ID,
+function hasOpenAICodexModel(models: ModelCatalogEntry[], modelId: string): boolean {
+  return models.some(
+    (entry) => entry.provider === CODEX_PROVIDER && entry.id.toLowerCase() === modelId,
   );
-  if (hasSpark) {
+}
+
+function findOpenAICodexTemplate(models: ModelCatalogEntry[]): ModelCatalogEntry | undefined {
+  for (const templateId of OPENAI_CODEX_TEMPLATE_MODEL_IDS) {
+    const match = models.find(
+      (entry) => entry.provider === CODEX_PROVIDER && entry.id.toLowerCase() === templateId,
+    );
+    if (match) {
+      return match;
+    }
+  }
+  return undefined;
+}
+
+function applyOpenAICodexCatalogFallbacks(models: ModelCatalogEntry[]): void {
+  if (!hasOpenAICodexModel(models, OPENAI_CODEX_GPT54_MODEL_ID)) {
+    const template = findOpenAICodexTemplate(models);
+    if (template) {
+      models.push({
+        ...template,
+        id: OPENAI_CODEX_GPT54_MODEL_ID,
+        name: OPENAI_CODEX_GPT54_MODEL_ID,
+      });
+    }
+  }
+
+  if (hasOpenAICodexModel(models, OPENAI_CODEX_GPT53_SPARK_MODEL_ID)) {
     return;
   }
 
@@ -218,7 +249,7 @@ export async function loadModelCatalog(params?: {
         models.push({ id, name, provider, contextWindow, reasoning, input });
       }
       mergeConfiguredOptInProviderModels({ config: cfg, models });
-      applyOpenAICodexSparkFallback(models);
+      applyOpenAICodexCatalogFallbacks(models);
 
       if (models.length === 0) {
         // If we found nothing, don't cache this result so we can try again.

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -235,6 +235,10 @@ describe("normalizeModelCompat", () => {
 });
 
 describe("isModernModelRef", () => {
+  it("treats gpt-5.4 as a modern openai-codex model", () => {
+    expect(isModernModelRef({ provider: "openai-codex", id: "gpt-5.4" })).toBe(true);
+  });
+
   it("excludes opencode minimax variants from modern selection", () => {
     expect(isModernModelRef({ provider: "opencode", id: "minimax-m2.5" })).toBe(false);
     expect(isModernModelRef({ provider: "opencode", id: "minimax-m2.5" })).toBe(false);
@@ -247,6 +251,49 @@ describe("isModernModelRef", () => {
 });
 
 describe("resolveForwardCompatModel", () => {
+  it("resolves openai-codex gpt-5.4 via codex templates", () => {
+    const registry = createRegistry({
+      "openai-codex/gpt-5.2-codex": {
+        ...createTemplateModel("openai-codex", "gpt-5.2-codex"),
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api",
+      } as Model<Api>,
+    });
+    const model = resolveForwardCompatModel("openai-codex", "gpt-5.4", registry);
+    expectResolvedForwardCompat(model, { provider: "openai-codex", id: "gpt-5.4" });
+  });
+
+  it("keeps unsupported openai-codex gpt-5 ids failing fast", () => {
+    const registry = createRegistry({
+      "openai-codex/gpt-5.2-codex": {
+        ...createTemplateModel("openai-codex", "gpt-5.2-codex"),
+        api: "openai-codex-responses",
+        baseUrl: "https://chatgpt.com/backend-api",
+      } as Model<Api>,
+    });
+    const model = resolveForwardCompatModel("openai-codex", "gpt-5.0", registry);
+    expect(model).toBeUndefined();
+  });
+
+  it("resolves github-copilot gpt-5.4 only from provider templates", () => {
+    const registry = createRegistry({
+      "github-copilot/gpt-5.2-codex": {
+        ...createTemplateModel("github-copilot", "gpt-5.2-codex"),
+        api: "openai-codex-responses",
+        baseUrl: "https://api.githubcopilot.com",
+      } as Model<Api>,
+    });
+    const model = resolveForwardCompatModel("github-copilot", "gpt-5.4", registry);
+    expectResolvedForwardCompat(model, { provider: "github-copilot", id: "gpt-5.4" });
+    expect(model?.baseUrl).toBe("https://api.githubcopilot.com");
+  });
+
+  it("does not synthesize github-copilot gpt-5.4 without provider templates", () => {
+    const registry = createRegistry({});
+    const model = resolveForwardCompatModel("github-copilot", "gpt-5.4", registry);
+    expect(model).toBeUndefined();
+  });
+
   it("resolves anthropic opus 4.6 via 4.5 template", () => {
     const registry = createRegistry({
       "anthropic/claude-opus-4-5": createTemplateModel("anthropic", "claude-opus-4-5"),

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -4,8 +4,15 @@ import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { normalizeModelCompat } from "./model-compat.js";
 import { normalizeProviderId } from "./model-selection.js";
 
+const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
-const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
+const OPENAI_CODEX_GPT_53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
+const OPENAI_CODEX_TEMPLATE_MODEL_IDS = [
+  OPENAI_CODEX_GPT_53_MODEL_ID,
+  "gpt-5.2-codex",
+  "gpt-5.2",
+  "gpt-5.1-codex",
+] as const;
 
 const ANTHROPIC_OPUS_46_MODEL_ID = "claude-opus-4-6";
 const ANTHROPIC_OPUS_46_DOT_MODEL_ID = "claude-opus-4.6";
@@ -48,23 +55,60 @@ function cloneFirstTemplateModel(params: {
   return undefined;
 }
 
-const CODEX_GPT53_ELIGIBLE_PROVIDERS = new Set(["openai-codex", "github-copilot"]);
+const OPENAI_CODEX_FORWARD_COMPAT = new Map<
+  string,
+  { allowSyntheticFallback: boolean; allowedIds: readonly string[] }
+>([
+  [
+    "openai-codex",
+    {
+      allowSyntheticFallback: true,
+      allowedIds: [
+        OPENAI_CODEX_GPT_54_MODEL_ID,
+        OPENAI_CODEX_GPT_53_MODEL_ID,
+        OPENAI_CODEX_GPT_53_SPARK_MODEL_ID,
+      ],
+    },
+  ],
+  [
+    "github-copilot",
+    {
+      // Copilot can reuse provider-native templates, but must never fall back to the
+      // synthetic chatgpt.com transport or requests will be routed with the wrong token.
+      allowSyntheticFallback: false,
+      allowedIds: [
+        OPENAI_CODEX_GPT_54_MODEL_ID,
+        OPENAI_CODEX_GPT_53_MODEL_ID,
+        OPENAI_CODEX_GPT_53_SPARK_MODEL_ID,
+      ],
+    },
+  ],
+]);
 
-function resolveOpenAICodexGpt53FallbackModel(
+function buildOpenAICodexTemplateIds(modelId: string): string[] {
+  const lower = modelId.toLowerCase();
+  const templateIds = [lower];
+  if (lower.endsWith("-spark")) {
+    templateIds.push(OPENAI_CODEX_GPT_53_SPARK_MODEL_ID);
+  }
+  templateIds.push(...OPENAI_CODEX_TEMPLATE_MODEL_IDS);
+  return templateIds;
+}
+
+function resolveOpenAICodexGpt5ForwardCompatModel(
   provider: string,
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
   const normalizedProvider = normalizeProviderId(provider);
   const trimmedModelId = modelId.trim();
-  if (!CODEX_GPT53_ELIGIBLE_PROVIDERS.has(normalizedProvider)) {
-    return undefined;
-  }
-  if (trimmedModelId.toLowerCase() !== OPENAI_CODEX_GPT_53_MODEL_ID) {
+  const lowerModelId = trimmedModelId.toLowerCase();
+  const forwardCompat = OPENAI_CODEX_FORWARD_COMPAT.get(normalizedProvider);
+  if (!forwardCompat?.allowedIds.includes(lowerModelId)) {
     return undefined;
   }
 
-  for (const templateId of OPENAI_CODEX_TEMPLATE_MODEL_IDS) {
+  for (const templateId of buildOpenAICodexTemplateIds(trimmedModelId)) {
     const template = modelRegistry.find(normalizedProvider, templateId) as Model<Api> | null;
     if (!template) {
       continue;
@@ -74,6 +118,10 @@ function resolveOpenAICodexGpt53FallbackModel(
       id: trimmedModelId,
       name: trimmedModelId,
     } as Model<Api>);
+  }
+
+  if (!forwardCompat.allowSyntheticFallback) {
+    return undefined;
   }
 
   return normalizeModelCompat({
@@ -248,7 +296,7 @@ export function resolveForwardCompatModel(
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
   return (
-    resolveOpenAICodexGpt53FallbackModel(provider, modelId, modelRegistry) ??
+    resolveOpenAICodexGpt5ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveZaiGlm5ForwardCompatModel(provider, modelId, modelRegistry) ??

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -41,18 +41,32 @@ describe("pi embedded model e2e smoke", () => {
     ]);
   });
 
-  it("builds an openai-codex forward-compat fallback for gpt-5.3-codex", () => {
+  it("builds an openai-codex forward-compat fallback for gpt-5.4", () => {
     mockOpenAICodexTemplateModel();
 
-    const result = resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent");
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent");
     expect(result.error).toBeUndefined();
-    expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.3-codex"));
+    expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
   });
 
   it("keeps unknown-model errors for non-forward-compat IDs", () => {
     const result = resolveModel("openai-codex", "gpt-4.1-mini", "/tmp/agent");
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: openai-codex/gpt-4.1-mini");
+  });
+
+  it("keeps unknown-model errors for unsupported openai-codex gpt-5 ids", () => {
+    mockOpenAICodexTemplateModel();
+
+    const result = resolveModel("openai-codex", "gpt-5.0", "/tmp/agent");
+    expect(result.model).toBeUndefined();
+    expect(result.error).toBe("Unknown model: openai-codex/gpt-5.0");
+  });
+
+  it("keeps unknown-model errors for github-copilot gpt-5.4", () => {
+    const result = resolveModel("github-copilot", "gpt-5.4", "/tmp/agent");
+    expect(result.model).toBeUndefined();
+    expect(result.error).toBe("Unknown model: github-copilot/gpt-5.4");
   });
 
   it("builds a google-gemini-cli forward-compat fallback for gemini-3.1-pro-preview", () => {

--- a/src/agents/pi-embedded-runner/model.test-harness.ts
+++ b/src/agents/pi-embedded-runner/model.test-harness.ts
@@ -34,7 +34,7 @@ export function mockOpenAICodexTemplateModel(): void {
 }
 
 export function buildOpenAICodexForwardCompatExpectation(
-  id: string = "gpt-5.3-codex",
+  id: string = "gpt-5.4",
 ): Partial<typeof OPENAI_CODEX_TEMPLATE_MODEL> & { provider: string; id: string } {
   return {
     provider: "openai-codex",

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -278,13 +278,13 @@ describe("resolveModel", () => {
     expect(result.model?.reasoning).toBe(true);
   });
 
-  it("builds an openai-codex fallback for gpt-5.3-codex", () => {
+  it("builds an openai-codex fallback for gpt-5.4", () => {
     mockOpenAICodexTemplateModel();
 
-    const result = resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent");
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent");
 
     expect(result.error).toBeUndefined();
-    expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.3-codex"));
+    expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
   });
 
   it("builds an anthropic forward-compat fallback for claude-opus-4-6", () => {
@@ -389,7 +389,7 @@ describe("resolveModel", () => {
         providers: {
           "openai-codex": {
             baseUrl: "https://custom.example.com",
-            // No models array, or models without gpt-5.3-codex
+            // No models array, or models without gpt-5.4
           },
         },
       },
@@ -397,11 +397,11 @@ describe("resolveModel", () => {
 
     expectResolvedForwardCompatFallback({
       provider: "openai-codex",
-      id: "gpt-5.3-codex",
+      id: "gpt-5.4",
       cfg,
       expectedModel: {
         api: "openai-codex-responses",
-        id: "gpt-5.3-codex",
+        id: "gpt-5.4",
         provider: "openai-codex",
       },
     });

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -43,6 +43,7 @@ describe("normalizeThinkLevel", () => {
 
 describe("listThinkingLevels", () => {
   it("includes xhigh for codex models", () => {
+    expect(listThinkingLevels(undefined, "gpt-5.4")).toContain("xhigh");
     expect(listThinkingLevels(undefined, "gpt-5.2-codex")).toContain("xhigh");
     expect(listThinkingLevels(undefined, "gpt-5.3-codex")).toContain("xhigh");
     expect(listThinkingLevels(undefined, "gpt-5.3-codex-spark")).toContain("xhigh");

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -23,6 +23,7 @@ export function isBinaryThinkingProvider(provider?: string | null): boolean {
 
 export const XHIGH_MODEL_REFS = [
   "openai/gpt-5.2",
+  "openai-codex/gpt-5.4",
   "openai-codex/gpt-5.3-codex",
   "openai-codex/gpt-5.3-codex-spark",
   "openai-codex/gpt-5.2-codex",

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -4,7 +4,7 @@ const mocks = vi.hoisted(() => {
   const printModelTable = vi.fn();
   return {
     loadConfig: vi.fn().mockReturnValue({
-      agents: { defaults: { model: { primary: "openai-codex/gpt-5.3-codex" } } },
+      agents: { defaults: { model: { primary: "openai-codex/gpt-5.4" } } },
       models: { providers: {} },
     }),
     ensureAuthProfileStore: vi.fn().mockReturnValue({ version: 1, profiles: {}, order: {} }),
@@ -14,8 +14,8 @@ const mocks = vi.hoisted(() => {
     resolveConfiguredEntries: vi.fn().mockReturnValue({
       entries: [
         {
-          key: "openai-codex/gpt-5.3-codex",
-          ref: { provider: "openai-codex", model: "gpt-5.3-codex" },
+          key: "openai-codex/gpt-5.4",
+          ref: { provider: "openai-codex", model: "gpt-5.4" },
           tags: new Set(["configured"]),
           aliases: [],
         },
@@ -24,8 +24,8 @@ const mocks = vi.hoisted(() => {
     printModelTable,
     resolveForwardCompatModel: vi.fn().mockReturnValue({
       provider: "openai-codex",
-      id: "gpt-5.3-codex",
-      name: "GPT-5.3 Codex",
+      id: "gpt-5.4",
+      name: "GPT-5.4",
       api: "openai-codex-responses",
       baseUrl: "https://chatgpt.com/backend-api",
       input: ["text"],
@@ -88,7 +88,7 @@ describe("modelsListCommand forward-compat", () => {
       missing: boolean;
     }>;
 
-    const codex = rows.find((r) => r.key === "openai-codex/gpt-5.3-codex");
+    const codex = rows.find((r) => r.key === "openai-codex/gpt-5.4");
     expect(codex).toBeTruthy();
     expect(codex?.missing).toBe(false);
     expect(codex?.tags).not.toContain("missing");

--- a/src/commands/openai-codex-model-default.ts
+++ b/src/commands/openai-codex-model-default.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { AgentModelListConfig } from "../config/types.js";
 
-export const OPENAI_CODEX_DEFAULT_MODEL = "openai-codex/gpt-5.3-codex";
+export const OPENAI_CODEX_DEFAULT_MODEL = "openai-codex/gpt-5.4";
 
 function shouldSetOpenAICodexModel(model?: string): boolean {
   const trimmed = model?.trim();


### PR DESCRIPTION
AI-assisted: Codex
Testing: targeted Vitest coverage (`pnpm vitest run src/agents/model-compat.test.ts src/agents/pi-embedded-runner/model.forward-compat.test.ts`)
Session logs: available locally if needed.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenAI Codex should default to `gpt-5.4`, but older local model catalogs still miss that ID and only exposed older Codex templates.
- Why it matters: defaulting to a model that the local PI registry does not know about produces `Unknown model` failures and made `models list`/auth guidance drift behind the intended Codex default.
- What changed: switched the OpenAI Codex default to `openai-codex/gpt-5.4`, taught the catalog and runner to surface `gpt-5.4` from existing Codex templates, and added regression coverage for unsupported GPT-5 IDs plus the GitHub Copilot no-synthetic-fallback path.
- What did NOT change (scope boundary): no provider auth flow changes, no live transport changes for GitHub Copilot, and no attempt to broaden forward-compat beyond the current Codex/Copilot GPT-5.4 rollout.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- OpenAI Codex defaults now point at `openai-codex/gpt-5.4`.
- `models list` and inline forward-compat resolution surface `gpt-5.4` from existing Codex templates instead of flagging it missing.
- Unsupported `openai-codex/gpt-5.x` typos still fail fast.
- `github-copilot/gpt-5.4` only resolves when a provider-native template exists; it no longer falls through to a synthetic ChatGPT transport.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) `No`
- Secrets/tokens handling changed? (`Yes/No`) `No`
- New/changed network calls? (`Yes/No`) `No`
- Command/tool execution surface changed? (`Yes/No`) `No`
- Data access scope changed? (`Yes/No`) `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, `pnpm`, Vitest
- Model/provider: `openai-codex/gpt-5.4`, `github-copilot/gpt-5.4`
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.model.primary=openai-codex/gpt-5.4`

### Steps

1. Start from a local model registry that still contains older Codex templates such as `gpt-5.3-codex`/`gpt-5.2-codex` but not `gpt-5.4`.
2. Resolve or list `openai-codex/gpt-5.4`, then try unsupported IDs such as `openai-codex/gpt-5.0` and `github-copilot/gpt-5.4` without a Copilot-native template.
3. Run `pnpm vitest run src/agents/model-compat.test.ts src/agents/pi-embedded-runner/model.forward-compat.test.ts`.

### Expected

- `openai-codex/gpt-5.4` resolves from Codex templates and becomes the default surfaced model.
- Unsupported Codex IDs still return `Unknown model`.
- GitHub Copilot never synthesizes the ChatGPT transport when no Copilot-native template exists.

### Actual

- Matches expected in targeted tests after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added regression coverage for the previously unsafe paths and verified the targeted Vitest suites pass locally.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran the targeted Vitest suites covering `openai-codex/gpt-5.4` forward-compat, unsupported `openai-codex/gpt-5.0`, and `github-copilot/gpt-5.4` without synthetic fallback.
- Edge cases checked: fail-fast behavior for unsupported GPT-5 IDs and Copilot template-only fallback behavior.
- What you did **not** verify: live OAuth-backed requests against OpenAI Codex or GitHub Copilot accounts.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) `Yes`
- Config/env changes? (`Yes/No`) `No`
- Migration needed? (`Yes/No`) `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `291e9a74a` or pin `agents.defaults.model.primary` back to `openai-codex/gpt-5.3-codex`.
- Files/config to restore: `src/commands/openai-codex-model-default.ts`, `src/agents/model-catalog.ts`, `src/agents/model-forward-compat.ts`.
- Known bad symptoms reviewers should watch for: `openai-codex/gpt-5.4` still showing as missing, or GitHub Copilot requests pointing at `https://chatgpt.com/backend-api`.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: provider catalogs may roll out new GPT-5 IDs before this allowlist is updated.
  - Mitigation: OpenAI Codex keeps a safe synthetic fallback for the supported IDs here, and GitHub Copilot can reuse provider-native templates for `gpt-5.4` without ever falling through to the wrong transport.
