### PR TITLE
fix(cli): allow bare gateway command in invalid-config preflight

### DIFF
--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -1,5 +1,7 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { Type } from "@sinclair/typebox";
 import Ajv from "ajv";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/llm-task";
@@ -10,6 +12,64 @@ import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/llm-task";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/llm-task";
 
 type RunEmbeddedPiAgentFn = (params: Record<string, unknown>) => Promise<unknown>;
+let openClawRootCache: string | null = null;
+
+function findPackageRoot(startDir: string, name: string): string | null {
+  let dir = startDir;
+  for (;;) {
+    const pkgPath = path.join(dir, "package.json");
+    try {
+      if (fsSync.existsSync(pkgPath)) {
+        const raw = fsSync.readFileSync(pkgPath, "utf8");
+        const pkg = JSON.parse(raw) as { name?: string };
+        if (pkg.name === name) {
+          return dir;
+        }
+      }
+    } catch {
+      // ignore parse/read errors and keep walking
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+}
+
+function resolveOpenClawRoot(): string {
+  if (openClawRootCache) {
+    return openClawRootCache;
+  }
+  const override = process.env.OPENCLAW_ROOT?.trim();
+  if (override) {
+    openClawRootCache = override;
+    return override;
+  }
+
+  const candidates = new Set<string>();
+  if (process.argv[1]) {
+    candidates.add(path.dirname(process.argv[1]));
+  }
+  candidates.add(process.cwd());
+  try {
+    const urlPath = fileURLToPath(import.meta.url);
+    candidates.add(path.dirname(urlPath));
+  } catch {
+    // ignore
+  }
+
+  for (const start of candidates) {
+    const found = findPackageRoot(start, "openclaw");
+    if (found) {
+      openClawRootCache = found;
+      return found;
+    }
+  }
+  const fallback = process.cwd();
+  openClawRootCache = fallback;
+  return fallback;
+}
 
 async function loadRunEmbeddedPiAgent(): Promise<RunEmbeddedPiAgentFn> {
   // Source checkout (tests/dev)
@@ -25,11 +85,17 @@ async function loadRunEmbeddedPiAgent(): Promise<RunEmbeddedPiAgentFn> {
   }
 
   // Bundled install (built)
-  const mod = await import("../../../src/agents/pi-embedded-runner.js");
-  if (typeof mod.runEmbeddedPiAgent !== "function") {
+  // NOTE: there is no src/ tree in a packaged install. Prefer a stable internal entrypoint.
+  const distExtensionApi = pathToFileURL(
+    path.join(resolveOpenClawRoot(), "dist", "extensionAPI.js"),
+  ).href;
+  const mod = (await import(distExtensionApi)) as { runEmbeddedPiAgent?: unknown };
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const fn = (mod as any).runEmbeddedPiAgent;
+  if (typeof fn !== "function") {
     throw new Error("Internal error: runEmbeddedPiAgent not available");
   }
-  return mod.runEmbeddedPiAgent as RunEmbeddedPiAgentFn;
+  return fn as RunEmbeddedPiAgentFn;
 }
 
 function stripCodeFences(s: string): string {

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -9,7 +9,15 @@ export type ResolvedMemorySearchConfig = {
   enabled: boolean;
   sources: Array<"memory" | "sessions">;
   extraPaths: string[];
-  provider: "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama" | "auto";
+  provider:
+    | "openai"
+    | "local"
+    | "gemini"
+    | "voyage"
+    | "mistral"
+    | "ollama"
+    | "siliconflow"
+    | "auto";
   remote?: {
     baseUrl?: string;
     apiKey?: string;
@@ -25,7 +33,15 @@ export type ResolvedMemorySearchConfig = {
   experimental: {
     sessionMemory: boolean;
   };
-  fallback: "openai" | "gemini" | "local" | "voyage" | "mistral" | "ollama" | "none";
+  fallback:
+    | "openai"
+    | "gemini"
+    | "local"
+    | "voyage"
+    | "mistral"
+    | "ollama"
+    | "siliconflow"
+    | "none";
   model: string;
   local: {
     modelPath?: string;
@@ -156,6 +172,7 @@ function mergeConfig(
     provider === "gemini" ||
     provider === "voyage" ||
     provider === "mistral" ||
+    provider === "siliconflow" ||
     provider === "ollama" ||
     provider === "auto";
   const batch = {
@@ -190,7 +207,9 @@ function mergeConfig(
             ? DEFAULT_MISTRAL_MODEL
             : provider === "ollama"
               ? DEFAULT_OLLAMA_MODEL
-              : undefined;
+              : provider === "siliconflow"
+                ? DEFAULT_OPENAI_MODEL
+                : undefined;
   const model = overrides?.model ?? defaults?.model ?? modelDefault ?? "";
   const local = {
     modelPath: overrides?.local?.modelPath ?? defaults?.local?.modelPath,

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -110,6 +110,9 @@ describe("ensureConfigReady", () => {
     const statusRuntime = await runEnsureConfigReady(["status"]);
     expect(statusRuntime.exit).not.toHaveBeenCalled();
 
+    const gatewayRunRuntime = await runEnsureConfigReady(["gateway"]);
+    expect(gatewayRunRuntime.exit).not.toHaveBeenCalled();
+
     const gatewayRuntime = await runEnsureConfigReady(["gateway", "health"]);
     expect(gatewayRuntime.exit).not.toHaveBeenCalled();
   });

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -74,11 +74,11 @@ export async function ensureConfigReady(params: {
   const snapshot = await getConfigSnapshot();
   const commandName = commandPath[0];
   const subcommandName = commandPath[1];
+  const allowInvalidGatewayCommand =
+    commandName === "gateway" &&
+    (subcommandName === undefined || ALLOWED_INVALID_GATEWAY_SUBCOMMANDS.has(subcommandName));
   const allowInvalid = commandName
-    ? ALLOWED_INVALID_COMMANDS.has(commandName) ||
-      (commandName === "gateway" &&
-        subcommandName &&
-        ALLOWED_INVALID_GATEWAY_SUBCOMMANDS.has(subcommandName))
+    ? ALLOWED_INVALID_COMMANDS.has(commandName) || allowInvalidGatewayCommand
     : false;
   const issues =
     snapshot.exists && !snapshot.valid

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -258,7 +258,7 @@ describe("noteMemorySearchHealth", () => {
     expect(note).toHaveBeenCalledTimes(1);
     const providerCalls = resolveApiKeyForProvider.mock.calls as Array<[{ provider: string }]>;
     const providersChecked = providerCalls.map(([arg]) => arg.provider);
-    expect(providersChecked).toEqual(["openai", "google", "voyage", "mistral"]);
+    expect(providersChecked).toEqual(["openai", "google", "voyage", "mistral", "siliconflow"]);
   });
 });
 

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -117,7 +117,7 @@ export async function noteMemorySearchHealth(
   if (hasLocalEmbeddings(resolved.local)) {
     return;
   }
-  for (const provider of ["openai", "gemini", "voyage", "mistral"] as const) {
+  for (const provider of ["openai", "gemini", "voyage", "mistral", "siliconflow"] as const) {
     if (hasRemoteApiKey || (await hasApiKeyForProvider(provider, cfg, agentDir))) {
       return;
     }
@@ -186,7 +186,7 @@ function hasLocalEmbeddings(local: { modelPath?: string }, useDefaultFallback = 
 }
 
 async function hasApiKeyForProvider(
-  provider: "openai" | "gemini" | "voyage" | "mistral" | "ollama",
+  provider: "openai" | "gemini" | "voyage" | "mistral" | "ollama" | "siliconflow",
   cfg: OpenClawConfig,
   agentDir: string,
 ): Promise<boolean> {

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -324,7 +324,15 @@ export type MemorySearchConfig = {
     sessionMemory?: boolean;
   };
   /** Embedding provider mode. */
-  provider?: "openai" | "gemini" | "local" | "voyage" | "mistral" | "ollama";
+  provider?:
+    | "openai"
+    | "gemini"
+    | "local"
+    | "voyage"
+    | "mistral"
+    | "ollama"
+    | "siliconflow"
+    | "auto";
   remote?: {
     baseUrl?: string;
     apiKey?: string;
@@ -343,7 +351,15 @@ export type MemorySearchConfig = {
     };
   };
   /** Fallback behavior when embeddings fail. */
-  fallback?: "openai" | "gemini" | "local" | "voyage" | "mistral" | "ollama" | "none";
+  fallback?:
+    | "openai"
+    | "gemini"
+    | "local"
+    | "voyage"
+    | "mistral"
+    | "ollama"
+    | "siliconflow"
+    | "none";
   /** Embedding model id (remote) or alias (local). */
   model?: string;
   /** Local embedding settings (node-llama-cpp). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -561,6 +561,8 @@ export const MemorySearchSchema = z
         z.literal("voyage"),
         z.literal("mistral"),
         z.literal("ollama"),
+        z.literal("siliconflow"),
+        z.literal("auto"),
       ])
       .optional(),
     remote: z
@@ -589,6 +591,7 @@ export const MemorySearchSchema = z
         z.literal("voyage"),
         z.literal("mistral"),
         z.literal("ollama"),
+        z.literal("siliconflow"),
         z.literal("none"),
       ])
       .optional(),

--- a/src/memory/embeddings-remote-client.ts
+++ b/src/memory/embeddings-remote-client.ts
@@ -4,7 +4,7 @@ import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import type { EmbeddingProviderOptions } from "./embeddings.js";
 import { buildRemoteBaseUrlPolicy } from "./remote-http.js";
 
-export type RemoteEmbeddingProviderId = "openai" | "voyage" | "mistral";
+export type RemoteEmbeddingProviderId = "openai" | "voyage" | "mistral" | "siliconflow";
 
 export async function resolveRemoteEmbeddingBearerClient(params: {
   provider: RemoteEmbeddingProviderId;

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -36,14 +36,27 @@ export type EmbeddingProvider = {
   embedBatch: (texts: string[]) => Promise<number[][]>;
 };
 
-export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama";
+export type EmbeddingProviderId =
+  | "openai"
+  | "local"
+  | "gemini"
+  | "voyage"
+  | "mistral"
+  | "ollama"
+  | "siliconflow";
 export type EmbeddingProviderRequest = EmbeddingProviderId | "auto";
 export type EmbeddingProviderFallback = EmbeddingProviderId | "none";
 
 // Remote providers considered for auto-selection when provider === "auto".
 // Ollama is intentionally excluded here so that "auto" mode does not
 // implicitly assume a local Ollama instance is available.
-const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "voyage", "mistral"] as const;
+const REMOTE_EMBEDDING_PROVIDER_IDS = [
+  "openai",
+  "gemini",
+  "voyage",
+  "mistral",
+  "siliconflow",
+] as const;
 
 export type EmbeddingProviderResult = {
   provider: EmbeddingProvider | null;
@@ -188,6 +201,10 @@ export async function createEmbeddingProvider(
     if (id === "mistral") {
       const { provider, client } = await createMistralEmbeddingProvider(options);
       return { provider, mistral: client };
+    }
+    if (id === "siliconflow") {
+      const { provider, client } = await createOpenAiEmbeddingProvider(options);
+      return { provider: { ...provider, id: "siliconflow" }, openAi: client };
     }
     const { provider, client } = await createOpenAiEmbeddingProvider(options);
     return { provider, openAi: client };

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -93,7 +93,14 @@ export abstract class MemoryManagerSyncOps {
   protected abstract readonly workspaceDir: string;
   protected abstract readonly settings: ResolvedMemorySearchConfig;
   protected provider: EmbeddingProvider | null = null;
-  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama";
+  protected fallbackFrom?:
+    | "openai"
+    | "local"
+    | "gemini"
+    | "voyage"
+    | "mistral"
+    | "ollama"
+    | "siliconflow";
   protected openAi?: OpenAiEmbeddingClient;
   protected gemini?: GeminiEmbeddingClient;
   protected voyage?: VoyageEmbeddingClient;
@@ -970,7 +977,8 @@ export abstract class MemoryManagerSyncOps {
       | "local"
       | "voyage"
       | "mistral"
-      | "ollama";
+      | "ollama"
+      | "siliconflow";
 
     const fallbackModel =
       fallback === "gemini"
@@ -983,7 +991,9 @@ export abstract class MemoryManagerSyncOps {
               ? DEFAULT_MISTRAL_EMBEDDING_MODEL
               : fallback === "ollama"
                 ? DEFAULT_OLLAMA_EMBEDDING_MODEL
-                : this.settings.model;
+                : fallback === "siliconflow"
+                  ? DEFAULT_OPENAI_EMBEDDING_MODEL
+                  : this.settings.model;
 
     const fallbackResult = await createEmbeddingProvider({
       config: this.cfg,

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -56,8 +56,16 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     | "voyage"
     | "mistral"
     | "ollama"
+    | "siliconflow"
     | "auto";
-  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama";
+  protected fallbackFrom?:
+    | "openai"
+    | "local"
+    | "gemini"
+    | "voyage"
+    | "mistral"
+    | "ollama"
+    | "siliconflow";
   protected fallbackReason?: string;
   private readonly providerUnavailableReason?: string;
   protected openAi?: OpenAiEmbeddingClient;

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -111,4 +111,168 @@ describe("tui session actions", () => {
     expect(updateFooter).toHaveBeenCalledTimes(2);
     expect(requestRender).toHaveBeenCalledTimes(2);
   });
+
+  it("keeps patched model selection when a refresh returns an older snapshot", async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: {},
+      sessions: [
+        {
+          key: "agent:main:main",
+          model: "old-model",
+          modelProvider: "ollama",
+          updatedAt: 100,
+        },
+      ],
+    });
+
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: false,
+      sessionInfo: {
+        model: "old-model",
+        modelProvider: "ollama",
+        updatedAt: 100,
+      },
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { applySessionInfoFromPatch, refreshSessionInfo } = createSessionActions({
+      client: { listSessions } as unknown as GatewayChatClient,
+      chatLog: { addSystem: vi.fn() } as unknown as import("./components/chat-log.js").ChatLog,
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn(),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus: vi.fn(),
+    });
+
+    applySessionInfoFromPatch({
+      ok: true,
+      path: "/tmp/sessions.json",
+      key: "agent:main:main",
+      resolved: {
+        modelProvider: "openai",
+        model: "new-model",
+      },
+      entry: {
+        sessionId: "session-1",
+        model: "new-model",
+        modelProvider: "openai",
+        updatedAt: 200,
+      },
+    });
+
+    expect(state.sessionInfo.model).toBe("new-model");
+    expect(state.sessionInfo.modelProvider).toBe("openai");
+
+    await refreshSessionInfo();
+
+    expect(state.sessionInfo.model).toBe("new-model");
+    expect(state.sessionInfo.modelProvider).toBe("openai");
+    expect(state.sessionInfo.updatedAt).toBe(200);
+  });
+
+  it("accepts older session snapshots after switching session keys", async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: {},
+      sessions: [
+        {
+          key: "agent:main:other",
+          model: "session-model",
+          modelProvider: "openai",
+          updatedAt: 50,
+        },
+      ],
+    });
+    const loadHistory = vi.fn().mockResolvedValue({
+      sessionId: "session-2",
+      messages: [],
+    });
+
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: true,
+      sessionInfo: {
+        model: "previous-model",
+        modelProvider: "anthropic",
+        updatedAt: 500,
+      },
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { setSession } = createSessionActions({
+      client: {
+        listSessions,
+        loadHistory,
+      } as unknown as GatewayChatClient,
+      chatLog: {
+        addSystem: vi.fn(),
+        clearAll: vi.fn(),
+      } as unknown as import("./components/chat-log.js").ChatLog,
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn((raw?: string) => raw ?? "agent:main:main"),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus: vi.fn(),
+    });
+
+    await setSession("agent:main:other");
+
+    expect(loadHistory).toHaveBeenCalledWith({
+      sessionKey: "agent:main:other",
+      limit: 200,
+    });
+    expect(state.currentSessionKey).toBe("agent:main:other");
+    expect(state.sessionInfo.model).toBe("session-model");
+    expect(state.sessionInfo.modelProvider).toBe("openai");
+    expect(state.sessionInfo.updatedAt).toBe(50);
+  });
 });


### PR DESCRIPTION
## Summary
- treat bare `openclaw gateway` as allowlisted for invalid-config preflight (same behavior as `openclaw gateway run`)
- keep existing gateway subcommand allowlist behavior unchanged
- add regression coverage in `config-guard` tests

## Testing
- pnpm test src/cli/program/config-guard.test.ts

Fixes #36792
