### PR TITLE
Telegram: skip empty text replies before send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/empty final reply guard: silently skip whitespace-only outbound text replies before `sendMessage` so blank agent acks no longer trigger Telegram 400 errors or restart the gateway. (#37278) Thanks @EanHD.
 - Tools/web_search Brave language-code validation: align `search_lang` handling with Brave-supported codes (including `zh-hans`, `zh-hant`, `en-gb`, and `pt-br`), map common alias inputs (`zh`, `ja`) to valid Brave values, and reject unsupported codes before upstream requests to prevent 422 failures. (#37260) Thanks @heyanming.
 - Models/openai-completions streaming compatibility: force `compat.supportsUsageInStreaming=false` for non-native OpenAI-compatible endpoints during model normalization, preventing usage-only stream chunks from triggering `choices[0]` parser crashes in provider streams. (#8714) Thanks @nonanon1.
 - Tools/xAI native web-search collision guard: drop OpenClaw `web_search` from tool registration when routing to xAI/Grok model providers (including OpenRouter `x-ai/*`) to avoid duplicate tool-name request failures against provider-native `web_search`. (#14749) Thanks @realsamrat.

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -94,6 +94,10 @@ function markDelivered(progress: DeliveryProgress): void {
   progress.deliveredCount += 1;
 }
 
+function shouldSkipTelegramTextChunk(chunk: { html: string; text: string } | undefined): boolean {
+  return !chunk || (!chunk.html.trim() && !chunk.text.trim());
+}
+
 async function deliverTextReply(params: {
   bot: Bot;
   chatId: string;
@@ -112,7 +116,7 @@ async function deliverTextReply(params: {
   const chunks = params.chunkText(params.replyText);
   for (let i = 0; i < chunks.length; i += 1) {
     const chunk = chunks[i];
-    if (!chunk) {
+    if (shouldSkipTelegramTextChunk(chunk)) {
       continue;
     }
     const shouldAttachButtons = i === 0 && params.replyMarkup;
@@ -161,6 +165,9 @@ async function sendPendingFollowUpText(params: {
   const chunks = params.chunkText(params.text);
   for (let i = 0; i < chunks.length; i += 1) {
     const chunk = chunks[i];
+    if (shouldSkipTelegramTextChunk(chunk)) {
+      continue;
+    }
     const replyToForFollowUp = resolveReplyToForSend({
       replyToId: params.replyToId,
       replyToMode: params.replyToMode,
@@ -210,6 +217,9 @@ async function sendTelegramVoiceFallbackText(opts: {
   let appliedReplyTo = false;
   for (let i = 0; i < chunks.length; i += 1) {
     const chunk = chunks[i];
+    if (shouldSkipTelegramTextChunk(chunk)) {
+      continue;
+    }
     // Only apply reply reference, quote text, and buttons to the first chunk.
     const replyToForChunk = !appliedReplyTo ? opts.replyToId : undefined;
     const messageId = await sendTelegramText(opts.bot, opts.chatId, chunk.html, opts.runtime, {
@@ -534,16 +544,11 @@ export async function deliverReplies(params: {
         ? [reply.mediaUrl]
         : [];
     const hasMedia = mediaList.length > 0;
-    if (!reply?.text && !hasMedia) {
-      if (reply?.audioAsVoice) {
-        logVerbose("telegram reply has audioAsVoice without media/text; skipping");
-        continue;
-      }
-      params.runtime.error?.(danger("reply missing text/media"));
+    const rawContent = reply?.text || "";
+    if (reply?.audioAsVoice && !rawContent && !hasMedia) {
+      logVerbose("telegram reply has audioAsVoice without media/text; skipping");
       continue;
     }
-
-    const rawContent = reply.text || "";
     if (hasMessageSendingHooks) {
       const hookResult = await hookRunner?.runMessageSending(
         {
@@ -569,7 +574,48 @@ export async function deliverReplies(params: {
       }
     }
 
-    const contentForSentHook = reply.text || "";
+    const replyText = reply?.text;
+    const contentForSentHook = replyText || "";
+    if (!hasMedia) {
+      if (typeof replyText !== "string") {
+        params.runtime.error?.(danger("reply missing text/media"));
+        if (hasMessageSentHooks) {
+          void hookRunner?.runMessageSent(
+            {
+              to: params.chatId,
+              content: contentForSentHook,
+              success: false,
+              error: "reply missing text/media",
+            },
+            {
+              channelId: "telegram",
+              accountId: params.accountId,
+              conversationId: params.chatId,
+            },
+          );
+        }
+        continue;
+      }
+      if (!replyText.trim()) {
+        logVerbose("telegram reply text empty after hooks/normalization; skipping");
+        if (hasMessageSentHooks) {
+          void hookRunner?.runMessageSent(
+            {
+              to: params.chatId,
+              content: contentForSentHook,
+              success: false,
+              error: "telegram reply text empty after hooks/normalization",
+            },
+            {
+              channelId: "telegram",
+              accountId: params.accountId,
+              conversationId: params.chatId,
+            },
+          );
+        }
+        continue;
+      }
+    }
 
     try {
       const deliveredCountBeforeReply = progress.deliveredCount;
@@ -586,7 +632,7 @@ export async function deliverReplies(params: {
           runtime: params.runtime,
           thread: params.thread,
           chunkText,
-          replyText: reply.text || "",
+          replyText: replyText || "",
           replyMarkup,
           replyQuoteText: params.replyQuoteText,
           linkPreview: params.linkPreview,

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -474,7 +474,7 @@ describe("deliverReplies", () => {
     );
   });
 
-  it("throws when formatted and plain fallback text are both empty", async () => {
+  it("silently skips whitespace-only text replies", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn();
     const bot = { api: { sendMessage } } as unknown as Bot;
@@ -489,7 +489,8 @@ describe("deliverReplies", () => {
         replyToMode: "off",
         textLimit: 4000,
       }),
-    ).rejects.toThrow("empty formatted text and empty plain fallback");
+    ).resolves.toEqual({ delivered: false });
+
     expect(sendMessage).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram final reply delivery could treat whitespace-only text payloads as send failures, bubbling an internal empty-text guard or Telegram 400 back up the provider path.
- Why it matters: blank agent acks like `NO_REPLY`/heartbeat-adjacent empty replies should be dropped silently, not crash/restart the Telegram channel.
- What changed: skip whitespace-only Telegram text replies before `sendMessage`, skip empty rendered text chunks/follow-ups, and keep `message_sent(success=false)` hook reporting when hooks blank a text-only reply.
- What did NOT change (scope boundary): no changes to generic outbound normalization, silent-token parsing, or Telegram media delivery semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37278
- Related #37278

## User-visible / Behavior Changes

- Telegram now silently skips whitespace-only final text replies instead of surfacing an empty-text send failure that can disrupt the channel.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3
- Runtime/container: Node v22.17.0
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): default Telegram reply delivery path

### Steps

1. Call Telegram reply delivery with a text-only payload whose final text is blank/whitespace after normalization or hook mutation.
2. Observe the provider path before this fix propagate an empty-text failure instead of silently dropping the reply.
3. Run the delivery path after this change and confirm no `sendMessage` call is attempted for the blank reply.

### Expected

- Blank Telegram text replies are dropped without an API call or provider crash.

### Actual

- Before this fix, the empty-text path could throw `telegram sendMessage failed: empty formatted text and empty plain fallback` or hit Telegram's `text must be non-empty` 400.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test src/telegram/bot/delivery.test.ts`; confirmed whitespace-only text replies are skipped, malformed replies still allow later valid replies through, and hook-blanked replies still report `message_sent(success=false)`.
- Edge cases checked: markdown chunks that render empty, follow-up text chunks, and voice-fallback text path all skip empty text chunks instead of attempting a send.
- What you did **not** verify: live Telegram delivery against a real bot/chat.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `8bfbcc207`.
- Files/config to restore: `src/telegram/bot/delivery.replies.ts`, `src/telegram/bot/delivery.test.ts`, `CHANGELOG.md`.
- Known bad symptoms reviewers should watch for: legitimate non-empty Telegram replies being skipped unexpectedly.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: a non-empty reply chunk could be skipped if the empty-chunk guard is too aggressive.
  - Mitigation: the guard only skips when both rendered HTML and plain fallback trim to empty, and the regression suite covers normal text, markdown-fallback, malformed entries, and hook-mutated replies.

AI-assisted: Codex.
Testing: fully tested locally with `pnpm test src/telegram/bot/delivery.test.ts` and `pnpm build`; `pnpm check` is currently red on `origin/main` due existing baseline issues in `extensions/tlon` (`@tloncorp/api` missing) and `src/gateway/openai-http.ts` (pre-existing type error).
