### PR TITLE
perf(channels): cache parsed external plugin catalog files

### DIFF
--- a/src/channels/plugins/catalog.cache.test.ts
+++ b/src/channels/plugins/catalog.cache.test.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+async function importCatalogWithEmptyDiscovery() {
+  vi.doMock("../../plugins/discovery.js", () => ({
+    discoverOpenClawPlugins: () => ({ candidates: [] }),
+  }));
+  return await import("./catalog.js");
+}
+
+describe("channel plugin external catalog cache", () => {
+  let tempDir = "";
+  let catalogPath = "";
+
+  beforeEach(() => {
+    vi.resetModules();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-catalog-cache-"));
+    catalogPath = path.join(tempDir, "catalog.json");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unmock("../../plugins/discovery.js");
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reuses parsed entries when external catalog file is unchanged", async () => {
+    fs.writeFileSync(
+      catalogPath,
+      JSON.stringify({
+        entries: [
+          {
+            name: "@openclaw/demo-channel",
+            openclaw: {
+              channel: {
+                id: "demo-channel",
+                label: "Demo Channel",
+                selectionLabel: "Demo Channel",
+                docsPath: "/channels/demo-channel",
+                blurb: "Demo entry",
+              },
+              install: {
+                npmSpec: "@openclaw/demo-channel",
+              },
+            },
+          },
+        ],
+      }),
+    );
+
+    const readSpy = vi.spyOn(fs, "readFileSync");
+    const { listChannelPluginCatalogEntries } = await importCatalogWithEmptyDiscovery();
+
+    const first = listChannelPluginCatalogEntries({ catalogPaths: [catalogPath] });
+    const second = listChannelPluginCatalogEntries({ catalogPaths: [catalogPath] });
+
+    expect(first.map((entry) => entry.id)).toContain("demo-channel");
+    expect(second.map((entry) => entry.id)).toContain("demo-channel");
+
+    const catalogReads = readSpy.mock.calls.filter(
+      ([filePath]) => String(filePath) === catalogPath,
+    );
+    expect(catalogReads).toHaveLength(1);
+  });
+
+  it("invalidates cache when catalog file metadata changes", async () => {
+    fs.writeFileSync(
+      catalogPath,
+      JSON.stringify({
+        entries: [
+          {
+            name: "@openclaw/demo-channel-v1",
+            openclaw: {
+              channel: {
+                id: "demo-channel-v1",
+                label: "Demo Channel V1",
+                selectionLabel: "Demo Channel V1",
+                docsPath: "/channels/demo-channel-v1",
+                blurb: "Demo entry",
+              },
+              install: {
+                npmSpec: "@openclaw/demo-channel-v1",
+              },
+            },
+          },
+        ],
+      }),
+    );
+
+    const readSpy = vi.spyOn(fs, "readFileSync");
+    const { listChannelPluginCatalogEntries } = await importCatalogWithEmptyDiscovery();
+
+    expect(
+      listChannelPluginCatalogEntries({ catalogPaths: [catalogPath] }).map((entry) => entry.id),
+    ).toContain("demo-channel-v1");
+
+    fs.writeFileSync(
+      catalogPath,
+      JSON.stringify({
+        entries: [
+          {
+            name: "@openclaw/demo-channel-v2",
+            openclaw: {
+              channel: {
+                id: "demo-channel-v2",
+                label: "Demo Channel V2",
+                selectionLabel: "Demo Channel V2",
+                docsPath: "/channels/demo-channel-v2",
+                blurb: "Demo entry",
+              },
+              install: {
+                npmSpec: "@openclaw/demo-channel-v2",
+              },
+            },
+          },
+        ],
+      }),
+    );
+    const bumped = new Date(Date.now() + 2_000);
+    fs.utimesSync(catalogPath, bumped, bumped);
+
+    const afterUpdate = listChannelPluginCatalogEntries({ catalogPaths: [catalogPath] }).map(
+      (entry) => entry.id,
+    );
+    expect(afterUpdate).toContain("demo-channel-v2");
+    expect(afterUpdate).not.toContain("demo-channel-v1");
+
+    const catalogReads = readSpy.mock.calls.filter(
+      ([filePath]) => String(filePath) === catalogPath,
+    );
+    expect(catalogReads).toHaveLength(2);
+  });
+});

--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -58,8 +58,17 @@ const DEFAULT_CATALOG_PATHS = [
 ];
 
 const ENV_CATALOG_PATHS = ["OPENCLAW_PLUGIN_CATALOG_PATHS", "OPENCLAW_MPM_CATALOG_PATHS"];
+const MAX_EXTERNAL_CATALOG_CACHE_ENTRIES = 32;
 
 type ManifestKey = typeof MANIFEST_KEY;
+
+type ExternalCatalogCacheEntry = {
+  mtimeMs: number;
+  size: number;
+  entries: ExternalCatalogEntry[];
+};
+
+const externalCatalogCache = new Map<string, ExternalCatalogCacheEntry>();
 
 function parseCatalogEntries(raw: unknown): ExternalCatalogEntry[] {
   if (Array.isArray(raw)) {
@@ -100,19 +109,59 @@ function resolveExternalCatalogPaths(options: CatalogOptions): string[] {
   return DEFAULT_CATALOG_PATHS;
 }
 
+function setExternalCatalogCacheEntry(pathKey: string, entry: ExternalCatalogCacheEntry): void {
+  if (externalCatalogCache.has(pathKey)) {
+    externalCatalogCache.delete(pathKey);
+  }
+  externalCatalogCache.set(pathKey, entry);
+  while (externalCatalogCache.size > MAX_EXTERNAL_CATALOG_CACHE_ENTRIES) {
+    const oldestKey = externalCatalogCache.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    externalCatalogCache.delete(oldestKey);
+  }
+}
+
 function loadExternalCatalogEntries(options: CatalogOptions): ExternalCatalogEntry[] {
   const paths = resolveExternalCatalogPaths(options);
   const entries: ExternalCatalogEntry[] = [];
   for (const rawPath of paths) {
     const resolved = resolveUserPath(rawPath);
-    if (!fs.existsSync(resolved)) {
+
+    let stats: fs.Stats;
+    try {
+      stats = fs.statSync(resolved);
+    } catch {
+      externalCatalogCache.delete(resolved);
       continue;
     }
+    if (!stats.isFile()) {
+      externalCatalogCache.delete(resolved);
+      continue;
+    }
+
+    const cached = externalCatalogCache.get(resolved);
+    if (cached && cached.mtimeMs === stats.mtimeMs && cached.size === stats.size) {
+      entries.push(...cached.entries);
+      continue;
+    }
+
     try {
       const payload = JSON.parse(fs.readFileSync(resolved, "utf-8")) as unknown;
-      entries.push(...parseCatalogEntries(payload));
+      const parsed = parseCatalogEntries(payload);
+      setExternalCatalogCacheEntry(resolved, {
+        mtimeMs: stats.mtimeMs,
+        size: stats.size,
+        entries: parsed,
+      });
+      entries.push(...parsed);
     } catch {
-      // Ignore invalid catalog files.
+      setExternalCatalogCacheEntry(resolved, {
+        mtimeMs: stats.mtimeMs,
+        size: stats.size,
+        entries: [],
+      });
     }
   }
   return entries;


### PR DESCRIPTION
## Summary
- cache parsed external plugin catalog JSON by path + metadata (mtime/size)
- bound cache size to 32 entries to avoid unbounded growth
- invalidate cache entries when files disappear, stop being regular files, or metadata changes
- cache invalid JSON as empty until the file changes to avoid repeated parse work
- add focused tests covering cache reuse and cache invalidation

## Why
listChannelPluginCatalogEntries can be called repeatedly by channel catalog surfaces and was re-reading and re-parsing unchanged external catalog files on every call.

## Risk
Low: existing catalog semantics are unchanged; only the loading path is memoized and automatically invalidated when file metadata changes.

## Validation
- pnpm vitest src/channels/plugins/catalog.cache.test.ts
- pnpm vitest src/channels/plugins/plugins-core.test.ts -t "includes external catalog entries"