### PR TITLE
fix(ui): separate device token from shared auth token

### DIFF
--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -179,14 +179,15 @@ export class GatewayBrowserClient {
     let canFallbackToShared = false;
     let authToken = this.opts.token;
 
+    let deviceToken: string | undefined;
+
     if (isSecureContext) {
       deviceIdentity = await loadOrCreateDeviceIdentity();
-      const storedToken = loadDeviceAuthToken({
+      deviceToken = loadDeviceAuthToken({
         deviceId: deviceIdentity.deviceId,
         role,
       })?.token;
-      authToken = storedToken ?? this.opts.token;
-      canFallbackToShared = Boolean(storedToken && this.opts.token);
+      canFallbackToShared = Boolean(deviceToken && this.opts.token);
     }
     const auth =
       authToken || this.opts.password
@@ -216,7 +217,7 @@ export class GatewayBrowserClient {
         role,
         scopes,
         signedAtMs,
-        token: authToken ?? null,
+        token: deviceToken ?? null,
         nonce,
       });
       const signature = await signDevicePayload(deviceIdentity.privateKey, payload);


### PR DESCRIPTION
## Summary

- **Problem**: Control UI fails with `device token mismatch` error when connecting to gateway, even though gateway is healthy and other channels work fine
- **Why it matters**: Users experience persistent offline state in Control UI, requiring manual low-level recovery steps (clear tokens, restart gateway, clear browser data)
- **What changed**: Separated `deviceToken` (for signed device auth payload) from `authToken` (for shared auth validation) in `GatewayBrowserClient`
- **What did NOT change**: Server-side token verification logic, device pairing flow, or other client implementations (CLI, TUI)

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24078
- Related #19681, #18562

## User-visible / Behavior Changes

**Before**: Control UI shows persistent "disconnected (1008): unauthorized: device token mismatch" error when stored device token exists, requiring manual recovery.

**After**: Control UI correctly uses shared auth token for validation and device token only for signed payloads, eliminating false token mismatch errors.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

**Explanation**: This change corrects token usage but does not introduce new security risks. Previously, the code incorrectly used the device token as the shared auth token, causing validation failures. The fix ensures each token is used for its intended purpose:
- `authToken` (from `opts.token`) → shared auth validation
- `deviceToken` (from stored pairing) → signed device auth payload only

This separation aligns with the server's token verification logic and reduces false authentication failures.

## Repro + Verification

### Environment

- OS: macOS 15.7.4 (arm64), also observed on Linux/WSL
- Runtime/container: Browser (Safari 18.6, Chrome)
- Model/provider: N/A (auth layer)
- Integration/channel: Control UI (WebSocket connection)
- Relevant config: `gateway.bind: loopback`, `gateway.auth.mode: token`

### Steps

1. Use Control UI normally with device pairing
2. Rotate/remove device tokens or restart gateway (causing token state changes)
3. Reopen Control UI in browser
4. Observe persistent "device token mismatch" error

### Expected

- UI should connect successfully using shared auth token
- Device token should only be used for signed device auth payload
- No false token mismatch errors

### Actual (before fix)

- UI shows offline with `1008: unauthorized: device token mismatch`
- Stored device token was incorrectly used as shared auth token
- Server compared device token against `gateway.auth.token`, causing mismatch

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

**Code path analysis**:
```typescript
// Before (incorrect):
authToken = storedToken ?? this.opts.token;
// Server compared storedToken against gateway.auth.token → mismatch

// After (correct):
authToken = this.opts.token;  // for shared auth validation
deviceToken = storedToken;     // only for signed payload
// Server compares opts.token against gateway.auth.token → match
```

## Human Verification

**Verified scenarios**:
- Control UI connection with existing device pairing
- Connection after gateway restart
- Connection with both shared token and device identity present

**Edge cases checked**:
- First-time connection (no stored device token)
- Secure context vs non-secure context
- Fallback to shared auth when device token unavailable

**What I did NOT verify**:
- CLI/TUI device auth flows (separate code paths)
- Gateway status RPC probe (server-side issue #18562)
- Internal tool calls (separate issue #19681)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

This is a client-side fix that corrects token usage. No server changes, config updates, or user migration required. Existing device pairings continue to work.

## Failure Recovery

**How to disable/revert**: 
```bash
git revert <this-commit-hash>
# Or temporarily: set gateway.controlUi.dangerouslyDisableDeviceAuth=true
```

**Files/config to restore**: `ui/src/ui/gateway.ts` (single file change)

**Known bad symptoms**:
- Control UI shows "device token mismatch" errors again
- Users report persistent offline state despite healthy gateway

## Risks and Mitigations

- **Risk**: Regression in device auth flow if token separation logic is incorrect
  - **Mitigation**: Code review confirms separation aligns with server-side verification logic; existing device pairings tested; fallback to shared auth preserved

- **Risk**: Edge case where both tokens are required but only one is sent
  - **Mitigation**: `canFallbackToShared` flag ensures graceful fallback; secure context check prevents device auth in non-HTTPS environments
