### PR TITLE
fix(discord): swallow reconnect-exhausted gateway crashes

### DIFF
--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -276,6 +276,20 @@ describe("runDiscordGatewayLifecycle", () => {
     });
   });
 
+  it("handles queued reconnect exhaustion errors without crashing lifecycle", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const { lifecycleParams, runtimeError } = createLifecycleHarness({
+      pendingGatewayErrors: [
+        new Error("Uncaught exception: Error: max reconnect attempts (0) reached after code 1006"),
+      ],
+    });
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+    expect(runtimeError).toHaveBeenCalledWith(
+      expect.stringContaining("reconnect attempts exhausted"),
+    );
+  });
+
   it("retries stalled HELLO with resume before forcing fresh identify", async () => {
     vi.useFakeTimers();
     try {

--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -278,16 +278,26 @@ describe("runDiscordGatewayLifecycle", () => {
 
   it("handles queued reconnect exhaustion errors without crashing lifecycle", async () => {
     const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
-    const { lifecycleParams, runtimeError } = createLifecycleHarness({
-      pendingGatewayErrors: [
-        new Error("Uncaught exception: Error: max reconnect attempts (0) reached after code 1006"),
-      ],
-    });
+    const { lifecycleParams, start, stop, threadStop, runtimeError, releaseEarlyGatewayErrorGuard } =
+      createLifecycleHarness({
+        pendingGatewayErrors: [
+          new Error(
+            "Uncaught exception: Error: max reconnect attempts (0) reached after code 1006",
+          ),
+        ],
+      });
 
     await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
     expect(runtimeError).toHaveBeenCalledWith(
       expect.stringContaining("reconnect attempts exhausted"),
     );
+    expectLifecycleCleanup({
+      start,
+      stop,
+      threadStop,
+      waitCalls: 0,
+      releaseEarlyGatewayErrorGuard,
+    });
   });
 
   it("retries stalled HELLO with resume before forcing fresh identify", async () => {

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -261,6 +261,8 @@ export async function runDiscordGatewayLifecycle(params: {
   }
 
   let sawDisallowedIntents = false;
+  let sawReconnectExhausted = false;
+  const isReconnectExhaustedError = (err: unknown) => /max reconnect attempts/i.test(String(err));
   const logGatewayError = (err: unknown) => {
     if (params.isDisallowedIntentsError(err)) {
       sawDisallowedIntents = true;
@@ -271,12 +273,21 @@ export async function runDiscordGatewayLifecycle(params: {
       );
       return;
     }
+    if (isReconnectExhaustedError(err)) {
+      sawReconnectExhausted = true;
+      params.runtime.error?.(
+        danger(
+          "discord gateway reconnect attempts exhausted; stopping Discord monitor without crashing the gateway",
+        ),
+      );
+      return;
+    }
     params.runtime.error?.(danger(`discord gateway error: ${String(err)}`));
   };
   const shouldStopOnGatewayError = (err: unknown) => {
     const message = String(err);
     return (
-      message.includes("Max reconnect attempts") ||
+      isReconnectExhaustedError(err) ||
       message.includes("Fatal Gateway error") ||
       params.isDisallowedIntentsError(err)
     );
@@ -323,7 +334,11 @@ export async function runDiscordGatewayLifecycle(params: {
       },
     });
   } catch (err) {
-    if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {
+    if (
+      !sawDisallowedIntents &&
+      !params.isDisallowedIntentsError(err) &&
+      !(sawReconnectExhausted && isReconnectExhaustedError(err))
+    ) {
       throw err;
     }
   } finally {


### PR DESCRIPTION
## Problem
Discord monitor could still bubble uncaught gateway errors like `Max reconnect attempts (0) reached after code 1006`, crashing gateway processes instead of degrading gracefully (#36055).

## Root cause
- Reconnect-exhausted detection was narrow/case-sensitive
- Lifecycle catch only suppressed disallowed-intents failures

## Fix
- Added case-insensitive reconnect-exhausted detection
- Logged explicit non-crashing runtime error for reconnect exhaustion
- Suppressed lifecycle throws for reconnect-exhausted failures (similar to disallowed intents handling)
- Added regression test for wrapped/lowercase reconnect-exhausted error text

## Testing
- `pnpm -s vitest run src/discord/monitor/provider.lifecycle.test.ts`

Closes #36055
