### PR TITLE
fix(telegram): split long messages at word boundaries, not character boundaries

### DIFF
--- a/src/telegram/format.test.ts
+++ b/src/telegram/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { markdownToTelegramHtml } from "./format.js";
+import { markdownToTelegramHtml, markdownToTelegramHtmlChunks } from "./format.js";
 
 describe("markdownToTelegramHtml", () => {
   it("handles core markdown-to-telegram conversions", () => {
@@ -111,5 +111,32 @@ describe("markdownToTelegramHtml", () => {
     const res = markdownToTelegramHtml("||secret|| trailing ||");
     expect(res).toContain("<tg-spoiler>secret</tg-spoiler>");
     expect(res).toContain("trailing ||");
+  });
+});
+
+describe("markdownToTelegramHtmlChunks", () => {
+  it("does not split words at character boundaries", () => {
+    // "Regulatory overhang lifts beta for UK banks" is 44 chars.
+    // With limit=30, naive slice would cut mid-"beta" ("...lifts bet" / "a for UK banks").
+    // Word-boundary split must keep "beta" intact in a single chunk.
+    const chunks = markdownToTelegramHtmlChunks(
+      "Regulatory overhang lifts beta for UK banks",
+      30,
+    );
+    expect(chunks.length).toBeGreaterThan(1);
+    const joined = chunks.join("");
+    // Every word from the original must appear complete in exactly one chunk
+    for (const word of ["Regulatory", "overhang", "lifts", "beta", "for", "UK", "banks"]) {
+      expect(chunks.some((c) => c.includes(word))).toBe(true);
+      // The word must not be split across a chunk boundary
+      expect(joined).toContain(word);
+    }
+  });
+
+  it("falls back gracefully when the limit is smaller than any word", () => {
+    // If no whitespace exists before the limit, split at the limit (unchanged behaviour)
+    const chunks = markdownToTelegramHtmlChunks("superlongwordwithnobreaks", 10);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe("superlongwordwithnobreaks");
   });
 });

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -312,7 +312,12 @@ function splitMarkdownIRPreserveWhitespace(ir: MarkdownIR, limit: number): Markd
   const chunks: MarkdownIR[] = [];
   let cursor = 0;
   while (cursor < ir.text.length) {
-    const end = Math.min(ir.text.length, cursor + normalizedLimit);
+    let end = Math.min(ir.text.length, cursor + normalizedLimit);
+    // Avoid splitting mid-word: find the last whitespace before the limit
+    if (end < ir.text.length) {
+      const lastSpace = ir.text.lastIndexOf(" ", end);
+      if (lastSpace > cursor) end = lastSpace;
+    }
     chunks.push({
       text: ir.text.slice(cursor, end),
       styles: sliceStyleSpans(ir.styles, cursor, end),


### PR DESCRIPTION
## Summary

Fixes #36644

`splitMarkdownIRPreserveWhitespace` used a naive `text.slice(cursor, cursor + limit)` cut, producing fragments like `...lifts bet` / `a for UK banks` when messages were re-chunked after HTML rendering.

Walk back to the last whitespace before the limit so chunks always end on a clean word boundary. Falls back to a hard character split only when no whitespace exists in the window (single token longer than the limit).

## Changes

- `src/telegram/format.ts`: in `splitMarkdownIRPreserveWhitespace`, find `lastIndexOf(" ", end)` and use it as the split point when one exists in the current window
- `src/telegram/format.test.ts`: add `markdownToTelegramHtmlChunks` word-boundary tests (no mid-word split; graceful fallback for single long tokens)

---
🤖 Generated with Claude Code