### PR TITLE
fix(feishu): add early event-level dedup to prevent duplicate message processing

### DIFF
--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -1,6 +1,7 @@
 import * as crypto from "crypto";
 import * as Lark from "@larksuiteoapi/node-sdk";
 import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "openclaw/plugin-sdk/feishu";
+import { createDedupeCache } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { raceWithTimeoutAndAbort } from "./async.js";
 import {
@@ -376,10 +377,24 @@ function registerEventHandlers(
     },
   });
 
+  // Early event-level dedup to drop duplicate webhook retries and WebSocket replays
+  // before they enter the debouncer or processing pipeline.  The downstream dedup in
+  // handleFeishuMessage guards against restarts (persistent), but cannot prevent two
+  // concurrent dispatches of the same event from both being enqueued.
+  const eventDedup = createDedupeCache({ ttlMs: 5 * 60 * 1000, maxSize: 2_000 });
+
   eventDispatcher.register({
     "im.message.receive_v1": async (data) => {
+      const event = data as unknown as FeishuMessageEvent;
+      const messageId = event.message?.message_id?.trim();
+      if (messageId) {
+        const eventKey = `${accountId}:evt:${messageId}`;
+        if (!eventDedup.check(eventKey)) {
+          log(`feishu[${accountId}]: dropping duplicate event for message ${messageId}`);
+          return;
+        }
+      }
       const processMessage = async () => {
-        const event = data as unknown as FeishuMessageEvent;
         await inboundDebouncer.enqueue(event);
       };
       if (fireAndForget) {


### PR DESCRIPTION
## Problem

Fixes #37477

Feishu webhook retries and WebSocket reconnect replays can deliver the same `im.message.receive_v1` event multiple times. The existing `messageId` dedup in `handleFeishuMessage` (bot.ts) runs downstream after the inbound debouncer, so two concurrent dispatches of the same event can both enter the pipeline before either records the `messageId` — causing duplicate replies.

## Fix

Add a synchronous in-memory dedup check at the `EventDispatcher` handler level (monitor.account.ts) using `message_id` as key with a 5-minute TTL and 2000-entry cap. This catches duplicates immediately when they arrive from the Lark SDK, before they enter the inbound debouncer or processing queue.

The dedup cache uses the same `createDedupeCache` utility already used by the persistent dedup module, keeping the implementation consistent.

The downstream persistent dedup in `bot.ts` is intentionally preserved — it guards against cross-restart duplicate processing which the in-memory cache cannot cover.

## Changes

- **`monitor.account.ts`**: Import `createDedupeCache` from `openclaw/plugin-sdk/feishu`. Create a per-account event dedup cache before registering event handlers. In the `im.message.receive_v1` handler, check `message_id` against the cache before passing to the debouncer.

## Test plan

- [ ] Send a message to Feishu bot in DM — should receive exactly one reply
- [ ] Simulate webhook retry by sending the same event payload twice — second should be logged as duplicate and dropped
- [ ] Verify existing behavior: messages from different users/chats still process normally
- [ ] Verify persistent dedup still works across gateway restarts
- [ ] Run `pnpm test -- extensions/feishu` — existing tests should pass