### PR TITLE
[Issue #37431] [Bug]: 网关自带的web应用总是出现吐字卡住

### DIFF
--- a/.github/issue-bootstrap/issue-37431.md
+++ b/.github/issue-bootstrap/issue-37431.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37431
+- Title: [Bug]: 网关自带的web应用总是出现吐字卡住
+- Source: https://github.com/openclaw/openclaw/issues/37431


### PR DESCRIPTION
## Source Issue
- Number: #37431
- URL: https://github.com/openclaw/openclaw/issues/37431
- Title: [Bug]: 网关自带的web应用总是出现吐字卡住

## Original Issue Description
Issue reports that the built-in web app frequently stalls while outputting text (“吐字卡住”), includes a screenshot, and marks the behavior as a regression. The issue body provides expected/actual behavior fields and environment metadata.

Closes #37431