### PR TITLE
fix(discord): wrap reaction REST calls with retry runner for consistency

### DIFF
--- a/src/discord/send.reactions.test.ts
+++ b/src/discord/send.reactions.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => ({
+    channels: {
+      discord: {
+        accounts: {
+          default: { config: { token: "test-token", retry: { attempts: 2 } } },
+        },
+      },
+    },
+  }),
+}));
+
+vi.mock("./accounts.js", () => ({
+  resolveDiscordAccount: () => ({
+    token: "test-token",
+    config: { token: "test-token", retry: { attempts: 2 } },
+  }),
+}));
+
+vi.mock("./token.js", () => ({
+  normalizeDiscordToken: (t: string | undefined) => t ?? "test-token",
+}));
+
+type MockRest = {
+  put: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+};
+
+let mockRest: MockRest;
+
+vi.mock("./client.js", () => ({
+  createDiscordClient: () => {
+    const request = async <T>(fn: () => Promise<T>) => fn();
+    return { token: "test-token", rest: mockRest, request };
+  },
+}));
+
+import {
+  reactMessageDiscord,
+  removeReactionDiscord,
+  removeOwnReactionsDiscord,
+  fetchReactionsDiscord,
+} from "./send.reactions.js";
+
+describe("Discord reaction functions use retry runner", () => {
+  beforeEach(() => {
+    mockRest = {
+      put: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      get: vi.fn().mockResolvedValue({}),
+    };
+  });
+
+  it("reactMessageDiscord calls rest.put via request()", async () => {
+    const result = await reactMessageDiscord("ch1", "msg1", "👍");
+    expect(result).toEqual({ ok: true });
+    expect(mockRest.put).toHaveBeenCalledTimes(1);
+  });
+
+  it("removeReactionDiscord calls rest.delete via request()", async () => {
+    const result = await removeReactionDiscord("ch1", "msg1", "👍");
+    expect(result).toEqual({ ok: true });
+    expect(mockRest.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it("removeOwnReactionsDiscord wraps rest.get and rest.delete via request()", async () => {
+    mockRest.get.mockResolvedValue({
+      reactions: [{ emoji: { id: null, name: "👍" } }],
+    });
+    mockRest.delete.mockResolvedValue(undefined);
+
+    const result = await removeOwnReactionsDiscord("ch1", "msg1");
+    expect(result.ok).toBe(true);
+    expect(result.removed.length).toBe(1);
+    expect(mockRest.get).toHaveBeenCalledTimes(1);
+    expect(mockRest.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it("removeOwnReactionsDiscord returns empty when no reactions", async () => {
+    mockRest.get.mockResolvedValue({ reactions: [] });
+    const result = await removeOwnReactionsDiscord("ch1", "msg1");
+    expect(result).toEqual({ ok: true, removed: [] });
+    expect(mockRest.delete).not.toHaveBeenCalled();
+  });
+
+  it("fetchReactionsDiscord wraps rest.get calls via request()", async () => {
+    mockRest.get
+      .mockResolvedValueOnce({
+        reactions: [{ count: 2, emoji: { id: null, name: "🔥" } }],
+      })
+      .mockResolvedValueOnce([
+        { id: "u1", username: "alice" },
+        { id: "u2", username: "bob", discriminator: "0001" },
+      ]);
+
+    const summaries = await fetchReactionsDiscord("ch1", "msg1");
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].count).toBe(2);
+    expect(summaries[0].users).toHaveLength(2);
+    expect(summaries[0].users[1].tag).toBe("bob#0001");
+    expect(mockRest.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("fetchReactionsDiscord returns empty when no reactions", async () => {
+    mockRest.get.mockResolvedValue({ reactions: [] });
+    const summaries = await fetchReactionsDiscord("ch1", "msg1");
+    expect(summaries).toEqual([]);
+  });
+});

--- a/src/discord/send.reactions.ts
+++ b/src/discord/send.reactions.ts
@@ -31,9 +31,12 @@ export async function removeReactionDiscord(
   opts: DiscordReactOpts = {},
 ) {
   const cfg = opts.cfg ?? loadConfig();
-  const { rest } = createDiscordClient(opts, cfg);
+  const { rest, request } = createDiscordClient(opts, cfg);
   const encoded = normalizeReactionEmoji(emoji);
-  await rest.delete(Routes.channelMessageOwnReaction(channelId, messageId, encoded));
+  await request(
+    () => rest.delete(Routes.channelMessageOwnReaction(channelId, messageId, encoded)),
+    "unreact",
+  );
   return { ok: true };
 }
 
@@ -43,8 +46,11 @@ export async function removeOwnReactionsDiscord(
   opts: DiscordReactOpts = {},
 ): Promise<{ ok: true; removed: string[] }> {
   const cfg = opts.cfg ?? loadConfig();
-  const { rest } = createDiscordClient(opts, cfg);
-  const message = (await rest.get(Routes.channelMessage(channelId, messageId))) as {
+  const { rest, request } = createDiscordClient(opts, cfg);
+  const message = (await request(
+    () => rest.get(Routes.channelMessage(channelId, messageId)),
+    "fetchMessage",
+  )) as {
     reactions?: Array<{ emoji: { id?: string | null; name?: string | null } }>;
   };
   const identifiers = new Set<string>();
@@ -61,8 +67,16 @@ export async function removeOwnReactionsDiscord(
   await Promise.allSettled(
     Array.from(identifiers, (identifier) => {
       removed.push(identifier);
-      return rest.delete(
-        Routes.channelMessageOwnReaction(channelId, messageId, normalizeReactionEmoji(identifier)),
+      return request(
+        () =>
+          rest.delete(
+            Routes.channelMessageOwnReaction(
+              channelId,
+              messageId,
+              normalizeReactionEmoji(identifier),
+            ),
+          ),
+        "unreact",
       );
     }),
   );
@@ -75,8 +89,11 @@ export async function fetchReactionsDiscord(
   opts: DiscordReactOpts & { limit?: number } = {},
 ): Promise<DiscordReactionSummary[]> {
   const cfg = opts.cfg ?? loadConfig();
-  const { rest } = createDiscordClient(opts, cfg);
-  const message = (await rest.get(Routes.channelMessage(channelId, messageId))) as {
+  const { rest, request } = createDiscordClient(opts, cfg);
+  const message = (await request(
+    () => rest.get(Routes.channelMessage(channelId, messageId)),
+    "fetchMessage",
+  )) as {
     reactions?: Array<{
       count: number;
       emoji: { id?: string | null; name?: string | null };
@@ -98,9 +115,13 @@ export async function fetchReactionsDiscord(
       continue;
     }
     const encoded = encodeURIComponent(identifier);
-    const users = (await rest.get(Routes.channelMessageReaction(channelId, messageId, encoded), {
-      limit,
-    })) as Array<{ id: string; username?: string; discriminator?: string }>;
+    const users = (await request(
+      () =>
+        rest.get(Routes.channelMessageReaction(channelId, messageId, encoded), {
+          limit,
+        }),
+      "fetchReactionUsers",
+    )) as Array<{ id: string; username?: string; discriminator?: string }>;
     summaries.push({
       emoji: {
         id: reaction.emoji.id ?? null,


### PR DESCRIPTION
## Summary

`reactMessageDiscord` correctly uses the `request()` retry runner returned by `createDiscordClient`, but the other three reaction functions — `removeReactionDiscord`, `removeOwnReactionsDiscord`, and `fetchReactionsDiscord` — call `rest.delete()` / `rest.get()` directly, bypassing the retry logic for transient errors and Discord API rate limits (HTTP 429).

**Impact:** Reaction removal and fetching fail on the first transient error instead of being retried, causing inconsistent behavior compared to adding reactions which retries correctly.

## Change type

Bug fix — wrap all Discord REST calls in the reaction module with the `request()` retry runner for consistency with the existing `reactMessageDiscord` pattern.

## Changes

- **`src/discord/send.reactions.ts`**
  - `removeReactionDiscord`: destructure `request` from `createDiscordClient`; wrap `rest.delete` with `request()`
  - `removeOwnReactionsDiscord`: destructure `request`; wrap the initial `rest.get` (fetch message) and each `rest.delete` (remove reaction) with `request()`
  - `fetchReactionsDiscord`: destructure `request`; wrap both `rest.get` calls (fetch message + fetch reaction users) with `request()`

- **`src/discord/send.reactions.test.ts`** — New test file with 6 test cases covering all four reaction functions

## How to reproduce

```ts
// Before fix: removeReactionDiscord bypasses retry
const { rest } = createDiscordClient(opts, cfg);
await rest.delete(...); // 429 → immediate failure, no retry

// After fix: uses request() for retry
const { rest, request } = createDiscordClient(opts, cfg);
await request(() => rest.delete(...), "unreact"); // 429 → retried
```

## Test plan

- [x] All 6 new unit tests pass
- [x] Existing test suite unaffected
- [x] Linter passes with 0 warnings

## Security

No security impact. This change only adds retry wrapping around existing REST calls.

## Compatibility

Fully backward-compatible. The retry runner is already created by `createDiscordClient` but was not being used by these functions.


Made with [Cursor](https://cursor.com)