### PR TITLE
fix(telegram): restore non-default account DM routing

### DIFF
--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -260,18 +260,28 @@ export const buildTelegramMessageContext = async ({
   const configuredBinding = configuredRoute.configuredBinding;
   const configuredBindingSessionKey = configuredRoute.boundSessionKey ?? "";
   route = configuredRoute.route;
-  const requiresExplicitAccountBinding = (candidate: ResolvedAgentRoute): boolean =>
+  const needsAccountScopedFallbackRoute = (candidate: ResolvedAgentRoute): boolean =>
     candidate.accountId !== DEFAULT_ACCOUNT_ID && candidate.matchedBy === "default";
-  // Fail closed for named Telegram accounts when route resolution falls back to
-  // default-agent routing. This prevents cross-account DM/session contamination.
-  if (requiresExplicitAccountBinding(route)) {
-    logInboundDrop({
-      log: logVerbose,
+  if (needsAccountScopedFallbackRoute(route)) {
+    // Keep non-default account traffic routable while forcing account-scoped session
+    // keys to avoid cross-account contamination when dmScope falls back to "main".
+    const fallbackSessionKey = buildAgentSessionKey({
+      agentId: route.agentId,
       channel: "telegram",
-      reason: "non-default account requires explicit binding",
-      target: route.accountId,
-    });
-    return null;
+      accountId: route.accountId,
+      peer: isGroup
+        ? { kind: "group", id: `${route.accountId}:${peerId}` }
+        : { kind: "direct", id: peerId },
+      dmScope: isGroup ? freshCfg.session?.dmScope : "per-account-channel-peer",
+      identityLinks: freshCfg.session?.identityLinks,
+    }).toLowerCase();
+    route = {
+      ...route,
+      sessionKey: fallbackSessionKey,
+    };
+    logVerbose(
+      `telegram: account-scoped fallback route applied for ${route.accountId} -> ${fallbackSessionKey}`,
+    );
   }
   // Calculate groupAllowOverride first - it's needed for both DM and group allowlist checks
   const groupAllowOverride = firstDefined(topicConfig?.allowFrom, groupConfig?.allowFrom);

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -813,7 +813,7 @@ describe("createTelegramBot", () => {
     expect(payload.SessionKey).toBe("agent:opie:main");
   });
 
-  it("drops non-default account DMs without explicit bindings", async () => {
+  it("routes non-default account DMs without explicit bindings to an account-scoped session", async () => {
     loadConfig.mockReturnValue({
       channels: {
         telegram: {
@@ -842,7 +842,10 @@ describe("createTelegramBot", () => {
       getFile: async () => ({ download: async () => new Uint8Array() }),
     });
 
-    expect(replySpy).not.toHaveBeenCalled();
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = replySpy.mock.calls[0][0];
+    expect(payload.AccountId).toBe("opie");
+    expect(payload.SessionKey).toBe("agent:main:telegram:opie:direct:999");
   });
 
   it("applies group mention overrides and fallback behavior", async () => {


### PR DESCRIPTION
## Summary
- replace the non-default Telegram account hard-drop (`matchedBy: "default"`) with an account-scoped fallback session route
- keep non-default account traffic routable while forcing account-specific session keys to avoid cross-account contamination
- update Telegram regression coverage to assert non-default accounts without explicit bindings still process DMs on isolated session keys

## Testing
- pnpm vitest src/telegram/bot.create-telegram-bot.test.ts src/telegram/bot-message-context.acp-bindings.test.ts

Fixes #36739
