### PR TITLE
feat(hooks): make llm_input/llm_output payloads mutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Tools/Diffs guidance: restore a short system-prompt hint for enabled diffs while keeping the detailed instructions in the companion skill, so diffs usage guidance stays out of user-prompt space. (#36904) thanks @gumadeiras.
 - Telegram/ACP topic bindings: accept Telegram Mac Unicode dash option prefixes in `/acp spawn`, support Telegram topic thread binding (`--thread here|auto`), route bound-topic follow-ups to ACP sessions, add actionable Telegram approval buttons with prefixed approval-id resolution, and pin successful bind confirmations in-topic. (#36683) Thanks @huntharo.
 - Hooks/Compaction lifecycle: emit `session:compact:before` and `session:compact:after` internal events plus plugin compaction callbacks with session/count metadata, so automations can react to compaction runs consistently. (#16788) thanks @vincentkoc.
+- Plugins/LLM middleware hooks: allow `llm_input` hooks to mutate per-turn prompt and history payloads (with prompt-image reload on prompt mutation), and allow `llm_output` hooks to mutate assistant text payloads before outbound formatting. (#20416)
 - CLI: make read-only SecretRef status flows degrade safely (#37023) thanks @joshavant.
 
 ### Breaking

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -75,6 +75,7 @@ const makeAttempt = (overrides: Partial<EmbeddedRunAttemptResult>): EmbeddedRunA
   systemPromptReport: undefined,
   messagesSnapshot: [],
   assistantTexts: [],
+  assistantTextsOverridden: false,
   toolMetas: [],
   lastAssistant: undefined,
   didSendViaMessagingTool: false,

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
@@ -33,6 +33,7 @@ export function makeAttemptResult(
     promptError: null,
     sessionIdUsed: "test-session",
     assistantTexts: ["Hello!"],
+    assistantTextsOverridden: false,
     toolMetas: [],
     lastAssistant: undefined,
     messagesSnapshot: [],

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1323,6 +1323,7 @@ export async function runEmbeddedPiAgent(
 
           const payloads = buildEmbeddedRunPayloads({
             assistantTexts: attempt.assistantTexts,
+            assistantTextsOverridden: attempt.assistantTextsOverridden,
             toolMetas: attempt.toolMetas,
             lastAssistant: attempt.lastAssistant,
             lastToolError: attempt.lastToolError,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1439,6 +1439,7 @@ export async function runEmbeddedAttempt(
         getCompactionCount,
       } = subscription;
       let assistantTexts = rawAssistantTexts;
+      let assistantTextsOverridden = false;
 
       const queueHandle: EmbeddedPiQueueHandle = {
         queueMessage: async (text: string) => {
@@ -1885,8 +1886,9 @@ export async function runEmbeddedAttempt(
               messageProvider: params.messageProvider ?? undefined,
             },
           );
-          if (llmOutputResult?.assistantTexts) {
+          if (Array.isArray(llmOutputResult?.assistantTexts)) {
             assistantTexts = llmOutputResult.assistantTexts;
+            assistantTextsOverridden = true;
           }
         } catch (err) {
           log.warn(`llm_output hook failed: ${String(err)}`);
@@ -1904,6 +1906,7 @@ export async function runEmbeddedAttempt(
         systemPromptReport,
         messagesSnapshot,
         assistantTexts,
+        assistantTextsOverridden,
         toolMetas: toolMetasNormalized,
         lastAssistant,
         lastToolError: getLastToolError?.(),

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1425,7 +1425,7 @@ export async function runEmbeddedAttempt(
       });
 
       const {
-        assistantTexts,
+        assistantTexts: rawAssistantTexts,
         toolMetas,
         unsubscribe,
         waitForCompactionRetry,
@@ -1438,6 +1438,7 @@ export async function runEmbeddedAttempt(
         getUsageTotals,
         getCompactionCount,
       } = subscription;
+      let assistantTexts = rawAssistantTexts;
 
       const queueHandle: EmbeddedPiQueueHandle = {
         queueMessage: async (text: string) => {
@@ -1597,22 +1598,70 @@ export async function runEmbeddedAttempt(
             activeSession.agent.replaceMessages(activeSession.messages);
           }
 
+          const resolvePromptImages = async (promptText: string) =>
+            detectAndLoadPromptImages({
+              prompt: promptText,
+              workspaceDir: effectiveWorkspace,
+              model: params.model,
+              existingImages: params.images,
+              maxBytes: MAX_IMAGE_BYTES,
+              maxDimensionPx: resolveImageSanitizationLimits(params.config).maxDimensionPx,
+              workspaceOnly: effectiveFsWorkspaceOnly,
+              // Enforce sandbox path restrictions when sandbox is enabled
+              sandbox:
+                sandbox?.enabled && sandbox?.fsBridge
+                  ? { root: sandbox.workspaceDir, bridge: sandbox.fsBridge }
+                  : undefined,
+            });
+
           // Detect and load images referenced in the prompt for vision-capable models.
           // Images are prompt-local only (pi-like behavior).
-          const imageResult = await detectAndLoadPromptImages({
-            prompt: effectivePrompt,
-            workspaceDir: effectiveWorkspace,
-            model: params.model,
-            existingImages: params.images,
-            maxBytes: MAX_IMAGE_BYTES,
-            maxDimensionPx: resolveImageSanitizationLimits(params.config).maxDimensionPx,
-            workspaceOnly: effectiveFsWorkspaceOnly,
-            // Enforce sandbox path restrictions when sandbox is enabled
-            sandbox:
-              sandbox?.enabled && sandbox?.fsBridge
-                ? { root: sandbox.workspaceDir, bridge: sandbox.fsBridge }
-                : undefined,
-          });
+          let imageResult = await resolvePromptImages(effectivePrompt);
+
+          if (hookRunner?.hasHooks("llm_input")) {
+            try {
+              const llmInputResult = await hookRunner.runLlmInput(
+                {
+                  runId: params.runId,
+                  sessionId: params.sessionId,
+                  provider: params.provider,
+                  model: params.modelId,
+                  systemPrompt: systemPromptText,
+                  prompt: effectivePrompt,
+                  historyMessages: activeSession.messages,
+                  imagesCount: imageResult.images.length,
+                },
+                {
+                  agentId: hookAgentId,
+                  sessionKey: params.sessionKey,
+                  sessionId: params.sessionId,
+                  workspaceDir: params.workspaceDir,
+                  messageProvider: params.messageProvider ?? undefined,
+                },
+              );
+
+              if (Array.isArray(llmInputResult?.historyMessages)) {
+                activeSession.messages.splice(
+                  0,
+                  activeSession.messages.length,
+                  ...(llmInputResult.historyMessages as AgentMessage[]),
+                );
+                activeSession.agent.replaceMessages(activeSession.messages);
+              }
+
+              if (
+                typeof llmInputResult?.prompt === "string" &&
+                llmInputResult.prompt !== effectivePrompt
+              ) {
+                const promptOverride = llmInputResult.prompt;
+                const promptOverrideImages = await resolvePromptImages(promptOverride);
+                effectivePrompt = promptOverride;
+                imageResult = promptOverrideImages;
+              }
+            } catch (err) {
+              log.warn(`llm_input hook failed: ${String(err)}`);
+            }
+          }
 
           cacheTrace?.recordStage("prompt:images", {
             prompt: effectivePrompt,
@@ -1636,32 +1685,6 @@ export async function runEmbeddedAttempt(
                 `promptImages=${imageResult.images.length} ` +
                 `provider=${params.provider}/${params.modelId} sessionFile=${params.sessionFile}`,
             );
-          }
-
-          if (hookRunner?.hasHooks("llm_input")) {
-            hookRunner
-              .runLlmInput(
-                {
-                  runId: params.runId,
-                  sessionId: params.sessionId,
-                  provider: params.provider,
-                  model: params.modelId,
-                  systemPrompt: systemPromptText,
-                  prompt: effectivePrompt,
-                  historyMessages: activeSession.messages,
-                  imagesCount: imageResult.images.length,
-                },
-                {
-                  agentId: hookAgentId,
-                  sessionKey: params.sessionKey,
-                  sessionId: params.sessionId,
-                  workspaceDir: params.workspaceDir,
-                  messageProvider: params.messageProvider ?? undefined,
-                },
-              )
-              .catch((err) => {
-                log.warn(`llm_input hook failed: ${String(err)}`);
-              });
           }
 
           // Only pass images option if there are actually images to pass
@@ -1843,8 +1866,8 @@ export async function runEmbeddedAttempt(
         .map((entry) => ({ toolName: entry.toolName, meta: entry.meta }));
 
       if (hookRunner?.hasHooks("llm_output")) {
-        hookRunner
-          .runLlmOutput(
+        try {
+          const llmOutputResult = await hookRunner.runLlmOutput(
             {
               runId: params.runId,
               sessionId: params.sessionId,
@@ -1861,10 +1884,13 @@ export async function runEmbeddedAttempt(
               workspaceDir: params.workspaceDir,
               messageProvider: params.messageProvider ?? undefined,
             },
-          )
-          .catch((err) => {
-            log.warn(`llm_output hook failed: ${String(err)}`);
-          });
+          );
+          if (llmOutputResult?.assistantTexts) {
+            assistantTexts = llmOutputResult.assistantTexts;
+          }
+        } catch (err) {
+          log.warn(`llm_output hook failed: ${String(err)}`);
+        }
       }
 
       return {

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -121,6 +121,33 @@ describe("buildEmbeddedRunPayloads", () => {
     expectSinglePayloadText(payloads, errorJsonPretty.trim());
   });
 
+  it("falls back to lastAssistant text when assistantTexts are empty without an explicit override", () => {
+    const payloads = buildPayloads({
+      assistantTexts: [],
+      lastAssistant: makeAssistant({
+        stopReason: "stop",
+        errorMessage: undefined,
+        content: [{ type: "text", text: "final assistant text" }],
+      }),
+    });
+
+    expectSinglePayloadText(payloads, "final assistant text");
+  });
+
+  it("does not fall back to lastAssistant text when llm_output explicitly overrides to empty", () => {
+    const payloads = buildPayloads({
+      assistantTexts: [],
+      assistantTextsOverridden: true,
+      lastAssistant: makeAssistant({
+        stopReason: "stop",
+        errorMessage: undefined,
+        content: [{ type: "text", text: "redacted assistant text" }],
+      }),
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
   it("adds a fallback error when a tool fails and no assistant output exists", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "browser", error: "tab not found" },

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -89,6 +89,7 @@ function resolveToolErrorWarningPolicy(params: {
 
 export function buildEmbeddedRunPayloads(params: {
   assistantTexts: string[];
+  assistantTextsOverridden?: boolean;
   toolMetas: ToolMetaEntry[];
   lastAssistant: AssistantMessage | undefined;
   lastToolError?: LastToolError;
@@ -243,12 +244,16 @@ export function buildEmbeddedRunPayloads(params: {
     }
     return isRawApiErrorPayload(trimmed);
   };
+  // If llm_output explicitly sets assistantTexts (including []), preserve that choice
+  // and do not fall back to lastAssistant text.
   const answerTexts = (
-    params.assistantTexts.length
+    params.assistantTextsOverridden
       ? params.assistantTexts
-      : fallbackAnswerText
-        ? [fallbackAnswerText]
-        : []
+      : params.assistantTexts.length
+        ? params.assistantTexts
+        : fallbackAnswerText
+          ? [fallbackAnswerText]
+          : []
   ).filter((text) => !shouldSuppressRawErrorText(text));
 
   let hasUserFacingAssistantReply = false;

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -35,6 +35,7 @@ export type EmbeddedRunAttemptResult = {
   systemPromptReport?: SessionSystemPromptReport;
   messagesSnapshot: AgentMessage[];
   assistantTexts: string[];
+  assistantTextsOverridden: boolean;
   toolMetas: Array<{ toolName: string; meta?: string }>;
   lastAssistant: AssistantMessage | undefined;
   lastToolError?: {

--- a/src/agents/pi-embedded-runner/usage-reporting.test.ts
+++ b/src/agents/pi-embedded-runner/usage-reporting.test.ts
@@ -32,6 +32,7 @@ describe("runEmbeddedPiAgent usage reporting", () => {
       timedOut: false,
       sessionIdUsed: "test-session",
       assistantTexts: ["Response 1", "Response 2"],
+      assistantTextsOverridden: false,
       lastAssistant: {
         usage: { input: 150, output: 50, total: 200 },
         stopReason: "end_turn",

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -347,8 +347,10 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       event,
       ctx,
       (acc, next) => ({
-        prompt: next.prompt ?? acc?.prompt,
-        historyMessages: next.historyMessages ?? acc?.historyMessages,
+        // runModifyingHook executes handlers high->low priority, so existing
+        // values in `acc` must win when multiple handlers set the same field.
+        prompt: acc?.prompt ?? next.prompt,
+        historyMessages: acc?.historyMessages ?? next.historyMessages,
       }),
     );
   }
@@ -366,7 +368,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       event,
       ctx,
       (acc, next) => ({
-        assistantTexts: next.assistantTexts ?? acc?.assistantTexts,
+        // Preserve the highest-priority override when multiple handlers compete.
+        assistantTexts: acc?.assistantTexts ?? next.assistantTexts,
       }),
     );
   }

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -20,7 +20,9 @@ import type {
   PluginHookBeforePromptBuildResult,
   PluginHookBeforeCompactionEvent,
   PluginHookLlmInputEvent,
+  PluginHookLlmInputResult,
   PluginHookLlmOutputEvent,
+  PluginHookLlmOutputResult,
   PluginHookBeforeResetEvent,
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
@@ -62,7 +64,9 @@ export type {
   PluginHookBeforePromptBuildEvent,
   PluginHookBeforePromptBuildResult,
   PluginHookLlmInputEvent,
+  PluginHookLlmInputResult,
   PluginHookLlmOutputEvent,
+  PluginHookLlmOutputResult,
   PluginHookAgentEndEvent,
   PluginHookBeforeCompactionEvent,
   PluginHookBeforeResetEvent,
@@ -332,20 +336,39 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
 
   /**
    * Run llm_input hook.
-   * Allows plugins to observe the exact input payload sent to the LLM.
-   * Runs in parallel (fire-and-forget).
+   * Allows plugins to observe or modify the exact input payload sent to the LLM.
    */
-  async function runLlmInput(event: PluginHookLlmInputEvent, ctx: PluginHookAgentContext) {
-    return runVoidHook("llm_input", event, ctx);
+  async function runLlmInput(
+    event: PluginHookLlmInputEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookLlmInputResult | undefined> {
+    return runModifyingHook<"llm_input", PluginHookLlmInputResult>(
+      "llm_input",
+      event,
+      ctx,
+      (acc, next) => ({
+        prompt: next.prompt ?? acc?.prompt,
+        historyMessages: next.historyMessages ?? acc?.historyMessages,
+      }),
+    );
   }
 
   /**
    * Run llm_output hook.
-   * Allows plugins to observe the exact output payload returned by the LLM.
-   * Runs in parallel (fire-and-forget).
+   * Allows plugins to observe or modify the exact output payload returned by the LLM.
    */
-  async function runLlmOutput(event: PluginHookLlmOutputEvent, ctx: PluginHookAgentContext) {
-    return runVoidHook("llm_output", event, ctx);
+  async function runLlmOutput(
+    event: PluginHookLlmOutputEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookLlmOutputResult | undefined> {
+    return runModifyingHook<"llm_output", PluginHookLlmOutputResult>(
+      "llm_output",
+      event,
+      ctx,
+      (acc, next) => ({
+        assistantTexts: next.assistantTexts ?? acc?.assistantTexts,
+      }),
+    );
   }
 
   /**

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -754,7 +754,7 @@ describe("loadOpenClawPlugins", () => {
     expect(disabled?.status).toBe("disabled");
   });
 
-  it("blocks before_prompt_build but preserves legacy model overrides when prompt injection is disabled", async () => {
+  it("blocks llm_input and before_prompt_build but preserves legacy model overrides when prompt injection is disabled", async () => {
     useNoBundledPlugins();
     const plugin = writePlugin({
       id: "hook-policy",
@@ -766,6 +766,7 @@ describe("loadOpenClawPlugins", () => {
     modelOverride: "gpt-4o",
     providerOverride: "anthropic",
   }));
+  api.on("llm_input", () => ({ prompt: "mutated" }));
   api.on("before_model_resolve", () => ({ providerOverride: "openai" }));
 } };`,
     });
@@ -800,7 +801,13 @@ describe("loadOpenClawPlugins", () => {
         "blocked by plugins.entries.hook-policy.hooks.allowPromptInjection=false",
       ),
     );
-    expect(blockedDiagnostics).toHaveLength(1);
+    expect(blockedDiagnostics).toHaveLength(2);
+    expect(
+      blockedDiagnostics.some((diag) => String(diag.message).includes('"before_prompt_build"')),
+    ).toBe(true);
+    expect(blockedDiagnostics.some((diag) => String(diag.message).includes('"llm_input"'))).toBe(
+      true,
+    );
     const constrainedDiagnostics = registry.diagnostics.filter((diag) =>
       String(diag.message).includes(
         "prompt fields constrained by plugins.entries.hook-policy.hooks.allowPromptInjection=false",
@@ -817,6 +824,7 @@ describe("loadOpenClawPlugins", () => {
       body: `module.exports = { id: "hook-policy-default", register(api) {
   api.on("before_prompt_build", () => ({ prependContext: "prepend" }));
   api.on("before_agent_start", () => ({ prependContext: "legacy" }));
+  api.on("llm_input", () => ({ prompt: "mutated" }));
 } };`,
     });
 
@@ -830,6 +838,7 @@ describe("loadOpenClawPlugins", () => {
     expect(registry.typedHooks.map((entry) => entry.hookName)).toEqual([
       "before_prompt_build",
       "before_agent_start",
+      "llm_input",
     ]);
   });
 

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -516,15 +516,6 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }
     let effectiveHandler = handler;
     if (policy?.allowPromptInjection === false && isPromptInjectionHookName(hookName)) {
-      if (hookName === "before_prompt_build") {
-        pushDiagnostic({
-          level: "warn",
-          pluginId: record.id,
-          source: record.source,
-          message: `typed hook "${hookName}" blocked by plugins.entries.${record.id}.hooks.allowPromptInjection=false`,
-        });
-        return;
-      }
       if (hookName === "before_agent_start") {
         pushDiagnostic({
           level: "warn",
@@ -535,6 +526,14 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
         effectiveHandler = constrainLegacyPromptInjectionHook(
           handler as PluginHookHandlerMap["before_agent_start"],
         ) as PluginHookHandlerMap[K];
+      } else {
+        pushDiagnostic({
+          level: "warn",
+          pluginId: record.id,
+          source: record.source,
+          message: `typed hook "${hookName}" blocked by plugins.entries.${record.id}.hooks.allowPromptInjection=false`,
+        });
+        return;
       }
     }
     record.hookCount += 1;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -373,6 +373,7 @@ export const isPluginHookName = (hookName: unknown): hookName is PluginHookName 
 export const PROMPT_INJECTION_HOOK_NAMES = [
   "before_prompt_build",
   "before_agent_start",
+  "llm_input",
 ] as const satisfies readonly PluginHookName[];
 
 export type PromptInjectionHookName = (typeof PROMPT_INJECTION_HOOK_NAMES)[number];

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -488,6 +488,13 @@ export type PluginHookLlmInputEvent = {
   imagesCount: number;
 };
 
+export type PluginHookLlmInputResult = {
+  /** Override the final prompt text sent to the model. */
+  prompt?: string;
+  /** Override the history messages used for this model call. */
+  historyMessages?: unknown[];
+};
+
 // llm_output hook
 export type PluginHookLlmOutputEvent = {
   runId: string;
@@ -503,6 +510,11 @@ export type PluginHookLlmOutputEvent = {
     cacheWrite?: number;
     total?: number;
   };
+};
+
+export type PluginHookLlmOutputResult = {
+  /** Override assistant text payloads before outbound delivery formatting. */
+  assistantTexts?: string[];
 };
 
 // agent_end hook
@@ -789,11 +801,14 @@ export type PluginHookHandlerMap = {
     event: PluginHookBeforeAgentStartEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforeAgentStartResult | void> | PluginHookBeforeAgentStartResult | void;
-  llm_input: (event: PluginHookLlmInputEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
+  llm_input: (
+    event: PluginHookLlmInputEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookLlmInputResult | void> | PluginHookLlmInputResult | void;
   llm_output: (
     event: PluginHookLlmOutputEvent,
     ctx: PluginHookAgentContext,
-  ) => Promise<void> | void;
+  ) => Promise<PluginHookLlmOutputResult | void> | PluginHookLlmOutputResult | void;
   agent_end: (event: PluginHookAgentEndEvent, ctx: PluginHookAgentContext) => Promise<void> | void;
   before_compaction: (
     event: PluginHookBeforeCompactionEvent,

--- a/src/plugins/wired-hooks-llm.test.ts
+++ b/src/plugins/wired-hooks-llm.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createHookRunner } from "./hooks.js";
-import { createMockPluginRegistry } from "./hooks.test-helpers.js";
+import { addTestHook, createMockPluginRegistry } from "./hooks.test-helpers.js";
 
 describe("llm hook runner methods", () => {
   it("runLlmInput invokes registered llm_input hooks", async () => {
@@ -150,6 +150,40 @@ describe("llm hook runner methods", () => {
     });
   });
 
+  it("runLlmInput keeps higher-priority prompt override on conflicts", async () => {
+    const registry = createMockPluginRegistry([]);
+    addTestHook({
+      registry,
+      pluginId: "high-priority",
+      hookName: "llm_input",
+      priority: 10,
+      handler: vi.fn().mockResolvedValue({ prompt: "high-priority prompt" }),
+    });
+    addTestHook({
+      registry,
+      pluginId: "low-priority",
+      hookName: "llm_input",
+      priority: 1,
+      handler: vi.fn().mockResolvedValue({ prompt: "low-priority prompt" }),
+    });
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runLlmInput(
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5",
+        prompt: "hello",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      { agentId: "main", sessionId: "session-1" },
+    );
+
+    expect(result).toEqual({ prompt: "high-priority prompt", historyMessages: undefined });
+  });
+
   it("runLlmOutput returns modified assistant texts", async () => {
     const handler = vi.fn().mockResolvedValue({ assistantTexts: ["rehydrated response"] });
     const registry = createMockPluginRegistry([{ hookName: "llm_output", handler }]);
@@ -189,5 +223,38 @@ describe("llm hook runner methods", () => {
     );
 
     expect(result).toBeUndefined();
+  });
+
+  it("runLlmOutput keeps higher-priority assistant override on conflicts", async () => {
+    const registry = createMockPluginRegistry([]);
+    addTestHook({
+      registry,
+      pluginId: "high-priority",
+      hookName: "llm_output",
+      priority: 10,
+      handler: vi.fn().mockResolvedValue({ assistantTexts: ["high-priority text"] }),
+    });
+    addTestHook({
+      registry,
+      pluginId: "low-priority",
+      hookName: "llm_output",
+      priority: 1,
+      handler: vi.fn().mockResolvedValue({ assistantTexts: ["low-priority text"] }),
+    });
+
+    const runner = createHookRunner(registry);
+    const result = await runner.runLlmOutput(
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5",
+        assistantTexts: ["hi"],
+        usage: { input: 10, output: 20, total: 30 },
+      },
+      { agentId: "main", sessionId: "session-1" },
+    );
+
+    expect(result).toEqual({ assistantTexts: ["high-priority text"] });
   });
 });

--- a/src/plugins/wired-hooks-llm.test.ts
+++ b/src/plugins/wired-hooks-llm.test.ts
@@ -69,4 +69,125 @@ describe("llm hook runner methods", () => {
     expect(runner.hasHooks("llm_input")).toBe(true);
     expect(runner.hasHooks("llm_output")).toBe(false);
   });
+
+  it("runLlmInput returns prompt and history overrides", async () => {
+    const handler = vi.fn().mockResolvedValue({
+      prompt: "redacted prompt",
+      historyMessages: [{ role: "user", content: "trimmed history" }],
+    });
+    const registry = createMockPluginRegistry([{ hookName: "llm_input", handler }]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runLlmInput(
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5",
+        systemPrompt: "be helpful",
+        prompt: "original prompt",
+        historyMessages: [{ role: "user", content: "original history" }],
+        imagesCount: 0,
+      },
+      { agentId: "main", sessionId: "session-1" },
+    );
+
+    expect(result).toEqual({
+      prompt: "redacted prompt",
+      historyMessages: [{ role: "user", content: "trimmed history" }],
+    });
+  });
+
+  it("runLlmInput preserves backward compatibility when handler returns void", async () => {
+    const handler = vi.fn(); // undefined return
+    const registry = createMockPluginRegistry([{ hookName: "llm_input", handler }]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runLlmInput(
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5",
+        prompt: "hello",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      { agentId: "main", sessionId: "session-1" },
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it("runLlmInput merges prompt/history across multiple handlers", async () => {
+    const registry = createMockPluginRegistry([
+      { hookName: "llm_input", handler: vi.fn().mockResolvedValue({ prompt: "first prompt" }) },
+      {
+        hookName: "llm_input",
+        handler: vi.fn().mockResolvedValue({
+          historyMessages: [{ role: "assistant", content: "history override" }],
+        }),
+      },
+    ]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runLlmInput(
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5",
+        prompt: "hello",
+        historyMessages: [],
+        imagesCount: 0,
+      },
+      { agentId: "main", sessionId: "session-1" },
+    );
+
+    expect(result).toEqual({
+      prompt: "first prompt",
+      historyMessages: [{ role: "assistant", content: "history override" }],
+    });
+  });
+
+  it("runLlmOutput returns modified assistant texts", async () => {
+    const handler = vi.fn().mockResolvedValue({ assistantTexts: ["rehydrated response"] });
+    const registry = createMockPluginRegistry([{ hookName: "llm_output", handler }]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runLlmOutput(
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5",
+        assistantTexts: ["raw masked response"],
+        lastAssistant: { role: "assistant", content: "raw masked response" },
+        usage: { input: 10, output: 20, total: 30 },
+      },
+      { agentId: "main", sessionId: "session-1" },
+    );
+
+    expect(result).toEqual({ assistantTexts: ["rehydrated response"] });
+  });
+
+  it("runLlmOutput preserves backward compatibility when handler returns void", async () => {
+    const handler = vi.fn(); // undefined return
+    const registry = createMockPluginRegistry([{ hookName: "llm_output", handler }]);
+    const runner = createHookRunner(registry);
+
+    const result = await runner.runLlmOutput(
+      {
+        runId: "run-1",
+        sessionId: "session-1",
+        provider: "openai",
+        model: "gpt-5",
+        assistantTexts: ["hi"],
+        usage: { input: 10, output: 20, total: 30 },
+      },
+      { agentId: "main", sessionId: "session-1" },
+    );
+
+    expect(result).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- convert `llm_input` / `llm_output` from observational void hooks to modifying hooks in the core hook runner
- add explicit hook result types (`PluginHookLlmInputResult`, `PluginHookLlmOutputResult`) and expose mutable signatures in `PluginHookHandlerMap`
- apply `llm_input` prompt/history overrides in embedded runs, including safe prompt-image re-resolution when prompt text is mutated
- apply `llm_output.assistantTexts` overrides before payload building/outbound formatting
- expand `wired-hooks-llm` tests for modify + merge + backward-compat behavior
- add changelog entry for #20416

## Why this shape
- focused on the highest-impact cross-user middleware gap in #20416 while keeping scope limited to `llm_input`/`llm_output`
- preserves backward compatibility for existing plugins returning `void`
- avoids broader unrelated hook-surface changes so this can be merged independently

## Validation
- `pnpm check`
- `pnpm test`
- `OPENCLAW_TEST_PROFILE=low OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test`

## Related
- Closes #20416
- Related: #22268
- Related PRs reviewed: #20426, #20802
