### PR TITLE
fix(cli): resolve version for openclaw-cli package and skip dev placeholder

### DIFF
--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -82,6 +82,33 @@ describe("version resolution", () => {
     });
   });
 
+  it("resolves version from openclaw-cli package name", async () => {
+    await withTempDir(async (root) => {
+      await writeJsonFixture(root, "package.json", { name: "openclaw-cli", version: "2026.3.2" });
+      const moduleUrl = await ensureModuleFixture(root);
+      expect(readVersionFromPackageJsonForModuleUrl(moduleUrl)).toBe("2026.3.2");
+    });
+  });
+
+  it("skips 'dev' placeholder version in package.json and build-info", async () => {
+    await withTempDir(async (root) => {
+      await writeJsonFixture(root, "package.json", { name: "openclaw", version: "dev" });
+      await writeJsonFixture(root, "build-info.json", { version: "dev" });
+      const moduleUrl = await ensureModuleFixture(root);
+      expectVersionMetadataToBeMissing(moduleUrl);
+    });
+  });
+
+  it("uses envVersion when module metadata is unavailable", () => {
+    expect(
+      resolveBinaryVersion({
+        moduleUrl: "not-a-valid-url",
+        envVersion: "2026.3.2",
+        fallback: "0.0.0",
+      }),
+    ).toBe("2026.3.2");
+  });
+
   it("ignores non-openclaw package and blank build-info versions", async () => {
     await withTempDir(async (root) => {
       await writeJsonFixture(root, "package.json", { name: "other-package", version: "9.9.9" });

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,7 +1,7 @@
 import { createRequire } from "node:module";
 
 declare const __OPENCLAW_VERSION__: string | undefined;
-const CORE_PACKAGE_NAME = "openclaw";
+const CORE_PACKAGE_NAMES = new Set(["openclaw", "openclaw-cli"]);
 
 const PACKAGE_JSON_CANDIDATES = [
   "../package.json",
@@ -30,7 +30,10 @@ function readVersionFromJsonCandidates(
         if (!version) {
           continue;
         }
-        if (opts.requirePackageName && parsed.name !== CORE_PACKAGE_NAME) {
+        if (opts.requirePackageName && !CORE_PACKAGE_NAMES.has(parsed.name ?? "")) {
+          continue;
+        }
+        if (version === "dev") {
           continue;
         }
         return version;
@@ -75,12 +78,13 @@ export function resolveBinaryVersion(params: {
   moduleUrl: string;
   injectedVersion?: string;
   bundledVersion?: string;
+  envVersion?: string;
   fallback?: string;
 }): string {
   return (
     firstNonEmpty(params.injectedVersion) ||
     resolveVersionFromModuleUrl(params.moduleUrl) ||
-    firstNonEmpty(params.bundledVersion) ||
+    firstNonEmpty(params.bundledVersion, params.envVersion) ||
     params.fallback ||
     "0.0.0"
   );
@@ -125,4 +129,5 @@ export const VERSION = resolveBinaryVersion({
   moduleUrl: import.meta.url,
   injectedVersion: typeof __OPENCLAW_VERSION__ === "string" ? __OPENCLAW_VERSION__ : undefined,
   bundledVersion: process.env.OPENCLAW_BUNDLED_VERSION,
+  envVersion: process.env.OPENCLAW_VERSION,
 });


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw --version` shows "dev" or "0.0.0" when installed via Homebrew because: (1) the Homebrew formula uses the `openclaw-cli` package name which didn't match the hard-coded `"openclaw"` check, (2) `build-info.json` may contain `"dev"` as a placeholder version, and (3) `OPENCLAW_VERSION` env var was not consulted by `resolveBinaryVersion`.
- **Why it matters:** Users cannot determine their installed version, making troubleshooting and bug reporting difficult.
- **What changed:** (1) Accept both `"openclaw"` and `"openclaw-cli"` as valid package names in `readVersionFromPackageJsonForModuleUrl`. (2) Filter out `"dev"` as a placeholder version. (3) Add `envVersion` (from `OPENCLAW_VERSION`) as a fallback in `resolveBinaryVersion`.
- **What did NOT change:** `resolveRuntimeServiceVersion`, build-info generation, or any other version resolution paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35768

## User-visible / Behavior Changes

- `openclaw --version` now shows the correct version when installed via Homebrew.
- Homebrew formulas can set `OPENCLAW_VERSION` as a fallback.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Homebrew)
- Runtime: Node.js 22

### Steps

1. Install OpenClaw via Homebrew: `brew install openclaw`
2. Run `openclaw --version`

### Expected

- Shows actual version (e.g. `2026.3.2`)

### Actual (before fix)

- Shows `dev` or `0.0.0`

## Evidence

```
 src/version.ts      | 12 ++++++++----
 src/version.test.ts | 26 ++++++++++++++++++++++++++
 2 files changed, 34 insertions(+), 4 deletions(-)
```

All 13 version tests pass including 3 new tests for openclaw-cli, dev filtering, and envVersion.

## Human Verification (required)

- Verified scenarios: openclaw-cli package name, dev placeholder skipping, envVersion fallback, existing precedence preserved
- Edge cases checked: blank versions, non-openclaw packages, malformed URLs
- What I did **not** verify: Actual Homebrew installation (tested via unit tests)

## Compatibility / Migration

- Backward compatible? `Yes — adds fallbacks without changing existing behavior`
- Config/env changes? `Optional: OPENCLAW_VERSION env var now works for --version`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/version.ts`
- Known bad symptoms: Reverts to showing "dev" on Homebrew

## Risks and Mitigations

- Risk: A legitimate package named `openclaw-cli` with a different version could be picked up. Mitigation: The `openclaw-cli` package is the official Homebrew distribution package.