### PR TITLE
[Issue #37111] MEDIA: relative local paths resolve against CWD, not allowed roots

### DIFF
--- a/automation/issue-tracker/issue-37111.md
+++ b/automation/issue-tracker/issue-37111.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37111
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37111
+- Title: MEDIA: relative local paths resolve against CWD, not allowed roots
+- Created at: 2026-03-06T03:38:14Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37111
- URL: https://github.com/openclaw/openclaw/issues/37111

## Original Issue Description
Relative `MEDIA:` local file paths are currently resolved against process CWD, causing non-deterministic failures against allowed local media roots. The issue requests root-aware relative resolution and clearer guidance text.

Relates to #37111