### PR TITLE
fix(telegram): split messages at word boundaries instead of mid-word

### DIFF
--- a/src/telegram/format.test.ts
+++ b/src/telegram/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { markdownToTelegramHtml } from "./format.js";
+import { markdownToTelegramHtml, markdownToTelegramHtmlChunks } from "./format.js";
 
 describe("markdownToTelegramHtml", () => {
   it("handles core markdown-to-telegram conversions", () => {
@@ -111,5 +111,42 @@ describe("markdownToTelegramHtml", () => {
     const res = markdownToTelegramHtml("||secret|| trailing ||");
     expect(res).toContain("<tg-spoiler>secret</tg-spoiler>");
     expect(res).toContain("trailing ||");
+  });
+});
+
+describe("markdownToTelegramHtmlChunks word-boundary splitting", () => {
+  it("splits at word boundaries instead of mid-word", () => {
+    // "Regulatory overhang lifts beta for UK banks" should never produce "b\ne\nta"
+    const text = "Regulatory overhang lifts beta for UK banks and more text padding here";
+    // Use a small limit so splitting is forced
+    const chunks = markdownToTelegramHtmlChunks(text, 35);
+    expect(chunks.length).toBeGreaterThan(1);
+    // Reassemble all chunks — every word from the original text must appear
+    // intact in exactly one chunk (no word should be split across chunks).
+    const words = text.split(/\s+/);
+    const joined = chunks.join(" ");
+    for (const word of words) {
+      expect(joined).toContain(word);
+    }
+    // Specifically verify "beta" is never split across chunks
+    for (const chunk of chunks) {
+      expect(chunk).not.toMatch(/\bbet$/);
+      expect(chunk).not.toMatch(/^a\b/);
+    }
+  });
+
+  it("handles text with no spaces (falls back to hard split)", () => {
+    const text = "abcdefghijklmnopqrstuvwxyz";
+    const chunks = markdownToTelegramHtmlChunks(text, 10);
+    expect(chunks.length).toBeGreaterThan(1);
+    // Should still produce all characters
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("does not split when text fits within limit", () => {
+    const text = "short message";
+    const chunks = markdownToTelegramHtmlChunks(text, 100);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toBe(text);
   });
 });

--- a/src/telegram/format.ts
+++ b/src/telegram/format.ts
@@ -312,7 +312,15 @@ function splitMarkdownIRPreserveWhitespace(ir: MarkdownIR, limit: number): Markd
   const chunks: MarkdownIR[] = [];
   let cursor = 0;
   while (cursor < ir.text.length) {
-    const end = Math.min(ir.text.length, cursor + normalizedLimit);
+    let end = Math.min(ir.text.length, cursor + normalizedLimit);
+    // When we are not at the very end of the text, try to break at the last
+    // whitespace within the allowed window so words are not split mid-token.
+    if (end < ir.text.length) {
+      const lastSpace = ir.text.lastIndexOf(" ", end);
+      if (lastSpace > cursor) {
+        end = lastSpace;
+      }
+    }
     chunks.push({
       text: ir.text.slice(cursor, end),
       styles: sliceStyleSpans(ir.styles, cursor, end),


### PR DESCRIPTION
## Summary

Fixes #36644

When long messages exceeded the Telegram character limit, `splitMarkdownIRPreserveWhitespace` sliced at exact character positions, splitting words across multiple messages (e.g. "beta" becoming "b" / "e" / "ta").

## Changes

- **`src/telegram/format.ts`**: Updated `splitMarkdownIRPreserveWhitespace` to look back for the nearest whitespace before the split point, keeping words intact. Falls back to hard character split when the chunk contains no spaces (e.g. very long URLs without whitespace).
- **`src/telegram/format.test.ts`**: Added 3 regression tests for word-boundary splitting, no-space fallback, and single-chunk passthrough.

## Before / After

**Before:** `Regulatory overhang lifts b` / `e` / `ta for UK banks`
**After:** `Regulatory overhang lifts` / `beta for UK banks`

## Testing

```bash
pnpm vitest run src/telegram/format.test.ts  # 19 tests pass
```