### PR TITLE
[Issue #36913] [Bug]:

### DIFF
--- a/automation/issue-tracker/issue-36913.md
+++ b/automation/issue-tracker/issue-36913.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36913
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36913
+- Title: [Bug]:
+- Created at: 2026-03-06T00:31:09Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36913
- URL: https://github.com/openclaw/openclaw/issues/36913

## Original Issue Description

### Bug type

Regression (worked before, now fails)

### Summary

openclaw --version (you have: 2026.3.2)
claude --version (you have: 2.1.63)
the probe output showing 401
HTTP 401 … Invalid bearer token 
but it&#39;s the right token and it works a bit before stops working, and sometimes it comes back

### Steps to reproduce

-

### Expected behavior

-

### Actual behavior

-

### OpenClaw version

2026.3.2

### Operating system

macos 14

### Install method

_No response_

### Logs, screenshots, and evidence

```shell

```

### Impact and severity

_No response_

### Additional information

_No response_

Refs #36913