### PR TITLE
fix(tts): enable Matrix voice-bubble replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Matrix/TTS voice-bubble output: treat Matrix as a voice-bubble-capable channel in the TTS pipeline so inbound auto-TTS replies use Opus + `audioAsVoice` and render as native Matrix voice messages instead of generic audio files. (#37061) Thanks @gucasbrg.
 - Tools/web_search Brave language-code validation: align `search_lang` handling with Brave-supported codes (including `zh-hans`, `zh-hant`, `en-gb`, and `pt-br`), map common alias inputs (`zh`, `ja`) to valid Brave values, and reject unsupported codes before upstream requests to prevent 422 failures. (#37260) Thanks @heyanming.
 - Models/openai-completions streaming compatibility: force `compat.supportsUsageInStreaming=false` for non-native OpenAI-compatible endpoints during model normalization, preventing usage-only stream chunks from triggering `choices[0]` parser crashes in provider streams. (#8714) Thanks @nonanon1.
 - Tools/xAI native web-search collision guard: drop OpenClaw `web_search` from tool registration when routing to xAI/Grok model providers (including OpenRouter `x-ai/*`) to avoid duplicate tool-name request failures against provider-native `web_search`. (#14749) Thanks @realsamrat.

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -162,7 +162,7 @@ describe("tts", () => {
   });
 
   describe("resolveOutputFormat", () => {
-    it("selects opus for voice-bubble channels (telegram/feishu/whatsapp) and mp3 for others", () => {
+    it("selects opus for voice-bubble channels (telegram/feishu/whatsapp/matrix) and mp3 for others", () => {
       const cases = [
         {
           channel: "telegram",
@@ -184,6 +184,15 @@ describe("tts", () => {
         },
         {
           channel: "whatsapp",
+          expected: {
+            openai: "opus",
+            elevenlabs: "opus_48000_64",
+            extension: ".opus",
+            voiceCompatible: true,
+          },
+        },
+        {
+          channel: "matrix",
           expected: {
             openai: "opus",
             elevenlabs: "opus_48000_64",
@@ -626,6 +635,21 @@ describe("tts", () => {
 
         expect(result.mediaUrl).toBeDefined();
         expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it("marks Matrix auto-TTS replies as voice bubbles", async () => {
+      await withMockedAutoTtsFetch(async () => {
+        const result = await maybeApplyTtsToPayload({
+          payload: { text: "Hello world from matrix voice message" },
+          cfg: baseCfg,
+          kind: "final",
+          inboundAudio: true,
+          channel: "matrix",
+        });
+
+        expect(result.mediaUrl).toBeDefined();
+        expect(result.audioAsVoice).toBe(true);
       });
     });
   });

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -12,7 +12,6 @@ import {
 import path from "node:path";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import { normalizeChannelId } from "../channels/plugins/index.js";
-import type { ChannelId } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { normalizeResolvedSecretInputString } from "../config/types.secrets.js";
 import type {
@@ -496,7 +495,7 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
 }
 
 /** Channels that require opus audio and support voice-bubble playback */
-const VOICE_BUBBLE_CHANNELS = new Set(["telegram", "feishu", "whatsapp"]);
+const VOICE_BUBBLE_CHANNELS = new Set(["telegram", "feishu", "whatsapp", "matrix"]);
 
 function resolveOutputFormat(channelId?: string | null) {
   if (channelId && VOICE_BUBBLE_CHANNELS.has(channelId)) {
@@ -505,8 +504,15 @@ function resolveOutputFormat(channelId?: string | null) {
   return DEFAULT_OUTPUT;
 }
 
-function resolveChannelId(channel: string | undefined): ChannelId | null {
-  return channel ? normalizeChannelId(channel) : null;
+function resolveChannelId(channel: string | undefined): string | null {
+  const normalized = channel?.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  if (VOICE_BUBBLE_CHANNELS.has(normalized)) {
+    return normalized;
+  }
+  return normalizeChannelId(normalized);
 }
 
 function resolveEdgeOutputFormat(config: ResolvedTtsConfig): string {


### PR DESCRIPTION
## Summary

- Problem: Matrix auto-TTS replies were still emitted as generic audio attachments because the TTS pipeline did not treat `matrix` as a voice-bubble-capable channel.
- Why it matters: Matrix already supports MSC3245 voice messages in the send pipeline, so inbound voice replies were missing inline playback, waveform, and voice-bubble UX.
- What changed: add `matrix` to the voice-bubble channel set and make TTS channel normalization fall back to stable local normalization before consulting the plugin registry, then add regression coverage for output selection and inbound auto-TTS voice-bubble delivery.
- What did NOT change (scope boundary): no Matrix send-adapter behavior, no new TTS providers, and no changes to non-voice-bubble channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37061
- Related #14225
- Related #32489

## User-visible / Behavior Changes

Matrix inbound auto-TTS replies now use Opus + `audioAsVoice` so Matrix sends them as native voice bubbles instead of generic downloadable audio files.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: OpenAI-compatible TTS test fixture
- Integration/channel (if any): Matrix
- Relevant config (redacted): `messages.tts.auto: inbound`, `messages.tts.provider: openai`

### Steps

1. Configure inbound auto-TTS for a Matrix bot.
2. Send the bot a voice message so the reply path enters `maybeApplyTtsToPayload`.
3. Observe the generated reply payload and Matrix delivery behavior.

### Expected

- Matrix replies use Opus output and set `audioAsVoice: true` so the Matrix adapter emits voice-message metadata.

### Actual

- Before this patch, Matrix fell back to the default MP3 output path and delivered a generic audio attachment.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test src/tts/tts.test.ts extensions/matrix/src/matrix/send.test.ts`, `pnpm build`, `pnpm exec oxlint src/tts/tts.ts src/tts/tts.test.ts`, `pnpm exec oxfmt --check src/tts/tts.ts src/tts/tts.test.ts CHANGELOG.md`
- Edge cases checked: Matrix output format selection, Matrix auto-TTS replies from inbound audio, and non-Matrix channels still using default output in existing tests.
- What you did **not** verify: live Matrix end-to-end delivery against a real homeserver.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or remove `matrix` from the TTS voice-bubble channel set.
- Files/config to restore: `src/tts/tts.ts`, `src/tts/tts.test.ts`
- Known bad symptoms reviewers should watch for: Matrix TTS replies arriving as plain file attachments again, or non-Matrix channels unexpectedly switching to Opus.

## Risks and Mitigations

- Risk: channel normalization could misclassify a future custom channel that shares a voice-bubble-capable ID.
  - Mitigation: keep the fallback restricted to the explicit `VOICE_BUBBLE_CHANNELS` set and preserve plugin-registry normalization for everything else.

## AI Use

- AI-assisted: Yes
- Human-reviewed: Yes
- Testing degree: targeted tests + local build + lint/format checks

## Notes

- `pnpm check` still fails on current `origin/main` because `extensions/tlon` is missing `@tloncorp/api` and `src/gateway/openai-http.ts:303` currently has a baseline type error unrelated to this PR.
