### PR TITLE
android: finalize notification controls v1 picker + hybrid discovery

### DIFF
--- a/apps/android/app/src/main/AndroidManifest.xml
+++ b/apps/android/app/src/main/AndroidManifest.xml
@@ -33,6 +33,13 @@
         android:name="android.hardware.telephony"
         android:required="false" />
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent>
+    </queries>
+
     <application
         android:name=".NodeApp"
         android:allowBackup="true"

--- a/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/MainViewModel.kt
@@ -63,6 +63,17 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   val gatewayToken: StateFlow<String> = runtime.gatewayToken
   val onboardingCompleted: StateFlow<Boolean> = runtime.onboardingCompleted
   val canvasDebugStatusEnabled: StateFlow<Boolean> = runtime.canvasDebugStatusEnabled
+  val notificationForwardingEnabled: StateFlow<Boolean> = runtime.notificationForwardingEnabled
+  val notificationForwardingMode: StateFlow<NotificationPackageFilterMode> =
+    runtime.notificationForwardingMode
+  val notificationForwardingPackages: StateFlow<Set<String>> = runtime.notificationForwardingPackages
+  val notificationForwardingQuietHoursEnabled: StateFlow<Boolean> =
+    runtime.notificationForwardingQuietHoursEnabled
+  val notificationForwardingQuietStart: StateFlow<String> = runtime.notificationForwardingQuietStart
+  val notificationForwardingQuietEnd: StateFlow<String> = runtime.notificationForwardingQuietEnd
+  val notificationForwardingMaxEventsPerMinute: StateFlow<Int> =
+    runtime.notificationForwardingMaxEventsPerMinute
+  val notificationForwardingSessionKey: StateFlow<String?> = runtime.notificationForwardingSessionKey
 
   val chatSessionKey: StateFlow<String> = runtime.chatSessionKey
   val chatSessionId: StateFlow<String?> = runtime.chatSessionId
@@ -129,6 +140,39 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {
     runtime.setCanvasDebugStatusEnabled(value)
+  }
+
+  fun setNotificationForwardingEnabled(value: Boolean) {
+    runtime.setNotificationForwardingEnabled(value)
+  }
+
+  fun setNotificationForwardingMode(mode: NotificationPackageFilterMode) {
+    runtime.setNotificationForwardingMode(mode)
+  }
+
+  fun setNotificationForwardingPackagesCsv(csv: String) {
+    val packages =
+      csv
+        .split(',')
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+    runtime.setNotificationForwardingPackages(packages)
+  }
+
+  fun setNotificationForwardingQuietHours(
+    enabled: Boolean,
+    start: String,
+    end: String,
+  ) {
+    runtime.setNotificationForwardingQuietHours(enabled = enabled, start = start, end = end)
+  }
+
+  fun setNotificationForwardingMaxEventsPerMinute(value: Int) {
+    runtime.setNotificationForwardingMaxEventsPerMinute(value)
+  }
+
+  fun setNotificationForwardingSessionKey(value: String?) {
+    runtime.setNotificationForwardingSessionKey(value)
   }
 
   fun setVoiceScreenActive(active: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -525,6 +525,17 @@ class NodeRuntime(context: Context) {
   fun setOnboardingCompleted(value: Boolean) = prefs.setOnboardingCompleted(value)
   val lastDiscoveredStableId: StateFlow<String> = prefs.lastDiscoveredStableId
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
+  val notificationForwardingEnabled: StateFlow<Boolean> = prefs.notificationForwardingEnabled
+  val notificationForwardingMode: StateFlow<NotificationPackageFilterMode> =
+    prefs.notificationForwardingMode
+  val notificationForwardingPackages: StateFlow<Set<String>> = prefs.notificationForwardingPackages
+  val notificationForwardingQuietHoursEnabled: StateFlow<Boolean> =
+    prefs.notificationForwardingQuietHoursEnabled
+  val notificationForwardingQuietStart: StateFlow<String> = prefs.notificationForwardingQuietStart
+  val notificationForwardingQuietEnd: StateFlow<String> = prefs.notificationForwardingQuietEnd
+  val notificationForwardingMaxEventsPerMinute: StateFlow<Int> =
+    prefs.notificationForwardingMaxEventsPerMinute
+  val notificationForwardingSessionKey: StateFlow<String?> = prefs.notificationForwardingSessionKey
 
   private var didAutoConnect = false
 
@@ -663,6 +674,34 @@ class NodeRuntime(context: Context) {
 
   fun setCanvasDebugStatusEnabled(value: Boolean) {
     prefs.setCanvasDebugStatusEnabled(value)
+  }
+
+  fun setNotificationForwardingEnabled(value: Boolean) {
+    prefs.setNotificationForwardingEnabled(value)
+  }
+
+  fun setNotificationForwardingMode(mode: NotificationPackageFilterMode) {
+    prefs.setNotificationForwardingMode(mode)
+  }
+
+  fun setNotificationForwardingPackages(packages: List<String>) {
+    prefs.setNotificationForwardingPackages(packages)
+  }
+
+  fun setNotificationForwardingQuietHours(
+    enabled: Boolean,
+    start: String,
+    end: String,
+  ) {
+    prefs.setNotificationForwardingQuietHours(enabled = enabled, start = start, end = end)
+  }
+
+  fun setNotificationForwardingMaxEventsPerMinute(value: Int) {
+    prefs.setNotificationForwardingMaxEventsPerMinute(value)
+  }
+
+  fun setNotificationForwardingSessionKey(value: String?) {
+    prefs.setNotificationForwardingSessionKey(value)
   }
 
   fun setVoiceScreenActive(active: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/android/NotificationForwardingPolicy.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NotificationForwardingPolicy.kt
@@ -1,0 +1,103 @@
+package ai.openclaw.android
+
+import java.time.Instant
+import java.time.ZoneId
+
+enum class NotificationPackageFilterMode(val rawValue: String) {
+  Allowlist("allowlist"),
+  Blocklist("blocklist"),
+  ;
+
+  companion object {
+    fun fromRawValue(raw: String?): NotificationPackageFilterMode {
+      return entries.firstOrNull { it.rawValue == raw?.trim()?.lowercase() } ?: Blocklist
+    }
+  }
+}
+
+internal data class NotificationForwardingPolicy(
+  val enabled: Boolean,
+  val mode: NotificationPackageFilterMode,
+  val packages: Set<String>,
+  val quietHoursEnabled: Boolean,
+  val quietStart: String,
+  val quietEnd: String,
+  val maxEventsPerMinute: Int,
+  val sessionKey: String?,
+)
+
+internal fun NotificationForwardingPolicy.allowsPackage(packageName: String): Boolean {
+  val normalized = packageName.trim()
+  if (normalized.isEmpty()) {
+    return false
+  }
+  return when (mode) {
+    NotificationPackageFilterMode.Allowlist -> packages.contains(normalized)
+    NotificationPackageFilterMode.Blocklist -> !packages.contains(normalized)
+  }
+}
+
+internal fun NotificationForwardingPolicy.isWithinQuietHours(
+  nowEpochMs: Long,
+  zoneId: ZoneId = ZoneId.systemDefault(),
+): Boolean {
+  if (!quietHoursEnabled) {
+    return false
+  }
+  val startMinutes = parseLocalHourMinute(quietStart) ?: return false
+  val endMinutes = parseLocalHourMinute(quietEnd) ?: return false
+  if (startMinutes == endMinutes) {
+    return true
+  }
+  val now =
+    Instant.ofEpochMilli(nowEpochMs)
+      .atZone(zoneId)
+      .toLocalTime()
+  val nowMinutes = now.hour * 60 + now.minute
+  return if (startMinutes < endMinutes) {
+    nowMinutes in startMinutes until endMinutes
+  } else {
+    nowMinutes >= startMinutes || nowMinutes < endMinutes
+  }
+}
+
+internal fun parseLocalHourMinute(raw: String): Int? {
+  val trimmed = raw.trim()
+  if (!trimmed.contains(':')) {
+    return null
+  }
+  val parts = trimmed.split(':')
+  if (parts.size != 2) {
+    return null
+  }
+  val hour = parts[0].toIntOrNull() ?: return null
+  val minute = parts[1].toIntOrNull() ?: return null
+  if (hour !in 0..23 || minute !in 0..59) {
+    return null
+  }
+  return hour * 60 + minute
+}
+
+internal class NotificationBurstLimiter {
+  private val lock = Any()
+  private var windowStartMs: Long = -1L
+  private var eventsInWindow: Int = 0
+
+  fun allow(nowEpochMs: Long, maxEventsPerMinute: Int): Boolean {
+    if (maxEventsPerMinute <= 0) {
+      return false
+    }
+    val currentWindow = nowEpochMs - (nowEpochMs % 60_000L)
+    synchronized(lock) {
+      if (currentWindow != windowStartMs) {
+        windowStartMs = currentWindow
+        eventsInWindow = 0
+      }
+      if (eventsInWindow >= maxEventsPerMinute) {
+        return false
+      }
+      eventsInWindow += 1
+      return true
+    }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt
@@ -22,6 +22,16 @@ class SecurePrefs(context: Context) {
     private const val voiceWakeModeKey = "voiceWake.mode"
     private const val plainPrefsName = "openclaw.node"
     private const val securePrefsName = "openclaw.node.secure"
+    private const val notificationsForwardingEnabledKey = "notifications.forwarding.enabled"
+    private const val notificationsForwardingModeKey = "notifications.forwarding.mode"
+    private const val notificationsForwardingPackagesKey = "notifications.forwarding.packages"
+    private const val notificationsForwardingQuietHoursEnabledKey =
+      "notifications.forwarding.quietHoursEnabled"
+    private const val notificationsForwardingQuietStartKey = "notifications.forwarding.quietStart"
+    private const val notificationsForwardingQuietEndKey = "notifications.forwarding.quietEnd"
+    private const val notificationsForwardingMaxEventsPerMinuteKey =
+      "notifications.forwarding.maxEventsPerMinute"
+    private const val notificationsForwardingSessionKeyKey = "notifications.forwarding.sessionKey"
   }
 
   private val appContext = context.applicationContext
@@ -89,6 +99,46 @@ class SecurePrefs(context: Context) {
   private val _canvasDebugStatusEnabled =
     MutableStateFlow(plainPrefs.getBoolean("canvas.debugStatusEnabled", false))
   val canvasDebugStatusEnabled: StateFlow<Boolean> = _canvasDebugStatusEnabled
+
+  private val _notificationForwardingEnabled =
+    MutableStateFlow(plainPrefs.getBoolean(notificationsForwardingEnabledKey, true))
+  val notificationForwardingEnabled: StateFlow<Boolean> = _notificationForwardingEnabled
+
+  private val _notificationForwardingMode =
+    MutableStateFlow(
+      NotificationPackageFilterMode.fromRawValue(
+        plainPrefs.getString(notificationsForwardingModeKey, null),
+      ),
+    )
+  val notificationForwardingMode: StateFlow<NotificationPackageFilterMode> = _notificationForwardingMode
+
+  private val _notificationForwardingPackages = MutableStateFlow(loadNotificationForwardingPackages())
+  val notificationForwardingPackages: StateFlow<Set<String>> = _notificationForwardingPackages
+
+  private val _notificationForwardingQuietHoursEnabled =
+    MutableStateFlow(plainPrefs.getBoolean(notificationsForwardingQuietHoursEnabledKey, false))
+  val notificationForwardingQuietHoursEnabled: StateFlow<Boolean> = _notificationForwardingQuietHoursEnabled
+
+  private val _notificationForwardingQuietStart =
+    MutableStateFlow(plainPrefs.getString(notificationsForwardingQuietStartKey, "22:00")?.trim().orEmpty())
+  val notificationForwardingQuietStart: StateFlow<String> = _notificationForwardingQuietStart
+
+  private val _notificationForwardingQuietEnd =
+    MutableStateFlow(plainPrefs.getString(notificationsForwardingQuietEndKey, "07:00")?.trim().orEmpty())
+  val notificationForwardingQuietEnd: StateFlow<String> = _notificationForwardingQuietEnd
+
+  private val _notificationForwardingMaxEventsPerMinute =
+    MutableStateFlow(plainPrefs.getInt(notificationsForwardingMaxEventsPerMinuteKey, 20).coerceAtLeast(1))
+  val notificationForwardingMaxEventsPerMinute: StateFlow<Int> = _notificationForwardingMaxEventsPerMinute
+
+  private val _notificationForwardingSessionKey =
+    MutableStateFlow(
+      plainPrefs
+        .getString(notificationsForwardingSessionKeyKey, "")
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() },
+    )
+  val notificationForwardingSessionKey: StateFlow<String?> = _notificationForwardingSessionKey
 
   private val _wakeWords = MutableStateFlow(loadWakeWords())
   val wakeWords: StateFlow<List<String>> = _wakeWords
@@ -276,6 +326,122 @@ class SecurePrefs(context: Context) {
   fun setSpeakerEnabled(value: Boolean) {
     plainPrefs.edit { putBoolean("voice.speakerEnabled", value) }
     _speakerEnabled.value = value
+  }
+
+  internal fun getNotificationForwardingPolicy(appPackageName: String): NotificationForwardingPolicy {
+    val modeRaw = plainPrefs.getString(notificationsForwardingModeKey, null)
+    val mode = NotificationPackageFilterMode.fromRawValue(modeRaw)
+
+    val configuredPackages = loadNotificationForwardingPackages()
+    val normalizedAppPackage = appPackageName.trim()
+    val defaultBlockedPackages =
+      if (normalizedAppPackage.isNotEmpty()) setOf(normalizedAppPackage) else emptySet()
+
+    val packages =
+      when (mode) {
+        NotificationPackageFilterMode.Allowlist -> configuredPackages
+        NotificationPackageFilterMode.Blocklist -> configuredPackages + defaultBlockedPackages
+      }
+
+    val maxEvents = plainPrefs.getInt(notificationsForwardingMaxEventsPerMinuteKey, 20)
+    val sessionKey =
+      plainPrefs
+        .getString(notificationsForwardingSessionKeyKey, "")
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+
+    return NotificationForwardingPolicy(
+      enabled = plainPrefs.getBoolean(notificationsForwardingEnabledKey, true),
+      mode = mode,
+      packages = packages,
+      quietHoursEnabled =
+        plainPrefs.getBoolean(notificationsForwardingQuietHoursEnabledKey, false),
+      quietStart =
+        plainPrefs.getString(notificationsForwardingQuietStartKey, "22:00")?.trim().orEmpty(),
+      quietEnd =
+        plainPrefs.getString(notificationsForwardingQuietEndKey, "07:00")?.trim().orEmpty(),
+      maxEventsPerMinute = maxEvents.coerceAtLeast(1),
+      sessionKey = sessionKey,
+    )
+  }
+
+  internal fun setNotificationForwardingEnabled(value: Boolean) {
+    plainPrefs.edit { putBoolean(notificationsForwardingEnabledKey, value) }
+    _notificationForwardingEnabled.value = value
+  }
+
+  internal fun setNotificationForwardingMode(mode: NotificationPackageFilterMode) {
+    plainPrefs.edit { putString(notificationsForwardingModeKey, mode.rawValue) }
+    _notificationForwardingMode.value = mode
+  }
+
+  internal fun setNotificationForwardingPackages(packages: List<String>) {
+    val sanitized =
+      packages
+        .asSequence()
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .toSet()
+        .toList()
+        .sorted()
+    val encoded = JsonArray(sanitized.map { JsonPrimitive(it) }).toString()
+    plainPrefs.edit { putString(notificationsForwardingPackagesKey, encoded) }
+    _notificationForwardingPackages.value = sanitized.toSet()
+  }
+
+  internal fun setNotificationForwardingQuietHours(
+    enabled: Boolean,
+    start: String,
+    end: String,
+  ) {
+    val normalizedStart = start.trim()
+    val normalizedEnd = end.trim()
+    plainPrefs.edit {
+      putBoolean(notificationsForwardingQuietHoursEnabledKey, enabled)
+      putString(notificationsForwardingQuietStartKey, normalizedStart)
+      putString(notificationsForwardingQuietEndKey, normalizedEnd)
+    }
+    _notificationForwardingQuietHoursEnabled.value = enabled
+    _notificationForwardingQuietStart.value = normalizedStart
+    _notificationForwardingQuietEnd.value = normalizedEnd
+  }
+
+  internal fun setNotificationForwardingMaxEventsPerMinute(value: Int) {
+    val normalized = value.coerceAtLeast(1)
+    plainPrefs.edit {
+      putInt(notificationsForwardingMaxEventsPerMinuteKey, normalized)
+    }
+    _notificationForwardingMaxEventsPerMinute.value = normalized
+  }
+
+  internal fun setNotificationForwardingSessionKey(value: String?) {
+    val normalized = value?.trim()?.takeIf { it.isNotEmpty() }
+    plainPrefs.edit {
+      putString(notificationsForwardingSessionKeyKey, normalized.orEmpty())
+    }
+    _notificationForwardingSessionKey.value = normalized
+  }
+
+  private fun loadNotificationForwardingPackages(): Set<String> {
+    val raw = plainPrefs.getString(notificationsForwardingPackagesKey, null)?.trim()
+    if (raw.isNullOrEmpty()) {
+      return emptySet()
+    }
+    return try {
+      val element = json.parseToJsonElement(raw)
+      val array = element as? JsonArray ?: return emptySet()
+      array
+        .mapNotNull { item ->
+          when (item) {
+            is JsonNull -> null
+            is JsonPrimitive -> item.content.trim().takeIf { it.isNotEmpty() }
+            else -> null
+          }
+        }
+        .toSet()
+    } catch (_: Throwable) {
+      emptySet()
+    }
   }
 
   private fun loadVoiceWakeMode(): VoiceWakeMode {

--- a/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/gateway/GatewaySession.kt
@@ -138,17 +138,10 @@ class GatewaySession(
 
   suspend fun sendNodeEvent(event: String, payloadJson: String?): Boolean {
     val conn = currentConnection ?: return false
-    val parsedPayload = payloadJson?.let { parseJsonOrNull(it) }
     val params =
       buildJsonObject {
         put("event", JsonPrimitive(event))
-        if (parsedPayload != null) {
-          put("payload", parsedPayload)
-        } else if (payloadJson != null) {
-          put("payloadJSON", JsonPrimitive(payloadJson))
-        } else {
-          put("payloadJSON", JsonNull)
-        }
+        put("payloadJSON", JsonPrimitive(payloadJson ?: "{}"))
       }
     try {
       conn.request("node.event", params, timeoutMs = 8_000)

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/DeviceNotificationListenerService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/DeviceNotificationListenerService.kt
@@ -8,6 +8,11 @@ import android.content.Context
 import android.content.Intent
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
+import ai.openclaw.android.NotificationBurstLimiter
+import ai.openclaw.android.NotificationForwardingPolicy
+import ai.openclaw.android.SecurePrefs
+import ai.openclaw.android.allowsPackage
+import ai.openclaw.android.isWithinQuietHours
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -126,6 +131,8 @@ private object DeviceNotificationStore {
 }
 
 class DeviceNotificationListenerService : NotificationListenerService() {
+  private val securePrefs by lazy { SecurePrefs(applicationContext) }
+
   override fun onListenerConnected() {
     super.onListenerConnected()
     activeService = this
@@ -152,7 +159,8 @@ class DeviceNotificationListenerService : NotificationListenerService() {
     super.onNotificationPosted(sbn)
     val entry = sbn?.toEntry() ?: return
     DeviceNotificationStore.upsert(entry)
-    if (entry.packageName == packageName) {
+    val policy = resolveForwardingPolicy()
+    if (!shouldForwardNotification(policy = policy, sourcePackage = entry.packageName)) {
       return
     }
     emitNotificationsChanged(
@@ -163,6 +171,7 @@ class DeviceNotificationListenerService : NotificationListenerService() {
         put("postTimeMs", JsonPrimitive(entry.postTimeMs))
         put("isOngoing", JsonPrimitive(entry.isOngoing))
         put("isClearable", JsonPrimitive(entry.isClearable))
+        policy.sessionKey?.let { put("sessionKey", JsonPrimitive(it)) }
         entry.title?.let { put("title", JsonPrimitive(it)) }
         entry.text?.let { put("text", JsonPrimitive(it)) }
         entry.subText?.let { put("subText", JsonPrimitive(it)) }
@@ -180,19 +189,49 @@ class DeviceNotificationListenerService : NotificationListenerService() {
       return
     }
     DeviceNotificationStore.remove(key)
-    if (removed.packageName == packageName) {
+    val removedPackageName = removed.packageName.trim()
+    val policy = resolveForwardingPolicy()
+    if (!shouldForwardNotification(policy = policy, sourcePackage = removedPackageName)) {
       return
     }
     emitNotificationsChanged(
       buildJsonObject {
         put("change", JsonPrimitive("removed"))
         put("key", JsonPrimitive(key))
-        val packageName = removed.packageName.trim()
-        if (packageName.isNotEmpty()) {
-          put("packageName", JsonPrimitive(packageName))
+        policy.sessionKey?.let { put("sessionKey", JsonPrimitive(it)) }
+        if (removedPackageName.isNotEmpty()) {
+          put("packageName", JsonPrimitive(removedPackageName))
         }
       }.toString(),
     )
+  }
+
+  private fun resolveForwardingPolicy(): NotificationForwardingPolicy {
+    return securePrefs.getNotificationForwardingPolicy(appPackageName = packageName)
+  }
+
+  private fun shouldForwardNotification(
+    policy: NotificationForwardingPolicy,
+    sourcePackage: String,
+    nowEpochMs: Long = System.currentTimeMillis(),
+  ): Boolean {
+    if (!policy.enabled) {
+      return false
+    }
+    val normalizedPackage = sourcePackage.trim()
+    if (normalizedPackage.isEmpty()) {
+      return false
+    }
+    if (normalizedPackage == packageName) {
+      return false
+    }
+    if (!policy.allowsPackage(normalizedPackage)) {
+      return false
+    }
+    if (policy.isWithinQuietHours(nowEpochMs)) {
+      return false
+    }
+    return burstLimiter.allow(nowEpochMs, policy.maxEventsPerMinute)
   }
 
   private fun refreshActiveNotifications() {
@@ -230,6 +269,7 @@ class DeviceNotificationListenerService : NotificationListenerService() {
   companion object {
     @Volatile private var activeService: DeviceNotificationListenerService? = null
     @Volatile private var nodeEventSink: ((event: String, payloadJson: String?) -> Unit)? = null
+    private val burstLimiter = NotificationBurstLimiter()
 
     private fun serviceComponent(context: Context): ComponentName {
       return ComponentName(context, DeviceNotificationListenerService::class.java)

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -48,10 +48,12 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -71,6 +73,9 @@ import ai.openclaw.android.LocationMode
 import ai.openclaw.android.MainViewModel
 import ai.openclaw.android.NotificationPackageFilterMode
 import ai.openclaw.android.node.DeviceNotificationListenerService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Composable
 fun SettingsSheet(viewModel: MainViewModel) {
@@ -204,8 +209,8 @@ fun SettingsSheet(viewModel: MainViewModel) {
   var notificationAppSearch by remember { mutableStateOf("") }
   var notificationShowSystemApps by remember { mutableStateOf(false) }
   var installedNotificationApps by
-    remember(context) {
-      mutableStateOf(queryInstalledApps(context))
+    remember {
+      mutableStateOf<List<InstalledApp>>(emptyList())
     }
   var notificationQuietStartDraft by
     remember(notificationForwardingQuietStart) {
@@ -299,6 +304,22 @@ fun SettingsSheet(viewModel: MainViewModel) {
       viewModel.refreshGatewayConnection()
     }
 
+  val settingsScope = rememberCoroutineScope()
+
+  fun refreshInstalledNotificationApps() {
+    settingsScope.launch {
+      val discoveredApps =
+        withContext(Dispatchers.IO) {
+          queryInstalledApps(context)
+        }
+      installedNotificationApps = discoveredApps
+    }
+  }
+
+  LaunchedEffect(context) {
+    refreshInstalledNotificationApps()
+  }
+
   DisposableEffect(lifecycleOwner, context) {
     val observer =
       LifecycleEventObserver { _, event ->
@@ -308,7 +329,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
               PackageManager.PERMISSION_GRANTED
           notificationsPermissionGranted = hasNotificationsPermission(context)
           notificationListenerEnabled = isNotificationListenerEnabled(context)
-          installedNotificationApps = queryInstalledApps(context)
+          refreshInstalledNotificationApps()
           photosPermissionGranted =
             ContextCompat.checkSelfPermission(context, photosPermission) ==
               PackageManager.PERMISSION_GRANTED
@@ -406,6 +427,10 @@ fun SettingsSheet(viewModel: MainViewModel) {
         }
         .toList()
     }
+
+  val quietHoursInputValid =
+    isValidHourMinute(notificationQuietStartDraft) &&
+      isValidHourMinute(notificationQuietEndDraft)
 
   Box(
     modifier =
@@ -777,6 +802,15 @@ fun SettingsSheet(viewModel: MainViewModel) {
             },
           )
         }
+        if (filteredNotificationApps.isEmpty()) {
+          item {
+            Text(
+              "No apps match your current filter yet.",
+              style = mobileCallout,
+              color = mobileTextSecondary,
+            )
+          }
+        }
         items(filteredNotificationApps, key = { it.packageName }) { app ->
           ListItem(
             modifier = Modifier.settingsRowModifier().alpha(if (notificationForwardingEnabled) 1f else 0.6f),
@@ -846,6 +880,15 @@ fun SettingsSheet(viewModel: MainViewModel) {
           enabled = notificationForwardingEnabled,
         )
       }
+      if (!quietHoursInputValid) {
+        item {
+          Text(
+            "Use 24-hour HH:mm format (example: 22:00).",
+            style = mobileCaption1,
+            color = mobileDanger,
+          )
+        }
+      }
       item {
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
           Button(
@@ -856,7 +899,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
                 end = notificationQuietEndDraft,
               )
             },
-            enabled = notificationForwardingEnabled,
+            enabled = notificationForwardingEnabled && quietHoursInputValid,
             colors = settingsPrimaryButtonColors(),
             shape = RoundedCornerShape(14.dp),
           ) {
@@ -1225,6 +1268,12 @@ fun SettingsSheet(viewModel: MainViewModel) {
       item { Spacer(modifier = Modifier.height(24.dp)) }
     }
   }
+}
+
+private val hourMinuteRegex = Regex("^([01]\\d|2[0-3]):[0-5]\\d$")
+
+private fun isValidHourMinute(value: String): Boolean {
+  return hourMinuteRegex.matches(value.trim())
 }
 
 private data class InstalledApp(

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -200,9 +200,12 @@ fun SettingsSheet(viewModel: MainViewModel) {
       mutableStateOf(isNotificationListenerEnabled(context))
     }
 
-  var notificationPackagesDraft by
-    remember(notificationForwardingPackages) {
-      mutableStateOf(notificationForwardingPackages.toList().sorted().joinToString(","))
+  var notificationPickerExpanded by remember { mutableStateOf(false) }
+  var notificationAppSearch by remember { mutableStateOf("") }
+  var notificationShowSystemApps by remember { mutableStateOf(false) }
+  var installedNotificationApps by
+    remember(context) {
+      mutableStateOf(queryInstalledApps(context))
     }
   var notificationQuietStartDraft by
     remember(notificationForwardingQuietStart) {
@@ -305,6 +308,7 @@ fun SettingsSheet(viewModel: MainViewModel) {
               PackageManager.PERMISSION_GRANTED
           notificationsPermissionGranted = hasNotificationsPermission(context)
           notificationListenerEnabled = isNotificationListenerEnabled(context)
+          installedNotificationApps = queryInstalledApps(context)
           photosPermissionGranted =
             ContextCompat.checkSelfPermission(context, photosPermission) ==
               PackageManager.PERMISSION_GRANTED
@@ -388,6 +392,20 @@ fun SettingsSheet(viewModel: MainViewModel) {
       locationPermissionLauncher.launch(arrayOf(Manifest.permission.ACCESS_FINE_LOCATION))
     }
   }
+
+  val normalizedAppSearch = notificationAppSearch.trim().lowercase()
+  val filteredNotificationApps =
+    remember(installedNotificationApps, normalizedAppSearch, notificationShowSystemApps) {
+      installedNotificationApps
+        .asSequence()
+        .filter { app -> notificationShowSystemApps || !app.isSystemApp }
+        .filter { app ->
+          normalizedAppSearch.isEmpty() ||
+            app.label.lowercase().contains(normalizedAppSearch) ||
+            app.packageName.lowercase().contains(normalizedAppSearch)
+        }
+        .toList()
+    }
 
   Box(
     modifier =
@@ -707,28 +725,80 @@ fun SettingsSheet(viewModel: MainViewModel) {
         }
       }
       item {
-        OutlinedTextField(
-          value = notificationPackagesDraft,
-          onValueChange = { notificationPackagesDraft = it },
-          label = {
-            Text("Package IDs (comma-separated)", style = mobileCaption1, color = mobileTextSecondary)
-          },
-          modifier = Modifier.fillMaxWidth(),
-          textStyle = mobileBody.copy(color = mobileText),
-          colors = settingsTextFieldColors(),
-          enabled = notificationForwardingEnabled,
-        )
-      }
-      item {
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
           Button(
-            onClick = { viewModel.setNotificationForwardingPackagesCsv(notificationPackagesDraft) },
+            onClick = { notificationPickerExpanded = !notificationPickerExpanded },
             enabled = notificationForwardingEnabled,
             colors = settingsPrimaryButtonColors(),
             shape = RoundedCornerShape(14.dp),
           ) {
-            Text("Save Packages", style = mobileCallout.copy(fontWeight = FontWeight.Bold))
+            Text(
+              if (notificationPickerExpanded) "Close App Picker" else "Open App Picker",
+              style = mobileCallout.copy(fontWeight = FontWeight.Bold),
+            )
           }
+        }
+      }
+      item {
+        Text(
+          "Selected: ${notificationForwardingPackages.size} package(s)",
+          style = mobileCallout,
+          color = mobileTextSecondary,
+        )
+      }
+      if (notificationPickerExpanded) {
+        item {
+          OutlinedTextField(
+            value = notificationAppSearch,
+            onValueChange = { notificationAppSearch = it },
+            label = {
+              Text("Search apps", style = mobileCaption1, color = mobileTextSecondary)
+            },
+            modifier = Modifier.fillMaxWidth(),
+            textStyle = mobileBody.copy(color = mobileText),
+            colors = settingsTextFieldColors(),
+            enabled = notificationForwardingEnabled,
+          )
+        }
+        item {
+          ListItem(
+            modifier = Modifier.settingsRowModifier().alpha(if (notificationForwardingEnabled) 1f else 0.6f),
+            colors = listItemColors,
+            headlineContent = { Text("Show System Apps", style = mobileHeadline) },
+            supportingContent = {
+              Text("Include Android/system packages in results.", style = mobileCallout)
+            },
+            trailingContent = {
+              Switch(
+                checked = notificationShowSystemApps,
+                onCheckedChange = { notificationShowSystemApps = it },
+                enabled = notificationForwardingEnabled,
+              )
+            },
+          )
+        }
+        items(filteredNotificationApps, key = { it.packageName }) { app ->
+          ListItem(
+            modifier = Modifier.settingsRowModifier().alpha(if (notificationForwardingEnabled) 1f else 0.6f),
+            colors = listItemColors,
+            headlineContent = { Text(app.label, style = mobileHeadline) },
+            supportingContent = { Text(app.packageName, style = mobileCallout) },
+            trailingContent = {
+              Switch(
+                checked = notificationForwardingPackages.contains(app.packageName),
+                onCheckedChange = { checked ->
+                  val next = notificationForwardingPackages.toMutableSet()
+                  if (checked) {
+                    next.add(app.packageName)
+                  } else {
+                    next.remove(app.packageName)
+                  }
+                  viewModel.setNotificationForwardingPackagesCsv(next.sorted().joinToString(","))
+                },
+                enabled = notificationForwardingEnabled,
+              )
+            },
+          )
         }
       }
       item {
@@ -824,7 +894,16 @@ fun SettingsSheet(viewModel: MainViewModel) {
         OutlinedTextField(
           value = notificationSessionKeyDraft,
           onValueChange = { notificationSessionKeyDraft = it },
-          label = { Text("Route Session Key (optional)", style = mobileCaption1, color = mobileTextSecondary) },
+          label = {
+            Text(
+              "Route Session Key (optional, blank = default route)",
+              style = mobileCaption1,
+              color = mobileTextSecondary,
+            )
+          },
+          placeholder = {
+            Text("Leave empty for default node route", style = mobileCaption1, color = mobileTextSecondary)
+          },
           modifier = Modifier.fillMaxWidth(),
           textStyle = mobileBody.copy(color = mobileText),
           colors = settingsTextFieldColors(),
@@ -1146,6 +1225,52 @@ fun SettingsSheet(viewModel: MainViewModel) {
       item { Spacer(modifier = Modifier.height(24.dp)) }
     }
   }
+}
+
+private data class InstalledApp(
+  val label: String,
+  val packageName: String,
+  val isSystemApp: Boolean,
+)
+
+private fun queryInstalledApps(context: Context): List<InstalledApp> {
+  val packageManager = context.packageManager
+  val launcherIntent = Intent(Intent.ACTION_MAIN).apply { addCategory(Intent.CATEGORY_LAUNCHER) }
+
+  val launcherPackages =
+    packageManager
+      .queryIntentActivities(launcherIntent, PackageManager.MATCH_ALL)
+      .asSequence()
+      .mapNotNull { it.activityInfo?.packageName?.trim()?.takeIf(String::isNotEmpty) }
+      .toMutableSet()
+
+  val recentNotificationPackages =
+    DeviceNotificationListenerService
+      .snapshot(context)
+      .notifications
+      .asSequence()
+      .map { it.packageName.trim() }
+      .filter { it.isNotEmpty() }
+      .toSet()
+
+  val candidatePackages = (launcherPackages + recentNotificationPackages)
+    .filter { it != context.packageName }
+
+  return candidatePackages
+    .asSequence()
+    .mapNotNull { packageName ->
+      runCatching {
+        val appInfo = packageManager.getApplicationInfo(packageName, 0)
+        val label = packageManager.getApplicationLabel(appInfo)?.toString()?.trim().orEmpty()
+        InstalledApp(
+          label = if (label.isEmpty()) packageName else label,
+          packageName = packageName,
+          isSystemApp = (appInfo.flags and android.content.pm.ApplicationInfo.FLAG_SYSTEM) != 0,
+        )
+      }.getOrNull()
+    }
+    .sortedWith(compareBy<InstalledApp> { it.label.lowercase() }.thenBy { it.packageName })
+    .toList()
 }
 
 @Composable

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -69,6 +69,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import ai.openclaw.android.BuildConfig
 import ai.openclaw.android.LocationMode
 import ai.openclaw.android.MainViewModel
+import ai.openclaw.android.NotificationPackageFilterMode
 import ai.openclaw.android.node.DeviceNotificationListenerService
 
 @Composable
@@ -82,6 +83,16 @@ fun SettingsSheet(viewModel: MainViewModel) {
   val locationPreciseEnabled by viewModel.locationPreciseEnabled.collectAsState()
   val preventSleep by viewModel.preventSleep.collectAsState()
   val canvasDebugStatusEnabled by viewModel.canvasDebugStatusEnabled.collectAsState()
+  val notificationForwardingEnabled by viewModel.notificationForwardingEnabled.collectAsState()
+  val notificationForwardingMode by viewModel.notificationForwardingMode.collectAsState()
+  val notificationForwardingPackages by viewModel.notificationForwardingPackages.collectAsState()
+  val notificationForwardingQuietHoursEnabled by
+    viewModel.notificationForwardingQuietHoursEnabled.collectAsState()
+  val notificationForwardingQuietStart by viewModel.notificationForwardingQuietStart.collectAsState()
+  val notificationForwardingQuietEnd by viewModel.notificationForwardingQuietEnd.collectAsState()
+  val notificationForwardingMaxEventsPerMinute by
+    viewModel.notificationForwardingMaxEventsPerMinute.collectAsState()
+  val notificationForwardingSessionKey by viewModel.notificationForwardingSessionKey.collectAsState()
 
   val listState = rememberLazyListState()
   val deviceModel =
@@ -187,6 +198,27 @@ fun SettingsSheet(viewModel: MainViewModel) {
   var notificationListenerEnabled by
     remember {
       mutableStateOf(isNotificationListenerEnabled(context))
+    }
+
+  var notificationPackagesDraft by
+    remember(notificationForwardingPackages) {
+      mutableStateOf(notificationForwardingPackages.toList().sorted().joinToString(","))
+    }
+  var notificationQuietStartDraft by
+    remember(notificationForwardingQuietStart) {
+      mutableStateOf(notificationForwardingQuietStart)
+    }
+  var notificationQuietEndDraft by
+    remember(notificationForwardingQuietEnd) {
+      mutableStateOf(notificationForwardingQuietEnd)
+    }
+  var notificationRateDraft by
+    remember(notificationForwardingMaxEventsPerMinute) {
+      mutableStateOf(notificationForwardingMaxEventsPerMinute.toString())
+    }
+  var notificationSessionKeyDraft by
+    remember(notificationForwardingSessionKey) {
+      mutableStateOf(notificationForwardingSessionKey.orEmpty())
     }
 
   var photosPermissionGranted by
@@ -612,6 +644,206 @@ fun SettingsSheet(viewModel: MainViewModel) {
             }
           },
         )
+      }
+      item {
+        ListItem(
+          modifier = Modifier.settingsRowModifier(),
+          colors = listItemColors,
+          headlineContent = { Text("Forward Notification Events", style = mobileHeadline) },
+          supportingContent = {
+            Text(
+              "Allow notification listener events to be forwarded to gateway node events.",
+              style = mobileCallout,
+            )
+          },
+          trailingContent = {
+            Switch(
+              checked = notificationForwardingEnabled,
+              onCheckedChange = viewModel::setNotificationForwardingEnabled,
+            )
+          },
+        )
+      }
+      item {
+        Column(
+          modifier = Modifier.settingsRowModifier().alpha(if (notificationForwardingEnabled) 1f else 0.6f),
+          verticalArrangement = Arrangement.spacedBy(0.dp),
+        ) {
+          ListItem(
+            modifier = Modifier.fillMaxWidth(),
+            colors = listItemColors,
+            headlineContent = { Text("Package Filter: Allowlist", style = mobileHeadline) },
+            supportingContent = {
+              Text("Only listed package IDs are forwarded.", style = mobileCallout)
+            },
+            trailingContent = {
+              RadioButton(
+                selected = notificationForwardingMode == NotificationPackageFilterMode.Allowlist,
+                onClick = {
+                  viewModel.setNotificationForwardingMode(NotificationPackageFilterMode.Allowlist)
+                },
+                enabled = notificationForwardingEnabled,
+              )
+            },
+          )
+          HorizontalDivider(color = mobileBorder)
+          ListItem(
+            modifier = Modifier.fillMaxWidth(),
+            colors = listItemColors,
+            headlineContent = { Text("Package Filter: Blocklist", style = mobileHeadline) },
+            supportingContent = {
+              Text("All packages except listed IDs are forwarded.", style = mobileCallout)
+            },
+            trailingContent = {
+              RadioButton(
+                selected = notificationForwardingMode == NotificationPackageFilterMode.Blocklist,
+                onClick = {
+                  viewModel.setNotificationForwardingMode(NotificationPackageFilterMode.Blocklist)
+                },
+                enabled = notificationForwardingEnabled,
+              )
+            },
+          )
+        }
+      }
+      item {
+        OutlinedTextField(
+          value = notificationPackagesDraft,
+          onValueChange = { notificationPackagesDraft = it },
+          label = {
+            Text("Package IDs (comma-separated)", style = mobileCaption1, color = mobileTextSecondary)
+          },
+          modifier = Modifier.fillMaxWidth(),
+          textStyle = mobileBody.copy(color = mobileText),
+          colors = settingsTextFieldColors(),
+          enabled = notificationForwardingEnabled,
+        )
+      }
+      item {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+          Button(
+            onClick = { viewModel.setNotificationForwardingPackagesCsv(notificationPackagesDraft) },
+            enabled = notificationForwardingEnabled,
+            colors = settingsPrimaryButtonColors(),
+            shape = RoundedCornerShape(14.dp),
+          ) {
+            Text("Save Packages", style = mobileCallout.copy(fontWeight = FontWeight.Bold))
+          }
+        }
+      }
+      item {
+        ListItem(
+          modifier = Modifier.settingsRowModifier().alpha(if (notificationForwardingEnabled) 1f else 0.6f),
+          colors = listItemColors,
+          headlineContent = { Text("Quiet Hours", style = mobileHeadline) },
+          supportingContent = {
+            Text("Suppress forwarding during a local time window.", style = mobileCallout)
+          },
+          trailingContent = {
+            Switch(
+              checked = notificationForwardingQuietHoursEnabled,
+              onCheckedChange = {
+                viewModel.setNotificationForwardingQuietHours(
+                  enabled = it,
+                  start = notificationQuietStartDraft,
+                  end = notificationQuietEndDraft,
+                )
+              },
+              enabled = notificationForwardingEnabled,
+            )
+          },
+        )
+      }
+      item {
+        OutlinedTextField(
+          value = notificationQuietStartDraft,
+          onValueChange = { notificationQuietStartDraft = it },
+          label = { Text("Quiet Start (HH:mm)", style = mobileCaption1, color = mobileTextSecondary) },
+          modifier = Modifier.fillMaxWidth(),
+          textStyle = mobileBody.copy(color = mobileText),
+          colors = settingsTextFieldColors(),
+          enabled = notificationForwardingEnabled,
+        )
+      }
+      item {
+        OutlinedTextField(
+          value = notificationQuietEndDraft,
+          onValueChange = { notificationQuietEndDraft = it },
+          label = { Text("Quiet End (HH:mm)", style = mobileCaption1, color = mobileTextSecondary) },
+          modifier = Modifier.fillMaxWidth(),
+          textStyle = mobileBody.copy(color = mobileText),
+          colors = settingsTextFieldColors(),
+          enabled = notificationForwardingEnabled,
+        )
+      }
+      item {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+          Button(
+            onClick = {
+              viewModel.setNotificationForwardingQuietHours(
+                enabled = notificationForwardingQuietHoursEnabled,
+                start = notificationQuietStartDraft,
+                end = notificationQuietEndDraft,
+              )
+            },
+            enabled = notificationForwardingEnabled,
+            colors = settingsPrimaryButtonColors(),
+            shape = RoundedCornerShape(14.dp),
+          ) {
+            Text("Save Quiet Hours", style = mobileCallout.copy(fontWeight = FontWeight.Bold))
+          }
+        }
+      }
+      item {
+        OutlinedTextField(
+          value = notificationRateDraft,
+          onValueChange = { notificationRateDraft = it.filter { c -> c.isDigit() } },
+          label = { Text("Max Events / Minute", style = mobileCaption1, color = mobileTextSecondary) },
+          modifier = Modifier.fillMaxWidth(),
+          textStyle = mobileBody.copy(color = mobileText),
+          colors = settingsTextFieldColors(),
+          enabled = notificationForwardingEnabled,
+        )
+      }
+      item {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+          Button(
+            onClick = {
+              val parsed = notificationRateDraft.toIntOrNull() ?: notificationForwardingMaxEventsPerMinute
+              viewModel.setNotificationForwardingMaxEventsPerMinute(parsed)
+            },
+            enabled = notificationForwardingEnabled,
+            colors = settingsPrimaryButtonColors(),
+            shape = RoundedCornerShape(14.dp),
+          ) {
+            Text("Save Rate", style = mobileCallout.copy(fontWeight = FontWeight.Bold))
+          }
+        }
+      }
+      item {
+        OutlinedTextField(
+          value = notificationSessionKeyDraft,
+          onValueChange = { notificationSessionKeyDraft = it },
+          label = { Text("Route Session Key (optional)", style = mobileCaption1, color = mobileTextSecondary) },
+          modifier = Modifier.fillMaxWidth(),
+          textStyle = mobileBody.copy(color = mobileText),
+          colors = settingsTextFieldColors(),
+          enabled = notificationForwardingEnabled,
+        )
+      }
+      item {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+          Button(
+            onClick = {
+              viewModel.setNotificationForwardingSessionKey(notificationSessionKeyDraft.trim().ifEmpty { null })
+            },
+            enabled = notificationForwardingEnabled,
+            colors = settingsPrimaryButtonColors(),
+            shape = RoundedCornerShape(14.dp),
+          ) {
+            Text("Save Session Route", style = mobileCallout.copy(fontWeight = FontWeight.Bold))
+          }
+        }
       }
       item { HorizontalDivider(color = mobileBorder) }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -846,14 +846,19 @@ fun SettingsSheet(viewModel: MainViewModel) {
           trailingContent = {
             Switch(
               checked = notificationForwardingQuietHoursEnabled,
-              onCheckedChange = {
+              onCheckedChange = { nextEnabled ->
+                if (nextEnabled && !quietHoursInputValid) {
+                  return@Switch
+                }
                 viewModel.setNotificationForwardingQuietHours(
-                  enabled = it,
+                  enabled = nextEnabled,
                   start = notificationQuietStartDraft,
                   end = notificationQuietEndDraft,
                 )
               },
-              enabled = notificationForwardingEnabled,
+              enabled =
+                notificationForwardingEnabled &&
+                  (notificationForwardingQuietHoursEnabled || quietHoursInputValid),
             )
           },
         )

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt
@@ -1312,7 +1312,7 @@ private fun queryInstalledApps(context: Context): List<InstalledApp> {
 
   return candidatePackages
     .asSequence()
-    .mapNotNull { packageName ->
+    .map { packageName ->
       runCatching {
         val appInfo = packageManager.getApplicationInfo(packageName, 0)
         val label = packageManager.getApplicationLabel(appInfo)?.toString()?.trim().orEmpty()
@@ -1321,7 +1321,13 @@ private fun queryInstalledApps(context: Context): List<InstalledApp> {
           packageName = packageName,
           isSystemApp = (appInfo.flags and android.content.pm.ApplicationInfo.FLAG_SYSTEM) != 0,
         )
-      }.getOrNull()
+      }.getOrElse {
+        InstalledApp(
+          label = packageName,
+          packageName = packageName,
+          isSystemApp = false,
+        )
+      }
     }
     .sortedWith(compareBy<InstalledApp> { it.label.lowercase() }.thenBy { it.packageName })
     .toList()

--- a/apps/android/app/src/test/java/ai/openclaw/android/NotificationForwardingPolicyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/NotificationForwardingPolicyTest.kt
@@ -1,0 +1,130 @@
+package ai.openclaw.android
+
+import java.time.LocalDateTime
+import java.time.ZoneId
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NotificationForwardingPolicyTest {
+  @Test
+  fun parseLocalHourMinute_parsesValidValues() {
+    assertEquals(0, parseLocalHourMinute("00:00"))
+    assertEquals(23 * 60 + 59, parseLocalHourMinute("23:59"))
+    assertEquals(7 * 60 + 5, parseLocalHourMinute("07:05"))
+  }
+
+  @Test
+  fun parseLocalHourMinute_rejectsInvalidValues() {
+    assertEquals(null, parseLocalHourMinute(""))
+    assertEquals(null, parseLocalHourMinute("24:00"))
+    assertEquals(null, parseLocalHourMinute("12:60"))
+    assertEquals(null, parseLocalHourMinute("abc"))
+  }
+
+  @Test
+  fun allowsPackage_blocklistBlocksConfiguredPackages() {
+    val policy =
+      NotificationForwardingPolicy(
+        enabled = true,
+        mode = NotificationPackageFilterMode.Blocklist,
+        packages = setOf("com.blocked.app"),
+        quietHoursEnabled = false,
+        quietStart = "22:00",
+        quietEnd = "07:00",
+        maxEventsPerMinute = 20,
+        sessionKey = null,
+      )
+
+    assertFalse(policy.allowsPackage("com.blocked.app"))
+    assertTrue(policy.allowsPackage("com.allowed.app"))
+  }
+
+  @Test
+  fun allowsPackage_allowlistOnlyAllowsConfiguredPackages() {
+    val policy =
+      NotificationForwardingPolicy(
+        enabled = true,
+        mode = NotificationPackageFilterMode.Allowlist,
+        packages = setOf("com.allowed.app"),
+        quietHoursEnabled = false,
+        quietStart = "22:00",
+        quietEnd = "07:00",
+        maxEventsPerMinute = 20,
+        sessionKey = null,
+      )
+
+    assertTrue(policy.allowsPackage("com.allowed.app"))
+    assertFalse(policy.allowsPackage("com.other.app"))
+  }
+
+  @Test
+  fun isWithinQuietHours_handlesWindowCrossingMidnight() {
+    val policy =
+      NotificationForwardingPolicy(
+        enabled = true,
+        mode = NotificationPackageFilterMode.Blocklist,
+        packages = emptySet(),
+        quietHoursEnabled = true,
+        quietStart = "22:00",
+        quietEnd = "07:00",
+        maxEventsPerMinute = 20,
+        sessionKey = null,
+      )
+
+    val zone = ZoneId.of("UTC")
+    val at2330 =
+      LocalDateTime
+        .of(2024, 1, 6, 23, 30)
+        .atZone(zone)
+        .toInstant()
+        .toEpochMilli()
+    val at1200 =
+      LocalDateTime
+        .of(2024, 1, 6, 12, 0)
+        .atZone(zone)
+        .toInstant()
+        .toEpochMilli()
+
+    assertTrue(policy.isWithinQuietHours(nowEpochMs = at2330, zoneId = zone))
+    assertFalse(policy.isWithinQuietHours(nowEpochMs = at1200, zoneId = zone))
+  }
+
+  @Test
+  fun isWithinQuietHours_sameStartEndMeansAlwaysQuiet() {
+    val policy =
+      NotificationForwardingPolicy(
+        enabled = true,
+        mode = NotificationPackageFilterMode.Blocklist,
+        packages = emptySet(),
+        quietHoursEnabled = true,
+        quietStart = "00:00",
+        quietEnd = "00:00",
+        maxEventsPerMinute = 20,
+        sessionKey = null,
+      )
+
+    assertTrue(policy.isWithinQuietHours(nowEpochMs = 1_704_098_400_000L, zoneId = ZoneId.of("UTC")))
+  }
+
+  @Test
+  fun burstLimiter_blocksEventsAboveLimitInSameMinute() {
+    val limiter = NotificationBurstLimiter()
+    val minute = 1_704_098_400_000L
+
+    assertTrue(limiter.allow(nowEpochMs = minute, maxEventsPerMinute = 2))
+    assertTrue(limiter.allow(nowEpochMs = minute + 1_000L, maxEventsPerMinute = 2))
+    assertFalse(limiter.allow(nowEpochMs = minute + 2_000L, maxEventsPerMinute = 2))
+  }
+
+  @Test
+  fun burstLimiter_resetsOnNextMinuteWindow() {
+    val limiter = NotificationBurstLimiter()
+    val minute = 1_704_098_400_000L
+
+    assertTrue(limiter.allow(nowEpochMs = minute, maxEventsPerMinute = 1))
+    assertFalse(limiter.allow(nowEpochMs = minute + 1_000L, maxEventsPerMinute = 1))
+    assertTrue(limiter.allow(nowEpochMs = minute + 60_000L, maxEventsPerMinute = 1))
+  }
+}

--- a/apps/android/docs/notification-controls-v1.md
+++ b/apps/android/docs/notification-controls-v1.md
@@ -1,0 +1,110 @@
+# Android Notification Controls v1 (upstream-safe plan)
+
+Status: draft implementation spec  
+Branch: `feature/android-notification-controls-v1`  
+Scope target: `openclaw/openclaw` main Android app (no custom-lane coupling)
+
+## Goal
+Add granular controls so NotificationListener permission does not automatically imply noisy ingestion into agent workflows.
+
+## Non-goals (v1)
+- No ML-based priority classification.
+- No per-conversation deep parsing by app-specific APIs.
+- No breaking changes to existing invoke methods.
+
+## Current behavior (baseline)
+- Android emits `notifications.changed` on posted/removed notifications.
+- Gateway enqueues system events and wakes heartbeat.
+- Flow is broadly enabled once notification access is granted.
+
+## v1 Controls
+
+### 1) Master ingestion switch
+- `enabled`: keep listener permission state separate from forwarding behavior.
+- If off: listener can remain granted, but no forwarding events are emitted.
+
+### 2) App policy filter
+- `mode`: `allowlist | blocklist`
+- `packages`: string[] package names.
+- Defaults:
+  - mode: `blocklist`
+  - packages: [OpenClaw package itself]
+
+### 3) Quiet hours
+- `quietHoursEnabled`: boolean
+- `quietStart`: `HH:mm`
+- `quietEnd`: `HH:mm`
+- During quiet hours: suppress event forwarding (still keep local snapshot available to explicit tool calls).
+
+### 4) Burst/rate guard
+- `maxEventsPerMinute`: integer (default 20)
+- Excess events are dropped with local counters.
+
+### 5) Session routing key (Android side)
+- `sessionKey`: optional string (default empty)
+- If set, include in `notifications.changed` payload for gateway routing.
+- If empty, preserve current gateway fallback behavior.
+
+## Data model (Android prefs)
+
+```json
+{
+  "notifications": {
+    "enabled": true,
+    "mode": "blocklist",
+    "packages": ["ai.openclaw.android"],
+    "quietHoursEnabled": false,
+    "quietStart": "22:00",
+    "quietEnd": "07:00",
+    "maxEventsPerMinute": 20,
+    "sessionKey": ""
+  }
+}
+```
+
+## Implementation file touch list (expected)
+
+### Android
+- `apps/android/app/src/main/java/ai/openclaw/android/SecurePrefs.kt`
+  - add notification policy state + setters/getters.
+- `apps/android/app/src/main/java/ai/openclaw/android/node/DeviceNotificationListenerService.kt`
+  - gate `emitNotificationsChanged(...)` with policy checks:
+    - master enabled
+    - package filter
+    - quiet hours
+    - rate guard
+  - include optional `sessionKey` in payload.
+- `apps/android/app/src/main/java/ai/openclaw/android/ui/SettingsSheet.kt`
+  - add Notification Controls section (minimal controls v1).
+- `apps/android/app/src/main/java/ai/openclaw/android/ui/OnboardingFlow.kt` (optional)
+  - keep permission flow unchanged; link to “advanced controls in settings”.
+
+### Tests
+- Unit tests for policy matcher/time window/rate limiter (new test file near listener service).
+- Existing notification handler tests extended for payload `sessionKey` when configured.
+
+## Backward compatibility
+- Default behavior should remain effectively current when:
+  - `enabled=true`
+  - no package constraints beyond self-filter
+  - quiet hours disabled
+- Existing gateway handlers remain unchanged.
+
+## Rollout plan
+1. Land Android-side policy internals + tests.
+2. Land settings UI toggles.
+3. Dogfood on personal device for 3–5 days.
+4. Capture metrics/observations (missed important notifications, false positives, token reduction).
+5. Upstream PR with feature defaults + docs.
+
+## PR strategy
+- PR 1: policy engine + prefs + tests (no UI)
+- PR 2: settings UI + docs
+- Keep each PR under ~500 LOC net where possible.
+
+## Acceptance criteria
+- Notification permission can be ON while forwarding is OFF.
+- Package filtering works deterministically.
+- Quiet hours suppress forwarding.
+- Rate limiter prevents bursts from flooding events.
+- Optional sessionKey routing works and does not break default behavior.


### PR DESCRIPTION
## Summary
This draft bundles the Android notification-controls v1 workstream and finalizes the picker/discovery UX.

## Included commits in this draft
- `feat(android): add granular notification forwarding controls`
- `android(gateway): always send string payloadJSON for node.event`
- `android: add notification app picker with hybrid discovery`

## What changed
- Added launcher-only manifest queries (`ACTION_MAIN` + `CATEGORY_LAUNCHER`) for app discovery
- Added Settings picker UX for forwarding package selection:
  - open/close picker
  - search
  - per-app toggles
  - selected package count
  - optional system-app visibility
- Implemented hybrid discovery source:
  - launcher apps
  - recent notification packages
  - deduped and sorted
- Added/updated forwarding controls + policy plumbing and tests for allowlist/blocklist, quiet hours, rate limits, and optional session route key
- Added payload serialization hardening for `node.event` (`payloadJSON` always string)
- Clarified route-session label text:
  - `Route Session Key (optional, blank = default route)`

## Scope guardrails
- Android notification controls/discovery work only (app + Android doc/test)
- No heartbeat architecture changes
- No broad package visibility (`QUERY_ALL_PACKAGES` is not used)

## Validation
- `./gradlew :app:compileDebugKotlin` passes
- Manual validation completed for:
  - picker flow (search/toggle/persist)
  - hybrid discovery quality
  - allowlist/blocklist behavior
  - quiet-hours on/off gating
  - restart persistence

<details>
<summary>Prompt used for implementation</summary>

```text
You are working in /Users/nimble/openclaw on branch feature/android-notification-controls-v1.

Goal:
Finalize Android notification-picker/discovery UX (v1) only.

Strict scope:
- Android-side notification settings UX + app discovery only
- Do NOT change gateway architecture
- Do NOT change heartbeat architecture
- Do NOT add QUERY_ALL_PACKAGES
- Keep diff tight

Required behavior:
1) Usable picker UI:
   - Search field
   - App toggle list
   - Selected count
   - Persist selected package IDs via existing forwarding package storage
2) Discovery quality:
   - Hybrid app discovery = launcher apps + recent notification packages
   - Deduplicate + sort
   - Optional show-system-apps toggle
3) Route session label clarity:
   - Route session key is optional
   - Blank means default route behavior (not forced agent:main:main)
```

</details>
