### PR TITLE
[Issue #37118] [Feature]: openclaw不知道自己json文件的规范

### DIFF
--- a/automation/issue-tracker/issue-37118.md
+++ b/automation/issue-tracker/issue-37118.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37118
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37118
+- Title: [Feature]: openclaw不知道自己json文件的规范
+- Created at: 2026-03-06T03:42:19Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37118
- URL: https://github.com/openclaw/openclaw/issues/37118

## Original Issue Description
The issue requests clearer version-aligned documentation/manual guidance for `openclaw.json` schema, so users can update configuration safely after upgrades without frequent breakage.

Relates to #37118