### PR TITLE
fix(matrix): import queue via matrix plugin-sdk facade

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/matrix";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 

--- a/src/plugin-sdk/matrix.ts
+++ b/src/plugin-sdk/matrix.ts
@@ -90,6 +90,7 @@ export {
 export { formatDocsLink } from "../terminal/links.js";
 export type { WizardPrompter } from "../wizard/prompts.js";
 export { createScopedPairingAccess } from "./pairing-access.js";
+export { KeyedAsyncQueue } from "./keyed-async-queue.js";
 export { formatResolvedUnresolvedNote } from "./resolution-notes.js";
 export { runPluginCommandWithTimeout } from "./run-command.js";
 export { createLoggerBackedRuntime } from "./runtime.js";


### PR DESCRIPTION
## Problem
Matrix plugin could fail to load with a missing `keyed-async-queue` module in some packaged installs (`Cannot find module './keyed-async-queue.js'`).

## Root cause
The extension imported `openclaw/plugin-sdk/keyed-async-queue` directly, which is brittle under certain launcher/packaging resolution paths.

## Fix
- Export `KeyedAsyncQueue` from `openclaw/plugin-sdk/matrix`
- Switch Matrix send queue import to the matrix channel facade (`openclaw/plugin-sdk/matrix`)

## Testing
- `pnpm -s vitest run extensions/matrix/src/matrix/send-queue.test.ts`

Closes #36501
