### PR TITLE
fix(telegram): skip empty replies instead of crashing

### DIFF
--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -58,7 +58,11 @@ function buildChunkTextResolver(params: {
       const nested = markdownToTelegramChunks(chunk, params.textLimit, {
         tableMode: params.tableMode,
       });
-      if (!nested.length && chunk) {
+
+      // If markdownToTelegramChunks returns no chunks, fall back to rendering the raw markdown.
+      // However, drop whitespace-only chunks: Telegram rejects empty text and we should not
+      // crash the channel/provider when an agent emits an empty reply.
+      if (!nested.length && typeof chunk === "string" && chunk.trim().length > 0) {
         chunks.push({
           html: wrapFileReferencesInHtml(
             markdownToTelegramHtml(chunk, { tableMode: params.tableMode, wrapFileRefs: false }),
@@ -136,11 +140,14 @@ async function deliverTextReply(params: {
         replyMarkup: shouldAttachButtons ? params.replyMarkup : undefined,
       },
     );
-    if (firstDeliveredMessageId == null) {
-      firstDeliveredMessageId = messageId;
+    // delivery.send.ts returns -1 when the message is intentionally dropped (empty content)
+    if (messageId >= 0) {
+      if (firstDeliveredMessageId == null) {
+        firstDeliveredMessageId = messageId;
+      }
+      markReplyApplied(params.progress, replyToForChunk);
+      markDelivered(params.progress);
     }
-    markReplyApplied(params.progress, replyToForChunk);
-    markDelivered(params.progress);
   }
   return firstDeliveredMessageId;
 }
@@ -166,7 +173,7 @@ async function sendPendingFollowUpText(params: {
       replyToMode: params.replyToMode,
       progress: params.progress,
     });
-    await sendTelegramText(params.bot, params.chatId, chunk.html, params.runtime, {
+    const messageId = await sendTelegramText(params.bot, params.chatId, chunk.html, params.runtime, {
       replyToMessageId: replyToForFollowUp,
       thread: params.thread,
       textMode: "html",
@@ -174,8 +181,10 @@ async function sendPendingFollowUpText(params: {
       linkPreview: params.linkPreview,
       replyMarkup: i === 0 ? params.replyMarkup : undefined,
     });
-    markReplyApplied(params.progress, replyToForFollowUp);
-    markDelivered(params.progress);
+    if (messageId >= 0) {
+      markReplyApplied(params.progress, replyToForFollowUp);
+      markDelivered(params.progress);
+    }
   }
 }
 
@@ -221,11 +230,13 @@ async function sendTelegramVoiceFallbackText(opts: {
       linkPreview: opts.linkPreview,
       replyMarkup: !appliedReplyTo ? opts.replyMarkup : undefined,
     });
-    if (firstDeliveredMessageId == null) {
-      firstDeliveredMessageId = messageId;
-    }
-    if (replyToForChunk) {
-      appliedReplyTo = true;
+    if (messageId >= 0) {
+      if (firstDeliveredMessageId == null) {
+        firstDeliveredMessageId = messageId;
+      }
+      if (replyToForChunk) {
+        appliedReplyTo = true;
+      }
     }
   }
   return firstDeliveredMessageId;

--- a/src/telegram/bot/delivery.send.ts
+++ b/src/telegram/bot/delivery.send.ts
@@ -132,9 +132,13 @@ export async function sendTelegramText(
   };
 
   // Markdown can render to empty HTML for syntax-only chunks; recover with plain text.
+  // If both formatted and fallback text are empty, silently drop the message.
   if (!htmlText.trim()) {
     if (!hasFallbackText) {
-      throw new Error("telegram sendMessage failed: empty formatted text and empty plain fallback");
+      runtime.log?.(
+        `telegram sendMessage skipped chat=${chatId}: empty formatted text and empty plain fallback`,
+      );
+      return -1;
     }
     return await sendPlainFallback();
   }
@@ -162,7 +166,10 @@ export async function sendTelegramText(
     const errText = formatErrorMessage(err);
     if (PARSE_ERR_RE.test(errText) || EMPTY_TEXT_ERR_RE.test(errText)) {
       if (!hasFallbackText) {
-        throw err;
+        runtime.log?.(
+          `telegram sendMessage skipped chat=${chatId}: empty formatted text and empty plain fallback (${errText})`,
+        );
+        return -1;
       }
       runtime.log?.(`telegram formatted send failed; retrying without formatting: ${errText}`);
       return await sendPlainFallback();

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -474,22 +474,22 @@ describe("deliverReplies", () => {
     );
   });
 
-  it("throws when formatted and plain fallback text are both empty", async () => {
+  it("drops the message when formatted and plain fallback text are both empty", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn();
     const bot = { api: { sendMessage } } as unknown as Bot;
 
-    await expect(
-      deliverReplies({
-        replies: [{ text: "   " }],
-        chatId: "123",
-        token: "tok",
-        runtime,
-        bot,
-        replyToMode: "off",
-        textLimit: 4000,
-      }),
-    ).rejects.toThrow("empty formatted text and empty plain fallback");
+    const res = await deliverReplies({
+      replies: [{ text: "   " }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+    });
+
+    expect(res).toEqual({ delivered: false });
     expect(sendMessage).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Fixes Telegram delivery crash when agent produces empty/whitespace content.

Closes #37278.