### PR TITLE
fix(agents): convert GIF images to JPEG before sending to vision models

### DIFF
--- a/src/agents/tool-images.test.ts
+++ b/src/agents/tool-images.test.ts
@@ -108,6 +108,30 @@ describe("tool image sanitizing", () => {
     expect(image.mimeType).toBe("image/jpeg");
   });
 
+  it("converts GIF images to JPEG for vision model compatibility", async () => {
+    // Create a minimal 1x1 GIF87a image
+    const gifBuffer = await sharp(Buffer.alloc(1 * 1 * 3, 0x7f), {
+      raw: { width: 1, height: 1, channels: 3 },
+    })
+      .gif()
+      .toBuffer();
+
+    const blocks = [
+      {
+        type: "image" as const,
+        data: gifBuffer.toString("base64"),
+        mimeType: "image/gif",
+      },
+    ];
+
+    const out = await sanitizeContentBlocksImages(blocks, "test");
+    const img = getImageBlock(out);
+
+    // GIF should be converted away from image/gif
+    expect(img.mimeType).not.toBe("image/gif");
+    expect(img.mimeType).toBe("image/jpeg");
+  });
+
   it("drops malformed image base64 payloads", async () => {
     const blocks = [
       {

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -167,7 +167,10 @@ async function resizeImageBase64IfNeeded(params: {
   const hasDimensions = typeof width === "number" && typeof height === "number";
   const overDimensions =
     hasDimensions && (width > params.maxDimensionPx || height > params.maxDimensionPx);
+  // GIF is not supported by most vision models — always convert to JPEG.
+  const needsFormatConversion = params.mimeType === "image/gif";
   if (
+    !needsFormatConversion &&
     hasDimensions &&
     !overBytes &&
     width <= params.maxDimensionPx &&


### PR DESCRIPTION
## Summary

- **Problem:** GIF image attachments sent to vision models (Gemini, Grok, etc.) cause HTTP 400 errors because most providers only accept JPEG, PNG, or WebP.
- **Root cause:** `resizeImageBase64IfNeeded` short-circuits when images are within size/dimension limits, passing GIFs unchanged to the model API.
- **Fix:** Add a format-conversion guard so GIF images always go through the JPEG conversion path, regardless of size.
- **Scope:** 2 files, ~27 lines added. No runtime logic changes outside the GIF path.

## Change Type

- [x] Bug fix

## Scope

- [x] Skills / tool execution

## Linked Issue

- Fixes #36635

## User-visible / Behavior Changes

GIF attachments from any channel (Signal, Telegram, etc.) are now auto-converted to JPEG before being sent to vision models. Users no longer see HTTP 400 errors.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Verification

```
pnpm vitest run src/agents/tool-images.test.ts
# Test Files  1 passed (1)
# Tests       6 passed (6)
```

New test creates a real 1×1 GIF via sharp, passes it through `sanitizeContentBlocksImages`, and asserts the output mimeType is no longer `image/gif`.

## Compatibility

- Backward compatible: Yes
- Config/env changes: No
- Migration needed: No

## Failure Recovery

- Revert single commit to restore previous behavior.
- No config changes needed.

## Risks and Mitigations

- Risk: Animated GIFs lose animation (only first frame kept).
  - Mitigation: Vision models cannot process animated content anyway; extracting the first frame is the correct behavior.