### PR TITLE
[Issue #37052] WebChat messages don't override lastChannel, causing replies to go to iMessage

### DIFF
--- a/automation/issue-tracker/issue-37052.md
+++ b/automation/issue-tracker/issue-37052.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37052
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37052
+- Title: WebChat messages don't override lastChannel, causing replies to go to iMessage
+- Created at: 2026-03-06T02:53:50Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37052
- URL: https://github.com/openclaw/openclaw/issues/37052

## Original Issue Description
The issue reports WebChat-originated messages not overriding session `lastChannel`, so delivery context remains on iMessage and replies are routed to the wrong channel.

For full original details, see the source issue body at the link above.

Relates to #37052