### PR TITLE
fix(tui): reload history when local final has no visible reply

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -446,4 +446,23 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.dropAssistant).toHaveBeenCalledWith("run-silent");
     expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
   });
+
+  it("reloads history when a local run final has no visible assistant payload", () => {
+    const { state, chatLog, loadHistory, noteLocalRunId, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null },
+    });
+
+    noteLocalRunId("run-local");
+
+    handleChatEvent({
+      runId: "run-local",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: { content: [] },
+    });
+
+    expect(chatLog.dropAssistant).toHaveBeenCalledWith("run-local");
+    expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -135,10 +135,13 @@ export function createEventHandlers(context: EventHandlerContext) {
     return sessionRuns.has(activeRunId);
   };
 
-  const maybeRefreshHistoryForRun = (runId: string) => {
-    if (isLocalRunId?.(runId)) {
+  const maybeRefreshHistoryForRun = (runId: string, opts?: { allowLocal?: boolean }) => {
+    const isLocal = isLocalRunId?.(runId) ?? false;
+    if (isLocal) {
       forgetLocalRunId?.(runId);
-      return;
+      if (!opts?.allowLocal) {
+        return;
+      }
     }
     if (hasConcurrentActiveRun(runId)) {
       return;
@@ -178,7 +181,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (evt.state === "final") {
       const wasActiveRun = state.activeChatRunId === evt.runId;
       if (!evt.message) {
-        maybeRefreshHistoryForRun(evt.runId);
+        maybeRefreshHistoryForRun(evt.runId, { allowLocal: true });
         chatLog.dropAssistant(evt.runId);
         finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle" });
         tui.requestRender();
@@ -208,9 +211,12 @@ export function createEventHandlers(context: EventHandlerContext) {
         state.showThinking,
         evt.errorMessage,
       );
+      const shouldReloadLocalTranscript =
+        finalText === "(no output)" && (isLocalRunId?.(evt.runId) ?? false);
       const suppressEmptyExternalPlaceholder =
-        finalText === "(no output)" && !isLocalRunId?.(evt.runId);
-      if (suppressEmptyExternalPlaceholder) {
+        finalText === "(no output)" && !shouldReloadLocalTranscript;
+      if (shouldReloadLocalTranscript || suppressEmptyExternalPlaceholder) {
+        maybeRefreshHistoryForRun(evt.runId, { allowLocal: shouldReloadLocalTranscript });
         chatLog.dropAssistant(evt.runId);
       } else {
         chatLog.finalizeAssistant(finalText, evt.runId);


### PR DESCRIPTION
## Summary
Local TUI runs could finish without ever rendering the assistant reply in the terminal when the final `chat.message.delta` payload had no visible content. The gateway still completed the run and the reply was available in session history, but the TUI skipped its local-run history refresh path, so users saw nothing in the terminal while the same reply appeared in the web UI.

This change keeps the existing local-run suppression for routine history refreshes, but allows a targeted fallback when the final event has no message or resolves to no visible assistant text. In that case the TUI reloads history for that local run and drops the empty assistant placeholder, which restores the completed assistant reply from the transcript instead of leaving the terminal blank.

## Root Cause
`maybeRefreshHistoryForRun` returned early for all local runs. That was normally correct, but it also blocked the only recovery path for final events that carried no visible assistant payload, so the TUI never reloaded the transcript that already contained the completed response.

## Testing
- `pnpm test -- src/tui/tui-event-handlers.test.ts`
- `pnpm test -- src/tui/tui-event-handlers.test.ts src/tui/tui.test.ts`
- `pnpm exec oxlint src/tui/tui-event-handlers.ts src/tui/tui-event-handlers.test.ts`

Fixes #37168
