### PR TITLE
Fix: handle Gemini 3 Flash schema incompatibility

### DIFF
--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { normalizeToolParameters } from "./pi-tools.schema.js";
+
+const createTool = (parameters: Record<string, unknown>) =>
+  ({
+    name: "test",
+    description: "test",
+    parameters,
+    execute: async () => ({ ok: true, content: [] }),
+  }) as unknown;
+
+describe("normalizeToolParameters", () => {
+  it("cleans Gemini-incompatible keywords for openrouter gemini proxy models", () => {
+    const tool = createTool({
+      type: "object",
+      properties: {
+        value: {
+          type: "object",
+          patternProperties: {
+            "^x-": {
+              type: "string",
+            },
+          },
+          properties: {
+            mode: {
+              type: "string",
+              minLength: 1,
+            },
+          },
+        },
+      },
+      required: ["value"],
+    }) as Parameters<typeof normalizeToolParameters>[0];
+
+    const normalized = normalizeToolParameters(tool, {
+      modelProvider: "openrouter",
+      modelId: "google/gemini-3-flash-preview",
+    });
+    const params = normalized.parameters as {
+      properties?: Record<string, { patternProperties?: unknown; minLength?: unknown; properties?: Record<string, unknown> }>;
+    };
+    const value = params.properties?.value as
+      | {
+          patternProperties?: unknown;
+          properties?: Record<string, { minLength?: unknown }>;
+        }
+      | undefined;
+
+    expect(value?.patternProperties).toBeUndefined();
+    expect(value?.properties?.mode?.minLength).toBeUndefined();
+  });
+
+  it("does not clean non-Gemini models", () => {
+    const tool = createTool({
+      type: "object",
+      properties: {
+        value: {
+          type: "string",
+          patternProperties: {
+            "^x-": {
+              type: "string",
+            },
+          },
+        },
+      },
+    }) as Parameters<typeof normalizeToolParameters>[0];
+
+    const normalized = normalizeToolParameters(tool, {
+      modelProvider: "openrouter",
+      modelId: "anthropic/claude-opus-4-5",
+    });
+    const params = normalized.parameters as { properties?: Record<string, { patternProperties?: unknown }> };
+
+    expect(params.properties?.value?.patternProperties).toBeDefined();
+  });
+});

--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -37,7 +37,10 @@ describe("normalizeToolParameters", () => {
       modelId: "google/gemini-3-flash-preview",
     });
     const params = normalized.parameters as {
-      properties?: Record<string, { patternProperties?: unknown; minLength?: unknown; properties?: Record<string, unknown> }>;
+      properties?: Record<
+        string,
+        { patternProperties?: unknown; minLength?: unknown; properties?: Record<string, unknown> }
+      >;
     };
     const value = params.properties?.value as
       | {
@@ -69,7 +72,9 @@ describe("normalizeToolParameters", () => {
       modelProvider: "openrouter",
       modelId: "anthropic/claude-opus-4-5",
     });
-    const params = normalized.parameters as { properties?: Record<string, { patternProperties?: unknown }> };
+    const params = normalized.parameters as {
+      properties?: Record<string, { patternProperties?: unknown }>;
+    };
 
     expect(params.properties?.value?.patternProperties).toBeDefined();
   });

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -94,14 +94,16 @@ export function normalizeToolParameters(
 
     // OpenRouter passes Gemini models through as "google/gemini-..." IDs.
     if (normalizedModelProvider === "openrouter") {
-      return normalizedModelId.startsWith("google/gemini") || normalizedModelId.startsWith("google/gemini-");
+      return (
+        normalizedModelId.startsWith("google/gemini") ||
+        normalizedModelId.startsWith("google/gemini-")
+      );
     }
 
     return false;
   }
 
-  const isGeminiProvider =
-    isGeminiProxyModel();
+  const isGeminiProvider = isGeminiProxyModel();
   const isAnthropicProvider = normalizedModelProvider.includes("anthropic");
   const isXai = isXaiProvider(options?.modelProvider, options?.modelId);
 

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -84,10 +84,25 @@ export function normalizeToolParameters(
   //
   // Normalize once here so callers can always pass `tools` through unchanged.
 
+  const normalizedModelProvider = options?.modelProvider?.toLowerCase() ?? "";
+  const normalizedModelId = options?.modelId?.toLowerCase() ?? "";
+
+  function isGeminiProxyModel(): boolean {
+    if (normalizedModelProvider.includes("google") || normalizedModelProvider.includes("gemini")) {
+      return true;
+    }
+
+    // OpenRouter passes Gemini models through as "google/gemini-..." IDs.
+    if (normalizedModelProvider === "openrouter") {
+      return normalizedModelId.startsWith("google/gemini") || normalizedModelId.startsWith("google/gemini-");
+    }
+
+    return false;
+  }
+
   const isGeminiProvider =
-    options?.modelProvider?.toLowerCase().includes("google") ||
-    options?.modelProvider?.toLowerCase().includes("gemini");
-  const isAnthropicProvider = options?.modelProvider?.toLowerCase().includes("anthropic");
+    isGeminiProxyModel();
+  const isAnthropicProvider = normalizedModelProvider.includes("anthropic");
   const isXai = isXaiProvider(options?.modelProvider, options?.modelId);
 
   function applyProviderCleaning(s: unknown): unknown {


### PR DESCRIPTION
## Summary
Fix schema compatibility for Gemini 3 Flash (including OpenRouter proxy entries) by normalizing `provider`/`modelId` handling in tool-schema conversion. This ensures unsupported JSON Schema constructs (like `patternProperties`) are stripped before function declaration payloads are sent.

## Security Impact
No new capabilities or privileges are introduced. The change only affects request payload shaping for tool schemas and reduces malformed API payloads; no secrets, credential handling, or auth paths are modified.

## Repro+Verification
Regression case: switch from default model to Gemini 3 Flash and send a normal message request. Before fix, Gemini returned HTTP 400 with `Unknown name "patternProperties" ...`. After this fix, the schema is cleaned for Gemini-compatible formats and requests should proceed.

## Testing
- Added regression tests in `src/agents/pi-tools.schema.test.ts` covering OpenRouter Gemini proxy model schema cleanup.
- Added negative test verifying non-Gemini OpenRouter models do not apply Gemini cleaning.
- Automated test execution not run in this environment; please run `pnpm test src/agents/pi-tools.schema.test.ts` in CI/locally.

## AI Assisted
This fix was implemented with AI assistance for root-cause tracing, conditional detection updates, and test coverage additions.

## Fixes
Closes #36672
