### PR TITLE
[Issue #36911] Control UI: reading indicator stuck after assistant response completes (runId mismatch)

### DIFF
--- a/automation/issue-tracker/issue-36911.md
+++ b/automation/issue-tracker/issue-36911.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36911
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36911
+- Title: Control UI: reading indicator stuck after assistant response completes (runId mismatch)
+- Created at: 2026-03-06T00:29:56Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36911
- URL: https://github.com/openclaw/openclaw/issues/36911

## Original Issue Description

## Bug Description

The Control UI webchat shows the reading indicator (three dots / typing animation) permanently after the assistant completes its response. Users must manually refresh the page to see the completed response.

## Steps to Reproduce

1. Open the Control UI webchat
2. Send any message
3. Wait for the assistant to finish responding
4. The reading indicator (three dots) remains visible indefinitely
5. Refreshing the page reveals the completed response

## Root Cause Analysis

The issue is a **runId mismatch** between the client-generated idempotency key and the server-assigned runId.

### In `Ep` (chat.send handler):
```js
const l = ti(); // generates a new UUID as idempotencyKey
e.chatRunId = l;
e.chatStream = &#34;&#34;;       // empty string, NOT null
e.chatStreamStartedAt = o;
// ...
await e.client.request(&#34;chat.send&#34;, { ..., idempotencyKey: l });
```

### In `Ip` (chat event handler):
```js
if (t.runId &amp;&amp; e.chatRunId &amp;&amp; t.runId !== e.chatRunId) {
    // Server&#39;s runId !== client&#39;s idempotencyKey
    if (t.state === &#34;final&#34;) {
        // Message gets added to chatMessages, BUT:
        // chatStream, chatRunId, chatStreamStartedAt are NEVER cleared
        return n &amp;&amp; !As(n) ? (e.chatMessages = [...e.chatMessages, n], null) : &#34;final&#34;;
    }
    return null; // delta events also silently dropped
}
```

### In `a$` (view builder):
```js
if (e.stream !== null) {
    // chatStream is &#34;&#34; (empty string from Ep, never cleared to null)
    // So this branch always triggers:
    e.stream.trim().length &gt; 0
        ? /* show streaming text */
        : /* show reading indicator (dots) ← STUCK HERE */
}
```

### Summary
- Client sets `chatRunId` to a locally-generated UUID (the idempotency key)
- Server responds with chat events using its own `runId`
- The mismatch causes the `&#34;final&#34;` handler to skip clearing `chatStream`/`chatRunId`/`chatStreamStartedAt`
- `chatStream` remains as `&#34;&#34;` (empty string, not `null`), so the reading indicator renders indefinitely

## Suggested Fix

In the `Ip` function, when `runId` mismatches and `state === &#34;final&#34;`, also clear the streaming state:

```js
if (t.runId &amp;&amp; e.chatRunId &amp;&amp; t.runId !== e.chatRunId) {
    if (t.state === &#34;final&#34;) {
        const n = ir(t.message);
        if (n &amp;&amp; !As(n)) {
            e.chatMessages = [...e.chatMessages, n];
        }
        // Clear streaming state even on runId mismatch
        e.chatStream = null;
        e.chatRunId = null;
        e.chatStreamStartedAt = null;
        return &#34;final&#34;;
    }
    return null;
}
```

Alternatively, `Ep` could avoid setting `chatRunId` to the idempotency key and instead wait for the server to confirm the actual `runId`.

## Environment

- **OpenClaw version:** 2026.3.2
- **Platform:** macOS (Darwin 23.6.0)
- **Model:** gemini-3.1-pro-preview (via Google provider)
- **UI:** Control UI webchat (localhost)

## Impact

Every message sent through the Control UI triggers this bug, making the webchat effectively unusable without constant page refreshes.

Refs #36911