### PR TITLE
fix(gateway): exit non-zero on restart shutdown timeout

### DIFF
--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -104,7 +104,7 @@ export async function runGatewayLoop(params: {
     const forceExitMs = isRestart ? DRAIN_TIMEOUT_MS + SHUTDOWN_TIMEOUT_MS : SHUTDOWN_TIMEOUT_MS;
     const forceExitTimer = setTimeout(() => {
       gatewayLog.error("shutdown timed out; exiting without full cleanup");
-      exitProcess(0);
+      exitProcess(isRestart ? 1 : 0);
     }, forceExitMs);
 
     void (async () => {


### PR DESCRIPTION
## Problem
Config-change restart fallback could hit shutdown timeout and exit with code `0`, which may leave supervisors treating the shutdown as clean while gateway runtime remains degraded (#36822).

## Root cause
`runGatewayLoop` used the same timeout exit code (`0`) for both stop and restart paths.

## Fix
- Keep graceful stop-timeout behavior as `exit(0)`
- Change restart-timeout path to `exit(1)` so launchd/systemd treat it as failure and recover with a clean process restart

## Testing
- `pnpm -s vitest run src/cli/gateway-cli/run-loop.test.ts`

Closes #36822
