### PR TITLE
docs(faq): remove broken troubleshooting anchor for Xfinity SSL

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -448,8 +448,7 @@ section is the latest shipped version. Entries are grouped by **Highlights**, **
 ### I can't access docs.openclaw.ai SSL error What now
 
 Some Comcast/Xfinity connections incorrectly block `docs.openclaw.ai` via Xfinity
-Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry. More
-detail: [Troubleshooting](/help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity).
+Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry.
 Please help us unblock it by reporting here: [https://spa.xfinity.com/check_url_status](https://spa.xfinity.com/check_url_status).
 
 If you still can't reach the site, the docs are mirrored on GitHub:


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: FAQ section linked to `/help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity`, but that anchor does not exist in `docs/help/troubleshooting.md`.
- Why it matters: Users clicking the troubleshooting link land without the intended section/anchor context and may assume the docs are broken or incomplete.
- What changed: Removed the broken cross-document anchor reference from the FAQ Xfinity SSL section while keeping the actionable workaround/reporting guidance.
- What did NOT change (scope boundary): No runtime code changes, no troubleshooting content expansion, no behavior/config changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36970
- Related #

## User-visible / Behavior Changes

FAQ no longer includes a broken troubleshooting anchor link in the Comcast/Xfinity SSL section.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.x
- Runtime/container: N/A (docs-only)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. On `main`, inspect `docs/help/faq.md` Xfinity SSL section and find `/help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity`.
2. Verify target anchor is absent from `docs/help/troubleshooting.md`.
3. Apply docs update removing the broken anchor reference and re-check with grep.

### Expected

- No broken `docsopenclawai-shows-an-ssl-error-comcastxfinity` anchor reference remains in `docs/help/faq.md`.

### Actual

- Verified via command: `grep -n "docsopenclawai-shows-an-ssl-error-comcastxfinity" docs/help/faq.md` returns no matches after the change.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before/after log evidence:
- Before: `docs/help/faq.md` contained `detail: [Troubleshooting](/help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity)`.
- After: grep for `docsopenclawai-shows-an-ssl-error-comcastxfinity` in `docs/help/faq.md` returns no result.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Manually inspected the edited FAQ section.
  - Ran grep to confirm broken anchor text is removed from FAQ.
  - Confirmed issue scope remains docs-only.
- Edge cases checked:
  - Ensured Xfinity workaround and reporting URL are still present and unchanged.
- What you did **not** verify:
  - Did not run full docs site build/link checker in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit.
- Files/config to restore: `docs/help/faq.md`
- Known bad symptoms reviewers should watch for: Missing guidance text in the Xfinity SSL FAQ block.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Removing the link might reduce discoverability of future troubleshooting details if that anchor is later added.
  - Mitigation: Keep core workaround/reporting instructions in FAQ; a follow-up can re-add a valid link once target section exists.