### PR TITLE
[Issue #36832] [Bug] npm global install creates broken symlink on Linux (Node 22.22.0)

### DIFF
--- a/automation/issue-tracker/issue-36832.md
+++ b/automation/issue-tracker/issue-36832.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36832
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36832
+- Title: [Bug] npm global install creates broken symlink on Linux (Node 22.22.0)
+- Created at: 2026-03-05T23:03:35Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36832
- URL: https://github.com/openclaw/openclaw/issues/36832

## Original Issue Description
Bug report for npm global install on Linux where `openclaw` symlink/entrypoint becomes unusable (`command not found` / `No such file or directory`) despite apparent installation.

For complete repro steps, investigation notes, and logs, see the source issue.

Closes #36832