### PR TITLE
perf(telegram): memoize sticker cache disk loads

### DIFF
--- a/src/telegram/sticker-cache.test.ts
+++ b/src/telegram/sticker-cache.test.ts
@@ -58,6 +58,36 @@ describe("sticker-cache", () => {
       expect(result).toEqual(sticker);
     });
 
+    it("memoizes disk reads across repeated cache lookups", () => {
+      const sticker = {
+        fileId: "memo-file",
+        fileUniqueId: "memo-unique",
+        description: "Memoized cache sticker",
+        cachedAt: "2026-01-26T12:00:00.000Z",
+      };
+
+      fs.mkdirSync(TEST_CACHE_DIR, { recursive: true });
+      fs.writeFileSync(
+        TEST_CACHE_FILE,
+        `${JSON.stringify({ version: 1, stickers: { [sticker.fileUniqueId]: sticker } }, null, 2)}\n`,
+        "utf-8",
+      );
+
+      const readSpy = vi.spyOn(fs, "readFileSync");
+      try {
+        expect(getCachedSticker("memo-unique")).toEqual(sticker);
+        expect(getCachedSticker("memo-unique")).toEqual(sticker);
+        expect(getAllCachedStickers()).toEqual([sticker]);
+
+        const cacheReads = readSpy.mock.calls.filter(
+          ([filePath]) => path.resolve(String(filePath)) === path.resolve(TEST_CACHE_FILE),
+        );
+        expect(cacheReads).toHaveLength(1);
+      } finally {
+        readSpy.mockRestore();
+      }
+    });
+
     it("returns null after cache is cleared", () => {
       const sticker = {
         fileId: "file123",

--- a/src/telegram/sticker-cache.ts
+++ b/src/telegram/sticker-cache.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveApiKeyForProvider } from "../agents/model-auth.js";
@@ -32,21 +33,63 @@ interface StickerCache {
   stickers: Record<string, CachedSticker>;
 }
 
-function loadCache(): StickerCache {
-  const data = loadJsonFile(CACHE_FILE);
+const EMPTY_CACHE: StickerCache = { version: CACHE_VERSION, stickers: {} };
+let inMemoryCache: StickerCache | null = null;
+let cacheBackedByFile = false;
+let cacheFileMtimeMs: number | null = null;
+
+function normalizeCache(data: unknown): StickerCache {
   if (!data || typeof data !== "object") {
-    return { version: CACHE_VERSION, stickers: {} };
+    return { ...EMPTY_CACHE, stickers: {} };
   }
   const cache = data as StickerCache;
   if (cache.version !== CACHE_VERSION) {
     // Future: handle migration if needed
-    return { version: CACHE_VERSION, stickers: {} };
+    return { ...EMPTY_CACHE, stickers: {} };
   }
   return cache;
 }
 
+function readCacheFileMtimeMs(): number | null {
+  try {
+    return fsSync.statSync(CACHE_FILE).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function loadCache(): StickerCache {
+  const currentMtimeMs = readCacheFileMtimeMs();
+
+  if (inMemoryCache) {
+    if (currentMtimeMs === null) {
+      if (cacheBackedByFile) {
+        inMemoryCache = { ...EMPTY_CACHE, stickers: {} };
+      }
+      cacheBackedByFile = false;
+      cacheFileMtimeMs = null;
+      return inMemoryCache;
+    }
+
+    if (!cacheBackedByFile || cacheFileMtimeMs === null || currentMtimeMs !== cacheFileMtimeMs) {
+      inMemoryCache = normalizeCache(loadJsonFile(CACHE_FILE));
+      cacheBackedByFile = true;
+      cacheFileMtimeMs = currentMtimeMs;
+    }
+    return inMemoryCache;
+  }
+
+  inMemoryCache = normalizeCache(loadJsonFile(CACHE_FILE));
+  cacheBackedByFile = currentMtimeMs !== null;
+  cacheFileMtimeMs = currentMtimeMs;
+  return inMemoryCache;
+}
+
 function saveCache(cache: StickerCache): void {
   saveJsonFile(CACHE_FILE, cache);
+  inMemoryCache = cache;
+  cacheFileMtimeMs = readCacheFileMtimeMs();
+  cacheBackedByFile = cacheFileMtimeMs !== null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- memoize sticker-cache load results to avoid disk reads on every lookup
- reload cache when the cache file timestamp changes or when the file is removed
- add a focused test asserting repeated lookups trigger only one cache file read

## Why
Sticker cache lookups can run frequently. Reading and parsing the cache file on each call adds avoidable sync I/O overhead.

## Risk
Low. Existing tests still pass and the new regression test covers the new memoized read behavior.