### PR TITLE
[Issue #37340] [Bug]: 2026.3.2 gateway install bug

### DIFF
--- a/.github/issue-bootstrap/issue-37340.md
+++ b/.github/issue-bootstrap/issue-37340.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37340
+- Title: [Bug]: 2026.3.2 gateway install bug
+- Source: https://github.com/openclaw/openclaw/issues/37340


### PR DESCRIPTION
## Source Issue
- Number: #37340
- URL: https://github.com/openclaw/openclaw/issues/37340
- Title: [Bug]: 2026.3.2 gateway install bug

## Original Issue Description
### Bug type

Regression (worked before, now fails)

### Summary

After full uninstall/reinstall on Linux with OpenClaw 2026.3.2, gateway install/onboard daemon step fails while checking systemctl service state.

### Steps to reproduce

1. `openclaw uninstall`
2. `npm uninstall -g openclaw`
3. `npm install -g openclaw@latest`
4. `openclaw onboard --install-daemon`
5. `openclaw gateway install`

### Expected behavior

Gateway installation succeeds.

### Actual behavior

Gateway installation fails due to service check failure.

### Environment

- OpenClaw: 2026.3.2
- OS: Ubuntu 24
- Install: npm global

Closes #37340