### PR TITLE
[Issue #37239] Internal reminder note leaks into chat output

### DIFF
--- a/.github/issue-bootstrap/issue-37239.md
+++ b/.github/issue-bootstrap/issue-37239.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37239
+- Title: Internal reminder note leaks into chat output
+- Source: https://github.com/openclaw/openclaw/issues/37239


### PR DESCRIPTION
## Source Issue
- Number: #37239
- URL: https://github.com/openclaw/openclaw/issues/37239
- Title: Internal reminder note leaks into chat output

## Original Issue Description
Issue reports an internal annotation can leak into user-visible channel output when no reminder/cron is scheduled in a turn.

Repro from issue:
- In turns without cron-tool usage, the note
  "Note: I did not schedule a reminder in this turn, so this will not trigger automatically."
  may appear in user-visible Discord messages.

Expected behavior:
- Internal system annotations should never be user-visible on delivery surfaces.

Full original description: https://github.com/openclaw/openclaw/issues/37239

Closes #37239