### PR TITLE
fix(channels): skip main-session lastRoute update when inbound session differs (per-channel-peer)

### DIFF
--- a/src/channels/session.test.ts
+++ b/src/channels/session.test.ts
@@ -22,7 +22,7 @@ describe("recordInboundSession", () => {
     updateLastRouteMock.mockClear();
   });
 
-  it("does not pass ctx when updating a different session key", async () => {
+  it("skips last-route update when inbound session differs from target (per-channel-peer)", async () => {
     const { recordInboundSession } = await import("./session.js");
 
     await recordInboundSession({
@@ -37,16 +37,9 @@ describe("recordInboundSession", () => {
       onRecordError: vi.fn(),
     });
 
-    expect(updateLastRouteMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionKey: "agent:main:main",
-        ctx: undefined,
-        deliveryContext: expect.objectContaining({
-          channel: "telegram",
-          to: "telegram:1234",
-        }),
-      }),
-    );
+    // When the inbound session key differs from the update target (main session),
+    // the update is skipped to prevent cross-channel delivery context contamination.
+    expect(updateLastRouteMock).not.toHaveBeenCalled();
   });
 
   it("passes ctx when updating the same session key", async () => {

--- a/src/channels/session.ts
+++ b/src/channels/session.ts
@@ -65,6 +65,14 @@ export async function recordInboundSession(params: {
     return;
   }
   const targetSessionKey = normalizeSessionStoreKey(update.sessionKey);
+  // When dmScope=per-channel-peer, the inbound session key differs from the
+  // main session key.  Updating the main session's delivery context would
+  // contaminate it with channel-specific routing, causing replies from webchat
+  // or other surfaces to be mis-routed to the originating channel.  Skip the
+  // update when the inbound session is not the target (main) session.
+  if (targetSessionKey !== canonicalSessionKey) {
+    return;
+  }
   await updateLastRoute({
     storePath,
     sessionKey: targetSessionKey,


### PR DESCRIPTION
## Summary

When `session.dmScope: per-channel-peer` is configured, inbound DMs correctly route to isolated session keys (e.g. `agent:main:imessage:direct:+1xxx`), but `recordInboundSession` still called `updateLastRoute` targeting the **main** session key.  This wrote channel-specific `deliveryContext` (`lastChannel`, `lastTo`) into the main session, causing webchat and other surfaces to mis-route replies through the originating channel.

## Root Cause

All channel monitors (iMessage, Telegram, Signal, Slack, Discord, LINE) pass `decision.route.mainSessionKey` as the `updateLastRoute` target unconditionally.  The existing `mainDmOwnerPin` guard relies on `resolvePinnedMainDmOwnerFromAllowlist`, which returns `null` when `dmScope !== 'main'`, so the update proceeds unchecked.

WhatsApp already had an inline guard (`params.route.sessionKey === params.route.mainSessionKey`), but the other 6 channels did not.

## Fix

Added a centralized guard in `recordInboundSession` (`src/channels/session.ts`): if the normalized inbound session key differs from the `updateLastRoute` target session key, skip the update entirely.  This fixes all affected channels in one place.

## Testing

- Updated existing test to verify `updateLastRoute` is **not called** when session keys differ (per-channel-peer scenario)
- All 447 channel tests pass
- All 37 session store tests pass

Fixes #36614