### PR TITLE
fix(agents): drop thinking blocks for all non-Anthropic providers

### DIFF
--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -93,13 +93,11 @@ export function resolveTranscriptPolicy(params: {
   const isOpenRouterGemini =
     (provider === "openrouter" || provider === "opencode" || provider === "kilocode") &&
     modelId.toLowerCase().includes("gemini");
-  const isCopilotClaude = provider === "github-copilot" && modelId.toLowerCase().includes("claude");
   const requiresOpenAiCompatibleToolIdSanitization = params.modelApi === "openai-completions";
 
-  // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
-  // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").
-  // Drop these blocks at send-time to keep sessions usable.
-  const dropThinkingBlocks = isCopilotClaude;
+  // Only Anthropic's API understands `type: "thinking"` blocks with signatures.
+  // Drop these blocks when sending to any non-Anthropic provider to avoid API errors.
+  const dropThinkingBlocks = !isAnthropic;
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 


### PR DESCRIPTION
Closes #37314

## Problem
When a session accumulates history with Claude's thinking content blocks (including thinkingSignature), switching the model to a non-Anthropic provider (e.g., Gemini via OpenRouter, Google Vertex) causes API errors because thinking blocks are sent as-is to providers that don't understand them.

Error: \`messages.147.content.0.thinking.signature: Field required\`

## Root Cause
The \`dropThinkingBlocks\` flag was only set for GitHub Copilot + Claude, but thinking blocks are Anthropic-specific and should be dropped for all non-Anthropic providers.

## Fix
Change the condition from:
\`\`\`typescript
const dropThinkingBlocks = isCopilotClaude;
\`\`\`

To:
\`\`\`typescript
const dropThinkingBlocks = !isAnthropic;
\`\`\`

This ensures thinking blocks are dropped when sending to any provider that doesn't understand them (Gemini, GPT, Mistral, etc.).

## Testing
- All existing transcript-policy tests pass
- Verified the logic: only Anthropic APIs understand \`type: \"thinking\"\` blocks with signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)