### PR TITLE
fix: treat launchctl ETIMEDOUT as supervised restart to prevent degraded state

### DIFF
--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -65,7 +65,9 @@ export async function runGatewayLoop(params: {
       const modeLabel =
         respawn.mode === "spawned"
           ? `spawned pid ${respawn.pid ?? "unknown"}`
-          : "supervisor restart";
+          : respawn.detail
+            ? `supervisor restart; ${respawn.detail}`
+            : "supervisor restart";
       gatewayLog.info(`restart mode: full process restart (${modeLabel})`);
       exitProcess(0);
       return;

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -95,6 +95,25 @@ describe("restartGatewayProcessWithFreshPid", () => {
     expect(result.detail).toContain("spawn failed");
   });
 
+  it("returns supervised when launchd kickstart times out (ETIMEDOUT) to avoid degraded state (#36822)", () => {
+    setPlatform("darwin");
+    process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
+    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+    triggerOpenClawRestartMock.mockReturnValue({
+      ok: false,
+      method: "launchctl",
+      detail: "spawnSync launchctl ETIMEDOUT",
+    });
+
+    const result = restartGatewayProcessWithFreshPid();
+
+    // ETIMEDOUT means launchctl timed out but the restart may be in-flight.
+    // Return "supervised" so the gateway exits cleanly and launchd KeepAlive
+    // restarts it, rather than falling back to a degraded in-process restart.
+    expect(result.mode).toBe("supervised");
+    expect(result.detail).toContain("ETIMEDOUT");
+  });
+
   it("does not schedule kickstart on non-darwin platforms", () => {
     setPlatform("linux");
     process.env.INVOCATION_ID = "abc123";

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -38,6 +38,17 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
     if (process.platform === "darwin" && process.env.OPENCLAW_LAUNCHD_LABEL?.trim()) {
       const restart = triggerOpenClawRestart();
       if (!restart.ok) {
+        // When launchctl kickstart times out (ETIMEDOUT), the command was still
+        // dispatched to launchd and the restart may be in-flight. Rather than
+        // falling back to an in-process restart (which leaves the gateway in a
+        // degraded state), exit cleanly so launchd's KeepAlive can start a
+        // fresh process. (#36822)
+        if (restart.detail?.includes("ETIMEDOUT")) {
+          return {
+            mode: "supervised",
+            detail: `launchctl kickstart timed out; trusting launchd KeepAlive to restart (${restart.detail})`,
+          };
+        }
         return {
           mode: "failed",
           detail: restart.detail ?? "launchctl kickstart failed",


### PR DESCRIPTION
## Summary

When a config change triggers a gateway restart on macOS (LaunchAgent), `spawnSync launchctl kickstart` can time out (ETIMEDOUT). Previously the code treated this as a failure and fell back to an in-process restart, leaving the gateway in a degraded state where memory indexing stopped working for hours.

**Root cause:** `triggerOpenClawRestart()` uses `spawnSync` with a 2-second timeout. On timeout, `spawnSync` sets `error.message = "spawnSync launchctl ETIMEDOUT"` and returns `ok: false`. The caller interpreted this as a hard failure and fell through to an in-process restart.

**Fix:** Detect ETIMEDOUT specifically in `restartGatewayProcessWithFreshPid()`. When launchctl times out, the kickstart command was already dispatched to launchd and the restart may be in-flight anyway. Even if not, launchd's `KeepAlive` will restart the process when it exits. Returning `mode: "supervised"` causes the gateway to exit cleanly (via `exitProcess(0)`), letting launchd restart a fresh process rather than continuing in a degraded state.

Also improves the log message in `run-loop.ts` to include the detail string when a supervised restart has additional context (e.g. the ETIMEDOUT note).

Fixes #36822

## Test plan

- [ ] Unit test added: `returns supervised when launchd kickstart times out (ETIMEDOUT)` in `src/infra/process-respawn.test.ts`
- [ ] `pnpm test src/infra/process-respawn.test.ts` passes (11 tests)
- [ ] On macOS with LaunchAgent: trigger a config change that requires restart during heavy memory indexing and verify the gateway exits cleanly and restarts via launchd instead of entering degraded state