### PR TITLE
fix(cron-cli): guard against undefined payload in list/run output

### DIFF
--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -214,7 +214,7 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
     const agentLabel = pad(truncate(job.agentId ?? "-", CRON_AGENT_PAD), CRON_AGENT_PAD);
     const modelLabel = pad(
       truncate(
-        (job.payload.kind === "agentTurn" ? job.payload.model : undefined) ?? "-",
+        (job.payload?.kind === "agentTurn" ? job.payload.model : undefined) ?? "-",
         CRON_MODEL_PAD,
       ),
       CRON_MODEL_PAD,
@@ -253,7 +253,7 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
       coloredStatus,
       coloredTarget,
       coloredAgent,
-      job.payload.kind === "agentTurn" && job.payload.model
+      job.payload?.kind === "agentTurn" && job.payload.model
         ? colorize(rich, theme.info, modelLabel)
         : colorize(rich, theme.muted, modelLabel),
     ].join(" ");


### PR DESCRIPTION
## Summary

Fixes #37299.

- Add optional chaining (`?.`) to `job.payload` access in `formatJobRow` (lines 217, 256)
- Prevents `TypeError: Cannot read properties of undefined (reading 'kind')` when running `openclaw cron list` or `openclaw cron run`
- Can occur with legacy cron jobs or deserialization issues where `payload` field is missing

## Change Type

- [x] Bug fix

## Scope

- [x] CLI

## Linked Issue/PR

- Fixes #37299

## User-visible / Behavior Changes

`openclaw cron list` and `openclaw cron run` no longer crash when encountering cron jobs with undefined payload. Model column shows "-" instead of crashing.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OpenClaw 2026.3.2
- Windows (reported), but affects all platforms

### Steps
1. Have cron jobs configured
2. Run `openclaw cron list`
3. Observe TypeError crash

### Expected (after fix)
List displays successfully, shows "-" for model column when payload is undefined

### Actual (before fix)
TypeError: Cannot read properties of undefined (reading 'kind')

## Evidence

- [x] All 9 existing cron-cli tests pass
- [x] Optional chaining prevents crash while maintaining display logic

## Human Verification

- Verified code path: `job.payload?.kind` safely returns undefined when payload is missing, fallback to "-" works
- Edge cases checked: Normal jobs with valid payload unaffected, only malformed jobs benefit from guard
- What I did not verify: End-to-end with actual malformed cron job (requires reproducing legacy data format)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert: `git revert` this commit
- Files to restore: `src/cli/cron-cli/shared.ts` lines 217, 256
- Known bad symptoms: Cron list/run commands revert to crashing on undefined payload

## Risks and Mitigations

None. Defensive programming change only, no logic changes.