### PR TITLE
fix(gateway): allow hardlinked control-ui assets (pnpm installs)

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -285,6 +285,27 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("serves hardlinked assets (pnpm content-addressable store)", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { filePath } = await writeAssetFile(tmp, "original.js", "console.log('ok');\n");
+        // Create a hardlink to simulate pnpm's content-addressable store layout
+        const hardlinkPath = path.join(path.dirname(filePath), "hardlinked.js");
+        await fs.link(filePath, hardlinkPath);
+
+        const { res, end, handled } = runControlUiRequest({
+          url: "/assets/hardlinked.js",
+          method: "GET",
+          rootPath: tmp,
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(String(end.mock.calls[0]?.[0] ?? "")).toBe("console.log('ok');\n");
+      },
+    });
+  });
+
   it("serves HEAD for in-root assets without writing a body", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -263,6 +263,7 @@ function resolveSafeControlUiFile(
     rootRealPath: rootReal,
     boundaryLabel: "control ui root",
     skipLexicalRootCheck: true,
+    rejectHardlinks: false,
   });
   if (!opened.ok) {
     if (opened.reason === "io") {


### PR DESCRIPTION
## Problem

When OpenClaw is installed via `pnpm add -g openclaw`, the Control UI returns **404 for all static files**. pnpm uses hardlinks (content-addressable store), so every file has `nlink > 1`.

The `resolveSafeControlUiFile` function calls `openBoundaryFileSync` without setting `rejectHardlinks`, which defaults to `true` — rejecting all hardlinked files with "hardlinked file path not allowed".

## Fix

Set `rejectHardlinks: false` for control-ui asset serving. These are trusted bundled files shipped with the package, so the hardlink security check is unnecessary here.

## Test

Added test that creates a hardlinked asset file and verifies it is served with 200 (previously would 404).

Fixes #37455