### PR TITLE
fix(agents): clear message tool error on retry with corrected media path

### DIFF
--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -65,6 +65,46 @@ describe("tool mutation helpers", () => {
     ).toBe(false);
   });
 
+  it("excludes media path from message tool fingerprint so retries match", () => {
+    const fp1 = buildToolActionFingerprint("message", {
+      action: "send",
+      target: "telegram:123",
+      path: "/tmp/image.jpg",
+    });
+    const fp2 = buildToolActionFingerprint("message", {
+      action: "send",
+      target: "telegram:123",
+      path: "/workspace/image.jpg",
+    });
+    expect(fp1).toBe(fp2);
+    expect(fp1).toContain("target=telegram:123");
+    expect(fp1).not.toContain("path=");
+  });
+
+  it("recognizes message retry with different media path as same action", () => {
+    const fp1 = buildToolActionFingerprint("message", {
+      action: "reply",
+      target: "telegram:456",
+      filePath: "/tmp/audio.ogg",
+    });
+    const fp2 = buildToolActionFingerprint("message", {
+      action: "reply",
+      target: "telegram:456",
+      filePath: "/data/workspace/audio.ogg",
+    });
+    expect(
+      isSameToolMutationAction(
+        { toolName: "message", actionFingerprint: fp1 },
+        { toolName: "message", actionFingerprint: fp2 },
+      ),
+    ).toBe(true);
+  });
+
+  it("still includes path in non-messaging tool fingerprints", () => {
+    const fp = buildToolActionFingerprint("write", { path: "/tmp/demo.txt" });
+    expect(fp).toContain("path=/tmp/demo.txt");
+  });
+
   it("keeps legacy name-only mutating heuristics for payload fallback", () => {
     expect(isLikelyMutatingToolName("sessions_send")).toBe(true);
     expect(isLikelyMutatingToolName("browser_actions")).toBe(true);

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -151,6 +151,14 @@ export function buildToolActionFingerprint(
   if (action) {
     parts.push(`action=${action}`);
   }
+  // For messaging tools, path/filePath represent media attachments, not the
+  // action target.  Exclude them so that retrying a message with a corrected
+  // media path is recognized as the same action and clears the prior error.
+  const isMessagingLike =
+    normalizedTool === "message" ||
+    normalizedTool === "sessions_send" ||
+    normalizedTool.startsWith("message_") ||
+    normalizedTool.includes("send");
   let hasStableTarget = false;
   for (const key of [
     "path",
@@ -165,6 +173,9 @@ export function buildToolActionFingerprint(
     "id",
     "model",
   ]) {
+    if (isMessagingLike && (key === "path" || key === "filePath")) {
+      continue;
+    }
     const value = normalizeFingerprintValue(record?.[key]);
     if (value) {
       parts.push(`${key.toLowerCase()}=${value}`);


### PR DESCRIPTION
## Summary

- Problem: When the `message` tool fails on first attempt (e.g., media path not in allowed directory) and the agent retries with a corrected path, the stale error notification is still delivered to the user after the successful retry.
- Why it matters: Users see `⚠️ ✉️ Message: <target> failed: <error>` after the message was already successfully delivered, causing confusion about whether the message was actually sent.
- What changed: `buildToolActionFingerprint()` now excludes `path`/`filePath` from the action fingerprint for messaging tools. These keys represent media attachments, not the action target. This allows `isSameToolMutationAction()` to recognize a retry with a corrected media path as the same action and clear `lastToolError`.
- What did NOT change (scope boundary): Non-messaging tools (e.g., `write`, `edit`) still include `path`/`filePath` in their fingerprint — for those tools the path IS the action target.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #37430

## User-visible / Behavior Changes

When the `message` tool fails on first attempt and succeeds on retry with a corrected media path, the stale error notification is no longer sent to the user.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Configure a gateway with Telegram channel
2. Send a message with a media file using a path outside the allowed directory (e.g., `/tmp/image.jpg`)
3. Agent detects the error and retries with the correct workspace path
4. Observe whether the error notification is delivered after the successful retry

### Expected

- No error notification after the successful retry — message is delivered cleanly

### Actual (before fix)

- `⚠️ ✉️ Message: <target> failed: Local media path is not under an allowed directory` notification sent to user after the message was already successfully delivered

## Evidence

- [x] Failing test/log before + passing after

The root cause is in `buildToolActionFingerprint()`:

| Tool call | Fingerprint (before fix) | Fingerprint (after fix) |
|-----------|--------------------------|-------------------------|
| Fail: `message send target=tg:123 path=/tmp/img.jpg` | `tool=message\|action=send\|path=/tmp/img.jpg\|target=tg:123` | `tool=message\|action=send\|target=tg:123` |
| Retry: `message send target=tg:123 path=/workspace/img.jpg` | `tool=message\|action=send\|path=/workspace/img.jpg\|target=tg:123` | `tool=message\|action=send\|target=tg:123` |
| **Match?** | **No** (path differs → error persists) | **Yes** (same action → error cleared) |

Three new test cases added to `tool-mutation.test.ts`:
1. Message fingerprint excludes `path` key
2. `isSameToolMutationAction` matches message retry with different `filePath`
3. Non-messaging tools still include `path` in fingerprint

## Human Verification (required)

- Verified scenarios: All 8 tests in `tool-mutation.test.ts` pass; all 28 tests in `payloads.errors.test.ts` pass
- Edge cases checked: Ensured `write`/`edit` tools still include `path` in fingerprint; verified `sessions_send` and `message_*` variants are also covered by the `isMessagingLike` check
- What you did **not** verify: Live end-to-end with a real Telegram channel (no gateway access)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; fingerprint behavior returns to pre-fix state
- Files/config to restore: `src/agents/tool-mutation.ts`
- Known bad symptoms reviewers should watch for: If messaging tool errors stop showing entirely (unlikely — the fix only affects fingerprint matching, not the warning policy logic)

## Risks and Mitigations

- Risk: A messaging tool with a `path` argument that IS the action target (not a media attachment) would lose fingerprint specificity.
  - Mitigation: Reviewed all messaging tool schemas — `path`/`filePath` are always media attachment fields for messaging tools. The `target`/`to` keys remain in the fingerprint for action identity.