### PR TITLE
docs: fix broken FAQ troubleshooting anchor

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -449,7 +449,7 @@ section is the latest shipped version. Entries are grouped by **Highlights**, **
 
 Some Comcast/Xfinity connections incorrectly block `docs.openclaw.ai` via Xfinity
 Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry. More
-detail: [Troubleshooting](/help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity).
+detail: [Troubleshooting](/help/troubleshooting).
 Please help us unblock it by reporting here: [https://spa.xfinity.com/check_url_status](https://spa.xfinity.com/check_url_status).
 
 If you still can't reach the site, the docs are mirrored on GitHub:


### PR DESCRIPTION
Closes #36970

Fix broken cross-doc link in FAQ by pointing to the troubleshooting page (without a non-existent anchor).
