### PR TITLE
fix(discord): drop guild messages when requireMention=true but botId is unresolved

### DIFF
--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -496,6 +496,82 @@ describe("preflightDiscordMessage", () => {
     expect(result).not.toBeNull();
   });
 
+  it("drops guild messages when requireMention=true even if botUserId is undefined", async () => {
+    const channelId = "channel-mention-no-botid";
+    const guildId = "guild-mention-no-botid";
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === channelId) {
+          return {
+            id: channelId,
+            type: ChannelType.GuildText,
+            name: "general",
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+    const message = {
+      id: "m-mention-no-botid",
+      content: "hello",
+      timestamp: new Date().toISOString(),
+      channelId,
+      attachments: [],
+      mentionedUsers: [],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "user-mention-1",
+        bot: false,
+        username: "Alice",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: {
+        session: {
+          mainKey: "main",
+          scope: "per-sender",
+        },
+      } as import("../../config/config.js").OpenClawConfig,
+      discordConfig: {} as NonNullable<
+        import("../../config/config.js").OpenClawConfig["channels"]
+      >["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: undefined,
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "open",
+      threadBindings: createNoopThreadBindingManager("default"),
+      guildEntries: {
+        [guildId]: {
+          requireMention: true,
+        },
+      },
+      data: {
+        channel_id: channelId,
+        guild_id: guildId,
+        guild: {
+          id: guildId,
+          name: "Guild One",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("drops guild messages that mention another user when ignoreOtherMentions=true", async () => {
     const channelId = "channel-other-mention-1";
     const guildId = "guild-other-mention-1";

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -681,9 +681,9 @@ export async function preflightDiscordMessage(
     `[discord-preflight] shouldRequireMention=${shouldRequireMention} baseRequireMention=${shouldRequireMentionByConfig} boundThreadSession=${isBoundThreadSession} mentionGate.shouldSkip=${mentionGate.shouldSkip} wasMentioned=${wasMentioned}`,
   );
   if (isGuildMessage && shouldRequireMention) {
-    if (botId && mentionGate.shouldSkip) {
+    if (mentionGate.shouldSkip || (!canDetectMention && !wasMentioned)) {
       logDebug(`[discord-preflight] drop: no-mention`);
-      logVerbose(`discord: drop guild message (mention required, botId=${botId})`);
+      logVerbose(`discord: drop guild message (mention required, botId=${botId ?? "unset"})`);
       logger.info(
         {
           channelId: messageChannelId,


### PR DESCRIPTION
## Summary

- **Problem:** When `requireMention: true` is configured for a Discord guild, the bot still responds to messages without being @mentioned. This happens because `canDetectMention` depends on `botId`, and when `botUserId` is `undefined` (e.g. `fetchUser("@me")` fails), `canDetectMention` is `false`. The mention gate then never sets `shouldSkip=true`, so messages are processed unconditionally.
- **Why it matters:** Users expect the bot to stay silent unless explicitly @mentioned in guild channels where `requireMention: true` is set. Instead, the bot responds to every message, creating noise and confusion.
- **What changed:** Added a fallback drop condition: when `requireMention` is true but mention detection is unavailable (`!canDetectMention`) and the message was not explicitly mentioned, the message is dropped. This ensures safe-by-default behavior.
- **What did NOT change:** DM handling, mention regex matching, bound thread behavior, or control command bypass logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34353

## User-visible / Behavior Changes

- Discord guilds with `requireMention: true` now correctly silence the bot for messages that don't @mention it, even when the bot user ID is temporarily unavailable.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22
- Integration/channel: Discord

### Steps

1. Configure a Discord guild with `requireMention: true`
2. Restart the gateway
3. Send a message in a guild channel **without** mentioning the bot

### Expected

- Bot does not respond or show "typing..."

### Actual

- Before fix: Bot responds to all messages regardless of mention
- After fix: Bot correctly ignores non-mentioned messages

## Evidence

```
 src/discord/monitor/message-handler.preflight.ts      |  2 +-
 src/discord/monitor/message-handler.preflight.test.ts | 76 +++++++++++++++++++
 2 files changed, 77 insertions(+), 1 deletion(-)
```

New test: "drops guild messages when requireMention=true even if botUserId is undefined" verifies the fix with `botUserId: undefined`.

## Human Verification (required)

- Verified scenarios: `requireMention: true` with `botUserId: undefined`, `requireMention: true` with valid `botUserId`, `requireMention: false` unaffected
- Edge cases checked: Bound thread sessions (bypass still works), control command bypass (still works), mention regex matching (still works when configured)
- What I did **not** verify: Live Discord gateway with actual `fetchUser("@me")` failure

## Compatibility / Migration

- Backward compatible? `Yes — only changes behavior for the already-broken requireMention path`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; or set `requireMention: false` in guild config
- Files/config to restore: `src/discord/monitor/message-handler.preflight.ts`
- Known bad symptoms: Bot would not respond in guilds even when mentioned (if mention detection is broken for other reasons)

## Risks and Mitigations

- Risk: If `botUserId` is temporarily `undefined` during startup, guild messages may be dropped before the bot ID resolves. Mitigation: This is the intended safe behavior — better to miss a few early messages than to respond to all non-mentions.