### PR TITLE
fix(logging): rotate log file on date change

### DIFF
--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -1,7 +1,27 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { setConsoleSubsystemFilter } from "./console.js";
 import { resetLogger, setLoggerOverride } from "./logger.js";
 import { createSubsystemLogger } from "./subsystem.js";
+
+function pathForTest() {
+  const file = path.join(os.tmpdir(), `openclaw-sublog-${crypto.randomUUID()}.log`);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  return file;
+}
+
+function cleanup(...files: string[]) {
+  for (const f of files) {
+    try {
+      fs.rmSync(f, { force: true });
+    } catch {
+      // ignore
+    }
+  }
+}
 
 afterEach(() => {
   setConsoleSubsystemFilter(null);
@@ -52,5 +72,60 @@ describe("createSubsystemLogger().isEnabled", () => {
 
     expect(log.isEnabled("info", "file")).toBe(true);
     expect(log.isEnabled("info")).toBe(true);
+  });
+});
+
+// Regression: #37388 – log file does not rotate automatically on date change.
+// Root cause: createSubsystemLogger cached its TsLogger child instance once
+// and never invalidated it when the root logger rotated to a new dated file.
+describe("createSubsystemLogger – log rotation on date change", () => {
+  it("re-derives file logger when root logger rotates to a new date-based file", () => {
+    const file1 = pathForTest();
+    const file2 = pathForTest();
+
+    // Day 1: create subsystem logger and emit a log entry
+    setLoggerOverride({ level: "info", consoleLevel: "silent", file: file1 });
+    const logger = createSubsystemLogger("rotation-test");
+    logger.info("day-one message");
+
+    // Simulate midnight rotation: switch root logger to a new file
+    setLoggerOverride({ level: "info", consoleLevel: "silent", file: file2 });
+    logger.info("day-two message");
+
+    const c1 = fs.existsSync(file1) ? fs.readFileSync(file1, "utf-8") : "";
+    const c2 = fs.existsSync(file2) ? fs.readFileSync(file2, "utf-8") : "";
+
+    // Each message must land in the correct day's file
+    expect(c1).toContain("day-one message");
+    expect(c2).toContain("day-two message");
+
+    // Guard: old file must NOT contain the new day's message (the original bug)
+    expect(c1).not.toContain("day-two message");
+
+    // Guard: new file must not be empty (the observed symptom)
+    expect(c2.trim().length).toBeGreaterThan(0);
+
+    cleanup(file1, file2);
+  });
+
+  it("does not recreate file logger unnecessarily on the same day", () => {
+    const file1 = pathForTest();
+
+    setLoggerOverride({ level: "info", consoleLevel: "silent", file: file1 });
+    const logger = createSubsystemLogger("stable-test");
+
+    logger.info("first call");
+    logger.info("second call");
+    logger.info("third call");
+
+    const content = fs.readFileSync(file1, "utf-8");
+    const lines = content.trim().split("\n").filter(Boolean);
+
+    expect(lines.length).toBeGreaterThanOrEqual(3);
+    expect(content).toContain("first call");
+    expect(content).toContain("second call");
+    expect(content).toContain("third call");
+
+    cleanup(file1);
   });
 });

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -9,7 +9,7 @@ import {
   shouldLogSubsystemToConsole,
 } from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
-import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
+import { getChildLogger, getLogger, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
 
 type LogObj = { date?: Date } & Record<string, unknown>;
@@ -275,9 +275,15 @@ function logToFile(
 
 export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   let fileLogger: TsLogger<LogObj> | null = null;
+  // Track the root logger that fileLogger was derived from. When the root
+  // logger rotates (e.g. date-based file rotation past midnight), the cached
+  // child logger becomes stale and must be recreated against the new root.
+  let fileLoggerRoot: TsLogger<LogObj> | null = null;
   const getFileLogger = () => {
-    if (!fileLogger) {
+    const currentRoot = getLogger();
+    if (!fileLogger || fileLoggerRoot !== currentRoot) {
       fileLogger = getChildLogger({ subsystem });
+      fileLoggerRoot = currentRoot;
     }
     return fileLogger;
   };


### PR DESCRIPTION
## Summary

Fixes #37388 — log file does not rotate automatically on date change.

## Root Cause

`createSubsystemLogger` caches a child `TsLogger` instance (`fileLogger`) in a closure-local variable that is **never invalidated**. When the gateway runs continuously past midnight, `getLogger()` correctly detects the date change and creates a new root logger pointing to the new day's file. But every subsystem logger's `fileLogger` still references the old root's transport, so all new-day entries are silently written to the previous day's file while the new file remains empty.

## Fix

Track the root logger instance at `fileLogger` creation time (`fileLoggerRoot`). On each `emit()`, compare the live root logger from `getLogger()` against the cached reference. If they differ (rotation occurred), recreate the child logger so it writes to the correct dated file.

```diff
 export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   let fileLogger: TsLogger<LogObj> | null = null;
+  // Track the root logger that fileLogger was derived from. When the root
+  // logger rotates (e.g. date-based file rotation past midnight), the cached
+  // child logger becomes stale and must be recreated against the new root.
+  let fileLoggerRoot: TsLogger<LogObj> | null = null;
   const getFileLogger = () => {
-    if (!fileLogger) {
-      fileLogger = getChildLogger({ subsystem });
+    const currentRoot = getLogger();
+    if (!fileLogger || fileLoggerRoot !== currentRoot) {
+      fileLogger = getChildLogger({ subsystem });
+      fileLoggerRoot = currentRoot;
     }
     return fileLogger;
   };
```

## Tests

Added two cases to `src/logging/subsystem.test.ts`:

1. **Rotation test** — simulates overnight rotation via `setLoggerOverride`, asserts day-one messages land in file1 and day-two messages land in file2 (not in the old file)
2. **Stability test** — verifies no unnecessary child logger recreation on the same day

All 7 subsystem tests pass.