### PR TITLE
[Issue #37048] [Bug]: [Bug] v2026.3.2 sends parallel_tool_calls to models that don't support it (breaks all tools)

### DIFF
--- a/automation/issue-tracker/issue-37048.md
+++ b/automation/issue-tracker/issue-37048.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37048
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37048
+- Title: [Bug]: [Bug] v2026.3.2 sends parallel_tool_calls to models that don't support it (breaks all tools)
+- Created at: 2026-03-06T02:51:48Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37048
- URL: https://github.com/openclaw/openclaw/issues/37048

## Original Issue Description
The issue reports v2026.3.2 sending `parallel_tool_calls: true` to providers/models that only support single tool calls, causing 400 errors and effectively breaking tool execution.

For full original details, see the source issue body at the link above.

Relates to #37048