### PR TITLE
fix(agents): detect OpenRouter API key in Perplexity Search and return clear error

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -15,6 +15,7 @@ const {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  isOpenRouterApiKey,
 } = __testing;
 
 describe("web_search brave language param normalization", () => {
@@ -269,5 +270,18 @@ describe("extractKimiCitations", () => {
         ],
       }).toSorted(),
     ).toEqual(["https://example.com/a", "https://example.com/b", "https://example.com/c"]);
+  });
+});
+
+describe("isOpenRouterApiKey", () => {
+  it("detects OpenRouter API keys by sk-or- prefix", () => {
+    expect(isOpenRouterApiKey("sk-or-v1-abc123")).toBe(true);
+    expect(isOpenRouterApiKey("sk-or-test")).toBe(true);
+  });
+
+  it("rejects non-OpenRouter API keys", () => {
+    expect(isOpenRouterApiKey("pplx-abc123")).toBe(false);
+    expect(isOpenRouterApiKey("sk-abc123")).toBe(false);
+    expect(isOpenRouterApiKey("")).toBe(false);
   });
 });

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -522,6 +522,10 @@ function normalizeApiKey(key: unknown): string {
   return normalizeSecretInput(key);
 }
 
+function isOpenRouterApiKey(key: string): boolean {
+  return key.startsWith("sk-or-");
+}
+
 function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
   if (!search || typeof search !== "object") {
     return {};
@@ -1435,6 +1439,16 @@ export function createWebSearchTool(options?: {
       if (!apiKey) {
         return jsonResult(missingSearchKeyPayload(provider));
       }
+      if (provider === "perplexity" && isOpenRouterApiKey(apiKey)) {
+        return jsonResult({
+          error: "incompatible_api_key",
+          message:
+            "Perplexity Search API requires a native Perplexity API key (pplx-*). " +
+            "OpenRouter API keys (sk-or-*) are not compatible with the Perplexity Search endpoint. " +
+            "Get a Perplexity API key at https://www.perplexity.ai/settings/api",
+          docs: "https://docs.openclaw.ai/tools/web",
+        });
+      }
       const params = args as Record<string, unknown>;
       const query = readStringParam(params, "query", { required: true });
       const count =
@@ -1620,4 +1634,5 @@ export const __testing = {
   resolveKimiBaseUrl,
   extractKimiCitations,
   resolveRedirectUrl: resolveCitationRedirectUrl,
+  isOpenRouterApiKey,
 } as const;


### PR DESCRIPTION
## Summary

- **Problem:** Perplexity Search API (`https://api.perplexity.ai/search`) only accepts native Perplexity API keys (`pplx-*`). Users who configure an OpenRouter API key (`sk-or-*`) get a confusing HTTP 401 error with no indication of what went wrong.
- **Why it matters:** Many users configure OpenRouter as their primary provider and expect Perplexity Search to work through it. The 401 error gives no hint that the API key type is incompatible.
- **What changed:** Added `isOpenRouterApiKey()` helper that detects `sk-or-` prefix. In the `web_search` tool execute path, when provider is `perplexity` and the API key is an OpenRouter key, return a clear `incompatible_api_key` error with instructions to obtain a native Perplexity key.
- **What did NOT change:** Perplexity Search API URL, authentication logic, or any other search provider behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36182

## User-visible / Behavior Changes

- When using an OpenRouter API key with Perplexity Search, the agent now returns a clear error message explaining the incompatibility and linking to the Perplexity API key page, instead of a cryptic HTTP 401.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No — only prefix detection, no key storage changes`
- New/changed network calls? `No — prevents the failing call`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22

### Steps

1. Configure `PERPLEXITY_API_KEY` with an OpenRouter key (`sk-or-v1-...`)
2. Ask the agent to search the web

### Expected

- Clear error: "Perplexity Search API requires a native Perplexity API key (pplx-*)"

### Actual (before fix)

- "Perplexity Search API error (401): Invalid API key provided"

## Evidence

```
 src/agents/tools/web-search.ts      | 15 +++++++++++++++
 src/agents/tools/web-search.test.ts | 14 ++++++++++++++
 2 files changed, 29 insertions(+)
```

All 30 web-search tests pass including 2 new OpenRouter key detection tests.

## Human Verification (required)

- Verified scenarios: sk-or-* key detected, pplx-* key passes through, empty/other keys pass through
- Edge cases checked: sk-abc (not OpenRouter), empty string
- What I did **not** verify: Live Perplexity API call with OpenRouter key (tested via unit test)

## Compatibility / Migration

- Backward compatible? `Yes — only adds early error for previously-failing key type`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/agents/tools/web-search.ts`
- Known bad symptoms: Reverts to the original 401 error

## Risks and Mitigations

- Risk: A future Perplexity key could start with `sk-or-`. Mitigation: Extremely unlikely; Perplexity uses `pplx-` prefix. If it happens, the check can be removed.