### PR TITLE
fix: clarify Telegram groupAllowFrom sender vs group ID semantics

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -815,7 +815,7 @@ Primary reference:
 - `channels.telegram.allowFrom`: DM allowlist (numeric Telegram user IDs). `allowlist` requires at least one sender ID. `open` requires `"*"`. `openclaw doctor --fix` can resolve legacy `@username` entries to IDs and can recover allowlist entries from pairing-store files in allowlist migration flows.
 - `channels.telegram.defaultTo`: default Telegram target used by CLI `--deliver` when no explicit `--reply-to` is provided.
 - `channels.telegram.groupPolicy`: `open | allowlist | disabled` (default: allowlist).
-- `channels.telegram.groupAllowFrom`: group sender allowlist (numeric Telegram user IDs). `openclaw doctor --fix` can resolve legacy `@username` entries to IDs. Non-numeric entries are ignored at auth time. Group auth does not use DM pairing-store fallback (`2026.2.25+`).
+- `channels.telegram.groupAllowFrom`: group sender allowlist (numeric Telegram user IDs). This field does **not** accept group/chat IDs (for example `-100...`). Use `channels.telegram.groups` to allowlist group chats, and `groupAllowFrom` to allowlist senders inside those chats. `openclaw doctor --fix` can resolve legacy `@username` entries to IDs. Non-numeric entries are ignored at auth time. Group auth does not use DM pairing-store fallback (`2026.2.25+`).
 - Multi-account precedence:
   - When two or more account IDs are configured, set `channels.telegram.defaultAccount` (or include `channels.telegram.accounts.default`) to make default routing explicit.
   - If neither is set, OpenClaw falls back to the first normalized account ID and `openclaw doctor` warns.

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -31,8 +31,8 @@ function warnInvalidAllowFromEntries(entries: string[]) {
       [
         "Invalid allowFrom entry:",
         JSON.stringify(entry),
-        "- allowFrom/groupAllowFrom authorization requires numeric Telegram sender IDs only.",
-        'If you had "@username" entries, re-run onboarding (it resolves @username to IDs) or replace them manually.',
+        "- allowFrom/groupAllowFrom authorization requires numeric Telegram sender IDs only (not group/chat IDs like -100...).",
+        'Use channels.telegram.groups (or channels.telegram.accounts.<id>.groups) to allowlist group chats. If you had "@username" entries, re-run onboarding (it resolves @username to IDs) or replace them manually.',
       ].join(" "),
     );
   }


### PR DESCRIPTION
## Summary

Clarifies Telegram allowlist behavior to avoid the `groupAllowFrom` confusion reported in #36753.

## Changes

- Updated Telegram auth warning text to explicitly state that `allowFrom/groupAllowFrom` accepts **sender IDs only**, not group/chat IDs like `-100...`.
- Added guidance in the warning to use `channels.telegram.groups` / `channels.telegram.accounts.<id>.groups` for group chat allowlisting.
- Updated docs (`docs/channels/telegram.md`) to clearly separate:
  - `groups` = allowlist chats
  - `groupAllowFrom` = allowlist senders inside chats

## Testing

- `pnpm exec vitest run src/telegram/group-access.group-policy.test.ts`

Fixes openclaw/openclaw#36753
