### PR TITLE
fix(daemon): handle systemctl not-found output in WSL2

### DIFF
--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -144,10 +144,13 @@ async function execSystemctl(
 }
 
 function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
-  // Concatenate both streams so pattern matchers (isSystemdUnitNotEnabled,
-  // isSystemctlMissing) can see the unit status from stdout even when
-  // execFileUtf8 populates stderr with the Node error message fallback.
-  return `${result.stderr} ${result.stdout}`.trim();
+  const stdout = result.stdout?.trim() ?? "";
+  const stderr = result.stderr?.trim() ?? "";
+  // Prefer stdout if it contains valid systemctl output (not the generic "Command failed" message)
+  if (stdout && !stdout.toLowerCase().includes("command failed")) {
+    return stdout;
+  }
+  return stderr || stdout;
 }
 
 function isSystemctlMissing(detail: string): boolean {


### PR DESCRIPTION
## Summary

When `systemctl --user is-enabled` returns 'not-found' on WSL2, Node.js execFile populates stderr with the error message `Command failed: systemctl ...` instead of the actual stdout output 'not-found'.

This causes `isSystemdUnitNotEnabled()` and `isSystemctlMissing()` to fail to recognize the not-found status, throwing an error during gateway service installation on WSL2.

## Fix

Prioritize stdout over stderr in `readSystemctlDetail()`, only using stderr when stdout doesn't contain valid systemctl output (i.e., the generic "Command failed" message).

## Testing

- All 24 systemd tests pass

## Related

- Fixes #36939