### PR TITLE
Telegram: reduce tokenFile sync I/O by removing pre-check fs call

### DIFF
--- a/src/telegram/token.test.ts
+++ b/src/telegram/token.test.ts
@@ -62,12 +62,31 @@ describe("resolveTelegramToken", () => {
     vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
     const dir = withTempDir();
     const tokenFile = path.join(dir, "missing-token.txt");
+    const logMissingFile = vi.fn();
     const cfg = {
       channels: { telegram: { tokenFile, botToken: "cfg-token" } },
     } as OpenClawConfig;
-    const res = resolveTelegramToken(cfg);
+    const res = resolveTelegramToken(cfg, { logMissingFile });
     expect(res.token).toBe("");
     expect(res.source).toBe("none");
+    expect(logMissingFile).toHaveBeenCalledWith(
+      `channels.telegram.tokenFile not found: ${tokenFile}`,
+    );
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("logs tokenFile read failures when file path is unreadable", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
+    const dir = withTempDir();
+    const logMissingFile = vi.fn();
+    const cfg = {
+      channels: { telegram: { tokenFile: dir, botToken: "cfg-token" } },
+    } as OpenClawConfig;
+    const res = resolveTelegramToken(cfg, { logMissingFile });
+    expect(res.token).toBe("");
+    expect(res.source).toBe("none");
+    expect(logMissingFile).toHaveBeenCalledTimes(1);
+    expect(logMissingFile.mock.calls[0]?.[0]).toContain("channels.telegram.tokenFile read failed:");
     fs.rmSync(dir, { recursive: true, force: true });
   });
 

--- a/src/telegram/token.ts
+++ b/src/telegram/token.ts
@@ -17,6 +17,30 @@ type ResolveTelegramTokenOpts = {
   logMissingFile?: (message: string) => void;
 };
 
+type ReadTelegramTokenFileResult = { ok: true; token: string } | { ok: false };
+
+function readTelegramTokenFile(params: {
+  tokenFile: string;
+  logMissingFile?: (message: string) => void;
+  missingMessage: string;
+  readFailedMessagePrefix: string;
+}): ReadTelegramTokenFileResult {
+  try {
+    return { ok: true, token: fs.readFileSync(params.tokenFile, "utf-8").trim() };
+  } catch (err) {
+    const code =
+      typeof err === "object" && err !== null && "code" in err
+        ? (err as { code?: unknown }).code
+        : undefined;
+    if (code === "ENOENT") {
+      params.logMissingFile?.(params.missingMessage);
+    } else {
+      params.logMissingFile?.(`${params.readFailedMessagePrefix}: ${String(err)}`);
+    }
+    return { ok: false };
+  }
+}
+
 export function resolveTelegramToken(
   cfg?: OpenClawConfig,
   opts: ResolveTelegramTokenOpts = {},
@@ -46,22 +70,17 @@ export function resolveTelegramToken(
   );
   const accountTokenFile = accountCfg?.tokenFile?.trim();
   if (accountTokenFile) {
-    if (!fs.existsSync(accountTokenFile)) {
-      opts.logMissingFile?.(
-        `channels.telegram.accounts.${accountId}.tokenFile not found: ${accountTokenFile}`,
-      );
+    const tokenResult = readTelegramTokenFile({
+      tokenFile: accountTokenFile,
+      logMissingFile: opts.logMissingFile,
+      missingMessage: `channels.telegram.accounts.${accountId}.tokenFile not found: ${accountTokenFile}`,
+      readFailedMessagePrefix: `channels.telegram.accounts.${accountId}.tokenFile read failed`,
+    });
+    if (!tokenResult.ok) {
       return { token: "", source: "none" };
     }
-    try {
-      const token = fs.readFileSync(accountTokenFile, "utf-8").trim();
-      if (token) {
-        return { token, source: "tokenFile" };
-      }
-    } catch (err) {
-      opts.logMissingFile?.(
-        `channels.telegram.accounts.${accountId}.tokenFile read failed: ${String(err)}`,
-      );
-      return { token: "", source: "none" };
+    if (tokenResult.token) {
+      return { token: tokenResult.token, source: "tokenFile" };
     }
     return { token: "", source: "none" };
   }
@@ -77,18 +96,17 @@ export function resolveTelegramToken(
   const allowEnv = accountId === DEFAULT_ACCOUNT_ID;
   const tokenFile = telegramCfg?.tokenFile?.trim();
   if (tokenFile) {
-    if (!fs.existsSync(tokenFile)) {
-      opts.logMissingFile?.(`channels.telegram.tokenFile not found: ${tokenFile}`);
+    const tokenResult = readTelegramTokenFile({
+      tokenFile,
+      logMissingFile: opts.logMissingFile,
+      missingMessage: `channels.telegram.tokenFile not found: ${tokenFile}`,
+      readFailedMessagePrefix: "channels.telegram.tokenFile read failed",
+    });
+    if (!tokenResult.ok) {
       return { token: "", source: "none" };
     }
-    try {
-      const token = fs.readFileSync(tokenFile, "utf-8").trim();
-      if (token) {
-        return { token, source: "tokenFile" };
-      }
-    } catch (err) {
-      opts.logMissingFile?.(`channels.telegram.tokenFile read failed: ${String(err)}`);
-      return { token: "", source: "none" };
+    if (tokenResult.token) {
+      return { token: tokenResult.token, source: "tokenFile" };
     }
   }
 


### PR DESCRIPTION
## Summary
- Remove the extra synchronous `existsSync` probe in Telegram token-file resolution.
- Read token files once via `readFileSync` and branch on error code (`ENOENT` vs other read failures).
- Preserve existing fallback behavior while centralizing token-file error handling.
- Add focused tests for missing-file and unreadable-path logging branches.

## Why
- `resolveTelegramToken` can be called frequently; avoiding a redundant sync filesystem check reduces syscall overhead on a hot path.

## Impact
- Same user-facing token resolution semantics.
- Fewer synchronous filesystem calls for token-file paths.
- Better observability coverage for token-file failure branches.

## Risk
- Low. The change is scoped to Telegram token-file reads and covered by focused tests.

## Testing
- `pnpm test src/telegram/token.test.ts`
