### PR TITLE
fix(telegram): support negative IDs in groupAllowFrom (#36753)

### DIFF
--- a/src/telegram/bot-access.test.ts
+++ b/src/telegram/bot-access.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAllowFrom } from "./bot-access.js";
+
+describe("normalizeAllowFrom", () => {
+  it("accepts signed numeric Telegram IDs and rejects usernames", () => {
+    const result = normalizeAllowFrom(["-1001234567890", " tg:-100999 ", "745123456", "@someone"]);
+
+    expect(result).toEqual({
+      entries: ["-1001234567890", "-100999", "745123456"],
+      hasWildcard: false,
+      hasEntries: true,
+      invalidEntries: ["@someone"],
+    });
+  });
+});

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -44,11 +44,12 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  // Support negative IDs for Telegram group/channel IDs (e.g., -1001234567890)
+  const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => /^-?\d+$/.test(value));
   return {
     entries: ids,
     hasWildcard,


### PR DESCRIPTION
Fixes #36753 - Telegram groupAllowFrom rejects negative group IDs

## Problem
`groupAllowFrom: ["-1001234567890"]` rejected with error:
> authorization requires numeric Telegram sender IDs only

## Root Cause
- Regex `/^\d+$/` only matches positive integers
- Telegram group/channel IDs are **negative** (e.g., `-1001234567890`)
- All group IDs rejected, field name misleading

## Fix
Change regex to `/^-?\d+$/` (support optional minus sign)

## Changes
- Line 47: `invalidEntries` filter regex updated
- Line 51: `ids` filter regex updated  
- +1 comment explaining negative ID support

## Testing
✅ Positive user IDs: `"745123456"` → still work
✅ Negative group IDs: `"-1001234567890"` → now accepted
⚠️  Invalid: `"@username"` → still warned

## Impact
- Users can now whitelist specific groups
- No need for insecure `groupPolicy: "open"` workaround
- Backward compatible (positive IDs unchanged)

+3 lines, -2 lines
