### PR TITLE
fix(feishu): drop unsupported media timeout options

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -182,7 +182,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("uses image upload timeout override for image media", async () => {
+  it("does not pass unsupported per-call timeout for image upload", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -190,11 +190,14 @@ describe("sendMediaFeishu msg_type routing", () => {
       fileName: "photo.png",
     });
 
-    expect(imageCreateMock).toHaveBeenCalledWith(
+    const callArg = imageCreateMock.mock.calls[0]?.[0];
+    expect(callArg).toEqual(
       expect.objectContaining({
-        timeout: 120_000,
+        data: expect.any(Object),
       }),
     );
+    expect(callArg).not.toHaveProperty("timeout");
+
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ msg_type: "image" }),
@@ -320,7 +323,6 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(imageGetMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { image_key: imageKey },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toEqual(Buffer.from("image-data"));
@@ -512,7 +514,6 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_audio_msg", file_key: "file_key_audio" },
         params: { type: "file" },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);
@@ -532,7 +533,6 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_img_msg", file_key: "img_key_1" },
         params: { type: "image" },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);


### PR DESCRIPTION
Closes #36581

The Feishu media helpers rely on the timeout-aware HTTP wrapper created in createFeishuClient(). Recent larksuite SDK typings no longer accept a top-level `timeout` field on media method payloads.

This updates the unit tests to assert we do not pass per-call `timeout` fields for image upload and download APIs.

Tests: pnpm vitest extensions/feishu/src/media.test.ts --run