### PR TITLE
[Issue #36754] Extension discovery silently skips symlinked plugin directories

### DIFF
--- a/automation/issue-tracker/issue-36754.md
+++ b/automation/issue-tracker/issue-36754.md
@@ -1,0 +1,4 @@
+# Issue 36754
+
+- Title: Extension discovery silently skips symlinked plugin directories
+- Source: https://github.com/openclaw/openclaw/issues/36754


### PR DESCRIPTION
## Source Issue
- #36754
- https://github.com/openclaw/openclaw/issues/36754

## Original Issue Description
Plugin discovery scans directory entries with `Dirent.isDirectory()` and silently skips symlinked plugin directories, so symlinked extensions under `~/.openclaw/extensions/` are not discovered.

Closes #36754