### PR TITLE
fix: respect user-configured baseUrl for MiniMax provider

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -929,11 +929,16 @@ export async function resolveImplicitProviders(params: {
     allowKeychainPrompt: false,
   });
 
+  const explicitMinimax = params.explicitProviders?.minimax;
   const minimaxKey =
     resolveEnvApiKeyVarName("minimax") ??
     resolveApiKeyFromProfiles({ provider: "minimax", store: authStore });
   if (minimaxKey) {
-    providers.minimax = { ...buildMinimaxProvider(), apiKey: minimaxKey };
+    providers.minimax = {
+      ...buildMinimaxProvider(),
+      ...(explicitMinimax?.baseUrl ? { baseUrl: explicitMinimax.baseUrl } : {}),
+      apiKey: minimaxKey,
+    };
   }
 
   const minimaxOauthProfile = listProfilesForProvider(authStore, "minimax-portal");


### PR DESCRIPTION
## Summary

Fixes #37142 - allows users to configure custom baseUrl for MiniMax provider.

## Problem

Users configuring MiniMax with alternative endpoints (e.g., `https://api.minimaxi.com/anthropic`) were getting HTTP 401/404 errors because `resolveImplicitProviders` always used the default endpoint (`https://api.minimax.io/anthropic`), ignoring the user configuration.

## Solution

Check `params.explicitProviders?.minimax?.baseUrl` before applying the default baseUrl. If the user has configured a custom baseUrl, use it.

Same pattern as Moonshot provider fix (PR #33909).

## Changes

- `src/agents/models-config.providers.ts`: Add explicit baseUrl check for MiniMax provider

## Testing

- Users can now configure MiniMax with alternative endpoints
- Default endpoint still works when no custom baseUrl is set