### PR TITLE
fix(agents): expand failover error code coverage for network and server failures

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -19,6 +19,12 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 504 })).toBe("timeout");
+    // Cloudflare-specific transient errors should also trigger failover as timeout.
+    expect(resolveFailoverReasonFromError({ status: 521 })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ status: 522 })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ status: 523 })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ status: 524 })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ status: 529 })).toBe("timeout");
   });
 
   it("infers format errors from error messages", () => {

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -14,7 +14,8 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 403 })).toBe("auth");
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 400 })).toBe("format");
-    // Transient server errors (502/503/504) should trigger failover as timeout.
+    // Transient server errors (500/502/503/504) should trigger failover as timeout.
+    expect(resolveFailoverReasonFromError({ status: 500 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 502 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 503 })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 504 })).toBe("timeout");
@@ -31,6 +32,9 @@ describe("failover-error", () => {
   it("infers timeout from common node error codes", () => {
     expect(resolveFailoverReasonFromError({ code: "ETIMEDOUT" })).toBe("timeout");
     expect(resolveFailoverReasonFromError({ code: "ECONNRESET" })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ code: "ECONNREFUSED" })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ code: "EHOSTUNREACH" })).toBe("timeout");
+    expect(resolveFailoverReasonFromError({ code: "ENETUNREACH" })).toBe("timeout");
   });
 
   it("infers timeout from abort stop-reason messages", () => {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -173,7 +173,17 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 408) {
     return "timeout";
   }
-  if (status === 500 || status === 502 || status === 503 || status === 504) {
+  if (
+    status === 500 ||
+    status === 502 ||
+    status === 503 ||
+    status === 504 ||
+    status === 521 ||
+    status === 522 ||
+    status === 523 ||
+    status === 524 ||
+    status === 529
+  ) {
     return "timeout";
   }
   if (status === 400) {

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -173,7 +173,7 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 408) {
     return "timeout";
   }
-  if (status === 502 || status === 503 || status === 504) {
+  if (status === 500 || status === 502 || status === 503 || status === 504) {
     return "timeout";
   }
   if (status === 400) {
@@ -181,7 +181,17 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   }
 
   const code = (getErrorCode(err) ?? "").toUpperCase();
-  if (["ETIMEDOUT", "ESOCKETTIMEDOUT", "ECONNRESET", "ECONNABORTED"].includes(code)) {
+  if (
+    [
+      "ETIMEDOUT",
+      "ESOCKETTIMEDOUT",
+      "ECONNRESET",
+      "ECONNABORTED",
+      "ECONNREFUSED",
+      "EHOSTUNREACH",
+      "ENETUNREACH",
+    ].includes(code)
+  ) {
     return "timeout";
   }
   if (isTimeoutError(err)) {


### PR DESCRIPTION
## Summary
- Added `ECONNREFUSED`, `EHOSTUNREACH`, and `ENETUNREACH` to the Node.js error code list in `resolveFailoverReasonFromError` — these network-level failures now reliably trigger failover instead of falling through to message-based classification
- Added HTTP 500 (Internal Server Error) to the status-code-based classification alongside the existing 502/503/504 handling, aligning with `TRANSIENT_HTTP_ERROR_CODES` in `pi-embedded-helpers/errors.ts`
- Updated tests to cover the new error codes

## Test plan
- [x] All 13 `failover-error.test.ts` tests pass
- [ ] Verify `ECONNREFUSED` errors from a downed provider now trigger failover retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)