### PR TITLE
Plugins: fix sqlite native binding resolution in jiti loader

### DIFF
--- a/src/plugins/loader.jiti-native-modules.test.ts
+++ b/src/plugins/loader.jiti-native-modules.test.ts
@@ -1,0 +1,78 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+const jitiMockState = vi.hoisted(() => ({
+  options: undefined as Record<string, unknown> | undefined,
+}));
+
+vi.mock("jiti", () => ({
+  createJiti: (_url: string, options: Record<string, unknown>) => {
+    jitiMockState.options = options;
+    return () => ({
+      default: {
+        id: "mock-plugin",
+        register() {},
+      },
+    });
+  },
+}));
+
+import { loadOpenClawPlugins } from "./loader.js";
+
+const fixtureRoot = path.join(os.tmpdir(), `openclaw-plugin-${randomUUID()}`);
+
+function createPluginFixture(pluginId: string): { dir: string; entry: string } {
+  const dir = path.join(fixtureRoot, pluginId);
+  fs.mkdirSync(dir, { recursive: true });
+  const entry = path.join(dir, "index.js");
+  fs.writeFileSync(entry, "module.exports = {};", "utf-8");
+  fs.writeFileSync(
+    path.join(dir, "openclaw.plugin.json"),
+    JSON.stringify(
+      {
+        id: pluginId,
+        configSchema: { type: "object", additionalProperties: false, properties: {} },
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+  return { dir, entry };
+}
+
+afterAll(() => {
+  try {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup failures
+  }
+});
+
+describe("loadOpenClawPlugins jiti native modules", () => {
+  it("forces sqlite native packages through node require", () => {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    const pluginId = "native-modules-probe";
+    const fixture = createPluginFixture(pluginId);
+
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: fixture.dir,
+      config: {
+        plugins: {
+          load: { paths: [fixture.entry] },
+          allow: [pluginId],
+        },
+      },
+    });
+
+    const nativeModules = jitiMockState.options?.nativeModules;
+    expect(Array.isArray(nativeModules)).toBe(true);
+    expect(nativeModules).toEqual(
+      expect.arrayContaining(["typescript", "sqlite3", "better-sqlite3", "bindings"]),
+    );
+  });
+});

--- a/src/plugins/loader.jiti-native-modules.test.ts
+++ b/src/plugins/loader.jiti-native-modules.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 
 const jitiMockState = vi.hoisted(() => ({
   options: undefined as Record<string, unknown> | undefined,
@@ -23,6 +23,7 @@ vi.mock("jiti", () => ({
 import { loadOpenClawPlugins } from "./loader.js";
 
 const fixtureRoot = path.join(os.tmpdir(), `openclaw-plugin-${randomUUID()}`);
+const prevBundledDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
 
 function createPluginFixture(pluginId: string): { dir: string; entry: string } {
   const dir = path.join(fixtureRoot, pluginId);
@@ -50,6 +51,14 @@ afterAll(() => {
   } catch {
     // ignore cleanup failures
   }
+});
+
+afterEach(() => {
+  if (prevBundledDir === undefined) {
+    delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+    return;
+  }
+  process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = prevBundledDir;
 });
 
 describe("loadOpenClawPlugins jiti native modules", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1163,6 +1163,86 @@ describe("loadOpenClawPlugins", () => {
     );
   });
 
+  it("loads sqlite3 via native module resolution path", () => {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    const pluginDir = makeTempDir();
+    const pluginId = "sqlite-native-resolution-check";
+    const entry = path.join(pluginDir, "index.js");
+    const nodeModulesDir = path.join(pluginDir, "node_modules");
+    const sqliteDir = path.join(nodeModulesDir, "sqlite3");
+    const bindingsDir = path.join(nodeModulesDir, "bindings");
+    fs.mkdirSync(sqliteDir, { recursive: true });
+    fs.mkdirSync(bindingsDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: pluginId,
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(bindingsDir, "index.js"),
+      `
+const path = require("node:path");
+module.exports = function resolveBinding(name) {
+  const caller = module.parent && module.parent.filename ? module.parent.filename : "";
+  return path.join(path.dirname(caller), "build", "Release", name);
+};
+      `.trim(),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(sqliteDir, "index.js"),
+      `
+const path = require("node:path");
+const bindingPath = require("bindings")("node_sqlite3.node");
+const expectedSuffix = path.join("sqlite3", "build", "Release", "node_sqlite3.node");
+if (!bindingPath.endsWith(expectedSuffix)) {
+  throw new Error("sqlite binding resolved from unexpected base: " + bindingPath);
+}
+module.exports = { bindingPath };
+      `.trim(),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      entry,
+      `
+const sqlite3 = require("sqlite3");
+module.exports = {
+  id: "${pluginId}",
+  register(api) {
+    api.registerGatewayMethod("${pluginId}.ping", ({ respond }) =>
+      respond(true, { ok: true, bindingPath: sqlite3.bindingPath }),
+    );
+  },
+};
+      `.trim(),
+      "utf-8",
+    );
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: pluginDir,
+      config: {
+        plugins: {
+          load: { paths: [entry] },
+          allow: [pluginId],
+        },
+      },
+    });
+
+    const plugin = registry.plugins.find((item) => item.id === pluginId);
+    expect(plugin?.status).toBe("loaded");
+    expect(plugin?.error).toBeUndefined();
+    expect(registry.gatewayHandlers[`${pluginId}.ping`]).toBeDefined();
+  });
+
   it("preserves runtime reflection semantics when runtime is lazily initialized", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -45,6 +45,7 @@ export type PluginLoadOptions = {
 const registryCache = new Map<string, PluginRegistry>();
 
 const defaultLogger = () => createSubsystemLogger("plugins");
+const jitiNativeModules = ["typescript", "sqlite3", "better-sqlite3", "bindings"] as const;
 
 const resolvePluginSdkAliasFile = (params: {
   srcFile: string;
@@ -574,6 +575,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     };
     jitiLoader = createJiti(import.meta.url, {
       interopDefault: true,
+      // Keep native modules on Node's require path so packages like sqlite3 resolve
+      // binary bindings relative to their own install location, not jiti internals.
+      nativeModules: [...jitiNativeModules],
       extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
       ...(Object.keys(aliasMap).length > 0
         ? {


### PR DESCRIPTION
## Summary

- Problem: Plugin loading through jiti could resolve sqlite native bindings from the wrong base path, causing sqlite-backed memory plugins (including Mem0 OSS) to fail with `Could not locate the bindings file`.
- Why it matters: This is a regression in 2026.3.x that breaks memory capture/recall for affected plugin setups.
- What changed: Added sqlite-related packages to jiti `nativeModules` in the plugin loader, and added regression tests for both loader configuration and loader-path sqlite binding resolution behavior.
- What did NOT change (scope boundary): No change to plugin discovery, allow/deny policy, slot selection, memory business logic, or CLI behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36377
- Related #31677

## User-visible / Behavior Changes

- sqlite-backed plugin memory flows no longer fail due to jiti resolving sqlite native bindings from jiti internals.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (dev), issue report on Ubuntu 24.04
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Plugin loader / memory plugins
- Relevant config (redacted): `plugins.load.paths`, `plugins.allow`, memory plugin slot defaults

### Steps

1. Configure a plugin loaded through `loadOpenClawPlugins` that requires sqlite via `bindings` lookup.
2. Load plugin registry through loader.
3. Verify plugin load succeeds and sqlite binding path resolves from sqlite package path.

### Expected

- Plugin loads successfully and sqlite binding resolution is rooted under sqlite package location.

### Actual

- Confirmed by tests after change.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Targeted tests: `pnpm test -- src/plugins/loader.test.ts src/plugins/loader.jiti-native-modules.test.ts`
  - Build: `pnpm build`
- Edge cases checked:
  - jiti native module list includes `typescript` default + sqlite stack (`sqlite3`, `better-sqlite3`, `bindings`)
  - Loader path still handles plugin registration and gateway method wiring unchanged

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `3b4036cfd`
- Files/config to restore:
  - `src/plugins/loader.ts`
  - `src/plugins/loader.test.ts`
  - `src/plugins/loader.jiti-native-modules.test.ts`
- Known bad symptoms reviewers should watch for:
  - Plugin loader errors mentioning sqlite native binding lookup paths under jiti directories.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Environment-specific native module behavior differences across package managers.
  - Mitigation: Added both config-level and loader-path behavior regression tests and preserved jiti default native module handling.
