### PR TITLE
fix(feishu): add 30s HTTP timeout to Feishu API client

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -12,11 +12,22 @@ const httpsProxyAgentCtorMock = vi.hoisted(() =>
   }),
 );
 
+const mockHttpInstance = vi.hoisted(() => ({
+  request: vi.fn(async () => ({})),
+  get: vi.fn(async () => ({})),
+  post: vi.fn(async () => ({})),
+  put: vi.fn(async () => ({})),
+  patch: vi.fn(async () => ({})),
+  delete: vi.fn(async () => ({})),
+}));
+
 vi.mock("@larksuiteoapi/node-sdk", () => ({
   AppType: { SelfBuild: "self" },
   Domain: { Feishu: "https://open.feishu.cn", Lark: "https://open.larksuite.com" },
   LoggerLevel: { info: "info" },
-  Client: vi.fn(),
+  Client: vi.fn().mockImplementation(function (this: { httpInstance: typeof mockHttpInstance }) {
+    this.httpInstance = mockHttpInstance;
+  }),
   WSClient: wsClientCtorMock,
   EventDispatcher: vi.fn(),
 }));
@@ -25,7 +36,7 @@ vi.mock("https-proxy-agent", () => ({
   HttpsProxyAgent: httpsProxyAgentCtorMock,
 }));
 
-import { createFeishuWSClient } from "./client.js";
+import { createFeishuClient, createFeishuWSClient, clearClientCache } from "./client.js";
 
 const proxyEnvKeys = ["https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY"] as const;
 type ProxyEnvKey = (typeof proxyEnvKeys)[number];
@@ -132,5 +143,23 @@ describe("createFeishuWSClient proxy handling", () => {
     expect(httpsProxyAgentCtorMock).toHaveBeenCalledWith("http://upper-http:8999");
     const options = firstWsClientOptions();
     expect(options.agent).toEqual({ proxyUrl: "http://upper-http:8999" });
+  });
+});
+
+describe("createFeishuClient HTTP timeout", () => {
+  it("injects default timeout when opts lack one", async () => {
+    clearClientCache();
+    createFeishuClient({ accountId: "timeout-a", appId: "a", appSecret: "s" });
+    const opts: Record<string, unknown> = { data: { msg_type: "text" } };
+    await mockHttpInstance.post(opts);
+    expect(opts.timeout).toBe(30_000);
+  });
+
+  it("preserves caller-specified timeout", async () => {
+    clearClientCache();
+    createFeishuClient({ accountId: "timeout-b", appId: "b", appSecret: "s" });
+    const opts = { data: {}, timeout: 5_000 };
+    await mockHttpInstance.post(opts);
+    expect(opts.timeout).toBe(5_000);
   });
 });

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -2,6 +2,8 @@ import * as Lark from "@larksuiteoapi/node-sdk";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import type { FeishuDomain, ResolvedFeishuAccount } from "./types.js";
 
+const FEISHU_HTTP_TIMEOUT_MS = 30_000;
+
 function getWsProxyAgent(): HttpsProxyAgent<string> | undefined {
   const proxyUrl =
     process.env.https_proxy ||
@@ -64,13 +66,15 @@ export function createFeishuClient(creds: FeishuClientCredentials): Lark.Client 
     return cached.client;
   }
 
-  // Create new client
+  // Create new client with HTTP timeout to prevent per-chat queue deadlocks
+  // when the Feishu API hangs (#36412).
   const client = new Lark.Client({
     appId,
     appSecret,
     appType: Lark.AppType.SelfBuild,
     domain: resolveDomain(domain),
   });
+  applyDefaultTimeout(client);
 
   // Cache it
   clientCache.set(accountId, {
@@ -127,5 +131,21 @@ export function clearClientCache(accountId?: string): void {
     clientCache.delete(accountId);
   } else {
     clientCache.clear();
+  }
+}
+
+function applyDefaultTimeout(client: Lark.Client): void {
+  const http = (client as unknown as { httpInstance: Record<string, unknown> }).httpInstance;
+  if (!http) return;
+  for (const method of ["request", "get", "post", "put", "patch", "delete"] as const) {
+    const original = http[method];
+    if (typeof original !== "function") continue;
+    http[method] = function (this: unknown, ...args: unknown[]) {
+      const opts = typeof args[0] === "object" && args[0] !== null ? args[0] : args[1];
+      if (opts && typeof opts === "object" && !("timeout" in (opts as Record<string, unknown>))) {
+        (opts as Record<string, unknown>).timeout = FEISHU_HTTP_TIMEOUT_MS;
+      }
+      return (original as (...a: unknown[]) => unknown).apply(this, args);
+    };
   }
 }


### PR DESCRIPTION
## Summary

- **Problem:** The Feishu plugin creates Lark SDK clients without configuring an HTTP timeout. When the Feishu API hangs, the per-chat message queue deadlocks permanently because the `sendChain` Promise never settles.
- **Why it matters:** A single hanging API call renders the affected group chat completely unresponsive until a manual gateway restart. DMs continue working because they use different chatId queues.
- **What changed:** Added `applyDefaultTimeout()` that wraps each `httpInstance` method to inject a 30-second default timeout. Callers that already specify a timeout are unaffected.
- **What did NOT change:** WebSocket client, event dispatcher, or any existing request logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36412

## User-visible / Behavior Changes

- Feishu API calls that hang for >30 seconds now time out instead of blocking forever.
- The per-chat queue recovers and processes the next message after a timeout.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes — adds 30s timeout to outbound Feishu API requests`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux / macOS
- Runtime: Node.js 22
- Integration/channel: Feishu (Lark)

### Steps

1. Configure Feishu channel
2. Send a message in a group chat
3. Trigger a scenario where the Feishu API hangs (network throttle, API downtime)
4. Send subsequent messages to the same group chat

### Expected

- After 30s timeout, queue recovers and processes next message

### Actual

- Before fix: Queue deadlocks permanently, group chat becomes unresponsive
- After fix: Request times out, sendChain settles via .catch(), queue moves on

## Evidence

```
 extensions/feishu/src/client.ts      | 27 ++++++++++++++++++++++++++-
 extensions/feishu/src/client.test.ts | 25 +++++++++++++++++++++++--
 2 files changed, 49 insertions(+), 3 deletions(-)
```

All 7 client tests pass (5 existing + 2 new timeout tests).

## Human Verification (required)

- Verified scenarios: Default timeout injected, explicit caller timeout preserved, proxy handling unaffected
- Edge cases checked: Methods without options object, cached client reuse
- What I did **not** verify: Live Feishu API with simulated network hang

## Compatibility / Migration

- Backward compatible? `Yes — only affects requests that previously had no timeout (infinite wait)`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `extensions/feishu/src/client.ts`
- Known bad symptoms: Deadlock vulnerability returns for hanging API calls

## Risks and Mitigations

- **Risk:** 30s timeout too aggressive for large file uploads → **Mitigated:** Media uploads can pass explicit `timeout` in their request options, which is preserved by the wrapper
- **Risk:** Wrapping httpInstance methods could break SDK internals → **Mitigated:** Wrapper only adds `timeout` to the options object when absent; all original arguments and `this` context are preserved