### PR TITLE
[Issue #36991] Gateway inserts synthetic tool results prematurely during restart/long-poll cycles

### DIFF
--- a/automation/issue-tracker/issue-36991.md
+++ b/automation/issue-tracker/issue-36991.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36991
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36991
+- Title: Gateway inserts synthetic tool results prematurely during restart/long-poll cycles
+- Created at: 2026-03-06T01:56:34Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36991
- URL: https://github.com/openclaw/openclaw/issues/36991

## Original Issue Description
The issue reports premature synthetic tool result insertion during restart/long-poll cycles and contains full investigation details and proposed fix directions in the source issue.

Closes #36991