### PR TITLE
[Issue #37136] Telegram heartbeat loop: agent sends message bursts every ~10min instead of HEARTBEAT_OK

### DIFF
--- a/automation/issue-tracker/issue-37136.md
+++ b/automation/issue-tracker/issue-37136.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37136
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37136
+- Title: Telegram heartbeat loop: agent sends message bursts every ~10min instead of HEARTBEAT_OK
+- Created at: 2026-03-06T03:55:52Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37136
- URL: https://github.com/openclaw/openclaw/issues/37136

## Original Issue Description
Telegram bot sessions can enter a loop where heartbeat produces real outbound message bursts every ~10 minutes instead of suppressed `HEARTBEAT_OK`, suggesting self-triggering/re-ingestion behavior.

Relates to #37136