### PR TITLE
[Issue #37466] [Bug]: Unable to load exec tool

### DIFF
--- a/.github/issue-bootstrap/issue-37466.md
+++ b/.github/issue-bootstrap/issue-37466.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37466
+- Title: [Bug]: Unable to load exec tool
+- Source: https://github.com/openclaw/openclaw/issues/37466


### PR DESCRIPTION
## Source Issue
- Number: #37466
- URL: https://github.com/openclaw/openclaw/issues/37466
- Title: [Bug]: Unable to load exec tool

## Original Issue Description
Issue reports that despite configuring `tools.exec` in `.openclaw/openclaw.json`, the runtime exposes only messaging/session tools and does not expose `exec`. Reporter includes config snippet, reproduction prompt, expected behavior, and actual tool list.

Closes #37466