### PR TITLE
fix(config): migrate removed acp.stream keys from v2026.3.2 (#35957)

### DIFF
--- a/src/config/config.acp-stream-migration.test.ts
+++ b/src/config/config.acp-stream-migration.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vitest";
+import { migrateLegacyConfig } from "./legacy-migrate.js";
+import { validateConfigObjectRaw } from "./validation.js";
+
+/**
+ * Regression tests for issue #35957.
+ *
+ * Several acp.stream keys were removed/renamed between v2026.3.2 and v2026.3.3:
+ *   - maxTurnChars        → maxOutputChars
+ *   - maxToolSummaryChars → maxSessionUpdateChars
+ *   - maxStatusChars      → removed (no replacement)
+ *   - maxMetaEventsPerTurn → removed (no replacement)
+ *   - metaMode            → removed (no replacement)
+ *   - showUsage           → removed (no replacement, superceded by repeatSuppression)
+ *
+ * Because every acp.stream schema node uses .strict(), configs written by v2026.3.2
+ * that contain any of those old keys cause a ZodError at gateway startup.
+ *
+ * The fix adds LEGACY_CONFIG_RULES entries (so migration is triggered) and
+ * LEGACY_CONFIG_MIGRATIONS entries (so old keys are stripped/renamed before
+ * strict validation runs).
+ */
+
+describe("acp.stream legacy key migration (issue #35957)", () => {
+  it("rejects old acp.stream.maxTurnChars via strict schema", () => {
+    const result = validateConfigObjectRaw({
+      acp: {
+        stream: {
+          maxTurnChars: 5000,
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects old acp.stream.maxToolSummaryChars via strict schema", () => {
+    const result = validateConfigObjectRaw({
+      acp: {
+        stream: {
+          maxToolSummaryChars: 1000,
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects old acp.stream.maxStatusChars via strict schema", () => {
+    const result = validateConfigObjectRaw({
+      acp: {
+        stream: {
+          maxStatusChars: 200,
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects old acp.stream.maxMetaEventsPerTurn via strict schema", () => {
+    const result = validateConfigObjectRaw({
+      acp: {
+        stream: {
+          maxMetaEventsPerTurn: 10,
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects old acp.stream.metaMode via strict schema", () => {
+    const result = validateConfigObjectRaw({
+      acp: {
+        stream: {
+          metaMode: "minimal",
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects old acp.stream.showUsage via strict schema", () => {
+    const result = validateConfigObjectRaw({
+      acp: {
+        stream: {
+          showUsage: true,
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("migrates acp.stream.maxTurnChars to maxOutputChars", () => {
+    const result = migrateLegacyConfig({
+      acp: {
+        stream: {
+          maxTurnChars: 5000,
+        },
+      },
+    });
+
+    expect(result.config).not.toBeNull();
+    const stream = result.config?.acp?.stream as Record<string, unknown> | undefined;
+    expect(stream?.maxOutputChars).toBe(5000);
+    expect(stream?.maxTurnChars).toBeUndefined();
+    expect(result.changes).toContain("Moved acp.stream.maxTurnChars → acp.stream.maxOutputChars.");
+  });
+
+  it("migrates acp.stream.maxToolSummaryChars to maxSessionUpdateChars", () => {
+    const result = migrateLegacyConfig({
+      acp: {
+        stream: {
+          maxToolSummaryChars: 1000,
+        },
+      },
+    });
+
+    expect(result.config).not.toBeNull();
+    const stream = result.config?.acp?.stream as Record<string, unknown> | undefined;
+    expect(stream?.maxSessionUpdateChars).toBe(1000);
+    expect(stream?.maxToolSummaryChars).toBeUndefined();
+    expect(result.changes).toContain(
+      "Moved acp.stream.maxToolSummaryChars → acp.stream.maxSessionUpdateChars.",
+    );
+  });
+
+  it("drops acp.stream.maxStatusChars with no replacement", () => {
+    const result = migrateLegacyConfig({
+      acp: {
+        stream: {
+          maxStatusChars: 200,
+        },
+      },
+    });
+
+    expect(result.config).not.toBeNull();
+    const stream = result.config?.acp?.stream as Record<string, unknown> | undefined;
+    expect(stream?.maxStatusChars).toBeUndefined();
+    expect(result.changes).toContain(
+      "Removed acp.stream.maxStatusChars (no replacement in v2026.3.3).",
+    );
+  });
+
+  it("drops acp.stream.maxMetaEventsPerTurn with no replacement", () => {
+    const result = migrateLegacyConfig({
+      acp: {
+        stream: {
+          maxMetaEventsPerTurn: 10,
+        },
+      },
+    });
+
+    expect(result.config).not.toBeNull();
+    const stream = result.config?.acp?.stream as Record<string, unknown> | undefined;
+    expect(stream?.maxMetaEventsPerTurn).toBeUndefined();
+    expect(result.changes).toContain(
+      "Removed acp.stream.maxMetaEventsPerTurn (no replacement in v2026.3.3).",
+    );
+  });
+
+  it("drops acp.stream.metaMode with no replacement", () => {
+    const result = migrateLegacyConfig({
+      acp: {
+        stream: {
+          metaMode: "verbose",
+        },
+      },
+    });
+
+    expect(result.config).not.toBeNull();
+    const stream = result.config?.acp?.stream as Record<string, unknown> | undefined;
+    expect(stream?.metaMode).toBeUndefined();
+    expect(result.changes).toContain("Removed acp.stream.metaMode (no replacement in v2026.3.3).");
+  });
+
+  it("drops acp.stream.showUsage with no replacement", () => {
+    const result = migrateLegacyConfig({
+      acp: {
+        stream: {
+          showUsage: true,
+        },
+      },
+    });
+
+    expect(result.config).not.toBeNull();
+    const stream = result.config?.acp?.stream as Record<string, unknown> | undefined;
+    expect(stream?.showUsage).toBeUndefined();
+    expect(result.changes).toContain("Removed acp.stream.showUsage (no replacement in v2026.3.3).");
+  });
+
+  it("handles all old acp.stream keys simultaneously (v2026.3.2 full config)", () => {
+    const result = migrateLegacyConfig({
+      acp: {
+        stream: {
+          coalesceIdleMs: 50,
+          maxChunkChars: 200,
+          metaMode: "minimal",
+          showUsage: false,
+          deliveryMode: "live",
+          maxTurnChars: 4000,
+          maxToolSummaryChars: 800,
+          maxStatusChars: 150,
+          maxMetaEventsPerTurn: 5,
+          tagVisibility: { tool_call: false },
+        },
+      },
+    });
+
+    expect(result.config).not.toBeNull();
+    const stream = result.config?.acp?.stream as Record<string, unknown> | undefined;
+
+    // Renamed keys should be present with new names
+    expect(stream?.maxOutputChars).toBe(4000);
+    expect(stream?.maxSessionUpdateChars).toBe(800);
+
+    // Removed keys should be gone
+    expect(stream?.maxTurnChars).toBeUndefined();
+    expect(stream?.maxToolSummaryChars).toBeUndefined();
+    expect(stream?.maxStatusChars).toBeUndefined();
+    expect(stream?.maxMetaEventsPerTurn).toBeUndefined();
+    expect(stream?.metaMode).toBeUndefined();
+    expect(stream?.showUsage).toBeUndefined();
+
+    // Untouched keys should still be present
+    expect(stream?.coalesceIdleMs).toBe(50);
+    expect(stream?.maxChunkChars).toBe(200);
+    expect(stream?.deliveryMode).toBe("live");
+    expect(stream?.tagVisibility).toEqual({ tool_call: false });
+
+    // Config should now pass strict validation
+    const validResult = validateConfigObjectRaw(result.config);
+    expect(validResult.ok).toBe(true);
+  });
+
+  it("does not migrate when new keys already present (maxTurnChars with existing maxOutputChars)", () => {
+    const result = migrateLegacyConfig({
+      acp: {
+        stream: {
+          maxTurnChars: 5000,
+          maxOutputChars: 3000,
+        },
+      },
+    });
+
+    expect(result.config).not.toBeNull();
+    const stream = result.config?.acp?.stream as Record<string, unknown> | undefined;
+    // Existing new key takes precedence
+    expect(stream?.maxOutputChars).toBe(3000);
+    expect(stream?.maxTurnChars).toBeUndefined();
+    expect(result.changes).toContain(
+      "Removed acp.stream.maxTurnChars (acp.stream.maxOutputChars already set).",
+    );
+  });
+
+  it("does not migrate when new keys already present (maxToolSummaryChars with existing maxSessionUpdateChars)", () => {
+    const result = migrateLegacyConfig({
+      acp: {
+        stream: {
+          maxToolSummaryChars: 1000,
+          maxSessionUpdateChars: 800,
+        },
+      },
+    });
+
+    expect(result.config).not.toBeNull();
+    const stream = result.config?.acp?.stream as Record<string, unknown> | undefined;
+    expect(stream?.maxSessionUpdateChars).toBe(800);
+    expect(stream?.maxToolSummaryChars).toBeUndefined();
+    expect(result.changes).toContain(
+      "Removed acp.stream.maxToolSummaryChars (acp.stream.maxSessionUpdateChars already set).",
+    );
+  });
+});

--- a/src/config/config.acp-stream-migration.test.ts
+++ b/src/config/config.acp-stream-migration.test.ts
@@ -189,7 +189,9 @@ describe("acp.stream legacy key migration (issue #35957)", () => {
     expect(result.config).not.toBeNull();
     const stream = result.config?.acp?.stream as Record<string, unknown> | undefined;
     expect(stream?.showUsage).toBeUndefined();
-    expect(result.changes).toContain("Removed acp.stream.showUsage (no replacement in v2026.3.3).");
+    expect(result.changes).toContain(
+      "Removed acp.stream.showUsage (no direct replacement; see acp.stream.repeatSuppression for similar functionality in v2026.3.3).",
+    );
   });
 
   it("handles all old acp.stream keys simultaneously (v2026.3.2 full config)", () => {

--- a/src/config/legacy.migrations.part-3.ts
+++ b/src/config/legacy.migrations.part-3.ts
@@ -380,4 +380,81 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_3: LegacyConfigMigration[] = [
       delete raw.identity;
     },
   },
+  {
+    id: "acp.stream-v2026.3.2-keys",
+    describe:
+      "Strip/rename acp.stream keys removed or renamed between v2026.3.2 and v2026.3.3: " +
+      "maxTurnChars→maxOutputChars, maxToolSummaryChars→maxSessionUpdateChars, " +
+      "maxStatusChars/maxMetaEventsPerTurn/metaMode/showUsage removed",
+    apply: (raw, changes) => {
+      const acp = getRecord(raw.acp);
+      if (!acp) {
+        return;
+      }
+      const stream = getRecord(acp.stream);
+      if (!stream) {
+        return;
+      }
+
+      // Renamed: maxTurnChars → maxOutputChars
+      if (stream.maxTurnChars !== undefined) {
+        if (stream.maxOutputChars === undefined) {
+          stream.maxOutputChars = stream.maxTurnChars;
+          changes.push("Moved acp.stream.maxTurnChars → acp.stream.maxOutputChars.");
+        } else {
+          changes.push("Removed acp.stream.maxTurnChars (acp.stream.maxOutputChars already set).");
+        }
+        delete stream.maxTurnChars;
+      }
+
+      // Renamed: maxToolSummaryChars → maxSessionUpdateChars
+      if (stream.maxToolSummaryChars !== undefined) {
+        if (stream.maxSessionUpdateChars === undefined) {
+          stream.maxSessionUpdateChars = stream.maxToolSummaryChars;
+          changes.push("Moved acp.stream.maxToolSummaryChars → acp.stream.maxSessionUpdateChars.");
+        } else {
+          changes.push(
+            "Removed acp.stream.maxToolSummaryChars (acp.stream.maxSessionUpdateChars already set).",
+          );
+        }
+        delete stream.maxToolSummaryChars;
+      }
+
+      // Removed: maxStatusChars (no replacement)
+      if (stream.maxStatusChars !== undefined) {
+        changes.push("Removed acp.stream.maxStatusChars (no replacement in v2026.3.3).");
+        delete stream.maxStatusChars;
+      }
+
+      // Removed: maxMetaEventsPerTurn (no replacement)
+      if (stream.maxMetaEventsPerTurn !== undefined) {
+        changes.push("Removed acp.stream.maxMetaEventsPerTurn (no replacement in v2026.3.3).");
+        delete stream.maxMetaEventsPerTurn;
+      }
+
+      // Removed: metaMode (no replacement)
+      if (stream.metaMode !== undefined) {
+        changes.push("Removed acp.stream.metaMode (no replacement in v2026.3.3).");
+        delete stream.metaMode;
+      }
+
+      // Removed: showUsage (replaced conceptually by repeatSuppression, but not a direct mapping)
+      if (stream.showUsage !== undefined) {
+        changes.push("Removed acp.stream.showUsage (no replacement in v2026.3.3).");
+        delete stream.showUsage;
+      }
+
+      if (Object.keys(stream).length === 0) {
+        delete acp.stream;
+      } else {
+        acp.stream = stream;
+      }
+
+      if (Object.keys(acp).length === 0) {
+        delete raw.acp;
+      } else {
+        raw.acp = acp;
+      }
+    },
+  },
 ];

--- a/src/config/legacy.migrations.part-3.ts
+++ b/src/config/legacy.migrations.part-3.ts
@@ -440,7 +440,9 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_3: LegacyConfigMigration[] = [
 
       // Removed: showUsage (replaced conceptually by repeatSuppression, but not a direct mapping)
       if (stream.showUsage !== undefined) {
-        changes.push("Removed acp.stream.showUsage (no replacement in v2026.3.3).");
+        changes.push(
+          "Removed acp.stream.showUsage (no direct replacement; see acp.stream.repeatSuppression for similar functionality in v2026.3.3).",
+        );
         delete stream.showUsage;
       }
 

--- a/src/config/legacy.rules.ts
+++ b/src/config/legacy.rules.ts
@@ -209,4 +209,34 @@ export const LEGACY_CONFIG_RULES: LegacyConfigRule[] = [
     message:
       "top-level heartbeat is not a valid config path; use agents.defaults.heartbeat (cadence/target/model settings) or channels.defaults.heartbeat (showOk/showAlerts/useIndicator).",
   },
+  {
+    path: ["acp", "stream", "maxTurnChars"],
+    message:
+      "acp.stream.maxTurnChars was renamed to acp.stream.maxOutputChars in v2026.3.3 (auto-migrated on load).",
+  },
+  {
+    path: ["acp", "stream", "maxToolSummaryChars"],
+    message:
+      "acp.stream.maxToolSummaryChars was renamed to acp.stream.maxSessionUpdateChars in v2026.3.3 (auto-migrated on load).",
+  },
+  {
+    path: ["acp", "stream", "maxStatusChars"],
+    message:
+      "acp.stream.maxStatusChars was removed in v2026.3.3 with no replacement (auto-migrated on load).",
+  },
+  {
+    path: ["acp", "stream", "maxMetaEventsPerTurn"],
+    message:
+      "acp.stream.maxMetaEventsPerTurn was removed in v2026.3.3 with no replacement (auto-migrated on load).",
+  },
+  {
+    path: ["acp", "stream", "metaMode"],
+    message:
+      "acp.stream.metaMode was removed in v2026.3.3 with no replacement (auto-migrated on load).",
+  },
+  {
+    path: ["acp", "stream", "showUsage"],
+    message:
+      "acp.stream.showUsage was removed in v2026.3.3 with no replacement (auto-migrated on load).",
+  },
 ];


### PR DESCRIPTION
## Problem

Gateways crash on startup with a `ZodError` when the on-disk config contains `acp.stream` keys that were valid in v2026.3.2 but were removed or renamed in v2026.3.3. The migration path is never triggered because none of the old keys were registered in `LEGACY_CONFIG_RULES`, so the gateway hard-fails at the strict Zod validation step.

## Root cause

Three ACP stream refactor commits landed between v2026.3.2 and v2026.3.3, removing or renaming six `acp.stream` config keys (`maxTurnChars`, `maxToolSummaryChars`, `maxStatusChars`, `maxMetaEventsPerTurn`, `metaMode`, `showUsage`). The `acp.stream` schema uses `.strict()`, so any surviving old keys cause a `ZodError`. Because none of the old keys were registered in `LEGACY_CONFIG_RULES`, `findLegacyConfigIssues()` returns empty, the migration path in `server.impl.ts` is never entered, and the gateway crashes before it can start.

## Fix

- **`src/config/legacy.rules.ts`**: Added one `LEGACY_CONFIG_RULES` entry per old key so that `findLegacyConfigIssues()` detects them and triggers auto-migration at gateway startup.
- **`src/config/legacy.migrations.part-3.ts`**: Added `acp.stream-v2026.3.2-keys` migration that renames `maxTurnChars`→`maxOutputChars` and `maxToolSummaryChars`→`maxSessionUpdateChars` (keeping any pre-existing new-name value), and unconditionally deletes `maxStatusChars`, `maxMetaEventsPerTurn`, `metaMode`, and `showUsage`.

## Verification
- **Test:** `src/config/config.acp-stream-migration.test.ts` — 9/15 fail on main (migration missing), 15/15 pass on fix
- **Build:** clean compile (`build-output.log`)
- **Test suite:** no regressions (`test-output.log`) — 6838 tests pass
- **Code proof:** old keys detected by rules, stripped/renamed by migration, absent from schema (`step6-verify.log`)

Closes #35957