### PR TITLE
[Issue #36604] Cron jobs fail with 'Failed to extract accountId from token' when falling back to OpenAI Codex provider

### DIFF
--- a/automation/issue-pr-intake/issue-36604.md
+++ b/automation/issue-pr-intake/issue-36604.md
@@ -1,0 +1,5 @@
+# Issue #36604
+
+Title: Cron jobs fail with 'Failed to extract accountId from token' when falling back to OpenAI Codex provider
+
+Source: https://github.com/openclaw/openclaw/issues/36604


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36604

## Original issue description
Cron jobs fail with `Failed to extract accountId from token` when fallback selects OpenAI Codex.

For the full original description, see the linked issue body.

Closes #36604