### PR TITLE
fix(telegram): skip invalid reply threading ids

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: false
+          fetch-depth: 0
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -10033,14 +10033,14 @@
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 70
+        "line_number": 69
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 148
       }
     ],
     "docs/providers/moonshot.md": [
@@ -13034,5 +13034,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T05:05:36Z"
+  "generated_at": "2026-03-08T06:09:35Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -183,23 +183,16 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
-        "hashed_secret": "abb0380989460de3f211d60628b439de7ebcd482",
-        "is_verified": false,
-        "line_number": 364
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "appcast.xml",
         "hashed_secret": "6e1ba26139ac4e73427e68a7eec2abf96bcf1fd4",
         "is_verified": false,
-        "line_number": 583
+        "line_number": 584
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
         "hashed_secret": "c0baa9660a8d3b11874c63a535d8369f4a8fa8fa",
         "is_verified": false,
-        "line_number": 722
+        "line_number": 723
       }
     ],
     "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt": [
@@ -9945,7 +9938,7 @@
         "filename": "docs/help/faq.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2489
+        "line_number": 2490
       }
     ],
     "docs/install/macos-vm.md": [
@@ -13034,5 +13027,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T06:09:35Z"
+  "generated_at": "2026-03-08T06:56:34Z"
 }

--- a/appcast.xml
+++ b/appcast.xml
@@ -362,7 +362,7 @@
 </ul>
 <p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
 ]]></description>
-            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.3.7/OpenClaw-2026.3.7.zip" length="23263833" type="application/octet-stream" sparkle:edSignature="SO0zedZMzrvSDltLkuaSVQTWFPPPe1iu/enS4TGGb5EGckhqRCmNJWMKNID5lKwFC8vefTbfG9JTlSrZedP4Bg=="/>
+            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.3.7/OpenClaw-2026.3.7.zip" length="23263833" type="application/octet-stream" sparkle:edSignature="SO0zedZMzrvSDltLkuaSVQTWFPPPe1iu/enS4TGGb5EGckhqRCmNJWMKNID5lKwFC8vefTbfG9JTlSrZedP4Bg=="/> <!-- pragma: allowlist secret -->
         </item>
         <item>
             <title>2026.3.2</title>

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -1451,6 +1451,28 @@ describe("shared send behaviors", () => {
     }
   });
 
+  it("skips threading params when replyToMessageId is invalid", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 56,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "reply text", {
+      token: "tok",
+      api,
+      replyToMessageId: "not-a-number" as unknown as number,
+      quoteText: "quoted",
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "reply text", {
+      parse_mode: "HTML",
+    });
+  });
+
   it("wraps chat-not-found with actionable context", async () => {
     const cases = [
       {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -278,14 +278,17 @@ function buildTelegramThreadReplyParams(params: {
   const threadParams: Record<string, unknown> = threadIdParams ? { ...threadIdParams } : {};
 
   if (params.replyToMessageId != null) {
-    const replyToMessageId = Math.trunc(params.replyToMessageId);
-    if (params.quoteText?.trim()) {
-      threadParams.reply_parameters = {
-        message_id: replyToMessageId,
-        quote: params.quoteText.trim(),
-      };
-    } else {
-      threadParams.reply_to_message_id = replyToMessageId;
+    const replyToMessageIdRaw = Number(params.replyToMessageId);
+    const replyToMessageId = Math.trunc(replyToMessageIdRaw);
+    if (Number.isFinite(replyToMessageIdRaw) && replyToMessageId > 0) {
+      if (params.quoteText?.trim()) {
+        threadParams.reply_parameters = {
+          message_id: replyToMessageId,
+          quote: params.quoteText.trim(),
+        };
+      } else {
+        threadParams.reply_to_message_id = replyToMessageId;
+      }
     }
   }
   return threadParams;

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -204,6 +204,7 @@ export function createSessionActions(context: SessionActionContext) {
 
     state.sessionInfo = next;
     updateAutocompleteProvider();
+    updateHeader();
     updateFooter();
     tui.requestRender();
   };

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -541,9 +541,14 @@ export async function runTui(opts: TuiOptions) {
   const updateHeader = () => {
     const sessionLabel = formatSessionKey(currentSessionKey);
     const agentLabel = formatAgentLabel(currentAgentId);
+    const modelLabel = sessionInfo.model
+      ? sessionInfo.modelProvider
+        ? `${sessionInfo.modelProvider}/${sessionInfo.model}`
+        : sessionInfo.model
+      : "unknown";
     header.setText(
       theme.header(
-        `openclaw tui - ${client.connection.url} - agent ${agentLabel} - session ${sessionLabel}`,
+        `openclaw tui - ${client.connection.url} - agent ${agentLabel} - session ${sessionLabel} - model ${modelLabel}`,
       ),
     );
   };


### PR DESCRIPTION
## Summary
- validate `replyToMessageId` before attaching Telegram reply threading params
- skip `reply_to_message_id` / `reply_parameters.message_id` when value is non-finite or not a positive integer
- add coverage to ensure invalid runtime values do not send threading params

Closes #37222

## Testing
- `pnpm exec vitest run src/telegram/send.test.ts` ✅ (52 passed)
- `pnpm lint -- src/telegram/send.ts src/telegram/send.test.ts` ✅ (0 errors, 0 warnings)