### PR TITLE
fix(msteams): filter non-file attachments from document placeholder

### DIFF
--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -406,6 +406,10 @@ const EMPTY_ATTACHMENT_PLACEHOLDER_CASES: AttachmentPlaceholderCase[] = [
     ],
     expected: "",
   }),
+  withLabel("returns empty string for text/html attachment without inline images", {
+    attachments: [createHtmlAttachment("<p>Hello world</p>")],
+    expected: "",
+  }),
 ];
 const COUNTED_ATTACHMENT_PLACEHOLDER_CASE_DEFS: CountedAttachmentPlaceholderCaseDef[] = [
   withLabel("returns image placeholder for one image attachment", {

--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -371,6 +371,41 @@ type GraphMediaSuccessCase = LabeledCase & {
 const EMPTY_ATTACHMENT_PLACEHOLDER_CASES: AttachmentPlaceholderCase[] = [
   withLabel("returns empty string when no attachments", { attachments: undefined, expected: "" }),
   withLabel("returns empty string when attachments are empty", { attachments: [], expected: "" }),
+  withLabel("returns empty string for adaptive card attachments", {
+    attachments: [
+      buildAttachment("application/vnd.microsoft.card.adaptive", {
+        content: { type: "AdaptiveCard", body: [] },
+      }),
+    ],
+    expected: "",
+  }),
+  withLabel("returns empty string for hero card attachments", {
+    attachments: [
+      buildAttachment("application/vnd.microsoft.card.hero", {
+        content: { title: "Hero" },
+      }),
+    ],
+    expected: "",
+  }),
+  withLabel("returns empty string for thumbnail card attachments", {
+    attachments: [
+      buildAttachment("application/vnd.microsoft.card.thumbnail", {
+        content: { title: "Thumb" },
+      }),
+    ],
+    expected: "",
+  }),
+  withLabel("returns empty string for multiple non-file attachments", {
+    attachments: [
+      buildAttachment("application/vnd.microsoft.card.adaptive", {
+        content: { type: "AdaptiveCard", body: [] },
+      }),
+      buildAttachment("application/vnd.microsoft.card.hero", {
+        content: { title: "Hero" },
+      }),
+    ],
+    expected: "",
+  }),
 ];
 const COUNTED_ATTACHMENT_PLACEHOLDER_CASE_DEFS: CountedAttachmentPlaceholderCaseDef[] = [
   withLabel("returns image placeholder for one image attachment", {
@@ -410,6 +445,16 @@ const COUNTED_ATTACHMENT_PLACEHOLDER_CASE_DEFS: CountedAttachmentPlaceholderCase
     attachments: createHtmlImageAttachments([TEST_URL_HTML_A, TEST_URL_HTML_B]),
     count: 2,
     formatPlaceholder: formatImagePlaceholder,
+  }),
+  withLabel("counts only downloadable files when mixed with non-file attachments", {
+    attachments: [
+      ...createPdfAttachments(TEST_URL_PDF),
+      buildAttachment("application/vnd.microsoft.card.adaptive", {
+        content: { type: "AdaptiveCard", body: [] },
+      }),
+    ],
+    count: 1,
+    formatPlaceholder: formatDocumentPlaceholder,
   }),
 ];
 const ATTACHMENT_PLACEHOLDER_CASES: AttachmentPlaceholderCase[] = [

--- a/extensions/msteams/src/attachments/html.ts
+++ b/extensions/msteams/src/attachments/html.ts
@@ -3,6 +3,7 @@ import {
   extractHtmlFromAttachment,
   extractInlineImageCandidates,
   IMG_SRC_RE,
+  isDownloadableAttachment,
   isLikelyImageAttachment,
   safeHostForUrl,
 } from "./shared.js";
@@ -85,6 +86,9 @@ export function buildMSTeamsAttachmentPlaceholder(
   if (totalImages > 0) {
     return `<media:image>${totalImages > 1 ? ` (${totalImages} images)` : ""}`;
   }
-  const count = list.length;
-  return `<media:document>${count > 1 ? ` (${count} files)` : ""}`;
+  const downloadable = list.filter(isDownloadableAttachment);
+  if (downloadable.length === 0) {
+    return "";
+  }
+  return `<media:document>${downloadable.length > 1 ? ` (${downloadable.length} files)` : ""}`;
 }


### PR DESCRIPTION
## Summary

- Problem: `buildMSTeamsAttachmentPlaceholder` counts **all** non-image attachments as documents, including Teams metadata attachments (adaptive cards, hero cards, thumbnail cards) that are not actual files. This causes agents to receive false `<media:document>` placeholders on regular text messages that happen to include rich formatting metadata.
- Why it matters: The agent treats `<media:document>` as a signal that files were sent and may reference or attempt to process documents that do not exist, degrading the user experience.
- What changed: The document-counting branch in `buildMSTeamsAttachmentPlaceholder` now filters attachments through the existing `isDownloadableAttachment` check, so only attachments with a `contentUrl` or `downloadUrl` generate `<media:document>` placeholders.
- What did NOT change (scope boundary): Image detection logic (`isLikelyImageAttachment`, `extractInlineImageCandidates`) is untouched. The `isDownloadableAttachment` function itself is unchanged — it already correctly distinguishes file attachments from metadata attachments.

### Attachment types affected

| Attachment `contentType` | Before | After |
|---|---|---|
| `application/vnd.microsoft.card.adaptive` | `<media:document>` | `""` (empty — no placeholder) |
| `application/vnd.microsoft.card.hero` | `<media:document>` | `""` |
| `application/vnd.microsoft.card.thumbnail` | `<media:document>` | `""` |
| `application/pdf` (with `contentUrl`) | `<media:document>` | `<media:document>` (unchanged) |
| `application/vnd.microsoft.teams.file.download.info` (with `downloadUrl`) | `<media:document>` | `<media:document>` (unchanged) |

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #26599

## User-visible / Behavior Changes

Messages from MS Teams that contain only rich text formatting (adaptive cards, hero cards) will no longer produce false `<media:document>` placeholders. Agents will see the actual text content instead of a spurious document reference.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: MS Teams (Bot Framework)

### Steps

1. Send a plain text message in MS Teams that includes rich formatting (bold, mentions, or emoji that produce adaptive card / hero card / thumbnail card attachments)
2. Observe the raw body received by the agent

### Expected

- Agent receives the text content without any `<media:document>` placeholder

### Actual (before fix)

- Agent receives `<media:document>` placeholder, causing it to reference non-existent files

## Evidence

- [x] Failing test/log before + passing after

5 new test cases added covering:
- Adaptive card attachment → returns `""`
- Hero card attachment → returns `""`
- Thumbnail card attachment → returns `""`
- Multiple non-file attachments → returns `""`
- Mixed downloadable file + adaptive card → returns `<media:document>` (counting only the real file)

## Human Verification (required)

- Verified scenarios: All 34 attachment tests pass (including 5 new cases). Existing document/image placeholder behavior unchanged.
- Edge cases checked: Empty attachments, mixed file + non-file attachments, multiple non-file attachments
- What you did **not** verify: Live MS Teams bot interaction (no access to a Teams environment)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; the change is isolated to `buildMSTeamsAttachmentPlaceholder` in `extensions/msteams/src/attachments/html.ts`
- Files/config to restore: `extensions/msteams/src/attachments/html.ts`
- Known bad symptoms reviewers should watch for: Actual file attachments (PDFs, downloads) no longer generating `<media:document>` placeholder — this would indicate the `isDownloadableAttachment` filter is too aggressive (unlikely since existing tests cover these cases)

## Risks and Mitigations

- Risk: Some rare Teams attachment type with a `contentUrl` that is not a real downloadable file could still produce a false placeholder
  - Mitigation: `isDownloadableAttachment` checks for `contentUrl` presence (trimmed non-empty) or Teams file download info `downloadUrl`, which are reliable indicators of actual file content. Non-file metadata attachments do not set these fields.