### PR TITLE
media: log stream cleanup failures in readResponseWithLimit

### DIFF
--- a/src/media/read-response-with-limit.test.ts
+++ b/src/media/read-response-with-limit.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  logVerbose: vi.fn(),
+}));
+const { logVerbose } = mocks;
+
+vi.mock("../globals.js", async () => {
+  const actual = await vi.importActual<typeof import("../globals.js")>("../globals.js");
+  return { ...actual, logVerbose };
+});
+
+const { readResponseWithLimit } = await import("./read-response-with-limit.js");
+
+function makeResponse(reader: {
+  read: () => Promise<{ done: boolean; value?: Uint8Array }>;
+  cancel: () => Promise<void>;
+  releaseLock: () => void;
+}): Response {
+  return {
+    body: {
+      getReader: () => reader,
+    },
+    url: "https://example.test/media.bin",
+  } as unknown as Response;
+}
+
+describe("readResponseWithLimit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps overflow behavior when cancel fails and logs the cancel error", async () => {
+    const reader = {
+      read: vi.fn().mockResolvedValueOnce({
+        done: false,
+        value: new Uint8Array([1, 2, 3, 4, 5]),
+      }),
+      cancel: vi.fn().mockRejectedValue(new Error("cancel failed")),
+      releaseLock: vi.fn(),
+    };
+
+    await expect(readResponseWithLimit(makeResponse(reader), 4)).rejects.toThrow(
+      "Content too large: 5 bytes (limit: 4 bytes)",
+    );
+    expect(reader.cancel).toHaveBeenCalledTimes(1);
+    expect(reader.releaseLock).toHaveBeenCalledTimes(1);
+    expect(logVerbose).toHaveBeenCalledTimes(1);
+    expect(logVerbose).toHaveBeenCalledWith(expect.stringContaining("reader.cancel failed"));
+  });
+
+  it("returns buffered data when releaseLock fails and logs the release error", async () => {
+    const reader = {
+      read: vi
+        .fn()
+        .mockResolvedValueOnce({
+          done: false,
+          value: new Uint8Array([7, 8, 9]),
+        })
+        .mockResolvedValueOnce({
+          done: true,
+          value: undefined,
+        }),
+      cancel: vi.fn().mockResolvedValue(undefined),
+      releaseLock: vi.fn(() => {
+        throw new Error("release failed");
+      }),
+    };
+
+    const result = await readResponseWithLimit(makeResponse(reader), 10);
+
+    expect(result).toEqual(Buffer.from([7, 8, 9]));
+    expect(reader.cancel).not.toHaveBeenCalled();
+    expect(logVerbose).toHaveBeenCalledTimes(1);
+    expect(logVerbose).toHaveBeenCalledWith(expect.stringContaining("reader.releaseLock failed"));
+  });
+});

--- a/src/media/read-response-with-limit.ts
+++ b/src/media/read-response-with-limit.ts
@@ -1,3 +1,5 @@
+import { logVerbose } from "../globals.js";
+
 export async function readResponseWithLimit(
   res: Response,
   maxBytes: number,
@@ -33,7 +35,9 @@ export async function readResponseWithLimit(
         if (total > maxBytes) {
           try {
             await reader.cancel();
-          } catch {}
+          } catch (err) {
+            logVerbose(`media: reader.cancel failed after overflow: ${String(err)}`);
+          }
           throw onOverflow({ size: total, maxBytes, res });
         }
         chunks.push(value);
@@ -42,7 +46,9 @@ export async function readResponseWithLimit(
   } finally {
     try {
       reader.releaseLock();
-    } catch {}
+    } catch (err) {
+      logVerbose(`media: reader.releaseLock failed: ${String(err)}`);
+    }
   }
 
   return Buffer.concat(


### PR DESCRIPTION
## Summary
- add verbose observability when `reader.cancel()` fails after max-bytes overflow
- add verbose observability when `reader.releaseLock()` fails in cleanup
- add focused unit tests covering both failure paths

## Why
`readResponseWithLimit` previously swallowed these exceptions silently, making overflow and stream-teardown diagnosis harder.

## Impact
Caller-facing behavior is unchanged:
- overflow still throws the same `onOverflow` error
- successful reads still return buffered content even if cleanup throws

## Risk
Low. The change only affects exceptional paths and adds verbose logging plus tests.

## Validation
- `pnpm vitest run src/media/read-response-with-limit.test.ts --config vitest.config.ts`