### PR TITLE
fix(gateway): resolve control-ui inbound channel as webchat

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -47,6 +47,20 @@ describe("buildInboundMetaSystemPrompt", () => {
     expect(payload["channel"]).toBe("telegram");
   });
 
+  it("resolves channel as webchat when sender is openclaw-control-ui", () => {
+    const prompt = buildInboundMetaSystemPrompt({
+      SenderId: "openclaw-control-ui",
+      OriginatingTo: "agent:main:slack:channel:C123",
+      OriginatingChannel: "slack",
+      Provider: "webchat",
+      Surface: "webchat",
+      ChatType: "direct",
+    } as TemplateContext);
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["channel"]).toBe("webchat");
+  });
+
   it("does not include per-turn message identifiers (cache stability)", () => {
     const prompt = buildInboundMetaSystemPrompt({
       MessageSid: "123",

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -32,6 +32,9 @@ function formatConversationTimestamp(value: unknown): string | undefined {
 }
 
 function resolveInboundChannel(ctx: TemplateContext): string | undefined {
+  if (safeTrim(ctx.SenderId) === "openclaw-control-ui") {
+    return "webchat";
+  }
   let channelValue = safeTrim(ctx.OriginatingChannel) ?? safeTrim(ctx.Surface);
   if (!channelValue) {
     const provider = safeTrim(ctx.Provider);


### PR DESCRIPTION
## Summary

- **Problem:** When the control-ui (web dashboard) sends a message to a channel-scoped session (e.g. `agent:main:slack:channel:C123`), the inbound metadata `channel` field is set to `"slack"` instead of `"webchat"`. This is because `OriginatingChannel` inherits the session's delivery target, and `resolveInboundChannel` prioritizes it over the actual message source.
- **Why it matters:** The agent sees `channel: "slack"` for webchat messages and routes responses to Slack instead of back to the web dashboard.
- **What changed:** Added a short-circuit in `resolveInboundChannel`: when `SenderId` is `"openclaw-control-ui"`, always return `"webchat"` regardless of `OriginatingChannel`.
- **What did NOT change:** Channel resolution for any other sender, Slack/Telegram/Discord routing, or session delivery targeting.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34647

## User-visible / Behavior Changes

- Control-UI/web dashboard messages now correctly show `channel: "webchat"` in inbound metadata, and agent responses route back to the web dashboard instead of leaking to Slack.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22
- Integration/channel: Control-UI (webchat) + Slack

### Steps

1. Open the web dashboard (control-ui)
2. Send a message to an agent that has an active Slack session
3. Check agent inbound metadata

### Expected

- `channel: "webchat"` in inbound metadata

### Actual

- Before fix: `channel: "slack"` — response routed to Slack
- After fix: `channel: "webchat"` — response routed to web dashboard

## Evidence

```
 src/auto-reply/reply/inbound-meta.ts      |  3 +++
 src/auto-reply/reply/inbound-meta.test.ts | 14 ++++++++++++++
 2 files changed, 17 insertions(+)
```

New test: "resolves channel as webchat when sender is openclaw-control-ui" with `OriginatingChannel: "slack"` confirms `channel` is `"webchat"`.

## Human Verification (required)

- Verified scenarios: control-ui sender with Slack OriginatingChannel, non-control-ui senders unaffected
- Edge cases checked: control-ui with no OriginatingChannel (still webchat), regular webchat sender (uses existing logic)
- What I did **not** verify: Live gateway with control-ui connected to Slack-scoped session

## Compatibility / Migration

- Backward compatible? `Yes — only changes behavior for control-ui sender`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/auto-reply/reply/inbound-meta.ts`
- Known bad symptoms: Control-ui messages would show wrong channel again

## Risks and Mitigations

- None. The check is specific to the `openclaw-control-ui` sender ID constant and cannot affect other senders.