### PR TITLE
fix(media): convert GIF to PNG before passing to vision models

### DIFF
--- a/src/media-understanding/providers/image.ts
+++ b/src/media-understanding/providers/image.ts
@@ -4,6 +4,7 @@ import { minimaxUnderstandImage } from "../../agents/minimax-vlm.js";
 import { getApiKeyForModel, requireApiKey } from "../../agents/model-auth.js";
 import { ensureOpenClawModelsJson } from "../../agents/models-config.js";
 import { coerceImageAssistantText } from "../../agents/tools/image-tool.helpers.js";
+import { convertGifFirstFrameToPng } from "../../media/image-ops.js";
 import type { ImageDescriptionRequest, ImageDescriptionResult } from "../types.js";
 
 let piModelDiscoveryRuntimePromise: Promise<
@@ -39,12 +40,25 @@ export async function describeImageWithModel(
   const apiKey = requireApiKey(apiKeyInfo, model.provider);
   authStorage.setRuntimeApiKey(model.provider, apiKey);
 
-  const base64 = params.buffer.toString("base64");
+  // Most vision APIs (Google Gemini, xAI Grok, OpenAI) reject image/gif.
+  // Extract the first frame and convert to PNG so the request succeeds.
+  let imageBuffer = params.buffer;
+  let imageMime = params.mime ?? "image/jpeg";
+  if (imageMime === "image/gif") {
+    try {
+      imageBuffer = await convertGifFirstFrameToPng(imageBuffer);
+      imageMime = "image/png";
+    } catch {
+      // Conversion failed — pass through as-is; the model error will surface normally.
+    }
+  }
+
+  const base64 = imageBuffer.toString("base64");
   if (model.provider === "minimax") {
     const text = await minimaxUnderstandImage({
       apiKey,
       prompt: params.prompt ?? "Describe the image.",
-      imageDataUrl: `data:${params.mime ?? "image/jpeg"};base64,${base64}`,
+      imageDataUrl: `data:${imageMime};base64,${base64}`,
       modelBaseUrl: model.baseUrl,
     });
     return { text, model: model.id };
@@ -56,7 +70,7 @@ export async function describeImageWithModel(
         role: "user",
         content: [
           { type: "text", text: params.prompt ?? "Describe the image." },
-          { type: "image", data: base64, mimeType: params.mime ?? "image/jpeg" },
+          { type: "image", data: base64, mimeType: imageMime },
         ],
         timestamp: Date.now(),
       },

--- a/src/media/image-ops.ts
+++ b/src/media/image-ops.ts
@@ -364,6 +364,19 @@ export async function convertHeicToJpeg(buffer: Buffer): Promise<Buffer> {
 }
 
 /**
+ * Extracts the first frame of a GIF and converts it to PNG.
+ * Most vision models (Google Gemini, xAI Grok, OpenAI) reject image/gif —
+ * this normalises animated or static GIFs to a widely-accepted format.
+ */
+export async function convertGifFirstFrameToPng(buffer: Buffer): Promise<Buffer> {
+  // Load sharp directly so we can pass `pages: 1` to restrict decoding to the
+  // first animation frame (keeps memory usage flat for large animated GIFs).
+  const mod = (await import("sharp")) as unknown as { default?: Sharp };
+  const sharp = mod.default ?? (mod as unknown as Sharp);
+  return await sharp(buffer, { pages: 1, failOnError: false }).png().toBuffer();
+}
+
+/**
  * Checks if an image has an alpha channel (transparency).
  * Returns true if the image has alpha, false otherwise.
  */


### PR DESCRIPTION
## Summary

Fixes #36635

Most vision APIs (Google Gemini, xAI Grok, OpenAI) return HTTP 400 for `image/gif` with:
> Invalid request content: Downloaded response does not contain a valid JPG, PNG, or WebP image.

The raw error leaks into chat as the bot's reply and can jam the agent for subsequent turns.

## Root cause

`describeImageWithModel` forwarded `params.mime` and the raw buffer directly to the provider. When the inbound file was a GIF, the MIME type `image/gif` was passed unchanged, causing rejection.

## Fix

Two-file change:

1. **`src/media/image-ops.ts`** — add `convertGifFirstFrameToPng(buffer)`: loads `sharp` with `{ pages: 1 }` (first animation frame only, to keep memory flat for large animated GIFs) and emits PNG.

2. **`src/media-understanding/providers/image.ts`** — before building the base64 payload, check `imageMime === "image/gif"` and run the conversion. Falls back silently on failure so the error surfaces through the normal model-response path rather than crashing the pipeline.

## Impact

- Static and animated GIFs sent via Signal (or any other channel) now produce a description instead of an error.
- Signal's built-in GIF picker (which sends mp4) is unaffected — this only triggers on `image/gif` MIME.
- No change to PNG / JPEG / WebP / HEIC paths.

---
🤖 Generated with Claude Code