### PR TITLE
[Issue #37061] Matrix TTS replies not sent as voice bubbles — missing from VOICE_BUBBLE_CHANNELS

### DIFF
--- a/automation/issue-tracker/issue-37061.md
+++ b/automation/issue-tracker/issue-37061.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37061
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37061
+- Title: Matrix TTS replies not sent as voice bubbles — missing from VOICE_BUBBLE_CHANNELS
+- Created at: 2026-03-06T02:58:37Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37061
- URL: https://github.com/openclaw/openclaw/issues/37061

## Original Issue Description
The issue reports Matrix TTS auto-replies being sent as generic audio attachments (not MSC3245 voice bubbles) because Matrix is missing from `VOICE_BUBBLE_CHANNELS`, causing non-voice-compatible output selection.

For full original details, see the source issue body at the link above.

Relates to #37061