### PR TITLE
[Issue #36983] [Bug] macOS app crashes on launch when Talk mode was previously enabled (Swift exclusivity violation in TalkOverlayView)

### DIFF
--- a/automation/issue-tracker/issue-36983.md
+++ b/automation/issue-tracker/issue-36983.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36983
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36983
+- Title: [Bug] macOS app crashes on launch when Talk mode was previously enabled (Swift exclusivity violation in TalkOverlayView)
+- Created at: 2026-03-06T01:43:55Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36983
- URL: https://github.com/openclaw/openclaw/issues/36983

## Original Issue Description
The issue reports a macOS launch crash related to Talk mode state restoration and includes environment, stack traces, and reproduction steps in the source issue body.

Closes #36983