### PR TITLE
fix(feishu): guard against undefined response.code in bitable, chat, and perm tools

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -32,7 +32,7 @@ function ensureLarkSuccess<T>(
   res: LarkResponse<T>,
   api: string,
   context?: Record<string, unknown>,
-): asserts res is LarkResponse<T> & { code: 0 } {
+): asserts res is LarkResponse<T> & { code: 0 | undefined } {
   if (res.code !== undefined && res.code !== 0) {
     throw new LarkApiError(res.code, res.msg ?? "unknown error", api, context);
   }

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -33,8 +33,8 @@ function ensureLarkSuccess<T>(
   api: string,
   context?: Record<string, unknown>,
 ): asserts res is LarkResponse<T> & { code: 0 } {
-  if (res.code !== 0) {
-    throw new LarkApiError(res.code ?? -1, res.msg ?? "unknown error", api, context);
+  if (res.code !== undefined && res.code !== 0) {
+    throw new LarkApiError(res.code, res.msg ?? "unknown error", api, context);
   }
 }
 

--- a/extensions/feishu/src/chat.ts
+++ b/extensions/feishu/src/chat.ts
@@ -14,7 +14,7 @@ function json(data: unknown) {
 
 async function getChatInfo(client: Lark.Client, chatId: string) {
   const res = await client.im.chat.get({ path: { chat_id: chatId } });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -53,7 +53,7 @@ async function getChatMembers(
     },
   });
 
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -52,7 +52,7 @@ async function listMembers(client: Lark.Client, token: string, type: string) {
     path: { token },
     params: { type: type as ListTokenType },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -84,7 +84,7 @@ async function addMember(
       perm: perm as PermType,
     },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 
@@ -105,7 +105,7 @@ async function removeMember(
     path: { token, member_id: memberId },
     params: { type: type as CreateTokenType, member_type: memberType as MemberType },
   });
-  if (res.code !== 0) {
+  if (res.code !== undefined && res.code !== 0) {
     throw new Error(res.msg);
   }
 


### PR DESCRIPTION
## Summary

Same class of bug as the messaging and drive/wiki layers: Feishu SDK v1.30+ may return success responses without a `code` field. The existing `res.code !== 0` checks treat `undefined !== 0` as `true`, incorrectly throwing on successful responses.

Applies the `media.ts` pattern:
```ts
// Before:
if (res.code !== 0)

// After:
if (res.code !== undefined && res.code !== 0)
```

## Changes

- **`bitable.ts`**: Fix `ensureLarkSuccess` assertion + remove unnecessary `?? -1` fallback
- **`chat.ts`**: Fix 2 response code checks in `getChatInfo` and `getChatMembers`
- **`perm.ts`**: Fix 3 response code checks in `listMembers`, `addMember`, `removeMember`

## Test plan

- [x] `npx oxlint` — 0 warnings, 0 errors
- [x] Same mechanical fix pattern already validated with tests in the messaging layer PR

lobster-biscuit