### PR TITLE
[Issue #36649] openai-image-gen: validate and normalize unsupported --output-format values

### DIFF
--- a/automation/issue-pr-intake/issue-36649.md
+++ b/automation/issue-pr-intake/issue-36649.md
@@ -1,0 +1,5 @@
+# Issue #36649
+
+Title: openai-image-gen: validate and normalize unsupported --output-format values
+
+Source: https://github.com/openclaw/openclaw/issues/36649


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36649

## Original issue description
`openai-image-gen` should normalize `jpg` and validate output formats to prevent invalid API requests and inconsistent output behavior.

For the full original description, see the linked issue body.

Closes #36649