### PR TITLE
fix(mattermost): validate replyToId before passing as root_id to API

### DIFF
--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -281,10 +281,18 @@ export async function sendMessageMattermost(
     throw new Error("Mattermost message is empty");
   }
 
+  const replyToId = opts.replyToId?.trim();
+  if (replyToId && !isMattermostId(replyToId)) {
+    logger.warn?.(
+      `mattermost send: ignoring invalid replyToId "${replyToId}" (expected 26-char alphanumeric Mattermost ID)`,
+    );
+  }
+  const rootId = replyToId && isMattermostId(replyToId) ? replyToId : undefined;
+
   const post = await createMattermostPost(client, {
     channelId,
     message,
-    rootId: opts.replyToId,
+    rootId,
     fileIds,
     props: opts.props,
   });


### PR DESCRIPTION
## Summary
- Validate `replyToId` against the 26-char Mattermost ID format before passing it as `root_id` to the Mattermost Posts API
- Invalid root IDs (e.g. channel names accidentally passed as thread IDs) now produce a clear warning log and are silently dropped, instead of causing opaque 400 errors from the Mattermost API
- Uses the existing `isMattermostId()` helper already used for channel ID validation

## Test plan
- [x] All 19 `send.test.ts` tests pass
- [x] Valid 26-char IDs are passed through unchanged
- [x] Invalid IDs (channel names, partial strings) are dropped with a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)