### PR TITLE
[Issue #37428] delivery-recovery burns retries before WhatsApp listener is ready after restart

### DIFF
--- a/.github/issue-bootstrap/issue-37428.md
+++ b/.github/issue-bootstrap/issue-37428.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37428
+- Title: delivery-recovery burns retries before WhatsApp listener is ready after restart
+- Source: https://github.com/openclaw/openclaw/issues/37428


### PR DESCRIPTION
## Source Issue
- Number: #37428
- URL: https://github.com/openclaw/openclaw/issues/37428
- Title: delivery-recovery burns retries before WhatsApp listener is ready after restart

## Original Issue Description
Issue reports that delivery recovery starts too early after gateway restart and retries WhatsApp outbound deliveries before the listener is ready, consuming retry counts and potentially pushing messages to failed queue. It proposes treating startup-readiness errors as transient and adding a delayed recovery pass after startup.

Closes #37428