### PR TITLE
routing: change dmScope default from "main" to "per-channel-peer"

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -32,6 +32,9 @@
       }
     }
   },
+  "contextual": {
+    "options": ["copy", "view", "claude", "chatgpt"]
+  },
   "navbar": {
     "links": [
       {

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,87 @@
+# OpenClaw
+
+> OpenClaw is a self-hosted gateway that connects WhatsApp, Telegram, Discord, iMessage, Signal, and more to AI coding agents. Run a single Gateway process on your own machine and message your AI assistant from anywhere.
+
+AI agents: every page on this site is available as clean Markdown by appending `.md` to the URL (e.g. `https://docs.openclaw.ai/tools/skills.md`). Use the Markdown versions to reduce token use and improve parsing accuracy. This file (`/llms.txt`) lists the key sections; `/llms-full.txt` contains all page content in a single file.
+
+## Getting Started
+
+- [Overview](https://docs.openclaw.ai/index.md)
+- [Getting started](https://docs.openclaw.ai/start/getting-started.md)
+- [Quickstart](https://docs.openclaw.ai/start/quickstart.md)
+- [Installation overview](https://docs.openclaw.ai/install/index.md)
+- [Docker](https://docs.openclaw.ai/install/docker.md)
+- [VPS / self-hosted](https://docs.openclaw.ai/vps.md)
+- [Setup wizard](https://docs.openclaw.ai/start/wizard.md)
+
+## Channels
+
+- [Channels overview](https://docs.openclaw.ai/channels/index.md)
+- [Telegram](https://docs.openclaw.ai/channels/telegram.md)
+- [Discord](https://docs.openclaw.ai/channels/discord.md)
+- [WhatsApp](https://docs.openclaw.ai/channels/whatsapp.md)
+- [iMessage / Bluebubbles](https://docs.openclaw.ai/channels/bluebubbles.md)
+- [Signal](https://docs.openclaw.ai/channels/signal.md)
+- [Slack](https://docs.openclaw.ai/channels/slack.md)
+- [Pairing](https://docs.openclaw.ai/channels/pairing.md)
+- [Group messages](https://docs.openclaw.ai/channels/group-messages.md)
+- [Channel routing](https://docs.openclaw.ai/channels/channel-routing.md)
+
+## Agents
+
+- [Agent overview](https://docs.openclaw.ai/pi.md)
+- [Architecture](https://docs.openclaw.ai/concepts/architecture.md)
+- [Agent loop](https://docs.openclaw.ai/concepts/agent-loop.md)
+- [Sessions](https://docs.openclaw.ai/concepts/session.md)
+- [Multi-agent](https://docs.openclaw.ai/concepts/multi-agent.md)
+- [Memory & compaction](https://docs.openclaw.ai/concepts/compaction.md)
+- [System prompt](https://docs.openclaw.ai/concepts/system-prompt.md)
+- [Context](https://docs.openclaw.ai/concepts/context.md)
+- [Agent workspace](https://docs.openclaw.ai/concepts/agent-workspace.md)
+- [Streaming](https://docs.openclaw.ai/concepts/streaming.md)
+- [Queue](https://docs.openclaw.ai/concepts/queue.md)
+
+## Tools
+
+- [Tools overview](https://docs.openclaw.ai/tools/index.md)
+- [Skills](https://docs.openclaw.ai/tools/skills.md)
+- [Creating skills](https://docs.openclaw.ai/tools/creating-skills.md)
+- [Skills configuration](https://docs.openclaw.ai/tools/skills-config.md)
+- [Slash commands](https://docs.openclaw.ai/tools/slash-commands.md)
+- [Exec (shell)](https://docs.openclaw.ai/tools/exec.md)
+- [Browser](https://docs.openclaw.ai/tools/browser.md)
+- [Subagents](https://docs.openclaw.ai/tools/subagents.md)
+- [Apply patch](https://docs.openclaw.ai/tools/apply-patch.md)
+- [Loop detection](https://docs.openclaw.ai/tools/loop-detection.md)
+- [Brave search](https://docs.openclaw.ai/brave-search.md)
+
+## Models & Providers
+
+- [Providers overview](https://docs.openclaw.ai/providers/index.md)
+- [Model catalog](https://docs.openclaw.ai/providers/models.md)
+- [Model providers](https://docs.openclaw.ai/concepts/model-providers.md)
+- [Model failover](https://docs.openclaw.ai/concepts/model-failover.md)
+
+## Configuration
+
+- [Gateway configuration](https://docs.openclaw.ai/gateway/configuration.md)
+- [Configuration reference](https://docs.openclaw.ai/reference/configuration.md)
+- [Nodes](https://docs.openclaw.ai/nodes/index.md)
+- [Automation / hooks](https://docs.openclaw.ai/automation/hooks.md)
+- [Cron jobs](https://docs.openclaw.ai/automation/cron-jobs.md)
+
+## Platforms
+
+- [macOS](https://docs.openclaw.ai/platforms/mac/index.md)
+- [Linux](https://docs.openclaw.ai/platforms/linux/index.md)
+- [Windows](https://docs.openclaw.ai/platforms/windows/index.md)
+- [Raspberry Pi / Pi](https://docs.openclaw.ai/pi.md)
+
+## Reference
+
+- [CLI reference](https://docs.openclaw.ai/cli/index.md)
+- [API / RPC](https://docs.openclaw.ai/reference/rpc.md)
+- [Security](https://docs.openclaw.ai/security/index.md)
+- [Troubleshooting](https://docs.openclaw.ai/help/index.md)
+- [Testing](https://docs.openclaw.ai/reference/test.md)
+- [Changelog](https://docs.openclaw.ai/reference/changelog.md)

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -118,7 +118,7 @@ export function maybeRetireLegacyMainDeliveryRoute(params: {
   isGroup: boolean;
   ctx: MsgContext;
 }): LegacyMainDeliveryRetirement | undefined {
-  const dmScope = params.sessionCfg?.dmScope ?? "main";
+  const dmScope = params.sessionCfg?.dmScope ?? "per-channel-peer";
   if (dmScope === "main" || params.isGroup) {
     return undefined;
   }

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -701,6 +701,9 @@ async function agentCommandInternal(
           !allowAnyModel &&
           !allowedModelKeys.has(key)
         ) {
+          log.warn(
+            `session model override ${normalizedOverride.provider}/${normalizedOverride.model} is not in the allowed model set; clearing override and falling back to default. Add it to models.allowed or set models.allowAny=true.`,
+          );
           const { updated } = applyModelOverrideToSessionEntry({
             entry,
             selection: { provider: defaultProvider, model: defaultModel, isDefault: true },
@@ -730,6 +733,13 @@ async function agentCommandInternal(
       ) {
         provider = normalizedStored.provider;
         model = normalizedStored.model;
+      } else {
+        // The stored model override is not in the configured allowlist; log a warning
+        // so callers (e.g. sessions_spawn) can diagnose why modelApplied=true did not
+        // take effect at runtime.
+        log.warn(
+          `session model override ${normalizedStored.provider}/${normalizedStored.model} is not in the allowed model set; running on default model instead. Add it to models.allowed or set models.allowAny=true.`,
+        );
       }
     }
     if (sessionEntry) {

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -152,7 +152,7 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
       allowFrom: params.allowFrom,
       normalizeEntry: params.normalizeEntry,
     });
-    const dmScope = cfg.session?.dmScope ?? "main";
+    const dmScope = cfg.session?.dmScope ?? "per-channel-peer";
 
     if (dmPolicy === "open") {
       const allowFromPath = `${params.allowFromPath}allowFrom`;

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -113,7 +113,7 @@ function buildBaseSessionKey(params: {
     channel: params.channel,
     accountId: params.accountId,
     peer: params.peer,
-    dmScope: params.cfg.session?.dmScope ?? "main",
+    dmScope: params.cfg.session?.dmScope ?? "per-channel-peer",
     identityLinks: params.cfg.session?.identityLinks,
   });
 }

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -24,7 +24,7 @@ describe("resolveAgentRoute", () => {
     });
     expect(route.agentId).toBe("main");
     expect(route.accountId).toBe("default");
-    expect(route.sessionKey).toBe("agent:main:main");
+    expect(route.sessionKey).toBe("agent:main:whatsapp:direct:+15551234567");
     expect(route.matchedBy).toBe("default");
   });
 
@@ -108,7 +108,7 @@ describe("resolveAgentRoute", () => {
       peer: { kind: "direct", id: "+1000" },
     });
     expect(route.agentId).toBe("a");
-    expect(route.sessionKey).toBe("agent:a:main");
+    expect(route.sessionKey).toBe("agent:a:whatsapp:direct:+1000");
     expect(route.matchedBy).toBe("binding.peer");
   });
 
@@ -362,7 +362,7 @@ describe("resolveAgentRoute", () => {
       peer: { kind: "direct", id: "+1000" },
     });
     expect(route.agentId).toBe("home");
-    expect(route.sessionKey).toBe("agent:home:main");
+    expect(route.sessionKey).toBe("agent:home:whatsapp:direct:+1000");
   });
 });
 

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -608,7 +608,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const teamId = normalizeId(input.teamId);
   const memberRoleIds = input.memberRoleIds ?? [];
   const memberRoleIdSet = new Set(memberRoleIds);
-  const dmScope = input.cfg.session?.dmScope ?? "main";
+  const dmScope = input.cfg.session?.dmScope ?? "per-channel-peer"; // default per-channel-peer prevents cross-channel DM leakage
   const identityLinks = input.cfg.session?.identityLinks;
   const shouldLogDebug = shouldLogVerbose();
   const parentPeer = input.parentPeer

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -137,7 +137,7 @@ export function buildAgentPeerSessionKey(params: {
 }): string {
   const peerKind = params.peerKind ?? "direct";
   if (peerKind === "direct") {
-    const dmScope = params.dmScope ?? "main";
+    const dmScope = params.dmScope ?? "per-channel-peer"; // default per-channel-peer prevents cross-channel DM leakage
     let peerId = (params.peerId ?? "").trim();
     const linkedPeerId =
       dmScope === "main"

--- a/src/security/audit-channel.ts
+++ b/src/security/audit-channel.ts
@@ -215,7 +215,7 @@ export async function collectChannelSecurityFindings(params: {
       allowFrom: input.allowFrom,
       normalizeEntry: input.normalizeEntry,
     });
-    const dmScope = params.cfg.session?.dmScope ?? "main";
+    const dmScope = params.cfg.session?.dmScope ?? "per-channel-peer";
 
     if (input.dmPolicy === "open") {
       const allowFromKey = `${input.allowFromPath}allowFrom`;

--- a/src/security/dm-policy-shared.ts
+++ b/src/security/dm-policy-shared.ts
@@ -9,7 +9,7 @@ export function resolvePinnedMainDmOwnerFromAllowlist(params: {
   allowFrom?: Array<string | number> | null;
   normalizeEntry: (entry: string) => string | undefined;
 }): string | null {
-  if ((params.dmScope ?? "main") !== "main") {
+  if ((params.dmScope ?? "per-channel-peer") !== "main") {
     return null;
   }
   const rawAllowFrom = Array.isArray(params.allowFrom) ? params.allowFrom : [];

--- a/src/slack/monitor.tool-result.test.ts
+++ b/src/slack/monitor.tool-result.test.ts
@@ -598,7 +598,7 @@ describe("monitorSlackProvider tool results", () => {
 
     expect(replyMock).toHaveBeenCalledTimes(1);
     const ctx = getFirstReplySessionCtx();
-    expect(ctx.SessionKey).toBe("agent:main:main:thread:123");
+    expect(ctx.SessionKey).toBe("agent:main:slack:direct:u1:thread:123");
     expect(ctx.ParentSessionKey).toBeUndefined();
   });
 

--- a/src/slack/monitor/monitor.test.ts
+++ b/src/slack/monitor/monitor.test.ts
@@ -229,7 +229,7 @@ describe("resolveSlackSystemEventSessionKey", () => {
         channelType: "im",
         senderId: "U123",
       }),
-    ).toBe("agent:ops-dm:main");
+    ).toBe("agent:ops-dm:slack:direct:u123");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #36687

After upgrading to 2026.3.2, users who had not explicitly set `session.dmScope` experienced cross-channel DM session leakage: WebChat/TUI replies were routing to iMessage contacts and vice versa. The root cause was the runtime fallback default of `"main"`, which causes all DMs from all channels to share a single session.

CLI onboarding has written `session.dmScope: "per-channel-peer"` for new installs since 2026.3.2, but users who upgraded without re-running onboarding (or installed before that change) never had the setting written and continued to use the `"main"` default at runtime.

**Changes:**

- `src/routing/session-key.ts` — `buildAgentPeerSessionKey`: fallback changed from `"main"` → `"per-channel-peer"`
- `src/routing/resolve-route.ts` — `resolveAgentRoute`: fallback changed
- `src/infra/outbound/outbound-session.ts` — outbound session key builder: fallback changed
- `src/auto-reply/reply/session-delivery.ts` — `maybeRetireLegacyMainDeliveryRoute`: fallback changed so migration helper correctly triggers for users who relied on the new default
- `src/security/audit-channel.ts` + `src/commands/doctor-security.ts` — audit/doctor checks now apply the same default so the `dmScope=main` multi-user DM warning fires correctly for unconfigured installs
- `src/security/dm-policy-shared.ts` — `resolvePinnedMainDmOwnerFromAllowlist`: fallback changed so pinned-owner logic only applies when `dmScope` is explicitly set to `"main"`

Users who need shared DM continuity across all channels can restore the old behavior by setting `session.dmScope: "main"` in their config.

## Test plan

- [ ] Without any `session.dmScope` config, DMs from different channels (e.g. iMessage vs WebChat) now get separate session keys (per-channel-peer behavior).
- [ ] Existing installs with explicit `session.dmScope: "main"` continue to share sessions as before.
- [ ] `openclaw doctor` no longer warns about `dmScope=main multiuser` for unconfigured installs (since the effective default is now safe).
- [ ] Run existing `routing/resolve-route.test.ts` and `routing/session-key.continuity.test.ts` — tests that explicitly set `dmScope: "main"` should be unaffected.