### PR TITLE
fix(agents): show all configured agents when allowAgents is unset

### DIFF
--- a/src/agents/openclaw-tools.agents.test.ts
+++ b/src/agents/openclaw-tools.agents.test.ts
@@ -109,6 +109,19 @@ describe("agents_list", () => {
     expect(agents?.map((agent) => agent.id)).toEqual(["main", "coder", "research"]);
   });
 
+  it("lists all configured agents when allowAgents is not set", async () => {
+    setConfigWithAgentList([
+      { id: "main", name: "Main" },
+      { id: "research", name: "Research" },
+      { id: "coder", name: "Coder" },
+    ]);
+
+    const tool = requireAgentsListTool();
+    const result = await tool.execute("call-vis", {});
+    const agents = readAgentList(result);
+    expect(agents?.map((agent) => agent.id)).toEqual(["main", "coder", "research"]);
+  });
+
   it("marks allowlisted-but-unconfigured agents", async () => {
     setConfigWithAgentList([
       {

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -67,7 +67,7 @@ export function createAgentsListTool(opts?: {
 
       const allowed = new Set<string>();
       allowed.add(requesterAgentId);
-      if (allowAny) {
+      if (allowAny || allowAgents.length === 0) {
         for (const id of configuredIds) {
           allowed.add(id);
         }


### PR DESCRIPTION
## Summary

- **Problem:** The `agents_list` tool only returns `["main"]` despite multiple agents being configured in `agents.list`. The CLI (`openclaw agents list`) correctly shows all agents, but the internal tool restricts visibility to the requester when `allowAgents` is not explicitly set.
- **Why it matters:** Subagents cannot discover available peers to spawn via `sessions_spawn`. Users must manually configure `allowAgents: ["*"]` on every agent just to see the list, which contradicts the CLI behavior and is undocumented.
- **What changed:** When `allowAgents` is empty (not configured), treat it the same as `["*"]` for visibility — show all configured agents. This only affects the `agents_list` response; `sessions_spawn` permission logic remains separate and unchanged.
- **What did NOT change:** `sessions_spawn` authorization, explicit `allowAgents` filtering (still respected), or the CLI agent listing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36634

## User-visible / Behavior Changes

- `agents_list` now returns all configured agents when `allowAgents` is not explicitly set, matching the CLI behavior.

## Security Impact (required)

- New permissions/capabilities? `No — visibility only, spawn permissions unchanged`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22
- Integration/channel: Any

### Steps

1. Configure multiple agents in `agents.list` without setting `allowAgents` on any
2. Call the `agents_list` tool from the main agent

### Expected

- All configured agents returned

### Actual

- Before fix: Only `["main"]` returned
- After fix: All configured agents returned

## Evidence

```
 src/agents/tools/agents-list-tool.ts         | 2 +-
 src/agents/openclaw-tools.agents.test.ts | 13 +++++++++++++
 2 files changed, 14 insertions(+), 1 deletion(-)
```

New test: "lists all configured agents when allowAgents is not set" with 3 configured agents, no allowAgents, confirms all 3 are listed.

## Human Verification (required)

- Verified scenarios: No allowAgents (all visible), explicit allowAgents (only listed agents visible), wildcard (all visible), no agents.list (only requester)
- Edge cases checked: Existing "defaults to the requester agent only" test still passes (no agents.list configured)
- What I did **not** verify: sessions_spawn actually rejects spawning non-allowed agents (separate test suite)

## Compatibility / Migration

- Backward compatible? `Yes — only changes agents_list visibility, not spawn permissions`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; or set explicit allowAgents to restrict visibility
- Files/config to restore: `src/agents/tools/agents-list-tool.ts`
- Known bad symptoms: Subagents would see more agents than intended (visibility only, not authorization)

## Risks and Mitigations

- Risk: Subagents may attempt to spawn agents they see but are not allowed to spawn. Mitigation: `sessions_spawn` enforces its own `allowAgents` check independently, so spawning will still be rejected.