### PR TITLE
fix(config-paths): support bracket notation for keys with periods

### DIFF
--- a/src/config/config-paths.ts
+++ b/src/config/config-paths.ts
@@ -3,6 +3,14 @@ import { isBlockedObjectKey } from "./prototype-keys.js";
 
 type PathNode = Record<string, unknown>;
 
+/**
+ * Parse a config path supporting both dot notation and bracket notation.
+ * - "foo.bar" → ["foo", "bar"]
+ * - "foo.bar.baz" → ["foo", "bar", "baz"]
+ * - 'foo["bar.baz"].qux' → ["foo", "bar.baz", "qux"]
+ * - "foo['bar'].baz" → ["foo", "bar", "baz"]
+ * - "providers.llama\\.cpp.baseUrl" → ["providers", "llama.cpp", "baseUrl"]
+ */
 export function parseConfigPath(raw: string): {
   ok: boolean;
   path?: string[];
@@ -15,16 +23,140 @@ export function parseConfigPath(raw: string): {
       error: "Invalid path. Use dot notation (e.g. foo.bar).",
     };
   }
-  const parts = trimmed.split(".").map((part) => part.trim());
+
+  // Parse using a simple state machine that handles bracket notation
+  const parts: string[] = [];
+  let current = "";
+  let inBracket = false;
+  let bracketType: "'" | '"' | null = null;
+  let i = 0;
+
+  while (i < trimmed.length) {
+    const char = trimmed[i];
+
+    if (inBracket) {
+      // Inside brackets - look for closing bracket
+      if (char === "\\" && i + 1 < trimmed.length) {
+        // Handle escaped characters inside brackets
+        const nextChar = trimmed[i + 1];
+        if (nextChar === "." || nextChar === bracketType) {
+          // Escaped dot or escaped quote
+          current += nextChar;
+        } else {
+          // Keep the backslash for other escape sequences
+          current += char;
+          current += nextChar;
+        }
+        i += 2;
+        continue;
+      }
+      if (char === bracketType) {
+        // Check if next char is also closing bracket (escaped quote)
+        if (i + 1 < trimmed.length && trimmed[i + 1] === bracketType) {
+          // Double bracket - treat as escaped bracket
+          current += char;
+          i += 2;
+          continue;
+        }
+        // Closing bracket - end of this segment
+        if (!current) {
+          // Empty bracket content - reject
+          return {
+            ok: false,
+            error: "Invalid path. Use dot notation (e.g. foo.bar).",
+          };
+        }
+        parts.push(current);
+        current = "";
+        inBracket = false;
+        bracketType = null;
+        i++;
+        // Skip trailing dot after closing bracket (e.g., foo["bar"].baz)
+        if (i < trimmed.length && trimmed[i] === ".") {
+          i++;
+        }
+        continue;
+      }
+      current += char;
+      i++;
+      continue;
+    }
+
+    // Not in brackets
+    if (char === "[") {
+      // Start of bracket notation
+      if (current) {
+        // Push the current segment (with escaped dots resolved)
+        parts.push(current.replace(/\\\./g, "."));
+        current = "";
+      }
+      // Check bracket type
+      if (i + 1 < trimmed.length && (trimmed[i + 1] === "'" || trimmed[i + 1] === '"')) {
+        bracketType = trimmed[i + 1];
+        inBracket = true;
+        i += 2;
+        continue;
+      }
+      // Numeric bracket like [0] - treat as part of path
+      current += char;
+      i++;
+      continue;
+    }
+
+    // Unmatched closing bracket - reject
+    if (char === "]") {
+      return {
+        ok: false,
+        error: "Invalid path. Use dot notation (e.g. foo.bar).",
+      };
+    }
+
+    if (char === ".") {
+      // Dot separator
+      if (current) {
+        // Push the current segment (with escaped dots resolved)
+        parts.push(current.replace(/\\\./g, "."));
+        current = "";
+      }
+      i++;
+      continue;
+    }
+
+    if (char === "\\" && i + 1 < trimmed.length && trimmed[i + 1] === ".") {
+      // Escaped dot - include literal dot in current segment
+      current += ".";
+      i += 2;
+      continue;
+    }
+
+    current += char;
+    i++;
+  }
+
+  // Handle remaining current segment
+  if (current) {
+    parts.push(current.replace(/\\\./g, "."));
+  }
+
+  // Check for unclosed brackets
+  if (inBracket) {
+    return {
+      ok: false,
+      error: "Invalid path. Use dot notation (e.g. foo.bar).",
+    };
+  }
+
   if (parts.some((part) => !part)) {
     return {
       ok: false,
       error: "Invalid path. Use dot notation (e.g. foo.bar).",
     };
   }
+
   if (parts.some((part) => isBlockedObjectKey(part))) {
     return { ok: false, error: "Invalid path segment." };
   }
+
   return { ok: true, path: parts };
 }
 


### PR DESCRIPTION
Parse config paths using a state machine that handles:
- Standard dot notation: foo.bar → ["foo", "bar"]
- Bracket notation: foo["bar.baz"] → ["foo", "bar.baz"]
- Single quotes: foo['bar'] → ["foo", "bar"]
- Escaped dots: foo\\.bar → ["foo", "bar"]

This fixes issue #36871 where custom provider keys containing periods
(e.g., llama.cpp) were incorrectly split into nested objects.
