### PR TITLE
[Issue #37140] skill-creator quick_validate: enforce allowed-tools list shape

### DIFF
--- a/automation/issue-tracker/issue-37140.md
+++ b/automation/issue-tracker/issue-37140.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37140
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37140
+- Title: skill-creator quick_validate: enforce allowed-tools list shape
+- Created at: 2026-03-06T03:57:51Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37140
- URL: https://github.com/openclaw/openclaw/issues/37140

## Original Issue Description
`quick_validate.py` reportedly accepts malformed `allowed-tools` frontmatter values. The issue requests validation as a list of non-empty strings, including fallback behavior when PyYAML is unavailable.

Relates to #37140