### PR TITLE
fix(telegram): enforce strict validation for replyToMessageId

### DIFF
--- a/src/channels/plugins/outbound/telegram.test.ts
+++ b/src/channels/plugins/outbound/telegram.test.ts
@@ -139,4 +139,40 @@ describe("telegramOutbound", () => {
     expect(secondCallOpts?.buttons).toBeUndefined();
     expect(result).toEqual({ channel: "telegram", messageId: "tg-2", chatId: "123" });
   });
+
+  it("drops replyToMessageId for non-numeric replyToId values", async () => {
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "tg-text-3", chatId: "123" });
+    const sendText = telegramOutbound.sendText;
+    expect(sendText).toBeDefined();
+
+    // UUID-like value from cross-surface routing
+    await sendText!({
+      cfg: {},
+      to: "123",
+      text: "hello",
+      replyToId: "35ce3628-8ceb-45a6-8092-c021c7e5bd53",
+      deps: { sendTelegram },
+    });
+
+    const opts = sendTelegram.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(opts?.replyToMessageId).toBeUndefined();
+  });
+
+  it("drops replyToMessageId for partially numeric replyToId values", async () => {
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "tg-text-4", chatId: "123" });
+    const sendText = telegramOutbound.sendText;
+    expect(sendText).toBeDefined();
+
+    // Partially numeric value that parseInt would accept as 123
+    await sendText!({
+      cfg: {},
+      to: "123",
+      text: "hello",
+      replyToId: "123abc",
+      deps: { sendTelegram },
+    });
+
+    const opts = sendTelegram.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(opts?.replyToMessageId).toBeUndefined();
+  });
 });

--- a/src/telegram/outbound-params.test.ts
+++ b/src/telegram/outbound-params.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound-params.js";
+
+describe("parseTelegramReplyToMessageId", () => {
+  it("parses a valid positive integer string", () => {
+    expect(parseTelegramReplyToMessageId("123")).toBe(123);
+  });
+
+  it("parses a large message id", () => {
+    expect(parseTelegramReplyToMessageId("9999999")).toBe(9999999);
+  });
+
+  it("returns undefined for null/undefined/empty", () => {
+    expect(parseTelegramReplyToMessageId(null)).toBeUndefined();
+    expect(parseTelegramReplyToMessageId(undefined)).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("   ")).toBeUndefined();
+  });
+
+  it("rejects UUID-like strings", () => {
+    expect(parseTelegramReplyToMessageId("35ce3628-8ceb-45a6-8092-c021c7e5bd53")).toBeUndefined();
+  });
+
+  it("rejects partially numeric strings that parseInt would accept", () => {
+    // Number.parseInt("123abc", 10) returns 123 — this must be rejected.
+    expect(parseTelegramReplyToMessageId("123abc")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("12 34")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("0x1A")).toBeUndefined();
+  });
+
+  it("rejects negative values", () => {
+    expect(parseTelegramReplyToMessageId("-1")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("-999")).toBeUndefined();
+  });
+
+  it("rejects zero", () => {
+    expect(parseTelegramReplyToMessageId("0")).toBeUndefined();
+  });
+
+  it("rejects floating-point strings", () => {
+    expect(parseTelegramReplyToMessageId("3.14")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("100.0")).toBeUndefined();
+  });
+
+  it("rejects non-numeric strings", () => {
+    expect(parseTelegramReplyToMessageId("abc")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("not-a-number")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("NaN")).toBeUndefined();
+  });
+
+  it("trims whitespace before validation", () => {
+    expect(parseTelegramReplyToMessageId("  456  ")).toBe(456);
+    expect(parseTelegramReplyToMessageId("42 ")).toBe(42);
+    expect(parseTelegramReplyToMessageId(" 42")).toBe(42);
+  });
+});
+
+describe("parseTelegramThreadId", () => {
+  it("parses a valid integer string", () => {
+    expect(parseTelegramThreadId("271")).toBe(271);
+  });
+
+  it("parses a scoped DM thread id", () => {
+    expect(parseTelegramThreadId("12345:99")).toBe(99);
+  });
+
+  it("parses a numeric value", () => {
+    expect(parseTelegramThreadId(42)).toBe(42);
+  });
+
+  it("returns undefined for null/undefined", () => {
+    expect(parseTelegramThreadId(null)).toBeUndefined();
+    expect(parseTelegramThreadId(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for NaN", () => {
+    expect(parseTelegramThreadId(Number.NaN)).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(parseTelegramThreadId("")).toBeUndefined();
+    expect(parseTelegramThreadId("   ")).toBeUndefined();
+  });
+});

--- a/src/telegram/outbound-params.ts
+++ b/src/telegram/outbound-params.ts
@@ -2,8 +2,21 @@ export function parseTelegramReplyToMessageId(replyToId?: string | null): number
   if (!replyToId) {
     return undefined;
   }
-  const parsed = Number.parseInt(replyToId, 10);
-  return Number.isFinite(parsed) ? parsed : undefined;
+  const trimmed = replyToId.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  // Strict: entire string must be digits (no leading sign, no trailing garbage).
+  // parseInt is permissive ("123abc" → 123), so pre-validate with regex.
+  if (!/^\d+$/.test(trimmed)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  // Telegram message IDs are always positive integers.
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return undefined;
+  }
+  return parsed;
 }
 
 function parseIntegerId(value: string): number | undefined {

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -1363,6 +1363,64 @@ describe("shared send behaviors", () => {
     }
   });
 
+  it("omits reply_to_message_id when replyToMessageId is NaN", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 80,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+    // Simulate a cross-surface UUID-like reply id cast to number (results in NaN)
+    await sendMessageTelegram(chatId, "hello", {
+      token: "tok",
+      api,
+      replyToMessageId: Number("not-a-number"),
+    });
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "hello", {
+      parse_mode: "HTML",
+    });
+  });
+
+  it("omits reply_to_message_id when replyToMessageId is zero", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 81,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+    await sendMessageTelegram(chatId, "hello", {
+      token: "tok",
+      api,
+      replyToMessageId: 0,
+    });
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "hello", {
+      parse_mode: "HTML",
+    });
+  });
+
+  it("omits reply_to_message_id when replyToMessageId is negative", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 82,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+    await sendMessageTelegram(chatId, "hello", {
+      token: "tok",
+      api,
+      replyToMessageId: -5,
+    });
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "hello", {
+      parse_mode: "HTML",
+    });
+  });
+
   it("wraps chat-not-found with actionable context", async () => {
     const cases = [
       {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -279,13 +279,18 @@ function buildTelegramThreadReplyParams(params: {
 
   if (params.replyToMessageId != null) {
     const replyToMessageId = Math.trunc(params.replyToMessageId);
-    if (params.quoteText?.trim()) {
-      threadParams.reply_parameters = {
-        message_id: replyToMessageId,
-        quote: params.quoteText.trim(),
-      };
-    } else {
-      threadParams.reply_to_message_id = replyToMessageId;
+    // Guard: only attach reply threading when the id is a finite positive integer.
+    // Non-numeric or non-positive values (e.g. NaN from cross-surface UUID cast)
+    // would cause Telegram API 400 "message to be replied not found".
+    if (Number.isFinite(replyToMessageId) && replyToMessageId > 0) {
+      if (params.quoteText?.trim()) {
+        threadParams.reply_parameters = {
+          message_id: replyToMessageId,
+          quote: params.quoteText.trim(),
+        };
+      } else {
+        threadParams.reply_to_message_id = replyToMessageId;
+      }
     }
   }
   return threadParams;


### PR DESCRIPTION

**Fixes:** #37220, #37222, #37252

## Summary

This pull request addresses a set of bugs causing Telegram message delivery failures when a non-numeric or partially-numeric `replyToId` is processed. In cross-channel routing scenarios (e.g., a reply originating from a platform that uses UUIDs for message identifiers), the previous implementation would either generate a `NaN` value or permissively parse an incorrect integer, leading to `400: Bad Request: message to be replied not found` errors from the Telegram API.

This fix ensures that `replyToMessageId` values are strictly validated at both the parameter parsing and message-sending layers, making the Telegram channel more robust and preventing hard failures from invalid inputs.

## Root Cause Analysis

The primary issue stemmed from the `parseTelegramReplyToMessageId` function located in `src/telegram/outbound-params.ts`. This function used the native `Number.parseInt()`, which is overly permissive. For example:

- A partially-numeric string like `"123abc"` would be incorrectly parsed as `123`.
- A UUID would be parsed as `NaN` after being forced into a number.

This behavior resulted in invalid message IDs being sent to Telegram. Furthermore, the implementation lacked checks to ensure the parsed ID was a positive integer, as required by the Telegram API.

## Solution

To provide a comprehensive and robust solution, this PR implements a two-layered fix:

1.  **Strict Parsing (Root Cause Fix)**: The `parseTelegramReplyToMessageId` function in `src/telegram/outbound-params.ts` has been rewritten to enforce strict validation. It now uses a regular expression (`/^\d+$/`) to ensure the input string contains only digits and then verifies that the parsed number is a positive integer (`> 0`). This change fixes the root cause by preventing malformed IDs from ever entering the system.

2.  **Defense-in-Depth**: A secondary guard has been added to the `buildTelegramThreadReplyParams` function in `src/telegram/send.ts`. This check ensures that any `replyToMessageId` value is a finite positive integer before it is attached to the API request payload. This serves as a robust fallback and internal safeguard.

### Test Coverage

To validate the fix and prevent future regressions, comprehensive test coverage has been added:

- A new test file, `src/telegram/outbound-params.test.ts`, has been created to specifically unit-test the strict parsing logic with various edge cases (UUIDs, partial numbers, negative values, zero, etc.).
- Additional tests have been added to `src/telegram/send.test.ts` and `src/channels/plugins/outbound/telegram.test.ts` to verify the end-to-end behavior, ensuring that invalid `replyToId` values are correctly ignored and dropped.

## Changed Files

| File                                               | Change Description                                                               |
| -------------------------------------------------- | -------------------------------------------------------------------------------- |
| `src/telegram/outbound-params.ts`                  | **Modified**: Implemented strict, regex-based validation for `replyToMessageId`. |
| `src/telegram/send.ts`                             | **Modified**: Added a defense-in-depth check to ensure `replyToMessageId` is a positive integer. |
| `src/telegram/outbound-params.test.ts`             | **Added**: New test suite for the strict `replyToMessageId` parsing logic.       |
| `src/telegram/send.test.ts`                        | **Modified**: Added tests for `NaN`, zero, and negative `replyToMessageId` values. |
| `src/channels/plugins/outbound/telegram.test.ts`   | **Modified**: Added tests to ensure invalid `replyToId` values are dropped.      |
