### PR TITLE
test(gateway): cover disable-device-auth with stale device token

### DIFF
--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -347,6 +347,31 @@ export function registerControlUiAndPairingSuite(): void {
     }
   });
 
+  test("ignores explicit wrong deviceToken when dangerouslyDisableDeviceAuth=true and shared token is valid", async () => {
+    testState.gatewayControlUi = { dangerouslyDisableDeviceAuth: true };
+    testState.gatewayAuth = { mode: "token", token: "secret" };
+    const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "secret";
+    try {
+      await withGatewayServer(async ({ port }) => {
+        const ws = await openWs(port, { origin: originForPort(port) });
+        const res = await connectReq(ws, {
+          token: "secret",
+          deviceToken: "stale-or-invalid-device-token",
+          scopes: ["operator.read"],
+          client: {
+            ...CONTROL_UI_CLIENT,
+          },
+        });
+        expect(res.ok).toBe(true);
+        expect(res.error?.message ?? "").not.toContain("device token mismatch");
+        ws.close();
+      });
+    } finally {
+      restoreGatewayToken(prevToken);
+    }
+  });
+
   test("device token auth matrix", async () => {
     const { server, ws, port, prevToken } = await startServerWithClient("secret");
     const { deviceToken, deviceIdentityPath } = await ensurePairedDeviceTokenForCurrentIdentity(ws);


### PR DESCRIPTION
## Problem
Users reported Control UI disconnects with `device token mismatch` even when `gateway.controlUi.dangerouslyDisableDeviceAuth=true` (#35944).

## Root cause
We lacked regression coverage for the mixed-auth handshake path where a valid shared token is present together with a stale explicit `auth.deviceToken` while device auth bypass is enabled.

## Fix
- Added a Control UI auth regression test that verifies:
  - `dangerouslyDisableDeviceAuth=true`
  - valid shared gateway token
  - stale explicit `auth.deviceToken`
  - connection still succeeds (no device-token mismatch rejection)

## Testing
- `pnpm -s vitest run src/gateway/server.auth.control-ui.test.ts`

Refs #35944
