### PR TITLE
[Issue #36973] Companion re-pair after macOS point update should auto-approve when isRepair=true and deviceId+publicKey match

### DIFF
--- a/automation/issue-tracker/issue-36973.md
+++ b/automation/issue-tracker/issue-36973.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36973
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36973
+- Title: Companion re-pair after macOS point update should auto-approve when isRepair=true and deviceId+publicKey match
+- Created at: 2026-03-06T01:33:16Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36973
- URL: https://github.com/openclaw/openclaw/issues/36973

## Original Issue Description
The issue requests auto-approval logic for trusted companion re-pair flows after macOS point updates; full details and examples are in the source issue.

Closes #36973