### PR TITLE
docs(faq): remove broken Xfinity SSL troubleshooting anchor link

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -448,8 +448,7 @@ section is the latest shipped version. Entries are grouped by **Highlights**, **
 ### I can't access docs.openclaw.ai SSL error What now
 
 Some Comcast/Xfinity connections incorrectly block `docs.openclaw.ai` via Xfinity
-Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry. More
-detail: [Troubleshooting](/help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity).
+Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry.
 Please help us unblock it by reporting here: [https://spa.xfinity.com/check_url_status](https://spa.xfinity.com/check_url_status).
 
 If you still can't reach the site, the docs are mirrored on GitHub:


### PR DESCRIPTION
## Summary

- Removes the broken cross-document anchor link `/help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity` from the FAQ Xfinity/SSL section
- That anchor does not exist in `docs/help/troubleshooting.md`; the page only has sections: "First 60 seconds", "Anthropic long context 429", "Plugin install fails with missing openclaw extensions", and "Decision tree"
- The FAQ section already contains the full workaround (disable Xfinity Advanced Security or allowlist `docs.openclaw.ai`), so the broken cross-reference was redundant

## Test plan
- [ ] Verify the FAQ section at `/help/faq#i-cant-access-docsopenclawai-ssl-error-what-now` no longer links to the missing anchor
- [ ] Confirm the remaining text still provides the workaround information

Fixes #36970