### PR TITLE
fix(runtime): suppress Node TLS setSession null-deref crashes

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -2,7 +2,7 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { loadDotEnv } from "../infra/dotenv.js";
 import { normalizeEnv } from "../infra/env.js";
-import { formatUncaughtError } from "../infra/errors.js";
+import { formatUncaughtError, isRecoverableTlsSessionNullDeref } from "../infra/errors.js";
 import { isMainModule } from "../infra/is-main.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
@@ -97,6 +97,13 @@ export async function runCli(argv: string[] = process.argv) {
   installUnhandledRejectionHandler();
 
   process.on("uncaughtException", (error) => {
+    if (isRecoverableTlsSessionNullDeref(error)) {
+      console.warn(
+        "[openclaw] Suppressed recoverable TLS reconnect null-deref:",
+        formatUncaughtError(error),
+      );
+      return;
+    }
     console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
     process.exit(1);
   });

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -97,11 +97,9 @@ export async function runCli(argv: string[] = process.argv) {
   installUnhandledRejectionHandler();
 
   process.on("uncaughtException", (error) => {
-    if (isRecoverableTlsSessionNullDeref(error)) {
-      console.warn(
-        "[openclaw] Suppressed recoverable TLS reconnect null-deref:",
-        formatUncaughtError(error),
-      );
+    const formatted = formatUncaughtError(error);
+    if (isRecoverableTlsSessionNullDeref(error, formatted)) {
+      console.warn("[openclaw] Suppressed recoverable TLS reconnect null-deref:", formatted);
       return;
     }
     console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import {
 import { ensureBinary } from "./infra/binaries.js";
 import { loadDotEnv } from "./infra/dotenv.js";
 import { normalizeEnv } from "./infra/env.js";
-import { formatUncaughtError } from "./infra/errors.js";
+import { formatUncaughtError, isRecoverableTlsSessionNullDeref } from "./infra/errors.js";
 import { isMainModule } from "./infra/is-main.js";
 import { ensureOpenClawCliOnPath } from "./infra/path-env.js";
 import {
@@ -82,6 +82,13 @@ if (isMain) {
   installUnhandledRejectionHandler();
 
   process.on("uncaughtException", (error) => {
+    if (isRecoverableTlsSessionNullDeref(error)) {
+      console.warn(
+        "[openclaw] Suppressed recoverable TLS reconnect null-deref:",
+        formatUncaughtError(error),
+      );
+      return;
+    }
     console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));
     process.exit(1);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,11 +82,9 @@ if (isMain) {
   installUnhandledRejectionHandler();
 
   process.on("uncaughtException", (error) => {
-    if (isRecoverableTlsSessionNullDeref(error)) {
-      console.warn(
-        "[openclaw] Suppressed recoverable TLS reconnect null-deref:",
-        formatUncaughtError(error),
-      );
+    const formatted = formatUncaughtError(error);
+    if (isRecoverableTlsSessionNullDeref(error, formatted)) {
+      console.warn("[openclaw] Suppressed recoverable TLS reconnect null-deref:", formatted);
       return;
     }
     console.error("[openclaw] Uncaught exception:", formatUncaughtError(error));

--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { isRecoverableTlsSessionNullDeref } from "./errors.js";
+
+describe("isRecoverableTlsSessionNullDeref", () => {
+  it("matches Node TLS setSession null deref stack", () => {
+    const err = new Error("Cannot read properties of null (reading 'setSession')");
+    err.stack = [
+      "TypeError: Cannot read properties of null (reading 'setSession')",
+      "    at TLSSocket.setSession (node:_tls_wrap:1132:16)",
+      "    at Object.connect (node:_tls_wrap:1826:13)",
+    ].join("\n");
+    expect(isRecoverableTlsSessionNullDeref(err)).toBe(true);
+  });
+
+  it("does not match unrelated uncaught errors", () => {
+    expect(isRecoverableTlsSessionNullDeref(new Error("Fatal Gateway error: 4014"))).toBe(false);
+  });
+});

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -84,8 +84,12 @@ export function formatErrorMessage(err: unknown): string {
   return redactSensitiveText(formatted);
 }
 
-export function isRecoverableTlsSessionNullDeref(err: unknown): boolean {
-  const text = formatUncaughtError(err).toLowerCase();
+export function isRecoverableTlsSessionNullDeref(
+  err: unknown,
+  formattedText?: string,
+): boolean {
+  const raw = formattedText ?? formatUncaughtError(err);
+  const text = typeof raw === "string" ? raw.toLowerCase() : String(raw ?? "").toLowerCase();
   return (
     text.includes("cannot read properties of null") &&
     text.includes("setsession") &&

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -84,6 +84,15 @@ export function formatErrorMessage(err: unknown): string {
   return redactSensitiveText(formatted);
 }
 
+export function isRecoverableTlsSessionNullDeref(err: unknown): boolean {
+  const text = formatUncaughtError(err).toLowerCase();
+  return (
+    text.includes("cannot read properties of null") &&
+    text.includes("setsession") &&
+    text.includes("_tls_wrap")
+  );
+}
+
 export function formatUncaughtError(err: unknown): string {
   if (extractErrorCode(err) === "INVALID_CONFIG") {
     return formatErrorMessage(err);


### PR DESCRIPTION
## Problem
Gateway process could crash on uncaught TLS reconnect errors under concurrent load/network churn:
`TypeError: Cannot read properties of null (reading 'setSession')` (#36585).

## Root cause
Global `uncaughtException` handlers always treated this known Node TLS null-handle reconnect race as fatal and called `process.exit(1)`.

## Fix
- Added `isRecoverableTlsSessionNullDeref` classifier in `infra/errors`
- Updated global `uncaughtException` handlers (`src/index.ts`, `src/cli/run-main.ts`) to:
  - log warning for this specific error shape
  - suppress process exit for this recoverable case
- Added regression tests for classifier behavior

## Testing
- `pnpm -s vitest run src/infra/errors.test.ts`

Closes #36585
