### PR TITLE
fix(infra): classify wrapped 'fetch failed' as transient

### DIFF
--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -85,6 +85,11 @@ describe("isTransientNetworkError", () => {
     expect(isTransientNetworkError(error)).toBe(true);
   });
 
+  it("returns true for Error that wraps fetch failed in message text", () => {
+    const error = new Error("Failed to get gateway information from Discord: fetch failed");
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
   it("returns true for nested cause chain with network error", () => {
     const innerCause = Object.assign(new Error("connection reset"), { code: "ECONNRESET" });
     const outerCause = Object.assign(new Error("wrapper"), { cause: innerCause });

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -58,6 +58,9 @@ const TRANSIENT_NETWORK_MESSAGE_SNIPPETS = [
   "network error",
   "network is unreachable",
   "temporary failure in name resolution",
+  // Node/undici can wrap network errors as a generic Error with this message fragment.
+  // Example: "Failed to get gateway information from Discord: fetch failed" (see #37375).
+  "fetch failed",
 ];
 
 function getErrorCause(err: unknown): unknown {


### PR DESCRIPTION
Closes #37375.

When network failures are wrapped by libraries/plugins into a plain `Error` message that includes `fetch failed` (e.g. "Failed to get gateway information from Discord: fetch failed"), `isTransientNetworkError` previously missed it and the gateway could crash via the unhandled rejection handler.

This change adds `fetch failed` to the transient network message snippets and adds a regression test for the wrapped-message case.