### PR TITLE
[Issue #36608] Sessions: .deleted .jsonl files not cleaned up from disk

### DIFF
--- a/automation/issue-pr-intake/issue-36608.md
+++ b/automation/issue-pr-intake/issue-36608.md
@@ -1,0 +1,5 @@
+# Issue #36608
+
+Title: Sessions: .deleted .jsonl files not cleaned up from disk
+
+Source: https://github.com/openclaw/openclaw/issues/36608


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36608

## Original issue description
Deleted session `.jsonl` files are renamed with `.deleted` suffixes but not cleaned up, causing disk and memory growth over time.

For the full original description, see the linked issue body.

Closes #36608