### PR TITLE
fix(control-ui): serve assets from pnpm hardlinked installs

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -146,6 +146,28 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("serves index.html when control-ui files are hardlinked", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const hardlinkSource = path.join(tmp, "index-source.html");
+        const hardlinkTarget = path.join(tmp, "index.html");
+        await fs.writeFile(hardlinkSource, "<html>pnpm-hardlink</html>\n");
+        await fs.rm(hardlinkTarget);
+        await fs.link(hardlinkSource, hardlinkTarget);
+
+        const { res, end, handled } = runControlUiRequest({
+          url: "/",
+          method: "GET",
+          rootPath: tmp,
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(String(end.mock.calls[0]?.[0] ?? "")).toBe("<html>pnpm-hardlink</html>\n");
+      },
+    });
+  });
+
   it("serves bootstrap config JSON", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -45,6 +45,7 @@ describe("handleControlUiHttpRequest", () => {
     method: "GET" | "HEAD" | "POST";
     rootPath: string;
     basePath?: string;
+    allowHardlinks?: boolean;
   }) {
     const { res, end } = makeMockHttpResponse();
     const handled = handleControlUiHttpRequest(
@@ -52,7 +53,11 @@ describe("handleControlUiHttpRequest", () => {
       res,
       {
         ...(params.basePath ? { basePath: params.basePath } : {}),
-        root: { kind: "resolved", path: params.rootPath },
+        root: {
+          kind: "resolved",
+          path: params.rootPath,
+          ...(params.allowHardlinks !== undefined ? { allowHardlinks: params.allowHardlinks } : {}),
+        },
       },
     );
     return { res, end, handled };
@@ -146,7 +151,7 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
-  it("serves index.html when control-ui files are hardlinked", async () => {
+  it("serves index.html when control-ui files are hardlinked in trusted roots", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {
         const hardlinkSource = path.join(tmp, "index-source.html");
@@ -159,11 +164,33 @@ describe("handleControlUiHttpRequest", () => {
           url: "/",
           method: "GET",
           rootPath: tmp,
+          allowHardlinks: true,
         });
 
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(200);
         expect(String(end.mock.calls[0]?.[0] ?? "")).toBe("<html>pnpm-hardlink</html>\n");
+      },
+    });
+  });
+
+  it("rejects hardlinked control-ui files for custom roots", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const hardlinkSource = path.join(tmp, "index-source.html");
+        const hardlinkTarget = path.join(tmp, "index.html");
+        await fs.writeFile(hardlinkSource, "<html>pnpm-hardlink</html>\n");
+        await fs.rm(hardlinkTarget);
+        await fs.link(hardlinkSource, hardlinkTarget);
+
+        const { res, end, handled } = runControlUiRequest({
+          url: "/",
+          method: "GET",
+          rootPath: tmp,
+          allowHardlinks: false,
+        });
+
+        expectNotFoundResponse({ handled, res, end });
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -39,7 +39,7 @@ export type ControlUiRequestOptions = {
 };
 
 export type ControlUiRootState =
-  | { kind: "resolved"; path: string }
+  | { kind: "resolved"; path: string; allowHardlinks?: boolean }
   | { kind: "invalid"; path: string }
   | { kind: "missing" };
 
@@ -256,6 +256,7 @@ function resolveSafeAvatarFile(filePath: string): { path: string; fd: number } |
 function resolveSafeControlUiFile(
   rootReal: string,
   filePath: string,
+  opts?: { allowHardlinks?: boolean },
 ): { path: string; fd: number } | null {
   const opened = openBoundaryFileSync({
     absolutePath: filePath,
@@ -264,9 +265,8 @@ function resolveSafeControlUiFile(
     boundaryLabel: "control ui root",
     skipLexicalRootCheck: true,
     // Package managers like pnpm install files as hardlinks in the global store.
-    // Control UI assets are trusted package files under a validated root path, so
-    // hardlink rejection would incorrectly 404 valid installs.
-    rejectHardlinks: false,
+    // Keep hardlink checks enabled for untrusted/custom roots.
+    rejectHardlinks: opts?.allowHardlinks !== true,
   });
   if (!opened.ok) {
     if (opened.reason === "io") {
@@ -423,7 +423,8 @@ export function handleControlUiHttpRequest(
     return true;
   }
 
-  const safeFile = resolveSafeControlUiFile(rootReal, filePath);
+  const allowHardlinks = opts?.root?.kind === "resolved" ? opts.root.allowHardlinks === true : true;
+  const safeFile = resolveSafeControlUiFile(rootReal, filePath, { allowHardlinks });
   if (safeFile) {
     try {
       if (respondHeadForFile(req, res, safeFile.path)) {
@@ -452,7 +453,7 @@ export function handleControlUiHttpRequest(
 
   // SPA fallback (client-side router): serve index.html for unknown paths.
   const indexPath = path.join(root, "index.html");
-  const safeIndex = resolveSafeControlUiFile(rootReal, indexPath);
+  const safeIndex = resolveSafeControlUiFile(rootReal, indexPath, { allowHardlinks });
   if (safeIndex) {
     try {
       if (respondHeadForFile(req, res, safeIndex.path)) {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -263,6 +263,10 @@ function resolveSafeControlUiFile(
     rootRealPath: rootReal,
     boundaryLabel: "control ui root",
     skipLexicalRootCheck: true,
+    // Package managers like pnpm install files as hardlinks in the global store.
+    // Control UI assets are trusted package files under a validated root path, so
+    // hardlink rejection would incorrectly 404 valid installs.
+    rejectHardlinks: false,
   });
   if (!opened.ok) {
     if (opened.reason === "io") {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -510,7 +510,7 @@ export async function startGatewayServer(
     const resolvedOverride = resolveControlUiRootOverrideSync(controlUiRootOverride);
     const resolvedOverridePath = path.resolve(controlUiRootOverride);
     controlUiRootState = resolvedOverride
-      ? { kind: "resolved", path: resolvedOverride }
+      ? { kind: "resolved", path: resolvedOverride, allowHardlinks: false }
       : { kind: "invalid", path: resolvedOverridePath };
     if (!resolvedOverride) {
       log.warn(`gateway: controlUi.root not found at ${resolvedOverridePath}`);
@@ -533,7 +533,7 @@ export async function startGatewayServer(
       });
     }
     controlUiRootState = resolvedRoot
-      ? { kind: "resolved", path: resolvedRoot }
+      ? { kind: "resolved", path: resolvedRoot, allowHardlinks: true }
       : { kind: "missing" };
   }
 


### PR DESCRIPTION
## Summary
- allow Control UI file serving to accept hardlinked files under the validated control-ui root
- keep existing boundary path and symlink protections unchanged
- add a regression test that serves `index.html` when it is a hardlink

Closes #37455

## Testing
- `pnpm vitest run src/gateway/control-ui.http.test.ts`
  - Passed: 19 passed, 0 failed