### PR TITLE
fix(docs): add missing SSL/Xfinity section to troubleshooting page

### DIFF
--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -65,6 +65,14 @@ Example:
 
 Reference: [/tools/plugin#distribution-npm](/tools/plugin#distribution-npm)
 
+## docs.openclaw.ai shows an SSL error (Comcast/Xfinity)
+
+Some Comcast/Xfinity connections block `docs.openclaw.ai` via Xfinity Advanced Security.
+Disable Advanced Security or allowlist `docs.openclaw.ai`, then retry.
+
+- Xfinity Advanced Security help: https://www.xfinity.com/support/articles/using-xfinity-xfi-advanced-security
+- Quick check: try a mobile hotspot or VPN to confirm this is ISP-level filtering
+
 ## Decision tree
 
 ```mermaid


### PR DESCRIPTION
## Summary

- **Problem:** The FAQ page links to `/help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity` but that anchor does not exist in the English `docs/help/troubleshooting.md`. The corresponding section exists in the Chinese docs (`docs/zh-CN/help/troubleshooting.md`) but was never added to the English version.
- **Why it matters:** Users clicking the "Troubleshooting" link from the FAQ SSL section land on a page with no matching anchor, seeing either a blank scroll or a GitHub "Error loading page" message.
- **What changed:** Added the SSL/Xfinity troubleshooting section to `docs/help/troubleshooting.md`, mirroring the Chinese docs content.
- **What did NOT change:** FAQ page, Chinese docs, or any other troubleshooting content.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36970

## User-visible / Behavior Changes

- The FAQ cross-reference link to the SSL/Xfinity troubleshooting section now resolves correctly, displaying the relevant troubleshooting content.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any (docs site)
- Runtime: N/A
- Integration/channel: N/A

### Steps

1. Open FAQ page section "I can't access docs.openclaw.ai (SSL error)"
2. Click the "Troubleshooting" link

### Expected

- Link navigates to a matching section with Xfinity/SSL troubleshooting details

### Actual

- Before fix: Anchor does not exist; page shows no matching content
- After fix: Section exists with Xfinity Advanced Security disable/allowlist guidance

## Evidence

```
 docs/help/troubleshooting.md | 8 ++++++++
 1 file changed, 8 insertions(+)
```

The new section heading `## docs.openclaw.ai shows an SSL error (Comcast/Xfinity)` produces the anchor `#docsopenclawai-shows-an-ssl-error-comcastxfinity`, matching the FAQ link target.

## Human Verification (required)

- Verified scenarios: Confirmed anchor target matches FAQ link, confirmed Chinese docs have identical content
- Edge cases checked: Markdown heading-to-anchor conversion rules (lowercase, punctuation stripped, spaces to hyphens)
- What I did **not** verify: Live deployment rendering on docs.openclaw.ai

## Compatibility / Migration

- Backward compatible? `Yes — purely additive docs content`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `docs/help/troubleshooting.md`
- Known bad symptoms: Only effect would be the broken anchor returning

## Risks and Mitigations

- None. This is a purely additive documentation section.