### PR TITLE
fix(cron): friendlier schedule display — relative time for 'at', unknown fallback

### DIFF
--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -100,6 +100,21 @@ export function coerceDisplayValue(
     const preview = values.slice(0, maxArrayEntries).join(", ");
     return values.length > maxArrayEntries ? `${preview}…` : preview;
   }
+  // Plain objects: try a compact JSON representation instead of [object Object].
+  if (typeof value === "object") {
+    try {
+      const json = JSON.stringify(value);
+      if (json && json.length <= maxStringChars) {
+        return json;
+      }
+      if (json) {
+        return `${json.slice(0, Math.max(0, maxStringChars - 1))}…`;
+      }
+    } catch {
+      // circular or non-serializable — skip
+    }
+    return undefined;
+  }
   return undefined;
 }
 

--- a/src/agents/tool-display.json
+++ b/src/agents/tool-display.json
@@ -151,7 +151,7 @@
         "list": { "label": "list" },
         "add": {
           "label": "add",
-          "detailKeys": ["job.name", "job.id", "job.schedule", "job.cron"]
+          "detailKeys": ["job.name", "job.id", "job.schedule.kind"]
         },
         "update": { "label": "update", "detailKeys": ["id"] },
         "remove": { "label": "remove", "detailKeys": ["id"] },

--- a/src/cron/service/normalize.ts
+++ b/src/cron/service/normalize.ts
@@ -1,3 +1,4 @@
+import { formatDurationHuman } from "../../infra/format-time/format-duration.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import type { CronPayload } from "../types.js";
@@ -71,7 +72,7 @@ export function inferLegacyName(job: {
     return `Cron: ${truncateText(job.schedule.expr, 52)}`;
   }
   if (kind === "every" && typeof job?.schedule?.everyMs === "number") {
-    return `Every: ${job.schedule.everyMs}ms`;
+    return `Every: ${formatDurationHuman(job.schedule.everyMs)}`;
   }
   if (kind === "at") {
     return "One-shot";

--- a/ui/src/ui/presenter.ts
+++ b/ui/src/ui/presenter.ts
@@ -55,12 +55,19 @@ export function formatCronSchedule(job: CronJob) {
   const s = job.schedule;
   if (s.kind === "at") {
     const atMs = Date.parse(s.at);
-    return Number.isFinite(atMs) ? `At ${formatMs(atMs)}` : `At ${s.at}`;
+    if (!Number.isFinite(atMs)) {
+      return `At ${s.at}`;
+    }
+    const rel = formatRelativeTimestamp(atMs);
+    return `Once ${rel}`;
   }
   if (s.kind === "every") {
     return `Every ${formatDurationHuman(s.everyMs)}`;
   }
-  return `Cron ${s.expr}${s.tz ? ` (${s.tz})` : ""}`;
+  if (s.kind === "cron") {
+    return `Cron ${s.expr}${s.tz ? ` (${s.tz})` : ""}`;
+  }
+  return "unknown";
 }
 
 export function formatCronPayload(job: CronJob) {

--- a/ui/src/ui/tool-display.json
+++ b/ui/src/ui/tool-display.json
@@ -146,7 +146,7 @@
         "list": { "label": "list" },
         "add": {
           "label": "add",
-          "detailKeys": ["job.name", "job.id", "job.schedule", "job.cron"]
+          "detailKeys": ["job.name", "job.id", "job.schedule.kind"]
         },
         "update": { "label": "update", "detailKeys": ["id"] },
         "remove": { "label": "remove", "detailKeys": ["id"] },


### PR DESCRIPTION
## Summary

Part 2 of task-002 (display pass). The `[object Object]` bug was fixed in the prior commit. This pass improves the schedule text shown in the /cron jobs list.

### Changes to `ui/src/ui/presenter.ts` → `formatCronSchedule()`

| Schedule kind | Before | After |
|---|---|---|
| `at` | `At 3/10/2026, 9:00 AM` | `Once in 2h` |
| `every` | `Every 15m` ✅ (unchanged) | `Every 15m` |
| `cron` | `Cron 0 9 * * *` ✅ (unchanged) | `Cron 0 9 * * *` |
| unknown | (fell through to cron branch) | `unknown` |

**`at` schedules** now show a relative time via `formatRelativeTimestamp()` (already used elsewhere in the UI) — e.g. `Once in 2h`, `Once 3d ago`. This is dynamic/live at render time, no timezone config needed.

**Unknown schedule kinds** now return `"unknown"` explicitly instead of falling through the cron branch.

### Test baseline
Pre-existing test failures (2 in cron.test.ts, 1 in controllers/cron.test.ts) are present on `main` and unchanged by this PR.