### PR TITLE
[Issue #37081] [Bug]: Root processes causing session timeouts - gateway becomes unresponsive

### DIFF
--- a/automation/issue-tracker/issue-37081.md
+++ b/automation/issue-tracker/issue-37081.md
@@ -1,0 +1,7 @@
+# Issue Tracker: #37081
+
+- Source issue: https://github.com/openclaw/openclaw/issues/37081
+- Title: [Bug]: Root processes causing session timeouts - gateway becomes unresponsive
+- Created at: 2026-03-06T03:07:17Z
+
+This file was added automatically by the issue monitor workflow.


### PR DESCRIPTION
## Source Issue
- Issue: #37081
- URL: https://github.com/openclaw/openclaw/issues/37081

## Original Issue Description
The issue reports spontaneous root-owned OpenClaw child processes with high CPU usage causing session timeouts and gateway unresponsiveness, with recurring production impact and manual recovery steps.

Relates to #37081