### PR TITLE
[Issue #36982] [Bug]: Qwen OAuth refresh token expired or invalid — requires frequent re-authentication since v2026.3.2

### DIFF
--- a/automation/issue-tracker/issue-36982.md
+++ b/automation/issue-tracker/issue-36982.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36982
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36982
+- Title: [Bug]: Qwen OAuth refresh token expired or invalid — requires frequent re-authentication since v2026.3.2
+- Created at: 2026-03-06T01:42:23Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36982
- URL: https://github.com/openclaw/openclaw/issues/36982

## Original Issue Description
The issue describes repeated Qwen OAuth refresh failures and includes environment, reproduction, and observed behavior in the source issue body.

Closes #36982