### PR TITLE
fix(prompt): stabilize runtime reasoning line for cache reuse

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -190,6 +190,24 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("<final>...</final>");
   });
 
+  it("keeps runtime reasoning line stable across reasoning toggles", () => {
+    const promptOff = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      reasoningLevel: "off",
+    });
+    const promptOn = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      reasoningLevel: "on",
+    });
+
+    const runtimeLine =
+      "Reasoning: controlled by runtime setting (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.";
+    expect(promptOff).toContain(runtimeLine);
+    expect(promptOn).toContain(runtimeLine);
+    expect(promptOff).not.toContain("Reasoning: off (hidden unless on/stream)");
+    expect(promptOn).not.toContain("Reasoning: on (hidden unless on/stream)");
+  });
+
   it("includes a CLI quick reference section", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
@@ -599,7 +617,7 @@ describe("buildAgentSystemPrompt", () => {
       reasoningLevel: "off",
     });
 
-    expect(prompt).toContain("Reasoning: off");
+    expect(prompt).toContain("Reasoning: controlled by runtime setting");
     expect(prompt).toContain("/reasoning");
     expect(prompt).toContain("/status shows Reasoning");
   });

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -360,7 +360,6 @@ export function buildAgentSystemPrompt(params: {
         "<final>Hey there! What would you like to do next?</final>",
       ].join(" ")
     : undefined;
-  const reasoningLevel = params.reasoningLevel ?? "off";
   const userTimezone = params.userTimezone?.trim();
   const skillsPrompt = params.skillsPrompt?.trim();
   const heartbeatPrompt = params.heartbeatPrompt?.trim();
@@ -678,7 +677,7 @@ export function buildAgentSystemPrompt(params: {
   lines.push(
     "## Runtime",
     buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities, params.defaultThinkLevel),
-    `Reasoning: ${reasoningLevel} (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.`,
+    "Reasoning: controlled by runtime setting (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.",
   );
 
   return lines.filter(Boolean).join("\n");


### PR DESCRIPTION
## Problem
Toggling `/reasoning` mutated the system prompt runtime footer (`Reasoning: off|on`), causing avoidable prompt-cache misses between otherwise identical turns (#36520).

## Root cause
`buildAgentSystemPrompt` interpolated volatile `reasoningLevel` into the static `## Runtime` section.

## Fix
- Replaced volatile runtime reasoning footer with stable wording
- Added regression test asserting same reasoning line for `reasoningLevel: off` and `reasoningLevel: on`
- Updated existing runtime hint assertion to match stable text

## Testing
- `pnpm -s vitest run src/agents/system-prompt.test.ts`

Refs #36520
