### PR TITLE
[Issue #36878] Missing calendar decline functionality in gog CLI

### DIFF
--- a/automation/issue-tracker/issue-36878.md
+++ b/automation/issue-tracker/issue-36878.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36878
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36878
+- Title: Missing calendar decline functionality in gog CLI
+- Created at: 2026-03-05T23:45:30Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36878
- URL: https://github.com/openclaw/openclaw/issues/36878

## Original Issue Description

Need `gog cal decline` support for calendar invitations.

Reported in issue:
- `gog cal decline` currently errors with “unexpected argument decline”
- expected decline response to organizer and event removal from calendar
- related request includes possible `accept` and `tentative` commands

Closes #36878