### PR TITLE
[Issue #36935] [Slack] Duplicate messages when using reply_to tags in DMs

### DIFF
--- a/automation/issue-tracker/issue-36935.md
+++ b/automation/issue-tracker/issue-36935.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36935
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36935
+- Title: [Slack] Duplicate messages when using reply_to tags in DMs
+- Created at: 2026-03-06T00:57:59Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36935
- URL: https://github.com/openclaw/openclaw/issues/36935

## Original Issue Description

## Description

When the agent uses `[[reply_to_current]]` tags in Slack DM replies, duplicate messages appear in the channel. The first message shows an &#34;(edited)&#34; indicator, and a second identical copy appears immediately after.

## Steps to Reproduce

1. User sends a message in a Slack DM session
2. Agent responds with a `[[reply_to_current]]` tagged reply (e.g., a short acknowledgment like &#34;Sent to Erica. 👍&#34;)
3. Two copies of the message appear in the DM — one marked &#34;(edited)&#34;, one without

## Expected Behavior

A single message should be delivered, threaded as a reply to the original message.

## Actual Behavior

Two messages appear:
- First message: posted via stream, then edited (to strip the reply tag and apply reply-to metadata)
- Second message: appears to be a duplicate post, possibly from the reply-to delivery path treating it as a separate send

## Environment

- OpenClaw version: 2026.2.15
- Channel: Slack (Socket Mode)
- Surface: DM (direct message)
- OS: macOS 26.3 (arm64)

## Workaround

Avoiding `[[reply_to_current]]` tags eliminates the duplicates. Plain text replies work correctly.

## Additional Context

Slack error logs show intermittent WebSocket pong timeouts around the same period, though it is unclear if this is related:
```
[WARN] socket-mode:SlackWebSocket: A pong was not received from the server before the timeout of 5000ms!
```

Screenshot attached showing the duplicate behavior in a DM conversation.

Refs #36935