### PR TITLE
fix(config): support bracket notation in config path parsing (#36871)

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -336,6 +336,27 @@ describe("config paths", () => {
     expect(unsetConfigValueAtPath(root, parsed.path)).toBe(true);
     expect(getConfigValueAtPath(root, parsed.path)).toBeUndefined();
   });
+
+  it("supports bracket notation for keys with periods", () => {
+    expect(parseConfigPath('foo["bar.baz"].qux')).toEqual({
+      ok: true,
+      path: ["foo", "bar.baz", "qux"],
+    });
+    expect(parseConfigPath("foo['bar.baz'].qux")).toEqual({
+      ok: true,
+      path: ["foo", "bar.baz", "qux"],
+    });
+    expect(parseConfigPath('providers["llama.cpp"].baseUrl')).toEqual({
+      ok: true,
+      path: ["providers", "llama.cpp", "baseUrl"],
+    });
+  });
+
+  it("handles edge cases in bracket notation", () => {
+    expect(parseConfigPath('foo[""].bar').ok).toBe(false);
+    expect(parseConfigPath("foo].bar").ok).toBe(false);
+    expect(parseConfigPath('foo["bar').ok).toBe(false);
+  });
 });
 
 describe("config strict validation", () => {

--- a/src/config/config-paths.ts
+++ b/src/config/config-paths.ts
@@ -58,24 +58,33 @@ export function parseConfigPath(raw: string): {
           i += 2;
           continue;
         }
-        // Closing bracket - end of this segment
-        if (!current) {
-          // Empty bracket content - reject
-          return {
-            ok: false,
-            error: "Invalid path. Use dot notation (e.g. foo.bar).",
-          };
+        // Closing quote - but we're still inside brackets, need to find closing ]
+        // Check if next char is ]
+        if (i + 1 < trimmed.length && trimmed[i + 1] === "]") {
+          // End of bracket notation
+          if (!current) {
+            // Empty bracket content - reject
+            return {
+              ok: false,
+              error: "Invalid path. Use dot notation (e.g. foo.bar).",
+            };
+          }
+          parts.push(current);
+          current = "";
+          inBracket = false;
+          bracketType = null;
+          i += 2; // Skip both " and ]
+          // Skip any dots after closing bracket
+          while (i < trimmed.length && trimmed[i] === ".") {
+            i++;
+          }
+          continue;
         }
-        parts.push(current);
-        current = "";
-        inBracket = false;
-        bracketType = null;
-        i++;
-        // Skip trailing dot after closing bracket (e.g., foo["bar"].baz)
-        if (i < trimmed.length && trimmed[i] === ".") {
-          i++;
-        }
-        continue;
+        // Closing quote without matching ] - this is an error
+        return {
+          ok: false,
+          error: "Invalid path. Use dot notation (e.g. foo.bar).",
+        };
       }
       current += char;
       i++;
@@ -92,7 +101,7 @@ export function parseConfigPath(raw: string): {
       }
       // Check bracket type
       if (i + 1 < trimmed.length && (trimmed[i + 1] === "'" || trimmed[i + 1] === '"')) {
-        bracketType = trimmed[i + 1];
+        bracketType = trimmed[i + 1] as "'" | '"';
         inBracket = true;
         i += 2;
         continue;

--- a/src/config/config-paths.ts
+++ b/src/config/config-paths.ts
@@ -3,6 +3,14 @@ import { isBlockedObjectKey } from "./prototype-keys.js";
 
 type PathNode = Record<string, unknown>;
 
+/**
+ * Parse a config path supporting both dot notation and bracket notation.
+ * - "foo.bar" → ["foo", "bar"]
+ * - "foo.bar.baz" → ["foo", "bar", "baz"]
+ * - 'foo["bar.baz"].qux' → ["foo", "bar.baz", "qux"]
+ * - "foo['bar'].baz" → ["foo", "bar", "baz"]
+ * - "providers.llama\\.cpp.baseUrl" → ["providers", "llama.cpp", "baseUrl"]
+ */
 export function parseConfigPath(raw: string): {
   ok: boolean;
   path?: string[];
@@ -15,16 +23,140 @@ export function parseConfigPath(raw: string): {
       error: "Invalid path. Use dot notation (e.g. foo.bar).",
     };
   }
-  const parts = trimmed.split(".").map((part) => part.trim());
+
+  // Parse using a simple state machine that handles bracket notation
+  const parts: string[] = [];
+  let current = "";
+  let inBracket = false;
+  let bracketType: "'" | '"' | null = null;
+  let i = 0;
+
+  while (i < trimmed.length) {
+    const char = trimmed[i];
+
+    if (inBracket) {
+      // Inside brackets - look for closing bracket
+      if (char === "\\" && i + 1 < trimmed.length) {
+        // Handle escaped characters inside brackets
+        const nextChar = trimmed[i + 1];
+        if (nextChar === "." || nextChar === bracketType) {
+          // Escaped dot or escaped quote
+          current += nextChar;
+        } else {
+          // Keep the backslash for other escape sequences
+          current += char;
+          current += nextChar;
+        }
+        i += 2;
+        continue;
+      }
+      if (char === bracketType) {
+        // Check if next char is also closing bracket (escaped quote)
+        if (i + 1 < trimmed.length && trimmed[i + 1] === bracketType) {
+          // Double bracket - treat as escaped bracket
+          current += char;
+          i += 2;
+          continue;
+        }
+        // Closing bracket - end of this segment
+        if (!current) {
+          // Empty bracket content - reject
+          return {
+            ok: false,
+            error: "Invalid path. Use dot notation (e.g. foo.bar).",
+          };
+        }
+        parts.push(current);
+        current = "";
+        inBracket = false;
+        bracketType = null;
+        i++;
+        // Skip trailing dot after closing bracket (e.g., foo["bar"].baz)
+        if (i < trimmed.length && trimmed[i] === ".") {
+          i++;
+        }
+        continue;
+      }
+      current += char;
+      i++;
+      continue;
+    }
+
+    // Not in brackets
+    if (char === "[") {
+      // Start of bracket notation
+      if (current) {
+        // Push the current segment (with escaped dots resolved)
+        parts.push(current.replace(/\\\./g, "."));
+        current = "";
+      }
+      // Check bracket type
+      if (i + 1 < trimmed.length && (trimmed[i + 1] === "'" || trimmed[i + 1] === '"')) {
+        bracketType = trimmed[i + 1];
+        inBracket = true;
+        i += 2;
+        continue;
+      }
+      // Numeric bracket like [0] - treat as part of path
+      current += char;
+      i++;
+      continue;
+    }
+
+    // Unmatched closing bracket - reject
+    if (char === "]") {
+      return {
+        ok: false,
+        error: "Invalid path. Use dot notation (e.g. foo.bar).",
+      };
+    }
+
+    if (char === ".") {
+      // Dot separator
+      if (current) {
+        // Push the current segment (with escaped dots resolved)
+        parts.push(current.replace(/\\\./g, "."));
+        current = "";
+      }
+      i++;
+      continue;
+    }
+
+    if (char === "\\" && i + 1 < trimmed.length && trimmed[i + 1] === ".") {
+      // Escaped dot - include literal dot in current segment
+      current += ".";
+      i += 2;
+      continue;
+    }
+
+    current += char;
+    i++;
+  }
+
+  // Handle remaining current segment
+  if (current) {
+    parts.push(current.replace(/\\\./g, "."));
+  }
+
+  // Check for unclosed brackets
+  if (inBracket) {
+    return {
+      ok: false,
+      error: "Invalid path. Use dot notation (e.g. foo.bar).",
+    };
+  }
+
   if (parts.some((part) => !part)) {
     return {
       ok: false,
       error: "Invalid path. Use dot notation (e.g. foo.bar).",
     };
   }
+
   if (parts.some((part) => isBlockedObjectKey(part))) {
     return { ok: false, error: "Invalid path segment." };
   }
+
   return { ok: true, path: parts };
 }
 


### PR DESCRIPTION
## Summary

This PR fixes issue #36871 where CLI incorrectly splits custom provider keys containing periods (e.g., llama.cpp).

## Changes

- Modified  in  to support:
  - Standard dot notation:  → 
  - Bracket notation with double quotes:  → 
  - Bracket notation with single quotes:  → 
  - Escaped dots:  → 

Now users can set config values for providers with periods in their names:
```
openclaw config set models.providers["llama.cpp"].baseUrl "http://localhost:8080"
```

## Testing

- Added unit tests in 
- All existing CLI config tests pass