### PR TITLE
[Issue #36736] Discord channel-edit does not pass appliedTags to API (forum post tags)

### DIFF
--- a/automation/issue-tracker/issue-36736.md
+++ b/automation/issue-tracker/issue-36736.md
@@ -1,0 +1,4 @@
+# Issue 36736
+
+- Title: Discord channel-edit does not pass appliedTags to API (forum post tags)
+- Source: https://github.com/openclaw/openclaw/issues/36736


### PR DESCRIPTION
## Source Issue
- #36736
- https://github.com/openclaw/openclaw/issues/36736

## Original Issue Description
`channel-edit` action ignores the `appliedTags` parameter, so forum post tags (for example Open -> Done) cannot be changed via the message tool.

Closes #36736