### PR TITLE
telegram: add diagnostics when update-offset state is unreadable

### DIFF
--- a/src/telegram/update-offset-store.test.ts
+++ b/src/telegram/update-offset-store.test.ts
@@ -1,7 +1,13 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+const logVerboseMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../globals.js", () => ({
+  logVerbose: logVerboseMock,
+}));
+
 import {
   deleteTelegramUpdateOffset,
   readTelegramUpdateOffset,
@@ -9,6 +15,10 @@ import {
 } from "./update-offset-store.js";
 
 describe("deleteTelegramUpdateOffset", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("removes the offset file so a new bot starts fresh", async () => {
     await withStateDirEnv("openclaw-tg-offset-", async () => {
       await writeTelegramUpdateOffset({ accountId: "default", updateId: 432_000_000 });
@@ -76,6 +86,30 @@ describe("deleteTelegramUpdateOffset", () => {
           botToken: "333333:token-c",
         }),
       ).toBeNull();
+    });
+  });
+  it("logs when stored state JSON is malformed", async () => {
+    await withStateDirEnv("openclaw-tg-offset-", async ({ stateDir }) => {
+      const offsetPath = path.join(stateDir, "telegram", "update-offset-default.json");
+      await fs.mkdir(path.dirname(offsetPath), { recursive: true });
+      await fs.writeFile(offsetPath, "{not-json}\n", "utf-8");
+
+      await expect(readTelegramUpdateOffset({ accountId: "default" })).resolves.toBeNull();
+      expect(logVerboseMock).toHaveBeenCalledWith(
+        expect.stringContaining("telegram update offset parse failed (default): invalid state"),
+      );
+    });
+  });
+
+  it("logs non-ENOENT read errors", async () => {
+    await withStateDirEnv("openclaw-tg-offset-", async ({ stateDir }) => {
+      const offsetPath = path.join(stateDir, "telegram", "update-offset-default.json");
+      await fs.mkdir(offsetPath, { recursive: true });
+
+      await expect(readTelegramUpdateOffset({ accountId: "default" })).resolves.toBeNull();
+      expect(logVerboseMock).toHaveBeenCalledWith(
+        expect.stringContaining("telegram update offset read failed (default):"),
+      );
     });
   });
 });

--- a/src/telegram/update-offset-store.ts
+++ b/src/telegram/update-offset-store.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
+import { logVerbose } from "../globals.js";
 import { writeJsonAtomic } from "../infra/json-files.js";
 
 const STORE_VERSION = 2;
@@ -80,19 +81,28 @@ export async function readTelegramUpdateOffset(params: {
   try {
     const raw = await fs.readFile(filePath, "utf-8");
     const parsed = safeParseState(raw);
+    if (!parsed) {
+      logVerbose(
+        `telegram update offset parse failed (${normalizeAccountId(params.accountId)}): invalid state`,
+      );
+      return null;
+    }
     const expectedBotId = extractBotIdFromToken(params.botToken);
-    if (expectedBotId && parsed?.botId && parsed.botId !== expectedBotId) {
+    if (expectedBotId && parsed.botId && parsed.botId !== expectedBotId) {
       return null;
     }
-    if (expectedBotId && parsed?.botId === null) {
+    if (expectedBotId && parsed.botId === null) {
       return null;
     }
-    return parsed?.lastUpdateId ?? null;
+    return parsed.lastUpdateId;
   } catch (err) {
     const code = (err as { code?: string }).code;
     if (code === "ENOENT") {
       return null;
     }
+    logVerbose(
+      `telegram update offset read failed (${normalizeAccountId(params.accountId)}): ${String(err)}`,
+    );
     return null;
   }
 }


### PR DESCRIPTION
## Summary\n- add verbose diagnostics when Telegram update-offset state JSON is malformed\n- add verbose diagnostics for non-ENOENT read failures in update-offset store\n- add focused unit tests that lock in both observability paths\n\n## Why\n intentionally falls back to , but previously did so silently for malformed state or unexpected I/O failures. This made operational triage harder because a fresh start and a corrupted store looked identical.\n\n## Risk\nLow: caller-visible behavior is unchanged ( fallback remains), only verbose diagnostics + tests were added.\n\n## Validation\n- Checking formatting...

All matched files use the correct format.
Finished in 22ms on 2 files using 10 threads.\n- 
[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/private/tmp/openclaw-review[39m

 [32m✓[39m src/telegram/update-offset-store.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 11[2mms[22m[39m

[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m7 passed[39m[22m[90m (7)[39m
[2m   Start at [22m 09:24:47
[2m   Duration [22m 198ms[2m (transform 90ms, setup 95ms, import 16ms, tests 11ms, environment 0ms)[22m