### PR TITLE
[Issue #37022] [Feature]: Add recursion_limit to prevent infinite agent loops

### DIFF
--- a/automation/issue-tracker/issue-37022.md
+++ b/automation/issue-tracker/issue-37022.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37022
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37022
+- Title: [Feature]: Add recursion_limit to prevent infinite agent loops
+- Created at: 2026-03-06T02:12:06Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37022
- URL: https://github.com/openclaw/openclaw/issues/37022

## Original Issue Description
Add a configurable `recursion_limit` (or `max_steps`) parameter to limit the number of reasoning/tool execution cycles in a single agent run, preventing infinite loops, excess token usage, latency, and cost.

For full original details, see the source issue body at the link above.

Relates to #37022