### PR TITLE
fix(tui): render initial/status updates without keypress

### DIFF
--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -693,9 +693,18 @@ export async function runTui(opts: TuiOptions) {
     lastActivityStatus = activityStatus;
   };
 
+  let tuiStarted = false;
+  const requestRenderIfStarted = () => {
+    if (!tuiStarted) {
+      return;
+    }
+    tui.requestRender();
+  };
+
   const setConnectionStatus = (text: string, ttlMs?: number) => {
     connectionStatus = text;
     renderStatus();
+    requestRenderIfStarted();
     if (statusTimeout) {
       clearTimeout(statusTimeout);
     }
@@ -703,6 +712,7 @@ export async function runTui(opts: TuiOptions) {
       statusTimeout = setTimeout(() => {
         connectionStatus = isConnected ? "connected" : "disconnected";
         renderStatus();
+        requestRenderIfStarted();
       }, ttlMs);
     }
   };
@@ -710,6 +720,7 @@ export async function runTui(opts: TuiOptions) {
   const setActivityStatus = (text: string) => {
     activityStatus = text;
     renderStatus();
+    requestRenderIfStarted();
   };
 
   const updateFooter = () => {
@@ -951,6 +962,8 @@ export async function runTui(opts: TuiOptions) {
   process.on("SIGINT", sigintHandler);
   process.on("SIGTERM", sigtermHandler);
   tui.start();
+  tuiStarted = true;
+  tui.requestRender();
   client.start();
   await new Promise<void>((resolve) => {
     const finish = () => {


### PR DESCRIPTION
## Summary
- fix a TUI rendering gap where startup/status text could stay invisible until a manual refresh keypress
- trigger render requests whenever connection/activity status changes (once TUI is started)
- force an initial render immediately after `tui.start()` so Windows/PowerShell startup shows UI without waiting for input

## Testing
- pnpm test -- src/tui/tui.test.ts src/tui/tui-command-handlers.test.ts src/tui/tui-event-handlers.test.ts

Fixes #32900
