### PR TITLE
fix: multiple targeted fixes (Matrix import, subagent steer, cron payload)

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 

--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/matrix";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1133,6 +1133,93 @@ describe("sessions tools", () => {
     }
   });
 
+  it("subagents steer failure does not clear a newer cooldown timestamp", async () => {
+    resetSubagentRegistryForTests();
+    let firstAgentReject: ((error: Error) => void) | undefined;
+    let agentCallCount = 0;
+    callGatewayMock.mockImplementation((opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        agentCallCount += 1;
+        if (agentCallCount === 1) {
+          return new Promise((_, reject) => {
+            firstAgentReject = reject;
+          });
+        }
+        return Promise.resolve({ runId: `run-steer-overlap-${agentCallCount}` });
+      }
+      return Promise.resolve({});
+    });
+    addSubagentRunForTests({
+      runId: "run-steer-overlap",
+      childSessionKey: "agent:main:subagent:steer-overlap",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "overlap steer",
+      cleanup: "keep",
+      createdAt: Date.now() - 60_000,
+      startedAt: Date.now() - 60_000,
+    });
+
+    const loadSessionStoreSpy = vi
+      .spyOn(sessionsModule, "loadSessionStore")
+      .mockImplementation(() => ({
+        "agent:main:subagent:steer-overlap": {
+          sessionId: "child-session-steer-overlap",
+          updatedAt: Date.now(),
+        },
+      }));
+
+    const nowSpy = vi.spyOn(Date, "now");
+    try {
+      const tool = createOpenClawTools({
+        agentSessionKey: "agent:main:main",
+      }).find((candidate) => candidate.name === "subagents");
+      expect(tool).toBeDefined();
+      if (!tool) {
+        throw new Error("missing subagents tool");
+      }
+
+      nowSpy.mockReturnValue(1_000);
+      const firstSteerPromise = tool.execute("call-subagents-steer-overlap-1", {
+        action: "steer",
+        target: "1",
+        message: "first steer",
+      });
+
+      // Let the first steer set its rate-limit timestamp and reach the pending dispatch.
+      await Promise.resolve();
+
+      nowSpy.mockReturnValue(3_501);
+      const secondSteer = await tool.execute("call-subagents-steer-overlap-2", {
+        action: "steer",
+        target: "1",
+        message: "second steer",
+      });
+      const secondDetails = secondSteer.details as { status?: string };
+      expect(secondDetails.status).toBe("accepted");
+
+      // First steer fails late and must not clear the newer (second steer) cooldown timestamp.
+      firstAgentReject?.(new Error("first steer failed late"));
+      const firstSteer = await firstSteerPromise;
+      const firstDetails = firstSteer.details as { status?: string; error?: string };
+      expect(firstDetails.status).toBe("error");
+      expect(firstDetails.error).toContain("first steer failed late");
+
+      nowSpy.mockReturnValue(3_600);
+      const thirdSteer = await tool.execute("call-subagents-steer-overlap-3", {
+        action: "steer",
+        target: "1",
+        message: "third steer should still be cooldown limited",
+      });
+      const thirdDetails = thirdSteer.details as { status?: string };
+      expect(thirdDetails.status).toBe("rate_limited");
+    } finally {
+      nowSpy.mockRestore();
+      loadSessionStoreSpy.mockRestore();
+    }
+  });
+
   it("subagents numeric targets follow active-first list ordering", async () => {
     resetSubagentRegistryForTests();
     addSubagentRunForTests({

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -1063,6 +1063,76 @@ describe("sessions tools", () => {
     }
   });
 
+  it("subagents steer clears rate limit after dispatch failure so retry can succeed immediately", async () => {
+    resetSubagentRegistryForTests();
+    let agentCallCount = 0;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        agentCallCount += 1;
+        if (agentCallCount === 1) {
+          throw new Error("gateway unavailable");
+        }
+        return { runId: "run-steer-retry" };
+      }
+      return {};
+    });
+    addSubagentRunForTests({
+      runId: "run-steer-fail",
+      childSessionKey: "agent:main:subagent:steer-fail",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "prepare delivery summary",
+      cleanup: "keep",
+      createdAt: Date.now() - 60_000,
+      startedAt: Date.now() - 60_000,
+    });
+
+    const loadSessionStoreSpy = vi
+      .spyOn(sessionsModule, "loadSessionStore")
+      .mockImplementation(() => ({
+        "agent:main:subagent:steer-fail": {
+          sessionId: "child-session-steer-fail",
+          updatedAt: Date.now(),
+        },
+      }));
+
+    try {
+      const tool = createOpenClawTools({
+        agentSessionKey: "agent:main:main",
+      }).find((candidate) => candidate.name === "subagents");
+      expect(tool).toBeDefined();
+      if (!tool) {
+        throw new Error("missing subagents tool");
+      }
+
+      const failed = await tool.execute("call-subagents-steer-fail", {
+        action: "steer",
+        target: "1",
+        message: "retry immediately after failure",
+      });
+      const failedDetails = failed.details as { status?: string; error?: string };
+      expect(failedDetails.status).toBe("error");
+      expect(failedDetails.error).toContain("gateway unavailable");
+
+      const retried = await tool.execute("call-subagents-steer-retry", {
+        action: "steer",
+        target: "1",
+        message: "retry immediately after failure",
+      });
+      const retriedDetails = retried.details as { status?: string; runId?: string };
+      expect(retriedDetails.status).toBe("accepted");
+      expect(retriedDetails.runId).toBe("run-steer-retry");
+
+      const trackedRuns = listSubagentRunsForRequester("agent:main:main");
+      expect(trackedRuns).toHaveLength(1);
+      expect(trackedRuns[0].runId).toBe("run-steer-retry");
+      expect(trackedRuns[0].endedAt).toBeUndefined();
+    } finally {
+      loadSessionStoreSpy.mockRestore();
+    }
+  });
+
   it("subagents numeric targets follow active-first list ordering", async () => {
     resetSubagentRegistryForTests();
     addSubagentRunForTests({

--- a/src/agents/tools/subagents-tool.ts
+++ b/src/agents/tools/subagents-tool.ts
@@ -664,7 +664,11 @@ export function createSubagentsTool(opts?: { agentSessionKey?: string }): AnyAge
           // Also roll back the steer rate-limit entry so callers can retry
           // immediately after a dispatch failure instead of waiting for a
           // successful-steer cooldown window.
-          steerRateLimit.delete(rateKey);
+          // Guard against overlap: if a newer steer already refreshed this key,
+          // keep the newer timestamp instead of deleting it.
+          if (steerRateLimit.get(rateKey) === now) {
+            steerRateLimit.delete(rateKey);
+          }
           const error = err instanceof Error ? err.message : String(err);
           return jsonResult({
             status: "error",

--- a/src/agents/tools/subagents-tool.ts
+++ b/src/agents/tools/subagents-tool.ts
@@ -661,6 +661,10 @@ export function createSubagentsTool(opts?: { agentSessionKey?: string }): AnyAge
           // Replacement launch failed; restore normal announce behavior for the
           // original run so completion is not silently suppressed.
           clearSubagentRunSteerRestart(resolved.entry.runId);
+          // Also roll back the steer rate-limit entry so callers can retry
+          // immediately after a dispatch failure instead of waiting for a
+          // successful-steer cooldown window.
+          steerRateLimit.delete(rateKey);
           const error = err instanceof Error ? err.message : String(err);
           return jsonResult({
             status: "error",

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -16,7 +16,7 @@ import {
 } from "./service.issue-regressions.test-helpers.js";
 import { CronService } from "./service.js";
 import { createDeferred, createRunningCronServiceState } from "./service.test-harness.js";
-import { computeJobNextRunAtMs } from "./service/jobs.js";
+import { applyJobPatch, computeJobNextRunAtMs } from "./service/jobs.js";
 import { run } from "./service/ops.js";
 import { createCronServiceState, type CronEvent } from "./service/state.js";
 import {
@@ -218,6 +218,31 @@ describe("Cron issue regressions", () => {
     expect(updated.state.nextRunAtMs).toBeGreaterThan(now);
 
     cron.stop();
+  });
+
+  it("applyJobPatch tolerates jobs with missing payload when patching payload", () => {
+    const brokenJob = {
+      id: "missing-payload-update",
+      name: "legacy missing payload for update",
+      enabled: true,
+      createdAtMs: Date.parse("2026-02-06T10:04:00.000Z"),
+      updatedAtMs: Date.parse("2026-02-06T10:04:00.000Z"),
+      schedule: { kind: "cron", expr: "0 */2 * * *", tz: "UTC" },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      state: {},
+    } as unknown as CronJob;
+
+    expect(() =>
+      applyJobPatch(brokenJob, {
+        payload: { kind: "agentTurn", message: "repair legacy payload" },
+      }),
+    ).not.toThrow();
+
+    expect(brokenJob.payload.kind).toBe("agentTurn");
+    if (brokenJob.payload.kind === "agentTurn") {
+      expect(brokenJob.payload.message).toBe("repair legacy payload");
+    }
   });
 
   it("treats persisted due jobs with missing enabled as runnable", async () => {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -131,10 +131,10 @@ function resolveEveryAnchorMs(params: {
 }
 
 export function assertSupportedJobSpec(job: Pick<CronJob, "sessionTarget" | "payload">) {
-  if (job.sessionTarget === "main" && job.payload.kind !== "systemEvent") {
+  if (job.sessionTarget === "main" && job.payload?.kind !== "systemEvent") {
     throw new Error('main cron jobs require payload.kind="systemEvent"');
   }
-  if (job.sessionTarget === "isolated" && job.payload.kind !== "agentTurn") {
+  if (job.sessionTarget === "isolated" && job.payload?.kind !== "agentTurn") {
     throw new Error('isolated cron jobs require payload.kind="agentTurn"');
   }
 }
@@ -608,7 +608,7 @@ export function applyJobPatch(
     if (
       legacyDeliveryPatch &&
       job.sessionTarget === "isolated" &&
-      job.payload.kind === "agentTurn"
+      job.payload?.kind === "agentTurn"
     ) {
       job.delivery = mergeCronDelivery(job.delivery, legacyDeliveryPatch);
     }
@@ -646,7 +646,11 @@ export function applyJobPatch(
   assertFailureDestinationSupport(job);
 }
 
-function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronPayload {
+function mergeCronPayload(existing: CronPayload | undefined, patch: CronPayloadPatch): CronPayload {
+  if (!existing || typeof existing !== "object" || typeof existing.kind !== "string") {
+    return buildPayloadFromPatch(patch);
+  }
+
   if (patch.kind !== existing.kind) {
     return buildPayloadFromPatch(patch);
   }
@@ -891,7 +895,7 @@ export function isJobDue(job: CronJob, nowMs: number, opts: { forced: boolean })
 }
 
 export function resolveJobPayloadTextForMain(job: CronJob): string | undefined {
-  if (job.payload.kind !== "systemEvent") {
+  if (job.payload?.kind !== "systemEvent") {
     return undefined;
   }
   const text = normalizePayloadToSystemText(job.payload);

--- a/src/plugin-sdk/matrix.ts
+++ b/src/plugin-sdk/matrix.ts
@@ -91,6 +91,7 @@ export { formatDocsLink } from "../terminal/links.js";
 export type { WizardPrompter } from "../wizard/prompts.js";
 export { createScopedPairingAccess } from "./pairing-access.js";
 export { formatResolvedUnresolvedNote } from "./resolution-notes.js";
+export { enqueueKeyedTask, KeyedAsyncQueue } from "./keyed-async-queue.js";
 export { runPluginCommandWithTimeout } from "./run-command.js";
 export { createLoggerBackedRuntime } from "./runtime.js";
 export { buildProbeChannelStatusSummary } from "./status-helpers.js";

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -49,6 +49,7 @@ export {
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "../config/runtime-group-policy.js";
+export { resolveChannelGroupRequireMention } from "../config/group-policy.js";
 export type { BlockStreamingCoalesceConfig, DmPolicy, GroupPolicy } from "../config/types.js";
 export type { SecretInput } from "../config/types.secrets.js";
 export {


### PR DESCRIPTION
## Summary

This PR includes multiple independent fixes that were batched together:

### 1. Matrix import path fix (fixes #36501)
- **Problem**: The Matrix extension imported `KeyedAsyncQueue` from the subpath `openclaw/plugin-sdk/keyed-async-queue`. In runtime environments where subpath fallback/alias resolution is not available, that import path can resolve incorrectly and fail.
- **Fix**: Switch Matrix send-queue import to the stable package entrypoint: `openclaw/plugin-sdk/matrix`.
- **Changes**: 
  - `extensions/matrix/src/matrix/send-queue.ts`: Updated import path
  - `src/plugin-sdk/matrix.ts`: Added `KeyedAsyncQueue` and `enqueueKeyedTask` exports

### 2. Subagents rate-limit rollback fix
- **Problem**: When a steer dispatch fails, the rate-limit entry was not cleared, preventing immediate retries.
- **Fix**: Roll back the steer rate-limit entry on dispatch failure so callers can retry immediately.
- **Changes**:
  - `src/agents/tools/subagents-tool.ts`: Added rate-limit cleanup on error
  - `src/agents/openclaw-tools.sessions.test.ts`: Added regression test

### 3. Cron jobs missing payload tolerance
- **Problem**: Jobs with missing `payload` field caused runtime errors during patch operations.
- **Fix**: Guard against missing/undefined payload in `applyJobPatch` and related functions.
- **Changes**:
  - `src/cron/service/jobs.ts`: Added null checks for payload
  - `src/cron/service.issue-regressions.test.ts`: Added regression test

### 4. Mattermost plugin-sdk export (supporting #36360)
- Added `resolveChannelGroupRequireMention` export to `src/plugin-sdk/mattermost.ts`

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Testing

- All CI checks pass (except `secrets` which has known false positives on main)
- `pnpm test` passes locally
- New unit tests added for subagents and cron fixes

## Risks

Low. All changes are backward compatible and focused on specific bug fixes.

---

Note: In retrospect, these should have been separate PRs. Apologies for the batched changes.