### PR TITLE
fix(telegram): compare full provider/model ref in model picker checkmark

### DIFF
--- a/src/telegram/model-buttons.test.ts
+++ b/src/telegram/model-buttons.test.ts
@@ -223,6 +223,18 @@ describe("buildModelsKeyboard", () => {
     }
   });
 
+  it("does not mark models from a different provider as current", () => {
+    const result = buildModelsKeyboard({
+      provider: "openrouter",
+      models: ["gpt-4o", "claude-sonnet-4"],
+      currentModel: "openai/gpt-4o",
+      currentPage: 1,
+      totalPages: 1,
+    });
+    expect(result[0]?.[0]?.text).toBe("gpt-4o");
+    expect(result[0]?.[0]?.text).not.toContain("✓");
+  });
+
   it("renders pagination controls for first, middle, and last pages", () => {
     const cases = [
       {

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -194,19 +194,13 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
   const endIndex = Math.min(startIndex + pageSize, models.length);
   const pageModels = models.slice(startIndex, endIndex);
 
-  // Model buttons - one per row
-  const currentModelId = currentModel?.includes("/")
-    ? currentModel.split("/").slice(1).join("/")
-    : currentModel;
-
   for (const model of pageModels) {
     const callbackData = buildModelSelectionCallbackData({ provider, model });
-    // Skip models that still exceed Telegram's callback_data limit.
     if (!callbackData) {
       continue;
     }
 
-    const isCurrentModel = model === currentModelId;
+    const isCurrentModel = currentModel === `${provider}/${model}`;
     const displayText = truncateModelId(model, 38);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
 


### PR DESCRIPTION
## Summary

- **Problem:** The `/model` inline keyboard in Telegram compared only the model ID (stripped of provider prefix) when marking the current selection with ✓. When multiple providers offer the same model ID (e.g. `openai/gpt-4o` and `openrouter/gpt-4o`), all of them showed a checkmark, even though only one was actually selected.
- **Why it matters:** Users couldn't tell which provider was actually active, leading to confusion when switching between providers.
- **What changed:** Replaced `model === currentModelId` (model-only comparison) with `currentModel === \`${provider}/${model}\`` (full ref comparison) in `buildModelsKeyboard`.
- **What did NOT change:** Provider keyboard, pagination, callback data encoding, or Discord model picker (which already uses the correct comparison).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35476

## User-visible / Behavior Changes

- The ✓ checkmark in the Telegram `/model` keyboard now only appears next to the model from the currently active provider, not on same-named models from other providers.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22
- Integration: Telegram

### Steps

1. Configure two providers with the same model ID (e.g. openai and openrouter both offering gpt-4o)
2. Select `openai/gpt-4o` as the current model
3. Open the `/model` keyboard and browse the openrouter page

### Expected

- Only `gpt-4o` on the openai page shows ✓

### Actual (before fix)

- `gpt-4o` on both openai and openrouter pages shows ✓

## Evidence

```
 src/telegram/model-buttons.ts      | 8 ++------
 src/telegram/model-buttons.test.ts | 12 ++++++++++++
 2 files changed, 14 insertions(+), 6 deletions(-)
```

All 21 model-buttons tests pass including the new cross-provider test.

## Human Verification (required)

- Verified scenarios: same provider match (✓ shown), different provider same model (✓ not shown), no current model (no ✓)
- Edge cases checked: existing test for anthropic/claude-sonnet-4 still passes
- What I did **not** verify: Live Telegram bot interaction

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/telegram/model-buttons.ts`
- Known bad symptoms: If currentModel is not in `provider/model` format, no model will show ✓ (safe fallback)

## Risks and Mitigations

- Risk: If `currentModel` is stored without provider prefix in some edge case, the checkmark won't appear. Mitigation: All model selection paths store the full `provider/model` ref.