### PR TITLE
Gateway: block SIGUSR1 restart when config is invalid

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -2,9 +2,43 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayBonjourBeacon } from "../../infra/bonjour-discovery.js";
 import { pickBeaconHost, pickGatewayPort } from "./discover.js";
 
+type ConfigSnapshotIssue = {
+  path: string;
+  message: string;
+};
+
+type MockConfigSnapshot = {
+  path: string;
+  exists: boolean;
+  raw: string | null;
+  parsed: Record<string, unknown>;
+  resolved: Record<string, unknown>;
+  valid: boolean;
+  config: Record<string, unknown>;
+  hash: string;
+  issues: ConfigSnapshotIssue[];
+  warnings: ConfigSnapshotIssue[];
+  legacyIssues: Array<Record<string, unknown>>;
+};
+
+const createValidConfigSnapshot = (): MockConfigSnapshot => ({
+  path: "/tmp/openclaw.json",
+  exists: true,
+  raw: "{}",
+  parsed: {},
+  resolved: {},
+  valid: true,
+  config: {},
+  hash: "hash",
+  issues: [],
+  warnings: [],
+  legacyIssues: [],
+});
+
 const acquireGatewayLock = vi.fn(async (_opts?: { port?: number }) => ({
   release: vi.fn(async () => {}),
 }));
+const readConfigFileSnapshot = vi.fn(async () => createValidConfigSnapshot());
 const consumeGatewaySigusr1RestartAuthorization = vi.fn(() => true);
 const isGatewaySigusr1RestartExternallyAllowed = vi.fn(() => false);
 const markGatewaySigusr1RestartHandled = vi.fn();
@@ -24,6 +58,10 @@ const gatewayLog = {
 
 vi.mock("../../infra/gateway-lock.js", () => ({
   acquireGatewayLock: (opts?: { port?: number }) => acquireGatewayLock(opts),
+}));
+
+vi.mock("../../config/io.js", () => ({
+  readConfigFileSnapshot: () => readConfigFileSnapshot(),
 }));
 
 vi.mock("../../infra/restart.js", () => ({
@@ -325,6 +363,35 @@ describe("runGatewayLoop", () => {
       expect(gatewayLog.error).toHaveBeenCalledWith(
         expect.stringContaining("failed to reacquire gateway lock for in-process restart"),
       );
+    });
+  });
+
+  it("blocks SIGUSR1 restart when config validation fails", async () => {
+    vi.clearAllMocks();
+
+    await withIsolatedSignals(async () => {
+      readConfigFileSnapshot.mockResolvedValueOnce({
+        ...createValidConfigSnapshot(),
+        valid: false,
+        issues: [{ path: "agents.defaults.pdfModel", message: "Unrecognized key" }],
+      });
+
+      const { close, exited } = await createSignaledLoopHarness();
+      process.emit("SIGUSR1");
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(close).not.toHaveBeenCalled();
+      expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
+      expect(gatewayLog.error).toHaveBeenCalledWith(
+        expect.stringContaining("SIGUSR1 restart blocked: config invalid"),
+      );
+      expect(gatewayLog.error).toHaveBeenCalledWith(
+        expect.stringContaining("agents.defaults.pdfModel: Unrecognized key"),
+      );
+
+      process.emit("SIGTERM");
+      await expect(exited).resolves.toBe(0);
     });
   });
 });

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,3 +1,4 @@
+import { readConfigFileSnapshot } from "../../config/io.js";
 import type { startGatewayServer } from "../../gateway/server.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
 import { restartGatewayProcessWithFreshPid } from "../../infra/process-respawn.js";
@@ -19,6 +20,25 @@ import type { defaultRuntime } from "../../runtime.js";
 const gatewayLog = createSubsystemLogger("gateway");
 
 type GatewayRunSignalAction = "stop" | "restart";
+
+function formatRestartConfigIssues(
+  issues: Array<{
+    path?: string;
+    message?: string;
+  }>,
+): string {
+  if (issues.length === 0) {
+    return "unknown validation issue";
+  }
+  return issues
+    .slice(0, 3)
+    .map((issue) => {
+      const path = issue.path?.trim() || "<root>";
+      const message = issue.message?.trim() || "invalid config";
+      return `${path}: ${message}`;
+    })
+    .join("; ");
+}
 
 export async function runGatewayLoop(params: {
   start: () => Promise<Awaited<ReturnType<typeof startGatewayServer>>>;
@@ -164,8 +184,25 @@ export async function runGatewayLoop(params: {
       );
       return;
     }
-    markGatewaySigusr1RestartHandled();
-    request("restart", "SIGUSR1");
+    void (async () => {
+      try {
+        const snapshot = await readConfigFileSnapshot();
+        if (!snapshot.valid) {
+          markGatewaySigusr1RestartHandled();
+          gatewayLog.error(
+            `SIGUSR1 restart blocked: config invalid (${formatRestartConfigIssues(snapshot.issues)}). Run \`openclaw doctor --fix\` and retry.`,
+          );
+          return;
+        }
+        markGatewaySigusr1RestartHandled();
+        request("restart", "SIGUSR1");
+      } catch (err) {
+        markGatewaySigusr1RestartHandled();
+        gatewayLog.error(
+          `SIGUSR1 restart blocked: failed to validate config before restart (${String(err)})`,
+        );
+      }
+    })();
   };
 
   process.on("SIGTERM", onSigterm);


### PR DESCRIPTION
## Summary
- preflight config validity before honoring `SIGUSR1` restart requests in gateway run loop
- block restart and log actionable validation details when the config snapshot is invalid
- add regression coverage to ensure invalid config does not trigger `close()`/restart and still marks restart handled

## Testing
- pnpm test src/cli/gateway-cli/run-loop.test.ts

Fixes #35862
