### PR TITLE
[Issue #36930] [Bug]: Node cannot connect to remote gateway even though OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1 is present as env var

### DIFF
--- a/automation/issue-tracker/issue-36930.md
+++ b/automation/issue-tracker/issue-36930.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36930
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36930
+- Title: [Bug]: Node cannot connect to remote gateway even though OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1 is present as env var
+- Created at: 2026-03-06T00:50:45Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36930
- URL: https://github.com/openclaw/openclaw/issues/36930

## Original Issue Description

### Bug type

Behavior bug (incorrect output/state without crash)

### Summary

During onboarding, a node opted to use the remote gateway cannot connect to it on ws:// even after providing OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1 as an env variable. This env variable should have allowed to connect with ws:// protocol

### Steps to reproduce

1. Setup a gateway node in a docker / kuberentes container
2. Setup another node in a docker/kubenetes container, exec into it and and follow the onboard process `openclaw onboard` 
3. It gets stuck in the following step 

Here is the output during onboarding.  The node does not fail, it just does not proceed beyond the below step. There are no logs which indicates any connection is being done. So this must be a config validation error where the OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1  is not honored even after it is provided in the env
```
Gateway WebSocket URL
│  ws://openclaw-gateway.ai:18789
└  Use wss:// for remote hosts, or ws://127.0.0.1/localhost via SSH tunnel. Break-glass:
OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1 for trusted private networks.
```

### Expected behavior

If OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1  is provided, the check for the `wss://` should not be required and it should allow the connections to `ws://`

### Actual behavior

The onboarding setup stops at the following step and does not allow to go after this step

```
Gateway WebSocket URL
│  ws://openclaw-gateway.ai:18789
└  Use wss:// for remote hosts, or ws://127.0.0.1/localhost via SSH tunnel. Break-glass:
OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1 for trusted private networks.
```

### OpenClaw version

2026.3.2

### Operating system

docker / kubernetes at both gateway and node

### Install method

docker image alpine/openclaw:2026.3.2

### Logs, screenshots, and evidence

```shell
Terminal output during the onboarding in the node

Gateway WebSocket URL
│  ws://openclaw-gateway.ai:18789
└  Use wss:// for remote hosts, or ws://127.0.0.1/localhost via SSH tunnel. Break-glass:
OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1 for trusted private networks.
```

### Impact and severity

Node cannot connect to gateway.  Since these setups are within the kubernetes / docker network, there should NOT be any need to host the gateway on `wss://`  so the connection from node to gateway should be allowed as `ws://` when the env var `OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1` is provided

### Additional information

_No response_

Refs #36930