### PR TITLE
fix: use safe dmScope default to prevent cross-channel reply leakage

### DIFF
--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -2,6 +2,7 @@ import { listChannelPlugins } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig, GatewayBindMode } from "../config/config.js";
+import { DEFAULT_DM_SCOPE } from "../config/types.base.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import { isLoopbackHost, resolveGatewayBindHost } from "../gateway/net.js";
 import { resolveDmAllowState } from "../security/dm-policy-shared.js";
@@ -104,7 +105,7 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
       allowFrom: params.allowFrom,
       normalizeEntry: params.normalizeEntry,
     });
-    const dmScope = cfg.session?.dmScope ?? "main";
+    const dmScope = cfg.session?.dmScope ?? DEFAULT_DM_SCOPE;
 
     if (dmPolicy === "open") {
       const allowFromPath = `${params.allowFromPath}allowFrom`;

--- a/src/commands/onboard-config.test.ts
+++ b/src/commands/onboard-config.test.ts
@@ -1,16 +1,14 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import {
-  applyOnboardingLocalWorkspaceConfig,
-  ONBOARDING_DEFAULT_DM_SCOPE,
-} from "./onboard-config.js";
+import { DEFAULT_DM_SCOPE } from "../config/types.base.js";
+import { applyOnboardingLocalWorkspaceConfig } from "./onboard-config.js";
 
 describe("applyOnboardingLocalWorkspaceConfig", () => {
   it("sets secure dmScope default when unset", () => {
     const baseConfig: OpenClawConfig = {};
     const result = applyOnboardingLocalWorkspaceConfig(baseConfig, "/tmp/workspace");
 
-    expect(result.session?.dmScope).toBe(ONBOARDING_DEFAULT_DM_SCOPE);
+    expect(result.session?.dmScope).toBe(DEFAULT_DM_SCOPE);
     expect(result.gateway?.mode).toBe("local");
     expect(result.agents?.defaults?.workspace).toBe("/tmp/workspace");
   });

--- a/src/commands/onboard-config.ts
+++ b/src/commands/onboard-config.ts
@@ -1,7 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
-import type { DmScope } from "../config/types.base.js";
-
-export const ONBOARDING_DEFAULT_DM_SCOPE: DmScope = "per-channel-peer";
+import { DEFAULT_DM_SCOPE } from "../config/types.base.js";
 
 export function applyOnboardingLocalWorkspaceConfig(
   baseConfig: OpenClawConfig,
@@ -22,7 +20,7 @@ export function applyOnboardingLocalWorkspaceConfig(
     },
     session: {
       ...baseConfig.session,
-      dmScope: baseConfig.session?.dmScope ?? ONBOARDING_DEFAULT_DM_SCOPE,
+      dmScope: baseConfig.session?.dmScope ?? DEFAULT_DM_SCOPE,
     },
   };
 }

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -4,6 +4,13 @@ export type ReplyMode = "text" | "command";
 export type TypingMode = "never" | "instant" | "thinking" | "message";
 export type SessionScope = "per-sender" | "global";
 export type DmScope = "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
+
+/**
+ * Safe default for dmScope when not explicitly configured.
+ * Matches the onboarding default ("per-channel-peer") to prevent
+ * cross-channel reply leakage after upgrades that don't preserve the setting.
+ */
+export const DEFAULT_DM_SCOPE: DmScope = "per-channel-peer";
 export type ReplyToMode = "off" | "first" | "all";
 export type GroupPolicy = "open" | "disabled" | "allowlist";
 export type DmPolicy = "pairing" | "allowlist" | "open" | "disabled";

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -4,6 +4,7 @@ import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { ChannelId } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { recordSessionMetaFromInbound, resolveStorePath } from "../../config/sessions.js";
+import { DEFAULT_DM_SCOPE } from "../../config/types.base.js";
 import { parseDiscordTarget } from "../../discord/targets.js";
 import { parseIMessageTarget, normalizeIMessageHandle } from "../../imessage/targets.js";
 import { buildAgentSessionKey, type RoutePeer } from "../../routing/resolve-route.js";
@@ -112,7 +113,7 @@ function buildBaseSessionKey(params: {
     channel: params.channel,
     accountId: params.accountId,
     peer: params.peer,
-    dmScope: params.cfg.session?.dmScope ?? "main",
+    dmScope: params.cfg.session?.dmScope ?? DEFAULT_DM_SCOPE,
     identityLinks: params.cfg.session?.identityLinks,
   });
 }

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -2,6 +2,7 @@ import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { ChatType } from "../channels/chat-type.js";
 import { normalizeChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { DEFAULT_DM_SCOPE } from "../config/types.base.js";
 import { shouldLogVerbose } from "../globals.js";
 import { logDebug } from "../logger.js";
 import { listBindings } from "./bindings.js";
@@ -304,7 +305,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
 
   const bindings = getEvaluatedBindingsForChannelAccount(input.cfg, channel, accountId);
 
-  const dmScope = input.cfg.session?.dmScope ?? "main";
+  const dmScope = input.cfg.session?.dmScope ?? DEFAULT_DM_SCOPE;
   const identityLinks = input.cfg.session?.identityLinks;
 
   const choose = (agentId: string, matchedBy: ResolvedAgentRoute["matchedBy"]) => {

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -1,4 +1,5 @@
 import type { ChatType } from "../channels/chat-type.js";
+import { DEFAULT_DM_SCOPE } from "../config/types.base.js";
 import { parseAgentSessionKey, type ParsedAgentSessionKey } from "../sessions/session-key-utils.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "./account-id.js";
 
@@ -124,7 +125,7 @@ export function buildAgentPeerSessionKey(params: {
 }): string {
   const peerKind = params.peerKind ?? "direct";
   if (peerKind === "direct") {
-    const dmScope = params.dmScope ?? "main";
+    const dmScope = params.dmScope ?? DEFAULT_DM_SCOPE;
     let peerId = (params.peerId ?? "").trim();
     const linkedPeerId =
       dmScope === "main"

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -9,6 +9,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { resolveNativeCommandsEnabled, resolveNativeSkillsEnabled } from "../config/commands.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { isDangerousNameMatchingEnabled } from "../config/dangerous-name-matching.js";
+import { DEFAULT_DM_SCOPE } from "../config/types.base.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
 import { normalizeStringEntries } from "../shared/string-normalization.js";
 import type { SecurityAuditFinding, SecurityAuditSeverity } from "./audit.js";
@@ -127,7 +128,7 @@ export async function collectChannelSecurityFindings(params: {
       allowFrom: input.allowFrom,
       normalizeEntry: input.normalizeEntry,
     });
-    const dmScope = params.cfg.session?.dmScope ?? "main";
+    const dmScope = params.cfg.session?.dmScope ?? DEFAULT_DM_SCOPE;
 
     if (input.dmPolicy === "open") {
       const allowFromKey = `${input.allowFromPath}allowFrom`;


### PR DESCRIPTION
## Problem

After upgrading to 2026.3.2, users with multi-channel setups (WebChat/TUI + iMessage) experienced cross-channel reply leakage. WebChat replies were also delivered to iMessage contacts because `dmScope` defaulted to `"main"` when not explicitly configured.

## Root Cause

Five runtime sites defaulted `dmScope` to `"main"` via `?? "main"`, while onboarding correctly defaults new installs to `"per-channel-peer"`. After an upgrade that didn't preserve the explicit dmScope setting, the runtime silently fell back to the unsafe `"main"` default, causing all channels to share the same session.

## Fix

- Introduce a shared `DEFAULT_DM_SCOPE` constant (`"per-channel-peer"`) in `config/types.base.ts`
- Replace all 5 hardcoded `?? "main"` fallbacks with the shared constant
- Consolidate with the onboarding default (was a separate `ONBOARDING_DEFAULT_DM_SCOPE` constant)

### Files changed (8):
- `src/config/types.base.ts` — new `DEFAULT_DM_SCOPE` constant
- `src/infra/outbound/outbound-session.ts` — outbound routing
- `src/routing/resolve-route.ts` — inbound routing  
- `src/routing/session-key.ts` — session key generation
- `src/security/audit-channel.ts` — security audit
- `src/commands/doctor-security.ts` — doctor checks
- `src/commands/onboard-config.ts` — consolidated with shared constant
- `src/commands/onboard-config.test.ts` — updated imports

## Testing

- All 96 existing tests pass (onboard-config: 3, session-key: 14, audit: 79)
- TypeScript compilation clean
- No behavior change for users who explicitly set `session.dmScope` in config

## Breaking Change Note

Users who intentionally relied on the implicit `"main"` default (without setting it in config) will now get `"per-channel-peer"` behavior. This is the safer default and matches what onboarding has always set for new installs. Users who want `"main"` can set it explicitly: `openclaw config set session.dmScope main`

Fixes #36687