### PR TITLE
[Issue #36870] [Bug]: QMD backend: openclaw memory search times out and deletes QMD collections (qmd collection remove …)

### DIFF
--- a/automation/issue-tracker/issue-36870.md
+++ b/automation/issue-tracker/issue-36870.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36870
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36870
+- Title: [Bug]: QMD backend: openclaw memory search times out and deletes QMD collections (qmd collection remove …)
+- Created at: 2026-03-05T23:32:11Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36870
- URL: https://github.com/openclaw/openclaw/issues/36870

## Original Issue Description

When using OpenClaw memory backend qmd, `openclaw memory search` frequently times out and appears to execute `qmd collection remove`, removing collections from the index.

Reported behavior:
- Search exceeds 20–40s and times out
- QMD collection gets removed during/after search
- `qmd collection list` then shows no collections

Expected behavior:
- Search should not remove collections
- SearchMode=search (BM25) should be fast and non-destructive

Environment and notes from issue:
- OpenClaw 2026.3.1
- QMD 1.0.7
- Node v24.13.1
- Debian

> This is extracted from the original issue description; full reproduction steps and workaround commands are in the source issue.

Closes #36870