### PR TITLE
[Issue #36865] [Bug] process tool 记录完整 TUI 输出导致 session transcript 爆炸

### DIFF
--- a/automation/issue-tracker/issue-36865.md
+++ b/automation/issue-tracker/issue-36865.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36865
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36865
+- Title: [Bug] process tool 记录完整 TUI 输出导致 session transcript 爆炸
+- Created at: 2026-03-05T23:28:18Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36865
- URL: https://github.com/openclaw/openclaw/issues/36865

## Original Issue Description

## 问题描述

使用 `process` 工具监控 Claude Code 等 TUI 应用时，完整的终端渲染数据（包括 ANSI 转义序列）被记录到 session transcript，导致单条记录达到 **~400KB**，session 文件迅速膨胀到 **2.3MB**，最终触发 `model_context_window_exceeded` 错误。

## 根因分析

session transcript 大小分布：
- 4 条 ~400KB 的 process toolResult（总计 ~1.6MB，占 70%）
- 其他记录（占 30%）
- 总计 2.3MB → 上下文爆炸

每次 `process action:log` 都返回完整的 TUI 界面渲染，包括 ANSI 颜色代码、光标移动序列、ASCII 边框，并原样写入 transcript。

## 建议的解决方案

1. 过滤 ANSI 转义序列（推荐）
2. 限制单条记录大小（如 50KB）
3. process 工具增加 `stripAnsi` 参数

> 以上内容直接摘自原始 issue 描述；完整复现步骤、示例与代码片段请见原 issue。

Closes #36865