### PR TITLE
[Issue #37322] [Bug]: tui and web return `run erro: 404 status code (no body)`

### DIFF
--- a/.github/issue-bootstrap/issue-37322.md
+++ b/.github/issue-bootstrap/issue-37322.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37322
+- Title: [Bug]: tui and web return `run erro: 404 status code (no body)`
+- Source: https://github.com/openclaw/openclaw/issues/37322


### PR DESCRIPTION
## Source Issue
- Number: #37322
- URL: https://github.com/openclaw/openclaw/issues/37322
- Title: [Bug]: tui and web return `run erro: 404 status code (no body)`

## Original Issue Description
### Bug type

Regression (worked before, now fails)

### Summary

User reports 404 status code errors in TUI and web after model changes, including aliyun/coding-plan.

### OpenClaw version

2026.3.2-beta.1

### Operating system

Ubuntu

### Install method

npm global

Closes #37322