### PR TITLE
browser: cap per-session tracked tab registry

### DIFF
--- a/src/browser/session-tab-registry.test.ts
+++ b/src/browser/session-tab-registry.test.ts
@@ -81,6 +81,36 @@ describe("session tab registry", () => {
     });
   });
 
+  it("evicts oldest tracked tabs when session limit is exceeded", async () => {
+    for (let i = 0; i < 101; i += 1) {
+      trackSessionBrowserTab({
+        sessionKey: "agent:main:main",
+        targetId: `tab-${i}`,
+      });
+    }
+
+    expect(__countTrackedSessionBrowserTabsForTests("agent:main:main")).toBe(100);
+
+    const closeTab = vi.fn(async () => {});
+    const closed = await closeTrackedBrowserTabsForSessions({
+      sessionKeys: ["agent:main:main"],
+      closeTab,
+    });
+
+    expect(closed).toBe(100);
+    expect(closeTab).toHaveBeenCalledTimes(100);
+    expect(closeTab).not.toHaveBeenCalledWith({
+      targetId: "tab-0",
+      baseUrl: undefined,
+      profile: undefined,
+    });
+    expect(closeTab).toHaveBeenCalledWith({
+      targetId: "tab-100",
+      baseUrl: undefined,
+      profile: undefined,
+    });
+  });
+
   it("deduplicates tabs and ignores expected close errors", async () => {
     trackSessionBrowserTab({
       sessionKey: "agent:main:main",

--- a/src/browser/session-tab-registry.ts
+++ b/src/browser/session-tab-registry.ts
@@ -9,6 +9,7 @@ export type TrackedSessionBrowserTab = {
 };
 
 const trackedTabsBySession = new Map<string, Map<string, TrackedSessionBrowserTab>>();
+const MAX_TRACKED_TABS_PER_SESSION = 100;
 
 function normalizeSessionKey(raw: string): string {
   return raw.trim().toLowerCase();
@@ -76,7 +77,18 @@ export function trackSessionBrowserTab(params: {
     trackedForSession = new Map();
     trackedTabsBySession.set(sessionKey, trackedForSession);
   }
+  if (trackedForSession.has(trackedId)) {
+    trackedForSession.delete(trackedId);
+  }
   trackedForSession.set(trackedId, tracked);
+
+  while (trackedForSession.size > MAX_TRACKED_TABS_PER_SESSION) {
+    const oldestTrackedId = trackedForSession.keys().next().value;
+    if (!oldestTrackedId) {
+      break;
+    }
+    trackedForSession.delete(oldestTrackedId);
+  }
 }
 
 export function untrackSessionBrowserTab(params: {


### PR DESCRIPTION
## Summary
- cap tracked browser tabs to 100 entries per session in src/browser/session-tab-registry.ts
- evict oldest entries when a session exceeds the cap
- add focused unit test covering eviction behavior

## Why
Session tab tracking can otherwise grow without bound for long-lived sessions that open many tabs and never trigger cleanup.

## Validation
- pnpm vitest src/browser/session-tab-registry.test.ts
- pnpm lint src/browser/session-tab-registry.ts src/browser/session-tab-registry.test.ts

## Risk
Low: change is isolated to in-memory tracking and covered by targeted tests.