### PR TITLE
[Issue #36620] [Bug]: UI lifecycle node tests cannot run under ui/vitest.node.config

### DIFF
--- a/automation/issue-pr-intake/issue-36620.md
+++ b/automation/issue-pr-intake/issue-36620.md
@@ -1,0 +1,5 @@
+# Issue #36620
+
+Title: [Bug]: UI lifecycle node tests cannot run under ui/vitest.node.config
+
+Source: https://github.com/openclaw/openclaw/issues/36620


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36620

## Original issue description
UI lifecycle node tests fail during initialization under `ui/vitest.node.config.ts` because of hoisted mock initialization and import-time browser global access.

For the full original description, see the linked issue body.

Closes #36620