### PR TITLE
fix(gateway): prevent TLS null dereference during concurrent reconnection

### DIFF
--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -42,6 +42,7 @@ function expectEnvProxyAgentConstructorCall(params: { nth: number; autoSelectFam
     connect: {
       autoSelectFamily: params.autoSelectFamily,
       autoSelectFamilyAttemptTimeout: 300,
+      maxCachedSessions: 0,
     },
   });
 }
@@ -218,6 +219,21 @@ describe("resolveTelegramFetch", () => {
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
     expectEnvProxyAgentConstructorCall({ nth: 1, autoSelectFamily: true });
     expectEnvProxyAgentConstructorCall({ nth: 2, autoSelectFamily: false });
+  });
+
+  it("retries dns-based fetch failures once after TLS session reconnect race", async () => {
+    const raceErr = new TypeError("Cannot read properties of null (reading 'setSession')");
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new TypeError("fetch failed"), { cause: raceErr }))
+      .mockResolvedValueOnce({ ok: true } as Response);
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const resolved = resolveTelegramFetchOrThrow();
+
+    await resolved("https://api.telegram.org/file/botx/photos/file_tls.jpg");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("retries once with ipv4 fallback when fetch fails with network timeout/unreachable", async () => {

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -88,6 +88,7 @@ function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void 
             connect: {
               autoSelectFamily: autoSelectDecision.value,
               autoSelectFamilyAttemptTimeout: 300,
+              maxCachedSessions: 0,
             },
           }),
         );
@@ -165,6 +166,20 @@ function shouldRetryWithIpv4Fallback(err: unknown): boolean {
   return true;
 }
 
+function isTlsSessionReconnectRace(err: unknown): boolean {
+  const msg =
+    err && typeof err === "object" && "message" in err ? String(err.message).toLowerCase() : "";
+  const cause = err && typeof err === "object" ? (err as { cause?: unknown }).cause : undefined;
+  const causeMsg =
+    cause && typeof cause === "object" && "message" in cause
+      ? String(cause.message).toLowerCase()
+      : "";
+  return (
+    msg.includes("cannot read properties of null (reading 'setsession')") ||
+    causeMsg.includes("cannot read properties of null (reading 'setsession')")
+  );
+}
+
 function applyTelegramIpv4Fallback(): void {
   applyTelegramNetworkWorkarounds({
     autoSelectFamily: false,
@@ -192,6 +207,10 @@ export function resolveTelegramFetch(
     try {
       return await sourceFetch(input, init);
     } catch (err) {
+      if (isTlsSessionReconnectRace(err)) {
+        log.warn("fetch fallback: retrying once after TLS session reconnect race");
+        return sourceFetch(input, init);
+      }
       if (shouldRetryWithIpv4Fallback(err)) {
         applyTelegramIpv4Fallback();
         return sourceFetch(input, init);


### PR DESCRIPTION
Closes #36585

Problem: Gateway crashes with TLS null dereference during socket reconnection
Fix: Disable TLS session caching for the global undici EnvHttpProxyAgent and add a one-shot safe retry when fetch fails with the TLS setSession null-dereference signature during reconnect races.