### PR TITLE
fix(agents): replace console.warn with subsystem logger in session-write-lock

### DIFF
--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -1,8 +1,11 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isPidAlive } from "../shared/pid-alive.js";
 import { resolveProcessScopedMap } from "../shared/process-scoped-map.js";
+
+const log = createSubsystemLogger("session-write-lock");
 
 type LockFilePayload = {
   pid?: number;
@@ -192,10 +195,7 @@ async function runLockWatchdogCheck(nowMs = Date.now()): Promise<number> {
       continue;
     }
 
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[session-write-lock] releasing lock held for ${heldForMs}ms (max=${held.maxHoldMs}ms): ${held.lockPath}`,
-    );
+    log.warn(`releasing lock held for ${heldForMs}ms (max=${held.maxHoldMs}ms): ${held.lockPath}`);
 
     const didRelease = await releaseHeldLock(sessionFile, held, { force: true });
     if (didRelease) {


### PR DESCRIPTION
## Summary
- Replaced bare `console.warn` (with `eslint-disable no-console`) in the lock watchdog with `createSubsystemLogger("session-write-lock").warn()`
- Watchdog warnings now flow through the structured logging pipeline, appear in the log file, and respect log-level configuration
- Removed the `eslint-disable` comment since the subsystem logger handles console output internally

## Test plan
- [x] All 14 `session-write-lock.test.ts` tests pass
- [ ] Verify watchdog warnings appear in structured log output when a lock exceeds max hold time

🤖 Generated with [Claude Code](https://claude.com/claude-code)