### PR TITLE
fix(telegram): support mediaLocalRoots for outbound local files

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -874,6 +874,7 @@ Primary reference:
 - `channels.telegram.linkPreview`: toggle link previews for outbound messages (default: true).
 - `channels.telegram.streaming`: `off | partial | block | progress` (live stream preview; default: `partial`; `progress` maps to `partial`; `block` is legacy preview mode compatibility). In DMs, `partial` uses native `sendMessageDraft` when available.
 - `channels.telegram.mediaMaxMb`: inbound Telegram media download/processing cap (MB).
+- `channels.telegram.mediaLocalRoots`: explicit allowlist of absolute local directories permitted for outbound local media paths (for example `~/Desktop`). Account override: `channels.telegram.accounts.<id>.mediaLocalRoots`.
 - `channels.telegram.retry`: retry policy for Telegram send helpers (CLI/tools/actions) on recoverable outbound API errors (attempts, minDelayMs, maxDelayMs, jitter).
 - `channels.telegram.network.autoSelectFamily`: override Node autoSelectFamily (true=enable, false=disable). Defaults to enabled on Node 22+, with WSL2 defaulting to disabled.
 - `channels.telegram.network.dnsResultOrder`: override DNS result order (`ipv4first` or `verbatim`). Defaults to `ipv4first` on Node 22+.
@@ -900,7 +901,7 @@ Telegram-specific high-signal fields:
 - threading/replies: `replyToMode`
 - streaming: `streaming` (preview), `blockStreaming`
 - formatting/delivery: `textChunkLimit`, `chunkMode`, `linkPreview`, `responsePrefix`
-- media/network: `mediaMaxMb`, `timeoutSeconds`, `retry`, `network.autoSelectFamily`, `proxy`
+- media/network: `mediaMaxMb`, `mediaLocalRoots`, `timeoutSeconds`, `retry`, `network.autoSelectFamily`, `proxy`
 - webhook: `webhookUrl`, `webhookSecret`, `webhookPath`, `webhookHost`
 - actions/capabilities: `capabilities.inlineButtons`, `actions.sendMessage|editMessage|deleteMessage|reactions|sticker`
 - reactions: `reactionNotifications`, `reactionLevel`

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -23,6 +23,18 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts telegram mediaLocalRoots overrides", () => {
+    const res = validateConfigObject({
+      channels: {
+        telegram: {
+          mediaLocalRoots: ["~/Desktop"],
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it('accepts memorySearch fallback "voyage"', () => {
     const res = validateConfigObject({
       agents: {

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -126,6 +126,8 @@ export type TelegramAccountConfig = {
   /** @deprecated Legacy key; migrated automatically to `streaming`. */
   streamMode?: "off" | "partial" | "block";
   mediaMaxMb?: number;
+  /** Explicit allowlist of local directories permitted for outbound local media paths. */
+  mediaLocalRoots?: string[];
   /** Telegram API client timeout in seconds (grammY ApiClientOptions). */
   timeoutSeconds?: number;
   /** Retry policy for outbound Telegram API calls. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -180,6 +180,7 @@ export const TelegramAccountSchemaBase = z
     // Legacy key kept for automatic migration to `streaming`.
     streamMode: z.enum(["off", "partial", "block"]).optional(),
     mediaMaxMb: z.number().positive().optional(),
+    mediaLocalRoots: z.array(z.string()).optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     retry: RetryConfigSchema,
     network: z

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { signalOutbound } from "../../channels/plugins/outbound/signal.js";
@@ -339,6 +340,30 @@ describe("deliverOutboundPayloads", () => {
       "hi",
       expect.objectContaining({
         mediaLocalRoots: expect.arrayContaining([resolvePreferredOpenClawTmpDir()]),
+      }),
+    );
+  });
+
+  it("includes configured telegram mediaLocalRoots in outbound delivery", async () => {
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "c1" });
+
+    await deliverTelegramPayload({
+      sendTelegram,
+      payload: { text: "hi", mediaUrl: "file:///Users/demo/Desktop/photo.png" },
+      cfg: {
+        channels: {
+          telegram: {
+            mediaLocalRoots: ["~/Desktop"],
+          },
+        },
+      },
+    });
+
+    expect(sendTelegram).toHaveBeenCalledWith(
+      "123",
+      "hi",
+      expect.objectContaining({
+        mediaLocalRoots: expect.arrayContaining([path.resolve(os.homedir(), "Desktop")]),
       }),
     );
   });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -28,7 +28,10 @@ import {
 } from "../../hooks/message-hook-mappers.js";
 import type { sendMessageIMessage } from "../../imessage/send.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
+import {
+  getAgentScopedMediaLocalRoots,
+  resolveTelegramMediaLocalRoots,
+} from "../../media/local-roots.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { markdownToSignalTextChunks, type SignalTextStyleRange } from "../../signal/format.js";
 import { sendMessageSignal } from "../../signal/send.js";
@@ -533,6 +536,7 @@ async function deliverOutboundPayloadsCore(
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(
     cfg,
     params.session?.agentId ?? params.mirror?.agentId,
+    channel === "telegram" ? resolveTelegramMediaLocalRoots(cfg, accountId) : undefined,
   );
   const results: OutboundDeliveryResult[] = [];
   const handler = await createChannelHandler({

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -13,7 +13,10 @@ import type {
   ChannelThreadingToolContext,
 } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
+import {
+  getAgentScopedMediaLocalRoots,
+  resolveTelegramMediaLocalRoots,
+} from "../../media/local-roots.js";
 import { hasPollCreationParams, resolveTelegramPollVisibility } from "../../poll-params.js";
 import { resolvePollMaxSelections } from "../../polls.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
@@ -730,7 +733,11 @@ export async function runMessageAction(
     params.accountId = accountId;
   }
   const dryRun = Boolean(input.dryRun ?? readBooleanParam(params, "dryRun"));
-  const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, resolvedAgentId);
+  const mediaLocalRoots = getAgentScopedMediaLocalRoots(
+    cfg,
+    resolvedAgentId,
+    channel === "telegram" ? resolveTelegramMediaLocalRoots(cfg, accountId) : undefined,
+  );
   const mediaPolicy = resolveAttachmentMediaPolicy({
     sandboxRoot: input.sandboxRoot,
     mediaLocalRoots,

--- a/src/infra/outbound/outbound-send-service.test.ts
+++ b/src/infra/outbound/outbound-send-service.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   sendMessage: vi.fn(),
   sendPoll: vi.fn(),
   getAgentScopedMediaLocalRoots: vi.fn(() => ["/tmp/agent-roots"]),
+  resolveTelegramMediaLocalRoots: vi.fn(() => ["/tmp/telegram-roots"]),
 }));
 
 vi.mock("../../channels/plugins/message-actions.js", () => ({
@@ -18,6 +19,7 @@ vi.mock("./message.js", () => ({
 
 vi.mock("../../media/local-roots.js", () => ({
   getAgentScopedMediaLocalRoots: mocks.getAgentScopedMediaLocalRoots,
+  resolveTelegramMediaLocalRoots: mocks.resolveTelegramMediaLocalRoots,
 }));
 
 import { executePollAction, executeSendAction } from "./outbound-send-service.js";
@@ -28,6 +30,7 @@ describe("executeSendAction", () => {
     mocks.sendMessage.mockClear();
     mocks.sendPoll.mockClear();
     mocks.getAgentScopedMediaLocalRoots.mockClear();
+    mocks.resolveTelegramMediaLocalRoots.mockClear();
   });
 
   it("forwards ctx.agentId to sendMessage on core outbound path", async () => {
@@ -112,10 +115,41 @@ describe("executeSendAction", () => {
       message: "hello",
     });
 
-    expect(mocks.getAgentScopedMediaLocalRoots).toHaveBeenCalledWith({}, "agent-1");
+    expect(mocks.getAgentScopedMediaLocalRoots).toHaveBeenCalledWith({}, "agent-1", undefined);
     expect(mocks.dispatchChannelMessageAction).toHaveBeenCalledWith(
       expect.objectContaining({
         mediaLocalRoots: ["/tmp/agent-roots"],
+      }),
+    );
+  });
+
+  it("normalizes null accountId to undefined on telegram plugin path", async () => {
+    mocks.dispatchChannelMessageAction.mockResolvedValue({
+      ok: true,
+      value: { messageId: "msg-plugin" },
+      continuePrompt: "",
+      output: "",
+      sessionId: "s1",
+      model: "gpt-5.2",
+      usage: {},
+    });
+
+    await executeSendAction({
+      ctx: {
+        cfg: {},
+        channel: "telegram",
+        params: { to: "chat:1", message: "hello" },
+        accountId: null,
+        dryRun: false,
+      },
+      to: "chat:1",
+      message: "hello",
+    });
+
+    expect(mocks.resolveTelegramMediaLocalRoots).toHaveBeenCalledWith({}, undefined);
+    expect(mocks.dispatchChannelMessageAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: undefined,
       }),
     );
   });

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -3,7 +3,10 @@ import { dispatchChannelMessageAction } from "../../channels/plugins/message-act
 import type { ChannelId, ChannelThreadingToolContext } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { appendAssistantMessageToSessionTranscript } from "../../config/sessions.js";
-import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
+import {
+  getAgentScopedMediaLocalRoots,
+  resolveTelegramMediaLocalRoots,
+} from "../../media/local-roots.js";
 import type { GatewayClientMode, GatewayClientName } from "../../utils/message-channel.js";
 import { throwIfAborted } from "./abort.js";
 import type { OutboundSendDeps } from "./deliver.js";
@@ -58,6 +61,9 @@ async function tryHandleWithPluginAction(params: {
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(
     params.ctx.cfg,
     params.ctx.agentId ?? params.ctx.mirror?.agentId,
+    params.ctx.channel === "telegram"
+      ? resolveTelegramMediaLocalRoots(params.ctx.cfg, params.ctx.accountId)
+      : undefined,
   );
   const handled = await dispatchChannelMessageAction({
     channel: params.ctx.channel,

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -58,11 +58,12 @@ async function tryHandleWithPluginAction(params: {
   if (params.ctx.dryRun) {
     return null;
   }
+  const accountId = params.ctx.accountId ?? undefined;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(
     params.ctx.cfg,
     params.ctx.agentId ?? params.ctx.mirror?.agentId,
     params.ctx.channel === "telegram"
-      ? resolveTelegramMediaLocalRoots(params.ctx.cfg, params.ctx.accountId)
+      ? resolveTelegramMediaLocalRoots(params.ctx.cfg, accountId)
       : undefined,
   );
   const handled = await dispatchChannelMessageAction({
@@ -71,7 +72,7 @@ async function tryHandleWithPluginAction(params: {
     cfg: params.ctx.cfg,
     params: params.ctx.params,
     mediaLocalRoots,
-    accountId: params.ctx.accountId ?? undefined,
+    accountId,
     gateway: params.ctx.gateway,
     toolContext: params.ctx.toolContext,
     dryRun: params.ctx.dryRun,

--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -3,6 +3,7 @@ import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+import { resolveUserPath } from "../utils.js";
 
 type BuildMediaLocalRootsOptions = {
   preferredTmpDir?: string;
@@ -36,11 +37,36 @@ export function getDefaultMediaLocalRoots(): readonly string[] {
   return buildMediaLocalRoots(resolveStateDir());
 }
 
+export function resolveTelegramMediaLocalRoots(
+  cfg: OpenClawConfig,
+  accountId?: string,
+): readonly string[] | undefined {
+  const telegram = cfg.channels?.telegram;
+  if (!telegram) {
+    return undefined;
+  }
+  const accountRoots = accountId ? telegram.accounts?.[accountId]?.mediaLocalRoots : undefined;
+  const roots = accountRoots ?? telegram.mediaLocalRoots;
+  if (!roots || roots.length === 0) {
+    return undefined;
+  }
+  return roots;
+}
+
 export function getAgentScopedMediaLocalRoots(
   cfg: OpenClawConfig,
   agentId?: string,
+  extraRoots?: readonly string[],
 ): readonly string[] {
   const roots = buildMediaLocalRoots(resolveStateDir());
+  if (extraRoots) {
+    for (const root of extraRoots) {
+      const normalizedRoot = path.resolve(resolveUserPath(root));
+      if (!roots.includes(normalizedRoot)) {
+        roots.push(normalizedRoot);
+      }
+    }
+  }
   if (!agentId?.trim()) {
     return roots;
   }

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -18,7 +18,10 @@ import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import type { OpenClawConfig, ReplyToMode, TelegramAccountConfig } from "../config/types.js";
 import { danger, logVerbose } from "../globals.js";
-import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
+import {
+  getAgentScopedMediaLocalRoots,
+  resolveTelegramMediaLocalRoots,
+} from "../media/local-roots.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 import type { TelegramBotOptions } from "./bot.js";
@@ -186,7 +189,11 @@ export const dispatchTelegramMessage = async ({
   const draftReplyToMessageId =
     replyToMode !== "off" && typeof msg.message_id === "number" ? msg.message_id : undefined;
   const draftMinInitialChars = DRAFT_MIN_INITIAL_CHARS;
-  const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
+  const mediaLocalRoots = getAgentScopedMediaLocalRoots(
+    cfg,
+    route.agentId,
+    resolveTelegramMediaLocalRoots(cfg, route.accountId),
+  );
   const archivedAnswerPreviews: ArchivedPreview[] = [];
   const archivedReasoningPreviewIds: number[] = [];
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -36,7 +36,10 @@ import type {
 } from "../config/types.js";
 import { danger, logVerbose } from "../globals.js";
 import { getChildLogger } from "../logging.js";
-import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
+import {
+  getAgentScopedMediaLocalRoots,
+  resolveTelegramMediaLocalRoots,
+} from "../media/local-roots.js";
 import {
   executePluginCommand,
   getPluginCommandSpecs,
@@ -484,7 +487,11 @@ export const registerTelegramNativeCommands = ({
         return null;
       }
     }
-    const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
+    const mediaLocalRoots = getAgentScopedMediaLocalRoots(
+      cfg,
+      route.agentId,
+      resolveTelegramMediaLocalRoots(cfg, route.accountId),
+    );
     const tableMode = resolveMarkdownTableMode({
       cfg,
       channel: "telegram",

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -1243,6 +1243,7 @@ describe("createTelegramBot", () => {
     expect(sendMessageSpy).toHaveBeenCalledWith(
       12345,
       "You are not authorized to use this command.",
+      expect.any(Object),
     );
   });
 


### PR DESCRIPTION
## Summary
- add `channels.telegram.mediaLocalRoots` and per-account `channels.telegram.accounts.<id>.mediaLocalRoots` schema support
- include these configured roots when resolving outbound Telegram media access paths (alongside existing default safe roots)
- document the new Telegram config key and add regression tests for schema + delivery root propagation

## Testing
- pnpm vitest run src/config/config.schema-regressions.test.ts src/infra/outbound/deliver.test.ts

Fixes #34233
