### PR TITLE
fix(infra): classify Telegram 400 errors as permanent in delivery recovery

### DIFF
--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -387,6 +387,9 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
+  /message is too long/i,
+  /message to be replied not found/i,
+  /reply message not found/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -166,6 +166,9 @@ describe("delivery-queue", () => {
       "Forbidden: bot was kicked from the group chat",
       "chat_id is empty",
       "Outbound not configured for channel: msteams",
+      "Bad Request: message is too long",
+      "Bad Request: message to be replied not found",
+      "Bad Request: reply message not found",
     ])("returns true for permanent error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(true);
     });


### PR DESCRIPTION
## Summary

Adds three Telegram-specific HTTP 400 error patterns to the permanent delivery error list, preventing infinite retries for messages that will never succeed.

## Problem

The delivery-recovery system retries failed deliveries on every gateway restart. Two common Telegram 400 errors — "message is too long" (exceeds 4096 char limit) and "message to be replied not found" (deleted reply target) — were not recognized as permanent. Since the message content doesn't change between retries, these deliveries would retry indefinitely, clogging the queue and generating noisy error logs.

## Changes

| File | Change |
|------|--------|
| `src/infra/outbound/delivery-queue.ts` | Added 3 patterns to `PERMANENT_ERROR_PATTERNS`: `message is too long`, `message to be replied not found`, `reply message not found` |
| `src/infra/outbound/outbound.test.ts` | Added test cases for the new permanent error patterns |

## How it works

When `recoverPendingDeliveries` catches a delivery error, it calls `isPermanentDeliveryError(errMsg)` to check if the error matches known permanent patterns. If it matches, the entry is moved to `failed/` immediately instead of being retried. The three new patterns cover:

1. **`message is too long`** — content exceeds Telegram's 4096 character limit; will never fit on retry
2. **`message to be replied not found`** — the referenced reply message was deleted; will never exist again
3. **`reply message not found`** — variant of the above from different Telegram API versions

## Test plan

- [x] All 61 existing delivery tests pass
- [x] New test cases verify all three patterns are classified as permanent
- [ ] Manual: create a delivery that triggers "message is too long", verify it moves to failed/ after one recovery cycle

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No** (moves entries between queue directories only)
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Create a delivery entry with text exceeding 4096 characters to a Telegram channel
2. Trigger delivery recovery (gateway restart)
3. Check that the entry moves to `failed/` instead of being retried indefinitely

## Failure Recovery

Revert the three new regex patterns from `PERMANENT_ERROR_PATTERNS` to restore the original retry behavior.

## Risks and Mitigations

- **Risk**: A transient Telegram error message coincidentally matches one of these patterns
- **Mitigation**: The patterns are specific Telegram error strings from the Bot API; they are deterministic and will never resolve on retry. The regex is case-insensitive but sufficiently specific to avoid false matches.