### PR TITLE
fix(failover): classify HTTP 402 as rate_limit when payload indicates usage limit (#30484)

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -37,6 +37,20 @@ const GROQ_SERVICE_UNAVAILABLE_MESSAGE =
 describe("failover-error", () => {
   it("infers failover reason from HTTP status", () => {
     expect(resolveFailoverReasonFromError({ status: 402 })).toBe("billing");
+    // Anthropic Claude Max plan surfaces rate limits as HTTP 402 (#30484)
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message: "HTTP 402: request reached organization usage limit, try again later",
+      }),
+    ).toBe("rate_limit");
+    // Explicit billing messages on 402 stay classified as billing
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message: "insufficient credits — please top up your account",
+      }),
+    ).toBe("billing");
     expect(resolveFailoverReasonFromError({ statusCode: "429" })).toBe("rate_limit");
     expect(resolveFailoverReasonFromError({ status: 403 })).toBe("auth");
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -51,6 +51,13 @@ describe("failover-error", () => {
         message: "insufficient credits — please top up your account",
       }),
     ).toBe("billing");
+    // Ambiguous "quota exceeded" + billing signal → billing wins
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message: "HTTP 402: You have exceeded your current quota. Please add more credits.",
+      }),
+    ).toBe("billing");
     expect(resolveFailoverReasonFromError({ statusCode: "429" })).toBe("rate_limit");
     expect(resolveFailoverReasonFromError({ status: 403 })).toBe("auth");
     expect(resolveFailoverReasonFromError({ status: 408 })).toBe("timeout");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -261,10 +261,22 @@ export function classifyFailoverReasonFromHttpStatus(
 
   if (status === 402) {
     // Some providers (e.g. Anthropic Claude Max plan) surface temporary
-    // usage/rate-limit failures as HTTP 402. Prefer the explicit rate-limit
-    // signal from the payload text when available (#30484).
-    if (message && isRateLimitErrorMessage(message)) {
-      return "rate_limit";
+    // usage/rate-limit failures as HTTP 402. Use a narrow matcher for
+    // temporary limits to avoid misclassifying billing failures (#30484).
+    if (message) {
+      const lower = message.toLowerCase();
+      // Temporary usage limit signals: retry language + usage/limit terminology
+      const hasTemporarySignal =
+        (lower.includes("try again") ||
+          lower.includes("retry") ||
+          lower.includes("temporary") ||
+          lower.includes("cooldown")) &&
+        (lower.includes("usage limit") ||
+          lower.includes("rate limit") ||
+          lower.includes("organization usage"));
+      if (hasTemporarySignal) {
+        return "rate_limit";
+      }
     }
     return "billing";
   }

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -260,6 +260,12 @@ export function classifyFailoverReasonFromHttpStatus(
   }
 
   if (status === 402) {
+    // Some providers (e.g. Anthropic Claude Max plan) surface temporary
+    // usage/rate-limit failures as HTTP 402. Prefer the explicit rate-limit
+    // signal from the payload text when available (#30484).
+    if (message && isRateLimitErrorMessage(message)) {
+      return "rate_limit";
+    }
     return "billing";
   }
   if (status === 429) {


### PR DESCRIPTION
## Summary

- **Problem:** Anthropic Claude Max plan surfaces temporary usage/rate-limit failures as HTTP 402 instead of 429. OpenClaw unconditionally maps all 402s to `billing`, producing a misleading "run out of credits" warning for users with valid billing.
- **Fix:** Before defaulting to `billing`, check the 402 payload for explicit rate-limit signals (`isRateLimitErrorMessage`). This follows the same pattern as the HTTP 400 billing check merged in #36783.
- **What did NOT change:** No user-facing error copy changes, no policy changes, no other status code remap.

## Changes

- `src/agents/pi-embedded-helpers/errors.ts`: `classifyFailoverReasonFromHttpStatus()` now returns `rate_limit` for 402 when the message text matches rate-limit patterns (e.g. "usage limit", "try again later")
- `src/agents/failover-error.test.ts`: Added regression tests for both rate-limit and billing paths on HTTP 402

## Validation

```
pnpm test src/agents/failover-error.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/agents/model-fallback.test.ts
```

All 139 tests pass.

Closes #30484