### PR TITLE
[Issue #36742] [Bug]: Gateway crashes with dual-account Telegram config under systemd

### DIFF
--- a/automation/issue-tracker/issue-36742.md
+++ b/automation/issue-tracker/issue-36742.md
@@ -1,0 +1,4 @@
+# Issue 36742
+
+- Title: [Bug]: Gateway crashes with dual-account Telegram config under systemd
+- Source: https://github.com/openclaw/openclaw/issues/36742


### PR DESCRIPTION
## Source Issue
- #36742
- https://github.com/openclaw/openclaw/issues/36742

## Original Issue Description
Adding a second Telegram account via `channels.telegram.accounts` causes the gateway to crash a few seconds after providers start polling under systemd, while single-account configuration remains stable.

Closes #36742