### PR TITLE
fix(agents_list): return all configured agents when allowAgents is not explicitly set

### DIFF
--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -46,7 +46,12 @@ export function createAgentsListTool(opts?: {
           DEFAULT_AGENT_ID,
       );
 
-      const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+      // Distinguish between "not configured" (undefined) and "explicitly empty" ([]).
+      // When allowAgents is not configured, fall back to all configured agents so
+      // that the tool matches the behavior of `openclaw agents list` in the CLI.
+      const rawAllowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents;
+      const allowAgentsConfigured = Array.isArray(rawAllowAgents);
+      const allowAgents = rawAllowAgents ?? [];
       const allowAny = allowAgents.some((value) => value.trim() === "*");
       const allowSet = new Set(
         allowAgents
@@ -67,7 +72,9 @@ export function createAgentsListTool(opts?: {
 
       const allowed = new Set<string>();
       allowed.add(requesterAgentId);
-      if (allowAny) {
+      if (allowAny || !allowAgentsConfigured) {
+        // allowAny: explicit "*" wildcard; !allowAgentsConfigured: no allowlist set,
+        // so show all configured agents (matches `openclaw agents list` CLI behavior).
         for (const id of configuredIds) {
           allowed.add(id);
         }


### PR DESCRIPTION
## Summary

Fixes #36634.

The `agents_list` tool was returning only `["main"]` (the requester agent) even when multiple agents were configured in the CLI. The root cause was that `subagents.allowAgents` defaults to `undefined` when unconfigured, and the code applied `?? []` before checking, collapsing "not configured" and "explicitly empty" into the same empty-array path — causing the tool to add nothing to the allowed set.

- Detect `allowAgents === undefined` (not configured) separately from `[]` (explicitly empty allowlist).
- When not configured, fall back to all agents from `cfg.agents.list`, matching the behavior of `openclaw agents list` in the CLI.
- Explicitly configured allowlists (including `["*"]`) continue to work as before.

## Test plan

- [ ] With multiple agents configured in `agents.list` and no `subagents.allowAgents` set, `agents_list` returns all configured agent IDs.
- [ ] With `subagents.allowAgents: ["agent-b"]` explicitly set, `agents_list` returns only `agent-b` (plus the requester).
- [ ] With `subagents.allowAgents: ["*"]`, `agents_list` returns all configured agents.
- [ ] With `subagents.allowAgents: []` (explicitly empty), `agents_list` returns only the requester agent.