### PR TITLE
[Issue #37323] [Bug]: --json mode CLI stdout is polluted by plugin/bootstrap logs, breaking machine-readable output

### DIFF
--- a/.github/issue-bootstrap/issue-37323.md
+++ b/.github/issue-bootstrap/issue-37323.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37323
+- Title: [Bug]: --json mode CLI stdout is polluted by plugin/bootstrap logs, breaking machine-readable output
+- Source: https://github.com/openclaw/openclaw/issues/37323


### PR DESCRIPTION
## Source Issue
- Number: #37323
- URL: https://github.com/openclaw/openclaw/issues/37323
- Title: [Bug]: --json mode CLI stdout is polluted by plugin/bootstrap logs, breaking machine-readable output

## Original Issue Description
## Bug type
Behavior bug (incorrect output/state without crash)

## Summary
Commands invoked with `--json` can emit plugin/bootstrap logs to stdout before JSON payload, breaking machine-readable output and causing `jq` parsing failures.

## Steps to reproduce
1. Run `openclaw plugins list --json | jq .`
2. Run `openclaw hooks list --json | jq .`
3. Observe plugin/bootstrap logs before JSON on stdout

## Expected behavior
When `--json` is used, stdout should contain only JSON. Non-fatal logs should go to stderr or be suppressed.

## Actual behavior
Plugin/bootstrap logs appear on stdout before JSON payload.

## OpenClaw version
2026.3.2 (85377a2)

## Operating system
Linux 6.17.4-2-pve (x64) in LXC

Closes #37323