### PR TITLE
fix(mac): avoid Talk overlay exclusivity crash when restoring Talk mode

### DIFF
--- a/apps/macos/Sources/OpenClaw/TalkOverlay.swift
+++ b/apps/macos/Sources/OpenClaw/TalkOverlay.swift
@@ -30,14 +30,20 @@ final class TalkOverlayController {
         self.ensureWindow()
         self.hostingView?.rootView = TalkOverlayView(controller: self)
         let target = self.targetFrame()
+
+        // Avoid taking an inout access to the whole `model` struct while the
+        // view reads sibling fields (phase/paused/level) during render.
+        // That exclusivity conflict can crash when Talk mode restores on launch.
+        var isVisible = self.model.isVisible
         OverlayPanelFactory.present(
             window: self.window,
-            isVisible: &self.model.isVisible,
+            isVisible: &isVisible,
             target: target)
         { window in
             window.setFrame(target, display: true)
             window.orderFrontRegardless()
         }
+        self.model.isVisible = isVisible
     }
 
     func dismiss() {


### PR DESCRIPTION
## Summary
- avoid passing `&self.model.isVisible` directly into `OverlayPanelFactory.present` in `TalkOverlayController.present()`
- use a local `isVisible` variable and write back after present to prevent overlapping access on the `model` struct during SwiftUI render
- this prevents Swift exclusivity violations when Talk mode is restored on app launch

## Why
Issue #37114 reports a crash loop on macOS when Talk mode is enabled and restored from persisted settings. The overlay view reads `model.phase/isPaused/level` during render while `present()` took an `inout` access to `model.isVisible`, which can trigger runtime exclusivity traps.

## Validation
- `swift build` (apps/macos) was attempted; build in this environment fails earlier on external macro/plugin resolution in dependency `swiftui-math` (`SwiftUIMacros.EntryMacro` not found), unrelated to this change.
