### PR TITLE
Synology Chat: surface delivery failures and add retry logic to sendFileUrl

### DIFF
--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -293,12 +293,23 @@ export function createSynologyChatPlugin() {
                 deliver: async (payload: { text?: string; body?: string }) => {
                   const text = payload?.text ?? payload?.body;
                   if (text) {
-                    await sendMessage(
+                    const ok = await sendMessage(
                       account.incomingUrl,
                       text,
                       sendUserId,
                       account.allowInsecureSsl,
                     );
+                    if (!ok) {
+                      // Log the failure so operators can diagnose delivery issues.
+                      // Throwing here surfaces the error to the dispatcher so it
+                      // can be tracked rather than silently dropping the message.
+                      log?.warn?.(
+                        `Synology Chat: failed to deliver message to user ${sendUserId} after retries`,
+                      );
+                      throw new Error(
+                        `Synology Chat: message delivery failed for user ${sendUserId}`,
+                      );
+                    }
                   }
                 },
                 onReplyStart: () => {

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -105,13 +105,32 @@ export async function sendFileUrl(
   const payload = JSON.stringify(payloadObj);
   const body = `payload=${encodeURIComponent(payload)}`;
 
-  try {
-    const ok = await doPost(incomingUrl, body, allowInsecureSsl);
-    lastSendTime = Date.now();
-    return ok;
-  } catch {
-    return false;
+  // Apply the same rate-limit guard and retry logic as sendMessage so file
+  // deliveries are equally resilient to transient network errors.
+  const now = Date.now();
+  const elapsed = now - lastSendTime;
+  if (elapsed < MIN_SEND_INTERVAL_MS) {
+    await sleep(MIN_SEND_INTERVAL_MS - elapsed);
   }
+
+  const maxRetries = 3;
+  const baseDelay = 300;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const ok = await doPost(incomingUrl, body, allowInsecureSsl);
+      lastSendTime = Date.now();
+      if (ok) return true;
+    } catch {
+      // will retry
+    }
+
+    if (attempt < maxRetries - 1) {
+      await sleep(baseDelay * Math.pow(2, attempt));
+    }
+  }
+
+  return false;
 }
 
 /**


### PR DESCRIPTION
Fixes #36439

Messages sent via Synology Chat were silently lost when delivery failed. Two changes:
1. Added proper error handling in the deliver callback - now throws on failure so the dispatcher can track and surface the error
2. Added the same rate-limit guard and exponential backoff retry (3 attempts) to sendFileUrl that sendMessage already had