### PR TITLE
docs(faq): fix broken Troubleshooting anchor link

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -448,8 +448,10 @@ section is the latest shipped version. Entries are grouped by **Highlights**, **
 ### I can't access docs.openclaw.ai SSL error What now
 
 Some Comcast/Xfinity connections incorrectly block `docs.openclaw.ai` via Xfinity
-Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry. More
-detail: [Troubleshooting](/help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity).
+Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry.
+
+More detail: [Troubleshooting](/help/troubleshooting).
+
 Please help us unblock it by reporting here: [https://spa.xfinity.com/check_url_status](https://spa.xfinity.com/check_url_status).
 
 If you still can't reach the site, the docs are mirrored on GitHub:


### PR DESCRIPTION
Closes #36970

Fixes a broken cross-document anchor link in the FAQ by linking to the Troubleshooting page without a non-existent section anchor.