### PR TITLE
fix(daemon): stamp Windows task script with current service version

### DIFF
--- a/src/daemon/schtasks.install-version-sync.test.ts
+++ b/src/daemon/schtasks.install-version-sync.test.ts
@@ -35,4 +35,31 @@ describe("installScheduledTask", () => {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it("ignores stale OPENCLAW_SERVICE_VERSION overrides from environment", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-schtasks-install-"));
+    try {
+      const { installScheduledTask, resolveTaskScriptPath } = await import("./schtasks.js");
+      const env = { USERPROFILE: tmpDir, OPENCLAW_PROFILE: "default" };
+      const stdout = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+      await installScheduledTask({
+        env,
+        stdout,
+        programArguments: ["node", "gateway.js"],
+        workingDirectory: "C:/openclaw",
+        environment: {
+          NODE_ENV: "production",
+          OPENCLAW_SERVICE_VERSION: "stale-version-should-be-dropped",
+        },
+      });
+
+      const script = await fs.readFile(resolveTaskScriptPath(env), "utf8");
+      expect(script).toContain("OPENCLAW_SERVICE_VERSION=");
+      expect(script).not.toContain("stale-version-should-be-dropped");
+      expect((script.match(/OPENCLAW_SERVICE_VERSION=/g) || []).length).toBe(1);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/daemon/schtasks.install-version-sync.test.ts
+++ b/src/daemon/schtasks.install-version-sync.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const execSchtasksMock = vi.fn(async () => ({ code: 0, stdout: "", stderr: "" }));
+vi.mock("./schtasks-exec.js", () => ({
+  execSchtasks: execSchtasksMock,
+}));
+
+describe("installScheduledTask", () => {
+  afterEach(() => {
+    execSchtasksMock.mockClear();
+  });
+
+  it("writes OPENCLAW_SERVICE_VERSION into generated gateway.cmd", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-schtasks-install-"));
+    try {
+      const { installScheduledTask, resolveTaskScriptPath } = await import("./schtasks.js");
+      const env = { USERPROFILE: tmpDir, OPENCLAW_PROFILE: "default" };
+      const stdout = { write: vi.fn() } as unknown as NodeJS.WriteStream;
+
+      await installScheduledTask({
+        env,
+        stdout,
+        programArguments: ["node", "gateway.js"],
+        workingDirectory: "C:/openclaw",
+        environment: { NODE_ENV: "production" },
+      });
+
+      const script = await fs.readFile(resolveTaskScriptPath(env), "utf8");
+      expect(script).toContain("OPENCLAW_SERVICE_VERSION=");
+      expect(script).toContain("node gateway.js");
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -230,12 +230,23 @@ export async function installScheduledTask({
   await assertSchtasksAvailable();
   const scriptPath = resolveTaskScriptPath(env);
   await fs.mkdir(path.dirname(scriptPath), { recursive: true });
-  const taskDescription = resolveGatewayServiceDescription({ env, environment, description });
+  const sanitizedEnvironment = environment
+    ? Object.fromEntries(
+        Object.entries(environment).filter(
+          ([key]) => key.toUpperCase() !== "OPENCLAW_SERVICE_VERSION",
+        ),
+      )
+    : undefined;
+  const taskDescription = resolveGatewayServiceDescription({
+    env,
+    environment: sanitizedEnvironment,
+    description,
+  });
   const script = buildTaskScript({
     description: taskDescription,
     programArguments,
     workingDirectory,
-    environment,
+    environment: sanitizedEnvironment,
   });
   await fs.writeFile(scriptPath, script, "utf8");
 

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { VERSION } from "../version.js";
 import { parseCmdScriptCommandLine, quoteCmdScriptArg } from "./cmd-argv.js";
 import { assertNoCmdLineBreak, parseCmdSetAssignment, renderCmdSetAssignment } from "./cmd-set.js";
 import { resolveGatewayServiceDescription, resolveGatewayWindowsTaskName } from "./constants.js";
@@ -194,9 +195,11 @@ function buildTaskScript({
   if (workingDirectory) {
     lines.push(`cd /d ${quoteCmdScriptArg(workingDirectory)}`);
   }
+  lines.push(renderCmdSetAssignment("OPENCLAW_SERVICE_VERSION", VERSION));
   if (environment) {
+    const serviceVersionKey = "OPENCLAW_SERVICE_VERSION";
     for (const [key, value] of Object.entries(environment)) {
-      if (!value) {
+      if (!value || key.toUpperCase() === serviceVersionKey) {
         continue;
       }
       lines.push(renderCmdSetAssignment(key, value));


### PR DESCRIPTION
## Problem
After npm global updates, Windows Scheduled Task `gateway.cmd` could retain stale `OPENCLAW_SERVICE_VERSION`, so Control UI instances kept showing an older gateway version until manual script edits (#36301).

## Root cause
`installScheduledTask` generated the task script without forcing `OPENCLAW_SERVICE_VERSION`, relying on ambient environment/script history.

## Fix
- Always inject `OPENCLAW_SERVICE_VERSION=<current VERSION>` into generated `gateway.cmd`
- Ignore duplicate `OPENCLAW_SERVICE_VERSION` from provided environment map (prevents stale overrides)
- Added regression test covering install path script contents

## Testing
- `pnpm -s vitest run src/daemon/schtasks.install-version-sync.test.ts src/daemon/schtasks.test.ts`

Closes #36301
