### PR TITLE
[Issue #37082] feat: Add --agent option to models set command

### DIFF
--- a/automation/issue-tracker/issue-37082.md
+++ b/automation/issue-tracker/issue-37082.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37082
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37082
+- Title: feat: Add --agent option to models set command
+- Created at: 2026-03-06T03:08:14Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37082
- URL: https://github.com/openclaw/openclaw/issues/37082

## Original Issue Description
`openclaw models set` currently updates only the global default model and does not support selecting a specific agent. The issue requests adding `--agent <id>` support so users can set per-agent models without editing `openclaw.json` manually.

Relates to #37082