### PR TITLE
gateway: avoid stale Control UI version from service env

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -23,7 +23,7 @@ import { rawDataToString } from "../../../infra/ws.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
 import { isGatewayCliClient, isWebchatClient } from "../../../utils/message-channel.js";
-import { resolveRuntimeServiceVersion } from "../../../version.js";
+import { resolveRuntimeClientVersion } from "../../../version.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
 import type { GatewayAuthResult, ResolvedGatewayAuth } from "../../auth.js";
 import { isLocalDirectRequest } from "../../auth.js";
@@ -1032,7 +1032,7 @@ export function attachGatewayWsMessageHandler(params: {
           type: "hello-ok",
           protocol: PROTOCOL_VERSION,
           server: {
-            version: resolveRuntimeServiceVersion(process.env),
+            version: resolveRuntimeClientVersion(process.env),
             connId,
           },
           features: { methods: gatewayMethods, events },

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -8,6 +8,7 @@ import {
   readVersionFromBuildInfoForModuleUrl,
   readVersionFromPackageJsonForModuleUrl,
   resolveBinaryVersion,
+  resolveRuntimeClientVersion,
   resolveRuntimeServiceVersion,
   resolveUsableRuntimeVersion,
   resolveVersionFromModuleUrl,
@@ -180,5 +181,26 @@ describe("version resolution", () => {
         "fallback",
       ),
     ).toBe(VERSION);
+  });
+
+  it("resolves client-visible runtime version without OPENCLAW_SERVICE_VERSION fallback", () => {
+    const expected = resolveUsableRuntimeVersion(VERSION) ?? "1.0.0-package";
+    expect(
+      resolveRuntimeClientVersion({
+        OPENCLAW_VERSION: " ",
+        OPENCLAW_SERVICE_VERSION: "9.9.9-stale",
+        npm_package_version: "1.0.0-package",
+      }),
+    ).toBe(expected);
+  });
+
+  it("still prioritizes OPENCLAW_VERSION for client-visible runtime version", () => {
+    expect(
+      resolveRuntimeClientVersion({
+        OPENCLAW_VERSION: "2026.9.9",
+        OPENCLAW_SERVICE_VERSION: "9.9.9-stale",
+        npm_package_version: "1.0.0-package",
+      }),
+    ).toBe("2026.9.9");
   });
 });

--- a/src/version.ts
+++ b/src/version.ts
@@ -118,6 +118,22 @@ export function resolveRuntimeServiceVersion(
   );
 }
 
+/**
+ * Resolve the runtime version shown to interactive clients (Control UI/TUI).
+ * Unlike service diagnostics, this intentionally ignores OPENCLAW_SERVICE_VERSION
+ * because that env can be stale across package upgrades until daemon reinstall.
+ */
+export function resolveRuntimeClientVersion(
+  env: RuntimeVersionEnv = process.env as RuntimeVersionEnv,
+  fallback = RUNTIME_SERVICE_VERSION_FALLBACK,
+): string {
+  const runtimeVersion = resolveUsableRuntimeVersion(VERSION);
+
+  return (
+    firstNonEmpty(env["OPENCLAW_VERSION"], runtimeVersion, env["npm_package_version"]) ?? fallback
+  );
+}
+
 // Single source of truth for the current OpenClaw version.
 // - Embedded/bundled builds: injected define or env var.
 // - Dev/npm builds: package.json.


### PR DESCRIPTION
## Summary
- add `resolveRuntimeClientVersion` for client-facing version display
- keep service diagnostics behavior unchanged (`resolveRuntimeServiceVersion` still includes `OPENCLAW_SERVICE_VERSION`)
- switch WebSocket `hello-ok.server.version` to `resolveRuntimeClientVersion(process.env)` so Control UI doesn't show stale daemon service-env versions after package upgrades
- add version-resolution tests covering client version precedence

## Validation
- `pnpm vitest run src/version.test.ts`
- `pnpm vitest run src/gateway/server.models-voicewake-misc.test.ts -t "hello-ok advertises the gateway port for canvas host"`

Fixes #30922
