### PR TITLE
feat(extension): add configurable audio-chat plugin for Telegram voice bubbles

### DIFF
--- a/extensions/audio-chat/README.md
+++ b/extensions/audio-chat/README.md
@@ -1,0 +1,40 @@
+# audio-chat
+
+Auto-send Telegram voice bubble replies from assistant text using local TTS.
+
+## Features
+
+- `/audio_chat on|off|status|max <n>` command
+- Per-chat enable/disable state persisted in gateway state dir
+- Markdown cleanup before TTS
+- Max-length guard with tip message
+- Debounced send to avoid duplicate voice output
+
+## Config
+
+Use `extensions.audioChat` (or `audioChat`) in gateway config:
+
+```json
+{
+  "extensions": {
+    "audioChat": {
+      "enabledByDefault": false,
+      "channels": ["telegram"],
+      "defaultMaxChars": 150,
+      "tooLongTip": "Message too long, skipped voice reply",
+      "voice": "zh-CN-YunxiaNeural",
+      "access": {
+        "directOnly": true,
+        "allowUserIds": []
+      }
+    }
+  }
+}
+```
+
+## Dependencies
+
+- `edge-tts` (Python module)
+- `ffmpeg`
+
+This plugin synthesizes speech locally and sends Telegram voice messages (`asVoice=true`).

--- a/extensions/audio-chat/index.ts
+++ b/extensions/audio-chat/index.ts
@@ -362,11 +362,20 @@ export default function register(api: any) {
       lastUpdatedAt: number;
     }
   >();
+  const outboundSeenAtByChat = new Map<string, number>();
+  const lastVoiceSentByChat = new Map<string, { text: string; at: number }>();
 
   function extractChatIdFromTo(to: string): string | null {
-    // Accept: "850..." or "telegram:850..." or "telegram:direct:850..." etc.
-    const m = String(to).match(/(\d+)$/);
+    // Accept: "850..." / "-100..." or "telegram:850..." / "telegram:-100..." etc.
+    const m = String(to).match(/(-?\d+)$/);
     return m?.[1] ?? null;
+  }
+
+  function isLikelyGroupTarget(to: string, chatId: string | null): boolean {
+    if (String(to).includes(":group:")) return true;
+    if (!chatId) return false;
+    // Telegram groups/supergroups are negative chat ids (commonly -100...)
+    return chatId.startsWith("-");
   }
 
   function resolveSendMessageTelegram() {
@@ -390,6 +399,7 @@ export default function register(api: any) {
     maxChars: number;
     textLen: number;
     tipText: string;
+    accountId?: string;
   }) {
     // Avoid loops and avoid spamming when multiple hooks fire.
     const now = nowMs();
@@ -401,7 +411,9 @@ export default function register(api: any) {
 
     try {
       const sendMessageTelegram = resolveSendMessageTelegram();
-      await sendMessageTelegram(params.to, tipText, {});
+      await sendMessageTelegram(params.to, tipText, {
+        ...(params.accountId ? { accountId: params.accountId } : {}),
+      });
       logger.info?.(
         `[${PLUGIN_ID}] too-long tip sent (chatId=${params.chatId} len=${params.textLen} max=${params.maxChars})`,
       );
@@ -416,6 +428,7 @@ export default function register(api: any) {
     to: string;
     text: string;
     maxChars: number;
+    accountId?: string;
   }) {
     const textRaw = (params.text ?? "").trim();
     const text = stripMarkdownForTTS(textRaw);
@@ -503,6 +516,7 @@ export default function register(api: any) {
       await sendMessageTelegram(params.to, "", {
         mediaUrl: oggPath,
         asVoice: true,
+        ...(params.accountId ? { accountId: params.accountId } : {}),
       });
     } finally {
       // Best-effort cleanup to avoid unbounded media growth.
@@ -525,13 +539,13 @@ export default function register(api: any) {
 
       const pluginCfg = getPluginConfig(api);
 
-      // Only act on configured outbound channels that succeeded (for sent phase).
+      // Only act on configured outbound channels after successful delivery.
       if (!isChannelAllowed(pluginCfg, channelId)) return;
-      if (phase === "sent" && !event?.success) return;
-      if (pluginCfg.access.directOnly && String(to).includes(":group:")) return;
+      if (!event?.success) return;
 
       const chatId = extractChatIdFromTo(to);
       if (!chatId) return;
+      if (pluginCfg.access.directOnly && isLikelyGroupTarget(to, chatId)) return;
       if (!isUserAllowed(pluginCfg, chatId)) return;
 
       const sessionKey = `agent:main:telegram:direct:${chatId}`;
@@ -555,11 +569,14 @@ export default function register(api: any) {
           maxChars,
           textLen: trimmed.length,
           tipText: pluginCfg.tooLongTip,
+          accountId: String(ctx?.accountId ?? "") || undefined,
         });
         return;
       }
 
       const key = chatId;
+      outboundSeenAtByChat.set(key, nowMs());
+
       const prev = pendingByChat.get(key);
       if (prev) clearTimeout(prev.timer);
 
@@ -568,7 +585,18 @@ export default function register(api: any) {
         if (!cur) return;
         pendingByChat.delete(key);
         try {
-          await synthAndSendVoice({ to, text: cur.lastText, maxChars });
+          const lastSent = lastVoiceSentByChat.get(key);
+          if (lastSent && lastSent.text === cur.lastText && nowMs() - lastSent.at < 10_000) {
+            return;
+          }
+
+          await synthAndSendVoice({
+            to,
+            text: cur.lastText,
+            maxChars,
+            accountId: String(ctx?.accountId ?? "") || undefined,
+          });
+          lastVoiceSentByChat.set(key, { text: cur.lastText, at: nowMs() });
           logger.info?.(`[${PLUGIN_ID}] voice-sent ok (to=${to})`);
         } catch (err: any) {
           logger.warn?.(
@@ -589,12 +617,8 @@ export default function register(api: any) {
     }
   }
 
-  // NOTE: In some gateway paths, outbound message hooks may not fire for agent replies.
-  // Keep them registered (useful for message tool sends), but also add an agent_end fallback.
-  api.on("message_sending", async (event: any, ctx: any) => {
-    await handleOutboundHook("sending", event, ctx);
-  });
-
+  // NOTE: Prefer message_sent (post-delivery) to avoid speaking messages that later fail/cancel.
+  // Keep agent_end as a guarded fallback for paths where outbound hooks may not fire.
   api.on("message_sent", async (event: any, ctx: any) => {
     await handleOutboundHook("sent", event, ctx);
   });
@@ -602,6 +626,8 @@ export default function register(api: any) {
   api.on("agent_end", async (event: any, ctx: any) => {
     try {
       const pluginCfg = getPluginConfig(api);
+      if (event?.success === false) return;
+
       const sessionKey = String(ctx?.sessionKey ?? "");
       if (!isTelegramDirectSessionKey(sessionKey)) return;
       if (pluginCfg.access.directOnly && !sessionKey.includes(":direct:")) return;
@@ -609,6 +635,10 @@ export default function register(api: any) {
       const chatId = sessionKeyToChatId(sessionKey);
       if (!chatId) return;
       if (!isUserAllowed(pluginCfg, chatId)) return;
+
+      // If outbound hook already observed this chat very recently, skip fallback to avoid duplicate voice sends.
+      const outboundSeenAt = outboundSeenAtByChat.get(chatId) ?? 0;
+      if (nowMs() - outboundSeenAt < 4_000) return;
 
       const entry = await getBySessionKey(sessionKey);
       const enabled = entry?.enabled ?? pluginCfg.enabledByDefault;
@@ -670,6 +700,7 @@ export default function register(api: any) {
           maxChars,
           textLen: trimmed.length,
           tipText: pluginCfg.tooLongTip,
+          accountId: String(ctx?.accountId ?? "") || undefined,
         });
         return;
       }
@@ -684,7 +715,18 @@ export default function register(api: any) {
         if (!cur) return;
         pendingByChat.delete(key);
         try {
-          await synthAndSendVoice({ to: chatId, text: cur.lastText, maxChars });
+          const lastSent = lastVoiceSentByChat.get(key);
+          if (lastSent && lastSent.text === cur.lastText && nowMs() - lastSent.at < 10_000) {
+            return;
+          }
+
+          await synthAndSendVoice({
+            to: chatId,
+            text: cur.lastText,
+            maxChars,
+            accountId: String(ctx?.accountId ?? "") || undefined,
+          });
+          lastVoiceSentByChat.set(key, { text: cur.lastText, at: nowMs() });
           logger.info?.(
             `[${PLUGIN_ID}] voice-sent ok (agent_end to=${chatId})`,
           );

--- a/extensions/audio-chat/index.ts
+++ b/extensions/audio-chat/index.ts
@@ -390,7 +390,6 @@ export default function register(api: any) {
     maxChars: number;
     textLen: number;
     tipText: string;
-    replyToMessageId?: number;
   }) {
     // Avoid loops and avoid spamming when multiple hooks fire.
     const now = nowMs();
@@ -459,51 +458,56 @@ export default function register(api: any) {
       }
     }
 
-    // 1) Edge TTS -> mp3
-    const edgeTtsPython = await resolveEdgeTtsPython();
-    await api.runtime.system.runCommandWithTimeout(
-      [
-        edgeTtsPython,
-        "-m",
-        "edge_tts",
-        "--voice",
-        voice,
-        "--text",
-        text,
-        "--write-media",
-        mp3Path,
-      ],
-      { timeoutMs: 60_000 },
-    );
+    try {
+      // 1) Edge TTS -> mp3
+      const edgeTtsPython = await resolveEdgeTtsPython();
+      await api.runtime.system.runCommandWithTimeout(
+        [
+          edgeTtsPython,
+          "-m",
+          "edge_tts",
+          "--voice",
+          voice,
+          "--text",
+          text,
+          "--write-media",
+          mp3Path,
+        ],
+        { timeoutMs: 60_000 },
+      );
 
-    // 2) ffmpeg mp3 -> ogg/opus
-    await api.runtime.system.runCommandWithTimeout(
-      [
-        "ffmpeg",
-        "-y",
-        "-i",
-        mp3Path,
-        "-ar",
-        "48000",
-        "-ac",
-        "1",
-        "-c:a",
-        "libopus",
-        "-b:a",
-        "32k",
-        oggPath,
-      ],
-      { timeoutMs: 60_000 },
-    );
+      // 2) ffmpeg mp3 -> ogg/opus
+      await api.runtime.system.runCommandWithTimeout(
+        [
+          "ffmpeg",
+          "-y",
+          "-i",
+          mp3Path,
+          "-ar",
+          "48000",
+          "-ac",
+          "1",
+          "-c:a",
+          "libopus",
+          "-b:a",
+          "32k",
+          oggPath,
+        ],
+        { timeoutMs: 60_000 },
+      );
 
-    // 3) send voice bubble (asVoice=true)
-    // NOTE: Telegram send supports local media paths under allowed roots.
-    const sendMessageTelegram = resolveSendMessageTelegram();
+      // 3) send voice bubble (asVoice=true)
+      // NOTE: Telegram send supports local media paths under allowed roots.
+      const sendMessageTelegram = resolveSendMessageTelegram();
 
-    await sendMessageTelegram(params.to, "", {
-      mediaUrl: oggPath,
-      asVoice: true,
-    });
+      await sendMessageTelegram(params.to, "", {
+        mediaUrl: oggPath,
+        asVoice: true,
+      });
+    } finally {
+      // Best-effort cleanup to avoid unbounded media growth.
+      await Promise.allSettled([fs.unlink(mp3Path), fs.unlink(oggPath)]);
+    }
   }
 
   async function handleOutboundHook(
@@ -541,27 +545,16 @@ export default function register(api: any) {
 
       // (reply-to cache removed)
 
-      // Don't react to our own tip.
-      if (trimmed === pluginCfg.tooLongTip) return;
+      // Don't react to our own tip (tip adds suffix like "（len/max）").
+      if (trimmed.startsWith(pluginCfg.tooLongTip)) return;
 
       if (trimmed.length > maxChars) {
-        // Best-effort: reply to the message we just sent (if we can find its message id).
-        const replyToMessageIdRaw =
-          event?.messageId ??
-          event?.result?.messageId ??
-          event?.telegram?.messageId ??
-          event?.telegram?.result?.messageId;
-        const replyToMessageId = Number(replyToMessageIdRaw);
-
         await maybeSendTooLongTip({
           to,
           chatId,
           maxChars,
           textLen: trimmed.length,
           tipText: pluginCfg.tooLongTip,
-          replyToMessageId: Number.isFinite(replyToMessageId)
-            ? replyToMessageId
-            : undefined,
         });
         return;
       }
@@ -667,8 +660,8 @@ export default function register(api: any) {
 
       if (!trimmed) return;
 
-      // Don't react to our own tip.
-      if (trimmed === pluginCfg.tooLongTip) return;
+      // Don't react to our own tip (tip adds suffix like "（len/max）").
+      if (trimmed.startsWith(pluginCfg.tooLongTip)) return;
 
       if (trimmed.length > maxChars) {
         await maybeSendTooLongTip({

--- a/extensions/audio-chat/index.ts
+++ b/extensions/audio-chat/index.ts
@@ -1,0 +1,720 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Bump this string whenever you want to confirm which build is loaded at runtime.
+const BUILD_FINGERPRINT = "audio-chat@2026-03-06a";
+
+// Debug / forensics toggles.
+// Keep this OFF in normal use to avoid log spam and extra disk writes.
+const DEBUG_FORENSICS = false;
+
+const PLUGIN_ID = "audio-chat";
+
+const DEFAULT_MAX_CHARS = 150;
+const DEFAULT_TOO_LONG_TIP = "本次回复字数过长未发语音";
+const DEFAULT_VOICE = "zh-CN-YunxiaNeural";
+
+type AudioChatPluginConfig = {
+  enabledByDefault: boolean;
+  channels: string[];
+  defaultMaxChars: number;
+  tooLongTip: string;
+  voice: string;
+  access: {
+    directOnly: boolean;
+    allowUserIds: string[];
+  };
+};
+
+function normalizeStringList(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .map((x) => String(x ?? "").trim())
+    .filter(Boolean);
+}
+
+function getPluginConfig(api: any): AudioChatPluginConfig {
+  const cfg = api?.runtime?.config?.loadConfig?.() ?? {};
+  const root = cfg?.extensions?.audioChat ?? cfg?.audioChat ?? {};
+  const access = root?.access ?? {};
+
+  const channels = normalizeStringList(root?.channels);
+  const allowUserIds = normalizeStringList(access?.allowUserIds);
+
+  const maxCharsRaw = Number(root?.defaultMaxChars);
+  const defaultMaxChars =
+    Number.isFinite(maxCharsRaw) && maxCharsRaw >= 10 && maxCharsRaw <= 5000
+      ? maxCharsRaw
+      : DEFAULT_MAX_CHARS;
+
+  return {
+    enabledByDefault: Boolean(root?.enabledByDefault ?? false),
+    channels: channels.length > 0 ? channels : ["telegram"],
+    defaultMaxChars,
+    tooLongTip:
+      String(root?.tooLongTip ?? DEFAULT_TOO_LONG_TIP).trim() ||
+      DEFAULT_TOO_LONG_TIP,
+    voice: String(root?.voice ?? DEFAULT_VOICE).trim() || DEFAULT_VOICE,
+    access: {
+      directOnly: Boolean(access?.directOnly ?? true),
+      allowUserIds,
+    },
+  };
+}
+
+function isChannelAllowed(cfg: AudioChatPluginConfig, channel: string): boolean {
+  return cfg.channels.includes(channel);
+}
+
+function isUserAllowed(cfg: AudioChatPluginConfig, userId?: string | null): boolean {
+  const id = String(userId ?? "").trim();
+  if (cfg.access.allowUserIds.length === 0) return true;
+  if (!id) return false;
+  return cfg.access.allowUserIds.includes(id);
+}
+
+// Pin edge-tts to a dedicated virtualenv to avoid breakage when Homebrew python upgrades.
+const AUDIO_CHAT_VENV_PYTHON = path.join(
+  process.env.HOME ?? "",
+  ".openclaw",
+  "venvs",
+  "audio-chat",
+  "bin",
+  "python",
+);
+
+function stripMarkdownForTTS(input: string): string {
+  let s = String(input ?? "");
+
+  // 0) Remove OpenClaw reply tags (e.g. [[reply_to_current]]) that should never be spoken.
+  s = s.replace(/^\s*\[\[[^\]]+\]\]\s*/g, "");
+
+  // 1) Fenced code blocks -> placeholder (avoid reading long code/symbol soup)
+  // ```lang\n...\n```
+  s = s.replace(/```[\s\S]*?```/g, "\n（代码略）\n");
+
+  // 2) Inline code: keep the content, just drop backticks.
+  // This avoids the annoying "这里有一段代码" being read for small inline snippets.
+  s = s.replace(/`([^`]*)`/g, "$1");
+
+  // 3) Links: [title](url) -> title
+  s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1");
+
+  // 4) Bare URLs -> drop
+  s = s.replace(/https?:\/\/\S+/g, "");
+
+  // 5) Common markdown markers
+  // Keep the words, drop markers.
+  s = s
+    .replace(/[*_~]/g, "") // emphasis/strikethrough markers
+    .replace(/^\s{0,3}#+\s+/gm, "") // headings
+    .replace(/^\s*>\s?/gm, "") // blockquotes
+    .replace(/^\s*[-+•]\s+/gm, ""); // list bullets
+
+  // 6) Cleanup whitespace
+  s = s.replace(/\n{3,}/g, "\n\n");
+  s = s.replace(/[ \t]{2,}/g, " ");
+
+  return s.trim();
+}
+
+type VoiceState = {
+  version: number;
+  updatedAt: number;
+  entries: Record<
+    string,
+    {
+      enabled: boolean;
+      maxChars: number;
+      updatedAt: number;
+    }
+  >;
+};
+
+function nowMs() {
+  return Date.now();
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveEdgeTtsPython() {
+  // Prefer pinned venv python; fallback to system python3 for backward compatibility.
+  if (AUDIO_CHAT_VENV_PYTHON && (await pathExists(AUDIO_CHAT_VENV_PYTHON))) {
+    return AUDIO_CHAT_VENV_PYTHON;
+  }
+  return "python3";
+}
+
+function isTelegramDirectSessionKey(sessionKey?: string) {
+  return (
+    typeof sessionKey === "string" && sessionKey.includes(":telegram:direct:")
+  );
+}
+
+function sessionKeyToChatId(sessionKey: string): string | null {
+  // agent:main:telegram:direct:<chatId>
+  const m = sessionKey.match(/:telegram:direct:(\d+)$/);
+  return m?.[1] ?? null;
+}
+
+function makeEntryKeyFromSessionKey(sessionKey: string) {
+  // Keep it explicit in case other surfaces reuse ids.
+  const chatId = sessionKeyToChatId(sessionKey);
+  if (!chatId) return null;
+  return `telegram:direct:${chatId}`;
+}
+
+async function loadState(stateDir: string, logger: any): Promise<VoiceState> {
+  const file = path.join(stateDir, "audio-chat.json");
+  try {
+    const raw = await fs.readFile(file, "utf8");
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") throw new Error("bad state");
+    return {
+      version: typeof parsed.version === "number" ? parsed.version : 1,
+      updatedAt:
+        typeof parsed.updatedAt === "number" ? parsed.updatedAt : nowMs(),
+      entries:
+        typeof parsed.entries === "object" && parsed.entries
+          ? parsed.entries
+          : {},
+    } as VoiceState;
+  } catch (err: any) {
+    if (err?.code !== "ENOENT")
+      logger.warn?.(
+        `[${PLUGIN_ID}] state load failed; using empty: ${String(err?.message ?? err)}`,
+      );
+    return { version: 1, updatedAt: nowMs(), entries: {} };
+  }
+}
+
+async function saveState(stateDir: string, state: VoiceState) {
+  const file = path.join(stateDir, "audio-chat.json");
+  await fs.mkdir(stateDir, { recursive: true });
+  await fs.writeFile(file, JSON.stringify(state, null, 2) + "\n", "utf8");
+}
+
+export default function register(api: any) {
+  const logger = api.logger;
+  const stateDir = api.runtime.state.resolveStateDir(api.config);
+
+  // Startup fingerprint: helps verify which exact file/version the gateway loaded.
+  // This should appear exactly once after each gateway restart.
+  (async () => {
+    try {
+      const filePath = fileURLToPath(import.meta.url);
+      const st = await fs.stat(filePath);
+      logger.info?.(
+        `[${PLUGIN_ID}] boot fingerprint=${BUILD_FINGERPRINT} file=${filePath} mtimeMs=${st.mtimeMs} size=${st.size}`,
+      );
+    } catch (err: any) {
+      logger.warn?.(
+        `[${PLUGIN_ID}] boot fingerprint failed: ${String(err?.message ?? err)} (fingerprint=${BUILD_FINGERPRINT})`,
+      );
+    }
+
+    // Startup healthcheck: verify edge-tts and ffmpeg availability.
+    try {
+      const py = await resolveEdgeTtsPython();
+      await api.runtime.system.runCommandWithTimeout(
+        [py, "-m", "edge_tts", "--help"],
+        { timeoutMs: 15_000 },
+      );
+      await api.runtime.system.runCommandWithTimeout(["ffmpeg", "-version"], {
+        timeoutMs: 15_000,
+      });
+      logger.info?.(`[${PLUGIN_ID}] deps ok (python=${py}, ffmpeg=ok)`);
+    } catch (err: any) {
+      logger.warn?.(
+        `[${PLUGIN_ID}] deps check failed: ${String(err?.message ?? err)}. ` +
+          `Fix: python3 -m venv ~/.openclaw/venvs/audio-chat && ` +
+          `~/.openclaw/venvs/audio-chat/bin/python -m pip install -U pip edge-tts`,
+      );
+    }
+  })();
+
+  async function setEnabledBySessionKey(sessionKey: string, enabled: boolean) {
+    const entryKey = makeEntryKeyFromSessionKey(sessionKey);
+    if (!entryKey) throw new Error(`Unsupported sessionKey: ${sessionKey}`);
+
+    const state = await loadState(stateDir, logger);
+    const prev = state.entries[entryKey];
+    state.entries[entryKey] = {
+      enabled,
+      maxChars: prev?.maxChars ?? getPluginConfig(api).defaultMaxChars,
+      updatedAt: nowMs(),
+    };
+    state.updatedAt = nowMs();
+    await saveState(stateDir, state);
+
+    return state.entries[entryKey];
+  }
+
+  async function getBySessionKey(sessionKey: string) {
+    const entryKey = makeEntryKeyFromSessionKey(sessionKey);
+    if (!entryKey) return null;
+    const state = await loadState(stateDir, logger);
+    return state.entries[entryKey] ?? null;
+  }
+
+  // /audio_chat on|off|status
+  api.registerCommand({
+    name: "audio_chat",
+    description: "Toggle Telegram voice bubble mode: /audio_chat on|off|status",
+    acceptsArgs: true,
+    requireAuth: true,
+    handler: async (ctx: any) => {
+      const pluginCfg = getPluginConfig(api);
+
+      // NOTE: PluginCommandContext.channel is the surface ("telegram"), channelId may be undefined.
+      if (!isChannelAllowed(pluginCfg, String(ctx.channel ?? ""))) {
+        return { text: `audio_chat：当前仅支持 ${pluginCfg.channels.join(", ")}。` };
+      }
+
+      const senderId = String(ctx.senderId ?? "").trim();
+      if (!isUserAllowed(pluginCfg, senderId)) {
+        return { text: "audio_chat：当前账号无权限使用该命令。" };
+      }
+
+      // Reconstruct sessionKey. Prefer `to` (chat id), fallback to sender.
+      const rawTo = ctx.to ? String(ctx.to) : "";
+      const rawFrom = ctx.from ? String(ctx.from) : "";
+      const chatId =
+        rawTo.match(/(\d+)$/)?.[1] ?? rawFrom.match(/(\d+)$/)?.[1] ?? senderId;
+
+      if (!chatId) {
+        return { text: "audio_chat：无法识别当前会话目标。" };
+      }
+
+      const sessionKey = `agent:main:telegram:direct:${chatId}`;
+
+      const arg = (ctx.args ?? "").trim().toLowerCase();
+      if (!arg || arg === "status") {
+        const entry = await getBySessionKey(sessionKey);
+        const enabled = entry?.enabled ?? pluginCfg.enabledByDefault;
+        const maxChars = entry?.maxChars ?? pluginCfg.defaultMaxChars;
+        return {
+          text: [
+            `audio_chat 状态：${enabled ? "ON" : "OFF"}`,
+            `频道：${pluginCfg.channels.join(", ")}`,
+            `阈值：${maxChars} 字（超过则提示“${pluginCfg.tooLongTip}”并不发语音）`,
+          ].join("\n"),
+        };
+      }
+
+      if (arg === "on" || arg === "enable" || arg === "1") {
+        const entry = await setEnabledBySessionKey(sessionKey, true);
+        return { text: `audio_chat 已开启（阈值 ${entry.maxChars} 字）。` };
+      }
+
+      if (arg === "off" || arg === "disable" || arg === "0") {
+        const entry = await setEnabledBySessionKey(sessionKey, false);
+        return { text: "audio_chat 已关闭。" };
+      }
+
+      // /audio_chat max 200
+      if (arg.startsWith("max")) {
+        const m = (ctx.args ?? "").trim().match(/^max\s+(\d+)$/i);
+        const n = m ? Number(m[1]) : NaN;
+        if (!Number.isFinite(n) || n < 10 || n > 5000) {
+          return { text: "用法：/audio_chat max <数字>（范围 10-5000）" };
+        }
+
+        const entryKey = makeEntryKeyFromSessionKey(sessionKey);
+        if (!entryKey) throw new Error(`Unsupported sessionKey: ${sessionKey}`);
+
+        const state = await loadState(stateDir, logger);
+        const prev = state.entries[entryKey];
+        state.entries[entryKey] = {
+          enabled: prev?.enabled ?? pluginCfg.enabledByDefault,
+          maxChars: n,
+          updatedAt: nowMs(),
+        };
+        state.updatedAt = nowMs();
+        await saveState(stateDir, state);
+
+        return {
+          text: `audio_chat 阈值已设置为 ${n} 字（当前：${state.entries[entryKey].enabled ? "ON" : "OFF"}）。`,
+        };
+      }
+
+      return {
+        text: "用法：/audio_chat on | /audio_chat off | /audio_chat status | /audio_chat max <数字>",
+      };
+    },
+  });
+
+  // v2 (方案一): do NOT rely on prompt injection. Auto-send voice bubble after text is sent.
+  // We debounce per chat to avoid duplicate voice sends when text is chunked.
+  const pendingByChat = new Map<
+    string,
+    {
+      timer: NodeJS.Timeout;
+      lastText: string;
+      lastUpdatedAt: number;
+    }
+  >();
+
+  function extractChatIdFromTo(to: string): string | null {
+    // Accept: "850..." or "telegram:850..." or "telegram:direct:850..." etc.
+    const m = String(to).match(/(\d+)$/);
+    return m?.[1] ?? null;
+  }
+
+  function resolveSendMessageTelegram() {
+    const sendMessageTelegram =
+      api?.runtime?.channels?.telegram?.sendMessageTelegram ??
+      api?.runtime?.channel?.telegram?.sendMessageTelegram ??
+      api?.runtime?.telegram?.sendMessageTelegram;
+    if (typeof sendMessageTelegram !== "function") {
+      throw new Error(
+        `Telegram send API not available (runtime keys=${Object.keys(api?.runtime ?? {}).join(",")})`,
+      );
+    }
+    return sendMessageTelegram;
+  }
+
+  const tooLongNotifiedAtByChat = new Map<string, number>();
+
+  async function maybeSendTooLongTip(params: {
+    to: string;
+    chatId: string;
+    maxChars: number;
+    textLen: number;
+    tipText: string;
+    replyToMessageId?: number;
+  }) {
+    // Avoid loops and avoid spamming when multiple hooks fire.
+    const now = nowMs();
+    const last = tooLongNotifiedAtByChat.get(params.chatId) ?? 0;
+    if (now - last < 2000) return;
+    tooLongNotifiedAtByChat.set(params.chatId, now);
+
+    const tipText = `${params.tipText}（${params.textLen}/${params.maxChars}）`;
+
+    try {
+      const sendMessageTelegram = resolveSendMessageTelegram();
+      await sendMessageTelegram(params.to, tipText, {});
+      logger.info?.(
+        `[${PLUGIN_ID}] too-long tip sent (chatId=${params.chatId} len=${params.textLen} max=${params.maxChars})`,
+      );
+    } catch (err: any) {
+      logger.warn?.(
+        `[${PLUGIN_ID}] too-long tip failed: ${String(err?.message ?? err)}`,
+      );
+    }
+  }
+
+  async function synthAndSendVoice(params: {
+    to: string;
+    text: string;
+    maxChars: number;
+  }) {
+    const textRaw = (params.text ?? "").trim();
+    const text = stripMarkdownForTTS(textRaw);
+    if (!text) return;
+    if (text.length > params.maxChars) return;
+
+    if (DEBUG_FORENSICS) {
+      // Debug: confirm markdown stripping works (truncate to avoid log spam).
+      const rawHasStar = textRaw.includes("*");
+      const cleanedHasStar = text.includes("*");
+      logger.info?.(
+        `[${PLUGIN_ID}] tts-prep rawHasStar=${rawHasStar} cleanHasStar=${cleanedHasStar} preview=${JSON.stringify(text.slice(0, 80))}`,
+      );
+    }
+
+    const mediaRoot = path.join(stateDir, "media", "audio-chat");
+    await fs.mkdir(mediaRoot, { recursive: true });
+    const ts = Date.now();
+    const mp3Path = path.join(mediaRoot, `audio-chat-${ts}.mp3`);
+    const oggPath = path.join(mediaRoot, `audio-chat-${ts}.ogg`);
+
+    const cfg = api.runtime.config.loadConfig();
+    const pluginCfg = getPluginConfig(api);
+    const voice =
+      String(cfg?.messages?.tts?.edge?.voice ?? pluginCfg.voice).trim() ||
+      pluginCfg.voice;
+
+    if (DEBUG_FORENSICS) {
+      // Debug: persist the exact text passed to TTS (for troubleshooting)
+      try {
+        await fs.writeFile(
+          path.join(mediaRoot, `audio-chat-${ts}.txt`),
+          text + "\n",
+          "utf8",
+        );
+      } catch (err: any) {
+        logger.warn?.(
+          `[${PLUGIN_ID}] write txt failed: ${String(err?.message ?? err)}`,
+        );
+      }
+    }
+
+    // 1) Edge TTS -> mp3
+    const edgeTtsPython = await resolveEdgeTtsPython();
+    await api.runtime.system.runCommandWithTimeout(
+      [
+        edgeTtsPython,
+        "-m",
+        "edge_tts",
+        "--voice",
+        voice,
+        "--text",
+        text,
+        "--write-media",
+        mp3Path,
+      ],
+      { timeoutMs: 60_000 },
+    );
+
+    // 2) ffmpeg mp3 -> ogg/opus
+    await api.runtime.system.runCommandWithTimeout(
+      [
+        "ffmpeg",
+        "-y",
+        "-i",
+        mp3Path,
+        "-ar",
+        "48000",
+        "-ac",
+        "1",
+        "-c:a",
+        "libopus",
+        "-b:a",
+        "32k",
+        oggPath,
+      ],
+      { timeoutMs: 60_000 },
+    );
+
+    // 3) send voice bubble (asVoice=true)
+    // NOTE: Telegram send supports local media paths under allowed roots.
+    const sendMessageTelegram = resolveSendMessageTelegram();
+
+    await sendMessageTelegram(params.to, "", {
+      mediaUrl: oggPath,
+      asVoice: true,
+    });
+  }
+
+  async function handleOutboundHook(
+    phase: "sending" | "sent",
+    event: any,
+    ctx: any,
+  ) {
+    try {
+      const channelId = String(ctx?.channelId ?? "");
+      const to = String(event?.to ?? "");
+      const content = String(event?.content ?? "");
+      logger.info?.(
+        `[${PLUGIN_ID}] hook:${phase} channelId=${channelId} to=${to} len=${content.trim().length} success=${String(event?.success ?? "")}`,
+      );
+
+      const pluginCfg = getPluginConfig(api);
+
+      // Only act on configured outbound channels that succeeded (for sent phase).
+      if (!isChannelAllowed(pluginCfg, channelId)) return;
+      if (phase === "sent" && !event?.success) return;
+      if (pluginCfg.access.directOnly && String(to).includes(":group:")) return;
+
+      const chatId = extractChatIdFromTo(to);
+      if (!chatId) return;
+      if (!isUserAllowed(pluginCfg, chatId)) return;
+
+      const sessionKey = `agent:main:telegram:direct:${chatId}`;
+      const entry = await getBySessionKey(sessionKey);
+      const enabled = entry?.enabled ?? pluginCfg.enabledByDefault;
+      if (!enabled) return;
+
+      const maxChars = entry?.maxChars ?? pluginCfg.defaultMaxChars;
+      const trimmed = content.trim();
+      if (!trimmed) return;
+
+      // (reply-to cache removed)
+
+      // Don't react to our own tip.
+      if (trimmed === pluginCfg.tooLongTip) return;
+
+      if (trimmed.length > maxChars) {
+        // Best-effort: reply to the message we just sent (if we can find its message id).
+        const replyToMessageIdRaw =
+          event?.messageId ??
+          event?.result?.messageId ??
+          event?.telegram?.messageId ??
+          event?.telegram?.result?.messageId;
+        const replyToMessageId = Number(replyToMessageIdRaw);
+
+        await maybeSendTooLongTip({
+          to,
+          chatId,
+          maxChars,
+          textLen: trimmed.length,
+          tipText: pluginCfg.tooLongTip,
+          replyToMessageId: Number.isFinite(replyToMessageId)
+            ? replyToMessageId
+            : undefined,
+        });
+        return;
+      }
+
+      const key = chatId;
+      const prev = pendingByChat.get(key);
+      if (prev) clearTimeout(prev.timer);
+
+      const timer = setTimeout(async () => {
+        const cur = pendingByChat.get(key);
+        if (!cur) return;
+        pendingByChat.delete(key);
+        try {
+          await synthAndSendVoice({ to, text: cur.lastText, maxChars });
+          logger.info?.(`[${PLUGIN_ID}] voice-sent ok (to=${to})`);
+        } catch (err: any) {
+          logger.warn?.(
+            `[${PLUGIN_ID}] auto-voice failed: ${String(err?.message ?? err)}`,
+          );
+        }
+      }, 650);
+
+      pendingByChat.set(key, {
+        timer,
+        lastText: trimmed,
+        lastUpdatedAt: nowMs(),
+      });
+    } catch (err: any) {
+      logger.warn?.(
+        `[${PLUGIN_ID}] hook handler error: ${String(err?.message ?? err)}`,
+      );
+    }
+  }
+
+  // NOTE: In some gateway paths, outbound message hooks may not fire for agent replies.
+  // Keep them registered (useful for message tool sends), but also add an agent_end fallback.
+  api.on("message_sending", async (event: any, ctx: any) => {
+    await handleOutboundHook("sending", event, ctx);
+  });
+
+  api.on("message_sent", async (event: any, ctx: any) => {
+    await handleOutboundHook("sent", event, ctx);
+  });
+
+  api.on("agent_end", async (event: any, ctx: any) => {
+    try {
+      const pluginCfg = getPluginConfig(api);
+      const sessionKey = String(ctx?.sessionKey ?? "");
+      if (!isTelegramDirectSessionKey(sessionKey)) return;
+      if (pluginCfg.access.directOnly && !sessionKey.includes(":direct:")) return;
+
+      const chatId = sessionKeyToChatId(sessionKey);
+      if (!chatId) return;
+      if (!isUserAllowed(pluginCfg, chatId)) return;
+
+      const entry = await getBySessionKey(sessionKey);
+      const enabled = entry?.enabled ?? pluginCfg.enabledByDefault;
+      if (!enabled) return;
+
+      const maxChars = entry?.maxChars ?? pluginCfg.defaultMaxChars;
+
+      const msgs: any[] = Array.isArray(event?.messages) ? event.messages : [];
+      const lastAssistant = [...msgs]
+        .reverse()
+        .find((m) => m && m.role === "assistant");
+      let text = "";
+      if (typeof lastAssistant?.content === "string")
+        text = lastAssistant.content;
+      else if (Array.isArray(lastAssistant?.content)) {
+        // OpenAI-style content parts
+        const parts = lastAssistant.content
+          .map((p: any) => (typeof p?.text === "string" ? p.text : ""))
+          .filter(Boolean);
+        text = parts.join("\n");
+      }
+
+      const trimmed = String(text ?? "").trim();
+      logger.info?.(
+        `[${PLUGIN_ID}] hook:agent_end sessionKey=${sessionKey} len=${trimmed.length} success=${String(event?.success ?? "")}`,
+      );
+
+      if (DEBUG_FORENSICS) {
+        // Forensics: record the *exact* assistant text we intend to pass into TTS (before stripMarkdownForTTS).
+        // Dual-channel logging: logger + console (so we can see it in both gateway.log and /tmp/openclaw/*.log).
+        // Keep it short to avoid log spam.
+        try {
+          const rawHasStar = trimmed.includes("*");
+          const cleaned = stripMarkdownForTTS(trimmed);
+          const cleanHasStar = cleaned.includes("*");
+          const rawPreview = trimmed.slice(0, 80).replace(/\s+/g, " ");
+          const cleanPreview = cleaned.slice(0, 80).replace(/\s+/g, " ");
+          const line = `[${PLUGIN_ID}] agent_end rawText rawLen=${trimmed.length} cleanLen=${cleaned.length} rawHasStar=${rawHasStar} cleanHasStar=${cleanHasStar} rawPreview=${JSON.stringify(rawPreview)} cleanPreview=${JSON.stringify(cleanPreview)}`;
+          logger.info?.(line);
+          // eslint-disable-next-line no-console
+          console.log(line);
+        } catch (err: any) {
+          const msg = `[${PLUGIN_ID}] agent_end rawText forensics failed: ${String(err?.message ?? err)}`;
+          logger.warn?.(msg);
+          // eslint-disable-next-line no-console
+          console.warn(msg);
+        }
+      }
+
+      if (!trimmed) return;
+
+      // Don't react to our own tip.
+      if (trimmed === pluginCfg.tooLongTip) return;
+
+      if (trimmed.length > maxChars) {
+        await maybeSendTooLongTip({
+          to: chatId,
+          chatId,
+          maxChars,
+          textLen: trimmed.length,
+          tipText: pluginCfg.tooLongTip,
+        });
+        return;
+      }
+
+      // Reuse same debounce map (keyed by chatId)
+      const key = chatId;
+      const prev = pendingByChat.get(key);
+      if (prev) clearTimeout(prev.timer);
+
+      const timer = setTimeout(async () => {
+        const cur = pendingByChat.get(key);
+        if (!cur) return;
+        pendingByChat.delete(key);
+        try {
+          await synthAndSendVoice({ to: chatId, text: cur.lastText, maxChars });
+          logger.info?.(
+            `[${PLUGIN_ID}] voice-sent ok (agent_end to=${chatId})`,
+          );
+        } catch (err: any) {
+          logger.warn?.(
+            `[${PLUGIN_ID}] agent_end auto-voice failed: ${String(err?.message ?? err)}`,
+          );
+        }
+      }, 650);
+
+      pendingByChat.set(key, {
+        timer,
+        lastText: trimmed,
+        lastUpdatedAt: nowMs(),
+      });
+    } catch (err: any) {
+      logger.warn?.(
+        `[${PLUGIN_ID}] agent_end handler error: ${String(err?.message ?? err)}`,
+      );
+    }
+  });
+
+  logger.info(
+    `[${PLUGIN_ID}] loaded (stateDir=${stateDir}) fingerprint=${BUILD_FINGERPRINT}`,
+  );
+}

--- a/extensions/audio-chat/index.ts
+++ b/extensions/audio-chat/index.ts
@@ -29,9 +29,7 @@ type AudioChatPluginConfig = {
 
 function normalizeStringList(input: unknown): string[] {
   if (!Array.isArray(input)) return [];
-  return input
-    .map((x) => String(x ?? "").trim())
-    .filter(Boolean);
+  return input.map((x) => String(x ?? "").trim()).filter(Boolean);
 }
 
 function getPluginConfig(api: any): AudioChatPluginConfig {
@@ -52,9 +50,7 @@ function getPluginConfig(api: any): AudioChatPluginConfig {
     enabledByDefault: Boolean(root?.enabledByDefault ?? false),
     channels: channels.length > 0 ? channels : ["telegram"],
     defaultMaxChars,
-    tooLongTip:
-      String(root?.tooLongTip ?? DEFAULT_TOO_LONG_TIP).trim() ||
-      DEFAULT_TOO_LONG_TIP,
+    tooLongTip: String(root?.tooLongTip ?? DEFAULT_TOO_LONG_TIP).trim() || DEFAULT_TOO_LONG_TIP,
     voice: String(root?.voice ?? DEFAULT_VOICE).trim() || DEFAULT_VOICE,
     access: {
       directOnly: Boolean(access?.directOnly ?? true),
@@ -154,9 +150,7 @@ async function resolveEdgeTtsPython() {
 }
 
 function isTelegramDirectSessionKey(sessionKey?: string) {
-  return (
-    typeof sessionKey === "string" && sessionKey.includes(":telegram:direct:")
-  );
+  return typeof sessionKey === "string" && sessionKey.includes(":telegram:direct:");
 }
 
 function sessionKeyToChatId(sessionKey: string): string | null {
@@ -180,12 +174,8 @@ async function loadState(stateDir: string, logger: any): Promise<VoiceState> {
     if (!parsed || typeof parsed !== "object") throw new Error("bad state");
     return {
       version: typeof parsed.version === "number" ? parsed.version : 1,
-      updatedAt:
-        typeof parsed.updatedAt === "number" ? parsed.updatedAt : nowMs(),
-      entries:
-        typeof parsed.entries === "object" && parsed.entries
-          ? parsed.entries
-          : {},
+      updatedAt: typeof parsed.updatedAt === "number" ? parsed.updatedAt : nowMs(),
+      entries: typeof parsed.entries === "object" && parsed.entries ? parsed.entries : {},
     } as VoiceState;
   } catch (err: any) {
     if (err?.code !== "ENOENT")
@@ -224,10 +214,9 @@ export default function register(api: any) {
     // Startup healthcheck: verify edge-tts and ffmpeg availability.
     try {
       const py = await resolveEdgeTtsPython();
-      await api.runtime.system.runCommandWithTimeout(
-        [py, "-m", "edge_tts", "--help"],
-        { timeoutMs: 15_000 },
-      );
+      await api.runtime.system.runCommandWithTimeout([py, "-m", "edge_tts", "--help"], {
+        timeoutMs: 15_000,
+      });
       await api.runtime.system.runCommandWithTimeout(["ffmpeg", "-version"], {
         timeoutMs: 15_000,
       });
@@ -287,8 +276,7 @@ export default function register(api: any) {
       // Reconstruct sessionKey. Prefer `to` (chat id), fallback to sender.
       const rawTo = ctx.to ? String(ctx.to) : "";
       const rawFrom = ctx.from ? String(ctx.from) : "";
-      const chatId =
-        rawTo.match(/(\d+)$/)?.[1] ?? rawFrom.match(/(\d+)$/)?.[1] ?? senderId;
+      const chatId = rawTo.match(/(\d+)$/)?.[1] ?? rawFrom.match(/(\d+)$/)?.[1] ?? senderId;
 
       if (!chatId) {
         return { text: "audio_chat：无法识别当前会话目标。" };
@@ -418,9 +406,7 @@ export default function register(api: any) {
         `[${PLUGIN_ID}] too-long tip sent (chatId=${params.chatId} len=${params.textLen} max=${params.maxChars})`,
       );
     } catch (err: any) {
-      logger.warn?.(
-        `[${PLUGIN_ID}] too-long tip failed: ${String(err?.message ?? err)}`,
-      );
+      logger.warn?.(`[${PLUGIN_ID}] too-long tip failed: ${String(err?.message ?? err)}`);
     }
   }
 
@@ -453,21 +439,14 @@ export default function register(api: any) {
     const cfg = api.runtime.config.loadConfig();
     const pluginCfg = getPluginConfig(api);
     const voice =
-      String(cfg?.messages?.tts?.edge?.voice ?? pluginCfg.voice).trim() ||
-      pluginCfg.voice;
+      String(cfg?.messages?.tts?.edge?.voice ?? pluginCfg.voice).trim() || pluginCfg.voice;
 
     if (DEBUG_FORENSICS) {
       // Debug: persist the exact text passed to TTS (for troubleshooting)
       try {
-        await fs.writeFile(
-          path.join(mediaRoot, `audio-chat-${ts}.txt`),
-          text + "\n",
-          "utf8",
-        );
+        await fs.writeFile(path.join(mediaRoot, `audio-chat-${ts}.txt`), text + "\n", "utf8");
       } catch (err: any) {
-        logger.warn?.(
-          `[${PLUGIN_ID}] write txt failed: ${String(err?.message ?? err)}`,
-        );
+        logger.warn?.(`[${PLUGIN_ID}] write txt failed: ${String(err?.message ?? err)}`);
       }
     }
 
@@ -524,11 +503,7 @@ export default function register(api: any) {
     }
   }
 
-  async function handleOutboundHook(
-    phase: "sending" | "sent",
-    event: any,
-    ctx: any,
-  ) {
+  async function handleOutboundHook(phase: "sending" | "sent", event: any, ctx: any) {
     try {
       const channelId = String(ctx?.channelId ?? "");
       const to = String(event?.to ?? "");
@@ -599,9 +574,7 @@ export default function register(api: any) {
           lastVoiceSentByChat.set(key, { text: cur.lastText, at: nowMs() });
           logger.info?.(`[${PLUGIN_ID}] voice-sent ok (to=${to})`);
         } catch (err: any) {
-          logger.warn?.(
-            `[${PLUGIN_ID}] auto-voice failed: ${String(err?.message ?? err)}`,
-          );
+          logger.warn?.(`[${PLUGIN_ID}] auto-voice failed: ${String(err?.message ?? err)}`);
         }
       }, 650);
 
@@ -611,9 +584,7 @@ export default function register(api: any) {
         lastUpdatedAt: nowMs(),
       });
     } catch (err: any) {
-      logger.warn?.(
-        `[${PLUGIN_ID}] hook handler error: ${String(err?.message ?? err)}`,
-      );
+      logger.warn?.(`[${PLUGIN_ID}] hook handler error: ${String(err?.message ?? err)}`);
     }
   }
 
@@ -647,12 +618,9 @@ export default function register(api: any) {
       const maxChars = entry?.maxChars ?? pluginCfg.defaultMaxChars;
 
       const msgs: any[] = Array.isArray(event?.messages) ? event.messages : [];
-      const lastAssistant = [...msgs]
-        .reverse()
-        .find((m) => m && m.role === "assistant");
+      const lastAssistant = [...msgs].reverse().find((m) => m && m.role === "assistant");
       let text = "";
-      if (typeof lastAssistant?.content === "string")
-        text = lastAssistant.content;
+      if (typeof lastAssistant?.content === "string") text = lastAssistant.content;
       else if (Array.isArray(lastAssistant?.content)) {
         // OpenAI-style content parts
         const parts = lastAssistant.content
@@ -727,9 +695,7 @@ export default function register(api: any) {
             accountId: String(ctx?.accountId ?? "") || undefined,
           });
           lastVoiceSentByChat.set(key, { text: cur.lastText, at: nowMs() });
-          logger.info?.(
-            `[${PLUGIN_ID}] voice-sent ok (agent_end to=${chatId})`,
-          );
+          logger.info?.(`[${PLUGIN_ID}] voice-sent ok (agent_end to=${chatId})`);
         } catch (err: any) {
           logger.warn?.(
             `[${PLUGIN_ID}] agent_end auto-voice failed: ${String(err?.message ?? err)}`,
@@ -743,13 +709,9 @@ export default function register(api: any) {
         lastUpdatedAt: nowMs(),
       });
     } catch (err: any) {
-      logger.warn?.(
-        `[${PLUGIN_ID}] agent_end handler error: ${String(err?.message ?? err)}`,
-      );
+      logger.warn?.(`[${PLUGIN_ID}] agent_end handler error: ${String(err?.message ?? err)}`);
     }
   });
 
-  logger.info(
-    `[${PLUGIN_ID}] loaded (stateDir=${stateDir}) fingerprint=${BUILD_FINGERPRINT}`,
-  );
+  logger.info(`[${PLUGIN_ID}] loaded (stateDir=${stateDir}) fingerprint=${BUILD_FINGERPRINT}`);
 }

--- a/extensions/audio-chat/openclaw.plugin.json
+++ b/extensions/audio-chat/openclaw.plugin.json
@@ -1,0 +1,31 @@
+{
+  "id": "audio-chat",
+  "name": "Audio Chat",
+  "description": "Auto-send Telegram voice bubble replies from assistant text with configurable access and limits.",
+  "version": "0.2.0",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabledByDefault": { "type": "boolean" },
+      "channels": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "defaultMaxChars": { "type": "integer", "minimum": 10, "maximum": 5000 },
+      "tooLongTip": { "type": "string" },
+      "voice": { "type": "string" },
+      "access": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "directOnly": { "type": "boolean" },
+          "allowUserIds": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add a new `audio-chat` extension plugin that auto-sends Telegram voice-bubble replies from assistant text, with configurable access rules and limits.

### What this adds
- New extension: `extensions/audio-chat/`
  - `index.ts`
  - `openclaw.plugin.json`
  - `README.md`

### Key behavior
- Command: `/audio_chat on|off|status|max <n>`
- Per-chat persisted state (`enabled`, `maxChars`)
- Config-driven defaults and access control:
  - `enabledByDefault`
  - `channels`
  - `defaultMaxChars`
  - `tooLongTip`
  - `voice`
  - `access.directOnly`
  - `access.allowUserIds`
- Markdown cleanup before TTS
- Debounced send to avoid duplicate voice output
- Over-length guard with user tip message

### Privacy / safety notes
- No hardcoded personal user id in plugin logic
- No personal account identifiers included in committed files
- Uses local synthesis (`edge-tts` + `ffmpeg`) and sends as Telegram voice media

## Example config

```json
{
  "extensions": {
    "audioChat": {
      "enabledByDefault": false,
      "channels": ["telegram"],
      "defaultMaxChars": 150,
      "tooLongTip": "Message too long, skipped voice reply",
      "voice": "zh-CN-YunxiaNeural",
      "access": {
        "directOnly": true,
        "allowUserIds": []
      }
    }
  }
}
```

## Manual validation
- `/audio_chat on/off/status/max` works
- Short assistant replies trigger voice-bubble send
- Long replies trigger tip and skip voice generation
- Disabled state does not trigger voice send
