### PR TITLE
fix(discord): pass appliedTags through channel-edit and editChannelDiscord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/channel-edit appliedTags: pass `appliedTags` through the `channel-edit` action payload and the `editChannelDiscord` REST call as `applied_tags` so forum thread tags can be updated via the message tool (e.g. toggling 🔴 Open → 🟢 Done). (#36736)
 - OpenAI Codex OAuth/login hardening: fail OAuth completion early when the returned token is missing `api.responses.write`, and allow `openclaw models auth login --provider openai-codex` to use the built-in OAuth path even when no provider plugins are installed. (#36660) Thanks @driesvints.
 - Gateway/remote WS break-glass hostname support: honor `OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1` for `ws://` hostname URLs (not only private IP literals) across onboarding validation and runtime gateway connection checks, while still rejecting public IP literals and non-unicast IPv6 endpoints. (#36930) Thanks @manju-rn.
 - Routing/binding lookup scalability: pre-index route bindings by channel/account and avoid full binding-list rescans on channel-account cache rollover, preventing multi-second `resolveAgentRoute` stalls in large binding configurations. (#36915) Thanks @songchenghao.

--- a/src/agents/tools/discord-actions-guild.ts
+++ b/src/agents/tools/discord-actions-guild.ts
@@ -327,6 +327,7 @@ export async function handleDiscordGuildAction(
         integer: true,
       });
       const availableTags = parseAvailableTags(params.availableTags);
+      const appliedTags = readStringArrayParam(params, "appliedTags");
       const editPayload = {
         channelId,
         name: name ?? undefined,
@@ -339,6 +340,7 @@ export async function handleDiscordGuildAction(
         locked,
         autoArchiveDuration: autoArchiveDuration ?? undefined,
         availableTags,
+        appliedTags: appliedTags ?? undefined,
       };
       const channel = accountId
         ? await editChannelDiscord(editPayload, { accountId })

--- a/src/agents/tools/discord-actions.test.ts
+++ b/src/agents/tools/discord-actions.test.ts
@@ -468,6 +468,20 @@ describe("handleDiscordGuildAction - channel management", () => {
     });
   });
 
+  it("passes appliedTags to editChannelDiscord for forum thread tag updates", async () => {
+    await handleDiscordGuildAction(
+      "channelEdit",
+      {
+        channelId: "T1",
+        appliedTags: ["tag-done-id"],
+      },
+      channelsEnabled,
+    );
+    expect(editChannelDiscord).toHaveBeenCalledWith(
+      expect.objectContaining({ channelId: "T1", appliedTags: ["tag-done-id"] }),
+    );
+  });
+
   it("deletes a channel", async () => {
     await handleDiscordGuildAction("channelDelete", { channelId: "C1" }, channelsEnabled);
     expect(deleteChannelDiscord).toHaveBeenCalledWith("C1");

--- a/src/discord/send.channels.ts
+++ b/src/discord/send.channels.ts
@@ -79,6 +79,9 @@ export async function editChannelDiscord(
       ...(t.emoji_name !== undefined && { emoji_name: t.emoji_name }),
     }));
   }
+  if (payload.appliedTags !== undefined) {
+    body.applied_tags = payload.appliedTags;
+  }
   return (await rest.patch(Routes.channel(payload.channelId), {
     body,
   })) as APIChannel;

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -158,6 +158,8 @@ export type DiscordChannelEdit = {
   locked?: boolean;
   autoArchiveDuration?: number;
   availableTags?: DiscordForumTag[];
+  /** Tag IDs to apply to a forum thread (Discord `applied_tags`). */
+  appliedTags?: string[];
 };
 
 export type DiscordChannelMove = {


### PR DESCRIPTION
## Summary

Fixes #36736. The `channel-edit` Discord action silently ignored `appliedTags`, so forum thread tags (e.g. 🔴 Open → 🟢 Done) could never be changed via the message tool — even though `thread-create` correctly handled them.

Two layers were missing the `appliedTags` passthrough:

- **`DiscordChannelEdit` type** (`send.types.ts`): added `appliedTags?: string[]` field.
- **`editChannelDiscord()`** (`send.channels.ts`): maps `payload.appliedTags` → `body.applied_tags` in the PATCH request.
- **`channelEdit` action handler** (`discord-actions-guild.ts`): reads `appliedTags` via `readStringArrayParam` and includes it in the edit payload.

`categoryEdit` does not need `appliedTags` (categories cannot have applied tags).

## Test plan

- [x] New test: `passes appliedTags to editChannelDiscord for forum thread tag updates` verifies that `appliedTags` is forwarded correctly.
- [x] All 39 tests in `src/agents/tools/discord-actions.test.ts` pass.