### PR TITLE
fix(telegram): route non-default accounts without explicit binding

### DIFF
--- a/src/telegram/bot-message-context.multi-account.test.ts
+++ b/src/telegram/bot-message-context.multi-account.test.ts
@@ -1,8 +1,31 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { loadConfig } from "../config/config.js";
 import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
 
+const { defaultRouteConfig } = vi.hoisted(() => ({
+  defaultRouteConfig: {
+    agents: {
+      list: [{ id: "main", default: true }],
+    },
+    channels: { telegram: {} },
+    messages: { groupChat: { mentionPatterns: [] } },
+  },
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: vi.fn(() => defaultRouteConfig),
+  };
+});
+
 describe("buildTelegramMessageContext multi-account defaults", () => {
-  it("processes inbound DMs for non-default accounts without explicit bindings", async () => {
+  beforeEach(() => {
+    vi.mocked(loadConfig).mockReturnValue(defaultRouteConfig as never);
+  });
+
+  it("blocks inbound DMs for non-default accounts without explicit bindings", async () => {
     const ctx = await buildTelegramMessageContextForTest({
       accountId: "jarvis2",
       message: {
@@ -12,33 +35,57 @@ describe("buildTelegramMessageContext multi-account defaults", () => {
       },
     });
 
-    expect(ctx).not.toBeNull();
-    expect(ctx?.route.accountId).toBe("jarvis2");
+    expect(ctx).toBeNull();
   });
 
-  it("routes non-default account DMs without relying on account enabled flags", async () => {
+  it("blocks non-default account when default account is disabled", async () => {
+    vi.mocked(loadConfig).mockReturnValue({
+      ...defaultRouteConfig,
+      channels: {
+        telegram: {
+          accounts: {
+            default: { enabled: false },
+            jarvis2: { enabled: true },
+          },
+          defaultAccount: "default",
+        },
+      },
+    } as never);
+
     const ctx = await buildTelegramMessageContextForTest({
       accountId: "jarvis2",
-      cfg: {
-        agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" } },
-        channels: {
-          telegram: {
-            accounts: {
-              default: { enabled: false },
-              jarvis2: { enabled: true },
-            },
-          },
-        },
-        messages: { groupChat: { mentionPatterns: [] } },
-      },
       message: {
         chat: { id: 99_002, type: "private" },
-        from: { id: 42, first_name: "Guido" },
-        text: "/ping",
+        from: { id: 42, first_name: "Alex" },
+        text: "hello",
       },
     });
 
-    expect(ctx).not.toBeNull();
-    expect(ctx?.route.accountId).toBe("jarvis2");
+    expect(ctx).toBeNull();
+  });
+
+  it("blocks non-default account when defaultAccount points to a missing id", async () => {
+    vi.mocked(loadConfig).mockReturnValue({
+      ...defaultRouteConfig,
+      channels: {
+        telegram: {
+          accounts: {
+            brainstorm: { enabled: true },
+          },
+          defaultAccount: "missing",
+        },
+      },
+    } as never);
+
+    const ctx = await buildTelegramMessageContextForTest({
+      accountId: "brainstorm",
+      message: {
+        chat: { id: 99_003, type: "private" },
+        from: { id: 43, first_name: "Maya" },
+        text: "hello",
+      },
+    });
+
+    expect(ctx).toBeNull();
   });
 });

--- a/src/telegram/bot-message-context.multi-account.test.ts
+++ b/src/telegram/bot-message-context.multi-account.test.ts
@@ -19,6 +19,18 @@ describe("buildTelegramMessageContext multi-account defaults", () => {
   it("routes non-default account DMs without relying on account enabled flags", async () => {
     const ctx = await buildTelegramMessageContextForTest({
       accountId: "jarvis2",
+      cfg: {
+        agents: { defaults: { model: "anthropic/claude-opus-4-5", workspace: "/tmp/openclaw" } },
+        channels: {
+          telegram: {
+            accounts: {
+              default: { enabled: false },
+              jarvis2: { enabled: true },
+            },
+          },
+        },
+        messages: { groupChat: { mentionPatterns: [] } },
+      },
       message: {
         chat: { id: 99_002, type: "private" },
         from: { id: 42, first_name: "Guido" },

--- a/src/telegram/bot-message-context.multi-account.test.ts
+++ b/src/telegram/bot-message-context.multi-account.test.ts
@@ -16,23 +16,13 @@ describe("buildTelegramMessageContext multi-account defaults", () => {
     expect(ctx?.route.accountId).toBe("jarvis2");
   });
 
-  it("still routes non-default account when default account is disabled", async () => {
+  it("routes non-default account DMs without relying on account enabled flags", async () => {
     const ctx = await buildTelegramMessageContextForTest({
       accountId: "jarvis2",
       message: {
         chat: { id: 99_002, type: "private" },
         from: { id: 42, first_name: "Guido" },
         text: "/ping",
-      },
-      cfg: {
-        channels: {
-          telegram: {
-            accounts: {
-              default: { enabled: false },
-              jarvis2: { enabled: true },
-            },
-          },
-        },
       },
     });
 

--- a/src/telegram/bot-message-context.multi-account.test.ts
+++ b/src/telegram/bot-message-context.multi-account.test.ts
@@ -25,7 +25,7 @@ describe("buildTelegramMessageContext multi-account defaults", () => {
     vi.mocked(loadConfig).mockReturnValue(defaultRouteConfig as never);
   });
 
-  it("blocks inbound DMs for non-default accounts without explicit bindings", async () => {
+  it("accepts inbound DMs for non-default accounts without explicit bindings", async () => {
     const ctx = await buildTelegramMessageContextForTest({
       accountId: "jarvis2",
       message: {
@@ -35,10 +35,10 @@ describe("buildTelegramMessageContext multi-account defaults", () => {
       },
     });
 
-    expect(ctx).toBeNull();
+    expect(ctx).not.toBeNull();
   });
 
-  it("blocks non-default account when default account is disabled", async () => {
+  it("accepts non-default account when default account is disabled", async () => {
     vi.mocked(loadConfig).mockReturnValue({
       ...defaultRouteConfig,
       channels: {
@@ -61,10 +61,10 @@ describe("buildTelegramMessageContext multi-account defaults", () => {
       },
     });
 
-    expect(ctx).toBeNull();
+    expect(ctx).not.toBeNull();
   });
 
-  it("blocks non-default account when defaultAccount points to a missing id", async () => {
+  it("accepts non-default account when defaultAccount points to a missing id", async () => {
     vi.mocked(loadConfig).mockReturnValue({
       ...defaultRouteConfig,
       channels: {
@@ -86,6 +86,6 @@ describe("buildTelegramMessageContext multi-account defaults", () => {
       },
     });
 
-    expect(ctx).toBeNull();
+    expect(ctx).not.toBeNull();
   });
 });

--- a/src/telegram/bot-message-context.multi-account.test.ts
+++ b/src/telegram/bot-message-context.multi-account.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+
+describe("buildTelegramMessageContext multi-account defaults", () => {
+  it("processes inbound DMs for non-default accounts without explicit bindings", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      accountId: "jarvis2",
+      message: {
+        chat: { id: 99_001, type: "private" },
+        from: { id: 41, first_name: "Guido" },
+        text: "/ping",
+      },
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.route.accountId).toBe("jarvis2");
+  });
+
+  it("still routes non-default account when default account is disabled", async () => {
+    const ctx = await buildTelegramMessageContextForTest({
+      accountId: "jarvis2",
+      message: {
+        chat: { id: 99_002, type: "private" },
+        from: { id: 42, first_name: "Guido" },
+        text: "/ping",
+      },
+      cfg: {
+        channels: {
+          telegram: {
+            accounts: {
+              default: { enabled: false },
+              jarvis2: { enabled: true },
+            },
+          },
+        },
+      },
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.route.accountId).toBe("jarvis2");
+  });
+});

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -48,7 +48,11 @@ import {
   resolveAgentRoute,
   type ResolvedAgentRoute,
 } from "../routing/resolve-route.js";
-import { buildAgentMainSessionKey, resolveThreadSessionKeys } from "../routing/session-key.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  buildAgentMainSessionKey,
+  resolveThreadSessionKeys,
+} from "../routing/session-key.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../security/dm-policy-shared.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
@@ -256,6 +260,19 @@ export const buildTelegramMessageContext = async ({
   const configuredBinding = configuredRoute.configuredBinding;
   const configuredBindingSessionKey = configuredRoute.boundSessionKey ?? "";
   route = configuredRoute.route;
+  const requiresExplicitAccountBinding = (candidate: ResolvedAgentRoute): boolean =>
+    candidate.accountId !== DEFAULT_ACCOUNT_ID && candidate.matchedBy === "default";
+  // Fail closed for named Telegram accounts when route resolution falls back to
+  // default-agent routing. This prevents cross-account DM/session contamination.
+  if (requiresExplicitAccountBinding(route)) {
+    logInboundDrop({
+      log: logVerbose,
+      channel: "telegram",
+      reason: "non-default account requires explicit binding",
+      target: route.accountId,
+    });
+    return null;
+  }
   // Calculate groupAllowOverride first - it's needed for both DM and group allowlist checks
   const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);
   // For DMs, prefer per-DM/topic allowFrom (groupAllowOverride) over account-level allowFrom

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -48,11 +48,7 @@ import {
   resolveAgentRoute,
   type ResolvedAgentRoute,
 } from "../routing/resolve-route.js";
-import {
-  DEFAULT_ACCOUNT_ID,
-  buildAgentMainSessionKey,
-  resolveThreadSessionKeys,
-} from "../routing/session-key.js";
+import { buildAgentMainSessionKey, resolveThreadSessionKeys } from "../routing/session-key.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../security/dm-policy-shared.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import {
@@ -260,19 +256,6 @@ export const buildTelegramMessageContext = async ({
   const configuredBinding = configuredRoute.configuredBinding;
   const configuredBindingSessionKey = configuredRoute.boundSessionKey ?? "";
   route = configuredRoute.route;
-  const requiresExplicitAccountBinding = (candidate: ResolvedAgentRoute): boolean =>
-    candidate.accountId !== DEFAULT_ACCOUNT_ID && candidate.matchedBy === "default";
-  // Fail closed for named Telegram accounts when route resolution falls back to
-  // default-agent routing. This prevents cross-account DM/session contamination.
-  if (requiresExplicitAccountBinding(route)) {
-    logInboundDrop({
-      log: logVerbose,
-      channel: "telegram",
-      reason: "non-default account requires explicit binding",
-      target: route.accountId,
-    });
-    return null;
-  }
   // Calculate groupAllowOverride first - it's needed for both DM and group allowlist checks
   const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);
   // For DMs, prefer per-DM/topic allowFrom (groupAllowOverride) over account-level allowFrom


### PR DESCRIPTION
## Problem
After 2026.3.2, non-default Telegram accounts could consume updates but silently drop inbound DMs unless explicitly ACP-bound; only `default` responded (#36739).

## Root cause
`buildTelegramMessageContext` had a fail-closed guard that dropped any non-default account route when `matchedBy === "default"`.

## Fix
- Removed the non-default fail-closed drop
- Added regression coverage that:
  - non-default DMs route without explicit binding
  - non-default routing still works when `accounts.default.enabled=false`

## Testing
- `pnpm -s vitest run src/telegram/bot-message-context.multi-account.test.ts src/telegram/bot-message-context.acp-bindings.test.ts`

Closes #36739
