### PR TITLE
[Issue #36614] per-channel-peer: updateLastRoute still contaminates main session with channel-specific delivery context

### DIFF
--- a/automation/issue-pr-intake/issue-36614.md
+++ b/automation/issue-pr-intake/issue-36614.md
@@ -1,0 +1,5 @@
+# Issue #36614
+
+Title: per-channel-peer: updateLastRoute still contaminates main session with channel-specific delivery context
+
+Source: https://github.com/openclaw/openclaw/issues/36614


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36614

## Original issue description
With `session.dmScope: per-channel-peer`, inbound channel metadata still contaminates main session route state, causing cross-channel misrouting.

For the full original description, see the linked issue body.

Closes #36614