### PR TITLE
fix(config): honour explicit contextWindow/maxTokens overrides for Ollama

### DIFF
--- a/src/agents/models-config.honours-explicit-contextwindow-override.test.ts
+++ b/src/agents/models-config.honours-explicit-contextwindow-override.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  installModelsConfigTestHooks,
+  withModelsTempHome as withTempHome,
+} from "./models-config.e2e-harness.js";
+import { ensureOpenClawModelsJson } from "./models-config.js";
+import { readGeneratedModelsJson } from "./models-config.test-utils.js";
+
+installModelsConfigTestHooks();
+
+type ModelEntry = {
+  id: string;
+  contextWindow?: number;
+  maxTokens?: number;
+};
+
+type ModelsJson = {
+  providers: Record<string, { models?: ModelEntry[] }>;
+};
+
+const MINIMAX_ENV_KEY = "MINIMAX_API_KEY";
+const MINIMAX_MODEL_ID = "MiniMax-M2.5";
+const MINIMAX_TEST_KEY = "sk-minimax-test";
+
+const baseMinimaxProvider = {
+  baseUrl: "https://api.minimax.io/anthropic",
+  api: "anthropic-messages",
+} as const;
+
+async function withMinimaxApiKey(run: () => Promise<void>) {
+  const prev = process.env[MINIMAX_ENV_KEY];
+  process.env[MINIMAX_ENV_KEY] = MINIMAX_TEST_KEY;
+  try {
+    await run();
+  } finally {
+    if (prev === undefined) {
+      delete process.env[MINIMAX_ENV_KEY];
+    } else {
+      process.env[MINIMAX_ENV_KEY] = prev;
+    }
+  }
+}
+
+async function generateAndReadMinimaxModel(cfg: OpenClawConfig): Promise<ModelEntry | undefined> {
+  await ensureOpenClawModelsJson(cfg);
+  const parsed = await readGeneratedModelsJson<ModelsJson>();
+  return parsed.providers.minimax?.models?.find((model) => model.id === MINIMAX_MODEL_ID);
+}
+
+describe("models-config: explicit contextWindow override", () => {
+  it("honours user contextWindow lower than built-in catalog value", async () => {
+    await withTempHome(async () => {
+      await withMinimaxApiKey(async () => {
+        const cfg: OpenClawConfig = {
+          models: {
+            providers: {
+              minimax: {
+                ...baseMinimaxProvider,
+                models: [
+                  {
+                    id: MINIMAX_MODEL_ID,
+                    name: "MiniMax M2.5",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 4096,
+                    maxTokens: 2048,
+                  },
+                ],
+              },
+            },
+          },
+        };
+
+        const model = await generateAndReadMinimaxModel(cfg);
+        expect(model).toBeDefined();
+        expect(model?.contextWindow).toBe(4096);
+        expect(model?.maxTokens).toBe(2048);
+      });
+    });
+  });
+
+  it("falls back to built-in contextWindow when user omits the field", async () => {
+    await withTempHome(async () => {
+      await withMinimaxApiKey(async () => {
+        const modelWithoutContextWindow = {
+          id: MINIMAX_MODEL_ID,
+          name: "MiniMax M2.5",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        };
+        const cfg: OpenClawConfig = {
+          models: {
+            providers: {
+              minimax: {
+                ...baseMinimaxProvider,
+                // @ts-expect-error Intentional: emulate user config omitting contextWindow/maxTokens.
+                models: [modelWithoutContextWindow],
+              },
+            },
+          },
+        };
+
+        const model = await generateAndReadMinimaxModel(cfg);
+        expect(model).toBeDefined();
+        // Built-in catalog value for MiniMax-M2.5 (200000) should be used.
+        expect(model?.contextWindow).toBe(200000);
+      });
+    });
+  });
+
+  it("honours user contextWindow higher than built-in catalog value", async () => {
+    await withTempHome(async () => {
+      await withMinimaxApiKey(async () => {
+        const cfg: OpenClawConfig = {
+          models: {
+            providers: {
+              minimax: {
+                ...baseMinimaxProvider,
+                models: [
+                  {
+                    id: MINIMAX_MODEL_ID,
+                    name: "MiniMax M2.5",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 500000,
+                    maxTokens: 16384,
+                  },
+                ],
+              },
+            },
+          },
+        };
+
+        const model = await generateAndReadMinimaxModel(cfg);
+        expect(model).toBeDefined();
+        expect(model?.contextWindow).toBe(500000);
+        expect(model?.maxTokens).toBe(16384);
+      });
+    });
+  });
+});

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -16,10 +16,18 @@ type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 
 const DEFAULT_MODE: NonNullable<ModelsConfig["mode"]> = "merge";
 
-function resolvePreferredTokenLimit(explicitValue: number, implicitValue: number): number {
-  // Keep catalog refresh behavior for stale low values while preserving
-  // intentional larger user overrides (for example Ollama >128k contexts).
-  return explicitValue > implicitValue ? explicitValue : implicitValue;
+function resolvePreferredTokenLimit(
+  explicitValue: number | undefined,
+  implicitValue: number,
+  explicitlySet: boolean,
+): number {
+  if (explicitlySet && typeof explicitValue === "number" && explicitValue > 0) {
+    return explicitValue;
+  }
+  if (typeof explicitValue === "number" && explicitValue > implicitValue) {
+    return explicitValue;
+  }
+  return implicitValue;
 }
 
 function mergeProviderModels(implicit: ProviderConfig, explicit: ProviderConfig): ProviderConfig {
@@ -54,10 +62,10 @@ function mergeProviderModels(implicit: ProviderConfig, explicit: ProviderConfig)
 
     // Refresh capability metadata from the implicit catalog while preserving
     // user-specific fields (cost, headers, compat, etc.) on explicit entries.
-    // reasoning is treated as user-overridable: if the user has explicitly set
-    // it in their config (key present), honour that value; otherwise fall back
-    // to the built-in catalog default so new reasoning models work out of the
-    // box without requiring every user to configure it.
+    // reasoning, contextWindow, and maxTokens are user-overridable: if the
+    // user has explicitly set them in their config (key present), honour
+    // that value; otherwise fall back to the built-in catalog default so
+    // discovered models work out of the box.
     return {
       ...explicitModel,
       input: implicitModel.input,
@@ -65,8 +73,13 @@ function mergeProviderModels(implicit: ProviderConfig, explicit: ProviderConfig)
       contextWindow: resolvePreferredTokenLimit(
         explicitModel.contextWindow,
         implicitModel.contextWindow,
+        "contextWindow" in explicitModel,
       ),
-      maxTokens: resolvePreferredTokenLimit(explicitModel.maxTokens, implicitModel.maxTokens),
+      maxTokens: resolvePreferredTokenLimit(
+        explicitModel.maxTokens,
+        implicitModel.maxTokens,
+        "maxTokens" in explicitModel,
+      ),
     };
   });
 


### PR DESCRIPTION
## Summary

Fixes Ollama sending hardcoded 128K context (KvSize=262144) regardless of user configuration, causing "model requires more system memory" errors on machines with less than ~40GB RAM.

## Problem

When merging user-configured model definitions with auto-discovered ones, `resolvePreferredTokenLimit` always picked the **larger** value. For Ollama, the auto-discovery endpoint (`/api/show`) reports the model's maximum `context_length` (e.g. 128000 for qwen3:4b). When a user explicitly set `contextWindow: 4096` in their config to stay within their machine's RAM limits, the merge silently replaced it with the discovered 128000 value. This caused Ollama to allocate a KV cache of 36GB for a 2.5GB model, making OpenClaw completely unusable on consumer hardware.

## Changes

| File | Change |
|------|--------|
| `src/agents/models-config.ts` | Modified `resolvePreferredTokenLimit` to accept an `explicitlySet` flag; when true, the explicit value is used regardless of the implicit value |
| `src/agents/models-config.ts` | Updated `mergeProviderModels` to pass `"contextWindow" in explicitModel` and `"maxTokens" in explicitModel` flags |
| `src/agents/models-config.honours-explicit-contextwindow-override.test.ts` | New test file with 3 tests verifying contextWindow/maxTokens merge behavior |

## How it works

`resolvePreferredTokenLimit` now has three parameters:

```typescript
function resolvePreferredTokenLimit(
  explicitValue: number | undefined,
  implicitValue: number,
  explicitlySet: boolean,
): number
```

- When `explicitlySet` is true and the value is a positive number, it is used as-is (the user's intent is authoritative)
- When `explicitlySet` is false, the higher value wins (preserving catalog refresh behavior for stale cached models)
- This matches the pattern already used for `reasoning` in the same merge function: `"reasoning" in explicitModel ? explicitModel.reasoning : implicitModel.reasoning`

## Test plan

- [x] 3 new tests pass: lower override honoured, omitted falls back to built-in, higher override honoured
- [x] Existing `models-config.preserves-explicit-reasoning-override` tests pass (2 tests)
- [x] Existing `models-config.providers.ollama` tests pass (13 tests)
- [ ] Manual: set `contextWindow: 8192` for an Ollama model, verify `num_ctx=8192` in Ollama runner logs

## Security Impact

- Does this change handle user input? **No** (configuration values only)
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **No** (only changes the `num_ctx` parameter sent to Ollama)
- Does this change introduce new dependencies? **No**

## Human Verification

1. Install Ollama and pull any model (e.g. `qwen3:4b`)
2. Set `models.providers.ollama.models[].contextWindow` to 8192 in `openclaw.json`
3. Start OpenClaw gateway and send a message
4. Check Ollama runner logs for `KvSize:16384` (8192 * 2) instead of `KvSize:262144`
5. Verify the model loads successfully without "model requires more system memory" errors

## Failure Recovery

Revert the `resolvePreferredTokenLimit` function to its original `Math.max(explicit, implicit)` behavior.

## Risks and Mitigations

- **Risk**: Users who previously relied on the implicit higher value (e.g., catalog had stale low contextWindow but discovery found a higher one) might see lower context windows
- **Mitigation**: The `explicitlySet` check uses `"contextWindow" in explicitModel`, so this only affects models where the user explicitly included the key in their config. Auto-discovered models without user overrides are unaffected.