### PR TITLE
[Issue #36990] [Security] Clawguard: OpenClaw skills/plugins scanner & guard (open-source)

### DIFF
--- a/automation/issue-tracker/issue-36990.md
+++ b/automation/issue-tracker/issue-36990.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36990
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36990
+- Title: [Security] Clawguard: OpenClaw skills/plugins scanner & guard (open-source)
+- Created at: 2026-03-06T01:51:48Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36990
- URL: https://github.com/openclaw/openclaw/issues/36990

## Original Issue Description
The issue introduces Clawguard and provides the original project summary, scope, and links in the source issue body.

Closes #36990