### PR TITLE
Bound Telegram sticker cache growth with automatic eviction

### DIFF
--- a/src/telegram/sticker-cache.test.ts
+++ b/src/telegram/sticker-cache.test.ts
@@ -115,6 +115,54 @@ describe("sticker-cache", () => {
     });
   });
 
+  describe("cache bounds", () => {
+    let originalLimit: string | undefined;
+
+    beforeEach(() => {
+      originalLimit = process.env.OPENCLAW_TELEGRAM_STICKER_CACHE_MAX;
+    });
+
+    afterEach(() => {
+      if (originalLimit === undefined) {
+        delete process.env.OPENCLAW_TELEGRAM_STICKER_CACHE_MAX;
+      } else {
+        process.env.OPENCLAW_TELEGRAM_STICKER_CACHE_MAX = originalLimit;
+      }
+    });
+
+    it("evicts oldest stickers when max entries is exceeded", () => {
+      process.env.OPENCLAW_TELEGRAM_STICKER_CACHE_MAX = "2";
+
+      cacheSticker({
+        fileId: "first",
+        fileUniqueId: "first-unique",
+        description: "First sticker",
+        cachedAt: "2026-01-20T10:00:00.000Z",
+      });
+      cacheSticker({
+        fileId: "second",
+        fileUniqueId: "second-unique",
+        description: "Second sticker",
+        cachedAt: "2026-01-21T10:00:00.000Z",
+      });
+      cacheSticker({
+        fileId: "third",
+        fileUniqueId: "third-unique",
+        description: "Third sticker",
+        cachedAt: "2026-01-22T10:00:00.000Z",
+      });
+
+      expect(getCachedSticker("first-unique")).toBeNull();
+      expect(getCachedSticker("second-unique")?.fileId).toBe("second");
+      expect(getCachedSticker("third-unique")?.fileId).toBe("third");
+
+      const stats = getCacheStats();
+      expect(stats.count).toBe(2);
+      expect(stats.oldestAt).toBe("2026-01-21T10:00:00.000Z");
+      expect(stats.newestAt).toBe("2026-01-22T10:00:00.000Z");
+    });
+  });
+
   describe("searchStickers", () => {
     beforeEach(() => {
       // Seed cache with test stickers

--- a/src/telegram/sticker-cache.ts
+++ b/src/telegram/sticker-cache.ts
@@ -16,6 +16,8 @@ import { resolveAutoImageModel } from "../media-understanding/runner.js";
 
 const CACHE_FILE = path.join(STATE_DIR, "telegram", "sticker-cache.json");
 const CACHE_VERSION = 1;
+const DEFAULT_CACHE_MAX_STICKERS = 1000;
+const MAX_CACHE_UPPER_BOUND = 10000;
 
 export interface CachedSticker {
   fileId: string;
@@ -49,6 +51,35 @@ function saveCache(cache: StickerCache): void {
   saveJsonFile(CACHE_FILE, cache);
 }
 
+function resolveCacheMaxStickers(): number {
+  const raw = process.env.OPENCLAW_TELEGRAM_STICKER_CACHE_MAX?.trim();
+  if (!raw) {
+    return DEFAULT_CACHE_MAX_STICKERS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return DEFAULT_CACHE_MAX_STICKERS;
+  }
+  return Math.min(parsed, MAX_CACHE_UPPER_BOUND);
+}
+
+function parseCachedAt(sticker: CachedSticker): number {
+  const parsed = Date.parse(sticker.cachedAt);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function enforceCacheBounds(cache: StickerCache): void {
+  const maxEntries = resolveCacheMaxStickers();
+  const entries = Object.entries(cache.stickers);
+  if (entries.length <= maxEntries) {
+    return;
+  }
+  const trimmed = entries
+    .toSorted(([, a], [, b]) => parseCachedAt(b) - parseCachedAt(a))
+    .slice(0, maxEntries);
+  cache.stickers = Object.fromEntries(trimmed);
+}
+
 /**
  * Get a cached sticker by its unique ID.
  */
@@ -63,6 +94,7 @@ export function getCachedSticker(fileUniqueId: string): CachedSticker | null {
 export function cacheSticker(sticker: CachedSticker): void {
   const cache = loadCache();
   cache.stickers[sticker.fileUniqueId] = sticker;
+  enforceCacheBounds(cache);
   saveCache(cache);
 }
 


### PR DESCRIPTION
## Summary
- enforce a bounded size for telegram/sticker-cache.json during writes
- keep the most recent entries by cachedAt and evict oldest when limit is exceeded
- add regression coverage for eviction behavior and cache stats

## Why
telegram/sticker-cache.json can currently grow indefinitely as sticker descriptions are cached, which increases disk usage and read/parse overhead over time.

## Behavior
- default maximum entries: 1000
- configurable via OPENCLAW_TELEGRAM_STICKER_CACHE_MAX
- upper bound clamp: 10000

## Validation
- pnpm vitest src/telegram/sticker-cache.test.ts --run