### PR TITLE
feat(tools): add Brave llm-context mode for web_search

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -15,6 +15,7 @@ const {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  resolveBraveMode,
 } = __testing;
 
 describe("web_search brave language param normalization", () => {
@@ -269,5 +270,20 @@ describe("extractKimiCitations", () => {
         ],
       }).toSorted(),
     ).toEqual(["https://example.com/a", "https://example.com/b", "https://example.com/c"]);
+  });
+});
+
+describe("web_search brave mode resolution", () => {
+  it("defaults to web when mode is missing", () => {
+    expect(resolveBraveMode(undefined)).toBe("web");
+    expect(resolveBraveMode({})).toBe("web");
+  });
+
+  it("returns llm-context when explicitly configured", () => {
+    expect(resolveBraveMode({ mode: "llm-context" })).toBe("llm-context");
+  });
+
+  it("returns web when explicitly configured", () => {
+    expect(resolveBraveMode({ mode: "web" })).toBe("web");
   });
 });

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -26,6 +26,7 @@ const DEFAULT_SEARCH_COUNT = 5;
 const MAX_SEARCH_COUNT = 10;
 
 const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
+const BRAVE_LLM_CONTEXT_ENDPOINT = "https://api.search.brave.com/res/v1/llm/context";
 const PERPLEXITY_SEARCH_ENDPOINT = "https://api.perplexity.ai/search";
 
 const XAI_API_ENDPOINT = "https://api.x.ai/v1/responses";
@@ -185,6 +186,22 @@ type BraveSearchResponse = {
   web?: {
     results?: BraveSearchResult[];
   };
+};
+
+type BraveLlmContextSnippet = string | { text?: string; snippet?: string };
+type BraveLlmContextResult = {
+  title?: string;
+  url?: string;
+  snippets?: BraveLlmContextSnippet[];
+};
+type BraveLlmContextResponse = {
+  grounding?: {
+    generic?: BraveLlmContextResult[];
+  };
+};
+
+type BraveConfig = {
+  mode?: "web" | "llm-context";
 };
 
 type PerplexityConfig = {
@@ -488,6 +505,24 @@ function resolveSearchProvider(search?: WebSearchConfig): (typeof SEARCH_PROVIDE
   }
 
   return "brave";
+}
+
+function resolveBraveConfig(search?: WebSearchConfig): BraveConfig {
+  if (!search || typeof search !== "object") {
+    return {};
+  }
+  const brave = "brave" in search ? search.brave : undefined;
+  if (!brave || typeof brave !== "object") {
+    return {};
+  }
+  return brave as BraveConfig;
+}
+
+function resolveBraveMode(brave?: BraveConfig): "web" | "llm-context" {
+  if (brave?.mode === "llm-context") {
+    return "llm-context";
+  }
+  return "web";
 }
 
 function resolvePerplexityConfig(search?: WebSearchConfig): PerplexityConfig {
@@ -1149,6 +1184,81 @@ async function runKimiSearch(params: {
   };
 }
 
+function normalizeBraveLlmSnippet(snippet: BraveLlmContextSnippet): string {
+  if (typeof snippet === "string") {
+    return snippet;
+  }
+  if (typeof snippet.text === "string") {
+    return snippet.text;
+  }
+  if (typeof snippet.snippet === "string") {
+    return snippet.snippet;
+  }
+  return "";
+}
+
+async function runBraveLlmContextSearch(params: {
+  query: string;
+  count: number;
+  apiKey: string;
+  timeoutSeconds: number;
+  country?: string;
+  search_lang?: string;
+}): Promise<
+  Array<{ title: string; url: string; content: string; siteName?: string; snippetCount: number }>
+> {
+  const url = new URL(BRAVE_LLM_CONTEXT_ENDPOINT);
+  url.searchParams.set("q", params.query);
+  url.searchParams.set("count", String(params.count));
+  if (params.country) {
+    url.searchParams.set("country", params.country);
+  }
+  if (params.search_lang) {
+    url.searchParams.set("search_lang", params.search_lang);
+  }
+
+  return withTrustedWebSearchEndpoint(
+    {
+      url: url.toString(),
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          "X-Subscription-Token": params.apiKey,
+        },
+      },
+    },
+    async (res) => {
+      if (!res.ok) {
+        const detailResult = await readResponseText(res, { maxBytes: 64_000 });
+        const detail = detailResult.text;
+        throw new Error(`Brave LLM Context API error (${res.status}): ${detail || res.statusText}`);
+      }
+
+      const data = (await res.json()) as BraveLlmContextResponse;
+      const results = Array.isArray(data.grounding?.generic) ? (data.grounding?.generic ?? []) : [];
+      return results.map((entry) => {
+        const snippetValues = (entry.snippets ?? [])
+          .map((snippet) => normalizeBraveLlmSnippet(snippet).trim())
+          .filter(Boolean);
+        const title = entry.title ?? "";
+        const url = entry.url ?? "";
+        return {
+          title: title ? wrapWebContent(title, "web_search") : "",
+          url,
+          content:
+            snippetValues.length > 0
+              ? wrapWebContent(snippetValues.join("\n\n"), "web_search")
+              : "",
+          siteName: resolveSiteName(url) || undefined,
+          snippetCount: snippetValues.length,
+        };
+      });
+    },
+  );
+}
+
 async function runWebSearch(params: {
   query: string;
   count: number;
@@ -1171,7 +1281,9 @@ async function runWebSearch(params: {
   geminiModel?: string;
   kimiBaseUrl?: string;
   kimiModel?: string;
+  braveMode?: "web" | "llm-context";
 }): Promise<Record<string, unknown>> {
+  const effectiveBraveMode = params.braveMode ?? "web";
   const providerSpecificKey =
     params.provider === "grok"
       ? `${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`
@@ -1181,7 +1293,9 @@ async function runWebSearch(params: {
           ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
           : "";
   const cacheKey = normalizeCacheKey(
-    `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}`,
+    params.provider === "brave" && effectiveBraveMode === "llm-context"
+      ? `${params.provider}:${effectiveBraveMode}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}`
+      : `${params.provider}:${effectiveBraveMode}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}`,
   );
   const cached = readCache(SEARCH_CACHE, cacheKey);
   if (cached) {
@@ -1308,6 +1422,35 @@ async function runWebSearch(params: {
     throw new Error("Unsupported web search provider.");
   }
 
+  if (effectiveBraveMode === "llm-context") {
+    const mapped = await runBraveLlmContextSearch({
+      query: params.query,
+      count: params.count,
+      apiKey: params.apiKey,
+      timeoutSeconds: params.timeoutSeconds,
+      country: params.country,
+      search_lang: params.search_lang || params.language,
+    });
+
+    const payload = {
+      query: params.query,
+      provider: params.provider,
+      mode: "llm-context" as const,
+      count: mapped.length,
+      snippetCount: mapped.reduce((total, entry) => total + entry.snippetCount, 0),
+      tookMs: Date.now() - start,
+      externalContent: {
+        untrusted: true,
+        source: "web_search",
+        provider: params.provider,
+        wrapped: true,
+      },
+      results: mapped.map(({ snippetCount: _snippetCount, ...result }) => result),
+    };
+    writeCache(SEARCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+    return payload;
+  }
+
   const url = new URL(BRAVE_SEARCH_ENDPOINT);
   url.searchParams.set("q", params.query);
   url.searchParams.set("count", String(params.count));
@@ -1401,6 +1544,8 @@ export function createWebSearchTool(options?: {
   const grokConfig = resolveGrokConfig(search);
   const geminiConfig = resolveGeminiConfig(search);
   const kimiConfig = resolveKimiConfig(search);
+  const braveConfig = resolveBraveConfig(search);
+  const braveMode = resolveBraveMode(braveConfig);
 
   const description =
     provider === "perplexity"
@@ -1411,7 +1556,9 @@ export function createWebSearchTool(options?: {
           ? "Search the web using Kimi by Moonshot. Returns AI-synthesized answers with citations from native $web_search."
           : provider === "gemini"
             ? "Search the web using Gemini with Google Search grounding. Returns AI-synthesized answers with citations from Google Search."
-            : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
+            : braveMode === "llm-context"
+              ? "Search the web using Brave Search LLM Context API. Returns pre-extracted page content optimized for LLM grounding."
+              : "Search the web using Brave Search API. Supports region-specific and localized search via country and language parameters. Returns titles, URLs, and snippets for fast research.";
 
   return {
     label: "Web Search",
@@ -1494,6 +1641,14 @@ export function createWebSearchTool(options?: {
           docs: "https://docs.openclaw.ai/tools/web",
         });
       }
+      if (rawFreshness && provider === "brave" && braveMode === "llm-context") {
+        return jsonResult({
+          error: "unsupported_freshness",
+          message:
+            "freshness filtering is not supported by Brave llm-context mode. Remove freshness or use Brave web mode.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        });
+      }
       const freshness = rawFreshness ? normalizeFreshness(rawFreshness, provider) : undefined;
       if (rawFreshness && !freshness) {
         return jsonResult({
@@ -1516,6 +1671,14 @@ export function createWebSearchTool(options?: {
         return jsonResult({
           error: "unsupported_date_filter",
           message: `date_after/date_before filtering is not supported by the ${provider} provider. Only Brave and Perplexity support date filtering.`,
+          docs: "https://docs.openclaw.ai/tools/web",
+        });
+      }
+      if ((rawDateAfter || rawDateBefore) && provider === "brave" && braveMode === "llm-context") {
+        return jsonResult({
+          error: "unsupported_date_filter",
+          message:
+            "date_after/date_before filtering is not supported by Brave llm-context mode. Use Brave web mode for date filters.",
           docs: "https://docs.openclaw.ai/tools/web",
         });
       }
@@ -1596,6 +1759,7 @@ export function createWebSearchTool(options?: {
         geminiModel: resolveGeminiModel(geminiConfig),
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
+        braveMode,
       });
       return jsonResult(result);
     },
@@ -1620,4 +1784,5 @@ export const __testing = {
   resolveKimiBaseUrl,
   extractKimiCitations,
   resolveRedirectUrl: resolveCitationRedirectUrl,
+  resolveBraveMode,
 } as const;

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1633,6 +1633,14 @@ export function createWebSearchTool(options?: {
       }
       const resolvedSearchLang = normalizedBraveLanguageParams.search_lang;
       const resolvedUiLang = normalizedBraveLanguageParams.ui_lang;
+      if (resolvedUiLang && provider === "brave" && braveMode === "llm-context") {
+        return jsonResult({
+          error: "unsupported_ui_lang",
+          message:
+            "ui_lang is not supported by Brave llm-context mode. Remove ui_lang or use Brave web mode for locale-based UI hints.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        });
+      }
       const rawFreshness = readStringParam(params, "freshness");
       if (rawFreshness && provider !== "brave" && provider !== "perplexity") {
         return jsonResult({

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -485,6 +485,24 @@ describe("web_search external content wrapping", () => {
     return mock;
   }
 
+  function installBraveLlmContextFetch(
+    result: Record<string, unknown>,
+    mock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            grounding: {
+              generic: [result],
+            },
+          }),
+      } as Response),
+    ),
+  ) {
+    global.fetch = withFetchPreconnect(mock);
+    return mock;
+  }
+
   async function executeBraveSearch(query: string) {
     const tool = createWebSearchTool({ config: undefined, sandboxed: true });
     return tool?.execute?.("call-1", { query });
@@ -517,6 +535,84 @@ describe("web_search external content wrapping", () => {
       source: "web_search",
       wrapped: true,
     });
+  });
+
+  it("uses Brave llm-context endpoint when mode is configured", async () => {
+    vi.stubEnv("BRAVE_API_KEY", "test-key");
+    const mockFetch = installBraveLlmContextFetch({
+      title: "Context title",
+      url: "https://example.com/ctx",
+      snippets: ["Context chunk one", "Context chunk two"],
+    });
+
+    const tool = createWebSearchTool({
+      config: {
+        tools: {
+          web: {
+            search: {
+              provider: "brave",
+              brave: {
+                mode: "llm-context",
+              },
+            },
+          },
+        },
+      },
+      sandboxed: true,
+    });
+    const result = await tool?.execute?.("call-1", {
+      query: "llm-context test",
+      count: 3,
+      country: "DE",
+      search_lang: "de",
+    });
+
+    const requestUrl = new URL(mockFetch.mock.calls[0]?.[0] as string);
+    expect(requestUrl.pathname).toBe("/res/v1/llm/context");
+    expect(requestUrl.searchParams.get("q")).toBe("llm-context test");
+    expect(requestUrl.searchParams.get("count")).toBe("3");
+    expect(requestUrl.searchParams.get("country")).toBe("DE");
+    expect(requestUrl.searchParams.get("search_lang")).toBe("de");
+
+    const details = result?.details as {
+      mode?: string;
+      results?: Array<{ title?: string; url?: string; content?: string; siteName?: string }>;
+    };
+    expect(details.mode).toBe("llm-context");
+    expect(details.results?.[0]?.url).toBe("https://example.com/ctx");
+    expect(details.results?.[0]?.title).toContain("<<<EXTERNAL_UNTRUSTED_CONTENT");
+    expect(details.results?.[0]?.content).toContain("<<<EXTERNAL_UNTRUSTED_CONTENT");
+    expect(details.results?.[0]?.content).toContain("Context chunk one");
+    expect(details.results?.[0]?.siteName).toBe("example.com");
+  });
+
+  it("rejects freshness in Brave llm-context mode", async () => {
+    vi.stubEnv("BRAVE_API_KEY", "test-key");
+    const mockFetch = installBraveLlmContextFetch({
+      title: "unused",
+      url: "https://example.com",
+      snippets: ["unused"],
+    });
+
+    const tool = createWebSearchTool({
+      config: {
+        tools: {
+          web: {
+            search: {
+              provider: "brave",
+              brave: {
+                mode: "llm-context",
+              },
+            },
+          },
+        },
+      },
+      sandboxed: true,
+    });
+    const result = await tool?.execute?.("call-1", { query: "test", freshness: "week" });
+
+    expect(result?.details).toMatchObject({ error: "unsupported_freshness" });
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("does not wrap Brave result urls (raw for tool chaining)", async () => {

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -615,6 +615,39 @@ describe("web_search external content wrapping", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it("rejects date_after/date_before in Brave llm-context mode", async () => {
+    vi.stubEnv("BRAVE_API_KEY", "test-key");
+    const mockFetch = installBraveLlmContextFetch({
+      title: "unused",
+      url: "https://example.com",
+      snippets: ["unused"],
+    });
+
+    const tool = createWebSearchTool({
+      config: {
+        tools: {
+          web: {
+            search: {
+              provider: "brave",
+              brave: {
+                mode: "llm-context",
+              },
+            },
+          },
+        },
+      },
+      sandboxed: true,
+    });
+    const result = await tool?.execute?.("call-1", {
+      query: "test",
+      date_after: "2025-01-01",
+      date_before: "2025-01-31",
+    });
+
+    expect(result?.details).toMatchObject({ error: "unsupported_date_filter" });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("does not wrap Brave result urls (raw for tool chaining)", async () => {
     vi.stubEnv("BRAVE_API_KEY", "test-key");
     const url = "https://example.com/some-page";

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -648,6 +648,38 @@ describe("web_search external content wrapping", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it("rejects ui_lang in Brave llm-context mode", async () => {
+    vi.stubEnv("BRAVE_API_KEY", "test-key");
+    const mockFetch = installBraveLlmContextFetch({
+      title: "unused",
+      url: "https://example.com",
+      snippets: ["unused"],
+    });
+
+    const tool = createWebSearchTool({
+      config: {
+        tools: {
+          web: {
+            search: {
+              provider: "brave",
+              brave: {
+                mode: "llm-context",
+              },
+            },
+          },
+        },
+      },
+      sandboxed: true,
+    });
+    const result = await tool?.execute?.("call-1", {
+      query: "test",
+      ui_lang: "de-DE",
+    });
+
+    expect(result?.details).toMatchObject({ error: "unsupported_ui_lang" });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("does not wrap Brave result urls (raw for tool chaining)", async () => {
     vi.stubEnv("BRAVE_API_KEY", "test-key");
     const url = "https://example.com/some-page";

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -48,6 +48,32 @@ describe("web search provider config", () => {
 
     expect(res.ok).toBe(true);
   });
+
+  it("accepts brave llm-context mode config", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        provider: "brave",
+        providerConfig: {
+          mode: "llm-context",
+        },
+      }),
+    );
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects invalid brave mode config values", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        provider: "brave",
+        providerConfig: {
+          mode: "invalid-mode",
+        },
+      }),
+    );
+
+    expect(res.ok).toBe(false);
+  });
 });
 
 describe("web search provider auto-detection", () => {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -624,6 +624,8 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.search.maxResults": "Default number of results to return (1-10).",
   "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
   "tools.web.search.cacheTtlMinutes": "Cache TTL in minutes for web_search results.",
+  "tools.web.search.brave.mode":
+    'Brave search mode: "web" for standard snippets or "llm-context" for pre-extracted page content.',
   "tools.web.search.gemini.apiKey":
     "Gemini API key for Google Search grounding (fallback: GEMINI_API_KEY env var).",
   "tools.web.search.gemini.model": 'Gemini model override (default: "gemini-2.5-flash").',

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -217,6 +217,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.web.search.maxResults": "Web Search Max Results",
   "tools.web.search.timeoutSeconds": "Web Search Timeout (sec)",
   "tools.web.search.cacheTtlMinutes": "Web Search Cache TTL (min)",
+  "tools.web.search.brave.mode": "Brave Search Mode",
   "tools.web.search.perplexity.apiKey": "Perplexity API Key",
   "tools.web.search.perplexity.baseUrl": "Perplexity Base URL",
   "tools.web.search.perplexity.model": "Perplexity Model",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -450,6 +450,11 @@ export type ToolsConfig = {
       timeoutSeconds?: number;
       /** Cache TTL in minutes for search results. */
       cacheTtlMinutes?: number;
+      /** Brave-specific configuration (used when provider="brave"). */
+      brave?: {
+        /** Search mode: "web" (default) or "llm-context" for LLM-optimized context. */
+        mode?: "web" | "llm-context";
+      };
       /** Perplexity-specific configuration (used when provider="perplexity"). */
       perplexity?: {
         /** API key for Perplexity (defaults to PERPLEXITY_API_KEY env var). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -275,6 +275,12 @@ export const ToolsWebSearchSchema = z
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     cacheTtlMinutes: z.number().nonnegative().optional(),
+    brave: z
+      .object({
+        mode: z.union([z.literal("web"), z.literal("llm-context")]).optional(),
+      })
+      .strict()
+      .optional(),
     perplexity: z
       .object({
         apiKey: SecretInputSchema.optional().register(sensitive),


### PR DESCRIPTION
## Summary
- add `tools.web.search.brave.mode` (`web` | `llm-context`) and wire it through config types/schema/help/labels
- add Brave LLM Context mode to `web_search` using `/res/v1/llm/context`
- keep external-content wrapping behavior intact while preserving raw URLs for chaining
- reject unsupported time filters (`freshness`, `date_after`, `date_before`) in `llm-context` mode
- add tests for mode resolution, endpoint behavior, wrapping, and config validation

## Linked Issues
- Closes #14992
- Related #15028

## Validation
- `pnpm vitest run src/agents/tools/web-search.test.ts src/agents/tools/web-tools.enabled-defaults.test.ts src/config/config.web-search-provider.test.ts`
- `pnpm check`
- `pnpm build`
