### PR TITLE
[Issue #37357] [Bug]: Fake streaming through Telegram.

### DIFF
--- a/.github/issue-bootstrap/issue-37357.md
+++ b/.github/issue-bootstrap/issue-37357.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37357
+- Title: [Bug]: Fake streaming through Telegram.
+- Source: https://github.com/openclaw/openclaw/issues/37357


### PR DESCRIPTION
## Source Issue
- Number: #37357
- URL: https://github.com/openclaw/openclaw/issues/37357
- Title: [Bug]: Fake streaming through Telegram.

## Original Issue Description
### Bug type

Regression (worked before, now fails)

### Summary

With streaming mode set to partial, Telegram appears to stream only after the full message is already complete (fake streaming).

### Steps to reproduce

Provider: github copilot / ollama

### Expected behavior

True streaming after first delta.

### Actual behavior

Streaming appears only after full message is generated.

### Environment

- OpenClaw: latest
- OS: macOS 26.3

Closes #37357