### PR TITLE
[Issue #36816] Feature Request: Hook for Slack thread session endings (session-end lifecycle event)

### DIFF
--- a/automation/issue-tracker/issue-36816.md
+++ b/automation/issue-tracker/issue-36816.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36816
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36816
+- Title: Feature Request: Hook for Slack thread session endings (session-end lifecycle event)
+- Created at: 2026-03-05T22:44:43Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36816
- URL: https://github.com/openclaw/openclaw/issues/36816

## Original Issue Description
Feature request for a new session-end lifecycle hook so thread-topic sessions can trigger memory flushes and cleanup/notification logic when they end due to inactivity or timeout.

For complete context, alternatives, and environment details, see the source issue.

Closes #36816