### PR TITLE
CLI: keep --json stdout machine-readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI JSON stdout hygiene: route plugin/bootstrap startup logs to stderr for explicit `--json` commands while keeping the JSON payload on stdout, so commands like `openclaw plugins list --json | jq .` stay machine-readable. (#37323) Thanks @furedericca-lab.
 - Onboarding/headless Linux daemon probe hardening: treat `systemctl --user is-enabled` probe failures as non-fatal during daemon install flow so onboarding no longer crashes on SSH/headless VPS environments before showing install guidance. (#37297) Thanks @acarbajal-web.
 - Memory/QMD mcporter Windows spawn hardening: when `mcporter.cmd` launch fails with `spawn EINVAL`, retry via bare `mcporter` shell resolution so QMD recall can continue instead of falling back to builtin memory search. (#27402) Thanks @i0ivi0i.
 - Tools/web_search Brave language-code validation: align `search_lang` handling with Brave-supported codes (including `zh-hans`, `zh-hant`, `en-gb`, and `pt-br`), map common alias inputs (`zh`, `ja`) to valid Brave values, and reject unsupported codes before upstream requests to prevent 422 failures. (#37260) Thanks @heyanming.

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -5,6 +5,7 @@ const setVerboseMock = vi.fn();
 const emitCliBannerMock = vi.fn();
 const ensureConfigReadyMock = vi.fn(async () => {});
 const ensurePluginRegistryLoadedMock = vi.fn();
+const routeLogsToStderrMock = vi.fn();
 
 const runtimeMock = {
   log: vi.fn(),
@@ -34,6 +35,10 @@ vi.mock("./config-guard.js", () => ({
 
 vi.mock("../plugin-registry.js", () => ({
   ensurePluginRegistryLoaded: ensurePluginRegistryLoadedMock,
+}));
+
+vi.mock("../../logging.js", () => ({
+  routeLogsToStderr: routeLogsToStderrMock,
 }));
 
 let registerPreActionHooks: typeof import("./preaction.js").registerPreActionHooks;
@@ -195,6 +200,7 @@ describe("registerPreActionHooks", () => {
       commandPath: ["update", "status"],
       suppressDoctorStdout: true,
     });
+    expect(routeLogsToStderrMock).toHaveBeenCalledTimes(1);
 
     vi.clearAllMocks();
     await runPreAction({
@@ -206,6 +212,7 @@ describe("registerPreActionHooks", () => {
       runtime: runtimeMock,
       commandPath: ["config", "set"],
     });
+    expect(routeLogsToStderrMock).not.toHaveBeenCalled();
   });
 
   it("bypasses config guard for config validate", async () => {

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { setVerbose } from "../../globals.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
+import { routeLogsToStderr } from "../../logging.js";
 import type { LogLevel } from "../../logging/levels.js";
 import { defaultRuntime } from "../../runtime.js";
 import {
@@ -127,6 +128,9 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       return;
     }
     const suppressDoctorStdout = isJsonOutputMode(commandPath, argv);
+    if (suppressDoctorStdout) {
+      routeLogsToStderr();
+    }
     const { ensureConfigReady } = await loadConfigGuardModule();
     await ensureConfigReady({
       runtime: defaultRuntime,

--- a/src/logging/console-capture.test.ts
+++ b/src/logging/console-capture.test.ts
@@ -109,6 +109,19 @@ describe("enableConsoleCapture", () => {
     expect(log).toHaveBeenCalledWith(payload);
   });
 
+  it("keeps JSON payloads on stdout when stderr routing is enabled", () => {
+    setLoggerOverride({ level: "info", file: tempLogPath() });
+    const log = vi.fn();
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    console.log = log;
+    routeLogsToStderr();
+    enableConsoleCapture();
+    const payload = JSON.stringify({ ok: true });
+    console.log(payload);
+    expect(log).toHaveBeenCalledWith(payload);
+    expect(stderrWrite).not.toHaveBeenCalled();
+  });
+
   it.each([
     { name: "stdout", stream: process.stdout },
     { name: "stderr", stream: process.stderr },

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -282,7 +282,7 @@ export function enableConsoleCapture(): void {
       } catch {
         // never block console output on logging failures
       }
-      if (loggingState.forceConsoleToStderr) {
+      if (loggingState.forceConsoleToStderr && !isJsonPayload(formatted)) {
         // in RPC/JSON mode, keep stdout clean
         try {
           const line = timestamp ? `${timestamp} ${formatted}` : formatted;


### PR DESCRIPTION
AI-assisted: yes. Human-reviewed, with targeted CLI/logging regression tests and local verification.

## Summary

- Problem: explicit `--json` CLI commands could emit plugin/bootstrap startup logs to stdout before the JSON payload.
- Why it matters: this breaks machine-readable contracts for commands like `openclaw plugins list --json | jq .` and `openclaw hooks list --json | jq .`.
- What changed: explicit JSON-output commands now enable stderr routing for startup logs during preaction, while the logging layer keeps actual JSON payloads on stdout.
- What did NOT change (scope boundary): no command payload schema changes, no plugin loading behavior changes, and no non-JSON CLI output changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37323
- Related #20890

## User-visible / Behavior Changes

- Explicit JSON CLI commands keep stdout reserved for JSON payloads even when plugin/bootstrap startup logs are emitted.
- Startup/plugin logs for those commands are routed to stderr instead of polluting stdout.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local verification), reporter reproduced on Linux LXC
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): plugin/bootstrap startup path
- Relevant config (redacted): plugin-enabled CLI startup where plugin bootstrap logs are emitted before command output

### Steps

1. Enable plugins that emit startup/bootstrap logs.
2. Run `openclaw plugins list --json | jq .` or `openclaw hooks list --json | jq .`.
3. Observe stdout/stderr separation.

### Expected

- Stdout contains only JSON.
- Non-fatal startup logs do not corrupt machine-readable output.

### Actual

- Before this change, startup logs could appear on stdout before JSON and break `jq` parsing.
- After this change, startup logs are redirected to stderr while JSON payloads remain on stdout.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added regression coverage for:
- explicit `--json` preaction routing in `src/cli/program/preaction.test.ts`
- JSON payload preservation under stderr-routing console capture in `src/logging/console-capture.test.ts`

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/cli/program/preaction.test.ts src/logging/console-capture.test.ts`
  - `pnpm build`
  - `pnpm exec oxlint src/cli/program/preaction.ts src/cli/program/preaction.test.ts src/logging/console.ts src/logging/console-capture.test.ts`
  - `pnpm exec oxfmt --check src/cli/program/preaction.ts src/cli/program/preaction.test.ts src/logging/console.ts src/logging/console-capture.test.ts CHANGELOG.md`
- Edge cases checked:
  - explicit JSON-output commands enable stderr routing
  - parse-only `config set --json` does not enable stderr routing
  - JSON console payloads remain on stdout when stderr routing is enabled
- What you did **not** verify:
  - Full `pnpm check` is currently blocked by an unrelated repo baseline error in `extensions/tlon` (`TS2307: Cannot find module '@tloncorp/api'`).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR's commit.
- Files/config to restore: CLI preaction JSON routing and console capture behavior.
- Known bad symptoms reviewers should watch for: JSON payload unexpectedly written to stderr, or plugin/bootstrap logs still appearing on stdout for explicit `--json` commands.

## Risks and Mitigations

- Risk: any non-command console output that happens to be valid JSON during explicit `--json` commands would remain on stdout.
  - Mitigation: the stdout-preservation exception is intentionally limited to valid JSON payloads, matching the machine-readable contract these commands already rely on.
