### PR TITLE
fix(google): sanitize tool schemas for google provider

### DIFF
--- a/src/agents/pi-embedded-runner/google.test.ts
+++ b/src/agents/pi-embedded-runner/google.test.ts
@@ -24,23 +24,26 @@ describe("sanitizeToolsForGoogle", () => {
     expect(params.properties?.foo?.format).toBeUndefined();
   };
 
-  it("strips unsupported schema keywords for Google providers", () => {
-    const tool = createTool({
-      type: "object",
-      additionalProperties: false,
-      properties: {
-        foo: {
-          type: "string",
-          format: "uuid",
+  it.each(["google-gemini-cli", "google"])(
+    "strips unsupported schema keywords for %s provider",
+    (provider) => {
+      const tool = createTool({
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          foo: {
+            type: "string",
+            format: "uuid",
+          },
         },
-      },
-    });
-    const [sanitized] = sanitizeToolsForGoogle({
-      tools: [tool],
-      provider: "google-gemini-cli",
-    });
-    expectFormatRemoved(sanitized, "additionalProperties");
-  });
+      });
+      const [sanitized] = sanitizeToolsForGoogle({
+        tools: [tool],
+        provider,
+      });
+      expectFormatRemoved(sanitized, "additionalProperties");
+    },
+  );
 
   it("returns original tools for non-google providers", () => {
     const tool = createTool({

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -245,7 +245,7 @@ export function sanitizeToolsForGoogle<
   // AND Claude models.  This field does not support JSON Schema keywords such as
   // patternProperties, additionalProperties, $ref, etc.  We must clean schemas
   // for every provider that routes through this path.
-  if (params.provider !== "google-gemini-cli") {
+  if (params.provider !== "google-gemini-cli" && params.provider !== "google") {
     return params.tools;
   }
   return params.tools.map((tool) => {


### PR DESCRIPTION
Problem: Google-model turns can fail with HTTP 400 "Invalid JSON payload" when tool schemas include unsupported keys like patternProperties.\n\nRoot cause: sanitizeToolsForGoogle only cleaned schemas for provider=google-gemini-cli, but provider=google uses the same Cloud Code Assist tool declaration path.\n\nFix: apply the same schema scrubbing when provider is google; added regression test coverage for both google-gemini-cli and google.\n\nTesting: pnpm vitest src/agents/pi-embedded-runner/google.test.ts\n\nRefs: #36672