### PR TITLE
fix(discord): pass appliedTags through channel edit

### DIFF
--- a/src/agents/tools/discord-actions-guild.ts
+++ b/src/agents/tools/discord-actions-guild.ts
@@ -327,6 +327,7 @@ export async function handleDiscordGuildAction(
         integer: true,
       });
       const availableTags = parseAvailableTags(params.availableTags);
+      const appliedTags = readStringArrayParam(params, "appliedTags");
       const editPayload = {
         channelId,
         name: name ?? undefined,
@@ -339,6 +340,7 @@ export async function handleDiscordGuildAction(
         locked,
         autoArchiveDuration: autoArchiveDuration ?? undefined,
         availableTags,
+        appliedTags: appliedTags ?? undefined,
       };
       const channel = accountId
         ? await editChannelDiscord(editPayload, { accountId })

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -387,6 +387,7 @@ describe("handleDiscordMessageAction", () => {
           archived: true,
           locked: false,
           autoArchiveDuration: 1440,
+          appliedTags: ["tag1"],
         },
       },
       expected: {
@@ -395,6 +396,7 @@ describe("handleDiscordMessageAction", () => {
         archived: true,
         locked: false,
         autoArchiveDuration: 1440,
+        appliedTags: ["tag1"],
       },
     },
   ] as const;

--- a/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
+++ b/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
@@ -197,6 +197,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
       integer: true,
     });
     const availableTags = parseAvailableTags(actionParams.availableTags);
+    const appliedTags = readStringArrayParam(actionParams, "appliedTags");
     return await handleDiscordAction(
       {
         action: "channelEdit",
@@ -212,6 +213,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         locked,
         autoArchiveDuration: autoArchiveDuration ?? undefined,
         availableTags,
+        appliedTags: appliedTags ?? undefined,
       },
       cfg,
     );

--- a/src/discord/send.channels.ts
+++ b/src/discord/send.channels.ts
@@ -79,6 +79,9 @@ export async function editChannelDiscord(
       ...(t.emoji_name !== undefined && { emoji_name: t.emoji_name }),
     }));
   }
+  if (payload.appliedTags !== undefined) {
+    body.applied_tags = payload.appliedTags;
+  }
   return (await rest.patch(Routes.channel(payload.channelId), {
     body,
   })) as APIChannel;

--- a/src/discord/send.edits-channel.test.ts
+++ b/src/discord/send.edits-channel.test.ts
@@ -1,0 +1,38 @@
+import { Routes } from "discord-api-types/v10";
+import { describe, expect, it } from "vitest";
+import { editChannelDiscord } from "./send.channels.js";
+import { makeDiscordRest } from "./send.test-harness.js";
+
+describe("editChannelDiscord", () => {
+  it("passes applied_tags when appliedTags is provided", async () => {
+    const { rest, patchMock } = makeDiscordRest();
+
+    await editChannelDiscord(
+      {
+        channelId: "123",
+        appliedTags: ["tag1", "tag2"],
+      },
+      { rest, token: "t" },
+    );
+
+    expect(patchMock).toHaveBeenCalledWith(Routes.channel("123"), {
+      body: expect.objectContaining({ applied_tags: ["tag1", "tag2"] }),
+    });
+  });
+
+  it("omits applied_tags when appliedTags is undefined", async () => {
+    const { rest, patchMock } = makeDiscordRest();
+
+    await editChannelDiscord(
+      {
+        channelId: "123",
+        name: "new-name",
+      },
+      { rest, token: "t" },
+    );
+
+    expect(patchMock).toHaveBeenCalledWith(Routes.channel("123"), {
+      body: expect.not.objectContaining({ applied_tags: expect.anything() }),
+    });
+  });
+});

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -158,6 +158,8 @@ export type DiscordChannelEdit = {
   locked?: boolean;
   autoArchiveDuration?: number;
   availableTags?: DiscordForumTag[];
+  /** Tag IDs to apply when editing a forum/media thread (Discord `applied_tags`). */
+  appliedTags?: string[];
 };
 
 export type DiscordChannelMove = {

--- a/test/discord/send.edits-channel.test.ts
+++ b/test/discord/send.edits-channel.test.ts
@@ -1,7 +1,7 @@
 import { Routes } from "discord-api-types/v10";
 import { describe, expect, it } from "vitest";
-import { editChannelDiscord } from "./send.channels.js";
-import { makeDiscordRest } from "./send.test-harness.js";
+import { editChannelDiscord } from "../../src/discord/send.channels.js";
+import { makeDiscordRest } from "../../src/discord/send.test-harness.js";
 
 describe("editChannelDiscord", () => {
   it("passes applied_tags when appliedTags is provided", async () => {


### PR DESCRIPTION
## Summary
Fixes Discord `channel-edit` so it forwards `appliedTags` (forum/media thread tags) to Discord as `applied_tags`.

## Repro
Call the message tool with `action: "channel-edit"` and provide `appliedTags`. Previously, OpenClaw returned ok but the tag did not change.

## Expected
Discord thread/forum tags update.

## Fix
- Parse `appliedTags` in the `channel-edit` handler(s) and pass it down.
- Map `appliedTags` to Discord REST payload `applied_tags` in `editChannelDiscord()`.

## Tests
- `pnpm -s vitest -c vitest.unit.config.ts run test/discord/send.edits-channel.test.ts`

Closes #36736