### PR TITLE
[Issue #36623] Bug: MEMORY.md injected twice on case-insensitive filesystems (macOS APFS)

### DIFF
--- a/automation/issue-pr-intake/issue-36623.md
+++ b/automation/issue-pr-intake/issue-36623.md
@@ -1,0 +1,5 @@
+# Issue #36623
+
+Title: Bug: MEMORY.md injected twice on case-insensitive filesystems (macOS APFS)
+
+Source: https://github.com/openclaw/openclaw/issues/36623


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36623

## Original issue description
On case-insensitive filesystems, bootstrap memory injection can read `MEMORY.md` and `memory.md` as the same file twice, duplicating prompt content.

For the full original description, see the linked issue body.

Closes #36623