### PR TITLE
test: stabilize memory/media/respawn tests under guarded network

### DIFF
--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -69,6 +69,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("returns supervised when launchd/systemd hints are present", () => {
     process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
+    triggerOpenClawRestartMock.mockReturnValue({ ok: true, method: "launchctl" });
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");
     expect(spawnMock).not.toHaveBeenCalled();

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -69,6 +69,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("returns supervised when launchd/systemd hints are present", () => {
     process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
+    delete process.env.OPENCLAW_LAUNCHD_LABEL;
     triggerOpenClawRestartMock.mockReturnValue({ ok: true, method: "launchctl" });
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");

--- a/src/media/store.redirect.test.ts
+++ b/src/media/store.redirect.test.ts
@@ -90,7 +90,7 @@ describe("media store redirects", () => {
     expect(path.extname(saved.path)).toBe(".txt");
     expect(await fs.readFile(saved.path, "utf8")).toBe("redirected");
     const stat = await fs.stat(saved.path);
-    const expectedMode = process.platform === "win32" ? 0o666 : 0o644;
+    const expectedMode = process.platform === "win32" ? 0o666 : 0o644 & ~process.umask();
     expect(stat.mode & 0o777).toBe(expectedMode);
   });
 

--- a/src/memory/batch-voyage.test.ts
+++ b/src/memory/batch-voyage.test.ts
@@ -25,6 +25,10 @@ describe("runVoyageEmbeddingBatches", () => {
     baseUrl: "https://api.voyageai.com/v1",
     headers: { Authorization: "Bearer test-key" },
     model: "voyage-4-large",
+    ssrfPolicy: {
+      allowedHostnames: ["api.voyageai.com"],
+      dangerouslyAllowPrivateNetwork: true,
+    },
   };
 
   const mockRequests: VoyageBatchRequest[] = [

--- a/src/memory/test-embeddings-mock.ts
+++ b/src/memory/test-embeddings-mock.ts
@@ -14,6 +14,13 @@ export function createOpenAIEmbeddingProviderMock(params: {
       baseUrl: "https://api.openai.com/v1",
       headers: { Authorization: "Bearer test", "Content-Type": "application/json" },
       model: "text-embedding-3-small",
+      // Tests stub global fetch and do not hit the network. In CI/dev sandboxes
+      // DNS can resolve public hosts to special-use ranges, which trips SSRF guard.
+      // Allow private-network resolution for this test helper so mocked fetch can run.
+      ssrfPolicy: {
+        allowedHostnames: ["api.openai.com"],
+        dangerouslyAllowPrivateNetwork: true,
+      },
     },
   };
 }


### PR DESCRIPTION
## Summary
This PR stabilizes a small set of flaky/host-sensitive tests encountered during local contributor setup.

### Changes
1. **memory test mock**
   - `src/memory/test-embeddings-mock.ts`
   - Added test-only `ssrfPolicy` allowing the mocked OpenAI hostname with private-network resolution enabled.
   - Reason: in guarded/local environments, DNS can resolve public hosts to special-use ranges, causing mocked batch tests to trip SSRF guard before fetch stubs are exercised.

2. **voyage batch tests**
   - `src/memory/batch-voyage.test.ts`
   - Added test client `ssrfPolicy` for the same mocked-network reason.

3. **media redirect test**
   - `src/media/store.redirect.test.ts`
   - Updated expected file mode to account for process `umask` on non-Windows platforms.

4. **process respawn test**
   - `src/infra/process-respawn.test.ts`
   - Stubbed launchd restart helper return in the supervised-hints test to match current restart path behavior on Darwin.

## Why
Running `pnpm test` in a locked-down local environment exposed failures caused by environmental assumptions (SSRF guard + DNS behavior, umask expectation, and launchd helper mocking).

This PR keeps behavior unchanged in production code paths while making tests deterministic and environment-robust.

## Testing Level
- **Fully tested locally**

## Verification
- `pnpm build` ✅
- `pnpm check` ✅
- `pnpm test` ✅

## AI Assistance Disclosure
- This PR is **AI-assisted**.
- The implementation and patch drafting were generated iteratively with OpenClaw assistant support, then validated by running the full local build/check/test pipeline.

## Prompt / Session Log (condensed)
- Goal: fix failing test suite before opening first contribution PR.
- Steps used:
  1. Reproduced failures with focused test runs.
  2. Traced failure causes to SSRF guard behavior, umask expectation, and respawn test mocking gap.
  3. Applied minimal test-focused patches.
  4. Re-ran targeted tests and full `build/check/test`.
