### PR TITLE
Telegram: skip unqualified commands in forum groups when message_thread_id is missing

### DIFF
--- a/src/telegram/bot-native-commands.session-meta.test.ts
+++ b/src/telegram/bot-native-commands.session-meta.test.ts
@@ -423,4 +423,3 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 });
-

--- a/src/telegram/bot-native-commands.session-meta.test.ts
+++ b/src/telegram/bot-native-commands.session-meta.test.ts
@@ -102,6 +102,26 @@ function buildStatusTopicCommandContext() {
   };
 }
 
+/** Simulates an unqualified command (/new without @botname) in a forum group.
+ * Telegram strips message_thread_id from unqualified commands in forum topics. */
+function buildForumCommandContextWithoutThreadId() {
+  return {
+    match: "",
+    message: {
+      message_id: 3,
+      date: Math.floor(Date.now() / 1000),
+      chat: {
+        id: -1001234567890,
+        type: "supergroup" as const,
+        title: "OpenClaw",
+        is_forum: true,
+      },
+      // No message_thread_id — Telegram strips it for unqualified commands (#35963)
+      from: { id: 200, username: "bob" },
+    },
+  };
+}
+
 function registerAndResolveStatusHandler(params: {
   cfg: OpenClawConfig;
   allowFrom?: string[];
@@ -383,4 +403,24 @@ describe("registerTelegramNativeCommands — session metadata", () => {
       expect.objectContaining({ message_thread_id: 42 }),
     );
   });
+
+  it("ignores unqualified forum commands that lack message_thread_id (#35963)", async () => {
+    // Telegram strips message_thread_id from unqualified commands (e.g. /new without @botname)
+    // sent in forum topics. Without a thread ID we cannot determine which topic the command
+    // belongs to, so OpenClaw skips it to prevent routing to the wrong session.
+    const { handler, sendMessage } = registerAndResolveCommandHandler({
+      commandName: "new",
+      cfg: {},
+      allowFrom: ["200"],
+      groupAllowFrom: ["200"],
+      useAccessGroups: false,
+    });
+    await handler(buildForumCommandContextWithoutThreadId());
+
+    // Command should be silently dropped — no session reset, no reply
+    expect(replyMocks.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    expect(sessionMocks.recordSessionMetaFromInbound).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
 });
+

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -174,6 +174,18 @@ async function resolveTelegramCommandAuth(params: {
   const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
   const messageThreadId = (msg as { message_thread_id?: number }).message_thread_id;
   const isForum = (msg.chat as { is_forum?: boolean }).is_forum === true;
+  // Guard: Telegram strips message_thread_id from unqualified slash commands
+  // (e.g. /new without @botname) sent in forum supergroups. Without a thread ID
+  // we cannot determine which topic the command belongs to, so we skip it to
+  // avoid routing to the wrong session (e.g. General topic when the command was
+  // sent in topic 158). Users should use qualified commands (/new@botname) in
+  // forum groups with multiple bots. (#35963)
+  if (isGroup && isForum && messageThreadId == null) {
+    logVerbose(
+      `telegram: skipping unqualified command in forum group ${chatId} — no message_thread_id`,
+    );
+    return null;
+  }
   const threadSpec = resolveTelegramThreadSpec({
     isGroup,
     isForum,


### PR DESCRIPTION
Fixes #35963

Telegram strips message_thread_id from unqualified slash commands (e.g. /new without @botname) in forum supergroups. Without the thread ID we cannot determine which topic the command belongs to, causing it to route to the wrong session (e.g. General instead of the active topic).

Fix: return null early in resolveTelegramCommandAuth when the command arrives in a forum group without a message_thread_id. Users should use qualified commands (/new@botname) in forum groups with multiple bots.