### PR TITLE
[Issue #36838] [Feature]: Please add gemini-3-flash-lite-preview to model catalog

### DIFF
--- a/automation/issue-tracker/issue-36838.md
+++ b/automation/issue-tracker/issue-36838.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36838
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36838
+- Title: [Feature]: Please add gemini-3-flash-lite-preview to model catalog
+- Created at: 2026-03-05T23:08:04Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36838
- URL: https://github.com/openclaw/openclaw/issues/36838

## Original Issue Description
Feature request to add `gemini-3-flash-lite-preview` to the model catalog/allowlist so users can select the new lower-cost model.

For full environment context, current model list output, and additional details, see the source issue.

Closes #36838