### PR TITLE
perf(routing): reuse binding cache across config snapshots

### DIFF
--- a/src/config/io.compat.test.ts
+++ b/src/config/io.compat.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { createConfigIO } from "./io.js";
+import { getConfigRuntimeHash } from "./runtime-hash.js";
 
 async function withTempHome(run: (home: string) => Promise<void>): Promise<void> {
   const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-config-"));
@@ -75,6 +76,27 @@ describe("config io paths", () => {
       const io = createIoForHome(home, { CLAWDBOT_CONFIG_PATH: customPath } as NodeJS.ProcessEnv);
       expect(io.configPath).toBe(customPath);
       expect(io.loadConfig().gateway?.port).toBe(20003);
+    });
+  });
+
+  it("attaches stable runtime hash metadata for repeated loads of the same config file", async () => {
+    await withTempHome(async (home) => {
+      await writeConfig(home, ".openclaw", 20004, "stable-hash.json");
+      const io = createConfigIO({
+        env: {
+          OPENCLAW_CONFIG_PATH: path.join(home, ".openclaw", "stable-hash.json"),
+        } as NodeJS.ProcessEnv,
+        homedir: () => home,
+      });
+
+      const first = io.loadConfig();
+      const second = io.loadConfig();
+      const firstHash = getConfigRuntimeHash(first);
+      const secondHash = getConfigRuntimeHash(second);
+
+      expect(firstHash).toBeTypeOf("string");
+      expect(firstHash).toBeTruthy();
+      expect(secondHash).toBe(firstHash);
     });
   });
 

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -45,6 +45,7 @@ import { normalizeExecSafeBinProfilesInConfig } from "./normalize-exec-safe-bin.
 import { normalizeConfigPaths } from "./normalize-paths.js";
 import { resolveConfigPath, resolveDefaultConfigCandidates, resolveStateDir } from "./paths.js";
 import { isBlockedObjectKey } from "./prototype-keys.js";
+import { setConfigRuntimeHash } from "./runtime-hash.js";
 import { applyConfigOverrides } from "./runtime-overrides.js";
 import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
 import {
@@ -679,6 +680,11 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
   const configPath =
     candidatePaths.find((candidate) => deps.fs.existsSync(candidate)) ?? requestedConfigPath;
 
+  const withRuntimeHash = (cfg: OpenClawConfig, rawForHash: string | null): OpenClawConfig => {
+    setConfigRuntimeHash(cfg, hashConfigRaw(rawForHash));
+    return cfg;
+  };
+
   function loadConfig(): OpenClawConfig {
     try {
       maybeLoadDotEnvForConfig(deps.env);
@@ -692,7 +698,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
             timeoutMs: resolveShellEnvFallbackTimeoutMs(deps.env),
           });
         }
-        return {};
+        return withRuntimeHash({}, null);
       }
       const raw = deps.fs.readFileSync(configPath, "utf-8");
       const parsed = deps.json5.parse(raw);
@@ -702,7 +708,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       );
       warnOnConfigMiskeys(resolvedConfig, deps.logger);
       if (typeof resolvedConfig !== "object" || resolvedConfig === null) {
-        return {};
+        return withRuntimeHash({}, raw);
       }
       const preValidationDuplicates = findDuplicateAgentDirs(resolvedConfig as OpenClawConfig, {
         env: deps.env,
@@ -802,7 +808,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         AUTO_OWNER_DISPLAY_SECRET_PERSIST_WARNED.delete(configPath);
       }
 
-      return applyConfigOverrides(cfgWithOwnerDisplaySecret);
+      return withRuntimeHash(applyConfigOverrides(cfgWithOwnerDisplaySecret), raw);
     } catch (err) {
       if (err instanceof DuplicateAgentDirError) {
         deps.logger.error(err.message);

--- a/src/config/runtime-hash.ts
+++ b/src/config/runtime-hash.ts
@@ -1,0 +1,24 @@
+import type { OpenClawConfig } from "./types.js";
+
+const configRuntimeHashByObject = new WeakMap<OpenClawConfig, string>();
+
+function normalizeHash(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function setConfigRuntimeHash(cfg: OpenClawConfig, hash: string | null | undefined): void {
+  const normalized = normalizeHash(hash);
+  if (!normalized) {
+    configRuntimeHashByObject.delete(cfg);
+    return;
+  }
+  configRuntimeHashByObject.set(cfg, normalized);
+}
+
+export function getConfigRuntimeHash(cfg: OpenClawConfig): string | null {
+  return configRuntimeHashByObject.get(cfg) ?? null;
+}

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import type { ChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { setConfigRuntimeHash } from "../config/runtime-hash.js";
 import * as routingBindings from "./bindings.js";
 import { resolveAgentRoute } from "./resolve-route.js";
 
@@ -803,6 +804,44 @@ describe("binding evaluation cache scalability", () => {
         peer: { kind: "direct", id: "user-0" },
       });
       expect(repeated.agentId).toBe("agent-0");
+      expect(listBindingsSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      listBindingsSpy.mockRestore();
+    }
+  });
+
+  test("reuses evaluated bindings across fresh config snapshots with same hash (#36915)", () => {
+    const sharedHash = "route-cache-shared-hash-36915";
+    const makeConfig = (): OpenClawConfig => ({
+      bindings: Array.from({ length: 1_500 }, (_, idx) => ({
+        agentId: `agent-${idx}`,
+        match: {
+          channel: "dingtalk",
+          accountId: `acct-${idx}`,
+          peer: { kind: "direct", id: `user-${idx}` },
+        },
+      })),
+    });
+    const firstCfg = makeConfig();
+    const secondCfg = makeConfig();
+    setConfigRuntimeHash(firstCfg, sharedHash);
+    setConfigRuntimeHash(secondCfg, sharedHash);
+    const listBindingsSpy = vi.spyOn(routingBindings, "listBindings");
+    try {
+      const firstRoute = resolveAgentRoute({
+        cfg: firstCfg,
+        channel: "dingtalk",
+        accountId: "acct-1499",
+        peer: { kind: "direct", id: "user-1499" },
+      });
+      const secondRoute = resolveAgentRoute({
+        cfg: secondCfg,
+        channel: "dingtalk",
+        accountId: "acct-1499",
+        peer: { kind: "direct", id: "user-1499" },
+      });
+      expect(firstRoute.agentId).toBe("agent-1499");
+      expect(secondRoute.agentId).toBe("agent-1499");
       expect(listBindingsSpy).toHaveBeenCalledTimes(1);
     } finally {
       listBindingsSpy.mockRestore();

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -2,6 +2,7 @@ import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { ChatType } from "../channels/chat-type.js";
 import { normalizeChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { getConfigRuntimeHash } from "../config/runtime-hash.js";
 import { shouldLogVerbose } from "../globals.js";
 import { logDebug } from "../logger.js";
 import { listBindings } from "./bindings.js";
@@ -183,7 +184,9 @@ type EvaluatedBindingsCache = {
 };
 
 const evaluatedBindingsCacheByCfg = new WeakMap<OpenClawConfig, EvaluatedBindingsCache>();
+const evaluatedBindingsCacheByConfigHash = new Map<string, EvaluatedBindingsCache>();
 const MAX_EVALUATED_BINDINGS_CACHE_KEYS = 2000;
+const MAX_EVALUATED_BINDINGS_HASH_CACHE_KEYS = 8;
 const resolvedRouteCacheByCfg = new WeakMap<
   OpenClawConfig,
   {
@@ -394,25 +397,49 @@ function buildEvaluatedBindingsIndex(bindings: EvaluatedBinding[]): EvaluatedBin
   };
 }
 
+function createEvaluatedBindingsCache(cfg: OpenClawConfig): EvaluatedBindingsCache {
+  return {
+    bindingsRef: cfg.bindings,
+    byChannel: buildEvaluatedBindingsByChannel(cfg),
+    byChannelAccount: new Map<string, EvaluatedBinding[]>(),
+    byChannelAccountIndex: new Map<string, EvaluatedBindingsIndex>(),
+  };
+}
+
+function resolveEvaluatedBindingsCache(cfg: OpenClawConfig): EvaluatedBindingsCache {
+  const configHash = getConfigRuntimeHash(cfg);
+  if (configHash) {
+    const existing = evaluatedBindingsCacheByConfigHash.get(configHash);
+    if (existing) {
+      return existing;
+    }
+    const created = createEvaluatedBindingsCache(cfg);
+    evaluatedBindingsCacheByConfigHash.set(configHash, created);
+    if (evaluatedBindingsCacheByConfigHash.size > MAX_EVALUATED_BINDINGS_HASH_CACHE_KEYS) {
+      const oldest = evaluatedBindingsCacheByConfigHash.keys().next().value;
+      if (typeof oldest === "string") {
+        evaluatedBindingsCacheByConfigHash.delete(oldest);
+      }
+    }
+    return created;
+  }
+
+  const bindingsRef = cfg.bindings;
+  const existing = evaluatedBindingsCacheByCfg.get(cfg);
+  if (existing && existing.bindingsRef === bindingsRef) {
+    return existing;
+  }
+  const created = createEvaluatedBindingsCache(cfg);
+  evaluatedBindingsCacheByCfg.set(cfg, created);
+  return created;
+}
+
 function getEvaluatedBindingsForChannelAccount(
   cfg: OpenClawConfig,
   channel: string,
   accountId: string,
 ): EvaluatedBinding[] {
-  const bindingsRef = cfg.bindings;
-  const existing = evaluatedBindingsCacheByCfg.get(cfg);
-  const cache =
-    existing && existing.bindingsRef === bindingsRef
-      ? existing
-      : {
-          bindingsRef,
-          byChannel: buildEvaluatedBindingsByChannel(cfg),
-          byChannelAccount: new Map<string, EvaluatedBinding[]>(),
-          byChannelAccountIndex: new Map<string, EvaluatedBindingsIndex>(),
-        };
-  if (cache !== existing) {
-    evaluatedBindingsCacheByCfg.set(cfg, cache);
-  }
+  const cache = resolveEvaluatedBindingsCache(cfg);
 
   const cacheKey = `${channel}\t${accountId}`;
   const hit = cache.byChannelAccount.get(cacheKey);
@@ -443,14 +470,14 @@ function getEvaluatedBindingIndexForChannelAccount(
   accountId: string,
 ): EvaluatedBindingsIndex {
   const bindings = getEvaluatedBindingsForChannelAccount(cfg, channel, accountId);
-  const existing = evaluatedBindingsCacheByCfg.get(cfg);
+  const cache = resolveEvaluatedBindingsCache(cfg);
   const cacheKey = `${channel}\t${accountId}`;
-  const indexed = existing?.byChannelAccountIndex.get(cacheKey);
+  const indexed = cache.byChannelAccountIndex.get(cacheKey);
   if (indexed) {
     return indexed;
   }
   const built = buildEvaluatedBindingsIndex(bindings);
-  existing?.byChannelAccountIndex.set(cacheKey, built);
+  cache.byChannelAccountIndex.set(cacheKey, built);
   return built;
 }
 


### PR DESCRIPTION
## Summary
- reuse evaluated route-binding caches across fresh config snapshots that represent the same config file content
- tag config objects loaded from disk with a stable runtime hash in config IO
- keep existing WeakMap cache behavior as fallback when no runtime hash is available
- add regression tests for hash tagging and cross-snapshot routing cache reuse

## Testing
- pnpm test -- src/routing/resolve-route.test.ts src/config/io.compat.test.ts

Fixes #36915
