### PR TITLE
fix(daemon): allow gateway install under sudo when user bus unavailable

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -102,7 +102,27 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(false);
   });
 
-  it("throws when systemctl is-enabled fails for non-state errors", async () => {
+  it("returns false when systemctl cannot connect to the user bus", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
+        const err = new Error("Failed to connect to bus") as Error & { code?: number };
+        err.code = 1;
+        cb(err, "", "Failed to connect to bus");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args[0]).toBe("--machine");
+        expect(String(args[1])).toMatch(/^[^@]+@$/);
+        expect(args.slice(2)).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
+        const err = new Error("Failed to connect to bus") as Error & { code?: number };
+        err.code = 1;
+        cb(err, "", "Failed to connect to bus");
+      });
+    await expect(isSystemdServiceEnabled({ env: {} })).resolves.toBe(false);
+  });
+
+  it("throws when systemctl is-enabled fails for other non-state errors", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock
       .mockImplementationOnce((_cmd, args, _opts, cb) => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -175,7 +175,11 @@ function isSystemdUnitNotEnabled(detail: string): boolean {
     normalized.includes("masked") ||
     normalized.includes("not-found") ||
     normalized.includes("could not be found") ||
-    normalized.includes("failed to get unit file state")
+    normalized.includes("failed to get unit file state") ||
+    // systemctl may be present but the user bus can be unavailable in
+    // non-interactive environments (e.g. running under sudo). Treat it as
+    // "not enabled" so install flows can continue.
+    normalized.includes("failed to connect to bus")
   );
 }
 


### PR DESCRIPTION
Fix systemd service detection so gateway install/onboard flows don't abort when `systemctl --user is-enabled` cannot connect to the user bus (common under sudo / non-interactive environments).

Treating this failure mode as "not enabled" allows `openclaw gateway install` to proceed and install the service.

Closes #37340