### PR TITLE
[Issue #37303] [Bug]: Onboarding crashes when using exec secret provider for channel tokens (telegram, slack, discord)

### DIFF
--- a/.github/issue-bootstrap/issue-37303.md
+++ b/.github/issue-bootstrap/issue-37303.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37303
+- Title: [Bug]: Onboarding crashes when using exec secret provider for channel tokens (telegram, slack, discord)
+- Source: https://github.com/openclaw/openclaw/issues/37303


### PR DESCRIPTION
## Source Issue
- Number: #37303
- URL: https://github.com/openclaw/openclaw/issues/37303
- Title: [Bug]: Onboarding crashes when using exec secret provider for channel tokens (telegram, slack, discord)

## Original Issue Description
### Bug type

Regression (worked before, now fails)

### Summary

When configuring a channel (Telegram, Slack, or Discord) during `openclaw onboard` and choosing an **exec secret provider** for the bot token, the onboarding wizard crashes immediately after the "Reference validated" step with:

```
Error: channels.telegram.botToken: unresolved SecretRef “exec:xxx:telegram/apiKey".
Resolve this command against an active gateway runtime snapshot before reading it.
```

The onboarding never completes, so the channel configuration is never written to `openclaw.json`. The exec provider (e.g. 1Password `op`) is called once during validation and works correctly, but is never called again for actual resolution.

### Steps to reproduce

1. Configure an exec secret provider (e.g. 1Password CLI) in `openclaw.json`
2. Run `openclaw onboard` and select Telegram (or Slack/Discord)
3. Choose "Use external secret provider" for the bot token
4. Select the configured provider and enter a secret ID
5. The reference validates successfully ("Reference validated")
6. Crash occurs immediately after

### Expected behavior

After validating the secret reference, onboarding should complete the remaining steps and write the channel config to `openclaw.json`.

### Actual behavior

Crash with unresolved SecretRef outside runtime snapshot.

### Additional information

Issue includes deep root-cause analysis and concrete file references for Telegram/Slack/Discord onboarding status checks.

Full original description: https://github.com/openclaw/openclaw/issues/37303

Closes #37303