### PR TITLE
[Issue #37371] [Bug]: can not access local files in the workspace directory.

### DIFF
--- a/.github/issue-bootstrap/issue-37371.md
+++ b/.github/issue-bootstrap/issue-37371.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37371
+- Title: [Bug]: can not access local files in the workspace directory.
+- Source: https://github.com/openclaw/openclaw/issues/37371


### PR DESCRIPTION
## Source Issue
- Number: #37371
- URL: https://github.com/openclaw/openclaw/issues/37371
- Title: [Bug]: can not access local files in the workspace directory.

## Original Issue Description
### Bug type

Regression (worked before, now fails)

### Summary

User reports OpenClaw cannot access files in workspace directory and asks user to paste text instead.

### Steps to reproduce

1. Install via `curl -fsSL https://openclaw.ai/install.sh | bash`
2. Configure Qwen-Max
3. Upload `1.txt` to workspace
4. Ask OpenClaw to read and summarize file

### Expected behavior

OpenClaw reads file and summarizes content.

### Actual behavior

OpenClaw says it cannot access file content.

### Environment

- OpenClaw: 2026.3.2
- OS: Ubuntu 24.04
- Install: install script

Closes #37371