### PR TITLE
fix(tools): map legacy fs/system tool aliases

### DIFF
--- a/src/agents/tool-policy-shared.ts
+++ b/src/agents/tool-policy-shared.ts
@@ -12,6 +12,8 @@ type ToolProfilePolicy = {
 const TOOL_NAME_ALIASES: Record<string, string> = {
   bash: "exec",
   "apply-patch": "apply_patch",
+  "fs.readfile": "read",
+  "system.exec": "exec",
 };
 
 export const TOOL_GROUPS: Record<string, string[]> = { ...CORE_TOOL_GROUPS };

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -73,6 +73,8 @@ describe("tool-policy", () => {
   it("normalizes tool names and aliases", () => {
     expect(normalizeToolName(" BASH ")).toBe("exec");
     expect(normalizeToolName("apply-patch")).toBe("apply_patch");
+    expect(normalizeToolName("fs.readFile")).toBe("read");
+    expect(normalizeToolName("system.exec")).toBe("exec");
     expect(normalizeToolName("READ")).toBe("read");
   });
 


### PR DESCRIPTION
Problem: v3.1-era tool names (for example  and ) no longer resolve to built-ins in v3.2, so old workflows/allowlists report missing read/execute tools.

Root cause: tool-name normalization only handled  and  aliases.

Fix:
- add  alias to 
- add  alias to 
- extend tool-policy regression test coverage

Testing:
- 
[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/private/tmp/openclaw-35350[39m

 [32m✓[39m src/agents/tool-policy.test.ts [2m([22m[2m20 tests[22m[2m)[22m[32m 4[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m20 passed[39m[22m[90m (20)[39m
[2m   Start at [22m 21:22:11
[2m   Duration [22m 1.00s[2m (transform 452ms, setup 103ms, import 804ms, tests 4ms, environment 0ms)[22m

Refs #35350