### PR TITLE
fix(config): accept tools.web.fetch.firecrawl in schema

### DIFF
--- a/src/config/config.web-fetch-firecrawl-schema.test.ts
+++ b/src/config/config.web-fetch-firecrawl-schema.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { validateConfigObjectRaw } from "./validation.js";
+
+describe("config schema: tools.web.fetch.firecrawl", () => {
+  it("accepts tools.web.fetch.firecrawl block", () => {
+    const raw = {
+      tools: {
+        web: {
+          fetch: {
+            firecrawl: {
+              apiKey: "fc-test",
+              baseUrl: "https://api.firecrawl.dev",
+              onlyMainContent: true,
+              maxAgeMs: 172800000,
+              timeoutSeconds: 60,
+            },
+          },
+        },
+      },
+    };
+
+    const validated = validateConfigObjectRaw(raw);
+    expect(validated.ok).toBe(true);
+    if (!validated.ok) {
+      throw new Error(validated.issues.map((iss) => `${iss.path}: ${iss.message}`).join("\n"));
+    }
+  });
+
+  it("rejects unknown key under tools.web.fetch.firecrawl", () => {
+    const raw = {
+      tools: {
+        web: {
+          fetch: {
+            firecrawl: {
+              apiKey: "fc-test",
+              nope: true,
+            },
+          },
+        },
+      },
+    };
+
+    const validated = validateConfigObjectRaw(raw);
+    expect(validated.ok).toBe(false);
+    if (validated.ok) {
+      throw new Error("Expected validation to fail");
+    }
+    expect(validated.issues.some((iss) => iss.path === "tools.web.fetch.firecrawl")).toBe(true);
+  });
+});

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -321,6 +321,18 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    readability: z.boolean().optional(),
+    firecrawl: z
+      .object({
+        enabled: z.boolean().optional(),
+        apiKey: SecretInputSchema.optional().register(sensitive),
+        baseUrl: z.string().optional(),
+        onlyMainContent: z.boolean().optional(),
+        maxAgeMs: z.number().int().nonnegative().optional(),
+        timeoutSeconds: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
Fixes validation regression where config schema rejected `tools.web.fetch.firecrawl` despite docs and runtime support.

- Adds `readability` and `firecrawl` to `ToolsWebFetchSchema`.
- Includes a focused unit test covering acceptance + unknown-key rejection.

Closes #27833