### PR TITLE
fix(discord): reject null placeholder responses in media fetch

### DIFF
--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -54,6 +54,26 @@ describe("fetchRemoteMedia", () => {
     ).rejects.toThrow("exceeds maxBytes");
   });
 
+  it("rejects null placeholder response", async () => {
+    const lookupFn = vi.fn(async () => [
+      { address: "93.184.216.34", family: 4 },
+    ]) as unknown as LookupFn;
+    const fetchImpl = async () =>
+      new Response("null", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+
+    await expect(
+      fetchRemoteMedia({
+        url: "https://cdn.discordapp.com/attachments/file.pdf",
+        fetchImpl,
+        maxBytes: 1024 * 1024,
+        lookupFn,
+      }),
+    ).rejects.toThrow("null placeholder");
+  });
+
   it("blocks private IP literals before fetching", async () => {
     const fetchImpl = vi.fn();
     await expect(

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -79,6 +79,12 @@ async function readErrorBodySnippet(res: Response, maxChars = 200): Promise<stri
   }
 }
 
+const NULL_LITERAL = Buffer.from("null", "utf8");
+
+function isNullPlaceholderResponse(buffer: Buffer): boolean {
+  return buffer.length <= NULL_LITERAL.length && buffer.equals(NULL_LITERAL);
+}
+
 export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<FetchMediaResult> {
   const {
     url,
@@ -151,6 +157,14 @@ export async function fetchRemoteMedia(options: FetchMediaOptions): Promise<Fetc
             ),
         })
       : Buffer.from(await res.arrayBuffer());
+
+    if (isNullPlaceholderResponse(buffer)) {
+      throw new MediaFetchError(
+        "fetch_failed",
+        `Failed to fetch media from ${url}: received null placeholder response (${buffer.byteLength} bytes)`,
+      );
+    }
+
     let fileNameFromUrl: string | undefined;
     try {
       const parsed = new URL(finalUrl);


### PR DESCRIPTION
## Summary

Adds validation in `fetchRemoteMedia` to detect and reject 4-byte ASCII "null" placeholder responses from CDNs, preventing Discord PDF uploads from being saved as invalid files.

## Problem

Discord's CDN sporadically returns HTTP 200 with the literal JSON body `"null"` (4 bytes) instead of the actual attachment content. Since `fetchRemoteMedia` only validated HTTP status and size limits, these responses passed all checks. `saveMediaBuffer` then wrote the 4-byte buffer to disk, producing corrupted files that appear valid in the filesystem but contain no usable content. This affected PDFs and other attachment types.

## Changes

| File | Change |
|------|--------|
| `src/media/fetch.ts` | Added `isNullPlaceholderResponse` helper and validation check after buffer download; throws `MediaFetchError("fetch_failed")` for null responses |
| `src/media/fetch.test.ts` | Added test case verifying null placeholder responses are rejected |

## How it works

After the response buffer is read (via `readResponseWithLimit` or `arrayBuffer()`), the new check compares the buffer against `Buffer.from("null", "utf8")`. If the buffer matches exactly, a `MediaFetchError` with code `"fetch_failed"` is thrown. This is caught by `appendResolvedMediaFromAttachments` in the Discord message handler, which falls back to preserving the attachment URL as context instead of saving a corrupted file.

The validation is placed in `fetchRemoteMedia` rather than Discord-specific code because null placeholder responses can occur from any CDN, benefiting all channel integrations (Slack, Telegram, etc.).

## Test plan

- [x] All 4 tests in `fetch.test.ts` pass
- [x] New test verifies null response triggers "null placeholder" error
- [x] Existing tests for maxBytes and SSRF continue to pass
- [ ] Manual: mock Discord CDN returning `"null"`, verify attachment URL is preserved instead of saving corrupted file

## Security Impact

- Does this change handle user input? **No** (validates CDN response content)
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **Yes** — prevents writing invalid files to media storage
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Upload a PDF to a Discord channel connected to OpenClaw
2. If the CDN returns a null response (sporadic), verify the agent receives the attachment URL as context rather than a corrupted file
3. Normal uploads should continue to work without any change

## Failure Recovery

Remove `isNullPlaceholderResponse` and the validation check from `fetchRemoteMedia` to restore the original behavior.

## Risks and Mitigations

- **Risk**: A legitimate 4-byte file named "null" could be rejected
- **Mitigation**: No valid media file (image, PDF, audio, video) can be exactly 4 bytes containing the ASCII text "null". This is exclusively a CDN error response pattern.