### PR TITLE
[Issue #37258] [Feature]: Point agents to agent-friendly version of docs.openclaw.ai

### DIFF
--- a/.github/issue-bootstrap/issue-37258.md
+++ b/.github/issue-bootstrap/issue-37258.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37258
+- Title: [Feature]: Point agents to agent-friendly version of docs.openclaw.ai
+- Source: https://github.com/openclaw/openclaw/issues/37258


### PR DESCRIPTION
## Source Issue
- Number: #37258
- URL: https://github.com/openclaw/openclaw/issues/37258
- Title: [Feature]: Point agents to agent-friendly version of docs.openclaw.ai

## Original Issue Description
### Summary

Prepend agent-oriented instructions (header?) to each docs page pointing to .md version of page and llms.txt.

### Problem to solve

Users point their agents (e.g. openclaw) at openclaw docs without necessarily knowing that there are .md versions of each page. Parsing the html app's version of the page wastes tokens and context. Instead, immediately redirect agents to the .md version of the page containing just the page contents.

### Proposed solution

Potentially a header in DOM tree on docs template (assuming docs site is generated on a template), e.g. on https://docs.openclaw.ai/tools/skills, AGENTS: use e.g. https://docs.openclaw.ai/tools/skills.md. Index at https://docs.openclaw.ai/llms.txt.

### Alternatives considered

I asked krill in help, which worked but was slower. https://discord.com/channels/1456350064065904867/1479355118687228121/1479355427647918151

### Impact

- Any openclaw agent or ai agent referencing openclaw docs
- annoying, not severe
- frequency: always, when asking ai agents to read openclaw docs (e.g. install, new config, or platform updates)
- consequence: wasted tokens, lower agent priority/attention to official docs


### Evidence/examples

_No response_

### Additional information

_No response_

Closes #37258