### PR TITLE
feat(models): add openai-codex gpt-5.4 forward-compat fallback

### DIFF
--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -26,7 +26,7 @@ async function loadRunEmbeddedPiAgent(): Promise<RunEmbeddedPiAgentFn> {
 
   // Bundled install (built)
   // NOTE: there is no src/ tree in a packaged install. Prefer a stable internal entrypoint.
-  const mod = await import("../../../dist/extensionAPI.js");
+  const mod = await import(new URL("../../../dist/extensionAPI.js", import.meta.url).href);
   // oxlint-disable-next-line typescript/no-explicit-any
   const fn = (mod as any).runEmbeddedPiAgent;
   if (typeof fn !== "function") {

--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -17,7 +17,6 @@ const CODEX_MODELS = [
   "gpt-5.3-codex",
   "gpt-5.3-codex-spark",
   "gpt-5.4",
-  "gpt-5.4-codex",
   "gpt-5.1-codex",
   "gpt-5.1-codex-mini",
   "gpt-5.1-codex-max",

--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -16,6 +16,8 @@ const CODEX_MODELS = [
   "gpt-5.2-codex",
   "gpt-5.3-codex",
   "gpt-5.3-codex-spark",
+  "gpt-5.4",
+  "gpt-5.4-codex",
   "gpt-5.1-codex",
   "gpt-5.1-codex-mini",
   "gpt-5.1-codex-max",

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -85,7 +85,7 @@ describe("loadModelCatalog", () => {
     }
   });
 
-  it("adds openai-codex/gpt-5.3-codex-spark when base gpt-5.3-codex exists", async () => {
+  it("adds openai-codex alias models when base gpt-5.3-codex exists", async () => {
     mockPiDiscoveryModels([
       {
         id: "gpt-5.3-codex",
@@ -103,15 +103,17 @@ describe("loadModelCatalog", () => {
     ]);
 
     const result = await loadModelCatalog({ config: {} as OpenClawConfig });
-    expect(result).toContainEqual(
-      expect.objectContaining({
-        provider: "openai-codex",
-        id: "gpt-5.3-codex-spark",
-      }),
-    );
-    const spark = result.find((entry) => entry.id === "gpt-5.3-codex-spark");
-    expect(spark?.name).toBe("gpt-5.3-codex-spark");
-    expect(spark?.reasoning).toBe(true);
+    for (const id of ["gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-codex"]) {
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          provider: "openai-codex",
+          id,
+        }),
+      );
+      const aliasModel = result.find((entry) => entry.id === id);
+      expect(aliasModel?.name).toBe(id);
+      expect(aliasModel?.reasoning).toBe(true);
+    }
   });
 
   it("merges configured models for opted-in non-pi-native providers", async () => {

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -103,7 +103,7 @@ describe("loadModelCatalog", () => {
     ]);
 
     const result = await loadModelCatalog({ config: {} as OpenClawConfig });
-    for (const id of ["gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-codex"]) {
+    for (const id of ["gpt-5.3-codex-spark", "gpt-5.4"]) {
       expect(result).toContainEqual(
         expect.objectContaining({
           provider: "openai-codex",

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -35,18 +35,11 @@ let importPiSdk = defaultImportPiSdk;
 const CODEX_PROVIDER = "openai-codex";
 const OPENAI_CODEX_GPT53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_GPT53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
+const OPENAI_CODEX_GPT54_MODEL_ID = "gpt-5.4";
+const OPENAI_CODEX_GPT54_CODEX_MODEL_ID = "gpt-5.4-codex";
 const NON_PI_NATIVE_MODEL_PROVIDERS = new Set(["kilocode"]);
 
 function applyOpenAICodexSparkFallback(models: ModelCatalogEntry[]): void {
-  const hasSpark = models.some(
-    (entry) =>
-      entry.provider === CODEX_PROVIDER &&
-      entry.id.toLowerCase() === OPENAI_CODEX_GPT53_SPARK_MODEL_ID,
-  );
-  if (hasSpark) {
-    return;
-  }
-
   const baseModel = models.find(
     (entry) =>
       entry.provider === CODEX_PROVIDER && entry.id.toLowerCase() === OPENAI_CODEX_GPT53_MODEL_ID,
@@ -55,11 +48,24 @@ function applyOpenAICodexSparkFallback(models: ModelCatalogEntry[]): void {
     return;
   }
 
-  models.push({
-    ...baseModel,
-    id: OPENAI_CODEX_GPT53_SPARK_MODEL_ID,
-    name: OPENAI_CODEX_GPT53_SPARK_MODEL_ID,
-  });
+  const ensureAliasModel = (id: string): void => {
+    const hasAlias = models.some(
+      (entry) => entry.provider === CODEX_PROVIDER && entry.id.toLowerCase() === id,
+    );
+    if (hasAlias) {
+      return;
+    }
+
+    models.push({
+      ...baseModel,
+      id,
+      name: id,
+    });
+  };
+
+  ensureAliasModel(OPENAI_CODEX_GPT53_SPARK_MODEL_ID);
+  ensureAliasModel(OPENAI_CODEX_GPT54_MODEL_ID);
+  ensureAliasModel(OPENAI_CODEX_GPT54_CODEX_MODEL_ID);
 }
 
 function normalizeConfiguredModelInput(input: unknown): ModelInputType[] | undefined {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -36,7 +36,6 @@ const CODEX_PROVIDER = "openai-codex";
 const OPENAI_CODEX_GPT53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_GPT53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 const OPENAI_CODEX_GPT54_MODEL_ID = "gpt-5.4";
-const OPENAI_CODEX_GPT54_CODEX_MODEL_ID = "gpt-5.4-codex";
 const NON_PI_NATIVE_MODEL_PROVIDERS = new Set(["kilocode"]);
 
 function applyOpenAICodexSparkFallback(models: ModelCatalogEntry[]): void {
@@ -65,7 +64,6 @@ function applyOpenAICodexSparkFallback(models: ModelCatalogEntry[]): void {
 
   ensureAliasModel(OPENAI_CODEX_GPT53_SPARK_MODEL_ID);
   ensureAliasModel(OPENAI_CODEX_GPT54_MODEL_ID);
-  ensureAliasModel(OPENAI_CODEX_GPT54_CODEX_MODEL_ID);
 }
 
 function normalizeConfiguredModelInput(input: unknown): ModelInputType[] | undefined {

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -4,7 +4,11 @@ import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { normalizeModelCompat } from "./model-compat.js";
 import { normalizeProviderId } from "./model-selection.js";
 
-const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
+const OPENAI_CODEX_FORWARD_COMPAT_MODEL_IDS = new Set([
+  "gpt-5.3-codex",
+  "gpt-5.4",
+  "gpt-5.4-codex",
+]);
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
 
 const ANTHROPIC_OPUS_46_MODEL_ID = "claude-opus-4-6";
@@ -60,7 +64,7 @@ function resolveOpenAICodexGpt53FallbackModel(
   if (!CODEX_GPT53_ELIGIBLE_PROVIDERS.has(normalizedProvider)) {
     return undefined;
   }
-  if (trimmedModelId.toLowerCase() !== OPENAI_CODEX_GPT_53_MODEL_ID) {
+  if (!OPENAI_CODEX_FORWARD_COMPAT_MODEL_IDS.has(trimmedModelId.toLowerCase())) {
     return undefined;
   }
 

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -4,11 +4,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { normalizeModelCompat } from "./model-compat.js";
 import { normalizeProviderId } from "./model-selection.js";
 
-const OPENAI_CODEX_FORWARD_COMPAT_MODEL_IDS = new Set([
-  "gpt-5.3-codex",
-  "gpt-5.4",
-  "gpt-5.4-codex",
-]);
+const OPENAI_CODEX_FORWARD_COMPAT_MODEL_IDS = new Set(["gpt-5.3-codex", "gpt-5.4"]);
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
 
 const ANTHROPIC_OPUS_46_MODEL_ID = "claude-opus-4-6";

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -49,6 +49,22 @@ describe("pi embedded model e2e smoke", () => {
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.3-codex"));
   });
 
+  it("builds an openai-codex forward-compat fallback for gpt-5.4", () => {
+    mockOpenAICodexTemplateModel();
+
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
+  });
+
+  it("builds an openai-codex forward-compat fallback for gpt-5.4-codex", () => {
+    mockOpenAICodexTemplateModel();
+
+    const result = resolveModel("openai-codex", "gpt-5.4-codex", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4-codex"));
+  });
+
   it("keeps unknown-model errors for non-forward-compat IDs", () => {
     const result = resolveModel("openai-codex", "gpt-4.1-mini", "/tmp/agent");
     expect(result.model).toBeUndefined();

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -57,14 +57,6 @@ describe("pi embedded model e2e smoke", () => {
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
   });
 
-  it("builds an openai-codex forward-compat fallback for gpt-5.4-codex", () => {
-    mockOpenAICodexTemplateModel();
-
-    const result = resolveModel("openai-codex", "gpt-5.4-codex", "/tmp/agent");
-    expect(result.error).toBeUndefined();
-    expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4-codex"));
-  });
-
   it("keeps unknown-model errors for non-forward-compat IDs", () => {
     const result = resolveModel("openai-codex", "gpt-4.1-mini", "/tmp/agent");
     expect(result.model).toBeUndefined();

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -408,15 +408,6 @@ describe("resolveModel", () => {
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
   });
 
-  it("builds an openai-codex fallback for gpt-5.4-codex", () => {
-    mockOpenAICodexTemplateModel();
-
-    const result = resolveModel("openai-codex", "gpt-5.4-codex", "/tmp/agent");
-
-    expect(result.error).toBeUndefined();
-    expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4-codex"));
-  });
-
   it("builds an anthropic forward-compat fallback for claude-opus-4-6", () => {
     mockDiscoveredModel({
       provider: "anthropic",

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -399,6 +399,24 @@ describe("resolveModel", () => {
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.3-codex"));
   });
 
+  it("builds an openai-codex fallback for gpt-5.4", () => {
+    mockOpenAICodexTemplateModel();
+
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
+  });
+
+  it("builds an openai-codex fallback for gpt-5.4-codex", () => {
+    mockOpenAICodexTemplateModel();
+
+    const result = resolveModel("openai-codex", "gpt-5.4-codex", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4-codex"));
+  });
+
   it("builds an anthropic forward-compat fallback for claude-opus-4-6", () => {
     mockDiscoveredModel({
       provider: "anthropic",

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -171,6 +171,8 @@ describe("tui session actions", () => {
     });
 
     applySessionInfoFromPatch({
+      ok: true,
+      path: "/tmp/sessions.json",
       key: "agent:main:main",
       entry: {
         sessionId: "session-1",


### PR DESCRIPTION
## Summary
- add forward-compat resolution for `openai-codex/gpt-5.4`
- surface `openai-codex/gpt-5.4` in the model catalog so it can be selected
- align a TUI session-patch fixture with the latest `SessionsPatchResult` shape so `pnpm check` passes on current main

## Why
`openai-codex/gpt-5.4` can be available upstream, but current OpenClaw rejects it as unknown in some paths. This change makes model resolution forward-compatible in the same way existing `gpt-5.3-codex` fallback works, without adding support for `gpt-5.4-codex`.

## Validation
- `corepack pnpm exec vitest run src/agents/model-catalog.test.ts src/agents/pi-embedded-runner/model.forward-compat.test.ts src/agents/pi-embedded-runner/model.test.ts --reporter=dot`
  - 3 files passed, 41 tests passed
- `pnpm check`
  - passed locally on latest `upstream/main`
