### PR TITLE
fix(telegram): preserve topic target for native /new and /reset

### DIFF
--- a/src/acp/conversation-id.test.ts
+++ b/src/acp/conversation-id.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { parseTelegramChatIdFromTarget } from "./conversation-id.js";
+
+describe("parseTelegramChatIdFromTarget", () => {
+  it("parses direct telegram targets", () => {
+    expect(parseTelegramChatIdFromTarget("telegram:-100123")).toBe("-100123");
+  });
+
+  it("parses telegram group targets with topic suffix", () => {
+    expect(parseTelegramChatIdFromTarget("telegram:group:-100123:topic:42")).toBe("-100123");
+  });
+
+  it("returns undefined for non-telegram targets", () => {
+    expect(parseTelegramChatIdFromTarget("slack:C123")).toBeUndefined();
+  });
+});

--- a/src/acp/conversation-id.ts
+++ b/src/acp/conversation-id.ts
@@ -19,11 +19,15 @@ export function parseTelegramChatIdFromTarget(raw: unknown): string | undefined 
   if (!text) {
     return undefined;
   }
-  const match = text.match(/^telegram:(-?\d+)$/);
-  if (!match?.[1]) {
-    return undefined;
+  const directMatch = text.match(/^telegram:(-?\d+)$/);
+  if (directMatch?.[1]) {
+    return directMatch[1];
   }
-  return match[1];
+  const groupMatch = text.match(/^telegram:group:(-?\d+)(?::topic:\d+)?$/);
+  if (groupMatch?.[1]) {
+    return groupMatch[1];
+  }
+  return undefined;
 }
 
 export function buildTelegramTopicConversationId(params: {

--- a/src/telegram/bot-native-commands.session-meta.test.ts
+++ b/src/telegram/bot-native-commands.session-meta.test.ts
@@ -261,10 +261,11 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(persistentBindingMocks.ensureConfiguredAcpBindingSession).toHaveBeenCalledTimes(1);
     const dispatchCall = (
       replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
-        [{ ctx?: { CommandTargetSessionKey?: string } }]
+        [{ ctx?: { CommandTargetSessionKey?: string; OriginatingTo?: string } }]
       >
     )[0]?.[0];
     expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe(boundSessionKey);
+    expect(dispatchCall?.ctx?.OriginatingTo).toBe("telegram:group:-1001234567890:topic:42");
   });
 
   it("aborts native command dispatch when configured ACP topic binding cannot initialize", async () => {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -676,7 +676,10 @@ export const registerTelegramNativeCommands = ({
             IsForum: isForum,
             // Originating context for sub-agent announce routing
             OriginatingChannel: "telegram" as const,
-            OriginatingTo: `telegram:${chatId}`,
+            OriginatingTo:
+              isGroup && resolvedThreadId != null
+                ? buildTelegramGroupFrom(chatId, resolvedThreadId)
+                : `telegram:${chatId}`,
           });
 
           await recordInboundSessionMetaSafe({


### PR DESCRIPTION
## Problem
In Telegram forum groups with multiple bots, `/new`/`/reset` issued inside a topic could resolve against general-topic context instead of the current topic (#35963).

## Root cause
Native command context always set `OriginatingTo` to `telegram:<chatId>`, dropping topic scope even when `resolvedThreadId` existed.

## Fix
- Preserve topic-qualified origin for group native commands
- Set `OriginatingTo` to `telegram:group:<chatId>:topic:<threadId>` when a forum topic id is resolved
- Added regression assertion in native command session-meta test

## Testing
- `pnpm -s vitest run src/telegram/bot-native-commands.session-meta.test.ts`

Closes #35963
