### PR TITLE
[Issue #37415] [Bug]: Unable to use websocket to connect to Feishu on windows10 WSL2

### DIFF
--- a/.github/issue-bootstrap/issue-37415.md
+++ b/.github/issue-bootstrap/issue-37415.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37415
+- Title: [Bug]: Unable to use websocket to connect to Feishu on windows10 WSL2
+- Source: https://github.com/openclaw/openclaw/issues/37415


### PR DESCRIPTION
## Source Issue
- Number: #37415
- URL: https://github.com/openclaw/openclaw/issues/37415
- Title: [Bug]: Unable to use websocket to connect to Feishu on windows10 WSL2

## Original Issue Description
Issue reports that Feishu websocket configuration cannot be saved on Windows 10 WSL2, despite successful plugin install and setup. The report includes reproduction steps, expected/actual behavior, environment details, and gateway logs showing an Axios `stream has been aborted` failure when calling `https://open.feishu.cn/open-apis/bot/v3/info`.

Closes #37415