### PR TITLE
fix(media): resolve relative paths against allowed roots instead of CWD

### DIFF
--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -39,10 +39,7 @@ function resolveWebMediaOptions(params: {
   options?: { ssrfPolicy?: SsrFPolicy; localRoots?: readonly string[] | "any" };
   optimizeImages: boolean;
 }): WebMediaOptions {
-  if (
-    typeof params.maxBytesOrOptions === "number" ||
-    params.maxBytesOrOptions === undefined
-  ) {
+  if (typeof params.maxBytesOrOptions === "number" || params.maxBytesOrOptions === undefined) {
     return {
       maxBytes: params.maxBytesOrOptions,
       optimizeImages: params.optimizeImages,
@@ -70,11 +67,7 @@ export type LocalMediaAccessErrorCode =
 export class LocalMediaAccessError extends Error {
   code: LocalMediaAccessErrorCode;
 
-  constructor(
-    code: LocalMediaAccessErrorCode,
-    message: string,
-    options?: ErrorOptions,
-  ) {
+  constructor(code: LocalMediaAccessErrorCode, message: string, options?: ErrorOptions) {
     super(message, options);
     this.code = code;
     this.name = "LocalMediaAccessError";
@@ -106,9 +99,7 @@ async function assertLocalMediaAllowed(
   // `workspace-*` state roots via the temp-root prefix match; require explicit
   // localRoots for those.
   if (localRoots === undefined) {
-    const workspaceRoot = roots.find(
-      (root) => path.basename(root) === "workspace",
-    );
+    const workspaceRoot = roots.find((root) => path.basename(root) === "workspace");
     if (workspaceRoot) {
       const stateDir = path.dirname(workspaceRoot);
       const rel = path.relative(stateDir, resolved);
@@ -136,10 +127,7 @@ async function assertLocalMediaAllowed(
         `Invalid localRoots entry (refuses filesystem root): ${root}. Pass a narrower directory.`,
       );
     }
-    if (
-      resolved === resolvedRoot ||
-      resolved.startsWith(resolvedRoot + path.sep)
-    ) {
+    if (resolved === resolvedRoot || resolved.startsWith(resolvedRoot + path.sep)) {
       return;
     }
   }
@@ -165,10 +153,7 @@ function formatCapReduce(label: string, cap: number, size: number): string {
   return `${label} could not be reduced below ${formatMb(cap, 0)}MB (got ${formatMb(size)}MB)`;
 }
 
-function isHeicSource(opts: {
-  contentType?: string;
-  fileName?: string;
-}): boolean {
+function isHeicSource(opts: { contentType?: string; fileName?: string }): boolean {
   if (opts.contentType && HEIC_MIME_RE.test(opts.contentType.trim())) {
     return true;
   }
@@ -206,10 +191,7 @@ type OptimizedImage = {
   compressionLevel?: number;
 };
 
-function logOptimizedImage(params: {
-  originalSize: number;
-  optimized: OptimizedImage;
-}): void {
+function logOptimizedImage(params: { originalSize: number; optimized: OptimizedImage }): void {
   if (!shouldLogVerbose()) {
     return;
   }
@@ -233,9 +215,7 @@ async function optimizeImageWithFallback(params: {
   meta?: { contentType?: string; fileName?: string };
 }): Promise<OptimizedImage> {
   const { buffer, cap, meta } = params;
-  const isPng =
-    meta?.contentType === "image/png" ||
-    meta?.fileName?.toLowerCase().endsWith(".png");
+  const isPng = meta?.contentType === "image/png" || meta?.fileName?.toLowerCase().endsWith(".png");
   const hasAlpha = isPng && (await hasAlphaChannel(buffer));
 
   if (hasAlpha) {
@@ -274,10 +254,7 @@ async function loadWebMediaInternal(
     try {
       mediaUrl = fileURLToPath(mediaUrl);
     } catch {
-      throw new LocalMediaAccessError(
-        "invalid-file-url",
-        `Invalid file:// URL: ${mediaUrl}`,
-      );
+      throw new LocalMediaAccessError("invalid-file-url", `Invalid file:// URL: ${mediaUrl}`);
     }
   }
 
@@ -316,15 +293,12 @@ async function loadWebMediaInternal(
   }): Promise<WebMediaResult> => {
     // If caller explicitly provides maxBytes, trust it (for channels that handle large files).
     // Otherwise fall back to per-kind defaults.
-    const cap =
-      maxBytes !== undefined ? maxBytes : maxBytesForKind(params.kind);
+    const cap = maxBytes !== undefined ? maxBytes : maxBytesForKind(params.kind);
     if (params.kind === "image") {
       const isGif = params.contentType === "image/gif";
       if (isGif || !optimizeImages) {
         if (params.buffer.length > cap) {
-          throw new Error(
-            formatCapLimit(isGif ? "GIF" : "Media", cap, params.buffer.length),
-          );
+          throw new Error(formatCapLimit(isGif ? "GIF" : "Media", cap, params.buffer.length));
         }
         return {
           buffer: params.buffer,
@@ -417,13 +391,9 @@ async function loadWebMediaInternal(
     } catch (err) {
       if (err instanceof SafeOpenError) {
         if (err.code === "not-found") {
-          throw new LocalMediaAccessError(
-            "not-found",
-            `Local media file not found: ${mediaUrl}`,
-            {
-              cause: err,
-            },
-          );
+          throw new LocalMediaAccessError("not-found", `Local media file not found: ${mediaUrl}`, {
+            cause: err,
+          });
         }
         if (err.code === "not-file") {
           throw new LocalMediaAccessError(

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -381,6 +381,10 @@ async function loadWebMediaInternal(
     const roots = localRoots ?? getDefaultLocalRoots();
     for (const root of roots) {
       const candidate = path.resolve(root, mediaUrl);
+      // Only accept candidates that actually stay inside this root.
+      if (candidate !== root && !candidate.startsWith(root + path.sep)) {
+        continue;
+      }
       try {
         await fs.access(candidate);
         mediaUrl = candidate;

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -39,7 +39,10 @@ function resolveWebMediaOptions(params: {
   options?: { ssrfPolicy?: SsrFPolicy; localRoots?: readonly string[] | "any" };
   optimizeImages: boolean;
 }): WebMediaOptions {
-  if (typeof params.maxBytesOrOptions === "number" || params.maxBytesOrOptions === undefined) {
+  if (
+    typeof params.maxBytesOrOptions === "number" ||
+    params.maxBytesOrOptions === undefined
+  ) {
     return {
       maxBytes: params.maxBytesOrOptions,
       optimizeImages: params.optimizeImages,
@@ -67,7 +70,11 @@ export type LocalMediaAccessErrorCode =
 export class LocalMediaAccessError extends Error {
   code: LocalMediaAccessErrorCode;
 
-  constructor(code: LocalMediaAccessErrorCode, message: string, options?: ErrorOptions) {
+  constructor(
+    code: LocalMediaAccessErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
     super(message, options);
     this.code = code;
     this.name = "LocalMediaAccessError";
@@ -99,7 +106,9 @@ async function assertLocalMediaAllowed(
   // `workspace-*` state roots via the temp-root prefix match; require explicit
   // localRoots for those.
   if (localRoots === undefined) {
-    const workspaceRoot = roots.find((root) => path.basename(root) === "workspace");
+    const workspaceRoot = roots.find(
+      (root) => path.basename(root) === "workspace",
+    );
     if (workspaceRoot) {
       const stateDir = path.dirname(workspaceRoot);
       const rel = path.relative(stateDir, resolved);
@@ -127,7 +136,10 @@ async function assertLocalMediaAllowed(
         `Invalid localRoots entry (refuses filesystem root): ${root}. Pass a narrower directory.`,
       );
     }
-    if (resolved === resolvedRoot || resolved.startsWith(resolvedRoot + path.sep)) {
+    if (
+      resolved === resolvedRoot ||
+      resolved.startsWith(resolvedRoot + path.sep)
+    ) {
       return;
     }
   }
@@ -153,7 +165,10 @@ function formatCapReduce(label: string, cap: number, size: number): string {
   return `${label} could not be reduced below ${formatMb(cap, 0)}MB (got ${formatMb(size)}MB)`;
 }
 
-function isHeicSource(opts: { contentType?: string; fileName?: string }): boolean {
+function isHeicSource(opts: {
+  contentType?: string;
+  fileName?: string;
+}): boolean {
   if (opts.contentType && HEIC_MIME_RE.test(opts.contentType.trim())) {
     return true;
   }
@@ -173,7 +188,11 @@ function toJpegFileName(fileName?: string): string | undefined {
   }
   const parsed = path.parse(trimmed);
   if (!parsed.ext || HEIC_EXT_RE.test(parsed.ext)) {
-    return path.format({ dir: parsed.dir, name: parsed.name || trimmed, ext: ".jpg" });
+    return path.format({
+      dir: parsed.dir,
+      name: parsed.name || trimmed,
+      ext: ".jpg",
+    });
   }
   return path.format({ dir: parsed.dir, name: parsed.name, ext: ".jpg" });
 }
@@ -187,7 +206,10 @@ type OptimizedImage = {
   compressionLevel?: number;
 };
 
-function logOptimizedImage(params: { originalSize: number; optimized: OptimizedImage }): void {
+function logOptimizedImage(params: {
+  originalSize: number;
+  optimized: OptimizedImage;
+}): void {
   if (!shouldLogVerbose()) {
     return;
   }
@@ -211,7 +233,9 @@ async function optimizeImageWithFallback(params: {
   meta?: { contentType?: string; fileName?: string };
 }): Promise<OptimizedImage> {
   const { buffer, cap, meta } = params;
-  const isPng = meta?.contentType === "image/png" || meta?.fileName?.toLowerCase().endsWith(".png");
+  const isPng =
+    meta?.contentType === "image/png" ||
+    meta?.fileName?.toLowerCase().endsWith(".png");
   const hasAlpha = isPng && (await hasAlphaChannel(buffer));
 
   if (hasAlpha) {
@@ -250,7 +274,10 @@ async function loadWebMediaInternal(
     try {
       mediaUrl = fileURLToPath(mediaUrl);
     } catch {
-      throw new LocalMediaAccessError("invalid-file-url", `Invalid file:// URL: ${mediaUrl}`);
+      throw new LocalMediaAccessError(
+        "invalid-file-url",
+        `Invalid file:// URL: ${mediaUrl}`,
+      );
     }
   }
 
@@ -289,12 +316,15 @@ async function loadWebMediaInternal(
   }): Promise<WebMediaResult> => {
     // If caller explicitly provides maxBytes, trust it (for channels that handle large files).
     // Otherwise fall back to per-kind defaults.
-    const cap = maxBytes !== undefined ? maxBytes : maxBytesForKind(params.kind);
+    const cap =
+      maxBytes !== undefined ? maxBytes : maxBytesForKind(params.kind);
     if (params.kind === "image") {
       const isGif = params.contentType === "image/gif";
       if (isGif || !optimizeImages) {
         if (params.buffer.length > cap) {
-          throw new Error(formatCapLimit(isGif ? "GIF" : "Media", cap, params.buffer.length));
+          throw new Error(
+            formatCapLimit(isGif ? "GIF" : "Media", cap, params.buffer.length),
+          );
         }
         return {
           buffer: params.buffer,
@@ -331,7 +361,11 @@ async function loadWebMediaInternal(
         : optimizeImages
           ? Math.max(maxBytes, defaultFetchCap)
           : maxBytes;
-    const fetched = await fetchRemoteMedia({ url: mediaUrl, maxBytes: fetchCap, ssrfPolicy });
+    const fetched = await fetchRemoteMedia({
+      url: mediaUrl,
+      maxBytes: fetchCap,
+      ssrfPolicy,
+    });
     const { buffer, contentType, fileName } = fetched;
     const kind = kindFromMime(contentType);
     return await clampAndFinalize({ buffer, contentType, kind, fileName });
@@ -340,6 +374,21 @@ async function loadWebMediaInternal(
   // Expand tilde paths to absolute paths (e.g., ~/Downloads/photo.jpg)
   if (mediaUrl.startsWith("~")) {
     mediaUrl = resolveUserPath(mediaUrl);
+  }
+
+  // Resolve relative paths against allowed roots instead of CWD.
+  if (!path.isAbsolute(mediaUrl) && localRoots !== "any") {
+    const roots = localRoots ?? getDefaultLocalRoots();
+    for (const root of roots) {
+      const candidate = path.resolve(root, mediaUrl);
+      try {
+        await fs.access(candidate);
+        mediaUrl = candidate;
+        break;
+      } catch {
+        // not found under this root, try next
+      }
+    }
   }
 
   if ((sandboxValidated || localRoots === "any") && !readFileOverride) {
@@ -364,9 +413,13 @@ async function loadWebMediaInternal(
     } catch (err) {
       if (err instanceof SafeOpenError) {
         if (err.code === "not-found") {
-          throw new LocalMediaAccessError("not-found", `Local media file not found: ${mediaUrl}`, {
-            cause: err,
-          });
+          throw new LocalMediaAccessError(
+            "not-found",
+            `Local media file not found: ${mediaUrl}`,
+            {
+              cause: err,
+            },
+          );
         }
         if (err.code === "not-file") {
           throw new LocalMediaAccessError(
@@ -408,7 +461,11 @@ export async function loadWebMedia(
 ): Promise<WebMediaResult> {
   return await loadWebMediaInternal(
     mediaUrl,
-    resolveWebMediaOptions({ maxBytesOrOptions, options, optimizeImages: true }),
+    resolveWebMediaOptions({
+      maxBytesOrOptions,
+      options,
+      optimizeImages: true,
+    }),
   );
 }
 
@@ -419,7 +476,11 @@ export async function loadWebMediaRaw(
 ): Promise<WebMediaResult> {
   return await loadWebMediaInternal(
     mediaUrl,
-    resolveWebMediaOptions({ maxBytesOrOptions, options, optimizeImages: false }),
+    resolveWebMediaOptions({
+      maxBytesOrOptions,
+      options,
+      optimizeImages: false,
+    }),
   );
 }
 
@@ -439,7 +500,9 @@ export async function optimizeImageToJpeg(
     try {
       source = await convertHeicToJpeg(buffer);
     } catch (err) {
-      throw new Error(`HEIC image conversion failed: ${String(err)}`, { cause: err });
+      throw new Error(`HEIC image conversion failed: ${String(err)}`, {
+        cause: err,
+      });
     }
   }
   const sides = [2048, 1536, 1280, 1024, 800];


### PR DESCRIPTION
Was debugging why my agent's media replies kept failing with "not under an allowed directory" even though the files existed.

## What

Relative MEDIA: paths (like ./image.png) resolve against process.cwd() instead of the configured allowed media roots. So the resolved path almost never falls under an allowed root, and the send fails.

## How I found this

Agent kept suggesting MEDIA:./output.png paths that worked fine when I tested manually from the media directory, but failed through the gateway. Traced it to the path.resolve call in media.ts that uses CWD as the base for relative paths.

## Fix

When a relative path is detected, try resolving it against each allowed root in order and use the first match where the file actually exists. Falls through to the existing error if no match is found.

Fixes #37111