### PR TITLE
Telegram: drop empty text chunks before send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/empty reply drop guard: skip whitespace-only text chunks before calling Telegram send APIs so blank final replies no longer trigger `message text is empty` failures or gateway restarts. (#37278) Thanks @EanHD.
 - Onboarding/headless Linux daemon probe hardening: treat `systemctl --user is-enabled` probe failures as non-fatal during daemon install flow so onboarding no longer crashes on SSH/headless VPS environments before showing install guidance. (#37297) Thanks @acarbajal-web.
 - Memory/QMD mcporter Windows spawn hardening: when `mcporter.cmd` launch fails with `spawn EINVAL`, retry via bare `mcporter` shell resolution so QMD recall can continue instead of falling back to builtin memory search. (#27402) Thanks @i0ivi0i.
 - Tools/web_search Brave language-code validation: align `search_lang` handling with Brave-supported codes (including `zh-hans`, `zh-hant`, `en-gb`, and `pt-br`), map common alias inputs (`zh`, `ja`) to valid Brave values, and reject unsupported codes before upstream requests to prevent 422 failures. (#37260) Thanks @heyanming.

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -103,6 +103,21 @@ function isEmptyTextChunk(chunk: { html?: string; text?: string } | undefined): 
   return !html && !text;
 }
 
+function shouldSkipEmptyTextChunk(params: {
+  chunk: { html?: string; text?: string } | undefined;
+  context: "reply" | "follow-up" | "voice fallback";
+  index: number;
+  total: number;
+}): boolean {
+  if (!isEmptyTextChunk(params.chunk)) {
+    return false;
+  }
+  logVerbose(
+    `telegram ${params.context} chunk ${params.index + 1}/${params.total} rendered empty; skipping`,
+  );
+  return true;
+}
+
 async function deliverTextReply(params: {
   bot: Bot;
   chatId: string;
@@ -119,12 +134,20 @@ async function deliverTextReply(params: {
 }): Promise<number | undefined> {
   let firstDeliveredMessageId: number | undefined;
   const chunks = params.chunkText(params.replyText);
+  let buttonsAttached = false;
   for (let i = 0; i < chunks.length; i += 1) {
     const chunk = chunks[i];
-    if (isEmptyTextChunk(chunk)) {
+    if (
+      shouldSkipEmptyTextChunk({
+        chunk,
+        context: "reply",
+        index: i,
+        total: chunks.length,
+      })
+    ) {
       continue;
     }
-    const shouldAttachButtons = i === 0 && params.replyMarkup;
+    const shouldAttachButtons = !buttonsAttached && params.replyMarkup;
     const replyToForChunk = resolveReplyToForSend({
       replyToId: params.replyToId,
       replyToMode: params.replyToMode,
@@ -145,6 +168,9 @@ async function deliverTextReply(params: {
         replyMarkup: shouldAttachButtons ? params.replyMarkup : undefined,
       },
     );
+    if (shouldAttachButtons) {
+      buttonsAttached = true;
+    }
     if (firstDeliveredMessageId == null) {
       firstDeliveredMessageId = messageId;
     }
@@ -168,9 +194,17 @@ async function sendPendingFollowUpText(params: {
   progress: DeliveryProgress;
 }): Promise<void> {
   const chunks = params.chunkText(params.text);
+  let buttonsAttached = false;
   for (let i = 0; i < chunks.length; i += 1) {
     const chunk = chunks[i];
-    if (isEmptyTextChunk(chunk)) {
+    if (
+      shouldSkipEmptyTextChunk({
+        chunk,
+        context: "follow-up",
+        index: i,
+        total: chunks.length,
+      })
+    ) {
       continue;
     }
     const replyToForFollowUp = resolveReplyToForSend({
@@ -184,8 +218,11 @@ async function sendPendingFollowUpText(params: {
       textMode: "html",
       plainText: chunk.text,
       linkPreview: params.linkPreview,
-      replyMarkup: i === 0 ? params.replyMarkup : undefined,
+      replyMarkup: !buttonsAttached ? params.replyMarkup : undefined,
     });
+    if (!buttonsAttached && params.replyMarkup) {
+      buttonsAttached = true;
+    }
     markReplyApplied(params.progress, replyToForFollowUp);
     markDelivered(params.progress);
   }
@@ -222,7 +259,14 @@ async function sendTelegramVoiceFallbackText(opts: {
   let appliedReplyTo = false;
   for (let i = 0; i < chunks.length; i += 1) {
     const chunk = chunks[i];
-    if (isEmptyTextChunk(chunk)) {
+    if (
+      shouldSkipEmptyTextChunk({
+        chunk,
+        context: "voice fallback",
+        index: i,
+        total: chunks.length,
+      })
+    ) {
       continue;
     }
     // Only apply reply reference, quote text, and buttons to the first chunk.

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -94,6 +94,15 @@ function markDelivered(progress: DeliveryProgress): void {
   progress.deliveredCount += 1;
 }
 
+function isEmptyTextChunk(chunk: { html?: string; text?: string } | undefined): boolean {
+  if (!chunk) {
+    return true;
+  }
+  const html = typeof chunk.html === "string" ? chunk.html.trim() : "";
+  const text = typeof chunk.text === "string" ? chunk.text.trim() : "";
+  return !html && !text;
+}
+
 async function deliverTextReply(params: {
   bot: Bot;
   chatId: string;
@@ -112,7 +121,7 @@ async function deliverTextReply(params: {
   const chunks = params.chunkText(params.replyText);
   for (let i = 0; i < chunks.length; i += 1) {
     const chunk = chunks[i];
-    if (!chunk) {
+    if (isEmptyTextChunk(chunk)) {
       continue;
     }
     const shouldAttachButtons = i === 0 && params.replyMarkup;
@@ -161,6 +170,9 @@ async function sendPendingFollowUpText(params: {
   const chunks = params.chunkText(params.text);
   for (let i = 0; i < chunks.length; i += 1) {
     const chunk = chunks[i];
+    if (isEmptyTextChunk(chunk)) {
+      continue;
+    }
     const replyToForFollowUp = resolveReplyToForSend({
       replyToId: params.replyToId,
       replyToMode: params.replyToMode,
@@ -210,6 +222,9 @@ async function sendTelegramVoiceFallbackText(opts: {
   let appliedReplyTo = false;
   for (let i = 0; i < chunks.length; i += 1) {
     const chunk = chunks[i];
+    if (isEmptyTextChunk(chunk)) {
+      continue;
+    }
     // Only apply reply reference, quote text, and buttons to the first chunk.
     const replyToForChunk = !appliedReplyTo ? opts.replyToId : undefined;
     const messageId = await sendTelegramText(opts.bot, opts.chatId, chunk.html, opts.runtime, {

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -56,7 +56,7 @@ function createBot(api: Record<string, unknown> = {}): Bot {
 }
 
 async function deliverWith(params: DeliverWithParams) {
-  await deliverReplies({
+  return await deliverReplies({
     ...baseDeliveryParams,
     ...params,
   });
@@ -479,17 +479,58 @@ describe("deliverReplies", () => {
     const sendMessage = vi.fn();
     const bot = { api: { sendMessage } } as unknown as Bot;
 
-    await deliverReplies({
-      replies: [{ text: "   " }],
+    await expect(
+      deliverReplies({
+        replies: [{ text: "   " }],
+        chatId: "123",
+        token: "tok",
+        runtime,
+        bot,
+        replyToMode: "off",
+        textLimit: 4000,
+      }),
+    ).resolves.toEqual({ delivered: false });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps inline buttons on the first non-empty text chunk after skipped whitespace", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 11,
+      chat: { id: "123" },
+    });
+    const bot = { api: { sendMessage } } as unknown as Bot;
+
+    const result = await deliverReplies({
+      replies: [
+        {
+          text: "   hello",
+          channelData: {
+            telegram: {
+              buttons: [[{ text: "Ack", callback_data: "ack" }]],
+            },
+          },
+        },
+      ],
       chatId: "123",
       token: "tok",
       runtime,
       bot,
       replyToMode: "off",
-      textLimit: 4000,
+      textLimit: 3,
     });
 
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(result).toEqual({ delivered: true });
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(sendMessage.mock.calls[0]?.[2]).toEqual(
+      expect.objectContaining({
+        reply_markup: {
+          inline_keyboard: [[{ text: "Ack", callback_data: "ack" }]],
+        },
+      }),
+    );
+    expect(sendMessage.mock.calls[1]?.[2]).not.toHaveProperty("reply_markup");
   });
 
   it("uses reply_to_message_id when quote text is provided", async () => {

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -474,22 +474,21 @@ describe("deliverReplies", () => {
     );
   });
 
-  it("throws when formatted and plain fallback text are both empty", async () => {
+  it("skips whitespace-only text replies without calling Telegram", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn();
     const bot = { api: { sendMessage } } as unknown as Bot;
 
-    await expect(
-      deliverReplies({
-        replies: [{ text: "   " }],
-        chatId: "123",
-        token: "tok",
-        runtime,
-        bot,
-        replyToMode: "off",
-        textLimit: 4000,
-      }),
-    ).rejects.toThrow("empty formatted text and empty plain fallback");
+    await deliverReplies({
+      replies: [{ text: "   " }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+    });
+
     expect(sendMessage).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- Problem: Telegram reply delivery could still try to send whitespace-only chunks, which Telegram rejects with `400: Bad Request: text must be non-empty`.
- Why it matters: a blank final reply can fail the Telegram send path and trigger disruptive gateway restarts.
- What changed: added a shared empty-chunk guard before Telegram text sends for normal text replies, pending follow-up text, and voice-to-text fallback sends.
- What did NOT change (scope boundary): no chunking rules, formatting behavior, or non-Telegram channel delivery paths changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37278
- Related #11340

## User-visible / Behavior Changes

- Telegram now silently drops whitespace-only final text chunks instead of attempting a `sendMessage` call that Telegram rejects as empty.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: n/a
- Integration/channel (if any): Telegram
- Relevant config (redacted): n/a

### Steps

1. Deliver a Telegram text reply whose rendered chunk content is whitespace-only.
2. Observe whether the Telegram send path calls `sendMessage` anyway.
3. Run the Telegram delivery tests covering empty reply handling.

### Expected

- Whitespace-only Telegram text chunks are skipped and no `sendMessage` call is made.

### Actual

- After this patch, whitespace-only chunks are skipped for normal text replies and the same guard also covers follow-up text and voice fallback text.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: whitespace-only Telegram text reply no longer calls `sendMessage`; existing Telegram delivery tests still pass.
- Edge cases checked: normal rendered text still sends; `pnpm build` succeeds after the delivery guard change.
- What you did **not** verify: live Telegram bot delivery against a real chat.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `5025f76a6`
- Files/config to restore: `src/telegram/bot/delivery.replies.ts`, `src/telegram/bot/delivery.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: legitimate Telegram text chunks being dropped unexpectedly.

## Risks and Mitigations

- Risk: trimming logic could accidentally hide a chunk that only contains formatting artifacts.
- Mitigation: the guard only skips when both rendered HTML and plain-text fallback are blank after trim, and the focused delivery test covers the reported whitespace-only failure mode.

## AI Disclosure

- AI-assisted: Yes. Human-reviewed and validated with the commands below.

## Validation

- `pnpm test src/telegram/bot/delivery.test.ts`
- `pnpm exec oxlint src/telegram/bot/delivery.replies.ts src/telegram/bot/delivery.test.ts`
- `pnpm exec oxfmt --check src/telegram/bot/delivery.replies.ts src/telegram/bot/delivery.test.ts CHANGELOG.md`
- `pnpm build`
- `pnpm check` (fails on existing baseline `extensions/tlon` missing `@tloncorp/api`, unrelated to this patch)
