### PR TITLE
cron: keep hot schedule evaluators in cache longer

### DIFF
--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -5,6 +5,7 @@ import {
   computeNextRunAtMs,
   computePreviousRunAtMs,
   getCronScheduleCacheSizeForTest,
+  hasCronScheduleCacheEntryForTest,
 } from "./schedule.js";
 
 describe("cron schedule", () => {
@@ -142,6 +143,34 @@ describe("cron schedule", () => {
     expect(second).toBeDefined();
     expect(third).toBeDefined();
     expect(getCronScheduleCacheSizeForTest()).toBe(2);
+  });
+
+  it("keeps recently used cron evaluators hot when cache reaches max size", () => {
+    const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
+    const hotExpr = "0 8 * * *";
+    const hotTz = "UTC";
+
+    computeNextRunAtMs({ kind: "cron", expr: hotExpr, tz: hotTz }, nowMs);
+
+    let i = 0;
+    while (getCronScheduleCacheSizeForTest() < 512 && i < 2_000) {
+      const minute = i % 60;
+      const hour = Math.floor(i / 60) % 24;
+      const expr = `0 ${minute} ${hour} * * *`;
+      computeNextRunAtMs({ kind: "cron", expr, tz: "UTC" }, nowMs + i * 1_000);
+      i += 1;
+    }
+
+    expect(getCronScheduleCacheSizeForTest()).toBe(512);
+    expect(hasCronScheduleCacheEntryForTest(hotExpr, hotTz)).toBe(true);
+
+    // Touch the hot key so LRU promotion keeps it from becoming the eviction candidate.
+    computeNextRunAtMs({ kind: "cron", expr: hotExpr, tz: hotTz }, nowMs + 10_000);
+
+    computeNextRunAtMs({ kind: "cron", expr: "1 59 23 * * *", tz: "UTC" }, nowMs + 20_000);
+
+    expect(getCronScheduleCacheSizeForTest()).toBe(512);
+    expect(hasCronScheduleCacheEntryForTest(hotExpr, hotTz)).toBe(true);
   });
 
   describe("cron with specific seconds (6-field pattern)", () => {

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -17,6 +17,9 @@ function resolveCachedCron(expr: string, timezone: string): Cron {
   const key = `${timezone}\u0000${expr}`;
   const cached = cronEvalCache.get(key);
   if (cached) {
+    // Promote hot entries so eviction behaves like LRU under high-churn workloads.
+    cronEvalCache.delete(key);
+    cronEvalCache.set(key, cached);
     return cached;
   }
   if (cronEvalCache.size >= CRON_EVAL_CACHE_MAX) {
@@ -163,4 +166,8 @@ export function clearCronScheduleCacheForTest(): void {
 
 export function getCronScheduleCacheSizeForTest(): number {
   return cronEvalCache.size;
+}
+
+export function hasCronScheduleCacheEntryForTest(expr: string, timezone: string): boolean {
+  return cronEvalCache.has(`${timezone}\u0000${expr}`);
 }


### PR DESCRIPTION
## Summary
- promote cron schedule cache hits to most-recently-used order
- keep current cache bound intact while reducing churn-driven recompilation
- add regression coverage proving hot entries survive max-size churn after a touch

## Why
Under high expression churn, FIFO-like eviction can drop frequently reused evaluators, causing avoidable Cron recompilation on hot paths.

## Risk
Low. Behavior changes only on cache-hit ordering and keeps the existing max-size bound unchanged.

## Validation
- pnpm -s vitest run src/cron/schedule.test.ts