### PR TITLE
fix(config): invalidate runtimeConfigSnapshot in writeConfigFile

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1035,6 +1035,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
 
   async function writeConfigFile(cfg: OpenClawConfig, options: ConfigWriteOptions = {}) {
     clearConfigCache();
+    clearRuntimeConfigSnapshot();
     let persistCandidate: unknown = cfg;
     const { snapshot } = await readConfigFileSnapshotInternal();
     let envRefMap: Map<string, string> | null = null;


### PR DESCRIPTION
## Summary

- **Problem**: `agents.create` followed by `agents.update` on a separate WebSocket connection fails with 'agent not found' despite the agent being created successfully 8ms earlier.
- **Root Cause**: In `writeConfigFile`, `clearConfigCache()` was called but `runtimeConfigSnapshot` was not reset. This caused subsequent `loadConfig()` calls on different connections to return stale in-memory snapshots.
- **Fix**: Added `clearRuntimeConfigSnapshot()` call after `clearConfigCache()` in `writeConfigFile`.

Fixes #37175

## Change Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Verification
- [x] Build passes: `pnpm build`
- [ ] Tests pass: `pnpm vitest run --config vitest.unit.config.ts src/config/io.write-config.test.ts`