### PR TITLE
[Issue #37172] Feature: Separate context visibility from response triggering in group chats (allowFrom drops pending history)

### DIFF
--- a/.github/issue-bootstrap/issue-37172.md
+++ b/.github/issue-bootstrap/issue-37172.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37172
+- Title: Feature: Separate context visibility from response triggering in group chats (allowFrom drops pending history)
+- Source: https://github.com/openclaw/openclaw/issues/37172


### PR DESCRIPTION
## Source Issue
- Number: #37172
- URL: https://github.com/openclaw/openclaw/issues/37172

## Original Issue Description
## Summary

In group chats, `allowFrom` / `groupAllowFrom` drops messages from non-listed senders entirely — they never enter the pending history buffer. This makes it impossible to configure "bot sees all messages for context, but only responds to specific users."

## Problem

When running a bot in a Telegram group (applies to other channels too), I want:
- Bot **sees** all group messages (for conversational context)
- Bot **only responds** to @mentions from a specific user (me)

The current config options force a choice:

| Config | Bot sees | Bot responds to |
|--------|----------|----------------|
| `groupPolicy: "allowlist"` + `allowFrom: [me]` | Only my messages | Only me |
| `groupPolicy: "open"` + `requireMention: true` | All messages | Anyone who @mentions |

There is no combination that gives "sees all, responds to one."

## Root Cause (source code trace, v2026.3.2)

The Telegram inbound message pipeline has three sequential gates:

1. **Access gate** (`evaluateTelegramGroupBaseAccess` / `shouldSkipGroupMessage`) — checks `allowFrom`, `groupAllowFrom`, `groupPolicy`. If sender fails → `return null` / `return true` with **no call to `recordPendingHistoryEntryIfEnabled`**
2. **DM access gate** (`enforceTelegramDmAccess`) — DM policy enforcement
3. **Mention gate** (`resolveMentionGatingWithBypass`) — if `requireMention: true` and no @mention → **calls `recordPendingHistoryEntryIfEnabled`** then `return null`

The pending history buffer (which provides "what happened since your last reply" context on the next @mention) is **exclusively populated at gate 3**. Messages blocked at gate 1 are silently dropped — they never reach the buffer.

This means `allowFrom` is simultaneously a visibility filter AND a trigger filter, with no way to separate the two.

**Verified across all channels**: every `recordPendingHistoryEntryIfEnabled` call site (Telegram, Discord, iMessage, Signal, Slack, WhatsApp) follows the same pattern — only called when the mention gate skips a message, never when the access gate blocks one.

## Proposed Solution

Add a `contextFrom` (or `observeFrom` / `storeFrom`) option at the group config level that controls whose messages enter the pending history buffer, independent of `allowFrom`:

```json
{
  "groups": {
    "-100XXXXXXXXXX": {
      "enabled": true,
      "requireMention": true,
      "allowFrom": ["123456789"],
      "contextFrom": "*"
    }
  }
}
```

**Behavior:**
- `allowFrom` gates who can **trigger** a response (existing behavior)
- `contextFrom` gates whose messages get **stored in pending history** for context
- `contextFrom: "*"` = store all group messages (default: inherit from `allowFrom`)

**Alternative**: move `recordPendingHistoryEntryIfEnabled` to run before the access gate return, so blocked messages still get buffered. This would make pending history always capture the full conversation regardless of access policy. Could be gated behind a `bufferAllMessages: true` flag to avoid breaking existing behavior.

## Use Case

Running an AI assistant in a small trusted group (~10 people). I want the bot to:
1. Read the full conversation (all participants) for context awareness
2. Only respond when I specifically @mention it
3. Refuse to act on @mentions from other users (even if they try)

Currently the only workaround I can identify is `groupPolicy: "open"` + `requireMention: true` + a system prompt that checks sender ID and refuses non-owner requests. This is a prompt-level guard, not a config-level one — it's not reliable enough for security-sensitive use cases since LLMs can be manipulated.

## Related

- Discussion #2314 — "Observer Mode / ReadOnly flag for Shadow Monitoring" (same underlying gap, different use case)
- Issue #5247 — "Per-group allowedUsers" (closed as not planned, but requested the opposite direction — more aggressive filtering)

## Environment

- OpenClaw v2026.3.2
- Channel: Telegram (but applies to all channels — same `recordPendingHistoryEntryIfEnabled` pattern)

Closes openclaw/openclaw#37172