### PR TITLE
fix(cron): make webhook destination rejection explicit with actionable reasons

### DIFF
--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -192,7 +192,7 @@ describe("applyJobPatch", () => {
   });
 
   it("rejects webhook delivery without a valid http(s) target URL", () => {
-    const expectedError = "cron webhook delivery requires delivery.to to be a valid http(s) URL";
+    const expectedError = "cron webhook delivery rejected:";
     const cases = [
       { name: "no delivery update", patch: { enabled: true } satisfies CronJobPatch },
       {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -21,7 +21,7 @@ import type {
   CronPayload,
   CronPayloadPatch,
 } from "../types.js";
-import { normalizeHttpWebhookUrl } from "../webhook-url.js";
+import { validateHttpWebhookUrl, normalizeHttpWebhookUrl } from "../webhook-url.js";
 import {
   normalizeOptionalAgentId,
   normalizeOptionalSessionKey,
@@ -181,11 +181,13 @@ function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">)
     return;
   }
   if (job.delivery.mode === "webhook") {
-    const target = normalizeHttpWebhookUrl(job.delivery.to);
-    if (!target) {
-      throw new Error("cron webhook delivery requires delivery.to to be a valid http(s) URL");
+    const result = validateHttpWebhookUrl(job.delivery.to);
+    if (!result.ok) {
+      throw new Error(
+        `cron webhook delivery rejected: ${result.reason} (delivery.to must be a valid http(s) URL)`,
+      );
     }
-    job.delivery.to = target;
+    job.delivery.to = result.url;
     return;
   }
   if (job.sessionTarget !== "isolated") {

--- a/src/cron/webhook-url.test.ts
+++ b/src/cron/webhook-url.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { validateHttpWebhookUrl, normalizeHttpWebhookUrl } from "./webhook-url.js";
+
+describe("validateHttpWebhookUrl", () => {
+  it("accepts valid https URL", () => {
+    const r = validateHttpWebhookUrl("https://example.com/hook");
+    expect(r).toEqual({ ok: true, url: "https://example.com/hook" });
+  });
+
+  it("accepts valid http URL", () => {
+    const r = validateHttpWebhookUrl("http://localhost:3000/callback");
+    expect(r).toEqual({ ok: true, url: "http://localhost:3000/callback" });
+  });
+
+  it("rejects non-string with reason", () => {
+    const r = validateHttpWebhookUrl(42);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toContain("expected string");
+    }
+  });
+
+  it("rejects empty string with reason", () => {
+    const r = validateHttpWebhookUrl("   ");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toContain("empty URL");
+    }
+  });
+
+  it("rejects malformed URL with reason", () => {
+    const r = validateHttpWebhookUrl("not-a-url");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toContain("malformed URL");
+    }
+  });
+
+  it("rejects ftp scheme with reason", () => {
+    const r = validateHttpWebhookUrl("ftp://files.example.com/data");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toContain("blocked scheme");
+    }
+  });
+
+  it("rejects file scheme with reason", () => {
+    const r = validateHttpWebhookUrl("file:///etc/passwd");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toContain("blocked scheme");
+    }
+  });
+
+  it("rejects javascript scheme with reason", () => {
+    // eslint-disable-next-line no-script-url
+    const r = validateHttpWebhookUrl("javascript:alert(1)");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toContain("blocked scheme");
+    }
+  });
+});
+
+describe("normalizeHttpWebhookUrl (legacy compat)", () => {
+  it("returns URL string for valid input", () => {
+    expect(normalizeHttpWebhookUrl("https://example.com")).toBe("https://example.com");
+  });
+
+  it("returns null for invalid input", () => {
+    expect(normalizeHttpWebhookUrl("ftp://bad")).toBeNull();
+    expect(normalizeHttpWebhookUrl("")).toBeNull();
+    expect(normalizeHttpWebhookUrl(undefined)).toBeNull();
+  });
+});

--- a/src/cron/webhook-url.ts
+++ b/src/cron/webhook-url.ts
@@ -2,21 +2,38 @@ function isAllowedWebhookProtocol(protocol: string) {
   return protocol === "http:" || protocol === "https:";
 }
 
-export function normalizeHttpWebhookUrl(value: unknown): string | null {
+export type WebhookUrlResult = { ok: true; url: string } | { ok: false; reason: string };
+
+/**
+ * Validate and normalize a webhook destination URL.
+ * Returns a result object with an explicit rejection reason when invalid,
+ * so callers can produce actionable log messages (#36551).
+ */
+export function validateHttpWebhookUrl(value: unknown): WebhookUrlResult {
   if (typeof value !== "string") {
-    return null;
+    return { ok: false, reason: `expected string, got ${typeof value}` };
   }
   const trimmed = value.trim();
   if (!trimmed) {
-    return null;
+    return { ok: false, reason: "empty URL" };
   }
+  let parsed: URL;
   try {
-    const parsed = new URL(trimmed);
-    if (!isAllowedWebhookProtocol(parsed.protocol)) {
-      return null;
-    }
-    return trimmed;
+    parsed = new URL(trimmed);
   } catch {
-    return null;
+    return { ok: false, reason: `malformed URL: "${trimmed}"` };
   }
+  if (!isAllowedWebhookProtocol(parsed.protocol)) {
+    return {
+      ok: false,
+      reason: `blocked scheme "${parsed.protocol}" (only http: and https: allowed)`,
+    };
+  }
+  return { ok: true, url: trimmed };
+}
+
+/** @deprecated Use validateHttpWebhookUrl for explicit rejection reasons. */
+export function normalizeHttpWebhookUrl(value: unknown): string | null {
+  const result = validateHttpWebhookUrl(value);
+  return result.ok ? result.url : null;
 }


### PR DESCRIPTION
Fixes #36551

`normalizeHttpWebhookUrl` returned `null` for any invalid URL without indicating why — bad scheme, malformed URL, wrong type, or empty string all produced the same opaque error. Operators couldn't diagnose webhook delivery failures.

**Changes:**
- Add `validateHttpWebhookUrl()` returning a typed result with explicit rejection reason
- Update `assertDeliverySupport` to surface the reason in error messages
- Keep `normalizeHttpWebhookUrl` as a thin compat wrapper
- 10 new tests covering all rejection paths (scheme, format, type, empty)

**Error messages now look like:**
- `cron webhook delivery rejected: blocked scheme "ftp:" (only http: and https: allowed)`
- `cron webhook delivery rejected: malformed URL: "not-a-url"`
- `cron webhook delivery rejected: empty URL`

4 files, +109/-15. All 417 cron tests pass.

---

AI-assisted PR (Claude via OpenClaw agent). I understand what this code does.