### PR TITLE
fix(agents): list configured agent ids when allowlist is unset

### DIFF
--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore, ProfileUsageStats } from "./types.js";
 import {
+  calculateAuthProfileCooldownMs,
   clearAuthProfileCooldown,
   clearExpiredCooldowns,
   isProfileInCooldown,
@@ -40,6 +41,27 @@ function expectProfileErrorStateCleared(
   expect(stats?.errorCount).toBe(0);
   expect(stats?.failureCounts).toBeUndefined();
 }
+
+describe("calculateAuthProfileCooldownMs", () => {
+  it("uses shorter first backoff for google-gemini-cli oauth-style failures", () => {
+    const googleTimeout = calculateAuthProfileCooldownMs(1, {
+      providerId: "google-gemini-cli",
+      reason: "timeout",
+    });
+    const googleAuth = calculateAuthProfileCooldownMs(1, {
+      providerId: "google-gemini-cli",
+      reason: "auth",
+    });
+    const defaultBackoff = calculateAuthProfileCooldownMs(1, {
+      providerId: "anthropic",
+      reason: "timeout",
+    });
+
+    expect(googleTimeout).toBe(10_000);
+    expect(googleAuth).toBe(10_000);
+    expect(defaultBackoff).toBe(60_000);
+  });
+});
 
 describe("resolveProfileUnusableUntil", () => {
   it("returns null when both values are missing or invalid", () => {

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -62,7 +62,7 @@ describe("calculateAuthProfileCooldownMs", () => {
     expect(defaultBackoff).toBe(60_000);
   });
 
-  it("applies full exponential backoff progression for google-gemini-cli oauth failures", () => {
+  it("applies exponential backoff for google-gemini-cli oauth failures and reaches max cooldown", () => {
     expect(
       calculateAuthProfileCooldownMs(1, {
         providerId: "google-gemini-cli",
@@ -92,7 +92,13 @@ describe("calculateAuthProfileCooldownMs", () => {
         providerId: "google-gemini-cli",
         reason: "auth",
       }),
-    ).toBe(1_250_000);
+    ).toBe(3_600_000);
+    expect(
+      calculateAuthProfileCooldownMs(7, {
+        providerId: "google-gemini-cli",
+        reason: "auth",
+      }),
+    ).toBe(3_600_000);
   });
 
   it("keeps default cooldown for google-gemini-cli non-oauth failures", () => {

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -61,6 +61,58 @@ describe("calculateAuthProfileCooldownMs", () => {
     expect(googleAuth).toBe(10_000);
     expect(defaultBackoff).toBe(60_000);
   });
+
+  it("applies full exponential backoff progression for google-gemini-cli oauth failures", () => {
+    expect(
+      calculateAuthProfileCooldownMs(1, {
+        providerId: "google-gemini-cli",
+        reason: "auth",
+      }),
+    ).toBe(10_000);
+    expect(
+      calculateAuthProfileCooldownMs(2, {
+        providerId: "google-gemini-cli",
+        reason: "auth",
+      }),
+    ).toBe(50_000);
+    expect(
+      calculateAuthProfileCooldownMs(3, {
+        providerId: "google-gemini-cli",
+        reason: "timeout",
+      }),
+    ).toBe(250_000);
+    expect(
+      calculateAuthProfileCooldownMs(4, {
+        providerId: "google-gemini-cli",
+        reason: "timeout",
+      }),
+    ).toBe(1_250_000);
+    expect(
+      calculateAuthProfileCooldownMs(5, {
+        providerId: "google-gemini-cli",
+        reason: "auth",
+      }),
+    ).toBe(1_250_000);
+  });
+
+  it("keeps default cooldown for google-gemini-cli non-oauth failures", () => {
+    expect(
+      calculateAuthProfileCooldownMs(1, {
+        providerId: "google-gemini-cli",
+        reason: "rate_limit",
+      }),
+    ).toBe(60_000);
+    expect(
+      calculateAuthProfileCooldownMs(1, {
+        providerId: "google-gemini-cli",
+        reason: "unknown",
+      }),
+    ).toBe(60_000);
+  });
+
+  it("remains backward compatible when called without options", () => {
+    expect(calculateAuthProfileCooldownMs(1)).toBe(60_000);
+  });
 });
 
 describe("resolveProfileUnusableUntil", () => {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -266,11 +266,24 @@ export async function markAuthProfileUsed(params: {
   saveAuthProfileStore(store, agentDir);
 }
 
-export function calculateAuthProfileCooldownMs(errorCount: number): number {
+const DEFAULT_PROFILE_COOLDOWN_BASE_MS = 60 * 1000;
+const GOOGLE_GEMINI_OAUTH_COOLDOWN_BASE_MS = 10 * 1000;
+
+export function calculateAuthProfileCooldownMs(
+  errorCount: number,
+  options?: { reason?: AuthProfileFailureReason; providerId?: string },
+): number {
   const normalized = Math.max(1, errorCount);
+  const providerId = normalizeProviderId(options?.providerId ?? "");
+  const isGoogleGeminiCli = providerId === "google-gemini-cli";
+  const isOauthLikeFailure = options?.reason === "auth" || options?.reason === "timeout";
+  const baseMs =
+    isGoogleGeminiCli && isOauthLikeFailure
+      ? GOOGLE_GEMINI_OAUTH_COOLDOWN_BASE_MS
+      : DEFAULT_PROFILE_COOLDOWN_BASE_MS;
   return Math.min(
     60 * 60 * 1000, // 1 hour max
-    60 * 1000 * 5 ** Math.min(normalized - 1, 3),
+    baseMs * 5 ** Math.min(normalized - 1, 3),
   );
 }
 
@@ -390,6 +403,7 @@ function computeNextProfileUsageStats(params: {
   existing: ProfileUsageStats;
   now: number;
   reason: AuthProfileFailureReason;
+  providerId?: string;
   cfgResolved: ResolvedAuthCooldownConfig;
 }): ProfileUsageStats {
   const windowMs = params.cfgResolved.failureWindowMs;
@@ -426,7 +440,10 @@ function computeNextProfileUsageStats(params: {
     });
     updatedStats.disabledReason = params.reason;
   } else {
-    const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount);
+    const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount, {
+      reason: params.reason,
+      providerId: params.providerId,
+    });
     // Keep active cooldown windows immutable so retries within the window
     // cannot push recovery further out.
     updatedStats.cooldownUntil = keepActiveWindowOrRecompute({
@@ -475,6 +492,7 @@ export async function markAuthProfileFailure(params: {
           existing: existing ?? {},
           now,
           reason,
+          providerId: providerKey,
           cfgResolved,
         }),
       );
@@ -501,6 +519,7 @@ export async function markAuthProfileFailure(params: {
       existing: existing ?? {},
       now,
       reason,
+      providerId: providerKey,
       cfgResolved,
     }),
   );

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -283,7 +283,7 @@ export function calculateAuthProfileCooldownMs(
       : DEFAULT_PROFILE_COOLDOWN_BASE_MS;
   return Math.min(
     60 * 60 * 1000, // 1 hour max
-    baseMs * 5 ** Math.min(normalized - 1, 3),
+    baseMs * 5 ** Math.max(normalized - 1, 0),
   );
 }
 

--- a/src/agents/openclaw-tools.agents.test.ts
+++ b/src/agents/openclaw-tools.agents.test.ts
@@ -50,13 +50,44 @@ describe("agents_list", () => {
     };
   });
 
-  it("defaults to the requester agent only", async () => {
+  it("falls back to configured agents when no allowlist is defined", async () => {
+    setConfigWithAgentList([
+      {
+        id: "main",
+        name: "Main",
+      },
+      {
+        id: "research",
+        name: "Research",
+      },
+    ]);
+
     const tool = requireAgentsListTool();
     const result = await tool.execute("call1", {});
     expect(result.details).toMatchObject({
       requester: "main",
       allowAny: false,
     });
+    const agents = readAgentList(result);
+    expect(agents?.map((agent) => agent.id)).toEqual(["main", "research"]);
+  });
+
+  it("keeps requester-only visibility when allowlist is explicitly empty", async () => {
+    setConfigWithAgentList([
+      {
+        id: "main",
+        subagents: {
+          allowAgents: [],
+        },
+      },
+      {
+        id: "research",
+        name: "Research",
+      },
+    ]);
+
+    const tool = requireAgentsListTool();
+    const result = await tool.execute("call1b", {});
     const agents = readAgentList(result);
     expect(agents?.map((agent) => agent.id)).toEqual(["main"]);
   });

--- a/src/agents/openclaw-tools.agents.test.ts
+++ b/src/agents/openclaw-tools.agents.test.ts
@@ -50,7 +50,7 @@ describe("agents_list", () => {
     };
   });
 
-  it("falls back to configured agents when no allowlist is defined", async () => {
+  it("keeps requester-only visibility when no allowlist is defined", async () => {
     setConfigWithAgentList([
       {
         id: "main",
@@ -69,7 +69,7 @@ describe("agents_list", () => {
       allowAny: false,
     });
     const agents = readAgentList(result);
-    expect(agents?.map((agent) => agent.id)).toEqual(["main", "research"]);
+    expect(agents?.map((agent) => agent.id)).toEqual(["main"]);
   });
 
   it("keeps requester-only visibility when allowlist is explicitly empty", async () => {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -147,6 +147,25 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
+  it("sessions_spawn allows configured cross-agent when allowlist is unset", async () => {
+    setSessionsSpawnConfigOverride({
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        list: [{ id: "main" }, { id: "beta" }],
+      },
+    });
+    const getChildSessionKey = mockAcceptedSpawn(5050);
+
+    const result = await executeSpawn("call6b", "beta");
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: "run-1",
+    });
+    expect(getChildSessionKey()?.startsWith("agent:beta:subagent:")).toBe(true);
+  });
+
+
   it("sessions_spawn forbids cross-agent spawning when not allowed", async () => {
     setSessionsSpawnConfigOverride({
       session: {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -147,22 +147,19 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
-  it("sessions_spawn allows configured cross-agent when allowlist is unset", async () => {
+  it("sessions_spawn forbids configured cross-agent when allowlist is unset", async () => {
     setSessionsSpawnConfigOverride({
       session: { mainKey: "main", scope: "per-sender" },
       agents: {
         list: [{ id: "main" }, { id: "beta" }],
       },
     });
-    const getChildSessionKey = mockAcceptedSpawn(5050);
-
     const result = await executeSpawn("call6b", "beta");
 
     expect(result.details).toMatchObject({
-      status: "accepted",
-      runId: "run-1",
+      status: "forbidden",
     });
-    expect(getChildSessionKey()?.startsWith("agent:beta:subagent:")).toBe(true);
+    expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
   it("sessions_spawn forbids configured cross-agent when requester is not configured and allowlist is unset", async () => {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -165,6 +165,30 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
     expect(getChildSessionKey()?.startsWith("agent:beta:subagent:")).toBe(true);
   });
 
+  it("sessions_spawn forbids configured cross-agent when requester is not configured and allowlist is unset", async () => {
+    setSessionsSpawnConfigOverride({
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        list: [{ id: "main" }, { id: "beta" }],
+      },
+    });
+
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "agent:ghost:main",
+      agentChannel: "whatsapp",
+    });
+
+    const result = await tool.execute("call6c", {
+      task: "do thing",
+      agentId: "beta",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "forbidden",
+    });
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
   it("sessions_spawn forbids cross-agent spawning when not allowed", async () => {
     setSessionsSpawnConfigOverride({
       session: {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -165,7 +165,6 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
     expect(getChildSessionKey()?.startsWith("agent:beta:subagent:")).toBe(true);
   });
 
-
   it("sessions_spawn forbids cross-agent spawning when not allowed", async () => {
     setSessionsSpawnConfigOverride({
       session: {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -344,7 +344,8 @@ export async function spawnSubagentDirect(
   );
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
   if (targetAgentId !== requesterAgentId) {
-    const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+    const explicitAllowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents;
+    const allowAgents = explicitAllowAgents ?? [];
     const allowAny = allowAgents.some((value) => value.trim() === "*");
     const normalizedTargetId = targetAgentId.toLowerCase();
     const allowSet = new Set(
@@ -352,8 +353,22 @@ export async function spawnSubagentDirect(
         .filter((value) => value.trim() && value.trim() !== "*")
         .map((value) => normalizeAgentId(value).toLowerCase()),
     );
-    if (!allowAny && !allowSet.has(normalizedTargetId)) {
-      const allowedText = allowSet.size > 0 ? Array.from(allowSet).join(", ") : "none";
+    const configuredSet = new Set(
+      (Array.isArray(cfg.agents?.list) ? cfg.agents.list : [])
+        .map((entry) => normalizeAgentId(entry.id).toLowerCase()),
+    );
+    const isAllowed = allowAny
+      ? true
+      : explicitAllowAgents === undefined
+        ? configuredSet.has(normalizedTargetId)
+        : allowSet.has(normalizedTargetId);
+    if (!isAllowed) {
+      const allowedText =
+        explicitAllowAgents === undefined
+          ? Array.from(configuredSet).join(", ") || "none"
+          : allowSet.size > 0
+            ? Array.from(allowSet).join(", ")
+            : "none";
       return {
         status: "forbidden",
         error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText})`,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -358,10 +358,11 @@ export async function spawnSubagentDirect(
         normalizeAgentId(entry.id).toLowerCase(),
       ),
     );
+    const normalizedRequesterId = requesterAgentId.toLowerCase();
     const isAllowed = allowAny
       ? true
       : explicitAllowAgents === undefined
-        ? configuredSet.has(normalizedTargetId)
+        ? configuredSet.has(normalizedRequesterId) && configuredSet.has(normalizedTargetId)
         : allowSet.has(normalizedTargetId);
     if (!isAllowed) {
       const allowedText =

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -353,24 +353,9 @@ export async function spawnSubagentDirect(
         .filter((value) => value.trim() && value.trim() !== "*")
         .map((value) => normalizeAgentId(value).toLowerCase()),
     );
-    const configuredSet = new Set(
-      (Array.isArray(cfg.agents?.list) ? cfg.agents.list : []).map((entry) =>
-        normalizeAgentId(entry.id).toLowerCase(),
-      ),
-    );
-    const normalizedRequesterId = requesterAgentId.toLowerCase();
-    const isAllowed = allowAny
-      ? true
-      : explicitAllowAgents === undefined
-        ? configuredSet.has(normalizedRequesterId) && configuredSet.has(normalizedTargetId)
-        : allowSet.has(normalizedTargetId);
+    const isAllowed = allowAny ? true : allowSet.has(normalizedTargetId);
     if (!isAllowed) {
-      const allowedText =
-        explicitAllowAgents === undefined
-          ? Array.from(configuredSet).join(", ") || "none"
-          : allowSet.size > 0
-            ? Array.from(allowSet).join(", ")
-            : "none";
+      const allowedText = allowSet.size > 0 ? Array.from(allowSet).join(", ") : "none";
       return {
         status: "forbidden",
         error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText})`,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -354,8 +354,9 @@ export async function spawnSubagentDirect(
         .map((value) => normalizeAgentId(value).toLowerCase()),
     );
     const configuredSet = new Set(
-      (Array.isArray(cfg.agents?.list) ? cfg.agents.list : [])
-        .map((entry) => normalizeAgentId(entry.id).toLowerCase()),
+      (Array.isArray(cfg.agents?.list) ? cfg.agents.list : []).map((entry) =>
+        normalizeAgentId(entry.id).toLowerCase(),
+      ),
     );
     const isAllowed = allowAny
       ? true

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -46,7 +46,9 @@ export function createAgentsListTool(opts?: {
           DEFAULT_AGENT_ID,
       );
 
-      const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+      const requesterAgentCfg = resolveAgentConfig(cfg, requesterAgentId);
+      const explicitAllowAgents = requesterAgentCfg?.subagents?.allowAgents;
+      const allowAgents = explicitAllowAgents ?? [];
       const allowAny = allowAgents.some((value) => value.trim() === "*");
       const allowSet = new Set(
         allowAgents
@@ -68,6 +70,10 @@ export function createAgentsListTool(opts?: {
       const allowed = new Set<string>();
       allowed.add(requesterAgentId);
       if (allowAny) {
+        for (const id of configuredIds) {
+          allowed.add(id);
+        }
+      } else if (explicitAllowAgents === undefined) {
         for (const id of configuredIds) {
           allowed.add(id);
         }

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -73,10 +73,6 @@ export function createAgentsListTool(opts?: {
         for (const id of configuredIds) {
           allowed.add(id);
         }
-      } else if (explicitAllowAgents === undefined) {
-        for (const id of configuredIds) {
-          allowed.add(id);
-        }
       } else {
         for (const id of allowSet) {
           allowed.add(id);


### PR DESCRIPTION
Problem: `agents_list` can return only `main` even when multiple agents are configured, when requester has no explicit `subagents.allowAgents` set.
Root cause: Missing allowlist was treated like an empty allowlist, so discovery output was restricted to requester id.
Fix: Distinguish `allowAgents` unset vs explicitly empty; when unset, include configured agent ids; keep explicit empty allowlist behavior unchanged.
Testing: `pnpm exec vitest run src/agents/openclaw-tools.agents.test.ts` (5 passed).

Refs #36634
