### PR TITLE
fix(hooks): extract correct agentId from session key in before_reset hook

### DIFF
--- a/src/auto-reply/reply/commands-core.before-reset-agent-id.test.ts
+++ b/src/auto-reply/reply/commands-core.before-reset-agent-id.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  hookRunner: {
+    hasHooks: vi.fn(() => true),
+    runBeforeReset: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => mocks.hookRunner,
+}));
+
+vi.mock("../../hooks/internal-hooks.js", () => ({
+  createInternalHookEvent: vi.fn(() => ({ messages: [] })),
+  triggerInternalHook: vi.fn(async () => {}),
+}));
+
+vi.mock("./route-reply.js", () => ({
+  routeReply: vi.fn(async () => {}),
+}));
+
+import { emitResetCommandHooks } from "./commands-core.js";
+
+// oxlint-disable typescript/no-explicit-any -- test stubs need partial objects
+
+describe("emitResetCommandHooks agent ID extraction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hookRunner.hasHooks.mockReturnValue(true);
+    mocks.hookRunner.runBeforeReset.mockResolvedValue(undefined);
+  });
+
+  it("extracts correct agentId from agent-prefixed session key", async () => {
+    await emitResetCommandHooks({
+      action: "reset",
+      ctx: { Body: "", From: "user" } as any,
+      cfg: {} as any,
+      command: { surface: "text", channel: "discord" } as any,
+      sessionKey: "agent:mybot:discord:default:direct:user123",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.hookRunner.runBeforeReset).toHaveBeenCalledTimes(1);
+    });
+
+    const hookCtx = mocks.hookRunner.runBeforeReset.mock.calls[0][1];
+    expect(hookCtx.agentId).toBe("mybot");
+  });
+
+  it("returns 'main' for undefined session key", async () => {
+    await emitResetCommandHooks({
+      action: "new",
+      ctx: { Body: "", From: "user" } as any,
+      cfg: {} as any,
+      command: { surface: "text", channel: "telegram" } as any,
+      sessionKey: undefined,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.hookRunner.runBeforeReset).toHaveBeenCalledTimes(1);
+    });
+
+    const hookCtx = mocks.hookRunner.runBeforeReset.mock.calls[0][1];
+    expect(hookCtx.agentId).toBe("main");
+  });
+
+  it("extracts agentId from simple agent session key", async () => {
+    await emitResetCommandHooks({
+      action: "reset",
+      ctx: { Body: "", From: "user" } as any,
+      cfg: {} as any,
+      command: { surface: "text", channel: "slack" } as any,
+      sessionKey: "agent:ops:slack:default:direct:U12345",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.hookRunner.runBeforeReset).toHaveBeenCalledTimes(1);
+    });
+
+    const hookCtx = mocks.hookRunner.runBeforeReset.mock.calls[0][1];
+    expect(hookCtx.agentId).toBe("ops");
+  });
+
+  it("does not return the literal string 'agent' as the agentId", async () => {
+    await emitResetCommandHooks({
+      action: "reset",
+      ctx: { Body: "", From: "user" } as any,
+      cfg: {} as any,
+      command: { surface: "text", channel: "discord" } as any,
+      sessionKey: "agent:helper:discord:default:direct:user1",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.hookRunner.runBeforeReset).toHaveBeenCalledTimes(1);
+    });
+
+    const hookCtx = mocks.hookRunner.runBeforeReset.mock.calls[0][1];
+    expect(hookCtx.agentId).not.toBe("agent");
+    expect(hookCtx.agentId).toBe("helper");
+  });
+});

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -3,7 +3,7 @@ import { resetAcpSessionInPlace } from "../../acp/persistent-bindings.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { isAcpSessionKey } from "../../routing/session-key.js";
+import { isAcpSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { shouldHandleTextCommands } from "../commands-registry.js";
 import { handleAcpCommand } from "./commands-acp.js";
@@ -120,7 +120,7 @@ export async function emitResetCommandHooks(params: {
         await hookRunner.runBeforeReset(
           { sessionFile, messages, reason: params.action },
           {
-            agentId: params.sessionKey?.split(":")[0] ?? "main",
+            agentId: resolveAgentIdFromSessionKey(params.sessionKey),
             sessionKey: params.sessionKey,
             sessionId: prevEntry?.sessionId,
             workspaceDir: params.workspaceDir,


### PR DESCRIPTION
## Summary

The `before_reset` plugin hook in `emitResetCommandHooks` was passing an incorrect `agentId` to hook consumers. It used `sessionKey.split(":")[0]` to extract the agent ID, but session keys use the format `agent:<agentId>:<rest>`, so `split(":")[0]` always returns the literal string `"agent"` instead of the actual agent ID (e.g. `"main"`, `"ops"`, `"helper"`).

## Bug

- **Root cause**: `params.sessionKey?.split(":")[0]` returns `"agent"` (the key prefix) not the actual agent ID
- **Impact**: All `before_reset` plugin hooks receive `agentId: "agent"` regardless of which agent triggered the reset. Plugins that route logic by agent ID silently misbehave.
- **Note**: The same bug existed in `compact.ts` and was already fixed there using `resolveSessionAgentIds`. This fix addresses the remaining occurrence.

## Fix

Replace `params.sessionKey?.split(":")[0] ?? "main"` with `resolveAgentIdFromSessionKey(params.sessionKey)`, which correctly parses the `agent:<id>:<rest>` format and falls back to `"main"` for `undefined` keys.

## Change type

Bug fix — corrects the agent ID passed to `before_reset` plugin hooks.

## Test plan

- [x] Added 4 unit tests covering:
  - Correct extraction from multi-segment session keys (`agent:mybot:discord:...` → `"mybot"`)
  - Correct extraction from different agent names (`agent:ops:...` → `"ops"`)
  - Fallback to `"main"` for `undefined` session keys
  - Explicit assertion that the literal string `"agent"` is never returned as the ID
- [x] All existing tests pass (`vitest run`)
- [x] Linter passes (`oxlint`)


Made with [Cursor](https://cursor.com)