### PR TITLE
fix(config): prefer config baseUrl over stale models.json in merge mode

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -207,7 +207,7 @@ describe("models-config", () => {
     });
   });
 
-  it("preserves non-empty agent apiKey/baseUrl for matching providers in merge mode", async () => {
+  it("preserves non-empty agent apiKey but prefers config baseUrl in merge mode", async () => {
     await withTempHome(async () => {
       const parsed = await runCustomProviderMergeTest({
         baseUrl: "https://agent.example/v1",
@@ -215,6 +215,37 @@ describe("models-config", () => {
         api: "openai-responses",
         models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
       });
+      expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
+      expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
+    });
+  });
+
+  it("falls back to agent baseUrl when config baseUrl is empty", async () => {
+    await withTempHome(async () => {
+      await writeAgentModelsJson({
+        providers: {
+          custom: {
+            baseUrl: "https://agent.example/v1",
+            apiKey: "AGENT_KEY",
+            api: "openai-responses",
+            models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
+          },
+        },
+      });
+      await ensureOpenClawModelsJson({
+        models: {
+          mode: "merge",
+          providers: {
+            custom: {
+              ...createMergeConfigProvider(),
+              baseUrl: "",
+            },
+          },
+        },
+      });
+      const parsed = await readGeneratedModelsJson<{
+        providers: Record<string, { apiKey?: string; baseUrl?: string }>;
+      }>();
       expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
       expect(parsed.providers.custom?.baseUrl).toBe("https://agent.example/v1");
     });

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -162,7 +162,11 @@ function mergeWithExistingProviderSecrets(params: {
     if (typeof existing.apiKey === "string" && existing.apiKey) {
       preserved.apiKey = existing.apiKey;
     }
-    if (typeof existing.baseUrl === "string" && existing.baseUrl) {
+    if (
+      typeof existing.baseUrl === "string" &&
+      existing.baseUrl &&
+      !(typeof newEntry.baseUrl === "string" && newEntry.baseUrl.trim())
+    ) {
       preserved.baseUrl = existing.baseUrl;
     }
     mergedProviders[key] = { ...newEntry, ...preserved };


### PR DESCRIPTION
## Summary

When `mode: "merge"` is configured, `mergeWithExistingProviderSecrets` unconditionally preserved the `baseUrl` from the agent's `models.json`, overriding the user's config value. This caused providers like kimi-coding with custom `baseUrl` settings to 404 because the stale default URL persisted across gateway restarts.

This PR changes the merge logic to only fall back to the `models.json` `baseUrl` when the config does not provide a non-empty value. The `apiKey` preservation behavior is unchanged (models.json always wins for apiKey).

## Changes

| File | What changed |
|------|-------------|
| `src/agents/models-config.ts` | `mergeWithExistingProviderSecrets`: only preserve existing `baseUrl` when `newEntry.baseUrl` is empty/missing |
| `src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts` | Updated existing merge test expectation; added new test for empty-config-baseUrl fallback |

## Test plan

- [x] Updated test: "preserves non-empty agent apiKey but prefers config baseUrl in merge mode" — verifies config baseUrl wins over models.json
- [x] New test: "falls back to agent baseUrl when config baseUrl is empty" — verifies models.json baseUrl is preserved when config omits it
- [x] All 8 existing merge config tests pass
- `npx vitest run src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts` — 8/8 passed

## Security Impact

- [ ] Does this PR introduce any new dependencies? **No**
- [ ] Does this PR modify authentication or authorization logic? **No**
- [ ] Does this PR expose any new API endpoints or modify existing ones? **No**
- [ ] Does this PR handle sensitive data (API keys, tokens, PII)? **No** (apiKey logic unchanged)
- [ ] Does this PR modify file system permissions or access patterns? **No**

## Human Verification Scenarios

1. Configure kimi-coding with custom `baseUrl: "https://api.kimi.com/coding"` in openclaw.json, restart gateway, verify API calls use the custom URL instead of the hardcoded default.
2. Remove `baseUrl` from the kimi-coding config, restart — verify the models.json cached URL is preserved as fallback.
3. Existing providers without explicit `baseUrl` in config should continue using their models.json values.

## Failure Recovery

Revert this single commit. The change is a 4-line condition guard in `mergeWithExistingProviderSecrets`; removal restores original "models.json always wins" behavior.

## Risks and Mitigations

- **Risk**: Users who manually edited `models.json` baseUrl (not via config) will see their edits overridden by config on next restart.
  - **Mitigation**: The documented workflow is to configure providers in `openclaw.json`, not by hand-editing `models.json`. The merge doc says models.json is for "preserving" values, not as a primary config source.

Closes #36353