### PR TITLE
[Issue #36803] Mission Control: show Artifacts/Deliverables badge in Sessions (backend-supported)

### DIFF
--- a/automation/issue-tracker/issue-36803.md
+++ b/automation/issue-tracker/issue-36803.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36803
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36803
+- Title: Mission Control: show Artifacts/Deliverables badge in Sessions (backend-supported)
+- Created at: 2026-03-05T22:28:49Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36803
- URL: https://github.com/openclaw/openclaw/issues/36803

## Original Issue Description
Proposal to expose per-session artifact summary metadata and render an Artifacts/Deliverables badge in Mission Control Sessions for easier discovery of run outputs.

For complete acceptance criteria and implementation details across gateway/API/UI, see the source issue.

Closes #36803