### PR TITLE
fix(agents): extend Gemini 3.1 forward-compat to google provider

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -242,14 +242,18 @@ function resolveAnthropicSonnet46ForwardCompatModel(
 }
 
 // gemini-3.1-pro-preview / gemini-3.1-flash-preview are not present in pi-ai's built-in
-// google-gemini-cli catalog yet. Clone the nearest gemini-3 template so users don't get
-// "Unknown model" errors when Google Gemini CLI gains new minor-version models.
-function resolveGoogleGeminiCli31ForwardCompatModel(
+// catalog yet. Clone the nearest gemini-3 template so users don't get "Unknown model"
+// errors when Google releases new minor-version models. Supports both the "google" and
+// "google-gemini-cli" providers.
+const GOOGLE_31_ELIGIBLE_PROVIDERS = new Set(["google", "google-gemini-cli"]);
+
+function resolveGoogleGemini31ForwardCompatModel(
   provider: string,
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
-  if (normalizeProviderId(provider) !== "google-gemini-cli") {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (!GOOGLE_31_ELIGIBLE_PROVIDERS.has(normalizedProvider)) {
     return undefined;
   }
   const trimmed = modelId.trim();
@@ -265,7 +269,7 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
   }
 
   return cloneFirstTemplateModel({
-    normalizedProvider: "google-gemini-cli",
+    normalizedProvider,
     trimmedModelId: trimmed,
     templateIds: [...templateIds],
     modelRegistry,
@@ -326,6 +330,6 @@ export function resolveForwardCompatModel(
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveZaiGlm5ForwardCompatModel(provider, modelId, modelRegistry) ??
-    resolveGoogleGeminiCli31ForwardCompatModel(provider, modelId, modelRegistry)
+    resolveGoogleGemini31ForwardCompatModel(provider, modelId, modelRegistry)
   );
 }

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -8,11 +8,14 @@ vi.mock("../pi-model-discovery.js", () => ({
 import { buildInlineProviderModels, resolveModel } from "./model.js";
 import {
   buildOpenAICodexForwardCompatExpectation,
+  GOOGLE_FLASH_TEMPLATE_MODEL,
   GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
   GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+  GOOGLE_PRO_TEMPLATE_MODEL,
   makeModel,
   mockGoogleGeminiCliFlashTemplateModel,
   mockGoogleGeminiCliProTemplateModel,
+  mockMultipleDiscoveredModels,
   mockOpenAICodexTemplateModel,
   resetMockDiscoverModels,
 } from "./model.test-harness.js";
@@ -93,5 +96,41 @@ describe("pi embedded model e2e smoke", () => {
     const result = resolveModel("google-gemini-cli", "gemini-4-unknown", "/tmp/agent");
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: google-gemini-cli/gemini-4-unknown");
+  });
+
+  it("builds a google (API key) forward-compat fallback for gemini-3.1-pro-preview", () => {
+    mockMultipleDiscoveredModels([
+      {
+        provider: "google",
+        modelId: "gemini-3-pro-preview",
+        templateModel: GOOGLE_PRO_TEMPLATE_MODEL,
+      },
+    ]);
+
+    const result = resolveModel("google", "gemini-3.1-pro-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "gemini-3.1-pro-preview",
+      provider: "google",
+      reasoning: true,
+    });
+  });
+
+  it("builds a google (API key) forward-compat fallback for gemini-3.1-flash-lite-preview", () => {
+    mockMultipleDiscoveredModels([
+      {
+        provider: "google",
+        modelId: "gemini-3-flash-preview",
+        templateModel: GOOGLE_FLASH_TEMPLATE_MODEL,
+      },
+    ]);
+
+    const result = resolveModel("google", "gemini-3.1-flash-lite-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      id: "gemini-3.1-flash-lite-preview",
+      provider: "google",
+      reasoning: true,
+    });
   });
 });

--- a/src/agents/pi-embedded-runner/model.test-harness.ts
+++ b/src/agents/pi-embedded-runner/model.test-harness.ts
@@ -109,3 +109,32 @@ export function mockDiscoveredModel(params: {
     }),
   } as unknown as ReturnType<typeof discoverModels>);
 }
+
+export function mockMultipleDiscoveredModels(
+  entries: Array<{ provider: string; modelId: string; templateModel: unknown }>,
+): void {
+  vi.mocked(discoverModels).mockReturnValue({
+    find: vi.fn((provider: string, modelId: string) => {
+      for (const entry of entries) {
+        if (provider === entry.provider && modelId === entry.modelId) {
+          return entry.templateModel;
+        }
+      }
+      return null;
+    }),
+  } as unknown as ReturnType<typeof discoverModels>);
+}
+
+export const GOOGLE_PRO_TEMPLATE_MODEL = {
+  ...GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+  provider: "google",
+  api: "google",
+  baseUrl: "https://generativelanguage.googleapis.com",
+};
+
+export const GOOGLE_FLASH_TEMPLATE_MODEL = {
+  ...GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
+  provider: "google",
+  api: "google",
+  baseUrl: "https://generativelanguage.googleapis.com",
+};


### PR DESCRIPTION
## Summary

- **Problem:** The forward-compat fallback for Gemini 3.1 models (`gemini-3.1-pro-preview`, `gemini-3.1-flash-preview`, `gemini-3.1-flash-lite-preview`) only accepted the `google-gemini-cli` provider. Users configuring Gemini via the `google` provider (API key) got "Unknown model" errors on fallback routing.
- **Why it matters:** Many users use the `google` provider with an API key rather than `google-gemini-cli`. When their primary model fails and fallback triggers, the Gemini 3.1 forward-compat doesn't kick in, causing a hard error.
- **What changed:** Renamed `resolveGoogleGeminiCli31ForwardCompatModel` to `resolveGoogleGemini31ForwardCompatModel` and extended the provider check to accept both `google` and `google-gemini-cli`. The cloned template now uses the actual normalized provider ID instead of hardcoded `"google-gemini-cli"`.
- **What did NOT change:** Template model selection, fallback template IDs, patch behavior, or any other forward-compat logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36111

## User-visible / Behavior Changes

- Gemini 3.1 models now resolve correctly when using the `google` provider, eliminating "Unknown model" errors during fallback routing.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22

### Steps

1. Configure `google` provider with an API key
2. Set primary model to `gemini-3.1-pro-preview`
3. Trigger a fallback (e.g. rate limit on primary)

### Expected

- Fallback resolves the model via forward-compat clone

### Actual (before fix)

- "Unknown model: google/gemini-3.1-pro-preview" error

## Evidence

```
 src/agents/model-forward-compat.ts                              | 13 ++++++-----
 src/agents/pi-embedded-runner/model.forward-compat.test.ts      | 27 ++++++++++++++++++++++
 src/agents/pi-embedded-runner/model.test-harness.ts             | 38 ++++++++++++++++++++++++++++++
 3 files changed, 72 insertions(+), 6 deletions(-)
```

All 9 forward-compat tests pass including 2 new google-provider tests.

## Human Verification (required)

- Verified scenarios: google/gemini-3.1-pro-preview, google/gemini-3.1-flash-lite-preview, google-gemini-cli unchanged
- Edge cases checked: unrecognized model IDs still return "Unknown model" error
- What I did **not** verify: Actual Gemini API rate limit fallback (tested via unit tests with mocked model registry)

## Compatibility / Migration

- Backward compatible? `Yes — only adds new provider to eligibility set`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/agents/model-forward-compat.ts`
- Known bad symptoms: If the google provider's template model has an incompatible API type, the cloned model might not work. But google and google-gemini-cli share the same Gemini model architecture.

## Risks and Mitigations

- None. This aligns the google provider with the existing google-gemini-cli forward-compat behavior.