### PR TITLE
fix(gateway): skip stale-socket check when no events have ever been received

### DIFF
--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -489,11 +489,24 @@ describe("channel-health-monitor", () => {
       await expectNoRestart(manager);
     });
 
-    it("restarts a channel that never received any event past the stale threshold", async () => {
+    it("does not restart a channel that never received any event (no stale baseline)", async () => {
       const now = Date.now();
       const manager = createSlackSnapshotManager(
         runningConnectedSlackAccount({
           lastStartAt: now - STALE_THRESHOLD - 60_000,
+        }),
+      );
+      const monitor = await startAndRunCheck(manager);
+      expect(manager.stopChannel).not.toHaveBeenCalled();
+      monitor.stop();
+    });
+
+    it("restarts a channel whose last event exceeds stale threshold", async () => {
+      const now = Date.now();
+      const manager = createSlackSnapshotManager(
+        runningConnectedSlackAccount({
+          lastStartAt: now - STALE_THRESHOLD - 60_000,
+          lastEventAt: now - STALE_THRESHOLD - 30_000,
         }),
       );
       await expectRestartedChannel(manager, "slack");

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -98,7 +98,26 @@ describe("evaluateChannelHealth", () => {
     expect(evaluation).toEqual({ healthy: false, reason: "disconnected" });
   });
 
-  it("flags stale sockets when no events arrive beyond threshold", () => {
+  it("flags stale sockets when last event exceeds threshold", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+        lastEventAt: 50_000,
+      },
+      {
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
+  });
+
+  it("stays healthy when lastEventAt is null (no events ever received)", () => {
     const evaluation = evaluateChannelHealth(
       {
         running: true,
@@ -114,7 +133,7 @@ describe("evaluateChannelHealth", () => {
         staleEventThresholdMs: 30_000,
       },
     );
-    expect(evaluation).toEqual({ healthy: false, reason: "stale-socket" });
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
   });
 });
 

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -96,8 +96,10 @@ export function evaluateChannelHealth(
     const upSince = snapshot.lastStartAt ?? 0;
     const upDuration = policy.now - upSince;
     if (upDuration > policy.staleEventThresholdMs) {
-      const lastEvent = snapshot.lastEventAt ?? 0;
-      const eventAge = policy.now - lastEvent;
+      if (snapshot.lastEventAt == null) {
+        return { healthy: true, reason: "healthy" };
+      }
+      const eventAge = policy.now - snapshot.lastEventAt;
       if (eventAge > policy.staleEventThresholdMs) {
         return { healthy: false, reason: "stale-socket" };
       }


### PR DESCRIPTION
## Summary

When a channel never reports `lastEventAt` (e.g., iMessage during normal idle periods), the health policy falls back to epoch (`0`), making the event age always exceed `staleEventThresholdMs` (30 min). This causes the health monitor to flag the channel as `stale-socket` and restart it every 30 minutes, creating an infinite restart loop during idle.

This PR changes `evaluateChannelHealth` to return `healthy` when `lastEventAt` is `null` (no events ever received). Only channels that have actually received at least one event can go "stale". Websocket-based channels (Discord, Slack) set `lastEventAt` almost immediately after connecting, so the stale-socket check still works for them.

## Changes

| File | What changed |
|------|-------------|
| `src/gateway/channel-health-policy.ts` | Return healthy when `lastEventAt` is null instead of falling back to epoch |
| `src/gateway/channel-health-policy.test.ts` | Updated stale-socket test to use explicit `lastEventAt`; added test for null `lastEventAt` → healthy |
| `src/gateway/channel-health-monitor.test.ts` | Updated integration test: null `lastEventAt` no longer triggers restart; added explicit lastEventAt test |

## Test plan

- [x] Unit test: "stays healthy when lastEventAt is null (no events ever received)" — verifies null lastEventAt → healthy
- [x] Unit test: "flags stale sockets when last event exceeds threshold" — verifies explicit lastEventAt triggers stale-socket
- [x] Integration test: "does not restart a channel that never received any event" — verifies monitor skips restart
- [x] Integration test: "restarts a channel whose last event exceeds stale threshold" — verifies explicit event staleness still triggers restart
- [x] All 36 health policy + monitor tests pass
- `npx vitest run src/gateway/channel-health-policy.test.ts src/gateway/channel-health-monitor.test.ts` — 36/36 passed

## Security Impact

- [ ] Does this PR introduce any new dependencies? **No**
- [ ] Does this PR modify authentication or authorization logic? **No**
- [ ] Does this PR expose any new API endpoints or modify existing ones? **No**
- [ ] Does this PR handle sensitive data (API keys, tokens, PII)? **No**
- [ ] Does this PR modify file system permissions or access patterns? **No**

## Human Verification Scenarios

1. Start iMessage channel, leave idle for 35+ minutes. Verify no restart occurs and health stays "healthy".
2. Start Slack channel, disconnect network after events have been received. After 30 min without events, verify stale-socket restart triggers.
3. Start Discord channel, verify normal event flow keeps channel healthy.

## Failure Recovery

Revert this single commit. Removal restores the `?? 0` fallback, which re-enables the false-positive restart for iMessage.

## Risks and Mitigations

- **Risk**: A truly broken channel that never receives its first event won't be detected as stale.
  - **Mitigation**: Such channels would still be caught by the `disconnected` check (if `connected === false`) or `not-running` check. The stale-socket heuristic is only meaningful after at least one event establishes a baseline.

Closes #35072