### PR TITLE
fix(infra): pass OPENCLAW_DOCKER_APT_PACKAGES build-arg in setup-podman.sh

### DIFF
--- a/setup-podman.sh
+++ b/setup-podman.sh
@@ -209,7 +209,9 @@ if ! run_as_openclaw test -f "$OPENCLAW_JSON"; then
 fi
 
 echo "Building image from $REPO_PATH..."
-podman build -t openclaw:local -f "$REPO_PATH/Dockerfile" "$REPO_PATH"
+podman build -t openclaw:local \
+  --build-arg "OPENCLAW_DOCKER_APT_PACKAGES=${OPENCLAW_DOCKER_APT_PACKAGES:-}" \
+  -f "$REPO_PATH/Dockerfile" "$REPO_PATH"
 
 echo "Loading image into $OPENCLAW_USER's Podman store..."
 TMP_IMAGE="$(mktemp -p /tmp openclaw-image.XXXXXX.tar)"


### PR DESCRIPTION
## Summary

`setup-podman.sh` invokes `podman build` without forwarding the `OPENCLAW_DOCKER_APT_PACKAGES` build-arg. The Dockerfile's ARG defaults to empty, so any user-specified extra packages (e.g., `ffmpeg`, `chromium`) are silently ignored during Podman-based installations.

This PR mirrors the existing `docker-setup.sh` approach by passing `--build-arg "OPENCLAW_DOCKER_APT_PACKAGES=${OPENCLAW_DOCKER_APT_PACKAGES:-}"` to the `podman build` command.

## Changes

| File | What changed |
|------|-------------|
| `setup-podman.sh` | Added `--build-arg OPENCLAW_DOCKER_APT_PACKAGES` to the `podman build` invocation |

## Test plan

- [x] Manual: set `OPENCLAW_DOCKER_APT_PACKAGES="curl htop"` and run `setup-podman.sh` — verify the packages appear in the built image
- [x] Verified Dockerfile ARG exists at line 25 and is consumed by the `apt-get install` RUN step
- [x] Verified `docker-setup.sh` passes the same build-arg (line 390) — this change makes podman parity

## Security Impact

- [ ] Does this PR introduce any new dependencies? **No**
- [ ] Does this PR modify authentication or authorization logic? **No**
- [ ] Does this PR expose any new API endpoints or modify existing ones? **No**
- [ ] Does this PR handle sensitive data (API keys, tokens, PII)? **No**
- [ ] Does this PR modify file system permissions or access patterns? **No**

## Human Verification Scenarios

1. Run `OPENCLAW_DOCKER_APT_PACKAGES="curl" sudo bash setup-podman.sh` — verify curl is installed in the resulting image.
2. Run without the env var — verify build completes normally with no extra packages.

## Failure Recovery

Revert this single commit. The only change is adding a `--build-arg` flag; removal restores original behavior (packages ignored).

## Risks and Mitigations

None. This is a strict parity fix with `docker-setup.sh`.

Closes #35397