### PR TITLE
[Issue #36659] feat: configurable retry policy for WhatsApp outbound message sends

### DIFF
--- a/automation/issue-pr-intake/issue-36659.md
+++ b/automation/issue-pr-intake/issue-36659.md
@@ -1,0 +1,5 @@
+# Issue #36659
+
+Title: feat: configurable retry policy for WhatsApp outbound message sends
+
+Source: https://github.com/openclaw/openclaw/issues/36659


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36659

## Original issue description
WhatsApp send retries are exhausted before socket reconnection completes; request is to make outbound retry policy configurable.

For the full original description, see the linked issue body.

Closes #36659