### PR TITLE
[Issue #36617] [Feature]: Japanese localization (ja-JP) for OpenClaw core UX

### DIFF
--- a/automation/issue-pr-intake/issue-36617.md
+++ b/automation/issue-pr-intake/issue-36617.md
@@ -1,0 +1,5 @@
+# Issue #36617
+
+Title: [Feature]: Japanese localization (ja-JP) for OpenClaw core UX
+
+Source: https://github.com/openclaw/openclaw/issues/36617


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36617

## Original issue description
Feature request to add first-class Japanese localization support across core OpenClaw UX surfaces.

For the full original description, see the linked issue body.

Closes #36617