### PR TITLE
[Issue #37497] delivery-recovery retries permanent failures indefinitely (message too long, reply target not found)

### DIFF
--- a/.github/issue-bootstrap/issue-37497.md
+++ b/.github/issue-bootstrap/issue-37497.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37497
+- Title: delivery-recovery retries permanent failures indefinitely (message too long, reply target not found)
+- Source: https://github.com/openclaw/openclaw/issues/37497


### PR DESCRIPTION
## Source Issue
- Number: #37497
- URL: https://github.com/openclaw/openclaw/issues/37497
- Title: delivery-recovery retries permanent failures indefinitely (message too long, reply target not found)

## Original Issue Description
Issue reports `delivery-recovery` retries permanently non-recoverable Telegram errors indefinitely (`message to be replied not found`, `message is too long`), across restarts. It requests classification of permanent vs transient failures so only retryable errors are retried.

Closes #37497