### PR TITLE
fix(feishu): replace bare console.error with subsystem logger in outbound and docx

### DIFF
--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -562,7 +562,13 @@ async function processImages(
 
       processed++;
     } catch (err) {
-      console.error(`Failed to process image ${url}:`, err);
+      try {
+        getFeishuRuntime()
+          .logging.getChildLogger({ module: "feishu-docx" })
+          .warn?.(`Failed to process image ${url}: ${String(err)}`);
+      } catch {
+        // Fallback when runtime logging is unavailable.
+      }
     }
   }
 

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -76,6 +76,14 @@ async function sendOutboundText(params: {
   return sendMessageFeishu({ cfg, to, text, accountId, replyToMessageId });
 }
 
+function logOutboundWarning(message: string): void {
+  try {
+    getFeishuRuntime().logging.getChildLogger({ module: "feishu-outbound" }).warn?.(message);
+  } catch {
+    // Fallback when runtime logging is unavailable (e.g. during tests).
+  }
+}
+
 export const feishuOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: (text, limit) => getFeishuRuntime().channel.text.chunkMarkdownText(text, limit),
@@ -98,7 +106,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         });
         return { channel: "feishu", ...result };
       } catch (err) {
-        console.error(`[feishu] local image path auto-send failed:`, err);
+        logOutboundWarning(`local image path auto-send failed: ${String(err)}`);
         // fall through to plain text as last resort
       }
     }
@@ -147,8 +155,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         });
         return { channel: "feishu", ...result };
       } catch (err) {
-        // Log the error for debugging
-        console.error(`[feishu] sendMediaFeishu failed:`, err);
+        logOutboundWarning(`sendMediaFeishu failed, falling back to URL text: ${String(err)}`);
         // Fallback to URL link if upload fails
         const fallbackText = `📎 ${mediaUrl}`;
         const result = await sendOutboundText({


### PR DESCRIPTION
## Summary
- Replace `console.error` calls in `outbound.ts` and `docx.ts` with the gateway's subsystem logger (`getChildLogger`)
- Ensures feishu outbound errors (media upload failures, local image path fallbacks) are routed through the structured logging infrastructure instead of bypassing it via bare `console.error`
- Consistent with the logging pattern used in `typing.ts`, `send.ts`, `monitor.ts`, and other feishu modules

## Test plan
- [x] All 13 `outbound.test.ts` tests pass (including the media send failure fallback path)
- [x] Verified logger is safely wrapped in try-catch to handle test environments where runtime logging mock may be incomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)