### PR TITLE
[Issue #36792] [Bug]: Gateway promises "best-effort config" on invalid config but exits instead

### DIFF
--- a/automation/issue-tracker/issue-36792.md
+++ b/automation/issue-tracker/issue-36792.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36792
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36792
+- Title: [Bug]: Gateway promises "best-effort config" on invalid config but exits instead
+- Created at: 2026-03-05T22:18:12Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36792
- URL: https://github.com/openclaw/openclaw/issues/36792

## Original Issue Description
Reporter describes a mismatch between startup logs and behavior: gateway says it will continue with best-effort config but exits with failure when config has invalid non-critical values.

For full impact details, expected behavior, and suggested fix, see the source issue.

Closes #36792