### PR TITLE
fix(voice-call): defer initial message to onConnect when streaming is enabled

### DIFF
--- a/extensions/voice-call/src/manager.notify.test.ts
+++ b/extensions/voice-call/src/manager.notify.test.ts
@@ -1,6 +1,61 @@
 import { describe, expect, it } from "vitest";
 import { createManagerHarness, FakeProvider } from "./manager.test-harness.js";
 
+describe("CallManager streaming initial message", () => {
+  it("skips initial message on answered when streaming is enabled", async () => {
+    const provider = new FakeProvider("twilio");
+    const { manager } = await createManagerHarness(
+      { streaming: { enabled: true } },
+      provider,
+    );
+
+    const { callId, success } = await manager.initiateCall("+15550000002", undefined, {
+      message: "Hello streamed",
+      mode: "conversation",
+    });
+    expect(success).toBe(true);
+
+    manager.processEvent({
+      id: "evt-stream-1",
+      type: "call.answered",
+      callId,
+      providerCallId: "call-uuid",
+      timestamp: Date.now(),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(provider.playTtsCalls).toHaveLength(0);
+  });
+
+  it("speaks initial message on answered when streaming is disabled", async () => {
+    const provider = new FakeProvider("twilio");
+    const { manager } = await createManagerHarness(
+      { streaming: { enabled: false } },
+      provider,
+    );
+
+    const { callId, success } = await manager.initiateCall("+15550000002", undefined, {
+      message: "Hello non-streamed",
+      mode: "notify",
+    });
+    expect(success).toBe(true);
+
+    manager.processEvent({
+      id: "evt-nostream-1",
+      type: "call.answered",
+      callId,
+      providerCallId: "call-uuid",
+      timestamp: Date.now(),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(provider.playTtsCalls).toHaveLength(1);
+    expect(provider.playTtsCalls[0]?.text).toBe("Hello non-streamed");
+  });
+});
+
 describe("CallManager notify and mapping", () => {
   it("upgrades providerCallId mapping when provider ID changes", async () => {
     const { manager } = await createManagerHarness();

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -270,6 +270,10 @@ export class CallManager {
   }
 
   private maybeSpeakInitialMessageOnAnswered(call: CallRecord): void {
+    if (this.config.streaming?.enabled) {
+      return;
+    }
+
     const initialMessage =
       typeof call.metadata?.initialMessage === "string" ? call.metadata.initialMessage.trim() : "";
 


### PR DESCRIPTION
## Summary

- **Problem:** For outbound calls with streaming enabled, `maybeSpeakInitialMessageOnAnswered` races with the WebSocket media stream connection. The `call.answered` event and the `<Connect><Stream>` TwiML are on the same HTTP request for outbound calls, so `onCallAnswered` fires before the stream connects. This causes `playTts` to fall back to TwiML `<Say>` (Polly) and consume `initialMessage`, leaving nothing for the stream's `onConnect` handler.
- **Why it matters:** Users configuring ElevenLabs or other streaming TTS providers for outbound calls never hear their initial message via the streaming provider — it always falls back to Polly.
- **What changed:** `maybeSpeakInitialMessageOnAnswered` now returns early when `this.config.streaming?.enabled` is true, deferring initial message delivery to the `onConnect` callback in `webhook.ts` which fires once the media stream is ready.
- **What did NOT change:** Non-streaming mode (TwiML `<Say>` fallback) continues to work as before. Inbound calls are unaffected (stream connects before `call.answered`).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36869

## User-visible / Behavior Changes

- Outbound calls with streaming enabled now correctly use the streaming TTS provider (e.g. ElevenLabs) for the initial message instead of falling back to Polly.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22
- Integration/channel: voice-call (Twilio)

### Steps

1. Configure voice-call with `streaming.enabled: true` and ElevenLabs TTS
2. Initiate an outbound call with `--mode conversation --message "Hello"`
3. Observe TTS provider used for initial message

### Expected

- Initial message spoken via ElevenLabs (streaming TTS)

### Actual

- Before fix: Initial message spoken via Polly (`<Say>` TwiML fallback), then consumed before stream connects
- After fix: Initial message deferred to `onConnect`, spoken via ElevenLabs once stream is ready

## Evidence

```
 extensions/voice-call/src/manager.notify.test.ts | 55 +++++++++++++++++++++
 extensions/voice-call/src/manager.ts             |  4 ++
 2 files changed, 59 insertions(+)
```

All 5 tests pass: 2 new tests verify streaming-enabled skips `onAnswered` path, streaming-disabled still speaks on `onAnswered`.

## Human Verification (required)

- Verified scenarios: streaming enabled skips onAnswered, streaming disabled speaks on onAnswered, no initial message is a no-op
- Edge cases checked: missing provider, missing providerCallId, empty initial message
- What I did **not** verify: Live Twilio outbound call with ElevenLabs streaming

## Compatibility / Migration

- Backward compatible? `Yes — non-streaming mode unchanged`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; or set `streaming.enabled: false`
- Files/config to restore: `extensions/voice-call/src/manager.ts`
- Known bad symptoms: If reverted, outbound streaming calls fall back to Polly for initial message

## Risks and Mitigations

- Risk: If `onConnect` never fires (stream fails to connect), initial message is never spoken
- Mitigation: This is the existing behavior for inbound calls which already rely on `onConnect`; the 500ms setTimeout in `onConnect` provides buffer for stream setup

