### PR TITLE
feat(telegram): add per-message linkPreview override to message tool

### DIFF
--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -198,6 +198,12 @@ function buildSendSchema(options: {
     quoteText: Type.Optional(
       Type.String({ description: "Quote text for Telegram reply_parameters" }),
     ),
+    linkPreview: Type.Optional(
+      Type.Boolean({
+        description:
+          "Controls whether URL link previews are shown (Telegram). Overrides account-level default.",
+      }),
+    ),
     bestEffort: Type.Optional(Type.Boolean()),
     gifPlayback: Type.Optional(Type.Boolean()),
     buttons: Type.Optional(

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -240,6 +240,7 @@ export async function handleTelegramAction(
       quoteText: quoteText ?? undefined,
       asVoice: typeof params.asVoice === "boolean" ? params.asVoice : undefined,
       silent: typeof params.silent === "boolean" ? params.silent : undefined,
+      linkPreview: typeof params.linkPreview === "boolean" ? params.linkPreview : undefined,
     });
     return jsonResult({
       ok: true,

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -30,6 +30,7 @@ function readTelegramSendParams(params: Record<string, unknown>) {
   const asVoice = typeof params.asVoice === "boolean" ? params.asVoice : undefined;
   const silent = typeof params.silent === "boolean" ? params.silent : undefined;
   const quoteText = readStringParam(params, "quoteText");
+  const linkPreview = typeof params.linkPreview === "boolean" ? params.linkPreview : undefined;
   return {
     to,
     content,
@@ -40,6 +41,7 @@ function readTelegramSendParams(params: Record<string, unknown>) {
     asVoice,
     silent,
     quoteText: quoteText ?? undefined,
+    linkPreview,
   };
 }
 

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -67,6 +67,8 @@ type TelegramSendOpts = {
   messageThreadId?: number;
   /** Inline keyboard buttons (reply markup). */
   buttons?: TelegramInlineButtons;
+  /** Per-message link preview override. When false, disables link previews. */
+  linkPreview?: boolean;
 };
 
 type TelegramSendResult = {
@@ -504,8 +506,8 @@ export async function sendMessageTelegram(
   });
   const renderHtmlText = (value: string) => renderTelegramHtmlText(value, { textMode, tableMode });
 
-  // Resolve link preview setting from config (default: enabled).
-  const linkPreviewEnabled = account.config.linkPreview ?? true;
+  // Per-message linkPreview overrides account-level config (default: enabled).
+  const linkPreviewEnabled = opts.linkPreview ?? account.config.linkPreview ?? true;
   const linkPreviewOptions = linkPreviewEnabled ? undefined : { is_disabled: true };
 
   const sendTelegramText = async (


### PR DESCRIPTION
## Summary

- **Problem:** OpenClaw supports account-level `linkPreview` config for Telegram, but agents have no way to suppress link previews for individual messages. Sending a URL always uses the account default.
- **Why it matters:** Agents sending status updates or lists with URLs often want to suppress previews to keep messages compact. Currently the only option is a global toggle.
- **What changed:**
  - `src/agents/tools/message-tool.ts`: Added `linkPreview` boolean parameter to `buildSendSchema()`.
  - `src/channels/plugins/actions/telegram.ts`: `readTelegramSendParams` now reads and forwards `linkPreview`.
  - `src/agents/tools/telegram-actions.ts`: Passes `linkPreview` to `sendMessageTelegram`.
  - `src/telegram/send.ts`: Added `linkPreview` to `TelegramSendOpts` and updated resolution: `opts.linkPreview ?? account.config.linkPreview ?? true`.
- **What did NOT change:** Account-level `linkPreview` config. Edit message flow (already supports per-call override). Bot delivery path (uses account config). Non-Telegram channels.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36757

## User-visible / Behavior Changes

- Message tool now accepts `linkPreview: false` to suppress link previews for individual Telegram messages.
- Precedence: per-message `linkPreview` > account-level `channels.telegram.linkPreview` > `true` (default).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22
- Integration/channel: Telegram

### Steps

1. Agent calls message tool with `{ "message": "Check https://example.com", "linkPreview": false }`
2. Observe link preview behavior

### Expected

- Link preview suppressed for this message

### Actual

- Before fix: No per-message control; always uses account default
- After fix: `linkPreview: false` disables preview; `linkPreview: true` forces preview; omitted uses account default

## Evidence

```
 src/agents/tools/message-tool.ts         | 6 ++++++
 src/agents/tools/telegram-actions.ts     | 1 +
 src/channels/plugins/actions/telegram.ts | 2 ++
 src/telegram/send.ts                     | 6 ++++--
 4 files changed, 13 insertions(+), 2 deletions(-)
```

All 51 existing Telegram send tests pass.

## Human Verification (required)

- Verified scenarios: linkPreview=false suppresses preview, linkPreview=true enables preview, omitted uses account config, undefined falls through to default
- Edge cases checked: boolean type validation (non-boolean ignored), interaction with account-level config
- What I did **not** verify: Live Telegram bot message with link preview

## Compatibility / Migration

- Backward compatible? `Yes — new optional parameter, existing behavior unchanged when omitted`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; agents that pass `linkPreview` will get it ignored (invalid param)
- Files/config to restore: 4 files listed above
- Known bad symptoms: None expected; invalid linkPreview values are safely ignored

## Risks and Mitigations

None — the parameter is optional and additive. Non-Telegram channels ignore unknown parameters.

