### PR TITLE
test(ui): make lifecycle node tests runnable in node config

### DIFF
--- a/ui/src/ui/app-lifecycle-connect.node.test.ts
+++ b/ui/src/ui/app-lifecycle-connect.node.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
 
-const connectGatewayMock = vi.fn();
-const loadBootstrapMock = vi.fn();
+const { connectGatewayMock, loadBootstrapMock } = vi.hoisted(() => ({
+  connectGatewayMock: vi.fn(),
+  loadBootstrapMock: vi.fn(),
+}));
+const { addEventListenerMock, removeEventListenerMock } = vi.hoisted(() => ({
+  addEventListenerMock: vi.fn(),
+  removeEventListenerMock: vi.fn(),
+}));
+
+vi.stubGlobal("window", {
+  addEventListener: addEventListenerMock,
+  removeEventListener: removeEventListenerMock,
+});
 
 vi.mock("./app-gateway.ts", () => ({
   connectGateway: connectGatewayMock,

--- a/ui/src/ui/app-lifecycle.node.test.ts
+++ b/ui/src/ui/app-lifecycle.node.test.ts
@@ -1,4 +1,47 @@
 import { describe, expect, it, vi } from "vitest";
+
+const { addEventListenerMock, removeEventListenerMock } = vi.hoisted(() => ({
+  addEventListenerMock: vi.fn(),
+  removeEventListenerMock: vi.fn(),
+}));
+
+vi.stubGlobal("window", {
+  addEventListener: addEventListenerMock,
+  removeEventListener: removeEventListenerMock,
+});
+
+vi.mock("./app-settings.ts", () => ({
+  applySettingsFromUrl: vi.fn(),
+  attachThemeListener: vi.fn(),
+  detachThemeListener: vi.fn(),
+  inferBasePath: vi.fn(() => "/"),
+  syncTabWithLocation: vi.fn(),
+  syncThemeWithSettings: vi.fn(),
+}));
+
+vi.mock("./app-gateway.ts", () => ({
+  connectGateway: vi.fn(),
+}));
+
+vi.mock("./controllers/control-ui-bootstrap.ts", () => ({
+  loadControlUiBootstrapConfig: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("./app-polling.ts", () => ({
+  startLogsPolling: vi.fn(),
+  startNodesPolling: vi.fn(),
+  stopLogsPolling: vi.fn(),
+  stopNodesPolling: vi.fn(),
+  startDebugPolling: vi.fn(),
+  stopDebugPolling: vi.fn(),
+}));
+
+vi.mock("./app-scroll.ts", () => ({
+  observeTopbar: vi.fn(),
+  scheduleChatScroll: vi.fn(),
+  scheduleLogsScroll: vi.fn(),
+}));
+
 import { handleDisconnected } from "./app-lifecycle.ts";
 
 function createHost() {
@@ -27,7 +70,6 @@ function createHost() {
 
 describe("handleDisconnected", () => {
   it("stops and clears gateway client on teardown", () => {
-    const removeSpy = vi.spyOn(window, "removeEventListener").mockImplementation(() => undefined);
     const host = createHost();
     const disconnectSpy = (
       host.topbarObserver as unknown as { disconnect: ReturnType<typeof vi.fn> }
@@ -35,12 +77,11 @@ describe("handleDisconnected", () => {
 
     handleDisconnected(host as unknown as Parameters<typeof handleDisconnected>[0]);
 
-    expect(removeSpy).toHaveBeenCalledWith("popstate", host.popStateHandler);
+    expect(removeEventListenerMock).toHaveBeenCalledWith("popstate", host.popStateHandler);
     expect(host.connectGeneration).toBe(1);
     expect(host.client).toBeNull();
     expect(host.connected).toBe(false);
     expect(disconnectSpy).toHaveBeenCalledTimes(1);
     expect(host.topbarObserver).toBeNull();
-    removeSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- fix hoisted mock initialization in `app-lifecycle-connect.node.test.ts` by moving shared mocks into `vi.hoisted`
- make lifecycle node tests runnable under `ui/vitest.node.config.ts` by stubbing `window` in node mode
- isolate `app-lifecycle.node.test.ts` from browser-only dependencies by mocking lifecycle imports used at module load

## Testing
- `cd ui && pnpm vitest run --config vitest.node.config.ts src/ui/app-lifecycle-connect.node.test.ts src/ui/app-lifecycle.node.test.ts`

Closes #36620
