### PR TITLE
[Issue #36917] [SEC] Plugin runtime config still exposes provider auth fields after plugin entry isolation

### DIFF
--- a/automation/issue-tracker/issue-36917.md
+++ b/automation/issue-tracker/issue-36917.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36917
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36917
+- Title: [SEC] Plugin runtime config still exposes provider auth fields after plugin entry isolation
+- Created at: 2026-03-06T00:36:38Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36917
- URL: https://github.com/openclaw/openclaw/issues/36917

## Original Issue Description

## Summary
`loadOpenClawPlugins` now isolates `plugins.entries` and strips `secrets.providers` (PR #36217), but plugin runtime code can still read sensitive provider auth fields from `api.config` (for example `models.providers.*.apiKey`, `headers.Authorization`, or other credential-bearing provider options).

## Why this matters
A malicious or compromised plugin can exfiltrate upstream provider credentials even when plugin entry isolation is enabled. This is a cross-boundary credential exposure risk (plugin boundary -> host config secrets).

## Reproduction sketch
1. Create a plugin that logs/exports `api.config.models.providers` inside `register(api)`.
2. Configure a provider with embedded auth values (e.g. API key/header-based auth) in OpenClaw config.
3. Load plugin.
4. Observe provider auth material is accessible to plugin runtime.

## Impact
- Credential disclosure to untrusted plugin code
- Potential outbound exfiltration if plugin has network/tool access

## Suggested fix
1. In plugin loader, redact provider auth-bearing fields before passing `config` into plugin API.
   - Candidate allowlist approach: expose only non-secret provider metadata (`model`, `baseUrl` if safe), redact `apiKey`, auth headers, tokens, and secret-ref internals.
2. Add unit tests that assert plugin runtime cannot read provider credential fields.
3. Document plugin config visibility contract in plugin security docs.

## Notes
- This issue is a hardening follow-up to PR #36217, not a blocker for unrelated functionality.
- If maintainers prefer, this can be handled in a separate minimal security PR to avoid branch conflict.

Refs #36917