### PR TITLE
fix(tools): convert array-format parameters to JSON Schema and add edge-case tests

### DIFF
--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { normalizeToolParameters } from "./pi-tools.schema.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+
+function makeTool(parameters: unknown): AnyAgentTool {
+  return { name: "test_tool", description: "test", parameters } as AnyAgentTool;
+}
+
+describe("normalizeToolParameters", () => {
+  it("returns tool unchanged when parameters is absent", () => {
+    const tool = { name: "t", description: "d" } as AnyAgentTool;
+    expect(normalizeToolParameters(tool)).toBe(tool);
+  });
+
+  it("returns tool unchanged when parameters is not an object", () => {
+    const tool = makeTool("invalid");
+    expect(normalizeToolParameters(tool)).toBe(tool);
+  });
+
+  it("returns tool unchanged when schema already has type and properties", () => {
+    const params = { type: "object", properties: { x: { type: "string" } } };
+    const tool = makeTool(params);
+    const result = normalizeToolParameters(tool);
+    expect(result.parameters).toBe(params);
+  });
+
+  it("converts array-format parameters to JSON Schema", () => {
+    const tool = makeTool([
+      { name: "command", type: "string", description: "Command to run", required: true },
+      { name: "target", type: "string", description: "Target", required: false },
+    ]);
+    const result = normalizeToolParameters(tool);
+    const schema = result.parameters as Record<string, unknown>;
+    expect(schema.type).toBe("object");
+    const props = schema.properties as Record<string, Record<string, unknown>>;
+    expect(props.command).toMatchObject({ type: "string", description: "Command to run" });
+    expect(props.target).toMatchObject({ type: "string", description: "Target" });
+    expect(schema.required).toEqual(["command"]);
+  });
+
+  it("converts array params with no required fields and omits required key", () => {
+    const tool = makeTool([{ name: "query", type: "string", required: false }]);
+    const result = normalizeToolParameters(tool);
+    const schema = result.parameters as Record<string, unknown>;
+    expect(schema.type).toBe("object");
+    expect(schema.required).toBeUndefined();
+  });
+
+  it("skips array entries without a name", () => {
+    const tool = makeTool([null, { type: "string" }, { name: "valid", type: "number" }]);
+    const result = normalizeToolParameters(tool);
+    const schema = result.parameters as Record<string, unknown>;
+    const props = schema.properties as Record<string, unknown>;
+    expect(Object.keys(props)).toEqual(["valid"]);
+  });
+
+  it("converts array params and applies Gemini cleaning", () => {
+    const tool = makeTool([{ name: "q", type: "string", description: "Query" }]);
+    const result = normalizeToolParameters(tool, { modelProvider: "google" });
+    const schema = result.parameters as Record<string, unknown>;
+    expect(schema.type).toBe("object");
+    const props = schema.properties as Record<string, Record<string, unknown>>;
+    expect(props.q?.type).toBe("string");
+  });
+
+  it("merges anyOf variants into a flat object schema", () => {
+    const tool = makeTool({
+      anyOf: [
+        { type: "object", properties: { a: { type: "string" } }, required: ["a"] },
+        { type: "object", properties: { b: { type: "number" } }, required: ["b"] },
+      ],
+    });
+    const result = normalizeToolParameters(tool);
+    const schema = result.parameters as Record<string, unknown>;
+    expect(schema.type).toBe("object");
+    const props = schema.properties as Record<string, unknown>;
+    expect(props).toHaveProperty("a");
+    expect(props).toHaveProperty("b");
+  });
+
+  it("forces type:object when schema has properties but no type", () => {
+    const tool = makeTool({ properties: { x: { type: "string" } } });
+    const result = normalizeToolParameters(tool);
+    const schema = result.parameters as Record<string, unknown>;
+    expect(schema.type).toBe("object");
+  });
+});

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -67,6 +67,39 @@ export function normalizeToolParameters(
   tool: AnyAgentTool,
   options?: { modelProvider?: string; modelId?: string },
 ): AnyAgentTool {
+  // Convert array-format parameters (e.g. [{name, type, ...}]) to JSON Schema.
+  // typeof [] === "object" passes the object check below, but no schema property
+  // checks match, leaving a raw array as parameters (rejected by Gemini with 400).
+  if (Array.isArray(tool.parameters)) {
+    const arrayParams = tool.parameters as Array<Record<string, unknown>>;
+    const properties: Record<string, unknown> = {};
+    const required: string[] = [];
+    for (const param of arrayParams) {
+      if (!param || typeof param.name !== "string") {
+        continue;
+      }
+      const prop: Record<string, unknown> = { type: param.type ?? "string" };
+      if (typeof param.description === "string") {
+        prop.description = param.description;
+      }
+      if (Array.isArray(param.enum)) {
+        prop.enum = param.enum;
+      }
+      properties[param.name] = prop;
+      if (param.required) {
+        required.push(param.name);
+      }
+    }
+    tool = {
+      ...tool,
+      parameters: {
+        type: "object",
+        properties,
+        ...(required.length > 0 ? { required } : {}),
+      },
+    };
+  }
+
   const schema =
     tool.parameters && typeof tool.parameters === "object"
       ? (tool.parameters as Record<string, unknown>)

--- a/src/infra/net/undici-global-dispatcher.test.ts
+++ b/src/infra/net/undici-global-dispatcher.test.ts
@@ -135,4 +135,29 @@ describe("ensureGlobalUndiciStreamTimeouts", () => {
       autoSelectFamilyAttemptTimeout: 300,
     });
   });
+
+  it("does not set dispatcher when timeoutMs is NaN", () => {
+    ensureGlobalUndiciStreamTimeouts({ timeoutMs: NaN });
+
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("clamps negative timeoutMs to 1ms", () => {
+    ensureGlobalUndiciStreamTimeouts({ timeoutMs: -500 });
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    expect(next.options?.bodyTimeout).toBe(1);
+    expect(next.options?.headersTimeout).toBe(1);
+  });
+
+  it("applies custom timeoutMs to bodyTimeout and headersTimeout", () => {
+    const customMs = 5 * 60 * 1000;
+    ensureGlobalUndiciStreamTimeouts({ timeoutMs: customMs });
+
+    expect(setGlobalDispatcher).toHaveBeenCalledTimes(1);
+    const next = getCurrentDispatcher() as { options?: Record<string, unknown> };
+    expect(next.options?.bodyTimeout).toBe(customMs);
+    expect(next.options?.headersTimeout).toBe(customMs);
+  });
 });

--- a/src/poll-params.test.ts
+++ b/src/poll-params.test.ts
@@ -57,4 +57,17 @@ describe("poll params", () => {
       /mutually exclusive/i,
     );
   });
+
+  it("treats non-empty pollQuestion string as poll creation intent", () => {
+    expect(hasPollCreationParams({ pollQuestion: "What's for lunch?" })).toBe(true);
+    expect(hasPollCreationParams({ pollQuestion: "  " })).toBe(false);
+    expect(hasPollCreationParams({ pollQuestion: "" })).toBe(false);
+  });
+
+  it("treats non-empty pollOption array as poll creation intent", () => {
+    expect(hasPollCreationParams({ pollOption: ["Pizza", "Sushi"] })).toBe(true);
+    expect(hasPollCreationParams({ pollOption: [] })).toBe(false);
+    expect(hasPollCreationParams({ pollOption: [" ", "  "] })).toBe(false);
+    expect(hasPollCreationParams({ pollOption: ["", ""] })).toBe(false);
+  });
 });

--- a/src/telegram/thread-bindings.test.ts
+++ b/src/telegram/thread-bindings.test.ts
@@ -163,4 +163,54 @@ describe("telegram thread bindings", () => {
     );
     expect(fs.existsSync(statePath)).toBe(false);
   });
+
+  it("getByConversationId returns undefined for an unbound conversation", async () => {
+    const manager = createTelegramThreadBindingManager({
+      accountId: "lookup-test",
+      persist: false,
+      enableSweeper: false,
+    });
+
+    expect(manager.getByConversationId("never-bound")).toBeUndefined();
+    expect(manager.getByConversationId("")).toBeUndefined();
+    expect(manager.getByConversationId("  ")).toBeUndefined();
+  });
+
+  it("listBySessionKey returns empty array for unknown session key", async () => {
+    const manager = createTelegramThreadBindingManager({
+      accountId: "list-test",
+      persist: false,
+      enableSweeper: false,
+    });
+
+    expect(manager.listBySessionKey("agent:main:subagent:unknown")).toEqual([]);
+    expect(manager.listBySessionKey("")).toEqual([]);
+  });
+
+  it("unbindConversation removes a binding and returns null on second call", async () => {
+    const manager = createTelegramThreadBindingManager({
+      accountId: "unbind-test",
+      persist: false,
+      enableSweeper: false,
+    });
+
+    await getSessionBindingService().bind({
+      targetSessionKey: "agent:main:subagent:child-3",
+      targetKind: "subagent",
+      conversation: {
+        channel: "telegram",
+        accountId: "unbind-test",
+        conversationId: "-100999:topic:1",
+      },
+    });
+
+    expect(manager.getByConversationId("-100999:topic:1")).toBeDefined();
+
+    const removed = manager.unbindConversation({ conversationId: "-100999:topic:1" });
+    expect(removed?.conversationId).toBe("-100999:topic:1");
+    expect(manager.getByConversationId("-100999:topic:1")).toBeUndefined();
+
+    const removedAgain = manager.unbindConversation({ conversationId: "-100999:topic:1" });
+    expect(removedAgain).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

### Bug fix: normalizeToolParameters array parameters (fixes #27570)

Array-format parameters were passed through unchanged because typeof [] === 'object' passes the object check but none of the schema property tests match, leaving a raw array as parameters. Gemini rejects this with a 400 error.

Fix: Add Array.isArray guard to convert array params to JSON Schema before processing.

New file: src/agents/pi-tools.schema.test.ts with comprehensive tests.

### Test coverage improvements

- undici-global-dispatcher: NaN timeout (no-op), negative timeout (clamped to 1ms), custom timeoutMs
- thread-bindings: getByConversationId unknown/blank, listBySessionKey unknown, unbindConversation idempotency
- poll-params: pollQuestion string intent, empty pollOption array, all-blank pollOption array

## Testing

All existing and new tests pass. pnpm check passes.