### PR TITLE
perf(media): surface cleanOldMedia cleanup failures via optional callback

### DIFF
--- a/src/media/store.test.ts
+++ b/src/media/store.test.ts
@@ -116,6 +116,50 @@ describe("media store", () => {
     });
   });
 
+  it("reports cleanup rm failures via onCleanupError callback", async () => {
+    await withTempStore(async (store) => {
+      const saved = await store.saveMediaBuffer(Buffer.from("stale"), "text/plain");
+      const past = Date.now() - 10_000;
+      await fs.utimes(saved.path, past / 1000, past / 1000);
+
+      const cleanupError = Object.assign(new Error("permission denied"), { code: "EACCES" });
+      const onCleanupError = vi.fn();
+      const rmSpy = vi.spyOn(fs, "rm").mockRejectedValueOnce(cleanupError);
+      try {
+        await store.cleanOldMedia(1, { onCleanupError });
+      } finally {
+        rmSpy.mockRestore();
+      }
+
+      expect(onCleanupError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: cleanupError,
+          path: saved.path,
+          operation: "rm",
+        }),
+      );
+    });
+  });
+
+  it("skips onCleanupError for expected ENOENT cleanup races", async () => {
+    await withTempStore(async (store) => {
+      const saved = await store.saveMediaBuffer(Buffer.from("stale"), "text/plain");
+      const past = Date.now() - 10_000;
+      await fs.utimes(saved.path, past / 1000, past / 1000);
+
+      const cleanupError = Object.assign(new Error("already removed"), { code: "ENOENT" });
+      const onCleanupError = vi.fn();
+      const rmSpy = vi.spyOn(fs, "rm").mockRejectedValueOnce(cleanupError);
+      try {
+        await store.cleanOldMedia(1, { onCleanupError });
+      } finally {
+        rmSpy.mockRestore();
+      }
+
+      expect(onCleanupError).not.toHaveBeenCalled();
+    });
+  });
+
   it("sets correct mime for xlsx by extension", async () => {
     await withTempStore(async (store, home) => {
       const xlsxPath = path.join(home, "sheet.xlsx");

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -88,21 +88,62 @@ export async function ensureMediaDir() {
   return mediaDir;
 }
 
-export async function cleanOldMedia(ttlMs = DEFAULT_TTL_MS) {
+export type CleanOldMediaErrorContext = {
+  error: unknown;
+  path: string;
+  operation: "readdir" | "stat" | "rm";
+};
+
+export type CleanOldMediaOptions = {
+  onCleanupError?: (context: CleanOldMediaErrorContext) => void;
+};
+
+function shouldReportCleanupError(error: unknown): boolean {
+  const rawCode =
+    typeof error === "object" && error !== null && "code" in error
+      ? (error as { code?: unknown }).code
+      : undefined;
+  const code =
+    typeof rawCode === "string" ? rawCode : typeof rawCode === "number" ? String(rawCode) : "";
+  return code !== "ENOENT";
+}
+
+function reportCleanupError(
+  options: CleanOldMediaOptions | undefined,
+  context: CleanOldMediaErrorContext,
+) {
+  if (!shouldReportCleanupError(context.error)) {
+    return;
+  }
+  options?.onCleanupError?.(context);
+}
+
+export async function cleanOldMedia(ttlMs = DEFAULT_TTL_MS, options?: CleanOldMediaOptions) {
   const mediaDir = await ensureMediaDir();
-  const entries = await fs.readdir(mediaDir).catch(() => []);
+  const entries = await fs.readdir(mediaDir).catch((error) => {
+    reportCleanupError(options, { error, path: mediaDir, operation: "readdir" });
+    return [];
+  });
   const now = Date.now();
   const removeExpiredFilesInDir = async (dir: string) => {
-    const dirEntries = await fs.readdir(dir).catch(() => []);
+    const dirEntries = await fs.readdir(dir).catch((error) => {
+      reportCleanupError(options, { error, path: dir, operation: "readdir" });
+      return [];
+    });
     await Promise.all(
       dirEntries.map(async (entry) => {
         const full = path.join(dir, entry);
-        const stat = await fs.stat(full).catch(() => null);
+        const stat = await fs.stat(full).catch((error) => {
+          reportCleanupError(options, { error, path: full, operation: "stat" });
+          return null;
+        });
         if (!stat || !stat.isFile()) {
           return;
         }
         if (now - stat.mtimeMs > ttlMs) {
-          await fs.rm(full).catch(() => {});
+          await fs.rm(full).catch((error) => {
+            reportCleanupError(options, { error, path: full, operation: "rm" });
+          });
         }
       }),
     );
@@ -111,7 +152,10 @@ export async function cleanOldMedia(ttlMs = DEFAULT_TTL_MS) {
   await Promise.all(
     entries.map(async (file) => {
       const full = path.join(mediaDir, file);
-      const stat = await fs.stat(full).catch(() => null);
+      const stat = await fs.stat(full).catch((error) => {
+        reportCleanupError(options, { error, path: full, operation: "stat" });
+        return null;
+      });
       if (!stat) {
         return;
       }
@@ -120,7 +164,9 @@ export async function cleanOldMedia(ttlMs = DEFAULT_TTL_MS) {
         return;
       }
       if (stat.isFile() && now - stat.mtimeMs > ttlMs) {
-        await fs.rm(full).catch(() => {});
+        await fs.rm(full).catch((error) => {
+          reportCleanupError(options, { error, path: full, operation: "rm" });
+        });
       }
     }),
   );


### PR DESCRIPTION
## Summary
- add optional onCleanupError to cleanOldMedia with structured context (operation, path, error)
- keep cleanup best-effort behavior while suppressing expected ENOENT races
- add targeted tests for rm-failure reporting and ENOENT suppression

## Why
cleanOldMedia previously swallowed cleanup failures, which made permission/filesystem issues hard to diagnose in production.

## Impact
Callers can now opt into observability without changing default behavior.

## Risk
Low: behavior is additive and tests cover the new error-reporting branches.

## Validation
- pnpm vitest src/media/store.test.ts --run
- pnpm exec oxlint --type-aware src/media/store.ts src/media/store.test.ts