### PR TITLE
Gateway: detect and surface version mismatch after npm update without restart

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -304,6 +304,7 @@ public struct Snapshot: Codable, Sendable {
     public let sessiondefaults: [String: AnyCodable]?
     public let authmode: AnyCodable?
     public let updateavailable: [String: AnyCodable]?
+    public let versionmismatch: [String: AnyCodable]?
 
     public init(
         presence: [PresenceEntry],
@@ -314,7 +315,8 @@ public struct Snapshot: Codable, Sendable {
         statedir: String?,
         sessiondefaults: [String: AnyCodable]?,
         authmode: AnyCodable?,
-        updateavailable: [String: AnyCodable]?)
+        updateavailable: [String: AnyCodable]?,
+        versionmismatch: [String: AnyCodable]?)
     {
         self.presence = presence
         self.health = health
@@ -325,6 +327,7 @@ public struct Snapshot: Codable, Sendable {
         self.sessiondefaults = sessiondefaults
         self.authmode = authmode
         self.updateavailable = updateavailable
+        self.versionmismatch = versionmismatch
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -337,6 +340,7 @@ public struct Snapshot: Codable, Sendable {
         case sessiondefaults = "sessionDefaults"
         case authmode = "authMode"
         case updateavailable = "updateAvailable"
+        case versionmismatch = "versionMismatch"
     }
 }
 
@@ -1460,6 +1464,20 @@ public struct ConfigPatchParams: Codable, Sendable {
 
 public struct ConfigSchemaParams: Codable, Sendable {}
 
+public struct ConfigSchemaLookupParams: Codable, Sendable {
+    public let path: String
+
+    public init(
+        path: String)
+    {
+        self.path = path
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+    }
+}
+
 public struct ConfigSchemaResponse: Codable, Sendable {
     public let schema: AnyCodable
     public let uihints: [String: AnyCodable]
@@ -1483,6 +1501,36 @@ public struct ConfigSchemaResponse: Codable, Sendable {
         case uihints = "uiHints"
         case version
         case generatedat = "generatedAt"
+    }
+}
+
+public struct ConfigSchemaLookupResult: Codable, Sendable {
+    public let path: String
+    public let schema: AnyCodable
+    public let hint: [String: AnyCodable]?
+    public let hintpath: String?
+    public let children: [[String: AnyCodable]]
+
+    public init(
+        path: String,
+        schema: AnyCodable,
+        hint: [String: AnyCodable]?,
+        hintpath: String?,
+        children: [[String: AnyCodable]])
+    {
+        self.path = path
+        self.schema = schema
+        self.hint = hint
+        self.hintpath = hintpath
+        self.children = children
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+        case schema
+        case hint
+        case hintpath = "hintPath"
+        case children
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -304,6 +304,7 @@ public struct Snapshot: Codable, Sendable {
     public let sessiondefaults: [String: AnyCodable]?
     public let authmode: AnyCodable?
     public let updateavailable: [String: AnyCodable]?
+    public let versionmismatch: [String: AnyCodable]?
 
     public init(
         presence: [PresenceEntry],
@@ -314,7 +315,8 @@ public struct Snapshot: Codable, Sendable {
         statedir: String?,
         sessiondefaults: [String: AnyCodable]?,
         authmode: AnyCodable?,
-        updateavailable: [String: AnyCodable]?)
+        updateavailable: [String: AnyCodable]?,
+        versionmismatch: [String: AnyCodable]?)
     {
         self.presence = presence
         self.health = health
@@ -325,6 +327,7 @@ public struct Snapshot: Codable, Sendable {
         self.sessiondefaults = sessiondefaults
         self.authmode = authmode
         self.updateavailable = updateavailable
+        self.versionmismatch = versionmismatch
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -337,6 +340,7 @@ public struct Snapshot: Codable, Sendable {
         case sessiondefaults = "sessionDefaults"
         case authmode = "authMode"
         case updateavailable = "updateAvailable"
+        case versionmismatch = "versionMismatch"
     }
 }
 
@@ -1460,6 +1464,20 @@ public struct ConfigPatchParams: Codable, Sendable {
 
 public struct ConfigSchemaParams: Codable, Sendable {}
 
+public struct ConfigSchemaLookupParams: Codable, Sendable {
+    public let path: String
+
+    public init(
+        path: String)
+    {
+        self.path = path
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+    }
+}
+
 public struct ConfigSchemaResponse: Codable, Sendable {
     public let schema: AnyCodable
     public let uihints: [String: AnyCodable]
@@ -1483,6 +1501,36 @@ public struct ConfigSchemaResponse: Codable, Sendable {
         case uihints = "uiHints"
         case version
         case generatedat = "generatedAt"
+    }
+}
+
+public struct ConfigSchemaLookupResult: Codable, Sendable {
+    public let path: String
+    public let schema: AnyCodable
+    public let hint: [String: AnyCodable]?
+    public let hintpath: String?
+    public let children: [[String: AnyCodable]]
+
+    public init(
+        path: String,
+        schema: AnyCodable,
+        hint: [String: AnyCodable]?,
+        hintpath: String?,
+        children: [[String: AnyCodable]])
+    {
+        self.path = path
+        self.schema = schema
+        self.hint = hint
+        self.hintpath = hintpath
+        self.children = children
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+        case schema
+        case hint
+        case hintpath = "hintPath"
+        case children
     }
 }
 

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -30,9 +30,22 @@ const ZAI_GLM5_TEMPLATE_MODEL_IDS = ["glm-4.7"] as const;
 // google-gemini-cli catalog. Clone the gemini-3-pro/flash-preview template so users
 // don't get "Unknown model" errors when Google releases a new minor version.
 const GEMINI_3_1_PRO_PREFIX = "gemini-3.1-pro";
+// gemini-3.1-flash-lite must be checked before gemini-3.1-flash to avoid prefix collision.
+const GEMINI_3_1_FLASH_LITE_PREFIX = "gemini-3.1-flash-lite";
 const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";
+// gemini-3-flash-lite-preview is not yet in pi-ai's catalog.
+const GEMINI_3_FLASH_LITE_PREVIEW_ID = "gemini-3-flash-lite-preview";
 const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3-pro-preview"] as const;
 const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview"] as const;
+// Clone from gemini-3-flash-preview since gemini-3-flash-lite-preview is not in pi-ai's catalog.
+const GEMINI_3_FLASH_LITE_TEMPLATE_IDS = ["gemini-3-flash-preview"] as const;
+const GEMINI_3_1_FLASH_LITE_TEMPLATE_IDS = [
+  "gemini-3-flash-lite-preview",
+  "gemini-3-flash-preview",
+] as const;
+
+// Google providers that host Gemini models via the google-generative-ai API.
+const GOOGLE_GENERATIVE_AI_PROVIDERS = new Set(["google", "google-antigravity", "atproxy"]);
 
 function resolveOpenAIGpt54ForwardCompatModel(
   provider: string,
@@ -258,6 +271,9 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
   let templateIds: readonly string[];
   if (lower.startsWith(GEMINI_3_1_PRO_PREFIX)) {
     templateIds = GEMINI_3_1_PRO_TEMPLATE_IDS;
+  } else if (lower.startsWith(GEMINI_3_1_FLASH_LITE_PREFIX)) {
+    // Check flash-lite before flash to avoid the shorter prefix matching first.
+    templateIds = GEMINI_3_1_FLASH_LITE_TEMPLATE_IDS;
   } else if (lower.startsWith(GEMINI_3_1_FLASH_PREFIX)) {
     templateIds = GEMINI_3_1_FLASH_TEMPLATE_IDS;
   } else {
@@ -271,6 +287,60 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
     modelRegistry,
     patch: { reasoning: true },
   });
+}
+
+// gemini-3-flash-lite-preview and gemini-3.1-flash-lite-preview are not in pi-ai's built-in
+// google / google-antigravity catalog. Clone the nearest gemini-3-flash template so users
+// don't get "Unknown model" errors when configuring Gemini Flash Lite models via the
+// google-generative-ai API.
+function resolveGoogleFlashLiteForwardCompatModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (!GOOGLE_GENERATIVE_AI_PROVIDERS.has(normalizedProvider)) {
+    return undefined;
+  }
+  const trimmed = modelId.trim();
+  const lower = trimmed.toLowerCase();
+
+  let templateIds: readonly string[];
+  if (lower === GEMINI_3_FLASH_LITE_PREVIEW_ID) {
+    templateIds = GEMINI_3_FLASH_LITE_TEMPLATE_IDS;
+  } else if (lower.startsWith(GEMINI_3_1_FLASH_LITE_PREFIX)) {
+    templateIds = GEMINI_3_1_FLASH_LITE_TEMPLATE_IDS;
+  } else if (lower.startsWith(GEMINI_3_1_PRO_PREFIX)) {
+    templateIds = GEMINI_3_1_PRO_TEMPLATE_IDS;
+  } else if (lower.startsWith(GEMINI_3_1_FLASH_PREFIX)) {
+    templateIds = GEMINI_3_1_FLASH_TEMPLATE_IDS;
+  } else {
+    return undefined;
+  }
+
+  const result = cloneFirstTemplateModel({
+    normalizedProvider,
+    trimmedModelId: trimmed,
+    templateIds: [...templateIds],
+    modelRegistry,
+    patch: { reasoning: true, api: "google-generative-ai" as Api },
+  });
+  if (result) {
+    return result;
+  }
+
+  // Fallback: synthesize a minimal model definition so routing succeeds.
+  return normalizeModelCompat({
+    id: trimmed,
+    name: trimmed,
+    api: "google-generative-ai" as Api,
+    provider: normalizedProvider,
+    reasoning: true,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_CONTEXT_TOKENS,
+    maxTokens: DEFAULT_CONTEXT_TOKENS,
+  } as Model<Api>);
 }
 
 // Z.ai's GLM-5 may not be present in pi-ai's built-in model catalog yet.
@@ -326,6 +396,7 @@ export function resolveForwardCompatModel(
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveZaiGlm5ForwardCompatModel(provider, modelId, modelRegistry) ??
+    resolveGoogleFlashLiteForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveGoogleGeminiCli31ForwardCompatModel(provider, modelId, modelRegistry)
   );
 }

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -444,6 +444,9 @@ export function normalizeGoogleModelId(id: string): string {
   if (id === "gemini-3-flash") {
     return "gemini-3-flash-preview";
   }
+  if (id === "gemini-3-flash-lite") {
+    return "gemini-3-flash-lite-preview";
+  }
   return id;
 }
 

--- a/src/gateway/protocol/schema/snapshot.ts
+++ b/src/gateway/protocol/schema/snapshot.ts
@@ -67,6 +67,12 @@ export const SnapshotSchema = Type.Object(
         channel: NonEmptyString,
       }),
     ),
+    versionMismatch: Type.Optional(
+      Type.Object({
+        runningVersion: NonEmptyString,
+        installedVersion: NonEmptyString,
+      }),
+    ),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -5,6 +5,7 @@ import { resolveMainSessionKey } from "../../config/sessions.js";
 import { listSystemPresence } from "../../infra/system-presence.js";
 import { getUpdateAvailable } from "../../infra/update-startup.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
+import { VERSION, readVersionFromPackageJsonForModuleUrl } from "../../version.js";
 import { resolveGatewayAuth } from "../auth.js";
 import type { Snapshot } from "../protocol/index.js";
 
@@ -24,6 +25,21 @@ export function buildGatewaySnapshot(): Snapshot {
   const uptimeMs = Math.round(process.uptime() * 1000);
   const auth = resolveGatewayAuth({ authConfig: cfg.gateway?.auth, env: process.env });
   const updateAvailable = getUpdateAvailable() ?? undefined;
+  // Detect version mismatch: compare the compiled-in VERSION against the
+  // package.json version currently on disk. If they differ, the package was
+  // updated after the gateway started and a restart is needed to pick up the
+  // new version.
+  let versionMismatch: { runningVersion: string; installedVersion: string } | undefined;
+  const installedVersion = readVersionFromPackageJsonForModuleUrl(import.meta.url);
+  if (
+    installedVersion &&
+    installedVersion !== "0.0.0" &&
+    VERSION &&
+    VERSION !== "0.0.0" &&
+    installedVersion !== VERSION
+  ) {
+    versionMismatch = { runningVersion: VERSION, installedVersion };
+  }
   // Health is async; caller should await getHealthSnapshot and replace later if needed.
   const emptyHealth: unknown = {};
   return {
@@ -42,6 +58,7 @@ export function buildGatewaySnapshot(): Snapshot {
     },
     authMode: auth.mode,
     updateAvailable,
+    versionMismatch,
   };
 }
 


### PR DESCRIPTION
Fixes #36301

After npm update -g openclaw, the gateway service still runs the old version but the UI showed no indication. Added versionMismatch field to the snapshot schema: the health state now compares the compiled VERSION against the on-disk package.json version and surfaces the mismatch in the gateway snapshot so the UI can display a restart prompt.