### PR TITLE
[Issue #36822] [Bug]: Config-change-triggered restart fails via launchctl (ETIMEDOUT), gateway enters degraded state, memory indexes stuck at zero for hours

### DIFF
--- a/automation/issue-tracker/issue-36822.md
+++ b/automation/issue-tracker/issue-36822.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36822
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36822
+- Title: [Bug]: Config-change-triggered restart fails via launchctl (ETIMEDOUT), gateway enters degraded state, memory indexes stuck at zero for hours
+- Created at: 2026-03-05T22:50:19Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36822
- URL: https://github.com/openclaw/openclaw/issues/36822

## Original Issue Description
Bug report describes restart failure on macOS LaunchAgent after config changes (`launchctl` timeout + fallback restart timeout), followed by prolonged degraded state where memory indexes remain stuck until eventual self-heal.

For full timeline, impact, logs, related issues, and suggested fixes, see the source issue.

Closes #36822