### PR TITLE
[Issue #36994] [Bug]: Exec and tools keep breaking

### DIFF
--- a/automation/issue-tracker/issue-36994.md
+++ b/automation/issue-tracker/issue-36994.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36994
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36994
+- Title: [Bug]: Exec and tools keep breaking
+- Created at: 2026-03-06T01:57:17Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36994
- URL: https://github.com/openclaw/openclaw/issues/36994

## Original Issue Description
The issue reports recurring exec/tool breakage after install/update and includes environment details, logs, and expected behavior in the source issue body.

Closes #36994