### PR TITLE
fix(reply): keep reminder guard notes internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Reply/reminder guard note visibility: stop appending the unscheduled reminder note to outbound chat replies and queue it as an internal system event instead, so Discord and other surfaces no longer leak the annotation to end users. (#37239)
 - Models/openai-completions streaming compatibility: force `compat.supportsUsageInStreaming=false` for non-native OpenAI-compatible endpoints during model normalization, preventing usage-only stream chunks from triggering `choices[0]` parser crashes in provider streams. (#8714) Thanks @nonanon1.
 - TUI/token copy-safety rendering: treat long credential-like mixed alphanumeric tokens (including quoted forms) as copy-sensitive in render sanitization so formatter hard-wrap guards no longer inject visible spaces into auth-style values before display. (#26710) Thanks @jasonthane.
 - WhatsApp/self-chat response prefix fallback: stop forcing `"[openclaw]"` as the implicit outbound response prefix when no identity name or response prefix is configured, so blank/default prefix settings no longer inject branding text unexpectedly in self-chat flows. (#27962) Thanks @ecanmor.

--- a/src/auto-reply/reply/agent-runner-reminder-guard.ts
+++ b/src/auto-reply/reply/agent-runner-reminder-guard.ts
@@ -1,5 +1,5 @@
 import { loadCronStore, resolveCronStorePath } from "../../cron/store.js";
-import type { ReplyPayload } from "../types.js";
+import { enqueueSystemEvent } from "../../infra/system-events.js";
 
 export const UNSCHEDULED_REMINDER_NOTE =
   "Note: I did not schedule a reminder in this turn, so this will not trigger automatically.";
@@ -45,20 +45,10 @@ export async function hasSessionRelatedCronJobs(params: {
   }
 }
 
-export function appendUnscheduledReminderNote(payloads: ReplyPayload[]): ReplyPayload[] {
-  let appended = false;
-  return payloads.map((payload) => {
-    if (appended || payload.isError || typeof payload.text !== "string") {
-      return payload;
-    }
-    if (!hasUnbackedReminderCommitment(payload.text)) {
-      return payload;
-    }
-    appended = true;
-    const trimmed = payload.text.trimEnd();
-    return {
-      ...payload,
-      text: `${trimmed}\n\n${UNSCHEDULED_REMINDER_NOTE}`,
-    };
-  });
+export function enqueueUnscheduledReminderNote(sessionKey?: string): boolean {
+  const trimmedSessionKey = sessionKey?.trim();
+  if (!trimmedSessionKey) {
+    return false;
+  }
+  return enqueueSystemEvent(UNSCHEDULED_REMINDER_NOTE, { sessionKey: trimmedSessionKey });
 }

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -8,6 +8,7 @@ import { loadSessionStore, saveSessionStore } from "../../config/sessions.js";
 import { onAgentEvent } from "../../infra/agent-events.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
 import type { TemplateContext } from "../templating.js";
+import { UNSCHEDULED_REMINDER_NOTE } from "./agent-runner-reminder-guard.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
 import { createMockTypingController } from "./test-helpers.js";
 
@@ -1167,7 +1168,7 @@ describe("runReplyAgent reminder commitment guard", () => {
     });
   }
 
-  it("appends guard note when reminder commitment is not backed by cron.add", async () => {
+  it("queues an internal guard note when reminder commitment is not backed by cron.add", async () => {
     runEmbeddedPiAgentMock.mockResolvedValueOnce({
       payloads: [{ text: "I'll remind you tomorrow morning." }],
       meta: {},
@@ -1176,8 +1177,9 @@ describe("runReplyAgent reminder commitment guard", () => {
 
     const result = await createRun();
     expect(result).toMatchObject({
-      text: "I'll remind you tomorrow morning.\n\nNote: I did not schedule a reminder in this turn, so this will not trigger automatically.",
+      text: "I'll remind you tomorrow morning.",
     });
+    expect(peekSystemEvents("main")).toContain(UNSCHEDULED_REMINDER_NOTE);
   });
 
   it("keeps reminder commitment unchanged when cron.add succeeded", async () => {
@@ -1191,6 +1193,7 @@ describe("runReplyAgent reminder commitment guard", () => {
     expect(result).toMatchObject({
       text: "I'll remind you tomorrow morning.",
     });
+    expect(peekSystemEvents("main")).toEqual([]);
   });
 
   it("suppresses guard note when session already has an active cron job", async () => {
@@ -1218,9 +1221,10 @@ describe("runReplyAgent reminder commitment guard", () => {
     expect(result).toMatchObject({
       text: "I'll ping you when it's done.",
     });
+    expect(peekSystemEvents("main")).toEqual([]);
   });
 
-  it("still appends guard note when cron jobs exist but not for the current session", async () => {
+  it("still queues the internal guard note when cron jobs exist but not for the current session", async () => {
     loadCronStoreMock.mockResolvedValueOnce({
       version: 1,
       jobs: [
@@ -1243,11 +1247,12 @@ describe("runReplyAgent reminder commitment guard", () => {
 
     const result = await createRun();
     expect(result).toMatchObject({
-      text: "I'll remind you tomorrow morning.\n\nNote: I did not schedule a reminder in this turn, so this will not trigger automatically.",
+      text: "I'll remind you tomorrow morning.",
     });
+    expect(peekSystemEvents("main")).toContain(UNSCHEDULED_REMINDER_NOTE);
   });
 
-  it("still appends guard note when cron jobs for session exist but are disabled", async () => {
+  it("still queues the internal guard note when cron jobs for session exist but are disabled", async () => {
     loadCronStoreMock.mockResolvedValueOnce({
       version: 1,
       jobs: [
@@ -1270,11 +1275,12 @@ describe("runReplyAgent reminder commitment guard", () => {
 
     const result = await createRun();
     expect(result).toMatchObject({
-      text: "I'll check back in an hour.\n\nNote: I did not schedule a reminder in this turn, so this will not trigger automatically.",
+      text: "I'll check back in an hour.",
     });
+    expect(peekSystemEvents("main")).toContain(UNSCHEDULED_REMINDER_NOTE);
   });
 
-  it("still appends guard note when sessionKey is missing", async () => {
+  it("does not leak or queue the guard note when sessionKey is missing", async () => {
     loadCronStoreMock.mockResolvedValueOnce({
       version: 1,
       jobs: [
@@ -1297,11 +1303,12 @@ describe("runReplyAgent reminder commitment guard", () => {
 
     const result = await createRun({ omitSessionKey: true });
     expect(result).toMatchObject({
-      text: "I'll ping you later.\n\nNote: I did not schedule a reminder in this turn, so this will not trigger automatically.",
+      text: "I'll ping you later.",
     });
+    expect(peekSystemEvents("main")).toEqual([]);
   });
 
-  it("still appends guard note when cron store read fails", async () => {
+  it("still queues the internal guard note when cron store read fails", async () => {
     loadCronStoreMock.mockRejectedValueOnce(new Error("store read failed"));
 
     runEmbeddedPiAgentMock.mockResolvedValueOnce({
@@ -1312,8 +1319,9 @@ describe("runReplyAgent reminder commitment guard", () => {
 
     const result = await createRun({ sessionKey: "main" });
     expect(result).toMatchObject({
-      text: "I'll remind you after lunch.\n\nNote: I did not schedule a reminder in this turn, so this will not trigger automatically.",
+      text: "I'll remind you after lunch.",
     });
+    expect(peekSystemEvents("main")).toContain(UNSCHEDULED_REMINDER_NOTE);
   });
 });
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -40,7 +40,7 @@ import {
 import { runMemoryFlushIfNeeded } from "./agent-runner-memory.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
 import {
-  appendUnscheduledReminderNote,
+  enqueueUnscheduledReminderNote,
   hasSessionRelatedCronJobs,
   hasUnbackedReminderCommitment,
 } from "./agent-runner-reminder-guard.js";
@@ -519,10 +519,10 @@ export async function runReplyAgent(params: {
             sessionKey,
           })
         : false;
-    const guardedReplyPayloads =
-      hasReminderCommitment && successfulCronAdds === 0 && !coveredByExistingCron
-        ? appendUnscheduledReminderNote(replyPayloads)
-        : replyPayloads;
+    if (hasReminderCommitment && successfulCronAdds === 0 && !coveredByExistingCron) {
+      enqueueUnscheduledReminderNote(sessionKey);
+    }
+    const guardedReplyPayloads = replyPayloads;
 
     await signalTypingIfNeeded(guardedReplyPayloads, typingSignals);
 


### PR DESCRIPTION
## Summary

- Problem: the unscheduled reminder guard note is appended directly to outbound reply text, so Discord and other chat surfaces can show an internal reminder annotation to end users.
- Why it matters: this note is an internal safety hint, not user-facing content, and it makes replies look broken or misleading when it leaks.
- What changed: keep the guard, but queue it as an internal system event instead of appending it to the delivered reply payload.
- What did NOT change (scope boundary): reminder commitment detection is unchanged, cron-backed commitments still suppress the guard, and no channel-specific delivery logic was touched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37239

## User-visible / Behavior Changes

- Replies that mention future reminders no longer include the internal `"I did not schedule a reminder..."` annotation in user-visible chat output.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: any provider path that can emit reminder commitments without cron scheduling
- Integration/channel (if any): Discord repro from issue; fix is channel-agnostic in reply assembly
- Relevant config (redacted): no successful `cron.add` in the turn

### Steps

1. Run a turn whose reply says something like `I'll remind you tomorrow morning.`
2. Ensure the turn does not call `cron.add` and there is no existing active cron job for the session.
3. Deliver the reply to a chat surface.

### Expected

- User sees only the assistant reply text.
- The guard note stays internal.

### Actual

- Before fix: the internal note was appended to the visible reply body.
- After fix: the visible reply text is unchanged, and the guard note is queued as a system event instead.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

- `pnpm test src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
- `pnpm exec oxfmt --check src/auto-reply/reply/agent-runner-reminder-guard.ts src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts CHANGELOG.md`
- `pnpm exec oxlint src/auto-reply/reply/agent-runner-reminder-guard.ts src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
- `pnpm build`
- `pnpm check` (fails on pre-existing missing dependency: `extensions/tlon` cannot resolve `@tloncorp/api` in this workspace)

## Human Verification (required)

- Verified scenarios:
  - unbacked reminder commitments no longer leak the guard note into reply text
  - the same turns still queue the guard note internally via system events
  - cron-backed or already-covered sessions still suppress the guard
- Edge cases checked:
  - missing `sessionKey` no longer leaks the note and also does not enqueue a system event
  - cron store read failure still keeps the note internal instead of visible
- What you did **not** verify:
  - live Discord delivery with a real bot account

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR commit
- Files/config to restore:
  - `src/auto-reply/reply/agent-runner-reminder-guard.ts`
  - `src/auto-reply/reply/agent-runner.ts`
  - `src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts`
  - `CHANGELOG.md`
- Known bad symptoms reviewers should watch for:
  - reminder guard notes becoming visible in replies again

## Risks and Mitigations

- Risk: without visible note text, silent regressions could hide the guard entirely.
  - Mitigation: regression tests now assert the note is queued as a system event while staying out of reply text.

AI-assisted: Yes (Codex)
