### PR TITLE
fix: matrix plugin load without keyed-async-queue subpath dependency

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/matrix";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 

--- a/src/plugin-sdk/matrix.ts
+++ b/src/plugin-sdk/matrix.ts
@@ -91,6 +91,7 @@ export { formatDocsLink } from "../terminal/links.js";
 export type { WizardPrompter } from "../wizard/prompts.js";
 export { createScopedPairingAccess } from "./pairing-access.js";
 export { formatResolvedUnresolvedNote } from "./resolution-notes.js";
+export { KeyedAsyncQueue } from "./keyed-async-queue.js";
 export { runPluginCommandWithTimeout } from "./run-command.js";
 export { createLoggerBackedRuntime } from "./runtime.js";
 export { buildProbeChannelStatusSummary } from "./status-helpers.js";


### PR DESCRIPTION
## Summary
Matrix extension imported `KeyedAsyncQueue` from `openclaw/plugin-sdk/keyed-async-queue`, which can fail at runtime in plugin-loading environments where that subpath JS file is not present/resolved.

This PR routes the import through `openclaw/plugin-sdk/matrix` (which is already the matrix plugin’s supported SDK surface) and re-exports `KeyedAsyncQueue` from that matrix SDK entry.

## Changes
- `extensions/matrix/src/matrix/send-queue.ts`
  - import `KeyedAsyncQueue` from `openclaw/plugin-sdk/matrix`
- `src/plugin-sdk/matrix.ts`
  - re-export `KeyedAsyncQueue` from `./keyed-async-queue.js`

## Testing
- `pnpm vitest run extensions/matrix/src/matrix/send-queue.test.ts extensions/matrix/src/matrix/deps.test.ts`
- Result: 2 files passed, 8 tests passed.

Fixes openclaw/openclaw#36501
