### PR TITLE
Matrix: inline KeyedAsyncQueue to fix plugin load failure in npm installs

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,11 +1,32 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
-
 export const DEFAULT_SEND_GAP_MS = 150;
 
 type MatrixSendQueueOptions = {
   gapMs?: number;
   delayFn?: (ms: number) => Promise<void>;
 };
+
+// Minimal keyed async queue: serializes concurrent tasks per key.
+// Inlined to avoid openclaw/plugin-sdk/keyed-async-queue alias resolution
+// failures in npm-installed (non-workspace) plugin environments.
+class KeyedAsyncQueue {
+  private readonly tails = new Map<string, Promise<void>>();
+
+  enqueue<T>(key: string, task: () => Promise<T>): Promise<T> {
+    const previous = this.tails.get(key) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(task);
+    const tail = current.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.tails.set(key, tail);
+    void tail.finally(() => {
+      if (this.tails.get(key) === tail) {
+        this.tails.delete(key);
+      }
+    });
+    return current;
+  }
+}
 
 // Serialize sends per room to preserve Matrix delivery order.
 const roomQueues = new KeyedAsyncQueue();


### PR DESCRIPTION
Fixes #36501

The @openclaw/matrix plugin failed to load after npm install because it imported KeyedAsyncQueue from an internal path that is not available in the published package. Inlined the utility to fix the missing module error.