### PR TITLE
[Issue #37131] [Feature]: Invoke tools directly without LLM round-trip

### DIFF
--- a/automation/issue-tracker/issue-37131.md
+++ b/automation/issue-tracker/issue-37131.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37131
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37131
+- Title: [Feature]: Invoke tools directly without LLM round-trip
+- Created at: 2026-03-06T03:52:10Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37131
- URL: https://github.com/openclaw/openclaw/issues/37131

## Original Issue Description
Feature request to support direct tool invocation (CLI/command/cron surfaces) without running an LLM turn first, to reduce latency and token cost for deterministic operations.

Relates to #37131