### PR TITLE
[Issue #36939] Gateway service check failed on WSL2 Ubuntu 24.04: systemctl is-enabled returns not-found but throws error

### DIFF
--- a/automation/issue-tracker/issue-36939.md
+++ b/automation/issue-tracker/issue-36939.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36939
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36939
+- Title: Gateway service check failed on WSL2 Ubuntu 24.04: systemctl is-enabled returns not-found but throws error
+- Created at: 2026-03-06T01:02:39Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36939
- URL: https://github.com/openclaw/openclaw/issues/36939

## Original Issue Description

## Description

When installing OpenClaw gateway service on Windows 10 WSL2 (Ubuntu 24.04), the installation fails with the following error:

```
Gateway service check failed: Error: systemctl is-enabled unavailable: Command failed: systemctl --user is-enabled openclaw-gateway.service
```

## Environment

- **OS**: Windows 10
- **WSL**: WSL2 with Ubuntu 24.04
- **systemd**: Enabled and working correctly
- **OpenClaw version**: 2026.3.2

## Steps to Reproduce

1. Enable systemd in WSL2 (via `/etc/wsl.conf` with `systemd=true`)
2. Verify systemd is working: `systemctl --user status` shows `State: running`
3. Run: `openclaw gateway install` or `openclaw gateway install --force`

## Expected Behavior

The command should recognize that the service is not installed (not-found) and proceed with installation.

## Actual Behavior

The command throws an error and exits.

## Root Cause Analysis

The issue is in the `readSystemctlDetail` function in [`src/daemon/systemd.ts`](https://github.com/openclaw/openclaw/blob/main/src/daemon/systemd.ts):

```typescript
function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
  return (result.stderr || result.stdout || &#34;&#34;).trim();
}
```

When `systemctl --user is-enabled openclaw-gateway.service` returns `not-found`:

1. The command outputs `not-found` to **stdout**
2. The command returns exit code 1 (non-zero)
3. Node.js `execFile` generates an error with message `Command failed: systemctl --user is-enabled openclaw-gateway.service`
4. Since **stderr is empty**, the [`execFileUtf8`](https://github.com/openclaw/openclaw/blob/main/src/daemon/exec-file.ts) function uses the error message as stderr
5. `readSystemctlDetail` prioritizes stderr over stdout, returning `Command failed: ...` instead of `not-found`
6. The `isSystemdUnitNotEnabled` function cannot recognize `not-found` status, so it throws an exception

## Verification

Running the command directly in WSL:

```bash
$ systemctl --user is-enabled openclaw-gateway.service
not-found
$ echo $?
1
```

The output `not-found` is a valid state indicating the service unit does not exist, which should be handled gracefully.

## Suggested Fix

Modify `readSystemctlDetail` to prioritize valid systemctl output over the error message:

```typescript
function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
  const stdout = result.stdout?.trim() ?? &#34;&#34;;
  const stderr = result.stderr?.trim() ?? &#34;&#34;;
  // Prefer stdout if it contains valid systemctl output (not the generic &#34;Command failed&#34; message)
  if (stdout &amp;&amp; !stdout.toLowerCase().includes(&#34;command failed&#34;)) {
    return stdout;
  }
  return stderr || stdout;
}
```

## Workaround

Users can manually create the systemd service unit file:

```bash
mkdir -p ~/.config/systemd/user
cat &gt; ~/.config/systemd/user/openclaw-gateway.service &lt;&lt; &#39;EOF&#39;
[Unit]
Description=OpenClaw Gateway
After=network-online.target
Wants=network-online.target

[Service]
ExecStart=/usr/local/bin/openclaw gateway --port 18789
Restart=always
RestartSec=5

[Install]
WantedBy=default.target
EOF

systemctl --user daemon-reload
systemctl --user enable --now openclaw-gateway.service
```

Refs #36939