### PR TITLE
refactor(agents): share failover HTTP status classification

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -14,13 +14,16 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 403 })).toBe("auth");
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
-    // Transient server errors should trigger failover as timeout (retry/fallback).
-    expect(resolveFailoverReasonFromError({ status: 500 })).toBe("timeout");
+    // Keep the status-only path behavior-preserving and conservative.
+    expect(resolveFailoverReasonFromError({ status: 500 })).toBeNull();
     expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 504 })).toBe("timeout");
-    // Anthropic 529 (overloaded) should also be treated as transient timeout.
-    expect(resolveFailoverReasonFromError({ status: 529 })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ status: 521 })).toBeNull();
+    expect(resolveFailoverReasonFromError({ status: 522 })).toBeNull();
+    expect(resolveFailoverReasonFromError({ status: 523 })).toBeNull();
+    expect(resolveFailoverReasonFromError({ status: 524 })).toBeNull();
+    expect(resolveFailoverReasonFromError({ status: 529 })).toBe("rate_limit");
   });
 
   it("infers format errors from error messages", () => {

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -14,12 +14,13 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 403 })).toBe("auth");
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
-    // Transient server errors (502/503/504) should trigger failover as timeout.
+    // Transient server errors should trigger failover as timeout (retry/fallback).
+    expect(resolveFailoverReasonFromError({ status: 500 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 504 })).toBe("timeout");
-    // Anthropic 529 (overloaded) should trigger failover as rate_limit.
-    expect(resolveFailoverReasonFromError({ status: 529 })).toBe("rate_limit");
+    // Anthropic 529 (overloaded) should also be treated as transient timeout.
+    expect(resolveFailoverReasonFromError({ status: 529 })).toBe("timeout");
   });
 
   it("infers format errors from error messages", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -1,7 +1,7 @@
 import { readErrorName } from "../infra/errors.js";
 import {
   classifyFailoverReason,
-  isAuthPermanentErrorMessage,
+  classifyFailoverReasonFromHttpStatus,
   isTimeoutErrorMessage,
   type FailoverReason,
 } from "./pi-embedded-helpers.js";
@@ -152,30 +152,10 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   }
 
   const status = getStatusCode(err);
-  if (status === 402) {
-    return "billing";
-  }
-  if (status === 429) {
-    return "rate_limit";
-  }
-  if (status === 401 || status === 403) {
-    const msg = getErrorMessage(err);
-    if (msg && isAuthPermanentErrorMessage(msg)) {
-      return "auth_permanent";
-    }
-    return "auth";
-  }
-  if (status === 408) {
-    return "timeout";
-  }
-  if (status === 502 || status === 503 || status === 504) {
-    return "timeout";
-  }
-  if (status === 529) {
-    return "rate_limit";
-  }
-  if (status === 400) {
-    return "format";
+  const message = getErrorMessage(err);
+  const statusReason = classifyFailoverReasonFromHttpStatus(status, message);
+  if (statusReason) {
+    return statusReason;
   }
 
   const code = (getErrorCode(err) ?? "").toUpperCase();
@@ -197,8 +177,6 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (isTimeoutError(err)) {
     return "timeout";
   }
-
-  const message = getErrorMessage(err);
   if (!message) {
     return null;
   }

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -13,6 +13,7 @@ export {
   BILLING_ERROR_USER_MESSAGE,
   formatBillingErrorMessage,
   classifyFailoverReason,
+  classifyFailoverReasonFromHttpStatus,
   formatRawAssistantErrorForUi,
   formatAssistantErrorText,
   getApiErrorPayloadFingerprint,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -271,8 +271,13 @@ export function classifyFailoverReasonFromHttpStatus(
   if (status === 408) {
     return "timeout";
   }
-  if (TRANSIENT_HTTP_ERROR_CODES.has(status)) {
+  // Keep the status-only path conservative and behavior-preserving.
+  // Message-path HTTP heuristics are broader and should not leak in here.
+  if (status === 502 || status === 503 || status === 504) {
     return "timeout";
+  }
+  if (status === 529) {
+    return "rate_limit";
   }
   if (status === 400) {
     return "format";

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -248,6 +248,38 @@ export function isTransientHttpError(raw: string): boolean {
   return TRANSIENT_HTTP_ERROR_CODES.has(status.code);
 }
 
+export function classifyFailoverReasonFromHttpStatus(
+  status: number | undefined,
+  message?: string,
+): FailoverReason | null {
+  if (typeof status !== "number" || !Number.isFinite(status)) {
+    return null;
+  }
+
+  if (status === 402) {
+    return "billing";
+  }
+  if (status === 429) {
+    return "rate_limit";
+  }
+  if (status === 401 || status === 403) {
+    if (message && isAuthPermanentErrorMessage(message)) {
+      return "auth_permanent";
+    }
+    return "auth";
+  }
+  if (status === 408) {
+    return "timeout";
+  }
+  if (TRANSIENT_HTTP_ERROR_CODES.has(status)) {
+    return "timeout";
+  }
+  if (status === 400) {
+    return "format";
+  }
+  return null;
+}
+
 function stripFinalTagsFromText(text: string): string {
   if (!text) {
     return text;


### PR DESCRIPTION
## Summary

- Problem: `resolveFailoverReasonFromError()` duplicated HTTP status mapping logic separately from the helper layer.
- Why it matters: duplicated status classification is easy to drift, especially around failover-sensitive codes.
- What changed: added a shared HTTP status -> failover reason helper and reused it in `failover-error`, while preserving the old status behavior exactly.
- What did NOT change (scope boundary): no new status semantics, no overload policy change, no runner retry/cooldown change.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #17231

## User-visible / Behavior Changes

- None.
- This PR preserves the previous status-path behavior while deduplicating the implementation.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Call `resolveFailoverReasonFromError()` with HTTP status-only error objects.
2. Verify shared helper output matches the old explicit mapping.
3. Run targeted tests and a full build.

### Expected

- `402 -> billing`
- `429 -> rate_limit`
- `401/403 -> auth/auth_permanent`
- `408 -> timeout`
- `502/503/504 -> timeout`
- `529 -> rate_limit`
- `500`, `521-524` remain unclassified in the status-only path

### Actual

- Shared helper preserves the legacy status behavior and the updated tests/build pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `resolveFailoverReasonFromError()` for `500`, `502`, `503`, `504`, `521`, `522`, `523`, `524`, `529`, `429`, `408`, `401`, `403`, and `400`; shared helper export wiring; local `pnpm build`.
- Edge cases checked: `auth_permanent` still depends on message content for `401/403`; message-path HTTP heuristics remain broader than the status-only path by design.
- What you did **not** verify: live provider behavior; overload/backoff policy changes are intentionally out of scope.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `e47bd6180` and `475c8490c`
- Files/config to restore: `src/agents/failover-error.ts`, `src/agents/failover-error.test.ts`, `src/agents/pi-embedded-helpers.ts`, `src/agents/pi-embedded-helpers/errors.ts`
- Known bad symptoms reviewers should watch for: unexpected changes in status-only failover classification for `500`, `521-524`, or `529`.

## Risks and Mitigations

- Risk: helper extraction accidentally broadens status behavior to match message-path heuristics.
  - Mitigation: added explicit tests locking `500`, `521-524`, and `529` to the legacy behavior.
