### PR TITLE
[Issue #36687] 2026.3.2 update reset session.dmScope to "main" and caused cross-channel reply leakage (WebChat -> iMessage)

### DIFF
--- a/automation/issue-pr-intake/issue-36687.md
+++ b/automation/issue-pr-intake/issue-36687.md
@@ -1,0 +1,5 @@
+# Issue #36687
+
+Title: 2026.3.2 update reset session.dmScope to "main" and caused cross-channel reply leakage (WebChat -> iMessage)
+
+Source: https://github.com/openclaw/openclaw/issues/36687


### PR DESCRIPTION
Linked issue: https://github.com/openclaw/openclaw/issues/36687

## Original issue description
After upgrade, session scope regression caused cross-channel reply leakage from WebChat/TUI into iMessage conversations.

For the full original description, see the linked issue body.

Closes #36687