### PR TITLE
Fix SecretRef crash in audit and add edge-case test coverage

### DIFF
--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -108,8 +108,26 @@ describe("parseDurationMs", () => {
     }
   });
 
+  it("uses defaultUnit for bare numbers", () => {
+    expect(parseDurationMs("10", { defaultUnit: "s" })).toBe(10_000);
+    expect(parseDurationMs("5", { defaultUnit: "m" })).toBe(300_000);
+    expect(parseDurationMs("1", { defaultUnit: "h" })).toBe(3_600_000);
+  });
+
+  it("parses zero durations", () => {
+    expect(parseDurationMs("0")).toBe(0);
+    expect(parseDurationMs("0ms")).toBe(0);
+    expect(parseDurationMs("0s")).toBe(0);
+  });
+
   it("rejects invalid composite strings", () => {
     expect(() => parseDurationMs("1h30")).toThrow();
     expect(() => parseDurationMs("1h-30m")).toThrow();
+  });
+
+  it("rejects invalid single-token inputs", () => {
+    expect(() => parseDurationMs("abc")).toThrow();
+    expect(() => parseDurationMs("   ")).toThrow();
+    expect(() => parseDurationMs("")).toThrow();
   });
 });

--- a/src/infra/format-time/format-duration.ts
+++ b/src/infra/format-time/format-duration.ts
@@ -28,7 +28,7 @@ export function formatDurationPrecise(
   ms: number,
   options: FormatDurationSecondsOptions = {},
 ): string {
-  if (!Number.isFinite(ms)) {
+  if (!Number.isFinite(ms) || ms < 0) {
     return "unknown";
   }
   if (ms < 1000) {

--- a/src/infra/format-time/format-time.test.ts
+++ b/src/infra/format-time/format-time.test.ts
@@ -61,6 +61,10 @@ describe("format-duration", () => {
       expect(formatDurationHuman(null, "unknown")).toBe("unknown");
     });
 
+    it("returns ms for zero input", () => {
+      expect(formatDurationHuman(0)).toBe("0ms");
+    });
+
     it("formats single-unit outputs and day threshold behavior", () => {
       const cases = [
         [500, "500ms"],
@@ -94,6 +98,11 @@ describe("format-duration", () => {
       expect(formatDurationPrecise(NaN)).toBe("unknown");
       expect(formatDurationPrecise(Infinity)).toBe("unknown");
     });
+
+    it("returns unknown for negative input", () => {
+      expect(formatDurationPrecise(-500)).toBe("unknown");
+      expect(formatDurationPrecise(-1500)).toBe("unknown");
+    });
   });
 
   describe("formatDurationSeconds", () => {
@@ -105,6 +114,10 @@ describe("format-duration", () => {
 
     it("supports seconds unit", () => {
       expect(formatDurationSeconds(2000, { unit: "seconds" })).toBe("2 seconds");
+    });
+
+    it("clamps negative input to 0", () => {
+      expect(formatDurationSeconds(-1000)).toBe("0s");
     });
   });
 });
@@ -164,6 +177,11 @@ describe("format-relative", () => {
       expect(formatTimeAgo(null, { fallback: "n/a" })).toBe("n/a");
     });
 
+    it("returns fallback for NaN and Infinity", () => {
+      expect(formatTimeAgo(NaN)).toBe("unknown");
+      expect(formatTimeAgo(Infinity)).toBe("unknown");
+    });
+
     it("formats relative age around key unit boundaries", () => {
       const cases = [
         [0, "just now"],
@@ -193,6 +211,11 @@ describe("format-relative", () => {
         expect(formatRelativeTimestamp(value)).toBe("n/a");
       }
       expect(formatRelativeTimestamp(null, { fallback: "unknown" })).toBe("unknown");
+    });
+
+    it("returns fallback for NaN and Infinity", () => {
+      expect(formatRelativeTimestamp(NaN)).toBe("n/a");
+      expect(formatRelativeTimestamp(Infinity)).toBe("n/a");
     });
 
     it.each([

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -211,7 +211,17 @@ export async function collectChannelSecurityFindings(params: {
         plugin.id,
         accountId,
       );
-      const account = plugin.config.resolveAccount(params.cfg, accountId);
+      let account: ReturnType<typeof plugin.config.resolveAccount>;
+      try {
+        account = plugin.config.resolveAccount(params.cfg, accountId);
+      } catch (err) {
+        // Skip accounts whose credentials are unresolved SecretRefs (e.g. file-backed tokens).
+        // The audit cannot inspect credentials that require a live gateway runtime to resolve.
+        if (err instanceof Error && err.message.includes("unresolved SecretRef")) {
+          continue;
+        }
+        throw err;
+      }
       const enabled = plugin.config.isEnabled ? plugin.config.isEnabled(account, params.cfg) : true;
       if (!enabled) {
         continue;


### PR DESCRIPTION
## Summary

This PR addresses two code issues and adds missing test coverage for edge cases in core utility functions.

## Changes

### Bug Fixes

- **src/security/audit-channel.ts**: Skip accounts with unresolved SecretRef in collectChannelSecurityFindings. Previously openclaw status would crash with an unhandled error when channels.telegram.botToken (or any channel credential) was stored as a file-backed SecretRef, because plugin.config.resolveAccount throws for unresolved refs. Now those accounts are skipped with a continue so the rest of the audit proceeds normally. Closes #36737.

- **src/infra/format-time/format-duration.ts**: ormatDurationPrecise now returns 'unknown' for negative input (consistent with ormatDurationHuman). Previously it returned e.g. '-500ms' for -500.

### Test Coverage

- ormat-time.test.ts: add ormatDurationPrecise negative tests, ormatDurationSeconds negative clamping test, ormatDurationHuman zero-input test, ormatTimeAgo NaN/Infinity tests, ormatRelativeTimestamp NaN/Infinity tests
- cli-utils.test.ts: add parseDurationMs tests for defaultUnit option (previously uncovered), zero-value inputs ('0', '0ms', '0s'), and invalid single-token inputs ('abc', '   ', '')