### PR TITLE
feat(agents): add maxSteps recursion_limit to prevent infinite agent loops

### DIFF
--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -105,7 +105,13 @@ export async function runBeforeToolCallHook(args: {
       sessionId: args.ctx?.agentId,
     });
 
-    const loopResult = detectToolCallLoop(sessionState, toolName, params, args.ctx.loopDetection);
+    const loopResult = detectToolCallLoop(
+      sessionState,
+      toolName,
+      params,
+      args.ctx.loopDetection,
+      args.ctx.runId,
+    );
 
     if (loopResult.stuck) {
       if (loopResult.level === "critical") {
@@ -144,7 +150,14 @@ export async function runBeforeToolCallHook(args: {
       }
     }
 
-    recordToolCall(sessionState, toolName, params, args.toolCallId, args.ctx.loopDetection);
+    recordToolCall(
+      sessionState,
+      toolName,
+      params,
+      args.toolCallId,
+      args.ctx.loopDetection,
+      args.ctx.runId,
+    );
   }
 
   const hookRunner = getGlobalHookRunner();

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -591,4 +591,89 @@ describe("tool-loop-detection", () => {
       expect(stats.mostFrequent?.count).toBe(7);
     });
   });
+
+  describe("maxSteps (recursion_limit)", () => {
+    it("does not block when maxSteps is not configured", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = { enabled: false };
+      const runId = "run-abc";
+      // Record many tool calls without setting maxSteps
+      for (let i = 0; i < 50; i += 1) {
+        recordToolCall(state, "read", { path: `/file-${i}.txt` }, `tc-${i}`, config, runId);
+      }
+      const result = detectToolCallLoop(state, "read", { path: "/file-50.txt" }, config, runId);
+      expect(result.stuck).toBe(false);
+    });
+
+    it("blocks when maxSteps limit is reached", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = { enabled: false, maxSteps: 3 };
+      const runId = "run-limit";
+      // Record exactly maxSteps calls
+      for (let i = 0; i < 3; i += 1) {
+        recordToolCall(state, "read", { path: `/file-${i}.txt` }, `tc-${i}`, config, runId);
+      }
+      // The 4th call should be blocked
+      const result = detectToolCallLoop(state, "read", { path: "/file-3.txt" }, config, runId);
+      expect(result.stuck).toBe(true);
+      if (result.stuck) {
+        expect(result.level).toBe("critical");
+        expect(result.detector).toBe("global_circuit_breaker");
+        expect(result.count).toBe(3);
+        expect(result.message).toMatch(/maxSteps limit/i);
+      }
+    });
+
+    it("does not block below maxSteps limit", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = { enabled: false, maxSteps: 5 };
+      const runId = "run-below";
+      // Record 4 calls (below limit of 5)
+      for (let i = 0; i < 4; i += 1) {
+        recordToolCall(state, "read", { path: `/file-${i}.txt` }, `tc-${i}`, config, runId);
+      }
+      const result = detectToolCallLoop(state, "read", { path: "/file-4.txt" }, config, runId);
+      expect(result.stuck).toBe(false);
+    });
+
+    it("enforces maxSteps even when pattern-based detection is disabled", () => {
+      const state = createState();
+      // enabled=false disables pattern detection but maxSteps still works
+      const config: ToolLoopDetectionConfig = { enabled: false, maxSteps: 2 };
+      const runId = "run-disabled";
+      for (let i = 0; i < 2; i += 1) {
+        recordToolCall(state, "unique", { id: i }, `tc-${i}`, config, runId);
+      }
+      const result = detectToolCallLoop(state, "unique", { id: 2 }, config, runId);
+      expect(result.stuck).toBe(true);
+      if (result.stuck) {
+        expect(result.level).toBe("critical");
+      }
+    });
+
+    it("tracks steps independently per runId", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = { enabled: false, maxSteps: 2 };
+      const runId1 = "run-one";
+      const runId2 = "run-two";
+      // Fill up run-one
+      for (let i = 0; i < 2; i += 1) {
+        recordToolCall(state, "read", { path: `/f${i}` }, `tc${i}`, config, runId1);
+      }
+      // run-one is blocked
+      const result1 = detectToolCallLoop(state, "read", { path: "/f3" }, config, runId1);
+      expect(result1.stuck).toBe(true);
+      // run-two is independent and not blocked
+      const result2 = detectToolCallLoop(state, "read", { path: "/f3" }, config, runId2);
+      expect(result2.stuck).toBe(false);
+    });
+
+    it("ignores maxSteps when runId is not provided", () => {
+      const state = createState();
+      const config: ToolLoopDetectionConfig = { enabled: false, maxSteps: 1 };
+      // No runId — maxSteps cannot be enforced without a run identifier
+      const result = detectToolCallLoop(state, "read", { path: "/file.txt" }, config, undefined);
+      expect(result.stuck).toBe(false);
+    });
+  });
 });

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -34,6 +34,7 @@ const DEFAULT_LOOP_DETECTION_CONFIG = {
   warningThreshold: WARNING_THRESHOLD,
   criticalThreshold: CRITICAL_THRESHOLD,
   globalCircuitBreakerThreshold: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+  maxSteps: 0,
   detectors: {
     genericRepeat: true,
     knownPollNoProgress: true,
@@ -47,6 +48,8 @@ type ResolvedLoopDetectionConfig = {
   warningThreshold: number;
   criticalThreshold: number;
   globalCircuitBreakerThreshold: number;
+  /** Hard cap on total tool calls per run. 0 = disabled. */
+  maxSteps: number;
   detectors: {
     genericRepeat: boolean;
     knownPollNoProgress: boolean;
@@ -74,6 +77,11 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
     config?.globalCircuitBreakerThreshold,
     DEFAULT_LOOP_DETECTION_CONFIG.globalCircuitBreakerThreshold,
   );
+  // maxSteps: 0 or undefined means disabled; any positive integer enables the hard cap.
+  const maxSteps =
+    typeof config?.maxSteps === "number" && Number.isInteger(config.maxSteps) && config.maxSteps > 0
+      ? config.maxSteps
+      : DEFAULT_LOOP_DETECTION_CONFIG.maxSteps;
 
   if (criticalThreshold <= warningThreshold) {
     criticalThreshold = warningThreshold + 1;
@@ -88,6 +96,7 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
     warningThreshold,
     criticalThreshold,
     globalCircuitBreakerThreshold,
+    maxSteps,
     detectors: {
       genericRepeat:
         config?.detectors?.genericRepeat ?? DEFAULT_LOOP_DETECTION_CONFIG.detectors.genericRepeat,
@@ -368,14 +377,34 @@ function canonicalPairKey(signatureA: string, signatureB: string): string {
 /**
  * Detect if an agent is stuck in a repetitive tool call loop.
  * Checks if the same tool+params combination has been called excessively.
+ * Also enforces the maxSteps hard cap (recursion_limit) when configured. (#37022)
  */
 export function detectToolCallLoop(
   state: SessionState,
   toolName: string,
   params: unknown,
   config?: ToolLoopDetectionConfig,
+  runId?: string,
 ): LoopDetectionResult {
   const resolvedConfig = resolveLoopDetectionConfig(config);
+  // maxSteps is enforced independently of `enabled` so it works even when
+  // pattern-based loop detection is disabled.
+  if (resolvedConfig.maxSteps > 0 && runId) {
+    const stepCount = state.runToolCallCounts?.get(runId) ?? 0;
+    if (stepCount >= resolvedConfig.maxSteps) {
+      log.error(
+        `maxSteps limit reached: runId=${runId} stepCount=${stepCount} maxSteps=${resolvedConfig.maxSteps}`,
+      );
+      return {
+        stuck: true,
+        level: "critical",
+        detector: "global_circuit_breaker",
+        count: stepCount,
+        message: `CRITICAL: Agent has exceeded the configured maxSteps limit of ${resolvedConfig.maxSteps} tool calls. Execution blocked to prevent infinite loops (recursion_limit). Use tools.loopDetection.maxSteps to adjust this limit.`,
+        warningKey: `maxsteps:${runId}`,
+      };
+    }
+  }
   if (!resolvedConfig.enabled) {
     return { stuck: false };
   }
@@ -496,7 +525,7 @@ export function detectToolCallLoop(
 
 /**
  * Record a tool call in the session's history for loop detection.
- * Maintains sliding window of last N calls.
+ * Maintains sliding window of last N calls and increments per-run step counter. (#37022)
  */
 export function recordToolCall(
   state: SessionState,
@@ -504,6 +533,7 @@ export function recordToolCall(
   params: unknown,
   toolCallId?: string,
   config?: ToolLoopDetectionConfig,
+  runId?: string,
 ): void {
   const resolvedConfig = resolveLoopDetectionConfig(config);
   if (!state.toolCallHistory) {
@@ -519,6 +549,21 @@ export function recordToolCall(
 
   if (state.toolCallHistory.length > resolvedConfig.historySize) {
     state.toolCallHistory.shift();
+  }
+
+  // Increment per-run step counter used by maxSteps enforcement.
+  if (runId) {
+    if (!state.runToolCallCounts) {
+      state.runToolCallCounts = new Map();
+    }
+    state.runToolCallCounts.set(runId, (state.runToolCallCounts.get(runId) ?? 0) + 1);
+    // Prune stale run entries to avoid unbounded growth (keep last 64 runs).
+    if (state.runToolCallCounts.size > 64) {
+      const oldestKey = state.runToolCallCounts.keys().next().value;
+      if (oldestKey) {
+        state.runToolCallCounts.delete(oldestKey);
+      }
+    }
   }
 }
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -521,6 +521,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Critical threshold for repetitive patterns when detector is enabled (default: 20).",
   "tools.loopDetection.globalCircuitBreakerThreshold":
     "Global no-progress breaker threshold (default: 30).",
+  "tools.loopDetection.maxSteps":
+    "Hard cap on total tool calls per agent run (recursion_limit). When an agent exceeds this many tool calls the run is blocked regardless of pattern. 0 = disabled (default). Equivalent to LangGraph recursion_limit.",
   "tools.loopDetection.detectors.genericRepeat":
     "Enable generic repeated same-tool/same-params loop detection (default: true).",
   "tools.loopDetection.detectors.knownPollNoProgress":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -167,6 +167,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.loopDetection.warningThreshold": "Tool-loop Warning Threshold",
   "tools.loopDetection.criticalThreshold": "Tool-loop Critical Threshold",
   "tools.loopDetection.globalCircuitBreakerThreshold": "Tool-loop Global Circuit Breaker Threshold",
+  "tools.loopDetection.maxSteps": "Max Steps (Recursion Limit)",
   "tools.loopDetection.detectors.genericRepeat": "Tool-loop Generic Repeat Detection",
   "tools.loopDetection.detectors.knownPollNoProgress": "Tool-loop Poll No-Progress Detection",
   "tools.loopDetection.detectors.pingPong": "Tool-loop Ping-Pong Detection",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -161,6 +161,13 @@ export type ToolLoopDetectionConfig = {
   criticalThreshold?: number;
   /** Global no-progress breaker threshold (default: 30). */
   globalCircuitBreakerThreshold?: number;
+  /**
+   * Hard cap on total tool calls per agent run (recursion_limit / max_steps).
+   * When the agent exceeds this many tool calls in a single session run, further
+   * tool execution is blocked regardless of pattern. Set to 0 or omit to disable.
+   * Equivalent to LangGraph's recursion_limit. (#37022)
+   */
+  maxSteps?: number;
   /** Detector toggles. */
   detectors?: ToolLoopDetectionDetectorConfig;
 };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -444,6 +444,7 @@ const ToolLoopDetectionSchema = z
     warningThreshold: z.number().int().positive().optional(),
     criticalThreshold: z.number().int().positive().optional(),
     globalCircuitBreakerThreshold: z.number().int().positive().optional(),
+    maxSteps: z.number().int().nonnegative().optional(),
     detectors: ToolLoopDetectionDetectorSchema,
   })
   .strict()

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -9,6 +9,8 @@ export type SessionState = {
   toolCallHistory?: ToolCallRecord[];
   toolLoopWarningBuckets?: Map<string, number>;
   commandPollCounts?: Map<string, { count: number; lastPollAt: number }>;
+  /** Per-run total tool call counts for maxSteps enforcement. Keys are runIds. (#37022) */
+  runToolCallCounts?: Map<string, number>;
 };
 
 export type ToolCallRecord = {


### PR DESCRIPTION
Fixes #37022

## Summary

Adds a `tools.loopDetection.maxSteps` config option that sets a hard cap on the total number of tool calls an agent can make in a single run — the equivalent of LangGraph's `recursion_limit` parameter.

- When an agent exceeds `maxSteps` tool calls, further execution is blocked with a `critical`-level error regardless of call patterns
- Enforced independently of `enabled`, so it works without turning on the full pattern-based loop detector
- Per-run step counts are tracked in `SessionState.runToolCallCounts` keyed by `runId`, keeping independent limits for concurrent agent runs
- 0 or omitted = disabled (default), no change to existing behavior

## Configuration

```yaml
tools:
  loopDetection:
    maxSteps: 50  # block after 50 tool calls per run
```

Or per-agent:
```yaml
agents:
  list:
    - id: my-agent
      tools:
        loopDetection:
          maxSteps: 20
```

## Test plan

- [ ] `tool-loop-detection.test.ts` — 6 new maxSteps tests pass (blocks at limit, per-run isolation, disabled when no runId)
- [ ] All 35 loop-detection tests pass