### PR TITLE
fix(docs): remove broken troubleshooting anchor link in FAQ SSL section

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -448,8 +448,7 @@ section is the latest shipped version. Entries are grouped by **Highlights**, **
 ### I can't access docs.openclaw.ai SSL error What now
 
 Some Comcast/Xfinity connections incorrectly block `docs.openclaw.ai` via Xfinity
-Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry. More
-detail: [Troubleshooting](/help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity).
+Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry.
 Please help us unblock it by reporting here: [https://spa.xfinity.com/check_url_status](https://spa.xfinity.com/check_url_status).
 
 If you still can't reach the site, the docs are mirrored on GitHub:


### PR DESCRIPTION
The FAQ entry for Xfinity/SSL errors linked to a non-existent anchor in `troubleshooting.md` (`#docsopenclawai-shows-an-ssl-error-comcastxfinity`). The FAQ section already contains the full workaround (disable Xfinity Advanced Security or allowlist docs.openclaw.ai), so the broken cross-reference was redundant.

Removes the dead link; no content lost.

Closes #36970