### PR TITLE
fix(telegram): prevent substring false-positive in hasBotMention text check

### DIFF
--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   buildTypingThreadParams,
   describeReplyTarget,
   expandTextLinks,
+  hasBotMention,
   normalizeForwardedContext,
   resolveTelegramDirectPeerId,
   resolveTelegramForumThreadId,
@@ -343,6 +344,62 @@ describe("describeReplyTarget", () => {
     expect(result?.forwardedFrom?.fromType).toBe("user");
     expect(result?.forwardedFrom?.fromId).toBe("123");
     expect(result?.forwardedFrom?.date).toBe(700);
+  });
+});
+
+describe("hasBotMention", () => {
+  const msg = (text: string, entities?: Array<{ type: string; offset: number; length: number }>) =>
+    ({
+      text,
+      entities: entities ?? [],
+      // oxlint-disable-next-line typescript/no-explicit-any
+    }) as any;
+
+  it("detects exact @mention in text", () => {
+    expect(hasBotMention(msg("hello @mybot"), "mybot")).toBe(true);
+  });
+
+  it("detects @mention at end of text", () => {
+    expect(hasBotMention(msg("ping @mybot"), "mybot")).toBe(true);
+  });
+
+  it("does not false-positive on prefix substring", () => {
+    expect(hasBotMention(msg("hello @mybothelper"), "mybot")).toBe(false);
+  });
+
+  it("does not false-positive on suffix with underscore", () => {
+    expect(hasBotMention(msg("hello @mybot_v2"), "mybot")).toBe(false);
+  });
+
+  it("does not false-positive on suffix with digit", () => {
+    expect(hasBotMention(msg("hello @mybot2"), "mybot")).toBe(false);
+  });
+
+  it("detects mention followed by punctuation", () => {
+    expect(hasBotMention(msg("hi @mybot!"), "mybot")).toBe(true);
+  });
+
+  it("detects mention followed by space", () => {
+    expect(hasBotMention(msg("@mybot how are you"), "mybot")).toBe(true);
+  });
+
+  it("does not match when entity refers to a different user", () => {
+    expect(
+      hasBotMention(
+        msg("hello @mybothelper", [{ type: "mention", offset: 6, length: 13 }]),
+        "mybot",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when no mention at all", () => {
+    expect(hasBotMention(msg("just a message"), "mybot")).toBe(false);
+  });
+
+  it("handles caption-based messages", () => {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    const captionMsg = { caption: "photo @mybot", caption_entities: [] } as any;
+    expect(hasBotMention(captionMsg, "mybot")).toBe(true);
   });
 });
 

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -280,10 +280,22 @@ export function buildGroupLabel(msg: Message, chatId: number | string, messageTh
   return `group:${chatId}${topicSuffix}`;
 }
 
+const TELEGRAM_USERNAME_CHAR = /[a-z0-9_]/;
+
 export function hasBotMention(msg: Message, botUsername: string) {
   const text = (msg.text ?? msg.caption ?? "").toLowerCase();
-  if (text.includes(`@${botUsername}`)) {
-    return true;
+  const mention = `@${botUsername}`;
+  let searchFrom = 0;
+  while (true) {
+    const idx = text.indexOf(mention, searchFrom);
+    if (idx === -1) {
+      break;
+    }
+    const afterIdx = idx + mention.length;
+    if (afterIdx >= text.length || !TELEGRAM_USERNAME_CHAR.test(text[afterIdx])) {
+      return true;
+    }
+    searchFrom = afterIdx;
   }
   const entities = msg.entities ?? msg.caption_entities ?? [];
   for (const ent of entities) {


### PR DESCRIPTION
## Summary

`hasBotMention` uses `String.includes()` for the text-based mention check, which matches substrings. A bot named `@mybot` incorrectly triggers on text containing `@mybothelper`, `@mybot_v2`, or any other username that starts with the bot's username.

**Impact:** The bot responds to messages that mention a *different* user whose username happens to start with the bot's username. This affects `requireMention` gating and ACK reactions — the bot processes messages it shouldn't.

## Change type

Bug fix — replace `includes()` with an `indexOf` loop that verifies the character after the matched `@username` is not a valid Telegram username character (`[a-z0-9_]`).

## Changes

- **`src/telegram/bot/helpers.ts`**
  - Add `TELEGRAM_USERNAME_CHAR` regex constant
  - Replace `text.includes(...)` with a loop that checks all occurrences and validates the following character is not a valid username character (word boundary)
  - The entity-based fallback (lines 288–297) already uses exact comparison (`===`) and is unaffected

- **`src/telegram/bot/helpers.test.ts`**
  - Add 10 new test cases for `hasBotMention` covering:
    - Exact mention at end of text
    - Mention followed by punctuation / space
    - **Substring false-positive prevention** (prefix, underscore, digit suffixes)
    - Entity-based detection for different users
    - Caption-based messages

## How to reproduce

```ts
import { hasBotMention } from "./helpers.js";

// Before fix: true (BUG — @mybothelper is a different user)
hasBotMention({ text: "hello @mybothelper" }, "mybot");

// After fix: false (correct — only exact @mybot matches)
hasBotMention({ text: "hello @mybothelper" }, "mybot");

// Still works for exact mentions:
hasBotMention({ text: "hello @mybot" }, "mybot");        // true
hasBotMention({ text: "hello @mybot!" }, "mybot");       // true
hasBotMention({ text: "@mybot how are you" }, "mybot");  // true
```

## Test plan

- [x] All 10 new `hasBotMention` tests pass
- [x] All 49 tests in `helpers.test.ts` pass (39 existing + 10 new)
- [x] Linter passes with 0 warnings

## Security

No security impact. This is a mention-matching correctness fix.

## Compatibility

Fully backward-compatible. Exact `@username` mentions continue to be detected. Only false-positive substring matches are eliminated.


Made with [Cursor](https://cursor.com)