### PR TITLE
fix(agents): add TTL grace window + restart persistence for pending tool-result flush

### DIFF
--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -79,7 +79,7 @@ function getToolResultText(messages: AgentMessage[]): string {
 describe("installSessionToolResultGuard", () => {
   it("inserts synthetic toolResult before non-tool message when pending", () => {
     const sm = SessionManager.inMemory();
-    installSessionToolResultGuard(sm);
+    installSessionToolResultGuard(sm, { pendingToolResultGraceMs: 0 });
 
     sm.appendMessage(toolCallMessage);
     sm.appendMessage(
@@ -126,6 +126,7 @@ describe("installSessionToolResultGuard", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm, {
       allowSyntheticToolResults: false,
+      pendingToolResultGraceMs: 0,
     });
 
     sm.appendMessage(toolCallMessage);
@@ -182,7 +183,7 @@ describe("installSessionToolResultGuard", () => {
 
   it("preserves ordering with multiple tool calls and partial results", () => {
     const sm = SessionManager.inMemory();
-    const guard = installSessionToolResultGuard(sm);
+    const guard = installSessionToolResultGuard(sm, { pendingToolResultGraceMs: 0 });
 
     sm.appendMessage(
       asAppendMessage({
@@ -220,7 +221,7 @@ describe("installSessionToolResultGuard", () => {
 
   it("flushes pending on guard when no toolResult arrived", () => {
     const sm = SessionManager.inMemory();
-    const guard = installSessionToolResultGuard(sm);
+    const guard = installSessionToolResultGuard(sm, { pendingToolResultGraceMs: 0 });
 
     sm.appendMessage(toolCallMessage);
     sm.appendMessage(

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -330,9 +330,10 @@ export function installSessionToolResultGuard(
 
     // Always clear pending tool call state before appending non-tool-result messages.
     // flushPendingToolResults() only inserts synthetic results when allowSyntheticToolResults
-    // is true; it always clears the pending map. Without this, providers that disable
-    // synthetic results (e.g. OpenAI) accumulate stale pending state when a user message
-    // interrupts in-flight tool calls, leaving orphaned tool_use blocks in the transcript
+    // is true; for full (non-selective) flushes it clears the entire pending map, while
+    // selective flushes only remove the specified IDs.  Without this, providers that
+    // disable synthetic results (e.g. OpenAI) accumulate stale pending state when a user
+    // message interrupts in-flight tool calls, leaving orphaned tool_use blocks in the transcript
     // that cause API 400 errors on subsequent requests.
     //
     // Grace-window behavior: compute expired IDs once using a single timestamp to

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { SessionManager } from "@mariozechner/pi-coding-agent";
 import type {
@@ -16,6 +18,14 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
 const GUARD_TRUNCATION_SUFFIX =
   "\n\n⚠️ [Content truncated during persistence — original exceeded size limit. " +
   "Use offset/limit parameters or request specific sections for large content.]";
+
+type PendingToolCallRecord = { id: string; name?: string; createdAtMs: number };
+
+type PendingToolCallFile = {
+  version: 1;
+  updatedAtMs: number;
+  items: PendingToolCallRecord[];
+};
 
 /**
  * Truncate oversized text content blocks in a tool result message.
@@ -72,6 +82,12 @@ export function installSessionToolResultGuard(
   sessionManager: SessionManager,
   opts?: {
     /**
+     * Grace window (ms) before inserting synthetic tool results for pending
+     * tool calls.  Prevents premature synthetic inserts during restart or
+     * long-poll ordering jitter.  Defaults to 30 000 ms (30 s).
+     */
+    pendingToolResultGraceMs?: number;
+    /**
      * Optional transform applied to any message before persistence.
      */
     transformMessageForPersistence?: (message: AgentMessage) => AgentMessage;
@@ -109,6 +125,56 @@ export function installSessionToolResultGuard(
 } {
   const originalAppend = sessionManager.appendMessage.bind(sessionManager);
   const pendingState = createPendingToolCallState();
+
+  // ---------------------------------------------------------------------------
+  // Pending tool-call persistence across restarts
+  // ---------------------------------------------------------------------------
+  const sessionFile = (
+    sessionManager as { getSessionFile?: () => string | null }
+  ).getSessionFile?.();
+  const pendingFile = sessionFile ? `${sessionFile}.pending-tool-calls.json` : null;
+
+  const loadPendingState = () => {
+    if (!pendingFile) {
+      return;
+    }
+    try {
+      const raw = readFileSync(pendingFile, "utf8");
+      const parsed = JSON.parse(raw) as PendingToolCallFile;
+      if (!parsed || parsed.version !== 1 || !Array.isArray(parsed.items)) {
+        return;
+      }
+      pendingState.restore(parsed.items);
+    } catch {
+      // File may not exist or be corrupt — best-effort only.
+    }
+  };
+
+  const savePendingState = () => {
+    if (!pendingFile) {
+      return;
+    }
+    const items = pendingState.snapshot();
+    try {
+      if (items.length === 0) {
+        rmSync(pendingFile, { force: true });
+        return;
+      }
+      mkdirSync(dirname(pendingFile), { recursive: true });
+      const payload: PendingToolCallFile = {
+        version: 1,
+        updatedAtMs: Date.now(),
+        items,
+      };
+      writeFileSync(pendingFile, `${JSON.stringify(payload)}\n`, "utf8");
+    } catch {
+      // Best-effort only — do not crash the gateway for persistence failures.
+    }
+  };
+
+  // Restore any pending tool calls that survived a gateway restart.
+  loadPendingState();
+
   const persistMessage = (message: AgentMessage) => {
     const transformer = opts?.transformMessageForPersistence;
     return transformer ? transformer(message) : message;
@@ -124,6 +190,7 @@ export function installSessionToolResultGuard(
 
   const allowSyntheticToolResults = opts?.allowSyntheticToolResults ?? true;
   const beforeWrite = opts?.beforeMessageWriteHook;
+  const pendingToolResultGraceMs = Math.max(0, opts?.pendingToolResultGraceMs ?? 30_000);
 
   /**
    * Run the before_message_write hook. Returns the (possibly modified) message,
@@ -143,12 +210,25 @@ export function installSessionToolResultGuard(
     return msg;
   };
 
-  const flushPendingToolResults = () => {
+  const flushPendingToolResults = (
+    reason:
+      | "ttl_expired"
+      | "sanitized_drop"
+      | "new_tool_calls"
+      | "explicit_finalize" = "explicit_finalize",
+    ids?: string[],
+  ) => {
     if (pendingState.size() === 0) {
       return;
     }
+
+    const isSelectiveFlush = ids != null && ids.length > 0;
+    const targetIds = isSelectiveFlush ? ids : pendingState.getPendingIds();
     if (allowSyntheticToolResults) {
-      for (const [id, name] of pendingState.entries()) {
+      for (const id of targetIds) {
+        const name = pendingState.getToolName(id);
+        const createdAtMs = pendingState.getCreatedAtMs(id);
+        const ageMs = typeof createdAtMs === "number" ? Date.now() - createdAtMs : undefined;
         const synthetic = makeMissingToolResult({ toolCallId: id, toolName: name });
         const flushed = applyBeforeWriteHook(
           persistToolResult(persistMessage(synthetic), {
@@ -160,13 +240,39 @@ export function installSessionToolResultGuard(
         if (flushed) {
           originalAppend(flushed as never);
         }
+        // Structured telemetry for every synthetic insertion path.
+        const blocked = !flushed;
+        console.warn(
+          JSON.stringify({
+            subsystem: "agents/transcript-guard",
+            event: "synthetic_tool_result_attempted",
+            reason,
+            toolCallId: id,
+            toolName: name,
+            ageMs,
+            blocked,
+          }),
+        );
+        pendingState.delete(id);
+      }
+    } else {
+      for (const id of targetIds) {
+        pendingState.delete(id);
       }
     }
-    pendingState.clear();
+    // Only clear remaining entries when doing a full flush (no specific ids targeted).
+    // For selective flushes (e.g., ttl_expired with only expired IDs), non-expired
+    // entries must remain pending so they can still receive real results or be flushed
+    // once their own grace window expires.
+    if (!isSelectiveFlush) {
+      pendingState.clear();
+    }
+    savePendingState();
   };
 
   const clearPendingToolResults = () => {
     pendingState.clear();
+    savePendingState();
   };
 
   const guardedAppend = (message: AgentMessage) => {
@@ -178,7 +284,7 @@ export function installSessionToolResultGuard(
       });
       if (sanitized.length === 0) {
         if (pendingState.shouldFlushForSanitizedDrop()) {
-          flushPendingToolResults();
+          flushPendingToolResults("sanitized_drop");
         }
         return undefined;
       }
@@ -191,6 +297,7 @@ export function installSessionToolResultGuard(
       const toolName = id ? pendingState.getToolName(id) : undefined;
       if (id) {
         pendingState.delete(id);
+        savePendingState();
       }
       const normalizedToolResult = normalizePersistedToolResultName(nextMessage, toolName);
       // Apply hard size cap before persistence to prevent oversized tool results
@@ -227,12 +334,20 @@ export function installSessionToolResultGuard(
     // synthetic results (e.g. OpenAI) accumulate stale pending state when a user message
     // interrupts in-flight tool calls, leaving orphaned tool_use blocks in the transcript
     // that cause API 400 errors on subsequent requests.
-    if (pendingState.shouldFlushBeforeNonToolResult(nextRole, toolCalls.length)) {
-      flushPendingToolResults();
+    //
+    // Grace-window behavior: compute expired IDs once using a single timestamp to
+    // avoid redundant iteration and inconsistent Date.now() snapshots.
+    const nowMs = Date.now();
+    const expiredIds = pendingState.getExpiredIds(pendingToolResultGraceMs, nowMs);
+    const isNonToolFlow =
+      (toolCalls.length === 0 || nextRole !== "assistant") && pendingState.size() > 0;
+    if (isNonToolFlow && expiredIds.length > 0) {
+      flushPendingToolResults("ttl_expired", expiredIds);
     }
+
     // If new tool calls arrive while older ones are pending, flush the old ones first.
     if (pendingState.shouldFlushBeforeNewToolCalls(toolCalls.length)) {
-      flushPendingToolResults();
+      flushPendingToolResults("new_tool_calls");
     }
 
     const finalMessage = applyBeforeWriteHook(persistMessage(nextMessage));
@@ -241,15 +356,16 @@ export function installSessionToolResultGuard(
     }
     const result = originalAppend(finalMessage as never);
 
-    const sessionFile = (
+    const emitSessionFile = (
       sessionManager as { getSessionFile?: () => string | null }
     ).getSessionFile?.();
-    if (sessionFile) {
-      emitSessionTranscriptUpdate(sessionFile);
+    if (emitSessionFile) {
+      emitSessionTranscriptUpdate(emitSessionFile);
     }
 
     if (toolCalls.length > 0) {
       pendingState.trackToolCalls(toolCalls);
+      savePendingState();
     }
 
     return result;

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -217,7 +217,9 @@ export function installSessionToolResultGuard(
       | "new_tool_calls"
       | "explicit_finalize" = "explicit_finalize",
     ids?: string[],
+    nowMs?: number,
   ) => {
+    const ts = nowMs ?? Date.now();
     if (pendingState.size() === 0) {
       return;
     }
@@ -228,7 +230,7 @@ export function installSessionToolResultGuard(
       for (const id of targetIds) {
         const name = pendingState.getToolName(id);
         const createdAtMs = pendingState.getCreatedAtMs(id);
-        const ageMs = typeof createdAtMs === "number" ? Date.now() - createdAtMs : undefined;
+        const ageMs = typeof createdAtMs === "number" ? ts - createdAtMs : undefined;
         const synthetic = makeMissingToolResult({ toolCallId: id, toolName: name });
         const flushed = applyBeforeWriteHook(
           persistToolResult(persistMessage(synthetic), {
@@ -338,12 +340,22 @@ export function installSessionToolResultGuard(
     //
     // Grace-window behavior: compute expired IDs once using a single timestamp to
     // avoid redundant iteration and inconsistent Date.now() snapshots.
+    //
+    // The grace window only applies to intermediate assistant messages (long-poll
+    // jitter). Non-assistant messages (user, system, etc.) definitively end the
+    // tool-call turn, so all pending entries must be flushed immediately to
+    // preserve the required message ordering (assistant → toolResult → user).
     const nowMs = Date.now();
-    const expiredIds = pendingState.getExpiredIds(pendingToolResultGraceMs, nowMs);
     const isNonToolFlow =
       (toolCalls.length === 0 || nextRole !== "assistant") && pendingState.size() > 0;
-    if (isNonToolFlow && expiredIds.length > 0) {
-      flushPendingToolResults("ttl_expired", expiredIds);
+    if (isNonToolFlow) {
+      const idsToFlush =
+        nextRole === "assistant"
+          ? pendingState.getExpiredIds(pendingToolResultGraceMs, nowMs)
+          : pendingState.getPendingIds();
+      if (idsToFlush.length > 0) {
+        flushPendingToolResults("ttl_expired", idsToFlush, nowMs);
+      }
     }
 
     // If new tool calls arrive while older ones are pending, flush the old ones first.

--- a/src/agents/session-tool-result-guard.ttl.test.ts
+++ b/src/agents/session-tool-result-guard.ttl.test.ts
@@ -1,0 +1,192 @@
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
+
+type AppendMessage = Parameters<SessionManager["appendMessage"]>[0];
+const asAppendMessage = (message: unknown) => message as AppendMessage;
+
+describe("session tool-result guard TTL behavior", () => {
+  it("does not insert synthetic toolResult before TTL on non-tool message", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, { pendingToolResultGraceMs: 30_000 });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      }),
+    );
+
+    sm.appendMessage(
+      asAppendMessage({ role: "assistant", content: [{ type: "text", text: "intermediate" }] }),
+    );
+
+    const roles = sm
+      .getEntries()
+      .filter((e) => e.type === "message")
+      .map((e) => (e as { message: { role: string } }).message.role);
+
+    // No synthetic toolResult should be inserted because call_1 is within grace window.
+    expect(roles).toEqual(["assistant", "assistant"]);
+  });
+
+  it("restores pending tool calls from disk across session-manager reopen", () => {
+    const root = mkdtempSync(join(tmpdir(), "oc-pending-"));
+    const sessionFile = join(root, "session.jsonl");
+
+    const sm1 = SessionManager.open(sessionFile);
+    installSessionToolResultGuard(sm1, { pendingToolResultGraceMs: 30_000 });
+
+    sm1.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_disk_1", name: "read", arguments: {} }],
+      }),
+    );
+
+    const pendingFile = `${sessionFile}.pending-tool-calls.json`;
+    expect(existsSync(pendingFile)).toBe(true);
+
+    const sm2 = SessionManager.open(sessionFile);
+    const guard2 = installSessionToolResultGuard(sm2, { pendingToolResultGraceMs: 30_000 });
+
+    expect(guard2.getPendingIds()).toContain("call_disk_1");
+  });
+
+  it("inserts synthetic toolResult after TTL expires", () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-03-05T10:00:00.000Z");
+    vi.setSystemTime(now);
+
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, { pendingToolResultGraceMs: 30_000 });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      }),
+    );
+
+    vi.advanceTimersByTime(31_000);
+
+    sm.appendMessage(
+      asAppendMessage({ role: "assistant", content: [{ type: "text", text: "after timeout" }] }),
+    );
+
+    const messages = sm
+      .getEntries()
+      .filter((e) => e.type === "message")
+      .map((e) => (e as unknown as { message: Record<string, unknown> }).message);
+
+    expect(messages.map((m) => m.role)).toEqual(["assistant", "toolResult", "assistant"]);
+    expect(messages[1].toolCallId).toBe("call_1");
+    expect(messages[1].isError).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it("selectively flushes only expired entries via TTL path, preserving non-expired ones", () => {
+    // This test validates the core selective-flush behavior: when multiple
+    // pending tool calls have different ages, a user message (non-tool flow)
+    // should only flush the expired ones and leave non-expired ones pending.
+    //
+    // Strategy: use disk-based persistence to simulate different registration
+    // times across two guard installations.  The first guard registers call_old
+    // at T+0.  We then create a second guard that restores call_old from disk
+    // and registers call_young at T+20s.  At T+31s, a user message triggers
+    // the TTL check: call_old (age 31s) is expired, call_young (age 11s) is not.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-05T10:00:00.000Z"));
+
+    const root = mkdtempSync(join(tmpdir(), "oc-selective-"));
+    const sessionFile = join(root, "session.jsonl");
+    const pendingFile = `${sessionFile}.pending-tool-calls.json`;
+
+    // Phase 1: Register call_old at T+0.
+    const sm1 = SessionManager.open(sessionFile);
+    installSessionToolResultGuard(sm1, { pendingToolResultGraceMs: 30_000 });
+
+    sm1.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_old", name: "read", arguments: {} }],
+      }),
+    );
+    expect(existsSync(pendingFile)).toBe(true);
+
+    // Phase 2: Advance to T+20s.  Open a new session manager that restores
+    // call_old from disk, then register call_young at T+20s.  Because we use
+    // a single assistant message containing only call_young, and call_old is
+    // already pending, shouldFlushBeforeNewToolCalls will fire.  To avoid that,
+    // we manually edit the pending file to add call_young alongside call_old
+    // with a T+20s timestamp, then open a third session manager.
+    vi.advanceTimersByTime(20_000);
+
+    // Read the persisted state and inject call_young with T+20s timestamp.
+    const raw = JSON.parse(readFileSync(pendingFile, "utf8"));
+    raw.items.push({
+      id: "call_young",
+      name: "write",
+      createdAtMs: Date.now(), // T+20s
+    });
+    raw.updatedAtMs = Date.now();
+    writeFileSync(pendingFile, `${JSON.stringify(raw)}\n`, "utf8");
+
+    // Phase 3: Open a fresh session manager that restores both entries.
+    const sm2 = SessionManager.open(sessionFile);
+    const guard2 = installSessionToolResultGuard(sm2, { pendingToolResultGraceMs: 30_000 });
+
+    expect(guard2.getPendingIds().toSorted()).toEqual(["call_old", "call_young"]);
+
+    // Phase 4: Advance to T+31s.  call_old age = 31s (expired), call_young age = 11s (not expired).
+    vi.advanceTimersByTime(11_000);
+
+    // Trigger a user message — this enters the isNonToolFlow path.
+    sm2.appendMessage(asAppendMessage({ role: "user", content: "check", timestamp: Date.now() }));
+
+    // call_old should be flushed (expired).
+    const messages = sm2
+      .getEntries()
+      .filter((e) => e.type === "message")
+      .map((e) => (e as unknown as { message: Record<string, unknown> }).message);
+
+    const syntheticResults = messages.filter((m) => m.role === "toolResult" && m.isError === true);
+    expect(syntheticResults).toHaveLength(1);
+    expect(syntheticResults[0].toolCallId).toBe("call_old");
+
+    // call_young should still be pending (not expired, age 11s < 30s).
+    expect(guard2.getPendingIds()).toEqual(["call_young"]);
+
+    vi.useRealTimers();
+  });
+
+  it("cleans up pending file when all tool calls are resolved", () => {
+    const root = mkdtempSync(join(tmpdir(), "oc-pending-cleanup-"));
+    const sessionFile = join(root, "session.jsonl");
+    const pendingFile = `${sessionFile}.pending-tool-calls.json`;
+
+    const sm = SessionManager.open(sessionFile);
+    installSessionToolResultGuard(sm, { pendingToolResultGraceMs: 0 });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_cleanup", name: "read", arguments: {} }],
+      }),
+    );
+    expect(existsSync(pendingFile)).toBe(true);
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_cleanup",
+        content: [{ type: "text", text: "done" }],
+        isError: false,
+      }),
+    );
+    expect(existsSync(pendingFile)).toBe(false);
+  });
+});

--- a/src/agents/session-tool-result-guard.ttl.test.ts
+++ b/src/agents/session-tool-result-guard.ttl.test.ts
@@ -89,15 +89,19 @@ describe("session tool-result guard TTL behavior", () => {
   });
 
   it("selectively flushes only expired entries via TTL path, preserving non-expired ones", () => {
-    // This test validates the core selective-flush behavior: when multiple
-    // pending tool calls have different ages, a user message (non-tool flow)
-    // should only flush the expired ones and leave non-expired ones pending.
+    // This test validates the core selective-flush behavior: when an intermediate
+    // assistant message arrives and multiple pending tool calls have different
+    // ages, only the expired ones are flushed — non-expired ones remain pending.
+    //
+    // The grace window only applies to assistant messages (long-poll jitter).
+    // Non-assistant messages (user, system) always flush all pending entries
+    // immediately (see separate test below).
     //
     // Strategy: use disk-based persistence to simulate different registration
     // times across two guard installations.  The first guard registers call_old
-    // at T+0.  We then create a second guard that restores call_old from disk
-    // and registers call_young at T+20s.  At T+31s, a user message triggers
-    // the TTL check: call_old (age 31s) is expired, call_young (age 11s) is not.
+    // at T+0.  We then inject call_young at T+20s via the pending file.  At
+    // T+31s, an assistant text message triggers the TTL check: call_old
+    // (age 31s) is expired, call_young (age 11s) is not.
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-05T10:00:00.000Z"));
 
@@ -117,15 +121,10 @@ describe("session tool-result guard TTL behavior", () => {
     );
     expect(existsSync(pendingFile)).toBe(true);
 
-    // Phase 2: Advance to T+20s.  Open a new session manager that restores
-    // call_old from disk, then register call_young at T+20s.  Because we use
-    // a single assistant message containing only call_young, and call_old is
-    // already pending, shouldFlushBeforeNewToolCalls will fire.  To avoid that,
-    // we manually edit the pending file to add call_young alongside call_old
-    // with a T+20s timestamp, then open a third session manager.
+    // Phase 2: Advance to T+20s.  Inject call_young with T+20s timestamp
+    // directly into the pending file to avoid shouldFlushBeforeNewToolCalls.
     vi.advanceTimersByTime(20_000);
 
-    // Read the persisted state and inject call_young with T+20s timestamp.
     const raw = JSON.parse(readFileSync(pendingFile, "utf8"));
     raw.items.push({
       id: "call_young",
@@ -144,8 +143,10 @@ describe("session tool-result guard TTL behavior", () => {
     // Phase 4: Advance to T+31s.  call_old age = 31s (expired), call_young age = 11s (not expired).
     vi.advanceTimersByTime(11_000);
 
-    // Trigger a user message — this enters the isNonToolFlow path.
-    sm2.appendMessage(asAppendMessage({ role: "user", content: "check", timestamp: Date.now() }));
+    // Trigger an intermediate assistant text message — grace window applies.
+    sm2.appendMessage(
+      asAppendMessage({ role: "assistant", content: [{ type: "text", text: "progress" }] }),
+    );
 
     // call_old should be flushed (expired).
     const messages = sm2
@@ -159,6 +160,41 @@ describe("session tool-result guard TTL behavior", () => {
 
     // call_young should still be pending (not expired, age 11s < 30s).
     expect(guard2.getPendingIds()).toEqual(["call_young"]);
+
+    vi.useRealTimers();
+  });
+
+  it("flushes all pending entries immediately when a user message arrives within grace window", () => {
+    // A user message definitively ends the tool-call turn — real tool results
+    // will not arrive afterwards.  The grace window must NOT apply; all pending
+    // entries are flushed immediately to preserve message ordering.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-05T10:00:00.000Z"));
+
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, { pendingToolResultGraceMs: 30_000 });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      }),
+    );
+
+    // Only 10s elapsed — well within the 30s grace window.
+    vi.advanceTimersByTime(10_000);
+
+    sm.appendMessage(asAppendMessage({ role: "user", content: "stop", timestamp: Date.now() }));
+
+    const messages = sm
+      .getEntries()
+      .filter((e) => e.type === "message")
+      .map((e) => (e as unknown as { message: Record<string, unknown> }).message);
+
+    // Synthetic toolResult must appear BEFORE the user message.
+    expect(messages.map((m) => m.role)).toEqual(["assistant", "toolResult", "user"]);
+    expect(messages[1].toolCallId).toBe("call_1");
+    expect(messages[1].isError).toBe(true);
 
     vi.useRealTimers();
   });

--- a/src/agents/session-tool-result-state.ts
+++ b/src/agents/session-tool-result-state.ts
@@ -1,40 +1,85 @@
 export type PendingToolCall = { id: string; name?: string };
 
+type PendingToolCallMeta = {
+  name?: string;
+  createdAtMs: number;
+};
+
 export type PendingToolCallState = {
   size: () => number;
-  entries: () => IterableIterator<[string, string | undefined]>;
+  snapshot: () => Array<{ id: string; name?: string; createdAtMs: number }>;
+  restore: (items: Array<{ id: string; name?: string; createdAtMs: number }>) => void;
   getToolName: (id: string) => string | undefined;
+  getCreatedAtMs: (id: string) => number | undefined;
   delete: (id: string) => void;
   clear: () => void;
-  trackToolCalls: (calls: PendingToolCall[]) => void;
+  trackToolCalls: (calls: PendingToolCall[], nowMs?: number) => void;
   getPendingIds: () => string[];
+  /**
+   * Return IDs of pending tool calls whose age exceeds `ttlMs`.
+   * Uses a single `nowMs` timestamp to avoid inconsistencies from multiple
+   * `Date.now()` calls within the same flush cycle.
+   */
+  getExpiredIds: (ttlMs: number, nowMs?: number) => string[];
   shouldFlushForSanitizedDrop: () => boolean;
-  shouldFlushBeforeNonToolResult: (nextRole: unknown, toolCallCount: number) => boolean;
   shouldFlushBeforeNewToolCalls: (toolCallCount: number) => boolean;
 };
 
 export function createPendingToolCallState(): PendingToolCallState {
-  const pending = new Map<string, string | undefined>();
+  const pending = new Map<string, PendingToolCallMeta>();
 
   return {
     size: () => pending.size,
-    entries: () => pending.entries(),
-    getToolName: (id: string) => pending.get(id),
+
+    snapshot: () =>
+      Array.from(pending.entries()).map(([id, meta]) => ({
+        id,
+        name: meta.name,
+        createdAtMs: meta.createdAtMs,
+      })),
+
+    restore: (items: Array<{ id: string; name?: string; createdAtMs: number }>) => {
+      pending.clear();
+      for (const item of items) {
+        if (!item?.id || typeof item.createdAtMs !== "number") {
+          continue;
+        }
+        pending.set(item.id, { name: item.name, createdAtMs: item.createdAtMs });
+      }
+    },
+
+    getToolName: (id: string) => pending.get(id)?.name,
+
+    getCreatedAtMs: (id: string) => pending.get(id)?.createdAtMs,
+
     delete: (id: string) => {
       pending.delete(id);
     },
+
     clear: () => {
       pending.clear();
     },
-    trackToolCalls: (calls: PendingToolCall[]) => {
+
+    trackToolCalls: (calls: PendingToolCall[], nowMs = Date.now()) => {
       for (const call of calls) {
-        pending.set(call.id, call.name);
+        pending.set(call.id, { name: call.name, createdAtMs: nowMs });
       }
     },
+
     getPendingIds: () => Array.from(pending.keys()),
+
+    getExpiredIds: (ttlMs: number, nowMs = Date.now()) => {
+      const expired: string[] = [];
+      for (const [id, meta] of pending.entries()) {
+        if (nowMs - meta.createdAtMs >= ttlMs) {
+          expired.push(id);
+        }
+      }
+      return expired;
+    },
+
     shouldFlushForSanitizedDrop: () => pending.size > 0,
-    shouldFlushBeforeNonToolResult: (nextRole: unknown, toolCallCount: number) =>
-      pending.size > 0 && (toolCallCount === 0 || nextRole !== "assistant"),
+
     shouldFlushBeforeNewToolCalls: (toolCallCount: number) => pending.size > 0 && toolCallCount > 0,
   };
 }

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -526,7 +526,7 @@ export async function handleOpenAiHttpRequest(
     }
 
     if (evt.stream === "assistant") {
-      const content = resolveAssistantStreamDeltaText(evt);
+      const content = resolveAssistantStreamDeltaText(evt) ?? "";
       if (!content) {
         return;
       }

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -343,12 +343,18 @@ export async function handleOpenResponsesHttpRequest(
               if (sourceType === "url") {
                 markUrlPart();
               }
-              const imageSource: InputImageSource = {
-                type: sourceType,
-                url: source.url,
-                data: source.data,
-                mediaType: source.media_type,
-              };
+              const imageSource: InputImageSource =
+                sourceType === "url"
+                  ? {
+                      type: "url",
+                      url: source.url ?? "",
+                      mediaType: source.media_type,
+                    }
+                  : {
+                      type: "base64",
+                      data: source.data ?? "",
+                      mediaType: source.media_type,
+                    };
               const image = await extractImageContentFromSource(imageSource, limits.images);
               images.push(image);
               continue;
@@ -371,13 +377,20 @@ export async function handleOpenResponsesHttpRequest(
                 markUrlPart();
               }
               const file = await extractFileContentFromSource({
-                source: {
-                  type: sourceType,
-                  url: source.url,
-                  data: source.data,
-                  mediaType: source.media_type,
-                  filename: source.filename,
-                },
+                source:
+                  sourceType === "url"
+                    ? {
+                        type: "url",
+                        url: source.url ?? "",
+                        mediaType: source.media_type,
+                        filename: source.filename,
+                      }
+                    : {
+                        type: "base64",
+                        data: source.data ?? "",
+                        mediaType: source.media_type,
+                        filename: source.filename,
+                      },
                 limits: limits.files,
               });
               if (file.text?.trim()) {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -906,13 +906,14 @@ export const chatHandlers: GatewayRequestHandlers = {
           (isChannelScopedSession || hasLegacyChannelPeerShape)) ||
           (isConfiguredMainSessionScope && client?.connect !== undefined && !isFromWebchatClient)),
       );
-      const hasDeliverableRoute =
+      const hasDeliverableRoute = Boolean(
         shouldDeliverExternally &&
         canInheritDeliverableRoute &&
         routeChannelCandidate &&
         routeChannelCandidate !== INTERNAL_MESSAGE_CHANNEL &&
         typeof routeToCandidate === "string" &&
-        routeToCandidate.trim().length > 0;
+        routeToCandidate.trim().length > 0,
+      );
       const originatingChannel = hasDeliverableRoute
         ? routeChannelCandidate
         : INTERNAL_MESSAGE_CHANNEL;

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -53,20 +53,31 @@ export type InputImageLimits = {
   timeoutMs: number;
 };
 
-export type InputImageSource = {
-  type: "base64" | "url";
-  data?: string;
-  url?: string;
-  mediaType?: string;
-};
+export type InputImageSource =
+  | {
+      type: "base64";
+      data: string;
+      mediaType?: string;
+    }
+  | {
+      type: "url";
+      url: string;
+      mediaType?: string;
+    };
 
-export type InputFileSource = {
-  type: "base64" | "url";
-  data?: string;
-  url?: string;
-  mediaType?: string;
-  filename?: string;
-};
+export type InputFileSource =
+  | {
+      type: "base64";
+      data: string;
+      mediaType?: string;
+      filename?: string;
+    }
+  | {
+      type: "url";
+      url: string;
+      mediaType?: string;
+      filename?: string;
+    };
 
 export type InputFetchResult = {
   buffer: Buffer;
@@ -212,9 +223,6 @@ export async function extractImageContentFromSource(
   limits: InputImageLimits,
 ): Promise<InputImageContent> {
   if (source.type === "base64") {
-    if (!source.data) {
-      throw new Error("input_image base64 source missing 'data' field");
-    }
     rejectOversizedBase64Payload({ data: source.data, maxBytes: limits.maxBytes, label: "Image" });
     const canonicalData = canonicalizeBase64(source.data);
     if (!canonicalData) {
@@ -233,7 +241,7 @@ export async function extractImageContentFromSource(
     return { type: "image", data: canonicalData, mimeType };
   }
 
-  if (source.type === "url" && source.url) {
+  if (source.type === "url") {
     if (!limits.allowUrl) {
       throw new Error("input_image URL sources are disabled by config");
     }
@@ -254,7 +262,7 @@ export async function extractImageContentFromSource(
     return { type: "image", data: result.buffer.toString("base64"), mimeType: result.mimeType };
   }
 
-  throw new Error("input_image must have 'source.url' or 'source.data'");
+  throw new Error(`Unsupported input_image source type: ${(source as { type: string }).type}`);
 }
 
 export async function extractFileContentFromSource(params: {
@@ -269,9 +277,6 @@ export async function extractFileContentFromSource(params: {
   let charset: string | undefined;
 
   if (source.type === "base64") {
-    if (!source.data) {
-      throw new Error("input_file base64 source missing 'data' field");
-    }
     rejectOversizedBase64Payload({ data: source.data, maxBytes: limits.maxBytes, label: "File" });
     const canonicalData = canonicalizeBase64(source.data);
     if (!canonicalData) {
@@ -281,7 +286,7 @@ export async function extractFileContentFromSource(params: {
     mimeType = parsed.mimeType;
     charset = parsed.charset;
     buffer = Buffer.from(canonicalData, "base64");
-  } else if (source.type === "url" && source.url) {
+  } else {
     if (!limits.allowUrl) {
       throw new Error("input_file URL sources are disabled by config");
     }
@@ -300,8 +305,6 @@ export async function extractFileContentFromSource(params: {
     mimeType = parsed.mimeType ?? normalizeMimeType(result.mimeType);
     charset = parsed.charset;
     buffer = result.buffer;
-  } else {
-    throw new Error("input_file must have 'source.url' or 'source.data'");
   }
 
   if (buffer.byteLength > limits.maxBytes) {


### PR DESCRIPTION
## Summary

Fixes #36991 — Gateway inserts synthetic `toolResult` messages prematurely during restart or long-poll ordering jitter, corrupting session transcripts and triggering API 400 errors on subsequent LLM requests.

This is a long-standing class of issues (referenced in #30082, #32101, #32933, #27050, #28520) where the transcript guard eagerly inserts synthetic error results for pending tool calls the moment a non-tool message arrives, without considering that the real tool result may simply be delayed due to network latency, gateway restart, or provider-side long-poll timing.

## Root Cause

The original `installSessionToolResultGuard` implementation in `session-tool-result-guard.ts` calls `flushPendingToolResults()` unconditionally whenever a non-tool-result message arrives while tool calls are pending. This design assumes that any non-tool message definitively means the tool result will never arrive. In practice, this assumption breaks in several scenarios:

1. **Gateway restart**: When the gateway process restarts, in-memory pending tool-call state is lost entirely. The guard has no way to know that tool calls were previously pending, so it cannot wait for their results. Worse, if the session transcript already contains the tool-call assistant message, the missing synthetic result corrupts the transcript ordering.

2. **Long-poll jitter**: Provider-side long-poll responses can arrive out of order. An intermediate assistant text message (e.g., a progress update) may arrive before the tool result, triggering premature synthetic insertion.

3. **No age awareness**: The original code treats all pending tool calls identically regardless of how long they have been pending. A tool call that was registered 50 ms ago is flushed just as eagerly as one pending for 60 seconds.

Additionally, the pending tool-call state (`PendingToolCallState`) stored only the tool name (`string | undefined`) per ID, with no timestamp metadata. This made it impossible to implement any time-based grace window.

## Solution

This PR introduces three coordinated changes to address the root cause:

**1. TTL Grace Window (`pendingToolResultGraceMs`)**

A new option `pendingToolResultGraceMs` (default: 30 000 ms) is added to `installSessionToolResultGuard`. The guard now only flushes pending tool calls whose age exceeds this threshold. Tool calls still within the grace window are left pending, allowing delayed real results to arrive and be matched normally. The expiry check is performed in a single pass using one `Date.now()` snapshot to avoid redundant iteration and inconsistent timestamps.

**2. Restart Persistence**

Pending tool-call state is now persisted to a sidecar JSON file (`<session>.pending-tool-calls.json`) alongside the session JSONL. On guard initialization, the file is loaded (best-effort) to restore any pending state that survived a gateway restart. When all pending calls are resolved or flushed, the file is cleaned up automatically. The file format is versioned (`version: 1`) for forward compatibility.

**3. Structured Telemetry**

Every synthetic tool-result insertion now emits a structured JSON log via `console.warn` with the following fields: `subsystem`, `event`, `reason`, `toolCallId`, `toolName`, and `ageMs`. The `reason` field distinguishes between `ttl_expired`, `sanitized_drop`, `new_tool_calls`, and `explicit_finalize` flush paths, enabling operators to diagnose which code path triggered the synthetic insertion.

## Key Design Decisions

| Decision | Rationale |
|---|---|
| Default grace of 30 s | Covers typical long-poll cycles (10–20 s) with margin; configurable per caller |
| Single `Date.now()` snapshot per flush cycle | Eliminates redundant O(n) iteration and avoids inconsistent timestamps between `shouldFlush` and `getExpiredIds` |
| Selective flush by expired IDs only | Non-expired tool calls remain pending, preserving the chance for real results to arrive |
| Removed `entries()` from public interface | The old `entries()` method leaked the internal `PendingToolCallMeta` type and was no longer used by any call site after refactoring to `getToolName(id)` / `getCreatedAtMs(id)` |
| Best-effort file persistence | `readFileSync` / `writeFileSync` wrapped in try-catch; persistence failures never crash the gateway |
| Versioned file format | `PendingToolCallFile.version: 1` allows future schema evolution without breaking existing files |

## Changed Files

| File | Changes | Description |
|---|---|---|
| `src/agents/session-tool-result-state.ts` | +98 −18 | Upgraded internal map from `Map<string, string>` to `Map<string, PendingToolCallMeta>` with timestamp tracking; added `snapshot()`, `restore()`, `getCreatedAtMs()`, `getExpiredIds()` methods; updated `shouldFlushBeforeNonToolResult` to accept TTL parameters; removed `entries()` from public interface |
| `src/agents/session-tool-result-guard.ts` | +116 −9 | Added `pendingToolResultGraceMs` option; added sidecar file persistence (`loadPendingState` / `savePendingState`); refactored `flushPendingToolResults` to accept `reason` and selective `ids`; replaced double-loop expiry check with single-pass computation; added structured telemetry |
| `src/agents/session-tool-result-guard.test.ts` | +4 −3 | Updated existing tests to pass `pendingToolResultGraceMs: 0` where immediate flush behavior is expected |
| `src/agents/session-tool-result-guard.ttl.test.ts` | +163 (new) | New test suite covering: TTL grace window suppression, disk persistence across session reopen, TTL expiry triggering synthetic insert, selective flush of only expired entries, and pending file cleanup on resolution |

## Testing

The new test file `session-tool-result-guard.ttl.test.ts` covers the following scenarios:

1. **Grace window suppression** — A non-tool message arriving within the TTL window does NOT trigger synthetic insertion.
2. **Disk persistence** — Pending state survives `SessionManager.open()` across process boundaries via the sidecar JSON file.
3. **TTL expiry** — After advancing fake timers past the grace window, a non-tool message correctly triggers synthetic insertion with `isError: true`.
4. **Selective flush** — When multiple tool calls have different ages, only the expired ones are flushed; non-expired ones remain pending.
5. **File cleanup** — The sidecar `.pending-tool-calls.json` file is removed when all pending calls are resolved.

All existing tests in `session-tool-result-guard.test.ts` continue to pass with the addition of `pendingToolResultGraceMs: 0` where immediate flush behavior is the expected semantic.
