### PR TITLE
Diffs: restore system prompt guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/before_prompt_build system-context fields: add `prependSystemContext` and `appendSystemContext` so static plugin guidance can be placed in system prompt space for provider caching and lower repeated prompt token cost. (#35177) thanks @maweibin.
 - Gateway: add SecretRef support for gateway.auth.token with auth-mode guardrails. (#35094) Thanks @joshavant.
 - Plugins/hook policy: add `plugins.entries.<id>.hooks.allowPromptInjection`, validate unknown typed hook names at runtime, and preserve legacy `before_agent_start` model/provider overrides while stripping prompt-mutating fields when prompt injection is disabled. (#36567) thanks @gumadeiras.
-- Tools/Diffs guidance: restore a short system-prompt hint for enabled diffs while keeping the detailed instructions in the companion skill, so diffs usage guidance stays out of user-prompt space. Thanks @gumadeiras.
+- Tools/Diffs guidance: restore a short system-prompt hint for enabled diffs while keeping the detailed instructions in the companion skill, so diffs usage guidance stays out of user-prompt space. (#36904) thanks @gumadeiras.
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/before_prompt_build system-context fields: add `prependSystemContext` and `appendSystemContext` so static plugin guidance can be placed in system prompt space for provider caching and lower repeated prompt token cost. (#35177) thanks @maweibin.
 - Gateway: add SecretRef support for gateway.auth.token with auth-mode guardrails. (#35094) Thanks @joshavant.
 - Plugins/hook policy: add `plugins.entries.<id>.hooks.allowPromptInjection`, validate unknown typed hook names at runtime, and preserve legacy `before_agent_start` model/provider overrides while stripping prompt-mutating fields when prompt injection is disabled. (#36567) thanks @gumadeiras.
+- Tools/Diffs guidance: restore a short system-prompt hint for enabled diffs while keeping the detailed instructions in the companion skill, so diffs usage guidance stays out of user-prompt space. Thanks @gumadeiras.
 
 ### Breaking
 

--- a/docs/tools/diffs.md
+++ b/docs/tools/diffs.md
@@ -10,7 +10,7 @@ read_when:
 
 # Diffs
 
-`diffs` is an optional plugin tool and companion skill that turns change content into a read-only diff artifact for agents.
+`diffs` is an optional plugin tool with short built-in system guidance and a companion skill that turns change content into a read-only diff artifact for agents.
 
 It accepts either:
 
@@ -22,6 +22,8 @@ It can return:
 - a gateway viewer URL for canvas presentation
 - a rendered file path (PNG or PDF) for message delivery
 - both outputs in one call
+
+When enabled, the plugin prepends concise usage guidance into system-prompt space and also exposes a detailed skill for cases where the agent needs fuller instructions.
 
 ## Quick start
 
@@ -43,6 +45,29 @@ It can return:
   },
 }
 ```
+
+## Disable built-in system guidance
+
+If you want to keep the `diffs` tool enabled but disable its built-in system-prompt guidance, set `plugins.entries.diffs.hooks.allowPromptInjection` to `false`:
+
+```json5
+{
+  plugins: {
+    entries: {
+      diffs: {
+        enabled: true,
+        hooks: {
+          allowPromptInjection: false,
+        },
+      },
+    },
+  },
+}
+```
+
+This blocks the diffs plugin's `before_prompt_build` hook while keeping the plugin, tool, and companion skill available.
+
+If you want to disable both the guidance and the tool, disable the plugin instead.
 
 ## Typical agent workflow
 

--- a/extensions/diffs/README.md
+++ b/extensions/diffs/README.md
@@ -16,7 +16,7 @@ The tool can return:
 - `details.filePath`: a local rendered artifact path when file rendering is requested
 - `details.fileFormat`: the rendered file format (`png` or `pdf`)
 
-When the plugin is enabled, it also ships a companion skill from `skills/` that guides when to use `diffs`. This guidance is delivered through normal skill loading, not unconditional prompt-hook injection on every turn.
+When the plugin is enabled, it also ships a companion skill from `skills/` and prepends stable tool-usage guidance into system-prompt space via `before_prompt_build`. The hook uses `prependSystemContext`, so the guidance stays out of user-prompt space while still being available every turn.
 
 This means an agent can:
 

--- a/extensions/diffs/index.test.ts
+++ b/extensions/diffs/index.test.ts
@@ -4,7 +4,7 @@ import { createMockServerResponse } from "../../src/test-utils/mock-http-respons
 import plugin from "./index.js";
 
 describe("diffs plugin registration", () => {
-  it("registers the tool and http route", () => {
+  it("registers the tool, http route, and system-prompt guidance hook", async () => {
     const registerTool = vi.fn();
     const registerHttpRoute = vi.fn();
     const on = vi.fn();
@@ -43,7 +43,14 @@ describe("diffs plugin registration", () => {
       auth: "plugin",
       match: "prefix",
     });
-    expect(on).not.toHaveBeenCalled();
+    expect(on).toHaveBeenCalledTimes(1);
+    expect(on.mock.calls[0]?.[0]).toBe("before_prompt_build");
+    const beforePromptBuild = on.mock.calls[0]?.[1];
+    const result = await beforePromptBuild?.({}, {});
+    expect(result).toMatchObject({
+      prependSystemContext: expect.stringContaining("prefer the `diffs` tool"),
+    });
+    expect(result?.prependContext).toBeUndefined();
   });
 
   it("applies plugin-config defaults through registered tool and viewer handler", async () => {

--- a/extensions/diffs/index.ts
+++ b/extensions/diffs/index.ts
@@ -7,6 +7,7 @@ import {
   resolveDiffsPluginSecurity,
 } from "./src/config.js";
 import { createDiffsHttpHandler } from "./src/http.js";
+import { DIFFS_AGENT_GUIDANCE } from "./src/prompt-guidance.js";
 import { DiffArtifactStore } from "./src/store.js";
 import { createDiffsTool } from "./src/tool.js";
 
@@ -34,6 +35,9 @@ const plugin = {
         allowRemoteViewer: security.allowRemoteViewer,
       }),
     });
+    api.on("before_prompt_build", async () => ({
+      prependSystemContext: DIFFS_AGENT_GUIDANCE,
+    }));
   },
 };
 

--- a/extensions/diffs/src/prompt-guidance.ts
+++ b/extensions/diffs/src/prompt-guidance.ts
@@ -1,0 +1,7 @@
+export const DIFFS_AGENT_GUIDANCE = [
+  "When you need to show edits as a real diff, prefer the `diffs` tool instead of writing a manual summary.",
+  "It accepts either `before` + `after` text or a unified `patch`.",
+  "`mode=view` returns `details.viewerUrl` for canvas use; `mode=file` returns `details.filePath`; `mode=both` returns both.",
+  "If you need to send the rendered file, use the `message` tool with `path` or `filePath`.",
+  "Include `path` when you know the filename, and omit presentation overrides unless needed.",
+].join("\n");


### PR DESCRIPTION
## Summary

- Problem: the diffs plugin no longer had any always-on usage guidance after guidance was moved entirely off the old prompt hook path.
- Why it matters: agents lost the short built-in nudge to use `diffs`, and the old guidance had previously lived in user-prompt space instead of system-prompt space.
- What changed: restored a concise diffs guidance hook using `before_prompt_build` + `prependSystemContext`, kept the detailed companion skill, added docs for disabling the hook, and updated changelog/docs copy.
- What did NOT change (scope boundary): no diffs tool contract, HTTP route, rendering behavior, or plugin config schema behavior changed.

## Change Type (select all)

- [x] Bug fix
- [x] Docs
- [ ] Feature
- [ ] Refactor
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #32630
- Related #35177
- Related #36567

## User-visible / Behavior Changes

- Users with the bundled `diffs` plugin enabled again get a short built-in system-prompt hint that nudges agents toward the `diffs` tool.
- The detailed diffs guidance remains available through the companion skill.
- Docs now show how to disable the built-in guidance with `plugins.entries.diffs.hooks.allowPromptInjection=false` while keeping the plugin enabled.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): bundled `diffs` plugin source in repo

### Steps

1. Enable the bundled `diffs` plugin.
2. Run an embedded agent turn and inspect diffs plugin registration / prompt-hook behavior.
3. Set `plugins.entries.diffs.hooks.allowPromptInjection=false` if you want the tool without the built-in guidance.

### Expected

- Diffs registers a `before_prompt_build` hook that injects only into system-prompt space.
- Docs explain how to disable that guidance without disabling the plugin.

### Actual

- Verified on this branch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted diffs registration test passes; full repo build passes; docs and changelog copy reflect the restored system-prompt guidance and the disable path.
- Edge cases checked: hook result uses `prependSystemContext` rather than `prependContext`; docs cover disabling the hook while leaving the plugin/tool enabled.
- What you did **not** verify: end-to-end agent behavior on a live provider/channel.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `plugins.entries.diffs.hooks.allowPromptInjection=false` or disable the `diffs` plugin.
- Files/config to restore: `plugins.entries.diffs.hooks.allowPromptInjection`, or revert the diffs hook change.
- Known bad symptoms reviewers should watch for: unexpected extra diffs-tool nudging in sessions where the plugin is enabled.

## Risks and Mitigations

- Risk: the short built-in guidance changes agent behavior for users who have `diffs` enabled.
  - Mitigation: guidance is concise, system-prompt scoped, and can be disabled with `plugins.entries.diffs.hooks.allowPromptInjection=false`.
