### PR TITLE
[Issue #36786] doctor: false positive gateway token mismatch when systemd uses EnvironmentFile

### DIFF
--- a/automation/issue-tracker/issue-36786.md
+++ b/automation/issue-tracker/issue-36786.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36786
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36786
+- Title: doctor: false positive gateway token mismatch when systemd uses EnvironmentFile
+- Created at: 2026-03-05T22:12:25Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36786
- URL: https://github.com/openclaw/openclaw/issues/36786

## Original Issue Description
`openclaw doctor` reports token drift/missing token when systemd user service provides `OPENCLAW_GATEWAY_TOKEN` via `EnvironmentFile=` rather than inline `Environment=`.

For full repro steps, environment details, and expected/actual behavior, see the source issue.

Closes #36786