### PR TITLE
fix(ui): hoist lifecycle connect test mocks

### DIFF
--- a/ui/src/ui/app-lifecycle-connect.node.test.ts
+++ b/ui/src/ui/app-lifecycle-connect.node.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
-const connectGatewayMock = vi.fn();
-const loadBootstrapMock = vi.fn();
+const { connectGatewayMock, loadBootstrapMock } = vi.hoisted(() => ({
+  connectGatewayMock: vi.fn(),
+  loadBootstrapMock: vi.fn(),
+}));
 
 vi.mock("./app-gateway.ts", () => ({
   connectGateway: connectGatewayMock,


### PR DESCRIPTION
## Summary

- Problem: `ui/src/ui/app-lifecycle-connect.node.test.ts` uses hoisted `vi.mock` factories that capture top-level mock variables, which breaks Vitest browser mode with an unhandled module-mocking error.
- Why it matters: The failing mock setup prevents the lifecycle connect test from running and aborts the broader Control UI browser test run before reporting that file.
- What changed: Replaced the top-level mock declarations with `vi.hoisted(...)` so the mocked functions are safe to reference from hoisted `vi.mock` factories.
- What did NOT change (scope boundary): No production Control UI code changed; this is test-only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes none
- Related none

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): Control UI tests
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm --dir ui exec vitest run --config vitest.config.ts src/ui/app-lifecycle-connect.node.test.ts`.
2. Observe the pre-fix browser mock crash from Vitest hoist rules.
3. Replace the test's top-level mock declarations with `vi.hoisted(...)` and rerun the same command.

### Expected

- `src/ui/app-lifecycle-connect.node.test.ts` runs normally under browser mode.

### Actual

- After the fix, the test file passes under browser mode.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm --dir ui exec vitest run --config vitest.config.ts src/ui/app-lifecycle-connect.node.test.ts` passed; `pnpm --dir ui build` passed.
- Edge cases checked: Confirmed the sibling `src/ui/app-gateway.node.test.ts` already passed and that the failure signature mapped specifically to the lifecycle connect test's mock pattern.
- What you did **not** verify: `pnpm --dir ui test` still reports other unrelated existing failures in `config-form.browser.test.ts`, `navigation.test.ts`, `open-external-url.test.ts`, `storage.node.test.ts`, `translate.test.ts`, and `views/cron.test.ts`.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR.
- Files/config to restore: `ui/src/ui/app-lifecycle-connect.node.test.ts`
- Known bad symptoms reviewers should watch for: The lifecycle connect test failing again with a Vitest hoist/mock error in browser mode.

## Risks and Mitigations

- Risk: Very low; test-only mock initialization changed.
  - Mitigation: Kept the fix to the repo's existing `vi.hoisted` testing pattern and verified the targeted browser test passes.

AI-assisted: yes.
Testing: targeted browser Vitest run and Control UI build.
