### PR TITLE
fix(agents): support parallel_tool_calls config per model

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1353,3 +1353,46 @@ describe("applyExtraParamsToAgent", () => {
     },
   );
 });
+
+describe("parallel_tool_calls wrapper", () => {
+  function capturePayload(provider: string, modelId: string, paramValue: boolean) {
+    let captured: Record<string, unknown> = {};
+    const fakeStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(captured);
+      return undefined as never;
+    };
+    const agent = { streamFn: fakeStreamFn };
+    applyExtraParamsToAgent(
+      agent,
+      {
+        agents: {
+          defaults: {
+            models: {
+              [`${provider}/${modelId}`]: {
+                params: { parallel_tool_calls: paramValue },
+              },
+            },
+          },
+        },
+      },
+      provider,
+      modelId,
+    );
+    void agent.streamFn(
+      { api: "openai-completions", provider, id: modelId } as Model<"openai-completions">,
+      {} as Context,
+      {},
+    );
+    return captured;
+  }
+
+  it("injects parallel_tool_calls=false when configured", () => {
+    const payload = capturePayload("nvidia-nim", "moonshotai/kimi-k2.5", false);
+    expect(payload.parallel_tool_calls).toBe(false);
+  });
+
+  it("injects parallel_tool_calls=true when configured", () => {
+    const payload = capturePayload("openai", "gpt-4", true);
+    expect(payload.parallel_tool_calls).toBe(true);
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -963,6 +963,25 @@ function createZaiToolStreamWrapper(
   };
 }
 
+function createParallelToolCallsWrapper(
+  baseStreamFn: StreamFn | undefined,
+  parallelToolCalls: boolean,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          (payload as Record<string, unknown>).parallel_tool_calls = parallelToolCalls;
+        }
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}
+
 /**
  * Apply extra params (like temperature) to an agent's streamFn.
  * Also adds OpenRouter app attribution headers when using the OpenRouter provider.
@@ -1067,6 +1086,13 @@ export function applyExtraParamsToAgent(
       log.debug(`enabling Z.AI tool_stream for ${provider}/${modelId}`);
       agent.streamFn = createZaiToolStreamWrapper(agent.streamFn, true);
     }
+  }
+
+  if (typeof merged?.parallel_tool_calls === "boolean") {
+    log.debug(
+      `applying parallel_tool_calls=${merged.parallel_tool_calls} for ${provider}/${modelId}`,
+    );
+    agent.streamFn = createParallelToolCallsWrapper(agent.streamFn, merged.parallel_tool_calls);
   }
 
   // Guard Google payloads against invalid negative thinking budgets emitted by


### PR DESCRIPTION
## Summary

- **Problem:** OpenClaw unconditionally sends `parallel_tool_calls: true` in LLM requests to all OpenAI-compatible providers. Models that don't support parallel tool calling (e.g. `moonshotai/kimi-k2.5` on NVIDIA NIM) return a 400 error, breaking ALL tool execution for the agent.
- **Why it matters:** Users on custom providers with models that only support single tool calls cannot use any tools at all. There was no config option to disable `parallel_tool_calls`.
- **What changed:** Added a `createParallelToolCallsWrapper` that reads `parallel_tool_calls` from model params and injects it into the LLM request payload via `onPayload`. Users can now set `parallel_tool_calls: false` per provider/model in their config.
- **What did NOT change:** Default behavior for providers that support parallel tool calls, any other request param handling, or the upstream pi-agent-core library.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37048

## User-visible / Behavior Changes

- Users can now configure `parallel_tool_calls: false` per model to disable parallel tool calling for providers that don't support it:
  ```json
  {
    "agents": {
      "defaults": {
        "models": {
          "nvidia-nim/moonshotai/kimi-k2.5": {
            "params": { "parallel_tool_calls": false }
          }
        }
      }
    }
  }
  ```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No — same endpoint, modified request body field`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22
- Integration/channel: Any (NVIDIA NIM, custom providers)

### Steps

1. Configure a custom provider with a model that doesn't support parallel tool calls
2. Set `parallel_tool_calls: false` in model params
3. Send a message that triggers tool use

### Expected

- Tools work correctly with single tool calls

### Actual

- Before fix: Provider returns 400, all tools break
- After fix: `parallel_tool_calls: false` injected into payload, single tool calls work

## Evidence

```
 src/agents/pi-embedded-runner/extra-params.ts         | 25 +++++++++++++++++++
 src/agents/pi-embedded-runner-extraparams.test.ts | 44 ++++++++++++++++++++++++++++++++
 2 files changed, 69 insertions(+)
```

Two new tests: "injects parallel_tool_calls=false when configured" and "injects parallel_tool_calls=true when configured" verify the wrapper.

## Human Verification (required)

- Verified scenarios: `parallel_tool_calls: false` (injected), `parallel_tool_calls: true` (injected), no param set (no wrapper applied, default behavior preserved)
- Edge cases checked: Config without agents.defaults.models (no crash), non-boolean values (ignored)
- What I did **not** verify: Live NVIDIA NIM endpoint with kimi-k2.5

## Compatibility / Migration

- Backward compatible? `Yes — only applies when parallel_tool_calls is explicitly set in model params`
- Config/env changes? `No — new optional param`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `parallel_tool_calls` from model params, or revert this commit
- Files/config to restore: `src/agents/pi-embedded-runner/extra-params.ts`
- Known bad symptoms: Models that don't support parallel tool calls would break again

## Risks and Mitigations

- Risk: Setting `parallel_tool_calls: false` for models that support it may reduce performance. Mitigation: The setting is per-model and opt-in only.