### PR TITLE
[Issue #37457] [Bug]: Auto-created agent dirs ignore OPENCLAW_STATE_DIR, fallback to ~/.openclaw/agents/

### DIFF
--- a/.github/issue-bootstrap/issue-37457.md
+++ b/.github/issue-bootstrap/issue-37457.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37457
+- Title: [Bug]: Auto-created agent dirs ignore OPENCLAW_STATE_DIR, fallback to ~/.openclaw/agents/
+- Source: https://github.com/openclaw/openclaw/issues/37457


### PR DESCRIPTION
## Source Issue
- Number: #37457
- URL: https://github.com/openclaw/openclaw/issues/37457
- Title: [Bug]: Auto-created agent dirs ignore OPENCLAW_STATE_DIR, fallback to ~/.openclaw/agents/

## Original Issue Description
Issue reports that the auto-created internal `main` agent ignores `OPENCLAW_STATE_DIR` and writes to `~/.openclaw/agents/main/agent/` instead of `$OPENCLAW_STATE_DIR/agents/main/agent/`. It also notes `models.json` in that fallback path may contain resolved plaintext API keys, creating additional security risk.

Closes #37457