### PR TITLE
[Issue #37401] feat: load workspace .env per-agent automatically

### DIFF
--- a/.github/issue-bootstrap/issue-37401.md
+++ b/.github/issue-bootstrap/issue-37401.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37401
+- Title: feat: load workspace .env per-agent automatically
+- Source: https://github.com/openclaw/openclaw/issues/37401


### PR DESCRIPTION
## Source Issue
- Number: #37401
- URL: https://github.com/openclaw/openclaw/issues/37401
- Title: feat: load workspace .env per-agent automatically

## Original Issue Description
## Problem

Gateway loads `.env` from startup cwd and global `~/.openclaw/.env`, but not per-agent workspace `.env` files.

## Expected behavior

Per-agent workspace `.env` should be loaded with non-override precedence beneath process env.

## Use case

Separate agents using different `GH_CONFIG_DIR` values and isolated GitHub accounts.

Closes #37401