### PR TITLE
fix(agents): add debug logging to silent catch blocks in sessions-resolution

### DIFF
--- a/src/agents/tools/sessions-resolution.ts
+++ b/src/agents/tools/sessions-resolution.ts
@@ -1,6 +1,9 @@
 import type { OpenClawConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { isAcpSessionKey, normalizeMainKey } from "../../routing/session-key.js";
+
+const log = createSubsystemLogger("sessions-resolution");
 
 function normalizeKey(value?: string) {
   const trimmed = value?.trim();
@@ -55,7 +58,10 @@ export async function listSpawnedSessionKeys(params: {
       .map((value) => value.trim())
       .filter(Boolean);
     return new Set(keys);
-  } catch {
+  } catch (err) {
+    log.debug(
+      `listSpawnedSessionKeys failed for requester=${params.requesterSessionKey}: ${String(err)}`,
+    );
     return new Set();
   }
 }
@@ -242,7 +248,8 @@ async function resolveSessionKeyFromKey(params: {
       }),
       resolvedViaSessionId: false,
     };
-  } catch {
+  } catch (err) {
+    log.debug(`resolveSessionKeyFromKey failed for key=${params.key}: ${String(err)}`);
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Added debug-level logging to two silent catch blocks in `sessions-resolution.ts`:
  - `listSpawnedSessionKeys()` — gateway failures now log the requester key and error, instead of silently returning an empty Set
  - `resolveSessionKeyFromKey()` — gateway failures now log the target key and error, instead of silently returning null
- Uses `createSubsystemLogger("sessions-resolution")` for structured log output
- Preserves existing graceful degradation behavior (empty Set / null fallback)

## Test plan
- [ ] Verify build succeeds (no test file for this module)
- [ ] Confirm debug messages appear in log file when gateway calls fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)