### PR TITLE
fix(slack): fail fast on permanent messaging errors to prevent agent retry loops

### DIFF
--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -467,4 +467,28 @@ describe("message tool sandbox passthrough", () => {
 
     expect(call?.requesterSenderId).toBe("1234567890");
   });
+
+  describe("permanent messaging errors", () => {
+    it.each([
+      "An API error occurred: message_not_found",
+      "An API error occurred: channel_not_found",
+      "An API error occurred: not_in_channel",
+      "An API error occurred: file_not_found",
+      "fileId required",
+    ])("enhances permanent error with do-not-retry guidance: %s", async (errorMsg) => {
+      mocks.runMessageAction.mockRejectedValueOnce(new Error(errorMsg));
+      const tool = createMessageTool({ config: {} as never });
+      await expect(
+        tool.execute("1", { action: "send", target: "slack:123", message: "hi" }),
+      ).rejects.toThrow(/permanent error.*will not resolve on retry/i);
+    });
+
+    it("does not alter transient error messages", async () => {
+      mocks.runMessageAction.mockRejectedValueOnce(new Error("rate limited"));
+      const tool = createMessageTool({ config: {} as never });
+      await expect(
+        tool.execute("1", { action: "send", target: "slack:123", message: "hi" }),
+      ).rejects.toThrow("rate limited");
+    });
+  });
 });

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -28,6 +28,20 @@ import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
 import { resolveGatewayOptions } from "./gateway.js";
 
+// Permanent messaging errors that will never succeed on retry.
+// Covers Slack API error codes and similar channel-level permanent failures.
+const PERMANENT_MESSAGING_ERROR_PATTERNS: readonly RegExp[] = [
+  /message_not_found/i,
+  /channel_not_found/i,
+  /not_in_channel/i,
+  /file_not_found/i,
+  /fileId required/i,
+];
+
+function isPermanentMessagingError(error: string): boolean {
+  return PERMANENT_MESSAGING_ERROR_PATTERNS.some((re) => re.test(error));
+}
+
 const AllMessageActions = CHANNEL_MESSAGE_ACTION_NAMES;
 const EXPLICIT_TARGET_ACTIONS = new Set<ChannelMessageActionName>([
   "send",
@@ -766,21 +780,33 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
             }
           : undefined;
 
-      const result = await runMessageAction({
-        cfg,
-        action,
-        params,
-        defaultAccountId: accountId ?? undefined,
-        requesterSenderId: options?.requesterSenderId,
-        gateway,
-        toolContext,
-        sessionKey: options?.agentSessionKey,
-        agentId: options?.agentSessionKey
-          ? resolveSessionAgentId({ sessionKey: options.agentSessionKey, config: cfg })
-          : undefined,
-        sandboxRoot: options?.sandboxRoot,
-        abortSignal: signal,
-      });
+      let result;
+      try {
+        result = await runMessageAction({
+          cfg,
+          action,
+          params,
+          defaultAccountId: accountId ?? undefined,
+          requesterSenderId: options?.requesterSenderId,
+          gateway,
+          toolContext,
+          sessionKey: options?.agentSessionKey,
+          agentId: options?.agentSessionKey
+            ? resolveSessionAgentId({ sessionKey: options.agentSessionKey, config: cfg })
+            : undefined,
+          sandboxRoot: options?.sandboxRoot,
+          abortSignal: signal,
+        });
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        if (isPermanentMessagingError(errMsg)) {
+          throw new Error(
+            `${errMsg} — this is a permanent error that will not resolve on retry. Do not retry this action with the same parameters.`,
+            { cause: err },
+          );
+        }
+        throw err;
+      }
 
       const toolResult = getToolResult(result);
       if (toolResult) {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -387,6 +387,12 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
+  // Slack permanent API errors — retrying these will never succeed.
+  /message_not_found/i,
+  /channel_not_found/i,
+  /not_in_channel/i,
+  /file_not_found/i,
+  /fileId required/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -166,6 +166,11 @@ describe("delivery-queue", () => {
       "Forbidden: bot was kicked from the group chat",
       "chat_id is empty",
       "Outbound not configured for channel: msteams",
+      "An API error occurred: message_not_found",
+      "An API error occurred: channel_not_found",
+      "An API error occurred: not_in_channel",
+      "An API error occurred: file_not_found",
+      "fileId required",
     ])("returns true for permanent error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(true);
     });


### PR DESCRIPTION
## Summary

- Problem: When the Slack message tool encounters permanent API errors like `message_not_found` or `fileId required`, the agent retries in a tight loop (9+ retries observed) instead of failing fast.
- Why it matters: The retry loop burns through Anthropic API rate limits, which cascades into failures for all other sessions — heartbeats, cron jobs — for hours.
- What changed: Two fixes:
  1. **Message tool**: permanent Slack errors are now caught and re-thrown with explicit "do not retry" guidance, so the LLM agent stops looping.
  2. **Delivery recovery**: the same error patterns are added to `isPermanentDeliveryError` so the recovery queue moves them to failed immediately.
- What did NOT change (scope boundary): No changes to the tool schema, routing, channel plugins, or any retry/backoff logic. Only error classification and messaging.

### Permanent error patterns added

| Pattern | When it fires |
|---------|--------------|
| `message_not_found` | Target message was deleted or never existed (Slack thread reply to deleted message) |
| `channel_not_found` | Target channel was deleted or bot no longer has access |
| `not_in_channel` | Bot was removed from the channel |
| `file_not_found` | Referenced file was deleted |
| `fileId required` | Upload flow validation failure (missing file reference in thread target) |

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] Integrations

## Linked Issue/PR

- Closes #37544

## User-visible / Behavior Changes

When the agent encounters a permanent Slack error, it now fails immediately with a clear message instead of retrying repeatedly. Users will see a single failure notification rather than being locked out of the session for hours due to rate limit exhaustion.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: Slack (Socket Mode)
- Model/provider: anthropic/claude-opus-4-6

### Steps

1. Set up a Slack channel with OpenClaw
2. Agent tries to reply to a thread where the parent message was deleted
3. Slack returns `message_not_found` error

### Expected

- Agent receives the error once and stops retrying
- Error message includes "permanent error...will not resolve on retry"

### Actual (before fix)

- Agent retries 9+ times in a tight loop
- Anthropic API rate limit exhausted
- All other sessions (heartbeats, cron) fail for ~4 hours

## Evidence

- [x] Failing test/log before + passing after
  - Added 5 permanent error test cases to `message-tool.test.ts` (all pass)
  - Added 5 permanent error patterns to `outbound.test.ts` `isPermanentDeliveryError` tests (all pass)
  - Verified transient errors (e.g., "rate limited") are NOT affected

## Human Verification (required)

- Verified scenarios: All 22 message-tool tests pass, all 63 delivery-queue tests pass
- Edge cases checked: Transient errors like "rate limited" and "500 Internal Server Error" are correctly NOT classified as permanent
- What you did **not** verify: Live Slack integration test (requires active Slack workspace)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit; the error classification is purely additive
- Files/config to restore: `src/agents/tools/message-tool.ts`, `src/infra/outbound/delivery-queue.ts`
- Known bad symptoms reviewers should watch for: If a previously-retryable Slack error is incorrectly classified as permanent, the agent would fail fast on an error that could have resolved on retry. The patterns chosen are well-known Slack API permanent error codes.

## Risks and Mitigations

- Risk: A pattern like `not_in_channel` could theoretically resolve if the bot is re-added to the channel between retries.
  - Mitigation: In practice, re-adding a bot happens on a human timescale (minutes), not between agent retry loops (milliseconds). The agent can be re-invoked after the bot is re-added.