### PR TITLE
fix(gateway): guard source.data with nullish coalesce in image_url byte count

### DIFF
--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -300,7 +300,9 @@ async function resolveImagesForRequest(
   for (const url of urls) {
     const source = parseImageUrlToSource(url);
     if (source.type === "base64") {
-      totalBytes += estimateBase64DecodedBytes(source.data);
+      // source.data is guaranteed non-empty by parseImageUrlToSource (it throws
+      // on empty data), but InputImageSource.data is typed as optional.
+      totalBytes += estimateBase64DecodedBytes(source.data ?? "");
       if (totalBytes > limits.maxTotalImageBytes) {
         throw new Error(
           `Total image payload too large (${totalBytes}; limit ${limits.maxTotalImageBytes})`,


### PR DESCRIPTION
## Problem

`InputImageSource.data` is typed as `data?: string` (optional), but `estimateBase64DecodedBytes()` expects `string`. This causes a TypeScript TS2345 error in CI:

```
src/gateway/openai-http.ts(303,48): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
```

This error was introduced in the commit that added image_url support to `openai-http.ts` (9c86a9fd2) and is now blocking CI on **14 open PRs** that were rebased on top of that commit.

## Fix

Add `?? ""` as a safe fallback. The runtime behavior is unchanged: `parseImageUrlToSource()` already throws when `data` is empty (line 254), so this branch is never reached with undefined data. The guard purely satisfies the TypeScript compiler.

## Impact

Unblocks CI for all PRs rebased on current `main` — without this fix every rebase triggers a `check` job failure unrelated to the PR's own changes.