### PR TITLE
[Issue #37307] [Bug]: 定时任务调用模型mistral-large-latest报错

### DIFF
--- a/.github/issue-bootstrap/issue-37307.md
+++ b/.github/issue-bootstrap/issue-37307.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37307
+- Title: [Bug]: 定时任务调用模型mistral-large-latest报错
+- Source: https://github.com/openclaw/openclaw/issues/37307


### PR DESCRIPTION
## Source Issue
- Number: #37307
- URL: https://github.com/openclaw/openclaw/issues/37307
- Title: [Bug]: 定时任务调用模型mistral-large-latest报错

## Original Issue Description
### Bug type

Behavior bug (incorrect output/state without crash)

### Summary

2026.3.2版本 配置mistral/mistral-large-latest模型后 通过定时任务推送到telegram机器人信息时报错

### Expected behavior

一切正常 

### Actual behavior

基本聊天是正常的
还是有问题
报错提示也不友好

### Logs

Issue includes timeout + message target errors captured from runtime logs.

Full original description: https://github.com/openclaw/openclaw/issues/37307

Closes #37307