### PR TITLE
fix(gateway): allow hardlinked control-ui files for pnpm global installs

### DIFF
--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -263,6 +263,10 @@ function resolveSafeControlUiFile(
     rootRealPath: rootReal,
     boundaryLabel: "control ui root",
     skipLexicalRootCheck: true,
+    // pnpm stores package files as hardlinks (nlink > 1) in its
+    // content-addressable store.  Rejecting hardlinks breaks the
+    // Control UI for all pnpm global installs.
+    rejectHardlinks: false,
   });
   if (!opened.ok) {
     if (opened.reason === "io") {


### PR DESCRIPTION
## Summary

When OpenClaw is installed globally via `pnpm add -g`, the Control UI returns 404 for all static files. The bootstrap config endpoint works fine, but every
HTML/JS/CSS/image asset fails.

## Root Cause

`resolveSafeControlUiFile` in `src/gateway/control-ui.ts` calls `openBoundaryFileSync` without setting `rejectHardlinks`. The default in `boundary-file-read.ts` is
`rejectHardlinks: true`.

pnpm stores all package files as **hardlinks** (`nlink > 1`) in its content-addressable store. `openVerifiedFileSync` sees `nlink > 1` and returns `{ ok: false, reason:
"validation" }`, rejecting every control-ui file.

## Fix

Pass `rejectHardlinks: false` to `openBoundaryFileSync` in the control-ui file resolver. Control UI assets are read-only bundled files — the hardlink check provides no
security benefit here since the boundary path check already ensures the file is within the control-ui root.

## Test plan

- [x] Existing 18 control-ui HTTP tests pass
- [x] Lint/type check clean

Closes #37455