### PR TITLE
[Issue #36807] Feature Request: Async Discord listener / keepalive during long agent runs

### DIFF
--- a/automation/issue-tracker/issue-36807.md
+++ b/automation/issue-tracker/issue-36807.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36807
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36807
+- Title: Feature Request: Async Discord listener / keepalive during long agent runs
+- Created at: 2026-03-05T22:31:36Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36807
- URL: https://github.com/openclaw/openclaw/issues/36807

## Original Issue Description
Feature request to decouple Discord message reception from long-running agent execution so incoming messages are queued/handled without listener blocking; includes optional keepalive/status behavior.

For complete repro observations and proposal details, see the source issue.

Closes #36807