### PR TITLE
fix(config): hash merged schema cache key inputs

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -162,6 +162,26 @@ describe("config schema", () => {
     expect(second).toBe(first);
   });
 
+  it("invalidates merged schema cache when plugin schema changes", () => {
+    const first = buildConfigSchema(cachedMergeInput);
+    const second = buildConfigSchema({
+      plugins: [
+        {
+          ...cachedMergeInput.plugins![0],
+          configSchema: {
+            ...(cachedMergeInput.plugins![0].configSchema as Record<string, unknown>),
+            properties: {
+              provider: { type: "string" },
+              region: { type: "string" },
+            },
+          },
+        },
+      ],
+      channels: [{ ...cachedMergeInput.channels![0] }],
+    });
+    expect(second).not.toBe(first);
+  });
+
   it("derives security/auth tags for credential paths", () => {
     const tags = deriveTagsForPath("gateway.auth.token");
     expect(tags).toContain("security");

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { CHANNEL_IDS } from "../channels/registry.js";
 import { VERSION } from "../version.js";
 import type { ConfigUiHint, ConfigUiHints } from "./schema.hints.js";
@@ -300,6 +301,10 @@ let cachedBase: ConfigSchemaResponse | null = null;
 const mergedSchemaCache = new Map<string, ConfigSchemaResponse>();
 const MERGED_SCHEMA_CACHE_MAX = 64;
 
+function hashJson(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
 function buildMergedSchemaCacheKey(params: {
   plugins: PluginUiMetadata[];
   channels: ChannelUiMetadata[];
@@ -309,8 +314,8 @@ function buildMergedSchemaCacheKey(params: {
       id: plugin.id,
       name: plugin.name,
       description: plugin.description,
-      configSchema: plugin.configSchema ?? null,
-      configUiHints: plugin.configUiHints ?? null,
+      configSchemaHash: hashJson(plugin.configSchema ?? null),
+      configUiHintsHash: hashJson(plugin.configUiHints ?? null),
     }))
     .toSorted((a, b) => a.id.localeCompare(b.id));
   const channels = params.channels
@@ -318,11 +323,11 @@ function buildMergedSchemaCacheKey(params: {
       id: channel.id,
       label: channel.label,
       description: channel.description,
-      configSchema: channel.configSchema ?? null,
-      configUiHints: channel.configUiHints ?? null,
+      configSchemaHash: hashJson(channel.configSchema ?? null),
+      configUiHintsHash: hashJson(channel.configUiHints ?? null),
     }))
     .toSorted((a, b) => a.id.localeCompare(b.id));
-  return JSON.stringify({ plugins, channels });
+  return hashJson({ plugins, channels });
 }
 
 function setMergedSchemaCache(key: string, value: ConfigSchemaResponse): void {


### PR DESCRIPTION
Problem:  serialized full plugin/channel schemas into one giant JSON cache key, which can overflow  with many configured channels/plugins and trigger RangeError (/OpenClaw status

Overview
┌─────────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Item            │ Value                                                                                             │
├─────────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Dashboard       │ http://127.0.0.1:18789/                                                                           │
│ OS              │ macos 26.3 (arm64) · node 25.5.0                                                                  │
│ Tailscale       │ off                                                                                               │
│ Channel         │ stable (default)                                                                                  │
│ Update          │ pnpm · npm latest 2026.3.2                                                                        │
│ Gateway         │ local · ws://127.0.0.1:18789 (local loopback) · reachable 8ms · auth token · DevMacs-MacBook-Air. │
│                 │ local (10.3.13.5) app 2026.2.24 macos 26.3                                                        │
│ Gateway service │ LaunchAgent installed · loaded · running (pid 16997, state active)                                │
│ Node service    │ LaunchAgent not installed                                                                         │
│ Agents          │ 1 · no bootstrap files · sessions 23 · default main active 1m ago                                 │
│ Memory          │ 0 files · 0 chunks · dirty · sources memory · plugin memory-core · vector unknown · fts ready ·   │
│                 │ cache on (0)                                                                                      │
│ Probes          │ skipped (use --deep)                                                                              │
│ Events          │ none                                                                                              │
│ Heartbeat       │ 10m (main)                                                                                        │
│ Sessions        │ 23 active · default gpt-5.3-codex (200k ctx) · ~/.openclaw/agents/main/sessions/sessions.json     │
└─────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────┘

Security audit
Summary: 1 critical · 4 warn · 2 info
  CRITICAL Gateway auth missing on loopback
    gateway.bind is loopback but no gateway auth secret is configured. If the Control UI is exposed through a reverse proxy, unauthenticated access is possible.
    Fix: Set gateway.auth (token recommended) or keep the Control UI local-only.
  WARN Reverse proxy headers are not trusted
    gateway.bind is loopback and gateway.trustedProxies is empty. If you expose the Control UI through a reverse proxy, configure trusted proxies so local-client c…
    Fix: Set gateway.trustedProxies to your proxy IPs or keep the Control UI local-only.
  WARN hooks.defaultSessionKey is not configured
    Hook agent runs without explicit sessionKey use generated per-request keys. Set hooks.defaultSessionKey to keep hook ingress scoped to a known session.
    Fix: Set hooks.defaultSessionKey (for example, "hook:ingress").
  WARN Gateway HTTP APIs are reachable without auth
    gateway.auth.mode="none" leaves /tools/invoke callable without a shared secret. Treat this as trusted-local only and avoid exposing the gateway beyond loopback.
    Fix: Set gateway.auth.mode to token/password (recommended). If you intentionally keep mode=none, keep gateway.bind=loopback and disable optional HTTP endpoints.
  WARN Potential multi-user setup detected (personal-assistant model warning)
    Heuristic signals indicate this gateway may be reachable by multiple users: - channels.slack.groupPolicy="allowlist" with configured group targets Runtime/proc…
    Fix: If users may be mutually untrusted, split trust boundaries (separate gateways + credentials, ideally separate OS users/hosts). If you intentionally run shared-user access, set agents.defaults.sandbox.mode="all", keep tools.fs.workspaceOnly=true, deny runtime/fs/web tools unless required, and keep personal/private identities + credentials off that runtime.
Full report: openclaw security audit
Deep probe: openclaw security audit --deep

Channels
┌──────────┬─────────┬────────┬───────────────────────────────────────────────────────────────────────────────────────┐
│ Channel  │ Enabled │ State  │ Detail                                                                                │
├──────────┼─────────┼────────┼───────────────────────────────────────────────────────────────────────────────────────┤
│ Slack    │ ON      │ OK     │ tokens ok (bot config, app config) (bot xoxb…OZXC · len 59, app xapp…c9cb · len 98)   │
│          │         │        │ · accounts 1/1                                                                        │
└──────────┴─────────┴────────┴───────────────────────────────────────────────────────────────────────────────────────┘

Sessions
┌────────────────────────────────────────────────┬────────┬─────────┬───────────────┬─────────────────────────────────┐
│ Key                                            │ Kind   │ Age     │ Model         │ Tokens                          │
├────────────────────────────────────────────────┼────────┼─────────┼───────────────┼─────────────────────────────────┤
│ agent:main:hook:gmail:19cbfa33a…               │ direct │ 1m ago  │ gpt-5.3-codex │ 16k/272k (6%)                   │
│ agent:main:slack:channel:c0aedl…               │ group  │ 1m ago  │ gpt-5.3-codex │ 28k/272k (10%) · 🗄️ 31% cached  │
│ agent:main:main                                │ direct │ 2m ago  │ gpt-5.3-codex │ unknown/200k (?%)               │
│ agent:main:subagent:bc8e00a4-c6…               │ direct │ 2m ago  │ gpt-5.3-codex │ 21k/272k (8%) · 🗄️ 1540% cached │
│ agent:main:subagent:c7c94d61-68…               │ direct │ 2m ago  │ gpt-5.3-codex │ 16k/272k (6%) · 🗄️ 1330% cached │
│ agent:main:slack:channel:c0ae4j…               │ group  │ 2m ago  │ gpt-5.3-codex │ 48k/272k (18%) · 🗄️ 100% cached │
│ agent:main:hook:gmail:19cbf9fc7…               │ direct │ 4m ago  │ gpt-5.3-codex │ 16k/272k (6%)                   │
│ agent:main:hook:gmail:19cbf9dd5…               │ direct │ 7m ago  │ gpt-5.3-codex │ 16k/272k (6%) · 🗄️ 9% cached    │
│ agent:main:hook:gmail:19cbf9dc1…               │ direct │ 7m ago  │ gpt-5.3-codex │ 16k/272k (6%)                   │
│ agent:main:hook:gmail:19cbf9d93…               │ direct │ 7m ago  │ gpt-5.3-codex │ 16k/272k (6%) · 🗄️ 10% cached   │
└────────────────────────────────────────────────┴────────┴─────────┴───────────────┴─────────────────────────────────┘

FAQ: https://docs.openclaw.ai/faq
Troubleshooting: https://docs.openclaw.ai/troubleshooting

Next steps:
  Need to share?      openclaw status --all
  Need to debug live? openclaw logs --follow
  Need to test channels? openclaw status --deep).

Root cause: cache key generation stored full schema payloads instead of a bounded fingerprint.

Fix:
- hash each plugin/channel  and  payload
- build a compact sorted metadata summary
- hash the summary to produce a fixed-size cache key

Testing:
- 
[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/Users/devmac/Projects/openclaw-36508[39m

 [32m✓[39m src/config/schema.test.ts [2m([22m[2m11 tests[22m[2m)[22m[33m 508[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m11 passed[39m[22m[90m (11)[39m
[2m   Start at [22m 21:15:12
[2m   Duration [22m 1.13s[2m (transform 315ms, setup 166ms, import 317ms, tests 508ms, environment 0ms)[22m
- added regression: cache invalidates when plugin schema changes

Refs #36508