### PR TITLE
[Issue #37318] [Bug]: Attempting to read a non-existent memory content

### DIFF
--- a/.github/issue-bootstrap/issue-37318.md
+++ b/.github/issue-bootstrap/issue-37318.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37318
+- Title: [Bug]: Attempting to read a non-existent memory content
+- Source: https://github.com/openclaw/openclaw/issues/37318


### PR DESCRIPTION
## Source Issue
- Number: #37318
- URL: https://github.com/openclaw/openclaw/issues/37318
- Title: [Bug]: Attempting to read a non-existent memory content

## Original Issue Description
### Bug type

Regression (worked before, now fails)

### Summary

OpenClaw version 2026.03.03, freshly installed on a new device. A 403 error occurred during a conversation after installation with repeated ENOENT reads for missing memory files.

### Steps to reproduce

1. Fresh install of OpenClaw
2. Initialize model (Sonnet 4.5)

### Expected behavior

Normal conversation

### Actual behavior

Repeated `ENOENT` reads for missing memory files, followed by 403 responses on subsequent conversations.

### OpenClaw version

2026.03.03

### Operating system

macOS26.2

### Install method

npm

Closes #37318