### PR TITLE
fix(slack): prevent duplicate messages in DMs from streaming fallback

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -302,6 +302,15 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       }
 
       const mediaCount = payload.mediaUrls?.length ?? (payload.mediaUrl ? 1 : 0);
+      // Flush any pending draft stream operations so messageId/channelId
+      // reflect the latest state before deciding whether to finalize via edit.
+      // Without this, a race between the throttled draft send and the final
+      // delivery callback can leave messageId() undefined, causing the
+      // finalize-via-edit path to be skipped and a duplicate message to be
+      // posted through deliverNormally.  See #36935.
+      if (previewStreamingEnabled && hasStreamedMessage) {
+        await draftStream.flush();
+      }
       const draftMessageId = draftStream?.messageId();
       const draftChannelId = draftStream?.channelId();
       const finalText = payload.text;
@@ -331,6 +340,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
           );
         }
       } else if (previewStreamingEnabled && streamMode === "status_final" && hasStreamedMessage) {
+        // The status message is intentionally kept visible alongside the
+        // final reply, so mark the stream as consumed to skip the
+        // post-delivery cleanup below.
+        hasStreamedMessage = false;
         try {
           const statusChannelId = draftStream?.channelId();
           const statusMessageId = draftStream?.messageId();
@@ -345,12 +358,21 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         } catch (err) {
           logVerbose(`slack: status_final completion update failed (${String(err)})`);
         }
-      } else if (mediaCount > 0) {
-        await draftStream?.clear();
-        hasStreamedMessage = false;
+      } else if (hasStreamedMessage) {
+        // Draft cleanup is handled below, after deliverNormally succeeds.
+        draftStream?.stop();
       }
 
       await deliverNormally(payload);
+
+      // Delete the draft only after the new message has been posted
+      // successfully.  If deliverNormally throws (e.g. Slack API outage),
+      // the draft remains visible so the user still sees a response
+      // rather than an empty DM.  See #36935.
+      if (hasStreamedMessage) {
+        await draftStream?.clear();
+        hasStreamedMessage = false;
+      }
     },
     onError: (err, info) => {
       runtime.error?.(danger(`slack ${info.kind} reply failed: ${String(err)}`));


### PR DESCRIPTION
Fixes #36935

## Summary

This PR resolves an issue where replies in Slack DMs would occasionally be duplicated when using preview streaming (the default mode). The first message would appear with an "(edited)" indicator, and a second, identical message would be posted immediately after.

## Root Cause

The duplication was caused by a race condition and a missing cleanup step in the final reply delivery logic within `src/slack/monitor/message-handler/dispatch.ts`.

1. **Race Condition**: The decision to finalize a draft message via `chat.update` (the `canFinalizeViaPreviewEdit` check) was made before ensuring that the draft stream's throttled send operation had completed. If the final delivery callback was invoked while the initial draft message send was still in-flight, `draftStream.messageId()` would return `undefined`. This caused `canFinalizeViaPreviewEdit` to be `false`, leading the code to fall back to `deliverNormally()`, which posts a new message. The original draft message, once its send operation completed, would then also appear, resulting in a duplicate.

2. **Missing Cleanup**: In cases where `canFinalizeViaPreviewEdit` was `false` for reasons other than the race condition (e.g., an error payload, or a text-only reply where the draft stream failed), the code would fall through to `deliverNormally()` without clearing the existing draft message. The original implementation only cleared the draft for media payloads (`mediaCount > 0`), leaving other fallback paths vulnerable to creating duplicates.

## Solution

This fix addresses both issues with targeted changes to the `deliver` callback in `dispatch.ts`:

1. **Synchronize Draft Stream**: An `await draftStream.flush()` is now called before reading `draftMessageId` and `draftChannelId`. This ensures any pending send/edit operations are complete, guaranteeing that the message IDs are available and up-to-date, thus preventing the race condition.

2. **Generalize Draft Cleanup**: The condition to trigger draft cleanup has been broadened from `mediaCount > 0` to `hasStreamedMessage`, covering all fallback scenarios including text-only replies.

3. **Deferred Cleanup (Post-Delivery)**: Draft deletion is now performed **after** `deliverNormally()` succeeds, not before. This ensures that if `deliverNormally` fails (e.g., during a Slack API outage), the draft message remains visible so the user still sees a response rather than an empty DM.

4. **Preserve `status_final` Message**: The `status_final` branch now sets `hasStreamedMessage = false` before its try block, so the post-delivery cleanup correctly skips the status message, which is intentionally preserved alongside the final reply.

## Changed Files

| File | Change |
|------|--------|
| `src/slack/monitor/message-handler/dispatch.ts` | Flush draft stream before finalize check; defer draft cleanup to after successful delivery; preserve `status_final` message |
