### PR TITLE
config: keep hot merged schema cache entries during eviction

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
-import { buildConfigSchema } from "./schema.js";
+import { buildConfigSchema, resetConfigSchemaCacheForTest } from "./schema.js";
 import { applyDerivedTags, CONFIG_TAGS, deriveTagsForPath } from "./schema.tags.js";
 
 describe("config schema", () => {
@@ -160,6 +160,39 @@ describe("config schema", () => {
       channels: [{ ...cachedMergeInput.channels![0] }],
     });
     expect(second).toBe(first);
+  });
+
+  it("keeps recently-read merged schema entries when pruning cache", () => {
+    resetConfigSchemaCacheForTest();
+
+    const makePluginSchemaInput = (id: string): SchemaInput => ({
+      plugins: [
+        {
+          id,
+          configSchema: {
+            type: "object",
+            properties: {
+              [`value_${id.replace(/[^a-z0-9]/gi, "_")}`]: { type: "string" },
+            },
+          },
+        },
+      ],
+    });
+
+    const hotInput = makePluginSchemaInput("cache-hot");
+    const warmInput = makePluginSchemaInput("cache-warm");
+
+    const hotEntry = buildConfigSchema(hotInput);
+    buildConfigSchema(warmInput);
+    expect(buildConfigSchema({ plugins: [{ ...hotInput.plugins![0] }] })).toBe(hotEntry);
+
+    // With a max size of 64 and two seeded entries, the 63rd insert triggers one eviction.
+    for (let i = 0; i < 63; i += 1) {
+      buildConfigSchema(makePluginSchemaInput(`cache-filler-${i}`));
+    }
+
+    const hotEntryAfterPrune = buildConfigSchema({ plugins: [{ ...hotInput.plugins![0] }] });
+    expect(hotEntryAfterPrune).toBe(hotEntry);
   });
 
   it("derives security/auth tags for credential paths", () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -353,6 +353,17 @@ function setMergedSchemaCache(key: string, value: ConfigSchemaResponse): void {
   mergedSchemaCache.set(key, value);
 }
 
+function getMergedSchemaCache(key: string): ConfigSchemaResponse | undefined {
+  const cached = mergedSchemaCache.get(key);
+  if (!cached) {
+    return undefined;
+  }
+  // Refresh hit order so frequently requested entries are evicted last.
+  mergedSchemaCache.delete(key);
+  mergedSchemaCache.set(key, cached);
+  return cached;
+}
+
 function stripChannelSchema(schema: ConfigSchema): ConfigSchema {
   const next = cloneSchema(schema);
   const root = asSchemaObject(next);
@@ -405,7 +416,7 @@ export function buildConfigSchema(params?: {
     return base;
   }
   const cacheKey = buildMergedSchemaCacheKey({ plugins, channels });
-  const cached = mergedSchemaCache.get(cacheKey);
+  const cached = getMergedSchemaCache(cacheKey);
   if (cached) {
     return cached;
   }
@@ -429,4 +440,9 @@ export function buildConfigSchema(params?: {
   };
   setMergedSchemaCache(cacheKey, merged);
   return merged;
+}
+
+export function resetConfigSchemaCacheForTest(): void {
+  cachedBase = null;
+  mergedSchemaCache.clear();
 }


### PR DESCRIPTION
## Summary
- refresh merged config-schema cache entries on read so frequently reused keys are evicted last
- preserve existing bounded cache size and keying behavior
- add a targeted regression test that verifies hot entry survival during prune pressure

## Why
The merged schema cache is bounded, but hit reads did not refresh recency. Under one-off plugin/channel churn, frequently reused schema keys could be pruned even when actively used.

## Risk
Low. The change only reorders existing cache entries (delete+set on hit) and does not alter schema generation, cache key computation, or cache capacity.

## Testing
- pnpm test src/config/schema.test.ts
