### PR TITLE
fix(web-search): allow locale variants in search_lang schema

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -127,7 +127,7 @@ function createWebSearchSchema(provider: (typeof SEARCH_PROVIDERS)[number]) {
       search_lang: Type.Optional(
         Type.String({
           description:
-            "Short ISO language code for search results (e.g., 'de', 'en', 'fr', 'tr'). Must be a 2-letter code, NOT a locale.",
+            "Language code for search results (e.g., 'en', 'de', 'fr', 'zh-hans', 'zh-hant'). Use ISO 639-1 codes or locale variants where required by the provider.",
         }),
       ),
       ui_lang: Type.Optional(


### PR DESCRIPTION
## Summary

Fixes #37260.

- Update `web_search` tool schema description to allow locale variants (e.g., `zh-hans`, `zh-hant`) for `search_lang` parameter
- Brave Search API updated validation to require specific localized codes for Chinese, rejecting the 2-letter code `zh`
- Previous schema description enforced "Must be a 2-letter code, NOT a locale", causing LLMs to pass `zh` and trigger 422 errors

## Change Type

- [x] Bug fix

## Scope

- [x] Tools

## Linked Issue/PR

- Fixes #37260

## User-visible / Behavior Changes

LLMs can now use locale variants like `zh-hans` and `zh-hant` for Chinese web searches without triggering Brave Search API 422 errors.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OpenClaw with Brave Search provider
- Chinese language search query

### Steps
1. Trigger `web_search` tool with Chinese query
2. LLM follows schema and passes `search_lang: "zh"`
3. Brave API returns 422: "Input should be 'zh-hans', 'zh-hant', ..."

### Expected (after fix)
Schema allows LLM to use `zh-hans` or `zh-hant`, search succeeds

### Actual (before fix)
Schema enforces 2-letter code, LLM passes `zh`, Brave rejects with 422

## Evidence

- [x] All 28 existing web-search tests pass
- [x] Error log from issue shows Brave API requires locale variants for Chinese

## Human Verification

- Verified code path: Schema description change only, no logic changes
- Edge cases checked: Other languages unaffected, existing 2-letter codes still work
- What I did not verify: End-to-end Chinese search with Brave API (requires Brave API key)

## Compatibility / Migration

- Backward compatible? Yes (existing 2-letter codes still accepted by Brave)
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert: `git revert` this commit
- Files to restore: `src/agents/tools/web-search.ts` line 129-130
- Known bad symptoms: Chinese searches revert to 422 errors

## Risks and Mitigations

None. Schema description change only, no runtime logic changes.