### PR TITLE
fix(config): support bracket notation in parseConfigPath for period-containing keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Config/CLI: update `parseConfigPath` to support bracket notation (`["key"]`) so provider keys containing periods (e.g. `llama.cpp`) are preserved as single path segments instead of being split into nested objects. (#36871)
 - Routing/binding lookup scalability: pre-index route bindings by channel/account and avoid full binding-list rescans on channel-account cache rollover, preventing multi-second `resolveAgentRoute` stalls in large binding configurations. (#36915) Thanks @songchenghao.
 - Browser/session cleanup: track browser tabs opened by session-scoped browser tool runs and close tracked tabs during `sessions.reset`/`sessions.delete` runtime cleanup, preventing orphaned tabs and unbounded browser memory growth after session teardown. (#36666) Thanks @Harnoor6693.
 - Slack/local file upload allowlist parity: propagate `mediaLocalRoots` through the Slack send action pipeline so workspace-rooted attachments pass `assertLocalMediaAllowed` checks while non-allowlisted paths remain blocked. (synthesis: #36656; overlap considered from #36516, #36496, #36493, #36484, #32648, #30888) Thanks @2233admin.

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -336,6 +336,62 @@ describe("config paths", () => {
     expect(unsetConfigValueAtPath(root, parsed.path)).toBe(true);
     expect(getConfigValueAtPath(root, parsed.path)).toBeUndefined();
   });
+
+  it("supports bracket notation for keys containing dots", () => {
+    const parsed = parseConfigPath('models.providers["llama.cpp"].baseUrl');
+    expect(parsed.ok).toBe(true);
+    expect(parsed.path).toEqual(["models", "providers", "llama.cpp", "baseUrl"]);
+
+    const root: Record<string, unknown> = {};
+    setConfigValueAtPath(root, parsed.path!, "http://localhost:8080");
+    expect(getConfigValueAtPath(root, parsed.path!)).toBe("http://localhost:8080");
+    // The key "llama.cpp" must survive as a single object key, not nested.
+    expect((root.models as Record<string, unknown>).providers).toEqual({
+      "llama.cpp": { baseUrl: "http://localhost:8080" },
+    });
+  });
+
+  it("supports single-quoted bracket notation", () => {
+    const parsed = parseConfigPath("models.providers['vllm.ai'].endpoint");
+    expect(parsed.ok).toBe(true);
+    expect(parsed.path).toEqual(["models", "providers", "vllm.ai", "endpoint"]);
+  });
+
+  it("supports bracket notation at the start of the path", () => {
+    const parsed = parseConfigPath('["top.level"].child');
+    expect(parsed.ok).toBe(true);
+    expect(parsed.path).toEqual(["top.level", "child"]);
+  });
+
+  it("supports consecutive bracket segments", () => {
+    const parsed = parseConfigPath('a["b.c"]["d.e"]');
+    expect(parsed.ok).toBe(true);
+    expect(parsed.path).toEqual(["a", "b.c", "d.e"]);
+  });
+
+  it("rejects bracket notation with empty key", () => {
+    expect(parseConfigPath('models.providers[""].baseUrl').ok).toBe(false);
+  });
+
+  it("rejects bracket notation with unclosed quote", () => {
+    expect(parseConfigPath('models.providers["llama.cpp].baseUrl').ok).toBe(false);
+  });
+
+  it("rejects bracket notation with missing closing bracket", () => {
+    expect(parseConfigPath('models.providers["llama.cpp"').ok).toBe(false);
+  });
+
+  it("rejects bracket notation with blocked keys", () => {
+    expect(parseConfigPath('models["__proto__"].polluted').ok).toBe(false);
+    expect(parseConfigPath('["constructor"].polluted').ok).toBe(false);
+  });
+
+  it("rejects leading/trailing dots and consecutive dots", () => {
+    expect(parseConfigPath(".foo.bar").ok).toBe(false);
+    expect(parseConfigPath("foo.bar.").ok).toBe(false);
+    expect(parseConfigPath("foo..bar").ok).toBe(false);
+    expect(parseConfigPath('foo["bar"].').ok).toBe(false);
+  });
 });
 
 describe("config strict validation", () => {

--- a/src/config/config-paths.ts
+++ b/src/config/config-paths.ts
@@ -15,12 +15,99 @@ export function parseConfigPath(raw: string): {
       error: "Invalid path. Use dot notation (e.g. foo.bar).",
     };
   }
-  const parts = trimmed.split(".").map((part) => part.trim());
-  if (parts.some((part) => !part)) {
+  // Reject obvious leading/trailing dot separators up front.
+  if (trimmed.startsWith(".") || trimmed.endsWith(".")) {
     return {
       ok: false,
       error: "Invalid path. Use dot notation (e.g. foo.bar).",
     };
+  }
+
+  const INVALID_PATH_ERROR = {
+    ok: false,
+    error: "Invalid path. Use dot notation (e.g. foo.bar).",
+  } as const;
+
+  // State-machine parser supporting both plain dot notation (foo.bar) and
+  // bracket notation (foo["bar.baz"]) so keys that contain dots (e.g. a
+  // provider named "llama.cpp") are treated as a single path segment.
+  const parts: string[] = [];
+  let current = "";
+  let i = 0;
+
+  while (i < trimmed.length) {
+    const ch = trimmed[i];
+
+    if (ch === "[") {
+      // Bracket notation: key["segment.with.dots"] or ["key"]
+      // Push any accumulated plain-text segment first.
+      if (current) {
+        parts.push(current);
+        current = "";
+      }
+      i += 1;
+      const quote = trimmed[i];
+      if (quote !== '"' && quote !== "'") {
+        return INVALID_PATH_ERROR;
+      }
+      i += 1;
+      let key = "";
+      while (i < trimmed.length && trimmed[i] !== quote) {
+        // Allow backslash-escaped characters inside the bracket key.
+        if (trimmed[i] === "\\") {
+          i += 1;
+          if (i < trimmed.length) {
+            key += trimmed[i];
+            i += 1;
+          }
+        } else {
+          key += trimmed[i];
+          i += 1;
+        }
+      }
+      if (i >= trimmed.length) {
+        // Unclosed quote.
+        return INVALID_PATH_ERROR;
+      }
+      i += 1; // skip closing quote
+      if (i >= trimmed.length || trimmed[i] !== "]") {
+        return INVALID_PATH_ERROR;
+      }
+      i += 1; // skip ]
+      if (!key) {
+        // Empty bracket key is not allowed.
+        return INVALID_PATH_ERROR;
+      }
+      parts.push(key);
+      // After ], optionally consume a separating dot before the next segment.
+      if (i < trimmed.length && trimmed[i] === ".") {
+        i += 1;
+        // A dot at the very end (or followed immediately by another dot) is invalid.
+        if (i >= trimmed.length || trimmed[i] === ".") {
+          return INVALID_PATH_ERROR;
+        }
+      }
+    } else if (ch === ".") {
+      // Dot separator: push the current accumulated segment.
+      if (!current) {
+        // Consecutive dots, or a leading dot that slipped past the pre-check.
+        return INVALID_PATH_ERROR;
+      }
+      parts.push(current);
+      current = "";
+      i += 1;
+    } else {
+      current += ch;
+      i += 1;
+    }
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  if (parts.length === 0 || parts.some((part) => !part)) {
+    return INVALID_PATH_ERROR;
   }
   if (parts.some((part) => isBlockedObjectKey(part))) {
     return { ok: false, error: "Invalid path segment." };


### PR DESCRIPTION
## Summary

Fixes #36871. `parseConfigPath` naively split the input on every `.`, which shattered provider keys that contain dots (e.g. `models.providers["llama.cpp"].baseUrl` → `["models","providers","\"llama","cpp\"]","baseUrl"]` instead of `["models","providers","llama.cpp","baseUrl"]`).

- Replace the simple `split(".")` with a state-machine parser that handles both plain dot notation (`foo.bar`) and bracket notation (`foo["bar.baz"]` or `foo['bar.baz']`).
- Bracket notation can appear at the start (`["top.level"].child`), consecutively (`a["b.c"]["d.e"]`), or mixed with dot notation.
- All existing security guardrails are preserved: `__proto__`, `prototype`, and `constructor` are still blocked in both plain and bracket notation.
- Error paths for malformed input (unclosed quotes, missing `]`, empty keys, leading/trailing/consecutive dots) are fully covered.

## Test plan

- [x] New tests added to `src/config/config-misc.test.ts` covering: double-quoted bracket, single-quoted bracket, bracket at path start, consecutive brackets, empty bracket key, unclosed quote, missing `]`, blocked keys in brackets, leading/trailing/consecutive dots.
- [x] All 40 tests in `src/config/config-misc.test.ts` pass (`pnpm test -- src/config/config-misc.test.ts`).