### PR TITLE
[Issue #37024] Subagent announce race condition: kill + completion race silently swallows results

### DIFF
--- a/automation/issue-tracker/issue-37024.md
+++ b/automation/issue-tracker/issue-37024.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37024
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37024
+- Title: Subagent announce race condition: kill + completion race silently swallows results
+- Created at: 2026-03-06T02:13:41Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37024
- URL: https://github.com/openclaw/openclaw/issues/37024

## Original Issue Description
The issue reports two compounding problems: (1) a race between kill and completion in subagent announce flow that can permanently suppress completion announcements, and (2) content truncation limits that cut off long announce payloads.

For full original details, see the source issue body at the link above.

Relates to #37024