### PR TITLE
fix(telegram): validate replyToMessageId is finite positive integer

### DIFF
--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -278,14 +278,18 @@ function buildTelegramThreadReplyParams(params: {
   const threadParams: Record<string, unknown> = threadIdParams ? { ...threadIdParams } : {};
 
   if (params.replyToMessageId != null) {
+    // Validate replyToMessageId is a finite positive integer to avoid 400 errors
+    // from non-numeric values (e.g., UUIDs from cross-surface reply tags)
     const replyToMessageId = Math.trunc(params.replyToMessageId);
-    if (params.quoteText?.trim()) {
-      threadParams.reply_parameters = {
-        message_id: replyToMessageId,
-        quote: params.quoteText.trim(),
-      };
-    } else {
-      threadParams.reply_to_message_id = replyToMessageId;
+    if (Number.isFinite(replyToMessageId) && replyToMessageId > 0) {
+      if (params.quoteText?.trim()) {
+        threadParams.reply_parameters = {
+          message_id: replyToMessageId,
+          quote: params.quoteText.trim(),
+        };
+      } else {
+        threadParams.reply_to_message_id = replyToMessageId;
+      }
     }
   }
   return threadParams;


### PR DESCRIPTION
## Summary

Guard against non-numeric `replyToMessageId` values (e.g., UUIDs from cross-surface reply tags) by validating the value is finite and > 0 before adding `reply_to_message_id` or `reply_parameters`.

This prevents 400 'Bad Request: message to be replied not found' errors when Telegram receives invalid reply message IDs.

## Root Cause

In `src/telegram/send.ts`, `replyToMessageId` was truncated with `Math.trunc()` without validating numeric validity first. In cross-surface routing scenarios, upstream reply ids may be UUID-like/non-numeric values.

## Fix

Added validation: `Number.isFinite(replyToMessageId) && replyToMessageId > 0` before using the value.

## Testing

- All 51 telegram send tests pass

Fixes #37220