### PR TITLE
fix(gateway): allow install when service not found

### DIFF
--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -48,8 +48,12 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
   try {
     loaded = await service.isLoaded({ env: process.env });
   } catch (err) {
-    fail(`Gateway service check failed: ${String(err)}`);
-    return;
+    // Service not found is expected during fresh install; only fail on system errors.
+    const message = String(err).toLowerCase();
+    if (!message.includes("not found") && !message.includes("not-found")) {
+      fail(`Gateway service check failed: ${String(err)}`);
+      return;
+    }
   }
   if (loaded) {
     if (!opts.force) {


### PR DESCRIPTION
## Summary

Fixes #37340.

- During fresh install, `isLoaded` throws when service doesn't exist (e.g. systemctl returns "not-found")
- The install command was treating this as a fatal error and aborting installation
- Now catch "not found" errors and continue with installation, only failing on genuine system errors
- Allows successful gateway installation after complete uninstall

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway
- [x] CLI

## Linked Issue/PR

- Fixes #37340

## User-visible / Behavior Changes

`openclaw gateway install` now succeeds on fresh installs when the service doesn't exist yet. Previously it would fail with "Gateway service check failed" error.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OpenClaw 2026.3.2
- Ubuntu 24 (reported), affects all Linux systemd systems

### Steps
1. `openclaw uninstall`
2. `npm uninstall -g openclaw`
3. `npm install -g openclaw@latest`
4. `openclaw gateway install`

### Expected (after fix)
Gateway installs successfully

### Actual (before fix)
Fails with "Gateway service check failed: not found" error

## Evidence

- [x] All 37 existing daemon-cli tests pass
- [x] Logic: "not found" errors are expected during fresh install and should not abort

## Human Verification

- Verified code path: `isLoaded` throws → catch checks for "not found" → continues if found, fails otherwise
- Edge cases checked: Genuine system errors (not "not found") still fail as expected
- What I did not verify: End-to-end fresh install on Ubuntu (requires clean system)

## Compatibility / Migration

- Backward compatible? Yes (fixes regression from 2026.3.2)
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to disable/revert: `git revert` this commit
- Files to restore: `src/cli/daemon-cli/install.ts` lines 46-53
- Known bad symptoms: Fresh installs revert to failing with "service check failed"

## Risks and Mitigations

Low risk. The change only affects error handling during the service existence check. Genuine system errors (not "not found") still fail as before.