### PR TITLE
fix(agents): prevent bundled skills from escaping sandbox path guard

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -323,6 +323,7 @@ export async function compactEmbeddedPiSessionDirect(
     sessionKey: sandboxSessionKey,
     workspaceDir: resolvedWorkspace,
   });
+  const isSandboxed = sandbox?.enabled === true && sandbox.workspaceAccess !== "rw";
   const effectiveWorkspace = sandbox?.enabled
     ? sandbox.workspaceAccess === "rw"
       ? resolvedWorkspace
@@ -342,6 +343,7 @@ export async function compactEmbeddedPiSessionDirect(
       workspaceDir: effectiveWorkspace,
       config: params.config,
       skillsSnapshot: params.skillsSnapshot,
+      sandboxed: isSandboxed,
     });
     restoreSkillEnv = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -700,6 +700,7 @@ export async function runEmbeddedAttempt(
     sessionKey: sandboxSessionKey,
     workspaceDir: resolvedWorkspace,
   });
+  const isSandboxed = sandbox?.enabled === true && sandbox.workspaceAccess !== "rw";
   const effectiveWorkspace = sandbox?.enabled
     ? sandbox.workspaceAccess === "rw"
       ? resolvedWorkspace
@@ -714,6 +715,7 @@ export async function runEmbeddedAttempt(
       workspaceDir: effectiveWorkspace,
       config: params.config,
       skillsSnapshot: params.skillsSnapshot,
+      sandboxed: isSandboxed,
     });
     restoreSkillEnv = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -5,6 +5,7 @@ export function resolveEmbeddedRunSkillEntries(params: {
   workspaceDir: string;
   config?: OpenClawConfig;
   skillsSnapshot?: SkillSnapshot;
+  sandboxed?: boolean;
 }): {
   shouldLoadSkillEntries: boolean;
   skillEntries: SkillEntry[];
@@ -13,7 +14,10 @@ export function resolveEmbeddedRunSkillEntries(params: {
   return {
     shouldLoadSkillEntries,
     skillEntries: shouldLoadSkillEntries
-      ? loadWorkspaceSkillEntries(params.workspaceDir, { config: params.config })
+      ? loadWorkspaceSkillEntries(params.workspaceDir, {
+          config: params.config,
+          sandboxMode: params.sandboxed,
+        })
       : [],
   };
 }

--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -235,6 +235,60 @@ describe("buildWorkspaceSkillsPrompt", () => {
   });
 });
 
+describe("loadWorkspaceSkillEntries sandboxMode", () => {
+  it("excludes bundled skills when sandboxMode is true", async () => {
+    const workspaceDir = await makeWorkspace();
+    const bundledDir = path.join(workspaceDir, ".bundled");
+    await writeSkill({
+      dir: path.join(bundledDir, "bundled-only"),
+      name: "bundled-only",
+      description: "Bundled skill",
+      body: "# Bundled\n",
+    });
+    await writeSkill({
+      dir: path.join(workspaceDir, "skills", "workspace-skill"),
+      name: "workspace-skill",
+      description: "Workspace skill",
+      body: "# Workspace\n",
+    });
+
+    const normal = loadWorkspaceSkillEntries(workspaceDir, {
+      ...resolveTestSkillDirs(workspaceDir),
+    });
+    expect(normal.some((e) => e.skill.name === "bundled-only")).toBe(true);
+    expect(normal.some((e) => e.skill.name === "workspace-skill")).toBe(true);
+
+    const sandboxed = loadWorkspaceSkillEntries(workspaceDir, {
+      ...resolveTestSkillDirs(workspaceDir),
+      sandboxMode: true,
+    });
+    expect(sandboxed.some((e) => e.skill.name === "bundled-only")).toBe(false);
+    expect(sandboxed.some((e) => e.skill.name === "workspace-skill")).toBe(true);
+  });
+
+  it("excludes managed skills when sandboxMode is true", async () => {
+    const workspaceDir = await makeWorkspace();
+    const managedDir = path.join(workspaceDir, ".managed");
+    await writeSkill({
+      dir: path.join(managedDir, "managed-only"),
+      name: "managed-only",
+      description: "Managed skill",
+      body: "# Managed\n",
+    });
+
+    const normal = loadWorkspaceSkillEntries(workspaceDir, {
+      ...resolveTestSkillDirs(workspaceDir),
+    });
+    expect(normal.some((e) => e.skill.name === "managed-only")).toBe(true);
+
+    const sandboxed = loadWorkspaceSkillEntries(workspaceDir, {
+      ...resolveTestSkillDirs(workspaceDir),
+      sandboxMode: true,
+    });
+    expect(sandboxed.some((e) => e.skill.name === "managed-only")).toBe(false);
+  });
+});
+
 describe("applySkillEnvOverrides", () => {
   it("sets and restores env vars", async () => {
     const workspaceDir = await makeWorkspace();

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -224,6 +224,7 @@ function loadSkillEntries(
     config?: OpenClawConfig;
     managedSkillsDir?: string;
     bundledSkillsDir?: string;
+    sandboxMode?: boolean;
   },
 ): SkillEntry[] {
   const limits = resolveSkillsLimits(opts?.config);
@@ -321,8 +322,17 @@ function loadSkillEntries(
     return loadedSkills;
   };
 
-  const managedSkillsDir = opts?.managedSkillsDir ?? path.join(CONFIG_DIR, "skills");
   const workspaceSkillsDir = path.resolve(workspaceDir, "skills");
+  const projectAgentsSkillsDir = path.resolve(workspaceDir, ".agents", "skills");
+
+  // In sandbox mode, all skills have been synced into the workspace by
+  // syncSkillsToWorkspace(). Loading from external host paths (bundled,
+  // managed, personal, extras) would inject filePath values that point outside
+  // the sandbox root, causing "Path escapes sandbox root" errors when the
+  // agent tries to read them.
+  const skipExternalDirs = opts?.sandboxMode === true;
+
+  const managedSkillsDir = opts?.managedSkillsDir ?? path.join(CONFIG_DIR, "skills");
   const bundledSkillsDir = opts?.bundledSkillsDir ?? resolveBundledSkillsDir();
   const extraDirsRaw = opts?.config?.skills?.load?.extraDirs ?? [];
   const extraDirs = extraDirsRaw
@@ -334,29 +344,35 @@ function loadSkillEntries(
   });
   const mergedExtraDirs = [...extraDirs, ...pluginSkillDirs];
 
-  const bundledSkills = bundledSkillsDir
-    ? loadSkills({
-        dir: bundledSkillsDir,
-        source: "openclaw-bundled",
-      })
-    : [];
-  const extraSkills = mergedExtraDirs.flatMap((dir) => {
-    const resolved = resolveUserPath(dir);
-    return loadSkills({
-      dir: resolved,
-      source: "openclaw-extra",
-    });
-  });
-  const managedSkills = loadSkills({
-    dir: managedSkillsDir,
-    source: "openclaw-managed",
-  });
+  const bundledSkills =
+    bundledSkillsDir && !skipExternalDirs
+      ? loadSkills({
+          dir: bundledSkillsDir,
+          source: "openclaw-bundled",
+        })
+      : [];
+  const extraSkills = skipExternalDirs
+    ? []
+    : mergedExtraDirs.flatMap((dir) => {
+        const resolved = resolveUserPath(dir);
+        return loadSkills({
+          dir: resolved,
+          source: "openclaw-extra",
+        });
+      });
+  const managedSkills = skipExternalDirs
+    ? []
+    : loadSkills({
+        dir: managedSkillsDir,
+        source: "openclaw-managed",
+      });
   const personalAgentsSkillsDir = path.resolve(os.homedir(), ".agents", "skills");
-  const personalAgentsSkills = loadSkills({
-    dir: personalAgentsSkillsDir,
-    source: "agents-skills-personal",
-  });
-  const projectAgentsSkillsDir = path.resolve(workspaceDir, ".agents", "skills");
+  const personalAgentsSkills = skipExternalDirs
+    ? []
+    : loadSkills({
+        dir: personalAgentsSkillsDir,
+        source: "agents-skills-personal",
+      });
   const projectAgentsSkills = loadSkills({
     dir: projectAgentsSkillsDir,
     source: "agents-skills-project",
@@ -542,6 +558,7 @@ export function loadWorkspaceSkillEntries(
     config?: OpenClawConfig;
     managedSkillsDir?: string;
     bundledSkillsDir?: string;
+    sandboxMode?: boolean;
   },
 ): SkillEntry[] {
   return loadSkillEntries(workspaceDir, opts);


### PR DESCRIPTION
## Summary

Fixes sandbox "Path escapes sandbox root" errors when agents try to read bundled or managed skill files. When sandbox mode is active, skill loading now skips external host directories (bundled, managed, personal agents, extras) and relies solely on the copies already synced into the sandbox workspace by `syncSkillsToWorkspace`.

## Problem

When `sandbox.mode = "all"` is configured, `syncSkillsToWorkspace()` copies all skills (bundled, managed, workspace, etc.) into the sandbox workspace directory. However, `loadSkillEntries()` still loads skills from host paths (e.g. `node_modules/openclaw/skills/`, `~/.openclaw/skills/`) in addition to the workspace. Although workspace skills have higher merge precedence and normally override external copies, the host paths can appear in the system prompt when:

1. Skill name conflicts cause de-duplication with suffixed names during sync
2. The sync partially fails (individual copy errors are logged but silently skipped)
3. A skills snapshot pre-built with host paths is used

When the model then tries to read a skill file at a host path like `/home/user/.nvm/.../node_modules/openclaw/skills/skill-creator/SKILL.md`, the sandbox path guard rejects it because it falls outside `~/.openclaw/workspace`.

## Changes

| File | Change |
|------|--------|
| `src/agents/skills/workspace.ts` | Added `sandboxMode` option to `loadSkillEntries` and `loadWorkspaceSkillEntries`. When true, skips loading from bundled, managed, personal agents, and extra directories. |
| `src/agents/pi-embedded-runner/skills-runtime.ts` | Added `sandboxed` parameter to `resolveEmbeddedRunSkillEntries`, forwarded as `sandboxMode` to `loadWorkspaceSkillEntries`. |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Passes `sandboxed: true` to `resolveEmbeddedRunSkillEntries` when sandbox is active with non-rw workspace access. |
| `src/agents/pi-embedded-runner/compact.ts` | Same sandbox flag propagation as `attempt.ts`. |
| `src/agents/skills.test.ts` | Added two tests verifying that `sandboxMode` excludes bundled and managed skills from loaded entries. |

## How it works

When `sandboxMode` is true in `loadSkillEntries`:
- `bundledSkills`, `managedSkills`, `personalAgentsSkills`, and `extraSkills` are set to empty arrays
- Only `workspaceSkills` and `projectAgentsSkills` (both inside the sandbox workspace) are loaded
- Since `syncSkillsToWorkspace` already copies all external skills into `workspaceDir/skills/`, the synced copies serve as the single source of truth

The `sandboxed` flag is derived in `attempt.ts` and `compact.ts` as:
```typescript
const isSandboxed = sandbox?.enabled === true && sandbox.workspaceAccess !== "rw";
```

This ensures the optimization only applies when the sandbox is actually restricting workspace access (not when `workspaceAccess: "rw"`, which uses the original workspace directly).

## Test plan

- [x] All 14 tests in `skills.test.ts` pass (including 2 new sandbox mode tests)
- [x] All 4 tests in `skills-runtime*.test.ts` pass
- [ ] Manual: enable `sandbox.mode = "all"`, trigger a bundled skill (e.g. `/skill-creator`), verify agent can read the skill file without path escape errors

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No** (skills are read-only files)
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Set `agents.defaults.sandbox.mode = "all"` and `agents.defaults.workspace = "~/.openclaw/workspace"`
2. Start a session and trigger a bundled skill like `/skill-creator`
3. Verify the agent reads the skill SKILL.md without "Path escapes sandbox root" errors
4. Verify the skill file path in the prompt points to the sandbox workspace copy

## Failure Recovery

Revert the `sandboxMode` option and remove the `isSandboxed` flag from `attempt.ts` and `compact.ts`. The original behavior (loading from all directories) is restored.

## Risks and Mitigations

- **Risk**: If `syncSkillsToWorkspace` fails completely, sandboxed agents won't see any bundled/managed skills
- **Mitigation**: `syncSkillsToWorkspace` errors are already logged at the error level. The existing sync mechanism is reliable for the common case. A total sync failure would also have caused missing skills before this change (workspace copies wouldn't exist), so the failure mode is unchanged.