### PR TITLE
fix(ui): make lifecycle node tests runnable (#36620)

### DIFF
--- a/ui/src/ui/app-lifecycle-connect.node.test.ts
+++ b/ui/src/ui/app-lifecycle-connect.node.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
-const connectGatewayMock = vi.fn();
-const loadBootstrapMock = vi.fn();
+const { connectGatewayMock, loadBootstrapMock } = vi.hoisted(() => ({
+  connectGatewayMock: vi.fn(),
+  loadBootstrapMock: vi.fn(),
+}));
 
 vi.mock("./app-gateway.ts", () => ({
   connectGateway: connectGatewayMock,
@@ -35,6 +37,10 @@ vi.mock("./app-scroll.ts", () => ({
   scheduleLogsScroll: vi.fn(),
 }));
 
+vi.stubGlobal("window", {
+  addEventListener: vi.fn(),
+});
+
 import { handleConnected } from "./app-lifecycle.ts";
 
 function createHost() {
@@ -59,6 +65,7 @@ function createHost() {
     logsEntries: [],
     popStateHandler: vi.fn(),
     topbarObserver: null,
+    visualViewportCleanup: null,
   };
 }
 

--- a/ui/src/ui/app-lifecycle.node.test.ts
+++ b/ui/src/ui/app-lifecycle.node.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it, vi } from "vitest";
-import { handleDisconnected } from "./app-lifecycle.ts";
+
+const removeEventListenerMock = vi.fn();
+
+vi.stubGlobal("window", {
+  removeEventListener: removeEventListenerMock,
+});
+vi.stubGlobal("localStorage", {
+  getItem: vi.fn(() => null),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+});
+vi.stubGlobal("navigator", {
+  language: "en-US",
+});
+
+const { handleDisconnected } = await import("./app-lifecycle.ts");
 
 function createHost() {
   return {
@@ -22,12 +37,12 @@ function createHost() {
     logsEntries: [],
     popStateHandler: vi.fn(),
     topbarObserver: { disconnect: vi.fn() } as unknown as ResizeObserver,
+    visualViewportCleanup: null,
   };
 }
 
 describe("handleDisconnected", () => {
   it("stops and clears gateway client on teardown", () => {
-    const removeSpy = vi.spyOn(window, "removeEventListener").mockImplementation(() => undefined);
     const host = createHost();
     const disconnectSpy = (
       host.topbarObserver as unknown as { disconnect: ReturnType<typeof vi.fn> }
@@ -35,12 +50,11 @@ describe("handleDisconnected", () => {
 
     handleDisconnected(host as unknown as Parameters<typeof handleDisconnected>[0]);
 
-    expect(removeSpy).toHaveBeenCalledWith("popstate", host.popStateHandler);
+    expect(removeEventListenerMock).toHaveBeenCalledWith("popstate", host.popStateHandler);
     expect(host.connectGeneration).toBe(1);
     expect(host.client).toBeNull();
     expect(host.connected).toBe(false);
     expect(disconnectSpy).toHaveBeenCalledTimes(1);
     expect(host.topbarObserver).toBeNull();
-    removeSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the existing UI lifecycle node tests do not run under `ui/vitest.node.config.ts` because one suite uses hoisted mocks incorrectly and the other imports browser-dependent globals before stubbing them.
- Why it matters: these suites currently provide zero regression coverage even though they exist in the repo.
- What changed: switched the connect suite to `vi.hoisted(...)` mocks and stubbed the minimal browser globals before importing the lifecycle module in the disconnect suite.
- What did NOT change (scope boundary): no runtime UI behavior, no lifecycle implementation logic, and no test config changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #36620
- Related #36612

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: `pnpm` + Vitest node config
- Model/provider: n/a
- Integration/channel (if any): Control UI tests
- Relevant config (redacted): none

### Steps

1. Run `cd ui && pnpm exec vitest run --config vitest.node.config.ts src/ui/app-lifecycle.node.test.ts src/ui/app-lifecycle-connect.node.test.ts` on current `main`.
2. Observe the suites fail before assertions with `ReferenceError: Cannot access 'connectGatewayMock' before initialization` and `ReferenceError: localStorage is not defined`.
3. Re-run the same command after this patch.

### Expected

- Both lifecycle node suites run and pass under `ui/vitest.node.config.ts`.

### Actual

- Before the patch, both suites fail during module initialization and provide no coverage.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reran the exact failing Vitest command from the issue and confirmed both suites now pass.
- Edge cases checked: verified the connect suite still exercises deferred bootstrap behavior, and the disconnect suite still asserts teardown side effects.
- What you did **not** verify: no browser-mode UI tests or runtime app behavior, because this PR only touches node test scaffolding.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `ui/src/ui/app-lifecycle.node.test.ts`, `ui/src/ui/app-lifecycle-connect.node.test.ts`
- Known bad symptoms reviewers should watch for: node tests failing again before assertions due to missing globals or hoisted mock initialization.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the test stubs could diverge from the minimal globals the lifecycle module expects.
  - Mitigation: only stub the specific globals touched by the import chain and keep the assertions focused on existing lifecycle behavior.
