### PR TITLE
[Issue #37463] [Feature]: we need dashscope provider support when onboarding

### DIFF
--- a/.github/issue-bootstrap/issue-37463.md
+++ b/.github/issue-bootstrap/issue-37463.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37463
+- Title: [Feature]: we need dashscope provider support when onboarding
+- Source: https://github.com/openclaw/openclaw/issues/37463


### PR DESCRIPTION
## Source Issue
- Number: #37463
- URL: https://github.com/openclaw/openclaw/issues/37463
- Title: [Feature]: we need dashscope provider support when onboarding

## Original Issue Description
Issue requests easier onboarding for DashScope model users, citing friction from current Agent/Provider/Model setup complexity. Reporter indicates a prepared PR for DashScope API support and describes onboarding pain as a frequent blocker for new users.

Closes #37463