### PR TITLE
fix(agents): don't restore stale baseUrl from models.json when config sets a new one

### DIFF
--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -120,6 +120,9 @@ export class AcpxRuntime implements AcpRuntime {
   private readonly spawnCommandCache: SpawnCommandCache = {};
   private readonly spawnCommandOptions: SpawnCommandOptions;
   private readonly loggedSpawnResolutions = new Set<string>();
+  /** Child processes currently running a turn, keyed by session handle name.
+   *  Used to kill zombies when the session TTL expires during an active turn. */
+  private readonly activeChildren = new Map<string, ReturnType<typeof spawnWithResolvedCommand>>();
 
   constructor(
     private readonly config: ResolvedAcpxPluginConfig,
@@ -297,6 +300,8 @@ export class AcpxRuntime implements AcpRuntime {
       },
       this.spawnCommandOptions,
     );
+    // Track the child so close() can kill it when the session TTL expires.
+    this.activeChildren.set(state.name, child);
     child.stdin.on("error", () => {
       // Ignore EPIPE when the child exits before stdin flush completes.
     });
@@ -366,6 +371,8 @@ export class AcpxRuntime implements AcpRuntime {
       }
     } finally {
       lines.close();
+      // Deregister the child process — it has exited or the generator was abandoned.
+      this.activeChildren.delete(state.name);
       if (input.signal) {
         input.signal.removeEventListener("abort", onAbort);
       }
@@ -552,6 +559,35 @@ export class AcpxRuntime implements AcpRuntime {
 
   async close(input: { handle: AcpRuntimeHandle; reason: string }): Promise<void> {
     const state = this.resolveHandleState(input.handle);
+
+    // Kill any child process that is still running a turn for this session so
+    // it does not linger as a zombie after the TTL expires.  Send SIGTERM first
+    // and follow up with SIGKILL after a short grace period.
+    const activeChild = this.activeChildren.get(state.name);
+    if (activeChild && activeChild.exitCode === null && activeChild.signalCode === null) {
+      this.logger?.debug?.(
+        `acpx close (reason=${input.reason}): sending SIGTERM to child pid=${activeChild.pid} for session ${state.name}`,
+      );
+      try {
+        activeChild.kill("SIGTERM");
+      } catch {
+        // Ignore kill races when the child exits concurrently.
+      }
+      // Schedule SIGKILL in case SIGTERM is not honoured within 2 seconds.
+      const sigkillTimer = setTimeout(() => {
+        if (activeChild.exitCode !== null || activeChild.signalCode !== null) {
+          return;
+        }
+        try {
+          activeChild.kill("SIGKILL");
+        } catch {
+          // Ignore kill races.
+        }
+      }, 2_000);
+      sigkillTimer.unref?.();
+      this.activeChildren.delete(state.name);
+    }
+
     await this.runControlCommand({
       args: this.buildControlArgs({
         cwd: state.cwd,

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -162,7 +162,13 @@ function mergeWithExistingProviderSecrets(params: {
     if (typeof existing.apiKey === "string" && existing.apiKey) {
       preserved.apiKey = existing.apiKey;
     }
-    if (typeof existing.baseUrl === "string" && existing.baseUrl) {
+    // Only restore the cached baseUrl when the new config does not explicitly set one.
+    // This ensures user updates to baseUrl in openclaw.json are not silently overwritten
+    // by the stale value cached in models.json (fixes #36353 and #37309).
+    const newEntryHasBaseUrl =
+      typeof (newEntry as { baseUrl?: unknown }).baseUrl === "string" &&
+      ((newEntry as { baseUrl?: string }).baseUrl ?? "").trim() !== "";
+    if (!newEntryHasBaseUrl && typeof existing.baseUrl === "string" && existing.baseUrl) {
       preserved.baseUrl = existing.baseUrl;
     }
     mergedProviders[key] = { ...newEntry, ...preserved };


### PR DESCRIPTION
## Summary

- `mergeWithExistingProviderSecrets` in `src/agents/models-config.ts` was unconditionally restoring the `baseUrl` cached in models.json on top of the freshly-computed config, ignoring any user update to `baseUrl` in `openclaw.json`.
- The fix adds a guard: the cached `baseUrl` is only preserved when the new config entry does **not** explicitly provide a `baseUrl`. When the user sets a `baseUrl` in `openclaw.json`, that value now takes priority.

Fixes #36353
Fixes #37309

## Test plan

- [ ] Configure a provider with a custom `baseUrl` in `openclaw.json`; run the agent; confirm the custom `baseUrl` is written to models.json (not overwritten by the previous cached value).
- [ ] Update `baseUrl` in `openclaw.json`; run the agent again; confirm models.json reflects the updated value.
- [ ] Configure a provider without `baseUrl` in `openclaw.json`; confirm that a previously-cached `baseUrl` in models.json (e.g. an OAuth-derived URL) is still preserved across runs.