### PR TITLE
fix(channels): warn once for invalid external plugin catalogs

### DIFF
--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -59,6 +59,8 @@ const DEFAULT_CATALOG_PATHS = [
 
 const ENV_CATALOG_PATHS = ["OPENCLAW_PLUGIN_CATALOG_PATHS", "OPENCLAW_MPM_CATALOG_PATHS"];
 
+const warnedInvalidCatalogPaths = new Set<string>();
+
 type ManifestKey = typeof MANIFEST_KEY;
 
 function parseCatalogEntries(raw: unknown): ExternalCatalogEntry[] {
@@ -100,6 +102,15 @@ function resolveExternalCatalogPaths(options: CatalogOptions): string[] {
   return DEFAULT_CATALOG_PATHS;
 }
 
+function warnInvalidCatalogFile(catalogPath: string, err: unknown): void {
+  if (warnedInvalidCatalogPaths.has(catalogPath)) {
+    return;
+  }
+  warnedInvalidCatalogPaths.add(catalogPath);
+  const detail = err instanceof Error ? err.message : String(err);
+  console.warn(`Ignoring invalid plugin catalog file at ${catalogPath}: ${detail}`);
+}
+
 function loadExternalCatalogEntries(options: CatalogOptions): ExternalCatalogEntry[] {
   const paths = resolveExternalCatalogPaths(options);
   const entries: ExternalCatalogEntry[] = [];
@@ -111,8 +122,8 @@ function loadExternalCatalogEntries(options: CatalogOptions): ExternalCatalogEnt
     try {
       const payload = JSON.parse(fs.readFileSync(resolved, "utf-8")) as unknown;
       entries.push(...parseCatalogEntries(payload));
-    } catch {
-      // Ignore invalid catalog files.
+    } catch (err) {
+      warnInvalidCatalogFile(resolved, err);
     }
   }
   return entries;

--- a/src/channels/plugins/plugins-core.test.ts
+++ b/src/channels/plugins/plugins-core.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { DiscordProbe } from "../../discord/probe.js";
 import type { DiscordTokenResolution } from "../../discord/token.js";
@@ -143,6 +143,24 @@ describe("channel plugin catalog", () => {
       (entry) => entry.id,
     );
     expect(ids).toContain("demo-channel");
+  });
+
+  it("warns once per file when external catalog json is invalid", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-catalog-invalid-"));
+    const catalogPath = path.join(dir, "catalog.json");
+    fs.writeFileSync(catalogPath, '{"entries": [', "utf-8");
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const first = listChannelPluginCatalogEntries({ catalogPaths: [catalogPath] });
+      const second = listChannelPluginCatalogEntries({ catalogPaths: [catalogPath] });
+      expect(first).toEqual(second);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toContain("Ignoring invalid plugin catalog file");
+      expect(warnSpy.mock.calls[0]?.[0]).toContain(catalogPath);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary\n- emit a warning when an external plugin catalog file cannot be parsed\n- deduplicate warnings so each invalid catalog path is only logged once per process\n- add a regression test that verifies invalid JSON is non-fatal and only warns once\n\n## Why\nInvalid catalog files were previously swallowed silently, which made misconfigured catalog paths and malformed JSON hard to diagnose.\n\n## Impact\nBehavior stays non-fatal, but operators now get actionable diagnostics without repeated log spam.\n\n## Risk\nLow: change is limited to the error path of external catalog parsing and is covered by targeted tests.