### PR TITLE
[Issue #37452] feat(ui): Dashboard 消息来源标识

### DIFF
--- a/.github/issue-bootstrap/issue-37452.md
+++ b/.github/issue-bootstrap/issue-37452.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37452
+- Title: feat(ui): Dashboard 消息来源标识
+- Source: https://github.com/openclaw/openclaw/issues/37452


### PR DESCRIPTION
## Source Issue
- Number: #37452
- URL: https://github.com/openclaw/openclaw/issues/37452
- Title: feat(ui): Dashboard 消息来源标识

## Original Issue Description
Issue requests dashboard chat UI changes to show message-source labels (Feishu vs Dashboard), add channel labels for Feishu, and visually distinguish message origins. It references `ui/src/ui/chat/grouped-render.ts`, `ui/src/ui/views/chat.ts`, and `ui/src/ui/app-render.helpers.ts`, with acceptance criteria for source tag display.

Closes #37452