### PR TITLE
[Issue #36666] Browser tabs not closed on session end — causes unbounded memory growth

### DIFF
--- a/automation/issue-pr-intake/issue-36666.md
+++ b/automation/issue-pr-intake/issue-36666.md
@@ -1,0 +1,5 @@
+# Issue #36666
+
+Title: Browser tabs not closed on session end — causes unbounded memory growth
+
+Source: https://github.com/openclaw/openclaw/issues/36666


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36666

## Original issue description
Browser pages created in sessions are not closed on teardown, causing persistent Chromium process and memory growth.

For the full original description, see the linked issue body.

Closes #36666