### PR TITLE
cli: keep stdout clean in --json mode

### DIFF
--- a/src/cli/program/json-mode.stderr-routing.test.ts
+++ b/src/cli/program/json-mode.stderr-routing.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { registerPreActionHooks } from "./preaction.js";
+
+function createProgramStub() {
+  return {
+    hook: vi.fn((_name: string, cb: (...args: unknown[]) => unknown) => {
+      (createProgramStub as unknown as { _cb?: (...args: unknown[]) => unknown })._cb = cb;
+    }),
+  };
+}
+
+function getHook(program: unknown): ((thisCommand: unknown, actionCommand: unknown) => unknown) {
+  const hookCall = (program as { hook: ReturnType<typeof vi.fn> }).hook.mock.calls[0];
+  if (!hookCall) {
+    throw new Error("hook not registered");
+  }
+  return hookCall[1] as (thisCommand: unknown, actionCommand: unknown) => unknown;
+}
+
+describe("preaction JSON mode", () => {
+  it("routes logs to stderr when --json is present", async () => {
+    const argv = process.argv;
+    const original = process.env.OPENCLAW_STATE_DIR;
+
+    const routeSpy = vi.fn();
+
+    vi.doMock("../../logging/console.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("../../logging/console.js")>();
+      return {
+        ...actual,
+        routeLogsToStderr: routeSpy,
+      };
+    });
+
+    // Prevent config guard from doing any work.
+    vi.doMock("./config-guard.js", () => ({
+      ensureConfigReady: vi.fn(async () => {}),
+    }));
+
+    // Avoid banner/log side effects from unrelated modules.
+    vi.doMock("../plugin-registry.js", () => ({
+      ensurePluginRegistryLoaded: vi.fn(),
+    }));
+
+    process.argv = ["node", "openclaw", "plugins", "list", "--json"];
+
+    const program = createProgramStub();
+    registerPreActionHooks(program as any, "0.0.0-test");
+
+    const hook = getHook(program);
+    await hook({}, { parent: null, name: () => "openclaw" });
+
+    expect(routeSpy).toHaveBeenCalledTimes(1);
+
+    // restore
+    process.argv = argv;
+    if (original === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = original;
+    }
+  });
+});

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -126,7 +126,16 @@ export function registerPreActionHooks(program: Command, programVersion: string)
     if (shouldBypassConfigGuard(commandPath)) {
       return;
     }
-    const suppressDoctorStdout = isJsonOutputMode(commandPath, argv);
+
+    const jsonOutputMode = isJsonOutputMode(commandPath, argv);
+    if (jsonOutputMode) {
+      // Keep stdout clean in JSON mode so startup/plugin logs do not corrupt
+      // machine-readable output.
+      const { routeLogsToStderr } = await import("../../logging/console.js");
+      routeLogsToStderr();
+    }
+
+    const suppressDoctorStdout = jsonOutputMode;
     const { ensureConfigReady } = await loadConfigGuardModule();
     await ensureConfigReady({
       runtime: defaultRuntime,


### PR DESCRIPTION
Closes #37323

When `--json` is present, route startup/plugin logs to stderr so stdout remains machine-readable JSON.

Validation:
- pnpm -s vitest run src/cli/program/json-mode.stderr-routing.test.ts