### PR TITLE
[Issue #37361] memory_search intermittently fails with ENOENT during embedding model finalize (.ipull -> .gguf)

### DIFF
--- a/.github/issue-bootstrap/issue-37361.md
+++ b/.github/issue-bootstrap/issue-37361.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37361
+- Title: memory_search intermittently fails with ENOENT during embedding model finalize (.ipull -> .gguf)
+- Source: https://github.com/openclaw/openclaw/issues/37361


### PR DESCRIPTION
## Source Issue
- Number: #37361
- URL: https://github.com/openclaw/openclaw/issues/37361
- Title: memory_search intermittently fails with ENOENT during embedding model finalize (.ipull -> .gguf)

## Original Issue Description
## Summary

`memory_search` intermittently fails with ENOENT while finalizing local embedding model files, temporarily disabling semantic memory.

## Observed error

`ENOENT: no such file or directory, rename '...Q8_0.gguf.ipull' -> '...Q8_0.gguf'`

## Expected behavior

Transient finalize states should retry/backoff and recover automatically without hard failure to callers.

## Notes

Observed on Linux ARM64 with local embedding provider (`embeddinggemma-300m-qat-q8_0`).

Closes #37361