### PR TITLE
fix(telegram): guard non-numeric replyToMessageId to prevent send failures

### DIFF
--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -1363,6 +1363,26 @@ describe("shared send behaviors", () => {
     }
   });
 
+  it("ignores non-numeric replyToMessageId instead of sending NaN", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 80,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+    // Simulate a cross-surface UUID-like reply id cast to number (results in NaN)
+    await sendMessageTelegram(chatId, "hello", {
+      token: "tok",
+      api,
+      replyToMessageId: Number("not-a-number"),
+    });
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "hello", {
+      parse_mode: "HTML",
+    });
+  });
+
   it("wraps chat-not-found with actionable context", async () => {
     const cases = [
       {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -279,13 +279,15 @@ function buildTelegramThreadReplyParams(params: {
 
   if (params.replyToMessageId != null) {
     const replyToMessageId = Math.trunc(params.replyToMessageId);
-    if (params.quoteText?.trim()) {
-      threadParams.reply_parameters = {
-        message_id: replyToMessageId,
-        quote: params.quoteText.trim(),
-      };
-    } else {
-      threadParams.reply_to_message_id = replyToMessageId;
+    if (Number.isFinite(replyToMessageId) && replyToMessageId > 0) {
+      if (params.quoteText?.trim()) {
+        threadParams.reply_parameters = {
+          message_id: replyToMessageId,
+          quote: params.quoteText.trim(),
+        };
+      } else {
+        threadParams.reply_to_message_id = replyToMessageId;
+      }
     }
   }
   return threadParams;


### PR DESCRIPTION
## Problem
In cross-surface routing scenarios, upstream reply ids may be UUID-like non-numeric values. When cast to `number`, these produce `NaN`, which `Math.trunc()` preserves. The `NaN` value is then sent to Telegram as `reply_to_message_id`, causing `400: Bad Request: message to be replied not found` errors.

## Fix
Validate `replyToMessageId` as a finite positive integer (`Number.isFinite() && > 0`) after `Math.trunc()` in `buildTelegramThreadReplyParams()`. If invalid, the reply threading fields are simply omitted and the message sends normally.

This covers all send paths (message, sticker, poll) since they all route through the same helper.

## Test
Added test case verifying that a `NaN` replyToMessageId is silently dropped rather than forwarded to Telegram.

Closes #37222