### PR TITLE
[Issue #37426] Reply media dedupe should normalize Windows local paths and file:// URLs

### DIFF
--- a/.github/issue-bootstrap/issue-37426.md
+++ b/.github/issue-bootstrap/issue-37426.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37426
+- Title: Reply media dedupe should normalize Windows local paths and file:// URLs
+- Source: https://github.com/openclaw/openclaw/issues/37426


### PR DESCRIPTION
## Source Issue
- Number: #37426
- URL: https://github.com/openclaw/openclaw/issues/37426
- Title: Reply media dedupe should normalize Windows local paths and file:// URLs

## Original Issue Description
Issue describes duplicate media sends caused by path-equivalence mismatches on Windows, where the same file can appear as `C:\...`, `C:/...`, or `file:///C:/...`. It asks to normalize filesystem-style path variants before dedupe matching so equivalent Windows paths compare consistently.

Closes #37426