### PR TITLE
[Issue #36968] [Bug]: ver 2026.3.2 can't access the local files, even they are located in the workspace directory.

### DIFF
--- a/automation/issue-tracker/issue-36968.md
+++ b/automation/issue-tracker/issue-36968.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36968
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36968
+- Title: [Bug]: ver 2026.3.2 can't access the local files, even they are located in the workspace directory.
+- Created at: 2026-03-06T01:28:20Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36968
- URL: https://github.com/openclaw/openclaw/issues/36968

## Original Issue Description
The issue reports inability to access local workspace files via tool usage and includes full reproduction details in the source issue body.

Closes #36968