### PR TITLE
fix(telegram): ignore non-numeric replyToMessageId

### DIFF
--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -683,6 +683,17 @@ describe("sendMessageTelegram", () => {
           reply_to_message_id: 999,
         },
       },
+      {
+        text: "Ignore invalid reply id",
+        options: {
+          // @ts-expect-error - runtime can receive cross-surface non-numeric ids.
+          replyToMessageId: "not-a-number",
+        },
+        expectedVideoNote: {},
+        expectedMessage: {
+          parse_mode: "HTML",
+        },
+      },
     ];
 
     for (const testCase of cases) {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -278,14 +278,20 @@ function buildTelegramThreadReplyParams(params: {
   const threadParams: Record<string, unknown> = threadIdParams ? { ...threadIdParams } : {};
 
   if (params.replyToMessageId != null) {
-    const replyToMessageId = Math.trunc(params.replyToMessageId);
-    if (params.quoteText?.trim()) {
-      threadParams.reply_parameters = {
-        message_id: replyToMessageId,
-        quote: params.quoteText.trim(),
-      };
-    } else {
-      threadParams.reply_to_message_id = replyToMessageId;
+    const rawReplyToMessageId = params.replyToMessageId;
+    const replyToMessageId = Math.trunc(rawReplyToMessageId);
+
+    // Cross-surface routing can leak non-Telegram reply ids.
+    // Telegram requires a finite positive integer message id.
+    if (Number.isFinite(rawReplyToMessageId) && replyToMessageId > 0) {
+      if (params.quoteText?.trim()) {
+        threadParams.reply_parameters = {
+          message_id: replyToMessageId,
+          quote: params.quoteText.trim(),
+        };
+      } else {
+        threadParams.reply_to_message_id = replyToMessageId;
+      }
     }
   }
   return threadParams;


### PR DESCRIPTION
Fix Telegram send threading by validating replyToMessageId before attaching reply fields.

Closes #37222

- Validate replyToMessageId is a finite positive integer before attaching reply threading fields.
- Adds a unit test ensuring non-numeric reply ids are ignored.