### PR TITLE
feat(tui): display current model in header

### DIFF
--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -204,6 +204,7 @@ export function createSessionActions(context: SessionActionContext) {
 
     state.sessionInfo = next;
     updateAutocompleteProvider();
+    updateHeader();
     updateFooter();
     tui.requestRender();
   };

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -541,9 +541,14 @@ export async function runTui(opts: TuiOptions) {
   const updateHeader = () => {
     const sessionLabel = formatSessionKey(currentSessionKey);
     const agentLabel = formatAgentLabel(currentAgentId);
+    const modelLabel = sessionInfo.model
+      ? sessionInfo.modelProvider
+        ? `${sessionInfo.modelProvider}/${sessionInfo.model}`
+        : sessionInfo.model
+      : "unknown";
     header.setText(
       theme.header(
-        `openclaw tui - ${client.connection.url} - agent ${agentLabel} - session ${sessionLabel}`,
+        `openclaw tui - ${client.connection.url} - agent ${agentLabel} - session ${sessionLabel} - model ${modelLabel}`,
       ),
     );
   };


### PR DESCRIPTION
## Summary
- Show the active provider/model in the TUI header.
- Refresh the header when session model metadata changes.

## Why
Users asked for a persistent model indicator in TUI without running extra commands.

Fixes #37150

## Testing
- `pnpm exec oxlint --type-aware src/tui/tui.ts src/tui/tui-session-actions.ts`
- `pnpm exec vitest run --config vitest.unit.config.ts src/tui`