### PR TITLE
[Issue #37260] bug: web_search tool schema enforces 2-letter language code, causing Brave Search API 422 error for Chinese

### DIFF
--- a/.github/issue-bootstrap/issue-37260.md
+++ b/.github/issue-bootstrap/issue-37260.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37260
+- Title: bug: web_search tool schema enforces 2-letter language code, causing Brave Search API 422 error for Chinese
+- Source: https://github.com/openclaw/openclaw/issues/37260


### PR DESCRIPTION
## Source Issue
- Number: #37260
- URL: https://github.com/openclaw/openclaw/issues/37260
- Title: bug: web_search tool schema enforces 2-letter language code, causing Brave Search API 422 error for Chinese

## Original Issue Description
### Describe the bug

The built-in `web_search` tool currently enforces a 2-letter ISO language code for the `search_lang` parameter in its schema description:
`"description": "Short ISO language code for search results (e.g., 'de', 'en', 'fr', 'tr'). Must be a 2-letter code, NOT a locale."`

However, the underlying Brave Search API has updated its validation and now requires specific localized codes for Chinese (e.g., `zh-hans`, `zh-hant`). When the LLM strictly follows the "2-letter code" rule and passes `"zh"`, the Gateway returns a `422 Unprocessable Entity` from the Brave Search API.

### Error Logs
```
2026-03-06T00:45:42.381Z error [tools] web_search failed: Brave Search API error (422): {"type":"ErrorResponse","error":{"id":"e008f95d-246c-4bfc-a44a-6b991ecb80f8","status":422,"detail":"Unable to validate request parameter(s)","meta":{"errors":[{"type":"enum","loc":["query","search_lang"],"msg":"Input should be 'ar', 'eu', 'bn', 'bg', 'ca', 'zh-hans', 'zh-hant', 'hr', 'cs', 'da', 'nl', 'en', 'en-gb', 'et', 'fi', 'fr', 'gl', 'de', 'el', 'gu', 'he', 'hi', 'hu', 'is', 'it', 'jp', 'kn', 'ko', 'lv', 'lt', 'ms', 'ml', 'mr', 'nb', 'pl', 'pt-br', 'pt-pt', 'pa', 'ro', 'ru', 'sr', 'sk', 'sl', 'es', 'sv', 'ta', 'te', 'th', 'tr', 'uk' or 'vi'","input":"zh"
```

### Proposed Solution

Update the `web_search` tool schema description to allow multi-letter language codes, specifically mentioning `zh-hans` and `zh-hant` for Chinese, and remove the strict "Must be a 2-letter code" constraint to align with current Brave Search API requirements.

Closes #37260