### PR TITLE
perf(media): bound HTTP error body snippet reads

### DIFF
--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -12,6 +12,21 @@ function makeStream(chunks: Uint8Array[]) {
   });
 }
 
+function makeNeverEndingStreamWithLateError(chunkText: string, throwAfterReads: number) {
+  const chunk = new TextEncoder().encode(chunkText);
+  let reads = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      reads += 1;
+      if (reads > throwAfterReads) {
+        controller.error(new Error("stream read overflow"));
+        return;
+      }
+      controller.enqueue(chunk);
+    },
+  });
+}
+
 describe("fetchRemoteMedia", () => {
   type LookupFn = NonNullable<Parameters<typeof fetchRemoteMedia>[0]["lookupFn"]>;
 
@@ -64,5 +79,24 @@ describe("fetchRemoteMedia", () => {
       }),
     ).rejects.toThrow(/private|internal|blocked/i);
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("captures an HTTP error body snippet without reading an unbounded stream", async () => {
+    const lookupFn = vi.fn(async () => [
+      { address: "93.184.216.34", family: 4 },
+    ]) as unknown as LookupFn;
+    const fetchImpl = async () =>
+      new Response(makeNeverEndingStreamWithLateError("x".repeat(1024), 6), {
+        status: 500,
+        statusText: "Internal Server Error",
+      });
+
+    await expect(
+      fetchRemoteMedia({
+        url: "https://example.com/fail.bin",
+        fetchImpl,
+        lookupFn,
+      }),
+    ).rejects.toThrow(/body: x{20}/);
   });
 });

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -60,9 +60,36 @@ function parseContentDispositionFileName(header?: string | null): string | undef
   return undefined;
 }
 
-async function readErrorBodySnippet(res: Response, maxChars = 200): Promise<string | undefined> {
+async function readErrorBodySnippet(
+  res: Response,
+  maxChars = 200,
+  maxBytes = 4 * 1024,
+): Promise<string | undefined> {
   try {
-    const text = await res.text();
+    if (!res.body) {
+      return undefined;
+    }
+    const reader = res.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (total < maxBytes) {
+      const { value, done } = await reader.read();
+      if (done || !value) {
+        break;
+      }
+      const remaining = maxBytes - total;
+      if (value.byteLength <= remaining) {
+        chunks.push(value);
+        total += value.byteLength;
+      } else {
+        chunks.push(value.subarray(0, remaining));
+        total += remaining;
+        break;
+      }
+    }
+    await reader.cancel().catch(() => undefined);
+
+    const text = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk))).toString("utf8");
     if (!text) {
       return undefined;
     }


### PR DESCRIPTION
## Summary
- avoid buffering entire non-OK HTTP response bodies in fetchRemoteMedia
- cap error-body sampling to 4KB before building a diagnostic snippet
- add a focused test that verifies snippet capture from a non-terminating stream with a late stream error

## Why
res.text() on the error path could read arbitrarily large payloads even though we only surface a short snippet. Bounding the read lowers memory/latency risk in failure handling.

## Risk
Low. This only changes non-2xx error-detail construction and keeps the existing message shape (body: ...).

## Validation
- pnpm vitest src/media/fetch.test.ts
