### PR TITLE
perf(usage): bound cost summary cache size

### DIFF
--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -158,4 +158,37 @@ describe("gateway usage helpers", () => {
     expect(b.totals.totalTokens).toBe(1);
     expect(vi.mocked(loadCostUsageSummary)).toHaveBeenCalledTimes(1);
   });
+
+  it("loadCostUsageSummaryCached bounds cache size and refreshes entry recency", async () => {
+    const config = {} as OpenClawConfig;
+    const max = __test.MAX_COST_USAGE_CACHE_ENTRIES;
+
+    for (let i = 0; i < max + 5; i += 1) {
+      await __test.loadCostUsageSummaryCached({
+        startMs: i,
+        endMs: i,
+        config,
+      });
+    }
+
+    expect(__test.costUsageCache.size).toBe(max);
+    expect(__test.costUsageCache.has("0-0")).toBe(false);
+
+    const promotedKey = `5-5`;
+    await __test.loadCostUsageSummaryCached({
+      startMs: 5,
+      endMs: 5,
+      config,
+    });
+
+    await __test.loadCostUsageSummaryCached({
+      startMs: max + 5,
+      endMs: max + 5,
+      config,
+    });
+
+    expect(__test.costUsageCache.size).toBe(max);
+    expect(__test.costUsageCache.has(promotedKey)).toBe(true);
+    expect(__test.costUsageCache.has("6-6")).toBe(false);
+  });
 });

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -44,6 +44,7 @@ import {
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 
 const COST_USAGE_CACHE_TTL_MS = 30_000;
+const MAX_COST_USAGE_CACHE_ENTRIES = 64;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 type DateRange = { startMs: number; endMs: number };
@@ -58,6 +59,20 @@ type CostUsageCacheEntry = {
 };
 
 const costUsageCache = new Map<string, CostUsageCacheEntry>();
+
+function setCostUsageCacheEntry(cacheKey: string, entry: CostUsageCacheEntry): void {
+  if (costUsageCache.has(cacheKey)) {
+    costUsageCache.delete(cacheKey);
+  }
+  costUsageCache.set(cacheKey, entry);
+  while (costUsageCache.size > MAX_COST_USAGE_CACHE_ENTRIES) {
+    const oldestKey = costUsageCache.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    costUsageCache.delete(oldestKey);
+  }
+}
 
 function resolveSessionUsageFileOrRespond(
   key: string,
@@ -288,6 +303,7 @@ async function loadCostUsageSummaryCached(params: {
   const now = Date.now();
   const cached = costUsageCache.get(cacheKey);
   if (cached?.summary && cached.updatedAt && now - cached.updatedAt < COST_USAGE_CACHE_TTL_MS) {
+    setCostUsageCacheEntry(cacheKey, cached);
     return cached.summary;
   }
 
@@ -305,7 +321,7 @@ async function loadCostUsageSummaryCached(params: {
     config: params.config,
   })
     .then((summary) => {
-      costUsageCache.set(cacheKey, { summary, updatedAt: Date.now() });
+      setCostUsageCacheEntry(cacheKey, { summary, updatedAt: Date.now() });
       return summary;
     })
     .catch((err) => {
@@ -318,12 +334,12 @@ async function loadCostUsageSummaryCached(params: {
       const current = costUsageCache.get(cacheKey);
       if (current?.inFlight === inFlight) {
         current.inFlight = undefined;
-        costUsageCache.set(cacheKey, current);
+        setCostUsageCacheEntry(cacheKey, current);
       }
     });
 
   entry.inFlight = inFlight;
-  costUsageCache.set(cacheKey, entry);
+  setCostUsageCacheEntry(cacheKey, entry);
 
   if (entry.summary) {
     return entry.summary;
@@ -343,6 +359,7 @@ export const __test = {
   discoverAllSessionsForUsage,
   loadCostUsageSummaryCached,
   costUsageCache,
+  MAX_COST_USAGE_CACHE_ENTRIES,
 };
 
 export type { SessionUsageEntry, SessionsUsageAggregates, SessionsUsageResult };


### PR DESCRIPTION
## Summary
- cap `usage.cost` in-memory cache entries to prevent unbounded growth across many date ranges
- promote entries on cache hits so frequently requested ranges stay warm
- add a focused unit test that verifies cap enforcement and recency refresh behavior

## Validation
- pnpm vitest run src/gateway/server-methods/usage.test.ts

## Risk
Low. This change only affects cache bookkeeping in `loadCostUsageSummaryCached` and is covered by tests.