### PR TITLE
Onboard: add Azure OpenAI auth choice

### DIFF
--- a/src/commands/auth-choice-options.test.ts
+++ b/src/commands/auth-choice-options.test.ts
@@ -22,6 +22,7 @@ describe("buildAuthChoiceOptions", () => {
     for (const value of [
       "github-copilot",
       "token",
+      "azure-openai-api-key",
       "zai-api-key",
       "xiaomi-api-key",
       "minimax-api",

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -26,8 +26,8 @@ const AUTH_CHOICE_GROUP_DEFS: {
   {
     value: "openai",
     label: "OpenAI",
-    hint: "Codex OAuth + API key",
-    choices: ["openai-codex", "openai-api-key"],
+    hint: "Codex OAuth + API key + Azure OpenAI",
+    choices: ["openai-codex", "openai-api-key", "azure-openai-api-key"],
   },
   {
     value: "anthropic",
@@ -188,6 +188,7 @@ const AUTH_CHOICE_GROUP_DEFS: {
 ];
 
 const PROVIDER_AUTH_CHOICE_OPTION_HINTS: Partial<Record<AuthChoice, string>> = {
+  "azure-openai-api-key": "Azure OpenAI / Azure AI Foundry endpoint",
   "litellm-api-key": "Unified gateway for 100+ LLM providers",
   "cloudflare-ai-gateway-api-key": "Account ID + Gateway ID + API key",
   "venice-api-key": "Privacy-focused inference (uncensored models)",
@@ -196,6 +197,7 @@ const PROVIDER_AUTH_CHOICE_OPTION_HINTS: Partial<Record<AuthChoice, string>> = {
 };
 
 const PROVIDER_AUTH_CHOICE_OPTION_LABELS: Partial<Record<AuthChoice, string>> = {
+  "azure-openai-api-key": "Azure OpenAI",
   "moonshot-api-key": "Kimi API key (.ai)",
   "moonshot-api-key-cn": "Kimi API key (.cn)",
   "kimi-code-api-key": "Kimi Code API key (subscription)",
@@ -239,6 +241,11 @@ const BASE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
     hint: "Uses GitHub device flow",
   },
   { value: "gemini-api-key", label: "Google Gemini API key" },
+  {
+    value: "azure-openai-api-key",
+    label: "Azure OpenAI",
+    hint: "Azure OpenAI / Azure AI Foundry (OpenAI-compatible)",
+  },
   {
     value: "google-gemini-cli",
     label: "Google Gemini CLI OAuth",

--- a/src/commands/auth-choice.preferred-provider.ts
+++ b/src/commands/auth-choice.preferred-provider.ts
@@ -11,6 +11,7 @@ const PREFERRED_PROVIDER_BY_AUTH_CHOICE: Partial<Record<AuthChoice, string>> = {
   "codex-cli": "openai-codex",
   chutes: "chutes",
   "openai-api-key": "openai",
+  "azure-openai-api-key": "custom",
   "openrouter-api-key": "openrouter",
   "kilocode-api-key": "kilocode",
   "ai-gateway-api-key": "vercel-ai-gateway",

--- a/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
+++ b/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
@@ -120,4 +120,18 @@ describe("promptAuthConfig", () => {
       "MiniMax-M2.5",
     ]);
   });
+
+  it("routes Azure OpenAI auth choice through the custom provider prompt", async () => {
+    mocks.applyAuthChoice.mockClear();
+    mocks.promptModelAllowlist.mockClear();
+    mocks.promptCustomApiConfig.mockClear();
+    mocks.promptAuthChoiceGrouped.mockResolvedValue("azure-openai-api-key");
+    mocks.promptCustomApiConfig.mockResolvedValue({ config: { models: { providers: {} } } });
+
+    await promptAuthConfig({}, makeRuntime(), noopPrompter);
+
+    expect(mocks.promptCustomApiConfig).toHaveBeenCalledTimes(1);
+    expect(mocks.applyAuthChoice).not.toHaveBeenCalled();
+    expect(mocks.promptModelAllowlist).not.toHaveBeenCalled();
+  });
 });

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -89,7 +89,7 @@ export async function promptAuthConfig(
   });
 
   let next = cfg;
-  if (authChoice === "custom-api-key") {
+  if (authChoice === "custom-api-key" || authChoice === "azure-openai-api-key") {
     const customResult = await promptCustomApiConfig({ prompter, runtime, config: next });
     next = customResult.config;
   } else if (authChoice !== "skip") {
@@ -120,7 +120,7 @@ export async function promptAuthConfig(
   const anthropicOAuth =
     authChoice === "setup-token" || authChoice === "token" || authChoice === "oauth";
 
-  if (authChoice !== "custom-api-key") {
+  if (authChoice !== "custom-api-key" && authChoice !== "azure-openai-api-key") {
     const allowlistSelection = await promptModelAllowlist({
       config: next,
       prompter,

--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -596,6 +596,30 @@ describe("onboard (non-interactive): provider auth", () => {
     });
   });
 
+  it("configures Azure OpenAI auth choice through the custom-provider path", async () => {
+    await withOnboardEnv("openclaw-onboard-azure-openai-", async ({ configPath, runtime }) => {
+      await runNonInteractiveOnboardingWithDefaults(runtime, {
+        authChoice: "azure-openai-api-key",
+        customBaseUrl: "https://my-resource.openai.azure.com",
+        customApiKey: "azure-test-key",
+        customModelId: "gpt-4.1",
+        skipSkills: true,
+      });
+
+      const cfg = await readJsonFile<ProviderAuthConfigSnapshot>(configPath);
+      const provider = cfg.models?.providers?.["custom-my-resource-openai-azure-com"];
+
+      expect(provider?.api).toBe("openai-completions");
+      expect(provider?.apiKey).toBe("azure-test-key");
+      expect(provider?.baseUrl).toBe(
+        "https://my-resource.openai.azure.com/openai/deployments/gpt-4.1",
+      );
+      expect(cfg.agents?.defaults?.model?.primary).toBe(
+        "custom-my-resource-openai-azure-com/gpt-4.1",
+      );
+    });
+  });
+
   it("infers custom provider auth choice from custom flags", async () => {
     await withOnboardEnv(
       "openclaw-onboard-custom-provider-infer-",

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -922,12 +922,15 @@ export async function applyNonInteractiveAuthChoice(params: {
     return applyHuggingfaceConfig(nextConfig);
   }
 
-  if (authChoice === "custom-api-key") {
+  if (authChoice === "custom-api-key" || authChoice === "azure-openai-api-key") {
     try {
       const customAuth = parseNonInteractiveCustomApiFlags({
         baseUrl: opts.customBaseUrl,
         modelId: opts.customModelId,
-        compatibility: opts.customCompatibility,
+        compatibility:
+          authChoice === "azure-openai-api-key" && !opts.customCompatibility
+            ? "openai"
+            : opts.customCompatibility,
         apiKey: opts.customApiKey,
         providerId: opts.customProviderId,
       });

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -12,6 +12,7 @@ export type AuthChoice =
   | "vllm"
   | "openai-codex"
   | "openai-api-key"
+  | "azure-openai-api-key"
   | "openrouter-api-key"
   | "kilocode-api-key"
   | "litellm-api-key"


### PR DESCRIPTION
Closes #37123

## Summary
- add an explicit Azure OpenAI auth choice to onboarding provider selection
- route the Azure choice through the existing custom-provider flow instead of duplicating provider logic
- default the non-interactive Azure alias to OpenAI compatibility while keeping the existing custom flags

## Testing
- pnpm test src/commands/auth-choice-options.test.ts src/commands/configure.gateway-auth.prompt-auth-config.test.ts src/commands/onboard-non-interactive.provider-auth.test.ts
- pnpm exec oxlint --type-aware src/commands/onboard-types.ts src/commands/auth-choice-options.ts src/commands/auth-choice.preferred-provider.ts src/commands/configure.gateway-auth.ts src/commands/onboard-non-interactive/local/auth-choice.ts src/commands/auth-choice-options.test.ts src/commands/onboard-non-interactive.provider-auth.test.ts src/commands/configure.gateway-auth.prompt-auth-config.test.ts
- pnpm exec oxfmt --check src/commands/onboard-types.ts src/commands/auth-choice-options.ts src/commands/auth-choice.preferred-provider.ts src/commands/configure.gateway-auth.ts src/commands/onboard-non-interactive/local/auth-choice.ts src/commands/auth-choice-options.test.ts src/commands/onboard-non-interactive.provider-auth.test.ts src/commands/configure.gateway-auth.prompt-auth-config.test.ts
