### PR TITLE
feat(channels): add preflight guardrails before token/config write

### DIFF
--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -52,6 +52,7 @@ const optionNamesAdd = [
   "groupChannels",
   "dmAllowlist",
   "autoDiscoverChannels",
+  "confirmTarget",
 ] as const;
 
 const optionNamesRemove = ["channel", "account", "delete"] as const;
@@ -198,6 +199,11 @@ export function registerChannelsCli(program: Command) {
     .option("--auto-discover-channels", "Tlon auto-discover group channels")
     .option("--no-auto-discover-channels", "Disable Tlon auto-discovery")
     .option("--use-env", "Use env token (default account only)", false)
+    .option(
+      "--confirm-target",
+      "Confirm target (channel + account) before applying token/config; required when running non-interactively",
+      false,
+    )
     .action(async (opts, command) => {
       await runChannelsCommand(async () => {
         const hasFlags = hasExplicitOptions(command, optionNamesAdd);

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -32,7 +32,7 @@ describe("channelsAddCommand", () => {
     });
 
     await channelsAddCommand(
-      { channel: "telegram", account: "default", token: "new-token" },
+      { channel: "telegram", account: "default", token: "new-token", confirmTarget: true },
       runtime,
       { hasFlags: true },
     );
@@ -52,7 +52,7 @@ describe("channelsAddCommand", () => {
     });
 
     await channelsAddCommand(
-      { channel: "telegram", account: "default", token: "same-token" },
+      { channel: "telegram", account: "default", token: "same-token", confirmTarget: true },
       runtime,
       { hasFlags: true },
     );

--- a/src/commands/channels.adds-non-default-telegram-account.test.ts
+++ b/src/commands/channels.adds-non-default-telegram-account.test.ts
@@ -69,9 +69,11 @@ describe("channels command", () => {
   }
 
   async function addTelegramAccount(account: string, token: string): Promise<void> {
-    await channelsAddCommand({ channel: "telegram", account, token }, runtime, {
-      hasFlags: true,
-    });
+    await channelsAddCommand(
+      { channel: "telegram", account, token, confirmTarget: true },
+      runtime,
+      { hasFlags: true },
+    );
   }
 
   async function addAlertsTelegramAccount(token: string): Promise<{
@@ -181,6 +183,7 @@ describe("channels command", () => {
         account: "default",
         botToken: "xoxb-1",
         appToken: "xapp-1",
+        confirmTarget: true,
       },
       runtime,
       { hasFlags: true },
@@ -227,7 +230,12 @@ describe("channels command", () => {
   it("adds a named WhatsApp account", async () => {
     configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
     await channelsAddCommand(
-      { channel: "whatsapp", account: "family", name: "Family Phone" },
+      {
+        channel: "whatsapp",
+        account: "family",
+        name: "Family Phone",
+        confirmTarget: true,
+      },
       runtime,
       { hasFlags: true },
     );
@@ -260,6 +268,7 @@ describe("channels command", () => {
         account: "lab",
         name: "Lab",
         signalNumber: "+15555550123",
+        confirmTarget: true,
       },
       runtime,
       { hasFlags: true },
@@ -350,6 +359,7 @@ describe("channels command", () => {
         account: "default",
         token: "123:abc",
         name: "Primary Bot",
+        confirmTarget: true,
       },
       runtime,
       { hasFlags: true },
@@ -380,9 +390,11 @@ describe("channels command", () => {
       },
     });
 
-    await channelsAddCommand({ channel: "discord", account: "work", token: "d1" }, runtime, {
-      hasFlags: true,
-    });
+    await channelsAddCommand(
+      { channel: "discord", account: "work", token: "d1", confirmTarget: true },
+      runtime,
+      { hasFlags: true },
+    );
 
     const next = getWrittenConfig<{
       channels?: {

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -18,6 +18,10 @@ import {
   reloadOnboardingPluginRegistry,
 } from "../onboarding/plugin-install.js";
 import { applyAccountName, applyChannelAccountConfig } from "./add-mutators.js";
+import {
+  preflightChannelConfigWrite,
+  preflightChannelConfigWriteBatch,
+} from "./preflight-token-apply.js";
 import { channelLabel, requireValidConfig, shouldUseWizard } from "./shared.js";
 
 export type ChannelsAddOptions = {
@@ -26,6 +30,8 @@ export type ChannelsAddOptions = {
   initialSyncLimit?: number | string;
   groupChannels?: string;
   dmAllowlist?: string;
+  /** Skip interactive preflight; allow token/config write (non-interactive use). */
+  confirmTarget?: boolean;
 } & Omit<ChannelSetupInput, "groupChannels" | "dmAllowlist" | "initialSyncLimit">;
 
 function parseList(value: string | undefined): string[] | undefined {
@@ -176,6 +182,18 @@ export async function channelsAddCommand(
       }
     }
 
+    const batchTargets = selection.map((ch) => ({
+      channel: ch,
+      accountId: (accountIds[ch] ?? DEFAULT_ACCOUNT_ID).trim(),
+    }));
+    const preflight = await preflightChannelConfigWriteBatch({
+      targets: batchTargets,
+      prompter,
+    });
+    if (!preflight.ok) {
+      await prompter.outro(preflight.reason ?? "Cancelled.");
+      return;
+    }
     await writeConfigFile(nextConfig);
     await prompter.outro("Channels updated.");
     return;
@@ -297,6 +315,17 @@ export async function channelsAddCommand(
     accountId,
     input,
   });
+
+  const preflight = await preflightChannelConfigWrite({
+    channel,
+    accountId,
+    confirmTarget: opts.confirmTarget,
+  });
+  if (!preflight.ok) {
+    runtime.error(preflight.reason ?? "Preflight cancelled.");
+    runtime.exit(1);
+    return;
+  }
 
   if (channel === "telegram") {
     const nextTelegramToken = resolveTelegramAccount({ cfg: nextConfig, accountId }).token.trim();

--- a/src/commands/channels/preflight-token-apply.test.ts
+++ b/src/commands/channels/preflight-token-apply.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  preflightChannelConfigWrite,
+  preflightChannelConfigWriteBatch,
+} from "./preflight-token-apply.js";
+
+describe("preflightChannelConfigWrite", () => {
+  it("returns ok when prompter confirms", async () => {
+    const result = await preflightChannelConfigWrite({
+      channel: "telegram",
+      accountId: "default",
+      prompter: { confirm: vi.fn().mockResolvedValue(true) },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns not ok when prompter cancels", async () => {
+    const result = await preflightChannelConfigWrite({
+      channel: "telegram",
+      accountId: "work",
+      prompter: { confirm: vi.fn().mockResolvedValue(false) },
+    });
+    expect(result.ok).toBe(false);
+    expect("reason" in result && result.reason).toContain("cancelled");
+  });
+
+  it("returns not ok when non-interactive and no confirmTarget", async () => {
+    const result = await preflightChannelConfigWrite({
+      channel: "telegram",
+      accountId: "default",
+    });
+    expect(result.ok).toBe(false);
+    expect("reason" in result && result.reason).toContain("--confirm-target");
+  });
+
+  it("returns ok when non-interactive with confirmTarget", async () => {
+    const result = await preflightChannelConfigWrite({
+      channel: "discord",
+      accountId: "default",
+      confirmTarget: true,
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("preflightChannelConfigWriteBatch", () => {
+  it("returns ok when prompter confirms", async () => {
+    const result = await preflightChannelConfigWriteBatch({
+      targets: [{ channel: "telegram", accountId: "default" }],
+      prompter: { confirm: vi.fn().mockResolvedValue(true) },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns ok for empty targets", async () => {
+    const result = await preflightChannelConfigWriteBatch({
+      targets: [],
+      prompter: { confirm: vi.fn() },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.ok && result).toBeTruthy();
+  });
+
+  it("returns not ok when prompter cancels", async () => {
+    const result = await preflightChannelConfigWriteBatch({
+      targets: [{ channel: "telegram", accountId: "default" }],
+      prompter: { confirm: vi.fn().mockResolvedValue(false) },
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/commands/channels/preflight-token-apply.ts
+++ b/src/commands/channels/preflight-token-apply.ts
@@ -1,0 +1,80 @@
+/**
+ * Preflight guardrails before applying channel token/config (fixes #37302).
+ * Ensures the operator explicitly confirms the target (channel + accountId)
+ * before write, reducing risk of applying token to the wrong bot/context.
+ */
+
+import type { WizardPrompter } from "../../wizard/prompts.js";
+
+export type PreflightChannelConfigWriteParams = {
+  channel: string;
+  accountId: string;
+  /** When set, prompt for confirmation (interactive). */
+  prompter?: Pick<WizardPrompter, "confirm">;
+  /** When true (e.g. CLI --confirm-target), skip interactive prompt and allow write. */
+  confirmTarget?: boolean;
+};
+
+export type PreflightChannelConfigWriteResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Runs preflight before writing channel account config. When interactive (prompter
+ * provided), prompts to confirm target. When non-interactive, requires confirmTarget
+ * to be set or the write is blocked.
+ */
+export async function preflightChannelConfigWrite(
+  params: PreflightChannelConfigWriteParams,
+): Promise<PreflightChannelConfigWriteResult> {
+  const { channel, accountId, prompter, confirmTarget } = params;
+  const targetLabel = `${channel} account "${accountId}"`;
+
+  if (prompter) {
+    const confirmed = await prompter.confirm({
+      message: `Apply config to ${targetLabel}?`,
+      initialValue: true,
+    });
+    if (!confirmed) {
+      return { ok: false, reason: "Target confirmation cancelled." };
+    }
+    return { ok: true };
+  }
+
+  if (confirmTarget) {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    reason: `Preflight: pass --confirm-target to apply token/config to ${targetLabel}, or run without channel flags for interactive confirmation.`,
+  };
+}
+
+export type PreflightChannelConfigWriteBatchParams = {
+  targets: Array<{ channel: string; accountId: string }>;
+  prompter: Pick<WizardPrompter, "confirm">;
+};
+
+/**
+ * Preflight for a batch write (e.g. wizard writing multiple channel accounts).
+ * Single confirmation for the whole set.
+ */
+export async function preflightChannelConfigWriteBatch(
+  params: PreflightChannelConfigWriteBatchParams,
+): Promise<PreflightChannelConfigWriteResult> {
+  const { targets, prompter } = params;
+  if (targets.length === 0) {
+    return { ok: true };
+  }
+  const label =
+    targets.length === 1
+      ? `${targets[0].channel} account "${targets[0].accountId}"`
+      : `${targets.length} channel accounts (${targets.map((t) => `${t.channel}/${t.accountId}`).join(", ")})`;
+  const confirmed = await prompter.confirm({
+    message: `Apply config to ${label}?`,
+    initialValue: true,
+  });
+  if (!confirmed) {
+    return { ok: false, reason: "Target confirmation cancelled." };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
Fixes #37302

## Summary
Adds a mandatory preflight step before writing channel token/config so the operator explicitly confirms the target (channel + accountId), reducing the risk of applying a token to the wrong bot/context in multi-account setups.

## Changes
- **Preflight module** (`src/commands/channels/preflight-token-apply.ts`):
  - `preflightChannelConfigWrite`: For single-account non-wizard path. With a prompter, asks "Apply config to {channel} account '{accountId}'? [Y/n]". Without a prompter (non-interactive), write is **blocked** unless `--confirm-target` is set.
  - `preflightChannelConfigWriteBatch`: For wizard path; one confirmation for the batch of selected channel accounts.
- **channels add**:
  - Wizard: Before `writeConfigFile`, runs batch preflight; on cancel, exits without writing.
  - Non-wizard: Before `writeConfigFile`, runs single-account preflight. Without `--confirm-target`, exits with a clear message asking to pass `--confirm-target` or run interactively.
- **CLI**: New option `--confirm-target` for `openclaw channels add` so non-interactive/scripted use can explicitly allow the write.
- **Tests**: New tests for preflight helpers; existing channel-add tests updated to pass `confirmTarget: true` where they expect a successful write.

## Behavior
- **Interactive (wizard)**: User sees "Apply config to N channel accounts (...)?" and can cancel.
- **Non-interactive (flags only)**: Write is blocked with:  
  `Preflight: pass --confirm-target to apply token/config to telegram account "default", or run without channel flags for interactive confirmation.`
- **Non-interactive with `--confirm-target`**: Write proceeds (for CI/scripts).

## Out of scope (follow-ups)
- Telegram target writeback (`maybePersistResolvedTelegramTarget`) and other write paths could be gated similarly.
- Audit trail and bot-username/chat fingerprint verification (e.g. getMe + show "Bot @X") can be added in a later PR.