### PR TITLE
fix(ollama): use conservative fallback num_ctx when contextWindow is missing

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -304,15 +304,17 @@ async function createOllamaTestStream(params: {
   baseUrl: string;
   defaultHeaders?: Record<string, string>;
   options?: { maxTokens?: number; signal?: AbortSignal; headers?: Record<string, string> };
+  omitModelContextWindow?: boolean;
 }) {
   const streamFn = createOllamaStreamFn(params.baseUrl, params.defaultHeaders);
+  const model = {
+    id: "qwen3:32b",
+    api: "ollama",
+    provider: "custom-ollama",
+    ...(params.omitModelContextWindow ? {} : { contextWindow: 131072 }),
+  };
   return streamFn(
-    {
-      id: "qwen3:32b",
-      api: "ollama",
-      provider: "custom-ollama",
-      contextWindow: 131072,
-    } as unknown as Parameters<typeof streamFn>[0],
+    model as unknown as Parameters<typeof streamFn>[0],
     {
       messages: [{ role: "user", content: "hello" }],
     } as unknown as Parameters<typeof streamFn>[1],
@@ -358,6 +360,32 @@ describe("createOllamaStreamFn", () => {
         };
         expect(requestBody.options.num_ctx).toBe(131072);
         expect(requestBody.options.num_predict).toBe(123);
+      },
+    );
+  });
+
+  it("uses a conservative default num_ctx when model contextWindow is missing", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const stream = await createOllamaTestStream({
+          baseUrl: "http://ollama-host:11434",
+          omitModelContextWindow: true,
+        });
+
+        const events = await collectStreamEvents(stream);
+        expect(events.at(-1)?.type).toBe("done");
+
+        if (typeof fetchMock.mock.calls[0]?.[1]?.body !== "string") {
+          throw new Error("Expected string request body");
+        }
+        const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body as string) as {
+          options: { num_ctx?: number };
+        };
+        expect(requestBody.options.num_ctx).toBe(8192);
       },
     );
   });

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -18,6 +18,7 @@ import {
 const log = createSubsystemLogger("ollama-stream");
 
 export const OLLAMA_NATIVE_BASE_URL = "http://127.0.0.1:11434";
+const OLLAMA_DEFAULT_NUM_CTX = 8192;
 
 // ── Ollama /api/chat request types ──────────────────────────────────────────
 
@@ -423,9 +424,14 @@ export function createOllamaStreamFn(
 
         const ollamaTools = extractOllamaTools(context.tools);
 
-        // Ollama defaults to num_ctx=4096 which is too small for large
-        // system prompts + many tool definitions. Use model's contextWindow.
-        const ollamaOptions: Record<string, unknown> = { num_ctx: model.contextWindow ?? 65536 };
+        // Ollama defaults to num_ctx=4096 which is often too small once tool
+        // definitions are included. Keep a conservative fallback to avoid
+        // over-allocating memory when model metadata omits contextWindow.
+        const numCtx =
+          typeof model.contextWindow === "number" && Number.isFinite(model.contextWindow)
+            ? Math.max(1, Math.floor(model.contextWindow))
+            : OLLAMA_DEFAULT_NUM_CTX;
+        const ollamaOptions: Record<string, unknown> = { num_ctx: numCtx };
         if (typeof options?.temperature === "number") {
           ollamaOptions.temperature = options.temperature;
         }


### PR DESCRIPTION
## Summary
- lower Ollama `num_ctx` fallback from `65536` to `8192` when model metadata does not provide `contextWindow`
- keep explicit `model.contextWindow` behavior unchanged
- add a focused regression test that verifies the missing-`contextWindow` path uses `8192`

## Why
On low-memory ARM CPU deployments, the previous `65536` fallback can force oversized KV cache allocation and trigger long hangs/error responses when OpenClaw calls Ollama `/api/chat`.

Fixes #33163

## Testing
- `pnpm test src/agents/ollama-stream.test.ts`
