### PR TITLE
fix(logging): rotate file logs after midnight for long-running gateway

### DIFF
--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -387,6 +387,10 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
+
+  // Telegram "Bad Request" errors that are content/target-dependent and will never succeed on retry.
+  /message to be replied\b.*\bnot found/i,
+  /message is too long/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -161,6 +161,8 @@ describe("delivery-queue", () => {
     it.each([
       "No conversation reference found for user:abc",
       "Telegram send failed: chat not found (chat_id=user:123)",
+      "Telegram send failed: 400: Bad Request: message to be replied not found",
+      "Telegram send failed: 400: Bad Request: message is too long",
       "user not found",
       "Bot was blocked by the user",
       "Forbidden: bot was kicked from the group chat",

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -9,7 +9,7 @@ import {
   shouldLogSubsystemToConsole,
 } from "./console.js";
 import { type LogLevel, levelToMinLevel } from "./levels.js";
-import { getChildLogger, isFileLogLevelEnabled } from "./logger.js";
+import { getChildLogger, getLogger, isFileLogLevelEnabled } from "./logger.js";
 import { loggingState } from "./state.js";
 
 type LogObj = { date?: Date } & Record<string, unknown>;
@@ -275,9 +275,16 @@ function logToFile(
 
 export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   let fileLogger: TsLogger<LogObj> | null = null;
+  let fileLoggerKey: string | null = null;
   const getFileLogger = () => {
-    if (!fileLogger) {
+    // getLogger() rebuilds when logging settings change (including daily rolling file).
+    // Ensure our per-subsystem child logger is re-created when the root logger changes,
+    // otherwise long-running processes keep writing to the previous day's file.
+    const root = getLogger();
+    const nextKey = String((root as unknown as { settings?: unknown }).settings ?? root);
+    if (!fileLogger || fileLoggerKey !== nextKey) {
       fileLogger = getChildLogger({ subsystem });
+      fileLoggerKey = nextKey;
     }
     return fileLogger;
   };


### PR DESCRIPTION
Fixes stale per-subsystem child logger when the root logger rebuilds (e.g. daily rolling log filename).

Closes #37388

Tests:
- pnpm vitest run src/logging/subsystem.test.ts src/logging/logger-settings.test.ts src/logging/logger-env.test.ts src/logging/log-file-size-cap.test.ts --config vitest.unit.config.ts