### PR TITLE
fix(delivery-recovery): stop retrying Telegram permanent Bad Request errors

### DIFF
--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -387,6 +387,10 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
+
+  // Telegram "Bad Request" errors that are content/target-dependent and will never succeed on retry.
+  /message to be replied\b.*\bnot found/i,
+  /message is too long/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -161,6 +161,8 @@ describe("delivery-queue", () => {
     it.each([
       "No conversation reference found for user:abc",
       "Telegram send failed: chat not found (chat_id=user:123)",
+      "Telegram send failed: 400: Bad Request: message to be replied not found",
+      "Telegram send failed: 400: Bad Request: message is too long",
       "user not found",
       "Bot was blocked by the user",
       "Forbidden: bot was kicked from the group chat",


### PR DESCRIPTION
Closes #37497.

When Telegram returns certain 400 Bad Request errors (e.g. replied message not found, message too long), retries will never succeed. Treat these errors as permanent during delivery recovery and move the queued entry to failed/ instead of retrying forever.

- Adds permanent error patterns for Telegram
- Expands unit test coverage for isPermanentDeliveryError()

Tests: npx --no-install vitest run src/infra/outbound/outbound.test.ts