### PR TITLE
[Issue #37311] Control UI returns 404 on pnpm installs — rejectHardlinks blocks hard-linked assets

### DIFF
--- a/.github/issue-bootstrap/issue-37311.md
+++ b/.github/issue-bootstrap/issue-37311.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37311
+- Title: Control UI returns 404 on pnpm installs — rejectHardlinks blocks hard-linked assets
+- Source: https://github.com/openclaw/openclaw/issues/37311


### PR DESCRIPTION
## Source Issue
- Number: #37311
- URL: https://github.com/openclaw/openclaw/issues/37311
- Title: Control UI returns 404 on pnpm installs — rejectHardlinks blocks hard-linked assets

## Original Issue Description
## Description

The Control UI returns 404 for all static assets when OpenClaw is installed via `pnpm add -g`. The gateway starts, `controlUi.enabled` is true, assets exist on disk, but every file request silently fails.

## Root Cause

`resolveSafeControlUiFile` (gateway-cli chunk) calls `openBoundaryFileSync` without setting `rejectHardlinks: false`. The default is `true`.

pnpm stores all package files as **hard links** (`nlink: 2+`) in its content-addressable store. `openVerifiedFileSync` sees `nlink > 1` and returns `{ ok: false, reason: "validation" }`, rejecting every control-ui file.

The bootstrap config endpoint (`/__openclaw/control-ui-config.json`) works fine because it is served inline via `sendJson` — no file boundary check. This was the key diagnostic clue.

## Reproduction

1. Install OpenClaw via pnpm: `pnpm add -g openclaw`
2. Set `gateway.controlUi.enabled: true`
3. Start the gateway
4. `curl http://127.0.0.1:18789/` → 404

Verify hard links: `stat .../openclaw/dist/control-ui/index.html` shows `Links: 2`

## Workaround

Copy assets to a local directory with hard links broken:

```bash
cp -r --no-preserve=links .../openclaw/dist/control-ui ~/.openclaw/control-ui/
```

Then set `gateway.controlUi.root` to the copied path. This breaks on upgrades (must re-copy).

## Suggested Fix

`resolveSafeControlUiFile` should pass `rejectHardlinks: false` to `openBoundaryFileSync`, since hard-linked package files from pnpm are expected and not a security concern.

## Environment

- OpenClaw: 2026.3.2 (pnpm global install)
- OS: Ubuntu 25.10
- Node: v24.13.1

Closes #37311