### PR TITLE
[Issue #36628] [Signal] Native quote-reply support missing — replyTo tag stripped but not translated to signal-cli quote params

### DIFF
--- a/automation/issue-pr-intake/issue-36628.md
+++ b/automation/issue-pr-intake/issue-36628.md
@@ -1,0 +1,5 @@
+# Issue #36628
+
+Title: [Signal] Native quote-reply support missing — replyTo tag stripped but not translated to signal-cli quote params
+
+Source: https://github.com/openclaw/openclaw/issues/36628


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36628

## Original issue description
Signal channel reply tags are stripped but not converted into native `signal-cli` quote parameters, so quote-replies do not render natively.

For the full original description, see the linked issue body.

Closes #36628