### PR TITLE
utils: preserve message identity when no directive tags are stripped

### DIFF
--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -38,6 +38,33 @@ describe("stripInlineDirectiveTagsFromMessageForDisplay", () => {
     expect(result?.content).toEqual([{ type: "text", text: "hello  world " }]);
   });
 
+  test("returns original message reference when no inline directives are present", () => {
+    const input = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "plain text" },
+        { type: "tool", name: "x", payload: { ok: true } },
+      ],
+    };
+    const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
+    expect(result).toBe(input);
+  });
+
+  test("only recreates text parts that actually changed", () => {
+    const unchanged = { type: "text", text: "plain text" };
+    const changed = { type: "text", text: "[[reply_to_current]] hello" };
+    const input = {
+      role: "assistant",
+      content: [unchanged, changed],
+    };
+    const result = stripInlineDirectiveTagsFromMessageForDisplay(input);
+    expect(result).toBeDefined();
+    expect(result).not.toBe(input);
+    expect(result?.content).toEqual([unchanged, { type: "text", text: " hello" }]);
+    expect(result?.content?.[0]).toBe(unchanged);
+    expect(result?.content?.[1]).not.toBe(changed);
+  });
+
   test("preserves empty-string text when directives are entire content", () => {
     const input = {
       role: "assistant",

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -61,8 +61,12 @@ describe("stripInlineDirectiveTagsFromMessageForDisplay", () => {
     expect(result).toBeDefined();
     expect(result).not.toBe(input);
     expect(result?.content).toEqual([unchanged, { type: "text", text: " hello" }]);
-    expect(result?.content?.[0]).toBe(unchanged);
-    expect(result?.content?.[1]).not.toBe(changed);
+    expect(Array.isArray(result?.content)).toBe(true);
+    if (!Array.isArray(result?.content)) {
+      throw new Error("Expected content array");
+    }
+    expect(result.content[0]).toBe(unchanged);
+    expect(result.content[1]).not.toBe(changed);
   });
 
   test("preserves empty-string text when directives are entire content", () => {

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -69,6 +69,7 @@ export function stripInlineDirectiveTagsFromMessageForDisplay(
   if (!Array.isArray(message.content)) {
     return message;
   }
+  let changed = false;
   const cleaned = message.content.map((part) => {
     if (!part || typeof part !== "object") {
       return part;
@@ -77,8 +78,16 @@ export function stripInlineDirectiveTagsFromMessageForDisplay(
     if (!isMessageTextPart(record)) {
       return part;
     }
-    return { ...record, text: stripInlineDirectiveTagsForDisplay(record.text).text };
+    const stripped = stripInlineDirectiveTagsForDisplay(record.text);
+    if (!stripped.changed) {
+      return part;
+    }
+    changed = true;
+    return { ...record, text: stripped.text };
   });
+  if (!changed) {
+    return message;
+  }
   return { ...message, content: cleaned };
 }
 


### PR DESCRIPTION
## What changed
- Updated `stripInlineDirectiveTagsFromMessageForDisplay` to avoid recreating message objects when no inline directive tags are removed.
- Reused existing text-part objects when a text block is unchanged.
- Added tests that verify:
  - the original message object is returned unchanged when no directives are present,
  - only changed text parts are recreated.

## Why
- The previous implementation always returned a new message object and rebuilt text parts, even when no directive tags were present.
- Preserving object identity for unchanged data reduces avoidable downstream rerenders/diff churn and keeps behavior more predictable for consumers relying on reference equality.

## Testing
- ✅ `scripts/clone_and_test.sh openclaw/openclaw` (pass)
- ✅ `corepack pnpm vitest src/utils/directive-tags.test.ts` (pass)
