### PR TITLE
fix(auto-reply): normalize followup queue keys with trim() for consistency

### DIFF
--- a/src/auto-reply/reply/queue/state.test.ts
+++ b/src/auto-reply/reply/queue/state.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearFollowupQueue,
+  FOLLOWUP_QUEUES,
+  getExistingFollowupQueue,
+  getFollowupQueue,
+} from "./state.js";
+
+const DEFAULT_SETTINGS = {
+  mode: "queue" as const,
+};
+
+afterEach(() => {
+  FOLLOWUP_QUEUES.clear();
+});
+
+describe("followup queue key normalization", () => {
+  it("trims whitespace from keys when creating a queue", () => {
+    const queue = getFollowupQueue("  session1  ", DEFAULT_SETTINGS);
+    expect(queue).toBeDefined();
+    expect(FOLLOWUP_QUEUES.has("session1")).toBe(true);
+    expect(FOLLOWUP_QUEUES.has("  session1  ")).toBe(false);
+  });
+
+  it("finds a queue created with whitespace via getExistingFollowupQueue", () => {
+    getFollowupQueue("  session2  ", DEFAULT_SETTINGS);
+    const found = getExistingFollowupQueue("session2");
+    expect(found).toBeDefined();
+  });
+
+  it("clears a queue created with whitespace via clearFollowupQueue", () => {
+    const queue = getFollowupQueue("  session3  ", DEFAULT_SETTINGS);
+    queue.items.push({} as never);
+    const cleared = clearFollowupQueue("session3");
+    expect(cleared).toBe(1);
+    expect(FOLLOWUP_QUEUES.has("session3")).toBe(false);
+  });
+
+  it("returns the same queue for trimmed and untrimmed keys", () => {
+    const q1 = getFollowupQueue("key", DEFAULT_SETTINGS);
+    const q2 = getFollowupQueue("  key  ", DEFAULT_SETTINGS);
+    expect(q1).toBe(q2);
+  });
+
+  it("returns undefined for empty/whitespace-only keys", () => {
+    expect(getExistingFollowupQueue("")).toBeUndefined();
+    expect(getExistingFollowupQueue("   ")).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/queue/state.ts
+++ b/src/auto-reply/reply/queue/state.ts
@@ -29,7 +29,8 @@ export function getExistingFollowupQueue(key: string): FollowupQueueState | unde
 }
 
 export function getFollowupQueue(key: string, settings: QueueSettings): FollowupQueueState {
-  const existing = FOLLOWUP_QUEUES.get(key);
+  const cleaned = key.trim();
+  const existing = FOLLOWUP_QUEUES.get(cleaned);
   if (existing) {
     applyQueueRuntimeSettings({
       target: existing,
@@ -59,7 +60,7 @@ export function getFollowupQueue(key: string, settings: QueueSettings): Followup
     target: created,
     settings,
   });
-  FOLLOWUP_QUEUES.set(key, created);
+  FOLLOWUP_QUEUES.set(cleaned, created);
   return created;
 }
 


### PR DESCRIPTION
## Summary

`getExistingFollowupQueue` and `clearFollowupQueue` both call `key.trim()` before looking up queues in the internal `Map`, but `getFollowupQueue` uses the raw (untrimmed) key for both `Map.get()` and `Map.set()`. This inconsistency means a queue created with a whitespace-padded key (e.g. `" session1 "`) is stored under that untrimmed key, but subsequent lookups and clears — which trim to `"session1"` — never find it.

**Impact:** Queued followup items accumulate without being drained or cleaned up when the key has surrounding whitespace, causing memory leaks and missed followup deliveries.

## Change type

Bug fix — normalize the `key` parameter in `getFollowupQueue` by adding `key.trim()`, matching the behavior of the other two public functions.

## Changes

- **`src/auto-reply/reply/queue/state.ts`** — Add `const cleaned = key.trim()` in `getFollowupQueue` and use `cleaned` for both `Map.get()` and `Map.set()`
- **`src/auto-reply/reply/queue/state.test.ts`** — New test file with 5 cases covering key normalization consistency, cross-function lookup/clear, and empty-key edge cases

## How to reproduce

```ts
import { getFollowupQueue, getExistingFollowupQueue, clearFollowupQueue } from "./state.js";

// Before fix: queue stored under "  key  ", lookups use "key" → miss
const q = getFollowupQueue("  key  ", { mode: "queue" });
getExistingFollowupQueue("key");   // undefined (bug)
clearFollowupQueue("key");          // 0, queue not cleared (bug)

// After fix: all three functions normalize to "key"
```

## Test plan

- [x] All 5 new unit tests pass (`npx vitest run src/auto-reply/reply/queue/state.test.ts`)
- [x] Existing test suite unaffected
- [x] Linter passes with 0 warnings

## Security

No security impact. This is a key-normalization consistency fix.

## Compatibility

Fully backward-compatible. Keys that were already trimmed behave identically. Only whitespace-padded keys are now correctly normalized.


Made with [Cursor](https://cursor.com)