### PR TITLE
[Issue #37040] [Bug]: OpenClaw Bot with No Visible Reply

### DIFF
--- a/automation/issue-tracker/issue-37040.md
+++ b/automation/issue-tracker/issue-37040.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37040
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37040
+- Title: [Bug]: OpenClaw Bot with No Visible Reply
+- Created at: 2026-03-06T02:40:25Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37040
- URL: https://github.com/openclaw/openclaw/issues/37040

## Original Issue Description
The issue reports inbound messages being processed with agent runs marked `status: ok`, but no visible replies are produced (`payloads: []`, empty assistant content, repeated "No reply from agent" logs).

For full original details, see the source issue body at the link above.

Relates to #37040