### PR TITLE
perf(media): avoid per-chunk buffer remapping in response limiter

### DIFF
--- a/src/media/read-response-with-limit.test.ts
+++ b/src/media/read-response-with-limit.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { readResponseWithLimit } from "./read-response-with-limit.js";
+
+function makeStream(chunks: Uint8Array[]) {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+}
+
+describe("readResponseWithLimit", () => {
+  it("concatenates streamed chunks", async () => {
+    const res = new Response(makeStream([new Uint8Array([1, 2]), new Uint8Array([3, 4, 5])]), {
+      status: 200,
+    });
+
+    const out = await readResponseWithLimit(res, 10);
+
+    expect(Array.from(out)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("uses overflow callback when streamed body exceeds maxBytes", async () => {
+    const res = new Response(makeStream([new Uint8Array([1, 2, 3]), new Uint8Array([4, 5])]), {
+      status: 200,
+    });
+    const onOverflow = vi.fn(
+      ({ size, maxBytes }: { size: number; maxBytes: number }) =>
+        new Error(`overflow:${size}/${maxBytes}`),
+    );
+
+    await expect(readResponseWithLimit(res, 4, { onOverflow })).rejects.toThrow("overflow:5/4");
+    expect(onOverflow).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to arrayBuffer when body stream is unavailable", async () => {
+    const raw = new Uint8Array([9, 8, 7]).buffer;
+    const res = {
+      body: null,
+      arrayBuffer: vi.fn(async () => raw),
+    } as unknown as Response;
+
+    const out = await readResponseWithLimit(res, 10);
+
+    expect(Array.from(out)).toEqual([9, 8, 7]);
+  });
+});

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -20,7 +20,7 @@ export async function readResponseWithLimit(
   }
 
   const reader = body.getReader();
-  const chunks: Uint8Array[] = [];
+  const chunks: Buffer[] = [];
   let total = 0;
   try {
     while (true) {
@@ -36,7 +36,7 @@ export async function readResponseWithLimit(
           } catch {}
           throw onOverflow({ size: total, maxBytes, res });
         }
-        chunks.push(value);
+        chunks.push(Buffer.from(value.buffer, value.byteOffset, value.byteLength));
       }
     }
   } finally {
@@ -45,8 +45,5 @@ export async function readResponseWithLimit(
     } catch {}
   }
 
-  return Buffer.concat(
-    chunks.map((chunk) => Buffer.from(chunk)),
-    total,
-  );
+  return Buffer.concat(chunks, total);
 }


### PR DESCRIPTION
## Summary
- store streamed chunks as `Buffer` views in `readResponseWithLimit` instead of `Uint8Array`
- remove final `chunks.map(Buffer.from)` remapping before concat
- add focused tests for stream concat, overflow callback, and arrayBuffer fallback

## Why
`readResponseWithLimit` sits on the media fetch hot path. The previous flow remapped every chunk into a `Buffer` right before concatenation, which adds avoidable per-chunk work for larger streamed payloads.

## Validation
- `pnpm -C /tmp/openclaw-review exec vitest run src/media/read-response-with-limit.test.ts`
- `pnpm -C /tmp/openclaw-review exec vitest run src/media/fetch.test.ts src/media/read-response-with-limit.test.ts`

## Risk
Low. Byte accounting and overflow behavior are unchanged; only chunk representation and final concat path were simplified.
