### PR TITLE
fix(agents): guard isTextBlock against malformed content blocks without text property

### DIFF
--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.test.ts
@@ -1,0 +1,78 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it } from "vitest";
+import {
+  estimateMessageCharsCached,
+  createMessageCharEstimateCache,
+  getToolResultText,
+  isToolResultMessage,
+} from "./tool-result-char-estimator.js";
+
+describe("isToolResultMessage", () => {
+  it("identifies toolResult role", () => {
+    expect(isToolResultMessage({ role: "toolResult" } as AgentMessage)).toBe(true);
+  });
+
+  it("identifies tool role", () => {
+    expect(isToolResultMessage({ role: "tool" } as AgentMessage)).toBe(true);
+  });
+
+  it("rejects assistant role", () => {
+    expect(isToolResultMessage({ role: "assistant" } as AgentMessage)).toBe(false);
+  });
+});
+
+describe("getToolResultText", () => {
+  it("extracts text from valid tool result", () => {
+    const msg = {
+      role: "toolResult",
+      content: [{ type: "text", text: "hello" }],
+    } as AgentMessage;
+    expect(getToolResultText(msg)).toBe("hello");
+  });
+
+  it("handles malformed text block missing text property", () => {
+    const msg = {
+      role: "toolResult",
+      content: [{ type: "text" }],
+    } as AgentMessage;
+    expect(getToolResultText(msg)).toBe("");
+  });
+
+  it("handles text block with non-string text", () => {
+    const msg = {
+      role: "toolResult",
+      content: [{ type: "text", text: 42 }],
+    } as AgentMessage;
+    expect(getToolResultText(msg)).toBe("");
+  });
+
+  it("handles null content block", () => {
+    const msg = {
+      role: "toolResult",
+      content: [null, { type: "text", text: "ok" }],
+    } as AgentMessage;
+    expect(getToolResultText(msg)).toBe("ok");
+  });
+});
+
+describe("estimateMessageCharsCached", () => {
+  it("does not crash on malformed text block in tool result", () => {
+    const cache = createMessageCharEstimateCache();
+    const msg = {
+      role: "toolResult",
+      content: [{ type: "text" }, { type: "text", text: "valid" }],
+    } as AgentMessage;
+    const estimate = estimateMessageCharsCached(msg, cache);
+    expect(estimate).toBeGreaterThanOrEqual(5);
+  });
+
+  it("does not crash on malformed text block in user message", () => {
+    const cache = createMessageCharEstimateCache();
+    const msg = {
+      role: "user",
+      content: [{ type: "text" }],
+    } as AgentMessage;
+    const estimate = estimateMessageCharsCached(msg, cache);
+    expect(estimate).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
@@ -7,7 +7,12 @@ const IMAGE_CHAR_ESTIMATE = 8_000;
 export type MessageCharEstimateCache = WeakMap<AgentMessage, number>;
 
 function isTextBlock(block: unknown): block is { type: "text"; text: string } {
-  return !!block && typeof block === "object" && (block as { type?: unknown }).type === "text";
+  return (
+    !!block &&
+    typeof block === "object" &&
+    (block as { type?: unknown }).type === "text" &&
+    typeof (block as { text?: unknown }).text === "string"
+  );
 }
 
 function isImageBlock(block: unknown): boolean {


### PR DESCRIPTION
## Summary

Strengthens the `isTextBlock` type guard to require `typeof text === "string"`, preventing crashes when malformed content blocks like `{ type: "text" }` (without a `text` property) are encountered during context estimation and truncation.

## Problem

The `isTextBlock` function in `tool-result-char-estimator.ts` only verified `type === "text"` without checking that the `text` property exists and is a string. When a malformed tool result content block like `{ type: "text" }` passed through the guard, subsequent code accessing `block.text.length` threw a `TypeError: Cannot read properties of undefined (reading 'length')`. Since this crash occurs during context truncation, it creates a session-permanent loop: every subsequent LLM call attempts truncation, hits the same malformed block, and crashes again — making the session permanently unusable.

## Changes

| File | Change |
|------|--------|
| `src/agents/pi-embedded-runner/tool-result-char-estimator.ts` | Added `typeof text === "string"` check to `isTextBlock` type guard |
| `src/agents/pi-embedded-runner/tool-result-char-estimator.test.ts` | New test file with 9 test cases covering malformed blocks in tool results and user messages |

## How it works

The `isTextBlock` type guard is used in `getToolResultText`, `estimateMessageChars`, and `estimateContextChars` to identify text content blocks. By adding the `typeof text === "string"` condition, malformed blocks are now treated as unknown blocks and handled by `estimateUnknownChars` (which uses `JSON.stringify` with a try/catch), preventing any crash.

## Test plan

- [x] All 9 new tests pass
- [x] Malformed `{ type: "text" }` block does not crash `getToolResultText`
- [x] Malformed block does not crash `estimateMessageCharsCached` for tool results
- [x] Malformed block does not crash `estimateMessageCharsCached` for user messages
- [x] Valid text blocks still work correctly
- [ ] Manual: inject a malformed tool result into a session JSONL, verify the session remains usable

## Security Impact

- Does this change handle user input? **No** (processes internal message structures)
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Create a session with a tool result containing `{ type: "text" }` (no `text` field) in the content array
2. Send a follow-up message that triggers context estimation
3. Verify the session continues without crashing

## Failure Recovery

Revert the `typeof text === "string"` check from `isTextBlock` to restore original behavior.

## Risks and Mitigations

- **Risk**: Malformed text blocks are now silently skipped instead of crashing
- **Mitigation**: This is the desired behavior — silent skip is preferable to a permanent crash loop. The `estimateUnknownChars` fallback still accounts for the block's size via JSON serialization.