### PR TITLE
fix(daemon): handle systemctl is-enabled not-found status from stdout on WSL2

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -138,6 +138,19 @@ describe("isSystemdServiceEnabled", () => {
     const result = await isSystemdServiceEnabled({ env: {} });
     expect(result).toBe(false);
   });
+
+  it("returns false when WSL2 returns not-found on stdout with generic error message", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = new Error(
+        "Command failed: systemctl --user is-enabled openclaw-gateway.service",
+      ) as Error & { code?: number };
+      err.code = 1;
+      cb(err, "not-found\n", "");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
 });
 
 describe("systemd runtime parsing", () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -433,6 +433,10 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
   if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
     return false;
   }
+  const stdoutRaw = (res.stdout ?? "").trim();
+  if (stdoutRaw && isSystemdUnitNotEnabled(stdoutRaw)) {
+    return false;
+  }
   throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** On WSL2 Ubuntu 24.04, `openclaw gateway install` fails with `systemctl is-enabled unavailable` because `systemctl --user is-enabled` returns `not-found` on stdout with exit code 1, but the error handler doesn't detect the status.
- **Why it matters:** WSL2 is a common development environment; the gateway install flow should handle the `not-found` unit state (meaning the service doesn't exist yet) and proceed with installation.
- **What changed:** Added a direct `res.stdout` fallback check in `isSystemdServiceEnabled` — when `readSystemctlDetail` concatenation misses the unit status, the raw stdout is checked for known non-enabled statuses (`not-found`, `disabled`, etc.).
- **What did NOT change:** The existing `readSystemctlDetail` concatenation logic, `isSystemdUnitNotEnabled` pattern list, or `execFileUtf8` error handling. The fix is purely additive defense-in-depth.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #36939

## User-visible / Behavior Changes

- `openclaw gateway install` on WSL2 Ubuntu 24.04 no longer fails with `systemctl is-enabled unavailable` when the service unit doesn't exist

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows 10 WSL2, Ubuntu 24.04
- Runtime: Node.js 22+
- Integration/channel: gateway service install

### Steps

1. Enable systemd in WSL2 (`/etc/wsl.conf` with `systemd=true`)
2. Run `openclaw gateway install`

### Expected

- Installation proceeds normally (service not found → install)

### Actual

- Before fix: throws `systemctl is-enabled unavailable: Command failed: ...`
- After fix: returns `false` (not enabled) and proceeds with installation

## Evidence

```
 ✓ src/daemon/systemd.test.ts (25 tests) 7ms

 Test Files  1 passed (1)
      Tests  25 passed (25)
```

New test verifies: WSL2 scenario where exit code 1 and stdout contains `not-found` with generic error message correctly returns `false`.

## Human Verification (required)

- Verified scenarios: not-found on stdout with exit code 1, not-found with exit code 4, disabled status, permission denied (still throws)
- Edge cases checked: empty stdout (falls through to existing throw), whitespace-only stdout
- What I did **not** verify: live WSL2 environment (no Windows access)

## Compatibility / Migration

- Backward compatible? `Yes` — only changes the error→false path for a specific status
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit; workaround is to manually create the systemd unit file
- Files/config to restore: `src/daemon/systemd.ts`
- Known bad symptoms: `systemctl is-enabled unavailable` error during gateway install

## Risks and Mitigations

- Risk: overly broad matching could return `false` when it should throw → mitigated by reusing the existing `isSystemdUnitNotEnabled` function which only matches known non-enabled states

