### PR TITLE
[Issue #37047] Discord thread starter metadata injects changing timestamp, busting prompt cache on every turn

### DIFF
--- a/automation/issue-tracker/issue-37047.md
+++ b/automation/issue-tracker/issue-37047.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37047
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37047
+- Title: Discord thread starter metadata injects changing timestamp, busting prompt cache on every turn
+- Created at: 2026-03-06T02:48:33Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37047
- URL: https://github.com/openclaw/openclaw/issues/37047

## Original Issue Description
The issue reports Discord thread starter metadata injection including changing timestamp fields each turn, which invalidates prompt caching and significantly increases token usage/cost in long threads.

For full original details, see the source issue body at the link above.

Relates to #37047