### PR TITLE
Skills: add optional index-first loading for skill discovery

### DIFF
--- a/docs/skills-index.md
+++ b/docs/skills-index.md
@@ -1,0 +1,77 @@
+# Skills Index
+
+OpenClaw can optionally load skills from a `skills-index.json` file instead of scanning every child directory in a skills root.
+
+This is an opt-in startup optimization for large skill collections. It reduces directory discovery work. It does not eliminate reading `SKILL.md` files.
+
+## Enable
+
+Add this to your config:
+
+```json
+{
+  "skills": {
+    "load": {
+      "indexFirst": true,
+      "indexFileName": "skills-index.json"
+    }
+  }
+}
+```
+
+If `indexFirst` is enabled, OpenClaw looks for `skills-index.json` in each skills root before falling back to normal directory scanning.
+
+## Strict mode
+
+```json
+{
+  "skills": {
+    "load": {
+      "indexFirst": true,
+      "strictIndex": true
+    }
+  }
+}
+```
+
+With `strictIndex: true`, indexed roots require a valid index instead of falling back to scanning.
+
+## Index format
+
+Use root-relative paths:
+
+```json
+{
+  "version": 1,
+  "generated": "2026-03-05T00:00:00.000Z",
+  "skills": [
+    {
+      "name": "klaviyo",
+      "path": "klaviyo",
+      "description": "Klaviyo API reference and task guide"
+    }
+  ]
+}
+```
+
+Notes:
+
+1. `path` must be relative to the indexed root.
+2. Absolute paths are rejected.
+3. Paths that resolve outside the root are rejected.
+
+## Build an index
+
+Use the helper script:
+
+```bash
+node scripts/build-skills-index.mjs ~/.agents/skills
+```
+
+If no path is provided, the script defaults to `~/.agents/skills`.
+
+## Watch behavior
+
+When `indexFirst` is enabled, OpenClaw watches `skills-index.json` for changes.
+
+If you add, remove, or rename skills in an indexed root, rebuild the index. Changes inside underlying skill directories are still watched through `SKILL.md`, but discovery changes depend on the index being refreshed.

--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -1,5 +1,7 @@
-import fs from "node:fs/promises";
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { Type } from "@sinclair/typebox";
 import Ajv from "ajv";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/llm-task";
@@ -26,8 +28,13 @@ async function loadRunEmbeddedPiAgent(): Promise<RunEmbeddedPiAgentFn> {
 
   // Bundled install (built)
   // NOTE: there is no src/ tree in a packaged install. Prefer a stable internal entrypoint.
-  const distExtensionApi = "../../../dist/extensionAPI.js";
-  const mod = (await import(distExtensionApi)) as { runEmbeddedPiAgent?: unknown };
+  const distModulePath = path.resolve(import.meta.dirname, "../../../dist/extensionAPI.js");
+  if (!fs.existsSync(distModulePath)) {
+    throw new Error(
+      `Internal error: missing core module at ${distModulePath}. Run \`pnpm build\` or install the official package.`,
+    );
+  }
+  const mod = await import(pathToFileURL(distModulePath).href);
   // oxlint-disable-next-line typescript/no-explicit-any
   const fn = (mod as any).runEmbeddedPiAgent;
   if (typeof fn !== "function") {
@@ -184,7 +191,7 @@ export function createLlmTaskTool(api: OpenClawPluginApi) {
 
       let tmpDir: string | null = null;
       try {
-        tmpDir = await fs.mkdtemp(
+        tmpDir = await fsPromises.mkdtemp(
           path.join(resolvePreferredOpenClawTmpDir(), "openclaw-llm-task-"),
         );
         const sessionId = `llm-task-${Date.now()}`;
@@ -248,7 +255,7 @@ export function createLlmTaskTool(api: OpenClawPluginApi) {
       } finally {
         if (tmpDir) {
           try {
-            await fs.rm(tmpDir, { recursive: true, force: true });
+            await fsPromises.rm(tmpDir, { recursive: true, force: true });
           } catch {
             // ignore
           }

--- a/scripts/build-skills-index.mjs
+++ b/scripts/build-skills-index.mjs
@@ -44,6 +44,23 @@ function readDescription(markdown) {
   return undefined;
 }
 
+function isSkillDirectoryEntry(entry) {
+  if (entry.name.startsWith(".") || entry.name === "node_modules") {
+    return false;
+  }
+  if (entry.isDirectory()) {
+    return true;
+  }
+  if (entry.isSymbolicLink()) {
+    try {
+      return fs.statSync(path.join(skillsRoot, entry.name)).isDirectory();
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
 const skillsRoot = resolveSkillsRoot();
 
 if (!fs.existsSync(skillsRoot) || !fs.statSync(skillsRoot).isDirectory()) {
@@ -53,9 +70,7 @@ if (!fs.existsSync(skillsRoot) || !fs.statSync(skillsRoot).isDirectory()) {
 
 const entries = fs
   .readdirSync(skillsRoot, { withFileTypes: true })
-  .filter(
-    (entry) => entry.isDirectory() && !entry.name.startsWith(".") && entry.name !== "node_modules",
-  )
+  .filter((entry) => isSkillDirectoryEntry(entry))
   .map((entry) => {
     const skillDir = path.join(skillsRoot, entry.name);
     const skillMd = path.join(skillDir, "SKILL.md");

--- a/scripts/build-skills-index.mjs
+++ b/scripts/build-skills-index.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+function resolveSkillsRoot() {
+  if (process.argv[2]) {
+    return path.resolve(process.argv[2]);
+  }
+
+  return path.join(os.homedir(), ".agents", "skills");
+}
+
+function readDescription(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  let index = 0;
+
+  if (lines[0]?.trim() === "---") {
+    index = 1;
+    for (; index < lines.length; index += 1) {
+      const line = lines[index].trim();
+      if (line === "---") {
+        index += 1;
+        break;
+      }
+      if (line.startsWith("description:")) {
+        return line
+          .slice("description:".length)
+          .trim()
+          .replace(/^['"]|['"]$/g, "");
+      }
+    }
+  }
+
+  for (; index < lines.length; index += 1) {
+    const line = lines[index].trim();
+    if (!line || line === "---" || line.startsWith("#")) {
+      continue;
+    }
+    return line.slice(0, 200);
+  }
+
+  return undefined;
+}
+
+const skillsRoot = resolveSkillsRoot();
+
+if (!fs.existsSync(skillsRoot) || !fs.statSync(skillsRoot).isDirectory()) {
+  console.error(`Skills directory not found: ${skillsRoot}`);
+  process.exit(1);
+}
+
+const entries = fs
+  .readdirSync(skillsRoot, { withFileTypes: true })
+  .filter(
+    (entry) => entry.isDirectory() && !entry.name.startsWith(".") && entry.name !== "node_modules",
+  )
+  .map((entry) => {
+    const skillDir = path.join(skillsRoot, entry.name);
+    const skillMd = path.join(skillDir, "SKILL.md");
+    if (!fs.existsSync(skillMd)) {
+      return null;
+    }
+
+    const markdown = fs.readFileSync(skillMd, "utf-8");
+    const description = readDescription(markdown);
+
+    return {
+      name: entry.name,
+      path: entry.name,
+      ...(description ? { description } : {}),
+    };
+  })
+  .filter(Boolean)
+  .toSorted((a, b) => a.name.localeCompare(b.name));
+
+const index = {
+  version: 1,
+  generated: new Date().toISOString(),
+  skills: entries,
+};
+
+const outputPath = path.join(skillsRoot, "skills-index.json");
+fs.writeFileSync(outputPath, JSON.stringify(index, null, 2) + "\n");
+console.log(`Wrote ${entries.length} skills to ${outputPath}`);

--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -267,6 +267,40 @@ describe("loadWorkspaceSkillEntries", () => {
     expect(entries.map((entry) => entry.skill.name)).not.toContain("strict-skill");
   });
 
+  it("loads valid index entries even when one entry is malformed", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const managedDir = path.join(workspaceDir, ".managed");
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    const extraRoot = path.join(workspaceDir, "extra-skills");
+
+    await fs.mkdir(extraRoot, { recursive: true });
+    await writeSkill({
+      dir: path.join(extraRoot, "valid-skill"),
+      name: "valid-skill",
+      description: "Still loads with a malformed sibling entry",
+    });
+    await fs.writeFile(
+      path.join(extraRoot, "skills-index.json"),
+      '{"version":1,"generated":"2026-03-05T00:00:00.000Z","skills":[{"name":"broken"},{"name":"valid-skill","path":"valid-skill"}]}',
+      "utf-8",
+    );
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      config: {
+        skills: {
+          load: {
+            indexFirst: true,
+            extraDirs: [extraRoot],
+          },
+        },
+      },
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: bundledDir,
+    });
+
+    expect(entries.map((entry) => entry.skill.name)).toContain("valid-skill");
+  });
+
   it("skips out-of-root index entries", async () => {
     const workspaceDir = await createTempWorkspaceDir();
     const managedDir = path.join(workspaceDir, ".managed");
@@ -282,6 +316,42 @@ describe("loadWorkspaceSkillEntries", () => {
     await fs.writeFile(
       path.join(extraRoot, "skills-index.json"),
       '{"version":1,"generated":"2026-03-05T00:00:00.000Z","skills":[{"name":"outside-skill","path":"../outside-skill"}]}',
+      "utf-8",
+    );
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      config: {
+        skills: {
+          load: {
+            indexFirst: true,
+            extraDirs: [extraRoot],
+          },
+        },
+      },
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: bundledDir,
+    });
+
+    expect(entries.map((entry) => entry.skill.name)).not.toContain("outside-skill");
+  });
+
+  it("skips symlinked index entries that resolve outside the root", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const managedDir = path.join(workspaceDir, ".managed");
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    const extraRoot = path.join(workspaceDir, "extra-skills");
+    const outsideSkillDir = path.join(workspaceDir, "outside-skill");
+
+    await fs.mkdir(extraRoot, { recursive: true });
+    await writeSkill({
+      dir: outsideSkillDir,
+      name: "outside-skill",
+      description: "Realpath escapes the indexed root",
+    });
+    await fs.symlink(outsideSkillDir, path.join(extraRoot, "linked-skill"));
+    await fs.writeFile(
+      path.join(extraRoot, "skills-index.json"),
+      '{"version":1,"generated":"2026-03-05T00:00:00.000Z","skills":[{"name":"linked-skill","path":"linked-skill"}]}',
       "utf-8",
     );
 

--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -175,4 +175,129 @@ describe("loadWorkspaceSkillEntries", () => {
       expect(entries.map((entry) => entry.skill.name)).not.toContain("outside-file-skill");
     },
   );
+
+  it("loads skills from skills-index.json when indexFirst is enabled", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const managedDir = path.join(workspaceDir, ".managed");
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    const extraRoot = path.join(workspaceDir, "extra-skills");
+
+    await fs.mkdir(extraRoot, { recursive: true });
+    await writeSkill({
+      dir: path.join(extraRoot, "indexed-skill"),
+      name: "indexed-skill",
+      description: "Loaded from index",
+    });
+    await fs.writeFile(
+      path.join(extraRoot, "skills-index.json"),
+      '{"version":1,"generated":"2026-03-05T00:00:00.000Z","skills":[{"name":"indexed-skill","path":"indexed-skill"}]}',
+      "utf-8",
+    );
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      config: {
+        skills: {
+          load: {
+            indexFirst: true,
+            extraDirs: [extraRoot],
+          },
+        },
+      },
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: bundledDir,
+    });
+
+    expect(entries.map((entry) => entry.skill.name)).toContain("indexed-skill");
+  });
+
+  it("falls back to scanning when the index is missing", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const managedDir = path.join(workspaceDir, ".managed");
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    const extraRoot = path.join(workspaceDir, "extra-skills");
+
+    await writeSkill({
+      dir: path.join(extraRoot, "fallback-skill"),
+      name: "fallback-skill",
+      description: "Loaded by scan fallback",
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      config: {
+        skills: {
+          load: {
+            indexFirst: true,
+            extraDirs: [extraRoot],
+          },
+        },
+      },
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: bundledDir,
+    });
+
+    expect(entries.map((entry) => entry.skill.name)).toContain("fallback-skill");
+  });
+
+  it("does not fall back when strictIndex is enabled and the index is missing", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const managedDir = path.join(workspaceDir, ".managed");
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    const extraRoot = path.join(workspaceDir, "extra-skills");
+
+    await writeSkill({
+      dir: path.join(extraRoot, "strict-skill"),
+      name: "strict-skill",
+      description: "Should not be loaded without an index",
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      config: {
+        skills: {
+          load: {
+            indexFirst: true,
+            strictIndex: true,
+            extraDirs: [extraRoot],
+          },
+        },
+      },
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: bundledDir,
+    });
+
+    expect(entries.map((entry) => entry.skill.name)).not.toContain("strict-skill");
+  });
+
+  it("skips out-of-root index entries", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const managedDir = path.join(workspaceDir, ".managed");
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    const extraRoot = path.join(workspaceDir, "extra-skills");
+
+    await fs.mkdir(extraRoot, { recursive: true });
+    await writeSkill({
+      dir: path.join(workspaceDir, "outside-skill"),
+      name: "outside-skill",
+      description: "Outside the indexed root",
+    });
+    await fs.writeFile(
+      path.join(extraRoot, "skills-index.json"),
+      '{"version":1,"generated":"2026-03-05T00:00:00.000Z","skills":[{"name":"outside-skill","path":"../outside-skill"}]}',
+      "utf-8",
+    );
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      config: {
+        skills: {
+          load: {
+            indexFirst: true,
+            extraDirs: [extraRoot],
+          },
+        },
+      },
+      managedSkillsDir: managedDir,
+      bundledSkillsDir: bundledDir,
+    });
+
+    expect(entries.map((entry) => entry.skill.name)).not.toContain("outside-skill");
+  });
 });

--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -89,9 +88,13 @@ describe("resolveWatchTargets", () => {
     expect(targets).toEqual(
       expect.arrayContaining([
         posix(path.join("/tmp/workspace", "skills", "skills-index.json")),
+        posix(path.join("/tmp/workspace", "skills", "skills", "skills-index.json")),
         posix(path.join("/tmp/workspace", ".agents", "skills", "skills-index.json")),
+        posix(path.join("/tmp/workspace", ".agents", "skills", "skills", "skills-index.json")),
         posix(path.join("/tmp/external-skills", "skills-index.json")),
+        posix(path.join("/tmp/external-skills", "skills", "skills-index.json")),
         posix(path.join(os.homedir(), ".agents", "skills", "skills-index.json")),
+        posix(path.join(os.homedir(), ".agents", "skills", "skills", "skills-index.json")),
       ]),
     );
   });
@@ -103,37 +106,28 @@ describe("resolveWatchTargets", () => {
     expect(targets.every((target) => !target.endsWith("/skills-index.json"))).toBe(true);
   });
 
-  it("watches the nested skills root when discovery auto-detects one", async () => {
-    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-watch-"));
-    const nestedSkillsDir = path.join(rootDir, "skills", "nested-skill");
-    await fs.mkdir(nestedSkillsDir, { recursive: true });
-    await fs.writeFile(
-      path.join(nestedSkillsDir, "SKILL.md"),
-      "---\nname: nested\ndescription: test\n---\n",
-      "utf-8",
-    );
-
-    try {
-      const mod = await import("./refresh.js");
-      const targets = mod.resolveWatchTargets("/tmp/workspace", {
-        skills: {
-          load: {
-            indexFirst: true,
-            extraDirs: [rootDir],
-          },
+  it("watches both direct and nested skills layouts without rescanning", async () => {
+    const mod = await import("./refresh.js");
+    const rootDir = path.join(os.tmpdir(), "openclaw-skills-watch-root");
+    const targets = mod.resolveWatchTargets("/tmp/workspace", {
+      skills: {
+        load: {
+          indexFirst: true,
+          extraDirs: [rootDir],
         },
-      });
+      },
+    });
 
-      const posix = (p: string) => p.replaceAll("\\", "/");
-      expect(targets).toEqual(
-        expect.arrayContaining([
-          posix(path.join(rootDir, "skills", "skills-index.json")),
-          posix(path.join(rootDir, "skills", "*", "SKILL.md")),
-        ]),
-      );
-      expect(targets).not.toContain(posix(path.join(rootDir, "skills-index.json")));
-    } finally {
-      await fs.rm(rootDir, { recursive: true, force: true });
-    }
+    const posix = (p: string) => p.replaceAll("\\", "/");
+    expect(targets).toEqual(
+      expect.arrayContaining([
+        posix(path.join(rootDir, "SKILL.md")),
+        posix(path.join(rootDir, "*", "SKILL.md")),
+        posix(path.join(rootDir, "skills", "SKILL.md")),
+        posix(path.join(rootDir, "skills", "*", "SKILL.md")),
+        posix(path.join(rootDir, "skills-index.json")),
+        posix(path.join(rootDir, "skills", "skills-index.json")),
+      ]),
+    );
   });
 });

--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -71,3 +71,34 @@ describe("ensureSkillsWatcher", () => {
     expect(ignored.some((re) => re.test("/tmp/workspace/skills/my-skill/SKILL.md"))).toBe(false);
   });
 });
+
+describe("resolveWatchTargets", () => {
+  it("includes skills-index.json when indexFirst is enabled", async () => {
+    const mod = await import("./refresh.js");
+    const targets = mod.resolveWatchTargets("/tmp/workspace", {
+      skills: {
+        load: {
+          indexFirst: true,
+          extraDirs: ["/tmp/external-skills"],
+        },
+      },
+    });
+
+    const posix = (p: string) => p.replaceAll("\\", "/");
+    expect(targets).toEqual(
+      expect.arrayContaining([
+        posix(path.join("/tmp/workspace", "skills", "skills-index.json")),
+        posix(path.join("/tmp/workspace", ".agents", "skills", "skills-index.json")),
+        posix(path.join("/tmp/external-skills", "skills-index.json")),
+        posix(path.join(os.homedir(), ".agents", "skills", "skills-index.json")),
+      ]),
+    );
+  });
+
+  it("does not include skills-index.json by default", async () => {
+    const mod = await import("./refresh.js");
+    const targets = mod.resolveWatchTargets("/tmp/workspace");
+
+    expect(targets.every((target) => !target.endsWith("/skills-index.json"))).toBe(true);
+  });
+});

--- a/src/agents/skills/refresh.test.ts
+++ b/src/agents/skills/refresh.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -100,5 +101,39 @@ describe("resolveWatchTargets", () => {
     const targets = mod.resolveWatchTargets("/tmp/workspace");
 
     expect(targets.every((target) => !target.endsWith("/skills-index.json"))).toBe(true);
+  });
+
+  it("watches the nested skills root when discovery auto-detects one", async () => {
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-watch-"));
+    const nestedSkillsDir = path.join(rootDir, "skills", "nested-skill");
+    await fs.mkdir(nestedSkillsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(nestedSkillsDir, "SKILL.md"),
+      "---\nname: nested\ndescription: test\n---\n",
+      "utf-8",
+    );
+
+    try {
+      const mod = await import("./refresh.js");
+      const targets = mod.resolveWatchTargets("/tmp/workspace", {
+        skills: {
+          load: {
+            indexFirst: true,
+            extraDirs: [rootDir],
+          },
+        },
+      });
+
+      const posix = (p: string) => p.replaceAll("\\", "/");
+      expect(targets).toEqual(
+        expect.arrayContaining([
+          posix(path.join(rootDir, "skills", "skills-index.json")),
+          posix(path.join(rootDir, "skills", "*", "SKILL.md")),
+        ]),
+      );
+      expect(targets).not.toContain(posix(path.join(rootDir, "skills-index.json")));
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -81,16 +81,21 @@ function toWatchGlobRoot(raw: string): string {
   return raw.replaceAll("\\", "/").replace(/\/+$/, "");
 }
 
-function resolveWatchTargets(workspaceDir: string, config?: OpenClawConfig): string[] {
+export function resolveWatchTargets(workspaceDir: string, config?: OpenClawConfig): string[] {
   // Skills are defined by SKILL.md; watch only those files to avoid traversing
   // or watching unrelated large trees (e.g. datasets) that can exhaust FDs.
   const targets = new Set<string>();
+  const loadConfig = config?.skills?.load;
+  const indexFileName = loadConfig?.indexFileName?.trim() || "skills-index.json";
   for (const root of resolveWatchPaths(workspaceDir, config)) {
     const globRoot = toWatchGlobRoot(root);
     // Some configs point directly at a skill folder.
     targets.add(`${globRoot}/SKILL.md`);
     // Standard layout: <skillsRoot>/<skillName>/SKILL.md
     targets.add(`${globRoot}/*/SKILL.md`);
+    if (loadConfig?.indexFirst) {
+      targets.add(`${globRoot}/${indexFileName}`);
+    }
   }
   return Array.from(targets).toSorted();
 }

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import chokidar, { type FSWatcher } from "chokidar";
@@ -82,52 +81,21 @@ function toWatchGlobRoot(raw: string): string {
   return raw.replaceAll("\\", "/").replace(/\/+$/, "");
 }
 
-function listChildDirectories(dir: string): string[] {
-  try {
-    const entries = fs.readdirSync(dir, { withFileTypes: true });
-    const dirs: string[] = [];
-    for (const entry of entries) {
-      if (entry.name.startsWith(".") || entry.name === "node_modules") {
-        continue;
-      }
-      const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        dirs.push(entry.name);
-        continue;
-      }
-      if (entry.isSymbolicLink()) {
-        try {
-          if (fs.statSync(fullPath).isDirectory()) {
-            dirs.push(entry.name);
-          }
-        } catch {
-          // ignore broken symlinks
-        }
-      }
-    }
-    return dirs;
-  } catch {
-    return [];
-  }
-}
-
-function resolveWatchRoot(dir: string): string {
-  const nested = path.join(dir, "skills");
-  try {
-    if (!fs.existsSync(nested) || !fs.statSync(nested).isDirectory()) {
-      return dir;
-    }
-  } catch {
-    return dir;
-  }
-
-  for (const name of listChildDirectories(nested)) {
-    if (fs.existsSync(path.join(nested, name, "SKILL.md"))) {
-      return nested;
+function addWatchTargets(params: {
+  root: string;
+  targets: Set<string>;
+  indexFirst: boolean;
+  indexFileName: string;
+}) {
+  const { root, targets, indexFirst, indexFileName } = params;
+  for (const watchRoot of [root, path.join(root, "skills")]) {
+    const globRoot = toWatchGlobRoot(watchRoot);
+    targets.add(`${globRoot}/SKILL.md`);
+    targets.add(`${globRoot}/*/SKILL.md`);
+    if (indexFirst) {
+      targets.add(`${globRoot}/${indexFileName}`);
     }
   }
-
-  return dir;
 }
 
 export function resolveWatchTargets(workspaceDir: string, config?: OpenClawConfig): string[] {
@@ -137,14 +105,12 @@ export function resolveWatchTargets(workspaceDir: string, config?: OpenClawConfi
   const loadConfig = config?.skills?.load;
   const indexFileName = loadConfig?.indexFileName?.trim() || "skills-index.json";
   for (const root of resolveWatchPaths(workspaceDir, config)) {
-    const globRoot = toWatchGlobRoot(resolveWatchRoot(root));
-    // Some configs point directly at a skill folder.
-    targets.add(`${globRoot}/SKILL.md`);
-    // Standard layout: <skillsRoot>/<skillName>/SKILL.md
-    targets.add(`${globRoot}/*/SKILL.md`);
-    if (loadConfig?.indexFirst) {
-      targets.add(`${globRoot}/${indexFileName}`);
-    }
+    addWatchTargets({
+      root,
+      targets,
+      indexFirst: loadConfig?.indexFirst === true,
+      indexFileName,
+    });
   }
   return Array.from(targets).toSorted();
 }

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import chokidar, { type FSWatcher } from "chokidar";
@@ -81,6 +82,54 @@ function toWatchGlobRoot(raw: string): string {
   return raw.replaceAll("\\", "/").replace(/\/+$/, "");
 }
 
+function listChildDirectories(dir: string): string[] {
+  try {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    const dirs: string[] = [];
+    for (const entry of entries) {
+      if (entry.name.startsWith(".") || entry.name === "node_modules") {
+        continue;
+      }
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        dirs.push(entry.name);
+        continue;
+      }
+      if (entry.isSymbolicLink()) {
+        try {
+          if (fs.statSync(fullPath).isDirectory()) {
+            dirs.push(entry.name);
+          }
+        } catch {
+          // ignore broken symlinks
+        }
+      }
+    }
+    return dirs;
+  } catch {
+    return [];
+  }
+}
+
+function resolveWatchRoot(dir: string): string {
+  const nested = path.join(dir, "skills");
+  try {
+    if (!fs.existsSync(nested) || !fs.statSync(nested).isDirectory()) {
+      return dir;
+    }
+  } catch {
+    return dir;
+  }
+
+  for (const name of listChildDirectories(nested)) {
+    if (fs.existsSync(path.join(nested, name, "SKILL.md"))) {
+      return nested;
+    }
+  }
+
+  return dir;
+}
+
 export function resolveWatchTargets(workspaceDir: string, config?: OpenClawConfig): string[] {
   // Skills are defined by SKILL.md; watch only those files to avoid traversing
   // or watching unrelated large trees (e.g. datasets) that can exhaust FDs.
@@ -88,7 +137,7 @@ export function resolveWatchTargets(workspaceDir: string, config?: OpenClawConfi
   const loadConfig = config?.skills?.load;
   const indexFileName = loadConfig?.indexFileName?.trim() || "skills-index.json";
   for (const root of resolveWatchPaths(workspaceDir, config)) {
-    const globRoot = toWatchGlobRoot(root);
+    const globRoot = toWatchGlobRoot(resolveWatchRoot(root));
     // Some configs point directly at a skill folder.
     targets.add(`${globRoot}/SKILL.md`);
     // Standard layout: <skillsRoot>/<skillName>/SKILL.md

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -305,7 +305,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function parseSkillsIndex(raw: string): SkillsIndex {
+function isPathWithinRoot(rootPath: string, targetPath: string): boolean {
+  const relativePath = path.relative(rootPath, targetPath);
+  return (
+    relativePath === "" || (!relativePath.startsWith(`..${path.sep}`) && relativePath !== "..")
+  );
+}
+
+function parseSkillsIndex(raw: string, indexPath: string): SkillsIndex {
   const parsed = JSON.parse(raw) as unknown;
   if (!isRecord(parsed) || !Array.isArray(parsed.skills)) {
     throw new Error("missing .skills array");
@@ -314,13 +321,21 @@ function parseSkillsIndex(raw: string): SkillsIndex {
   const skills: SkillIndexEntry[] = [];
   for (const entry of parsed.skills) {
     if (!isRecord(entry) || typeof entry.name !== "string" || typeof entry.path !== "string") {
-      throw new Error("invalid skill entry");
+      skillsLogger.warn("Skipping invalid skill entry in skills index.", {
+        indexPath,
+        entry,
+      });
+      continue;
     }
 
     const name = entry.name.trim();
     const entryPath = entry.path.trim();
     if (!name || !entryPath) {
-      throw new Error("skill entry name and path must be non-empty");
+      skillsLogger.warn("Skipping skill entry with empty name or path in skills index.", {
+        indexPath,
+        entry,
+      });
+      continue;
     }
 
     skills.push({
@@ -356,7 +371,7 @@ function loadSkillsFromIndex(params: {
 
   let parsed: SkillsIndex;
   try {
-    parsed = parseSkillsIndex(fs.readFileSync(indexPath, "utf-8"));
+    parsed = parseSkillsIndex(fs.readFileSync(indexPath, "utf-8"), indexPath);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     skillsLogger.warn("Failed to parse skills index.", { baseDir, indexPath, error: message });
@@ -366,6 +381,7 @@ function loadSkillsFromIndex(params: {
     return null;
   }
 
+  const baseRealPath = fs.realpathSync.native?.(baseDir) ?? fs.realpathSync(baseDir);
   const loadedSkills: Skill[] = [];
   for (const entry of parsed.skills) {
     if (loadedSkills.length >= limits.maxSkillsLoadedPerSource) {
@@ -382,12 +398,7 @@ function loadSkillsFromIndex(params: {
     }
 
     const skillDir = path.resolve(baseDir, entry.path);
-    const relativePath = path.relative(baseDir, skillDir);
-    if (
-      relativePath === ".." ||
-      relativePath.startsWith(`..${path.sep}`) ||
-      path.isAbsolute(relativePath)
-    ) {
+    if (!isPathWithinRoot(baseDir, skillDir)) {
       skillsLogger.warn("Skipping out-of-root path in skills index.", {
         baseDir,
         indexPath,
@@ -398,6 +409,22 @@ function loadSkillsFromIndex(params: {
 
     const skillMd = path.join(skillDir, "SKILL.md");
     if (!fs.existsSync(skillMd)) {
+      continue;
+    }
+
+    let skillRealPath: string;
+    try {
+      skillRealPath = fs.realpathSync.native?.(skillDir) ?? fs.realpathSync(skillDir);
+    } catch {
+      continue;
+    }
+    if (!isPathWithinRoot(baseRealPath, skillRealPath)) {
+      skillsLogger.warn("Skipping symlinked out-of-root path in skills index.", {
+        baseDir,
+        indexPath,
+        entryPath: entry.path,
+        skillRealPath,
+      });
       continue;
     }
 

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -136,6 +136,18 @@ type ResolvedSkillsLimits = {
   maxSkillFileBytes: number;
 };
 
+type SkillIndexEntry = {
+  name: string;
+  path: string;
+  description?: string;
+};
+
+type SkillsIndex = {
+  version: number;
+  generated?: string;
+  skills: SkillIndexEntry[];
+};
+
 function resolveSkillsLimits(config?: OpenClawConfig): ResolvedSkillsLimits {
   const limits = config?.skills?.limits;
   return {
@@ -289,6 +301,135 @@ function unwrapLoadedSkills(loaded: unknown): Skill[] {
   return [];
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseSkillsIndex(raw: string): SkillsIndex {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!isRecord(parsed) || !Array.isArray(parsed.skills)) {
+    throw new Error("missing .skills array");
+  }
+
+  const skills: SkillIndexEntry[] = [];
+  for (const entry of parsed.skills) {
+    if (!isRecord(entry) || typeof entry.name !== "string" || typeof entry.path !== "string") {
+      throw new Error("invalid skill entry");
+    }
+
+    const name = entry.name.trim();
+    const entryPath = entry.path.trim();
+    if (!name || !entryPath) {
+      throw new Error("skill entry name and path must be non-empty");
+    }
+
+    skills.push({
+      name,
+      path: entryPath,
+      description: typeof entry.description === "string" ? entry.description : undefined,
+    });
+  }
+
+  return {
+    version: typeof parsed.version === "number" ? parsed.version : 1,
+    generated: typeof parsed.generated === "string" ? parsed.generated : undefined,
+    skills,
+  };
+}
+
+function loadSkillsFromIndex(params: {
+  baseDir: string;
+  indexPath: string;
+  source: string;
+  limits: ResolvedSkillsLimits;
+  strict: boolean;
+}): Skill[] | null {
+  const { baseDir, indexPath, source, limits, strict } = params;
+
+  if (!fs.existsSync(indexPath)) {
+    if (strict) {
+      skillsLogger.warn("Skills index missing and strictIndex is enabled.", { baseDir, indexPath });
+      return [];
+    }
+    return null;
+  }
+
+  let parsed: SkillsIndex;
+  try {
+    parsed = parseSkillsIndex(fs.readFileSync(indexPath, "utf-8"));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    skillsLogger.warn("Failed to parse skills index.", { baseDir, indexPath, error: message });
+    if (strict) {
+      return [];
+    }
+    return null;
+  }
+
+  const loadedSkills: Skill[] = [];
+  for (const entry of parsed.skills) {
+    if (loadedSkills.length >= limits.maxSkillsLoadedPerSource) {
+      break;
+    }
+
+    if (path.isAbsolute(entry.path)) {
+      skillsLogger.warn("Skipping absolute path in skills index.", {
+        baseDir,
+        indexPath,
+        entryPath: entry.path,
+      });
+      continue;
+    }
+
+    const skillDir = path.resolve(baseDir, entry.path);
+    const relativePath = path.relative(baseDir, skillDir);
+    if (
+      relativePath === ".." ||
+      relativePath.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativePath)
+    ) {
+      skillsLogger.warn("Skipping out-of-root path in skills index.", {
+        baseDir,
+        indexPath,
+        entryPath: entry.path,
+      });
+      continue;
+    }
+
+    const skillMd = path.join(skillDir, "SKILL.md");
+    if (!fs.existsSync(skillMd)) {
+      continue;
+    }
+
+    try {
+      const size = fs.statSync(skillMd).size;
+      if (size > limits.maxSkillFileBytes) {
+        skillsLogger.warn("Skipping indexed skill due to oversized SKILL.md.", {
+          skill: entry.name,
+          filePath: skillMd,
+          size,
+          maxSkillFileBytes: limits.maxSkillFileBytes,
+        });
+        continue;
+      }
+    } catch {
+      continue;
+    }
+
+    const loaded = loadSkillsFromDir({ dir: skillDir, source });
+    loadedSkills.push(...unwrapLoadedSkills(loaded));
+  }
+
+  if (loadedSkills.length > limits.maxSkillsLoadedPerSource) {
+    return loadedSkills
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .slice(0, limits.maxSkillsLoadedPerSource);
+  }
+
+  return loadedSkills;
+}
+
 function loadSkillEntries(
   workspaceDir: string,
   opts?: {
@@ -306,6 +447,22 @@ function loadSkillEntries(
       maxEntriesToScan: limits.maxCandidatesPerRoot,
     });
     const baseDir = resolved.baseDir;
+    const loadConfig = opts?.config?.skills?.load;
+
+    if (loadConfig?.indexFirst) {
+      const indexFileName = loadConfig.indexFileName?.trim() || "skills-index.json";
+      const indexedSkills = loadSkillsFromIndex({
+        baseDir,
+        indexPath: path.join(baseDir, indexFileName),
+        source: params.source,
+        limits,
+        strict: loadConfig.strictIndex === true,
+      });
+      if (indexedSkills !== null) {
+        return indexedSkills;
+      }
+    }
+
     const baseDirRealPath = resolveContainedSkillPath({
       source: params.source,
       rootDir,

--- a/src/config/types.skills.test.ts
+++ b/src/config/types.skills.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import type { SkillsLoadConfig } from "./types.skills.js";
+
+describe("SkillsLoadConfig", () => {
+  it("accepts index loading fields", () => {
+    const cfg: SkillsLoadConfig = {
+      indexFileName: "skills-index.json",
+      indexFirst: true,
+      strictIndex: true,
+    };
+
+    expect(cfg.indexFileName).toBe("skills-index.json");
+    expect(cfg.indexFirst).toBe(true);
+    expect(cfg.strictIndex).toBe(true);
+  });
+});

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -17,6 +17,12 @@ export type SkillsLoadConfig = {
   watch?: boolean;
   /** Debounce for the skills watcher (ms). */
   watchDebounceMs?: number;
+  /** Name of the index file to look for in each skills root. */
+  indexFileName?: string;
+  /** Attempt index loading before scanning skill directories. */
+  indexFirst?: boolean;
+  /** Require a valid index instead of falling back to directory scanning. */
+  strictIndex?: boolean;
 };
 
 export type SkillsInstallConfig = {

--- a/src/config/zod-schema.skills-load.test.ts
+++ b/src/config/zod-schema.skills-load.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { skillsLoadConfigSchema } from "./zod-schema.js";
+
+describe("skillsLoadConfigSchema", () => {
+  it("accepts index loading fields", () => {
+    const result = skillsLoadConfigSchema.safeParse({
+      indexFileName: "skills-index.json",
+      indexFirst: true,
+      strictIndex: true,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown fields", () => {
+    const result = skillsLoadConfigSchema.safeParse({
+      extraDirs: [],
+      bogusField: 123,
+    } as never);
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -120,6 +120,17 @@ const MemorySchema = z
   .strict()
   .optional();
 
+export const skillsLoadConfigSchema = z
+  .object({
+    extraDirs: z.array(z.string()).optional(),
+    watch: z.boolean().optional(),
+    watchDebounceMs: z.number().int().min(0).optional(),
+    indexFileName: z.string().optional(),
+    indexFirst: z.boolean().optional(),
+    strictIndex: z.boolean().optional(),
+  })
+  .strict();
+
 const HttpUrlSchema = z
   .string()
   .url()
@@ -811,14 +822,7 @@ export const OpenClawSchema = z
     skills: z
       .object({
         allowBundled: z.array(z.string()).optional(),
-        load: z
-          .object({
-            extraDirs: z.array(z.string()).optional(),
-            watch: z.boolean().optional(),
-            watchDebounceMs: z.number().int().min(0).optional(),
-          })
-          .strict()
-          .optional(),
+        load: skillsLoadConfigSchema.optional(),
         install: z
           .object({
             preferBrew: z.boolean().optional(),

--- a/test/scripts/build-skills-index.test.ts
+++ b/test/scripts/build-skills-index.test.ts
@@ -1,0 +1,50 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const tempDirs: string[] = [];
+
+async function createTempSkillsRoot() {
+  const skillsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-index-"));
+  tempDirs.push(skillsRoot);
+  return skillsRoot;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0, tempDirs.length).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe("build-skills-index.mjs", () => {
+  it("includes symlinked skill directories in the generated index", async () => {
+    const skillsRoot = await createTempSkillsRoot();
+    const actualSkillDir = path.join(skillsRoot, "actual-skill");
+    const linkedSkillDir = path.join(skillsRoot, "linked-skill");
+
+    await fs.mkdir(actualSkillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(actualSkillDir, "SKILL.md"),
+      "---\nname: actual-skill\ndescription: test\n---\n",
+      "utf-8",
+    );
+    await fs.symlink(actualSkillDir, linkedSkillDir);
+
+    await execFileAsync("node", ["scripts/build-skills-index.mjs", skillsRoot], {
+      cwd: "/Users/knox/repos/openclaw",
+    });
+
+    const index = JSON.parse(
+      await fs.readFile(path.join(skillsRoot, "skills-index.json"), "utf-8"),
+    ) as {
+      skills: Array<{ path: string }>;
+    };
+    expect(index.skills.map((entry) => entry.path)).toEqual(
+      expect.arrayContaining(["actual-skill", "linked-skill"]),
+    );
+  });
+});

--- a/test/scripts/build-skills-index.test.ts
+++ b/test/scripts/build-skills-index.test.ts
@@ -34,9 +34,7 @@ describe("build-skills-index.mjs", () => {
     );
     await fs.symlink(actualSkillDir, linkedSkillDir);
 
-    await execFileAsync("node", ["scripts/build-skills-index.mjs", skillsRoot], {
-      cwd: "/Users/knox/repos/openclaw",
-    });
+    await execFileAsync("node", ["scripts/build-skills-index.mjs", skillsRoot]);
 
     const index = JSON.parse(
       await fs.readFile(path.join(skillsRoot, "skills-index.json"), "utf-8"),


### PR DESCRIPTION
## Summary

- Problem: large skills roots currently rely on directory scanning during discovery, which adds filesystem overhead before skill loading.
- Why it matters: skills are invoked on demand, but discovery is eager, so large personal or project-wide skill collections pay startup cost even when most skills are never used.
- What changed: added an optional `skills-index.json` path with config/schema support, index-first loading with scan fallback, watch support, a generator script, and docs.
- What did NOT change (scope boundary): this does not eliminate `SKILL.md` reads or redesign skill parsing.
- AI-assisted: yes.

## Change Type (select all)

- [x] Feature
- [x] Docs

## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] API / contracts
- [x] UI / DX

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- New optional `skills.load.indexFirst` config to prefer `skills-index.json` over directory scanning.
- New optional `skills.load.indexFileName` config, defaulting to `skills-index.json`.
- New optional `skills.load.strictIndex` config to disable scan fallback for indexed roots.
- New manual helper script: `scripts/build-skills-index.mjs`.
- New docs page: `docs/skills-index.md`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `skills.load.indexFirst`, `skills.load.indexFileName`, `skills.load.strictIndex`

### Steps

1. Create a skills root with one or more skill folders and a `skills-index.json` file.
2. Enable `skills.load.indexFirst` in config.
3. Load workspace skill entries or start the gateway.

### Expected

- Indexed roots load from `skills-index.json` when present.
- Missing or invalid indexes fall back to scan unless `strictIndex` is enabled.
- Indexed roots watch `skills-index.json` for refresh.

### Actual

- Matches expected in targeted tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted validation run:

- `pnpm vitest run src/config/types.skills.test.ts src/config/zod-schema.skills-load.test.ts src/agents/skills.loadworkspaceskillentries.test.ts src/agents/skills/refresh.test.ts` ✅
- `pnpm build` ✅
- `pnpm test` ⚠️ blocked by unrelated existing failures in `src/tui/gateway-chat.test.ts`
- `pnpm check` ⚠️ blocked by unrelated existing TypeScript error in `src/tui/gateway-chat.ts:248`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - valid index is used when `indexFirst` is enabled
  - scan fallback still works when no index is present
  - `strictIndex` prevents fallback for indexed roots
  - out-of-root index entries are ignored
  - watch targets include `skills-index.json` only when enabled
- Edge cases checked:
  - missing index
  - malformed/unknown config shape rejection via schema test
  - out-of-root paths in the index
- What you did **not** verify:
  - startup perf measurement on a real 200+ skills directory
  - end-to-end gateway behavior with a live long-running indexed root

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `skills.load.indexFirst` to `false` or remove the setting.
- Files/config to restore: remove `skills-index.json` usage and rely on existing directory scanning.
- Known bad symptoms reviewers should watch for: indexed roots silently missing skills when the index is stale or invalid.

## Risks and Mitigations

- Risk: stale indexes can make newly added or renamed skills undiscoverable.
  - Mitigation: docs call out regeneration requirements and watch support only targets the index file for discovery changes.
- Risk: permissive index paths could point outside the root.
  - Mitigation: the loader rejects absolute and out-of-root paths.
- Risk: reviewers may expect memory wins larger than this change can realistically provide.
  - Mitigation: docs and PR scope explicitly state this only optimizes discovery, not `SKILL.md` reads.
