### PR TITLE
[Issue #37036] [Bug]: In Windows, when opening the OpenClaw dashboard, it shows "Not Found".

### DIFF
--- a/automation/issue-tracker/issue-37036.md
+++ b/automation/issue-tracker/issue-37036.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37036
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37036
+- Title: [Bug]: In Windows, when opening the OpenClaw dashboard, it shows "Not Found".
+- Created at: 2026-03-06T02:34:20Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37036
- URL: https://github.com/openclaw/openclaw/issues/37036

## Original Issue Description
On Windows 10/11, after onboarding and starting gateway, running `openclaw dashboard` shows a "Not Found" page instead of the expected dashboard content.

For full original details, see the source issue body at the link above.

Relates to #37036