### PR TITLE
fix(telegram): skip empty messages instead of throwing error

### DIFF
--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -136,11 +136,14 @@ async function deliverTextReply(params: {
         replyMarkup: shouldAttachButtons ? params.replyMarkup : undefined,
       },
     );
-    if (firstDeliveredMessageId == null) {
-      firstDeliveredMessageId = messageId;
+    // Skip delivery tracking for skipped messages (messageId === 0 means empty content was skipped)
+    if (messageId !== 0) {
+      if (firstDeliveredMessageId == null) {
+        firstDeliveredMessageId = messageId;
+      }
+      markReplyApplied(params.progress, replyToForChunk);
+      markDelivered(params.progress);
     }
-    markReplyApplied(params.progress, replyToForChunk);
-    markDelivered(params.progress);
   }
   return firstDeliveredMessageId;
 }
@@ -166,7 +169,7 @@ async function sendPendingFollowUpText(params: {
       replyToMode: params.replyToMode,
       progress: params.progress,
     });
-    await sendTelegramText(params.bot, params.chatId, chunk.html, params.runtime, {
+    const messageId = await sendTelegramText(params.bot, params.chatId, chunk.html, params.runtime, {
       replyToMessageId: replyToForFollowUp,
       thread: params.thread,
       textMode: "html",
@@ -174,8 +177,11 @@ async function sendPendingFollowUpText(params: {
       linkPreview: params.linkPreview,
       replyMarkup: i === 0 ? params.replyMarkup : undefined,
     });
-    markReplyApplied(params.progress, replyToForFollowUp);
-    markDelivered(params.progress);
+    // Skip delivery tracking for skipped messages (messageId === 0 means empty content was skipped)
+    if (messageId !== 0) {
+      markReplyApplied(params.progress, replyToForFollowUp);
+      markDelivered(params.progress);
+    }
   }
 }
 

--- a/src/telegram/bot/delivery.send.ts
+++ b/src/telegram/bot/delivery.send.ts
@@ -134,7 +134,9 @@ export async function sendTelegramText(
   // Markdown can render to empty HTML for syntax-only chunks; recover with plain text.
   if (!htmlText.trim()) {
     if (!hasFallbackText) {
-      throw new Error("telegram sendMessage failed: empty formatted text and empty plain fallback");
+      // Silently skip empty messages to avoid Telegram API 400 error
+      runtime.log?.("telegram sendMessage skipped: empty content");
+      return 0;
     }
     return await sendPlainFallback();
   }

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -474,23 +474,25 @@ describe("deliverReplies", () => {
     );
   });
 
-  it("throws when formatted and plain fallback text are both empty", async () => {
+  it("skips when formatted and plain fallback text are both empty", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn();
     const bot = { api: { sendMessage } } as unknown as Bot;
 
-    await expect(
-      deliverReplies({
-        replies: [{ text: "   " }],
-        chatId: "123",
-        token: "tok",
-        runtime,
-        bot,
-        replyToMode: "off",
-        textLimit: 4000,
-      }),
-    ).rejects.toThrow("empty formatted text and empty plain fallback");
+    await deliverReplies({
+      replies: [{ text: "   " }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+    });
+
     expect(sendMessage).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("telegram sendMessage skipped"),
+    );
   });
 
   it("uses reply_to_message_id when quote text is provided", async () => {


### PR DESCRIPTION
## Summary

- Problem: Telegram channel crashes when agent emits empty reply (GrammyError 400: text must be non-empty)
- Why it matters: Gateway restarts on each occurrence, causing disruption to users
- What changed: Silently skip empty messages instead of throwing error
- What did NOT change: Normal message delivery behavior

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue

- Closes #37278

## User-visible / Behavior Changes

Empty agent replies (e.g., NO_REPLY, heartbeat ack) are now silently skipped instead of causing gateway crashes.

## Security Impact

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Steps
1. Configure Telegram channel with heartbeat enabled
2. Trigger an empty reply scenario
3. Observe gateway no longer crashes

### Expected
- Empty messages are skipped silently
- No Telegram API 400 errors
- Gateway remains stable

### Actual
- Verified with unit tests: skips when formatted and plain fallback text are both empty

## Evidence

- ✅ Updated test passes
- ✅ All 26 delivery tests pass

## Human Verification

- Verified scenarios: Empty text, whitespace-only text, normal text delivery
- Edge cases checked: Threaded mode, plain text fallback
- What you did not verify: Integration with real Telegram API

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery

- How to disable/revert this change quickly: Revert commit
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: Missing legitimate messages

## Risks and Mitigations

- Risk: Legitimate empty responses might be silently dropped
  - Mitigation: This matches expected behavior for NO_REPLY and heartbeat responses