### PR TITLE
test: add schema regression tests for telegram topic agentId and threadBindings

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -184,4 +184,40 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it("accepts telegram topic agentId for per-topic agent routing (#35399)", () => {
+    const res = validateConfigObject({
+      channels: {
+        telegram: {
+          groups: {
+            "-1001234567890": {
+              topics: {
+                "1": { agentId: "main" },
+                "3": { agentId: "coder" },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts telegram threadBindings with spawnAcpSessions", () => {
+    const res = validateConfigObject({
+      channels: {
+        telegram: {
+          threadBindings: {
+            enabled: true,
+            spawnAcpSessions: true,
+            idleHours: 24,
+            maxAgeHours: 72,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Adds schema regression tests to prevent [#35399](https://github.com/openclaw/openclaw/issues/35399) from recurring.

## Changes

Two new regression tests in `config.schema-regressions.test.ts`:

1. **Topic agentId** — validates that per-topic `agentId` routing config is accepted (the exact config shape from #35399 that previously failed validation)
2. **Telegram threadBindings** — validates that `threadBindings` with `spawnAcpSessions`, `idleHours`, and `maxAgeHours` is accepted (added in #36683 but lacked regression coverage)

## Testing

```
npx vitest run src/config/config.schema-regressions.test.ts
# 15 tests passed
```

Closes #35399