### PR TITLE
fix(feishu): fix streaming card sequence skew, card action chat_type, and webhook cleanup

### DIFF
--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -17,6 +17,8 @@ export type FeishuCardActionEvent = {
     open_id: string;
     user_id: string;
     chat_id: string;
+    /** Present in card action callback v2; "group" or "p2p" */
+    chat_type?: "group" | "p2p";
   };
 };
 
@@ -58,7 +60,14 @@ export async function handleFeishuCardAction(params: {
     message: {
       message_id: `card-action-${event.token}`,
       chat_id: event.context.chat_id || event.operator.open_id,
-      chat_type: event.context.chat_id ? "group" : "p2p",
+      // Use explicit chat_type from callback when available; fall back to
+      // comparing chat_id with operator open_id (p2p chats use the user's
+      // open_id as implicit chat target, groups always have a distinct chat_id).
+      chat_type:
+        event.context.chat_type ??
+        (event.context.chat_id && event.context.chat_id !== event.operator.open_id
+          ? "group"
+          : "p2p"),
       message_type: "text",
       content: JSON.stringify({ text: content }),
     },

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -159,6 +159,7 @@ export async function monitorWebhook({
 
     server.on("error", (err) => {
       error(`feishu[${accountId}]: Webhook server error: ${err}`);
+      cleanup();
       abortSignal?.removeEventListener("abort", handleAbort);
       reject(err);
     });

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -266,28 +266,35 @@ export class FeishuStreamingSession {
       return;
     }
     const apiBase = resolveApiBase(this.creds.domain);
-    this.state.sequence += 1;
-    await fetchWithSsrFGuard({
-      url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/content/content`,
-      init: {
-        method: "PUT",
-        headers: {
-          Authorization: `Bearer ${await getToken(this.creds)}`,
-          "Content-Type": "application/json",
+    const nextSequence = this.state.sequence + 1;
+    try {
+      const { response, release } = await fetchWithSsrFGuard({
+        url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/content/content`,
+        init: {
+          method: "PUT",
+          headers: {
+            Authorization: `Bearer ${await getToken(this.creds)}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            content: text,
+            sequence: nextSequence,
+            uuid: `s_${this.state.cardId}_${nextSequence}`,
+          }),
         },
-        body: JSON.stringify({
-          content: text,
-          sequence: this.state.sequence,
-          uuid: `s_${this.state.cardId}_${this.state.sequence}`,
-        }),
-      },
-      policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
-      auditContext: "feishu.streaming-card.update",
-    })
-      .then(async ({ release }) => {
+        policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
+        auditContext: "feishu.streaming-card.update",
+      });
+      if (!response.ok) {
         await release();
-      })
-      .catch((error) => onError?.(error));
+        throw new Error(`Card element update failed with HTTP ${response.status}`);
+      }
+      await release();
+      // Only advance sequence after confirmed success
+      this.state.sequence = nextSequence;
+    } catch (error) {
+      onError?.(error);
+    }
   }
 
   async update(text: string): Promise<void> {
@@ -340,30 +347,37 @@ export class FeishuStreamingSession {
     }
 
     // Close streaming mode
-    this.state.sequence += 1;
-    await fetchWithSsrFGuard({
-      url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/settings`,
-      init: {
-        method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${await getToken(this.creds)}`,
-          "Content-Type": "application/json; charset=utf-8",
-        },
-        body: JSON.stringify({
-          settings: JSON.stringify({
-            config: { streaming_mode: false, summary: { content: truncateSummary(text) } },
+    const closeSequence = this.state.sequence + 1;
+    try {
+      const { response, release } = await fetchWithSsrFGuard({
+        url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/settings`,
+        init: {
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${await getToken(this.creds)}`,
+            "Content-Type": "application/json; charset=utf-8",
+          },
+          body: JSON.stringify({
+            settings: JSON.stringify({
+              config: { streaming_mode: false, summary: { content: truncateSummary(text) } },
+            }),
+            sequence: closeSequence,
+            uuid: `c_${this.state.cardId}_${closeSequence}`,
           }),
-          sequence: this.state.sequence,
-          uuid: `c_${this.state.cardId}_${this.state.sequence}`,
-        }),
-      },
-      policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
-      auditContext: "feishu.streaming-card.close",
-    })
-      .then(async ({ release }) => {
+        },
+        policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
+        auditContext: "feishu.streaming-card.close",
+      });
+      if (!response.ok) {
         await release();
-      })
-      .catch((e) => this.log?.(`Close failed: ${String(e)}`));
+        this.log?.(`Close failed: HTTP ${response.status}`);
+      } else {
+        await release();
+        this.state.sequence = closeSequence;
+      }
+    } catch (e) {
+      this.log?.(`Close failed: ${String(e)}`);
+    }
 
     this.log?.(`Closed streaming: cardId=${this.state.cardId}`);
   }

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -290,8 +290,10 @@ export class FeishuStreamingSession {
         throw new Error(`Card element update failed with HTTP ${response.status}`);
       }
       await release();
-      // Only advance sequence after confirmed success
+      // Only advance sequence/currentText after confirmed success to avoid
+      // close() skipping the final update when a prior request failed.
       this.state.sequence = nextSequence;
+      this.state.currentText = text;
     } catch (error) {
       onError?.(error);
     }
@@ -323,7 +325,6 @@ export class FeishuStreamingSession {
       if (!mergedText || mergedText === this.state.currentText) {
         return;
       }
-      this.state.currentText = mergedText;
       await this.updateCardContent(mergedText, (e) => this.log?.(`Update failed: ${String(e)}`));
     });
     await this.queue;
@@ -343,7 +344,6 @@ export class FeishuStreamingSession {
     // Only send final update if content differs from what's already displayed
     if (text && text !== this.state.currentText) {
       await this.updateCardContent(text);
-      this.state.currentText = text;
     }
 
     // Close streaming mode


### PR DESCRIPTION
## Summary

- **streaming-card.ts**: Check `response.ok` before advancing sequence number. Previously HTTP errors (429, 500, etc.) were silently swallowed and the sequence was incremented unconditionally, causing all subsequent card updates to be rejected by the Feishu Card Kit API due to skipped sequence numbers.

- **card-action.ts**: Use explicit `chat_type` from card action callback v2 when available. The previous logic `event.context.chat_id ? "group" : "p2p"` always returned `"group"` because `chat_id` is present for both DM and group card actions, causing DM card interactions to be misrouted as group messages.

- **monitor.transport.ts**: Call `cleanup()` before `reject()` in the webhook server error handler so that `httpServers.delete()` and `server.close()` run on EADDRINUSE, preventing a stale server reference from blocking restart.

## Test plan

- [x] All 321 existing Feishu extension tests pass (`pnpm test -- extensions/feishu`)
- [x] TypeScript type check passes (`pnpm tsgo`)
- [x] Formatting passes (`pnpm format:fix`)
- [ ] Manual verification: streaming card updates should recover from transient HTTP errors instead of permanently breaking the card
- [ ] Manual verification: card action button clicks in DM chats should be routed as DM (not group) messages
- [ ] Manual verification: restarting webhook server after EADDRINUSE should succeed cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)