### PR TITLE
fix(cron): create cron files and directories with restrictive permissions

### DIFF
--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -182,3 +182,25 @@ describe("cron run log", () => {
     });
   });
 });
+
+describe("appendCronRunLog permissions", () => {
+  it("creates runs directory with 700 permissions", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-runlog-"));
+    const logPath = path.join(dir, "runs", "job-1.jsonl");
+    const entry: CronRunLogEntry = { ts: Date.now(), jobId: "job-1", action: "finished" };
+    await appendCronRunLog(logPath, entry);
+    const dirStat = await fs.stat(path.join(dir, "runs"));
+    expect((dirStat.mode & 0o777).toString(8)).toBe("700");
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("creates run log file with 600 permissions", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-runlog-"));
+    const logPath = path.join(dir, "runs", "job-1.jsonl");
+    const entry: CronRunLogEntry = { ts: Date.now(), jobId: "job-1", action: "finished" };
+    await appendCronRunLog(logPath, entry);
+    const fileStat = await fs.stat(logPath);
+    expect((fileStat.mode & 0o777).toString(8)).toBe("600");
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+});

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -39,7 +39,7 @@ async function pruneIfNeeded(filePath: string, opts: { maxBytes: number; keepLin
   const kept = lines.slice(Math.max(0, lines.length - opts.keepLines));
   const { randomBytes } = await import("node:crypto");
   const tmp = `${filePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
-  await fs.writeFile(tmp, `${kept.join("\n")}\n`, "utf-8");
+  await fs.writeFile(tmp, `${kept.join("\n")}\n`, { encoding: "utf-8", mode: 0o600 });
   await fs.rename(tmp, filePath);
 }
 
@@ -53,8 +53,8 @@ export async function appendCronRunLog(
   const next = prev
     .catch(() => undefined)
     .then(async () => {
-      await fs.mkdir(path.dirname(resolved), { recursive: true });
-      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, "utf-8");
+      await fs.mkdir(path.dirname(resolved), { recursive: true, mode: 0o700 });
+      await fs.appendFile(resolved, `${JSON.stringify(entry)}\n`, { encoding: "utf-8", mode: 0o600 });
       await pruneIfNeeded(resolved, {
         maxBytes: opts?.maxBytes ?? 2_000_000,
         keepLines: opts?.keepLines ?? 2_000,

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -44,3 +44,31 @@ describe("cron store", () => {
     await store.cleanup();
   });
 });
+
+import { saveCronStore } from "./store.js";
+
+describe("saveCronStore permissions", () => {
+  it("creates cron directory with 700 permissions", async () => {
+    const store = await makeStorePath();
+    await saveCronStore(store.storePath, { version: 1, jobs: [] });
+    const dirStat = await fs.stat(store.dir);
+    expect((dirStat.mode & 0o777).toString(8)).toBe("700");
+    await store.cleanup();
+  });
+
+  it("creates jobs.json with 600 permissions", async () => {
+    const store = await makeStorePath();
+    await saveCronStore(store.storePath, { version: 1, jobs: [] });
+    const fileStat = await fs.stat(store.storePath);
+    expect((fileStat.mode & 0o777).toString(8)).toBe("600");
+    await store.cleanup();
+  });
+
+  it("creates jobs.json.bak with 600 permissions", async () => {
+    const store = await makeStorePath();
+    await saveCronStore(store.storePath, { version: 1, jobs: [] });
+    const bakStat = await fs.stat(`${store.storePath}.bak`);
+    expect((bakStat.mode & 0o777).toString(8)).toBe("600");
+    await store.cleanup();
+  });
+});

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -48,14 +48,15 @@ export async function loadCronStore(storePath: string): Promise<CronStoreFile> {
 }
 
 export async function saveCronStore(storePath: string, store: CronStoreFile) {
-  await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.promises.mkdir(path.dirname(storePath), { recursive: true, mode: 0o700 });
   const { randomBytes } = await import("node:crypto");
   const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
   const json = JSON.stringify(store, null, 2);
-  await fs.promises.writeFile(tmp, json, "utf-8");
+  await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: 0o600 });
   await fs.promises.rename(tmp, storePath);
   try {
     await fs.promises.copyFile(storePath, `${storePath}.bak`);
+    await fs.promises.chmod(`${storePath}.bak`, 0o600);
   } catch {
     // best-effort
   }


### PR DESCRIPTION
## Summary

Fixes #35881

## Problem

Cron-related files were being created with default `0644` permissions (world-readable), and the `runs/` directory with `0755`. While the parent `~/.openclaw/cron/` directory is `0700` (providing protection in practice), creating files with world-readable permissions is not defense-in-depth and may expose sensitive cron job data (schedules, message content, delivery targets) in environments where the home directory or umask is configured differently.

## Changes

### `src/cron/store.ts`
- `mkdir` for cron directory: added `mode: 0o700`
- `writeFile` for temp file: changed from `"utf-8"` to `{ encoding: "utf-8", mode: 0o600 }`
- After `copyFile` to `.bak`: added `chmod(..., 0o600)` (best-effort, same try/catch block)

### `src/cron/run-log.ts`
- `mkdir` for `runs/` directory: added `mode: 0o700`
- `appendFile` for log entries: changed from `"utf-8"` to `{ encoding: "utf-8", mode: 0o600 }`
- `writeFile` in `pruneIfNeeded`: changed from `"utf-8"` to `{ encoding: "utf-8", mode: 0o600 }`

## Tests Added

- `store.test.ts`: 3 new tests verifying `0700` dir and `0600` file/bak permissions
- `run-log.test.ts`: 2 new tests verifying `0700` runs dir and `0600` log file permissions