### PR TITLE
fix(models-config): let config baseUrl/apiKey override agent models.json in merge mode

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -207,7 +207,7 @@ describe("models-config", () => {
     });
   });
 
-  it("preserves non-empty agent apiKey/baseUrl for matching providers in merge mode", async () => {
+  it("uses config apiKey/baseUrl when config provides non-empty values (fixes #37309)", async () => {
     await withTempHome(async () => {
       const parsed = await runCustomProviderMergeTest({
         baseUrl: "https://agent.example/v1",
@@ -215,6 +215,49 @@ describe("models-config", () => {
         api: "openai-responses",
         models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
       });
+      expect(parsed.providers.custom?.apiKey).toBe("CONFIG_KEY");
+      expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
+    });
+  });
+
+  it("preserves agent apiKey/baseUrl when config values are empty", async () => {
+    await withTempHome(async () => {
+      await writeAgentModelsJson({
+        providers: {
+          custom: {
+            baseUrl: "https://agent.example/v1",
+            apiKey: "AGENT_KEY",
+            api: "openai-responses",
+            models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
+          },
+        },
+      });
+      await ensureOpenClawModelsJson({
+        models: {
+          mode: "merge",
+          providers: {
+            custom: {
+              baseUrl: "",
+              apiKey: "",
+              api: "openai-responses",
+              models: [
+                {
+                  id: "config-model",
+                  name: "Config model",
+                  input: ["text"],
+                  reasoning: false,
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 2048,
+                },
+              ],
+            },
+          },
+        },
+      });
+      const parsed = await readGeneratedModelsJson<{
+        providers: Record<string, { apiKey?: string; baseUrl?: string }>;
+      }>();
       expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
       expect(parsed.providers.custom?.baseUrl).toBe("https://agent.example/v1");
     });

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -158,11 +158,19 @@ function mergeWithExistingProviderSecrets(params: {
       mergedProviders[key] = newEntry;
       continue;
     }
+    // Only preserve agent apiKey/baseUrl when config does not provide a non-empty value,
+    // so that updating openclaw.json and restarting takes effect (fixes #37309).
     const preserved: Record<string, unknown> = {};
-    if (typeof existing.apiKey === "string" && existing.apiKey) {
+    const configHasApiKey =
+      typeof (newEntry as { apiKey?: string }).apiKey === "string" &&
+      (newEntry as { apiKey?: string }).apiKey !== "";
+    const configHasBaseUrl =
+      typeof (newEntry as { baseUrl?: string }).baseUrl === "string" &&
+      (newEntry as { baseUrl?: string }).baseUrl !== "";
+    if (typeof existing.apiKey === "string" && existing.apiKey && !configHasApiKey) {
       preserved.apiKey = existing.apiKey;
     }
-    if (typeof existing.baseUrl === "string" && existing.baseUrl) {
+    if (typeof existing.baseUrl === "string" && existing.baseUrl && !configHasBaseUrl) {
       preserved.baseUrl = existing.baseUrl;
     }
     mergedProviders[key] = { ...newEntry, ...preserved };

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -686,7 +686,7 @@ export const FIELD_HELP: Record<string, string> = {
   models:
     "Model catalog root for provider definitions, merge/replace behavior, and optional Bedrock discovery integration. Keep provider definitions explicit and validated before relying on production failover paths.",
   "models.mode":
-    'Controls provider catalog behavior: "merge" keeps built-ins and overlays your custom providers, while "replace" uses only your configured providers. In "merge", matching provider IDs preserve non-empty agent models.json apiKey/baseUrl values and fall back to config when agent values are empty or missing; matching model contextWindow/maxTokens use the higher value between explicit and implicit entries.',
+    'Controls provider catalog behavior: "merge" keeps built-ins and overlays your custom providers, while "replace" uses only your configured providers. In "merge", matching provider IDs use config apiKey/baseUrl when config provides non-empty values (so updating openclaw.json and restarting takes effect); when config omits or leaves them empty, non-empty agent models.json values are preserved. Matching model contextWindow/maxTokens use the higher value between explicit and implicit entries.',
   "models.providers":
     "Provider map keyed by provider ID containing connection/auth settings and concrete model definitions. Use stable provider keys so references from agents and tooling remain portable across environments.",
   "models.providers.*.baseUrl":


### PR DESCRIPTION
Fixes #37309

## Problem
In `models.mode: "merge"`, updating `baseUrl` (or `apiKey`) in `openclaw.json` and restarting the gateway had no effect: the agent kept using the values stored in `.openclaw/agent/.../models.json`. Users had to manually edit the hidden `models.json` to correct a wrong URL.

## Cause
`mergeWithExistingProviderSecrets` always preserved non-empty `apiKey`/`baseUrl` from the existing agent `models.json`, overwriting the values coming from config, so config was never able to override once agent state existed.

## Solution
In merge mode, only preserve agent `apiKey`/`baseUrl` when config does **not** provide a non-empty value. When config provides a non-empty `baseUrl` or `apiKey`, config wins. Thus:
- Correcting `openclaw.json` and restarting takes effect.
- When config omits or leaves these fields empty, existing agent values are still preserved.

## Changes
- **src/agents/models-config.ts**: In `mergeWithExistingProviderSecrets`, preserve existing `apiKey`/`baseUrl` only when the corresponding value from config is missing or empty.
- **src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts**: Renamed and updated the test that had expected agent-to-win; added a test that agent values are preserved when config provides empty strings.
- **src/config/schema.help.ts**: Updated `models.mode` help text to describe the new merge behavior.

## Testing
- `pnpm test -- src/agents/models-config --run` (71 tests) passes.