### PR TITLE
fix(security): classify localized Windows SYSTEM names as trusted

### DIFF
--- a/src/security/windows-acl.test.ts
+++ b/src/security/windows-acl.test.ts
@@ -492,6 +492,32 @@ Successfully processed 1 files`;
       expectTrustedOnly([aclEntry({ principal: "AUTORIDAD NT\\SYSTEM" })]);
     });
 
+    it("classifies Russian SYSTEM (NT AUTHORITY\\СИСТЕМА) as trusted", () => {
+      expectTrustedOnly([
+        aclEntry({ principal: "NT AUTHORITY\\\u0421\u0418\u0421\u0422\u0415\u041c\u0410" }),
+      ]);
+    });
+
+    it("classifies Italian/Spanish SYSTEM via \\sistema suffix as trusted", () => {
+      expectTrustedOnly([aclEntry({ principal: "NT AUTHORITY\\sistema" })]);
+    });
+
+    it("classifies Dutch SYSTEM via \\systeem suffix as trusted", () => {
+      expectTrustedOnly([aclEntry({ principal: "NT AUTHORITY\\systeem" })]);
+    });
+
+    it("Russian Windows full scenario: user + СИСТЕМА only → no untrusted", () => {
+      const entries: WindowsAclEntry[] = [
+        aclEntry({ principal: "MYPC\\karte" }),
+        aclEntry({ principal: "NT AUTHORITY\\\u0421\u0418\u0421\u0422\u0415\u041c\u0410" }),
+      ];
+      const env = { USERNAME: "karte", USERDOMAIN: "MYPC" };
+      const { trusted, untrustedWorld, untrustedGroup } = summarizeWindowsAcl(entries, env);
+      expect(trusted).toHaveLength(2);
+      expect(untrustedWorld).toHaveLength(0);
+      expect(untrustedGroup).toHaveLength(0);
+    });
+
     it("French Windows full scenario: user + Système only → no untrusted", () => {
       const entries: WindowsAclEntry[] = [
         aclEntry({ principal: "MYPC\\Pierre" }),

--- a/src/security/windows-acl.ts
+++ b/src/security/windows-acl.ts
@@ -33,14 +33,24 @@ const TRUSTED_BASE = new Set([
   "system",
   "builtin\\administrators",
   "creator owner",
-  // Localized SYSTEM account names (French, German, Spanish, Portuguese)
-  "autorite nt\\système",
-  "nt-autorität\\system",
-  "autoridad nt\\system",
-  "autoridade nt\\system",
+  // Localized SYSTEM account names
+  "autorite nt\\système", // French
+  "nt-autorität\\system", // German
+  "autoridad nt\\system", // Spanish
+  "autoridade nt\\system", // Portuguese
+  "nt authority\\система", // Russian
 ]);
 const WORLD_SUFFIXES = ["\\users", "\\authenticated users"];
-const TRUSTED_SUFFIXES = ["\\administrators", "\\system", "\\système"];
+const TRUSTED_SUFFIXES = [
+  "\\administrators",
+  "\\system",
+  "\\système", // French
+  "\\система", // Russian
+  "\\sistema", // Italian / Spanish / Portuguese
+  "\\systeem", // Dutch
+  "\\sistem", // Turkish / Romanian
+  "\\systém", // Czech
+];
 
 const SID_RE = /^s-\d+-\d+(-\d+)+$/i;
 const TRUSTED_SIDS = new Set([


### PR DESCRIPTION
## Summary

- **Problem:** On localized Windows (Russian, Italian, Dutch, Turkish, Czech), the SYSTEM account name is rendered in the local language (e.g. `СИСТЕМА`, `sistema`, `systeem`). The security audit only recognized French, German, Spanish and Portuguese variants, so other localized names fell through to the "group" bucket, triggering false-positive "others writable" findings.
- **Why it matters:** Users on non-English Windows see spurious security warnings that cannot be resolved, eroding trust in the audit output.
- **What changed:** Added Russian (`\\система`), Italian/Spanish/Portuguese (`\\sistema`), Dutch (`\\systeem`), Turkish/Romanian (`\\sistem`), and Czech (`\\systém`) suffixes to `TRUSTED_SUFFIXES`. Added Russian full principal to `TRUSTED_BASE`.
- **What did NOT change:** Classification logic, diacritics fallback, SID-based classification, or any other audit behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35834

## User-visible / Behavior Changes

- Security audit no longer reports false-positive "others writable" findings on localized Windows where SYSTEM is named in Russian, Italian, Dutch, Turkish, Czech, or Romanian.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No — this only suppresses false positives`

## Repro + Verification

### Environment

- OS: Windows with non-English locale (e.g. Russian)
- Runtime: Node.js 22

### Steps

1. Run `openclaw doctor` or `openclaw status` on a Russian Windows installation
2. Observe the security audit output

### Expected

- No "others writable" finding when only the current user and SYSTEM (СИСТЕМА) have access

### Actual (before fix)

- `СИСТЕМА` is classified as "group" (untrusted), triggering a false warning

## Evidence

```
 src/security/windows-acl.ts      | 16 ++++++++++------
 src/security/windows-acl.test.ts | 32 ++++++++++++++++++++++++++++++++
 2 files changed, 42 insertions(+), 6 deletions(-)
```

All 44 windows-acl tests pass including 4 new localized SYSTEM tests.

## Human Verification (required)

- Verified scenarios: Russian СИСТЕМА, Italian sistema, Dutch systeem, full-scenario with user + localized SYSTEM
- Edge cases checked: Existing French/German/Spanish tests still pass, diacritics fallback unchanged
- What I did **not** verify: Actual Windows machine with Russian locale (tested via unit tests with mock icacls output)

## Compatibility / Migration

- Backward compatible? `Yes — only adds new trusted principals`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/security/windows-acl.ts`
- Known bad symptoms: None — worst case reverts to the current false-positive behavior

## Risks and Mitigations

- Risk: A non-SYSTEM account with a name ending in one of the new suffixes could be incorrectly trusted. Mitigation: The suffixes are specific system account names that are extremely unlikely to appear as regular user/group names.