### PR TITLE
fix(gateway): allow hardlinked control-ui assets

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -303,6 +303,28 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("serves hardlinked assets inside control-ui root (pnpm global installs)", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { filePath } = await writeAssetFile(tmp, "hardlink.txt", "hardlink-ok\n");
+        const linkPath = path.join(path.dirname(filePath), "hardlink-copy.txt");
+
+        // Create a hardlink to simulate pnpm's global-store layout.
+        await fs.link(filePath, linkPath);
+
+        const { res, end, handled } = runControlUiRequest({
+          url: "/assets/hardlink-copy.txt",
+          method: "GET",
+          rootPath: tmp,
+        });
+
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(String(end.mock.calls[0]?.[0] ?? "")).toBe("hardlink-ok\n");
+      },
+    });
+  });
+
   it("rejects symlinked SPA fallback index.html outside control-ui root", async () => {
     await withControlUiRoot({
       fn: async (tmp) => {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -263,6 +263,10 @@ function resolveSafeControlUiFile(
     rootRealPath: rootReal,
     boundaryLabel: "control ui root",
     skipLexicalRootCheck: true,
+    // Control UI assets may be shipped as hardlinks (e.g. pnpm global installs).
+    // This root is a trusted, explicitly resolved directory, so allow hardlinks
+    // to avoid false 404s for legitimate static assets.
+    rejectHardlinks: false,
   });
   if (!opened.ok) {
     if (opened.reason === "io") {


### PR DESCRIPTION
Closes #37455

Control UI static assets may be hardlinked (nlink>1) when installed via pnpm (e.g. global store layout). The security boundary check treated these as suspicious and returned 404s.

Changes:
- Allow hardlinked static assets under the explicitly-resolved control-ui root by passing rejectHardlinks:false to boundary open.
- Add a regression test that creates a hardlink and verifies it is served.

Test:
- pnpm -s vitest -c vitest.gateway.config.ts src/gateway/control-ui.http.test.ts