### PR TITLE
Media: resolve relative local paths within allowed roots

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -381,7 +381,7 @@ export async function runPreparedReply(
   const prefixedBody = [threadContextNote, prefixedBodyBase].filter(Boolean).join("\n\n");
   const mediaNote = buildInboundMediaNote(ctx);
   const mediaReplyHint = mediaNote
-    ? "To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg (spaces ok, quote if needed) or a safe relative path like MEDIA:./image.jpg. Avoid absolute paths (MEDIA:/...) and ~ paths — they are blocked for security. Keep caption in the text body."
+    ? "To send an image back, prefer the message tool (media/path/filePath). If you must inline, use MEDIA:https://example.com/image.jpg (spaces ok, quote if needed) or a relative path like MEDIA:./image.jpg. Local paths must stay under an allowed media root; use a message-tool file path when in doubt. Keep caption in the text body."
     : undefined;
   let prefixedCommandBody = mediaNote
     ? [mediaNote, mediaReplyHint, prefixedBody ?? ""].filter(Boolean).join("\n").trim()

--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -361,6 +361,27 @@ describe("local media root guard", () => {
     expect(result.kind).toBe("image");
   });
 
+  it("resolves relative local paths against explicit roots", async () => {
+    const nestedRoot = await fs.mkdtemp(path.join(fixtureRoot, "relative-root-"));
+    const imagesDir = path.join(nestedRoot, "images");
+    const imageFile = path.join(imagesDir, "sample.png");
+
+    try {
+      await fs.mkdir(imagesDir, { recursive: true });
+      await fs.writeFile(imageFile, tinyPngBuffer);
+
+      const result = await loadWebMediaRaw("images/sample.png", {
+        maxBytes: 1024 * 1024,
+        localRoots: [nestedRoot],
+      });
+
+      expect(result.kind).toBe("image");
+      expect(result.buffer.equals(tinyPngBuffer)).toBe(true);
+    } finally {
+      await fs.rm(nestedRoot, { recursive: true, force: true });
+    }
+  });
+
   it("accepts win32 dev=0 stat mismatch for local file loads", async () => {
     const actualLstat = await fs.lstat(tinyPngFile);
     const actualStat = await fs.stat(tinyPngFile);

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -78,6 +78,28 @@ export function getDefaultLocalRoots(): readonly string[] {
   return getDefaultMediaLocalRoots();
 }
 
+async function resolveRelativeMediaPath(
+  mediaPath: string,
+  localRoots: readonly string[] | "any" | undefined,
+): Promise<string> {
+  if (path.isAbsolute(mediaPath) || localRoots === "any") {
+    return mediaPath;
+  }
+
+  const roots = localRoots ?? getDefaultLocalRoots();
+  for (const root of roots) {
+    const candidate = path.resolve(root, mediaPath);
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // Keep scanning allowed roots until one exists.
+    }
+  }
+
+  return mediaPath;
+}
+
 async function assertLocalMediaAllowed(
   mediaPath: string,
   localRoots: readonly string[] | "any" | undefined,
@@ -341,6 +363,8 @@ async function loadWebMediaInternal(
   if (mediaUrl.startsWith("~")) {
     mediaUrl = resolveUserPath(mediaUrl);
   }
+
+  mediaUrl = await resolveRelativeMediaPath(mediaUrl, localRoots);
 
   if ((sandboxValidated || localRoots === "any") && !readFileOverride) {
     throw new LocalMediaAccessError(


### PR DESCRIPTION
Closes #37111

## Summary
- resolve relative local media paths against configured allowed roots before validation
- add a regression test covering relative-path loads under an explicit root
- update reply guidance so it describes local media in terms of allowed roots instead of claiming absolute or `~` paths are always blocked

## Testing
- pnpm test src/web/media.test.ts
- pnpm exec oxlint --type-aware src/web/media.ts src/web/media.test.ts src/auto-reply/reply/get-reply-run.ts
