### PR TITLE
Gateway: refresh LaunchAgent env only for loaded restarts

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -123,4 +123,21 @@ describe("runServiceRestart token drift", () => {
     const payload = JSON.parse(jsonLine ?? "{}") as { warnings?: string[] };
     expect(payload.warnings).toBeUndefined();
   });
+
+  it("runs preRestartCheck only when service is loaded", async () => {
+    const preRestartCheck = vi.fn().mockResolvedValue(undefined);
+    service.isLoaded.mockResolvedValueOnce(false);
+
+    const restarted = await runServiceRestart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true },
+      preRestartCheck,
+    });
+
+    expect(restarted).toBe(false);
+    expect(preRestartCheck).not.toHaveBeenCalled();
+    expect(service.restart).not.toHaveBeenCalled();
+  });
 });

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -30,6 +30,13 @@ type RestartPostCheckContext = {
   fail: (message: string, hints?: string[]) => void;
 };
 
+type RestartPreCheckContext = {
+  json: boolean;
+  stdout: Writable;
+  warnings: string[];
+  fail: (message: string, hints?: string[]) => void;
+};
+
 async function maybeAugmentSystemdHints(hints: string[]): Promise<string[]> {
   if (process.platform !== "linux") {
     return hints;
@@ -252,6 +259,7 @@ export async function runServiceRestart(params: {
   renderStartHints: () => string[];
   opts?: DaemonLifecycleOptions;
   checkTokenDrift?: boolean;
+  preRestartCheck?: (ctx: RestartPreCheckContext) => Promise<void>;
   postRestartCheck?: (ctx: RestartPostCheckContext) => Promise<void>;
 }): Promise<boolean> {
   const json = Boolean(params.opts?.json);
@@ -315,6 +323,9 @@ export async function runServiceRestart(params: {
   }
 
   try {
+    if (params.preRestartCheck) {
+      await params.preRestartCheck({ json, stdout, warnings, fail });
+    }
     await params.service.restart({ env: process.env, stdout });
     if (params.postRestartCheck) {
       await params.postRestartCheck({ json, stdout, warnings, fail });

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -24,18 +24,13 @@ type DaemonLifecycleOptions = {
 };
 
 type RestartPostCheckContext = {
+  serviceCommand?: Awaited<ReturnType<GatewayService["readCommand"]>>;
   json: boolean;
   stdout: Writable;
   warnings: string[];
   fail: (message: string, hints?: string[]) => void;
 };
-
-type RestartPreCheckContext = {
-  json: boolean;
-  stdout: Writable;
-  warnings: string[];
-  fail: (message: string, hints?: string[]) => void;
-};
+type RestartCheckContext = RestartPostCheckContext;
 
 async function maybeAugmentSystemdHints(hints: string[]): Promise<string[]> {
   if (process.platform !== "linux") {
@@ -259,7 +254,7 @@ export async function runServiceRestart(params: {
   renderStartHints: () => string[];
   opts?: DaemonLifecycleOptions;
   checkTokenDrift?: boolean;
-  preRestartCheck?: (ctx: RestartPreCheckContext) => Promise<void>;
+  preRestartCheck?: (ctx: RestartCheckContext) => Promise<void>;
   postRestartCheck?: (ctx: RestartPostCheckContext) => Promise<void>;
 }): Promise<boolean> {
   const json = Boolean(params.opts?.json);
@@ -286,11 +281,12 @@ export async function runServiceRestart(params: {
   }
 
   const warnings: string[] = [];
+  let serviceCommand: Awaited<ReturnType<GatewayService["readCommand"]>> | undefined;
   if (params.checkTokenDrift) {
     // Check for token drift before restart (service token vs config token)
     try {
-      const command = await params.service.readCommand(process.env);
-      const serviceToken = command?.environment?.OPENCLAW_GATEWAY_TOKEN;
+      serviceCommand = await params.service.readCommand(process.env);
+      const serviceToken = serviceCommand?.environment?.OPENCLAW_GATEWAY_TOKEN;
       const cfg = loadConfig();
       const configToken = resolveGatewayCredentialsFromConfig({
         cfg,
@@ -324,11 +320,11 @@ export async function runServiceRestart(params: {
 
   try {
     if (params.preRestartCheck) {
-      await params.preRestartCheck({ json, stdout, warnings, fail });
+      await params.preRestartCheck({ json, stdout, warnings, fail, serviceCommand });
     }
     await params.service.restart({ env: process.env, stdout });
     if (params.postRestartCheck) {
-      await params.postRestartCheck({ json, stdout, warnings, fail });
+      await params.postRestartCheck({ json, stdout, warnings, fail, serviceCommand });
     }
     let restarted = true;
     try {

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -16,12 +16,15 @@ type RestartPostCheckContext = {
 
 type RestartParams = {
   opts?: { json?: boolean };
+  preRestartCheck?: (ctx: RestartPostCheckContext) => Promise<void>;
   postRestartCheck?: (ctx: RestartPostCheckContext) => Promise<void>;
 };
 
 const service = {
   readCommand: vi.fn(),
   restart: vi.fn(),
+  install: vi.fn(),
+  label: "LaunchAgent",
 };
 
 const runServiceRestart = vi.fn();
@@ -30,14 +33,25 @@ const terminateStaleGatewayPids = vi.fn();
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const loadConfig = vi.fn(() => ({}));
+const collectConfigServiceEnvVars = vi.fn(() => ({}));
+const buildServiceEnvironment = vi.fn(() => ({
+  OPENCLAW_GATEWAY_PORT: "18789",
+  OPENCLAW_GATEWAY_TOKEN: "tok",
+}));
 
 vi.mock("../../config/config.js", () => ({
   loadConfig: () => loadConfig(),
   resolveGatewayPort,
 }));
+vi.mock("../../config/env-vars.js", () => ({
+  collectConfigServiceEnvVars: (...args: unknown[]) => collectConfigServiceEnvVars(...args),
+}));
 
 vi.mock("../../daemon/service.js", () => ({
   resolveGatewayService: () => service,
+}));
+vi.mock("../../daemon/service-env.js", () => ({
+  buildServiceEnvironment: (...args: unknown[]) => buildServiceEnvironment(...args),
 }));
 
 vi.mock("./restart-health.js", () => ({
@@ -65,16 +79,24 @@ describe("runDaemonRestart health checks", () => {
   beforeEach(() => {
     service.readCommand.mockClear();
     service.restart.mockClear();
+    service.install.mockClear();
     runServiceRestart.mockClear();
     waitForGatewayHealthyRestart.mockClear();
     terminateStaleGatewayPids.mockClear();
     renderRestartDiagnostics.mockClear();
     resolveGatewayPort.mockClear();
     loadConfig.mockClear();
+    collectConfigServiceEnvVars.mockClear();
+    buildServiceEnvironment.mockClear();
+    service.label = "LaunchAgent";
 
     service.readCommand.mockResolvedValue({
       programArguments: ["openclaw", "gateway", "--port", "18789"],
-      environment: {},
+      workingDirectory: "/tmp/openclaw",
+      environment: {
+        OPENCLAW_GATEWAY_PORT: "18789",
+        OPENCLAW_GATEWAY_TOKEN: "tok",
+      },
     });
 
     runServiceRestart.mockImplementation(async (params: RestartParams) => {
@@ -83,11 +105,15 @@ describe("runDaemonRestart health checks", () => {
         err.hints = hints;
         throw err;
       };
-      await params.postRestartCheck?.({
+      const context = {
         json: Boolean(params.opts?.json),
         stdout: process.stdout,
         warnings: [],
         fail,
+      };
+      await params.preRestartCheck?.(context);
+      await params.postRestartCheck?.({
+        ...context,
       });
       return true;
     });
@@ -132,5 +158,73 @@ describe("runDaemonRestart health checks", () => {
     });
     expect(terminateStaleGatewayPids).not.toHaveBeenCalled();
     expect(renderRestartDiagnostics).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes launch agent env before restart when config env changes", async () => {
+    service.readCommand.mockResolvedValue({
+      programArguments: ["openclaw", "gateway", "--port", "18789"],
+      workingDirectory: "/tmp/openclaw",
+      environment: {
+        OPENCLAW_GATEWAY_PORT: "18789",
+        OPENCLAW_GATEWAY_TOKEN: "tok",
+        MAIL_API_KEY: "old",
+      },
+    });
+    collectConfigServiceEnvVars.mockReturnValueOnce({ MAIL_API_KEY: "new" });
+    waitForGatewayHealthyRestart.mockResolvedValue({
+      healthy: true,
+      staleGatewayPids: [],
+      runtime: { status: "running" },
+      portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
+    });
+
+    const result = await runDaemonRestart({ json: true });
+
+    expect(result).toBe(true);
+    expect(service.install).toHaveBeenCalledTimes(1);
+    expect(service.install).toHaveBeenCalledWith(
+      expect.objectContaining({
+        programArguments: ["openclaw", "gateway", "--port", "18789"],
+        environment: expect.objectContaining({
+          MAIL_API_KEY: "new",
+          OPENCLAW_GATEWAY_PORT: "18789",
+          OPENCLAW_GATEWAY_TOKEN: "tok",
+        }),
+      }),
+    );
+  });
+
+  it("skips env refresh when not using launch agent service", async () => {
+    service.label = "systemd";
+    waitForGatewayHealthyRestart.mockResolvedValue({
+      healthy: true,
+      staleGatewayPids: [],
+      runtime: { status: "running" },
+      portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
+    });
+
+    const result = await runDaemonRestart({ json: true });
+
+    expect(result).toBe(true);
+    expect(service.install).not.toHaveBeenCalled();
+  });
+
+  it("skips launch agent env refresh when plist env already matches", async () => {
+    collectConfigServiceEnvVars.mockReturnValueOnce({});
+    buildServiceEnvironment.mockReturnValueOnce({
+      OPENCLAW_GATEWAY_PORT: "18789",
+      OPENCLAW_GATEWAY_TOKEN: "tok",
+    });
+    waitForGatewayHealthyRestart.mockResolvedValue({
+      healthy: true,
+      staleGatewayPids: [],
+      runtime: { status: "running" },
+      portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
+    });
+
+    const result = await runDaemonRestart({ json: true });
+
+    expect(result).toBe(true);
+    expect(service.install).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -1,4 +1,6 @@
 import { loadConfig, resolveGatewayPort } from "../../config/config.js";
+import { collectConfigServiceEnvVars } from "../../config/env-vars.js";
+import { buildServiceEnvironment } from "../../daemon/service-env.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import { defaultRuntime } from "../../runtime.js";
 import { theme } from "../../terminal/theme.js";
@@ -33,6 +35,97 @@ async function resolveGatewayRestartPort() {
 
   const portFromArgs = parsePortFromArgs(command?.programArguments);
   return portFromArgs ?? resolveGatewayPort(loadConfig(), mergedEnv);
+}
+
+function normalizeServiceEnvironment(
+  env: Record<string, string | undefined> | undefined,
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  if (!env) {
+    return normalized;
+  }
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      continue;
+    }
+    normalized[key] = trimmed;
+  }
+  return normalized;
+}
+
+function areServiceEnvironmentsEqual(
+  left: Record<string, string | undefined> | undefined,
+  right: Record<string, string | undefined> | undefined,
+): boolean {
+  const a = normalizeServiceEnvironment(left);
+  const b = normalizeServiceEnvironment(right);
+  const aKeys = Object.keys(a).toSorted();
+  const bKeys = Object.keys(b).toSorted();
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  for (let i = 0; i < aKeys.length; i += 1) {
+    const key = aKeys[i];
+    if (key !== bKeys[i]) {
+      return false;
+    }
+    if (a[key] !== b[key]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function maybeRefreshLaunchAgentEnvironment(params: {
+  service: ReturnType<typeof resolveGatewayService>;
+  port: number;
+  json: boolean;
+  warnings: string[];
+}): Promise<void> {
+  if (params.service.label !== "LaunchAgent") {
+    return;
+  }
+
+  const command = await params.service.readCommand(process.env).catch(() => null);
+  if (!command?.programArguments?.length) {
+    return;
+  }
+
+  const cfg = loadConfig();
+  const serviceEnvironment = buildServiceEnvironment({
+    env: process.env as Record<string, string | undefined>,
+    port: params.port,
+    token: command.environment?.OPENCLAW_GATEWAY_TOKEN,
+  });
+  const refreshedEnvironment: Record<string, string | undefined> = {
+    ...collectConfigServiceEnvVars(cfg),
+    ...serviceEnvironment,
+  };
+
+  if (areServiceEnvironmentsEqual(command.environment, refreshedEnvironment)) {
+    return;
+  }
+
+  const silentStdout = { write: () => true } as unknown as NodeJS.WritableStream;
+  try {
+    await params.service.install({
+      env: process.env as Record<string, string | undefined>,
+      stdout: silentStdout,
+      programArguments: command.programArguments,
+      workingDirectory: command.workingDirectory,
+      environment: refreshedEnvironment,
+    });
+  } catch (err) {
+    const warning = `Failed to refresh LaunchAgent environment before restart: ${String(err)}`;
+    params.warnings.push(warning);
+    if (!params.json) {
+      defaultRuntime.log(theme.warn(warning));
+    }
+  }
 }
 
 export async function runDaemonUninstall(opts: DaemonLifecycleOptions = {}) {
@@ -82,6 +175,14 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
     renderStartHints: renderGatewayServiceStartHints,
     opts,
     checkTokenDrift: true,
+    preRestartCheck: async ({ warnings }) => {
+      await maybeRefreshLaunchAgentEnvironment({
+        service,
+        port: restartPort,
+        json,
+        warnings,
+      });
+    },
     postRestartCheck: async ({ warnings, fail, stdout }) => {
       let health = await waitForGatewayHealthyRestart({
         service,

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -11,6 +11,7 @@ import {
   runServiceStop,
   runServiceUninstall,
 } from "./lifecycle-core.js";
+import { createNullWriter } from "./response.js";
 import {
   DEFAULT_RESTART_HEALTH_ATTEMPTS,
   DEFAULT_RESTART_HEALTH_DELAY_MS,
@@ -83,6 +84,7 @@ function areServiceEnvironmentsEqual(
 async function maybeRefreshLaunchAgentEnvironment(params: {
   service: ReturnType<typeof resolveGatewayService>;
   port: number;
+  command?: Awaited<ReturnType<ReturnType<typeof resolveGatewayService>["readCommand"]>>;
   json: boolean;
   warnings: string[];
 }): Promise<void> {
@@ -90,7 +92,8 @@ async function maybeRefreshLaunchAgentEnvironment(params: {
     return;
   }
 
-  const command = await params.service.readCommand(process.env).catch(() => null);
+  const command =
+    params.command ?? (await params.service.readCommand(process.env).catch(() => null));
   if (!command?.programArguments?.length) {
     return;
   }
@@ -110,11 +113,10 @@ async function maybeRefreshLaunchAgentEnvironment(params: {
     return;
   }
 
-  const silentStdout = { write: () => true } as unknown as NodeJS.WritableStream;
   try {
     await params.service.install({
       env: process.env as Record<string, string | undefined>,
-      stdout: silentStdout,
+      stdout: createNullWriter(),
       programArguments: command.programArguments,
       workingDirectory: command.workingDirectory,
       environment: refreshedEnvironment,
@@ -175,10 +177,11 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
     renderStartHints: renderGatewayServiceStartHints,
     opts,
     checkTokenDrift: true,
-    preRestartCheck: async ({ warnings }) => {
+    preRestartCheck: async ({ warnings, serviceCommand }) => {
       await maybeRefreshLaunchAgentEnvironment({
         service,
         port: restartPort,
+        command: serviceCommand,
         json,
         warnings,
       });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw gateway restart` on macOS LaunchAgent could keep stale env values from plist, so updated config env (for example `env.MAIL_API_KEY`) was not applied.
- Why it matters: credential rotation and env updates could silently fail for running gateway services.
- What changed: added LaunchAgent env refresh during restart by reconciling plist env with current config-derived service env before restart execution.
- What did NOT change (scope boundary): no change to systemd/schtasks restart behavior, and restart still returns `not-loaded` when service is not loaded.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37101
- Related #

## User-visible / Behavior Changes

- On macOS LaunchAgent installs, `openclaw gateway restart` now applies updated config env values to the service environment before restart.
- Restart semantics for unloaded services are preserved (`not-loaded` path remains non-mutating).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS LaunchAgent target behavior (implemented/tested via unit tests)
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `env.MAIL_API_KEY` in `~/.openclaw/openclaw.json`

### Steps

1. Start gateway via LaunchAgent with config env value A.
2. Update config env value to B.
3. Run `openclaw gateway restart`.

### Expected

- Service env is refreshed from latest config and restart picks up value B.

### Actual

- Fixed by this PR.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- src/cli/daemon-cli/lifecycle.test.ts src/cli/daemon-cli/lifecycle-core.test.ts`
- Edge cases checked:
  - env refresh runs only for LaunchAgent
  - env refresh skipped when service env already matches
  - pre-restart env refresh is deferred until loaded-check passes (no mutation for `not-loaded`)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `6aad2fae7`
- Files/config to restore:
  - `src/cli/daemon-cli/lifecycle.ts`
  - `src/cli/daemon-cli/lifecycle-core.ts`
  - `src/cli/daemon-cli/lifecycle.test.ts`
  - `src/cli/daemon-cli/lifecycle-core.test.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected service mutation on `restart` when service is `not-loaded`

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: LaunchAgent-specific pre-restart env reconciliation could change restart behavior if triggered in wrong path.
  - Mitigation: moved reconciliation behind loaded-check via restart pre-check hook and added regression test for not-loaded path.
