### PR TITLE
Agents: exclude default reasoningLevel from system prompt to stabilize prompt cache

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -597,15 +597,37 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("agent=work");
   });
 
-  it("includes reasoning visibility hint", () => {
+  it("omits reasoning line when level is off (default) to avoid cache invalidation", () => {
+    // When reasoning is off (default), the Reasoning line must NOT appear in the
+    // system prompt. Including it would change the prompt every time reasoning is
+    // toggled, invalidating the prompt cache on every subsequent turn. (#36520)
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
       reasoningLevel: "off",
     });
 
-    expect(prompt).toContain("Reasoning: off");
+    expect(prompt).not.toContain("Reasoning: off");
+    expect(prompt).not.toContain("Reasoning:");
+  });
+
+  it("includes reasoning visibility hint when reasoning is enabled", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      reasoningLevel: "on",
+    });
+
+    expect(prompt).toContain("Reasoning: on");
     expect(prompt).toContain("/reasoning");
     expect(prompt).toContain("/status shows Reasoning");
+  });
+
+  it("includes reasoning hint for stream level", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      reasoningLevel: "stream",
+    });
+
+    expect(prompt).toContain("Reasoning: stream");
   });
 
   it("builds runtime line with agent and channel details", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -675,10 +675,18 @@ export function buildAgentSystemPrompt(params: {
     );
   }
 
+  // Only include the reasoning level line when it is non-default (non-"off").
+  // Including it unconditionally with the current value would change the system
+  // prompt every time the user toggles reasoning, invalidating the prompt cache
+  // and increasing cost on every subsequent turn. (#36520)
+  const reasoningLine =
+    reasoningLevel !== "off"
+      ? `Reasoning: ${reasoningLevel} (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.`
+      : "";
   lines.push(
     "## Runtime",
     buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities, params.defaultThinkLevel),
-    `Reasoning: ${reasoningLevel} (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.`,
+    reasoningLine,
   );
 
   return lines.filter(Boolean).join("\n");


### PR DESCRIPTION
Fixes #36520

reasoningLevel was interpolated into the system prompt footer on every turn including when set to default off, causing prompt cache invalidation. Only include the Reasoning line when non-default.