### PR TITLE
fix(infra): guard negative ms in formatDurationPrecise and expand duration tests

### DIFF
--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -112,4 +112,21 @@ describe("parseDurationMs", () => {
     expect(() => parseDurationMs("1h30")).toThrow();
     expect(() => parseDurationMs("1h-30m")).toThrow();
   });
+
+  it("respects defaultUnit option for bare numbers", () => {
+    expect(parseDurationMs("10", { defaultUnit: "s" })).toBe(10_000);
+    expect(parseDurationMs("2", { defaultUnit: "m" })).toBe(120_000);
+    expect(parseDurationMs("1", { defaultUnit: "h" })).toBe(3_600_000);
+  });
+
+  it("returns 0 for zero input with any unit", () => {
+    expect(parseDurationMs("0")).toBe(0);
+    expect(parseDurationMs("0ms")).toBe(0);
+    expect(parseDurationMs("0s")).toBe(0);
+  });
+
+  it("rejects non-numeric and whitespace-only strings", () => {
+    expect(() => parseDurationMs("abc")).toThrow();
+    expect(() => parseDurationMs("  ")).toThrow();
+  });
 });

--- a/src/infra/format-time/format-duration.ts
+++ b/src/infra/format-time/format-duration.ts
@@ -28,7 +28,7 @@ export function formatDurationPrecise(
   ms: number,
   options: FormatDurationSecondsOptions = {},
 ): string {
-  if (!Number.isFinite(ms)) {
+  if (!Number.isFinite(ms) || ms < 0) {
     return "unknown";
   }
   if (ms < 1000) {

--- a/src/infra/format-time/format-time.test.ts
+++ b/src/infra/format-time/format-time.test.ts
@@ -61,6 +61,10 @@ describe("format-duration", () => {
       expect(formatDurationHuman(null, "unknown")).toBe("unknown");
     });
 
+    it("formats zero duration as 0ms", () => {
+      expect(formatDurationHuman(0)).toBe("0ms");
+    });
+
     it("formats single-unit outputs and day threshold behavior", () => {
       const cases = [
         [500, "500ms"],
@@ -90,9 +94,10 @@ describe("format-duration", () => {
       expect(formatDurationPrecise(1234)).toBe("1.23s");
     });
 
-    it("returns unknown for non-finite", () => {
+    it("returns unknown for non-finite or negative", () => {
       expect(formatDurationPrecise(NaN)).toBe("unknown");
       expect(formatDurationPrecise(Infinity)).toBe("unknown");
+      expect(formatDurationPrecise(-500)).toBe("unknown");
     });
   });
 
@@ -105,6 +110,10 @@ describe("format-duration", () => {
 
     it("supports seconds unit", () => {
       expect(formatDurationSeconds(2000, { unit: "seconds" })).toBe("2 seconds");
+    });
+
+    it("clamps negative values to 0s", () => {
+      expect(formatDurationSeconds(-1000)).toBe("0s");
     });
   });
 });
@@ -158,8 +167,8 @@ describe("format-datetime", () => {
 describe("format-relative", () => {
   describe("formatTimeAgo", () => {
     it("returns fallback for invalid elapsed input", () => {
-      for (const value of [null, undefined, -100]) {
-        expect(formatTimeAgo(value)).toBe("unknown");
+      for (const value of [null, undefined, -100, NaN, Infinity]) {
+        expect(formatTimeAgo(value as never)).toBe("unknown");
       }
       expect(formatTimeAgo(null, { fallback: "n/a" })).toBe("n/a");
     });
@@ -189,8 +198,8 @@ describe("format-relative", () => {
 
   describe("formatRelativeTimestamp", () => {
     it("returns fallback for invalid timestamp input", () => {
-      for (const value of [null, undefined]) {
-        expect(formatRelativeTimestamp(value)).toBe("n/a");
+      for (const value of [null, undefined, NaN, Infinity]) {
+        expect(formatRelativeTimestamp(value as never)).toBe("n/a");
       }
       expect(formatRelativeTimestamp(null, { fallback: "unknown" })).toBe("unknown");
     });


### PR DESCRIPTION
## Summary

### Bug fix: formatDurationPrecise returns garbage for negative input

formatDurationPrecise(ms) checked for non-finite (NaN, Infinity) but not for negative values.
A call like formatDurationPrecise(-500) falls through to the sub-second branch and returns -500ms.
This is inconsistent with formatDurationHuman which guards ms less than 0 and returns a fallback.

Fix: combine the non-finite guard with a negative check so formatDurationPrecise(-500) returns
unknown just like formatDurationPrecise(NaN).

### Test coverage additions

src/infra/format-time/format-time.test.ts
- formatDurationPrecise: add negative input case (-500 returns unknown)
- formatDurationSeconds: add negative clamping test (-1000 returns 0s via Math.max)
- formatDurationHuman: add zero-duration test (0 returns 0ms)
- formatTimeAgo: extend fallback test to cover NaN and Infinity
- formatRelativeTimestamp: extend fallback test to cover NaN and Infinity

src/cli/cli-utils.test.ts
- parseDurationMs: test defaultUnit option (10 with defaultUnit s returns 10000)
- parseDurationMs: test zero input with ms, s, and no unit (returns 0)
- parseDurationMs: test non-numeric string and whitespace-only string throw

## Testing

All 48 tests pass.
