### PR TITLE
fix(discord): use trimmed file path consistently in ensureOggOpus

### DIFF
--- a/src/discord/voice-message.test.ts
+++ b/src/discord/voice-message.test.ts
@@ -101,6 +101,36 @@ describe("ensureOggOpus", () => {
     expect(execCalls).toHaveLength(0);
   });
 
+  it("rejects URL/protocol input even with surrounding whitespace", async () => {
+    await expect(ensureOggOpus("  https://example.com/audio.ogg  ")).rejects.toThrow(
+      /local file path/i,
+    );
+    expect(execCalls).toHaveLength(0);
+  });
+
+  it("trims whitespace from file path before passing to ffprobe/ffmpeg", async () => {
+    mockExecResults.push({ stdout: "opus,48000\n" });
+
+    const result = await ensureOggOpus("  /tmp/input.ogg  ");
+
+    expect(result).toEqual({ path: "/tmp/input.ogg", cleanup: false });
+    expect(execCalls).toHaveLength(1);
+    const ffprobeArgs = execCalls[0].args;
+    expect(ffprobeArgs[ffprobeArgs.length - 1]).toBe("/tmp/input.ogg");
+  });
+
+  it("uses trimmed path for ffmpeg conversion", async () => {
+    mockExecResults.push({ stdout: "" });
+
+    const result = await ensureOggOpus("  /tmp/input.mp3  ");
+
+    expect(result.cleanup).toBe(true);
+    const ffmpegCall = execCalls.find((call) => call.command === "ffmpeg");
+    expect(ffmpegCall).toBeDefined();
+    const inputIdx = ffmpegCall!.args.indexOf("-i");
+    expect(ffmpegCall!.args[inputIdx + 1]).toBe("/tmp/input.mp3");
+  });
+
   it("keeps .ogg only when codec is opus and sample rate is 48kHz", async () => {
     mockExecResults.push({ stdout: "opus,48000\n" });
 

--- a/src/discord/voice-message.ts
+++ b/src/discord/voice-message.ts
@@ -156,7 +156,7 @@ export async function ensureOggOpus(filePath: string): Promise<{ path: string; c
     );
   }
 
-  const ext = path.extname(filePath).toLowerCase();
+  const ext = path.extname(trimmed).toLowerCase();
 
   // Check if already OGG
   if (ext === ".ogg") {
@@ -171,11 +171,11 @@ export async function ensureOggOpus(filePath: string): Promise<{ path: string; c
         "stream=codec_name,sample_rate",
         "-of",
         "csv=p=0",
-        filePath,
+        trimmed,
       ]);
       const { codec, sampleRateHz } = parseFfprobeCodecAndSampleRate(stdout);
       if (codec === "opus" && sampleRateHz === DISCORD_OPUS_SAMPLE_RATE_HZ) {
-        return { path: filePath, cleanup: false };
+        return { path: trimmed, cleanup: false };
       }
     } catch {
       // If probe fails, convert anyway
@@ -191,7 +191,7 @@ export async function ensureOggOpus(filePath: string): Promise<{ path: string; c
   await runFfmpeg([
     "-y",
     "-i",
-    filePath,
+    trimmed,
     "-vn",
     "-sn",
     "-dn",


### PR DESCRIPTION
## Summary

`ensureOggOpus` trims the input file path for URL/protocol validation but then passes the original untrimmed `filePath` to `path.extname()`, `runFfprobe()`, `runFfmpeg()`, and the return value. If the path has leading/trailing whitespace, the URL check passes correctly, but all subsequent operations receive a path that doesn't exist on disk.

**Impact:** Voice message conversion silently fails when file paths have surrounding whitespace — ffprobe/ffmpeg receive `"  /path/to/file.ogg  "` instead of `"/path/to/file.ogg"`, causing "No such file" errors.

## Change type

Bug fix — use the trimmed path consistently throughout the function.

## Changes

- **`src/discord/voice-message.ts`**
  - Replace 4 remaining uses of `filePath` with `trimmed` (after the existing `filePath.trim()` on line 151):
    - `path.extname(trimmed)` instead of `path.extname(filePath)`
    - `runFfprobe([..., trimmed])` instead of `runFfprobe([..., filePath])`
    - `return { path: trimmed, ... }` instead of `return { path: filePath, ... }`
    - `runFfmpeg([..., "-i", trimmed, ...])` instead of `runFfmpeg([..., "-i", filePath, ...])`

- **`src/discord/voice-message.test.ts`**
  - Add 3 new test cases:
    - URL rejection works with surrounding whitespace
    - Trimmed path is passed to ffprobe (not the original)
    - Trimmed path is passed to ffmpeg (not the original)

## Test plan

- [x] All 7 tests pass (4 existing + 3 new)
- [x] Linter passes with 0 warnings

## Security

Strengthens path validation — ensures the trimmed path used for URL rejection is the same path passed to subprocess commands, preventing any bypass via whitespace padding.

## Compatibility

Fully backward-compatible. Paths without whitespace are unaffected since `trim()` is a no-op on them.


Made with [Cursor](https://cursor.com)