### PR TITLE
[Issue #37028] [Bug] Feishu plugin duplicate registration causes Gateway crash

### DIFF
--- a/automation/issue-tracker/issue-37028.md
+++ b/automation/issue-tracker/issue-37028.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37028
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37028
+- Title: [Bug] Feishu plugin duplicate registration causes Gateway crash
+- Created at: 2026-03-06T02:19:33Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37028
- URL: https://github.com/openclaw/openclaw/issues/37028

## Original Issue Description
The issue reports duplicate Feishu plugin registration warnings and gateway instability/crashes when channel configuration is modified, likely due to plugin loading conflicts.

For full original details, see the source issue body at the link above.

Relates to #37028