### PR TITLE
fix(agents): add TTL grace + restart persistence for pending tool-result flush

### DIFF
--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -79,7 +79,7 @@ function getToolResultText(messages: AgentMessage[]): string {
 describe("installSessionToolResultGuard", () => {
   it("inserts synthetic toolResult before non-tool message when pending", () => {
     const sm = SessionManager.inMemory();
-    installSessionToolResultGuard(sm);
+    installSessionToolResultGuard(sm, { pendingToolResultGraceMs: 0 });
 
     sm.appendMessage(toolCallMessage);
     sm.appendMessage(
@@ -115,6 +115,7 @@ describe("installSessionToolResultGuard", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm, {
       allowSyntheticToolResults: false,
+      pendingToolResultGraceMs: 0,
     });
 
     sm.appendMessage(toolCallMessage);
@@ -171,7 +172,7 @@ describe("installSessionToolResultGuard", () => {
 
   it("preserves ordering with multiple tool calls and partial results", () => {
     const sm = SessionManager.inMemory();
-    const guard = installSessionToolResultGuard(sm);
+    const guard = installSessionToolResultGuard(sm, { pendingToolResultGraceMs: 0 });
 
     sm.appendMessage(
       asAppendMessage({
@@ -209,7 +210,7 @@ describe("installSessionToolResultGuard", () => {
 
   it("flushes pending on guard when no toolResult arrived", () => {
     const sm = SessionManager.inMemory();
-    const guard = installSessionToolResultGuard(sm);
+    const guard = installSessionToolResultGuard(sm, { pendingToolResultGraceMs: 0 });
 
     sm.appendMessage(toolCallMessage);
     sm.appendMessage(

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
 import type {
@@ -16,6 +18,14 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
 const GUARD_TRUNCATION_SUFFIX =
   "\n\n⚠️ [Content truncated during persistence — original exceeded size limit. " +
   "Use offset/limit parameters or request specific sections for large content.]";
+
+type PendingToolCallRecord = { id: string; name?: string; createdAtMs: number };
+
+type PendingToolCallFile = {
+  version: 1;
+  updatedAtMs: number;
+  items: PendingToolCallRecord[];
+};
 
 /**
  * Truncate oversized text content blocks in a tool result message.
@@ -113,6 +123,52 @@ export function installSessionToolResultGuard(
 } {
   const originalAppend = sessionManager.appendMessage.bind(sessionManager);
   const pendingState = createPendingToolCallState();
+
+  const sessionFile = (
+    sessionManager as { getSessionFile?: () => string | null }
+  ).getSessionFile?.();
+  const pendingFile = sessionFile ? `${sessionFile}.pending-tool-calls.json` : null;
+
+  const loadPendingState = () => {
+    if (!pendingFile) {
+      return;
+    }
+    try {
+      const raw = readFileSync(pendingFile, "utf8");
+      const parsed = JSON.parse(raw) as PendingToolCallFile;
+      if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.items)) {
+        return;
+      }
+      pendingState.restore(parsed.items);
+    } catch {
+      // best-effort only
+    }
+  };
+
+  const savePendingState = () => {
+    if (!pendingFile) {
+      return;
+    }
+    const items = pendingState.snapshot();
+    try {
+      if (items.length === 0) {
+        rmSync(pendingFile, { force: true });
+        return;
+      }
+      mkdirSync(dirname(pendingFile), { recursive: true });
+      const payload: PendingToolCallFile = {
+        version: 1,
+        updatedAtMs: Date.now(),
+        items,
+      };
+      writeFileSync(pendingFile, `${JSON.stringify(payload)}\n`, "utf8");
+    } catch {
+      // best-effort only
+    }
+  };
+
+  loadPendingState();
+
   const persistMessage = (message: AgentMessage) => {
     const transformer = opts?.transformMessageForPersistence;
     return transformer ? transformer(message) : message;
@@ -195,6 +251,7 @@ export function installSessionToolResultGuard(
         pendingState.delete(id);
       }
     }
+    savePendingState();
   };
 
   const guardedAppend = (message: AgentMessage) => {
@@ -219,6 +276,7 @@ export function installSessionToolResultGuard(
       const toolName = id ? pendingState.getToolName(id) : undefined;
       if (id) {
         pendingState.delete(id);
+        savePendingState();
       }
       const normalizedToolResult = normalizePersistedToolResultName(nextMessage, toolName);
       // Apply hard size cap before persistence to prevent oversized tool results
@@ -288,6 +346,7 @@ export function installSessionToolResultGuard(
 
     if (toolCalls.length > 0) {
       pendingState.trackToolCalls(toolCalls);
+      savePendingState();
     }
 
     return result;

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -72,6 +72,11 @@ export function installSessionToolResultGuard(
   sessionManager: SessionManager,
   opts?: {
     /**
+     * Grace window before inserting synthetic tool results for pending tool calls.
+     * Prevents premature synthetic inserts during restart/long-poll ordering jitter.
+     */
+    pendingToolResultGraceMs?: number;
+    /**
      * Optional transform applied to any message before persistence.
      */
     transformMessageForPersistence?: (message: AgentMessage) => AgentMessage;
@@ -123,6 +128,7 @@ export function installSessionToolResultGuard(
 
   const allowSyntheticToolResults = opts?.allowSyntheticToolResults ?? true;
   const beforeWrite = opts?.beforeMessageWriteHook;
+  const pendingToolResultGraceMs = Math.max(0, opts?.pendingToolResultGraceMs ?? 30_000);
 
   /**
    * Run the before_message_write hook. Returns the (possibly modified) message,
@@ -142,12 +148,24 @@ export function installSessionToolResultGuard(
     return msg;
   };
 
-  const flushPendingToolResults = () => {
+  const flushPendingToolResults = (
+    reason:
+      | "ttl_expired"
+      | "sanitized_drop"
+      | "new_tool_calls"
+      | "explicit_finalize" = "explicit_finalize",
+    ids?: string[],
+  ) => {
     if (pendingState.size() === 0) {
       return;
     }
+
+    const targetIds = ids?.length ? ids : pendingState.getPendingIds();
     if (allowSyntheticToolResults) {
-      for (const [id, name] of pendingState.entries()) {
+      for (const id of targetIds) {
+        const name = pendingState.getToolName(id);
+        const createdAtMs = pendingState.getCreatedAtMs(id);
+        const ageMs = typeof createdAtMs === "number" ? Date.now() - createdAtMs : undefined;
         const synthetic = makeMissingToolResult({ toolCallId: id, toolName: name });
         const flushed = applyBeforeWriteHook(
           persistToolResult(persistMessage(synthetic), {
@@ -159,9 +177,24 @@ export function installSessionToolResultGuard(
         if (flushed) {
           originalAppend(flushed as never);
         }
+        // Structured telemetry for every synthetic insertion path.
+        console.warn(
+          JSON.stringify({
+            subsystem: "agents/transcript-guard",
+            event: "synthetic_tool_result_inserted",
+            reason,
+            toolCallId: id,
+            toolName: name,
+            ageMs,
+          }),
+        );
+        pendingState.delete(id);
+      }
+    } else {
+      for (const id of targetIds) {
+        pendingState.delete(id);
       }
     }
-    pendingState.clear();
   };
 
   const guardedAppend = (message: AgentMessage) => {
@@ -173,7 +206,7 @@ export function installSessionToolResultGuard(
       });
       if (sanitized.length === 0) {
         if (pendingState.shouldFlushForSanitizedDrop()) {
-          flushPendingToolResults();
+          flushPendingToolResults("sanitized_drop");
         }
         return undefined;
       }
@@ -222,12 +255,22 @@ export function installSessionToolResultGuard(
     // synthetic results (e.g. OpenAI) accumulate stale pending state when a user message
     // interrupts in-flight tool calls, leaving orphaned tool_use blocks in the transcript
     // that cause API 400 errors on subsequent requests.
-    if (pendingState.shouldFlushBeforeNonToolResult(nextRole, toolCalls.length)) {
-      flushPendingToolResults();
+    if (
+      pendingState.shouldFlushBeforeNonToolResult(
+        nextRole,
+        toolCalls.length,
+        pendingToolResultGraceMs,
+        Date.now(),
+      )
+    ) {
+      const expiredIds = pendingState.getExpiredIds(pendingToolResultGraceMs, Date.now());
+      if (expiredIds.length > 0) {
+        flushPendingToolResults("ttl_expired", expiredIds);
+      }
     }
     // If new tool calls arrive while older ones are pending, flush the old ones first.
     if (pendingState.shouldFlushBeforeNewToolCalls(toolCalls.length)) {
-      flushPendingToolResults();
+      flushPendingToolResults("new_tool_calls");
     }
 
     const finalMessage = applyBeforeWriteHook(persistMessage(nextMessage));

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -274,10 +274,6 @@ export function installSessionToolResultGuard(
     if (nextRole === "toolResult") {
       const id = extractToolResultId(nextMessage as Extract<AgentMessage, { role: "toolResult" }>);
       const toolName = id ? pendingState.getToolName(id) : undefined;
-      if (id) {
-        pendingState.delete(id);
-        savePendingState();
-      }
       const normalizedToolResult = normalizePersistedToolResultName(nextMessage, toolName);
       // Apply hard size cap before persistence to prevent oversized tool results
       // from consuming the entire context window on subsequent LLM calls.
@@ -292,7 +288,13 @@ export function installSessionToolResultGuard(
       if (!persisted) {
         return undefined;
       }
-      return originalAppend(persisted as never);
+      const appendResult = originalAppend(persisted as never);
+      // Update pending sidecar only after JSONL append succeeds.
+      if (id) {
+        pendingState.delete(id);
+        savePendingState();
+      }
+      return appendResult;
     }
 
     // Skip tool call extraction for aborted/errored assistant messages.
@@ -313,18 +315,10 @@ export function installSessionToolResultGuard(
     // synthetic results (e.g. OpenAI) accumulate stale pending state when a user message
     // interrupts in-flight tool calls, leaving orphaned tool_use blocks in the transcript
     // that cause API 400 errors on subsequent requests.
-    if (
-      pendingState.shouldFlushBeforeNonToolResult(
-        nextRole,
-        toolCalls.length,
-        pendingToolResultGraceMs,
-        Date.now(),
-      )
-    ) {
-      const expiredIds = pendingState.getExpiredIds(pendingToolResultGraceMs, Date.now());
-      if (expiredIds.length > 0) {
-        flushPendingToolResults("ttl_expired", expiredIds);
-      }
+    const expiredIds = pendingState.getExpiredIds(pendingToolResultGraceMs, Date.now());
+    const isNonToolFlow = toolCalls.length === 0 || nextRole !== "assistant";
+    if (isNonToolFlow && expiredIds.length > 0) {
+      flushPendingToolResults("ttl_expired", expiredIds);
     }
     // If new tool calls arrive while older ones are pending, flush the old ones first.
     if (pendingState.shouldFlushBeforeNewToolCalls(toolCalls.length)) {

--- a/src/agents/session-tool-result-guard.ttl.test.ts
+++ b/src/agents/session-tool-result-guard.ttl.test.ts
@@ -1,0 +1,63 @@
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
+
+type AppendMessage = Parameters<SessionManager["appendMessage"]>[0];
+const asAppendMessage = (message: unknown) => message as AppendMessage;
+
+describe("session tool-result guard TTL behavior", () => {
+  it("does not insert synthetic toolResult before TTL on non-tool message", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, { pendingToolResultGraceMs: 30_000 });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      }),
+    );
+
+    sm.appendMessage(
+      asAppendMessage({ role: "assistant", content: [{ type: "text", text: "intermediate" }] }),
+    );
+
+    const roles = sm
+      .getEntries()
+      .filter((e) => e.type === "message")
+      .map((e) => (e as { message: { role: string } }).message.role);
+
+    expect(roles).toEqual(["assistant", "assistant"]);
+  });
+
+  it("inserts synthetic toolResult after TTL expires", () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-03-05T10:00:00.000Z");
+    vi.setSystemTime(now);
+
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, { pendingToolResultGraceMs: 30_000 });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      }),
+    );
+
+    vi.advanceTimersByTime(31_000);
+
+    sm.appendMessage(
+      asAppendMessage({ role: "assistant", content: [{ type: "text", text: "after timeout" }] }),
+    );
+
+    const messages = sm
+      .getEntries()
+      .filter((e) => e.type === "message")
+      .map((e) => (e as { message: Record<string, unknown> }).message);
+
+    expect(messages.map((m) => m.role)).toEqual(["assistant", "toolResult", "assistant"]);
+    expect(messages[1].toolCallId).toBe("call_1");
+    expect(messages[1].isError).toBe(true);
+    vi.useRealTimers();
+  });
+});

--- a/src/agents/session-tool-result-guard.ttl.test.ts
+++ b/src/agents/session-tool-result-guard.ttl.test.ts
@@ -1,3 +1,6 @@
+import { existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
@@ -27,6 +30,29 @@ describe("session tool-result guard TTL behavior", () => {
       .map((e) => (e as { message: { role: string } }).message.role);
 
     expect(roles).toEqual(["assistant", "assistant"]);
+  });
+
+  it("restores pending tool calls from disk across session-manager reopen", () => {
+    const root = mkdtempSync(join(tmpdir(), "oc-pending-"));
+    const sessionFile = join(root, "session.jsonl");
+
+    const sm1 = SessionManager.open(sessionFile);
+    installSessionToolResultGuard(sm1, { pendingToolResultGraceMs: 30_000 });
+
+    sm1.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_disk_1", name: "read", arguments: {} }],
+      }),
+    );
+
+    const pendingFile = `${sessionFile}.pending-tool-calls.json`;
+    expect(existsSync(pendingFile)).toBe(true);
+
+    const sm2 = SessionManager.open(sessionFile);
+    const guard2 = installSessionToolResultGuard(sm2, { pendingToolResultGraceMs: 30_000 });
+
+    expect(guard2.getPendingIds()).toContain("call_disk_1");
   });
 
   it("inserts synthetic toolResult after TTL expires", () => {

--- a/src/agents/session-tool-result-guard.ttl.test.ts
+++ b/src/agents/session-tool-result-guard.ttl.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
@@ -79,11 +80,12 @@ describe("session tool-result guard TTL behavior", () => {
     const messages = sm
       .getEntries()
       .filter((e) => e.type === "message")
-      .map((e) => (e as { message: Record<string, unknown> }).message);
+      .map((e) => (e as unknown as { message: AgentMessage }).message);
 
     expect(messages.map((m) => m.role)).toEqual(["assistant", "toolResult", "assistant"]);
-    expect(messages[1].toolCallId).toBe("call_1");
-    expect(messages[1].isError).toBe(true);
+    const synthetic = messages[1] as Extract<AgentMessage, { role: "toolResult" }>;
+    expect(synthetic.toolCallId).toBe("call_1");
+    expect(synthetic.isError).toBe(true);
     vi.useRealTimers();
   });
 });

--- a/src/agents/session-tool-result-state.ts
+++ b/src/agents/session-tool-result-state.ts
@@ -7,7 +7,6 @@ type PendingToolCallMeta = {
 
 export type PendingToolCallState = {
   size: () => number;
-  entries: () => IterableIterator<[string, PendingToolCallMeta]>;
   snapshot: () => Array<{ id: string; name?: string; createdAtMs: number }>;
   restore: (items: Array<{ id: string; name?: string; createdAtMs: number }>) => void;
   getToolName: (id: string) => string | undefined;
@@ -18,12 +17,6 @@ export type PendingToolCallState = {
   getPendingIds: () => string[];
   getExpiredIds: (ttlMs: number, nowMs?: number) => string[];
   shouldFlushForSanitizedDrop: () => boolean;
-  shouldFlushBeforeNonToolResult: (
-    nextRole: unknown,
-    toolCallCount: number,
-    ttlMs: number,
-    nowMs?: number,
-  ) => boolean;
   shouldFlushBeforeNewToolCalls: (toolCallCount: number) => boolean;
 };
 
@@ -32,7 +25,6 @@ export function createPendingToolCallState(): PendingToolCallState {
 
   return {
     size: () => pending.size,
-    entries: () => pending.entries(),
     snapshot: () => Array.from(pending.entries()).map(([id, meta]) => ({ id, ...meta })),
     restore: (items: Array<{ id: string; name?: string; createdAtMs: number }>) => {
       pending.clear();
@@ -67,28 +59,6 @@ export function createPendingToolCallState(): PendingToolCallState {
       return expired;
     },
     shouldFlushForSanitizedDrop: () => pending.size > 0,
-    // Grace-window behavior: do not flush immediately on first non-tool message.
-    // Only flush when at least one pending tool call has exceeded ttlMs.
-    shouldFlushBeforeNonToolResult: (
-      nextRole: unknown,
-      toolCallCount: number,
-      ttlMs: number,
-      nowMs = Date.now(),
-    ) => {
-      if (pending.size === 0) {
-        return false;
-      }
-      const isNonToolFlow = toolCallCount === 0 || nextRole !== "assistant";
-      if (!isNonToolFlow) {
-        return false;
-      }
-      for (const meta of pending.values()) {
-        if (nowMs - meta.createdAtMs >= ttlMs) {
-          return true;
-        }
-      }
-      return false;
-    },
     shouldFlushBeforeNewToolCalls: (toolCallCount: number) => pending.size > 0 && toolCallCount > 0,
   };
 }

--- a/src/agents/session-tool-result-state.ts
+++ b/src/agents/session-tool-result-state.ts
@@ -1,40 +1,82 @@
 export type PendingToolCall = { id: string; name?: string };
 
+type PendingToolCallMeta = {
+  name?: string;
+  createdAtMs: number;
+};
+
 export type PendingToolCallState = {
   size: () => number;
-  entries: () => IterableIterator<[string, string | undefined]>;
+  entries: () => IterableIterator<[string, PendingToolCallMeta]>;
   getToolName: (id: string) => string | undefined;
+  getCreatedAtMs: (id: string) => number | undefined;
   delete: (id: string) => void;
   clear: () => void;
-  trackToolCalls: (calls: PendingToolCall[]) => void;
+  trackToolCalls: (calls: PendingToolCall[], nowMs?: number) => void;
   getPendingIds: () => string[];
+  getExpiredIds: (ttlMs: number, nowMs?: number) => string[];
   shouldFlushForSanitizedDrop: () => boolean;
-  shouldFlushBeforeNonToolResult: (nextRole: unknown, toolCallCount: number) => boolean;
+  shouldFlushBeforeNonToolResult: (
+    nextRole: unknown,
+    toolCallCount: number,
+    ttlMs: number,
+    nowMs?: number,
+  ) => boolean;
   shouldFlushBeforeNewToolCalls: (toolCallCount: number) => boolean;
 };
 
 export function createPendingToolCallState(): PendingToolCallState {
-  const pending = new Map<string, string | undefined>();
+  const pending = new Map<string, PendingToolCallMeta>();
 
   return {
     size: () => pending.size,
     entries: () => pending.entries(),
-    getToolName: (id: string) => pending.get(id),
+    getToolName: (id: string) => pending.get(id)?.name,
+    getCreatedAtMs: (id: string) => pending.get(id)?.createdAtMs,
     delete: (id: string) => {
       pending.delete(id);
     },
     clear: () => {
       pending.clear();
     },
-    trackToolCalls: (calls: PendingToolCall[]) => {
+    trackToolCalls: (calls: PendingToolCall[], nowMs = Date.now()) => {
       for (const call of calls) {
-        pending.set(call.id, call.name);
+        pending.set(call.id, { name: call.name, createdAtMs: nowMs });
       }
     },
     getPendingIds: () => Array.from(pending.keys()),
+    getExpiredIds: (ttlMs: number, nowMs = Date.now()) => {
+      const expired: string[] = [];
+      for (const [id, meta] of pending.entries()) {
+        if (nowMs - meta.createdAtMs >= ttlMs) {
+          expired.push(id);
+        }
+      }
+      return expired;
+    },
     shouldFlushForSanitizedDrop: () => pending.size > 0,
-    shouldFlushBeforeNonToolResult: (nextRole: unknown, toolCallCount: number) =>
-      pending.size > 0 && (toolCallCount === 0 || nextRole !== "assistant"),
+    // Grace-window behavior: do not flush immediately on first non-tool message.
+    // Only flush when at least one pending tool call has exceeded ttlMs.
+    shouldFlushBeforeNonToolResult: (
+      nextRole: unknown,
+      toolCallCount: number,
+      ttlMs: number,
+      nowMs = Date.now(),
+    ) => {
+      if (pending.size === 0) {
+        return false;
+      }
+      const isNonToolFlow = toolCallCount === 0 || nextRole !== "assistant";
+      if (!isNonToolFlow) {
+        return false;
+      }
+      for (const meta of pending.values()) {
+        if (nowMs - meta.createdAtMs >= ttlMs) {
+          return true;
+        }
+      }
+      return false;
+    },
     shouldFlushBeforeNewToolCalls: (toolCallCount: number) => pending.size > 0 && toolCallCount > 0,
   };
 }

--- a/src/agents/session-tool-result-state.ts
+++ b/src/agents/session-tool-result-state.ts
@@ -8,6 +8,8 @@ type PendingToolCallMeta = {
 export type PendingToolCallState = {
   size: () => number;
   entries: () => IterableIterator<[string, PendingToolCallMeta]>;
+  snapshot: () => Array<{ id: string; name?: string; createdAtMs: number }>;
+  restore: (items: Array<{ id: string; name?: string; createdAtMs: number }>) => void;
   getToolName: (id: string) => string | undefined;
   getCreatedAtMs: (id: string) => number | undefined;
   delete: (id: string) => void;
@@ -31,6 +33,16 @@ export function createPendingToolCallState(): PendingToolCallState {
   return {
     size: () => pending.size,
     entries: () => pending.entries(),
+    snapshot: () => Array.from(pending.entries()).map(([id, meta]) => ({ id, ...meta })),
+    restore: (items: Array<{ id: string; name?: string; createdAtMs: number }>) => {
+      pending.clear();
+      for (const item of items) {
+        if (!item?.id || typeof item.createdAtMs !== "number") {
+          continue;
+        }
+        pending.set(item.id, { name: item.name, createdAtMs: item.createdAtMs });
+      }
+    },
     getToolName: (id: string) => pending.get(id)?.name,
     getCreatedAtMs: (id: string) => pending.get(id)?.createdAtMs,
     delete: (id: string) => {


### PR DESCRIPTION
## Summary
Fixes an edge-path class where pending tool calls can be flushed too early (synthetic toolResult insertion) during restart/long-poll ordering jitter.

This PR adds two protections:
1. **TTL grace window before non-tool flush** (default 30s) instead of immediate synthetic insertion on first non-tool message.
2. **Pending tool-call persistence across restart** via a sidecar file (`<session>.pending-tool-calls.json`) so in-flight pending IDs survive session-manager reopen.

Also adds structured telemetry when synthetic insertion occurs:
- `subsystem=agents/transcript-guard`
- `event=synthetic_tool_result_inserted`
- `reason`, `toolCallId`, `toolName`, `ageMs`

## Why
Issue context: synthetic insertions were observed during restart/long-poll cycles even when real tool results were expected shortly after.

Closes/addresses: #36991
Related: #30082 #32101 #32933 #27050 #28520

## Changes
- `src/agents/session-tool-result-state.ts`
  - Track pending metadata (`createdAtMs`)
  - Added `getExpiredIds()`, `snapshot()`, `restore()`
- `src/agents/session-tool-result-guard.ts`
  - New option: `pendingToolResultGraceMs` (default `30_000`)
  - Non-tool flush now gated by TTL expiry
  - Pending persistence load/save sidecar
  - Structured telemetry on synthetic insertion
- `src/agents/session-tool-result-guard.ttl.test.ts`
  - Added tests for no pre-TTL flush, post-TTL synthetic insertion, and disk restore across reopen
- `src/agents/session-tool-result-guard.test.ts`
  - Existing immediate-flush expectations now explicitly set `pendingToolResultGraceMs: 0`

## Validation
Ran locally on v2026.3.2 branch:
- `pnpm vitest src/agents/session-tool-result-guard.test.ts src/agents/session-tool-result-guard.ttl.test.ts --run` ✅
- `pnpm build` ✅
- Isolated gateway startup/health check on separate state dir/port ✅

## Notes
- This is intentionally best-effort persistence (sidecar IO failures do not crash runtime).
- Follow-up could migrate sidecar persistence into a unified session metadata abstraction if preferred.
