### PR TITLE
fix(ui): reload active file content on Core Files refresh

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -639,7 +639,15 @@ export function renderApp(state: AppViewState) {
                     void state.loadCron();
                   }
                 },
-                onLoadFiles: (agentId) => loadAgentFiles(state, agentId),
+                onLoadFiles: async (agentId) => {
+                  await loadAgentFiles(state, agentId);
+                  if (state.agentFileActive) {
+                    await loadAgentFileContent(state, agentId, state.agentFileActive, {
+                      force: true,
+                      preserveDraft: false,
+                    });
+                  }
+                },
                 onSelectFile: (name) => {
                   state.agentFileActive = name;
                   if (!resolvedAgentId) {

--- a/ui/src/ui/controllers/agent-files.test.ts
+++ b/ui/src/ui/controllers/agent-files.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../gateway.ts";
+import { loadAgentFileContent, type AgentFilesState } from "./agent-files.ts";
+
+const mockRequest = vi.fn().mockResolvedValue(null);
+
+function createState(overrides?: Partial<AgentFilesState>): AgentFilesState {
+  mockRequest.mockClear().mockResolvedValue(null);
+  return {
+    client: { request: mockRequest } as unknown as GatewayBrowserClient,
+    connected: true,
+    agentFilesLoading: false,
+    agentFilesError: null,
+    agentFilesList: null,
+    agentFileContents: {},
+    agentFileDrafts: {},
+    agentFileActive: null,
+    agentFileSaving: false,
+    ...overrides,
+  };
+}
+
+describe("loadAgentFileContent", () => {
+  it("skips fetch when content is cached and force is not set", async () => {
+    const state = createState({
+      agentFileContents: { "AGENTS.md": "old content" },
+    });
+    await loadAgentFileContent(state, "main", "AGENTS.md");
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it("fetches fresh content when force is true even if cached", async () => {
+    const state = createState({
+      agentFileContents: { "AGENTS.md": "old content" },
+      agentFileDrafts: { "AGENTS.md": "old content" },
+    });
+    mockRequest.mockResolvedValue({
+      file: { name: "AGENTS.md", content: "new content" },
+    });
+
+    await loadAgentFileContent(state, "main", "AGENTS.md", {
+      force: true,
+      preserveDraft: false,
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith("agents.files.get", {
+      agentId: "main",
+      name: "AGENTS.md",
+    });
+    expect(state.agentFileContents["AGENTS.md"]).toBe("new content");
+    expect(state.agentFileDrafts["AGENTS.md"]).toBe("new content");
+  });
+
+  it("preserves user draft when preserveDraft is true and draft differs from base", async () => {
+    const state = createState({
+      agentFileContents: { "AGENTS.md": "original" },
+      agentFileDrafts: { "AGENTS.md": "user edits" },
+    });
+    mockRequest.mockResolvedValue({
+      file: { name: "AGENTS.md", content: "updated externally" },
+    });
+
+    await loadAgentFileContent(state, "main", "AGENTS.md", {
+      force: true,
+      preserveDraft: true,
+    });
+
+    expect(state.agentFileContents["AGENTS.md"]).toBe("updated externally");
+    expect(state.agentFileDrafts["AGENTS.md"]).toBe("user edits");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -85,6 +85,7 @@ export default defineConfig({
       "ui/src/ui/views/agents-utils.test.ts",
       "ui/src/ui/views/usage-render-details.test.ts",
       "ui/src/ui/controllers/agents.test.ts",
+      "ui/src/ui/controllers/agent-files.test.ts",
       "ui/src/ui/controllers/chat.test.ts",
     ],
     setupFiles: ["test/setup.ts"],


### PR DESCRIPTION
## Summary

The "Refresh" button in the Control UI Core Files panel only reloads the file list via `loadAgentFiles`, but does not reload the currently active file's content. `loadAgentFileContent` has a cache guard (`!opts?.force && Object.hasOwn(state.agentFileContents, name)`) that skips re-fetching when content is already cached, so external edits (e.g., from a text editor) are invisible until the user manually switches to another file and back.

This PR adds a `loadAgentFileContent(state, agentId, activeFile, { force: true, preserveDraft: false })` call after `loadAgentFiles` completes, so the active file's content is always re-fetched on refresh.

## Changes

| File | What changed |
|------|-------------|
| `ui/src/ui/app-render.ts` | `onLoadFiles` callback now also force-reloads active file content |
| `ui/src/ui/controllers/agent-files.test.ts` | New test file: 3 tests for cache skip, force reload, and draft preservation |
| `vitest.config.ts` | Added `agent-files.test.ts` to the test include list |

## Test plan

- [x] New test: "skips fetch when content is cached and force is not set" — verifies cache guard works
- [x] New test: "fetches fresh content when force is true even if cached" — verifies force bypass
- [x] New test: "preserves user draft when preserveDraft is true and draft differs from base" — verifies draft safety
- `npx vitest run ui/src/ui/controllers/agent-files.test.ts` — 3/3 passed

## Security Impact

- [ ] Does this PR introduce any new dependencies? **No**
- [ ] Does this PR modify authentication or authorization logic? **No**
- [ ] Does this PR expose any new API endpoints or modify existing ones? **No**
- [ ] Does this PR handle sensitive data (API keys, tokens, PII)? **No**
- [ ] Does this PR modify file system permissions or access patterns? **No**

## Human Verification Scenarios

1. Open Control UI, select "AGENTS.md" in Core Files. Edit the file externally (e.g., `vim ~/.openclaw/AGENTS.md`). Click Refresh. Verify the new content appears immediately.
2. Open a file, make unsaved edits in the editor, then click Refresh. With `preserveDraft: false`, the editor should show the disk content (not the stale draft).

## Failure Recovery

Revert this single commit. The only change is an additional `loadAgentFileContent` call after refresh; removal restores the original "list-only refresh" behavior.

## Risks and Mitigations

- **Risk**: If the user has unsaved edits and clicks Refresh, their draft will be replaced by the on-disk version.
  - **Mitigation**: This is intentional — "Refresh" should show the latest disk state. Users can undo in the editor or re-apply their changes.

Closes #35428