### PR TITLE
[Issue #37243] [Bug] TUI reply goes to wrong channel after upgrade to v2026.3.2

### DIFF
--- a/.github/issue-bootstrap/issue-37243.md
+++ b/.github/issue-bootstrap/issue-37243.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37243
+- Title: [Bug] TUI reply goes to wrong channel after upgrade to v2026.3.2
+- Source: https://github.com/openclaw/openclaw/issues/37243


### PR DESCRIPTION
## Source Issue
- Number: #37243
- URL: https://github.com/openclaw/openclaw/issues/37243
- Title: [Bug] TUI reply goes to wrong channel after upgrade to v2026.3.2

## Original Issue Description
Issue reports regression after upgrade from v2026.2.25 to v2026.3.2: messages sent from TUI are replied to in Telegram instead of back in TUI.

Issue form details:
- Bug type: Regression.
- Repro: configure Telegram, send from TUI, observe reply routed to Telegram.
- Expected: responses should return to TUI for TUI-originated messages.
- Actual: replies go to Telegram consistently.

Environment in issue:
- OpenClaw 2026.3.2 on Windows 11.

Full original description: https://github.com/openclaw/openclaw/issues/37243

Closes #37243