### PR TITLE
[Issue #36644] Telegram message splitting breaks mid-word

### DIFF
--- a/automation/issue-pr-intake/issue-36644.md
+++ b/automation/issue-pr-intake/issue-36644.md
@@ -1,0 +1,5 @@
+# Issue #36644
+
+Title: Telegram message splitting breaks mid-word
+
+Source: https://github.com/openclaw/openclaw/issues/36644


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36644

## Original issue description
Long Telegram messages are split at hard character boundaries, breaking words and degrading readability.

For the full original description, see the linked issue body.

Closes #36644