### PR TITLE
fix(ui): clear stuck reading indicator on mismatched-runId final event

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -390,6 +390,30 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe("Working...");
   });
 
+  it("clears stuck streaming state on mismatched-runId final when chatStream is empty", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "client-idempotency-key",
+      chatStream: "",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "server-assigned-run-id",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello!" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe(null);
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatStreamStartedAt).toBe(null);
+    expect(state.chatMessages).toHaveLength(1);
+  });
+
   it("drops NO_REPLY final payload from own run", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -253,6 +253,11 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
   // See https://github.com/openclaw/openclaw/issues/1909
   if (payload.runId && state.chatRunId && payload.runId !== state.chatRunId) {
     if (payload.state === "final") {
+      if (!state.chatStream?.trim()) {
+        state.chatStream = null;
+        state.chatRunId = null;
+        state.chatStreamStartedAt = null;
+      }
       const finalMessage = normalizeFinalAssistantMessage(payload.message);
       if (finalMessage && !isAssistantSilentReply(finalMessage)) {
         state.chatMessages = [...state.chatMessages, finalMessage];


### PR DESCRIPTION
## Summary

- **Problem:** Control UI webchat shows the reading indicator (three dots animation) permanently after the assistant completes its response. Users must manually refresh to see the completed reply.
- **Why it matters:** The stuck indicator makes the webchat appear broken — users can't tell if the agent finished, is still thinking, or crashed.
- **What changed:** In the chat event handler's mismatched-runId branch, when `payload.state === "final"` and `chatStream` is empty (the exact stuck scenario), clear `chatStream`, `chatRunId`, and `chatStreamStartedAt` so the reading indicator stops rendering.
- **What did NOT change:** Active streams with content (e.g., sub-agent announce arriving while main run is mid-stream) are preserved — only the stuck empty-stream case is cleared.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36911

## User-visible / Behavior Changes

- Reading indicator no longer stays permanently after assistant response completes
- Sub-agent announce messages during active streaming are unaffected

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Browser (Control UI webchat)
- Integration/channel: WebChat

### Steps

1. Open Control UI webchat
2. Send a message
3. Wait for the assistant to finish responding

### Expected

- Reading indicator disappears when response completes

### Actual

- Before fix: reading indicator stays permanently (requires page refresh)
- After fix: reading indicator clears when final event arrives

## Evidence

```
 ✓ ui/src/ui/controllers/chat.test.ts (26 tests) 6ms

 Test Files  1 passed (1)
      Tests  26 passed (26)
```

New test verifies: when server sends final event with different runId and chatStream is empty, streaming state is cleared and the message is added to history.

All 25 existing tests pass unchanged — the conservative fix (only clear when chatStream is empty) preserves behavior for sub-agent announce scenarios.

## Human Verification (required)

- Verified scenarios: empty chatStream cleared on mismatched final, non-empty chatStream preserved, NO_REPLY handling, sub-agent announce handling
- Edge cases checked: chatStream with whitespace only (treated as empty), null chatStream (no-op), active streaming with content (preserved)
- What I did **not** verify: live webchat UI (requires running gateway and Control UI)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit; users refresh page as workaround
- Files/config to restore: `ui/src/ui/controllers/chat.ts`
- Known bad symptoms: reading indicator stuck after response (same as before)

## Risks and Mitigations

- Risk: clearing streaming state during a concurrent sub-agent announce could interrupt active stream display → mitigated by only clearing when chatStream is empty (trim check), preserving active streams with content

