### PR TITLE
[Issue #36757] [Feature]: Add per-message link preview control to Telegram message tool

### DIFF
--- a/automation/issue-tracker/issue-36757.md
+++ b/automation/issue-tracker/issue-36757.md
@@ -1,0 +1,4 @@
+# Issue 36757
+
+- Title: [Feature]: Add per-message link preview control to Telegram message tool
+- Source: https://github.com/openclaw/openclaw/issues/36757


### PR DESCRIPTION
## Source Issue
- #36757
- https://github.com/openclaw/openclaw/issues/36757

## Original Issue Description
Request to add per-message `linkPreview` control to the Telegram message tool so URL previews can be disabled on specific sends instead of only by account-level defaults.

Closes #36757