### PR TITLE
fix(imessage): recover sender identity when sender is missing

### DIFF
--- a/src/imessage/monitor/inbound-processing.test.ts
+++ b/src/imessage/monitor/inbound-processing.test.ts
@@ -91,6 +91,39 @@ describe("resolveIMessageInboundDecision sender fallback", () => {
     expect(decision).toEqual({ kind: "drop", reason: "missing sender" });
   });
 
+  it("trims whitespace on reply_to_sender fallback", () => {
+    const decision = resolveIMessageInboundDecision({
+      cfg,
+      accountId: "default",
+      message: {
+        id: 770,
+        sender: "",
+        reply_to_sender: "  +15555550009  ",
+        text: "hello",
+        is_from_me: false,
+        is_group: false,
+      },
+      opts: undefined,
+      messageText: "hello",
+      bodyText: "hello",
+      allowFrom: [],
+      groupAllowFrom: [],
+      groupPolicy: "open",
+      dmPolicy: "open",
+      storeAllowFrom: [],
+      historyLimit: 0,
+      groupHistories: new Map(),
+      echoCache: undefined,
+      logVerbose: undefined,
+    });
+
+    expect(decision.kind).toBe("dispatch");
+    if (decision.kind !== "dispatch") {
+      return;
+    }
+    expect(decision.sender).toBe("+15555550009");
+  });
+
   it("uses single participant as group sender fallback when sender is missing", () => {
     const decision = resolveIMessageInboundDecision({
       cfg,

--- a/src/imessage/monitor/inbound-processing.test.ts
+++ b/src/imessage/monitor/inbound-processing.test.ts
@@ -91,7 +91,7 @@ describe("resolveIMessageInboundDecision sender fallback", () => {
     expect(decision).toEqual({ kind: "drop", reason: "missing sender" });
   });
 
-  it("trims whitespace on reply_to_sender fallback", () => {
+  it("keeps ignoring reply_to_sender even when padded with whitespace", () => {
     const decision = resolveIMessageInboundDecision({
       cfg,
       accountId: "default",
@@ -117,11 +117,7 @@ describe("resolveIMessageInboundDecision sender fallback", () => {
       logVerbose: undefined,
     });
 
-    expect(decision.kind).toBe("dispatch");
-    if (decision.kind !== "dispatch") {
-      return;
-    }
-    expect(decision.sender).toBe("+15555550009");
+    expect(decision).toEqual({ kind: "drop", reason: "missing sender" });
   });
 
   it("uses single participant as group sender fallback when sender is missing", () => {
@@ -156,6 +152,40 @@ describe("resolveIMessageInboundDecision sender fallback", () => {
       return;
     }
     expect(decision.sender).toBe("+15555550002");
+  });
+
+  it("trims whitespace in single-participant group fallback", () => {
+    const decision = resolveIMessageInboundDecision({
+      cfg,
+      accountId: "default",
+      message: {
+        id: 781,
+        sender: "",
+        participants: ["   +15555550008   "],
+        text: "group msg",
+        chat_id: 1,
+        is_from_me: false,
+        is_group: true,
+      },
+      opts: undefined,
+      messageText: "group msg",
+      bodyText: "group msg",
+      allowFrom: [],
+      groupAllowFrom: [],
+      groupPolicy: "open",
+      dmPolicy: "open",
+      storeAllowFrom: [],
+      historyLimit: 0,
+      groupHistories: new Map(),
+      echoCache: undefined,
+      logVerbose: undefined,
+    });
+
+    expect(decision.kind).toBe("dispatch");
+    if (decision.kind !== "dispatch") {
+      return;
+    }
+    expect(decision.sender).toBe("+15555550008");
   });
 
   it("keeps dropping ambiguous group sender when multiple participants exist", () => {

--- a/src/imessage/monitor/inbound-processing.test.ts
+++ b/src/imessage/monitor/inbound-processing.test.ts
@@ -62,7 +62,7 @@ describe("describeIMessageEchoDropLog", () => {
 describe("resolveIMessageInboundDecision sender fallback", () => {
   const cfg = {} as OpenClawConfig;
 
-  it("uses reply_to_sender when sender is missing", () => {
+  it("does not use reply_to_sender as sender fallback", () => {
     const decision = resolveIMessageInboundDecision({
       cfg,
       accountId: "default",
@@ -88,11 +88,7 @@ describe("resolveIMessageInboundDecision sender fallback", () => {
       logVerbose: undefined,
     });
 
-    expect(decision.kind).toBe("dispatch");
-    if (decision.kind !== "dispatch") {
-      return;
-    }
-    expect(decision.sender).toBe("+15555550001");
+    expect(decision).toEqual({ kind: "drop", reason: "missing sender" });
   });
 
   it("uses single participant as group sender fallback when sender is missing", () => {
@@ -104,7 +100,7 @@ describe("resolveIMessageInboundDecision sender fallback", () => {
         sender: "",
         participants: ["+15555550002"],
         text: "group msg",
-        chat_id: "chat-1",
+        chat_id: 1,
         is_from_me: false,
         is_group: true,
       },
@@ -138,7 +134,7 @@ describe("resolveIMessageInboundDecision sender fallback", () => {
         sender: "",
         participants: ["+15555550002", "+15555550003"],
         text: "group msg",
-        chat_id: "chat-1",
+        chat_id: 1,
         is_from_me: false,
         is_group: true,
       },

--- a/src/imessage/monitor/inbound-processing.test.ts
+++ b/src/imessage/monitor/inbound-processing.test.ts
@@ -128,6 +128,36 @@ describe("resolveIMessageInboundDecision sender fallback", () => {
     }
     expect(decision.sender).toBe("+15555550002");
   });
+
+  it("keeps dropping ambiguous group sender when multiple participants exist", () => {
+    const decision = resolveIMessageInboundDecision({
+      cfg,
+      accountId: "default",
+      message: {
+        id: 79,
+        sender: "",
+        participants: ["+15555550002", "+15555550003"],
+        text: "group msg",
+        chat_id: "chat-1",
+        is_from_me: false,
+        is_group: true,
+      },
+      opts: undefined,
+      messageText: "group msg",
+      bodyText: "group msg",
+      allowFrom: [],
+      groupAllowFrom: [],
+      groupPolicy: "open",
+      dmPolicy: "open",
+      storeAllowFrom: [],
+      historyLimit: 0,
+      groupHistories: new Map(),
+      echoCache: undefined,
+      logVerbose: undefined,
+    });
+
+    expect(decision).toEqual({ kind: "drop", reason: "missing sender" });
+  });
 });
 
 describe("resolveIMessageInboundDecision command auth", () => {

--- a/src/imessage/monitor/inbound-processing.test.ts
+++ b/src/imessage/monitor/inbound-processing.test.ts
@@ -59,6 +59,77 @@ describe("describeIMessageEchoDropLog", () => {
   });
 });
 
+describe("resolveIMessageInboundDecision sender fallback", () => {
+  const cfg = {} as OpenClawConfig;
+
+  it("uses reply_to_sender when sender is missing", () => {
+    const decision = resolveIMessageInboundDecision({
+      cfg,
+      accountId: "default",
+      message: {
+        id: 77,
+        sender: "",
+        reply_to_sender: "+15555550001",
+        text: "hello",
+        is_from_me: false,
+        is_group: false,
+      },
+      opts: undefined,
+      messageText: "hello",
+      bodyText: "hello",
+      allowFrom: [],
+      groupAllowFrom: [],
+      groupPolicy: "open",
+      dmPolicy: "open",
+      storeAllowFrom: [],
+      historyLimit: 0,
+      groupHistories: new Map(),
+      echoCache: undefined,
+      logVerbose: undefined,
+    });
+
+    expect(decision.kind).toBe("dispatch");
+    if (decision.kind !== "dispatch") {
+      return;
+    }
+    expect(decision.sender).toBe("+15555550001");
+  });
+
+  it("uses single participant as group sender fallback when sender is missing", () => {
+    const decision = resolveIMessageInboundDecision({
+      cfg,
+      accountId: "default",
+      message: {
+        id: 78,
+        sender: "",
+        participants: ["+15555550002"],
+        text: "group msg",
+        chat_id: "chat-1",
+        is_from_me: false,
+        is_group: true,
+      },
+      opts: undefined,
+      messageText: "group msg",
+      bodyText: "group msg",
+      allowFrom: [],
+      groupAllowFrom: [],
+      groupPolicy: "open",
+      dmPolicy: "open",
+      storeAllowFrom: [],
+      historyLimit: 0,
+      groupHistories: new Map(),
+      echoCache: undefined,
+      logVerbose: undefined,
+    });
+
+    expect(decision.kind).toBe("dispatch");
+    if (decision.kind !== "dispatch") {
+      return;
+    }
+    expect(decision.sender).toBe("+15555550002");
+  });
+});
+
 describe("resolveIMessageInboundDecision command auth", () => {
   const cfg = {} as OpenClawConfig;
   const resolveDmCommandDecision = (params: { messageId: number; storeAllowFrom: string[] }) =>

--- a/src/imessage/monitor/inbound-processing.ts
+++ b/src/imessage/monitor/inbound-processing.ts
@@ -86,10 +86,6 @@ export type IMessageInboundDecision =
   | IMessageInboundDispatchDecision;
 
 function resolveFallbackSender(message: IMessagePayload): string {
-  const replyToSender = (message.reply_to_sender ?? "").trim();
-  if (replyToSender) {
-    return replyToSender;
-  }
   if (!message.is_group) {
     return "";
   }

--- a/src/imessage/monitor/inbound-processing.ts
+++ b/src/imessage/monitor/inbound-processing.ts
@@ -85,6 +85,21 @@ export type IMessageInboundDecision =
   | { kind: "pairing"; senderId: string }
   | IMessageInboundDispatchDecision;
 
+function resolveFallbackSender(message: IMessagePayload): string {
+  const replyToSender = (message.reply_to_sender ?? "").trim();
+  if (replyToSender) {
+    return replyToSender;
+  }
+  if (!message.is_group) {
+    return "";
+  }
+  const participants = (message.participants ?? []).map((v) => v.trim()).filter(Boolean);
+  if (participants.length === 1) {
+    return participants[0] ?? "";
+  }
+  return "";
+}
+
 export function resolveIMessageInboundDecision(params: {
   cfg: OpenClawConfig;
   accountId: string;
@@ -103,7 +118,7 @@ export function resolveIMessageInboundDecision(params: {
   logVerbose?: (msg: string) => void;
 }): IMessageInboundDecision {
   const senderRaw = params.message.sender ?? "";
-  const sender = senderRaw.trim();
+  const sender = senderRaw.trim() || resolveFallbackSender(params.message);
   if (!sender) {
     return { kind: "drop", reason: "missing sender" };
   }


### PR DESCRIPTION
Problem: some iMessage group payloads arrive without , so inbound processing drops them with "missing sender" and cannot identify the member.

Root cause: sender resolution only read  and ignored fallback identity fields already present in payloads.

Fix:
- add sender fallback to 
- for group payloads with exactly one participant, use that participant as sender fallback
- keep drop behavior unchanged when sender remains ambiguous/missing

Testing:
- 
[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/private/tmp/openclaw-35563[39m

 [32m✓[39m src/imessage/monitor/inbound-processing.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 7[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m6 passed[39m[22m[90m (6)[39m
[2m   Start at [22m 21:25:12
[2m   Duration [22m 5.43s[2m (transform 3.41s, setup 109ms, import 5.22s, tests 7ms, environment 0ms)[22m
- added regression tests for both fallback paths

Refs #35563