### PR TITLE
[Issue #36830] [Bug]:  OpenClaw 2026.3.2 — the TUI keyboard handling broke in this version.

### DIFF
--- a/automation/issue-tracker/issue-36830.md
+++ b/automation/issue-tracker/issue-36830.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36830
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36830
+- Title: [Bug]:  OpenClaw 2026.3.2 — the TUI keyboard handling broke in this version.
+- Created at: 2026-03-05T23:01:17Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36830
- URL: https://github.com/openclaw/openclaw/issues/36830

## Original Issue Description
Regression report for OpenClaw 2026.3.2 where TUI keyboard handling in VS Code terminal maps special characters/numpad input incorrectly.

For full reproduction steps and environment details, see the source issue.

Closes #36830