### PR TITLE
Logging: rotate rolling file writes at midnight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Logging/daily file rotation: roll rolling gateway log writes over to the current local-date file at midnight so long-running processes stop appending new-day logs into the previous day's file. (#37388) Thanks @Narlea.
 - Onboarding/headless Linux daemon probe hardening: treat `systemctl --user is-enabled` probe failures as non-fatal during daemon install flow so onboarding no longer crashes on SSH/headless VPS environments before showing install guidance. (#37297) Thanks @acarbajal-web.
 - Memory/QMD mcporter Windows spawn hardening: when `mcporter.cmd` launch fails with `spawn EINVAL`, retry via bare `mcporter` shell resolution so QMD recall can continue instead of falling back to builtin memory search. (#27402) Thanks @i0ivi0i.
 - Tools/web_search Brave language-code validation: align `search_lang` handling with Brave-supported codes (including `zh-hans`, `zh-hant`, `en-gb`, and `pt-br`), map common alias inputs (`zh`, `ja`) to valid Brave values, and reject unsupported codes before upstream requests to prevent 422 failures. (#37260) Thanks @heyanming.

--- a/src/logging/logger-rotation.test.ts
+++ b/src/logging/logger-rotation.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getLogger, resetLogger, setLoggerOverride } from "../logging.js";
+
+describe("rolling file logger", () => {
+  let logDir = "";
+
+  beforeEach(() => {
+    logDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-log-rotate-"));
+    resetLogger();
+    setLoggerOverride(null);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetLogger();
+    setLoggerOverride(null);
+    try {
+      fs.rmSync(logDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it("rotates rolling log writes when the local date changes", () => {
+    const firstDay = new Date("2026-03-05T23:59:58");
+    const secondDay = new Date("2026-03-06T00:00:02");
+    const firstFile = path.join(logDir, "openclaw-2026-03-05.log");
+    const secondFile = path.join(logDir, "openclaw-2026-03-06.log");
+
+    vi.setSystemTime(firstDay);
+    setLoggerOverride({ level: "info", file: firstFile });
+    const logger = getLogger();
+
+    logger.info("before-midnight");
+
+    vi.setSystemTime(secondDay);
+    logger.info("after-midnight");
+
+    const firstContent = fs.readFileSync(firstFile, "utf8");
+    const secondContent = fs.readFileSync(secondFile, "utf8");
+
+    expect(firstContent).toContain("before-midnight");
+    expect(firstContent).not.toContain("after-midnight");
+    expect(secondContent).toContain("after-midnight");
+    expect(secondContent).not.toContain("before-midnight");
+  });
+});

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -143,12 +143,24 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   if (isRollingPath(settings.file)) {
     pruneOldRollingLogs(path.dirname(settings.file));
   }
-  let currentFileBytes = getCurrentLogFileBytes(settings.file);
+  let currentFile = settings.file;
+  let currentFileBytes = getCurrentLogFileBytes(currentFile);
   let warnedAboutSizeCap = false;
 
   logger.attachTransport((logObj: LogObj) => {
     try {
-      const time = formatLocalIsoWithOffset(logObj.date ?? new Date());
+      const now = logObj.date ?? new Date();
+      if (isRollingPath(settings.file)) {
+        const nextFile = resolveRollingPathForDate(settings.file, now);
+        if (nextFile !== currentFile) {
+          fs.mkdirSync(path.dirname(nextFile), { recursive: true });
+          currentFile = nextFile;
+          currentFileBytes = getCurrentLogFileBytes(currentFile);
+          warnedAboutSizeCap = false;
+          pruneOldRollingLogs(path.dirname(currentFile));
+        }
+      }
+      const time = formatLocalIsoWithOffset(now);
       const line = JSON.stringify({ ...logObj, time });
       const payload = `${line}\n`;
       const payloadBytes = Buffer.byteLength(payload, "utf8");
@@ -160,16 +172,16 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
             time: formatLocalIsoWithOffset(new Date()),
             level: "warn",
             subsystem: "logging",
-            message: `log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}`,
+            message: `log file size cap reached; suppressing writes file=${currentFile} maxFileBytes=${settings.maxFileBytes}`,
           });
-          appendLogLine(settings.file, `${warningLine}\n`);
+          appendLogLine(currentFile, `${warningLine}\n`);
           process.stderr.write(
-            `[openclaw] log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}\n`,
+            `[openclaw] log file size cap reached; suppressing writes file=${currentFile} maxFileBytes=${settings.maxFileBytes}\n`,
           );
         }
         return;
       }
-      if (appendLogLine(settings.file, payload)) {
+      if (appendLogLine(currentFile, payload)) {
         currentFileBytes = nextBytes;
       }
     } catch {
@@ -309,6 +321,10 @@ function formatLocalDate(date: Date): string {
 function defaultRollingPathForToday(): string {
   const today = formatLocalDate(new Date());
   return path.join(DEFAULT_LOG_DIR, `${LOG_PREFIX}-${today}${LOG_SUFFIX}`);
+}
+
+function resolveRollingPathForDate(file: string, date: Date): string {
+  return path.join(path.dirname(file), `${LOG_PREFIX}-${formatLocalDate(date)}${LOG_SUFFIX}`);
 }
 
 function isRollingPath(file: string): boolean {


### PR DESCRIPTION
## Summary

- Problem: rolling file logging keeps appending to the previous day's file after midnight because the logger transport pins the target file when the logger is first built.
- Why it matters: long-running gateways show the new day's log path in status, but fresh logs still land in yesterday's file until a manual restart.
- What changed: rolling file writes now recompute the current local-date log path on each transport write and switch files when the date rolls over; added a regression test that keeps the same logger instance alive across midnight.
- What did NOT change (scope boundary): no log line format changes, no CLI log-reading changes, and no non-rolling/custom single-file log behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37388
- Related #37387

## User-visible / Behavior Changes

- Gateways that keep running across midnight now start writing new entries to the current local-date rolling log file without requiring a restart.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: n/a
- Integration/channel (if any): gateway file logging
- Relevant config (redacted): rolling log file path under a temp log directory

### Steps

1. Build a logger configured to write to a rolling `openclaw-YYYY-MM-DD.log` path.
2. Write once before local midnight and once after local midnight using the same logger instance.
3. Check which dated files received the two log lines.

### Expected

- The pre-midnight line stays in the first day's file and the post-midnight line lands in the next day's file.

### Actual

- After this patch, the logger transport switches files at the local date boundary without needing a logger rebuild or gateway restart.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: same logger instance writes to `openclaw-2026-03-05.log` before midnight and `openclaw-2026-03-06.log` after midnight in the new regression test.
- Edge cases checked: existing file-size cap and timestamp tests still pass; `pnpm build` succeeds.
- What you did **not** verify: a live gateway process running through an actual midnight boundary.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `83a11a7ac`
- Files/config to restore: `src/logging/logger.ts`, `src/logging/logger-rotation.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: logs unexpectedly switching away from the configured rolling file during normal same-day writes.

## Risks and Mitigations

- Risk: rotating logic could reset file-size accounting at the wrong time.
- Mitigation: size accounting is only reset when the resolved rolling file path actually changes, and the existing size-cap regression test still passes.

## AI Disclosure

- AI-assisted: Yes. Human-reviewed and validated with the commands below.

## Validation

- `pnpm test src/logging/logger-rotation.test.ts src/logging/log-file-size-cap.test.ts src/logging/logger-timestamp.test.ts`
- `pnpm exec oxlint src/logging/logger.ts src/logging/logger-rotation.test.ts src/logging/log-file-size-cap.test.ts src/logging/logger-timestamp.test.ts`
- `pnpm exec oxfmt --check src/logging/logger.ts src/logging/logger-rotation.test.ts src/logging/log-file-size-cap.test.ts src/logging/logger-timestamp.test.ts CHANGELOG.md`
- `pnpm build`
- `pnpm check` (fails on existing baseline `extensions/tlon` missing `@tloncorp/api`, unrelated to this patch)
