### PR TITLE
fix(feishu): use ReadStream for local file uploads to prevent binary corruption

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -364,6 +364,36 @@ describe("sendMediaFeishu msg_type routing", () => {
     }
   });
 
+  it("resolves tilde paths consistently with loadWebMedia for local uploads (#32123)", async () => {
+    const homeDir = require("os").homedir();
+    const tmpDir = path.join(homeDir, ".openclaw-test-" + Date.now());
+    await fs.mkdir(tmpDir, { recursive: true });
+    const tmpFile = path.join(tmpDir, "doc.pdf");
+    await fs.writeFile(tmpFile, Buffer.from("fake-pdf"));
+    const tildePath = "~/.openclaw-test-" + path.basename(tmpDir).split("-").pop() + "/doc.pdf";
+
+    try {
+      loadWebMediaMock.mockResolvedValue({
+        buffer: Buffer.from("ignored"),
+        fileName: "doc.pdf",
+        kind: "document",
+        contentType: "application/pdf",
+      });
+
+      await sendMediaFeishu({
+        cfg: {} as any,
+        to: "user:ou_target",
+        mediaUrl: tmpFile.replace(homeDir, "~"),
+      });
+
+      // Should use a ReadStream (not Buffer) for the upload
+      const createCall = fileCreateMock.mock.calls[0][0];
+      expect(createCall.data.file).toBeInstanceOf(fsSync.ReadStream);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("still uses buffer for remote URLs (not local paths)", async () => {
     loadWebMediaMock.mockResolvedValue({
       buffer: Buffer.from("remote-file"),

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -263,29 +264,135 @@ describe("sendMediaFeishu msg_type routing", () => {
   });
 
   it("passes mediaLocalRoots as localRoots to loadWebMedia for local paths (#27884)", async () => {
+    // Create a real temp file since local paths now use ReadStream (not buffer).
+    const tmpDir = path.join(resolvePreferredOpenClawTmpDir(), "media-roots-test-" + Date.now());
+    await fs.mkdir(tmpDir, { recursive: true });
+    const tmpFile = path.join(tmpDir, "file.pdf");
+    await fs.writeFile(tmpFile, Buffer.from("fake-pdf"));
+
+    try {
+      loadWebMediaMock.mockResolvedValue({
+        buffer: Buffer.from("local-file"),
+        fileName: "file.pdf",
+        kind: "document",
+        contentType: "application/pdf",
+      });
+
+      const roots = [tmpDir, "/tmp/openclaw"];
+      await sendMediaFeishu({
+        cfg: {} as any,
+        to: "user:ou_target",
+        mediaUrl: tmpFile,
+        mediaLocalRoots: roots,
+      });
+
+      expect(loadWebMediaMock).toHaveBeenCalledWith(
+        tmpFile,
+        expect.objectContaining({
+          maxBytes: expect.any(Number),
+          optimizeImages: false,
+          localRoots: roots,
+        }),
+      );
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses ReadStream for local file uploads to preserve binary integrity (#32123)", async () => {
+    // Create a real temp file so fs.createReadStream can open it.
+    const tmpDir = path.join(resolvePreferredOpenClawTmpDir(), "media-test-" + Date.now());
+    await fs.mkdir(tmpDir, { recursive: true });
+    const tmpFile = path.join(tmpDir, "report.xlsx");
+    await fs.writeFile(tmpFile, Buffer.from("PK\x03\x04fake-xlsx-content"));
+
+    try {
+      // loadWebMedia validates the path but the actual upload should use a
+      // ReadStream (not the in-memory buffer) to avoid binary corruption in
+      // the axios/form-data multipart serialization layer.
+      loadWebMediaMock.mockResolvedValue({
+        buffer: Buffer.from("should-not-be-used"),
+        fileName: "report.xlsx",
+        kind: "document",
+        contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      });
+
+      await sendMediaFeishu({
+        cfg: {} as any,
+        to: "user:ou_target",
+        mediaUrl: tmpFile,
+      });
+
+      // loadWebMedia is called for path validation + size check
+      expect(loadWebMediaMock).toHaveBeenCalledWith(
+        tmpFile,
+        expect.objectContaining({ optimizeImages: false }),
+      );
+
+      // The SDK should receive a ReadStream, not a Buffer.
+      const createCall = fileCreateMock.mock.calls[0][0];
+      expect(createCall.data.file).toBeInstanceOf(fsSync.ReadStream);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses ReadStream for local image uploads to preserve binary integrity (#32123)", async () => {
+    const tmpDir = path.join(resolvePreferredOpenClawTmpDir(), "media-test-" + Date.now());
+    await fs.mkdir(tmpDir, { recursive: true });
+    const tmpFile = path.join(tmpDir, "photo.png");
+    await fs.writeFile(tmpFile, Buffer.from("fake-png"));
+
+    try {
+      loadWebMediaMock.mockResolvedValue({
+        buffer: Buffer.from("image-bytes"),
+        fileName: "photo.png",
+        kind: "image",
+        contentType: "image/png",
+      });
+
+      await sendMediaFeishu({
+        cfg: {} as any,
+        to: "user:ou_target",
+        mediaUrl: tmpFile,
+      });
+
+      const createCall = imageCreateMock.mock.calls[0][0];
+      expect(createCall.data.image).toBeInstanceOf(fsSync.ReadStream);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("still uses buffer for remote URLs (not local paths)", async () => {
     loadWebMediaMock.mockResolvedValue({
-      buffer: Buffer.from("local-file"),
+      buffer: Buffer.from("remote-file"),
       fileName: "doc.pdf",
       kind: "document",
       contentType: "application/pdf",
     });
 
-    const roots = ["/allowed/workspace", "/tmp/openclaw"];
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
-      mediaUrl: "/allowed/workspace/file.pdf",
-      mediaLocalRoots: roots,
+      mediaUrl: "https://example.com/doc.pdf",
     });
 
-    expect(loadWebMediaMock).toHaveBeenCalledWith(
-      "/allowed/workspace/file.pdf",
-      expect.objectContaining({
-        maxBytes: expect.any(Number),
-        optimizeImages: false,
-        localRoots: roots,
-      }),
-    );
+    const createCall = fileCreateMock.mock.calls[0][0];
+    expect(Buffer.isBuffer(createCall.data.file)).toBe(true);
+  });
+
+  it("still uses buffer when mediaBuffer is provided directly", async () => {
+    const buf = Buffer.from("direct-buffer");
+    await sendMediaFeishu({
+      cfg: {} as any,
+      to: "user:ou_target",
+      mediaBuffer: buf,
+      fileName: "file.xlsx",
+    });
+
+    const createCall = fileCreateMock.mock.calls[0][0];
+    expect(Buffer.isBuffer(createCall.data.file)).toBe(true);
   });
 
   it("fails closed when media URL fetch is blocked", async () => {

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import os from "os";
 import path from "path";
 import { Readable } from "stream";
 import { withTempDownloadPath, type ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
@@ -475,8 +476,10 @@ export async function sendMediaFeishu(params: {
     });
     // loadWebMedia succeeded → path is safe and within size limits.
     // Now use the raw file path for upload to preserve binary fidelity.
+    // Use os.homedir() for tilde expansion to stay consistent with
+    // loadWebMedia's internal resolveUserPath (which also uses os.homedir).
     const resolvedPath = mediaUrl.startsWith("~")
-      ? path.join(process.env.HOME ?? "", mediaUrl.slice(1))
+      ? path.join(os.homedir(), mediaUrl.slice(1))
       : mediaUrl;
     const name = fileName ?? (path.basename(resolvedPath) || "file");
     const ext = path.extname(name).toLowerCase();

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -414,9 +414,24 @@ export function detectFileType(
 }
 
 /**
+ * Check whether a media source is a local file path (not a URL or data URI).
+ */
+function isLocalFilePath(mediaUrl: string): boolean {
+  if (/^(https?:\/\/|data:|file:\/\/)/i.test(mediaUrl)) {
+    return false;
+  }
+  return path.isAbsolute(mediaUrl) || mediaUrl.startsWith("~");
+}
+
+/**
  * Upload and send media (image or file) from URL, local path, or buffer.
  * When mediaUrl is a local path, mediaLocalRoots (from core outbound context)
  * must be passed so loadWebMedia allows the path (post CVE-2026-26321).
+ *
+ * For local files, we pass the file path directly to the SDK upload functions
+ * so they use fs.createReadStream() instead of an in-memory Buffer.  This
+ * avoids binary corruption caused by the axios/form-data multipart
+ * serialization layer when given a raw Buffer (see #32123).
  */
 export async function sendMediaFeishu(params: {
   cfg: ClawdbotConfig;
@@ -447,6 +462,54 @@ export async function sendMediaFeishu(params: {
   }
   const mediaMaxBytes = (account.config?.mediaMaxMb ?? 30) * 1024 * 1024;
 
+  // For local file paths, pass the path directly to the SDK upload functions
+  // so they use fs.createReadStream().  This preserves binary integrity that
+  // can be lost when the Buffer is serialized through axios's multipart
+  // form-data layer (#32123).
+  if (!mediaBuffer && mediaUrl && isLocalFilePath(mediaUrl)) {
+    // Validate the path is allowed before passing it to the SDK.
+    await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
+      maxBytes: mediaMaxBytes,
+      optimizeImages: false,
+      localRoots: mediaLocalRoots?.length ? mediaLocalRoots : undefined,
+    });
+    // loadWebMedia succeeded → path is safe and within size limits.
+    // Now use the raw file path for upload to preserve binary fidelity.
+    const resolvedPath = mediaUrl.startsWith("~")
+      ? path.join(process.env.HOME ?? "", mediaUrl.slice(1))
+      : mediaUrl;
+    const name = fileName ?? (path.basename(resolvedPath) || "file");
+    const ext = path.extname(name).toLowerCase();
+    const isImage = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".ico", ".tiff"].includes(
+      ext,
+    );
+
+    if (isImage) {
+      const { imageKey } = await uploadImageFeishu({ cfg, image: resolvedPath, accountId });
+      return sendImageFeishu({ cfg, to, imageKey, replyToMessageId, replyInThread, accountId });
+    }
+
+    const fileType = detectFileType(name);
+    const { fileKey } = await uploadFileFeishu({
+      cfg,
+      file: resolvedPath,
+      fileName: name,
+      fileType,
+      accountId,
+    });
+    const msgType = fileType === "opus" ? "audio" : fileType === "mp4" ? "media" : "file";
+    return sendFileFeishu({
+      cfg,
+      to,
+      fileKey,
+      msgType,
+      replyToMessageId,
+      replyInThread,
+      accountId,
+    });
+  }
+
+  // Remote URL or in-memory buffer path: read into a Buffer as before.
   let buffer: Buffer;
   let name: string;
 


### PR DESCRIPTION
## Summary

Fixes #32123 — binary files (xlsx, pdf, etc.) sent via the `message` tool `filePath` parameter were corrupted when delivered through the Feishu channel.

## Root Cause

When `sendMediaFeishu` handles a local file path, it was:
1. Reading the file into a Buffer via `loadWebMedia` → `readLocalFileSafely`
2. Passing the Buffer to `uploadFileFeishu` → Lark SDK `client.im.file.create()`
3. The Lark SDK uses axios with `Content-Type: multipart/form-data`, and axios's form-data serialization layer can corrupt raw Buffers during multipart boundary encoding

The issue reporter confirmed that direct SDK uploads with `fs.createReadStream()` work fine, while the same file through the OpenClaw pipeline gets corrupted.

## Fix

For local file paths, we now:
1. Still call `loadWebMedia` for **path validation and size checking** (security/SSRF guards)
2. Pass the **resolved file path string** (not the buffer) to `uploadFileFeishu`/`uploadImageFeishu`
3. These functions already handle string paths by creating `fs.createReadStream()`, which the form-data library serializes correctly

For remote URLs and direct buffer inputs, the existing buffer-based path is preserved unchanged.

## Tests

Added 4 new test cases:
- ✅ Local file uploads use ReadStream (not Buffer)
- ✅ Local image uploads use ReadStream (not Buffer)
- ✅ Remote URLs still use Buffer (existing behavior)
- ✅ Direct `mediaBuffer` still uses Buffer (existing behavior)

## Related

- #32123 — original bug report with detailed investigation
- Lark SDK issue: https://github.com/larksuite/node-sdk/issues/121 (Buffer vs ReadStream)