### PR TITLE
fix(discord): pass appliedTags through channel-edit action

### DIFF
--- a/src/agents/tools/discord-actions-guild.ts
+++ b/src/agents/tools/discord-actions-guild.ts
@@ -327,6 +327,7 @@ export async function handleDiscordGuildAction(
         integer: true,
       });
       const availableTags = parseAvailableTags(params.availableTags);
+      const appliedTags = readStringArrayParam(params, "appliedTags");
       const editPayload = {
         channelId,
         name: name ?? undefined,
@@ -339,6 +340,7 @@ export async function handleDiscordGuildAction(
         locked,
         autoArchiveDuration: autoArchiveDuration ?? undefined,
         availableTags,
+        appliedTags: appliedTags ?? undefined,
       };
       const channel = accountId
         ? await editChannelDiscord(editPayload, { accountId })

--- a/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
+++ b/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
@@ -197,6 +197,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
       integer: true,
     });
     const availableTags = parseAvailableTags(actionParams.availableTags);
+    const appliedTags = readStringArrayParam(actionParams, "appliedTags");
     return await handleDiscordAction(
       {
         action: "channelEdit",
@@ -212,6 +213,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         locked,
         autoArchiveDuration: autoArchiveDuration ?? undefined,
         availableTags,
+        appliedTags: appliedTags ?? undefined,
       },
       cfg,
     );

--- a/src/discord/send.channels.ts
+++ b/src/discord/send.channels.ts
@@ -79,6 +79,9 @@ export async function editChannelDiscord(
       ...(t.emoji_name !== undefined && { emoji_name: t.emoji_name }),
     }));
   }
+  if (payload.appliedTags?.length) {
+    body.applied_tags = payload.appliedTags;
+  }
   return (await rest.patch(Routes.channel(payload.channelId), {
     body,
   })) as APIChannel;

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -158,6 +158,8 @@ export type DiscordChannelEdit = {
   locked?: boolean;
   autoArchiveDuration?: number;
   availableTags?: DiscordForumTag[];
+  /** Tag IDs to apply to a forum thread/post (PATCH applied_tags). */
+  appliedTags?: string[];
 };
 
 export type DiscordChannelMove = {


### PR DESCRIPTION
Fixes #36736

The `channel-edit` action parsed `availableTags` (forum tag definitions) but never read or forwarded `appliedTags` (tag IDs applied to a forum thread/post). Meanwhile `thread-create` already handled `appliedTags` correctly — this was simply missed for `channel-edit`.

### Changes
- **`src/discord/send.types.ts`**: Add `appliedTags?: string[]` to `DiscordChannelEdit`
- **`src/discord/send.channels.ts`**: Map `appliedTags` → `body.applied_tags` in `editChannelDiscord()`
- **`src/channels/plugins/actions/discord/handle-action.guild-admin.ts`**: Read `appliedTags` param in channel-edit handler
- **`src/agents/tools/discord-actions-guild.ts`**: Read `appliedTags` param in channelEdit case