### PR TITLE
[Issue #37232] TTL-aware status layer: prevent stale facts in USER.md/MEMORY.md from being treated as current truth

### DIFF
--- a/.github/issue-bootstrap/issue-37232.md
+++ b/.github/issue-bootstrap/issue-37232.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37232
+- Title: TTL-aware status layer: prevent stale facts in USER.md/MEMORY.md from being treated as current truth
+- Source: https://github.com/openclaw/openclaw/issues/37232


### PR DESCRIPTION
## Source Issue
- Number: #37232
- URL: https://github.com/openclaw/openclaw/issues/37232
- Title: TTL-aware status layer: prevent stale facts in USER.md/MEMORY.md from being treated as current truth

## Original Issue Description
Issue reports stale time-sensitive facts in USER.md/MEMORY.md can be interpreted as current truth, causing incorrect inference.

Root cause described:
- USER.md/MEMORY.md are timeless markdown with no timestamp/TTL/review date.
- Agent inference cannot separate durable facts from ephemeral status reliably.

Requested mitigation in issue:
- Split durable memory from time-bounded status (for example STATUS.md/NOW.md).
- Add explicit `updatedAt` and review/expiry (TTL) metadata.
- Prefer absolute dates for time-sensitive context.
- Add targeted cross-validation guardrails for time/location/itinerary/project-stage inferences.

Full original description: https://github.com/openclaw/openclaw/issues/37232

Closes #37232