### PR TITLE
[Issue #36660] [Bug]: openai-codex OAuth completes successfully, but openai-codex/gpt-5.3-codex runs fail; direct token lacks api.responses.write

### DIFF
--- a/automation/issue-pr-intake/issue-36660.md
+++ b/automation/issue-pr-intake/issue-36660.md
@@ -1,0 +1,5 @@
+# Issue #36660
+
+Title: [Bug]: openai-codex OAuth completes successfully, but openai-codex/gpt-5.3-codex runs fail; direct token lacks api.responses.write
+
+Source: https://github.com/openclaw/openclaw/issues/36660


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36660

## Original issue description
OpenAI Codex OAuth appears successful but runtime requests fail because resulting token lacks required `api.responses.write` scope.

For the full original description, see the linked issue body.

Closes #36660