### PR TITLE
[Issue #36882] Webchat: HEARTBEAT_OK and heartbeat prompt visible to user instead of being suppressed

### DIFF
--- a/automation/issue-tracker/issue-36882.md
+++ b/automation/issue-tracker/issue-36882.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36882
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36882
+- Title: Webchat: HEARTBEAT_OK and heartbeat prompt visible to user instead of being suppressed
+- Created at: 2026-03-05T23:54:32Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36882
- URL: https://github.com/openclaw/openclaw/issues/36882

## Original Issue Description

On Webchat, heartbeat prompt messages and `HEARTBEAT_OK` acknowledgements are shown as visible chat messages, but should be suppressed as internal/system messages (similar to Telegram behavior).

Repro from issue:
1. configure heartbeat
2. open webchat session
3. wait for heartbeat/restart gateway
4. heartbeat prompt and reply appear visibly

Expected:
- neither internal heartbeat prompt nor `HEARTBEAT_OK` should be visible in Webchat UI

Closes #36882