### PR TITLE
fix(session-logs): widen glob patterns to include archived transcripts

### DIFF
--- a/skills/session-logs/SKILL.md
+++ b/skills/session-logs/SKILL.md
@@ -34,7 +34,7 @@ Each `.jsonl` file contains messages with:
 ### List all sessions by date and size
 
 ```bash
-for f in ~/.openclaw/agents/<agentId>/sessions/*.jsonl; do
+for f in ~/.openclaw/agents/<agentId>/sessions/*.jsonl*; do
   date=$(head -1 "$f" | jq -r '.timestamp' | cut -dT -f1)
   size=$(ls -lh "$f" | awk '{print $5}')
   echo "$date $size $(basename $f)"
@@ -44,7 +44,7 @@ done | sort -r
 ### Find sessions from a specific day
 
 ```bash
-for f in ~/.openclaw/agents/<agentId>/sessions/*.jsonl; do
+for f in ~/.openclaw/agents/<agentId>/sessions/*.jsonl*; do
   head -1 "$f" | jq -r '.timestamp' | grep -q "2026-01-06" && echo "$f"
 done
 ```
@@ -70,7 +70,7 @@ jq -s '[.[] | .message.usage.cost.total // 0] | add' <session>.jsonl
 ### Daily cost summary
 
 ```bash
-for f in ~/.openclaw/agents/<agentId>/sessions/*.jsonl; do
+for f in ~/.openclaw/agents/<agentId>/sessions/*.jsonl*; do
   date=$(head -1 "$f" | jq -r '.timestamp' | cut -dT -f1)
   cost=$(jq -s '[.[] | .message.usage.cost.total // 0] | add' "$f")
   echo "$date $cost"
@@ -98,7 +98,7 @@ jq -r '.message.content[]? | select(.type == "toolCall") | .name' <session>.json
 ### Search across ALL sessions for a phrase
 
 ```bash
-rg -l "phrase" ~/.openclaw/agents/<agentId>/sessions/*.jsonl
+rg -l "phrase" ~/.openclaw/agents/<agentId>/sessions/*.jsonl*
 ```
 
 ## Tips
@@ -106,7 +106,10 @@ rg -l "phrase" ~/.openclaw/agents/<agentId>/sessions/*.jsonl
 - Sessions are append-only JSONL (one JSON object per line)
 - Large sessions can be several MB - use `head`/`tail` for sampling
 - The `sessions.json` index maps chat providers (discord, whatsapp, etc.) to session IDs
-- Deleted sessions have `.deleted.<timestamp>` suffix
+- Three transcript file types exist (use `*.jsonl*` globs to match all):
+  - `<id>.jsonl` — active session transcript
+  - `<id>.jsonl.reset.<timestamp>` — archived by `/new`, `/reset`, daily auto-reset, or idle expiry
+  - `<id>.jsonl.deleted.<timestamp>` — soft-deleted session transcript
 
 ## Fast text-only hint (low noise)
 


### PR DESCRIPTION
## Summary

- Widen all four `*.jsonl` glob patterns in session-logs SKILL.md to `*.jsonl*` so archived `.reset.*` and `.deleted.*` transcripts are included in search results
- Document the three transcript file types (active, reset, deleted) in the Tips section

## Changes

- `skills/session-logs/SKILL.md`: Updated glob patterns in "List all sessions", "Find sessions from a specific day", "Daily cost summary", and "Search across ALL sessions" examples from `*.jsonl` → `*.jsonl*`
- Added documentation for the three transcript file types with their suffixes

## Why

Archived transcripts created by `/new`, `/reset`, daily auto-reset, and idle expiry use `.jsonl.reset.<timestamp>` suffixes. Deleted sessions use `.jsonl.deleted.<timestamp>`. The previous `*.jsonl` globs silently excluded these files, causing a large portion of conversation history to be invisible to the session-logs skill.

## Test Plan

- Verified glob `*.jsonl*` matches all three file types: `.jsonl`, `.jsonl.reset.<ts>`, `.jsonl.deleted.<ts>`
- Confirmed the updated examples remain syntactically valid bash

## Security Impact

- [x] No sensitive data exposure
- [x] No new authentication/authorization changes
- [x] No new external API calls or data flows
- [x] No changes to encryption or security protocols
- [x] No new file system or network access

## Human Verification

Run `ls ~/.openclaw/agents/<id>/sessions/` and confirm `.reset.*` files exist. Then run one of the updated example commands and verify archived sessions appear in the output.

## Failure Recovery

If the wider glob matches unexpected files, the worst case is a jq parse error on a non-JSONL file — the loop continues with other files. No data loss risk.

## Risks and Mitigations

- **Risk**: `*.jsonl*` could match `.jsonl.lock` files → **Mitigation**: Lock files are ephemeral and empty/tiny JSON; jq silently skips them or produces null output. No functional impact.

Closes #36799

🤖 Generated with [Claude Code](https://claude.com/claude-code)