### PR TITLE
[Issue #37508] [Bug]: WebUI Tool Result ID Not Found

### DIFF
--- a/.github/issue-bootstrap/issue-37508.md
+++ b/.github/issue-bootstrap/issue-37508.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37508
+- Title: [Bug]: WebUI Tool Result ID Not Found
+- Source: https://github.com/openclaw/openclaw/issues/37508


### PR DESCRIPTION
## Source Issue
- Number: #37508
- URL: https://github.com/openclaw/openclaw/issues/37508
- Title: [Bug]: WebUI Tool Result ID Not Found

## Original Issue Description
Issue reports WebUI command execution succeeds but tool result return fails due to tool ID mismatch (`tool result's tool id ... not found (2013)`), causing indefinite UI spinning. Reporter suspects session-state/concurrency handling in tool-call result mapping.

Closes #37508