### PR TITLE
fix(plugins): suppress duplicate warning for same-version plugins

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -185,6 +185,51 @@ describe("loadPluginManifestRegistry", () => {
     expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
   });
 
+  it("suppresses duplicate warning when both candidates have the same manifest version", () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    const manifest = { id: "feishu", version: "2026.3.2", configSchema: { type: "object" } };
+    writeManifest(dirA, manifest);
+    writeManifest(dirB, manifest);
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: dirA,
+        origin: "bundled",
+      }),
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: dirB,
+        origin: "global",
+      }),
+    ];
+
+    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
+  });
+
+  it("emits duplicate warning when same id but different versions", () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    writeManifest(dirA, { id: "feishu", version: "2026.3.1", configSchema: { type: "object" } });
+    writeManifest(dirB, { id: "feishu", version: "2026.3.2", configSchema: { type: "object" } });
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: dirA,
+        origin: "bundled",
+      }),
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: dirB,
+        origin: "global",
+      }),
+    ];
+
+    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
+  });
+
   it("suppresses duplicate warning when candidates have identical rootDir paths", () => {
     const dir = makeTempDir();
     const manifest = { id: "same-path-plugin", configSchema: { type: "object" } };

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -10,6 +10,7 @@ import type { PluginConfigUiHint, PluginDiagnostic, PluginKind, PluginOrigin } f
 type SeenIdEntry = {
   candidate: PluginCandidate;
   recordIndex: number;
+  version?: string;
 };
 
 // Precedence: config > workspace > global > bundled
@@ -212,7 +213,15 @@ export function loadPluginManifestRegistry(params: {
         }
         const existingReal = safeRealpathSync(existing.candidate.rootDir, realpathCache);
         const candidateReal = safeRealpathSync(candidate.rootDir, realpathCache);
-        return Boolean(existingReal && candidateReal && existingReal === candidateReal);
+        if (existingReal && candidateReal && existingReal === candidateReal) {
+          return true;
+        }
+        // Treat as the same logical plugin when both have a matching version
+        // (e.g. bundled and global copies installed from the same release).
+        if (existing.version && manifest.version && existing.version === manifest.version) {
+          return true;
+        }
+        return false;
       })();
       if (samePlugin) {
         // Prefer higher-precedence origins even if candidates are passed in
@@ -225,7 +234,11 @@ export function loadPluginManifestRegistry(params: {
             schemaCacheKey,
             configSchema,
           });
-          seenIds.set(manifest.id, { candidate, recordIndex: existing.recordIndex });
+          seenIds.set(manifest.id, {
+            candidate,
+            recordIndex: existing.recordIndex,
+            version: manifest.version,
+          });
         }
         continue;
       }
@@ -236,7 +249,11 @@ export function loadPluginManifestRegistry(params: {
         message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
       });
     } else {
-      seenIds.set(manifest.id, { candidate, recordIndex: records.length });
+      seenIds.set(manifest.id, {
+        candidate,
+        recordIndex: records.length,
+        version: manifest.version,
+      });
     }
 
     records.push(


### PR DESCRIPTION
## Summary

- **Problem:** When the same plugin (e.g. feishu) exists in both the bundled extensions directory and the global config extensions directory, the manifest registry emitted a false-positive "duplicate plugin id detected" warning. This happened because the two directories have different physical paths, even though they contain the same plugin from the same release.
- **Why it matters:** Users see a spurious config warning on every startup that they cannot resolve without manually deleting one copy of the plugin.
- **What changed:** Extended the `samePlugin` check in `manifest-registry.ts` to also treat plugins with matching `id` and `version` as the same logical plugin. Added `version` tracking to the `SeenIdEntry` type. Plugins with the same id but different versions still emit the duplicate warning.
- **What did NOT change:** Symlink-based duplicate suppression, origin precedence logic, manifest loading, or any other plugin behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35884

## User-visible / Behavior Changes

- "duplicate plugin id detected" warning no longer appears when the same plugin version exists in multiple extension directories.
- Different versions of the same plugin id still emit the warning (genuine conflict).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22

### Steps

1. Install feishu plugin globally (`openclaw plugins install feishu`)
2. The bundled feishu also exists at `<app>/extensions/feishu`
3. Run `openclaw status` or start the gateway

### Expected

- No duplicate plugin warning (same version in both locations)

### Actual (before fix)

- `plugins.entries.feishu: plugin feishu: duplicate plugin id detected`

## Evidence

```
 src/plugins/manifest-registry.ts      | 12 ++++++++++--
 src/plugins/manifest-registry.test.ts | 44 ++++++++++++++++++++++++++++++++++
 2 files changed, 54 insertions(+), 2 deletions(-)
```

All 9 manifest-registry tests pass including 2 new version-based duplicate suppression tests.

## Human Verification (required)

- Verified scenarios: same version suppresses warning, different versions still warn, symlink suppression unchanged, same path suppression unchanged
- Edge cases checked: plugins without version field (undefined !== undefined → falls through to existing behavior)
- What I did **not** verify: Live multi-directory plugin installation

## Compatibility / Migration

- Backward compatible? `Yes — only suppresses previously false-positive warnings`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/plugins/manifest-registry.ts`
- Known bad symptoms: Reverts to showing the false-positive warning

## Risks and Mitigations

- Risk: Two genuinely different plugins could have the same id and version, in which case the warning would be suppressed. Mitigation: This is extremely unlikely for published plugins; the combination of id + version is a strong identity signal.