### PR TITLE
feat(agents): add per-message context utilization footer for messaging channels

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -12,6 +12,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
 }));
 
 const {
+  formatContextFooterLine,
   buildEmbeddedRunBaseParams,
   buildEmbeddedRunContexts,
   resolveModelFallbackOptions,
@@ -172,5 +173,39 @@ describe("agent-runner-utils", () => {
 
     expect(resolved.embeddedContext.messageProvider).toBe("telegram");
     expect(resolved.embeddedContext.messageTo).toBe("268300329");
+  });
+});
+
+describe("formatContextFooterLine", () => {
+  it("formats compact footer with token counts", () => {
+    const line = formatContextFooterLine({
+      totalTokens: 87000,
+      contextTokens: 200000,
+      deltaTokens: 3200,
+    });
+    expect(line).toBe("[ctx: 87k/200k · +3.2k this msg]");
+  });
+
+  it("formats full footer with session key", () => {
+    const line = formatContextFooterLine({
+      totalTokens: 150000,
+      contextTokens: 200000,
+      deltaTokens: 5000,
+      format: "full",
+      sessionKey: "agent:main:telegram:direct:12345",
+    });
+    expect(line).toContain("[ctx: 150k/200k · +5.0k this msg]");
+    expect(line).toContain("session `agent:main:telegram:direct:12345`");
+  });
+
+  it("compact format ignores session key", () => {
+    const line = formatContextFooterLine({
+      totalTokens: 1000,
+      contextTokens: 8000,
+      deltaTokens: 200,
+      format: "compact",
+      sessionKey: "agent:main:main",
+    });
+    expect(line).toBe("[ctx: 1.0k/8.0k · +200 this msg]");
   });
 });

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -119,6 +119,24 @@ export const formatResponseUsageLine = (params: {
   return `Usage: ${inputLabel} in / ${outputLabel} out${suffix}`;
 };
 
+export const formatContextFooterLine = (params: {
+  totalTokens: number;
+  contextTokens: number;
+  deltaTokens: number;
+  format?: "compact" | "full";
+  sessionKey?: string;
+}): string => {
+  const { totalTokens, contextTokens, deltaTokens, format = "compact" } = params;
+  const usedLabel = formatTokenCount(totalTokens);
+  const limitLabel = formatTokenCount(contextTokens);
+  const deltaLabel = formatTokenCount(deltaTokens);
+  const base = `[ctx: ${usedLabel}/${limitLabel} · +${deltaLabel} this msg]`;
+  if (format === "full" && params.sessionKey) {
+    return `${base} · session \`${params.sessionKey}\``;
+  }
+  return base;
+};
+
 export const appendUsageLine = (payloads: ReplyPayload[], line: string): ReplyPayload[] => {
   let index = -1;
   for (let i = payloads.length - 1; i >= 0; i -= 1) {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -44,7 +44,11 @@ import {
   hasSessionRelatedCronJobs,
   hasUnbackedReminderCommitment,
 } from "./agent-runner-reminder-guard.js";
-import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.js";
+import {
+  appendUsageLine,
+  formatContextFooterLine,
+  formatResponseUsageLine,
+} from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
@@ -687,6 +691,29 @@ export async function runReplyAgent(params: {
     }
     if (responseUsageLine) {
       finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);
+    }
+
+    const contextFooterCfg = cfg.agents?.defaults?.contextFooter;
+    if (contextFooterCfg?.enabled && hasNonzeroUsage(usage) && contextTokensUsed > 0) {
+      const normalizedChannel = (replyToChannel ?? "").toLowerCase().trim();
+      const allowedChannels = contextFooterCfg.channels?.map((c) => c.toLowerCase().trim()) ?? [
+        "telegram",
+        "signal",
+        "discord",
+      ];
+      if (normalizedChannel && allowedChannels.includes(normalizedChannel)) {
+        const input = usage?.input ?? 0;
+        const output = usage?.output ?? 0;
+        const totalTokens = usage?.total ?? input + output;
+        const footerLine = formatContextFooterLine({
+          totalTokens,
+          contextTokens: contextTokensUsed,
+          deltaTokens: output,
+          format: contextFooterCfg.format ?? "compact",
+          sessionKey: contextFooterCfg.format === "full" ? sessionKey : undefined,
+        });
+        finalPayloads = appendUsageLine(finalPayloads, footerLine);
+      }
     }
 
     return finalizeWithFollowup(

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -284,6 +284,15 @@ export type AgentDefaultsConfig = {
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;
+  /** Optional context utilization footer appended to assistant replies on messaging channels. */
+  contextFooter?: {
+    /** Enable the footer (default: false). */
+    enabled?: boolean;
+    /** Footer format: "compact" (default) or "full" (includes session key). */
+    format?: "compact" | "full";
+    /** Channels to show the footer on (default: ["telegram", "signal", "discord"]). */
+    channels?: string[];
+  };
 };
 
 export type AgentCompactionMode = "default" | "safeguard";

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -187,6 +187,14 @@ export const AgentDefaultsSchema = z
       .strict()
       .optional(),
     sandbox: AgentSandboxSchema,
+    contextFooter: z
+      .object({
+        enabled: z.boolean().optional(),
+        format: z.enum(["compact", "full"]).optional(),
+        channels: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

- **Problem:** Non-UI channels (Telegram, Signal, Discord) have no way to see context utilization without asking the agent to run `session_status`, which wastes tokens and breaks conversation flow.
- **Why it matters:** Power users on mobile need to know when to `/reset` before compaction, but guessing based on message count is unreliable since tool calls vary wildly.
- **What changed:** Added an optional inline context footer appended to assistant replies on messaging channels. Format: `[ctx: 87k/200k · +3.2k this msg]`. Configurable via `agents.defaults.contextFooter` with `enabled`, `format` (compact/full), and `channels` allowlist. Uses existing `formatTokenCount` utility and `appendUsageLine` infrastructure.
- **What did NOT change:** Default behavior (footer disabled), existing `responseUsage` line behavior, WebChat/TUI display, token counting, or context management logic.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36515

## User-visible / Behavior Changes

- New optional config `agents.defaults.contextFooter`:
  - `enabled: true` — opt-in, off by default
  - `format: "compact" | "full"` — compact shows `[ctx: X/Y · +Z this msg]`, full adds session key
  - `channels: string[]` — defaults to `["telegram", "signal", "discord"]`
- When enabled, each assistant reply on allowed channels gets a one-line footer with token utilization

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 20+
- Integration/channel: Telegram, Signal, Discord

### Steps

1. Set `agents.defaults.contextFooter.enabled` to `true`
2. Send a message on Telegram
3. Observe the assistant reply includes a context footer line

### Expected

- Reply ends with `[ctx: 87k/200k · +3.2k this msg]` (values vary)

### Actual

- Before fix: no context information on messaging channels
- After fix: optional footer appended when enabled

## Evidence

```
 ✓ src/auto-reply/reply/agent-runner-utils.test.ts (8 tests) 3ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
```

New tests for `formatContextFooterLine`:
- Compact format with realistic token counts
- Full format with session key
- Compact format ignores session key

## Human Verification (required)

- Verified scenarios: compact format, full format with session key, channel filtering logic
- Edge cases checked: missing usage data (skipped), zero context tokens (skipped), channel not in allowlist (skipped), empty channel (skipped)
- What I did **not** verify: live Telegram/Signal/Discord delivery (requires active channel connections)

## Compatibility / Migration

- Backward compatible? `Yes` — new config field, disabled by default
- Config/env changes? `No` — optional addition only
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: set `agents.defaults.contextFooter.enabled: false` or remove the config key
- Files/config to restore: `src/auto-reply/reply/agent-runner.ts`
- Known bad symptoms: duplicate footer lines or incorrect token counts in messaging replies

## Risks and Mitigations

- Risk: footer adds visual noise to replies → mitigated by being opt-in and channel-scoped
- Risk: token counts may differ from actual context window usage → mitigated by using the same `usage` and `contextTokensUsed` data used by `responseUsage`

