### PR TITLE
fix(models): let explicit config baseUrl/apiKey override stale models.json cache

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1460,6 +1460,20 @@ public struct ConfigPatchParams: Codable, Sendable {
 
 public struct ConfigSchemaParams: Codable, Sendable {}
 
+public struct ConfigSchemaLookupParams: Codable, Sendable {
+    public let path: String
+
+    public init(
+        path: String)
+    {
+        self.path = path
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+    }
+}
+
 public struct ConfigSchemaResponse: Codable, Sendable {
     public let schema: AnyCodable
     public let uihints: [String: AnyCodable]
@@ -1483,6 +1497,36 @@ public struct ConfigSchemaResponse: Codable, Sendable {
         case uihints = "uiHints"
         case version
         case generatedat = "generatedAt"
+    }
+}
+
+public struct ConfigSchemaLookupResult: Codable, Sendable {
+    public let path: String
+    public let schema: AnyCodable
+    public let hint: [String: AnyCodable]?
+    public let hintpath: String?
+    public let children: [[String: AnyCodable]]
+
+    public init(
+        path: String,
+        schema: AnyCodable,
+        hint: [String: AnyCodable]?,
+        hintpath: String?,
+        children: [[String: AnyCodable]])
+    {
+        self.path = path
+        self.schema = schema
+        self.hint = hint
+        self.hintpath = hintpath
+        self.children = children
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+        case schema
+        case hint
+        case hintpath = "hintPath"
+        case children
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1460,6 +1460,20 @@ public struct ConfigPatchParams: Codable, Sendable {
 
 public struct ConfigSchemaParams: Codable, Sendable {}
 
+public struct ConfigSchemaLookupParams: Codable, Sendable {
+    public let path: String
+
+    public init(
+        path: String)
+    {
+        self.path = path
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+    }
+}
+
 public struct ConfigSchemaResponse: Codable, Sendable {
     public let schema: AnyCodable
     public let uihints: [String: AnyCodable]
@@ -1483,6 +1497,36 @@ public struct ConfigSchemaResponse: Codable, Sendable {
         case uihints = "uiHints"
         case version
         case generatedat = "generatedAt"
+    }
+}
+
+public struct ConfigSchemaLookupResult: Codable, Sendable {
+    public let path: String
+    public let schema: AnyCodable
+    public let hint: [String: AnyCodable]?
+    public let hintpath: String?
+    public let children: [[String: AnyCodable]]
+
+    public init(
+        path: String,
+        schema: AnyCodable,
+        hint: [String: AnyCodable]?,
+        hintpath: String?,
+        children: [[String: AnyCodable]])
+    {
+        self.path = path
+        self.schema = schema
+        self.hint = hint
+        self.hintpath = hintpath
+        self.children = children
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+        case schema
+        case hint
+        case hintpath = "hintPath"
+        case children
     }
 }
 

--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -207,7 +207,7 @@ describe("models-config", () => {
     });
   });
 
-  it("preserves non-empty agent apiKey/baseUrl for matching providers in merge mode", async () => {
+  it("config apiKey/baseUrl wins over cached agent values in merge mode", async () => {
     await withTempHome(async () => {
       const parsed = await runCustomProviderMergeTest({
         baseUrl: "https://agent.example/v1",
@@ -215,6 +215,51 @@ describe("models-config", () => {
         api: "openai-responses",
         models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
       });
+      // Config values should take precedence over stale cached values so
+      // that user edits to openclaw.json (e.g. correcting a baseUrl) are
+      // reflected immediately without manual cache cleanup.
+      expect(parsed.providers.custom?.apiKey).toBe("CONFIG_KEY");
+      expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
+    });
+  });
+
+  it("preserves cached agent apiKey/baseUrl when config omits them", async () => {
+    await withTempHome(async () => {
+      await writeAgentModelsJson({
+        providers: {
+          custom: {
+            baseUrl: "https://agent.example/v1",
+            apiKey: "AGENT_KEY",
+            api: "openai-responses",
+            models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
+          },
+        },
+      });
+      // Config has no apiKey/baseUrl — cached values should be preserved.
+      await ensureOpenClawModelsJson({
+        models: {
+          mode: "merge",
+          providers: {
+            custom: {
+              api: "openai-responses" as const,
+              models: [
+                {
+                  id: "config-model",
+                  name: "Config model",
+                  input: ["text"] as Array<"text" | "image">,
+                  reasoning: false,
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8192,
+                  maxTokens: 2048,
+                },
+              ],
+            },
+          },
+        },
+      });
+      const parsed = await readGeneratedModelsJson<{
+        providers: Record<string, { apiKey?: string; baseUrl?: string }>;
+      }>();
       expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
       expect(parsed.providers.custom?.baseUrl).toBe("https://agent.example/v1");
     });

--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -241,6 +241,7 @@ describe("models-config", () => {
           mode: "merge",
           providers: {
             custom: {
+              baseUrl: "",
               api: "openai-responses" as const,
               models: [
                 {

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -159,10 +159,24 @@ function mergeWithExistingProviderSecrets(params: {
       continue;
     }
     const preserved: Record<string, unknown> = {};
-    if (typeof existing.apiKey === "string" && existing.apiKey) {
+    const newApiKey = (newEntry as { apiKey?: string }).apiKey;
+    const newBaseUrl = (newEntry as { baseUrl?: string }).baseUrl;
+    // Only fall back to the cached value when the fresh config does not
+    // provide an explicit override.  This ensures that user edits to
+    // openclaw.json (e.g. correcting a baseUrl) take effect immediately
+    // instead of being shadowed by stale values persisted in models.json.
+    if (
+      !(typeof newApiKey === "string" && newApiKey) &&
+      typeof existing.apiKey === "string" &&
+      existing.apiKey
+    ) {
       preserved.apiKey = existing.apiKey;
     }
-    if (typeof existing.baseUrl === "string" && existing.baseUrl) {
+    if (
+      !(typeof newBaseUrl === "string" && newBaseUrl) &&
+      typeof existing.baseUrl === "string" &&
+      existing.baseUrl
+    ) {
       preserved.baseUrl = existing.baseUrl;
     }
     mergedProviders[key] = { ...newEntry, ...preserved };

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -686,7 +686,7 @@ export const FIELD_HELP: Record<string, string> = {
   models:
     "Model catalog root for provider definitions, merge/replace behavior, and optional Bedrock discovery integration. Keep provider definitions explicit and validated before relying on production failover paths.",
   "models.mode":
-    'Controls provider catalog behavior: "merge" keeps built-ins and overlays your custom providers, while "replace" uses only your configured providers. In "merge", matching provider IDs preserve non-empty agent models.json apiKey/baseUrl values and fall back to config when agent values are empty or missing; matching model contextWindow/maxTokens use the higher value between explicit and implicit entries.',
+    'Controls provider catalog behavior: "merge" keeps built-ins and overlays your custom providers, while "replace" uses only your configured providers. In "merge", explicit config apiKey/baseUrl values take precedence over cached agent models.json values; cached values are only preserved when the config omits them. Matching model contextWindow/maxTokens use the higher value between explicit and implicit entries.',
   "models.providers":
     "Provider map keyed by provider ID containing connection/auth settings and concrete model definitions. Use stable provider keys so references from agents and tooling remain portable across environments.",
   "models.providers.*.baseUrl":

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -272,7 +272,7 @@ describe("config schema", () => {
   });
 
   it("rejects overly deep lookup paths", () => {
-    const buildNestedObjectSchema = (segments: string[]) => {
+    const buildNestedObjectSchema = (segments: string[]): Record<string, unknown> => {
       const [head, ...rest] = segments;
       if (!head) {
         return { type: "string" };


### PR DESCRIPTION
## Summary

- When `models.mode` is `"merge"` (the default), `mergeWithExistingProviderSecrets` unconditionally preserved `baseUrl` and `apiKey` from the cached `models.json`, even
when the user had set new values in `openclaw.json`. This caused user edits (e.g. correcting a vLLM `baseUrl`) to be silently ignored until the user manually edited the
hidden `.openclaw/agent/main/agent/models.json` file.
- The fix makes explicit config values take precedence; cached values are only used as a fallback when the config omits them.
- Updated `models.mode` help text in `schema.help.ts` to reflect the new semantics.

## Root Cause

In `src/agents/models-config.ts`, `mergeWithExistingProviderSecrets` spread `preserved` (from disk cache) **after** `newEntry` (from config):

```typescript
mergedProviders[key] = { ...newEntry, ...preserved };
```
Since preserved always included any non-empty cached baseUrl/apiKey, the stale values shadowed the fresh config values on every ensureOpenClawModelsJson call.

Fix

Only populate preserved.baseUrl / preserved.apiKey when the fresh config entry does not provide a non-empty value for that field. When the config has an explicit value,
it wins.

Test plan

- Updated existing test: config apiKey/baseUrl now wins over cached agent values in merge mode
- Added new test: cached values are still preserved when config omits them
- All 17 models-config test files pass (71 tests)
- Lint/format clean

Closes #37309