### PR TITLE
fix(telegram): avoid live dispatcher swaps during IPv4 fallback

### DIFF
--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -248,6 +248,9 @@ describe("resolveTelegramFetch", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
     expectEnvProxyAgentConstructorCall({ nth: 1, autoSelectFamily: true });
+    // Verify partial fallback: dns order + net-level autoSelectFamily still fire
+    expect(setDefaultAutoSelectFamily).toHaveBeenCalledWith(false);
+    expect(setDefaultResultOrder).toHaveBeenCalledWith("ipv4first");
   });
 
   it("retries with ipv4 fallback once per request, not once per process", async () => {

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -246,9 +246,8 @@ describe("resolveTelegramFetch", () => {
     await resolved("https://api.telegram.org/file/botx/photos/file_1.jpg");
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(setGlobalDispatcher).toHaveBeenCalledTimes(2);
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
     expectEnvProxyAgentConstructorCall({ nth: 1, autoSelectFamily: true });
-    expectEnvProxyAgentConstructorCall({ nth: 2, autoSelectFamily: false });
   });
 
   it("retries with ipv4 fallback once per request, not once per process", async () => {

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -13,6 +13,7 @@ import {
 let appliedAutoSelectFamily: boolean | null = null;
 let appliedDnsResultOrder: string | null = null;
 let appliedGlobalDispatcherAutoSelectFamily: boolean | null = null;
+let skippedGlobalDispatcherAutoSelectFamily: boolean | null = null;
 const log = createSubsystemLogger("telegram/network");
 function isProxyLikeDispatcher(dispatcher: unknown): boolean {
   const ctorName = (dispatcher as { constructor?: { name?: string } })?.constructor?.name;
@@ -51,7 +52,17 @@ const IPV4_FALLBACK_RULES: readonly Ipv4FallbackRule[] = [
 // Node 22 workaround: enable autoSelectFamily to allow IPv4 fallback on broken IPv6 networks.
 // Many networks have IPv6 configured but not routed, causing "Network is unreachable" errors.
 // See: https://github.com/nodejs/node/issues/54359
-function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void {
+
+type TelegramNetworkWorkaroundOptions = {
+  allowGlobalDispatcherUpdate?: boolean;
+};
+
+function applyTelegramNetworkWorkarounds(
+  network?: TelegramNetworkConfig,
+  options: TelegramNetworkWorkaroundOptions = {},
+): void {
+  const allowGlobalDispatcherUpdate = options.allowGlobalDispatcherUpdate !== false;
+
   // Apply autoSelectFamily workaround
   const autoSelectDecision = resolveTelegramAutoSelectFamilyDecision({ network });
   if (autoSelectDecision.value !== null && autoSelectDecision.value !== appliedAutoSelectFamily) {
@@ -78,23 +89,33 @@ function applyTelegramNetworkWorkarounds(network?: TelegramNetworkConfig): void 
     autoSelectDecision.value !== null &&
     autoSelectDecision.value !== appliedGlobalDispatcherAutoSelectFamily
   ) {
-    const existingGlobalDispatcher = getGlobalDispatcher();
-    const shouldPreserveExistingProxy =
-      isProxyLikeDispatcher(existingGlobalDispatcher) && !hasProxyEnvConfigured();
-    if (!shouldPreserveExistingProxy) {
-      try {
-        setGlobalDispatcher(
-          new EnvHttpProxyAgent({
-            connect: {
-              autoSelectFamily: autoSelectDecision.value,
-              autoSelectFamilyAttemptTimeout: 300,
-            },
-          }),
+    if (!allowGlobalDispatcherUpdate) {
+      if (skippedGlobalDispatcherAutoSelectFamily !== autoSelectDecision.value) {
+        skippedGlobalDispatcherAutoSelectFamily = autoSelectDecision.value;
+        log.warn(
+          "skip global undici dispatcher reconfigure during live IPv4 fallback; keeping existing dispatcher to avoid destabilizing active polling",
         );
-        appliedGlobalDispatcherAutoSelectFamily = autoSelectDecision.value;
-        log.info(`global undici dispatcher autoSelectFamily=${autoSelectDecision.value}`);
-      } catch {
-        // ignore if setGlobalDispatcher is unavailable
+      }
+    } else {
+      const existingGlobalDispatcher = getGlobalDispatcher();
+      const shouldPreserveExistingProxy =
+        isProxyLikeDispatcher(existingGlobalDispatcher) && !hasProxyEnvConfigured();
+      if (!shouldPreserveExistingProxy) {
+        try {
+          setGlobalDispatcher(
+            new EnvHttpProxyAgent({
+              connect: {
+                autoSelectFamily: autoSelectDecision.value,
+                autoSelectFamilyAttemptTimeout: 300,
+              },
+            }),
+          );
+          appliedGlobalDispatcherAutoSelectFamily = autoSelectDecision.value;
+          skippedGlobalDispatcherAutoSelectFamily = null;
+          log.info(`global undici dispatcher autoSelectFamily=${autoSelectDecision.value}`);
+        } catch {
+          // ignore if setGlobalDispatcher is unavailable
+        }
       }
     }
   }
@@ -166,11 +187,18 @@ function shouldRetryWithIpv4Fallback(err: unknown): boolean {
 }
 
 function applyTelegramIpv4Fallback(): void {
-  applyTelegramNetworkWorkarounds({
-    autoSelectFamily: false,
-    dnsResultOrder: "ipv4first",
-  });
-  log.warn("fetch fallback: forcing autoSelectFamily=false + dnsResultOrder=ipv4first");
+  applyTelegramNetworkWorkarounds(
+    {
+      autoSelectFamily: false,
+      dnsResultOrder: "ipv4first",
+    },
+    {
+      allowGlobalDispatcherUpdate: false,
+    },
+  );
+  log.warn(
+    "fetch fallback: forcing autoSelectFamily=false + dnsResultOrder=ipv4first without live dispatcher swap",
+  );
 }
 
 // Prefer wrapped fetch when available to normalize AbortSignal across runtimes.
@@ -205,4 +233,5 @@ export function resetTelegramFetchStateForTests(): void {
   appliedAutoSelectFamily = null;
   appliedDnsResultOrder = null;
   appliedGlobalDispatcherAutoSelectFamily = null;
+  skippedGlobalDispatcherAutoSelectFamily = null;
 }


### PR DESCRIPTION
## Summary
- guard Telegram IPv4 fallback from reconfiguring the global undici dispatcher while polling is already live
- keep startup-time dispatcher setup behavior unchanged
- keep IPv4 fallback retries, but apply fallback network defaults without a live dispatcher swap
- update Telegram fetch tests to match the safer fallback behavior

## Why
Issue #36742 reports gateway crash loops under dual-account Telegram/systemd setups shortly after polling starts. This change removes live global dispatcher swaps during fallback retries, reducing runtime destabilization risk while preserving startup configuration and retry behavior.

## Testing
- pnpm test src/telegram/fetch.test.ts
- bash /Users/newdldewdl/.openclaw/workspace/skills/openclaw-autonomous-contributor/scripts/quality_gate.sh /Users/newdldewdl/.openclaw/workspace/tmp/openclaw-issue-36742-1772763889

AI-assisted: yes.