### PR TITLE
fix(ui): make node tests stub browser globals before import (#36626)

### DIFF
--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -1,6 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GATEWAY_EVENT_UPDATE_AVAILABLE } from "../../../src/gateway/events.js";
-import { connectGateway, resolveControlUiClientVersion } from "./app-gateway.ts";
+
+vi.stubGlobal("localStorage", {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+});
+vi.stubGlobal("navigator", { language: "en-US" });
+
+const { connectGateway, resolveControlUiClientVersion } = await import("./app-gateway.ts");
 
 type GatewayClientMock = {
   start: ReturnType<typeof vi.fn>;

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it } from "vitest";
-import {
-  isCronSessionKey,
-  parseSessionKey,
-  resolveSessionDisplayName,
-} from "./app-render.helpers.ts";
+import { describe, expect, it, vi } from "vitest";
 import type { SessionsListResult } from "./types.ts";
+
+vi.stubGlobal("localStorage", {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+});
+vi.stubGlobal("navigator", { language: "en-US" });
+
+const { isCronSessionKey, parseSessionKey, resolveSessionDisplayName } =
+  await import("./app-render.helpers.ts");
 
 type SessionRow = SessionsListResult["sessions"][number];
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `cd ui && pnpm exec vitest run --config vitest.node.config.ts` fails before running `app-gateway.node.test.ts` and `app-render.helpers.node.test.ts` because both files statically import modules that trigger i18n startup reads from `localStorage`/`navigator`.
- Why it matters: the node-mode UI suite stops early, so regressions in gateway/render helpers are easy to miss and these tests cannot be run in the intended non-browser environment.
- What changed: both node tests now stub the minimal browser globals they depend on and switch to dynamic imports so those stubs exist before module evaluation.
- What did NOT change (scope boundary): no production UI/runtime code changed, no browser behavior changed, and I did not fold in the separate already-open `app-lifecycle` node-test fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #36626
- Related #36622

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+/pnpm workspace
- Model/provider: n/a
- Integration/channel (if any): UI node-mode tests
- Relevant config (redacted): none

### Steps

1. From repo root, run `cd ui && pnpm exec vitest run --config vitest.node.config.ts src/ui/app-gateway.node.test.ts src/ui/app-render.helpers.node.test.ts` on current `main` before this patch.
2. Observe import-time failure from `src/i18n/lib/translate.ts` because `localStorage` is undefined in the node test environment.
3. Re-run the same command after this patch.

### Expected

- Both node test files should execute under `vitest.node.config.ts`.

### Actual

- Before fix: module evaluation aborts with `ReferenceError: localStorage is not defined`.
- After fix: both suites pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `cd ui && pnpm exec vitest run --config vitest.node.config.ts src/ui/app-gateway.node.test.ts src/ui/app-render.helpers.node.test.ts`
  - `pnpm check`
- Edge cases checked:
  - kept the stubs test-local and limited to the minimal globals required for import-time i18n startup
  - confirmed the branch stays scoped to the two failing node tests only
- What you did **not** verify:
  - I did not claim a full `ui` node-config sweep here because current `upstream/main` still has the separate `app-lifecycle` node-test failure covered by #36622

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit; it only changes two test files
- Files/config to restore: `ui/src/ui/app-gateway.node.test.ts`, `ui/src/ui/app-render.helpers.node.test.ts`
- Known bad symptoms reviewers should watch for: node tests failing earlier than assertions with browser-global reference errors

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: future import-time code may start depending on additional browser globals beyond `localStorage` and `navigator`.
  - Mitigation: the failure mode remains explicit in node-mode tests, and the current fix keeps the stubs narrow so new gaps are still visible.
