### PR TITLE
fix(telegram): suppress NO_REPLY streaming prefixes like 'NO'

### DIFF
--- a/src/config/config-paths.ts
+++ b/src/config/config-paths.ts
@@ -3,6 +3,50 @@ import { isBlockedObjectKey } from "./prototype-keys.js";
 
 type PathNode = Record<string, unknown>;
 
+function tokenizePath(raw: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let inBracket = false;
+  let bracketChar: string | null = null;
+
+  for (let i = 0; i < raw.length; i++) {
+    const char = raw[i];
+
+    if (inBracket) {
+      if (char === bracketChar && raw[i + 1] === "]") {
+        tokens.push(current.trim());
+        current = "";
+        inBracket = false;
+        bracketChar = null;
+        i++; // skip the closing ]
+      } else {
+        current += char;
+      }
+    } else if (char === "[" && (raw[i + 1] === '"' || raw[i + 1] === "'")) {
+      if (current) {
+        tokens.push(current.trim());
+        current = "";
+      }
+      inBracket = true;
+      bracketChar = raw[i + 1];
+      i++; // skip the opening quote
+    } else if (char === ".") {
+      if (current.trim()) {
+        tokens.push(current.trim());
+        current = "";
+      }
+    } else {
+      current += char;
+    }
+  }
+
+  if (current.trim()) {
+    tokens.push(current.trim());
+  }
+
+  return tokens;
+}
+
 export function parseConfigPath(raw: string): {
   ok: boolean;
   path?: string[];
@@ -15,7 +59,7 @@ export function parseConfigPath(raw: string): {
       error: "Invalid path. Use dot notation (e.g. foo.bar).",
     };
   }
-  const parts = trimmed.split(".").map((part) => part.trim());
+  const parts = tokenizePath(trimmed);
   if (parts.some((part) => !part)) {
     return {
       ok: false,

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -5,6 +5,7 @@ import type {
   ReactionTypeEmoji,
 } from "@grammyjs/types";
 import { type ApiClientOptions, Bot, HttpError, InputFile } from "grammy";
+import { isSilentReplyText } from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
@@ -463,6 +464,13 @@ export async function sendMessageTelegram(
   text: string,
   opts: TelegramSendOpts = {},
 ): Promise<TelegramSendResult> {
+  // Suppress NO_REPLY sentinel - same guard as Slack
+  const trimmedText = text?.trim() ?? "";
+  if (isSilentReplyText(trimmedText) && !opts.mediaUrl && !opts.buttons) {
+    logVerbose("telegram send: suppressed NO_REPLY token before API call");
+    return { messageId: "suppressed", chatId: "" };
+  }
+
   const { cfg, account, api } = resolveTelegramApiContext(opts);
   const target = parseTelegramTarget(to);
   const chatId = await resolveAndPersistChatId({

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -5,7 +5,7 @@ import type {
   ReactionTypeEmoji,
 } from "@grammyjs/types";
 import { type ApiClientOptions, Bot, HttpError, InputFile } from "grammy";
-import { isSilentReplyText } from "../auto-reply/tokens.js";
+import { isSilentReplyPrefixText, isSilentReplyText } from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
@@ -468,6 +468,11 @@ export async function sendMessageTelegram(
   const trimmedText = text?.trim() ?? "";
   if (isSilentReplyText(trimmedText) && !opts.mediaUrl && !opts.buttons) {
     logVerbose("telegram send: suppressed NO_REPLY token before API call");
+    return { messageId: "suppressed", chatId: "" };
+  }
+  // Also suppress streaming prefixes like "NO" from "NO_REPLY"
+  if (isSilentReplyPrefixText(trimmedText) && !opts.mediaUrl && !opts.buttons) {
+    logVerbose("telegram send: suppressed NO_REPLY prefix token before API call");
     return { messageId: "suppressed", chatId: "" };
   }
 


### PR DESCRIPTION
## Summary

When the agent responds with , streaming can emit 'NO' before the full 'NO_REPLY' token. The existing  check only matches the exact token, so 'NO' was being sent to Telegram channels and got auto-pinned.

## Fix

Added  check to suppress streaming fragments like 'NO' that appear during NO_REPLY delivery.

## Testing

- Existing tests in  cover the  function behavior

## Related

- Fixes #36811