### PR TITLE
[Issue #36995] 【安全分享】Clawguard：OpenClaw 技能/插件风险扫描与拦截（开源）

### DIFF
--- a/automation/issue-tracker/issue-36995.md
+++ b/automation/issue-tracker/issue-36995.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #36995
+
+- Source issue: https://github.com/openclaw/openclaw/issues/36995
+- Title: 【安全分享】Clawguard：OpenClaw 技能/插件风险扫描与拦截（开源）
+- Created at: 2026-03-06T01:57:27Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #36995
- URL: https://github.com/openclaw/openclaw/issues/36995

## Original Issue Description
The issue shares Clawguard security scanning/guarding capabilities and includes the full original description with project links in the source issue body.

Closes #36995