### PR TITLE
[Issue #37142] [Bug]: MiniMax provider returns HTTP 401 despite valid API key — anthropic-messages mode

### DIFF
--- a/automation/issue-tracker/issue-37142.md
+++ b/automation/issue-tracker/issue-37142.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37142
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37142
+- Title: [Bug]: MiniMax provider returns HTTP 401 despite valid API key — anthropic-messages mode
+- Created at: 2026-03-06T03:59:30Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37142
- URL: https://github.com/openclaw/openclaw/issues/37142

## Original Issue Description
Using MiniMax with `anthropic-messages` and valid key reportedly returns persistent authentication failures in OpenClaw while direct curl works, suggesting authorization header handling mismatch in this mode.

Relates to #37142