### PR TITLE
fix(discord): check commands.allowFrom in slash command handler

### DIFF
--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -150,7 +150,7 @@ function resolveOwnerAllowFromList(params: {
  * Returns the provider-specific list if defined, otherwise the "*" global list.
  * Returns null if commands.allowFrom is not configured at all (fall back to channel allowFrom).
  */
-function resolveCommandsAllowFromList(params: {
+export function resolveCommandsAllowFromList(params: {
   dock?: ChannelDock;
   cfg: OpenClawConfig;
   accountId?: string | null;

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
-import { resolveCommandAuthorization } from "./command-auth.js";
+import { resolveCommandAuthorization, resolveCommandsAllowFromList } from "./command-auth.js";
 import { hasControlCommand, hasInlineCommandTokens } from "./command-detection.js";
 import { listChatCommands } from "./commands-registry.js";
 import { parseActivationCommand } from "./group-activation.js";
@@ -456,6 +456,37 @@ describe("resolveCommandAuthorization", () => {
       });
 
       expect(deniedAuth.isAuthorizedSender).toBe(false);
+    });
+
+    it("resolveCommandsAllowFromList returns global list for unconfigured provider", () => {
+      const cfg = {
+        commands: {
+          allowFrom: {
+            "*": ["allowed-user"],
+          },
+        },
+      } as OpenClawConfig;
+      const list = resolveCommandsAllowFromList({ cfg, providerId: "discord" });
+      expect(list).toEqual(["allowed-user"]);
+    });
+
+    it("resolveCommandsAllowFromList returns null when not configured", () => {
+      const cfg = {} as OpenClawConfig;
+      const list = resolveCommandsAllowFromList({ cfg, providerId: "discord" });
+      expect(list).toBeNull();
+    });
+
+    it("resolveCommandsAllowFromList prefers provider-specific list", () => {
+      const cfg = {
+        commands: {
+          allowFrom: {
+            "*": ["global-user"],
+            discord: ["discord-user"],
+          },
+        },
+      } as OpenClawConfig;
+      const list = resolveCommandsAllowFromList({ cfg, providerId: "discord" });
+      expect(list).toEqual(["discord-user"]);
     });
   });
 

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -20,6 +20,7 @@ import {
 } from "../../acp/persistent-bindings.route.js";
 import { resolveHumanDelayConfig } from "../../agents/identity.js";
 import { resolveChunkMode, resolveTextChunkLimit } from "../../auto-reply/chunk.js";
+import { resolveCommandsAllowFromList } from "../../auto-reply/command-auth.js";
 import type {
   ChatCommandDefinition,
   CommandArgDefinition,
@@ -1435,6 +1436,25 @@ async function dispatchDiscordCommandInteraction(params: {
   if (isGroupDm && discordConfig?.dm?.groupEnabled === false) {
     await respond("Discord group DMs are disabled.");
     return;
+  }
+
+  const commandsAllowFromList = resolveCommandsAllowFromList({
+    cfg,
+    accountId,
+    providerId: "discord",
+  });
+  if (commandsAllowFromList !== null) {
+    const commandsAllowAll = commandsAllowFromList.some((entry) => entry.trim() === "*");
+    if (!commandsAllowAll) {
+      const senderCandidates = [sender.id, sender.tag, sender.name].filter(Boolean);
+      const matched = senderCandidates.some((candidate) =>
+        commandsAllowFromList.includes(candidate),
+      );
+      if (!matched) {
+        await respond("You are not authorized to use this command.", { ephemeral: true });
+        return;
+      }
+    }
   }
 
   const menu = resolveCommandArgMenu({


### PR DESCRIPTION
## Summary

Adds `commands.allowFrom` authorization check in the Discord slash command handler, preventing silent timeouts for unauthorized users by responding with an ephemeral "not authorized" message.

## Problem

When `commands.allowFrom` is configured, the Discord slash command handler (`dispatchDiscordCommandInteraction`) only checked channel-specific allowFrom lists (`discordConfig.allowFrom`) but never consulted the global `commands.allowFrom` config. The interaction was deferred by Carbon before `run()` executes, so unauthorized users saw the "thinking..." state but never received a response, causing a visible 15-second timeout. The `commands.allowFrom` check only happened later in the reply pipeline (`resolveCommandAuthorization`), where a rejection returned `{ shouldContinue: false }` without sending any Discord response.

## Changes

| File | Change |
|------|--------|
| `src/auto-reply/command-auth.ts` | Exported `resolveCommandsAllowFromList` for use in Discord handler |
| `src/discord/monitor/native-command.ts` | Added `commands.allowFrom` check after guild/DM access checks, responds with ephemeral "not authorized" message when user is not in the list |
| `src/auto-reply/command-control.test.ts` | Added 3 test cases for `resolveCommandsAllowFromList`: global list, null when unconfigured, provider-specific override |

## How it works

After the existing Discord-specific access checks (DM policy, guild member roles) but before command argument menu resolution, the handler now calls `resolveCommandsAllowFromList` to get the applicable allowFrom list for the `"discord"` provider. If the list exists and the sender's ID, tag, or name doesn't match any entry, the handler responds with an ephemeral "You are not authorized to use this command." message and returns early.

## Test plan

- [x] All 30 tests in `command-control.test.ts` pass
- [x] `resolveCommandsAllowFromList` returns global list for unconfigured provider
- [x] `resolveCommandsAllowFromList` returns null when not configured
- [x] `resolveCommandsAllowFromList` prefers provider-specific list over global
- [ ] Manual: configure `commands.allowFrom: { "*": ["allowed-user-id"] }`, use a slash command with a different Discord user, verify ephemeral "not authorized" response

## Security Impact

- Does this change handle user input? **No** (checks config-defined allowlist against sender identity)
- Does this change affect authentication/authorization? **Yes** — enforces `commands.allowFrom` in the Discord slash command path
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Set `commands.allowFrom: { "*": ["123456789"] }` in config
2. Use a Discord slash command with user ID `123456789` — should work normally
3. Use a Discord slash command with a different user — should see ephemeral "not authorized" message immediately

## Failure Recovery

Remove the `resolveCommandsAllowFromList` check from `dispatchDiscordCommandInteraction` and unexport `resolveCommandsAllowFromList` from `command-auth.ts`.

## Risks and Mitigations

- **Risk**: Discord-specific sender identity matching (tag, name) may differ from the reply pipeline's normalization
- **Mitigation**: The check uses the same sender identity fields (`sender.id`, `sender.tag`, `sender.name`) that the existing Discord access checks use; `resolveCommandsAllowFromList` applies `formatAllowFromList` for consistent normalization