### PR TITLE
fix(agents): drop thinking blocks for all non-Anthropic providers

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -120,6 +120,57 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.preserveSignatures).toBe(false);
   });
 
+  it("drops thinking blocks for non-Anthropic providers (#37314)", () => {
+    const google = resolveTranscriptPolicy({
+      provider: "google",
+      modelId: "gemini-2.0-flash",
+      modelApi: "google-generative-ai",
+    });
+    expect(google.dropThinkingBlocks).toBe(true);
+
+    const openai = resolveTranscriptPolicy({
+      provider: "openai",
+      modelId: "gpt-4o",
+      modelApi: "openai",
+    });
+    expect(openai.dropThinkingBlocks).toBe(true);
+
+    const mistral = resolveTranscriptPolicy({
+      provider: "mistral",
+      modelId: "mistral-large-latest",
+    });
+    expect(mistral.dropThinkingBlocks).toBe(true);
+
+    const copilotClaude = resolveTranscriptPolicy({
+      provider: "github-copilot",
+      modelId: "claude-opus-4-5",
+    });
+    expect(copilotClaude.dropThinkingBlocks).toBe(true);
+
+    const openrouterGemini = resolveTranscriptPolicy({
+      provider: "openrouter",
+      modelId: "google/gemini-3-flash-preview",
+      modelApi: "openai-completions",
+    });
+    expect(openrouterGemini.dropThinkingBlocks).toBe(true);
+  });
+
+  it("preserves thinking blocks for Anthropic providers (#37314)", () => {
+    const anthropic = resolveTranscriptPolicy({
+      provider: "anthropic",
+      modelId: "claude-opus-4-5",
+      modelApi: "anthropic-messages",
+    });
+    expect(anthropic.dropThinkingBlocks).toBe(false);
+
+    const bedrock = resolveTranscriptPolicy({
+      provider: "amazon-bedrock",
+      modelId: "us.anthropic.claude-opus-4-6-v1",
+      modelApi: "bedrock-converse-stream",
+    });
+    expect(bedrock.dropThinkingBlocks).toBe(false);
+  });
+
   it("keeps OpenRouter on its existing turn-validation path", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openrouter",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -93,13 +93,12 @@ export function resolveTranscriptPolicy(params: {
   const isOpenRouterGemini =
     (provider === "openrouter" || provider === "opencode" || provider === "kilocode") &&
     modelId.toLowerCase().includes("gemini");
-  const isCopilotClaude = provider === "github-copilot" && modelId.toLowerCase().includes("claude");
   const requiresOpenAiCompatibleToolIdSanitization = params.modelApi === "openai-completions";
 
-  // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
-  // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").
-  // Drop these blocks at send-time to keep sessions usable.
-  const dropThinkingBlocks = isCopilotClaude;
+  // Only Anthropic's API understands `type: "thinking"` blocks with signatures.
+  // Drop these blocks when sending to any non-Anthropic provider to prevent
+  // API errors (e.g. "thinking.signature: Field required" on Gemini/OpenAI).
+  const dropThinkingBlocks = !isAnthropic;
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 


### PR DESCRIPTION
## Summary

- Problem: `dropThinkingBlocks` only activates for GitHub Copilot Claude, so switching a session from Claude to Gemini/OpenAI/Mistral sends persisted `type: "thinking"` blocks that those APIs reject (`thinking.signature: Field required`)
- Why it matters: users cannot switch models mid-session without losing all conversation history (must delete session files)
- What changed: broadened `dropThinkingBlocks` condition from `isCopilotClaude` to `!isAnthropic` — the `dropThinkingBlocks()` function already exists and handles empty-message preservation
- What did NOT change (scope boundary): Anthropic/Bedrock providers still preserve thinking blocks; `sanitizeThoughtSignatures` logic for Google/OpenRouter Gemini is untouched; no changes to the `dropThinkingBlocks()` function itself

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #37314

## User-visible / Behavior Changes

Sessions with Claude thinking history can now be switched to any non-Anthropic provider without API errors. Thinking blocks are silently dropped (replaced with empty text blocks to preserve message structure) when sending to non-Anthropic APIs.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: any
- Runtime/container: Node 22+
- Model/provider: Claude → Gemini/OpenAI/Mistral switch
- Integration/channel (if any): any

### Steps

1. Start a session with Claude (any model with extended thinking enabled)
2. Have a conversation that generates thinking blocks in history
3. Switch the session model to `openrouter/google/gemini-3-flash-preview`
4. Send a message

### Expected

- Message processes normally; thinking blocks from previous Claude turns are silently dropped

### Actual (before fix)

- Error: `messages.147.content.0.thinking.signature: Field required`

## Evidence

- [x] Failing test/log before + passing after

| Provider | `dropThinkingBlocks` before | `dropThinkingBlocks` after |
|----------|---------------------------|--------------------------|
| `anthropic` (anthropic-messages) | `false` | `false` (preserved) |
| `amazon-bedrock` (bedrock-converse-stream) | `false` | `false` (preserved) |
| `google` (google-generative-ai) | `false` | `true` (dropped) |
| `openai` | `false` | `true` (dropped) |
| `mistral` | `false` | `true` (dropped) |
| `github-copilot` (claude) | `true` | `true` (dropped) |
| `openrouter` (gemini) | `false` | `true` (dropped) |

Added 2 test cases covering 7 provider configurations.

## Human Verification (required)

- Verified scenarios: all 7 provider configurations tested via `resolveTranscriptPolicy` unit tests
- Edge cases checked: Bedrock (Anthropic API via AWS) correctly preserves thinking blocks; OpenRouter Gemini correctly drops them
- What you did **not** verify: end-to-end session switch with real API calls (unit test only)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the single condition in `transcript-policy.ts` to `isCopilotClaude`
- Files/config to restore: `src/agents/transcript-policy.ts`
- Known bad symptoms reviewers should watch for: if a non-Anthropic provider somehow needs thinking blocks preserved, they would be dropped incorrectly

## Risks and Mitigations

- Risk: a future non-Anthropic provider might support Anthropic-style thinking blocks
  - Mitigation: such a provider would need to be added to the `isAnthropicApi()` check, which is the correct place to register Anthropic-compatible APIs