### PR TITLE
fix(gateway): remove session transcripts on delete (#36608)

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -38,6 +38,7 @@ import {
 import {
   archiveFileOnDisk,
   archiveSessionTranscripts,
+  deleteSessionTranscripts,
   listSessionsFromStore,
   loadCombinedSessionStoreForGateway,
   loadSessionEntry,
@@ -588,14 +589,14 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return hadEntry;
     });
 
-    const archived =
-      deleted && deleteTranscript
-        ? archiveSessionTranscriptsForSession({
+    const removedTranscripts =
+      deleted && deleteTranscript && sessionId
+        ? await deleteSessionTranscripts({
             sessionId,
             storePath,
             sessionFile: entry?.sessionFile,
             agentId: target.agentId,
-            reason: "deleted",
+            restrictToStoreDir: true,
           })
         : [];
     if (deleted) {
@@ -607,7 +608,11 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       });
     }
 
-    respond(true, { ok: true, key: target.canonicalKey, deleted, archived }, undefined);
+    respond(
+      true,
+      { ok: true, key: target.canonicalKey, deleted, archived: removedTranscripts },
+      undefined,
+    );
   },
   "sessions.compact": async ({ params, respond }) => {
     if (!assertValidParams(params, validateSessionsCompactParams, "sessions.compact", respond)) {

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -502,7 +502,8 @@ describe("gateway server sessions", () => {
       listAfterDelete.payload?.sessions.some((s) => s.key === "agent:main:discord:group:dev"),
     ).toBe(false);
     const filesAfterDelete = await fs.readdir(dir);
-    expect(filesAfterDelete.some((f) => f.startsWith("sess-group.jsonl.deleted."))).toBe(true);
+    expect(filesAfterDelete).not.toContain("sess-group.jsonl");
+    expect(filesAfterDelete.some((f) => f.startsWith("sess-group.jsonl.deleted."))).toBe(false);
 
     const reset = await rpcReq<{
       ok: true;

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -227,6 +227,53 @@ export function archiveSessionTranscripts(opts: {
   return archived;
 }
 
+/**
+ * Removes all transcript files for a given session.
+ * Best-effort: silently skips files that don't exist or fail to delete.
+ */
+export async function deleteSessionTranscripts(opts: {
+  sessionId: string;
+  storePath: string | undefined;
+  sessionFile?: string;
+  agentId?: string;
+  /**
+   * When true, only delete files resolved under the session store directory.
+   * This prevents cleanup operations from mutating paths outside the agent sessions dir.
+   */
+  restrictToStoreDir?: boolean;
+}): Promise<string[]> {
+  const deleted: string[] = [];
+  const storeDir =
+    opts.restrictToStoreDir && opts.storePath
+      ? canonicalizePathForComparison(path.dirname(opts.storePath))
+      : null;
+  for (const candidate of resolveSessionTranscriptCandidates(
+    opts.sessionId,
+    opts.storePath,
+    opts.sessionFile,
+    opts.agentId,
+  )) {
+    const candidatePath = canonicalizePathForComparison(candidate);
+    if (storeDir) {
+      const relative = path.relative(storeDir, candidatePath);
+      if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+        continue;
+      }
+    }
+    const stat = await fs.promises.stat(candidatePath).catch(() => null);
+    if (!stat?.isFile()) {
+      continue;
+    }
+    try {
+      await fs.promises.rm(candidatePath);
+      deleted.push(candidatePath);
+    } catch {
+      // Best-effort.
+    }
+  }
+  return deleted;
+}
+
 export async function cleanupArchivedSessionTranscripts(opts: {
   directories: string[];
   olderThanMs: number;

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -50,6 +50,7 @@ export {
   archiveFileOnDisk,
   archiveSessionTranscripts,
   capArrayByJsonBytes,
+  deleteSessionTranscripts,
   readFirstUserMessageFromTranscript,
   readLastMessagePreviewFromTranscript,
   readSessionTitleFieldsFromTranscript,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `sessions.delete` removes the session entry from `sessions.json` but renames the transcript to `.jsonl.deleted.<timestamp>` and leaves it on disk indefinitely.
- Why it matters: repeated deletes accumulate orphaned transcript files, wasting disk and leaving deleted-session artifacts behind until unrelated maintenance eventually touches them.
- What changed: explicit `sessions.delete` now removes transcript files directly instead of archiving them under a `.deleted.*` suffix.
- What did NOT change (scope boundary): pruning/capping maintenance still uses archive files, reset behavior still uses `.reset.*`, and I did not change session-maintenance retention settings.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36608
- Related #36622

## User-visible / Behavior Changes

Deleting a session now removes its transcript file immediately instead of leaving a `.deleted.*` artifact on disk.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+/pnpm workspace
- Model/provider: n/a
- Integration/channel (if any): gateway `sessions.delete` RPC
- Relevant config (redacted): none

### Steps

1. Create a session store entry with an on-disk transcript.
2. Call `sessions.delete` for that session.
3. Inspect the session directory contents.

### Expected

- The session entry is removed.
- The transcript file is removed.
- No new `.jsonl.deleted.*` artifact is left behind for an explicit delete.

### Actual

- Before fix: the transcript was renamed to `.jsonl.deleted.<timestamp>` and remained on disk.
- After fix: the transcript file is removed directly.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/gateway/server.sessions.gateway-server-sessions-a.test.ts src/gateway/session-utils.fs.test.ts`
  - `pnpm check`
- Edge cases checked:
  - deletes remain best-effort and still stay restricted to files under the session store directory
  - failed delete attempts for active sessions still leave transcripts untouched
- What you did **not** verify:
  - I did not add a broader retention-policy change for maintenance-pruned `.deleted.*` archives in this PR

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit; it is isolated to the `sessions.delete` transcript path
- Files/config to restore: `src/gateway/server-methods/sessions.ts`, `src/gateway/session-utils.fs.ts`, `src/gateway/session-utils.ts`
- Known bad symptoms reviewers should watch for: deleted sessions leaving transcript files behind, or delete responses succeeding while the transcript still exists

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: any workflow that implicitly relied on deleted-session transcript archives being left on disk will no longer find those files after explicit deletes.
  - Mitigation: the change is intentionally limited to explicit user-driven `sessions.delete`; reset/pruning archive flows are unchanged.
