### PR TITLE
process: fix Windows npm fallback spawn EINVAL

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -65,8 +65,9 @@ function resolveNpmArgvForWindows(argv: string[]): string[] | null {
 
 /**
  * Resolves a command for Windows compatibility.
- * On Windows, non-.exe commands (like pnpm, yarn) are resolved to .cmd; npm/npx
- * are handled by resolveNpmArgvForWindows to avoid spawn EINVAL (no direct .cmd).
+ * On Windows, non-.exe commands (npm, npx, pnpm, yarn) are resolved to .cmd.
+ * npm/npx prefer resolveNpmArgvForWindows, but .cmd fallback is required when
+ * npm-cli.js cannot be found (for example, non-standard Node installs).
  */
 function resolveCommand(command: string): string {
   if (process.platform !== "win32") {
@@ -77,7 +78,7 @@ function resolveCommand(command: string): string {
   if (ext) {
     return command;
   }
-  const cmdCommands = ["pnpm", "yarn"];
+  const cmdCommands = ["npm", "npx", "pnpm", "yarn"];
   if (cmdCommands.includes(basename)) {
     return `${command}.cmd`;
   }

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const spawnMock = vi.hoisted(() => vi.fn());
@@ -53,13 +54,14 @@ type ExecCall = [
 function expectCmdWrappedInvocation(params: {
   captured: SpawnCall | ExecCall | undefined;
   expectedComSpec: string;
+  expectedCommand: string;
 }) {
   if (!params.captured) {
     throw new Error("expected command wrapper to be called");
   }
   expect(params.captured[0]).toBe(params.expectedComSpec);
   expect(params.captured[1].slice(0, 3)).toEqual(["/d", "/s", "/c"]);
-  expect(params.captured[1][3]).toContain("pnpm.cmd --version");
+  expect(params.captured[1][3]).toContain(`${params.expectedCommand} --version`);
   expect(params.captured[2].windowsVerbatimArguments).toBe(true);
 }
 
@@ -82,9 +84,29 @@ describe("windows command wrapper behavior", () => {
       const result = await runCommandWithTimeout(["pnpm", "--version"], { timeoutMs: 1000 });
       expect(result.code).toBe(0);
       const captured = spawnMock.mock.calls[0] as SpawnCall | undefined;
-      expectCmdWrappedInvocation({ captured, expectedComSpec });
+      expectCmdWrappedInvocation({ captured, expectedComSpec, expectedCommand: "pnpm.cmd" });
     } finally {
       platformSpy.mockRestore();
+    }
+  });
+
+  it("falls back to npm.cmd wrapper in runCommandWithTimeout when npm-cli.js is missing", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
+
+    spawnMock.mockImplementation(
+      (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
+    );
+
+    try {
+      const result = await runCommandWithTimeout(["npm", "--version"], { timeoutMs: 1000 });
+      expect(result.code).toBe(0);
+      const captured = spawnMock.mock.calls[0] as SpawnCall | undefined;
+      expectCmdWrappedInvocation({ captured, expectedComSpec, expectedCommand: "npm.cmd" });
+    } finally {
+      platformSpy.mockRestore();
+      existsSpy.mockRestore();
     }
   });
 
@@ -106,9 +128,35 @@ describe("windows command wrapper behavior", () => {
     try {
       await runExec("pnpm", ["--version"], 1000);
       const captured = execFileMock.mock.calls[0] as ExecCall | undefined;
-      expectCmdWrappedInvocation({ captured, expectedComSpec });
+      expectCmdWrappedInvocation({ captured, expectedComSpec, expectedCommand: "pnpm.cmd" });
     } finally {
       platformSpy.mockRestore();
+    }
+  });
+
+  it("falls back to npm.cmd wrapper in runExec when npm-cli.js is missing", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
+
+    execFileMock.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        cb: (err: Error | null, stdout: string, stderr: string) => void,
+      ) => {
+        cb(null, "ok", "");
+      },
+    );
+
+    try {
+      await runExec("npm", ["--version"], 1000);
+      const captured = execFileMock.mock.calls[0] as ExecCall | undefined;
+      expectCmdWrappedInvocation({ captured, expectedComSpec, expectedCommand: "npm.cmd" });
+    } finally {
+      platformSpy.mockRestore();
+      existsSpy.mockRestore();
     }
   });
 });

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -51,6 +51,20 @@ type ExecCall = [
   (err: Error | null, stdout: string, stderr: string) => void,
 ];
 
+function mockMissingNpmCli() {
+  const originalExistsSync = fs.existsSync.bind(fs);
+  return vi.spyOn(fs, "existsSync").mockImplementation((candidate: fs.PathLike) => {
+    const normalized = String(candidate).replaceAll("\\", "/").toLowerCase();
+    if (normalized.endsWith("/node_modules/npm/bin/npm-cli.js")) {
+      return false;
+    }
+    if (normalized.endsWith("/node_modules/npm/bin/npx-cli.js")) {
+      return false;
+    }
+    return originalExistsSync(candidate);
+  });
+}
+
 function expectCmdWrappedInvocation(params: {
   captured: SpawnCall | ExecCall | undefined;
   expectedComSpec: string;
@@ -92,7 +106,7 @@ describe("windows command wrapper behavior", () => {
 
   it("falls back to npm.cmd wrapper in runCommandWithTimeout when npm-cli.js is missing", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    const existsSpy = mockMissingNpmCli();
     const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
 
     spawnMock.mockImplementation(
@@ -136,7 +150,7 @@ describe("windows command wrapper behavior", () => {
 
   it("falls back to npm.cmd wrapper in runExec when npm-cli.js is missing", async () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    const existsSpy = mockMissingNpmCli();
     const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
 
     execFileMock.mockImplementation(


### PR DESCRIPTION
## Summary
- Fix the unresolved Windows fallback for `spawn EINVAL` by resolving `npm`/`npx` to `.cmd` when `resolveNpmArgvForWindows` cannot find `npm-cli.js`.
- Keep the existing secure execution path (`cmd.exe /d /s /c` wrapper + argument escaping), and do **not** enable `shell: true`.
- Add deterministic Windows regression tests for both `runCommandWithTimeout` and `runExec` that force missing `npm-cli.js` and verify `npm.cmd` fallback.

## Why
`#31147` fixed the standard Node layout (`node + npm-cli.js`) but fallback cases (nvm/portable/non-standard installs where `npm-cli.js` is not present at the expected path) still hit `spawn EINVAL` in the `npm` path.

## Related
- closes #7631
- related #8836
- related #9224
- related #12593
- related #13936
- related #33194
- related #33830

## Validation
- `pnpm exec vitest run src/process/exec.windows.test.ts src/process/exec.test.ts`
- `pnpm check`
- `pnpm build`
