### PR TITLE
[Issue #36725] # Bug Report: Telegram Multi-Account - Non-Default Accounts Don't Process Messages

### DIFF
--- a/automation/issue-tracker/issue-36725.md
+++ b/automation/issue-tracker/issue-36725.md
@@ -1,0 +1,4 @@
+# Issue 36725
+
+- Title: # Bug Report: Telegram Multi-Account - Non-Default Accounts Don't Process Messages
+- Source: https://github.com/openclaw/openclaw/issues/36725


### PR DESCRIPTION
## Source Issue
- #36725
- https://github.com/openclaw/openclaw/issues/36725

## Original Issue Description
When multiple Telegram bot accounts are configured, only the "default" account processes incoming messages. Secondary accounts successfully connect to Telegram API and consume messages, but OpenClaw does not route them to the agent (no processing, no logs, no responses).

Closes #36725