### PR TITLE
[Issue #36738] [Feature]: Plugin SDK — registerAgent() + manifest agents array for portable agent distribution

### DIFF
--- a/automation/issue-tracker/issue-36738.md
+++ b/automation/issue-tracker/issue-36738.md
@@ -1,0 +1,4 @@
+# Issue 36738
+
+- Title: [Feature]: Plugin SDK — registerAgent() + manifest agents array for portable agent distribution
+- Source: https://github.com/openclaw/openclaw/issues/36738


### PR DESCRIPTION
## Source Issue
- #36738
- https://github.com/openclaw/openclaw/issues/36738

## Original Issue Description
Plugins should be able to declare and register agents via the plugin manifest and SDK, enabling portable agent distribution through the plugin ecosystem.

Closes #36738