### PR TITLE
[Issue #37094] [Feature]:Add clipboard image paste support in Webchat

### DIFF
--- a/automation/issue-tracker/issue-37094.md
+++ b/automation/issue-tracker/issue-37094.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37094
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37094
+- Title: [Feature]:Add clipboard image paste support in Webchat
+- Created at: 2026-03-06T03:22:24Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37094
- URL: https://github.com/openclaw/openclaw/issues/37094

## Original Issue Description
Webchat currently does not handle pasted clipboard images. The issue requests adding paste-to-upload behavior in chat input (with optional preview) so users can share screenshots without manual file-save workflows.

Relates to #37094