### PR TITLE
Cron/CLI: guard malformed cron list and run jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/CLI malformed-job guards: harden `openclaw cron list` and manual `cron run` against persisted jobs missing `schedule.kind` or `payload.kind`, so the commands show or record a readable error instead of crashing with `TypeError`. (#37299) Thanks @blizzardetna-ship-it.
 - Memory/QMD mcporter Windows spawn hardening: when `mcporter.cmd` launch fails with `spawn EINVAL`, retry via bare `mcporter` shell resolution so QMD recall can continue instead of falling back to builtin memory search. (#27402) Thanks @i0ivi0i.
 - Tools/web_search Brave language-code validation: align `search_lang` handling with Brave-supported codes (including `zh-hans`, `zh-hant`, `en-gb`, and `pt-br`), map common alias inputs (`zh`, `ja`) to valid Brave values, and reject unsupported codes before upstream requests to prevent 422 failures. (#37260) Thanks @heyanming.
 - Models/openai-completions streaming compatibility: force `compat.supportsUsageInStreaming=false` for non-native OpenAI-compatible endpoints during model normalization, preventing usage-only stream chunks from triggering `choices[0]` parser crashes in provider streams. (#8714) Thanks @nonanon1.

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -166,4 +166,19 @@ describe("printCronList", () => {
     printCronList([job], runtime);
     expect(logs.some((line) => line.includes("(exact)"))).toBe(true);
   });
+
+  it("guards malformed jobs that are missing schedule/payload kind metadata (#37299)", () => {
+    const { logs, runtime } = createRuntimeLogCapture();
+    const job = createBaseJob({
+      id: "malformed-job",
+      name: "Malformed",
+      schedule: { at: new Date(Date.now() + 3600000).toISOString() } as CronJob["schedule"],
+      payload: { text: "legacy payload" } as CronJob["payload"],
+      state: {},
+    });
+
+    expect(() => printCronList([job], runtime)).not.toThrow();
+    expect(logs.some((line) => line.includes("malformed-job"))).toBe(true);
+    expect(logs.some((line) => line.includes("invalid"))).toBe(true);
+  });
 });

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -149,14 +149,36 @@ const formatRelative = (ms: number | null | undefined, nowMs: number) => {
   return delta >= 0 ? `in ${label}` : `${label} ago`;
 };
 
-const formatSchedule = (schedule: CronSchedule) => {
-  if (schedule.kind === "at") {
-    return `at ${formatIsoMinute(schedule.at)}`;
+const isAtSchedule = (schedule: unknown): schedule is Extract<CronSchedule, { kind: "at" }> =>
+  (schedule as { kind?: unknown } | null | undefined)?.kind === "at";
+
+const isEverySchedule = (schedule: unknown): schedule is Extract<CronSchedule, { kind: "every" }> =>
+  (schedule as { kind?: unknown } | null | undefined)?.kind === "every";
+
+const isCronSchedule = (schedule: unknown): schedule is Extract<CronSchedule, { kind: "cron" }> =>
+  (schedule as { kind?: unknown } | null | undefined)?.kind === "cron";
+
+const isAgentTurnPayload = (
+  payload: CronJob["payload"] | undefined,
+): payload is Extract<CronJob["payload"], { kind: "agentTurn" }> => payload?.kind === "agentTurn";
+
+const formatSchedule = (schedule: CronSchedule | undefined) => {
+  if (isAtSchedule(schedule)) {
+    const at = typeof schedule.at === "string" ? schedule.at : "";
+    return at ? `at ${formatIsoMinute(at)}` : "at -";
   }
-  if (schedule.kind === "every") {
-    return `every ${formatDurationHuman(schedule.everyMs)}`;
+  if (isEverySchedule(schedule)) {
+    const everyMs = typeof schedule.everyMs === "number" ? schedule.everyMs : null;
+    return everyMs && Number.isFinite(everyMs)
+      ? `every ${formatDurationHuman(everyMs)}`
+      : "every -";
   }
-  const base = schedule.tz ? `cron ${schedule.expr} @ ${schedule.tz}` : `cron ${schedule.expr}`;
+  if (!isCronSchedule(schedule)) {
+    return "invalid";
+  }
+  const expr = typeof schedule.expr === "string" && schedule.expr.trim() ? schedule.expr : "?";
+  const tz = typeof schedule.tz === "string" && schedule.tz.trim() ? schedule.tz : undefined;
+  const base = tz ? `cron ${expr} @ ${tz}` : `cron ${expr}`;
   const staggerMs = resolveCronStaggerMs(schedule);
   if (staggerMs <= 0) {
     return `${base} (exact)`;
@@ -165,13 +187,14 @@ const formatSchedule = (schedule: CronSchedule) => {
 };
 
 const formatStatus = (job: CronJob) => {
+  const state = job.state ?? {};
   if (!job.enabled) {
     return "disabled";
   }
-  if (job.state.runningAtMs) {
+  if (state.runningAtMs) {
     return "running";
   }
-  return job.state.lastStatus ?? "idle";
+  return state.lastStatus ?? "idle";
 };
 
 export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
@@ -197,6 +220,8 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
   const now = Date.now();
 
   for (const job of jobs) {
+    const state = job.state ?? {};
+    const agentPayload = isAgentTurnPayload(job.payload) ? job.payload : undefined;
     const idLabel = pad(job.id, CRON_ID_PAD);
     const nameLabel = pad(truncate(job.name, CRON_NAME_PAD), CRON_NAME_PAD);
     const scheduleLabel = pad(
@@ -204,21 +229,15 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
       CRON_SCHEDULE_PAD,
     );
     const nextLabel = pad(
-      job.enabled ? formatRelative(job.state.nextRunAtMs, now) : "-",
+      job.enabled ? formatRelative(state.nextRunAtMs, now) : "-",
       CRON_NEXT_PAD,
     );
-    const lastLabel = pad(formatRelative(job.state.lastRunAtMs, now), CRON_LAST_PAD);
+    const lastLabel = pad(formatRelative(state.lastRunAtMs, now), CRON_LAST_PAD);
     const statusRaw = formatStatus(job);
     const statusLabel = pad(statusRaw, CRON_STATUS_PAD);
     const targetLabel = pad(job.sessionTarget ?? "-", CRON_TARGET_PAD);
     const agentLabel = pad(truncate(job.agentId ?? "-", CRON_AGENT_PAD), CRON_AGENT_PAD);
-    const modelLabel = pad(
-      truncate(
-        (job.payload.kind === "agentTurn" ? job.payload.model : undefined) ?? "-",
-        CRON_MODEL_PAD,
-      ),
-      CRON_MODEL_PAD,
-    );
+    const modelLabel = pad(truncate(agentPayload?.model ?? "-", CRON_MODEL_PAD), CRON_MODEL_PAD);
 
     const coloredStatus = (() => {
       if (statusRaw === "ok") {
@@ -253,7 +272,7 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
       coloredStatus,
       coloredTarget,
       coloredAgent,
-      job.payload.kind === "agentTurn" && job.payload.model
+      agentPayload?.model
         ? colorize(rich, theme.info, modelLabel)
         : colorize(rich, theme.muted, modelLabel),
     ].join(" ");

--- a/src/cron/delivery.ts
+++ b/src/cron/delivery.ts
@@ -48,7 +48,7 @@ function normalizeAccountId(value: unknown): string | undefined {
 }
 
 export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
-  const payload = job.payload.kind === "agentTurn" ? job.payload : null;
+  const payload = job.payload?.kind === "agentTurn" ? job.payload : null;
   const delivery = job.delivery;
   const hasDelivery = delivery && typeof delivery === "object";
   const rawMode = hasDelivery ? (delivery as { mode?: unknown }).mode : undefined;

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -1295,6 +1295,37 @@ describe("Cron issue regressions", () => {
     );
   });
 
+  it("skips malformed main-job payloads during manual run instead of throwing (#37299)", async () => {
+    const store = makeStorePath();
+    const now = Date.parse("2026-02-06T10:05:00.000Z");
+    await writeCronStoreSnapshot(store.storePath, [
+      {
+        id: "malformed-main",
+        name: "malformed main",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(now - 1000).toISOString() },
+        sessionTarget: "main",
+        wakeMode: "now",
+        state: { nextRunAtMs: now - 1000 },
+      },
+    ]);
+
+    const state = createCronServiceState({
+      cronEnabled: true,
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn().mockResolvedValue({ status: "ok", summary: "ok" }),
+    });
+
+    await expect(run(state, "malformed-main", "force")).resolves.toEqual({ ok: true, ran: true });
+    expect(state.store?.jobs.find((job) => job.id === "malformed-main")?.state.lastError).toBe(
+      'main job requires payload.kind="systemEvent"',
+    );
+  });
+
   it("honors cron maxConcurrentRuns for due jobs", async () => {
     vi.useRealTimers();
     const store = makeStorePath();

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -26,7 +26,6 @@ import {
   normalizeOptionalAgentId,
   normalizeOptionalSessionKey,
   normalizeOptionalText,
-  normalizePayloadToSystemText,
   normalizeRequiredName,
 } from "./normalize.js";
 import type { CronServiceState } from "./state.js";
@@ -891,9 +890,9 @@ export function isJobDue(job: CronJob, nowMs: number, opts: { forced: boolean })
 }
 
 export function resolveJobPayloadTextForMain(job: CronJob): string | undefined {
-  if (job.payload.kind !== "systemEvent") {
+  if (job.payload?.kind !== "systemEvent") {
     return undefined;
   }
-  const text = normalizePayloadToSystemText(job.payload);
+  const text = typeof job.payload.text === "string" ? job.payload.text.trim() : "";
   return text.trim() ? text : undefined;
 }

--- a/src/cron/service/timeout-policy.ts
+++ b/src/cron/service/timeout-policy.ts
@@ -15,11 +15,13 @@ export const AGENT_TURN_SAFETY_TIMEOUT_MS = 60 * 60_000; // 60 minutes
 
 export function resolveCronJobTimeoutMs(job: CronJob): number | undefined {
   const configuredTimeoutMs =
-    job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
+    job.payload?.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
       ? Math.floor(job.payload.timeoutSeconds * 1_000)
       : undefined;
   if (configuredTimeoutMs === undefined) {
-    return job.payload.kind === "agentTurn" ? AGENT_TURN_SAFETY_TIMEOUT_MS : DEFAULT_JOB_TIMEOUT_MS;
+    return job.payload?.kind === "agentTurn"
+      ? AGENT_TURN_SAFETY_TIMEOUT_MS
+      : DEFAULT_JOB_TIMEOUT_MS;
   }
   return configuredTimeoutMs <= 0 ? undefined : configuredTimeoutMs;
 }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -322,7 +322,7 @@ export function applyJobResult(
     if (alertConfig && job.state.consecutiveErrors >= alertConfig.after) {
       const isBestEffort =
         job.delivery?.bestEffort === true ||
-        (job.payload.kind === "agentTurn" && job.payload.bestEffortDeliver === true);
+        (job.payload?.kind === "agentTurn" && job.payload.bestEffortDeliver === true);
       if (!isBestEffort) {
         const now = state.deps.nowMs();
         const lastAlert = job.state.lastFailureAlertAtMs;
@@ -956,7 +956,7 @@ export async function executeJobCore(
   if (job.sessionTarget === "main") {
     const text = resolveJobPayloadTextForMain(job);
     if (!text) {
-      const kind = job.payload.kind;
+      const kind = job.payload?.kind;
       return {
         status: "skipped",
         error:
@@ -1038,7 +1038,8 @@ export async function executeJobCore(
     }
   }
 
-  if (job.payload.kind !== "agentTurn") {
+  const agentPayload = job.payload?.kind === "agentTurn" ? job.payload : null;
+  if (!agentPayload) {
     return { status: "skipped", error: "isolated job requires payload.kind=agentTurn" };
   }
   if (abortSignal?.aborted) {
@@ -1047,7 +1048,7 @@ export async function executeJobCore(
 
   const res = await state.deps.runIsolatedAgentJob({
     job,
-    message: job.payload.message,
+    message: agentPayload.message,
     abortSignal,
   });
 


### PR DESCRIPTION
AI-assisted: yes. Human-reviewed, with targeted regression tests and local verification.

## Summary

- Problem: `openclaw cron list` and `openclaw cron run <id>` could crash with `TypeError` when older persisted jobs were missing `schedule.kind` or `payload.kind` metadata.
- Why it matters: the CLI became unusable for affected users even though the cron jobs themselves were still present and runnable in the scheduler.
- What changed: hardened cron CLI rendering and cron execution paths to treat malformed persisted jobs as invalid/skipped with readable output or recorded errors instead of throwing.
- What did NOT change (scope boundary): no scheduler semantics, no cron file migration, and no behavior changes for well-formed cron jobs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37299
- Related #9649

## User-visible / Behavior Changes

- `openclaw cron list` now shows malformed persisted jobs without crashing, using an `invalid` schedule label when required schedule metadata is missing.
- Manual cron execution now records a readable job error for malformed main-session payloads instead of throwing a `TypeError`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local verification), issue reproduced by reporter on Windows
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): persisted cron store containing legacy/malformed jobs with missing `schedule.kind` or `payload.kind`

### Steps

1. Persist a cron job missing `schedule.kind` or `payload.kind` metadata.
2. Run `openclaw cron list` or `openclaw cron run <job-id>`.
3. Observe CLI behavior.

### Expected

- The CLI should show the job or record a readable validation error without crashing.

### Actual

- Before this change, the CLI could throw `TypeError: Cannot read properties of undefined (reading 'kind')`.
- After this change, malformed jobs render safely and manual execution records a readable error instead of throwing.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added regression coverage for both CLI listing and manual run handling:
- `src/cli/cron-cli/shared.test.ts`
- `src/cron/service.issue-regressions.test.ts`

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/cli/cron-cli/shared.test.ts src/cron/service.issue-regressions.test.ts`
  - `pnpm build`
  - `pnpm exec oxlint src/cli/cron-cli/shared.ts src/cli/cron-cli/shared.test.ts src/cron/delivery.ts src/cron/service/jobs.ts src/cron/service/timer.ts src/cron/service/timeout-policy.ts src/cron/service.issue-regressions.test.ts`
  - `pnpm exec oxfmt --check src/cli/cron-cli/shared.ts src/cli/cron-cli/shared.test.ts src/cron/delivery.ts src/cron/service/jobs.ts src/cron/service/timer.ts src/cron/service/timeout-policy.ts src/cron/service.issue-regressions.test.ts CHANGELOG.md`
- Edge cases checked:
  - missing `schedule.kind`
  - missing `payload.kind`
  - malformed main-session payload during manual run
  - well-formed agent-turn jobs still show the model column correctly
- What you did **not** verify:
  - Full `pnpm check` is currently blocked by an unrelated repo baseline error in `extensions/tlon` (`TS2307: Cannot find module '@tloncorp/api'`).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR's commit.
- Files/config to restore: cron CLI/shared formatting and cron service guards touched in this PR.
- Known bad symptoms reviewers should watch for: missing model values in `cron list` for valid agent-turn jobs, or malformed jobs still crashing `cron list` / `cron run`.

## Risks and Mitigations

- Risk: malformed persisted jobs might now surface as `invalid`/`skipped`, which could slightly change CLI output for corrupted stores.
  - Mitigation: behavior is only different for already-broken persisted data, and the new output is explicit and non-crashing.
