### PR TITLE
[Issue #36796] Feature: pre-exec hook for shell command interception (dcg integration)

### DIFF
--- a/automation/issue-tracker/issue-36796.md
+++ b/automation/issue-tracker/issue-36796.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36796
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36796
+- Title: Feature: pre-exec hook for shell command interception (dcg integration)
+- Created at: 2026-03-05T22:21:44Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36796
- URL: https://github.com/openclaw/openclaw/issues/36796

## Original Issue Description
Feature request for a configurable pre-exec hook before `exec` tool calls, enabling external command guards (for example, destructive-command protection tooling) to allow/block commands.

For complete motivation, proposal, and environment details, see the source issue.

Closes #36796