### PR TITLE
Bound Telegram sticker cache growth

### DIFF
--- a/src/telegram/sticker-cache.test.ts
+++ b/src/telegram/sticker-cache.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  __setStickerCacheMaxEntriesForTest,
   cacheSticker,
   getAllCachedStickers,
   getCachedSticker,
@@ -34,6 +35,7 @@ describe("sticker-cache", () => {
     if (fs.existsSync(TEST_CACHE_FILE)) {
       fs.unlinkSync(TEST_CACHE_FILE);
     }
+    __setStickerCacheMaxEntriesForTest();
   });
 
   describe("getCachedSticker", () => {
@@ -112,6 +114,37 @@ describe("sticker-cache", () => {
       const result = getCachedSticker("unique789");
       expect(result?.description).toBe("Updated description");
       expect(result?.fileId).toBe("file789-new");
+    });
+  });
+
+  describe("cache bounds", () => {
+    it("prunes oldest entries when cache exceeds max size", () => {
+      __setStickerCacheMaxEntriesForTest(2);
+
+      cacheSticker({
+        fileId: "old",
+        fileUniqueId: "old-unique",
+        description: "Old sticker",
+        cachedAt: "2026-01-20T10:00:00.000Z",
+      });
+      cacheSticker({
+        fileId: "mid",
+        fileUniqueId: "mid-unique",
+        description: "Middle sticker",
+        cachedAt: "2026-01-21T10:00:00.000Z",
+      });
+      cacheSticker({
+        fileId: "new",
+        fileUniqueId: "new-unique",
+        description: "Newest sticker",
+        cachedAt: "2026-01-22T10:00:00.000Z",
+      });
+
+      const all = getAllCachedStickers();
+      expect(all).toHaveLength(2);
+      expect(getCachedSticker("old-unique")).toBeNull();
+      expect(getCachedSticker("mid-unique")).not.toBeNull();
+      expect(getCachedSticker("new-unique")).not.toBeNull();
     });
   });
 

--- a/src/telegram/sticker-cache.ts
+++ b/src/telegram/sticker-cache.ts
@@ -16,6 +16,8 @@ import { resolveAutoImageModel } from "../media-understanding/runner.js";
 
 const CACHE_FILE = path.join(STATE_DIR, "telegram", "sticker-cache.json");
 const CACHE_VERSION = 1;
+const DEFAULT_STICKER_CACHE_MAX_ENTRIES = 2000;
+let stickerCacheMaxEntries = DEFAULT_STICKER_CACHE_MAX_ENTRIES;
 
 export interface CachedSticker {
   fileId: string;
@@ -30,6 +32,33 @@ export interface CachedSticker {
 interface StickerCache {
   version: number;
   stickers: Record<string, CachedSticker>;
+}
+
+function toCacheTimestampMs(value: string | undefined): number {
+  if (!value) {
+    return 0;
+  }
+  const ts = Date.parse(value);
+  return Number.isFinite(ts) ? ts : 0;
+}
+
+function pruneStickerCache(stickers: Record<string, CachedSticker>): void {
+  const entries = Object.entries(stickers);
+  if (entries.length <= stickerCacheMaxEntries) {
+    return;
+  }
+
+  entries.sort(
+    ([, left], [, right]) => toCacheTimestampMs(left.cachedAt) - toCacheTimestampMs(right.cachedAt),
+  );
+  const overflow = entries.length - stickerCacheMaxEntries;
+  for (let i = 0; i < overflow; i++) {
+    const key = entries[i]?.[0];
+    if (!key) {
+      continue;
+    }
+    delete stickers[key];
+  }
 }
 
 function loadCache(): StickerCache {
@@ -63,7 +92,16 @@ export function getCachedSticker(fileUniqueId: string): CachedSticker | null {
 export function cacheSticker(sticker: CachedSticker): void {
   const cache = loadCache();
   cache.stickers[sticker.fileUniqueId] = sticker;
+  pruneStickerCache(cache.stickers);
   saveCache(cache);
+}
+
+export function __setStickerCacheMaxEntriesForTest(max?: number): void {
+  if (typeof max === "number" && Number.isFinite(max) && max >= 1) {
+    stickerCacheMaxEntries = Math.floor(max);
+    return;
+  }
+  stickerCacheMaxEntries = DEFAULT_STICKER_CACHE_MAX_ENTRIES;
 }
 
 /**


### PR DESCRIPTION
## Summary
- cap persisted Telegram sticker cache size at 2000 entries
- evict oldest entries by `cachedAt` when the cap is exceeded
- add targeted tests for cache-size pruning behavior

## Why
`sticker-cache.json` could grow unbounded over time as more unique stickers were observed. This keeps the file size and read/write overhead predictable.

## Risk
Low: change is localized to cache writes and covered by focused tests.
