### PR TITLE
perf(ui): avoid per-event array allocation in eventLogBuffer

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -62,6 +62,8 @@ function isGenericBrowserFetchFailure(message: string): boolean {
   return /^(?:typeerror:\s*)?(?:fetch failed|failed to fetch)$/i.test(message.trim());
 }
 
+const EVENT_LOG_MAX = 250;
+
 type GatewayHost = {
   settings: UiSettings;
   password: string;
@@ -426,12 +428,12 @@ function handleSessionMessageGatewayEvent(
 }
 
 function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
-  host.eventLogBuffer = [
-    { ts: Date.now(), event: evt.event, payload: evt.payload },
-    ...host.eventLogBuffer,
-  ].slice(0, 250);
+  host.eventLogBuffer.unshift({ ts: Date.now(), event: evt.event, payload: evt.payload });
+  if (host.eventLogBuffer.length > EVENT_LOG_MAX) {
+    host.eventLogBuffer.length = EVENT_LOG_MAX;
+  }
   if (host.tab === "debug" || host.tab === "overview") {
-    host.eventLog = host.eventLogBuffer;
+    host.eventLog = [...host.eventLogBuffer];
   }
 
   if (evt.event === "agent") {

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -352,7 +352,7 @@ export async function refreshActiveTab(host: SettingsHost) {
       return;
     case "debug":
       await loadDebug(app);
-      host.eventLog = host.eventLogBuffer;
+      host.eventLog = [...host.eventLogBuffer];
       return;
     case "logs":
       host.logsAtBottom = true;


### PR DESCRIPTION
# perf(ui): avoid per-event array allocation in eventLogBuffer

## Summary

Reduce GC pressure in the gateway event handler by mutating `eventLogBuffer` in place instead of creating a new array on every event.

Previously, each gateway event triggered a spread + `slice` that allocated a fresh 250-element array — wasteful under high-frequency event bursts (e.g. rapid tool-stream events). The new approach uses `unshift` + length truncation to reuse the existing array, and only creates a shallow copy when the debug tab is active (to satisfy Lit's reference-equality dirty check on the `@state()` `eventLog` property).

Also extracts the magic number `250` into a named `EVENT_LOG_MAX` constant.

## Behavior Changes

- **No user-visible change.** The event log buffer capacity (250 entries) and debug-tab rendering remain identical.