### PR TITLE
fix(feishu): correct deliveryContext.to prefix

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -267,6 +267,9 @@ describe("handleFeishuMessage command authorization", () => {
         CommandAuthorized: false,
         SenderId: "ou-attacker",
         Surface: "feishu",
+        // Used for outbound reply routing.
+        To: "feishu:ou-attacker",
+        OriginatingTo: "feishu:ou-attacker",
       }),
     );
   });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1153,7 +1153,10 @@ export async function handleFeishuMessage(params: {
     // In group chats, the session is scoped to the group, but the *speaker* is the sender.
     // Using a group-scoped From causes the agent to treat different users as the same person.
     const feishuFrom = `feishu:${ctx.senderOpenId}`;
-    const feishuTo = isGroup ? `chat:${ctx.chatId}` : `user:${ctx.senderOpenId}`;
+    // `To` / `OriginatingTo` is used to derive reply routing. It must use the
+    // channel-qualified prefix (e.g. `feishu:...`) instead of the generic
+    // `user:` prefix, otherwise outbound delivery cannot resolve the send target.
+    const feishuTo = isGroup ? `feishu:group:${ctx.chatId}` : `feishu:${ctx.senderOpenId}`;
     const peerId = isGroup ? (groupSession?.peerId ?? ctx.chatId) : ctx.senderOpenId;
     const parentPeer = isGroup ? (groupSession?.parentPeer ?? null) : null;
     const replyInThread = isGroup ? (groupSession?.replyInThread ?? false) : false;


### PR DESCRIPTION
Closes #36987

Feishu inbound context used `user:` / `chat:` targets for `To`/`OriginatingTo`, which are later used to derive session delivery routing. This made outbound replies fail to resolve the Feishu send target.

This change sets `To`/`OriginatingTo` to channel-qualified targets (`feishu:<open_id>` and `feishu:group:<chat_id>`) and adds a regression assertion in the Feishu bot tests.