### PR TITLE
fix(matrix): resolve plugin-sdk keyed queue import path regression

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 

--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,4 +1,4 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/matrix";
 
 export const DEFAULT_SEND_GAP_MS = 150;
 

--- a/src/plugin-sdk/matrix.ts
+++ b/src/plugin-sdk/matrix.ts
@@ -89,6 +89,8 @@ export {
 } from "../security/dm-policy-shared.js";
 export { formatDocsLink } from "../terminal/links.js";
 export type { WizardPrompter } from "../wizard/prompts.js";
+export type { KeyedAsyncQueueHooks } from "../plugin-sdk/keyed-async-queue.js";
+export { enqueueKeyedTask, KeyedAsyncQueue } from "../plugin-sdk/keyed-async-queue.js";
 export { createScopedPairingAccess } from "./pairing-access.js";
 export { formatResolvedUnresolvedNote } from "./resolution-notes.js";
 export { runPluginCommandWithTimeout } from "./run-command.js";


### PR DESCRIPTION
## Summary
- switch Matrix send queue to import `KeyedAsyncQueue` from `openclaw/plugin-sdk`
- avoid runtime resolution of removed subpath `openclaw/plugin-sdk/keyed-async-queue`

## Testing
- pnpm -s vitest run extensions/matrix/src/matrix/send-queue.test.ts

Fixes #37026
