### PR TITLE
openai-image-gen: validate --background and --style options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,7 @@ Docs: https://docs.openclaw.ai
 - Agents/failover: classify periodic provider limit exhaustion text (for example `Weekly/Monthly Limit Exhausted`) as `rate_limit` while keeping explicit `402 Payment Required` variants in billing, so failover continues without misclassifying billing-wrapped quota errors. (#33813) thanks @zhouhe-xydt.
 - Mattermost/interactive button callbacks: allow external callback base URLs and stop requiring loopback-origin requests so button clicks work when Mattermost reaches the gateway over Tailscale, LAN, or a reverse proxy. (#37543) thanks @mukhtharcm.
 - Skills/nano-banana-pro resolution override: respect explicit `--resolution` values during image editing and only auto-detect output size from input images when the flag is omitted. (#36880) Thanks @shuofengzhang and @vincentkoc.
+- Skills/openai-image-gen CLI validation: validate `--background` and `--style` inputs early, normalize supported values, and warn when those flags are ignored for incompatible models. (#36762) Thanks @shuofengzhang and @vincentkoc.
 
 ## 2026.3.2
 

--- a/skills/openai-image-gen/scripts/gen.py
+++ b/skills/openai-image-gen/scripts/gen.py
@@ -77,11 +77,15 @@ def get_model_defaults(model: str) -> tuple[str, str]:
 
 def normalize_background(model: str, background: str) -> str:
     """Validate --background for GPT image models."""
-    if not model.startswith("gpt-image"):
-        return ""
-
     value = background.strip().lower()
     if not value:
+        return ""
+
+    if not model.startswith("gpt-image"):
+        print(
+            f"Warning: --background is only supported for gpt-image models; ignoring for '{model}'.",
+            file=sys.stderr,
+        )
         return ""
 
     allowed = {"transparent", "opaque", "auto"}
@@ -94,11 +98,15 @@ def normalize_background(model: str, background: str) -> str:
 
 def normalize_style(model: str, style: str) -> str:
     """Validate --style for dall-e-3."""
-    if model != "dall-e-3":
-        return ""
-
     value = style.strip().lower()
     if not value:
+        return ""
+
+    if model != "dall-e-3":
+        print(
+            f"Warning: --style is only supported for dall-e-3; ignoring for '{model}'.",
+            file=sys.stderr,
+        )
         return ""
 
     allowed = {"vivid", "natural"}

--- a/skills/openai-image-gen/scripts/gen.py
+++ b/skills/openai-image-gen/scripts/gen.py
@@ -75,6 +75,40 @@ def get_model_defaults(model: str) -> tuple[str, str]:
         return ("1024x1024", "high")
 
 
+def normalize_background(model: str, background: str) -> str:
+    """Validate --background for GPT image models."""
+    if not model.startswith("gpt-image"):
+        return ""
+
+    value = background.strip().lower()
+    if not value:
+        return ""
+
+    allowed = {"transparent", "opaque", "auto"}
+    if value not in allowed:
+        raise ValueError(
+            f"Invalid --background '{background}'. Allowed values: transparent, opaque, auto."
+        )
+    return value
+
+
+def normalize_style(model: str, style: str) -> str:
+    """Validate --style for dall-e-3."""
+    if model != "dall-e-3":
+        return ""
+
+    value = style.strip().lower()
+    if not value:
+        return ""
+
+    allowed = {"vivid", "natural"}
+    if value not in allowed:
+        raise ValueError(
+            f"Invalid --style '{style}'. Allowed values for dall-e-3: vivid, natural."
+        )
+    return value
+
+
 def request_images(
     api_key: str,
     prompt: str,
@@ -194,6 +228,13 @@ def main() -> int:
 
     prompts = [args.prompt] * count if args.prompt else pick_prompts(count)
 
+    try:
+        normalized_background = normalize_background(args.model, args.background)
+        normalized_style = normalize_style(args.model, args.style)
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        return 2
+
     # Determine file extension based on output format
     if args.model.startswith("gpt-image") and args.output_format:
         file_ext = args.output_format
@@ -209,9 +250,9 @@ def main() -> int:
             args.model,
             size,
             quality,
-            args.background,
+            normalized_background,
             args.output_format,
-            args.style,
+            normalized_style,
         )
         data = res.get("data", [{}])[0]
         image_b64 = data.get("b64_json")

--- a/skills/openai-image-gen/scripts/test_gen.py
+++ b/skills/openai-image-gen/scripts/test_gen.py
@@ -1,9 +1,37 @@
-"""Tests for write_gallery HTML escaping (fixes #12538 - stored XSS)."""
+"""Tests for openai-image-gen helpers."""
 
 import tempfile
 from pathlib import Path
 
-from gen import write_gallery
+import pytest
+
+from gen import normalize_background, normalize_style, write_gallery
+
+
+def test_normalize_background_allows_empty_for_non_gpt_models():
+    assert normalize_background("dall-e-3", "transparent") == ""
+
+
+def test_normalize_background_normalizes_case_for_gpt_models():
+    assert normalize_background("gpt-image-1", "TRANSPARENT") == "transparent"
+
+
+def test_normalize_background_rejects_invalid_values():
+    with pytest.raises(ValueError, match="Invalid --background"):
+        normalize_background("gpt-image-1", "checkerboard")
+
+
+def test_normalize_style_allows_empty_for_non_dalle3_models():
+    assert normalize_style("gpt-image-1", "vivid") == ""
+
+
+def test_normalize_style_normalizes_case_for_dalle3():
+    assert normalize_style("dall-e-3", "NATURAL") == "natural"
+
+
+def test_normalize_style_rejects_invalid_values():
+    with pytest.raises(ValueError, match="Invalid --style"):
+        normalize_style("dall-e-3", "cinematic")
 
 
 def test_write_gallery_escapes_prompt_xss():

--- a/skills/openai-image-gen/scripts/test_gen.py
+++ b/skills/openai-image-gen/scripts/test_gen.py
@@ -12,8 +12,19 @@ def test_normalize_background_allows_empty_for_non_gpt_models():
     assert normalize_background("dall-e-3", "transparent") == ""
 
 
+def test_normalize_background_allows_empty_for_gpt_models():
+    assert normalize_background("gpt-image-1", "") == ""
+    assert normalize_background("gpt-image-1", "   ") == ""
+
+
 def test_normalize_background_normalizes_case_for_gpt_models():
     assert normalize_background("gpt-image-1", "TRANSPARENT") == "transparent"
+
+
+def test_normalize_background_warns_when_model_does_not_support_flag(capsys):
+    assert normalize_background("dall-e-3", "transparent") == ""
+    captured = capsys.readouterr()
+    assert "--background is only supported for gpt-image models" in captured.err
 
 
 def test_normalize_background_rejects_invalid_values():
@@ -25,8 +36,19 @@ def test_normalize_style_allows_empty_for_non_dalle3_models():
     assert normalize_style("gpt-image-1", "vivid") == ""
 
 
+def test_normalize_style_allows_empty_for_dalle3():
+    assert normalize_style("dall-e-3", "") == ""
+    assert normalize_style("dall-e-3", "   ") == ""
+
+
 def test_normalize_style_normalizes_case_for_dalle3():
     assert normalize_style("dall-e-3", "NATURAL") == "natural"
+
+
+def test_normalize_style_warns_when_model_does_not_support_flag(capsys):
+    assert normalize_style("gpt-image-1", "vivid") == ""
+    captured = capsys.readouterr()
+    assert "--style is only supported for dall-e-3" in captured.err
 
 
 def test_normalize_style_rejects_invalid_values():
@@ -75,4 +97,3 @@ def test_write_gallery_normal_output():
         assert "a lobster astronaut, golden hour" in html
         assert 'src="001-lobster.png"' in html
         assert "002-nook.png" in html
-

--- a/skills/openai-image-gen/scripts/test_gen.py
+++ b/skills/openai-image-gen/scripts/test_gen.py
@@ -4,7 +4,6 @@ import tempfile
 from pathlib import Path
 
 import pytest
-
 from gen import normalize_background, normalize_style, write_gallery
 
 


### PR DESCRIPTION
## What changed
- Added validation for `--background` and `--style` in `skills/openai-image-gen/scripts/gen.py`.
- Normalized accepted values to lowercase before sending requests.
- Warned and ignored those flags when the selected model does not support them instead of silently discarding them.
- Added unit tests for valid, invalid, empty-input, and incompatible-model warning paths in `skills/openai-image-gen/scripts/test_gen.py`.
- Added a changelog entry with contributor attribution.

## Why
- Invalid values previously failed late with API errors.
- Incompatible models could silently drop `--background` / `--style`, which is confusing CLI behavior.
- Early validation and explicit warnings make the tool behavior predictable and avoid unnecessary failed requests.

## Testing
- ✅ `python3 -m ruff check skills/openai-image-gen/scripts/test_gen.py`
- ✅ `python3 -m pytest -q skills/openai-image-gen/scripts/test_gen.py` (14 passed)

Fixes #36763
