### PR TITLE
fix(version): prefer build-info when package version is dev placeholder

### DIFF
--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -75,6 +75,17 @@ describe("version resolution", () => {
     });
   });
 
+  it("prefers build-info version when package metadata uses dev placeholder", async () => {
+    await withTempDir(async (root) => {
+      await writeJsonFixture(root, "package.json", { name: "openclaw", version: "dev" });
+      await writeJsonFixture(root, "build-info.json", { version: "2026.3.2" });
+      const moduleUrl = await ensureModuleFixture(root);
+      expect(readVersionFromPackageJsonForModuleUrl(moduleUrl)).toBe("dev");
+      expect(readVersionFromBuildInfoForModuleUrl(moduleUrl)).toBe("2026.3.2");
+      expect(resolveVersionFromModuleUrl(moduleUrl)).toBe("2026.3.2");
+    });
+  });
+
   it("returns null when no version metadata exists", async () => {
     await withTempDir(async (root) => {
       const moduleUrl = await ensureModuleFixture(root);

--- a/src/version.ts
+++ b/src/version.ts
@@ -15,6 +15,7 @@ const BUILD_INFO_CANDIDATES = [
   "../../build-info.json",
   "./build-info.json",
 ] as const;
+const DEV_VERSION_PLACEHOLDER = "dev";
 
 function readVersionFromJsonCandidates(
   moduleUrl: string,
@@ -65,10 +66,16 @@ export function readVersionFromBuildInfoForModuleUrl(moduleUrl: string): string 
 }
 
 export function resolveVersionFromModuleUrl(moduleUrl: string): string | null {
-  return (
-    readVersionFromPackageJsonForModuleUrl(moduleUrl) ||
-    readVersionFromBuildInfoForModuleUrl(moduleUrl)
-  );
+  const packageVersion = readVersionFromPackageJsonForModuleUrl(moduleUrl);
+  const buildInfoVersion = readVersionFromBuildInfoForModuleUrl(moduleUrl);
+  // Homebrew and other wrappers can stamp package.json as "dev"; prefer build metadata when present.
+  if (
+    packageVersion?.trim().toLowerCase() === DEV_VERSION_PLACEHOLDER &&
+    buildInfoVersion?.trim()
+  ) {
+    return buildInfoVersion;
+  }
+  return packageVersion || buildInfoVersion;
 }
 
 export function resolveBinaryVersion(params: {


### PR DESCRIPTION
## Summary
- Fixes Homebrew/packaging cases where package metadata reports `dev` and causes `openclaw --version` to print `dev`
- Update version resolution to prefer `build-info.json` when package version is the placeholder `dev`
- Keep existing behavior unchanged when a concrete package version is present, and still fall back to `dev` if build-info is unavailable

## Testing
- pnpm test -- src/version.test.ts

Fixes #35768
