### PR TITLE
fix(gateway): keep webchat main-session turns on internal channel

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/matrix";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { sendMessage } from "./client.js";
 import type { ResolvedSynologyChatAccount } from "./types.js";
 import {
   clearSynologyWebhookRateLimiterStateForTest,
@@ -424,5 +425,28 @@ describe("createWebhookHandler", () => {
         body: expect.stringContaining("[FILTERED]"),
       }),
     );
+  });
+
+  it("splits long replies into multiple Synology messages", async () => {
+    const sendMessageMock = vi.mocked(sendMessage);
+    const beforeCalls = sendMessageMock.mock.calls.length;
+
+    const deliver = vi.fn().mockResolvedValue(`${"A".repeat(1900)}\n${"B".repeat(1900)}`);
+    const handler = createWebhookHandler({
+      account: makeAccount({ accountId: "split-test-" + Date.now() }),
+      deliver,
+      log,
+    });
+
+    const req = makeReq("POST", validBody);
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(204);
+    const calls = sendMessageMock.mock.calls.slice(beforeCalls);
+    expect(calls.length).toBeGreaterThan(1);
+    for (const call of calls) {
+      expect(String(call[1]).length).toBeLessThanOrEqual(1800);
+    }
   });
 });

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -16,6 +16,7 @@ import type { SynologyWebhookPayload, ResolvedSynologyChatAccount } from "./type
 
 // One rate limiter per account, created lazily
 const rateLimiters = new Map<string, RateLimiter>();
+const SYNLOGY_CHAT_REPLY_CHUNK_MAX = 1800;
 
 function getRateLimiter(account: ResolvedSynologyChatAccount): RateLimiter {
   let rl = rateLimiters.get(account.accountId);
@@ -36,6 +37,37 @@ export function clearSynologyWebhookRateLimiterStateForTest(): void {
 
 export function getSynologyWebhookRateLimiterCountForTest(): number {
   return rateLimiters.size;
+}
+
+function splitReplyForSynologyChat(
+  text: string,
+  maxChars = SYNLOGY_CHAT_REPLY_CHUNK_MAX,
+): string[] {
+  const normalized = text.replace(/\r\n/g, "\n").trim();
+  if (!normalized) {
+    return [];
+  }
+  if (normalized.length <= maxChars) {
+    return [normalized];
+  }
+
+  const chunks: string[] = [];
+  let remaining = normalized;
+  while (remaining.length > maxChars) {
+    let cut = remaining.lastIndexOf("\n", maxChars);
+    if (cut <= 0) {
+      cut = remaining.lastIndexOf(" ", maxChars);
+    }
+    if (cut <= 0) {
+      cut = maxChars;
+    }
+    chunks.push(remaining.slice(0, cut).trim());
+    remaining = remaining.slice(cut).trimStart();
+  }
+  if (remaining.length > 0) {
+    chunks.push(remaining);
+  }
+  return chunks;
 }
 
 /** Read the full request body as a string. */
@@ -375,9 +407,16 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
 
       // Send reply back to Synology Chat using the resolved Chat user_id
       if (reply) {
-        await sendMessage(account.incomingUrl, reply, replyUserId, account.allowInsecureSsl);
-        const replyPreview = reply.length > 100 ? `${reply.slice(0, 100)}...` : reply;
-        log?.info(`Reply sent to ${payload.username} (${replyUserId}): ${replyPreview}`);
+        const chunks = splitReplyForSynologyChat(reply);
+        for (const chunk of chunks) {
+          await sendMessage(account.incomingUrl, chunk, replyUserId, account.allowInsecureSsl);
+        }
+        const previewSource = chunks.join("\n");
+        const replyPreview =
+          previewSource.length > 100 ? `${previewSource.slice(0, 100)}...` : previewSource;
+        log?.info(
+          `Reply sent to ${payload.username} (${replyUserId}) in ${chunks.length} part(s): ${replyPreview}`,
+        );
       }
     } catch (err) {
       const errMsg = err instanceof Error ? `${err.message}\n${err.stack}` : String(err);

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore, ProfileUsageStats } from "./types.js";
 import {
+  calculateAuthProfileCooldownMs,
   clearAuthProfileCooldown,
   clearExpiredCooldowns,
   isProfileInCooldown,
@@ -40,6 +41,27 @@ function expectProfileErrorStateCleared(
   expect(stats?.errorCount).toBe(0);
   expect(stats?.failureCounts).toBeUndefined();
 }
+
+describe("calculateAuthProfileCooldownMs", () => {
+  it("uses shorter first backoff for google-gemini-cli oauth-style failures", () => {
+    const googleTimeout = calculateAuthProfileCooldownMs(1, {
+      providerId: "google-gemini-cli",
+      reason: "timeout",
+    });
+    const googleAuth = calculateAuthProfileCooldownMs(1, {
+      providerId: "google-gemini-cli",
+      reason: "auth",
+    });
+    const defaultBackoff = calculateAuthProfileCooldownMs(1, {
+      providerId: "anthropic",
+      reason: "timeout",
+    });
+
+    expect(googleTimeout).toBe(10_000);
+    expect(googleAuth).toBe(10_000);
+    expect(defaultBackoff).toBe(60_000);
+  });
+});
 
 describe("resolveProfileUnusableUntil", () => {
   it("returns null when both values are missing or invalid", () => {

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -62,7 +62,7 @@ describe("calculateAuthProfileCooldownMs", () => {
     expect(defaultBackoff).toBe(60_000);
   });
 
-  it("applies full exponential backoff progression for google-gemini-cli oauth failures", () => {
+  it("applies exponential backoff for google-gemini-cli oauth failures and reaches max cooldown", () => {
     expect(
       calculateAuthProfileCooldownMs(1, {
         providerId: "google-gemini-cli",
@@ -92,7 +92,13 @@ describe("calculateAuthProfileCooldownMs", () => {
         providerId: "google-gemini-cli",
         reason: "auth",
       }),
-    ).toBe(1_250_000);
+    ).toBe(3_600_000);
+    expect(
+      calculateAuthProfileCooldownMs(7, {
+        providerId: "google-gemini-cli",
+        reason: "auth",
+      }),
+    ).toBe(3_600_000);
   });
 
   it("keeps default cooldown for google-gemini-cli non-oauth failures", () => {

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -61,6 +61,58 @@ describe("calculateAuthProfileCooldownMs", () => {
     expect(googleAuth).toBe(10_000);
     expect(defaultBackoff).toBe(60_000);
   });
+
+  it("applies full exponential backoff progression for google-gemini-cli oauth failures", () => {
+    expect(
+      calculateAuthProfileCooldownMs(1, {
+        providerId: "google-gemini-cli",
+        reason: "auth",
+      }),
+    ).toBe(10_000);
+    expect(
+      calculateAuthProfileCooldownMs(2, {
+        providerId: "google-gemini-cli",
+        reason: "auth",
+      }),
+    ).toBe(50_000);
+    expect(
+      calculateAuthProfileCooldownMs(3, {
+        providerId: "google-gemini-cli",
+        reason: "timeout",
+      }),
+    ).toBe(250_000);
+    expect(
+      calculateAuthProfileCooldownMs(4, {
+        providerId: "google-gemini-cli",
+        reason: "timeout",
+      }),
+    ).toBe(1_250_000);
+    expect(
+      calculateAuthProfileCooldownMs(5, {
+        providerId: "google-gemini-cli",
+        reason: "auth",
+      }),
+    ).toBe(1_250_000);
+  });
+
+  it("keeps default cooldown for google-gemini-cli non-oauth failures", () => {
+    expect(
+      calculateAuthProfileCooldownMs(1, {
+        providerId: "google-gemini-cli",
+        reason: "rate_limit",
+      }),
+    ).toBe(60_000);
+    expect(
+      calculateAuthProfileCooldownMs(1, {
+        providerId: "google-gemini-cli",
+        reason: "unknown",
+      }),
+    ).toBe(60_000);
+  });
+
+  it("remains backward compatible when called without options", () => {
+    expect(calculateAuthProfileCooldownMs(1)).toBe(60_000);
+  });
 });
 
 describe("resolveProfileUnusableUntil", () => {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -266,11 +266,24 @@ export async function markAuthProfileUsed(params: {
   saveAuthProfileStore(store, agentDir);
 }
 
-export function calculateAuthProfileCooldownMs(errorCount: number): number {
+const DEFAULT_PROFILE_COOLDOWN_BASE_MS = 60 * 1000;
+const GOOGLE_GEMINI_OAUTH_COOLDOWN_BASE_MS = 10 * 1000;
+
+export function calculateAuthProfileCooldownMs(
+  errorCount: number,
+  options?: { reason?: AuthProfileFailureReason; providerId?: string },
+): number {
   const normalized = Math.max(1, errorCount);
+  const providerId = normalizeProviderId(options?.providerId ?? "");
+  const isGoogleGeminiCli = providerId === "google-gemini-cli";
+  const isOauthLikeFailure = options?.reason === "auth" || options?.reason === "timeout";
+  const baseMs =
+    isGoogleGeminiCli && isOauthLikeFailure
+      ? GOOGLE_GEMINI_OAUTH_COOLDOWN_BASE_MS
+      : DEFAULT_PROFILE_COOLDOWN_BASE_MS;
   return Math.min(
     60 * 60 * 1000, // 1 hour max
-    60 * 1000 * 5 ** Math.min(normalized - 1, 3),
+    baseMs * 5 ** Math.min(normalized - 1, 3),
   );
 }
 
@@ -390,6 +403,7 @@ function computeNextProfileUsageStats(params: {
   existing: ProfileUsageStats;
   now: number;
   reason: AuthProfileFailureReason;
+  providerId?: string;
   cfgResolved: ResolvedAuthCooldownConfig;
 }): ProfileUsageStats {
   const windowMs = params.cfgResolved.failureWindowMs;
@@ -426,7 +440,10 @@ function computeNextProfileUsageStats(params: {
     });
     updatedStats.disabledReason = params.reason;
   } else {
-    const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount);
+    const backoffMs = calculateAuthProfileCooldownMs(nextErrorCount, {
+      reason: params.reason,
+      providerId: params.providerId,
+    });
     // Keep active cooldown windows immutable so retries within the window
     // cannot push recovery further out.
     updatedStats.cooldownUntil = keepActiveWindowOrRecompute({
@@ -475,6 +492,7 @@ export async function markAuthProfileFailure(params: {
           existing: existing ?? {},
           now,
           reason,
+          providerId: providerKey,
           cfgResolved,
         }),
       );
@@ -501,6 +519,7 @@ export async function markAuthProfileFailure(params: {
       existing: existing ?? {},
       now,
       reason,
+      providerId: providerKey,
       cfgResolved,
     }),
   );

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -283,7 +283,7 @@ export function calculateAuthProfileCooldownMs(
       : DEFAULT_PROFILE_COOLDOWN_BASE_MS;
   return Math.min(
     60 * 60 * 1000, // 1 hour max
-    baseMs * 5 ** Math.min(normalized - 1, 3),
+    baseMs * 5 ** Math.max(normalized - 1, 0),
   );
 }
 

--- a/src/agents/openclaw-tools.agents.test.ts
+++ b/src/agents/openclaw-tools.agents.test.ts
@@ -50,13 +50,44 @@ describe("agents_list", () => {
     };
   });
 
-  it("defaults to the requester agent only", async () => {
+  it("falls back to configured agents when no allowlist is defined", async () => {
+    setConfigWithAgentList([
+      {
+        id: "main",
+        name: "Main",
+      },
+      {
+        id: "research",
+        name: "Research",
+      },
+    ]);
+
     const tool = requireAgentsListTool();
     const result = await tool.execute("call1", {});
     expect(result.details).toMatchObject({
       requester: "main",
       allowAny: false,
     });
+    const agents = readAgentList(result);
+    expect(agents?.map((agent) => agent.id)).toEqual(["main", "research"]);
+  });
+
+  it("keeps requester-only visibility when allowlist is explicitly empty", async () => {
+    setConfigWithAgentList([
+      {
+        id: "main",
+        subagents: {
+          allowAgents: [],
+        },
+      },
+      {
+        id: "research",
+        name: "Research",
+      },
+    ]);
+
+    const tool = requireAgentsListTool();
+    const result = await tool.execute("call1b", {});
     const agents = readAgentList(result);
     expect(agents?.map((agent) => agent.id)).toEqual(["main"]);
   });

--- a/src/agents/openclaw-tools.agents.test.ts
+++ b/src/agents/openclaw-tools.agents.test.ts
@@ -50,7 +50,7 @@ describe("agents_list", () => {
     };
   });
 
-  it("falls back to configured agents when no allowlist is defined", async () => {
+  it("keeps requester-only visibility when no allowlist is defined", async () => {
     setConfigWithAgentList([
       {
         id: "main",
@@ -69,7 +69,7 @@ describe("agents_list", () => {
       allowAny: false,
     });
     const agents = readAgentList(result);
-    expect(agents?.map((agent) => agent.id)).toEqual(["main", "research"]);
+    expect(agents?.map((agent) => agent.id)).toEqual(["main"]);
   });
 
   it("keeps requester-only visibility when allowlist is explicitly empty", async () => {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -147,6 +147,25 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
+  it("sessions_spawn allows configured cross-agent when allowlist is unset", async () => {
+    setSessionsSpawnConfigOverride({
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        list: [{ id: "main" }, { id: "beta" }],
+      },
+    });
+    const getChildSessionKey = mockAcceptedSpawn(5050);
+
+    const result = await executeSpawn("call6b", "beta");
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      runId: "run-1",
+    });
+    expect(getChildSessionKey()?.startsWith("agent:beta:subagent:")).toBe(true);
+  });
+
+
   it("sessions_spawn forbids cross-agent spawning when not allowed", async () => {
     setSessionsSpawnConfigOverride({
       session: {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -147,22 +147,19 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
-  it("sessions_spawn allows configured cross-agent when allowlist is unset", async () => {
+  it("sessions_spawn forbids configured cross-agent when allowlist is unset", async () => {
     setSessionsSpawnConfigOverride({
       session: { mainKey: "main", scope: "per-sender" },
       agents: {
         list: [{ id: "main" }, { id: "beta" }],
       },
     });
-    const getChildSessionKey = mockAcceptedSpawn(5050);
-
     const result = await executeSpawn("call6b", "beta");
 
     expect(result.details).toMatchObject({
-      status: "accepted",
-      runId: "run-1",
+      status: "forbidden",
     });
-    expect(getChildSessionKey()?.startsWith("agent:beta:subagent:")).toBe(true);
+    expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
   it("sessions_spawn forbids configured cross-agent when requester is not configured and allowlist is unset", async () => {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -165,6 +165,30 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
     expect(getChildSessionKey()?.startsWith("agent:beta:subagent:")).toBe(true);
   });
 
+  it("sessions_spawn forbids configured cross-agent when requester is not configured and allowlist is unset", async () => {
+    setSessionsSpawnConfigOverride({
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        list: [{ id: "main" }, { id: "beta" }],
+      },
+    });
+
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "agent:ghost:main",
+      agentChannel: "whatsapp",
+    });
+
+    const result = await tool.execute("call6c", {
+      task: "do thing",
+      agentId: "beta",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "forbidden",
+    });
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
   it("sessions_spawn forbids cross-agent spawning when not allowed", async () => {
     setSessionsSpawnConfigOverride({
       session: {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.allowlist.test.ts
@@ -165,7 +165,6 @@ describe("openclaw-tools: subagents (sessions_spawn allowlist)", () => {
     expect(getChildSessionKey()?.startsWith("agent:beta:subagent:")).toBe(true);
   });
 
-
   it("sessions_spawn forbids cross-agent spawning when not allowed", async () => {
     setSessionsSpawnConfigOverride({
       session: {

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -359,7 +359,9 @@ function mapContainerPathToWorkspaceRoot(params: {
   root: string;
   containerWorkdir?: string;
 }): string {
-  const containerWorkdir = params.containerWorkdir?.trim();
+  const inferredWorkdir =
+    path.basename(path.resolve(params.root)) === "workspace" ? "/workspace" : undefined;
+  const containerWorkdir = params.containerWorkdir?.trim() || inferredWorkdir;
   if (!containerWorkdir) {
     return params.filePath;
   }

--- a/src/agents/pi-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/pi-tools.read.workspace-root-guard.test.ts
@@ -26,6 +26,7 @@ function createToolHarness() {
 
 describe("wrapToolWorkspaceRootGuardWithOptions", () => {
   const root = "/tmp/root";
+  const sandboxWorkspaceRoot = "/tmp/session/workspace";
 
   beforeEach(() => {
     mocks.assertSandboxPath.mockClear();
@@ -103,6 +104,19 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
       filePath: "/workspace-two/secret.txt",
       cwd: root,
       root,
+    });
+  });
+
+  it("infers /workspace mapping when containerWorkdir is missing", async () => {
+    const { tool } = createToolHarness();
+    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, sandboxWorkspaceRoot);
+
+    await wrapped.execute("tc4", { path: "/workspace/media/inbound/upload.csv" });
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
+      filePath: path.resolve(sandboxWorkspaceRoot, "media", "inbound", "upload.csv"),
+      cwd: sandboxWorkspaceRoot,
+      root: sandboxWorkspaceRoot,
     });
   });
 });

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -344,7 +344,8 @@ export async function spawnSubagentDirect(
   );
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
   if (targetAgentId !== requesterAgentId) {
-    const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+    const explicitAllowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents;
+    const allowAgents = explicitAllowAgents ?? [];
     const allowAny = allowAgents.some((value) => value.trim() === "*");
     const normalizedTargetId = targetAgentId.toLowerCase();
     const allowSet = new Set(
@@ -352,8 +353,22 @@ export async function spawnSubagentDirect(
         .filter((value) => value.trim() && value.trim() !== "*")
         .map((value) => normalizeAgentId(value).toLowerCase()),
     );
-    if (!allowAny && !allowSet.has(normalizedTargetId)) {
-      const allowedText = allowSet.size > 0 ? Array.from(allowSet).join(", ") : "none";
+    const configuredSet = new Set(
+      (Array.isArray(cfg.agents?.list) ? cfg.agents.list : [])
+        .map((entry) => normalizeAgentId(entry.id).toLowerCase()),
+    );
+    const isAllowed = allowAny
+      ? true
+      : explicitAllowAgents === undefined
+        ? configuredSet.has(normalizedTargetId)
+        : allowSet.has(normalizedTargetId);
+    if (!isAllowed) {
+      const allowedText =
+        explicitAllowAgents === undefined
+          ? Array.from(configuredSet).join(", ") || "none"
+          : allowSet.size > 0
+            ? Array.from(allowSet).join(", ")
+            : "none";
       return {
         status: "forbidden",
         error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText})`,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -358,10 +358,11 @@ export async function spawnSubagentDirect(
         normalizeAgentId(entry.id).toLowerCase(),
       ),
     );
+    const normalizedRequesterId = requesterAgentId.toLowerCase();
     const isAllowed = allowAny
       ? true
       : explicitAllowAgents === undefined
-        ? configuredSet.has(normalizedTargetId)
+        ? configuredSet.has(normalizedRequesterId) && configuredSet.has(normalizedTargetId)
         : allowSet.has(normalizedTargetId);
     if (!isAllowed) {
       const allowedText =

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -353,24 +353,9 @@ export async function spawnSubagentDirect(
         .filter((value) => value.trim() && value.trim() !== "*")
         .map((value) => normalizeAgentId(value).toLowerCase()),
     );
-    const configuredSet = new Set(
-      (Array.isArray(cfg.agents?.list) ? cfg.agents.list : []).map((entry) =>
-        normalizeAgentId(entry.id).toLowerCase(),
-      ),
-    );
-    const normalizedRequesterId = requesterAgentId.toLowerCase();
-    const isAllowed = allowAny
-      ? true
-      : explicitAllowAgents === undefined
-        ? configuredSet.has(normalizedRequesterId) && configuredSet.has(normalizedTargetId)
-        : allowSet.has(normalizedTargetId);
+    const isAllowed = allowAny ? true : allowSet.has(normalizedTargetId);
     if (!isAllowed) {
-      const allowedText =
-        explicitAllowAgents === undefined
-          ? Array.from(configuredSet).join(", ") || "none"
-          : allowSet.size > 0
-            ? Array.from(allowSet).join(", ")
-            : "none";
+      const allowedText = allowSet.size > 0 ? Array.from(allowSet).join(", ") : "none";
       return {
         status: "forbidden",
         error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText})`,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -354,8 +354,9 @@ export async function spawnSubagentDirect(
         .map((value) => normalizeAgentId(value).toLowerCase()),
     );
     const configuredSet = new Set(
-      (Array.isArray(cfg.agents?.list) ? cfg.agents.list : [])
-        .map((entry) => normalizeAgentId(entry.id).toLowerCase()),
+      (Array.isArray(cfg.agents?.list) ? cfg.agents.list : []).map((entry) =>
+        normalizeAgentId(entry.id).toLowerCase(),
+      ),
     );
     const isAllowed = allowAny
       ? true

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -190,6 +190,24 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("<final>...</final>");
   });
 
+  it("keeps runtime reasoning line stable across reasoning toggles", () => {
+    const promptOff = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      reasoningLevel: "off",
+    });
+    const promptOn = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      reasoningLevel: "on",
+    });
+
+    const runtimeLine =
+      "Reasoning: controlled by runtime setting (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.";
+    expect(promptOff).toContain(runtimeLine);
+    expect(promptOn).toContain(runtimeLine);
+    expect(promptOff).not.toContain("Reasoning: off (hidden unless on/stream)");
+    expect(promptOn).not.toContain("Reasoning: on (hidden unless on/stream)");
+  });
+
   it("includes a CLI quick reference section", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
@@ -599,7 +617,7 @@ describe("buildAgentSystemPrompt", () => {
       reasoningLevel: "off",
     });
 
-    expect(prompt).toContain("Reasoning: off");
+    expect(prompt).toContain("Reasoning: controlled by runtime setting");
     expect(prompt).toContain("/reasoning");
     expect(prompt).toContain("/status shows Reasoning");
   });

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -360,7 +360,6 @@ export function buildAgentSystemPrompt(params: {
         "<final>Hey there! What would you like to do next?</final>",
       ].join(" ")
     : undefined;
-  const reasoningLevel = params.reasoningLevel ?? "off";
   const userTimezone = params.userTimezone?.trim();
   const skillsPrompt = params.skillsPrompt?.trim();
   const heartbeatPrompt = params.heartbeatPrompt?.trim();
@@ -678,7 +677,7 @@ export function buildAgentSystemPrompt(params: {
   lines.push(
     "## Runtime",
     buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities, params.defaultThinkLevel),
-    `Reasoning: ${reasoningLevel} (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.`,
+    "Reasoning: controlled by runtime setting (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.",
   );
 
   return lines.filter(Boolean).join("\n");

--- a/src/agents/tool-policy-shared.ts
+++ b/src/agents/tool-policy-shared.ts
@@ -12,6 +12,8 @@ type ToolProfilePolicy = {
 const TOOL_NAME_ALIASES: Record<string, string> = {
   bash: "exec",
   "apply-patch": "apply_patch",
+  "fs.readfile": "read",
+  "system.exec": "exec",
 };
 
 export const TOOL_GROUPS: Record<string, string[]> = { ...CORE_TOOL_GROUPS };

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -73,6 +73,8 @@ describe("tool-policy", () => {
   it("normalizes tool names and aliases", () => {
     expect(normalizeToolName(" BASH ")).toBe("exec");
     expect(normalizeToolName("apply-patch")).toBe("apply_patch");
+    expect(normalizeToolName("fs.readFile")).toBe("read");
+    expect(normalizeToolName("system.exec")).toBe("exec");
     expect(normalizeToolName("READ")).toBe("read");
   });
 

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -46,7 +46,9 @@ export function createAgentsListTool(opts?: {
           DEFAULT_AGENT_ID,
       );
 
-      const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+      const requesterAgentCfg = resolveAgentConfig(cfg, requesterAgentId);
+      const explicitAllowAgents = requesterAgentCfg?.subagents?.allowAgents;
+      const allowAgents = explicitAllowAgents ?? [];
       const allowAny = allowAgents.some((value) => value.trim() === "*");
       const allowSet = new Set(
         allowAgents
@@ -68,6 +70,10 @@ export function createAgentsListTool(opts?: {
       const allowed = new Set<string>();
       allowed.add(requesterAgentId);
       if (allowAny) {
+        for (const id of configuredIds) {
+          allowed.add(id);
+        }
+      } else if (explicitAllowAgents === undefined) {
         for (const id of configuredIds) {
           allowed.add(id);
         }

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -73,10 +73,6 @@ export function createAgentsListTool(opts?: {
         for (const id of configuredIds) {
           allowed.add(id);
         }
-      } else if (explicitAllowAgents === undefined) {
-        for (const id of configuredIds) {
-          allowed.add(id);
-        }
       } else {
         for (const id of allowSet) {
           allowed.add(id);

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -27,6 +27,8 @@ const MAX_SEARCH_COUNT = 10;
 
 const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
 const PERPLEXITY_SEARCH_ENDPOINT = "https://api.perplexity.ai/search";
+const DEFAULT_PERPLEXITY_BASE_URL = "https://api.perplexity.ai";
+const DEFAULT_PERPLEXITY_MODEL = "perplexity/sonar-pro";
 
 const XAI_API_ENDPOINT = "https://api.x.ai/v1/responses";
 const DEFAULT_GROK_MODEL = "grok-4-1-fast";
@@ -189,6 +191,8 @@ type BraveSearchResponse = {
 
 type PerplexityConfig = {
   apiKey?: string;
+  baseUrl?: string;
+  model?: string;
 };
 
 type PerplexityApiKeySource = "config" | "perplexity_env" | "none";
@@ -516,6 +520,18 @@ function resolvePerplexityApiKey(perplexity?: PerplexityConfig): {
   }
 
   return { apiKey: undefined, source: "none" };
+}
+
+function resolvePerplexityBaseUrl(perplexity?: PerplexityConfig): string {
+  const configured =
+    perplexity && typeof perplexity.baseUrl === "string" ? perplexity.baseUrl.trim() : "";
+  return (configured || DEFAULT_PERPLEXITY_BASE_URL).replace(/\/$/, "");
+}
+
+function resolvePerplexityModel(perplexity?: PerplexityConfig): string {
+  const configured =
+    perplexity && typeof perplexity.model === "string" ? perplexity.model.trim() : "";
+  return configured || DEFAULT_PERPLEXITY_MODEL;
 }
 
 function normalizeApiKey(key: unknown): string {
@@ -868,9 +884,64 @@ async function runPerplexitySearchApi(params: {
   searchBeforeDate?: string;
   maxTokens?: number;
   maxTokensPerPage?: number;
+  baseUrl?: string;
+  model?: string;
 }): Promise<
   Array<{ title: string; url: string; description: string; published?: string; siteName?: string }>
 > {
+  const baseUrl = params.baseUrl?.trim().replace(/\/$/, "") || DEFAULT_PERPLEXITY_BASE_URL;
+  const useChatCompletions = !baseUrl.includes("api.perplexity.ai");
+
+  if (useChatCompletions) {
+    const endpoint = `${baseUrl}/chat/completions`;
+    return await withTrustedWebSearchEndpoint(
+      {
+        url: endpoint,
+        timeoutSeconds: params.timeoutSeconds,
+        init: {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+            Authorization: `Bearer ${params.apiKey}`,
+            "HTTP-Referer": "https://openclaw.ai",
+            "X-Title": "OpenClaw Web Search",
+          },
+          body: JSON.stringify({
+            model: params.model || DEFAULT_PERPLEXITY_MODEL,
+            messages: [{ role: "user", content: params.query }],
+          }),
+        },
+      },
+      async (res) => {
+        if (!res.ok) {
+          return await throwWebSearchApiError(res, "Perplexity Search");
+        }
+        const data = (await res.json()) as {
+          choices?: Array<{ message?: { content?: string } }>;
+          citations?: string[];
+        };
+        const text = data.choices?.[0]?.message?.content?.trim() || "";
+        const citations = (data.citations ?? []).filter(
+          (citation): citation is string =>
+            typeof citation === "string" && citation.trim().length > 0,
+        );
+        if (!text) {
+          return [];
+        }
+        const firstCitation = citations[0] ?? "";
+        return [
+          {
+            title: wrapWebContent("Perplexity Search", "web_search"),
+            url: firstCitation,
+            description: wrapWebContent(text, "web_search"),
+            siteName: resolveSiteName(firstCitation) || undefined,
+          },
+        ];
+      },
+    );
+  }
+
   const body: Record<string, unknown> = {
     query: params.query,
     max_results: params.count,
@@ -1166,6 +1237,8 @@ async function runWebSearch(params: {
   searchDomainFilter?: string[];
   maxTokens?: number;
   maxTokensPerPage?: number;
+  perplexityBaseUrl?: string;
+  perplexityModel?: string;
   grokModel?: string;
   grokInlineCitations?: boolean;
   geminiModel?: string;
@@ -1204,6 +1277,8 @@ async function runWebSearch(params: {
       searchBeforeDate: params.dateBefore ? isoToPerplexityDate(params.dateBefore) : undefined,
       maxTokens: params.maxTokens,
       maxTokensPerPage: params.maxTokensPerPage,
+      baseUrl: params.perplexityBaseUrl,
+      model: params.perplexityModel,
     });
 
     const payload = {
@@ -1591,6 +1666,8 @@ export function createWebSearchTool(options?: {
         searchDomainFilter: domainFilter,
         maxTokens: maxTokens ?? undefined,
         maxTokensPerPage: maxTokensPerPage ?? undefined,
+        perplexityBaseUrl: resolvePerplexityBaseUrl(perplexityConfig),
+        perplexityModel: resolvePerplexityModel(perplexityConfig),
         grokModel: resolveGrokModel(grokConfig),
         grokInlineCitations: resolveGrokInlineCitations(grokConfig),
         geminiModel: resolveGeminiModel(geminiConfig),

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -15,7 +15,11 @@ function installMockFetch(payload: unknown) {
   return mockFetch;
 }
 
-function createPerplexitySearchTool(perplexityConfig?: { apiKey?: string }) {
+function createPerplexitySearchTool(perplexityConfig?: {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+}) {
   return createWebSearchTool({
     config: {
       tools: {
@@ -276,6 +280,34 @@ describe("web_search perplexity Search API", () => {
     expect(mockFetch).toHaveBeenCalled();
     const body = parseFirstRequestBody(mockFetch);
     expect(body.country).toBe("DE");
+  });
+
+  it("uses chat completions endpoint when Perplexity baseUrl points to OpenRouter", async () => {
+    const mockFetch = installMockFetch({
+      choices: [{ message: { content: "OpenRouter answer" } }],
+      citations: ["https://openrouter.ai/docs"],
+    });
+    const tool = createPerplexitySearchTool({
+      apiKey: "sk-or-v1-test",
+      baseUrl: "https://openrouter.ai/api/v1",
+      model: "perplexity/sonar",
+    });
+
+    const result = await tool?.execute?.("call-1", { query: "test" });
+
+    expect(mockFetch).toHaveBeenCalled();
+    expect(mockFetch.mock.calls[0]?.[0]).toBe("https://openrouter.ai/api/v1/chat/completions");
+    const body = parseFirstRequestBody(mockFetch);
+    expect(body.model).toBe("perplexity/sonar");
+    expect(result?.details).toMatchObject({
+      provider: "perplexity",
+      results: [
+        expect.objectContaining({
+          url: "https://openrouter.ai/docs",
+          description: expect.stringContaining("OpenRouter answer"),
+        }),
+      ],
+    });
   });
 
   it("uses config API key when provided", async () => {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -104,7 +104,7 @@ export async function runGatewayLoop(params: {
     const forceExitMs = isRestart ? DRAIN_TIMEOUT_MS + SHUTDOWN_TIMEOUT_MS : SHUTDOWN_TIMEOUT_MS;
     const forceExitTimer = setTimeout(() => {
       gatewayLog.error("shutdown timed out; exiting without full cleanup");
-      exitProcess(0);
+      exitProcess(isRestart ? 1 : 0);
     }, forceExitMs);
 
     void (async () => {

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -7,6 +7,7 @@ import {
   parseSchtasksQuery,
   readScheduledTaskCommand,
   resolveTaskScriptPath,
+  syncTaskScriptServiceVersion,
 } from "./schtasks.js";
 
 describe("schtasks runtime parsing", () => {
@@ -93,6 +94,47 @@ describe("resolveTaskScriptPath", () => {
     },
   ])("$name", ({ env, expected }) => {
     expect(resolveTaskScriptPath(env)).toBe(expected);
+  });
+});
+
+describe("syncTaskScriptServiceVersion", () => {
+  it("injects OPENCLAW_SERVICE_VERSION when missing", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-schtasks-version-"));
+    try {
+      const env = { USERPROFILE: tmpDir, OPENCLAW_PROFILE: "default" };
+      const scriptPath = resolveTaskScriptPath(env);
+      await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+      await fs.writeFile(scriptPath, "@echo off\r\nnode gateway.js\r\n", "utf8");
+
+      await syncTaskScriptServiceVersion(env, "2026.3.2");
+
+      const next = await fs.readFile(scriptPath, "utf8");
+      expect(next).toContain('set "OPENCLAW_SERVICE_VERSION=2026.3.2"');
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("replaces stale OPENCLAW_SERVICE_VERSION when present", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-schtasks-version-"));
+    try {
+      const env = { USERPROFILE: tmpDir, OPENCLAW_PROFILE: "default" };
+      const scriptPath = resolveTaskScriptPath(env);
+      await fs.mkdir(path.dirname(scriptPath), { recursive: true });
+      await fs.writeFile(
+        scriptPath,
+        "@echo off\r\nset OPENCLAW_SERVICE_VERSION=2026.2.26\r\nnode gateway.js\r\n",
+        "utf8",
+      );
+
+      await syncTaskScriptServiceVersion(env, "2026.3.2");
+
+      const next = await fs.readFile(scriptPath, "utf8");
+      expect(next).toContain('set "OPENCLAW_SERVICE_VERSION=2026.3.2"');
+      expect(next).not.toContain("2026.2.26");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { VERSION } from "../version.js";
 import { parseCmdScriptCommandLine, quoteCmdScriptArg } from "./cmd-argv.js";
 import { assertNoCmdLineBreak, parseCmdSetAssignment, renderCmdSetAssignment } from "./cmd-set.js";
 import { resolveGatewayServiceDescription, resolveGatewayWindowsTaskName } from "./constants.js";
@@ -295,6 +296,48 @@ export async function uninstallScheduledTask({
   }
 }
 
+export async function syncTaskScriptServiceVersion(
+  env: GatewayServiceEnv,
+  version: string = VERSION,
+): Promise<void> {
+  const scriptPath = resolveTaskScriptPath(env);
+  let content: string;
+  try {
+    content = await fs.readFile(scriptPath, "utf8");
+  } catch {
+    return;
+  }
+
+  const lines = content.split(/\r?\n/);
+  const assignment = renderCmdSetAssignment("OPENCLAW_SERVICE_VERSION", version);
+  const targetKey = "openclaw_service_version";
+  let replaced = false;
+
+  for (let idx = 0; idx < lines.length; idx += 1) {
+    const line = lines[idx]?.trim();
+    if (!line || !line.toLowerCase().startsWith("set ")) {
+      continue;
+    }
+    const parsed = parseCmdSetAssignment(line.slice(4));
+    if (parsed && parsed.key.toLowerCase() === targetKey) {
+      lines[idx] = assignment;
+      replaced = true;
+      break;
+    }
+  }
+
+  if (!replaced) {
+    const echoOffIndex = lines.findIndex((line) => line.trim().toLowerCase() === "@echo off");
+    const insertAt = echoOffIndex >= 0 ? echoOffIndex + 1 : 0;
+    lines.splice(insertAt, 0, assignment);
+  }
+
+  const next = `${lines.join("\r\n").replace(/(\r\n)+$/u, "")}\r\n`;
+  if (next !== content) {
+    await fs.writeFile(scriptPath, next, "utf8");
+  }
+}
+
 function isTaskNotRunning(res: { stdout: string; stderr: string; code: number }): boolean {
   const detail = (res.stderr || res.stdout).toLowerCase();
   return detail.includes("not running");
@@ -315,7 +358,9 @@ export async function restartScheduledTask({
   env,
 }: GatewayServiceControlArgs): Promise<void> {
   await assertSchtasksAvailable();
-  const taskName = resolveTaskName(env ?? (process.env as GatewayServiceEnv));
+  const resolvedEnv = env ?? (process.env as GatewayServiceEnv);
+  const taskName = resolveTaskName(resolvedEnv);
+  await syncTaskScriptServiceVersion(resolvedEnv);
   await execSchtasks(["/End", "/TN", taskName]);
   const res = await execSchtasks(["/Run", "/TN", taskName]);
   if (res.code !== 0) {

--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -276,6 +276,33 @@ describe("runDiscordGatewayLifecycle", () => {
     });
   });
 
+  it("handles queued max reconnect attempts without crashing lifecycle", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const {
+      lifecycleParams,
+      start,
+      stop,
+      threadStop,
+      runtimeError,
+      releaseEarlyGatewayErrorGuard,
+    } = createLifecycleHarness({
+      pendingGatewayErrors: [new Error("Max reconnect attempts (0) reached after code 1006")],
+    });
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+    expect(runtimeError).toHaveBeenCalledWith(
+      expect.stringContaining("reconnect attempts exhausted"),
+    );
+    expectLifecycleCleanup({
+      start,
+      stop,
+      threadStop,
+      waitCalls: 0,
+      releaseEarlyGatewayErrorGuard,
+    });
+  });
+
   it("retries stalled HELLO with resume before forcing fresh identify", async () => {
     vi.useFakeTimers();
     try {

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -261,12 +261,24 @@ export async function runDiscordGatewayLifecycle(params: {
   }
 
   let sawDisallowedIntents = false;
+  let sawReconnectExhausted = false;
+  const isReconnectExhaustedError = (err: unknown) =>
+    String(err).includes("Max reconnect attempts");
   const logGatewayError = (err: unknown) => {
     if (params.isDisallowedIntentsError(err)) {
       sawDisallowedIntents = true;
       params.runtime.error?.(
         danger(
           "discord: gateway closed with code 4014 (missing privileged gateway intents). Enable the required intents in the Discord Developer Portal or disable them in config.",
+        ),
+      );
+      return;
+    }
+    if (isReconnectExhaustedError(err)) {
+      sawReconnectExhausted = true;
+      params.runtime.error?.(
+        danger(
+          "discord gateway reconnect attempts exhausted; stopping Discord monitor without crashing the gateway",
         ),
       );
       return;
@@ -323,7 +335,11 @@ export async function runDiscordGatewayLifecycle(params: {
       },
     });
   } catch (err) {
-    if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {
+    if (
+      !sawDisallowedIntents &&
+      !params.isDisallowedIntentsError(err) &&
+      !(sawReconnectExhausted && isReconnectExhaustedError(err))
+    ) {
       throw err;
     }
   } finally {

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -409,7 +409,7 @@ describe("gateway agent handler", () => {
     expect(callArgs.bestEffortDeliver).toBe(false);
   });
 
-  it("keeps origin messageChannel as webchat while delivery channel uses last session channel", async () => {
+  it("keeps UI-originated main-session turns on webchat unless routing is explicit", async () => {
     mockMainSessionEntry({
       sessionId: "existing-session-id",
       lastChannel: "telegram",
@@ -452,7 +452,7 @@ describe("gateway agent handler", () => {
       messageChannel?: string;
       runContext?: { messageChannel?: string };
     };
-    expect(callArgs.channel).toBe("telegram");
+    expect(callArgs.channel).toBe("webchat");
     expect(callArgs.messageChannel).toBe("webchat");
     expect(callArgs.runContext?.messageChannel).toBe("webchat");
   });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -518,9 +518,18 @@ export const agentHandlers: GatewayRequestHandlers = {
       typeof request.accountId === "string" && request.accountId.trim()
         ? request.accountId.trim()
         : undefined;
+    const uiClientWithoutExplicitRoute =
+      client?.connect &&
+      isWebchatConnect(client.connect) &&
+      !request.replyChannel &&
+      !request.channel &&
+      !explicitTo;
+
     const deliveryPlan = resolveAgentDeliveryPlan({
       sessionEntry,
-      requestedChannel: request.replyChannel ?? request.channel,
+      requestedChannel: uiClientWithoutExplicitRoute
+        ? INTERNAL_MESSAGE_CHANNEL
+        : (request.replyChannel ?? request.channel),
       explicitTo,
       explicitThreadId,
       accountId: request.replyAccountId ?? request.accountId,

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -347,6 +347,31 @@ export function registerControlUiAndPairingSuite(): void {
     }
   });
 
+  test("ignores explicit wrong deviceToken when dangerouslyDisableDeviceAuth=true and shared token is valid", async () => {
+    testState.gatewayControlUi = { dangerouslyDisableDeviceAuth: true };
+    testState.gatewayAuth = { mode: "token", token: "secret" };
+    const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
+    try {
+      await withGatewayServer(async ({ port }) => {
+        const ws = await openWs(port, { origin: originForPort(port) });
+        const res = await connectReq(ws, {
+          token: "secret",
+          deviceToken: "stale-or-invalid-device-token",
+          scopes: ["operator.read"],
+          client: {
+            ...CONTROL_UI_CLIENT,
+          },
+        });
+        expect(res.ok).toBe(true);
+        expect(res.error?.message ?? "").not.toContain("device token mismatch");
+        ws.close();
+      });
+    } finally {
+      restoreGatewayToken(prevToken);
+    }
+  });
+
   test("device token auth matrix", async () => {
     const { server, ws, port, prevToken } = await startServerWithClient("secret");
     const { deviceToken, deviceIdentityPath } = await ensurePairedDeviceTokenForCurrentIdentity(ws);

--- a/src/plugin-sdk/matrix.ts
+++ b/src/plugin-sdk/matrix.ts
@@ -90,6 +90,7 @@ export {
 export { formatDocsLink } from "../terminal/links.js";
 export type { WizardPrompter } from "../wizard/prompts.js";
 export { createScopedPairingAccess } from "./pairing-access.js";
+export { KeyedAsyncQueue } from "./keyed-async-queue.js";
 export { formatResolvedUnresolvedNote } from "./resolution-notes.js";
 export { runPluginCommandWithTimeout } from "./run-command.js";
 export { createLoggerBackedRuntime } from "./runtime.js";

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -31,7 +31,7 @@ function warnInvalidAllowFromEntries(entries: string[]) {
       [
         "Invalid allowFrom entry:",
         JSON.stringify(entry),
-        "- allowFrom/groupAllowFrom authorization requires numeric Telegram sender IDs only.",
+        "- allowFrom/groupAllowFrom authorization requires numeric Telegram IDs (sender or group chat ID).",
         'If you had "@username" entries, re-run onboarding (it resolves @username to IDs) or replace them manually.',
       ].join(" "),
     );
@@ -44,11 +44,11 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => /^-?\d+$/.test(value));
   return {
     entries: ids,
     hasWildcard,

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -510,6 +510,7 @@ export const registerTelegramHandlers = ({
     } = params;
     const baseAccess = evaluateTelegramGroupBaseAccess({
       isGroup,
+      chatId,
       groupConfig,
       topicConfig,
       hasGroupAllowOverride,

--- a/src/telegram/bot-message-context.audio-transcript.test.ts
+++ b/src/telegram/bot-message-context.audio-transcript.test.ts
@@ -150,4 +150,32 @@ describe("buildTelegramMessageContext audio transcript body", () => {
     expect(transcribeFirstAudioMock).not.toHaveBeenCalled();
     expectAudioPlaceholderRendered(ctx);
   });
+
+  it("uses preflight transcript for DM voice-only messages", async () => {
+    transcribeFirstAudioMock.mockResolvedValueOnce("dm transcript sample");
+
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 5,
+        chat: { id: 777001, type: "private" },
+        date: 1700000400,
+        text: undefined,
+        from: { id: 46, first_name: "Eve" },
+        voice: { file_id: "voice-5" },
+      },
+      allMedia: [{ path: "/tmp/voice5.ogg", contentType: "audio/ogg" }],
+      cfg: {
+        agents: { defaults: { model: DEFAULT_MODEL, workspace: DEFAULT_WORKSPACE } },
+        channels: { telegram: {} },
+      },
+      resolveGroupActivation: () => true,
+      resolveGroupRequireMention: () => false,
+      resolveTelegramGroupConfig: () => ({ groupConfig: undefined, topicConfig: undefined }),
+    });
+
+    expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
+    expect(ctx).not.toBeNull();
+    expect(ctx?.ctxPayload?.BodyForAgent).toBe("dm transcript sample");
+    expect(ctx?.ctxPayload?.Body).toContain("dm transcript sample");
+  });
 });

--- a/src/telegram/bot-message-context.multi-account.test.ts
+++ b/src/telegram/bot-message-context.multi-account.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+
+describe("buildTelegramMessageContext multi-account defaults", () => {
+  it("processes inbound DMs for non-default accounts without explicit bindings", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      accountId: "jarvis2",
+      message: {
+        chat: { id: 99_001, type: "private" },
+        from: { id: 41, first_name: "Guido" },
+        text: "/ping",
+      },
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.route.accountId).toBe("jarvis2");
+  });
+});

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -48,11 +48,7 @@ import {
   resolveAgentRoute,
   type ResolvedAgentRoute,
 } from "../routing/resolve-route.js";
-import {
-  DEFAULT_ACCOUNT_ID,
-  buildAgentMainSessionKey,
-  resolveThreadSessionKeys,
-} from "../routing/session-key.js";
+import { buildAgentMainSessionKey, resolveThreadSessionKeys } from "../routing/session-key.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../security/dm-policy-shared.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
@@ -260,19 +256,6 @@ export const buildTelegramMessageContext = async ({
   const configuredBinding = configuredRoute.configuredBinding;
   const configuredBindingSessionKey = configuredRoute.boundSessionKey ?? "";
   route = configuredRoute.route;
-  const requiresExplicitAccountBinding = (candidate: ResolvedAgentRoute): boolean =>
-    candidate.accountId !== DEFAULT_ACCOUNT_ID && candidate.matchedBy === "default";
-  // Fail closed for named Telegram accounts when route resolution falls back to
-  // default-agent routing. This prevents cross-account DM/session contamination.
-  if (requiresExplicitAccountBinding(route)) {
-    logInboundDrop({
-      log: logVerbose,
-      channel: "telegram",
-      reason: "non-default account requires explicit binding",
-      target: route.accountId,
-    });
-    return null;
-  }
   // Calculate groupAllowOverride first - it's needed for both DM and group allowlist checks
   const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);
   // For DMs, prefer per-DM/topic allowFrom (groupAllowOverride) over account-level allowFrom
@@ -288,6 +271,7 @@ export const buildTelegramMessageContext = async ({
   const senderUsername = msg.from?.username ?? "";
   const baseAccess = evaluateTelegramGroupBaseAccess({
     isGroup,
+    chatId,
     groupConfig,
     topicConfig,
     hasGroupAllowOverride,
@@ -478,16 +462,15 @@ export const buildTelegramMessageContext = async ({
       (groupConfig as TelegramGroupConfig | undefined)?.disableAudioPreflight,
     ) === true;
 
-  // Preflight audio transcription for mention detection in groups
-  // This allows voice notes to be checked for mentions before being dropped
+  // Preflight audio transcription:
+  // - in mention-gated groups, enables mention detection for voice notes
+  // - in DMs, provides transcript context for voice-only messages
   let preflightTranscript: string | undefined;
   const needsPreflightTranscription =
-    isGroup &&
-    requireMention &&
     hasAudio &&
     !hasUserText &&
-    mentionRegexes.length > 0 &&
-    !disableAudioPreflight;
+    !disableAudioPreflight &&
+    ((isGroup && requireMention && mentionRegexes.length > 0) || !isGroup);
 
   if (needsPreflightTranscription) {
     try {

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -527,7 +527,9 @@ export const buildTelegramMessageContext = async ({
   const hasAnyMention = (msg.entities ?? msg.caption_entities ?? []).some(
     (ent) => ent.type === "mention",
   );
-  const explicitlyMentioned = botUsername ? hasBotMention(msg, botUsername) : false;
+  const explicitlyMentioned = botUsername
+    ? hasBotMention(msg, botUsername, { botUserId: primaryCtx.me?.id })
+    : false;
 
   const computedWasMentioned = matchesMentionWithExplicit({
     text: msg.text ?? msg.caption ?? "",

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   buildTypingThreadParams,
   describeReplyTarget,
   expandTextLinks,
+  hasBotMention,
   normalizeForwardedContext,
   resolveTelegramDirectPeerId,
   resolveTelegramForumThreadId,
@@ -65,6 +66,29 @@ describe("resolveTelegramDirectPeerId", () => {
     expect(resolveTelegramDirectPeerId({ chatId: 777777777, senderId: undefined })).toBe(
       "777777777",
     );
+  });
+});
+
+describe("hasBotMention", () => {
+  it("detects classic @username mention", () => {
+    const msg = { text: "hi @openclaw_bot" } as Parameters<typeof hasBotMention>[0];
+    expect(hasBotMention(msg, "openclaw_bot")).toBe(true);
+  });
+
+  it("detects text_mention entities that target the bot id", () => {
+    const msg = {
+      text: "hi OpenClaw",
+      entities: [{ type: "text_mention", offset: 3, length: 8, user: { id: 4242 } }],
+    } as unknown as Parameters<typeof hasBotMention>[0];
+    expect(hasBotMention(msg, "openclaw_bot", { botUserId: 4242 })).toBe(true);
+  });
+
+  it("does not match text_mention when user id differs", () => {
+    const msg = {
+      text: "hi OpenClaw",
+      entities: [{ type: "text_mention", offset: 3, length: 8, user: { id: 1111 } }],
+    } as unknown as Parameters<typeof hasBotMention>[0];
+    expect(hasBotMention(msg, "openclaw_bot", { botUserId: 4242 })).toBe(false);
   });
 });
 

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -280,19 +280,29 @@ export function buildGroupLabel(msg: Message, chatId: number | string, messageTh
   return `group:${chatId}${topicSuffix}`;
 }
 
-export function hasBotMention(msg: Message, botUsername: string) {
+export function hasBotMention(
+  msg: Message,
+  botUsername: string,
+  params?: { botUserId?: number | null },
+) {
   const text = (msg.text ?? msg.caption ?? "").toLowerCase();
   if (text.includes(`@${botUsername}`)) {
     return true;
   }
   const entities = msg.entities ?? msg.caption_entities ?? [];
   for (const ent of entities) {
-    if (ent.type !== "mention") {
+    if (ent.type === "mention") {
+      const slice = (msg.text ?? msg.caption ?? "").slice(ent.offset, ent.offset + ent.length);
+      if (slice.toLowerCase() === `@${botUsername}`) {
+        return true;
+      }
       continue;
     }
-    const slice = (msg.text ?? msg.caption ?? "").slice(ent.offset, ent.offset + ent.length);
-    if (slice.toLowerCase() === `@${botUsername}`) {
-      return true;
+    if (ent.type === "text_mention") {
+      const targetId = (ent as { user?: { id?: number } })?.user?.id;
+      if (params?.botUserId != null && targetId === params.botUserId) {
+        return true;
+      }
     }
   }
   return false;

--- a/src/telegram/group-access.base-access.test.ts
+++ b/src/telegram/group-access.base-access.test.ts
@@ -53,4 +53,19 @@ describe("evaluateTelegramGroupBaseAccess", () => {
 
     expect(result).toEqual({ allowed: true });
   });
+
+  it("allows group when group chat id is explicitly listed in override", () => {
+    const result = evaluateTelegramGroupBaseAccess({
+      isGroup: true,
+      chatId: "-10012345",
+      hasGroupAllowOverride: true,
+      effectiveGroupAllow: allow(["-10012345"]),
+      senderId: "98765",
+      senderUsername: "tester",
+      enforceAllowOverride: true,
+      requireSenderForAllowOverride: true,
+    });
+
+    expect(result).toEqual({ allowed: true });
+  });
 });

--- a/src/telegram/group-access.policy-access.test.ts
+++ b/src/telegram/group-access.policy-access.test.ts
@@ -193,4 +193,24 @@ describe("evaluateTelegramGroupPolicyAccess – chat allowlist vs sender allowli
 
     expect(result).toEqual({ allowed: true, groupPolicy: "allowlist" });
   });
+
+  it("allows group when chat id is present in groupAllowFrom entries", () => {
+    const result = runAccess({
+      chatId: "-100123456",
+      effectiveGroupAllow: {
+        entries: ["-100123456"],
+        hasWildcard: false,
+        hasEntries: true,
+        invalidEntries: [],
+      },
+      senderId: "222",
+      resolveGroupPolicy: () => ({
+        allowlistEnabled: true,
+        allowed: true,
+        groupConfig: undefined,
+      }),
+    });
+
+    expect(result).toEqual({ allowed: true, groupPolicy: "allowlist" });
+  });
 });

--- a/src/telegram/group-access.ts
+++ b/src/telegram/group-access.ts
@@ -21,12 +21,17 @@ export type TelegramGroupBaseAccessResult =
 
 function isGroupAllowOverrideAuthorized(params: {
   effectiveGroupAllow: NormalizedAllowFrom;
+  chatId?: string | number;
   senderId?: string;
   senderUsername?: string;
   requireSenderForAllowOverride: boolean;
 }): boolean {
   if (!params.effectiveGroupAllow.hasEntries) {
     return false;
+  }
+  const chatId = params.chatId != null ? String(params.chatId) : "";
+  if (chatId && params.effectiveGroupAllow.entries.includes(chatId)) {
+    return true;
   }
   const senderId = params.senderId ?? "";
   if (params.requireSenderForAllowOverride && !senderId) {
@@ -41,6 +46,7 @@ function isGroupAllowOverrideAuthorized(params: {
 
 export const evaluateTelegramGroupBaseAccess = (params: {
   isGroup: boolean;
+  chatId?: string | number;
   groupConfig?: TelegramGroupConfig | TelegramDirectConfig;
   topicConfig?: TelegramTopicConfig;
   hasGroupAllowOverride: boolean;
@@ -63,6 +69,7 @@ export const evaluateTelegramGroupBaseAccess = (params: {
       if (
         !isGroupAllowOverrideAuthorized({
           effectiveGroupAllow: params.effectiveGroupAllow,
+          chatId: params.chatId,
           senderId: params.senderId,
           senderUsername: params.senderUsername,
           requireSenderForAllowOverride: params.requireSenderForAllowOverride,
@@ -80,6 +87,7 @@ export const evaluateTelegramGroupBaseAccess = (params: {
   if (
     !isGroupAllowOverrideAuthorized({
       effectiveGroupAllow: params.effectiveGroupAllow,
+      chatId: params.chatId,
       senderId: params.senderId,
       senderUsername: params.senderUsername,
       requireSenderForAllowOverride: params.requireSenderForAllowOverride,
@@ -192,7 +200,9 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
       return { allowed: true, groupPolicy };
     }
     const senderUsername = params.senderUsername ?? "";
+    const chatIdAllowed = params.effectiveGroupAllow.entries.includes(String(params.chatId));
     if (
+      !chatIdAllowed &&
       !isSenderAllowed({
         allow: params.effectiveGroupAllow,
         senderId,


### PR DESCRIPTION
Problem: WebChat turns on shared main sessions could inherit stale external delivery context and leak replies to another channel (e.g. iMessage).\n\nRoot cause: gateway agent routing resolved implicit reply channel from session history even for WebChat clients when no explicit route was provided.\n\nFix: force INTERNAL_MESSAGE_CHANNEL for WebChat requests that do not include explicit routing metadata (channel/replyChannel/to).\n\nTesting: pnpm vitest src/gateway/server-methods/agent.test.ts\n\nRefs: #36687