### PR TITLE
agents: scope parallel_tool_calls to OpenAI-compatible payloads

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -190,9 +190,14 @@ describe("sendMediaFeishu msg_type routing", () => {
       fileName: "photo.png",
     });
 
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpTimeoutMs: 120_000,
+      }),
+    );
     expect(imageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        timeout: 120_000,
+        data: expect.objectContaining({ image_type: "message" }),
       }),
     );
     expect(messageCreateMock).toHaveBeenCalledWith(
@@ -320,7 +325,6 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(imageGetMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { image_key: imageKey },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toEqual(Buffer.from("image-data"));
@@ -512,7 +516,6 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_audio_msg", file_key: "file_key_audio" },
         params: { type: "file" },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);
@@ -532,7 +535,6 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_img_msg", file_key: "img_key_1" },
         params: { type: "image" },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -106,7 +106,6 @@ export async function downloadImageFeishu(params: {
 
   const response = await client.im.image.get({
     path: { image_key: normalizedImageKey },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   const buffer = await readFeishuResponseBuffer({
@@ -146,7 +145,6 @@ export async function downloadMessageResourceFeishu(params: {
   const response = await client.im.messageResource.get({
     path: { message_id: messageId, file_key: normalizedFileKey },
     params: { type },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   const buffer = await readFeishuResponseBuffer({
@@ -202,7 +200,6 @@ export async function uploadImageFeishu(params: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
       image: imageData as any,
     },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   // SDK v1.30+ returns data directly without code wrapper on success
@@ -277,7 +274,6 @@ export async function uploadFileFeishu(params: {
       file: fileData as any,
       ...(duration !== undefined && { duration }),
     },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   // SDK v1.30+ returns data directly without code wrapper on success

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -190,6 +190,29 @@ describe("applyExtraParamsToAgent", () => {
     return payload;
   }
 
+  function runParallelToolCallsPayloadMutationCase(params: {
+    applyProvider: string;
+    applyModelId: string;
+    model: Model<"openai-responses"> | Model<"openai-completions"> | Model<"anthropic-messages">;
+    cfg?: Record<string, unknown>;
+  }) {
+    const payload: Record<string, unknown> = {};
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    applyExtraParamsToAgent(
+      agent,
+      params.cfg as Parameters<typeof applyExtraParamsToAgent>[1],
+      params.applyProvider,
+      params.applyModelId,
+    );
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(params.model, context, {});
+    return payload;
+  }
+
   function runAnthropicHeaderCase(params: {
     cfg: Record<string, unknown>;
     modelId: string;
@@ -1556,4 +1579,128 @@ describe("applyExtraParamsToAgent", () => {
       expect(run().store).toBe(false);
     },
   );
+
+  it("injects parallel_tool_calls=false for openai-completions payloads", () => {
+    const payload = runParallelToolCallsPayloadMutationCase({
+      applyProvider: "nvidia",
+      applyModelId: "moonshotai/kimi-k2.5",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "nvidia/moonshotai/kimi-k2.5": {
+                params: {
+                  parallel_tool_calls: false,
+                },
+              },
+            },
+          },
+        },
+      },
+      model: {
+        api: "openai-completions",
+        provider: "nvidia",
+        id: "moonshotai/kimi-k2.5",
+      } as Model<"openai-completions">,
+    });
+    expect(payload.parallel_tool_calls).toBe(false);
+  });
+
+  it("supports parallelToolCalls camelCase config alias", () => {
+    const payload = runParallelToolCallsPayloadMutationCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5": {
+                params: {
+                  parallelToolCalls: true,
+                },
+              },
+            },
+          },
+        },
+      },
+      model: {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5",
+        baseUrl: "https://proxy.example.com/v1",
+      } as unknown as Model<"openai-responses">,
+    });
+    expect(payload.parallel_tool_calls).toBe(true);
+  });
+
+  it("does not inject parallel_tool_calls for non OpenAI-compatible APIs", () => {
+    const payload = runParallelToolCallsPayloadMutationCase({
+      applyProvider: "anthropic",
+      applyModelId: "claude-opus-4-6",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-opus-4-6": {
+                params: {
+                  parallel_tool_calls: false,
+                },
+              },
+            },
+          },
+        },
+      },
+      model: {
+        api: "anthropic-messages",
+        provider: "anthropic",
+        id: "claude-opus-4-6",
+      } as Model<"anthropic-messages">,
+    });
+    expect(payload).not.toHaveProperty("parallel_tool_calls");
+  });
+
+  it("warns and ignores invalid parallel tool call values", () => {
+    const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => undefined);
+    try {
+      const payload = runParallelToolCallsPayloadMutationCase({
+        applyProvider: "nvidia",
+        applyModelId: "moonshotai/kimi-k2.5",
+        cfg: {
+          agents: {
+            defaults: {
+              models: {
+                "nvidia/moonshotai/kimi-k2.5": {
+                  params: {
+                    parallelToolCalls: "nope",
+                  },
+                },
+              },
+            },
+          },
+        },
+        model: {
+          api: "openai-completions",
+          provider: "nvidia",
+          id: "moonshotai/kimi-k2.5",
+        } as Model<"openai-completions">,
+      });
+      expect(payload).not.toHaveProperty("parallel_tool_calls");
+      expect(warnSpy).toHaveBeenCalledWith("ignoring invalid parallel tool calls param: nope");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("leaves payload untouched when parallel tool calls are not configured", () => {
+    const payload = runParallelToolCallsPayloadMutationCase({
+      applyProvider: "nvidia",
+      applyModelId: "moonshotai/kimi-k2.5",
+      model: {
+        api: "openai-completions",
+        provider: "nvidia",
+        id: "moonshotai/kimi-k2.5",
+      } as Model<"openai-completions">,
+    });
+    expect(payload).not.toHaveProperty("parallel_tool_calls");
+  });
 });

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -150,6 +150,40 @@ describe("resolveExtraParams", () => {
     expect(result).not.toHaveProperty("parallelToolCalls");
   });
 
+  it("keeps explicit null alias overrides from higher-precedence params", () => {
+    const result = resolveExtraParams({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5": {
+                params: {
+                  parallel_tool_calls: true,
+                },
+              },
+            },
+          },
+          list: [
+            {
+              id: "risk-reviewer",
+              params: {
+                parallelToolCalls: null,
+              },
+            },
+          ],
+        },
+      },
+      provider: "openai",
+      modelId: "gpt-5",
+      agentId: "risk-reviewer",
+    });
+
+    expect(result).toMatchObject({
+      parallel_tool_calls: null,
+    });
+    expect(result).not.toHaveProperty("parallelToolCalls");
+  });
+
   it("ignores per-agent params when agentId does not match", () => {
     const result = resolveExtraParams({
       cfg: {
@@ -1752,6 +1786,41 @@ describe("applyExtraParamsToAgent", () => {
       });
       expect(payload).not.toHaveProperty("parallel_tool_calls");
       expect(warnSpy).toHaveBeenCalledWith("ignoring invalid parallel tool calls param: nope");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("does not fall back to lower-scope values when override sets null alias", () => {
+    const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => undefined);
+    try {
+      const payload = runParallelToolCallsPayloadMutationCase({
+        applyProvider: "nvidia",
+        applyModelId: "moonshotai/kimi-k2.5",
+        cfg: {
+          agents: {
+            defaults: {
+              models: {
+                "nvidia/moonshotai/kimi-k2.5": {
+                  params: {
+                    parallel_tool_calls: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+        extraParamsOverride: {
+          parallelToolCalls: null,
+        },
+        model: {
+          api: "openai-completions",
+          provider: "nvidia",
+          id: "moonshotai/kimi-k2.5",
+        } as Model<"openai-completions">,
+      });
+      expect(payload).not.toHaveProperty("parallel_tool_calls");
+      expect(warnSpy).toHaveBeenCalledWith("ignoring invalid parallel tool calls param: object");
     } finally {
       warnSpy.mockRestore();
     }

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -116,6 +116,40 @@ describe("resolveExtraParams", () => {
     });
   });
 
+  it("preserves per-agent precedence across parallel tool call aliases", () => {
+    const result = resolveExtraParams({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5": {
+                params: {
+                  parallel_tool_calls: true,
+                },
+              },
+            },
+          },
+          list: [
+            {
+              id: "risk-reviewer",
+              params: {
+                parallelToolCalls: false,
+              },
+            },
+          ],
+        },
+      },
+      provider: "openai",
+      modelId: "gpt-5",
+      agentId: "risk-reviewer",
+    });
+
+    expect(result).toMatchObject({
+      parallel_tool_calls: false,
+    });
+    expect(result).not.toHaveProperty("parallelToolCalls");
+  });
+
   it("ignores per-agent params when agentId does not match", () => {
     const result = resolveExtraParams({
       cfg: {
@@ -195,6 +229,7 @@ describe("applyExtraParamsToAgent", () => {
     applyModelId: string;
     model: Model<"openai-responses"> | Model<"openai-completions"> | Model<"anthropic-messages">;
     cfg?: Record<string, unknown>;
+    extraParamsOverride?: Record<string, unknown>;
   }) {
     const payload: Record<string, unknown> = {};
     const baseStreamFn: StreamFn = (_model, _context, options) => {
@@ -207,6 +242,7 @@ describe("applyExtraParamsToAgent", () => {
       params.cfg as Parameters<typeof applyExtraParamsToAgent>[1],
       params.applyProvider,
       params.applyModelId,
+      params.extraParamsOverride,
     );
     const context: Context = { messages: [] };
     void agent.streamFn?.(params.model, context, {});
@@ -1631,6 +1667,36 @@ describe("applyExtraParamsToAgent", () => {
       } as unknown as Model<"openai-responses">,
     });
     expect(payload.parallel_tool_calls).toBe(true);
+  });
+
+  it("lets extra param overrides win across parallel tool call aliases", () => {
+    const payload = runParallelToolCallsPayloadMutationCase({
+      applyProvider: "openai",
+      applyModelId: "gpt-5",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5": {
+                params: {
+                  parallel_tool_calls: true,
+                },
+              },
+            },
+          },
+        },
+      },
+      extraParamsOverride: {
+        parallelToolCalls: false,
+      },
+      model: {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5",
+        baseUrl: "https://proxy.example.com/v1",
+      } as unknown as Model<"openai-responses">,
+    });
+    expect(payload.parallel_tool_calls).toBe(false);
   });
 
   it("does not inject parallel_tool_calls for non OpenAI-compatible APIs", () => {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -15,6 +15,7 @@ const ANTHROPIC_1M_MODEL_PREFIXES = ["claude-opus-4", "claude-sonnet-4"] as cons
 // Codex responses (chatgpt.com/backend-api/codex/responses) require `store=false`.
 const OPENAI_RESPONSES_APIS = new Set(["openai-responses"]);
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai-responses"]);
+const PARALLEL_TOOL_CALLS_APIS = new Set(["openai-completions", "openai-responses"]);
 
 /**
  * Resolve provider-specific extra params from model config.
@@ -353,6 +354,21 @@ function resolveOpenAIServiceTier(
     log.warn(`ignoring invalid OpenAI service tier param: ${rawSummary}`);
   }
   return normalized;
+}
+
+function resolveParallelToolCalls(
+  extraParams: Record<string, unknown> | undefined,
+): boolean | undefined {
+  const raw = extraParams?.parallel_tool_calls ?? extraParams?.parallelToolCalls;
+  if (raw === undefined) {
+    return undefined;
+  }
+  if (typeof raw !== "boolean") {
+    const rawSummary = typeof raw === "string" ? raw : typeof raw;
+    log.warn(`ignoring invalid parallel tool calls param: ${rawSummary}`);
+    return undefined;
+  }
+  return raw;
 }
 
 function createOpenAIServiceTierWrapper(
@@ -1033,6 +1049,28 @@ function createZaiToolStreamWrapper(
   };
 }
 
+function createParallelToolCallsWrapper(
+  baseStreamFn: StreamFn | undefined,
+  parallelToolCalls: boolean,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (!PARALLEL_TOOL_CALLS_APIS.has(model.api)) {
+      return underlying(model, context, options);
+    }
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          (payload as Record<string, unknown>).parallel_tool_calls = parallelToolCalls;
+        }
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}
+
 /**
  * Apply extra params (like temperature) to an agent's streamFn.
  * Also adds OpenRouter app attribution headers when using the OpenRouter provider.
@@ -1137,6 +1175,12 @@ export function applyExtraParamsToAgent(
       log.debug(`enabling Z.AI tool_stream for ${provider}/${modelId}`);
       agent.streamFn = createZaiToolStreamWrapper(agent.streamFn, true);
     }
+  }
+
+  const parallelToolCalls = resolveParallelToolCalls(merged);
+  if (parallelToolCalls !== undefined) {
+    log.debug(`applying parallel_tool_calls=${parallelToolCalls} for ${provider}/${modelId}`);
+    agent.streamFn = createParallelToolCallsWrapper(agent.streamFn, parallelToolCalls);
   }
 
   // Guard Google payloads against invalid negative thinking budgets emitted by

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -1179,7 +1179,9 @@ export function applyExtraParamsToAgent(
 
   const parallelToolCalls = resolveParallelToolCalls(merged);
   if (parallelToolCalls !== undefined) {
-    log.debug(`applying parallel_tool_calls=${parallelToolCalls} for ${provider}/${modelId}`);
+    log.debug(
+      `configuring parallel_tool_calls wrapper=${parallelToolCalls} for ${provider}/${modelId}`,
+    );
     agent.streamFn = createParallelToolCallsWrapper(agent.streamFn, parallelToolCalls);
   }
 

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -17,6 +17,22 @@ const OPENAI_RESPONSES_APIS = new Set(["openai-responses"]);
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai-responses"]);
 const PARALLEL_TOOL_CALLS_APIS = new Set(["openai-completions", "openai-responses"]);
 
+function resolveParallelToolCallsAliasRaw(params: Record<string, unknown> | undefined): {
+  found: boolean;
+  value: unknown;
+} {
+  if (!params) {
+    return { found: false, value: undefined };
+  }
+  if (Object.prototype.hasOwnProperty.call(params, "parallel_tool_calls")) {
+    return { found: true, value: params.parallel_tool_calls };
+  }
+  if (Object.prototype.hasOwnProperty.call(params, "parallelToolCalls")) {
+    return { found: true, value: params.parallelToolCalls };
+  }
+  return { found: false, value: undefined };
+}
+
 function mergeExtraParamsWithAliasPrecedence(
   lowerPriority: Record<string, unknown> | undefined,
   higherPriority: Record<string, unknown> | undefined,
@@ -26,13 +42,12 @@ function mergeExtraParamsWithAliasPrecedence(
   }
 
   const merged = Object.assign({}, lowerPriority, higherPriority);
-  const parallelToolCallsRaw =
-    higherPriority?.parallel_tool_calls ??
-    higherPriority?.parallelToolCalls ??
-    lowerPriority?.parallel_tool_calls ??
-    lowerPriority?.parallelToolCalls;
-  if (parallelToolCallsRaw !== undefined) {
-    merged.parallel_tool_calls = parallelToolCallsRaw;
+  const higherParallelToolCalls = resolveParallelToolCallsAliasRaw(higherPriority);
+  const lowerParallelToolCalls = resolveParallelToolCallsAliasRaw(lowerPriority);
+  if (higherParallelToolCalls.found || lowerParallelToolCalls.found) {
+    merged.parallel_tool_calls = higherParallelToolCalls.found
+      ? higherParallelToolCalls.value
+      : lowerParallelToolCalls.value;
     delete merged.parallelToolCalls;
   }
   return merged;
@@ -380,10 +395,11 @@ function resolveOpenAIServiceTier(
 function resolveParallelToolCalls(
   extraParams: Record<string, unknown> | undefined,
 ): boolean | undefined {
-  const raw = extraParams?.parallel_tool_calls ?? extraParams?.parallelToolCalls;
-  if (raw === undefined) {
+  const rawAlias = resolveParallelToolCallsAliasRaw(extraParams);
+  if (!rawAlias.found) {
     return undefined;
   }
+  const raw = rawAlias.value;
   if (typeof raw !== "boolean") {
     const rawSummary = typeof raw === "string" ? raw : typeof raw;
     log.warn(`ignoring invalid parallel tool calls param: ${rawSummary}`);

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -17,6 +17,27 @@ const OPENAI_RESPONSES_APIS = new Set(["openai-responses"]);
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai-responses"]);
 const PARALLEL_TOOL_CALLS_APIS = new Set(["openai-completions", "openai-responses"]);
 
+function mergeExtraParamsWithAliasPrecedence(
+  lowerPriority: Record<string, unknown> | undefined,
+  higherPriority: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!lowerPriority && !higherPriority) {
+    return undefined;
+  }
+
+  const merged = Object.assign({}, lowerPriority, higherPriority);
+  const parallelToolCallsRaw =
+    higherPriority?.parallel_tool_calls ??
+    higherPriority?.parallelToolCalls ??
+    lowerPriority?.parallel_tool_calls ??
+    lowerPriority?.parallelToolCalls;
+  if (parallelToolCallsRaw !== undefined) {
+    merged.parallel_tool_calls = parallelToolCallsRaw;
+    delete merged.parallelToolCalls;
+  }
+  return merged;
+}
+
 /**
  * Resolve provider-specific extra params from model config.
  * Used to pass through stream params like temperature/maxTokens.
@@ -41,7 +62,7 @@ export function resolveExtraParams(params: {
     return undefined;
   }
 
-  return Object.assign({}, globalParams, agentParams);
+  return mergeExtraParamsWithAliasPrecedence(globalParams, agentParams);
 }
 
 type CacheRetention = "none" | "short" | "long";
@@ -1105,7 +1126,7 @@ export function applyExtraParamsToAgent(
           Object.entries(extraParamsOverride).filter(([, value]) => value !== undefined),
         )
       : undefined;
-  const merged = Object.assign({}, extraParams, override);
+  const merged = mergeExtraParamsWithAliasPrecedence(extraParams, override);
   const wrappedStreamFn = createStreamFnWithExtraParams(agent.streamFn, merged, provider);
 
   if (wrappedStreamFn) {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -17,6 +17,8 @@ const OPENAI_RESPONSES_APIS = new Set(["openai-responses"]);
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai-responses"]);
 const PARALLEL_TOOL_CALLS_APIS = new Set(["openai-completions", "openai-responses"]);
 
+// Use key presence (not nullish checks) so explicit higher-scope null values
+// still override lower defaults and flow into validation/warning logic.
 function resolveParallelToolCallsAliasRaw(params: Record<string, unknown> | undefined): {
   found: boolean;
   value: unknown;

--- a/src/cron/legacy-delivery.ts
+++ b/src/cron/legacy-delivery.ts
@@ -2,13 +2,13 @@ export function hasLegacyDeliveryHints(payload: Record<string, unknown>) {
   if (typeof payload.deliver === "boolean") {
     return true;
   }
-  if (typeof payload.bestEffortDeliver === "boolean") {
-    return true;
-  }
   if (typeof payload.channel === "string" && payload.channel.trim()) {
     return true;
   }
   if (typeof payload.provider === "string" && payload.provider.trim()) {
+    return true;
+  }
+  if (typeof payload.bestEffortDeliver === "boolean") {
     return true;
   }
   if (typeof payload.to === "string" && payload.to.trim()) {
@@ -22,16 +22,14 @@ export function buildDeliveryFromLegacyPayload(
 ): Record<string, unknown> {
   const deliver = payload.deliver;
   const mode = deliver === false ? "none" : "announce";
-  const channelRaw =
-    typeof payload.channel === "string" && payload.channel.trim()
-      ? payload.channel.trim().toLowerCase()
-      : typeof payload.provider === "string"
-        ? payload.provider.trim().toLowerCase()
-        : "";
+  const channelRaw = typeof payload.channel === "string" ? payload.channel.trim().toLowerCase() : "";
+  const providerRaw =
+    typeof payload.provider === "string" ? payload.provider.trim().toLowerCase() : "";
+  const resolvedChannel = channelRaw || providerRaw;
   const toRaw = typeof payload.to === "string" ? payload.to.trim() : "";
   const next: Record<string, unknown> = { mode };
-  if (channelRaw) {
-    next.channel = channelRaw;
+  if (resolvedChannel) {
+    next.channel = resolvedChannel;
   }
   if (toRaw) {
     next.to = toRaw;
@@ -46,11 +44,11 @@ export function stripLegacyDeliveryFields(payload: Record<string, unknown>) {
   if ("deliver" in payload) {
     delete payload.deliver;
   }
-  if ("channel" in payload) {
-    delete payload.channel;
-  }
   if ("provider" in payload) {
     delete payload.provider;
+  }
+  if ("channel" in payload) {
+    delete payload.channel;
   }
   if ("to" in payload) {
     delete payload.to;

--- a/src/cron/legacy-delivery.ts
+++ b/src/cron/legacy-delivery.ts
@@ -22,7 +22,8 @@ export function buildDeliveryFromLegacyPayload(
 ): Record<string, unknown> {
   const deliver = payload.deliver;
   const mode = deliver === false ? "none" : "announce";
-  const channelRaw = typeof payload.channel === "string" ? payload.channel.trim().toLowerCase() : "";
+  const channelRaw =
+    typeof payload.channel === "string" ? payload.channel.trim().toLowerCase() : "";
   const providerRaw =
     typeof payload.provider === "string" ? payload.provider.trim().toLowerCase() : "";
   const resolvedChannel = channelRaw || providerRaw;

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -193,6 +193,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 beforeEach(() => {
   fsState.entries.clear();
   fsState.nowMs = 0;
+  // Keep incrementing fixture ids across tests so cron store cache keys do not collide.
   ensureDir(fixturesRoot);
 });
 
@@ -542,7 +543,16 @@ describe("CronService", () => {
     const job = await addWakeModeNowMainSystemEventJob(cron, { name: "wakeMode now waits" });
 
     const runPromise = cron.run(job.id, "force");
-    await heartbeatStarted.promise;
+    // `cron.run()` now persists the running marker before executing the job.
+    // Allow more microtask turns so the post-lock execution can start.
+    for (let i = 0; i < 500; i++) {
+      if (runHeartbeatOnce.mock.calls.length > 0) {
+        break;
+      }
+      // Let the locked() chain progress.
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1);
+    }
 
     expect(runHeartbeatOnce).toHaveBeenCalledTimes(1);
     expect(requestHeartbeatNow).not.toHaveBeenCalled();

--- a/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
+++ b/src/cron/service.runs-one-shot-main-job-disables-it.test.ts
@@ -357,7 +357,8 @@ async function addWakeModeNowMainSystemEventJob(
     ...(options?.agentId ? { agentId: options.agentId } : {}),
     ...(options?.sessionKey ? { sessionKey: options.sessionKey } : {}),
     enabled: true,
-    schedule: { kind: "at", at: new Date(1).toISOString() },
+    // Keep this job out of normal due scans so force-run tests do not race with timer execution.
+    schedule: { kind: "at", at: new Date("2100-01-01T00:00:00.000Z").toISOString() },
     sessionTarget: "main",
     wakeMode: "now",
     payload: { kind: "systemEvent", text: "hello" },

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -300,6 +300,9 @@ async function resolveImagesForRequest(
   for (const url of urls) {
     const source = parseImageUrlToSource(url);
     if (source.type === "base64") {
+      if (typeof source.data !== "string") {
+        throw new Error("image_url data URI is missing payload data");
+      }
       const sourceBytes = estimateBase64DecodedBytes(source.data);
       if (totalBytes + sourceBytes > limits.maxTotalImageBytes) {
         throw new Error(


### PR DESCRIPTION
## Summary
- scope `parallel_tool_calls` payload injection to OpenAI-compatible request APIs only (`openai-completions`, `openai-responses`)
- support both `params.parallel_tool_calls` and `params.parallelToolCalls`
- ignore and warn on invalid non-boolean values instead of mutating payloads
- add regression tests for supported injection, unsupported API no-op, invalid value handling, and no-config behavior

## Why
Issue #37048 reports a high-impact regression where models that reject parallel tool calls return 400 and break tool execution. Existing proposals added payload injection but did not guard API compatibility. This patch keeps the fix while preventing accidental injection into strict non-OpenAI schemas.

## Validation
- `pnpm vitest run src/agents/pi-embedded-runner-extraparams.test.ts`
- `pnpm build`
- `pnpm check` currently fails in this branch due pre-existing unrelated type errors:
  - `src/gateway/openai-http.ts(303,48)`
  - `src/gateway/server-methods/chat.ts(938,9)`

## Related
- Closes #37048
- Supersedes the fix direction in #37201 by adding API scoping + config alias/validation coverage
