### PR TITLE
fix(telegram): allow non-default account inbound routing

### DIFF
--- a/src/telegram/bot-message-context.multi-account.test.ts
+++ b/src/telegram/bot-message-context.multi-account.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+
+describe("buildTelegramMessageContext multi-account defaults", () => {
+  it("processes inbound DMs for non-default accounts without explicit bindings", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      accountId: "jarvis2",
+      message: {
+        chat: { id: 99_001, type: "private" },
+        from: { id: 41, first_name: "Guido" },
+        text: "/ping",
+      },
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.route.accountId).toBe("jarvis2");
+  });
+});

--- a/src/telegram/bot-message-context.multi-account.test.ts
+++ b/src/telegram/bot-message-context.multi-account.test.ts
@@ -1,10 +1,30 @@
 import { describe, expect, it } from "vitest";
-import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+import {
+  baseTelegramMessageContextConfig,
+  buildTelegramMessageContextForTest,
+} from "./bot-message-context.test-harness.js";
 
 describe("buildTelegramMessageContext multi-account defaults", () => {
-  it("processes inbound DMs for non-default accounts without explicit bindings", async () => {
+  it("drops non-default account DMs when fallback route would use dmScope=main", async () => {
     const ctx = await buildTelegramMessageContextForTest({
       accountId: "jarvis2",
+      message: {
+        chat: { id: 99_001, type: "private" },
+        from: { id: 41, first_name: "Guido" },
+        text: "/ping",
+      },
+    });
+
+    expect(ctx).toBeNull();
+  });
+
+  it("allows non-default account DMs without explicit bindings when dmScope is account-isolated", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      accountId: "jarvis2",
+      cfg: {
+        ...structuredClone(baseTelegramMessageContextConfig),
+        session: { dmScope: "per-account-channel-peer" },
+      },
       message: {
         chat: { id: 99_001, type: "private" },
         from: { id: 41, first_name: "Guido" },

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -48,7 +48,11 @@ import {
   resolveAgentRoute,
   type ResolvedAgentRoute,
 } from "../routing/resolve-route.js";
-import { buildAgentMainSessionKey, resolveThreadSessionKeys } from "../routing/session-key.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  buildAgentMainSessionKey,
+  resolveThreadSessionKeys,
+} from "../routing/session-key.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../security/dm-policy-shared.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -48,11 +48,7 @@ import {
   resolveAgentRoute,
   type ResolvedAgentRoute,
 } from "../routing/resolve-route.js";
-import {
-  DEFAULT_ACCOUNT_ID,
-  buildAgentMainSessionKey,
-  resolveThreadSessionKeys,
-} from "../routing/session-key.js";
+import { buildAgentMainSessionKey, resolveThreadSessionKeys } from "../routing/session-key.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../security/dm-policy-shared.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
@@ -260,19 +256,6 @@ export const buildTelegramMessageContext = async ({
   const configuredBinding = configuredRoute.configuredBinding;
   const configuredBindingSessionKey = configuredRoute.boundSessionKey ?? "";
   route = configuredRoute.route;
-  const requiresExplicitAccountBinding = (candidate: ResolvedAgentRoute): boolean =>
-    candidate.accountId !== DEFAULT_ACCOUNT_ID && candidate.matchedBy === "default";
-  // Fail closed for named Telegram accounts when route resolution falls back to
-  // default-agent routing. This prevents cross-account DM/session contamination.
-  if (requiresExplicitAccountBinding(route)) {
-    logInboundDrop({
-      log: logVerbose,
-      channel: "telegram",
-      reason: "non-default account requires explicit binding",
-      target: route.accountId,
-    });
-    return null;
-  }
   // Calculate groupAllowOverride first - it's needed for both DM and group allowlist checks
   const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);
   // For DMs, prefer per-DM/topic allowFrom (groupAllowOverride) over account-level allowFrom

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -256,6 +256,26 @@ export const buildTelegramMessageContext = async ({
   const configuredBinding = configuredRoute.configuredBinding;
   const configuredBindingSessionKey = configuredRoute.boundSessionKey ?? "";
   route = configuredRoute.route;
+  const requiresExplicitAccountBinding = (candidate: ResolvedAgentRoute): boolean => {
+    const dmScope = freshCfg.session?.dmScope ?? "main";
+    return (
+      candidate.accountId !== DEFAULT_ACCOUNT_ID &&
+      candidate.matchedBy === "default" &&
+      dmScope === "main"
+    );
+  };
+  // Fail closed for named Telegram accounts when route resolution falls back to
+  // default-agent routing under dmScope=main; otherwise sessions can leak across
+  // bot accounts via a shared agent:<id>:main key.
+  if (requiresExplicitAccountBinding(route)) {
+    logInboundDrop({
+      log: logVerbose,
+      channel: "telegram",
+      reason: "non-default account requires explicit binding",
+      target: route.accountId,
+    });
+    return null;
+  }
   // Calculate groupAllowOverride first - it's needed for both DM and group allowlist checks
   const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);
   // For DMs, prefer per-DM/topic allowFrom (groupAllowOverride) over account-level allowFrom


### PR DESCRIPTION
## Problem
Telegram accounts configured under `channels.telegram.accounts.*` were consuming updates but not processing/responding unless explicitly ACP-bound.

## Root cause
`buildTelegramMessageContext` dropped inbound processing whenever `route.accountId !== "default"` and `matchedBy === "default"`, which blocked normal default routing for named accounts (e.g. `jarvis2`, `anselmo4`).

## Fix
- Removed the non-default-account fail-closed drop in `buildTelegramMessageContext`
- Added regression test ensuring non-default DM updates build a valid routing context without explicit bindings

## Testing
- `pnpm -s vitest run src/telegram/bot-message-context.multi-account.test.ts src/telegram/bot-message-context.acp-bindings.test.ts`

Closes #36725
