### PR TITLE
fix(cli): support bracket notation for dotted config keys

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -200,6 +200,27 @@ describe("config cli", () => {
         apiKey: "ollama-local",
       });
     });
+
+    it("supports bracket notation for provider ids that contain periods", async () => {
+      const resolved: OpenClawConfig = {
+        models: { providers: {} },
+      };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        'models.providers["llama.cpp"].baseUrl',
+        '"http://localhost:8080"',
+      ]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = mockWriteConfigFile.mock.calls[0]?.[0];
+      expect(written.models?.providers?.["llama.cpp"]).toEqual({
+        baseUrl: "http://localhost:8080",
+      });
+      expect(written.models?.providers).not.toHaveProperty("llama");
+    });
   });
 
   describe("config get", () => {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import JSON5 from "json5";
+import { splitConfigPath } from "../config/config-paths.js";
 import { readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
 import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
 import { CONFIG_PATH } from "../config/paths.js";
@@ -27,55 +28,14 @@ function isIndexSegment(raw: string): boolean {
 }
 
 function parsePath(raw: string): PathSegment[] {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return [];
-  }
-  const parts: string[] = [];
-  let current = "";
-  let i = 0;
-  while (i < trimmed.length) {
-    const ch = trimmed[i];
-    if (ch === "\\") {
-      const next = trimmed[i + 1];
-      if (next) {
-        current += next;
-      }
-      i += 2;
-      continue;
+  const parsed = splitConfigPath(raw);
+  if (!parsed.ok) {
+    if (!raw.trim()) {
+      return [];
     }
-    if (ch === ".") {
-      if (current) {
-        parts.push(current);
-      }
-      current = "";
-      i += 1;
-      continue;
-    }
-    if (ch === "[") {
-      if (current) {
-        parts.push(current);
-      }
-      current = "";
-      const close = trimmed.indexOf("]", i);
-      if (close === -1) {
-        throw new Error(`Invalid path (missing "]"): ${raw}`);
-      }
-      const inside = trimmed.slice(i + 1, close).trim();
-      if (!inside) {
-        throw new Error(`Invalid path (empty "[]"): ${raw}`);
-      }
-      parts.push(inside);
-      i = close + 1;
-      continue;
-    }
-    current += ch;
-    i += 1;
+    throw new Error(parsed.error);
   }
-  if (current) {
-    parts.push(current);
-  }
-  return parts.map((part) => part.trim()).filter(Boolean);
+  return parsed.path;
 }
 
 function parseValue(raw: string, opts: ConfigSetParseOpts): unknown {

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -3,6 +3,7 @@ import {
   getConfigValueAtPath,
   parseConfigPath,
   setConfigValueAtPath,
+  splitConfigPath,
   unsetConfigValueAtPath,
 } from "./config-paths.js";
 import { readConfigFileSnapshot, validateConfigObject } from "./config.js";
@@ -318,11 +319,36 @@ describe("config paths", () => {
   it("rejects empty and blocked paths", () => {
     expect(parseConfigPath("")).toEqual({
       ok: false,
-      error: "Invalid path. Use dot notation (e.g. foo.bar).",
+      error: 'Invalid path. Use dot or bracket notation (e.g. foo.bar or foo["bar.baz"]).',
     });
     expect(parseConfigPath("__proto__.polluted").ok).toBe(false);
     expect(parseConfigPath("constructor.polluted").ok).toBe(false);
     expect(parseConfigPath("prototype.polluted").ok).toBe(false);
+  });
+
+  it("supports quoted bracket segments for keys that contain periods", () => {
+    expect(parseConfigPath('models.providers["llama.cpp"].baseUrl')).toEqual({
+      ok: true,
+      path: ["models", "providers", "llama.cpp", "baseUrl"],
+    });
+    expect(parseConfigPath("models.providers['vllm.ai'].baseUrl")).toEqual({
+      ok: true,
+      path: ["models", "providers", "vllm.ai", "baseUrl"],
+    });
+  });
+
+  it("preserves escaped dot segments for CLI-compatible paths", () => {
+    expect(splitConfigPath(String.raw`models.providers.llama\.cpp.baseUrl`)).toEqual({
+      ok: true,
+      path: ["models", "providers", "llama.cpp", "baseUrl"],
+    });
+  });
+
+  it("rejects blocked keys inside bracket notation", () => {
+    expect(parseConfigPath('models.providers["__proto__"].baseUrl')).toEqual({
+      ok: false,
+      error: "Invalid path segment.",
+    });
   });
 
   it("sets, gets, and unsets nested values", () => {

--- a/src/config/config-paths.ts
+++ b/src/config/config-paths.ts
@@ -3,25 +3,184 @@ import { isBlockedObjectKey } from "./prototype-keys.js";
 
 type PathNode = Record<string, unknown>;
 
+const INVALID_PATH_ERROR =
+  'Invalid path. Use dot or bracket notation (e.g. foo.bar or foo["bar.baz"]).';
+
+type ParsedPathResult =
+  | {
+      ok: true;
+      path: string[];
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+function parseQuotedBracketSegment(
+  raw: string,
+  start: number,
+): ParsedPathResult & { next?: number } {
+  let cursor = start;
+  while (cursor < raw.length && /\s/.test(raw[cursor])) {
+    cursor += 1;
+  }
+  if (cursor >= raw.length) {
+    return { ok: false, error: INVALID_PATH_ERROR };
+  }
+
+  const quote = raw[cursor];
+  if (quote !== `"` && quote !== `'`) {
+    const close = raw.indexOf("]", cursor);
+    if (close === -1) {
+      return { ok: false, error: INVALID_PATH_ERROR };
+    }
+    const value = raw.slice(cursor, close).trim();
+    if (!value) {
+      return { ok: false, error: INVALID_PATH_ERROR };
+    }
+    return { ok: true, path: [value], next: close + 1 };
+  }
+
+  cursor += 1;
+  let value = "";
+  while (cursor < raw.length) {
+    const ch = raw[cursor];
+    if (ch === "\\") {
+      const next = raw[cursor + 1];
+      if (!next) {
+        return { ok: false, error: INVALID_PATH_ERROR };
+      }
+      value += next;
+      cursor += 2;
+      continue;
+    }
+    if (ch === quote) {
+      cursor += 1;
+      while (cursor < raw.length && /\s/.test(raw[cursor])) {
+        cursor += 1;
+      }
+      if (raw[cursor] !== "]") {
+        return { ok: false, error: INVALID_PATH_ERROR };
+      }
+      if (!value.trim()) {
+        return { ok: false, error: INVALID_PATH_ERROR };
+      }
+      return { ok: true, path: [value], next: cursor + 1 };
+    }
+    value += ch;
+    cursor += 1;
+  }
+  return { ok: false, error: INVALID_PATH_ERROR };
+}
+
+export function splitConfigPath(raw: string): ParsedPathResult {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return {
+      ok: false,
+      error: INVALID_PATH_ERROR,
+    };
+  }
+
+  const parts: string[] = [];
+  let current = "";
+  let cursor = 0;
+  let expectSegment = true;
+
+  const pushCurrent = (): boolean => {
+    const segment = current.trim();
+    current = "";
+    if (!segment) {
+      return false;
+    }
+    parts.push(segment);
+    return true;
+  };
+
+  while (cursor < trimmed.length) {
+    const ch = trimmed[cursor];
+
+    if (/\s/.test(ch) && !current) {
+      cursor += 1;
+      continue;
+    }
+
+    if (ch === "\\") {
+      const next = trimmed[cursor + 1];
+      if (!next) {
+        return { ok: false, error: INVALID_PATH_ERROR };
+      }
+      current += next;
+      expectSegment = false;
+      cursor += 2;
+      continue;
+    }
+
+    if (ch === ".") {
+      if (current) {
+        if (!pushCurrent()) {
+          return { ok: false, error: INVALID_PATH_ERROR };
+        }
+        expectSegment = true;
+        cursor += 1;
+        continue;
+      }
+      if (!expectSegment) {
+        expectSegment = true;
+        cursor += 1;
+        continue;
+      }
+      return { ok: false, error: INVALID_PATH_ERROR };
+    }
+
+    if (ch === "[") {
+      if (current && !pushCurrent()) {
+        return { ok: false, error: INVALID_PATH_ERROR };
+      }
+      const bracket = parseQuotedBracketSegment(trimmed, cursor + 1);
+      if (!bracket.ok || bracket.next == null) {
+        return bracket;
+      }
+      parts.push(bracket.path[0]);
+      expectSegment = false;
+      cursor = bracket.next;
+      continue;
+    }
+
+    if (!current && !expectSegment) {
+      return { ok: false, error: INVALID_PATH_ERROR };
+    }
+
+    current += ch;
+    expectSegment = false;
+    cursor += 1;
+  }
+
+  if (current) {
+    if (!pushCurrent()) {
+      return { ok: false, error: INVALID_PATH_ERROR };
+    }
+  } else if (expectSegment) {
+    return { ok: false, error: INVALID_PATH_ERROR };
+  }
+
+  if (parts.length === 0) {
+    return { ok: false, error: INVALID_PATH_ERROR };
+  }
+
+  return { ok: true, path: parts };
+}
+
 export function parseConfigPath(raw: string): {
   ok: boolean;
   path?: string[];
   error?: string;
 } {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return {
-      ok: false,
-      error: "Invalid path. Use dot notation (e.g. foo.bar).",
-    };
+  const parsed = splitConfigPath(raw);
+  if (!parsed.ok) {
+    return parsed;
   }
-  const parts = trimmed.split(".").map((part) => part.trim());
-  if (parts.some((part) => !part)) {
-    return {
-      ok: false,
-      error: "Invalid path. Use dot notation (e.g. foo.bar).",
-    };
-  }
+  const parts = parsed.path;
   if (parts.some((part) => isBlockedObjectKey(part))) {
     return { ok: false, error: "Invalid path segment." };
   }


### PR DESCRIPTION
## Summary
- support quoted bracket notation in config paths so keys like `models.providers["llama.cpp"].baseUrl` parse as a single provider id
- reuse the shared config-path parser in the CLI so `config set/get/unset` and other config-path consumers behave consistently
- keep existing blocked-key protection and escaped-dot support, with regression coverage for both parser and CLI behavior

## Testing
- `pnpm vitest run src/config/config-misc.test.ts src/cli/config-cli.test.ts`
- `pnpm exec oxlint src/config/config-paths.ts src/config/config-misc.test.ts src/cli/config-cli.ts src/cli/config-cli.test.ts`

Fixes #36871
