### PR TITLE
fix(feishu): guard against undefined response.code in drive and wiki tools

### DIFF
--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -23,8 +23,8 @@ async function getRootFolderToken(client: Lark.Client): Promise<string> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accessing internal SDK property
   const res = (await (client as any).httpInstance.get(
     `${domain}/open-apis/drive/explorer/v2/root_folder/meta`,
-  )) as { code: number; msg?: string; data?: { token?: string } };
-  if (res.code !== 0) {
+  )) as { code?: number; msg?: string; data?: { token?: string } };
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg ?? "Failed to get root folder");
   }
   const token = res.data?.token;
@@ -40,7 +40,7 @@ async function listFolder(client: Lark.Client, folderToken?: string) {
   const res = await client.drive.file.list({
     params: validFolderToken ? { folder_token: validFolderToken } : {},
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -64,7 +64,7 @@ async function getFileInfo(client: Lark.Client, fileToken: string, folderToken?:
   const res = await client.drive.file.list({
     params: folderToken ? { folder_token: folderToken } : {},
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -103,7 +103,7 @@ async function createFolder(client: Lark.Client, name: string, folderToken?: str
       folder_token: effectiveToken,
     },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -129,7 +129,7 @@ async function moveFile(client: Lark.Client, fileToken: string, type: string, fo
       folder_token: folderToken,
     },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -155,7 +155,7 @@ async function deleteFile(client: Lark.Client, fileToken: string, type: string) 
         | "shortcut",
     },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -23,7 +23,7 @@ const WIKI_ACCESS_HINT =
 
 async function listSpaces(client: Lark.Client) {
   const res = await client.wiki.space.list({});
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -46,7 +46,7 @@ async function listNodes(client: Lark.Client, spaceId: string, parentNodeToken?:
     path: { space_id: spaceId },
     params: { parent_node_token: parentNodeToken },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -66,7 +66,7 @@ async function getNode(client: Lark.Client, token: string) {
   const res = await client.wiki.space.getNode({
     params: { token },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -100,7 +100,7 @@ async function createNode(
       parent_node_token: parentNodeToken,
     },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -127,7 +127,7 @@ async function moveNode(
       target_parent_token: targetParentToken,
     },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -142,7 +142,7 @@ async function renameNode(client: Lark.Client, spaceId: string, nodeToken: strin
     path: { space_id: spaceId, node_token: nodeToken },
     data: { title },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 


### PR DESCRIPTION
## Summary

Same class of bug as the messaging layer: Feishu SDK v1.30+ may return success responses without a `code` field. The existing `res.code !== 0` checks treat `undefined !== 0` as `true`, incorrectly throwing on successful responses.

Applies the `media.ts` pattern to drive and wiki tool files:
```ts
// Before:
if (res.code !== 0)

// After:
if (res.code !== undefined && res.code !== 0)
```

## Changes

- **`drive.ts`**: Fix 6 response code checks + update `getRootFolderToken` type cast from `code: number` to `code?: number`
- **`wiki.ts`**: Fix 6 response code checks

## Test plan

- [x] `npx oxlint` — 0 warnings, 0 errors
- [x] Same mechanical fix pattern already validated with tests in the messaging layer PR

lobster-biscuit