### PR TITLE
[Issue #37388] [Bug]: Log file does not rotate automatically on date change (stuck in previous day's file)

### DIFF
--- a/.github/issue-bootstrap/issue-37388.md
+++ b/.github/issue-bootstrap/issue-37388.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37388
+- Title: [Bug]: Log file does not rotate automatically on date change (stuck in previous day's file)
+- Source: https://github.com/openclaw/openclaw/issues/37388


### PR DESCRIPTION
## Source Issue
- Number: #37388
- URL: https://github.com/openclaw/openclaw/issues/37388
- Title: [Bug]: Log file does not rotate automatically on date change (stuck in previous day's file)

## Original Issue Description
### Bug type
Behavior bug (incorrect output/state without crash)

### Summary
When gateway runs across midnight, logs continue writing to previous day’s file until a manual gateway restart.

### Expected behavior
Daily log file should rotate automatically and write new-day logs to new-day file.

### Actual behavior
New file may be created but remains empty while logs continue in prior day file.

### Environment
- OpenClaw: 2026.3.2
- OS: macOS

Closes #37388