### PR TITLE
[Issue #37056] [Feature]: Add retry configuration for embedded agent (subagent) announce operations

### DIFF
--- a/automation/issue-tracker/issue-37056.md
+++ b/automation/issue-tracker/issue-37056.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37056
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37056
+- Title: [Feature]: Add retry configuration for embedded agent (subagent) announce operations
+- Created at: 2026-03-06T02:55:43Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37056
- URL: https://github.com/openclaw/openclaw/issues/37056

## Original Issue Description
The issue proposes retry/timeout configuration for embedded subagent announce operations to handle network timeouts/transient gateway errors and reduce dropped completion announcements.

For full original details, see the source issue body at the link above.

Relates to #37056