### PR TITLE
[Issue #36635] GIF images cause HTTP 400 error when sent to vision model

### DIFF
--- a/automation/issue-pr-intake/issue-36635.md
+++ b/automation/issue-pr-intake/issue-36635.md
@@ -1,0 +1,5 @@
+# Issue #36635
+
+Title: GIF images cause HTTP 400 error when sent to vision model
+
+Source: https://github.com/openclaw/openclaw/issues/36635


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36635

## Original issue description
Raw GIF attachments sent to vision models trigger HTTP 400 invalid image errors and can disrupt normal agent responses.

For the full original description, see the linked issue body.

Closes #36635