### PR TITLE
fix(agents): remove volatile reasoning/thinking state from system prompt

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -593,15 +593,29 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("agent=work");
   });
 
-  it("includes reasoning visibility hint", () => {
+  it("includes static reasoning visibility hint", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
       reasoningLevel: "off",
     });
 
-    expect(prompt).toContain("Reasoning: off");
+    expect(prompt).toContain("Reasoning:");
     expect(prompt).toContain("/reasoning");
     expect(prompt).toContain("/status shows Reasoning");
+    expect(prompt).not.toContain("Reasoning: off");
+  });
+
+  it("does not embed volatile reasoning level in system prompt", () => {
+    const promptOff = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      reasoningLevel: "off",
+    });
+    const promptOn = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      reasoningLevel: "stream",
+    });
+    const runtimeSection = (text: string) => text.slice(text.indexOf("## Runtime"));
+    expect(runtimeSection(promptOff)).toBe(runtimeSection(promptOn));
   });
 
   it("builds runtime line with agent and channel details", () => {
@@ -618,7 +632,6 @@ describe("buildAgentSystemPrompt", () => {
       },
       "telegram",
       ["inlineButtons"],
-      "low",
     );
 
     expect(line).toContain("agent=work");
@@ -630,7 +643,7 @@ describe("buildAgentSystemPrompt", () => {
     expect(line).toContain("default_model=anthropic/claude-opus-4-5");
     expect(line).toContain("channel=telegram");
     expect(line).toContain("capabilities=inlineButtons");
-    expect(line).toContain("thinking=low");
+    expect(line).not.toContain("thinking=");
   });
 
   it("describes sandboxed runtime and elevated when allowed", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -360,7 +360,6 @@ export function buildAgentSystemPrompt(params: {
         "<final>Hey there! What would you like to do next?</final>",
       ].join(" ")
     : undefined;
-  const reasoningLevel = params.reasoningLevel ?? "off";
   const userTimezone = params.userTimezone?.trim();
   const skillsPrompt = params.skillsPrompt?.trim();
   const heartbeatPrompt = params.heartbeatPrompt?.trim();
@@ -677,8 +676,8 @@ export function buildAgentSystemPrompt(params: {
 
   lines.push(
     "## Runtime",
-    buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities, params.defaultThinkLevel),
-    `Reasoning: ${reasoningLevel} (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.`,
+    buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities),
+    "Reasoning: toggle with /reasoning; /status shows Reasoning when enabled.",
   );
 
   return lines.filter(Boolean).join("\n");
@@ -698,7 +697,6 @@ export function buildRuntimeLine(
   },
   runtimeChannel?: string,
   runtimeCapabilities: string[] = [],
-  defaultThinkLevel?: ThinkLevel,
 ): string {
   return `Runtime: ${[
     runtimeInfo?.agentId ? `agent=${runtimeInfo.agentId}` : "",
@@ -717,7 +715,6 @@ export function buildRuntimeLine(
     runtimeChannel
       ? `capabilities=${runtimeCapabilities.length > 0 ? runtimeCapabilities.join(",") : "none"}`
       : "",
-    `thinking=${defaultThinkLevel ?? "off"}`,
   ]
     .filter(Boolean)
     .join(" | ")}`;


### PR DESCRIPTION
## Summary

- **Problem:** `reasoningLevel` (e.g. "off", "stream") and `defaultThinkLevel` (e.g. "off", "low") were interpolated into the system prompt. Toggling `/reasoning` or `/think` changed the system prompt text between turns, invalidating prompt caches (local KV prefix match and cloud `cache_read`) on every subsequent turn.
- **Why it matters:** Prompt caching is a significant optimization — providers only process new tokens after a cache hit. When the system prompt changes, the entire prompt must be reprocessed, increasing latency and token costs.
- **What changed:** Made the reasoning line static (`"Reasoning: toggle with /reasoning; ..."`) and removed the `thinking=` field from the runtime line. The actual reasoning/thinking behavior is already controlled via request-level params (`reasoning_effort`, thinking budget); the system prompt only needs instructional text, not current state.
- **What did NOT change:** Runtime system events in user messages, actual reasoning/thinking behavior, or any other system prompt content.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36520

## User-visible / Behavior Changes

- System prompt no longer changes when toggling `/reasoning` or `/think`, preserving prompt cache across turns.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22
- Integration/channel: Any

### Steps

1. Start a conversation and build up context
2. Toggle `/reasoning` (or `/think`)
3. Send a new message

### Expected

- System prompt is identical between turns; prompt cache is reused

### Actual

- Before fix: System prompt changes (reasoning level embedded), cache invalidated
- After fix: System prompt is static, cache preserved

## Evidence

```
 src/agents/system-prompt.ts      | 10 ++++------
 src/agents/system-prompt.test.ts | 18 +++++++++++++-----
 2 files changed, 17 insertions(+), 11 deletions(-)
```

New test "does not embed volatile reasoning level in system prompt" confirms the Runtime section is identical regardless of reasoningLevel.

## Human Verification (required)

- Verified scenarios: reasoningLevel="off" vs "stream" produce identical system prompts, buildRuntimeLine no longer includes thinking=
- Edge cases checked: Default reasoningLevel (undefined), all ThinkLevel values
- What I did **not** verify: Live cache_read metrics from cloud provider after toggle

## Compatibility / Migration

- Backward compatible? `Yes — the model's behavior was never driven by the system prompt text; it's controlled by request params`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/agents/system-prompt.ts`
- Known bad symptoms: If a model relied on reading its reasoning mode from the system prompt (unlikely), it would not know the current state

## Risks and Mitigations

- Risk: Models that somehow depended on reading "Reasoning: off" from the system prompt would lose that signal. Mitigation: All supported providers use request-level params for reasoning control, not system prompt text.