### PR TITLE
fix: preserve anthropic path prefixes for kimi-coding baseUrl

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -116,7 +116,16 @@ describe("normalizeModelCompat — Anthropic baseUrl", () => {
       baseUrl: "https://my-proxy.example.com/anthropic/v1",
     };
     const normalized = normalizeModelCompat(model);
-    expect(normalized.baseUrl).toBe("https://my-proxy.example.com/anthropic");
+    expect(normalized.baseUrl).toBe("https://my-proxy.example.com/anthropic/");
+  });
+
+  it("adds trailing slash for anthropic-messages baseUrl with path prefix", () => {
+    const model = {
+      ...anthropicBase(),
+      baseUrl: "https://api.kimi.com/coding",
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(normalized.baseUrl).toBe("https://api.kimi.com/coding/");
   });
 });
 

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -37,6 +37,8 @@ function normalizeAnthropicBaseUrl(baseUrl: string): string {
   const stripped = baseUrl.replace(/\/v1\/?$/, "");
   try {
     const parsed = new URL(stripped);
+    // Root-origin URLs (`/`) don't need a trailing slash for relative resolution,
+    // but path-prefixed base URLs do (for example `/coding`) or the prefix can be dropped.
     if (parsed.pathname !== "/" && !parsed.pathname.endsWith("/")) {
       parsed.pathname = `${parsed.pathname}/`;
       return parsed.toString();

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -34,7 +34,17 @@ function isAnthropicMessagesModel(model: Model<Api>): model is Model<"anthropic-
  * baseUrl for anthropic-messages models so users with either format work.
  */
 function normalizeAnthropicBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/v1\/?$/, "");
+  const stripped = baseUrl.replace(/\/v1\/?$/, "");
+  try {
+    const parsed = new URL(stripped);
+    if (parsed.pathname !== "/" && !parsed.pathname.endsWith("/")) {
+      parsed.pathname = `${parsed.pathname}/`;
+      return parsed.toString();
+    }
+  } catch {
+    return stripped;
+  }
+  return stripped;
 }
 export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   const baseUrl = model.baseUrl ?? "";


### PR DESCRIPTION
## Summary
Fix anthropic-messages baseUrl normalization to preserve non-root path prefixes by ensuring path-prefixed base URLs keep a trailing slash after normalization.

## Changes
- Keep existing trailing /v1 stripping for anthropic-messages providers.
- Add trailing slash when anthropic baseUrl contains a path prefix (e.g. /coding) so request URL builders do not drop the prefix.
- Add regression tests for custom proxy + kimi-coding-style baseUrl.

## Testing
- pnpm vitest run src/agents/model-compat.test.ts

Fixes openclaw/openclaw#36353