### PR TITLE
[Issue #36626] [Bug]: UI node tests fail on import-time localStorage access

### DIFF
--- a/automation/issue-pr-intake/issue-36626.md
+++ b/automation/issue-pr-intake/issue-36626.md
@@ -1,0 +1,5 @@
+# Issue #36626
+
+Title: [Bug]: UI node tests fail on import-time localStorage access
+
+Source: https://github.com/openclaw/openclaw/issues/36626


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36626

## Original issue description
UI node-mode tests fail before assertions because import-time i18n initialization accesses `localStorage` in a non-browser test environment.

For the full original description, see the linked issue body.

Closes #36626