### PR TITLE
fix(slack): propagate mediaLocalRoots for send actions

### DIFF
--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -41,6 +41,35 @@ describe("slackPlugin actions", () => {
       undefined,
     );
   });
+
+  it("forwards trusted mediaLocalRoots for send actions", async () => {
+    handleSlackActionMock.mockResolvedValueOnce({ details: { ok: true } });
+    const handleAction = slackPlugin.actions?.handleAction;
+    expect(handleAction).toBeDefined();
+    const mediaLocalRoots = ["/tmp/workspace-agent"] as const;
+
+    await handleAction!({
+      action: "send",
+      channel: "slack",
+      accountId: "default",
+      cfg: {},
+      mediaLocalRoots,
+      params: {
+        to: "channel:C123",
+        media: "/tmp/workspace-agent/report.pdf",
+      },
+    });
+
+    expect(handleSlackActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sendMessage",
+        to: "channel:C123",
+        mediaUrl: "/tmp/workspace-agent/report.pdf",
+      }),
+      {},
+      expect.objectContaining({ mediaLocalRoots }),
+    );
+  });
 });
 
 describe("slackPlugin outbound", () => {

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -246,8 +246,17 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount> = {
         providerId: meta.id,
         ctx,
         includeReadThreadId: true,
-        invoke: async (action, cfg, toolContext) =>
-          await getSlackRuntime().channel.slack.handleSlackAction(action, cfg, toolContext),
+        invoke: async (action, cfg, toolContext, actionContext) =>
+          await getSlackRuntime().channel.slack.handleSlackAction(
+            action,
+            cfg,
+            toolContext || actionContext
+              ? {
+                  ...toolContext,
+                  ...actionContext,
+                }
+              : undefined,
+          ),
       }),
   },
   setup: {

--- a/src/agents/tools/slack-actions.test.ts
+++ b/src/agents/tools/slack-actions.test.ts
@@ -194,6 +194,28 @@ describe("handleSlackAction", () => {
     });
   });
 
+  it("passes mediaLocalRoots to sendSlackMessage for media sends", async () => {
+    const mediaLocalRoots = ["/tmp/workspace-agent"] as const;
+
+    await handleSlackAction(
+      {
+        action: "sendMessage",
+        to: "channel:C123",
+        content: "Hello file",
+        mediaUrl: "/tmp/workspace-agent/report.pdf",
+      },
+      slackConfig(),
+      { mediaLocalRoots } as Parameters<typeof handleSlackAction>[2],
+    );
+
+    expect(sendSlackMessage).toHaveBeenCalledWith("channel:C123", "Hello file", {
+      mediaUrl: "/tmp/workspace-agent/report.pdf",
+      mediaLocalRoots,
+      threadTs: undefined,
+      blocks: undefined,
+    });
+  });
+
   it.each([
     {
       name: "JSON blocks",

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -37,6 +37,7 @@ export type SlackActionContext = {
   currentChannelId?: string;
   /** Current thread timestamp for auto-threading. */
   currentThreadTs?: string;
+  mediaLocalRoots?: readonly string[];
   /** Reply-to mode for auto-threading. */
   replyToMode?: "off" | "first" | "all";
   /** Mutable ref to track if a reply was sent (for "first" mode). */
@@ -196,6 +197,7 @@ export async function handleSlackAction(
         const result = await sendSlackMessage(to, content ?? "", {
           ...writeOpts,
           mediaUrl: mediaUrl ?? undefined,
+          mediaLocalRoots: context?.mediaLocalRoots,
           threadTs: threadTs ?? undefined,
           blocks,
         });

--- a/src/channels/plugins/slack.actions.ts
+++ b/src/channels/plugins/slack.actions.ts
@@ -14,8 +14,17 @@ export function createSlackActions(providerId: string): ChannelMessageActionAdap
         ctx,
         normalizeChannelId: resolveSlackChannelId,
         includeReadThreadId: true,
-        invoke: async (action, cfg, toolContext) =>
-          await handleSlackAction(action, cfg, toolContext as SlackActionContext | undefined),
+        invoke: async (action, cfg, toolContext, actionContext) =>
+          await handleSlackAction(
+            action,
+            cfg,
+            toolContext || actionContext
+              ? {
+                  ...(toolContext as SlackActionContext | undefined),
+                  ...actionContext,
+                }
+              : undefined,
+          ),
       });
     },
   };

--- a/src/plugin-sdk/slack-message-actions.test.ts
+++ b/src/plugin-sdk/slack-message-actions.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleSlackMessageAction } from "./slack-message-actions.js";
+
+function createInvokeSpy() {
+  return vi.fn(async (action: Record<string, unknown>) => ({
+    ok: true,
+    content: action,
+  }));
+}
+
+describe("handleSlackMessageAction", () => {
+  it("forwards trusted mediaLocalRoots for send actions", async () => {
+    const invoke = createInvokeSpy();
+    const mediaLocalRoots = ["/tmp/workspace-agent"] as const;
+
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "send",
+        cfg: {},
+        mediaLocalRoots,
+        params: {
+          to: "channel:C1",
+          media: "/tmp/workspace-agent/report.pdf",
+        },
+      } as never,
+      invoke: invoke as never,
+    });
+
+    expect(invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sendMessage",
+        to: "channel:C1",
+        mediaUrl: "/tmp/workspace-agent/report.pdf",
+      }),
+      {},
+      undefined,
+      { mediaLocalRoots },
+    );
+  });
+});

--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -7,6 +7,9 @@ type SlackActionInvoke = (
   action: Record<string, unknown>,
   cfg: ChannelMessageActionContext["cfg"],
   toolContext?: ChannelMessageActionContext["toolContext"],
+  actionContext?: {
+    mediaLocalRoots?: readonly string[];
+  },
 ) => Promise<AgentToolResult<unknown>>;
 
 function readSlackBlocksParam(actionParams: Record<string, unknown>) {
@@ -58,6 +61,7 @@ export async function handleSlackMessageAction(params: {
       },
       cfg,
       ctx.toolContext,
+      { mediaLocalRoots: ctx.mediaLocalRoots },
     );
   }
 

--- a/src/slack/actions.send.test.ts
+++ b/src/slack/actions.send.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+const sendMessageSlack = vi.fn(async (..._args: unknown[]) => ({
+  messageId: "m1",
+  channelId: "C1",
+}));
+
+vi.mock("./send.js", () => ({
+  sendMessageSlack: (...args: Parameters<typeof sendMessageSlack>) => sendMessageSlack(...args),
+}));
+
+const { sendSlackMessage } = await import("./actions.js");
+
+describe("sendSlackMessage", () => {
+  it("passes mediaLocalRoots through to sendMessageSlack", async () => {
+    const mediaLocalRoots = ["/tmp/workspace-agent"] as const;
+
+    await sendSlackMessage("channel:C1", "report", {
+      mediaUrl: "/tmp/workspace-agent/report.pdf",
+      mediaLocalRoots,
+      token: "xoxb-test",
+    });
+
+    expect(sendMessageSlack).toHaveBeenCalledWith("channel:C1", "report", {
+      accountId: undefined,
+      token: "xoxb-test",
+      mediaUrl: "/tmp/workspace-agent/report.pdf",
+      mediaLocalRoots,
+      client: undefined,
+      threadTs: undefined,
+      blocks: undefined,
+    });
+  });
+});

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -151,6 +151,7 @@ export async function sendSlackMessage(
   content: string,
   opts: SlackActionClientOpts & {
     mediaUrl?: string;
+    mediaLocalRoots?: readonly string[];
     threadTs?: string;
     blocks?: (Block | KnownBlock)[];
   } = {},
@@ -159,6 +160,7 @@ export async function sendSlackMessage(
     accountId: opts.accountId,
     token: opts.token,
     mediaUrl: opts.mediaUrl,
+    mediaLocalRoots: opts.mediaLocalRoots,
     client: opts.client,
     threadTs: opts.threadTs,
     blocks: opts.blocks,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Slack send actions dropped trusted `mediaLocalRoots` while moving from the channel action context through the plugin SDK and Slack tool layers.
- Why it matters: local media sends rely on those trusted roots to resolve local attachments safely, so the action path could lose access to allowed local files.
- What changed: threaded `mediaLocalRoots` through the Slack action invoke path, merged it into the Slack action context, and passed it through `sendSlackMessage` into `sendMessageSlack`.
- What did NOT change (scope boundary): Slack token selection, network behavior, message formatting, and non-send Slack actions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36477
- Related #36687

## User-visible / Behavior Changes

Slack send actions now preserve trusted local media roots when sending local attachments. No other Slack action behavior changed.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Slack
- Relevant config (redacted): Slack account with a send action that references a trusted local file path

### Steps

1. Trigger a Slack `send` action with a local file path and trusted `mediaLocalRoots` on the channel action context.
2. Follow the action through `handleSlackMessageAction`, the Slack action adapter, and `handleSlackAction`.
3. Observe the final `sendMessageSlack` call.

### Expected

- Trusted `mediaLocalRoots` are preserved all the way to the final Slack send wrapper so local attachments can be resolved safely.

### Actual

- Before this change, `mediaLocalRoots` were dropped before reaching `sendSlackMessage` / `sendMessageSlack`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm vitest run extensions/slack/src/channel.test.ts src/plugin-sdk/slack-message-actions.test.ts src/agents/tools/slack-actions.test.ts src/slack/actions.send.test.ts`; `pnpm vitest run src/channels/plugins/actions/actions.test.ts`; `pnpm build`
- Edge cases checked: existing Slack read-thread action behavior still passes, send actions without `mediaLocalRoots` still keep the previous flow, and both adapter layers preserve `undefined` when no action context is present.
- What you did **not** verify: a live end-to-end Slack workspace send with a real local attachment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `da4e4605` or remove the `mediaLocalRoots` forwarding from the Slack action path.
- Files/config to restore: `extensions/slack/src/channel.ts`, `src/channels/plugins/slack.actions.ts`, `src/plugin-sdk/slack-message-actions.ts`, `src/agents/tools/slack-actions.ts`, `src/slack/actions.ts`
- Known bad symptoms reviewers should watch for: Slack send actions losing access to trusted local attachments, or `sendMessageSlack` receiving missing `mediaLocalRoots` for local file sends.

## Risks and Mitigations

- Risk: merging trusted action context into the Slack tool context could overwrite similarly named fields in the future.
  - Mitigation: the new field is narrowly scoped to `mediaLocalRoots`, and regression tests cover the forwarding path through all touched layers.