### PR TITLE
[Issue #37235] [Bug] Media download returns cached/wrong image - all images have same MD5

### DIFF
--- a/.github/issue-bootstrap/issue-37235.md
+++ b/.github/issue-bootstrap/issue-37235.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37235
+- Title: [Bug] Media download returns cached/wrong image - all images have same MD5
+- Source: https://github.com/openclaw/openclaw/issues/37235


### PR DESCRIPTION
## Source Issue
- Number: #37235
- URL: https://github.com/openclaw/openclaw/issues/37235
- Title: [Bug] Media download returns cached/wrong image - all images have same MD5

## Original Issue Description
Issue reports downloaded inbound images are incorrect and share the same MD5 hash despite different source images.

Observed behavior from issue:
- Different images sent through Feishu/WebChat are saved with different UUID filenames but identical content hash.
- Image recognition is effectively broken because the wrong image content is delivered downstream.

Expected behavior:
- Each downloaded file should match the actual source image sent by user.

Environment noted:
- OpenClaw 2026.3.2 on Linux x86_64 (Ubuntu 22.04)
- Affected channels include Feishu and WebChat.

Full original description: https://github.com/openclaw/openclaw/issues/37235

Closes #37235