### PR TITLE
line: cache credential file reads in account resolution

### DIFF
--- a/src/line/accounts.test.ts
+++ b/src/line/accounts.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   resolveLineAccount,
@@ -96,6 +99,60 @@ describe("LINE accounts", () => {
       expect(account.channelAccessToken).toBe("");
       expect(account.channelSecret).toBe("");
       expect(account.tokenSource).toBe("none");
+    });
+
+    it("reuses credential file reads until file metadata changes", () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-line-account-"));
+      const tokenPath = path.join(tmpDir, "token.txt");
+      const secretPath = path.join(tmpDir, "secret.txt");
+      fs.writeFileSync(tokenPath, "token-v1\n", "utf-8");
+      fs.writeFileSync(secretPath, "secret-v1\n", "utf-8");
+
+      const cfg: OpenClawConfig = {
+        channels: {
+          line: {
+            tokenFile: tokenPath,
+            secretFile: secretPath,
+          },
+        },
+      };
+
+      const readSpy = vi.spyOn(fs, "readFileSync");
+      try {
+        const first = resolveLineAccount({ cfg });
+        const second = resolveLineAccount({ cfg });
+
+        expect(first.channelAccessToken).toBe("token-v1");
+        expect(first.channelSecret).toBe("secret-v1");
+        expect(second.channelAccessToken).toBe("token-v1");
+        expect(second.channelSecret).toBe("secret-v1");
+
+        const tokenReadsBeforeChange = readSpy.mock.calls.filter(
+          ([candidate]) => String(candidate) === tokenPath,
+        ).length;
+        const secretReadsBeforeChange = readSpy.mock.calls.filter(
+          ([candidate]) => String(candidate) === secretPath,
+        ).length;
+        expect(tokenReadsBeforeChange).toBe(1);
+        expect(secretReadsBeforeChange).toBe(1);
+
+        fs.writeFileSync(tokenPath, "token-v2-long\n", "utf-8");
+        const third = resolveLineAccount({ cfg });
+        expect(third.channelAccessToken).toBe("token-v2-long");
+        expect(third.channelSecret).toBe("secret-v1");
+
+        const tokenReadsAfterChange = readSpy.mock.calls.filter(
+          ([candidate]) => String(candidate) === tokenPath,
+        ).length;
+        const secretReadsAfterChange = readSpy.mock.calls.filter(
+          ([candidate]) => String(candidate) === secretPath,
+        ).length;
+        expect(tokenReadsAfterChange).toBe(2);
+        expect(secretReadsAfterChange).toBe(1);
+      } finally {
+        readSpy.mockRestore();
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/src/line/accounts.ts
+++ b/src/line/accounts.ts
@@ -15,13 +15,51 @@ import type {
 
 export { DEFAULT_ACCOUNT_ID } from "../routing/account-id.js";
 
+type CredentialFileCacheEntry = {
+  mtimeMs: number;
+  size: number;
+  value: string;
+};
+
+const MAX_CREDENTIAL_FILE_CACHE_ENTRIES = 32;
+const CREDENTIAL_FILE_CACHE = new Map<string, CredentialFileCacheEntry>();
+
+function refreshCredentialFileCacheEntry(filePath: string, entry: CredentialFileCacheEntry): void {
+  CREDENTIAL_FILE_CACHE.delete(filePath);
+  CREDENTIAL_FILE_CACHE.set(filePath, entry);
+}
+
+function setCredentialFileCacheEntry(filePath: string, entry: CredentialFileCacheEntry): void {
+  refreshCredentialFileCacheEntry(filePath, entry);
+  while (CREDENTIAL_FILE_CACHE.size > MAX_CREDENTIAL_FILE_CACHE_ENTRIES) {
+    const oldest = CREDENTIAL_FILE_CACHE.keys().next().value;
+    if (!oldest) {
+      break;
+    }
+    CREDENTIAL_FILE_CACHE.delete(oldest);
+  }
+}
+
 function readFileIfExists(filePath: string | undefined): string | undefined {
   if (!filePath) {
     return undefined;
   }
   try {
-    return fs.readFileSync(filePath, "utf-8").trim();
+    const stat = fs.statSync(filePath);
+    const cached = CREDENTIAL_FILE_CACHE.get(filePath);
+    if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+      refreshCredentialFileCacheEntry(filePath, cached);
+      return cached.value;
+    }
+    const value = fs.readFileSync(filePath, "utf-8").trim();
+    setCredentialFileCacheEntry(filePath, {
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+      value,
+    });
+    return value;
   } catch {
+    CREDENTIAL_FILE_CACHE.delete(filePath);
     return undefined;
   }
 }


### PR DESCRIPTION
## Why
resolveLineAccount can run per webhook and currently re-reads token/secret files synchronously on every call.

## Impact
- Add a small bounded in-memory cache (32 entries) for credential file contents.
- Reuse cached values when file metadata (mtimeMs + size) is unchanged.
- Refresh automatically when file content changes.

## Risk
Low: behavior is preserved, cache is bounded, and any file errors still fall back to existing undefined handling.

## Validation
- pnpm vitest src/line/accounts.test.ts
- Added test: reuses credential file reads until file metadata changes
