### PR TITLE
fix(security): include Gemini, Grok, Kimi, and OpenRouter in web search key audit

### DIFF
--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { collectAttackSurfaceSummaryFindings } from "./audit-extra.sync.js";
+import { collectAttackSurfaceSummaryFindings, hasWebSearchKey } from "./audit-extra.sync.js";
 import { safeEqualSecret } from "./secret-equal.js";
 
 describe("collectAttackSurfaceSummaryFindings", () => {
@@ -31,6 +31,59 @@ describe("collectAttackSurfaceSummaryFindings", () => {
     const [finding] = collectAttackSurfaceSummaryFindings(cfg);
     expect(finding.detail).toContain("hooks.webhooks: disabled");
     expect(finding.detail).toContain("hooks.internal: disabled");
+  });
+});
+
+describe("hasWebSearchKey", () => {
+  const empty: NodeJS.ProcessEnv = {};
+
+  it("detects Brave API key in config", () => {
+    const cfg: OpenClawConfig = { tools: { web: { search: { apiKey: "brave-key" } } } };
+    expect(hasWebSearchKey(cfg, empty)).toBe(true);
+  });
+
+  it("detects Perplexity API key in config", () => {
+    const cfg: OpenClawConfig = {
+      tools: { web: { search: { perplexity: { apiKey: "pplx-key" } } } },
+    };
+    expect(hasWebSearchKey(cfg, empty)).toBe(true);
+  });
+
+  it("detects Gemini API key in config", () => {
+    const cfg: OpenClawConfig = {
+      tools: { web: { search: { gemini: { apiKey: "gemini-key" } } } },
+    };
+    expect(hasWebSearchKey(cfg, empty)).toBe(true);
+  });
+
+  it("detects Grok API key in config", () => {
+    const cfg: OpenClawConfig = {
+      tools: { web: { search: { grok: { apiKey: "grok-key" } } } },
+    };
+    expect(hasWebSearchKey(cfg, empty)).toBe(true);
+  });
+
+  it("detects Kimi API key in config", () => {
+    const cfg: OpenClawConfig = {
+      tools: { web: { search: { kimi: { apiKey: "kimi-key" } } } },
+    };
+    expect(hasWebSearchKey(cfg, empty)).toBe(true);
+  });
+
+  it.each([
+    ["BRAVE_API_KEY"],
+    ["PERPLEXITY_API_KEY"],
+    ["GEMINI_API_KEY"],
+    ["XAI_API_KEY"],
+    ["KIMI_API_KEY"],
+    ["MOONSHOT_API_KEY"],
+    ["OPENROUTER_API_KEY"],
+  ])("detects %s environment variable", (envVar) => {
+    expect(hasWebSearchKey({}, { [envVar]: "key-value" })).toBe(true);
+  });
+
+  it("returns false when no keys are configured", () => {
+    expect(hasWebSearchKey({}, empty)).toBe(false);
   });
 });
 

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -326,10 +326,21 @@ function resolveToolPolicies(params: {
   return policies;
 }
 
-function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
+export function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
   return Boolean(
-    search?.apiKey || search?.perplexity?.apiKey || env.BRAVE_API_KEY || env.PERPLEXITY_API_KEY,
+    search?.apiKey ||
+    search?.perplexity?.apiKey ||
+    search?.gemini?.apiKey ||
+    search?.grok?.apiKey ||
+    search?.kimi?.apiKey ||
+    env.BRAVE_API_KEY ||
+    env.PERPLEXITY_API_KEY ||
+    env.GEMINI_API_KEY ||
+    env.XAI_API_KEY ||
+    env.KIMI_API_KEY ||
+    env.MOONSHOT_API_KEY ||
+    env.OPENROUTER_API_KEY,
   );
 }
 


### PR DESCRIPTION
## Summary

Extends `hasWebSearchKey` to cover all supported web search providers (Gemini, Grok/xAI, Kimi/Moonshot, OpenRouter) and their environment variable fallbacks, fixing under-reported web search exposure in security audits.

## Problem

The `hasWebSearchKey` function in `audit-extra.sync.ts` only checked Brave (`search.apiKey`, `BRAVE_API_KEY`) and Perplexity (`search.perplexity.apiKey`, `PERPLEXITY_API_KEY`) providers. Users who configured web search via Gemini, Grok, Kimi, or OpenRouter would not trigger web-search-related security findings (e.g. `models.small_params` web tool exposure), causing the audit to under-report attack surface.

## Changes

| File | Change |
|------|--------|
| `src/security/audit-extra.sync.ts` | Added `search.gemini.apiKey`, `search.grok.apiKey`, `search.kimi.apiKey` config checks and `GEMINI_API_KEY`, `XAI_API_KEY`, `KIMI_API_KEY`, `MOONSHOT_API_KEY`, `OPENROUTER_API_KEY` env var checks to `hasWebSearchKey`; exported the function for direct testing |
| `src/security/audit-extra.sync.test.ts` | Added 12 test cases covering all config-based and env-var-based key detection paths |

## How it works

`hasWebSearchKey` is called by `isWebSearchEnabled`, which gates whether web search tools appear in small-model risk findings and other audit checks. The fix adds all provider-specific config keys and environment variables that the rest of the codebase already recognizes (matching `config/types.tools.ts` and `config/config.web-search-provider.test.ts`).

## Test plan

- [x] All 20 tests in `audit-extra.sync.test.ts` pass
- [x] Each provider config key detected: Brave, Perplexity, Gemini, Grok, Kimi
- [x] Each env var detected: BRAVE_API_KEY, PERPLEXITY_API_KEY, GEMINI_API_KEY, XAI_API_KEY, KIMI_API_KEY, MOONSHOT_API_KEY, OPENROUTER_API_KEY
- [x] Returns false when no keys are configured
- [ ] Manual: run `openclaw security audit` with only GEMINI_API_KEY set, verify web search exposure appears in findings

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Set only `GEMINI_API_KEY` env var and run `openclaw security audit`
2. Verify that web search exposure is reported in small model findings
3. Remove all web search keys, verify no web search exposure is reported

## Failure Recovery

Revert the additional conditions in `hasWebSearchKey` to restore the original Brave+Perplexity-only check.

## Risks and Mitigations

- **Risk**: Exporting `hasWebSearchKey` increases public API surface
- **Mitigation**: The function is a pure, stateless predicate with no security implications from being callable externally; it only reads config and env vars