### PR TITLE
fix(tts): include Matrix in voice bubble channels

### DIFF
--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -496,7 +496,7 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
 }
 
 /** Channels that require opus audio and support voice-bubble playback */
-const VOICE_BUBBLE_CHANNELS = new Set(["telegram", "feishu", "whatsapp"]);
+const VOICE_BUBBLE_CHANNELS = new Set(["telegram", "feishu", "whatsapp", "matrix"]);
 
 function resolveOutputFormat(channelId?: string | null) {
   if (channelId && VOICE_BUBBLE_CHANNELS.has(channelId)) {


### PR DESCRIPTION
## Summary

Fixes #37061.

- Add `"matrix"` to `VOICE_BUBBLE_CHANNELS` in `src/tts/tts.ts`
- Matrix send pipeline already supports MSC3245 voice messages via `audioAsVoice`, but TTS auto-reply never set the flag because Matrix was missing from the channel set
- This caused TTS replies to use MP3 format and appear as generic file attachments instead of native voice bubbles with inline playback

## Change Type

- [x] Bug fix

## Scope

- [x] TTS
- [x] Matrix

## Linked Issue/PR

- Fixes #37061

## User-visible / Behavior Changes

Matrix users receiving TTS auto-replies will now see native voice message bubbles (MSC3245) with inline playback, instead of downloadable MP3 file attachments.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OpenClaw 2026.3.2
- Matrix channel with TTS auto-reply enabled
- User sends voice message

### Steps
1. Configure `messages.tts.auto: "inbound"`
2. Send voice message on Matrix
3. Bot transcribes and generates TTS reply

### Expected
TTS reply appears as voice bubble with inline playback (Opus format, MSC3245 metadata)

### Actual (before fix)
TTS reply appears as generic audio file attachment (MP3 format, no voice metadata)

## Evidence

- [x] All 28 existing TTS tests pass
- [x] Matrix send layer already supports `audioAsVoice` (verified in `extensions/matrix/src/matrix/send.ts` and tests)

## Human Verification

- Verified code path: `VOICE_BUBBLE_CHANNELS.has("matrix")` → `resolveOutputFormat` returns `TELEGRAM_OUTPUT` (Opus + voiceCompatible) → `audioAsVoice: true` → Matrix send applies MSC3245 metadata
- Edge cases checked: Other channels (Telegram, Feishu, WhatsApp) unaffected, Matrix non-TTS messages unaffected
- What I did not verify: End-to-end Matrix voice bubble rendering (requires live Matrix server + TTS provider)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert: `git revert` this commit
- Files to restore: `src/tts/tts.ts` line 499
- Known bad symptoms: Matrix TTS replies revert to MP3 file attachments

## Risks and Mitigations

None. One-line addition to existing Set literal, no logic changes.