### PR TITLE
fix(discord): pass appliedTags through channel-edit to Discord API

### DIFF
--- a/src/agents/tools/discord-actions-guild.ts
+++ b/src/agents/tools/discord-actions-guild.ts
@@ -336,6 +336,7 @@ export async function handleDiscordGuildAction(
         integer: true,
       });
       const availableTags = parseAvailableTags(params.availableTags);
+      const appliedTags = readStringArrayParam(params, "appliedTags");
       const channel = accountId
         ? await editChannelDiscord(
             {
@@ -350,6 +351,7 @@ export async function handleDiscordGuildAction(
               locked,
               autoArchiveDuration: autoArchiveDuration ?? undefined,
               availableTags,
+              appliedTags: appliedTags ?? undefined,
             },
             { accountId },
           )
@@ -365,6 +367,7 @@ export async function handleDiscordGuildAction(
             locked,
             autoArchiveDuration: autoArchiveDuration ?? undefined,
             availableTags,
+            appliedTags: appliedTags ?? undefined,
           });
       return jsonResult({ ok: true, channel });
     }

--- a/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
+++ b/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
@@ -197,6 +197,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
       integer: true,
     });
     const availableTags = parseAvailableTags(actionParams.availableTags);
+    const appliedTags = readStringArrayParam(actionParams, "appliedTags");
     return await handleDiscordAction(
       {
         action: "channelEdit",
@@ -212,6 +213,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         locked,
         autoArchiveDuration: autoArchiveDuration ?? undefined,
         availableTags,
+        appliedTags: appliedTags ?? undefined,
       },
       cfg,
     );

--- a/src/discord/send.channels.ts
+++ b/src/discord/send.channels.ts
@@ -79,6 +79,9 @@ export async function editChannelDiscord(
       ...(t.emoji_name !== undefined && { emoji_name: t.emoji_name }),
     }));
   }
+  if (payload.appliedTags !== undefined) {
+    body.applied_tags = payload.appliedTags;
+  }
   return (await rest.patch(Routes.channel(payload.channelId), {
     body,
   })) as APIChannel;

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -154,6 +154,8 @@ export type DiscordChannelEdit = {
   locked?: boolean;
   autoArchiveDuration?: number;
   availableTags?: DiscordForumTag[];
+  /** Tag IDs to apply to a forum thread (applied_tags in Discord API). */
+  appliedTags?: string[];
 };
 
 export type DiscordChannelMove = {


### PR DESCRIPTION
## Summary

- Add `appliedTags` parameter support to the `channel-edit` Discord action so forum post tags (e.g. Open → Done) can be changed

## Changes

- `src/discord/send.types.ts`: Add `appliedTags?: string[]` to `DiscordChannelEdit` type
- `src/discord/send.channels.ts`: Map `payload.appliedTags` to `body.applied_tags` in `editChannelDiscord()`
- `src/channels/plugins/actions/discord/handle-action.guild-admin.ts`: Parse `appliedTags` via `readStringArrayParam` in channel-edit handler
- `src/agents/tools/discord-actions-guild.ts`: Parse `appliedTags` via `readStringArrayParam` in channelEdit case

## Why

The `channel-edit` action already supported `availableTags` (defining which tags exist on a forum channel) but ignored `appliedTags` (which tags are applied to a specific forum thread). This made it impossible to update a forum post's status tags. The `applied_tags` field is a standard Discord API parameter for thread channels.

## Test Plan

- Verified the change compiles without type errors
- Confirmed `readStringArrayParam` is already imported in both files
- Verified `editChannelDiscord` correctly maps to Discord's `applied_tags` API field

## Security Impact

- [x] No sensitive data exposure
- [x] No new authentication/authorization changes
- [x] No new external API calls or data flows
- [x] No changes to encryption or security protocols
- [x] No new file system or network access

## Human Verification

Use the `channel-edit` action with `appliedTags: ["tag-id-1"]` on a forum thread and verify the tags update in Discord.

## Failure Recovery

If invalid tag IDs are provided, the Discord API returns a 400 error which is already handled by the existing error path. No new failure modes introduced.

## Risks and Mitigations

- **Risk**: Passing non-existent tag IDs → **Mitigation**: Discord API validates tag IDs server-side and returns clear error messages

Closes #36736

🤖 Generated with [Claude Code](https://claude.com/claude-code)