### PR TITLE
[Issue #36638] Exec approvals prompt persists with ask=off/full on node+gateway

### DIFF
--- a/automation/issue-pr-intake/issue-36638.md
+++ b/automation/issue-pr-intake/issue-36638.md
@@ -1,0 +1,5 @@
+# Issue #36638
+
+Title: Exec approvals prompt persists with ask=off/full on node+gateway
+
+Source: https://github.com/openclaw/openclaw/issues/36638


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36638

## Original issue description
Execution approval prompts continue appearing even with approvals policies configured for non-interactive full access.

For the full original description, see the linked issue body.

Closes #36638