### PR TITLE
perf: bound channel registry loader cache growth

### DIFF
--- a/src/channels/plugins/registry-loader.test.ts
+++ b/src/channels/plugins/registry-loader.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
+import { createChannelRegistryLoader } from "./registry-loader.js";
+import type { ChannelPlugin } from "./types.js";
+
+const emptyRegistry = createTestRegistry([]);
+
+const createPlugin = (id: string): ChannelPlugin =>
+  createChannelTestPluginBase({
+    id,
+    label: id,
+  }) as ChannelPlugin;
+
+describe("createChannelRegistryLoader", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(emptyRegistry);
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(emptyRegistry);
+  });
+
+  it("bounds cached entries and re-loads values evicted by the cap", async () => {
+    const channels = [
+      { pluginId: "a", plugin: createPlugin("a"), source: "test" },
+      { pluginId: "b", plugin: createPlugin("b"), source: "test" },
+      { pluginId: "c", plugin: createPlugin("c"), source: "test" },
+    ];
+    const findSpy = vi.spyOn(channels, "find");
+    setActivePluginRegistry(createTestRegistry(channels));
+
+    const loader = createChannelRegistryLoader<ChannelPlugin>((entry) => entry.plugin, {
+      maxEntries: 2,
+    });
+
+    expect(await loader("a")).toBe(channels[0].plugin);
+    expect(await loader("a")).toBe(channels[0].plugin);
+    expect(findSpy).toHaveBeenCalledTimes(1);
+
+    expect(await loader("b")).toBe(channels[1].plugin);
+    expect(await loader("c")).toBe(channels[2].plugin);
+    expect(await loader("a")).toBe(channels[0].plugin);
+    expect(findSpy).toHaveBeenCalledTimes(4);
+  });
+});

--- a/src/channels/plugins/registry-loader.ts
+++ b/src/channels/plugins/registry-loader.ts
@@ -6,10 +6,25 @@ type ChannelRegistryValueResolver<TValue> = (
   entry: PluginChannelRegistration,
 ) => TValue | undefined;
 
+type ChannelRegistryLoaderOptions = {
+  maxEntries?: number;
+};
+
+const DEFAULT_CACHE_MAX_ENTRIES = 256;
+
+function resolveCacheMaxEntries(maxEntries?: number): number {
+  if (typeof maxEntries !== "number" || !Number.isFinite(maxEntries)) {
+    return DEFAULT_CACHE_MAX_ENTRIES;
+  }
+  return Math.max(1, Math.floor(maxEntries));
+}
+
 export function createChannelRegistryLoader<TValue>(
   resolveValue: ChannelRegistryValueResolver<TValue>,
+  options?: ChannelRegistryLoaderOptions,
 ): (id: ChannelId) => Promise<TValue | undefined> {
   const cache = new Map<ChannelId, TValue>();
+  const maxEntries = resolveCacheMaxEntries(options?.maxEntries);
   let lastRegistry: PluginRegistry | null = null;
 
   return async (id: ChannelId): Promise<TValue | undefined> => {
@@ -28,6 +43,9 @@ export function createChannelRegistryLoader<TValue>(
     }
     const resolved = resolveValue(pluginEntry);
     if (resolved) {
+      if (!cache.has(id) && cache.size >= maxEntries) {
+        cache.clear();
+      }
       cache.set(id, resolved);
     }
     return resolved;


### PR DESCRIPTION
## Summary
- add a bounded cache policy to channel registry loader entries
- support an optional max entry override (default remains conservative)
- add a focused unit test proving capped cache eviction/reload behavior

## Why
The loader cache previously had no upper bound. In long-lived processes with many unique channel ids, this can cause avoidable memory growth from one-off lookups.

## Risk
Low. The change only affects lookups after the cache reaches capacity, where old entries are intentionally dropped and lazily repopulated.