### PR TITLE
Media: resolve relative MEDIA paths against allowed roots

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -170,6 +170,8 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.prompt).toContain("[Thread history - for context]");
     expect(call?.followupRun.prompt).toContain("Earlier message in this thread");
     expect(call?.followupRun.prompt).toContain("[User sent media without caption]");
+    expect(call?.commandBody).toContain("To send an image back:");
+    expect(call?.commandBody).toContain("include `MEDIA:` lines");
   });
 
   it("keeps thread history context on follow-up turns", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -380,10 +380,11 @@ export async function runPreparedReply(
   const skillsSnapshot = skillResult.skillsSnapshot;
   const prefixedBody = [threadContextNote, prefixedBodyBase].filter(Boolean).join("\n\n");
   const mediaNote = buildInboundMediaNote(ctx);
-  const mediaReplyHint = mediaNote
-    ? "To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg (spaces ok, quote if needed) or a safe relative path like MEDIA:./image.jpg. Avoid absolute paths (MEDIA:/...) and ~ paths — they are blocked for security. Keep caption in the text body."
+  const shouldAddMediaReplyHint = Boolean(mediaNote || hasMediaAttachment);
+  const mediaReplyHint = shouldAddMediaReplyHint
+    ? "To send an image back: if the `message` tool is available, prefer it (media/path/filePath). Otherwise, include `MEDIA:` lines in your reply (one per file). `MEDIA:` supports `https://...` URLs and local paths under the allowed roots (agent workspace / OpenClaw state dir). Quote the path if it contains spaces. Keep the caption in the text body."
     : undefined;
-  let prefixedCommandBody = mediaNote
+  let prefixedCommandBody = shouldAddMediaReplyHint
     ? [mediaNote, mediaReplyHint, prefixedBody ?? ""].filter(Boolean).join("\n").trim()
     : prefixedBody;
   if (!resolvedThinkLevel) {

--- a/src/test-helpers/ssrf.ts
+++ b/src/test-helpers/ssrf.ts
@@ -2,7 +2,9 @@ import { vi } from "vitest";
 import * as ssrf from "../infra/net/ssrf.js";
 
 export function mockPinnedHostnameResolution(addresses: string[] = ["93.184.216.34"]) {
-  return vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation(async (hostname) => {
+  const originalResolvePinnedHostnameWithPolicy = ssrf.resolvePinnedHostnameWithPolicy;
+
+  const buildPinned = (hostname: string) => {
     const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
     const pinnedAddresses = [...addresses];
     return {
@@ -10,5 +12,18 @@ export function mockPinnedHostnameResolution(addresses: string[] = ["93.184.216.
       addresses: pinnedAddresses,
       lookup: ssrf.createPinnedLookup({ hostname: normalized, addresses: pinnedAddresses }),
     };
+  };
+
+  vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockImplementation(async (hostname, params) => {
+    const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
+    // Preserve fail-closed blocking behavior for private/internal hosts without relying on DNS.
+    if (ssrf.isBlockedHostnameOrIp(normalized, params?.policy)) {
+      return await originalResolvePinnedHostnameWithPolicy(hostname, params);
+    }
+    return buildPinned(hostname);
+  });
+
+  return vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation(async (hostname, lookupFn) => {
+    return await ssrf.resolvePinnedHostnameWithPolicy(hostname, { lookupFn });
   });
 }

--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -361,6 +361,29 @@ describe("local media root guard", () => {
     expect(result.kind).toBe("image");
   });
 
+  it("resolves relative local media paths against allowed roots (not process cwd)", async () => {
+    const prevCwd = process.cwd();
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-cwd-"));
+    const allowedRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-media-root-"));
+    const relFile = path.join(allowedRoot, "relative.png");
+    await fs.writeFile(relFile, tinyPngBuffer);
+
+    try {
+      process.chdir(outsideDir);
+
+      const result = await loadWebMedia("./relative.png", {
+        maxBytes: 1024 * 1024,
+        localRoots: [allowedRoot],
+      });
+      expect(result.kind).toBe("image");
+      expect(result.buffer.length).toBeGreaterThan(0);
+    } finally {
+      process.chdir(prevCwd);
+      await fs.rm(outsideDir, { recursive: true, force: true });
+      await fs.rm(allowedRoot, { recursive: true, force: true });
+    }
+  });
+
   it("accepts win32 dev=0 stat mismatch for local file loads", async () => {
     const actualLstat = await fs.lstat(tinyPngFile);
     const actualStat = await fs.stat(tinyPngFile);

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -137,6 +137,41 @@ async function assertLocalMediaAllowed(
   );
 }
 
+function prioritizeRelativeResolutionRoots(roots: readonly string[]): string[] {
+  const workspaceRoots: string[] = [];
+  const otherRoots: string[] = [];
+  for (const root of roots) {
+    const base = path.basename(root).toLowerCase();
+    if (base === "workspace" || base.startsWith("workspace-")) {
+      workspaceRoots.push(root);
+      continue;
+    }
+    otherRoots.push(root);
+  }
+  return [...workspaceRoots, ...otherRoots];
+}
+
+async function resolveRelativeMediaPathAgainstRoots(params: {
+  mediaPath: string;
+  roots: readonly string[];
+}): Promise<string | undefined> {
+  // Resolve relative paths against allowed roots instead of process.cwd().
+  // This keeps MEDIA:./file behavior deterministic across delivery paths.
+  for (const root of prioritizeRelativeResolutionRoots(params.roots)) {
+    const candidate = path.resolve(root, params.mediaPath);
+    try {
+      const stat = await fs.stat(candidate);
+      if (!stat.isFile()) {
+        continue;
+      }
+      return candidate;
+    } catch {
+      // Ignore missing/cannot-stat candidates.
+    }
+  }
+  return undefined;
+}
+
 const HEIC_MIME_RE = /^image\/hei[cf]$/i;
 const HEIC_EXT_RE = /\.(heic|heif)$/i;
 const MB = 1024 * 1024;
@@ -340,6 +375,24 @@ async function loadWebMediaInternal(
   // Expand tilde paths to absolute paths (e.g., ~/Downloads/photo.jpg)
   if (mediaUrl.startsWith("~")) {
     mediaUrl = resolveUserPath(mediaUrl);
+  }
+
+  // Resolve relative paths (MEDIA:./..., ./file, etc.) against allowed roots so delivery
+  // doesn't depend on the gateway's current working directory.
+  if (
+    !readFileOverride &&
+    !sandboxValidated &&
+    localRoots !== "any" &&
+    !path.isAbsolute(mediaUrl)
+  ) {
+    const rootsForResolution = localRoots ?? getDefaultLocalRoots();
+    const resolved = await resolveRelativeMediaPathAgainstRoots({
+      mediaPath: mediaUrl,
+      roots: rootsForResolution,
+    });
+    if (resolved) {
+      mediaUrl = resolved;
+    }
   }
 
   if ((sandboxValidated || localRoots === "any") && !readFileOverride) {


### PR DESCRIPTION
## Summary

- Problem: Relative local media references like `MEDIA:./image.png` resolve against the gateway CWD, so they frequently fail localRoots validation with `Local media path is not under an allowed directory`.
- Why it matters: The auto-reply hint currently suggests `MEDIA:./...` as a safe fallback, but this is non-deterministic and confuses users when sends fail.
- What changed: `loadWebMedia` now resolves relative local paths against allowed localRoots (agent-scoped + defaults) before validating, and the media reply hint text no longer claims absolute/`~` paths are always blocked.
- What did NOT change (scope boundary): No expansion of allowed read scope; local reads remain constrained by localRoots and the existing guardrails.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37111

## User-visible / Behavior Changes

- Relative local media paths (for example `MEDIA:./image.png`) can be resolved within allowed media roots instead of depending on process CWD.
- Auto-reply media guidance text better matches actual attachment rules and doesn't assume the `message` tool is always available.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No; still constrained by localRoots)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev
- Model/provider: N/A (unit tests)
- Integration/channel (if any): N/A
- Relevant config (redacted): default

### Steps

1. Put a file under an allowed local media root.
2. Reference it via a relative `MEDIA:` path (for example `MEDIA:./relative.png`) while the process CWD is outside that root.
3. Attempt to load/send the media.

### Expected

- The relative path is resolved within allowed roots and loads successfully.

### Actual

- Before: the relative path is resolved against CWD and rejected by localRoots validation.

## Evidence

- [x] Added regression test: `src/web/media.test.ts` (relative path resolution)
- [x] Ran focused tests locally:
  - `pnpm vitest run src/web/media.test.ts`
  - `pnpm vitest run src/infra/outbound/message-action-runner.test.ts`
  - `pnpm vitest run src/auto-reply/reply/get-reply-run.media-only.test.ts`

## Human Verification (required)

- Verified scenarios: unit tests covering relative local media resolution and prompt hint insertion.
- Edge cases checked: CWD outside allowed root; SSRF pinning remains deterministic in tests.
- What you did **not** verify: live end-to-end delivery on Mattermost/Slack/etc.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the commit in this PR.
- Files/config to restore: `src/web/media.ts`, `src/auto-reply/reply/get-reply-run.ts`.
- Known bad symptoms reviewers should watch for: unexpected local media loads from relative paths (should still be constrained to localRoots).

## Risks and Mitigations

- Risk: Relative path resolution could probe a few candidate roots.
  - Mitigation: Only selects existing files and still validates against localRoots before reading.
