### PR TITLE
cron: await finished run-log writes

### DIFF
--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -352,7 +352,9 @@ describe("Cron issue regressions", () => {
     targetJobId = job.id;
     await vi.advanceTimersByTimeAsync(2);
     await started.promise;
-    expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+    });
 
     const manualResult = await cron.run(job.id, "force");
     expect(manualResult).toEqual({ ok: true, ran: false, reason: "already-running" });
@@ -1513,6 +1515,57 @@ describe("Cron issue regressions", () => {
     expect(job.state.lastError).toMatch(/^schedule error:/);
     expect(job.state.nextRunAtMs).toBe(endedAt + 30_000);
     expect(job.enabled).toBe(true);
+  });
+
+  it("awaits async finished event handlers before completing due-job ticks", async () => {
+    const store = makeStorePath();
+    const dueAt = Date.parse("2026-03-02T12:05:00.000Z");
+    const job = createDueIsolatedJob({
+      id: "await-finished-event",
+      nowMs: dueAt,
+      nextRunAtMs: dueAt,
+    });
+    await writeCronStoreSnapshot(store.storePath, [job]);
+
+    const releaseFinished = createDeferred<void>();
+    let finishedSeen = false;
+    let timerSettled = false;
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => dueAt,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      onEvent: async (evt: CronEvent) => {
+        if (evt.jobId !== job.id || evt.action !== "finished") {
+          return;
+        }
+        finishedSeen = true;
+        await releaseFinished.promise;
+      },
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const, summary: "ok" })),
+    });
+
+    const timerPromise = onTimer(state).then(() => {
+      timerSettled = true;
+    });
+
+    await vi.waitFor(() => {
+      expect(finishedSeen).toBe(true);
+    });
+    expect(timerSettled).toBe(false);
+
+    releaseFinished.resolve();
+    await timerPromise;
+
+    expect(timerSettled).toBe(true);
+    const persisted = JSON.parse(await fs.readFile(store.storePath, "utf8")) as {
+      jobs: Array<{ id: string; state?: CronJobState }>;
+    };
+    const persistedJob = persisted.jobs.find((entry) => entry.id === job.id);
+    expect(persistedJob?.state?.lastStatus).toBe("ok");
   });
 
   it("force run preserves 'every' anchor while recording manual lastRunAtMs", () => {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -255,7 +255,7 @@ export async function add(state: CronServiceState, input: CronJobCreate) {
       "cron: job added",
     );
 
-    emit(state, {
+    await emit(state, {
       jobId: job.id,
       action: "added",
       nextRunAtMs: job.state.nextRunAtMs,
@@ -309,7 +309,7 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
 
     await persist(state);
     armTimer(state);
-    emit(state, {
+    await emit(state, {
       jobId: id,
       action: "updated",
       nextRunAtMs: job.state.nextRunAtMs,
@@ -331,7 +331,7 @@ export async function remove(state: CronServiceState, id: string) {
     await persist(state);
     armTimer(state);
     if (removed) {
-      emit(state, { jobId: id, action: "removed" });
+      await emit(state, { jobId: id, action: "removed" });
     }
     return { ok: true, removed } as const;
   });
@@ -362,7 +362,7 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
     // Persist the running marker before releasing lock so timer ticks that
     // force-reload from disk cannot start the same job concurrently.
     await persist(state);
-    emit(state, { jobId: job.id, action: "started", runAtMs: now });
+    await emit(state, { jobId: job.id, action: "started", runAtMs: now });
     const executionJob = JSON.parse(JSON.stringify(job)) as typeof job;
     return {
       ok: true,
@@ -411,7 +411,7 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
       { preserveSchedule: mode === "force" },
     );
 
-    emit(state, {
+    await emit(state, {
       jobId: job.id,
       action: "finished",
       status: coreResult.status,
@@ -432,7 +432,7 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
 
     if (shouldDelete && state.store) {
       state.store.jobs = state.store.jobs.filter((entry) => entry.id !== job.id);
-      emit(state, { jobId: job.id, action: "removed" });
+      await emit(state, { jobId: job.id, action: "removed" });
     }
 
     // Manual runs should not advance other due jobs without executing them.

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -99,7 +99,7 @@ export type CronServiceDeps = {
     mode?: "announce" | "webhook";
     accountId?: string;
   }) => Promise<void>;
-  onEvent?: (evt: CronEvent) => void;
+  onEvent?: (evt: CronEvent) => Promise<void> | void;
 };
 
 export type CronServiceDepsInternal = Omit<CronServiceDeps, "nowMs"> & {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -454,7 +454,10 @@ export function applyJobResult(
   return shouldDelete;
 }
 
-function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOutcome): void {
+async function applyOutcomeToStoredJob(
+  state: CronServiceState,
+  result: TimedCronRunOutcome,
+): Promise<void> {
   const store = state.store;
   if (!store) {
     return;
@@ -477,11 +480,11 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
     endedAt: result.endedAt,
   });
 
-  emitJobFinished(state, job, result, result.startedAt);
+  await emitJobFinished(state, job, result, result.startedAt);
 
   if (shouldDelete) {
     store.jobs = jobs.filter((entry) => entry.id !== job.id);
-    emit(state, { jobId: job.id, action: "removed" });
+    await emit(state, { jobId: job.id, action: "removed" });
   }
 }
 
@@ -609,7 +612,7 @@ export async function onTimer(state: CronServiceState) {
       const { id, job } = params;
       const startedAt = state.deps.nowMs();
       job.state.runningAtMs = startedAt;
-      emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
+      await emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
       const jobTimeoutMs = resolveCronJobTimeoutMs(job);
 
       try {
@@ -658,7 +661,7 @@ export async function onTimer(state: CronServiceState) {
         await ensureLoaded(state, { forceReload: true, skipRecompute: true });
 
         for (const result of completedResults) {
-          applyOutcomeToStoredJob(state, result);
+          await applyOutcomeToStoredJob(state, result);
         }
 
         // Use maintenance-only recompute to avoid advancing past-due
@@ -860,7 +863,7 @@ export async function runMissedJobs(
   const outcomes: Array<TimedCronRunOutcome> = [];
   for (const candidate of startupCandidates) {
     const startedAt = state.deps.nowMs();
-    emit(state, { jobId: candidate.job.id, action: "started", runAtMs: startedAt });
+    await emit(state, { jobId: candidate.job.id, action: "started", runAtMs: startedAt });
     try {
       const result = await executeJobCoreWithTimeout(state, candidate.job);
       outcomes.push({
@@ -895,7 +898,7 @@ export async function runMissedJobs(
     }
 
     for (const result of outcomes) {
-      applyOutcomeToStoredJob(state, result);
+      await applyOutcomeToStoredJob(state, result);
     }
 
     // Preserve any new past-due nextRunAtMs values that became due while
@@ -1125,7 +1128,7 @@ export async function executeJob(
   const startedAt = state.deps.nowMs();
   job.state.runningAtMs = startedAt;
   job.state.lastError = undefined;
-  emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
+  await emit(state, { jobId: job.id, action: "started", runAtMs: startedAt });
 
   let coreResult: {
     status: CronRunStatus;
@@ -1147,15 +1150,15 @@ export async function executeJob(
     endedAt,
   });
 
-  emitJobFinished(state, job, coreResult, startedAt);
+  await emitJobFinished(state, job, coreResult, startedAt);
 
   if (shouldDelete && state.store) {
     state.store.jobs = state.store.jobs.filter((j) => j.id !== job.id);
-    emit(state, { jobId: job.id, action: "removed" });
+    await emit(state, { jobId: job.id, action: "removed" });
   }
 }
 
-function emitJobFinished(
+async function emitJobFinished(
   state: CronServiceState,
   job: CronJob,
   result: {
@@ -1165,7 +1168,7 @@ function emitJobFinished(
     CronRunTelemetry,
   runAtMs: number,
 ) {
-  emit(state, {
+  await emit(state, {
     jobId: job.id,
     action: "finished",
     status: result.status,
@@ -1207,9 +1210,9 @@ export function stopTimer(state: CronServiceState) {
   state.timer = null;
 }
 
-export function emit(state: CronServiceState, evt: CronEvent) {
+export async function emit(state: CronServiceState, evt: CronEvent): Promise<void> {
   try {
-    state.deps.onEvent?.(evt);
+    await state.deps.onEvent?.(evt);
   } catch {
     /* ignore */
   }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -355,9 +355,41 @@ export function buildGatewayCronService(params: {
       });
     },
     log: getChildLogger({ module: "cron", storePath }),
-    onEvent: (evt) => {
+    onEvent: async (evt) => {
       params.broadcast("cron", evt, { dropIfSlow: true });
       if (evt.action === "finished") {
+        const logPath = resolveCronRunLogPath({
+          storePath,
+          jobId: evt.jobId,
+        });
+        try {
+          await appendCronRunLog(
+            logPath,
+            {
+              ts: Date.now(),
+              jobId: evt.jobId,
+              action: "finished",
+              status: evt.status,
+              error: evt.error,
+              summary: evt.summary,
+              delivered: evt.delivered,
+              deliveryStatus: evt.deliveryStatus,
+              deliveryError: evt.deliveryError,
+              sessionId: evt.sessionId,
+              sessionKey: evt.sessionKey,
+              runAtMs: evt.runAtMs,
+              durationMs: evt.durationMs,
+              nextRunAtMs: evt.nextRunAtMs,
+              model: evt.model,
+              provider: evt.provider,
+              usage: evt.usage,
+            },
+            runLogPrune,
+          );
+        } catch (err) {
+          cronLogger.warn({ err: String(err), logPath }, "cron: run log append failed");
+        }
+
         const webhookToken = trimToOptionalString(params.cfg.cron?.webhookToken);
         const legacyWebhook = trimToOptionalString(params.cfg.cron?.webhook);
         const job = cron.getJob(evt.jobId);
@@ -467,36 +499,6 @@ export function buildGatewayCronService(params: {
             }
           }
         }
-
-        const logPath = resolveCronRunLogPath({
-          storePath,
-          jobId: evt.jobId,
-        });
-        void appendCronRunLog(
-          logPath,
-          {
-            ts: Date.now(),
-            jobId: evt.jobId,
-            action: "finished",
-            status: evt.status,
-            error: evt.error,
-            summary: evt.summary,
-            delivered: evt.delivered,
-            deliveryStatus: evt.deliveryStatus,
-            deliveryError: evt.deliveryError,
-            sessionId: evt.sessionId,
-            sessionKey: evt.sessionKey,
-            runAtMs: evt.runAtMs,
-            durationMs: evt.durationMs,
-            nextRunAtMs: evt.nextRunAtMs,
-            model: evt.model,
-            provider: evt.provider,
-            usage: evt.usage,
-          },
-          runLogPrune,
-        ).catch((err) => {
-          cronLogger.warn({ err: String(err), logPath }, "cron: run log append failed");
-        });
       }
     },
   });


### PR DESCRIPTION
## Summary
- make cron event handlers awaitable so scheduler paths can wait for finished-event side effects
- await the cron run-log append in the gateway instead of firing it off with `void`
- add a regression test that proves due-job ticks wait for async finished handlers before completing

## Why
A cron job could finish real work, but the finished run-log write was still fire-and-forget. If the process died in that gap, the run could disappear from `cron/runs/<jobId>.jsonl`, which makes cron history incomplete and makes restart catch-up more likely to replay stale jobs.

## Testing
- [x] AI-assisted: Codex
- [x] Fully tested
- `pnpm build`
- `pnpm check`
- `pnpm test`
- `pnpm exec vitest run src/cron/service.issue-regressions.test.ts src/cron/service.restart-catchup.test.ts src/cron/run-log.test.ts src/gateway/server.cron.test.ts`

## Notes
- This is a focused durability fix for finished run logging.
- It does not try to solve full crash-safe exactly-once delivery for cron side effects.