### PR TITLE
fix(gateway): create transcript file on chat.inject when missing

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1142,7 +1142,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       storePath,
       sessionFile: entry?.sessionFile,
       agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
-      createIfMissing: false,
+      createIfMissing: true,
     });
     if (!appended.ok || !appended.messageId || !appended.message) {
       respond(


### PR DESCRIPTION
## Summary

- **Problem:** `chat.inject` calls `appendAssistantTranscriptMessage` with `createIfMissing: false`. When the transcript file does not exist on disk (e.g. after an ACP oneshot session), the call fails with `"failed to write transcript: transcript file not found"`. Users must manually `touch` the file as a workaround.
- **Why it matters:** This breaks transcript persistence for `chat.inject`, making `chat.history` and `sessions_history` return empty. It also prevents injecting messages into sessions created by ACP workflows.
- **What changed:** Set `createIfMissing` to `true` for the `chat.inject` path, aligning it with `chat.send` and `chat.abort` which already use `createIfMissing: true`.
- **What did NOT change:** `appendAssistantTranscriptMessage` logic, `ensureTranscriptFile` behavior, or any other transcript paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36170

## User-visible / Behavior Changes

- `chat.inject` now creates the transcript file when it doesn't exist, instead of failing with "transcript file not found".

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22
- Integration/channel: Any (gateway RPC)

### Steps

1. Run an ACP oneshot session (transcript file may not exist on disk)
2. Call `chat.inject` with a sessionKey and message

### Expected

- Message is injected; transcript file is created if needed

### Actual

- Before fix: `"failed to write transcript: transcript file not found"`
- After fix: Transcript file created, message injected successfully

## Evidence

```
 src/gateway/server-methods/chat.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

One-line change: `createIfMissing: false` → `createIfMissing: true`. Aligns with `chat.send` (line ~1025) and `persistAbortedPartials` (line ~492) which already use `createIfMissing: true`.

## Human Verification (required)

- Verified scenarios: chat.inject with missing transcript file path, chat.inject with existing transcript file (unchanged behavior)
- Edge cases checked: Other callers of appendAssistantTranscriptMessage already use createIfMissing: true
- What I did **not** verify: Full gateway integration test with ACP oneshot session

## Compatibility / Migration

- Backward compatible? `Yes — only fixes a previously-failing code path`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/gateway/server-methods/chat.ts`
- Known bad symptoms: If ensureTranscriptFile fails for some reason, the error message will be "failed to create transcript file" instead of "transcript file not found"

## Risks and Mitigations

- None. This aligns chat.inject with the existing behavior of chat.send and chat.abort.