### PR TITLE
fix(agents): broaden JSON API internal server error detection for failover

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -527,4 +527,14 @@ describe("classifyFailoverReason", () => {
       ),
     ).toBe("timeout");
   });
+  it("classifies JSON server_error internal server failures as timeout", () => {
+    expect(
+      classifyFailoverReason('{"error":{"type":"server_error","message":"Internal server error"}}'),
+    ).toBe("timeout");
+    expect(
+      classifyFailoverReason(
+        '{"error":{"type":"internal_server_error","message":"Internal server error"}}',
+      ),
+    ).toBe("timeout");
+  });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -780,9 +780,17 @@ function isJsonApiInternalServerError(raw: string): boolean {
     return false;
   }
   const value = raw.toLowerCase();
-  // Anthropic often wraps transient 500s in JSON payloads like:
-  // {"type":"error","error":{"type":"api_error","message":"Internal server error"}}
-  return value.includes('"type":"api_error"') && value.includes("internal server error");
+  if (!value.includes("internal server error")) {
+    return false;
+  }
+  // Anthropic wraps transient 500s as: {"type":"error","error":{"type":"api_error",...}}
+  // OpenAI uses: {"error":{"type":"server_error",...}}
+  // Some proxies emit: {"error":{"type":"internal_server_error",...}}
+  return (
+    value.includes('"type":"api_error"') ||
+    value.includes('"type":"server_error"') ||
+    value.includes('"type":"internal_server_error"')
+  );
 }
 
 export function parseImageDimensionError(raw: string): {


### PR DESCRIPTION
## Summary
- Broadened `isJsonApiInternalServerError` to recognize transient 500s from multiple providers:
  - `"type":"api_error"` (Anthropic) — already handled
  - `"type":"server_error"` (OpenAI) — **newly added**
  - `"type":"internal_server_error"` (generic proxies) — **newly added**
- All patterns require an "internal server error" message to match, preserving specificity
- Added tests for the new OpenAI and generic proxy patterns

## Test plan
- [x] All 42 `pi-embedded-helpers.isbillingerrormessage.test.ts` tests pass (including 1 new test)
- [ ] Verify OpenAI `server_error` JSON payloads now trigger failover retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)