### PR TITLE
[Issue #36782] Control UI: Channels/Accounts show 'Unsupported schema node' instead of rendering config

### DIFF
--- a/automation/issue-tracker/issue-36782.md
+++ b/automation/issue-tracker/issue-36782.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36782
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36782
+- Title: Control UI: Channels/Accounts show 'Unsupported schema node' instead of rendering config
+- Created at: 2026-03-05T22:08:27Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36782
- URL: https://github.com/openclaw/openclaw/issues/36782

## Original Issue Description
The control UI `/overview` page reports "Unsupported schema node. Use Raw mode." for Channels and Accounts instead of rendering nested editable config fields.

For full details, environment, analysis, and repro steps, see the source issue.

Closes #36782