### PR TITLE
[Issue #36605] Feature: Pre-compaction channel notification at configurable context threshold

### DIFF
--- a/automation/issue-pr-intake/issue-36605.md
+++ b/automation/issue-pr-intake/issue-36605.md
@@ -1,0 +1,5 @@
+# Issue #36605
+
+Title: Feature: Pre-compaction channel notification at configurable context threshold
+
+Source: https://github.com/openclaw/openclaw/issues/36605


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36605

## Original issue description
Request to add pre-compaction warning and post-compaction confirmation messages on user channels at configurable context thresholds.

For the full original description, see the linked issue body.

Closes #36605