### PR TITLE
[Issue #37114] macOS app crash-loops when Talk mode enabled (TalkOverlayView Swift exclusivity error)

### DIFF
--- a/automation/issue-tracker/issue-37114.md
+++ b/automation/issue-tracker/issue-37114.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37114
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37114
+- Title: macOS app crash-loops when Talk mode enabled (TalkOverlayView Swift exclusivity error)
+- Created at: 2026-03-06T03:40:21Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37114
- URL: https://github.com/openclaw/openclaw/issues/37114

## Original Issue Description
Enabling Talk mode in the macOS app can crash immediately and then crash-loop on relaunch because Talk mode state persists. The issue includes Swift exclusivity violation details around `TalkOverlayView`/`TalkOverlayController`.

Relates to #37114