### PR TITLE
fix(agents): flush pending tool results on gateway restart (#30082)

### DIFF
--- a/src/agents/session-tool-result-guard-wrapper.flush-registry.test.ts
+++ b/src/agents/session-tool-result-guard-wrapper.flush-registry.test.ts
@@ -1,0 +1,79 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  flushAllActiveSessionGuards,
+  guardSessionManager,
+} from "./session-tool-result-guard-wrapper.js";
+
+function assistantToolCall(id: string): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "toolCall", id, name: "n", arguments: {} }],
+  } as AgentMessage;
+}
+
+function getMessages(sm: SessionManager): AgentMessage[] {
+  return sm
+    .getEntries()
+    .filter((e) => e.type === "message")
+    .map((e) => (e as { message: AgentMessage }).message);
+}
+
+describe("flushAllActiveSessionGuards", () => {
+  afterEach(() => {
+    // Clean up any remaining registry state between tests.
+    flushAllActiveSessionGuards();
+  });
+
+  it("flushes pending tool results for all active guarded sessions on gateway restart", () => {
+    // Simulate two in-flight sessions with open tool calls (e.g. gateway restart mid-turn).
+    const sm1 = guardSessionManager(SessionManager.inMemory());
+    const sm2 = guardSessionManager(SessionManager.inMemory());
+    const append1 = sm1.appendMessage.bind(sm1) as unknown as (msg: AgentMessage) => void;
+    const append2 = sm2.appendMessage.bind(sm2) as unknown as (msg: AgentMessage) => void;
+
+    // Each session has an outstanding tool call with no matching result yet.
+    append1(assistantToolCall("call_a"));
+    append2(assistantToolCall("call_b"));
+
+    // Before flush: no synthetic tool results.
+    expect(getMessages(sm1).map((m) => m.role)).toEqual(["assistant"]);
+    expect(getMessages(sm2).map((m) => m.role)).toEqual(["assistant"]);
+
+    // Simulate gateway restart — flush all pending tool results globally.
+    flushAllActiveSessionGuards();
+
+    // After flush: each session gets a synthetic toolResult closing the orphaned call.
+    const msgs1 = getMessages(sm1);
+    const msgs2 = getMessages(sm2);
+    expect(msgs1.map((m) => m.role)).toEqual(["assistant", "toolResult"]);
+    expect(msgs2.map((m) => m.role)).toEqual(["assistant", "toolResult"]);
+    expect((msgs1[1] as { toolCallId?: string }).toolCallId).toBe("call_a");
+    expect((msgs2[1] as { toolCallId?: string }).toolCallId).toBe("call_b");
+  });
+
+  it("deregisters from global registry when session flushPendingToolResults is called directly", () => {
+    const sm = guardSessionManager(SessionManager.inMemory());
+    const append = sm.appendMessage.bind(sm) as unknown as (msg: AgentMessage) => void;
+    append(assistantToolCall("call_c"));
+
+    // Normal teardown path: flush via the session manager directly.
+    sm.flushPendingToolResults?.();
+
+    // Verify synthetic result was written.
+    const msgs = getMessages(sm);
+    expect(msgs.map((m) => m.role)).toEqual(["assistant", "toolResult"]);
+    expect((msgs[1] as { toolCallId?: string }).toolCallId).toBe("call_c");
+
+    // Subsequent global flush must not double-flush or throw.
+    expect(() => flushAllActiveSessionGuards()).not.toThrow();
+
+    // No additional messages appended by second flush.
+    expect(getMessages(sm).map((m) => m.role)).toEqual(["assistant", "toolResult"]);
+  });
+
+  it("is a no-op when no sessions are active", () => {
+    expect(() => flushAllActiveSessionGuards()).not.toThrow();
+  });
+});

--- a/src/agents/session-tool-result-guard-wrapper.flush-registry.test.ts
+++ b/src/agents/session-tool-result-guard-wrapper.flush-registry.test.ts
@@ -73,6 +73,23 @@ describe("flushAllActiveSessionGuards", () => {
     expect(getMessages(sm).map((m) => m.role)).toEqual(["assistant", "toolResult"]);
   });
 
+  it("deregisters from global registry when clearPendingToolResults is called (memory-leak fix)", () => {
+    const sm = guardSessionManager(SessionManager.inMemory());
+    const append = sm.appendMessage.bind(sm) as unknown as (msg: AgentMessage) => void;
+    append(assistantToolCall("call_d"));
+
+    // Discard path (session ends without persisting tool result).
+    sm.clearPendingToolResults?.();
+
+    // Global flush must not invoke an already-cleared session.
+    // If the registry leaked the closure, flushAllActiveSessionGuards would
+    // try to write a synthetic result into a discarded session.
+    const msgsBefore = getMessages(sm).length;
+    flushAllActiveSessionGuards();
+    // No new messages should appear — the session was already cleared.
+    expect(getMessages(sm).length).toBe(msgsBefore);
+  });
+
   it("is a no-op when no sessions are active", () => {
     expect(() => flushAllActiveSessionGuards()).not.toThrow();
   });

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -114,6 +114,18 @@ export function guardSessionManager(
   activeSessionGuardFlushes.add(wrappedFlush);
 
   (sessionManager as GuardedSessionManager).flushPendingToolResults = wrappedFlush;
-  (sessionManager as GuardedSessionManager).clearPendingToolResults = guard.clearPendingToolResults;
+
+  // Wrap clearPendingToolResults symmetrically so sessions that discard (instead
+  // of flush) also deregister from the global restart registry — prevents the
+  // set from accumulating closures indefinitely in long-running gateways.
+  const rawClear = guard.clearPendingToolResults;
+  (sessionManager as GuardedSessionManager).clearPendingToolResults = rawClear
+    ? () => {
+        activeSessionGuardFlushes.delete(wrappedFlush);
+        rawClear();
+      }
+    : () => {
+        activeSessionGuardFlushes.delete(wrappedFlush);
+      };
   return sessionManager as GuardedSessionManager;
 }

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -14,6 +14,38 @@ export type GuardedSessionManager = SessionManager & {
 };
 
 /**
+ * Module-level registry of pending-flush callbacks for all active guarded sessions.
+ *
+ * Each entry is the session-level flushPendingToolResults wrapper. The wrapper
+ * removes itself from this set when called directly (normal teardown path), so
+ * the set only ever holds sessions whose tool calls are still unresolved.
+ *
+ * flushAllActiveSessionGuards() drains this set during gateway restart.
+ */
+const activeSessionGuardFlushes = new Set<() => void>();
+
+/**
+ * Flush pending tool results for ALL currently active guarded sessions.
+ *
+ * Called by the gateway restart sequence (run-loop) after the drain phase,
+ * before server.close().  Prevents orphaned tool_use blocks in JSONL
+ * transcripts that would otherwise cause silent turns on the next startup.
+ *
+ * Safe to call at any time; idempotent per session.
+ */
+export function flushAllActiveSessionGuards(): void {
+  const flushes = Array.from(activeSessionGuardFlushes);
+  activeSessionGuardFlushes.clear();
+  for (const flush of flushes) {
+    try {
+      flush();
+    } catch {
+      // Best-effort: flush as many sessions as possible even if one throws.
+    }
+  }
+}
+
+/**
  * Apply the tool-result guard to a SessionManager exactly once and expose
  * a flush method on the instance for easy teardown handling.
  */
@@ -70,7 +102,18 @@ export function guardSessionManager(
     allowedToolNames: opts?.allowedToolNames,
     beforeMessageWriteHook: beforeMessageWrite,
   });
-  (sessionManager as GuardedSessionManager).flushPendingToolResults = guard.flushPendingToolResults;
+
+  // Wrap flushPendingToolResults to auto-deregister from the global restart
+  // registry when the session flushes via the normal teardown path.  This
+  // prevents the global flush from double-invoking an already-flushed session.
+  const rawFlush = guard.flushPendingToolResults;
+  const wrappedFlush = () => {
+    activeSessionGuardFlushes.delete(wrappedFlush);
+    rawFlush();
+  };
+  activeSessionGuardFlushes.add(wrappedFlush);
+
+  (sessionManager as GuardedSessionManager).flushPendingToolResults = wrappedFlush;
   (sessionManager as GuardedSessionManager).clearPendingToolResults = guard.clearPendingToolResults;
   return sessionManager as GuardedSessionManager;
 }

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,3 +1,4 @@
+import { flushAllActiveSessionGuards } from "../../agents/session-tool-result-guard-wrapper.js";
 import type { startGatewayServer } from "../../gateway/server.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
 import { restartGatewayProcessWithFreshPid } from "../../infra/process-respawn.js";
@@ -127,6 +128,11 @@ export async function runGatewayLoop(params: {
               gatewayLog.warn("drain timeout reached; proceeding with restart");
             }
           }
+          // Flush any tool calls still in-flight so the JSONL transcript does
+          // not contain orphaned tool_use blocks.  This prevents the next
+          // gateway boot from synthesising a result and delivering a silent
+          // turn with no assistant reply.
+          flushAllActiveSessionGuards();
         }
 
         await server?.close({

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -128,12 +128,14 @@ export async function runGatewayLoop(params: {
               gatewayLog.warn("drain timeout reached; proceeding with restart");
             }
           }
-          // Flush any tool calls still in-flight so the JSONL transcript does
-          // not contain orphaned tool_use blocks.  This prevents the next
-          // gateway boot from synthesising a result and delivering a silent
-          // turn with no assistant reply.
-          flushAllActiveSessionGuards();
         }
+
+        // Flush any tool calls still in-flight so the JSONL transcript does
+        // not contain orphaned tool_use blocks on the next boot.  Runs on both
+        // restart and SIGTERM stop — rolling-update deployments send SIGTERM
+        // before launching a new instance, so in-flight calls must be resolved
+        // in both paths.
+        flushAllActiveSessionGuards();
 
         await server?.close({
           reason: isRestart ? "gateway restarting" : "gateway stopping",


### PR DESCRIPTION
## Problem
When the gateway restarts mid-turn (SIGTERM or update restart), any in-flight tool calls tracked by `installSessionToolResultGuard` are lost because the in-memory `pendingState` is never flushed. The JSONL transcript ends up with orphaned `tool_use` blocks that have no matching `tool_result`. On the next boot, transcript repair synthesises results and marks the turn complete — but no assistant message is delivered, producing a silent turn.

## Root cause
`guardSessionManager()` in `src/agents/session-tool-result-guard-wrapper.ts` installs a `flushPendingToolResults` closure on each session manager, but there was no global registry to track active sessions. `run-loop.ts` had no way to enumerate and flush them before `server?.close()`.

## Fix
- Added `activeSessionGuardFlushes: Set<() => void>` in `session-tool-result-guard-wrapper.ts` — a module-level registry of every active session's flush callback.
- Exported `flushAllActiveSessionGuards()` which copies + clears the set, then calls each flush best-effort.
- Wrapped the per-session `flushPendingToolResults` to auto-deregister from the set on normal teardown (prevents double-flush).
- Called `flushAllActiveSessionGuards()` in `run-loop.ts` after the drain phase, immediately before `server?.close()`.

## Verification
- **Test:** `src/agents/session-tool-result-guard-wrapper.flush-registry.test.ts` — fails on main (`flushAllActiveSessionGuards` not exported), passes on fix (3/3 ✅)
- **Build:** clean compile (`build-output.log`)
- **Test suite:** no regressions (`test-output.log`, pre-existing failures match baseline)
- **Code proof:** old pattern removed, new pattern confirmed (`step6-verify.log`)

Closes #30082