### PR TITLE
perf(channels): cache loader misses and invalidate by registry version

### DIFF
--- a/src/channels/plugins/plugins-core.test.ts
+++ b/src/channels/plugins/plugins-core.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, expectTypeOf, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { DiscordProbe } from "../../discord/probe.js";
 import type { DiscordTokenResolution } from "../../discord/token.js";
@@ -261,6 +261,36 @@ describe("channel plugin loader", () => {
     expect(await loadChannelOutboundAdapter("msteams")).toBe(msteamsOutbound);
     setActivePluginRegistry(registryWithMSTeamsV2);
     expect(await loadChannelOutboundAdapter("msteams")).toBe(msteamsOutboundV2);
+  });
+
+  it("refreshes cached loader values when the same registry instance is re-activated", async () => {
+    const registry = createTestRegistry([
+      { pluginId: "msteams", plugin: msteamsPlugin, source: "test" },
+    ]);
+
+    setActivePluginRegistry(registry, "loader-same-instance");
+    expect(await loadChannelPlugin("msteams")).toBe(msteamsPlugin);
+    expect(await loadChannelOutboundAdapter("msteams")).toBe(msteamsOutbound);
+
+    registry.channels = [
+      { pluginId: "msteams", plugin: msteamsPluginV2, source: "test-v2" },
+    ] as typeof registry.channels;
+    setActivePluginRegistry(registry, "loader-same-instance");
+
+    expect(await loadChannelPlugin("msteams")).toBe(msteamsPluginV2);
+    expect(await loadChannelOutboundAdapter("msteams")).toBe(msteamsOutboundV2);
+  });
+
+  it("caches undefined outbound lookups within the active registry version", async () => {
+    const channels = [
+      { pluginId: "msteams", plugin: mstNoOutboundPlugin, source: "test-no-outbound" },
+    ];
+    const findSpy = vi.spyOn(channels, "find");
+    setActivePluginRegistry(createTestRegistry(channels));
+
+    expect(await loadChannelOutboundAdapter("msteams")).toBeUndefined();
+    expect(await loadChannelOutboundAdapter("msteams")).toBeUndefined();
+    expect(findSpy).toHaveBeenCalledTimes(1);
   });
 
   it("returns undefined when plugin has no outbound adapter", async () => {

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -1,5 +1,5 @@
-import type { PluginChannelRegistration, PluginRegistry } from "../../plugins/registry.js";
-import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import type { PluginChannelRegistration } from "../../plugins/registry.js";
+import { getActivePluginRegistry, getActivePluginRegistryVersion } from "../../plugins/runtime.js";
 import type { ChannelId } from "./types.js";
 
 type ChannelRegistryValueResolver<TValue> = (
@@ -9,27 +9,34 @@ type ChannelRegistryValueResolver<TValue> = (
 export function createChannelRegistryLoader<TValue>(
   resolveValue: ChannelRegistryValueResolver<TValue>,
 ): (id: ChannelId) => Promise<TValue | undefined> {
-  const cache = new Map<ChannelId, TValue>();
-  let lastRegistry: PluginRegistry | null = null;
+  const MISSING = Symbol("channel-registry-loader-missing");
+  const cache = new Map<ChannelId, TValue | typeof MISSING>();
+  let lastRegistryVersion = -1;
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
-    const registry = getActivePluginRegistry();
-    if (registry !== lastRegistry) {
+    const registryVersion = getActivePluginRegistryVersion();
+    if (registryVersion !== lastRegistryVersion) {
       cache.clear();
-      lastRegistry = registry;
+      lastRegistryVersion = registryVersion;
     }
-    const cached = cache.get(id);
-    if (cached) {
+
+    if (cache.has(id)) {
+      const cached = cache.get(id);
+      if (cached === MISSING) {
+        return undefined;
+      }
       return cached;
     }
+
+    const registry = getActivePluginRegistry();
     const pluginEntry = registry?.channels.find((entry) => entry.plugin.id === id);
     if (!pluginEntry) {
+      cache.set(id, MISSING);
       return undefined;
     }
+
     const resolved = resolveValue(pluginEntry);
-    if (resolved) {
-      cache.set(id, resolved);
-    }
+    cache.set(id, resolved === undefined ? MISSING : resolved);
     return resolved;
   };
 }


### PR DESCRIPTION
## Summary
- invalidate channel registry loader cache using plugin registry version instead of object identity
- cache undefined/miss lookups with a sentinel to avoid repeated scans on hot paths
- add regression tests for same-instance registry re-activation and undefined outbound caching

## Why
The loader previously only cleared cache when the registry object reference changed, which can miss updates when the same registry instance is re-activated with a new version. It also skipped caching undefined results, causing repeated find scans for missing/outbound-less plugins.

## Validation
- pnpm vitest run --config vitest.unit.config.ts src/channels/plugins/plugins-core.test.ts -t "channel plugin loader"
- pnpm tsgo

## Risk
Low: targeted behavior change with focused tests.
