### PR TITLE
fix(slack): propagate mediaLocalRoots through Slack send path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/local file upload allowlist parity: propagate `mediaLocalRoots` through the Slack send action pipeline so workspace-rooted attachments pass `assertLocalMediaAllowed` checks while non-allowlisted paths remain blocked. (synthesis: #36656; overlap considered from #36516, #36496, #36493, #36484, #32648, #30888) Thanks @2233admin.
 - Agents/compaction safeguard pre-check: skip embedded compaction before entering the Pi SDK when a session has no real conversation messages, avoiding unnecessary LLM API calls on idle sessions. (#36451) thanks @Sid-Qin.
 - iMessage/cron completion announces: strip leaked inline reply tags (for example `[[reply_to:6100]]`) from user-visible completion text so announcement deliveries do not expose threading metadata. (#24600) Thanks @vincentkoc.
 - Feishu/group slash command detection: normalize group mention wrappers before command-authorization probing so mention-prefixed commands (for example `@Bot/model` and `@Bot /reset`) are recognized as gateway commands instead of being forwarded to the agent. (#35994) Thanks @liuxiaopai-ai.

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -50,6 +50,8 @@ export type SlackActionContext = {
   replyToMode?: "off" | "first" | "all";
   /** Mutable ref to track if a reply was sent (for "first" mode). */
   hasRepliedRef?: { value: boolean };
+  /** Allowed local media directories for file uploads. */
+  mediaLocalRoots?: readonly string[];
 };
 
 /**
@@ -209,6 +211,7 @@ export async function handleSlackAction(
         const result = await sendSlackMessage(to, content ?? "", {
           ...writeOpts,
           mediaUrl: mediaUrl ?? undefined,
+          mediaLocalRoots: context?.mediaLocalRoots,
           threadTs: threadTs ?? undefined,
           blocks,
         });

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -15,7 +15,10 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
         normalizeChannelId: resolveSlackChannelId,
         includeReadThreadId: true,
         invoke: async (action, cfg, toolContext) =>
-          await handleSlackAction(action, cfg, toolContext as SlackActionContext | undefined),
+          await handleSlackAction(action, cfg, {
+            ...(toolContext as SlackActionContext | undefined),
+            mediaLocalRoots: ctx.mediaLocalRoots,
+          }),
       });
     },
   };

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -159,6 +159,7 @@ export async function sendSlackMessage(
   content: string,
   opts: SlackActionClientOpts & {
     mediaUrl?: string;
+    mediaLocalRoots?: readonly string[];
     threadTs?: string;
     blocks?: (Block | KnownBlock)[];
   } = {},
@@ -167,6 +168,7 @@ export async function sendSlackMessage(
     accountId: opts.accountId,
     token: opts.token,
     mediaUrl: opts.mediaUrl,
+    mediaLocalRoots: opts.mediaLocalRoots,
     client: opts.client,
     threadTs: opts.threadTs,
     blocks: opts.blocks,


### PR DESCRIPTION
## Summary

After the CVE fix in v2026.3.2 added `assertLocalMediaAllowed` enforcement for outbound file attachments, all local file uploads via Slack fail with `LocalMediaAccessError("path-not-allowed")`. The Feishu plugin was patched in #27884 but Slack was missed.

**Root cause**: `mediaLocalRoots` (from `ChannelMessageActionContext`) is available at the channel layer but never propagated through the three-layer Slack call chain:

1. `slack.actions.ts` — invoke callback didn't pass `ctx.mediaLocalRoots`
2. `slack-actions.ts` — `SlackActionContext` didn't include `mediaLocalRoots`, `handleSlackAction` didn't forward it
3. `actions.ts` — `sendSlackMessage` didn't accept or pass `mediaLocalRoots` to `sendMessageSlack`

Note: `sendMessageSlack` in `send.ts` already supports `mediaLocalRoots` — it just was never receiving it.

**Fix**: Propagate `mediaLocalRoots` through all three layers, matching the pattern used by Discord and Feishu.

Fixes #36477

## Test plan

- [ ] Configure agent with workspace outside default state dirs, generate a file, send via Slack — verify upload succeeds
- [ ] Verify files outside allowed roots are still blocked
- [ ] Existing Slack action tests pass