### PR TITLE
[Issue #37125] feat(browser): support per-profile headless mode

### DIFF
--- a/automation/issue-tracker/issue-37125.md
+++ b/automation/issue-tracker/issue-37125.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37125
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37125
+- Title: feat(browser): support per-profile headless mode
+- Created at: 2026-03-06T03:49:02Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37125
- URL: https://github.com/openclaw/openclaw/issues/37125

## Original Issue Description
`browser.headless` is currently global and applies to all profiles. The issue requests profile-level `headless` override support so mixed headed/headless profile setups can coexist.

Relates to #37125