### PR TITLE
[Issue #36985] Migrate legacy gateway.bind config on srv1325349

### DIFF
--- a/automation/issue-tracker/issue-36985.md
+++ b/automation/issue-tracker/issue-36985.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36985
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36985
+- Title: Migrate legacy gateway.bind config on srv1325349
+- Created at: 2026-03-06T01:47:20Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36985
- URL: https://github.com/openclaw/openclaw/issues/36985

## Original Issue Description
The issue requests migration from legacy `gateway.bind` format on srv1325349; full operational details are included in the source issue body.

Closes #36985