### PR TITLE
Gateway: improve 'origin not allowed' error message to guide allowedOrigins config

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -507,8 +507,14 @@ export function attachGatewayWsMessageHandler(params: {
             isLocalClient,
           });
           if (!originCheck.ok) {
+            // Build an actionable error message that tells the user exactly
+            // how to add their origin to the allowlist.
+            const originHint = requestOrigin ? ` (received origin: ${requestOrigin})` : "";
             const errorMessage =
-              "origin not allowed (open the Control UI from the gateway host or allow it in gateway.controlUi.allowedOrigins)";
+              `origin not allowed${originHint}. To allow access from a non-gateway host, add your ` +
+              `origin to gateway.controlUi.allowedOrigins in your openclaw config ` +
+              `(e.g. openclaw config set gateway.controlUi.allowedOrigins '["https://your-host"]'). ` +
+              `See docs: /gateway/control-ui#allowed-origins`;
             markHandshakeFailure("origin-mismatch", {
               origin: requestOrigin ?? "n/a",
               host: requestHost ?? "n/a",


### PR DESCRIPTION
Fixes #36056

When users tried to access the Control UI from a different host than the gateway, the error message 'origin not allowed' gave no guidance on how to fix it.

Improved the error response to include the expected config key (gateway.controlUi.allowedOrigins) and an example value so users can self-serve the fix.