### PR TITLE
[Issue #36634] [Bug]: Issue Title: agents_list tool only returns "main" despite multiple agents configured in CLI

### DIFF
--- a/automation/issue-pr-intake/issue-36634.md
+++ b/automation/issue-pr-intake/issue-36634.md
@@ -1,0 +1,5 @@
+# Issue #36634
+
+Title: [Bug]: Issue Title: agents_list tool only returns "main" despite multiple agents configured in CLI
+
+Source: https://github.com/openclaw/openclaw/issues/36634


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36634

## Original issue description
`agents_list` only returns `main` while CLI reports multiple configured agents, which prevents spawning specific agent personas by `agentId`.

For the full original description, see the linked issue body.

Closes #36634