### PR TITLE
fix(gateway): allow hard-linked assets in Control UI file resolution

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -285,6 +285,27 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("serves hard-linked assets (pnpm content-addressable store)", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { filePath } = await writeAssetFile(tmp, "app.js", "console.log('ok');\n");
+        // Create a hard link (nlink > 1), simulating pnpm's store layout
+        const linkPath = path.join(path.dirname(filePath), "app-link.js");
+        await fs.link(filePath, linkPath);
+
+        const { res, end, handled } = runControlUiRequest({
+          url: "/assets/app-link.js",
+          method: "GET",
+          rootPath: tmp,
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(String(end.mock.calls[0]?.[0] ?? "")).toBe("console.log('ok');\n");
+      },
+    });
+  });
+
   it("serves HEAD for in-root assets without writing a body", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -263,6 +263,9 @@ function resolveSafeControlUiFile(
     rootRealPath: rootReal,
     boundaryLabel: "control ui root",
     skipLexicalRootCheck: true,
+    // pnpm stores package files as hard links in its content-addressable store,
+    // so nlink > 1 is expected and not a security concern for read-only assets.
+    rejectHardlinks: false,
   });
   if (!opened.ok) {
     if (opened.reason === "io") {


### PR DESCRIPTION
## Summary

- **Problem:** `resolveSafeControlUiFile` calls `openBoundaryFileSync` without setting `rejectHardlinks`, which defaults to `true` in `openBoundaryFileResolved`. pnpm stores all package files as hard links (`nlink > 1`) in its content-addressable store, so every control-ui file is rejected, returning 404 for all static assets.
- **Why it matters:** Any user installing OpenClaw via `pnpm add -g` gets a completely broken Control UI — all pages return 404 except the bootstrap config JSON endpoint (which is served inline via `sendJson`).
- **What changed:** Added `rejectHardlinks: false` to the `openBoundaryFileSync` call in `resolveSafeControlUiFile`.
- **What did NOT change:** No changes to boundary path validation, symlink rejection, or other file security checks. Avatar file resolution is unaffected.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #37311

## User-visible / Behavior Changes

Control UI static assets now load correctly when OpenClaw is installed via `pnpm add -g`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No — boundary path check still prevents directory traversal; only the hard-link count check (`nlink > 1`) is relaxed for read-only bundled assets.

## Repro + Verification

### Environment

- OS: Ubuntu 25.10
- Runtime: Node 24+
- Install method: `pnpm add -g openclaw`

### Steps

1. Install via `pnpm add -g openclaw`
2. Enable Control UI: `gateway.controlUi.enabled: true`
3. Start gateway
4. `curl http://127.0.0.1:18789/`

### Expected

- 200 with index.html content

### Actual (before fix)

- 404 Not Found

## Evidence

- [x] Failing test/log before + passing after

```
# Without fix:
× serves hard-linked assets (pnpm content-addressable store)

# With fix:
✓ serves hard-linked assets (pnpm content-addressable store)
```

Test creates a hard link (`fs.link`) to simulate pnpm's store layout and verifies the file is served with 200.

## Human Verification (required)

- Verified scenarios: Hard-linked asset file is served correctly (200); test confirmed to FAIL without the fix and PASS with it
- Edge cases checked: Symlink rejection still works (existing test covers this); boundary path traversal rejection unchanged
- What I did **not** verify: Live pnpm global install (no pnpm environment available)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this single commit
- Files: `src/gateway/control-ui.ts`

## Risks and Mitigations

- Risk: Relaxing `rejectHardlinks` could theoretically allow serving files that are hard-linked to sensitive locations outside the control-ui root.
  - Mitigation: The boundary path resolution check (`resolveBoundaryPathSync`) already validates that the resolved file path is within the control-ui root directory. A hard link inside the root pointing to data outside cannot exist without first being placed inside the root by an attacker with write access, which is a higher privilege than this check defends against.