### PR TITLE
[Issue #36829] WhatsApp group: wasMentioned always false despite correct LID→E.164 resolution and mentionPatterns

### DIFF
--- a/automation/issue-tracker/issue-36829.md
+++ b/automation/issue-tracker/issue-36829.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36829
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36829
+- Title: WhatsApp group: wasMentioned always false despite correct LID→E.164 resolution and mentionPatterns
+- Created at: 2026-03-05T22:59:06Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36829
- URL: https://github.com/openclaw/openclaw/issues/36829

## Original Issue Description
Bug report indicates `wasMentioned` remains false in WhatsApp group chats even when LID mention normalization resolves to the bot E.164 and configured mention patterns should match.

For full config, logs, and expected/actual behavior details, see the source issue.

Closes #36829