### PR TITLE
fix(skill-creator): validate allowed-tools frontmatter shape

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -64,6 +64,36 @@ def _parse_simple_frontmatter(frontmatter_text: str) -> Optional[dict[str, str]]
     return parsed
 
 
+def _parse_allowed_tools_fallback(raw: str) -> tuple[bool, list[str] | str]:
+    """Parse allowed-tools from the fallback frontmatter parser.
+
+    The fallback parser flattens indented YAML into newline-joined strings.
+    For `allowed-tools`, we support a minimal YAML list syntax:
+
+      allowed-tools:
+        - gh
+        - browser
+
+    Returns (ok, tools) where tools is a list[str] if ok else an error message.
+    """
+    lines = [ln.strip() for ln in (raw or "").splitlines() if ln.strip()]
+    tools: list[str] = []
+
+    # Reject scalars like `allowed-tools: gh` to match the expected list shape.
+    if not lines:
+        return True, tools
+
+    for ln in lines:
+        if not ln.startswith("-"):
+            return False, "allowed-tools must be a YAML list of non-empty strings"
+        item = ln[1:].strip()
+        if not item:
+            return False, "allowed-tools must be a YAML list of non-empty strings"
+        tools.append(item)
+
+    return True, tools
+
+
 def validate_skill(skill_path):
     """Basic validation of a skill"""
     skill_path = Path(skill_path)
@@ -110,6 +140,21 @@ def validate_skill(skill_path):
         return False, "Missing 'name' in frontmatter"
     if "description" not in frontmatter:
         return False, "Missing 'description' in frontmatter"
+
+    # `allowed-tools` is optional, but when present it must be a list of non-empty strings.
+    if "allowed-tools" in frontmatter:
+        allowed_tools = frontmatter.get("allowed-tools")
+        if yaml is None:
+            if not isinstance(allowed_tools, str):
+                return False, "allowed-tools must be a YAML list of non-empty strings"
+            ok, parsed = _parse_allowed_tools_fallback(allowed_tools)
+            if not ok:
+                return False, parsed  # type: ignore[return-value]
+        else:
+            if not isinstance(allowed_tools, list) or any(
+                (not isinstance(x, str) or not x.strip()) for x in allowed_tools
+            ):
+                return False, "allowed-tools must be a YAML list of non-empty strings"
 
     name = frontmatter.get("name", "")
     if not isinstance(name, str):

--- a/skills/skill-creator/scripts/test_quick_validate.py
+++ b/skills/skill-creator/scripts/test_quick_validate.py
@@ -67,6 +67,87 @@ metadata: |
 
         self.assertTrue(valid, message)
 
+    def test_rejects_allowed_tools_scalar_with_pyyaml(self):
+        skill_dir = self.temp_dir / "scalar-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = """---
+name: scalar-skill
+description: bad allowed-tools
+allowed-tools: gh
+---
+# Skill
+"""
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        valid, message = quick_validate.validate_skill(skill_dir)
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "allowed-tools must be a YAML list of non-empty strings")
+
+    def test_rejects_allowed_tools_empty_entries_with_pyyaml(self):
+        skill_dir = self.temp_dir / "empty-allowed-tools-skill"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = """---
+name: empty-allowed-tools-skill
+description: bad allowed-tools
+allowed-tools:
+  - gh
+  - ""
+---
+# Skill
+"""
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        valid, message = quick_validate.validate_skill(skill_dir)
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "allowed-tools must be a YAML list of non-empty strings")
+
+    def test_rejects_allowed_tools_scalar_without_pyyaml(self):
+        skill_dir = self.temp_dir / "scalar-skill-fallback"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = """---
+name: scalar-skill-fallback
+description: bad allowed-tools
+allowed-tools: gh
+---
+# Skill
+"""
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        previous_yaml = quick_validate.yaml
+        quick_validate.yaml = None
+        try:
+            valid, message = quick_validate.validate_skill(skill_dir)
+        finally:
+            quick_validate.yaml = previous_yaml
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "allowed-tools must be a YAML list of non-empty strings")
+
+    def test_rejects_allowed_tools_non_list_syntax_without_pyyaml(self):
+        skill_dir = self.temp_dir / "bad-list-skill-fallback"
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        content = """---
+name: bad-list-skill-fallback
+description: bad allowed-tools
+allowed-tools:
+  gh
+---
+# Skill
+"""
+        (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
+
+        previous_yaml = quick_validate.yaml
+        quick_validate.yaml = None
+        try:
+            valid, message = quick_validate.validate_skill(skill_dir)
+        finally:
+            quick_validate.yaml = previous_yaml
+
+        self.assertFalse(valid)
+        self.assertEqual(message, "allowed-tools must be a YAML list of non-empty strings")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Closes #37140.

- Enforce `allowed-tools` is a list of non-empty strings when present.
- Add regression coverage for both PyYAML and fallback parser paths.
