### PR TITLE
fix(gateway): include rejected origin in control-ui auth errors

### DIFF
--- a/src/gateway/server.auth.browser-hardening.test.ts
+++ b/src/gateway/server.auth.browser-hardening.test.ts
@@ -84,6 +84,7 @@ describe("gateway auth browser hardening", () => {
         });
         expect(res.ok).toBe(false);
         expect(res.error?.message ?? "").toContain("origin not allowed");
+        expect(res.error?.message ?? "").toContain("Received origin: https://attacker.example");
       } finally {
         ws.close();
       }

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -507,8 +507,10 @@ export function attachGatewayWsMessageHandler(params: {
             isLocalClient,
           });
           if (!originCheck.ok) {
+            const originHint = requestOrigin ? ` Received origin: ${requestOrigin}.` : "";
             const errorMessage =
-              "origin not allowed (open the Control UI from the gateway host or allow it in gateway.controlUi.allowedOrigins)";
+              "origin not allowed (open the Control UI from the gateway host or allow it in gateway.controlUi.allowedOrigins)." +
+              originHint;
             markHandshakeFailure("origin-mismatch", {
               origin: requestOrigin ?? "n/a",
               host: requestHost ?? "n/a",


### PR DESCRIPTION
## Problem
Control UI origin mismatch errors were too generic (`origin not allowed`), making LAN allowlist troubleshooting hard (#36056).

## Root cause
WebSocket connect rejection message did not include the incoming `Origin` value that was denied by `gateway.controlUi.allowedOrigins`.

## Fix
- Include denied request origin in the connect error message
- Keep existing remediation guidance intact
- Added regression assertion in browser hardening test

## Testing
- `pnpm -s vitest run src/gateway/server.auth.browser-hardening.test.ts`

Closes #36056
