### PR TITLE
fix(whatsapp): prevent reasoning leak when responsePrefix is enabled

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -15,6 +15,12 @@ import {
 
 export type NormalizeReplySkipReason = "empty" | "silent" | "heartbeat";
 
+const REASONING_PREFIX = "reasoning:";
+
+function isReasoningPrefixedText(text: string): boolean {
+  return text.trimStart().toLowerCase().startsWith(REASONING_PREFIX);
+}
+
 export type NormalizeReplyOptions = {
   responsePrefix?: string;
   /** Context for template variable interpolation in responsePrefix */
@@ -100,6 +106,10 @@ export function normalizeReplyPayload(
     effectivePrefix &&
     text &&
     text.trim() !== HEARTBEAT_TOKEN &&
+    // Preserve reasoning suppression behavior in downstream channel deliverers.
+    // Some channels (e.g. WhatsApp) suppress payloads that start with "Reasoning:",
+    // but adding a prefix would prevent that detection and leak the reasoning block.
+    !isReasoningPrefixedText(text) &&
     !text.startsWith(effectivePrefix)
   ) {
     text = `${effectivePrefix} ${text}`;

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -150,6 +150,15 @@ describe("normalizeReplyPayload", () => {
     expect(result!.text).toBe("");
     expect(result!.mediaUrl).toBe("https://example.com/img.png");
   });
+
+  it("does not prefix reasoning-prefixed messages", () => {
+    const result = normalizeReplyPayload(
+      { text: "Reasoning:\n_hidden_" },
+      { responsePrefix: "[openclaw]" },
+    );
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe("Reasoning:\n_hidden_");
+  });
 });
 
 describe("typing controller", () => {


### PR DESCRIPTION
## **Summary**

- Problem: WhatsApp delivery suppresses replies that start with `Reasoning:`, but response prefix normalization can prepend a prefix (for example `[openclaw]`) and prevent suppression, leaking internal reasoning text to end users.
- Why it matters: This is a privacy/safety issue — internal reasoning content should never be sent over external messaging channels.
- What changed: `normalizeReplyPayload` now skips applying `responsePrefix` when the message is reasoning-prefixed (case-insensitive, ignoring leading whitespace); added a regression test ensuring reasoning-prefixed messages are not prefixed.
- What did NOT change (scope boundary): No changes to reasoning suppression rules themselves; no changes to routing, streaming, or channel discovery.

## **Change Type (select all)**

- [x]  Bug fix
- [ ]  Feature
- [ ]  Refactor
- [ ]  Docs
- [x]  Security hardening
- [ ]  Chore/infra

## **Scope (select all touched areas)**

- [ ]  Gateway / orchestration
- [ ]  Skills / tool execution
- [ ]  Auth / tokens
- [ ]  Memory / storage
- [x]  Integrations
- [ ]  API / contracts
- [ ]  UI / DX
- [ ]  CI/CD / infra

## **Linked Issue/PR**

- Closes Bug: Reasoning output leaked to WhatsApp channel #28751

## **User-visible / Behavior Changes**

Reasoning-prefixed blocks will no longer receive `responsePrefix`; downstream WhatsApp suppression can reliably drop them instead of delivering them.

## **Security Impact (required)**

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## **Repro + Verification**

### **Environment**

- OS: macOS
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): N/A

### **Steps**

1. Run `pnpm test src/auto-reply/reply/reply-utils.test.ts`.

### **Expected**

- Reasoning-prefixed messages are not prefixed, preserving downstream suppression.

### **Actual**

- Before fix: responsePrefix could be prepended, producing `[openclaw] Reasoning:...` and bypassing WhatsApp suppression.

## **Evidence**

- [x]  Passing test (added regression coverage): `src/auto-reply/reply/reply-utils.test.ts`

## **Human Verification (required)**

- Verified scenarios: `pnpm test src/auto-reply/reply/reply-utils.test.ts`
- Edge cases checked: non-reasoning messages still receive `responsePrefix` as before
- What you did **not** verify: Full end-to-end WhatsApp gateway run with a real device

## **Compatibility / Migration**

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## **Failure Recovery (if this breaks)**

- Revert this commit.

## **Risks and Mitigations**

Risk: A user-intended message that begins with `Reasoning:` will no longer get `responsePrefix` applied.

Mitigation: `Reasoning:` is reserved for internal reasoning blocks; skipping the prefix preserves suppression behavior and prevents leaks on external channels.
