### PR TITLE
docs(troubleshooting): add Xfinity SSL error section for FAQ anchor link

### DIFF
--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -34,6 +34,14 @@ Good output in one line:
 - `openclaw channels status --probe` → channels report `connected` or `ready`.
 - `openclaw logs --follow` → steady activity, no repeating fatal errors.
 
+## docs.openclaw.ai shows an SSL error Comcast/Xfinity
+
+If you see SSL/connection errors when accessing `docs.openclaw.ai` from a Comcast/Xfinity connection:
+
+1. **Disable Xfinity Advanced Security** or allowlist `docs.openclaw.ai`
+2. **Report the false positive** at [https://spa.xfinity.com/check_url_status](https://spa.xfinity.com/check_url_status)
+3. **Use the GitHub mirror** if the site remains blocked: [https://github.com/openclaw/openclaw/tree/main/docs](https://github.com/openclaw/openclaw/tree/main/docs)
+
 ## Anthropic long context 429
 
 If you see:


### PR DESCRIPTION
## Summary

Fixes #36970 - adds missing troubleshooting section for Xfinity/SSL errors that FAQ links to.

## Problem

The FAQ page contains a link to `/help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity` but that anchor does not exist in `troubleshooting.md`.

## Solution

Add a section in `troubleshooting.md` with the corresponding anchor that provides:
- Steps to disable Xfinity Advanced Security or allowlist docs.openclaw.ai
- Link to Xfinity URL status checker for reporting false positives
- Alternative GitHub docs mirror

## Testing

Verified the anchor ID matches the FAQ link format.