### PR TITLE
Sessions: preserve sessionKey in reset archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Sessions/reset archive metadata: append `sessionKey` metadata to archived `.reset.*` transcript JSONL files so reset history remains traceable to the original channel/session context. (#37225) Thanks @yulin7645.
 - Models/openai-completions streaming compatibility: force `compat.supportsUsageInStreaming=false` for non-native OpenAI-compatible endpoints during model normalization, preventing usage-only stream chunks from triggering `choices[0]` parser crashes in provider streams. (#8714) Thanks @nonanon1.
 - Tools/xAI native web-search collision guard: drop OpenClaw `web_search` from tool registration when routing to xAI/Grok model providers (including OpenRouter `x-ai/*`) to avoid duplicate tool-name request failures against provider-native `web_search`. (#14749) Thanks @realsamrat.
 - TUI/token copy-safety rendering: treat long credential-like mixed alphanumeric tokens (including quoted forms) as copy-sensitive in render sanitization so formatter hard-wrap guards no longer inject visible spaces into auth-style values before display. (#26710) Thanks @jasonthane.

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1451,6 +1451,7 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       expect.objectContaining({
         sessionId: existingSessionId,
         storePath,
+        sessionKey,
         reason: "reset",
       }),
     );
@@ -1503,6 +1504,7 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
         expect.objectContaining({
           sessionId: existingSessionId,
           storePath,
+          sessionKey,
           reason: "reset",
         }),
       );

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -565,6 +565,7 @@ export async function initSessionState(params: {
       storePath,
       sessionFile: previousSessionEntry.sessionFile,
       agentId,
+      sessionKey,
       reason: "reset",
     });
   }

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -132,6 +132,7 @@ function archiveSessionTranscriptsForSession(params: {
   storePath: string;
   sessionFile?: string;
   agentId?: string;
+  sessionKey?: string;
   reason: "reset" | "deleted";
 }): string[] {
   if (!params.sessionId) {
@@ -142,6 +143,7 @@ function archiveSessionTranscriptsForSession(params: {
     storePath: params.storePath,
     sessionFile: params.sessionFile,
     agentId: params.agentId,
+    sessionKey: params.sessionKey,
     reason: params.reason,
   });
 }
@@ -544,6 +546,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       storePath,
       sessionFile: oldSessionFile,
       agentId: target.agentId,
+      sessionKey: target.canonicalKey ?? key,
       reason: "reset",
     });
     if (hadExistingEntry) {

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -786,4 +786,49 @@ describe("archiveSessionTranscripts", () => {
     expect(archived[0]).toContain(".deleted.");
     expect(fs.existsSync(transcriptPath)).toBe(false);
   });
+
+  test("appends session metadata to reset archives", () => {
+    const sessionId = "sess-archive-meta";
+    const sessionKey = "agent:main:discord:channel:123";
+    writeTranscript(tmpDir, sessionId, buildBasicSessionTranscript(sessionId));
+
+    const archived = archiveSessionTranscripts({
+      sessionId,
+      storePath,
+      sessionKey,
+      reason: "reset",
+    });
+
+    expect(archived).toHaveLength(1);
+    const lines = fs
+      .readFileSync(archived[0], "utf-8")
+      .split(/\r?\n/)
+      .filter((line) => line.trim().length > 0);
+    expect(lines).toHaveLength(4);
+    expect(JSON.parse(lines[3])).toMatchObject({
+      type: "session_archive_metadata",
+      reason: "reset",
+      sessionId,
+      sessionKey,
+    });
+  });
+
+  test("does not append session metadata to deleted archives", () => {
+    const sessionId = "sess-archive-delete";
+    writeTranscript(tmpDir, sessionId, buildBasicSessionTranscript(sessionId));
+
+    const archived = archiveSessionTranscripts({
+      sessionId,
+      storePath,
+      sessionKey: "agent:main:discord:channel:456",
+      reason: "deleted",
+    });
+
+    expect(archived).toHaveLength(1);
+    const lines = fs
+      .readFileSync(archived[0], "utf-8")
+      .split(/\r?\n/)
+      .filter((line) => line.trim().length > 0);
+    expect(lines).toHaveLength(3);
+  });
 });

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -165,6 +165,14 @@ export function resolveSessionTranscriptCandidates(
 
 export type ArchiveFileReason = SessionArchiveReason;
 
+type ResetArchiveMetadataLine = {
+  type: "session_archive_metadata";
+  reason: "reset";
+  sessionId: string;
+  sessionKey: string;
+  resetAt: string;
+};
+
 function canonicalizePathForComparison(filePath: string): string {
   const resolved = path.resolve(filePath);
   try {
@@ -174,8 +182,35 @@ function canonicalizePathForComparison(filePath: string): string {
   }
 }
 
-export function archiveFileOnDisk(filePath: string, reason: ArchiveFileReason): string {
-  const ts = formatSessionArchiveTimestamp();
+function appendResetArchiveMetadata(filePath: string, metadata: ResetArchiveMetadataLine): void {
+  const prefix = fs.statSync(filePath).size > 0 ? "\n" : "";
+  fs.appendFileSync(filePath, `${prefix}${JSON.stringify(metadata)}\n`, "utf-8");
+}
+
+export function archiveFileOnDisk(
+  filePath: string,
+  reason: ArchiveFileReason,
+  opts?: {
+    sessionId?: string;
+    sessionKey?: string;
+    nowMs?: number;
+  },
+): string {
+  const nowMs = opts?.nowMs ?? Date.now();
+  if (reason === "reset" && opts?.sessionId && opts.sessionKey) {
+    try {
+      appendResetArchiveMetadata(filePath, {
+        type: "session_archive_metadata",
+        reason: "reset",
+        sessionId: opts.sessionId,
+        sessionKey: opts.sessionKey,
+        resetAt: new Date(nowMs).toISOString(),
+      });
+    } catch {
+      // Best-effort: keep transcript archival working even if metadata append fails.
+    }
+  }
+  const ts = formatSessionArchiveTimestamp(nowMs);
   const archived = `${filePath}.${reason}.${ts}`;
   fs.renameSync(filePath, archived);
   return archived;
@@ -190,6 +225,7 @@ export function archiveSessionTranscripts(opts: {
   storePath: string | undefined;
   sessionFile?: string;
   agentId?: string;
+  sessionKey?: string;
   reason: "reset" | "deleted";
   /**
    * When true, only archive files resolved under the session store directory.
@@ -219,7 +255,12 @@ export function archiveSessionTranscripts(opts: {
       continue;
     }
     try {
-      archived.push(archiveFileOnDisk(candidatePath, opts.reason));
+      archived.push(
+        archiveFileOnDisk(candidatePath, opts.reason, {
+          sessionId: opts.sessionId,
+          sessionKey: opts.sessionKey,
+        }),
+      );
     } catch {
       // Best-effort.
     }


### PR DESCRIPTION
## Summary

- Problem: archived `.reset.*` transcript files lose the original `sessionKey`, so they cannot be traced back to the channel/session that created them.
- Why it matters: tools and users cannot reliably index, audit, or prune reset archives by session context after `/new` or `sessions.reset`.
- What changed: append a `session_archive_metadata` JSONL record with `sessionId`, `sessionKey`, and `resetAt` before renaming reset archives; thread `sessionKey` through both reply-session resets and gateway `sessions.reset`.
- What did NOT change (scope boundary): live session transcripts, deleted archives, retention/cleanup behavior, and active session routing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37225

## User-visible / Behavior Changes

Archived `.reset.*` transcript files now end with a metadata JSONL line containing the original `sessionKey` and reset timestamp. Live session files and `.deleted.*` archives are unchanged.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): session store / gateway sessions
- Relevant config (redacted): temp session store paths in tests

### Steps

1. Start with a session store entry that points a `sessionKey` at an existing transcript.
2. Trigger `/new` or `sessions.reset` so the old transcript is archived as `.reset.<timestamp>`.
3. Inspect the archived JSONL file.

### Expected

- The archived reset transcript remains traceable to its original session context.

### Actual

- Before this change, the archived file had no durable link back to the original `sessionKey`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reset archives append metadata with the original `sessionKey`; gateway `sessions.reset` behavior still passes end-to-end tests; deleted archives remain metadata-free.
- Edge cases checked: default transcript path, explicit `sessionFile`, and archived-file readers continuing to ignore non-message metadata lines.
- What you did **not** verify: external third-party scripts that parse archived reset transcripts outside OpenClaw.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR to stop appending metadata to future reset archives.
- Files/config to restore: `src/gateway/session-utils.fs.ts`, `src/auto-reply/reply/session.ts`, `src/gateway/server-methods/sessions.ts`
- Known bad symptoms reviewers should watch for: custom archive-processing scripts that assume every JSONL row in `.reset.*` files is a chat message.

## Risks and Mitigations

- Risk: downstream tooling that parses reset archives as message-only JSONL may need to ignore one new metadata record.
  - Mitigation: only `.reset.*` archives get the new record; active transcripts and `.deleted.*` archives are unchanged, and OpenClaw readers already ignore unknown non-message rows.

## Verification

- `pnpm test src/gateway/session-utils.fs.test.ts src/auto-reply/reply/session.test.ts src/gateway/server.sessions.gateway-server-sessions-a.test.ts`
- `pnpm exec oxfmt --check src/gateway/session-utils.fs.ts src/gateway/session-utils.fs.test.ts src/auto-reply/reply/session.ts src/auto-reply/reply/session.test.ts src/gateway/server-methods/sessions.ts CHANGELOG.md`
- `pnpm exec oxlint src/gateway/session-utils.fs.ts src/gateway/session-utils.fs.test.ts src/auto-reply/reply/session.ts src/auto-reply/reply/session.test.ts src/gateway/server-methods/sessions.ts`
- `pnpm build`
- `pnpm check` currently fails in untouched base-branch files: `extensions/tlon/*` missing `@tloncorp/api`, plus `src/gateway/openai-http.ts:303` typecheck failure.

AI-assisted: Yes (Codex)
