### PR TITLE
perf(gateway): fast-path safe chat message sanitization

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -95,15 +95,18 @@ const CHANNEL_AGNOSTIC_SESSION_SCOPES = new Set([
 ]);
 const CHANNEL_SCOPED_SESSION_SHAPES = new Set(["direct", "dm", "group", "channel"]);
 
+const CHAT_DISALLOWED_CONTROL_CHAR_PATTERN = "[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F]";
+const CHAT_DISALLOWED_CONTROL_CHAR_DETECT_RE = new RegExp(CHAT_DISALLOWED_CONTROL_CHAR_PATTERN);
+const CHAT_DISALLOWED_CONTROL_CHAR_REPLACE_RE = new RegExp(
+  CHAT_DISALLOWED_CONTROL_CHAR_PATTERN,
+  "g",
+);
+
 function stripDisallowedChatControlChars(message: string): string {
-  let output = "";
-  for (const char of message) {
-    const code = char.charCodeAt(0);
-    if (code === 9 || code === 10 || code === 13 || (code >= 32 && code !== 127)) {
-      output += char;
-    }
+  if (!CHAT_DISALLOWED_CONTROL_CHAR_DETECT_RE.test(message)) {
+    return message;
   }
-  return output;
+  return message.replace(CHAT_DISALLOWED_CONTROL_CHAR_REPLACE_RE, "");
 }
 
 export function sanitizeChatSendMessageInput(

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -267,6 +267,11 @@ describe("sanitizeChatSendMessageInput", () => {
     });
   });
 
+  it("keeps already-safe messages unchanged", () => {
+    const message = "safe text\twith whitespace\nemoji 😀";
+    expect(sanitizeChatSendMessageInput(message)).toEqual({ ok: true, message });
+  });
+
   it("strips unsafe control characters while preserving tab/newline/carriage return", () => {
     const result = sanitizeChatSendMessageInput("a\u0001b\tc\nd\re\u0007f\u007f");
     expect(result).toEqual({ ok: true, message: "ab\tc\nd\ref" });


### PR DESCRIPTION
## Summary
- replace the per-character sanitizer loop with a detect-then-replace regex path
- return early for already-safe inputs in `sanitizeChatSendMessageInput`
- add a regression test to confirm safe messages are preserved

## Why
`sanitizeChatSendMessageInput` is on the chat-send hot path. Most inputs are already safe, so avoiding needless per-character reconstruction reduces overhead.

## Risk
Low: filtering rules are unchanged and covered by existing sanitizer tests plus one new safe-input case.

## Validation
- `pnpm vitest src/gateway/server-methods/server-methods.test.ts -t sanitizeChatSendMessageInput`
