### PR TITLE
[Issue #37097] [Bug]: Model params.effort not honored for Claude Opus 4.6 with thinking: adaptive

### DIFF
--- a/automation/issue-tracker/issue-37097.md
+++ b/automation/issue-tracker/issue-37097.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37097
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37097
+- Title: [Bug]: Model params.effort not honored for Claude Opus 4.6 with thinking: adaptive
+- Created at: 2026-03-06T03:24:17Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37097
- URL: https://github.com/openclaw/openclaw/issues/37097

## Original Issue Description
When users set `thinking: adaptive` and `effort: max`, the outgoing Anthropic payload still ends with `output_config.effort: "medium"`. The issue reports that explicit `effort` is dropped and requests preserving/pass-through of configured effort.

Relates to #37097