### PR TITLE
fix(logging): rotate log file at midnight by invalidating stale child loggers

### DIFF
--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -9,7 +9,7 @@ import {
   shouldLogSubsystemToConsole,
 } from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
-import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
+import { getChildLogger, getLogger, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
 
 type LogObj = { date?: Date } & Record<string, unknown>;
@@ -274,10 +274,17 @@ function logToFile(
 }
 
 export function createSubsystemLogger(subsystem: string): SubsystemLogger {
+  // Cache the child logger alongside its parent so we can detect when the base logger
+  // is rebuilt (e.g. when the log file rolls over at midnight). Without this, the
+  // cached child logger continues writing to the previous day's log file even after
+  // getLogger() switches to a new file. See: fix/issue-37388-log-date-rotation
   let fileLogger: TsLogger<LogObj> | null = null;
+  let fileLoggerBaseRef: TsLogger<LogObj> | null = null;
   const getFileLogger = () => {
-    if (!fileLogger) {
+    const base = getLogger();
+    if (fileLogger === null || fileLoggerBaseRef !== base) {
       fileLogger = getChildLogger({ subsystem });
+      fileLoggerBaseRef = base;
     }
     return fileLogger;
   };


### PR DESCRIPTION
## Summary

- The subsystem logger (`createSubsystemLogger`) cached a child `TsLogger` after first use and never released it
- When the date changed past midnight, `getLogger()` correctly detected the stale file path (via `settingsChanged`) and rebuilt its internal logger pointing to the new day's log file — but each subsystem closure held a reference to a child derived from the **old** parent, so writes kept going to the previous day's log file until the process restarted
- Fix: track the base logger reference alongside the cached child. Before each write, compare the current base (from `getLogger()`) with the stored base; if they differ, rebuild the child logger from the new parent so writes land in the current day's file
- The check is a single reference comparison (`!==`) per log write — no filesystem stats, no `Date()` calls, no observable perf regression in the common case

## Test plan
- [ ] Gateway runs continuously across midnight
- [ ] After midnight, verify new logs are written to `openclaw-YYYY-MM-DD.log` (new date), not to the previous day's file
- [ ] Verify `openclaw models list` and other commands still work normally

Fixes #37388