### PR TITLE
fix(synology-chat): chunk long replies before sending

### DIFF
--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { sendMessage } from "./client.js";
 import type { ResolvedSynologyChatAccount } from "./types.js";
 import {
   clearSynologyWebhookRateLimiterStateForTest,
@@ -424,5 +425,28 @@ describe("createWebhookHandler", () => {
         body: expect.stringContaining("[FILTERED]"),
       }),
     );
+  });
+
+  it("splits long replies into multiple Synology messages", async () => {
+    const sendMessageMock = vi.mocked(sendMessage);
+    const beforeCalls = sendMessageMock.mock.calls.length;
+
+    const deliver = vi.fn().mockResolvedValue(`${"A".repeat(1900)}\n${"B".repeat(1900)}`);
+    const handler = createWebhookHandler({
+      account: makeAccount({ accountId: "split-test-" + Date.now() }),
+      deliver,
+      log,
+    });
+
+    const req = makeReq("POST", validBody);
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(204);
+    const calls = sendMessageMock.mock.calls.slice(beforeCalls);
+    expect(calls.length).toBeGreaterThan(1);
+    for (const call of calls) {
+      expect(String(call[1]).length).toBeLessThanOrEqual(1800);
+    }
   });
 });

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -16,6 +16,7 @@ import type { SynologyWebhookPayload, ResolvedSynologyChatAccount } from "./type
 
 // One rate limiter per account, created lazily
 const rateLimiters = new Map<string, RateLimiter>();
+const SYNLOGY_CHAT_REPLY_CHUNK_MAX = 1800;
 
 function getRateLimiter(account: ResolvedSynologyChatAccount): RateLimiter {
   let rl = rateLimiters.get(account.accountId);
@@ -36,6 +37,37 @@ export function clearSynologyWebhookRateLimiterStateForTest(): void {
 
 export function getSynologyWebhookRateLimiterCountForTest(): number {
   return rateLimiters.size;
+}
+
+function splitReplyForSynologyChat(
+  text: string,
+  maxChars = SYNLOGY_CHAT_REPLY_CHUNK_MAX,
+): string[] {
+  const normalized = text.replace(/\r\n/g, "\n").trim();
+  if (!normalized) {
+    return [];
+  }
+  if (normalized.length <= maxChars) {
+    return [normalized];
+  }
+
+  const chunks: string[] = [];
+  let remaining = normalized;
+  while (remaining.length > maxChars) {
+    let cut = remaining.lastIndexOf("\n", maxChars);
+    if (cut <= 0) {
+      cut = remaining.lastIndexOf(" ", maxChars);
+    }
+    if (cut <= 0) {
+      cut = maxChars;
+    }
+    chunks.push(remaining.slice(0, cut).trim());
+    remaining = remaining.slice(cut).trimStart();
+  }
+  if (remaining.length > 0) {
+    chunks.push(remaining);
+  }
+  return chunks;
 }
 
 /** Read the full request body as a string. */
@@ -375,9 +407,16 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
 
       // Send reply back to Synology Chat using the resolved Chat user_id
       if (reply) {
-        await sendMessage(account.incomingUrl, reply, replyUserId, account.allowInsecureSsl);
-        const replyPreview = reply.length > 100 ? `${reply.slice(0, 100)}...` : reply;
-        log?.info(`Reply sent to ${payload.username} (${replyUserId}): ${replyPreview}`);
+        const chunks = splitReplyForSynologyChat(reply);
+        for (const chunk of chunks) {
+          await sendMessage(account.incomingUrl, chunk, replyUserId, account.allowInsecureSsl);
+        }
+        const previewSource = chunks.join("\n");
+        const replyPreview =
+          previewSource.length > 100 ? `${previewSource.slice(0, 100)}...` : previewSource;
+        log?.info(
+          `Reply sent to ${payload.username} (${replyUserId}) in ${chunks.length} part(s): ${replyPreview}`,
+        );
       }
     } catch (err) {
       const errMsg = err instanceof Error ? `${err.message}\n${err.stack}` : String(err);

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -43,7 +43,7 @@ function splitReplyForSynologyChat(
   text: string,
   maxChars = SYNLOGY_CHAT_REPLY_CHUNK_MAX,
 ): string[] {
-  const normalized = text.replace(/\r\n/g, "\n").trim();
+  const normalized = text.replace(/\r\n/g, "\n");
   if (!normalized) {
     return [];
   }
@@ -61,8 +61,8 @@ function splitReplyForSynologyChat(
     if (cut <= 0) {
       cut = maxChars;
     }
-    chunks.push(remaining.slice(0, cut).trim());
-    remaining = remaining.slice(cut).trimStart();
+    chunks.push(remaining.slice(0, cut));
+    remaining = remaining.slice(cut);
   }
   if (remaining.length > 0) {
     chunks.push(remaining);

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -16,7 +16,7 @@ import type { SynologyWebhookPayload, ResolvedSynologyChatAccount } from "./type
 
 // One rate limiter per account, created lazily
 const rateLimiters = new Map<string, RateLimiter>();
-const SYNLOGY_CHAT_REPLY_CHUNK_MAX = 1800;
+const SYNOLOGY_CHAT_REPLY_CHUNK_MAX = 1800;
 
 function getRateLimiter(account: ResolvedSynologyChatAccount): RateLimiter {
   let rl = rateLimiters.get(account.accountId);
@@ -41,7 +41,7 @@ export function getSynologyWebhookRateLimiterCountForTest(): number {
 
 function splitReplyForSynologyChat(
   text: string,
-  maxChars = SYNLOGY_CHAT_REPLY_CHUNK_MAX,
+  maxChars = SYNOLOGY_CHAT_REPLY_CHUNK_MAX,
 ): string[] {
   const normalized = text.replace(/\r\n/g, "\n");
   if (!normalized) {


### PR DESCRIPTION
## Problem
Synology Chat users reported reply content being cut off, with large sections missing in long responses.

## Root cause
The Synology webhook handler sent the full assistant reply as a single message payload, which can be truncated by Synology Chat limits.

## Fix
- Added reply chunking helper for Synology Chat outbound replies
- Split long replies into bounded chunks (<=1800 chars)
- Sent chunks sequentially through existing sendMessage path
- Added regression test that validates long replies are split into multiple sends

## Testing
- `pnpm -s vitest run extensions/synology-chat/src/webhook-handler.test.ts`

Closes #36439
