### PR TITLE
[Issue #37326] [Bug]: memory.qmd.update.embedInterval never triggers qmd embed

### DIFF
--- a/.github/issue-bootstrap/issue-37326.md
+++ b/.github/issue-bootstrap/issue-37326.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37326
+- Title: [Bug]: memory.qmd.update.embedInterval never triggers qmd embed
+- Source: https://github.com/openclaw/openclaw/issues/37326


### PR DESCRIPTION
## Source Issue
- Number: #37326
- URL: https://github.com/openclaw/openclaw/issues/37326
- Title: [Bug]: memory.qmd.update.embedInterval never triggers qmd embed

## Original Issue Description
## Summary

`memory.qmd.update.embedInterval` is configured but never executes `qmd embed` despite startup logs indicating initialization is armed.

## Evidence

Multiple days of logs show only startup initialization lines and no embed runs; pending documents remain unembedded.

## Expected Behavior

Gateway should execute `qmd embed` at configured interval.

## Actual Behavior

Interval appears armed but never fires; pending docs accumulate.

## Environment

- OpenClaw: 2026.3.2
- QMD: 1.0.7
- node-llama-cpp: 3.17.1
- macOS 26.3 (M4)
- Node: v22.22.0

Closes #37326