### PR TITLE
[Issue #37306] [Test] API提交bug report测试

### DIFF
--- a/.github/issue-bootstrap/issue-37306.md
+++ b/.github/issue-bootstrap/issue-37306.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37306
+- Title: [Test] API提交bug report测试
+- Source: https://github.com/openclaw/openclaw/issues/37306


### PR DESCRIPTION
## Source Issue
- Number: #37306
- URL: https://github.com/openclaw/openclaw/issues/37306
- Title: [Test] API提交bug report测试

## Original Issue Description
这是一条测试消息，用于验证 GitHub Token 是否可以自动提交 bug

Closes #37306