### PR TITLE
Fix Telegram DM completion announce routing (handle direct kind + warnings)

### DIFF
--- a/src/agents/tools/sessions-announce-target.ts
+++ b/src/agents/tools/sessions-announce-target.ts
@@ -1,8 +1,11 @@
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { callGateway } from "../../gateway/call.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { SessionListRow } from "./sessions-helpers.js";
 import type { AnnounceTarget } from "./sessions-send-helpers.js";
 import { resolveAnnounceTargetFromKey } from "./sessions-send-helpers.js";
+
+const log = createSubsystemLogger("agents/sessions-announce-target");
 
 export async function resolveAnnounceTarget(params: {
   sessionKey: string;
@@ -47,11 +50,25 @@ export async function resolveAnnounceTarget(params: {
     const accountId =
       (typeof deliveryContext?.accountId === "string" ? deliveryContext.accountId : undefined) ??
       (typeof match?.lastAccountId === "string" ? match.lastAccountId : undefined);
+    const rawThreadId = deliveryContext?.threadId ?? match?.lastThreadId;
+    const threadId =
+      typeof rawThreadId === "number" && Number.isFinite(rawThreadId)
+        ? String(Math.trunc(rawThreadId))
+        : typeof rawThreadId === "string" && rawThreadId
+          ? rawThreadId
+          : undefined;
     if (channel && to) {
-      return { channel, to, accountId };
+      return { channel, to, accountId, ...(threadId !== undefined ? { threadId } : {}) };
     }
   } catch {
-    // ignore
+    // ignore — gateway may be unavailable; fall through to fallback
+  }
+
+  if (!fallback) {
+    log.warn("resolveAnnounceTarget: could not resolve announce target; announcement may be lost", {
+      sessionKey: params.sessionKey,
+      displayKey: params.displayKey,
+    });
   }
 
   return fallback;

--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -41,6 +41,7 @@ export type SessionListDeliveryContext = {
   channel?: string;
   to?: string;
   accountId?: string;
+  threadId?: string | number;
 };
 
 export type SessionListRow = {
@@ -63,6 +64,7 @@ export type SessionListRow = {
   lastChannel?: string;
   lastTo?: string;
   lastAccountId?: string;
+  lastThreadId?: string | number;
   transcriptPath?: string;
   messages?: unknown[];
 };

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -24,7 +24,7 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
     return null;
   }
   const [channelRaw, kind, ...rest] = parts;
-  if (kind !== "group" && kind !== "channel") {
+  if (kind !== "group" && kind !== "channel" && kind !== "direct" && kind !== "dm") {
     return null;
   }
 
@@ -51,7 +51,14 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
   }
   const normalizedChannel = normalizeAnyChannelId(channelRaw) ?? normalizeChatChannelId(channelRaw);
   const channel = normalizedChannel ?? channelRaw.toLowerCase();
+  const isDmKind = kind === "direct" || kind === "dm";
   const kindTarget = (() => {
+    if (isDmKind) {
+      // DM session keys (per-channel-peer / per-account-channel-peer scopes).
+      // The `id` is the raw peer ID (e.g., Telegram chatId). Return it as-is so
+      // the channel's send function can resolve it without further wrapping.
+      return id;
+    }
     if (!normalizedChannel) {
       return id;
     }

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -54,9 +54,12 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
   const isDmKind = kind === "direct" || kind === "dm";
   const kindTarget = (() => {
     if (isDmKind) {
-      // DM session keys (per-channel-peer / per-account-channel-peer scopes).
-      // The `id` is the raw peer ID (e.g., Telegram chatId). Return it as-is so
-      // the channel's send function can resolve it without further wrapping.
+      // DM session keys: kind is direct/dm and `id` should be channel-native.
+      // Note: normalizeTarget may still rewrite the final target.
+      if (normalizedChannel === "discord" && !id.includes(":")) {
+        // Discord DMs are addressed to users, not channels.
+        return `user:${id}`;
+      }
       return id;
     }
     if (!normalizedChannel) {

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -127,6 +127,7 @@ export async function runSessionsSendA2AFlow(params: {
             message: announceReply.trim(),
             channel: announceTarget.channel,
             accountId: announceTarget.accountId,
+            ...(announceTarget.threadId ? { threadId: announceTarget.threadId } : {}),
             idempotencyKey: crypto.randomUUID(),
           },
           timeoutMs: 10_000,

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -31,6 +31,7 @@ vi.mock("../../config/config.js", async (importOriginal) => {
 });
 
 import { createSessionsListTool } from "./sessions-list-tool.js";
+import { resolveAnnounceTargetFromKey } from "./sessions-send-helpers.js";
 import { createSessionsSendTool } from "./sessions-send-tool.js";
 
 let resolveAnnounceTarget: (typeof import("./sessions-announce-target.js"))["resolveAnnounceTarget"];
@@ -243,6 +244,110 @@ describe("resolveAnnounceTarget", () => {
     const first = callGatewayMock.mock.calls[0]?.[0] as { method?: string } | undefined;
     expect(first).toBeDefined();
     expect(first?.method).toBe("sessions.list");
+  });
+});
+
+describe("resolveAnnounceTargetFromKey — DM session keys", () => {
+  it("returns null for legacy main key (agent:main:main)", () => {
+    // Legacy DM key — only 1 part after stripping agent:main, cannot resolve without gateway
+    expect(resolveAnnounceTargetFromKey("agent:main:main")).toBeNull();
+  });
+
+  it("resolves per-channel-peer DM key (direct kind)", () => {
+    const result = resolveAnnounceTargetFromKey("agent:main:telegram:direct:102272550");
+    expect(result).not.toBeNull();
+    expect(result?.channel).toBe("telegram");
+    expect(result?.to).toBe("102272550");
+    expect(result?.threadId).toBeUndefined();
+  });
+
+  it("DM key and group key for same channel do not collide", () => {
+    const dm = resolveAnnounceTargetFromKey("agent:main:telegram:direct:102272550");
+    const group = resolveAnnounceTargetFromKey("agent:main:telegram:group:-1001234567890");
+    expect(dm?.to).not.toBe(group?.to);
+    expect(dm?.channel).toBe(group?.channel);
+  });
+
+  it("resolves group key with topic thread ID", () => {
+    const result = resolveAnnounceTargetFromKey(
+      "agent:main:telegram:group:-1001234567890:topic:99",
+    );
+    expect(result).not.toBeNull();
+    expect(result?.threadId).toBe("99");
+  });
+
+  it("resolves group key without topic", () => {
+    const result = resolveAnnounceTargetFromKey("agent:main:discord:group:dev");
+    expect(result).toEqual({ channel: "discord", to: "channel:dev", threadId: undefined });
+  });
+
+  it("returns null for unknown key shape", () => {
+    expect(resolveAnnounceTargetFromKey("agent:main:webchat:internal")).toBeNull();
+  });
+});
+
+describe("resolveAnnounceTarget — DM gateway fallback with threadId", () => {
+  beforeEach(async () => {
+    callGatewayMock.mockClear();
+    await installRegistry();
+  });
+
+  it("returns threadId from deliveryContext when resolving DM via gateway fallback", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:main",
+          deliveryContext: {
+            channel: "telegram",
+            to: "telegram:102272550",
+            accountId: "mybot",
+            threadId: 42,
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:main",
+      displayKey: "agent:main:main",
+    });
+    expect(target).toEqual({
+      channel: "telegram",
+      to: "telegram:102272550",
+      accountId: "mybot",
+      threadId: "42",
+    });
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits threadId when deliveryContext has none", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:main",
+          deliveryContext: {
+            channel: "telegram",
+            to: "telegram:102272550",
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:main",
+      displayKey: "agent:main:main",
+    });
+    expect(target).not.toBeNull();
+    expect(target?.threadId).toBeUndefined();
+  });
+
+  it("returns null when gateway has no matching session and key parsing fails", async () => {
+    callGatewayMock.mockResolvedValueOnce({ sessions: [] });
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:main",
+      displayKey: "agent:main:main",
+    });
+    expect(target).toBeNull();
   });
 });
 

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -261,6 +261,14 @@ describe("resolveAnnounceTargetFromKey — DM session keys", () => {
     expect(result?.threadId).toBeUndefined();
   });
 
+  it("resolves per-channel-peer DM key (dm kind)", () => {
+    const result = resolveAnnounceTargetFromKey("agent:main:telegram:dm:102272550");
+    expect(result).not.toBeNull();
+    expect(result?.channel).toBe("telegram");
+    expect(result?.to).toBe("102272550");
+    expect(result?.threadId).toBeUndefined();
+  });
+
   it("DM key and group key for same channel do not collide", () => {
     const dm = resolveAnnounceTargetFromKey("agent:main:telegram:direct:102272550");
     const group = resolveAnnounceTargetFromKey("agent:main:telegram:group:-1001234567890");
@@ -274,6 +282,16 @@ describe("resolveAnnounceTargetFromKey — DM session keys", () => {
     );
     expect(result).not.toBeNull();
     expect(result?.threadId).toBe("99");
+  });
+
+  it("resolves Discord DM key (direct kind) as user target", () => {
+    const result = resolveAnnounceTargetFromKey("agent:main:discord:direct:214905613497532417");
+    expect(result).not.toBeNull();
+    expect(result).toEqual({
+      channel: "discord",
+      to: "user:214905613497532417",
+      threadId: undefined,
+    });
   });
 
   it("resolves group key without topic", () => {

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -9,6 +9,12 @@ vi.mock("../../gateway/call.js", () => ({
   callGateway: (opts: unknown) => callGatewayMock(opts),
 }));
 
+// A2A flow: stub agent-step helpers (we only assert outbound send params)
+vi.mock("./agent-step.js", () => ({
+  readLatestAssistantReply: async () => "latest reply",
+  runAgentStep: async () => "announce reply",
+}));
+
 type SessionsToolTestConfig = {
   session: { scope: "per-sender"; mainKey: string };
   tools: {
@@ -32,6 +38,7 @@ vi.mock("../../config/config.js", async (importOriginal) => {
 
 import { createSessionsListTool } from "./sessions-list-tool.js";
 import { resolveAnnounceTargetFromKey } from "./sessions-send-helpers.js";
+import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 import { createSessionsSendTool } from "./sessions-send-tool.js";
 
 let resolveAnnounceTarget: (typeof import("./sessions-announce-target.js"))["resolveAnnounceTarget"];
@@ -60,6 +67,32 @@ const installRegistry = async () => {
           config: {
             listAccountIds: () => ["default"],
             resolveAccount: () => ({}),
+          },
+        },
+      },
+      {
+        pluginId: "telegram",
+        source: "test",
+        plugin: {
+          id: "telegram",
+          meta: {
+            id: "telegram",
+            label: "Telegram",
+            selectionLabel: "Telegram",
+            docsPath: "/channels/telegram",
+            blurb: "Telegram test stub.",
+          },
+          capabilities: { chatTypes: ["direct", "group", "thread"] },
+          config: {
+            listAccountIds: () => ["default"],
+            resolveAccount: () => ({}),
+          },
+          messaging: {
+            normalizeTarget: (t: string) => {
+              // Minimal normalizer used by resolveAnnounceTargetFromKey tests.
+              // In real telegram plugin, chat ids are raw strings.
+              return t.replace(/^(group:|channel:)/, "");
+            },
           },
         },
       },
@@ -366,6 +399,45 @@ describe("resolveAnnounceTarget — DM gateway fallback with threadId", () => {
       displayKey: "agent:main:main",
     });
     expect(target).toBeNull();
+  });
+});
+
+describe("runSessionsSendA2AFlow — forwards threadId to send", () => {
+  beforeEach(async () => {
+    callGatewayMock.mockClear();
+    await installRegistry();
+  });
+
+  it("includes threadId when announce target has one", async () => {
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:main:telegram:group:-1001234567890:topic:99",
+      displayKey: "agent:main:telegram:group:-1001234567890:topic:99",
+      message: "hello",
+      announceTimeoutMs: 1000,
+      maxPingPongTurns: 0,
+      roundOneReply: "round one",
+    });
+
+    type GatewayCall = { method?: unknown; params?: unknown };
+    const asGatewayCall = (x: unknown): GatewayCall | null => {
+      if (!x || typeof x !== "object") {
+        return null;
+      }
+      const obj = x as Record<string, unknown>;
+      return { method: obj.method, params: obj.params };
+    };
+
+    const sendCalls = callGatewayMock.mock.calls
+      .map((c) => asGatewayCall(c?.[0]))
+      .filter((c): c is GatewayCall => !!c && c.method === "send");
+
+    expect(sendCalls.length).toBe(1);
+    const params = sendCalls[0]?.params;
+    expect(params).toMatchObject({
+      channel: "telegram",
+      to: "-1001234567890",
+      threadId: "99",
+    });
   });
 });
 


### PR DESCRIPTION
Root cause: `resolveAnnounceTargetFromKey` didn’t handle DM session keys with kind `direct`/`dm` (e.g. `agent:main:telegram:direct:<peerId>`), causing null targets and dropped completion announcements.

Fix:
- Support `direct`/`dm` kinds in `resolveAnnounceTargetFromKey`.
- Preserve `threadId` when resolving via gateway fallback; emit a warning when no announce target can be resolved.

Tests:
- Updated `src/agents/tools/sessions.test.ts` (focused vitest run) to cover `direct` + `dm` DM keys, DM/group isolation, Discord DM direct targets, and threadId preservation.

Role separation: Telegram→planner routing remains a config/binding concern; this patch only affects completion announce delivery.
