### PR TITLE
[Issue #37058] [Bug] Group chat mention-triggered context injection can miss pre-mention messages

### DIFF
--- a/automation/issue-tracker/issue-37058.md
+++ b/automation/issue-tracker/issue-37058.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37058
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37058
+- Title: [Bug] Group chat mention-triggered context injection can miss pre-mention messages
+- Created at: 2026-03-06T02:57:43Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37058
- URL: https://github.com/openclaw/openclaw/issues/37058

## Original Issue Description
The issue reports incomplete pre-mention history injection in mention-gated group chats, leading to partial context and inconsistent responses when the bot is mentioned.

For full original details, see the source issue body at the link above.

Relates to #37058