### PR TITLE
fix: save session memory on archived sessions

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1518,51 +1518,54 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     const sessionKey = "agent:main:telegram:dm:user-idle-hook";
     const existingSessionId = "existing-session-idle-hook";
     const triggerHookSpy = vi.spyOn(internalHooks, "triggerInternalHook").mockResolvedValue();
-    await seedSessionStoreWithOverrides({
-      storePath,
-      sessionKey,
-      sessionId: existingSessionId,
-      overrides: {
-        updatedAt: Date.now() - 10 * 60_000,
-        verboseLevel: "on",
-      },
-    });
-
-    const cfg = {
-      session: { store: storePath, idleMinutes: 1 },
-    } as OpenClawConfig;
-
-    const result = await initSessionState({
-      ctx: {
-        Body: "hello after idle timeout",
-        RawBody: "hello after idle timeout",
-        CommandBody: "hello after idle timeout",
-        From: "user-idle-hook",
-        To: "bot",
-        ChatType: "direct",
-        SessionKey: sessionKey,
-        Provider: "telegram",
-        Surface: "telegram",
-      },
-      cfg,
-      commandAuthorized: true,
-    });
-
-    expect(result.isNewSession).toBe(true);
-    expect(result.resetTriggered).toBe(false);
-    expect(result.previousSessionEntry?.sessionId).toBe(existingSessionId);
-    expect(triggerHookSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "session",
-        action: "archived",
+    try {
+      await seedSessionStoreWithOverrides({
+        storePath,
         sessionKey,
-        context: expect.objectContaining({
-          archiveReason: "reset",
-          previousSessionEntry: expect.objectContaining({ sessionId: existingSessionId }),
+        sessionId: existingSessionId,
+        overrides: {
+          updatedAt: Date.now() - 10 * 60_000,
+          verboseLevel: "on",
+        },
+      });
+
+      const cfg = {
+        session: { store: storePath, idleMinutes: 1 },
+      } as OpenClawConfig;
+
+      const result = await initSessionState({
+        ctx: {
+          Body: "hello after idle timeout",
+          RawBody: "hello after idle timeout",
+          CommandBody: "hello after idle timeout",
+          From: "user-idle-hook",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "telegram",
+          Surface: "telegram",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.resetTriggered).toBe(false);
+      expect(result.previousSessionEntry?.sessionId).toBe(existingSessionId);
+      expect(triggerHookSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "session",
+          action: "archived",
+          sessionKey,
+          context: expect.objectContaining({
+            archiveReason: "reset",
+            previousSessionEntry: expect.objectContaining({ sessionId: existingSessionId }),
+          }),
         }),
-      }),
-    );
-    triggerHookSpy.mockRestore();
+      );
+    } finally {
+      triggerHookSpy.mockRestore();
+    }
   });
 
   it("idle-based new session does NOT preserve overrides (no entry to read)", async () => {

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -5,6 +5,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { buildModelAliasIndex } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import * as internalHooks from "../../hooks/internal-hooks.js";
 import { formatZonedTimestamp } from "../../infra/format-time/format-datetime.ts";
 import {
   __testing as sessionBindingTesting,
@@ -1510,6 +1511,58 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("emits session:archived hooks for implicit idle resets", async () => {
+    const storePath = await createStorePath("openclaw-idle-hook-");
+    const sessionKey = "agent:main:telegram:dm:user-idle-hook";
+    const existingSessionId = "existing-session-idle-hook";
+    const triggerHookSpy = vi.spyOn(internalHooks, "triggerInternalHook").mockResolvedValue();
+    await seedSessionStoreWithOverrides({
+      storePath,
+      sessionKey,
+      sessionId: existingSessionId,
+      overrides: {
+        updatedAt: Date.now() - 10 * 60_000,
+        verboseLevel: "on",
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 1 },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "hello after idle timeout",
+        RawBody: "hello after idle timeout",
+        CommandBody: "hello after idle timeout",
+        From: "user-idle-hook",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "telegram",
+        Surface: "telegram",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(false);
+    expect(result.previousSessionEntry?.sessionId).toBe(existingSessionId);
+    expect(triggerHookSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "session",
+        action: "archived",
+        sessionKey,
+        context: expect.objectContaining({
+          archiveReason: "reset",
+          previousSessionEntry: expect.objectContaining({ sessionId: existingSessionId }),
+        }),
+      }),
+    );
+    triggerHookSpy.mockRestore();
   });
 
   it("idle-based new session does NOT preserve overrides (no entry to read)", async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -562,7 +562,7 @@ export async function initSessionState(params: {
 
   // Archive old transcript so it doesn't accumulate on disk (#14869).
   if (previousSessionEntry?.sessionId) {
-    archiveSessionTranscripts({
+    const archived = archiveSessionTranscripts({
       sessionId: previousSessionEntry.sessionId,
       storePath,
       sessionFile: previousSessionEntry.sessionFile,
@@ -577,6 +577,7 @@ export async function initSessionState(params: {
           previousSessionEntry,
           archiveReason: "reset",
           archiveSource: "auto-reply:init-session",
+          archived,
         }),
       );
     }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -28,6 +28,7 @@ import {
 } from "../../config/sessions.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { archiveSessionTranscripts } from "../../gateway/session-utils.fs.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { resolveConversationIdFromTargets } from "../../infra/outbound/conversation-id.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -358,6 +359,7 @@ export async function initSessionState(params: {
   // and for scheduled/daily resets where the session has become stale (!freshEntry).
   // Without this, daily-reset transcripts are left as orphaned files on disk (#35481).
   const previousSessionEntry = (resetTriggered || !freshEntry) && entry ? { ...entry } : undefined;
+  const shouldEmitImplicitArchivedHook = Boolean(previousSessionEntry && !resetTriggered);
 
   if (!isNewSession && freshEntry) {
     sessionId = entry.sessionId;
@@ -567,6 +569,17 @@ export async function initSessionState(params: {
       agentId,
       reason: "reset",
     });
+    if (shouldEmitImplicitArchivedHook) {
+      await triggerInternalHook(
+        createInternalHookEvent("session", "archived", sessionKey, {
+          cfg,
+          sessionEntry: previousSessionEntry,
+          previousSessionEntry,
+          archiveReason: "reset",
+          archiveSource: "auto-reply:init-session",
+        }),
+      );
+    }
   }
 
   const sessionCtx: TemplateContext = {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -614,6 +614,18 @@ export const sessionsHandlers: GatewayRequestHandlers = {
             reason: "deleted",
           })
         : [];
+    if (deleted && archived.length > 0 && entry) {
+      await triggerInternalHook(
+        createInternalHookEvent("session", "archived", target.canonicalKey ?? key, {
+          cfg,
+          sessionEntry: entry,
+          previousSessionEntry: entry,
+          archiveReason: "deleted",
+          archiveSource: "gateway:sessions.delete",
+          archived,
+        }),
+      );
+    }
     if (deleted) {
       const emitLifecycleHooks = p.emitLifecycleHooks !== false;
       await emitSessionUnboundLifecycleEvent({

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -614,7 +614,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
             reason: "deleted",
           })
         : [];
-    if (deleted && archived.length > 0 && entry) {
+    const emitLifecycleHooks = p.emitLifecycleHooks !== false;
+    if (deleted && emitLifecycleHooks && archived.length > 0 && entry) {
       await triggerInternalHook(
         createInternalHookEvent("session", "archived", target.canonicalKey ?? key, {
           cfg,
@@ -627,7 +628,6 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       );
     }
     if (deleted) {
-      const emitLifecycleHooks = p.emitLifecycleHooks !== false;
       await emitSessionUnboundLifecycleEvent({
         targetSessionKey: target.canonicalKey ?? key,
         reason: "session-delete",

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -863,6 +863,40 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
+  test("sessions.delete emits internal archived hook when transcript is archived", async () => {
+    const { dir } = await createSessionStoreDir();
+    await writeSingleLineSession(dir, "sess-subagent", "hello");
+    await writeSessionStore({
+      entries: {
+        "agent:main:subagent:worker": {
+          sessionId: "sess-subagent",
+          updatedAt: Date.now(),
+        },
+      },
+    });
+
+    const { ws } = await openClient();
+    const deleted = await rpcReq<{ ok: true; deleted: boolean }>(ws, "sessions.delete", {
+      key: "agent:main:subagent:worker",
+    });
+
+    expect(deleted.ok).toBe(true);
+    expect(deleted.payload?.deleted).toBe(true);
+    expect(sessionHookMocks.triggerInternalHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "session",
+        action: "archived",
+        sessionKey: "agent:main:subagent:worker",
+        context: expect.objectContaining({
+          archiveReason: "deleted",
+          previousSessionEntry: expect.objectContaining({ sessionId: "sess-subagent" }),
+        }),
+      }),
+    );
+
+    ws.close();
+  });
+
   test("sessions.delete can skip lifecycle hooks while still unbinding thread bindings", async () => {
     const { dir } = await createSessionStoreDir();
     await writeSingleLineSession(dir, "sess-subagent", "hello");

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -916,6 +916,7 @@ describe("gateway server sessions", () => {
     });
     expect(deleted.ok).toBe(true);
     expect(deleted.payload?.deleted).toBe(true);
+    expect(sessionHookMocks.triggerInternalHook).not.toHaveBeenCalled();
     expect(subagentLifecycleHookMocks.runSubagentEnded).not.toHaveBeenCalled();
     expect(threadBindingMocks.unbindThreadBindingsBySessionKey).toHaveBeenCalledTimes(1);
     expect(threadBindingMocks.unbindThreadBindingsBySessionKey).toHaveBeenCalledWith({

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -1,13 +1,13 @@
 ---
 name: session-memory
-description: "Save session context to memory when /new or /reset command is issued"
+description: "Save session context to memory when sessions reset or are archived"
 homepage: https://docs.openclaw.ai/automation/hooks#session-memory
 metadata:
   {
     "openclaw":
       {
         "emoji": "💾",
-        "events": ["command:new", "command:reset"],
+        "events": ["command:new", "command:reset", "session:archived"],
         "requires": { "config": ["workspace.dir"] },
         "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
       },
@@ -16,11 +16,11 @@ metadata:
 
 # Session Memory Hook
 
-Automatically saves session context to your workspace memory when you issue `/new` or `/reset`.
+Automatically saves session context to your workspace memory when you issue `/new`, `/reset`, or when OpenClaw automatically archives a session during reset/delete flows.
 
 ## What It Does
 
-When you run `/new` or `/reset` to start a fresh session:
+When you run `/new` or `/reset` to start a fresh session, or when OpenClaw archives a prior session automatically:
 
 1. **Finds the previous session** - Uses the pre-reset session entry to locate the correct transcript
 2. **Extracts conversation** - Reads the last N user/assistant messages from the session (default: 15, configurable)

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -242,6 +242,38 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("assistant: Captured before reset");
   });
 
+  it("creates memory file with session content on session:archived", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-session-memory-");
+    const sessionsDir = path.join(tempDir, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "archived-session.jsonl",
+      content: createMockSessionContent([
+        { role: "user", content: "Keep this archived context" },
+        { role: "assistant", content: "Archived and saved" },
+      ]),
+    });
+
+    const event = createHookEvent("session", "archived", "agent:main:telegram:direct:123", {
+      cfg: {
+        agents: { defaults: { workspace: tempDir } },
+      } satisfies OpenClawConfig,
+      previousSessionEntry: { sessionId: "archived-123", sessionFile },
+      sessionEntry: { sessionId: "archived-123", sessionFile },
+      archiveReason: "reset",
+    });
+
+    await handler(event);
+
+    const memoryDir = path.join(tempDir, "memory");
+    const files = await fs.readdir(memoryDir);
+    expect(files).toHaveLength(1);
+    const memoryContent = await fs.readFile(path.join(memoryDir, files[0]), "utf-8");
+    expect(memoryContent).toContain("user: Keep this archived context");
+    expect(memoryContent).toContain("assistant: Archived and saved");
+  });
+
   it("filters out non-message entries (tool calls, system)", async () => {
     // Create session with mixed entry types
     const sessionContent = createMockSessionContent([

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
-import { writeWorkspaceFile } from "../../../test-helpers/workspace.js";
+import { makeTempWorkspace, writeWorkspaceFile } from "../../../test-helpers/workspace.js";
 import type { HookHandler } from "../../hooks.js";
 import { createHookEvent } from "../../hooks.js";
 

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -274,6 +274,39 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("assistant: Archived and saved");
   });
 
+  it("loads archived transcript content from deleted session files", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-session-memory-deleted-");
+    const sessionsDir = path.join(tempDir, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const deletedArchive = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "deleted-session.jsonl.deleted.2026-03-06T03-00-00.000Z",
+      content: createMockSessionContent([
+        { role: "user", content: "Remember this deleted thread" },
+        { role: "assistant", content: "Deleted transcript recovered" },
+      ]),
+    });
+
+    const event = createHookEvent("session", "archived", "agent:main:telegram:direct:123", {
+      cfg: {
+        agents: { defaults: { workspace: tempDir } },
+      } satisfies OpenClawConfig,
+      previousSessionEntry: { sessionId: "deleted-session" },
+      sessionEntry: { sessionId: "deleted-session" },
+      archiveReason: "deleted",
+      archived: [deletedArchive],
+    });
+
+    await handler(event);
+
+    const memoryDir = path.join(tempDir, "memory");
+    const files = await fs.readdir(memoryDir);
+    expect(files).toHaveLength(1);
+    const memoryContent = await fs.readFile(path.join(memoryDir, files[0]), "utf-8");
+    expect(memoryContent).toContain("user: Remember this deleted thread");
+    expect(memoryContent).toContain("assistant: Deleted transcript recovered");
+  });
+
   it("filters out non-message entries (tool calls, system)", async () => {
     // Create session with mixed entry types
     const sessionContent = createMockSessionContent([

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -274,6 +274,49 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("assistant: Archived and saved");
   });
 
+  it("prefers the first archived transcript candidate when multiple archives exist", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-session-memory-archived-priority-");
+    const sessionsDir = path.join(tempDir, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const primaryArchive = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "priority-session.jsonl.reset.2026-03-06T03-00-00.000Z",
+      content: createMockSessionContent([
+        { role: "user", content: "Use the primary archive" },
+        { role: "assistant", content: "Primary transcript wins" },
+      ]),
+    });
+    const legacyArchive = await writeWorkspaceFile({
+      dir: sessionsDir,
+      name: "priority-session.jsonl.deleted.2026-03-06T04-00-00.000Z",
+      content: createMockSessionContent([
+        { role: "user", content: "Ignore the legacy archive" },
+        { role: "assistant", content: "Legacy transcript should not win" },
+      ]),
+    });
+
+    const event = createHookEvent("session", "archived", "agent:main:telegram:direct:123", {
+      cfg: {
+        agents: { defaults: { workspace: tempDir } },
+      } satisfies OpenClawConfig,
+      previousSessionEntry: { sessionId: "priority-session" },
+      sessionEntry: { sessionId: "priority-session" },
+      archiveReason: "reset",
+      archived: [primaryArchive, legacyArchive],
+    });
+
+    await handler(event);
+
+    const memoryDir = path.join(tempDir, "memory");
+    const files = await fs.readdir(memoryDir);
+    expect(files).toHaveLength(1);
+    const memoryContent = await fs.readFile(path.join(memoryDir, files[0]), "utf-8");
+    expect(memoryContent).toContain("user: Use the primary archive");
+    expect(memoryContent).toContain("assistant: Primary transcript wins");
+    expect(memoryContent).not.toContain("Ignore the legacy archive");
+    expect(memoryContent).not.toContain("Legacy transcript should not win");
+  });
+
   it("loads archived transcript content from deleted session files", async () => {
     const tempDir = await makeTempWorkspace("openclaw-session-memory-deleted-");
     const sessionsDir = path.join(tempDir, "sessions");

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -21,6 +21,13 @@ import { generateSlugViaLLM } from "../../llm-slug-generator.js";
 
 const log = createSubsystemLogger("hooks/session-memory");
 
+function isSessionMemoryTrigger(event: Parameters<HookHandler>[0]): boolean {
+  if (event.type === "command") {
+    return event.action === "new" || event.action === "reset";
+  }
+  return event.type === "session" && event.action === "archived";
+}
+
 /**
  * Read recent messages from session file for slug generation
  */
@@ -171,14 +178,15 @@ async function findPreviousSessionFile(params: {
  * Save session context to memory when /new or /reset command is triggered
  */
 const saveSessionToMemory: HookHandler = async (event) => {
-  // Only trigger on reset/new commands
-  const isResetCommand = event.action === "new" || event.action === "reset";
-  if (event.type !== "command" || !isResetCommand) {
+  if (!isSessionMemoryTrigger(event)) {
     return;
   }
 
   try {
-    log.debug("Hook triggered for reset/new command", { action: event.action });
+    log.debug("Hook triggered for session-memory capture", {
+      type: event.type,
+      action: event.action,
+    });
 
     const context = event.context || {};
     const cfg = context.cfg as OpenClawConfig | undefined;

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -75,11 +75,15 @@ async function getRecentSessionContent(
   }
 }
 
+function getArchivePrefixes(baseName: string): string[] {
+  return [`${baseName}.reset.`, `${baseName}.deleted.`];
+}
+
 /**
  * Try the active transcript first; if /new already rotated it,
- * fallback to the latest .jsonl.reset.* sibling.
+ * fallback to the latest archived sibling.
  */
-async function getRecentSessionContentWithResetFallback(
+async function getRecentSessionContentWithArchiveFallback(
   sessionFilePath: string,
   messageCount: number = 15,
 ): Promise<string | null> {
@@ -91,21 +95,22 @@ async function getRecentSessionContentWithResetFallback(
   try {
     const dir = path.dirname(sessionFilePath);
     const base = path.basename(sessionFilePath);
-    const resetPrefix = `${base}.reset.`;
     const files = await fs.readdir(dir);
-    const resetCandidates = files.filter((name) => name.startsWith(resetPrefix)).toSorted();
+    const archiveCandidates = files
+      .filter((name) => getArchivePrefixes(base).some((prefix) => name.startsWith(prefix)))
+      .toSorted();
 
-    if (resetCandidates.length === 0) {
+    if (archiveCandidates.length === 0) {
       return primary;
     }
 
-    const latestResetPath = path.join(dir, resetCandidates[resetCandidates.length - 1]);
-    const fallback = await getRecentSessionContent(latestResetPath, messageCount);
+    const latestArchivePath = path.join(dir, archiveCandidates[archiveCandidates.length - 1]);
+    const fallback = await getRecentSessionContent(latestArchivePath, messageCount);
 
     if (fallback) {
-      log.debug("Loaded session content from reset fallback", {
+      log.debug("Loaded session content from archive fallback", {
         sessionFilePath,
-        latestResetPath,
+        latestArchivePath,
       });
     }
 
@@ -174,6 +179,26 @@ async function findPreviousSessionFile(params: {
   return undefined;
 }
 
+async function resolveArchivedSessionFile(archived: unknown): Promise<string | undefined> {
+  if (!Array.isArray(archived)) {
+    return undefined;
+  }
+
+  const candidates = archived.filter(
+    (value): value is string => typeof value === "string" && value.trim().length > 0,
+  );
+  for (let i = candidates.length - 1; i >= 0; i -= 1) {
+    const candidate = candidates[i];
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // Try the next archived candidate.
+    }
+  }
+  return undefined;
+}
+
 /**
  * Save session context to memory when /new or /reset command is triggered
  */
@@ -209,9 +234,13 @@ const saveSessionToMemory: HookHandler = async (event) => {
     >;
     const currentSessionId = sessionEntry.sessionId as string;
     let currentSessionFile = (sessionEntry.sessionFile as string) || undefined;
+    const archivedSessionFile = await resolveArchivedSessionFile(context.archived);
+    if (archivedSessionFile) {
+      currentSessionFile = archivedSessionFile;
+    }
 
     // If sessionFile is empty or looks like a new/reset file, try to find the previous session file.
-    if (!currentSessionFile || currentSessionFile.includes(".reset.")) {
+    if (!archivedSessionFile && (!currentSessionFile || currentSessionFile.includes(".reset."))) {
       const sessionsDirs = new Set<string>();
       if (currentSessionFile) {
         sessionsDirs.add(path.dirname(currentSessionFile));
@@ -252,8 +281,8 @@ const saveSessionToMemory: HookHandler = async (event) => {
     let sessionContent: string | null = null;
 
     if (sessionFile) {
-      // Get recent conversation content, with fallback to rotated reset transcript.
-      sessionContent = await getRecentSessionContentWithResetFallback(sessionFile, messageCount);
+      // Get recent conversation content, with fallback to rotated archive transcripts.
+      sessionContent = await getRecentSessionContentWithArchiveFallback(sessionFile, messageCount);
       log.debug("Session content loaded", {
         length: sessionContent?.length ?? 0,
         messageCount,

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -187,8 +187,7 @@ async function resolveArchivedSessionFile(archived: unknown): Promise<string | u
   const candidates = archived.filter(
     (value): value is string => typeof value === "string" && value.trim().length > 0,
   );
-  for (let i = candidates.length - 1; i >= 0; i -= 1) {
-    const candidate = candidates[i];
+  for (const candidate of candidates) {
     try {
       await fs.access(candidate);
       return candidate;


### PR DESCRIPTION
Closes #37027

## Summary
- emit `session:archived` internal hooks when implicit session resets archive the previous transcript
- emit the same archived hook from `sessions.delete` after transcript archival
- let bundled `session-memory` handle `session:archived` and cover both idle reset and delete paths with tests

## Testing
- pnpm check
- pnpm build
- pnpm test
