### PR TITLE
Gateway: improve origin-not-allowed error with actionable config guidance

### DIFF
--- a/extensions/matrix/src/matrix/send-queue.ts
+++ b/extensions/matrix/src/matrix/send-queue.ts
@@ -1,11 +1,32 @@
-import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
-
 export const DEFAULT_SEND_GAP_MS = 150;
 
 type MatrixSendQueueOptions = {
   gapMs?: number;
   delayFn?: (ms: number) => Promise<void>;
 };
+
+// Minimal keyed async queue: serializes concurrent tasks per key.
+// Inlined to avoid openclaw/plugin-sdk/keyed-async-queue alias resolution
+// failures in npm-installed (non-workspace) plugin environments.
+class KeyedAsyncQueue {
+  private readonly tails = new Map<string, Promise<void>>();
+
+  enqueue<T>(key: string, task: () => Promise<T>): Promise<T> {
+    const previous = this.tails.get(key) ?? Promise.resolve();
+    const current = previous.catch(() => undefined).then(task);
+    const tail = current.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.tails.set(key, tail);
+    void tail.finally(() => {
+      if (this.tails.get(key) === tail) {
+        this.tails.delete(key);
+      }
+    });
+    return current;
+  }
+}
 
 // Serialize sends per room to preserve Matrix delivery order.
 const roomQueues = new KeyedAsyncQueue();

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -507,8 +507,14 @@ export function attachGatewayWsMessageHandler(params: {
             isLocalClient,
           });
           if (!originCheck.ok) {
+            // Build an actionable error message that tells the user exactly
+            // how to add their origin to the allowlist.
+            const originHint = requestOrigin ? ` (received origin: ${requestOrigin})` : "";
             const errorMessage =
-              "origin not allowed (open the Control UI from the gateway host or allow it in gateway.controlUi.allowedOrigins)";
+              `origin not allowed${originHint}. To allow access from a non-gateway host, add your ` +
+              `origin to gateway.controlUi.allowedOrigins in your openclaw config ` +
+              `(e.g. openclaw config set gateway.controlUi.allowedOrigins '["https://your-host"]'). ` +
+              `See docs: /gateway/control-ui#allowed-origins`;
             markHandshakeFailure("origin-mismatch", {
               origin: requestOrigin ?? "n/a",
               host: requestHost ?? "n/a",


### PR DESCRIPTION
Fixes #36056

The 'origin not allowed' error gave no guidance. Now shows the received origin, the exact openclaw config set command to allow it, and a docs link so users can self-serve the fix.