### PR TITLE
fix(tts): enable Matrix voice-bubble output for auto TTS replies

### DIFF
--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -162,7 +162,7 @@ describe("tts", () => {
   });
 
   describe("resolveOutputFormat", () => {
-    it("selects opus for voice-bubble channels (telegram/feishu/whatsapp) and mp3 for others", () => {
+    it("selects opus for voice-bubble channels (telegram/feishu/whatsapp/matrix) and mp3 for others", () => {
       const cases = [
         {
           channel: "telegram",
@@ -184,6 +184,15 @@ describe("tts", () => {
         },
         {
           channel: "whatsapp",
+          expected: {
+            openai: "opus",
+            elevenlabs: "opus_48000_64",
+            extension: ".opus",
+            voiceCompatible: true,
+          },
+        },
+        {
+          channel: "matrix",
           expected: {
             openai: "opus",
             elevenlabs: "opus_48000_64",

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -496,7 +496,7 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
 }
 
 /** Channels that require opus audio and support voice-bubble playback */
-const VOICE_BUBBLE_CHANNELS = new Set(["telegram", "feishu", "whatsapp"]);
+const VOICE_BUBBLE_CHANNELS = new Set(["telegram", "feishu", "whatsapp", "matrix"]);
 
 function resolveOutputFormat(channelId?: string | null) {
   if (channelId && VOICE_BUBBLE_CHANNELS.has(channelId)) {


### PR DESCRIPTION
## Summary

- Problem: Matrix channel was missing from `VOICE_BUBBLE_CHANNELS` in `src/tts/tts.ts`, so auto TTS replies defaulted to MP3 and `voiceCompatible=false`.
- Why it matters: Matrix supports MSC3245 voice messages, but replies were sent as generic file attachments instead of native voice bubbles.
- What changed: Added `"matrix"` to `VOICE_BUBBLE_CHANNELS` and extended `resolveOutputFormat` regression test coverage to include Matrix.
- What did NOT change (scope boundary): No changes to Matrix send adapter logic, message tool routing, or non-TTS channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37061
- Related #14225
- Related #32489

## User-visible / Behavior Changes

- Matrix TTS auto-replies now use Opus output and are marked voice-compatible, enabling native voice-bubble playback where supported.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (dev), Matrix behavior validated via unit-level output-format logic
- Runtime/container: Node + Vitest
- Model/provider: N/A (format selection logic)
- Integration/channel (if any): Matrix / Telegram / Feishu / WhatsApp mapping path
- Relevant config (redacted): `messages.tts.auto: inbound`

### Steps

1. In pre-fix code path, call `resolveOutputFormat("matrix")`.
2. Observe output format and `voiceCompatible` flag.
3. Apply fix and re-run `src/tts/tts.test.ts`.

### Expected

- Matrix resolves to Opus output with `voiceCompatible: true`.

### Actual

- Verified after fix: Matrix case now resolves to `{ openai: "opus", elevenlabs: "opus_48000_64", extension: ".opus", voiceCompatible: true }`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Command run:

- `pnpm -s test src/tts/tts.test.ts` → passed (28 tests)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Confirmed `VOICE_BUBBLE_CHANNELS` now includes `matrix`.
  - Confirmed `resolveOutputFormat` test matrix includes a Matrix case and passes.
- Edge cases checked:
  - Existing voice-bubble channels (telegram/feishu/whatsapp) still map to Opus.
  - Non-voice-bubble channel (discord) still maps to MP3 with `voiceCompatible: false`.
- What you did **not** verify:
  - End-to-end Matrix client playback UX in a live homeserver session.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit to remove `matrix` from `VOICE_BUBBLE_CHANNELS`.
- Files/config to restore:
  - `src/tts/tts.ts`
  - `src/tts/tts.test.ts`
- Known bad symptoms reviewers should watch for:
  - Matrix TTS attachments failing to play if a downstream environment unexpectedly rejects Opus metadata.

## Risks and Mitigations

- Risk: Some Matrix deployments/clients may handle voice metadata inconsistently.
  - Mitigation: Change is narrowly scoped to format selection; existing Matrix sender path already supports `audioAsVoice` metadata. Regression test locks expected mapping.
