### PR TITLE
[Issue #37027] Bug: session-memory hook not triggered on session archive/delete

### DIFF
--- a/automation/issue-tracker/issue-37027.md
+++ b/automation/issue-tracker/issue-37027.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37027
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37027
+- Title: Bug: session-memory hook not triggered on session archive/delete
+- Created at: 2026-03-06T02:15:23Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37027
- URL: https://github.com/openclaw/openclaw/issues/37027

## Original Issue Description
The issue states that session-memory hooks trigger for `/new` and `/reset` but not for archive/delete paths, causing memory loss across non-TUI channels when sessions are rotated.

For full original details, see the source issue body at the link above.

Relates to #37027