### PR TITLE
fix(discord): catch synchronous disconnect error during abort

### DIFF
--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -446,4 +446,37 @@ describe("runDiscordGatewayLifecycle", () => {
     const connectedTrue = statusUpdates.find((s) => s.connected === true);
     expect(connectedTrue).toBeUndefined();
   });
+
+  it("does not throw when gateway.disconnect raises Max reconnect attempts", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const { emitter, gateway } = createGatewayHarness();
+      gateway.disconnect.mockImplementation(() => {
+        throw new Error("Max reconnect attempts (0) reached after code 1006");
+      });
+      getDiscordGatewayEmitterMock.mockReturnValue(emitter);
+
+      const ac = new AbortController();
+      const { lifecycleParams } = createLifecycleHarness({ gateway });
+      lifecycleParams.abortSignal = ac.signal;
+
+      waitForDiscordGatewayStopMock.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            emitter.once("disconnect", () => resolve());
+          }),
+      );
+
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+      ac.abort();
+      await vi.advanceTimersByTimeAsync(100);
+      emitter.emit("disconnect", new Error("Max reconnect attempts (0) reached"));
+      await vi.advanceTimersByTimeAsync(100);
+
+      await expect(lifecyclePromise).resolves.not.toThrow();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -98,7 +98,12 @@ export async function runDiscordGatewayLifecycle(params: {
     }
     gatewayEmitter?.once("error", () => {});
     gateway.options.reconnect = { maxAttempts: 0 };
-    gateway.disconnect();
+    try {
+      gateway.disconnect();
+    } catch {
+      // Swallow "Max reconnect attempts (0) reached" thrown synchronously
+      // when the gateway processes a pending close code during disconnect.
+    }
   };
 
   if (params.abortSignal?.aborted) {


### PR DESCRIPTION
## Summary

When the Discord gateway abort handler sets `reconnect.maxAttempts = 0` and calls `gateway.disconnect()`, the eris library may throw `"Max reconnect attempts (0) reached"` synchronously if a pending WebSocket close code (e.g. 1006) is being processed at that moment. This uncaught exception crashes the process.

This PR wraps `gateway.disconnect()` in a `try/catch` block inside the `onAbort` handler, swallowing the synchronous error since the lifecycle is already shutting down.

## Changes

| File | What changed |
|------|-------------|
| `src/discord/monitor/provider.lifecycle.ts` | Wrapped `gateway.disconnect()` in `try/catch` inside the abort handler |
| `src/discord/monitor/provider.lifecycle.test.ts` | Added test verifying `disconnect()` throwing does not crash the lifecycle |

## Test plan

- [x] New unit test: mocks `gateway.disconnect` to throw `"Max reconnect attempts (0) reached"`, asserts lifecycle resolves without throwing
- [x] All 12 existing lifecycle tests continue to pass
- `npx vitest run src/discord/monitor/provider.lifecycle.test.ts` — 12/12 passed

## Security Impact

- [ ] Does this PR introduce any new dependencies? **No**
- [ ] Does this PR modify authentication or authorization logic? **No**
- [ ] Does this PR expose any new API endpoints or modify existing ones? **No**
- [ ] Does this PR handle sensitive data (API keys, tokens, PII)? **No**
- [ ] Does this PR modify file system permissions or access patterns? **No**

## Human Verification Scenarios

1. Connect a Discord bot with `requireMention: true`, then abort the lifecycle (e.g., via SIGINT). Verify no crash from "Max reconnect attempts" error.
2. Simulate a WebSocket close code 1006 during graceful shutdown — lifecycle should resolve cleanly.

## Failure Recovery

Revert this single commit. The only change is a `try/catch` wrapper; removal restores original behavior.

## Risks and Mitigations

- **Risk**: Swallowing the error could mask a genuine failure during disconnect.
  - **Mitigation**: The catch block is narrowly scoped to the abort path only, where the lifecycle is already terminating. All other disconnect paths remain unchanged.

Closes #36055