### PR TITLE
Memory: honor explicit QMD embed interval in search mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory/QMD explicit embed interval: honor `memory.qmd.update.embedInterval` even when QMD search mode stays `search`, so configured background `qmd embed` runs no longer stay permanently skipped. (#37326) Thanks @barronlroth.
 - Onboarding/headless Linux daemon probe hardening: treat `systemctl --user is-enabled` probe failures as non-fatal during daemon install flow so onboarding no longer crashes on SSH/headless VPS environments before showing install guidance. (#37297) Thanks @acarbajal-web.
 - Memory/QMD mcporter Windows spawn hardening: when `mcporter.cmd` launch fails with `spawn EINVAL`, retry via bare `mcporter` shell resolution so QMD recall can continue instead of falling back to builtin memory search. (#27402) Thanks @i0ivi0i.
 - Tools/web_search Brave language-code validation: align `search_lang` handling with Brave-supported codes (including `zh-hans`, `zh-hant`, `en-gb`, and `pt-br`), map common alias inputs (`zh`, `ja`) to valid Brave values, and reject unsupported codes before upstream requests to prevent 422 failures. (#37260) Thanks @heyanming.

--- a/src/memory/backend-config.ts
+++ b/src/memory/backend-config.ts
@@ -33,6 +33,7 @@ export type ResolvedQmdUpdateConfig = {
   onBoot: boolean;
   waitForBootSync: boolean;
   embedIntervalMs: number;
+  explicitEmbedInterval: boolean;
   commandTimeoutMs: number;
   updateTimeoutMs: number;
   embedTimeoutMs: number;
@@ -329,6 +330,7 @@ export function resolveMemoryBackendConfig(params: {
       onBoot: qmdCfg?.update?.onBoot !== false,
       waitForBootSync: qmdCfg?.update?.waitForBootSync === true,
       embedIntervalMs: resolveEmbedIntervalMs(qmdCfg?.update?.embedInterval),
+      explicitEmbedInterval: qmdCfg?.update?.embedInterval !== undefined,
       commandTimeoutMs: resolveTimeoutMs(
         qmdCfg?.update?.commandTimeoutMs,
         DEFAULT_QMD_COMMAND_TIMEOUT_MS,

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -1966,6 +1966,31 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("runs qmd embed in search mode when embedInterval is explicitly configured", async () => {
+    vi.useFakeTimers();
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "search",
+          update: { interval: "5m", debounceMs: 0, onBoot: false, embedInterval: "30m" },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const { manager } = await createManager({ mode: "full" });
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+    const commandCalls = spawnMock.mock.calls
+      .map((call: unknown[]) => call[1] as string[])
+      .filter((args: string[]) => args[0] === "update" || args[0] === "embed");
+    expect(commandCalls).toEqual([["update"], ["embed"]]);
+    await manager.close();
+  });
+
   it("retries boot update when qmd reports a retryable lock error", async () => {
     cfg = {
       ...cfg,

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1124,7 +1124,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   }
 
   private shouldRunEmbed(force?: boolean): boolean {
-    if (this.qmd.searchMode === "search") {
+    if (this.qmd.searchMode === "search" && !this.qmd.update.explicitEmbedInterval) {
       return false;
     }
     const now = Date.now();


### PR DESCRIPTION
## Summary

- Problem: `memory.qmd.update.embedInterval` is ignored when QMD stays in `search` mode, so users can explicitly configure background embeds and still never get a `qmd embed` run.
- Why it matters: pending QMD documents accumulate indefinitely even though the config advertises periodic embedding and the gateway reports startup initialization as armed.
- What changed: tracked whether `embedInterval` was explicitly configured, and let explicit embed scheduling bypass the default `search`-mode embed skip while preserving the old default behavior when no embed interval was set.
- What did NOT change (scope boundary): default `search` mode still skips background embeds unless the operator explicitly configured `memory.qmd.update.embedInterval`; search result behavior and QMD query mode selection are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37326
- Related #8952

## User-visible / Behavior Changes

- When operators explicitly set `memory.qmd.update.embedInterval`, QMD background embed runs now happen even if `memory.qmd.searchMode` remains `search`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: n/a
- Integration/channel (if any): QMD memory backend
- Relevant config (redacted): `memory.backend=qmd`, `memory.qmd.searchMode=search`, `memory.qmd.update.embedInterval=30m`

### Steps

1. Configure QMD with `searchMode: "search"` and an explicit `memory.qmd.update.embedInterval`.
2. Start the manager in full mode with periodic updates enabled.
3. Advance the periodic update timer and inspect which QMD commands were spawned.

### Expected

- The interval update triggers both `qmd update` and `qmd embed` when `embedInterval` was explicitly configured.

### Actual

- After this patch, explicit embed scheduling works in `search` mode while the old default skip remains in place for configs that never opted into embed intervals.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: existing `search`-mode forced sync test still skips embed by default; new regression test confirms explicit `embedInterval` causes `update` + `embed` on the first interval tick.
- Edge cases checked: `pnpm build` succeeds after the config/runtime change.
- What you did **not** verify: a live gateway process over a real 30-minute wall-clock interval.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `75a85bbc0`
- Files/config to restore: `src/memory/backend-config.ts`, `src/memory/qmd-manager.ts`, `src/memory/qmd-manager.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: unexpected background embed workload in configs that did not explicitly opt into `embedInterval`.

## Risks and Mitigations

- Risk: explicit embed scheduling in `search` mode could add background work for operators who set `embedInterval` without realizing `search` mode used to suppress embeds.
- Mitigation: the behavior only changes for configs that explicitly set `memory.qmd.update.embedInterval`; default `search` mode behavior remains unchanged and is covered by the existing regression test.

## AI Disclosure

- AI-assisted: Yes. Human-reviewed and validated with the commands below.

## Validation

- `pnpm test src/memory/qmd-manager.test.ts`
- `pnpm exec oxlint src/memory/backend-config.ts src/memory/qmd-manager.ts src/memory/qmd-manager.test.ts`
- `pnpm exec oxfmt --check src/memory/backend-config.ts src/memory/qmd-manager.ts src/memory/qmd-manager.test.ts CHANGELOG.md`
- `pnpm build`
- `pnpm check` (fails on existing baseline `extensions/tlon` missing `@tloncorp/api`, unrelated to this patch)
