### PR TITLE
Fix/feishu allowlist markdown envelope security

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -61,7 +61,7 @@ runs:
       if: inputs.install-bun == 'true'
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: "1.3.9"
+        bun-version: "1.3.10"
 
     - name: Runtime versions
       shell: bash

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -1,8 +1,8 @@
 import { getChannelDock } from "../../channels/dock.js";
 import { resolveChannelConfigWrites } from "../../channels/plugins/config-writes.js";
+import { normalizeChannelId } from "../../channels/plugins/index.js";
 import { listPairingChannels } from "../../channels/plugins/pairing.js";
 import type { ChannelId } from "../../channels/plugins/types.js";
-import { normalizeChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   readConfigFileSnapshot,
@@ -196,6 +196,44 @@ function extractConfigAllowlist(account: {
   };
 }
 
+function readAllowlistEntries(raw: unknown): string[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw.map((entry) => String(entry));
+}
+
+function readPolicyValue(raw: unknown): string | undefined {
+  const value = typeof raw === "string" ? raw.trim() : "";
+  return value || undefined;
+}
+
+function resolveChannelAccountConfig(params: {
+  cfg: OpenClawConfig;
+  channelId: ChannelId;
+  accountId?: string | null;
+}): Record<string, unknown> | null {
+  const channels = params.cfg.channels as Record<string, unknown> | undefined;
+  const channelValue = channels?.[params.channelId];
+  if (!channelValue || typeof channelValue !== "object") {
+    return null;
+  }
+  const channel = channelValue as Record<string, unknown>;
+  const normalizedAccountId = normalizeAccountId(params.accountId);
+  const accountsValue = channel.accounts;
+  const hasAccounts = Boolean(accountsValue && typeof accountsValue === "object");
+  const useAccount = normalizedAccountId !== DEFAULT_ACCOUNT_ID || hasAccounts;
+  if (!useAccount || !hasAccounts) {
+    return channel;
+  }
+  const accounts = accountsValue as Record<string, unknown>;
+  const accountValue = accounts[normalizedAccountId];
+  if (!accountValue || typeof accountValue !== "object") {
+    return channel;
+  }
+  return accountValue as Record<string, unknown>;
+}
+
 function resolveAccountTarget(
   parsed: Record<string, unknown>,
   channelId: ChannelId,
@@ -288,7 +326,8 @@ function resolveChannelAllowFromPaths(
     channelId === "telegram" ||
     channelId === "whatsapp" ||
     channelId === "signal" ||
-    channelId === "imessage";
+    channelId === "imessage" ||
+    channelId === "feishu";
   if (scope === "all") {
     return null;
   }
@@ -307,6 +346,31 @@ function resolveChannelAllowFromPaths(
       return ["groupAllowFrom"];
     }
     return null;
+  }
+  return null;
+}
+
+function resolveAllowlistChannelId(params: {
+  raw?: string | null;
+  cfg: OpenClawConfig;
+}): ChannelId | null {
+  const normalized = normalizeChannelId(params.raw);
+  if (normalized) {
+    return normalized;
+  }
+  const fallback = params.raw?.trim().toLowerCase();
+  if (!fallback) {
+    return null;
+  }
+  const channels = params.cfg.channels as Record<string, unknown> | undefined;
+  if (channels && Object.hasOwn(channels, fallback)) {
+    return fallback as ChannelId;
+  }
+  if (getChannelDock(fallback as ChannelId)) {
+    return fallback as ChannelId;
+  }
+  if (listPairingChannels().includes(fallback as ChannelId)) {
+    return fallback as ChannelId;
   }
   return null;
 }
@@ -366,9 +430,9 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
   }
 
   const channelId =
-    normalizeChannelId(parsed.channel) ??
+    resolveAllowlistChannelId({ raw: parsed.channel, cfg: params.cfg }) ??
     params.command.channelId ??
-    normalizeChannelId(params.command.channel);
+    resolveAllowlistChannelId({ raw: params.command.channel, cfg: params.cfg });
   if (!channelId) {
     return {
       shouldContinue: false,
@@ -460,6 +524,12 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
           }
         }
       }
+    } else if (channelId === "feishu") {
+      const account = resolveChannelAccountConfig({ cfg: params.cfg, channelId, accountId });
+      dmAllowFrom = readAllowlistEntries(account?.allowFrom);
+      groupAllowFrom = readAllowlistEntries(account?.groupAllowFrom);
+      dmPolicy = readPolicyValue(account?.dmPolicy);
+      groupPolicy = readPolicyValue(account?.groupPolicy);
     }
 
     const dmDisplay = normalizeAllowFrom({

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -234,6 +234,23 @@ function resolveChannelAccountConfig(params: {
   return accountValue as Record<string, unknown>;
 }
 
+function resolveFeishuFallbackAllowlistAccountId(accountsValue: unknown): string | undefined {
+  if (!accountsValue || typeof accountsValue !== "object") {
+    return undefined;
+  }
+  const ids = Array.from(
+    new Set(
+      Object.keys(accountsValue as Record<string, unknown>)
+        .map((key) => normalizeOptionalAccountId(key))
+        .filter((key): key is string => Boolean(key)),
+    ),
+  ).toSorted((a, b) => a.localeCompare(b));
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  return ids[0];
+}
+
 function resolveEffectiveAllowlistAccountId(params: {
   cfg: OpenClawConfig;
   channelId: ChannelId;
@@ -255,11 +272,18 @@ function resolveEffectiveAllowlistAccountId(params: {
     return normalizeAccountId(undefined);
   }
   const record = channel as Record<string, unknown>;
-  const hasAccounts = Boolean(record.accounts && typeof record.accounts === "object");
+  const accountsValue = record.accounts;
+  const hasAccounts = Boolean(accountsValue && typeof accountsValue === "object");
   const rawDefaultAccount =
     typeof record.defaultAccount === "string" ? record.defaultAccount.trim() : "";
   if (hasAccounts && rawDefaultAccount) {
     return normalizeAccountId(rawDefaultAccount);
+  }
+  if (params.channelId === "feishu" && hasAccounts) {
+    const fallbackAccountId = resolveFeishuFallbackAllowlistAccountId(accountsValue);
+    if (fallbackAccountId) {
+      return normalizeAccountId(fallbackAccountId);
+    }
   }
   return normalizeAccountId(undefined);
 }
@@ -667,7 +691,7 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
     const allowWrites = resolveChannelConfigWrites({
       cfg: params.cfg,
       channelId,
-      accountId: params.ctx.AccountId,
+      accountId,
     });
     if (!allowWrites) {
       const hint = `channels.${channelId}.configWrites=true`;

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -208,6 +208,23 @@ function readPolicyValue(raw: unknown): string | undefined {
   return value || undefined;
 }
 
+function listNormalizedConfiguredAccountIds(accountsValue: unknown): string[] {
+  if (!accountsValue || typeof accountsValue !== "object") {
+    return [];
+  }
+  return Array.from(
+    new Set(
+      Object.keys(accountsValue as Record<string, unknown>)
+        .map((key) => normalizeOptionalAccountId(key))
+        .filter((key): key is string => Boolean(key)),
+    ),
+  ).toSorted((a, b) => a.localeCompare(b));
+}
+
+function hasConfiguredAccountId(accountsValue: unknown, accountId: string): boolean {
+  return listNormalizedConfiguredAccountIds(accountsValue).includes(normalizeAccountId(accountId));
+}
+
 function resolveChannelAccountConfig(params: {
   cfg: OpenClawConfig;
   channelId: ChannelId;
@@ -234,17 +251,30 @@ function resolveChannelAccountConfig(params: {
   return accountValue as Record<string, unknown>;
 }
 
-function resolveFeishuFallbackAllowlistAccountId(accountsValue: unknown): string | undefined {
-  if (!accountsValue || typeof accountsValue !== "object") {
-    return undefined;
+function resolveMergedFeishuAllowlistConfig(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): Record<string, unknown> | null {
+  const channels = params.cfg.channels as Record<string, unknown> | undefined;
+  const channelValue = channels?.feishu;
+  if (!channelValue || typeof channelValue !== "object") {
+    return null;
   }
-  const ids = Array.from(
-    new Set(
-      Object.keys(accountsValue as Record<string, unknown>)
-        .map((key) => normalizeOptionalAccountId(key))
-        .filter((key): key is string => Boolean(key)),
-    ),
-  ).toSorted((a, b) => a.localeCompare(b));
+  const channel = channelValue as Record<string, unknown>;
+  const account = resolveChannelAccountConfig({
+    cfg: params.cfg,
+    channelId: "feishu",
+    accountId: params.accountId,
+  });
+  const { accounts: _ignoredAccounts, defaultAccount: _ignoredDefaultAccount, ...base } = channel;
+  if (!account || account === channel) {
+    return base;
+  }
+  return { ...base, ...account };
+}
+
+function resolveFeishuFallbackAllowlistAccountId(accountsValue: unknown): string | undefined {
+  const ids = listNormalizedConfiguredAccountIds(accountsValue);
   if (ids.includes(DEFAULT_ACCOUNT_ID)) {
     return DEFAULT_ACCOUNT_ID;
   }
@@ -277,7 +307,10 @@ function resolveEffectiveAllowlistAccountId(params: {
   const rawDefaultAccount =
     typeof record.defaultAccount === "string" ? record.defaultAccount.trim() : "";
   if (hasAccounts && rawDefaultAccount) {
-    return normalizeAccountId(rawDefaultAccount);
+    const normalizedDefaultAccount = normalizeAccountId(rawDefaultAccount);
+    if (hasConfiguredAccountId(accountsValue, normalizedDefaultAccount)) {
+      return normalizedDefaultAccount;
+    }
   }
   if (params.channelId === "feishu" && hasAccounts) {
     const fallbackAccountId = resolveFeishuFallbackAllowlistAccountId(accountsValue);
@@ -404,21 +437,14 @@ function resolveChannelAllowFromPaths(
   return null;
 }
 
-function resolveAllowlistChannelId(params: {
-  raw?: string | null;
-  cfg: OpenClawConfig;
-}): ChannelId | null {
-  const normalized = normalizeChannelId(params.raw);
+function resolveAllowlistChannelId(raw?: string | null): ChannelId | null {
+  const normalized = normalizeChannelId(raw);
   if (normalized) {
     return normalized;
   }
-  const fallback = params.raw?.trim().toLowerCase();
+  const fallback = raw?.trim().toLowerCase();
   if (!fallback) {
     return null;
-  }
-  const channels = params.cfg.channels as Record<string, unknown> | undefined;
-  if (channels && Object.hasOwn(channels, fallback)) {
-    return fallback as ChannelId;
   }
   if (getChannelDock(fallback as ChannelId)) {
     return fallback as ChannelId;
@@ -483,10 +509,17 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
     return unauthorized;
   }
 
+  const requestedChannelId = resolveAllowlistChannelId(parsed.channel);
+  if (parsed.channel?.trim() && !requestedChannelId) {
+    return {
+      shouldContinue: false,
+      reply: { text: "⚠️ Unknown channel. Add channel=<id> to the command." },
+    };
+  }
   const channelId =
-    resolveAllowlistChannelId({ raw: parsed.channel, cfg: params.cfg }) ??
+    requestedChannelId ??
     params.command.channelId ??
-    resolveAllowlistChannelId({ raw: params.command.channel, cfg: params.cfg });
+    resolveAllowlistChannelId(params.command.channel);
   if (!channelId) {
     return {
       shouldContinue: false,
@@ -584,7 +617,7 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
         }
       }
     } else if (channelId === "feishu") {
-      const account = resolveChannelAccountConfig({ cfg: params.cfg, channelId, accountId });
+      const account = resolveMergedFeishuAllowlistConfig({ cfg: params.cfg, accountId });
       dmAllowFrom = readAllowlistEntries(account?.allowFrom);
       groupAllowFrom = readAllowlistEntries(account?.groupAllowFrom);
       dmPolicy = readPolicyValue(account?.dmPolicy);

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -234,6 +234,36 @@ function resolveChannelAccountConfig(params: {
   return accountValue as Record<string, unknown>;
 }
 
+function resolveEffectiveAllowlistAccountId(params: {
+  cfg: OpenClawConfig;
+  channelId: ChannelId;
+  accountIdFromCommand?: string | null;
+  accountIdFromContext?: string | null;
+}): string {
+  const explicit = normalizeOptionalAccountId(params.accountIdFromCommand);
+  if (explicit) {
+    return normalizeAccountId(explicit);
+  }
+  const fromContext = normalizeOptionalAccountId(params.accountIdFromContext);
+  if (fromContext) {
+    return normalizeAccountId(fromContext);
+  }
+
+  const channels = params.cfg.channels as Record<string, unknown> | undefined;
+  const channel = channels?.[params.channelId];
+  if (!channel || typeof channel !== "object") {
+    return normalizeAccountId(undefined);
+  }
+  const record = channel as Record<string, unknown>;
+  const hasAccounts = Boolean(record.accounts && typeof record.accounts === "object");
+  const rawDefaultAccount =
+    typeof record.defaultAccount === "string" ? record.defaultAccount.trim() : "";
+  if (hasAccounts && rawDefaultAccount) {
+    return normalizeAccountId(rawDefaultAccount);
+  }
+  return normalizeAccountId(undefined);
+}
+
 function resolveAccountTarget(
   parsed: Record<string, unknown>,
   channelId: ChannelId,
@@ -447,7 +477,12 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
       },
     };
   }
-  const accountId = normalizeAccountId(parsed.account ?? params.ctx.AccountId);
+  const accountId = resolveEffectiveAllowlistAccountId({
+    cfg: params.cfg,
+    channelId,
+    accountIdFromCommand: parsed.account,
+    accountIdFromContext: params.ctx.AccountId,
+  });
   const scope = parsed.scope;
 
   if (parsed.action === "list") {

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -708,6 +708,103 @@ describe("handleCommands /allowlist", () => {
     expect(result.reply?.text).toContain("DM allowlist added");
   });
 
+  it("respects channel=feishu for DM config edits", async () => {
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      parsed: {
+        channels: {
+          telegram: { allowFrom: ["123"], configWrites: true },
+          feishu: { allowFrom: ["user:old"], configWrites: true },
+        },
+      },
+    });
+    validateConfigObjectWithPluginsMock.mockImplementation((config: unknown) => ({
+      ok: true,
+      config,
+    }));
+
+    const cfg = {
+      commands: { text: true, config: true },
+      channels: {
+        telegram: { allowFrom: ["123"], configWrites: true },
+        feishu: { allowFrom: ["user:old"], configWrites: true },
+      },
+    } as OpenClawConfig;
+    const params = buildPolicyParams("/allowlist add dm channel=feishu --config user:ou_abc", cfg);
+    const result = await handleCommands(params);
+
+    expect(result.shouldContinue).toBe(false);
+    expect(writeConfigFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channels: expect.objectContaining({
+          feishu: expect.objectContaining({
+            allowFrom: expect.arrayContaining(["user:old", "user:ou_abc"]),
+          }),
+        }),
+      }),
+    );
+    expect(result.reply?.text).toContain("channels.feishu.allowFrom");
+  });
+
+  it("supports feishu group allowlist config edits", async () => {
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      parsed: {
+        channels: {
+          feishu: { allowFrom: ["user:owner"], configWrites: true },
+        },
+      },
+    });
+    validateConfigObjectWithPluginsMock.mockImplementation((config: unknown) => ({
+      ok: true,
+      config,
+    }));
+
+    const cfg = {
+      commands: { text: true, config: true },
+      channels: {
+        feishu: { allowFrom: ["user:owner"], configWrites: true },
+      },
+    } as OpenClawConfig;
+    const params = buildPolicyParams("/allowlist add group channel=feishu --config chat:ops", cfg);
+    const result = await handleCommands(params);
+
+    expect(result.shouldContinue).toBe(false);
+    expect(writeConfigFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channels: expect.objectContaining({
+          feishu: expect.objectContaining({
+            groupAllowFrom: expect.arrayContaining(["chat:ops"]),
+          }),
+        }),
+      }),
+    );
+    expect(result.reply?.text).toContain("channels.feishu.groupAllowFrom");
+  });
+
+  it("lists feishu DM/group allowlist from config", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: {
+        feishu: {
+          dmPolicy: "allowlist",
+          allowFrom: ["user:alice"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["chat:team"],
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildPolicyParams("/allowlist list all channel=feishu", cfg);
+    const result = await handleCommands(params);
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Channel: feishu");
+    expect(result.reply?.text).toContain("DM policy: allowlist");
+    expect(result.reply?.text).toContain("Group policy: allowlist");
+    expect(result.reply?.text).toContain("DM allowFrom (config): user:alice");
+    expect(result.reply?.text).toContain("Group allowFrom (config): chat:team");
+  });
+
   it("rejects blocked account ids and keeps Object.prototype clean", async () => {
     delete (Object.prototype as Record<string, unknown>).allowFrom;
 

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -805,6 +805,99 @@ describe("handleCommands /allowlist", () => {
     expect(result.reply?.text).toContain("Group allowFrom (config): chat:team");
   });
 
+  it("uses feishu defaultAccount for list when --account is omitted", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: {
+        feishu: {
+          defaultAccount: "ops",
+          accounts: {
+            default: {
+              dmPolicy: "allowlist",
+              allowFrom: ["user:default"],
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["chat:default"],
+            },
+            ops: {
+              dmPolicy: "allowlist",
+              allowFrom: ["user:ops"],
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["chat:ops"],
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildPolicyParams("/allowlist list all channel=feishu", cfg, {
+      AccountId: undefined,
+    });
+    const result = await handleCommands(params);
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Channel: feishu (account ops)");
+    expect(result.reply?.text).toContain("DM allowFrom (config): user:ops");
+    expect(result.reply?.text).toContain("Group allowFrom (config): chat:ops");
+    expect(result.reply?.text).not.toContain("user:default");
+  });
+
+  it("writes to feishu defaultAccount for config edits when --account is omitted", async () => {
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      parsed: {
+        channels: {
+          feishu: {
+            defaultAccount: "ops",
+            accounts: {
+              default: {
+                allowFrom: ["user:default"],
+              },
+              ops: {
+                allowFrom: ["user:ops"],
+              },
+            },
+          },
+        },
+      },
+    });
+    validateConfigObjectWithPluginsMock.mockImplementation((config: unknown) => ({
+      ok: true,
+      config,
+    }));
+
+    const cfg = {
+      commands: { text: true, config: true },
+      channels: {
+        feishu: {
+          defaultAccount: "ops",
+          configWrites: true,
+          accounts: {
+            default: {
+              allowFrom: ["user:default"],
+              configWrites: true,
+            },
+            ops: {
+              allowFrom: ["user:ops"],
+              configWrites: true,
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildPolicyParams("/allowlist add dm channel=feishu --config user:new", cfg, {
+      AccountId: undefined,
+    });
+    const result = await handleCommands(params);
+
+    expect(result.shouldContinue).toBe(false);
+    const written = writeConfigFileMock.mock.calls.at(-1)?.[0] as OpenClawConfig;
+    const feishuCfg = written.channels?.feishu as {
+      accounts?: Record<string, { allowFrom?: string[] }>;
+    };
+    expect(feishuCfg.accounts?.ops?.allowFrom).toEqual(["user:ops", "user:new"]);
+    expect(feishuCfg.accounts?.default?.allowFrom).toEqual(["user:default"]);
+    expect(result.reply?.text).toContain("channels.feishu.accounts.ops.allowFrom");
+  });
+
   it("rejects blocked account ids and keeps Object.prototype clean", async () => {
     delete (Object.prototype as Record<string, unknown>).allowFrom;
 

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -54,6 +54,25 @@ vi.mock("../../pairing/pairing-store.js", async () => {
   };
 });
 
+vi.mock("../../channels/dock.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../channels/dock.js")>("../../channels/dock.js");
+  return {
+    ...actual,
+    getChannelDock: (channelId: string) =>
+      actual.getChannelDock(channelId as never) ??
+      (channelId === "feishu"
+        ? ({
+            id: "feishu",
+            config: {
+              formatAllowFrom: ({ allowFrom }: { allowFrom: Array<string | number> }) =>
+                allowFrom.map((entry) => String(entry).trim()).filter(Boolean),
+            },
+          } as never)
+        : null),
+  };
+});
+
 vi.mock("../../channels/plugins/pairing.js", async () => {
   const actual = await vi.importActual<typeof import("../../channels/plugins/pairing.js")>(
     "../../channels/plugins/pairing.js",
@@ -840,6 +859,34 @@ describe("handleCommands /allowlist", () => {
     expect(result.reply?.text).not.toContain("user:default");
   });
 
+  it("falls back when feishu defaultAccount points to a missing account", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: {
+        feishu: {
+          defaultAccount: "missing",
+          accounts: {
+            ops: {
+              dmPolicy: "allowlist",
+              allowFrom: ["user:ops"],
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["chat:ops"],
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildPolicyParams("/allowlist list all channel=feishu", cfg, {
+      AccountId: undefined,
+    });
+    const result = await handleCommands(params);
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Channel: feishu (account ops)");
+    expect(result.reply?.text).toContain("DM allowFrom (config): user:ops");
+    expect(result.reply?.text).not.toContain("account missing");
+  });
+
   it("writes to feishu defaultAccount for config edits when --account is omitted", async () => {
     readConfigFileSnapshotMock.mockResolvedValueOnce({
       valid: true,
@@ -898,6 +945,33 @@ describe("handleCommands /allowlist", () => {
     expect(result.reply?.text).toContain("channels.feishu.accounts.ops.allowFrom");
   });
 
+  it("lists merged feishu account config when account inherits top-level allowlist", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: {
+        feishu: {
+          dmPolicy: "allowlist",
+          allowFrom: ["user:owner"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["chat:shared"],
+          accounts: {
+            ops: {
+              groupAllowFrom: ["chat:ops"],
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildPolicyParams("/allowlist list all channel=feishu --account ops", cfg);
+    const result = await handleCommands(params);
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Channel: feishu (account ops)");
+    expect(result.reply?.text).toContain("DM policy: allowlist");
+    expect(result.reply?.text).toContain("DM allowFrom (config): user:owner");
+    expect(result.reply?.text).toContain("Group allowFrom (config): chat:ops");
+  });
+
   it("falls back to first feishu account when defaultAccount is unset", async () => {
     const cfg = {
       commands: { text: true },
@@ -954,6 +1028,22 @@ describe("handleCommands /allowlist", () => {
     expect(result.reply?.text).toContain("Config writes are disabled for feishu");
     expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
     expect(writeConfigFileMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown channel ids instead of accepting typoed config keys", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: {
+        feishuu: {
+          allowFrom: ["user:typo"],
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildPolicyParams("/allowlist list dm channel=feishuu", cfg);
+    const result = await handleCommands(params);
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Unknown channel");
   });
 
   it("rejects blocked account ids and keeps Object.prototype clean", async () => {

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -898,6 +898,64 @@ describe("handleCommands /allowlist", () => {
     expect(result.reply?.text).toContain("channels.feishu.accounts.ops.allowFrom");
   });
 
+  it("falls back to first feishu account when defaultAccount is unset", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: {
+        feishu: {
+          accounts: {
+            ops: {
+              dmPolicy: "allowlist",
+              allowFrom: ["user:ops"],
+              groupPolicy: "allowlist",
+              groupAllowFrom: ["chat:ops"],
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildPolicyParams("/allowlist list all channel=feishu", cfg, {
+      AccountId: undefined,
+    });
+    const result = await handleCommands(params);
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Channel: feishu (account ops)");
+    expect(result.reply?.text).toContain("DM allowFrom (config): user:ops");
+    expect(result.reply?.text).toContain("Group allowFrom (config): chat:ops");
+    expect(result.reply?.text).not.toContain("account default");
+  });
+
+  it("checks feishu configWrites against resolved allowlist account", async () => {
+    const cfg = {
+      commands: { text: true, config: true },
+      channels: {
+        feishu: {
+          defaultAccount: "ops",
+          configWrites: true,
+          accounts: {
+            default: {
+              configWrites: true,
+            },
+            ops: {
+              configWrites: false,
+              allowFrom: ["user:ops"],
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildPolicyParams("/allowlist add dm channel=feishu --config user:new", cfg, {
+      AccountId: undefined,
+    });
+    const result = await handleCommands(params);
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Config writes are disabled for feishu");
+    expect(readConfigFileSnapshotMock).not.toHaveBeenCalled();
+    expect(writeConfigFileMock).not.toHaveBeenCalled();
+  });
+
   it("rejects blocked account ids and keeps Object.prototype clean", async () => {
     delete (Object.prototype as Record<string, unknown>).allowFrom;
 

--- a/src/config/config.hooks-module-paths.test.ts
+++ b/src/config/config.hooks-module-paths.test.ts
@@ -11,6 +11,23 @@ describe("config hooks module paths", () => {
     expect(res.issues.some((iss) => iss.path === expectedPath)).toBe(true);
   };
 
+  it("accepts hooks.mappings[].channel=feishu", () => {
+    const res = validateConfigObjectWithPlugins({
+      agents: { list: [{ id: "pi" }] },
+      hooks: {
+        mappings: [
+          {
+            match: { path: "gmail" },
+            action: "agent",
+            messageTemplate: "email",
+            channel: "feishu",
+          },
+        ],
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
   it("rejects absolute hooks.mappings[].transform.module", () => {
     expectRejectedIssuePath(
       {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1192,7 +1192,7 @@ export const FIELD_HELP: Record<string, string> = {
   "hooks.mappings[].allowUnsafeExternalContent":
     "When true, mapping content may include less-sanitized external payload data in generated messages. Keep false by default and enable only for trusted sources with reviewed transform logic.",
   "hooks.mappings[].channel":
-    'Delivery channel override for mapping outputs (for example "last", "telegram", "discord", "slack", "signal", "imessage", or "msteams"). Keep channel overrides explicit to avoid accidental cross-channel sends.',
+    'Delivery channel override for mapping outputs (for example "last", "telegram", "discord", "slack", "signal", "imessage", "msteams", or "feishu"). Keep channel overrides explicit to avoid accidental cross-channel sends.',
   "hooks.mappings[].to":
     "Destination identifier inside the selected channel when mapping replies should route to a fixed target. Verify provider-specific destination formats before enabling production mappings.",
   "hooks.mappings[].model":

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -32,7 +32,8 @@ export type HookMappingConfig = {
     | "slack"
     | "signal"
     | "imessage"
-    | "msteams";
+    | "msteams"
+    | "feishu";
   to?: string;
   /** Override model for this hook (provider/model or alias). */
   model?: string;

--- a/src/config/validation.allowed-values.test.ts
+++ b/src/config/validation.allowed-values.test.ts
@@ -74,4 +74,20 @@ describe("config validation allowed-values metadata", () => {
       expect(issue?.message).not.toContain("(allowed:");
     }
   });
+
+  it("includes feishu for hooks.mappings[].channel allowed values", () => {
+    const result = validateConfigObjectRaw({
+      hooks: {
+        mappings: [{ action: "agent", messageTemplate: "hello", channel: "invalid-channel" }],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const issue = result.issues.find((entry) => entry.path === "hooks.mappings.0.channel");
+      expect(issue).toBeDefined();
+      expect(issue?.allowedValues).toContain("feishu");
+      expect(issue?.message).toContain('"feishu"');
+    }
+  });
 });

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -60,6 +60,7 @@ export const HookMappingSchema = z
         z.literal("signal"),
         z.literal("imessage"),
         z.literal("msteams"),
+        z.literal("feishu"),
       ])
       .optional(),
     to: z.string().optional(),

--- a/src/gateway/chat-sanitize.test.ts
+++ b/src/gateway/chat-sanitize.test.ts
@@ -11,6 +11,15 @@ describe("stripEnvelopeFromMessage", () => {
     expect(result.content).toBe("yolo");
   });
 
+  test("removes Feishu envelope headers from user messages", () => {
+    const input = {
+      role: "user",
+      content: "[Feishu 2026-01-24 13:36] ping",
+    };
+    const result = stripEnvelopeFromMessage(input) as { content?: string };
+    expect(result.content).toBe("ping");
+  });
+
   test("removes message_id hint lines from text content arrays", () => {
     const input = {
       role: "user",

--- a/src/security/fix.test.ts
+++ b/src/security/fix.test.ts
@@ -106,6 +106,7 @@ describe("security fix", () => {
         discord: { groupPolicy: "open" },
         signal: { groupPolicy: "open" },
         imessage: { groupPolicy: "open" },
+        feishu: { groupPolicy: "open" },
       },
       logging: { redactSensitive: "off" },
     });
@@ -124,6 +125,7 @@ describe("security fix", () => {
         "channels.discord.groupPolicy=open -> allowlist",
         "channels.signal.groupPolicy=open -> allowlist",
         "channels.imessage.groupPolicy=open -> allowlist",
+        "channels.feishu.groupPolicy=open -> allowlist",
         'logging.redactSensitive=off -> "tools"',
       ]),
     );
@@ -137,6 +139,7 @@ describe("security fix", () => {
     expect(channels.discord.groupPolicy).toBe("allowlist");
     expect(channels.signal.groupPolicy).toBe("allowlist");
     expect(channels.imessage.groupPolicy).toBe("allowlist");
+    expect(channels.feishu.groupPolicy).toBe("allowlist");
 
     expect(channels.whatsapp.groupAllowFrom).toEqual(["+15551234567"]);
   });

--- a/src/security/fix.ts
+++ b/src/security/fix.ts
@@ -295,6 +295,7 @@ function applyConfigFixes(params: { cfg: OpenClawConfig; env: NodeJS.ProcessEnv 
     "imessage",
     "slack",
     "msteams",
+    "feishu",
   ]) {
     setGroupPolicyAllowlist({ cfg: next, channel, changes, policyFlips });
   }

--- a/src/shared/chat-envelope.ts
+++ b/src/shared/chat-envelope.ts
@@ -7,6 +7,7 @@ const ENVELOPE_CHANNELS = [
   "Slack",
   "Discord",
   "Google Chat",
+  "Feishu",
   "iMessage",
   "Teams",
   "Matrix",

--- a/src/utils/message-channel.test.ts
+++ b/src/utils/message-channel.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createMSTeamsTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
-import { resolveGatewayMessageChannel } from "./message-channel.js";
+import {
+  isMarkdownCapableMessageChannel,
+  resolveGatewayMessageChannel,
+} from "./message-channel.js";
 
 const emptyRegistry = createTestRegistry([]);
 const msteamsPlugin: ChannelPlugin = {
@@ -30,5 +33,9 @@ describe("message-channel", () => {
       createTestRegistry([{ pluginId: "msteams", plugin: msteamsPlugin, source: "test" }]),
     );
     expect(resolveGatewayMessageChannel("teams")).toBe("msteams");
+  });
+
+  it("treats feishu as markdown-capable for tool result formatting", () => {
+    expect(isMarkdownCapableMessageChannel("feishu")).toBe(true);
   });
 });

--- a/src/utils/message-channel.ts
+++ b/src/utils/message-channel.ts
@@ -23,6 +23,7 @@ const MARKDOWN_CAPABLE_CHANNELS = new Set<string>([
   "signal",
   "discord",
   "googlechat",
+  "feishu",
   "tui",
   INTERNAL_MESSAGE_CHANNEL,
 ]);


### PR DESCRIPTION
> I originally wanted to add a small feature, but during review I found **two hard blockers** (both under the `/allowlist` path) plus **three consistency gaps** (Markdown capability, envelope detection, and security auto-fix). As a result, Feishu can’t reliably be “plug-and-play optional”: it may run into unavailable commands, capability degradation, or require manual additional configuration.
> My current fix only keeps using hardcoded logic to patch those hard blockers and consistency gaps, so other channels may still have similar issues. But if we want *all* supported channels to be plug-and-play out of the box, I recommend unifying a single “channel capability declaration source” on the plugin/DOCK side. Then `/allowlist`, `message-channel`, `chat-envelope`, and `security/fix` should all read from that capability source, instead of relying on scattered static lists.
> This is beyond my scope, so I’m only proposing the idea and would appreciate feedback on the recommendation. 


## Summary
﻿
- Problem: `feishu` was not fully supported in shared channel paths. `/allowlist` had hardcoded handling, and 3 consistency lists (markdown capability, envelope recognition, security auto-fix) missed `feishu`.
- Why it matters: Feishu users hit unsupported/fallback behavior and needed manual workarounds.
- What changed:
- `/allowlist` now resolves plugin channels for `channel=...` and supports Feishu DM/group config paths + `list` output.
- Added `feishu` to markdown-capable channels.
- Added `Feishu` to envelope header recognition.
- Added `feishu` to `security fix` groupPolicy hardening.
- Added targeted regression tests.
﻿
## Change Type (select all)
﻿
- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra
﻿
## Scope (select all touched areas)
﻿
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra
﻿
## Linked Issue/PR
None
﻿
## User-visible / Behavior Changes
﻿
- `/allowlist add/remove/list` now works with `channel=feishu` for config-based DM/group allowlist operations.
- Feishu is now treated as markdown-capable in tool-result formatting paths.
- Feishu envelope headers (e.g. `[Feishu ...]`) are recognized/stripped in sanitize flow.
- `openclaw security audit --fix` now hardens `channels.feishu.groupPolicy=open` to `allowlist`.
﻿
## Security Impact (required)
﻿
- New permissions/capabilities? (`Yes/No`): Yes
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): Yes
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:
- Risk: `/allowlist` can now edit Feishu allowlists; operator mistakes could target wrong channel.
- Mitigation: existing command auth, `configWrites` gating, and config validation remain in place; regression tests added.
- Risk: `security --fix` now mutates Feishu groupPolicy.
- Mitigation: only in explicit `--fix` flow; reported in change output.
﻿
## Repro + Verification
﻿
### Environment
﻿
- OS: macOS (zsh)
- Runtime/container: Node + pnpm + Vitest
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): `commands.text/config=true`, `channels.feishu.configWrites=true`
﻿
### Steps
﻿
1. `/allowlist add dm channel=feishu --config user:ou_abc`
2. `/allowlist add group channel=feishu --config chat:ops`
3. `/allowlist list all channel=feishu`
4. Run tests:
`corepack pnpm exec vitest run src/auto-reply/reply/commands.test.ts src/utils/message-channel.test.ts src/gateway/chat-sanitize.test.ts src/security/fix.test.ts`
﻿
### Expected
﻿
- Feishu channel resolves correctly (no fallback/unsupported errors).
- DM/group allowlist edits and list output work for Feishu.
- Markdown/envelope/security-fix consistency behavior includes Feishu.
- Tests pass.
﻿
### Actual
﻿
- All expected behaviors observed.
- Targeted tests passed: 4 files, 65 tests.
﻿
## Evidence
﻿
- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)
<img width="1064" height="369" alt="image" src="https://github.com/user-attachments/assets/34923838-78dc-4a59-9955-f47e558541e4" />
## Human Verification (required)
﻿
- Verified scenarios:
- Feishu `/allowlist` DM/group/list behavior via unit tests.
- Feishu markdown-capable detection.
- Feishu envelope stripping.
- Feishu security-fix hardening.
- Edge cases checked:
- Explicit `channel=feishu` resolution in test runtime where plugin registry may be minimal.
- What you did **not** verify:
- Full repo test suite.
- Live Feishu E2E against external APIs.
﻿
## Compatibility / Migration
﻿
- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:
﻿
## Failure Recovery (if this breaks)
﻿
- How to disable/revert this change quickly:
- Revert this PR commit(s). Temporary workaround: disable config-edit commands (`commands.config=false`).
- Files/config to restore:
- `src/auto-reply/reply/commands-allowlist.ts`
- `src/utils/message-channel.ts`
- `src/shared/chat-envelope.ts`
- `src/security/fix.ts`
- Known bad symptoms reviewers should watch for:
- `/allowlist channel=feishu` unsupported/fallback behavior.
- Feishu tool results rendered as plain unexpectedly.
- `[Feishu ...]` headers not stripped.
- `security --fix` not hardening Feishu groupPolicy.
﻿
## Risks and Mitigations
﻿
- Risk: Channel resolution fallback may accept unintended IDs if they match config keys.
- Mitigation: auth/gates/validation unchanged; tests cover Feishu path.
- Risk: Security fix behavior change for Feishu may surprise operators.
- Mitigation: only under explicit `security audit --fix`, with surfaced change entries.