### PR TITLE
fix(podman): pass OPENCLAW_DOCKER_APT_PACKAGES to podman build

### DIFF
--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -209,7 +209,15 @@ if ! run_as_openclaw test -f "$OPENCLAW_JSON"; then
 fi
 
 echo "Building image from $REPO_PATH..."
-podman build -t openclaw:local -f "$REPO_PATH/Dockerfile" "$REPO_PATH"
+# Optional apt packages for the container build (matches docker-setup.sh behavior).
+# Example:
+#   export OPENCLAW_DOCKER_APT_PACKAGES="ffmpeg imagemagick"
+OPENCLAW_DOCKER_APT_PACKAGES="${OPENCLAW_DOCKER_APT_PACKAGES:-}"
+podman build \
+  --build-arg "OPENCLAW_DOCKER_APT_PACKAGES=${OPENCLAW_DOCKER_APT_PACKAGES}" \
+  -t openclaw:local \
+  -f "$REPO_PATH/Dockerfile" \
+  "$REPO_PATH"
 
 echo "Loading image into $OPENCLAW_USER's Podman store..."
 TMP_IMAGE="$(mktemp -p /tmp openclaw-image.XXXXXX.tar)"

--- a/test/setup-podman.apt-packages.test.sh
+++ b/test/setup-podman.apt-packages.test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test for: OPENCLAW_DOCKER_APT_PACKAGES is ignored by setup-podman.sh
+# We don't execute podman; we only assert the build arg is wired.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if ! grep -q -- '--build-arg "OPENCLAW_DOCKER_APT_PACKAGES=${OPENCLAW_DOCKER_APT_PACKAGES}"' "$REPO_ROOT/setup-podman.sh"; then
+  echo "setup-podman.sh does not pass OPENCLAW_DOCKER_APT_PACKAGES through to podman build" >&2
+  exit 1
+fi
+
+echo "ok"


### PR DESCRIPTION
Fixes setup-podman.sh to forward OPENCLAW_DOCKER_APT_PACKAGES to the Dockerfile build arg, matching docker-setup.sh behavior.

Closes #35397