### PR TITLE
fix(feishu): replace console.log with subsystem logger in typing indicator

### DIFF
--- a/extensions/feishu/src/typing.ts
+++ b/extensions/feishu/src/typing.ts
@@ -3,9 +3,9 @@ import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { getFeishuRuntime } from "./runtime.js";
 
-function logTypingDebug(message: string): void {
+function logTypingWarn(message: string): void {
   try {
-    getFeishuRuntime().logging.getChildLogger({ module: "feishu-typing" }).debug?.(message);
+    getFeishuRuntime().logging.getChildLogger({ module: "feishu-typing" }).warn(message);
   } catch {
     // Fallback when runtime logging is unavailable (e.g. during tests).
   }
@@ -50,7 +50,7 @@ export async function addTypingIndicator(params: {
     return { messageId, reactionId };
   } catch (err) {
     // Silently fail - typing indicator is not critical
-    logTypingDebug(`failed to add typing indicator: ${err}`);
+    logTypingWarn(`failed to add typing indicator: ${err}`);
     return { messageId, reactionId: null };
   }
 }
@@ -84,6 +84,6 @@ export async function removeTypingIndicator(params: {
     });
   } catch (err) {
     // Silently fail - cleanup is not critical
-    logTypingDebug(`failed to remove typing indicator: ${err}`);
+    logTypingWarn(`failed to remove typing indicator: ${err}`);
   }
 }

--- a/extensions/feishu/src/typing.ts
+++ b/extensions/feishu/src/typing.ts
@@ -1,6 +1,15 @@
 import type { ClawdbotConfig } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { getFeishuRuntime } from "./runtime.js";
+
+function logTypingDebug(message: string): void {
+  try {
+    getFeishuRuntime().logging.getChildLogger({ module: "feishu-typing" }).debug?.(message);
+  } catch {
+    // Fallback when runtime logging is unavailable (e.g. during tests).
+  }
+}
 
 // Feishu emoji types for typing indicator
 // See: https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce
@@ -41,7 +50,7 @@ export async function addTypingIndicator(params: {
     return { messageId, reactionId };
   } catch (err) {
     // Silently fail - typing indicator is not critical
-    console.log(`[feishu] failed to add typing indicator: ${err}`);
+    logTypingDebug(`failed to add typing indicator: ${err}`);
     return { messageId, reactionId: null };
   }
 }
@@ -75,6 +84,6 @@ export async function removeTypingIndicator(params: {
     });
   } catch (err) {
     // Silently fail - cleanup is not critical
-    console.log(`[feishu] failed to remove typing indicator: ${err}`);
+    logTypingDebug(`failed to remove typing indicator: ${err}`);
   }
 }


### PR DESCRIPTION
## Summary
- Replaced bare `console.log` calls in `addTypingIndicator` and `removeTypingIndicator` with the runtime subsystem logger (`getFeishuRuntime().logging.getChildLogger`)
- Typing indicator failures now flow through the structured logging pipeline and respect log-level configuration
- Uses a try-catch wrapper (`logTypingDebug`) to gracefully degrade when the runtime logger is unavailable (e.g. during unit tests)

## Test plan
- [ ] Verify existing feishu tests pass
- [ ] Confirm typing indicator failures now appear in the structured log file instead of raw stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)