### PR TITLE
[Issue #37057] feat: RTK exec proxy — compress tool output to save context tokens

### DIFF
--- a/automation/issue-tracker/issue-37057.md
+++ b/automation/issue-tracker/issue-37057.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37057
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37057
+- Title: feat: RTK exec proxy — compress tool output to save context tokens
+- Created at: 2026-03-06T02:56:22Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37057
- URL: https://github.com/openclaw/openclaw/issues/37057

## Original Issue Description
The issue proposes optional RTK-based exec output compression to reduce context usage and costs by rewriting selected command outputs before they enter agent context.

For full original details, see the source issue body at the link above.

Relates to #37057