### PR TITLE
[Issue #37101] [Bug]: Gateway restart does not reload updated env.MAIL_API_KEY (LaunchAgent keeps stale env)

### DIFF
--- a/automation/issue-tracker/issue-37101.md
+++ b/automation/issue-tracker/issue-37101.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37101
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37101
+- Title: [Bug]: Gateway restart does not reload updated env.MAIL_API_KEY (LaunchAgent keeps stale env)
+- Created at: 2026-03-06T03:30:10Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37101
- URL: https://github.com/openclaw/openclaw/issues/37101

## Original Issue Description
On macOS LaunchAgent setups, updating `env.MAIL_API_KEY` in config and running `openclaw gateway restart` can keep stale environment values from the plist. The issue requests restart behavior that refreshes service env from latest config values.

Relates to #37101