### PR TITLE
Cron: skip recently-ran jobs on startup catchup to prevent gateway restart loop

### DIFF
--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -351,4 +351,55 @@ describe("CronService restart catch-up", () => {
     cron.stop();
     await store.cleanup();
   });
+
+  it("does not replay a cron job that ran recently (within 5 min) to prevent infinite restart loops (#37198)", async () => {
+    // Simulates: cron job runs, triggers gateway restart, gateway restarts.
+    // On startup, runMissedJobs must NOT re-run jobs that completed within the
+    // last 5 minutes — they may have triggered the restart themselves.
+    vi.setSystemTime(new Date("2025-12-13T04:02:00.000Z"));
+    const store = await makeStorePath();
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    // Job ran 2 minutes ago (within the 5-min grace window).
+    // A tiny timing sliver (lastRunAtMs slightly before the scheduled slot)
+    // would cause previousRunAtMs > lastRunAtMs and re-trigger it.
+    await writeStoreJobs(store.storePath, [
+      {
+        id: "restart-loop-guard",
+        name: "gateway-restart-job",
+        enabled: true,
+        createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
+        updatedAtMs: Date.parse("2025-12-13T04:00:00.000Z"),
+        schedule: { kind: "cron", expr: "* * * * *", tz: "UTC" },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "gateway restart" },
+        state: {
+          // Ran at 04:00:00.000 (the :00 slot), which is 2 minutes ago.
+          // nextRunAtMs was already advanced to the next slot before restart.
+          nextRunAtMs: Date.parse("2025-12-13T04:03:00.000Z"),
+          lastRunAtMs: Date.parse("2025-12-13T04:00:00.000Z"),
+          lastRunStatus: "ok",
+          lastStatus: "ok",
+        },
+      },
+    ]);
+
+    const cron = createRestartCronService({
+      storePath: store.storePath,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+    });
+
+    await cron.start();
+
+    // Job must NOT be re-run on startup — it ran 2 minutes ago and would
+    // cause another restart, creating an infinite loop.
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(requestHeartbeatNow).not.toHaveBeenCalled();
+
+    cron.stop();
+    await store.cleanup();
+  });
 });

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -718,6 +718,11 @@ function isRunnableJob(params: {
   skipJobIds?: ReadonlySet<string>;
   skipAtIfAlreadyRan?: boolean;
   allowCronMissedRunByLastRun?: boolean;
+  /** When set (during startup catchup), skip jobs whose last successful run
+   * started within this many milliseconds of nowMs. Prevents a cron job that
+   * triggered a gateway restart from being re-run immediately on startup,
+   * which would create an infinite restart loop. (#37198) */
+  skipIfRanWithinMs?: number;
 }): boolean {
   const { job, nowMs } = params;
   if (!job.state) {
@@ -766,6 +771,21 @@ function isRunnableJob(params: {
   if (!params.allowCronMissedRunByLastRun || job.schedule.kind !== "cron") {
     return false;
   }
+  // Guard against re-running jobs that ran recently and may have triggered the
+  // gateway restart. Without this, a cron job whose payload causes a restart
+  // (e.g. via the gateway tool action=restart) would loop: job runs → restart
+  // → runMissedJobs replays job → restart → ... (#37198)
+  if (typeof params.skipIfRanWithinMs === "number" && params.skipIfRanWithinMs > 0) {
+    const lastRun = job.state.lastRunAtMs;
+    if (
+      typeof lastRun === "number" &&
+      Number.isFinite(lastRun) &&
+      (job.state.lastRunStatus === "ok" || job.state.lastStatus === "ok") &&
+      nowMs - lastRun < params.skipIfRanWithinMs
+    ) {
+      return false;
+    }
+  }
   let previousRunAtMs: number | undefined;
   try {
     previousRunAtMs = computeJobPreviousRunAtMs(job, nowMs);
@@ -806,6 +826,7 @@ function collectRunnableJobs(
     skipJobIds?: ReadonlySet<string>;
     skipAtIfAlreadyRan?: boolean;
     allowCronMissedRunByLastRun?: boolean;
+    skipIfRanWithinMs?: number;
   },
 ): CronJob[] {
   if (!state.store) {
@@ -818,9 +839,19 @@ function collectRunnableJobs(
       skipJobIds: opts?.skipJobIds,
       skipAtIfAlreadyRan: opts?.skipAtIfAlreadyRan,
       allowCronMissedRunByLastRun: opts?.allowCronMissedRunByLastRun,
+      skipIfRanWithinMs: opts?.skipIfRanWithinMs,
     }),
   );
 }
+
+/**
+ * Startup catchup grace period: if a cron job ran successfully within this
+ * window before the current time, it is excluded from the startup missed-job
+ * sweep. This prevents a job that triggered a gateway restart (e.g. via the
+ * gateway tool action=restart) from being re-run immediately on startup and
+ * creating an infinite restart loop. (#37198)
+ */
+const STARTUP_CATCHUP_SKIP_RECENT_RUN_MS = 5 * 60_000; // 5 minutes
 
 export async function runMissedJobs(
   state: CronServiceState,
@@ -837,6 +868,9 @@ export async function runMissedJobs(
       skipJobIds,
       skipAtIfAlreadyRan: true,
       allowCronMissedRunByLastRun: true,
+      // Skip jobs that ran successfully within the grace window: they may have
+      // triggered the restart themselves and must not be re-run immediately.
+      skipIfRanWithinMs: STARTUP_CATCHUP_SKIP_RECENT_RUN_MS,
     });
     if (missed.length === 0) {
       return [] as Array<{ jobId: string; job: CronJob }>;


### PR DESCRIPTION
Fixes #37198

When a cron job whose message triggers a gateway restart was manually run after its scheduled time, it created an infinite restart loop: job fires → agent restarts gateway → on startup runMissedJobs sees the job as missed → re-runs it → repeat.

Added a skipIfRanWithinMs option to isRunnableJob and collectRunnableJobs. During startup catchup, jobs that completed successfully within the last 5 minutes are skipped, breaking the restart loop.