### PR TITLE
[Issue #36737] openclaw status fails when Telegram botToken uses file SecretRef (reload succeeds)

### DIFF
--- a/automation/issue-tracker/issue-36737.md
+++ b/automation/issue-tracker/issue-36737.md
@@ -1,0 +1,4 @@
+# Issue 36737
+
+- Title: openclaw status fails when Telegram botToken uses file SecretRef (reload succeeds)
+- Source: https://github.com/openclaw/openclaw/issues/36737


### PR DESCRIPTION
## Source Issue
- #36737
- https://github.com/openclaw/openclaw/issues/36737

## Original Issue Description
When `channels.telegram.botToken` is configured as a file-backed SecretRef, `openclaw status` fails with an unresolved SecretRef error even though `openclaw secrets reload --json` reports success.

Closes #36737