### PR TITLE
fix(browser): accept openclaw driver in Zod schema

### DIFF
--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -309,7 +309,9 @@ export const OpenClawSchema = z
               .object({
                 cdpPort: z.number().int().min(1).max(65535).optional(),
                 cdpUrl: z.string().optional(),
-                driver: z.union([z.literal("clawd"), z.literal("extension")]).optional(),
+                driver: z
+                  .union([z.literal("openclaw"), z.literal("clawd"), z.literal("extension")])
+                  .optional(),
                 attachOnly: z.boolean().optional(),
                 color: HexColorSchema,
               })


### PR DESCRIPTION
## Summary
- Problem: Browser profile driver schema only accepts clawd and extension, but TypeScript type defines openclaw
- Fix: Add openclaw to the Zod schema union

## Change Type
- [x] Bug fix

## Scope
- [x] Config / Schema

## Testing
- Local TypeScript check passed