### PR TITLE
agent --local: close Playwright connection on exit to prevent process hang

### DIFF
--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -1,4 +1,5 @@
 import { listAgentIds } from "../agents/agent-scope.js";
+import { isPwAiLoaded } from "../browser/pw-ai-state.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { CliDeps } from "../cli/deps.js";
 import { withProgress } from "../cli/progress.js";
@@ -184,7 +185,20 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
     replyAccountId: opts.replyAccount,
   };
   if (opts.local === true) {
-    return await agentCommand(localOpts, runtime, deps);
+    try {
+      return await agentCommand(localOpts, runtime, deps);
+    } finally {
+      // Release the cached Playwright browser connection if the Browser tool was used.
+      // Without this the Node.js event loop stays alive and the process never exits.
+      if (isPwAiLoaded()) {
+        try {
+          const mod = await import("../browser/pw-ai.js");
+          await mod.closePlaywrightBrowserConnection();
+        } catch {
+          // ignore cleanup errors
+        }
+      }
+    }
   }
 
   try {


### PR DESCRIPTION
## Summary

`openclaw agent --local` never exits after the agent completes when the Browser tool is used. Without the Browser tool the process exits normally.

**Root cause:** When a Browser tool call is made, `pw-ai.ts` is loaded and marks `pwAiLoaded = true` via `markPwAiLoaded()`. The Playwright browser connection is cached at module level in `pw-session.ts`. The browser's `"disconnected"` event listener and page/context observers keep the Node.js event loop alive. The gateway server already cleans up via `closePlaywrightBrowserConnection()` in its shutdown path, but the `--local` CLI runner never triggered this cleanup.

**Fix:** In `agentCliCommand` (`commands/agent-via-gateway.ts`), wrap the `--local` path's `agentCommand` call in a try/finally block. After the run completes (success or error), check `isPwAiLoaded()` and — if true — dynamically import `pw-ai.js` and call `closePlaywrightBrowserConnection()`. This mirrors the existing cleanup in `browser/server.ts`.

Fixes #36388