### PR TITLE
[Issue #36881] nano-banana-pro: explicit --resolution 1K can be overridden by auto-detection

### DIFF
--- a/automation/issue-tracker/issue-36881.md
+++ b/automation/issue-tracker/issue-36881.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36881
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36881
+- Title: nano-banana-pro: explicit --resolution 1K can be overridden by auto-detection
+- Created at: 2026-03-05T23:53:45Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36881
- URL: https://github.com/openclaw/openclaw/issues/36881

## Original Issue Description

Issue reports that `skills/nano-banana-pro/scripts/generate_image.py` may auto-upgrade resolution (`1K` → `2K/4K`) even when the user explicitly passes `--resolution 1K`.

Root cause from issue:
- `1K` is used both as parser default and as explicit user value
- script cannot distinguish omitted flag vs explicit `1K`

Expected behavior:
- explicit `--resolution` is always respected
- auto-detection only runs when flag is omitted

Closes #36881