### PR TITLE
fix(cron): handle paginated cron.list response

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -5,7 +5,6 @@ import { sanitizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
-
 import { parsePositiveIntOrUndefined } from "../program/helpers.js";
 import {
   getCronChannelOptions,

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -5,6 +5,7 @@ import { sanitizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
+
 import { parsePositiveIntOrUndefined } from "../program/helpers.js";
 import {
   getCronChannelOptions,
@@ -49,7 +50,11 @@ export function registerCronListCommand(cron: Command) {
             defaultRuntime.log(JSON.stringify(res, null, 2));
             return;
           }
-          const jobs = (res as { jobs?: CronJob[] } | null)?.jobs ?? [];
+          // Gateway returns a paginated response: { jobs, total, ... }.
+          // Be defensive in case older gateways return a raw array.
+          const jobs = Array.isArray(res)
+            ? (res as CronJob[])
+            : ((res as { jobs?: CronJob[] } | null)?.jobs ?? []);
           printCronList(jobs, defaultRuntime);
         } catch (err) {
           defaultRuntime.error(danger(String(err)));


### PR DESCRIPTION
Closes #37299

Cron CLI commands like `openclaw cron list` could throw `TypeError: Cannot read properties of undefined (reading 'kind')` when the gateway returned the paginated `cron.list` response shape.

This change makes the CLI tolerate both response shapes:
- `CronJob[]` (legacy)
- `{ jobs: CronJob[], total, ... }` (paginated)

Validation:
- `pnpm test:fast src/cli/cron-cli/shared.test.ts`

Notes:
- Follow-up commit fixes `oxfmt --check` formatting failure in this file.