### PR TITLE
[Issue #37499] Context compaction causes conversation to freeze/hang

### DIFF
--- a/.github/issue-bootstrap/issue-37499.md
+++ b/.github/issue-bootstrap/issue-37499.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37499
+- Title: Context compaction causes conversation to freeze/hang
+- Source: https://github.com/openclaw/openclaw/issues/37499


### PR DESCRIPTION
## Source Issue
- Number: #37499
- URL: https://github.com/openclaw/openclaw/issues/37499
- Title: Context compaction causes conversation to freeze/hang

## Original Issue Description
Issue reports that after multiple context compaction cycles, conversation can freeze and the assistant stops responding. Reporter suspects compaction may lose critical state/history and requests reliability improvements for continuity after compaction.

Closes #37499