### PR TITLE
[Issue #36640] Bidirectional message relay between Telegram and WebChat (Control UI)

### DIFF
--- a/automation/issue-pr-intake/issue-36640.md
+++ b/automation/issue-pr-intake/issue-36640.md
@@ -1,0 +1,5 @@
+# Issue #36640
+
+Title: Bidirectional message relay between Telegram and WebChat (Control UI)
+
+Source: https://github.com/openclaw/openclaw/issues/36640


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36640

## Original issue description
Request to mirror inbound Telegram user messages into WebChat/Control UI so both sides of the conversation are visible across surfaces.

For the full original description, see the linked issue body.

Closes #36640