### PR TITLE
fix(discord): avoid crash when reconnect attempts are exhausted

### DIFF
--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -276,6 +276,33 @@ describe("runDiscordGatewayLifecycle", () => {
     });
   });
 
+  it("handles queued max reconnect attempts without crashing lifecycle", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const {
+      lifecycleParams,
+      start,
+      stop,
+      threadStop,
+      runtimeError,
+      releaseEarlyGatewayErrorGuard,
+    } = createLifecycleHarness({
+      pendingGatewayErrors: [new Error("Max reconnect attempts (0) reached after code 1006")],
+    });
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+    expect(runtimeError).toHaveBeenCalledWith(
+      expect.stringContaining("reconnect attempts exhausted"),
+    );
+    expectLifecycleCleanup({
+      start,
+      stop,
+      threadStop,
+      waitCalls: 0,
+      releaseEarlyGatewayErrorGuard,
+    });
+  });
+
   it("retries stalled HELLO with resume before forcing fresh identify", async () => {
     vi.useFakeTimers();
     try {

--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -303,6 +303,40 @@ describe("runDiscordGatewayLifecycle", () => {
     });
   });
 
+  it("handles live max reconnect attempts without crashing lifecycle", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const reconnectError = new Error("Max reconnect attempts (3) reached after code 1006");
+    waitForDiscordGatewayStopMock.mockImplementationOnce(
+      async (waitParams: WaitForDiscordGatewayStopParams) => {
+        waitParams.onGatewayError?.(reconnectError);
+        if (waitParams.shouldStopOnError?.(reconnectError)) {
+          throw reconnectError;
+        }
+      },
+    );
+    const {
+      lifecycleParams,
+      start,
+      stop,
+      threadStop,
+      runtimeError,
+      releaseEarlyGatewayErrorGuard,
+    } = createLifecycleHarness();
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+    expect(runtimeError).toHaveBeenCalledWith(
+      expect.stringContaining("reconnect attempts exhausted"),
+    );
+    expectLifecycleCleanup({
+      start,
+      stop,
+      threadStop,
+      waitCalls: 1,
+      releaseEarlyGatewayErrorGuard,
+    });
+  });
+
   it("retries stalled HELLO with resume before forcing fresh identify", async () => {
     vi.useFakeTimers();
     try {

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -261,12 +261,24 @@ export async function runDiscordGatewayLifecycle(params: {
   }
 
   let sawDisallowedIntents = false;
+  let sawReconnectExhausted = false;
+  const isReconnectExhaustedError = (err: unknown) =>
+    String(err).includes("Max reconnect attempts");
   const logGatewayError = (err: unknown) => {
     if (params.isDisallowedIntentsError(err)) {
       sawDisallowedIntents = true;
       params.runtime.error?.(
         danger(
           "discord: gateway closed with code 4014 (missing privileged gateway intents). Enable the required intents in the Discord Developer Portal or disable them in config.",
+        ),
+      );
+      return;
+    }
+    if (isReconnectExhaustedError(err)) {
+      sawReconnectExhausted = true;
+      params.runtime.error?.(
+        danger(
+          "discord gateway reconnect attempts exhausted; stopping Discord monitor without crashing the gateway",
         ),
       );
       return;
@@ -323,7 +335,11 @@ export async function runDiscordGatewayLifecycle(params: {
       },
     });
   } catch (err) {
-    if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {
+    if (
+      !sawDisallowedIntents &&
+      !params.isDisallowedIntentsError(err) &&
+      !(sawReconnectExhausted && isReconnectExhaustedError(err))
+    ) {
       throw err;
     }
   } finally {

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -338,7 +338,8 @@ export async function runDiscordGatewayLifecycle(params: {
     if (
       !sawDisallowedIntents &&
       !params.isDisallowedIntentsError(err) &&
-      !(sawReconnectExhausted && isReconnectExhaustedError(err))
+      !sawReconnectExhausted &&
+      !isReconnectExhaustedError(err)
     ) {
       throw err;
     }


### PR DESCRIPTION
Problem: Discord gateway reconnect exhaustion (`Max reconnect attempts ...`) could surface as an uncaught exception and crash OpenClaw.\n\nRoot cause: lifecycle path treated reconnect exhaustion like a fatal error and rethrew it after logging.\n\nFix: classify reconnect exhaustion explicitly, log a clear non-crashing shutdown message, and finish lifecycle cleanup without rethrowing.\n\nTesting: pnpm vitest src/discord/monitor/provider.lifecycle.test.ts\n\nRefs: #36055