### PR TITLE
fix(feishu): guard against undefined response.code in SDK v1.30+ success responses

### DIFF
--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -18,7 +18,7 @@ export type ProbeFeishuOptions = {
 };
 
 type FeishuBotInfoResponse = {
-  code: number;
+  code?: number;
   msg?: string;
   bot?: { bot_name?: string; open_id?: string };
   data?: { bot?: { bot_name?: string; open_id?: string } };
@@ -114,7 +114,7 @@ export async function probeFeishu(
       };
     }
 
-    if (response.code !== 0) {
+    if (response.code !== undefined && response.code !== 0) {
       return setCachedProbeResult(
         cacheKey,
         {

--- a/extensions/feishu/src/reactions.ts
+++ b/extensions/feishu/src/reactions.ts
@@ -41,7 +41,7 @@ export async function addReactionFeishu(params: {
     data?: { reaction_id?: string };
   };
 
-  if (response.code !== 0) {
+  if (response.code !== undefined && response.code !== 0) {
     throw new Error(`Feishu add reaction failed: ${response.msg || `code ${response.code}`}`);
   }
 
@@ -77,7 +77,7 @@ export async function removeReactionFeishu(params: {
     },
   })) as { code?: number; msg?: string };
 
-  if (response.code !== 0) {
+  if (response.code !== undefined && response.code !== 0) {
     throw new Error(`Feishu remove reaction failed: ${response.msg || `code ${response.code}`}`);
   }
 }
@@ -115,7 +115,7 @@ export async function listReactionsFeishu(params: {
     };
   };
 
-  if (response.code !== 0) {
+  if (response.code !== undefined && response.code !== 0) {
     throw new Error(`Feishu list reactions failed: ${response.msg || `code ${response.code}`}`);
   }
 

--- a/extensions/feishu/src/send-result.test.ts
+++ b/extensions/feishu/src/send-result.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { assertFeishuMessageApiSuccess } from "./send-result.js";
+
+describe("assertFeishuMessageApiSuccess", () => {
+  it("does not throw when code is 0", () => {
+    expect(() => {
+      assertFeishuMessageApiSuccess({ code: 0 }, "test");
+    }).not.toThrow();
+  });
+
+  it("does not throw when code is undefined (SDK v1.30+ success)", () => {
+    expect(() => {
+      assertFeishuMessageApiSuccess({}, "test");
+    }).not.toThrow();
+  });
+
+  it("throws when code is a non-zero number", () => {
+    expect(() => {
+      assertFeishuMessageApiSuccess({ code: 99991, msg: "invalid token" }, "Feishu send failed");
+    }).toThrow("Feishu send failed: invalid token");
+  });
+
+  it("throws with code fallback when msg is empty", () => {
+    expect(() => {
+      assertFeishuMessageApiSuccess({ code: 40003 }, "Feishu send failed");
+    }).toThrow("Feishu send failed: code 40003");
+  });
+});

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -10,7 +10,7 @@ export function assertFeishuMessageApiSuccess(
   response: FeishuMessageApiResponse,
   errorPrefix: string,
 ) {
-  if (response.code !== 0) {
+  if (response.code !== undefined && response.code !== 0) {
     throw new Error(`${errorPrefix}: ${response.msg || `code ${response.code}`}`);
   }
 }

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -206,7 +206,7 @@ export async function getMessageFeishu(params: {
       };
     };
 
-    if (response.code !== 0) {
+    if (response.code !== undefined && response.code !== 0) {
       return null;
     }
 
@@ -387,7 +387,7 @@ export async function updateCardFeishu(params: {
     data: { content },
   });
 
-  if (response.code !== 0) {
+  if (response.code !== undefined && response.code !== 0) {
     throw new Error(`Feishu card update failed: ${response.msg || `code ${response.code}`}`);
   }
 }
@@ -471,7 +471,7 @@ export async function editMessageFeishu(params: {
     },
   });
 
-  if (response.code !== 0) {
+  if (response.code !== undefined && response.code !== 0) {
     throw new Error(`Feishu message edit failed: ${response.msg || `code ${response.code}`}`);
   }
 }


### PR DESCRIPTION
## Summary

The Feishu SDK v1.30+ may return success responses without a `code` field, returning data directly instead of wrapping in `{ code: 0, data: ... }`. The existing `response.code !== 0` checks evaluate `undefined !== 0` as `true`, incorrectly treating successful responses as errors.

This PR aligns all response code checks in the feishu extension with the correct pattern already established in `media.ts`:
```ts
// Before (broken for SDK v1.30+ success without code field):
if (response.code !== 0)

// After (matches media.ts pattern):
if (response.code !== undefined && response.code !== 0)
```

## Changes

- **`send-result.ts`**: Fix `assertFeishuMessageApiSuccess` — the core assertion used by 12+ call sites
- **`reactions.ts`**: Fix 3 inline checks in `addReactionFeishu`, `removeReactionFeishu`, `listReactionsFeishu`
- **`probe.ts`**: Fix 1 check + update `FeishuBotInfoResponse` type from `code: number` to `code?: number`
- **`send.ts`**: Fix 3 inline checks in `getMessageFeishu`, `updateCardFeishu`, `editMessageFeishu`
- **`send-result.test.ts`**: Add regression tests covering `code: 0`, `code: undefined`, and `code: nonzero`

## Why

`media.ts` already handles this correctly (lines 31, 198, 268) with comments noting SDK v1.30+ behavior. The same guard was missing from the other files.

## Test plan

- [x] `npx vitest run extensions/feishu/src/send-result.test.ts` — 4/4 pass
- [x] `npx oxlint` — 0 warnings, 0 errors
- [x] Verified `media.ts` already uses the correct pattern as reference

lobster-biscuit