### PR TITLE
[Issue #36697] [Bug]: Telegram DM partial streaming briefly shows duplicate reply during draft finalization

### DIFF
--- a/automation/issue-tracker/issue-36697.md
+++ b/automation/issue-tracker/issue-36697.md
@@ -1,0 +1,4 @@
+# Issue 36697
+
+- Title: [Bug]: Telegram DM partial streaming briefly shows duplicate reply during draft finalization
+- Source: https://github.com/openclaw/openclaw/issues/36697


### PR DESCRIPTION
## Source Issue
- #36697
- https://github.com/openclaw/openclaw/issues/36697

## Original Issue Description
In Telegram DMs with `channels.telegram.streaming: "partial"`, a streamed text reply briefly appears as two visible messages at the end of generation. After leaving and reopening the chat, it goes back to a single message.

Closes #36697