### PR TITLE
[Issue #37500] [Control UI] Chat auto-scroll overrides user scroll during streaming

### DIFF
--- a/.github/issue-bootstrap/issue-37500.md
+++ b/.github/issue-bootstrap/issue-37500.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37500
+- Title: [Control UI] Chat auto-scroll overrides user scroll during streaming
+- Source: https://github.com/openclaw/openclaw/issues/37500


### PR DESCRIPTION
## Source Issue
- Number: #37500
- URL: https://github.com/openclaw/openclaw/issues/37500
- Title: [Control UI] Chat auto-scroll overrides user scroll during streaming

## Original Issue Description
Issue reports Control UI chat keeps auto-scrolling to bottom during streaming and prevents users from reviewing older messages. It suggests pausing auto-scroll on manual upward scroll, reducing near-bottom threshold, and preventing content-growth-triggered forced scrolling.

Closes #37500