### PR TITLE
[Issue #36672] [Bug]: HTTP 400: error: Invalid JSON payload received on every request: OpenClaw bricked

### DIFF
--- a/automation/issue-pr-intake/issue-36672.md
+++ b/automation/issue-pr-intake/issue-36672.md
@@ -1,0 +1,5 @@
+# Issue #36672
+
+Title: [Bug]: HTTP 400: error: Invalid JSON payload received on every request: OpenClaw bricked
+
+Source: https://github.com/openclaw/openclaw/issues/36672


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36672

## Original issue description
Every request fails with invalid tool schema payload errors, leaving the instance effectively unusable after model change.

For the full original description, see the linked issue body.

Closes #36672