### PR TITLE
agent: warn when session model override is silently dropped by allowlist

### DIFF
--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -701,6 +701,9 @@ async function agentCommandInternal(
           !allowAnyModel &&
           !allowedModelKeys.has(key)
         ) {
+          log.warn(
+            `session model override ${normalizedOverride.provider}/${normalizedOverride.model} is not in the allowed model set; clearing override and falling back to default. Add it to models.allowed or set models.allowAny=true.`,
+          );
           const { updated } = applyModelOverrideToSessionEntry({
             entry,
             selection: { provider: defaultProvider, model: defaultModel, isDefault: true },
@@ -730,6 +733,13 @@ async function agentCommandInternal(
       ) {
         provider = normalizedStored.provider;
         model = normalizedStored.model;
+      } else {
+        // The stored model override is not in the configured allowlist; log a warning
+        // so callers (e.g. sessions_spawn) can diagnose why modelApplied=true did not
+        // take effect at runtime.
+        log.warn(
+          `session model override ${normalizedStored.provider}/${normalizedStored.model} is not in the allowed model set; running on default model instead. Add it to models.allowed or set models.allowAny=true.`,
+        );
       }
     }
     if (sessionEntry) {


### PR DESCRIPTION
## Summary

`sessions_spawn` targeting `google/gemini-*` models returns `modelApplied: true` but the sub-agent actually runs on the default Anthropic model. The model override is silently ignored with no log output, making this impossible to diagnose.

**Root cause:** In `agentCommand` (`commands/agent.ts`), there are two separate places where a stored session model override can be discarded if the model is not in `allowedModelKeys` and `allowAnyModel=false`:

1. Lines 699–716: The override is cleared from the session entry and persisted back to disk (reset to default) — no log.
2. Lines 726–733: The stored override is read but the `if` condition fails, so `provider`/`model` stay as default — no log.

Both drops are silent, so callers see `modelApplied: true` from the `sessions.patch` call (which only validates against the model catalog, not the runtime allowlist) but the agent runs on the wrong model.

**Fix:** Add `log.warn()` at both drop points with a message that identifies the model and points to the config keys needed to allow it (`models.allowed` / `models.allowAny`).

Fixes #36134