### PR TITLE
fix(agents): honor OPENCLAW_STATE_DIR when legacy default agent dir is inherited

### DIFF
--- a/src/agents/agent-paths.test.ts
+++ b/src/agents/agent-paths.test.ts
@@ -65,6 +65,22 @@ describe("resolveOpenClawAgentDir", () => {
     });
   });
 
+  it("ignores legacy OPENCLAW_AGENT_DIR when OPENCLAW_STATE_DIR is set", async () => {
+    await withTempStateDir((stateDir) => {
+      withEnv(
+        {
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_AGENT_DIR: "~/.openclaw/agents/main/agent",
+          PI_CODING_AGENT_DIR: undefined,
+        },
+        () => {
+          const resolved = resolveOpenClawAgentDir();
+          expect(resolved).toBe(path.join(stateDir, "agents", "main", "agent"));
+        },
+      );
+    });
+  });
+
   it("prefers OPENCLAW_AGENT_DIR over PI_CODING_AGENT_DIR when both are set", async () => {
     await withTempStateDir((stateDir) => {
       const primaryOverride = path.join(stateDir, "primary-agent");

--- a/src/agents/agent-paths.ts
+++ b/src/agents/agent-paths.ts
@@ -3,14 +3,27 @@ import { resolveStateDir } from "../config/paths.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
 
+function resolveDefaultAgentDir(): string {
+  return resolveUserPath(path.join(resolveStateDir(), "agents", DEFAULT_AGENT_ID, "agent"));
+}
+
+function isLegacyDefaultAgentDir(override: string): boolean {
+  const legacyDefault = resolveUserPath("~/.openclaw/agents/main/agent");
+  return path.resolve(resolveUserPath(override)) === path.resolve(legacyDefault);
+}
+
 export function resolveOpenClawAgentDir(): string {
   const override =
     process.env.OPENCLAW_AGENT_DIR?.trim() || process.env.PI_CODING_AGENT_DIR?.trim();
   if (override) {
+    const stateOverride =
+      process.env.OPENCLAW_STATE_DIR?.trim() || process.env.CLAWDBOT_STATE_DIR?.trim();
+    if (stateOverride && isLegacyDefaultAgentDir(override)) {
+      return resolveDefaultAgentDir();
+    }
     return resolveUserPath(override);
   }
-  const defaultAgentDir = path.join(resolveStateDir(), "agents", DEFAULT_AGENT_ID, "agent");
-  return resolveUserPath(defaultAgentDir);
+  return resolveDefaultAgentDir();
 }
 
 export function ensureOpenClawAgentEnv(): string {


### PR DESCRIPTION
## Summary
- treat `~/.openclaw/agents/main/agent` as a legacy default override only when `OPENCLAW_STATE_DIR` is explicitly set
- in that case, resolve the default main-agent directory from `OPENCLAW_STATE_DIR/agents/main/agent` instead of honoring the stale legacy env path
- keep explicit custom `OPENCLAW_AGENT_DIR` / `PI_CODING_AGENT_DIR` overrides unchanged

## Why
Issue #37457 reports that internal auto-created main-agent state still lands under `~/.openclaw/agents/main/agent` even when `OPENCLAW_STATE_DIR` is configured. This happens when old env defaults persist as `OPENCLAW_AGENT_DIR`.

## Validation
- `pnpm vitest run src/agents/agent-paths.test.ts`
