### PR TITLE
fix(agents): recover OpenAI WS mid-request failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- OpenAI Responses/WebSocket recovery: when auto transport hits a stale `rs_*` reference, transient 502/503/504 upstream failure, or a mid-request WS close before any text has streamed, reset the broken WS session and fall back to the HTTP path once instead of failing hard on the first attempt. (#37230)
 - TUI/token copy-safety rendering: treat long credential-like mixed alphanumeric tokens (including quoted forms) as copy-sensitive in render sanitization so formatter hard-wrap guards no longer inject visible spaces into auth-style values before display. (#26710) Thanks @jasonthane.
 - WhatsApp/self-chat response prefix fallback: stop forcing `"[openclaw]"` as the implicit outbound response prefix when no identity name or response prefix is configured, so blank/default prefix settings no longer inject branding text unexpectedly in self-chat flows. (#27962) Thanks @ecanmor.
 - Memory/QMD search result decoding: accept `qmd search` hits that only include `file` URIs (for example `qmd://collection/path.md`) without `docid`, resolve them through managed collection roots, and keep multi-collection results keyed by file fallback so valid QMD hits no longer collapse to empty `memory_search` output. (#28181) Thanks @0x76696265.

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -634,6 +634,11 @@ describe("createOpenAIWebSocketStreamFn", () => {
     releaseWsSession("sess-incremental");
     releaseWsSession("sess-full");
     releaseWsSession("sess-tools");
+    releaseWsSession("sess-drop");
+    releaseWsSession("sess-drop-ws");
+    releaseWsSession("sess-drop-after-delta");
+    releaseWsSession("sess-502");
+    releaseWsSession("sess-stale-ref");
   });
 
   it("connects to the WebSocket on first call", async () => {
@@ -828,6 +833,82 @@ describe("createOpenAIWebSocketStreamFn", () => {
     expect(inputTypes).toHaveLength(1);
   });
 
+  it("falls back to HTTP when a stale OpenAI response item error is raised before output starts", async () => {
+    const sessionId = "sess-stale-ref";
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", sessionId);
+
+    const ctx1 = {
+      systemPrompt: "You are helpful.",
+      messages: [userMsg("Run ls")] as Parameters<typeof convertMessagesToInputItems>[0],
+      tools: [],
+    };
+
+    const stream1 = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      ctx1 as Parameters<typeof streamFn>[1],
+    );
+    await new Promise<void>((resolve, reject) => {
+      queueMicrotask(async () => {
+        try {
+          await new Promise((r) => setImmediate(r));
+          MockManager.lastInstance!.simulateEvent({
+            type: "response.completed",
+            response: makeResponseObject("resp_turn1", "OK"),
+          });
+          for await (const _ of await resolveStream(stream1)) {
+            /* consume */
+          }
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+
+    const manager = MockManager.lastInstance!;
+    manager.setPreviousResponseId("resp_turn1");
+    const callsBefore = streamSimpleCalls.length;
+    const stream2 = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      {
+        systemPrompt: "You are helpful.",
+        messages: [
+          userMsg("Run ls"),
+          assistantMsg([], [{ id: "call_1", name: "exec", args: { cmd: "ls" } }]),
+          toolResultMsg("call_1", "file.txt"),
+        ] as Parameters<typeof convertMessagesToInputItems>[0],
+        tools: [],
+      } as Parameters<typeof streamFn>[1],
+    );
+
+    await new Promise<void>((resolve, reject) => {
+      queueMicrotask(async () => {
+        try {
+          await new Promise((r) => setImmediate(r));
+          manager.simulateEvent({
+            type: "response.failed",
+            response: {
+              ...makeResponseObject("resp_failed"),
+              error: {
+                code: "not_found",
+                message: "HTTP 404: Item with id 'rs_stale' not found",
+              },
+            },
+          });
+          for await (const _ of await resolveStream(stream2)) {
+            /* consume */
+          }
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+
+    expect(streamSimpleCalls.length).toBe(callsBefore + 1);
+    expect(hasWsSession(sessionId)).toBe(false);
+  });
+
   it("sends instructions (system prompt) in each request", async () => {
     const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-tools");
     const ctx = {
@@ -1000,32 +1081,126 @@ describe("createOpenAIWebSocketStreamFn", () => {
     expect(sent.tool_choice).toBe("auto");
   });
 
-  it("rejects promise when WebSocket drops mid-request", async () => {
+  it("falls back to HTTP when WebSocket drops mid-request in auto mode", async () => {
     const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-drop");
     const stream = streamFn(
       modelStub as Parameters<typeof streamFn>[0],
       contextStub as Parameters<typeof streamFn>[1],
       {} as Parameters<typeof streamFn>[2],
     );
-    // Let the send go through, then simulate connection drop before response.completed
+    const callsBefore = streamSimpleCalls.length;
+    await new Promise<void>((resolve, reject) => {
+      queueMicrotask(async () => {
+        try {
+          await new Promise((r) => setImmediate(r));
+          MockManager.lastInstance!.simulateClose(1006, "connection lost");
+          for await (const ev of await resolveStream(stream)) {
+            void ev;
+          }
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+    expect(streamSimpleCalls.length).toBe(callsBefore + 1);
+    expect(hasWsSession("sess-drop")).toBe(false);
+  });
+
+  it("surfaces mid-request WebSocket drops in forced websocket mode", async () => {
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-drop-ws");
+    const stream = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      contextStub as Parameters<typeof streamFn>[1],
+      { transport: "websocket" } as Parameters<typeof streamFn>[2],
+    );
     await new Promise<void>((resolve) => {
       queueMicrotask(async () => {
         try {
           await new Promise((r) => setImmediate(r));
-          // Simulate a connection drop instead of sending response.completed
           MockManager.lastInstance!.simulateClose(1006, "connection lost");
           const events: unknown[] = [];
           for await (const ev of await resolveStream(stream)) {
             events.push(ev);
           }
-          // Should have gotten an error event, not hung forever
           const hasError = events.some(
             (e) => typeof e === "object" && e !== null && (e as { type: string }).type === "error",
           );
           expect(hasError).toBe(true);
           resolve();
         } catch {
-          // The error propagation is also acceptable — promise rejected
+          resolve();
+        }
+      });
+    });
+  });
+
+  it("falls back to HTTP on transient 502 response failures before output starts", async () => {
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-502");
+    const stream = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      contextStub as Parameters<typeof streamFn>[1],
+      {} as Parameters<typeof streamFn>[2],
+    );
+    const callsBefore = streamSimpleCalls.length;
+    await new Promise<void>((resolve, reject) => {
+      queueMicrotask(async () => {
+        try {
+          await new Promise((r) => setImmediate(r));
+          MockManager.lastInstance!.simulateEvent({
+            type: "response.failed",
+            response: {
+              ...makeResponseObject("resp_502"),
+              error: {
+                code: "server_error",
+                message: "HTTP 502 Bad Gateway",
+              },
+            },
+          });
+          for await (const ev of await resolveStream(stream)) {
+            void ev;
+          }
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+    expect(streamSimpleCalls.length).toBe(callsBefore + 1);
+    expect(hasWsSession("sess-502")).toBe(false);
+  });
+
+  it("does not fall back to HTTP after text deltas have already streamed", async () => {
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-drop-after-delta");
+    const stream = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      contextStub as Parameters<typeof streamFn>[1],
+      {} as Parameters<typeof streamFn>[2],
+    );
+    const callsBefore = streamSimpleCalls.length;
+    await new Promise<void>((resolve) => {
+      queueMicrotask(async () => {
+        try {
+          await new Promise((r) => setImmediate(r));
+          MockManager.lastInstance!.simulateEvent({
+            type: "response.output_text.delta",
+            item_id: "msg_1",
+            output_index: 0,
+            content_index: 0,
+            delta: "Hello",
+          });
+          MockManager.lastInstance!.simulateClose(1006, "connection lost");
+          const events: unknown[] = [];
+          for await (const ev of await resolveStream(stream)) {
+            events.push(ev);
+          }
+          const hasError = events.some(
+            (e) => typeof e === "object" && e !== null && (e as { type: string }).type === "error",
+          );
+          expect(hasError).toBe(true);
+          expect(streamSimpleCalls.length).toBe(callsBefore);
+          resolve();
+        } catch {
           resolve();
         }
       });

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -346,6 +346,10 @@ export interface OpenAIWebSocketStreamOptions {
 
 type WsTransport = "sse" | "websocket" | "auto";
 const WARM_UP_TIMEOUT_MS = 8_000;
+const TRANSIENT_OPENAI_WS_FAILURE_RE =
+  /\b(?:502|503|504)\b|bad gateway|gateway timeout|stream closed/i;
+const STALE_OPENAI_RESPONSE_ITEM_RE =
+  /\b404\b.*\brs_[\w-]+\b|\bItem with id ['"]rs_[^'"]+['"] not found\b/i;
 
 function resolveWsTransport(options: Parameters<StreamFn>[2]): WsTransport {
   const transport = (options as { transport?: unknown } | undefined)?.transport;
@@ -359,6 +363,31 @@ type WsOptions = Parameters<StreamFn>[2] & { openaiWsWarmup?: unknown; signal?: 
 function resolveWsWarmup(options: Parameters<StreamFn>[2]): boolean {
   const warmup = (options as WsOptions | undefined)?.openaiWsWarmup;
   return warmup === true;
+}
+
+function resetWsSession(sessionId: string, session: WsSession): void {
+  try {
+    session.manager.close();
+  } catch {
+    /* ignore */
+  }
+  wsRegistry.delete(sessionId);
+}
+
+function shouldFallbackAfterMidRequestError(params: {
+  error: Error;
+  sawTextDelta: boolean;
+  transport: WsTransport;
+}): boolean {
+  if (params.transport !== "auto" || params.sawTextDelta) {
+    return false;
+  }
+  const message = params.error.message;
+  return (
+    message.includes("WebSocket closed mid-request") ||
+    STALE_OPENAI_RESPONSE_ITEM_RE.test(message) ||
+    TRANSIENT_OPENAI_WS_FAILURE_RE.test(message)
+  );
 }
 
 async function runWarmUp(params: {
@@ -491,12 +520,7 @@ export function createOpenAIWebSocketStreamFn(
         log.warn(`[ws-stream] session=${sessionId} broken/disconnected; falling back to HTTP`);
         // Clean up stale session to prevent next turn from using stale
         // previousResponseId / lastContextLength after a mid-request drop.
-        try {
-          session.manager.close();
-        } catch {
-          /* ignore */
-        }
-        wsRegistry.delete(sessionId);
+        resetWsSession(sessionId, session);
         return fallbackToHttp(model, context, options, eventStream, opts.signal);
       }
 
@@ -632,72 +656,87 @@ export function createOpenAIWebSocketStreamFn(
 
       // ── 5. Wait for response.completed ───────────────────────────────────
       const capturedContextLength = context.messages.length;
-
-      await new Promise<void>((resolve, reject) => {
-        // Honour abort signal
-        const abortHandler = () => {
-          cleanup();
-          reject(new Error("aborted"));
-        };
-        if (signal?.aborted) {
-          reject(new Error("aborted"));
-          return;
-        }
-        signal?.addEventListener("abort", abortHandler, { once: true });
-
-        // If the WebSocket drops mid-request, reject so we don't hang forever.
-        const closeHandler = (code: number, reason: string) => {
-          cleanup();
-          reject(
-            new Error(`WebSocket closed mid-request (code=${code}, reason=${reason || "unknown"})`),
-          );
-        };
-        session.manager.on("close", closeHandler);
-
-        const cleanup = () => {
-          signal?.removeEventListener("abort", abortHandler);
-          session.manager.off("close", closeHandler);
-          unsubscribe();
-        };
-
-        const unsubscribe = session.manager.onMessage((event) => {
-          if (event.type === "response.completed") {
+      let sawTextDelta = false;
+      try {
+        await new Promise<void>((resolve, reject) => {
+          // Honour abort signal
+          const abortHandler = () => {
             cleanup();
-            // Update session state
-            session.lastContextLength = capturedContextLength;
-            // Build and emit the assistant message
-            const assistantMsg = buildAssistantMessageFromResponse(event.response, {
-              api: model.api,
-              provider: model.provider,
-              id: model.id,
-            });
-            const reason: Extract<StopReason, "stop" | "length" | "toolUse"> =
-              assistantMsg.stopReason === "toolUse" ? "toolUse" : "stop";
-            eventStream.push({ type: "done", reason, message: assistantMsg });
-            resolve();
-          } else if (event.type === "response.failed") {
-            cleanup();
-            const errMsg = event.response?.error?.message ?? "Response failed";
-            reject(new Error(`OpenAI WebSocket response failed: ${errMsg}`));
-          } else if (event.type === "error") {
-            cleanup();
-            reject(new Error(`OpenAI WebSocket error: ${event.message} (code=${event.code})`));
-          } else if (event.type === "response.output_text.delta") {
-            // Stream partial text updates for responsive UI
-            const partialMsg: AssistantMessage = buildAssistantMessageWithZeroUsage({
-              model,
-              content: [{ type: "text", text: event.delta }],
-              stopReason: "stop",
-            });
-            eventStream.push({
-              type: "text_delta",
-              contentIndex: 0,
-              delta: event.delta,
-              partial: partialMsg,
-            });
+            reject(new Error("aborted"));
+          };
+          if (signal?.aborted) {
+            reject(new Error("aborted"));
+            return;
           }
+          signal?.addEventListener("abort", abortHandler, { once: true });
+
+          // If the WebSocket drops mid-request, reject so we don't hang forever.
+          const closeHandler = (code: number, reason: string) => {
+            cleanup();
+            reject(
+              new Error(
+                `WebSocket closed mid-request (code=${code}, reason=${reason || "unknown"})`,
+              ),
+            );
+          };
+          session.manager.on("close", closeHandler);
+
+          const cleanup = () => {
+            signal?.removeEventListener("abort", abortHandler);
+            session.manager.off("close", closeHandler);
+            unsubscribe();
+          };
+
+          const unsubscribe = session.manager.onMessage((event) => {
+            if (event.type === "response.completed") {
+              cleanup();
+              // Update session state
+              session.lastContextLength = capturedContextLength;
+              // Build and emit the assistant message
+              const assistantMsg = buildAssistantMessageFromResponse(event.response, {
+                api: model.api,
+                provider: model.provider,
+                id: model.id,
+              });
+              const reason: Extract<StopReason, "stop" | "length" | "toolUse"> =
+                assistantMsg.stopReason === "toolUse" ? "toolUse" : "stop";
+              eventStream.push({ type: "done", reason, message: assistantMsg });
+              resolve();
+            } else if (event.type === "response.failed") {
+              cleanup();
+              const errMsg = event.response?.error?.message ?? "Response failed";
+              reject(new Error(`OpenAI WebSocket response failed: ${errMsg}`));
+            } else if (event.type === "error") {
+              cleanup();
+              reject(new Error(`OpenAI WebSocket error: ${event.message} (code=${event.code})`));
+            } else if (event.type === "response.output_text.delta") {
+              sawTextDelta = true;
+              // Stream partial text updates for responsive UI
+              const partialMsg: AssistantMessage = buildAssistantMessageWithZeroUsage({
+                model,
+                content: [{ type: "text", text: event.delta }],
+                stopReason: "stop",
+              });
+              eventStream.push({
+                type: "text_delta",
+                contentIndex: 0,
+                delta: event.delta,
+                partial: partialMsg,
+              });
+            }
+          });
         });
-      });
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        if (shouldFallbackAfterMidRequestError({ error, sawTextDelta, transport })) {
+          log.warn(
+            `[ws-stream] mid-request failure for session=${sessionId}; falling back to HTTP. error=${error.message}`,
+          );
+          resetWsSession(sessionId, session);
+          return fallbackToHttp(model, context, options, eventStream, signal, { skipStart: true });
+        }
+        throw error;
+      }
     };
 
     queueMicrotask(() =>
@@ -739,10 +778,14 @@ async function fallbackToHttp(
   options: Parameters<StreamFn>[2],
   eventStream: ReturnType<typeof createAssistantMessageEventStream>,
   signal?: AbortSignal,
+  opts: { skipStart?: boolean } = {},
 ): Promise<void> {
   const mergedOptions = signal ? { ...options, signal } : options;
   const httpStream = streamSimple(model, context, mergedOptions);
   for await (const event of httpStream) {
+    if (opts.skipStart && event.type === "start") {
+      continue;
+    }
     eventStream.push(event);
   }
 }


### PR DESCRIPTION
## Summary

- Problem: the OpenAI Responses WebSocket path can fail hard on stale `rs_*` references and transient upstream failures after the request has already been sent.
- Why it matters: in `transport: "auto"`, these failures leave users with a broken turn even though the HTTP path can still recover the request.
- What changed: detect stale `rs_*` / transient 502-504 / pre-output mid-request WS close failures, reset the broken WS session, and fall back to the HTTP path once.
- What did NOT change (scope boundary): forced `transport: "websocket"` still surfaces WS errors, and we do not retry after visible text deltas have already started streaming.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37230

## User-visible / Behavior Changes

- In auto transport mode, some OpenAI Responses WS failures now recover transparently by falling back to the HTTP path instead of failing the turn immediately.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: OpenAI Responses / WebSocket stream path
- Integration/channel (if any): N/A
- Relevant config (redacted): `transport: "auto"`

### Steps

1. Start an OpenAI Responses turn through the WS stream path.
2. Trigger one of these failures before `response.completed`: stale `rs_*` item error, transient `502/503/504`, or WS close before any text delta.
3. Observe whether the turn recovers through the HTTP path.

### Expected

- Auto transport should recover once by resetting the broken WS session and falling back to HTTP.

### Actual

- Before fix: the turn failed immediately on those WS-only errors.
- After fix: the same failures fall back to HTTP once, while explicit `transport: "websocket"` still returns the WS error.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

- `pnpm test src/agents/openai-ws-stream.test.ts`
- `pnpm exec oxfmt --check src/agents/openai-ws-stream.ts src/agents/openai-ws-stream.test.ts CHANGELOG.md`
- `pnpm build`
- `pnpm check` (fails on pre-existing missing dependency: `extensions/tlon` cannot resolve `@tloncorp/api` in this workspace)

## Human Verification (required)

- Verified scenarios:
  - stale `rs_*` failures now fall back to HTTP once
  - transient `502` failures now fall back to HTTP once
  - mid-request WS close in auto mode now falls back to HTTP once
  - forced `transport: "websocket"` still surfaces the original WS error
- Edge cases checked:
  - no fallback after text deltas have already started, to avoid duplicate visible output
  - broken WS sessions are removed from the registry before the fallback turn
- What you did **not** verify:
  - live OpenAI WS traffic against the real API

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR commit
- Files/config to restore:
  - `src/agents/openai-ws-stream.ts`
  - `src/agents/openai-ws-stream.test.ts`
  - `CHANGELOG.md`
- Known bad symptoms reviewers should watch for:
  - unexpected HTTP fallback on WS errors after visible output has already started

## Risks and Mitigations

- Risk: falling back after partial output could duplicate visible content.
  - Mitigation: fallback is disabled once any text delta has streamed.

AI-assisted: Yes (Codex)
