### PR TITLE
reply: normalize Windows file paths for media dedupe

### DIFF
--- a/src/auto-reply/reply/reply-payloads.test.ts
+++ b/src/auto-reply/reply/reply-payloads.test.ts
@@ -77,6 +77,22 @@ describe("filterMessagingToolMediaDuplicates", () => {
     });
     expect(result).toEqual([{ text: "hello", mediaUrl: undefined, mediaUrls: undefined }]);
   });
+
+  it("dedupes Windows paths against file:// URLs", () => {
+    const result = filterMessagingToolMediaDuplicates({
+      payloads: [{ text: "hello", mediaUrl: "C:\\tmp\\photo one.jpg" }],
+      sentMediaUrls: ["file:///C:/tmp/photo%20one.jpg"],
+    });
+    expect(result).toEqual([{ text: "hello", mediaUrl: undefined, mediaUrls: undefined }]);
+  });
+
+  it("dedupes Windows paths regardless of drive letter case", () => {
+    const result = filterMessagingToolMediaDuplicates({
+      payloads: [{ text: "hello", mediaUrl: "C:/tmp/photo.jpg" }],
+      sentMediaUrls: ["file:///c:/tmp/photo.jpg"],
+    });
+    expect(result).toEqual([{ text: "hello", mediaUrl: undefined, mediaUrls: undefined }]);
+  });
 });
 
 describe("shouldSuppressMessagingToolReplies", () => {

--- a/src/auto-reply/reply/reply-payloads.ts
+++ b/src/auto-reply/reply/reply-payloads.ts
@@ -106,23 +106,39 @@ export function filterMessagingToolMediaDuplicates(params: {
   payloads: ReplyPayload[];
   sentMediaUrls: string[];
 }): ReplyPayload[] {
+  const normalizeFilesystemPathForDedupe = (path: string): string => {
+    if (!path) {
+      return "";
+    }
+    let normalized = path.replace(/\\/g, "/");
+    if (/^\/[a-zA-Z]:\//.test(normalized)) {
+      normalized = normalized.slice(1);
+    }
+    if (/^[a-zA-Z]:\//.test(normalized)) {
+      normalized = `${normalized[0]?.toLowerCase()}:${normalized.slice(2)}`;
+    }
+    return normalized;
+  };
+
   const normalizeMediaForDedupe = (value: string): string => {
     const trimmed = value.trim();
     if (!trimmed) {
       return "";
     }
     if (!trimmed.toLowerCase().startsWith("file://")) {
-      return trimmed;
+      return normalizeFilesystemPathForDedupe(trimmed);
     }
     try {
       const parsed = new URL(trimmed);
       if (parsed.protocol === "file:") {
-        return decodeURIComponent(parsed.pathname || "");
+        const pathname = decodeURIComponent(parsed.pathname || "");
+        const filePath = parsed.host ? `//${parsed.host}${pathname}` : pathname;
+        return normalizeFilesystemPathForDedupe(filePath);
       }
     } catch {
       // Keep fallback below for non-URL-like inputs.
     }
-    return trimmed.replace(/^file:\/\//i, "");
+    return normalizeFilesystemPathForDedupe(trimmed.replace(/^file:\/\//i, ""));
   };
 
   const { payloads, sentMediaUrls } = params;


### PR DESCRIPTION
## What changed
- Normalized filesystem-style media paths before dedupe matching in `filterMessagingToolMediaDuplicates`.
- Added Windows-aware path normalization for:
  - backslash (`\\`) vs slash (`/`) separators
  - `file:///C:/...` vs local `C:\...` / `C:/...` forms
  - drive-letter case differences (`C:` vs `c:`)
- Added focused unit tests covering Windows path + `file://` URL equivalence.

## Why
- Media dedupe should suppress duplicate sends even when the same file path is represented differently across platforms.
- Before this change, Windows local paths could fail to match equivalent `file://` URLs, causing duplicate media payloads.
- This keeps dedupe behavior consistent and low-noise for cross-platform usage.

## Testing
- ✅ `scripts/clone_and_test.sh openclaw/openclaw` (pass: `16 passed`)
- ✅ `npx vitest --run src/auto-reply/reply/reply-payloads.test.ts` (pass: `17 passed`)
