### PR TITLE
fix(auth): treat missing OAuth scopes as permanent auth failure

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -113,6 +113,13 @@ describe("formatAssistantErrorText", () => {
     expect(formatAssistantErrorText(msg)).toContain("rate limit reached");
   });
 
+  it("returns a scope remediation hint for missing OAuth scopes", () => {
+    const msg = makeAssistantError("401 Unauthorized - Missing scopes: api.responses.write");
+    const text = formatAssistantErrorText(msg);
+    expect(text).toContain("missing required API scopes");
+    expect(text).toContain("Re-authenticate");
+  });
+
   it("returns a friendly message for empty stream chunk errors", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -120,6 +120,15 @@ describe("formatAssistantErrorText", () => {
     expect(text).toContain("Re-authenticate");
   });
 
+  it("returns the same scope remediation hint for JSON-wrapped missing-scope errors", () => {
+    const msg = makeAssistantError(
+      '{"error":{"message":"Missing scopes: api.responses.write","type":"invalid_request_error"}}',
+    );
+    const text = formatAssistantErrorText(msg);
+    expect(text).toContain("missing required API scopes");
+    expect(text).toContain("Re-authenticate");
+  });
+
   it("returns a friendly message for empty stream chunk errors", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -117,6 +117,7 @@ describe("formatAssistantErrorText", () => {
     const msg = makeAssistantError("401 Unauthorized - Missing scopes: api.responses.write");
     const text = formatAssistantErrorText(msg);
     expect(text).toContain("missing required API scopes");
+    expect(text).toContain("Missing: api.responses.write");
     expect(text).toContain("Re-authenticate");
   });
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -30,6 +30,7 @@ describe("isAuthPermanentErrorMessage", () => {
       "could not validate credentials",
       "API_KEY_REVOKED",
       "api_key_deleted",
+      "401 Unauthorized - Missing scopes: api.responses.write",
     ];
     for (const sample of samples) {
       expect(isAuthPermanentErrorMessage(sample)).toBe(true);
@@ -492,7 +493,7 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("You have insufficient permissions for this operation.")).toBe(
       "auth",
     );
-    expect(classifyFailoverReason("Missing scopes: model.request")).toBe("auth");
+    expect(classifyFailoverReason("Missing scopes: model.request")).toBe("auth_permanent");
     expect(classifyFailoverReason("429 too many requests")).toBe("rate_limit");
     expect(classifyFailoverReason("resource has been exhausted")).toBe("rate_limit");
     expect(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -551,6 +551,13 @@ export function formatAssistantErrorText(
     return transientCopy;
   }
 
+  if (/missing scopes?:/i.test(raw)) {
+    return (
+      "Authentication succeeded but the token is missing required API scopes. " +
+      "Re-authenticate with the provider and ensure the required scopes are granted."
+    );
+  }
+
   if (isTimeoutErrorMessage(raw)) {
     return "LLM request timed out.";
   }

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -551,10 +551,14 @@ export function formatAssistantErrorText(
     return transientCopy;
   }
 
-  if (/missing scopes?:/i.test(raw)) {
+  const missingScopesMatch = raw.match(/missing scopes?:\s*([^\n]+)/i);
+  if (missingScopesMatch) {
+    const scopes = missingScopesMatch[1]?.trim();
+    const suffix = scopes ? ` Missing: ${scopes}.` : "";
     return (
-      "Authentication succeeded but the token is missing required API scopes. " +
-      "Re-authenticate with the provider and ensure the required scopes are granted."
+      "Authentication succeeded but the token is missing required API scopes." +
+      suffix +
+      " Re-authenticate with the provider and ensure the required scopes are granted."
     );
   }
 

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -53,6 +53,7 @@ const ERROR_PATTERNS = {
     /could not (?:authenticate|validate).*(?:api[_ ]?key|credentials)/i,
     "permission_error",
     "not allowed for this organization",
+    /missing scopes?:/i,
   ],
   auth: [
     /invalid[_ ]?api[_ ]?key/,


### PR DESCRIPTION
Problem: OpenAI Codex OAuth can return "Missing scopes: api.responses.write" and later retries may surface generic 5xx pages, hiding the real root cause.

Root cause: missing-scope errors were classified as generic auth instead of permanent auth.

Fix:
- classify "Missing scopes:" messages as auth_permanent
- add regression coverage for classifyFailoverReason + matcher behavior

Testing:
- pnpm vitest run src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts

Refs #36660