### PR TITLE
[Issue #37297] [Bug]: Onboarding fails on headless VPS/SSH: systemctl --user is-enabled unavailable

### DIFF
--- a/.github/issue-bootstrap/issue-37297.md
+++ b/.github/issue-bootstrap/issue-37297.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37297
+- Title: [Bug]: Onboarding fails on headless VPS/SSH: systemctl --user is-enabled unavailable
+- Source: https://github.com/openclaw/openclaw/issues/37297


### PR DESCRIPTION
## Source Issue
- Number: #37297
- URL: https://github.com/openclaw/openclaw/issues/37297
- Title: [Bug]: Onboarding fails on headless VPS/SSH: systemctl --user is-enabled unavailable

## Original Issue Description
### Bug type

Regression (worked before, now fails)

### Summary

## Environment
- OS: Ubuntu (VPS via SSH, no GUI session)
- Install method: npm install -g openclaw
- Node: v22+

## Bug
During onboarding, the installer attempts to create a systemd user service 
and fails with:

Error: systemctl is-enabled unavailable: Command failed: 
systemctl --user is-enabled openclaw-gateway.service

## Root cause
systemd --user requires an active login session with dbus and XDG_RUNTIME_DIR. 
This does not exist on headless VPS environments (no GUI, running via SSH, 
or running as root). This is an extremely common setup.

## Impact
This is affecting many users — there are multiple Reddit threads and forum 
posts reporting the exact same error. The installation appears to fail 
completely, when in reality only the daemon registration step failed.

## Suggested fix
Before attempting systemctl --user, detect whether a user systemd session 
is available:
- Check for XDG_RUNTIME_DIR
- Check loginctl session
- If unavailable, fall back to system-level service (/etc/systemd/system/) 
  or show a clear error with documented instructions

## Workaround (for other users)
Create a system-level service manually:

sudo tee /etc/systemd/system/openclaw.service << 'EOF'
[Unit]
Description=OpenClaw Gateway
After=network.target

[Service]
Type=simple
User=YOUR_USER
Environment=NODE_ENV=production
ExecStart=/path/to/openclaw gateway start
Restart=always
RestartSec=5

[Install]
WantedBy=multi-user.target
EOF

sudo systemctl daemon-reload
sudo systemctl enable openclaw
sudo systemctl start openclaw

### Steps to reproduce

## Steps to Reproduce

1. Provision a fresh Ubuntu VPS (tested on Ubuntu 22.04/24.04)
2. Connect via SSH (no GUI session, no desktop environment)
3. Install openclaw globally:
   npm install -g openclaw
4. Run onboarding:
   openclaw onboard
5. Complete all onboarding steps (model, auth, channels, etc.)
6. When installer reaches "Gateway service runtime" step and attempts 
   to register the service, the following error appears:

   Error: systemctl is-enabled unavailable: Command failed: 
   systemctl --user is-enabled openclaw-gateway.service

## Expected behavior
Installer detects the environment, registers the gateway service 
successfully and reports active (running).

## Actual behavior
Installer crashes at the service registration step. The rest of the 
installation (model auth, config files, workspace) completed correctly — 
only the daemon registration failed, but the error message gives the 
impression that the entire installation failed.

### OpenClaw version

## OpenClaw version 2026.3.2

### Operating system

## Operating System - Distributor: Ubuntu 24.04.4 LTS (Noble) - Kernel: 6.17.8-orbstack (aarch64) - Architecture: ARM64 - Environment: OrbStack Linux VM (macOS host)

Closes #37297