### PR TITLE
fix(gateway): guard against undefined channelAccounts in health monitor

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -499,6 +499,15 @@ describe("channel-health-monitor", () => {
       await expectRestartedChannel(manager, "slack");
     });
 
+    it("does not crash when channelAccounts is undefined", async () => {
+      const manager = createMockChannelManager({
+        getRuntimeSnapshot: vi.fn(() => ({ channels: {} }) as unknown as ChannelRuntimeSnapshot),
+      });
+      const monitor = await startAndRunCheck(manager);
+      expect(manager.stopChannel).not.toHaveBeenCalled();
+      monitor.stop();
+    });
+
     it("respects custom staleEventThresholdMs", async () => {
       const customThreshold = 10 * 60_000;
       const now = Date.now();

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -111,7 +111,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
 
       const snapshot = channelManager.getRuntimeSnapshot();
 
-      for (const [channelId, accounts] of Object.entries(snapshot.channelAccounts)) {
+      for (const [channelId, accounts] of Object.entries(snapshot.channelAccounts ?? {})) {
         if (!accounts) {
           continue;
         }


### PR DESCRIPTION
## Summary

- **Problem:** The channel health monitor crashes with `"Cannot convert undefined or null to object"` when `channelAccounts` is undefined in the runtime snapshot. This surfaces as `"Google Chat: failed (unknown)"` in `doctor --fix` output.
- **Why it matters:** The crash breaks the health monitor loop for all channels, not just Google Chat. No channel health monitoring can function while this error persists.
- **What changed:** Added nullish coalescing (`snapshot.channelAccounts ?? {}`) so the iteration gracefully skips when no account data is available.
- **What did NOT change:** Channel health evaluation logic, restart policies, or snapshot generation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33117

## User-visible / Behavior Changes

- `doctor --fix` no longer shows "Cannot convert undefined or null to object" for channels with incomplete initialization.
- Health monitor continues monitoring other channels even when one channel's snapshot is incomplete.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Ubuntu 24 / macOS
- Runtime: Node.js 22
- Integration/channel: Google Chat (or any channel that fails to initialize)

### Steps

1. Configure Google Chat channel
2. Upgrade from 2026.2.x to latest
3. Run `openclaw doctor --fix`

### Expected

- Doctor reports configuration issues clearly without TypeError

### Actual

- Before fix: `"Google Chat: failed (unknown) - Cannot convert undefined or null to object"`
- After fix: Health monitor skips undefined channelAccounts gracefully

## Evidence

```
 src/gateway/channel-health-monitor.ts      | 2 +-
 src/gateway/channel-health-monitor.test.ts | 9 +++++++++
 2 files changed, 10 insertions(+), 1 deletion(-)
```

All 28 existing health monitor tests pass plus 1 new test for undefined channelAccounts.

## Human Verification (required)

- Verified scenarios: Undefined channelAccounts, normal channel accounts, empty channel accounts
- Edge cases checked: Snapshot with `channels` but no `channelAccounts`
- What I did **not** verify: Live Google Chat channel with incomplete service account

## Compatibility / Migration

- Backward compatible? `Yes — defensive null guard`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/gateway/channel-health-monitor.ts`
- Known bad symptoms: TypeError returns for incomplete channel snapshots

## Risks and Mitigations

- None. This is a defensive null guard matching the pattern used in `ui/src/ui/views/agents-panels-status-files.ts` and `ui/src/ui/app-render.ts`.