### PR TITLE
[Issue #36739] [Bug]: # Bug Report: Telegram Multi-Account - Non-Default Accounts Don't Process Messages [REGRESSION]  ⚠️ **REGRESSION:** This issue appeared AFTER upgrading to OpenClaw 2026.3.2. Multi-account Telegram bots worked correctly in the previous version.

### DIFF
--- a/automation/issue-tracker/issue-36739.md
+++ b/automation/issue-tracker/issue-36739.md
@@ -1,0 +1,4 @@
+# Issue 36739
+
+- Title: [Bug]: # Bug Report: Telegram Multi-Account - Non-Default Accounts Don't Process Messages [REGRESSION] ⚠️
+- Source: https://github.com/openclaw/openclaw/issues/36739


### PR DESCRIPTION
## Source Issue
- #36739
- https://github.com/openclaw/openclaw/issues/36739

## Original Issue Description
Regression report: after upgrading to OpenClaw 2026.3.2, only the default Telegram account processes messages while secondary configured accounts stop processing despite appearing connected.

Closes #36739