### PR TITLE
fix(models): add openai-codex as built-in provider for models auth login

### DIFF
--- a/src/commands/models/auth.builtin-providers.test.ts
+++ b/src/commands/models/auth.builtin-providers.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  loginOpenAICodexOAuth: vi.fn(),
+}));
+
+vi.mock("../openai-codex-oauth.js", () => ({
+  loginOpenAICodexOAuth: mocks.loginOpenAICodexOAuth,
+}));
+
+import type { ProviderAuthContext } from "../../plugins/types.js";
+import { BUILTIN_AUTH_PROVIDERS } from "./auth.builtin-providers.js";
+
+function fakeContext(): ProviderAuthContext {
+  const spin = { update: vi.fn(), stop: vi.fn() };
+  return {
+    config: {} as ProviderAuthContext["config"],
+    agentDir: undefined,
+    workspaceDir: undefined,
+    isRemote: false,
+    openUrl: vi.fn(async () => {}),
+    runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    prompter: {
+      note: vi.fn(async () => {}),
+      progress: vi.fn(() => spin),
+    } as unknown as ProviderAuthContext["prompter"],
+    oauth: {
+      createVpsAwareHandlers: vi.fn(),
+    } as unknown as ProviderAuthContext["oauth"],
+  };
+}
+
+describe("BUILTIN_AUTH_PROVIDERS", () => {
+  it("includes openai-codex provider", () => {
+    const codex = BUILTIN_AUTH_PROVIDERS.find((p) => p.id === "openai-codex");
+    expect(codex).toBeDefined();
+    expect(codex?.aliases).toContain("codex");
+    expect(codex?.auth).toHaveLength(1);
+    expect(codex?.auth[0]?.id).toBe("oauth");
+    expect(codex?.auth[0]?.kind).toBe("oauth");
+  });
+
+  describe("openai-codex oauth method", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("returns profiles with credentials on successful OAuth", async () => {
+      const creds = {
+        access: "access-token",
+        refresh: "refresh-token",
+        expires: Date.now() + 60_000,
+        email: "user@example.com",
+      };
+      mocks.loginOpenAICodexOAuth.mockResolvedValue(creds);
+
+      const codex = BUILTIN_AUTH_PROVIDERS.find((p) => p.id === "openai-codex")!;
+      const ctx = fakeContext();
+      const result = await codex.auth[0].run(ctx);
+
+      expect(result.profiles).toHaveLength(1);
+      expect(result.profiles[0]?.credential.provider).toBe("openai-codex");
+      expect(result.profiles[0]?.credential.type).toBe("oauth");
+      expect(result.defaultModel).toBeDefined();
+    });
+
+    it("returns empty profiles when OAuth returns null (user cancelled)", async () => {
+      mocks.loginOpenAICodexOAuth.mockResolvedValue(null);
+
+      const codex = BUILTIN_AUTH_PROVIDERS.find((p) => p.id === "openai-codex")!;
+      const result = await codex.auth[0].run(fakeContext());
+
+      expect(result.profiles).toHaveLength(0);
+      expect(result.defaultModel).toBeUndefined();
+    });
+
+    it("propagates OAuth errors", async () => {
+      mocks.loginOpenAICodexOAuth.mockRejectedValue(new Error("network error"));
+
+      const codex = BUILTIN_AUTH_PROVIDERS.find((p) => p.id === "openai-codex")!;
+      await expect(codex.auth[0].run(fakeContext())).rejects.toThrow("network error");
+    });
+  });
+});

--- a/src/commands/models/auth.builtin-providers.ts
+++ b/src/commands/models/auth.builtin-providers.ts
@@ -36,9 +36,11 @@ export const BUILTIN_AUTH_PROVIDERS: ProviderPlugin[] = [
             providerId: "openai-codex",
             defaultModel: OPENAI_CODEX_DEFAULT_MODEL,
             access: creds.access,
-            refresh: creds.refresh ?? undefined,
-            expires: creds.expires ?? undefined,
-            email: creds.email ?? undefined,
+            refresh: creds.refresh,
+            expires: creds.expires,
+            // openai-codex tokens use accountId not email; profile id becomes "openai-codex:default"
+            credentialExtra:
+              typeof creds.accountId === "string" ? { accountId: creds.accountId } : undefined,
           });
         },
       },

--- a/src/commands/models/auth.builtin-providers.ts
+++ b/src/commands/models/auth.builtin-providers.ts
@@ -1,0 +1,47 @@
+import { buildOauthProviderAuthResult } from "../../plugin-sdk/provider-auth-result.js";
+import type { ProviderPlugin } from "../../plugins/types.js";
+import { OPENAI_CODEX_DEFAULT_MODEL } from "../openai-codex-model-default.js";
+import { loginOpenAICodexOAuth } from "../openai-codex-oauth.js";
+
+/**
+ * Built-in providers for `models auth login` that don't require a separate plugin.
+ * These are first-party OAuth flows whose logic lives in the core package.
+ */
+export const BUILTIN_AUTH_PROVIDERS: ProviderPlugin[] = [
+  {
+    id: "openai-codex",
+    label: "OpenAI Codex OAuth",
+    docsPath: "/providers/openai-codex",
+    aliases: ["codex"],
+    auth: [
+      {
+        id: "oauth",
+        label: "OpenAI OAuth",
+        hint: "Browser-based sign-in (localhost:1455 callback)",
+        kind: "oauth",
+        run: async (ctx) => {
+          const creds = await loginOpenAICodexOAuth({
+            prompter: ctx.prompter,
+            runtime: ctx.runtime,
+            isRemote: ctx.isRemote,
+            openUrl: ctx.openUrl,
+          });
+
+          if (!creds) {
+            // User cancelled / OAuth returned no credentials
+            return { profiles: [] };
+          }
+
+          return buildOauthProviderAuthResult({
+            providerId: "openai-codex",
+            defaultModel: OPENAI_CODEX_DEFAULT_MODEL,
+            access: creds.access,
+            refresh: creds.refresh ?? undefined,
+            expires: creds.expires ?? undefined,
+            email: creds.email ?? undefined,
+          });
+        },
+      },
+    ],
+  },
+];

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -27,6 +27,7 @@ import {
   pickAuthMethod,
   resolveProviderMatch,
 } from "../provider-auth-helpers.js";
+import { BUILTIN_AUTH_PROVIDERS } from "./auth.builtin-providers.js";
 import { loadValidConfigOrThrow, updateConfig } from "./shared.js";
 
 const confirm = (params: Parameters<typeof clackConfirm>[0]) =>
@@ -283,12 +284,14 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
   const workspaceDir =
     resolveAgentWorkspaceDir(config, defaultAgentId) ?? resolveDefaultAgentWorkspaceDir();
 
-  const providers = resolvePluginProviders({ config, workspaceDir });
-  if (providers.length === 0) {
-    throw new Error(
-      `No provider plugins found. Install one via \`${formatCliCommand("openclaw plugins install")}\`.`,
-    );
-  }
+  const pluginProviders = resolvePluginProviders({ config, workspaceDir });
+  // Merge built-in providers (e.g. openai-codex) ahead of plugin-registered ones.
+  // Plugin registrations override built-ins when IDs collide.
+  const pluginIds = new Set(pluginProviders.map((p) => p.id));
+  const providers = [
+    ...BUILTIN_AUTH_PROVIDERS.filter((p) => !pluginIds.has(p.id)),
+    ...pluginProviders,
+  ];
 
   const prompter = createClackPrompter();
   const requestedProvider = resolveRequestedLoginProviderOrThrow(providers, opts.provider);


### PR DESCRIPTION
## Summary

Fixes #36511 — V8 fatal crash when running `openclaw models auth login --provider openai-codex` on Linux.

**Root cause:** The `models auth login` command resolves providers exclusively from installed plugins. No plugin registers `openai-codex`, so when `--provider openai-codex` is passed the command reaches a code path inside `resolvePluginProviders` / the IC resolution loop that triggers a V8 fatal error (`Runtime_LoadIC_Miss` bounds-check failure) in the compiled `openclaw-models` binary on Linux.

**Fix:** Register `openai-codex` as a built-in provider in the `models auth login` flow, reusing the existing `loginOpenAICodexOAuth` function (already used for onboarding). Built-in providers are merged ahead of plugin-registered ones; if a plugin later registers the same `openai-codex` id, the plugin wins.

## Changes

- **`src/commands/models/auth.builtin-providers.ts`** — New file: `BUILTIN_AUTH_PROVIDERS` array containing an `openai-codex` provider plugin that delegates to `loginOpenAICodexOAuth` and returns a `ProviderAuthResult` via `buildOauthProviderAuthResult`.
- **`src/commands/models/auth.ts`** — `modelsAuthLoginCommand` now merges built-in providers with plugin providers before any lookup or selection prompt, so `--provider openai-codex` resolves correctly without a plugin installed.
- **`src/commands/models/auth.builtin-providers.test.ts`** — Unit tests covering successful OAuth, null/cancelled OAuth, and error propagation.

## Test plan

- [ ] `pnpm test src/commands/models/auth.builtin-providers.test.ts` — 4 new tests pass
- [ ] `pnpm test src/commands/openai-codex-oauth.test.ts` — existing tests still pass
- [ ] Manual: `openclaw models auth login --provider openai-codex` launches OAuth flow without crashing

— [Joel Nishanth](https://offlyn.ai) · [offlyn.AI](https://offlyn.ai)

Made with [Cursor](https://cursor.com)