### PR TITLE
fix(web-search): support Perplexity via OpenRouter baseUrl

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1246,13 +1246,15 @@ async function runWebSearch(params: {
   kimiModel?: string;
 }): Promise<Record<string, unknown>> {
   const providerSpecificKey =
-    params.provider === "grok"
-      ? `${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`
-      : params.provider === "gemini"
-        ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
-        : params.provider === "kimi"
-          ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
-          : "";
+    params.provider === "perplexity"
+      ? `${params.perplexityBaseUrl ?? DEFAULT_PERPLEXITY_BASE_URL}:${params.perplexityModel ?? DEFAULT_PERPLEXITY_MODEL}`
+      : params.provider === "grok"
+        ? `${params.grokModel ?? DEFAULT_GROK_MODEL}:${String(params.grokInlineCitations ?? false)}`
+        : params.provider === "gemini"
+          ? (params.geminiModel ?? DEFAULT_GEMINI_MODEL)
+          : params.provider === "kimi"
+            ? `${params.kimiBaseUrl ?? DEFAULT_KIMI_BASE_URL}:${params.kimiModel ?? DEFAULT_KIMI_MODEL}`
+            : "";
   const cacheKey = normalizeCacheKey(
     `${params.provider}:${params.query}:${params.count}:${params.country || "default"}:${params.search_lang || params.language || "default"}:${params.ui_lang || "default"}:${params.freshness || "default"}:${params.dateAfter || "default"}:${params.dateBefore || "default"}:${params.searchDomainFilter?.join(",") || "default"}:${params.maxTokens || "default"}:${params.maxTokensPerPage || "default"}:${providerSpecificKey}`,
   );

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -27,6 +27,8 @@ const MAX_SEARCH_COUNT = 10;
 
 const BRAVE_SEARCH_ENDPOINT = "https://api.search.brave.com/res/v1/web/search";
 const PERPLEXITY_SEARCH_ENDPOINT = "https://api.perplexity.ai/search";
+const DEFAULT_PERPLEXITY_BASE_URL = "https://api.perplexity.ai";
+const DEFAULT_PERPLEXITY_MODEL = "perplexity/sonar-pro";
 
 const XAI_API_ENDPOINT = "https://api.x.ai/v1/responses";
 const DEFAULT_GROK_MODEL = "grok-4-1-fast";
@@ -189,6 +191,8 @@ type BraveSearchResponse = {
 
 type PerplexityConfig = {
   apiKey?: string;
+  baseUrl?: string;
+  model?: string;
 };
 
 type PerplexityApiKeySource = "config" | "perplexity_env" | "none";
@@ -516,6 +520,18 @@ function resolvePerplexityApiKey(perplexity?: PerplexityConfig): {
   }
 
   return { apiKey: undefined, source: "none" };
+}
+
+function resolvePerplexityBaseUrl(perplexity?: PerplexityConfig): string {
+  const configured =
+    perplexity && typeof perplexity.baseUrl === "string" ? perplexity.baseUrl.trim() : "";
+  return (configured || DEFAULT_PERPLEXITY_BASE_URL).replace(/\/$/, "");
+}
+
+function resolvePerplexityModel(perplexity?: PerplexityConfig): string {
+  const configured =
+    perplexity && typeof perplexity.model === "string" ? perplexity.model.trim() : "";
+  return configured || DEFAULT_PERPLEXITY_MODEL;
 }
 
 function normalizeApiKey(key: unknown): string {
@@ -868,9 +884,64 @@ async function runPerplexitySearchApi(params: {
   searchBeforeDate?: string;
   maxTokens?: number;
   maxTokensPerPage?: number;
+  baseUrl?: string;
+  model?: string;
 }): Promise<
   Array<{ title: string; url: string; description: string; published?: string; siteName?: string }>
 > {
+  const baseUrl = params.baseUrl?.trim().replace(/\/$/, "") || DEFAULT_PERPLEXITY_BASE_URL;
+  const useChatCompletions = !baseUrl.includes("api.perplexity.ai");
+
+  if (useChatCompletions) {
+    const endpoint = `${baseUrl}/chat/completions`;
+    return await withTrustedWebSearchEndpoint(
+      {
+        url: endpoint,
+        timeoutSeconds: params.timeoutSeconds,
+        init: {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+            Authorization: `Bearer ${params.apiKey}`,
+            "HTTP-Referer": "https://openclaw.ai",
+            "X-Title": "OpenClaw Web Search",
+          },
+          body: JSON.stringify({
+            model: params.model || DEFAULT_PERPLEXITY_MODEL,
+            messages: [{ role: "user", content: params.query }],
+          }),
+        },
+      },
+      async (res) => {
+        if (!res.ok) {
+          return await throwWebSearchApiError(res, "Perplexity Search");
+        }
+        const data = (await res.json()) as {
+          choices?: Array<{ message?: { content?: string } }>;
+          citations?: string[];
+        };
+        const text = data.choices?.[0]?.message?.content?.trim() || "";
+        const citations = (data.citations ?? []).filter(
+          (citation): citation is string =>
+            typeof citation === "string" && citation.trim().length > 0,
+        );
+        if (!text) {
+          return [];
+        }
+        const firstCitation = citations[0] ?? "";
+        return [
+          {
+            title: wrapWebContent("Perplexity Search", "web_search"),
+            url: firstCitation,
+            description: wrapWebContent(text, "web_search"),
+            siteName: resolveSiteName(firstCitation) || undefined,
+          },
+        ];
+      },
+    );
+  }
+
   const body: Record<string, unknown> = {
     query: params.query,
     max_results: params.count,
@@ -1166,6 +1237,8 @@ async function runWebSearch(params: {
   searchDomainFilter?: string[];
   maxTokens?: number;
   maxTokensPerPage?: number;
+  perplexityBaseUrl?: string;
+  perplexityModel?: string;
   grokModel?: string;
   grokInlineCitations?: boolean;
   geminiModel?: string;
@@ -1204,6 +1277,8 @@ async function runWebSearch(params: {
       searchBeforeDate: params.dateBefore ? isoToPerplexityDate(params.dateBefore) : undefined,
       maxTokens: params.maxTokens,
       maxTokensPerPage: params.maxTokensPerPage,
+      baseUrl: params.perplexityBaseUrl,
+      model: params.perplexityModel,
     });
 
     const payload = {
@@ -1591,6 +1666,8 @@ export function createWebSearchTool(options?: {
         searchDomainFilter: domainFilter,
         maxTokens: maxTokens ?? undefined,
         maxTokensPerPage: maxTokensPerPage ?? undefined,
+        perplexityBaseUrl: resolvePerplexityBaseUrl(perplexityConfig),
+        perplexityModel: resolvePerplexityModel(perplexityConfig),
         grokModel: resolveGrokModel(grokConfig),
         grokInlineCitations: resolveGrokInlineCitations(grokConfig),
         geminiModel: resolveGeminiModel(geminiConfig),

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -15,7 +15,11 @@ function installMockFetch(payload: unknown) {
   return mockFetch;
 }
 
-function createPerplexitySearchTool(perplexityConfig?: { apiKey?: string }) {
+function createPerplexitySearchTool(perplexityConfig?: {
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+}) {
   return createWebSearchTool({
     config: {
       tools: {
@@ -276,6 +280,34 @@ describe("web_search perplexity Search API", () => {
     expect(mockFetch).toHaveBeenCalled();
     const body = parseFirstRequestBody(mockFetch);
     expect(body.country).toBe("DE");
+  });
+
+  it("uses chat completions endpoint when Perplexity baseUrl points to OpenRouter", async () => {
+    const mockFetch = installMockFetch({
+      choices: [{ message: { content: "OpenRouter answer" } }],
+      citations: ["https://openrouter.ai/docs"],
+    });
+    const tool = createPerplexitySearchTool({
+      apiKey: "sk-or-v1-test",
+      baseUrl: "https://openrouter.ai/api/v1",
+      model: "perplexity/sonar",
+    });
+
+    const result = await tool?.execute?.("call-1", { query: "test" });
+
+    expect(mockFetch).toHaveBeenCalled();
+    expect(mockFetch.mock.calls[0]?.[0]).toBe("https://openrouter.ai/api/v1/chat/completions");
+    const body = parseFirstRequestBody(mockFetch);
+    expect(body.model).toBe("perplexity/sonar");
+    expect(result?.details).toMatchObject({
+      provider: "perplexity",
+      results: [
+        expect.objectContaining({
+          url: "https://openrouter.ai/docs",
+          description: expect.stringContaining("OpenRouter answer"),
+        }),
+      ],
+    });
   });
 
   it("uses config API key when provided", async () => {


### PR DESCRIPTION
## Problem
`web_search` with `provider=perplexity` fails with 401 when users configure OpenRouter (`tools.web.search.perplexity.baseUrl=https://openrouter.ai/api/v1` + `sk-or-v1...` key).

## Root cause
Perplexity search flow always called `https://api.perplexity.ai/search` and ignored `tools.web.search.perplexity.baseUrl` / `model`, so OpenRouter credentials were sent to the wrong API.

## Fix
- Added Perplexity config resolution for `baseUrl` and `model`
- Kept native Perplexity Search API path for `api.perplexity.ai`
- Added fallback path for non-Perplexity base URLs (including OpenRouter) using `POST {baseUrl}/chat/completions`
- Added regression test covering OpenRouter endpoint/model behavior

## Testing
- `pnpm -s vitest run src/agents/tools/web-tools.enabled-defaults.test.ts`

Closes #36182
