### PR TITLE
perf(plugins): memoize plugin-sdk alias resolution

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { withEnv } from "../test-utils/env.js";
 import { getGlobalHookRunner, resetGlobalHookRunner } from "./hook-runner-global.js";
 import { createHookRunner } from "./hooks.js";
@@ -229,6 +229,7 @@ function createPluginSdkAliasFixture(params?: {
 }
 
 afterEach(() => {
+  __testing.resetPluginSdkAliasResolutionCache();
   if (prevBundledDir === undefined) {
     delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
   } else {
@@ -1273,5 +1274,35 @@ describe("loadOpenClawPlugins", () => {
       }),
     );
     expect(resolved).toBe(srcFile);
+  });
+
+  it("memoizes plugin-sdk alias resolution to avoid repeated fs lookups", () => {
+    const { root, srcFile } = createPluginSdkAliasFixture({
+      srcFile: "memo.ts",
+      distFile: "memo.js",
+    });
+    const modulePath = path.join(root, "src", "plugins", "loader.ts");
+    const existsSyncSpy = vi.spyOn(fs, "existsSync");
+
+    const first = __testing.resolvePluginSdkAliasFile({
+      srcFile: "memo.ts",
+      distFile: "memo.js",
+      modulePath,
+    });
+    const firstCallCount = existsSyncSpy.mock.calls.length;
+
+    const second = __testing.resolvePluginSdkAliasFile({
+      srcFile: "memo.ts",
+      distFile: "memo.js",
+      modulePath,
+    });
+    const secondCallCount = existsSyncSpy.mock.calls.length;
+
+    existsSyncSpy.mockRestore();
+
+    expect(first).toBe(srcFile);
+    expect(second).toBe(srcFile);
+    expect(firstCallCount).toBeGreaterThan(0);
+    expect(secondCallCount).toBe(firstCallCount);
   });
 });

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -43,6 +43,7 @@ export type PluginLoadOptions = {
 };
 
 const registryCache = new Map<string, PluginRegistry>();
+const pluginSdkAliasResolutionCache = new Map<string, string | null>();
 
 const defaultLogger = () => createSubsystemLogger("plugins");
 
@@ -51,8 +52,21 @@ const resolvePluginSdkAliasFile = (params: {
   distFile: string;
   modulePath?: string;
 }): string | null => {
+  const modulePath = params.modulePath ?? fileURLToPath(import.meta.url);
+  const cacheKey = [
+    params.srcFile,
+    params.distFile,
+    modulePath,
+    process.env.NODE_ENV ?? "",
+    process.env.VITEST ? "1" : "0",
+  ].join("::");
+  const cached = pluginSdkAliasResolutionCache.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let resolved: string | null = null;
   try {
-    const modulePath = params.modulePath ?? fileURLToPath(import.meta.url);
     const isProduction = process.env.NODE_ENV === "production";
     const isTest = process.env.VITEST || process.env.NODE_ENV === "test";
     const normalizedModulePath = modulePath.replace(/\\/g, "/");
@@ -70,8 +84,12 @@ const resolvePluginSdkAliasFile = (params: {
           : [srcCandidate, distCandidate];
       for (const candidate of orderedCandidates) {
         if (fs.existsSync(candidate)) {
-          return candidate;
+          resolved = candidate;
+          break;
         }
+      }
+      if (resolved) {
+        break;
       }
       const parent = path.dirname(cursor);
       if (parent === cursor) {
@@ -82,7 +100,9 @@ const resolvePluginSdkAliasFile = (params: {
   } catch {
     // ignore
   }
-  return null;
+
+  pluginSdkAliasResolutionCache.set(cacheKey, resolved);
+  return resolved;
 };
 
 const resolvePluginSdkAlias = (): string | null =>
@@ -194,6 +214,7 @@ const resolvePluginSdkScopedAliasMap = (): Record<string, string> => {
 
 export const __testing = {
   resolvePluginSdkAliasFile,
+  resetPluginSdkAliasResolutionCache: () => pluginSdkAliasResolutionCache.clear(),
 };
 
 function buildCacheKey(params: {


### PR DESCRIPTION
## Summary
- memoize `resolvePluginSdkAliasFile` results by source/dist/modulePath+env
- avoid repeating the same synchronous `fs.existsSync` directory walk when plugin-sdk aliases are resolved multiple times
- expose a test-only cache reset helper and add a focused test proving repeated lookups are cache hits

## Why
Plugin loading resolves many plugin-sdk alias entries. Without memoization, each lookup repeats the same sync filesystem checks. This change keeps behavior the same while reducing startup sync I/O in that startup path.

## Risk
Low. Resolution semantics are unchanged; only repeated calls are cached. Existing alias preference tests remain, and a new memoization test verifies cache behavior.
