### PR TITLE
fix(config): strip deprecated gateway.controlUi device-auth keys on upgrade (#35957)

### DIFF
--- a/src/config/legacy-migrate.test.ts
+++ b/src/config/legacy-migrate.test.ts
@@ -344,4 +344,23 @@ describe("legacy migrate controlUi.allowedOrigins seed (issue #29385)", () => {
       "http://127.0.0.1:18789",
     ]);
   });
+
+  // Issue #35957: autoApproveDevices and requirePairing were removed in v2026.3.3
+  // and caused gateway startup failures when upgrading from v2026.3.2.
+  it("strips deprecated gateway.controlUi.autoApproveDevices and requirePairing on upgrade", () => {
+    const res = migrateLegacyConfig({
+      gateway: {
+        controlUi: {
+          enabled: true,
+          autoApproveDevices: true,
+          requirePairing: false,
+        },
+      },
+    });
+    expect(res.config?.gateway?.controlUi).not.toHaveProperty("autoApproveDevices");
+    expect(res.config?.gateway?.controlUi).not.toHaveProperty("requirePairing");
+    expect((res.config?.gateway?.controlUi as Record<string, unknown>)?.enabled).toBe(true);
+    expect(res.changes.some((c) => c.includes("autoApproveDevices"))).toBe(true);
+    expect(res.changes.some((c) => c.includes("requirePairing"))).toBe(true);
+  });
 });

--- a/src/config/legacy.migrations.part-3.ts
+++ b/src/config/legacy.migrations.part-3.ts
@@ -357,6 +357,37 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_3: LegacyConfigMigration[] = [
     },
   },
   {
+    id: "gateway.controlUi.strip-deprecated-device-auth-keys",
+    describe:
+      "Remove gateway.controlUi.autoApproveDevices and gateway.controlUi.requirePairing (removed in v2026.3.3)",
+    apply: (raw, changes) => {
+      const gateway = getRecord(raw.gateway);
+      if (!gateway) {
+        return;
+      }
+      const controlUi = getRecord(gateway.controlUi);
+      if (!controlUi) {
+        return;
+      }
+      if ("autoApproveDevices" in controlUi) {
+        delete controlUi.autoApproveDevices;
+        gateway.controlUi = controlUi;
+        raw.gateway = gateway;
+        changes.push(
+          "Removed gateway.controlUi.autoApproveDevices (deprecated in v2026.3.3; use dangerouslyDisableDeviceAuth if device auth bypass is still needed).",
+        );
+      }
+      if ("requirePairing" in controlUi) {
+        delete controlUi.requirePairing;
+        gateway.controlUi = controlUi;
+        raw.gateway = gateway;
+        changes.push(
+          "Removed gateway.controlUi.requirePairing (deprecated in v2026.3.3; device pairing is now controlled via dangerouslyDisableDeviceAuth).",
+        );
+      }
+    },
+  },
+  {
     id: "identity->agents.list",
     describe: "Move identity to agents.list[].identity",
     apply: (raw, changes) => {


### PR DESCRIPTION
## Problem

Users upgrading from v2026.3.2 → v2026.3.3 with `autoApproveDevices` or `requirePairing` in their `gateway.controlUi` config hit an immediate gateway startup failure:

```
gateway.controlUi: Unrecognized keys: "autoApproveDevices", "requirePairing"
```

These keys were removed in v2026.3.3 but no migration was added, so the Zod `.strict()` schema rejects the old config entirely — causing 18+ hours of downtime per report.

Fixes #35957.

## Fix

Add a legacy migration (`gateway.controlUi.strip-deprecated-device-auth-keys`) that runs before Zod validation:
- Detects `autoApproveDevices` / `requirePairing` in `gateway.controlUi`
- Removes them and logs a migration message pointing to `dangerouslyDisableDeviceAuth`
- Saves the cleaned config transparently

Users who upgrade will see a migration notice in the gateway log but no startup failure.

## Testing

Added `legacy-migrate.test.ts` case (21 tests, all pass).