### PR TITLE
[Issue #37083] Control UI: Messages disappear during tool execution

### DIFF
--- a/automation/issue-tracker/issue-37083.md
+++ b/automation/issue-tracker/issue-37083.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37083
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37083
+- Title: Control UI: Messages disappear during tool execution
+- Created at: 2026-03-06T03:09:24Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37083
- URL: https://github.com/openclaw/openclaw/issues/37083

## Original Issue Description
In Control UI, prior user messages disappear from the chat while tools execute, even though session JSONL still contains them. The issue details runId mismatch handling and full-history replacement behavior that can drop messages from the rendered UI.

Relates to #37083