### PR TITLE
fix(agents): pass through explicit effort param to Anthropic output_config

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.effort-override.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.effort-override.test.ts
@@ -1,0 +1,158 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+vi.mock("@mariozechner/pi-ai", () => ({
+  streamSimple: vi.fn(() => ({
+    push: vi.fn(),
+    result: vi.fn(),
+  })),
+}));
+
+type EffortCase = {
+  applyProvider: string;
+  applyModelId: string;
+  model: Model<"anthropic-messages">;
+  cfg?: Parameters<typeof applyExtraParamsToAgent>[1];
+  options?: SimpleStreamOptions;
+};
+
+function runEffortCase(params: EffortCase) {
+  const payload: Record<string, unknown> = { model: params.model.id, messages: [] };
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    options?.onPayload?.(payload);
+    return {} as ReturnType<StreamFn>;
+  };
+  const agent = { streamFn: baseStreamFn };
+
+  applyExtraParamsToAgent(agent, params.cfg, params.applyProvider, params.applyModelId);
+
+  const context: Context = { messages: [] };
+  void agent.streamFn?.(params.model, context, params.options ?? {});
+
+  return payload;
+}
+
+describe("extra-params: effort override for Anthropic models", () => {
+  it("injects output_config.effort when params.effort is set", () => {
+    const payload = runEffortCase({
+      applyProvider: "anthropic",
+      applyModelId: "claude-opus-4-6",
+      model: {
+        api: "anthropic-messages",
+        provider: "anthropic",
+        id: "claude-opus-4-6",
+      } as Model<"anthropic-messages">,
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-opus-4-6": {
+                params: {
+                  effort: "max",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(payload.output_config).toEqual({ effort: "max" });
+  });
+
+  it("does not inject output_config.effort for non-anthropic API models", () => {
+    const payload: Record<string, unknown> = { model: "gpt-5", messages: [] };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(
+      agent,
+      {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5": {
+                params: {
+                  effort: "max",
+                },
+              },
+            },
+          },
+        },
+      },
+      "openai",
+      "gpt-5",
+    );
+
+    const context: Context = { messages: [] };
+    const model = {
+      api: "openai-completions",
+      provider: "openai",
+      id: "gpt-5",
+    } as Model<"openai-completions">;
+    void agent.streamFn?.(model, context, {});
+
+    expect(payload).not.toHaveProperty("output_config");
+  });
+
+  it("does not inject output_config.effort when no effort param is configured", () => {
+    const payload = runEffortCase({
+      applyProvider: "anthropic",
+      applyModelId: "claude-opus-4-6",
+      model: {
+        api: "anthropic-messages",
+        provider: "anthropic",
+        id: "claude-opus-4-6",
+      } as Model<"anthropic-messages">,
+    });
+
+    expect(payload).not.toHaveProperty("output_config");
+  });
+
+  it("preserves existing output_config fields when injecting effort", () => {
+    const payload: Record<string, unknown> = {
+      model: "claude-opus-4-6",
+      messages: [],
+      output_config: { existing_field: true },
+    };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(
+      agent,
+      {
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-opus-4-6": {
+                params: {
+                  effort: "high",
+                },
+              },
+            },
+          },
+        },
+      },
+      "anthropic",
+      "claude-opus-4-6",
+    );
+
+    const context: Context = { messages: [] };
+    const model = {
+      api: "anthropic-messages",
+      provider: "anthropic",
+      id: "claude-opus-4-6",
+    } as Model<"anthropic-messages">;
+    void agent.streamFn?.(model, context, {});
+
+    expect(payload.output_config).toEqual({ existing_field: true, effort: "high" });
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -773,6 +773,36 @@ function createKimiCodingAnthropicToolSchemaWrapper(baseStreamFn: StreamFn | und
 }
 
 /**
+ * Pass through the user's explicit `effort` parameter to the Anthropic
+ * `output_config.effort` field.  Without this, the SDK derives effort from
+ * the mapped thinking level ("medium" for adaptive) and silently ignores
+ * the user's value because it never reaches the API payload.
+ */
+function createEffortOverrideWrapper(baseStreamFn: StreamFn | undefined, effort: string): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (
+          payload &&
+          typeof payload === "object" &&
+          typeof model.api === "string" &&
+          model.api.includes("anthropic")
+        ) {
+          const payloadObj = payload as Record<string, unknown>;
+          const outputConfig = (payloadObj.output_config ?? {}) as Record<string, unknown>;
+          outputConfig.effort = effort;
+          payloadObj.output_config = outputConfig;
+        }
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}
+
+/**
  * Create a streamFn wrapper that adds OpenRouter app attribution headers
  * and injects reasoning.effort based on the configured thinking level.
  */
@@ -1067,6 +1097,15 @@ export function applyExtraParamsToAgent(
       log.debug(`enabling Z.AI tool_stream for ${provider}/${modelId}`);
       agent.streamFn = createZaiToolStreamWrapper(agent.streamFn, true);
     }
+  }
+
+  // Pass through user-configured effort to Anthropic output_config.effort.
+  // Without this, the SDK derives effort from the mapped thinking level and
+  // the user's explicit params.effort value is silently dropped.
+  const explicitEffort = merged?.effort;
+  if (typeof explicitEffort === "string" && explicitEffort.trim()) {
+    log.debug(`applying explicit effort override: ${explicitEffort} for ${provider}/${modelId}`);
+    agent.streamFn = createEffortOverrideWrapper(agent.streamFn, explicitEffort.trim());
   }
 
   // Guard Google payloads against invalid negative thinking budgets emitted by


### PR DESCRIPTION
## Summary

- Problem: When users configure `params.effort: "max"` for Anthropic models with `thinking: "adaptive"`, the `effort` value is silently dropped by `createStreamFnWithExtraParams()` because it is not in the recognized parameter whitelist. The Pi SDK then derives `output_config.effort` from the mapped thinking level (`"medium"` for adaptive), completely ignoring the user's explicit setting.
- Why it matters: Users cannot control reasoning depth for Claude Opus 4.6 / Sonnet 4.6 adaptive thinking — the API always receives `effort: "medium"` regardless of configuration.
- What changed: Added `createEffortOverrideWrapper()` that injects the user's explicit `effort` value into the Anthropic API payload's `output_config.effort` field via `onPayload` hook. Applied in `applyExtraParamsToAgent()` when `params.effort` is a non-empty string.
- What did NOT change (scope boundary): `mapThinkingLevel()` mapping of `"adaptive"` → `"medium"` is preserved (required by pi-agent-core's `ThinkingLevel` type). The SDK's internal thinking-to-effort derivation is unchanged. No other provider's payload format is affected — the wrapper only fires for `model.api` containing `"anthropic"`.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #37097

## User-visible / Behavior Changes

When `params.effort` is configured for an Anthropic model, the value now reaches the API payload as `output_config.effort`. Previously it was silently dropped.

| Config | Before | After |
|--------|--------|-------|
| `effort: "max"` | `output_config.effort: "medium"` (SDK-derived) | `output_config.effort: "max"` (user value) |
| `effort: "high"` | `output_config.effort: "medium"` (SDK-derived) | `output_config.effort: "high"` (user value) |
| No `effort` set | `output_config.effort: "medium"` (SDK-derived) | `output_config.effort: "medium"` (unchanged) |

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Model/provider: Any Anthropic-compatible provider (direct Anthropic, custom Anthropic-compatible)
- Relevant config (redacted):
```json
{
  "models": {
    "anthropic/claude-opus-4-6": {
      "params": {
        "thinking": "adaptive",
        "effort": "max"
      }
    }
  }
}
```

### Steps

1. Configure `params.effort: "max"` for an Anthropic model with `thinking: "adaptive"`.
2. Send a message to trigger an API request.
3. Inspect the outgoing API payload.

### Expected

- `output_config.effort` should be `"max"` (matching user config).

### Actual (before fix)

- `output_config.effort` is always `"medium"` (derived from mapped thinking level, ignoring user config).

## Evidence

- [x] Failing test/log before + passing after

4 new unit tests covering:
1. Effort injection for Anthropic models (`effort: "max"` → `output_config.effort: "max"`)
2. No injection for non-Anthropic API models (OpenAI completions)
3. No injection when no effort param is configured
4. Preservation of existing `output_config` fields when injecting effort

## Human Verification (required)

- Verified scenarios: All 4 test cases pass. Existing extra-params tests (cache-retention, openrouter-cache-control, zai-tool-stream — 14 tests total) pass with zero regression.
- Edge cases checked: Non-Anthropic providers, missing effort config, pre-existing output_config fields.
- What I did **not** verify: Live API request with real Anthropic credentials (no access to Anthropic API in test environment).

## Compatibility / Migration

- Backward compatible? Yes — only activates when `params.effort` is explicitly configured. No change for users without this config.
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `params.effort` from model config to revert to SDK-derived effort.
- Files/config to restore: `src/agents/pi-embedded-runner/extra-params.ts`
- Known bad symptoms reviewers should watch for: Unexpected `output_config.effort` values in API payloads for Anthropic models.

## Risks and Mitigations

- Risk: User configures an invalid effort value (e.g. `effort: "turbo"`) that the Anthropic API rejects.
  - Mitigation: The value is passed through as-is, matching the pattern used by other extra-params (temperature, maxTokens). Invalid values will produce clear API errors, same as other unsupported param values.