### PR TITLE
[Issue #37123] [Bug]: Azure OpenAI provider not appearing during onboarding

### DIFF
--- a/automation/issue-tracker/issue-37123.md
+++ b/automation/issue-tracker/issue-37123.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37123
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37123
+- Title: [Bug]: Azure OpenAI provider not appearing during onboarding
+- Created at: 2026-03-06T03:48:01Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37123
- URL: https://github.com/openclaw/openclaw/issues/37123

## Original Issue Description
Onboarding flow reportedly does not expose Azure OpenAI provider selection on the referenced branch, and proceeds directly to channel setup with unrelated provider auth messages.

Relates to #37123