### PR TITLE
docs: fix broken Xfinity SSL troubleshooting anchor

### DIFF
--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -77,7 +77,7 @@ Fix:
 
 Reference:
 
-- Xfinity Advanced Security help: https://www.xfinity.com/support/articles/using-xfinity-xfi-advanced-security
+- Xfinity Advanced Security help: <https://www.xfinity.com/support/articles/using-xfinity-xfi-advanced-security>
 
 ## Decision tree
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -65,6 +65,20 @@ Example:
 
 Reference: [/tools/plugin#distribution-npm](/tools/plugin#distribution-npm)
 
+## `docs.openclaw.ai` shows an SSL error (Comcast/Xfinity)
+
+Some Comcast/Xfinity connections incorrectly block `docs.openclaw.ai` via Xfinity
+Advanced Security.
+
+Fix:
+
+- Disable Xfinity Advanced Security (or allowlist `docs.openclaw.ai`), then retry.
+- Quick check: try a mobile hotspot or VPN to confirm this is ISP-level filtering.
+
+Reference:
+
+- Xfinity Advanced Security help: https://www.xfinity.com/support/articles/using-xfinity-xfi-advanced-security
+
 ## Decision tree
 
 ```mermaid


### PR DESCRIPTION
Fixes the broken Troubleshooting anchor in the Xfinity/Comcast SSL section and avoids a bare external URL which markdownlint flags and some renderers parse oddly.

Closes #36970.