### PR TITLE
[Issue #37494] [Bug]: MAC install issue SHARP_IGNOR_GLOBAL_LIBVIPS=1

### DIFF
--- a/.github/issue-bootstrap/issue-37494.md
+++ b/.github/issue-bootstrap/issue-37494.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37494
+- Title: [Bug]: MAC install issue SHARP_IGNOR_GLOBAL_LIBVIPS=1
+- Source: https://github.com/openclaw/openclaw/issues/37494


### PR DESCRIPTION
## Source Issue
- Number: #37494
- URL: https://github.com/openclaw/openclaw/issues/37494
- Title: [Bug]: MAC install issue SHARP_IGNOR_GLOBAL_LIBVIPS=1

## Original Issue Description
Issue reports install failure on macOS with `SHARP_IGNOR_GLOBAL_LIBVIPS=1`-related errors and inability to proceed through installation despite attempted environment and sudo workarounds.

Closes #37494