### PR TITLE
fix(anthropic): inject SSE event lines for custom baseUrl proxy (#37571)

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -228,4 +228,10 @@ openclaw onboard --auth-choice setup-token
 - Check `openclaw models status --json` for `auth.unusableProfiles`.
 - Add another Anthropic profile or wait for cooldown.
 
+**"request ended without sending any chunks" with custom baseUrl (proxy)**
+
+- Some proxies return only SSE `data:` lines and omit `event:` lines; the Anthropic SDK then drops events and the run fails.
+- When you use `api: "anthropic-messages"` with a custom `baseUrl` (not `https://api.anthropic.com`), OpenClaw automatically injects missing `event:` lines from the `data` payload so the stream works.
+- If you still see this error, ensure your model config uses `anthropic-messages` and a custom `baseUrl`, or try `api: "openai-completions"` with an OpenAI-compatible proxy.
+
 More: [/gateway/troubleshooting](/gateway/troubleshooting) and [/help/faq](/help/faq).

--- a/src/agents/anthropic-sse-event-inject.test.ts
+++ b/src/agents/anthropic-sse-event-inject.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import {
+  __testingResetInstall,
+  isCustomAnthropicBaseUrl,
+  runWithAnthropicSSEEventInject,
+} from "./anthropic-sse-event-inject.js";
+
+describe("isCustomAnthropicBaseUrl", () => {
+  it("returns false for undefined or empty", () => {
+    expect(isCustomAnthropicBaseUrl(undefined)).toBe(false);
+    expect(isCustomAnthropicBaseUrl("")).toBe(false);
+  });
+
+  it("returns false for official Anthropic base", () => {
+    expect(isCustomAnthropicBaseUrl("https://api.anthropic.com")).toBe(false);
+    expect(isCustomAnthropicBaseUrl("https://api.anthropic.com/")).toBe(false);
+    expect(isCustomAnthropicBaseUrl("https://api.anthropic.com/v1")).toBe(false);
+  });
+
+  it("returns true for custom/proxy base URLs", () => {
+    expect(isCustomAnthropicBaseUrl("https://proxy.example.com")).toBe(true);
+    expect(isCustomAnthropicBaseUrl("https://proxy.example.com/")).toBe(true);
+    expect(isCustomAnthropicBaseUrl("http://localhost:8080")).toBe(true);
+  });
+
+  it("returns true for hostnames that only share the official prefix (boundary check)", () => {
+    expect(isCustomAnthropicBaseUrl("https://api.anthropic.com.evil.com")).toBe(true);
+    expect(isCustomAnthropicBaseUrl("https://api.anthropic.comx")).toBe(true);
+  });
+});
+
+describe("runWithAnthropicSSEEventInject", () => {
+  const baseUrl = "https://proxy.example.com";
+  const encoder = new TextEncoder();
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    __testingResetInstall();
+  });
+
+  it("injects event lines before data lines when proxy omits them", async () => {
+    const sseWithoutEvents =
+      'data: {"type":"message_start"}\n\n' +
+      'data: {"type":"content_block_start"}\n\n' +
+      'data: {"type":"ping"}\n\n';
+    globalThis.fetch = async () =>
+      new Response(
+        new ReadableStream({
+          start(c) {
+            c.enqueue(encoder.encode(sseWithoutEvents));
+            c.close();
+          },
+        }),
+      );
+
+    const result = await runWithAnthropicSSEEventInject(baseUrl, async () => {
+      const res = await fetch(`${baseUrl}/v1/messages`);
+      return await new Response(res.body).text();
+    });
+
+    expect(result).toContain("event: message_start\n");
+    expect(result).toContain("event: content_block_start\n");
+    expect(result).toContain("event: ping\n");
+    expect(result).toContain('data: {"type":"message_start"}');
+  });
+
+  it("does not duplicate event lines when proxy already sends them", async () => {
+    const sseWithEvents = 'event: message_start\ndata: {"type":"message_start"}\n\n';
+    globalThis.fetch = async () =>
+      new Response(
+        new ReadableStream({
+          start(c) {
+            c.enqueue(encoder.encode(sseWithEvents));
+            c.close();
+          },
+        }),
+      );
+
+    const result = await runWithAnthropicSSEEventInject(baseUrl, async () => {
+      const res = await fetch(`${baseUrl}/v1/messages`);
+      return await new Response(res.body).text();
+    });
+
+    // Should still have exactly one "event: message_start"
+    const eventCount = (result.match(/event: message_start/g) ?? []).length;
+    expect(eventCount).toBe(1);
+  });
+});

--- a/src/agents/anthropic-sse-event-inject.test.ts
+++ b/src/agents/anthropic-sse-event-inject.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import {
+  __testingResetInstall,
+  isCustomAnthropicBaseUrl,
+  runWithAnthropicSSEEventInject,
+} from "./anthropic-sse-event-inject.js";
+
+describe("isCustomAnthropicBaseUrl", () => {
+  it("returns false for undefined or empty", () => {
+    expect(isCustomAnthropicBaseUrl(undefined)).toBe(false);
+    expect(isCustomAnthropicBaseUrl("")).toBe(false);
+  });
+
+  it("returns false for official Anthropic base", () => {
+    expect(isCustomAnthropicBaseUrl("https://api.anthropic.com")).toBe(false);
+    expect(isCustomAnthropicBaseUrl("https://api.anthropic.com/")).toBe(false);
+    expect(isCustomAnthropicBaseUrl("https://api.anthropic.com/v1")).toBe(false);
+  });
+
+  it("returns true for custom/proxy base URLs", () => {
+    expect(isCustomAnthropicBaseUrl("https://proxy.example.com")).toBe(true);
+    expect(isCustomAnthropicBaseUrl("https://proxy.example.com/")).toBe(true);
+    expect(isCustomAnthropicBaseUrl("http://localhost:8080")).toBe(true);
+  });
+});
+
+describe("runWithAnthropicSSEEventInject", () => {
+  const baseUrl = "https://proxy.example.com";
+  const encoder = new TextEncoder();
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    __testingResetInstall();
+  });
+
+  it("injects event lines before data lines when proxy omits them", async () => {
+    const sseWithoutEvents =
+      'data: {"type":"message_start"}\n\n' +
+      'data: {"type":"content_block_start"}\n\n' +
+      'data: {"type":"ping"}\n\n';
+    globalThis.fetch = async () =>
+      new Response(
+        new ReadableStream({
+          start(c) {
+            c.enqueue(encoder.encode(sseWithoutEvents));
+            c.close();
+          },
+        }),
+      );
+
+    const result = await runWithAnthropicSSEEventInject(baseUrl, async () => {
+      const res = await fetch(`${baseUrl}/v1/messages`);
+      return await new Response(res.body).text();
+    });
+
+    expect(result).toContain("event: message_start\n");
+    expect(result).toContain("event: content_block_start\n");
+    expect(result).toContain("event: ping\n");
+    expect(result).toContain('data: {"type":"message_start"}');
+  });
+
+  it("does not duplicate event lines when proxy already sends them", async () => {
+    const sseWithEvents = 'event: message_start\ndata: {"type":"message_start"}\n\n';
+    globalThis.fetch = async () =>
+      new Response(
+        new ReadableStream({
+          start(c) {
+            c.enqueue(encoder.encode(sseWithEvents));
+            c.close();
+          },
+        }),
+      );
+
+    const result = await runWithAnthropicSSEEventInject(baseUrl, async () => {
+      const res = await fetch(`${baseUrl}/v1/messages`);
+      return await new Response(res.body).text();
+    });
+
+    // Should still have exactly one "event: message_start"
+    const eventCount = (result.match(/event: message_start/g) ?? []).length;
+    expect(eventCount).toBe(1);
+  });
+});

--- a/src/agents/anthropic-sse-event-inject.ts
+++ b/src/agents/anthropic-sse-event-inject.ts
@@ -1,0 +1,136 @@
+/**
+ * Injects missing SSE "event:" lines for anthropic-messages proxies that only send
+ * "data:" lines (fixes #37571). The @anthropic-ai/sdk parser requires "event:" to
+ * dispatch; when missing, events are dropped and the stream fails with
+ * "request ended without sending any chunks".
+ *
+ * Impact: only active when using anthropic-messages with a custom baseUrl (proxy).
+ * Uses AsyncLocalStorage so only requests to that baseUrl are transformed.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const ANTHROPIC_OFFICIAL_BASE = "https://api.anthropic.com";
+
+const anthropicProxyBaseUrlStorage = new AsyncLocalStorage<{ anthropicProxyBaseUrl: string }>();
+
+let fetchWrapperInstalled = false;
+
+/** Reset install state for tests so the wrapper can be re-installed with a new realFetch. */
+export function __testingResetInstall(): void {
+  fetchWrapperInstalled = false;
+}
+
+/**
+ * Returns true when the model uses a custom/proxy base URL (not official Anthropic).
+ * For those, we may need to inject "event:" lines if the proxy omits them.
+ */
+export function isCustomAnthropicBaseUrl(baseUrl: string | undefined): boolean {
+  if (!baseUrl || typeof baseUrl !== "string") {
+    return false;
+  }
+  const normalized = baseUrl.trim().replace(/\/+$/, "");
+  if (!normalized) {
+    return false;
+  }
+  return (
+    !normalized.startsWith(ANTHROPIC_OFFICIAL_BASE) &&
+    !normalized.startsWith("https://api.anthropic.com/")
+  );
+}
+
+/**
+ * Run fn inside an async context that marks requests to baseUrl as needing
+ * SSE event injection. Used when calling streamSimple for anthropic-messages
+ * with a custom baseUrl so the SDK's fetch sees the context.
+ */
+export function runWithAnthropicSSEEventInject<T>(baseUrl: string, fn: () => T): T {
+  ensureFetchWrapperInstalled();
+  return anthropicProxyBaseUrlStorage.run(
+    { anthropicProxyBaseUrl: baseUrl.trim().replace(/\/+$/, "") },
+    fn,
+  );
+}
+
+function ensureFetchWrapperInstalled(): void {
+  if (fetchWrapperInstalled) {
+    return;
+  }
+  fetchWrapperInstalled = true;
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const store = anthropicProxyBaseUrlStorage.getStore();
+    if (!store?.anthropicProxyBaseUrl) {
+      return realFetch(input, init);
+    }
+    const res = await realFetch(input, init);
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (!url.startsWith(store.anthropicProxyBaseUrl) || !res.body) {
+      return res;
+    }
+    const transformedBody = res.body.pipeThrough(createSSEEventInjectTransform());
+    return new Response(transformedBody, {
+      status: res.status,
+      statusText: res.statusText,
+      headers: res.headers,
+    });
+  };
+}
+
+/**
+ * TransformStream that, for each SSE "data:" line that contains JSON with a "type"
+ * field, prepends "event: <type>\n" when the previous line was not already "event:".
+ * This makes proxies that omit "event:" lines compatible with the SDK parser.
+ */
+function createSSEEventInjectTransform(): TransformStream<Uint8Array, Uint8Array> {
+  const encoder = new TextEncoder();
+  let buffer = "";
+  let lastLineWasEvent = false;
+
+  function flushLine(line: string): string {
+    const trimmed = line.replace(/\r$/, "");
+    if (!trimmed) {
+      lastLineWasEvent = false;
+      return line;
+    }
+    if (trimmed.startsWith("event:")) {
+      lastLineWasEvent = true;
+      return line;
+    }
+    if (trimmed.startsWith("data:")) {
+      const value = trimmed.slice(5).replace(/^\s+/, "");
+      let out = line;
+      if (!lastLineWasEvent && value) {
+        try {
+          const parsed = JSON.parse(value) as { type?: string };
+          if (typeof parsed?.type === "string" && parsed.type.trim()) {
+            out = `event: ${parsed.type.trim()}\n${line}`;
+          }
+        } catch {
+          // not JSON or no type; leave as-is
+        }
+      }
+      lastLineWasEvent = false;
+      return out;
+    }
+    lastLineWasEvent = false;
+    return line;
+  }
+
+  return new TransformStream({
+    transform(chunk, controller) {
+      buffer += new TextDecoder().decode(chunk);
+      const lines = buffer.split(/\r\n|\n/);
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        const flushed = flushLine(line + "\n");
+        controller.enqueue(encoder.encode(flushed));
+      }
+    },
+    flush(controller) {
+      if (buffer) {
+        controller.enqueue(encoder.encode(buffer));
+      }
+    },
+  });
+}

--- a/src/agents/anthropic-sse-event-inject.ts
+++ b/src/agents/anthropic-sse-event-inject.ts
@@ -1,0 +1,138 @@
+/**
+ * Injects missing SSE "event:" lines for anthropic-messages proxies that only send
+ * "data:" lines (fixes #37571). The @anthropic-ai/sdk parser requires "event:" to
+ * dispatch; when missing, events are dropped and the stream fails with
+ * "request ended without sending any chunks".
+ *
+ * Impact: only active when using anthropic-messages with a custom baseUrl (proxy).
+ * Uses AsyncLocalStorage so only requests to that baseUrl are transformed.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const ANTHROPIC_OFFICIAL_BASE = "https://api.anthropic.com";
+
+const anthropicProxyBaseUrlStorage = new AsyncLocalStorage<{ anthropicProxyBaseUrl: string }>();
+
+let fetchWrapperInstalled = false;
+
+/** Reset install state for tests so the wrapper can be re-installed with a new realFetch. */
+export function __testingResetInstall(): void {
+  fetchWrapperInstalled = false;
+}
+
+/**
+ * Returns true when the model uses a custom/proxy base URL (not official Anthropic).
+ * For those, we may need to inject "event:" lines if the proxy omits them.
+ * Uses a boundary check so only exact "https://api.anthropic.com" or
+ * "https://api.anthropic.com/..." is treated as official (avoids false negatives
+ * for hostnames like https://api.anthropic.com.evil.com).
+ */
+export function isCustomAnthropicBaseUrl(baseUrl: string | undefined): boolean {
+  if (!baseUrl || typeof baseUrl !== "string") {
+    return false;
+  }
+  const normalized = baseUrl.trim().replace(/\/+$/, "");
+  if (!normalized) {
+    return false;
+  }
+  const isOfficial =
+    normalized === ANTHROPIC_OFFICIAL_BASE || normalized.startsWith(ANTHROPIC_OFFICIAL_BASE + "/");
+  return !isOfficial;
+}
+
+/**
+ * Run fn inside an async context that marks requests to baseUrl as needing
+ * SSE event injection. Used when calling streamSimple for anthropic-messages
+ * with a custom baseUrl so the SDK's fetch sees the context.
+ */
+export function runWithAnthropicSSEEventInject<T>(baseUrl: string, fn: () => T): T {
+  ensureFetchWrapperInstalled();
+  return anthropicProxyBaseUrlStorage.run(
+    { anthropicProxyBaseUrl: baseUrl.trim().replace(/\/+$/, "") },
+    fn,
+  );
+}
+
+function ensureFetchWrapperInstalled(): void {
+  if (fetchWrapperInstalled) {
+    return;
+  }
+  fetchWrapperInstalled = true;
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const store = anthropicProxyBaseUrlStorage.getStore();
+    if (!store?.anthropicProxyBaseUrl) {
+      return realFetch(input, init);
+    }
+    const res = await realFetch(input, init);
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (!url.startsWith(store.anthropicProxyBaseUrl) || !res.body) {
+      return res;
+    }
+    const transformedBody = res.body.pipeThrough(createSSEEventInjectTransform());
+    return new Response(transformedBody, {
+      status: res.status,
+      statusText: res.statusText,
+      headers: res.headers,
+    });
+  };
+}
+
+/**
+ * TransformStream that, for each SSE "data:" line that contains JSON with a "type"
+ * field, prepends "event: <type>\n" when the previous line was not already "event:".
+ * This makes proxies that omit "event:" lines compatible with the SDK parser.
+ */
+function createSSEEventInjectTransform(): TransformStream<Uint8Array, Uint8Array> {
+  const encoder = new TextEncoder();
+  let buffer = "";
+  let lastLineWasEvent = false;
+
+  function flushLine(line: string): string {
+    const trimmed = line.replace(/\r$/, "");
+    if (!trimmed) {
+      lastLineWasEvent = false;
+      return line;
+    }
+    if (trimmed.startsWith("event:")) {
+      lastLineWasEvent = true;
+      return line;
+    }
+    if (trimmed.startsWith("data:")) {
+      const value = trimmed.slice(5).replace(/^\s+/, "");
+      let out = line;
+      if (!lastLineWasEvent && value) {
+        try {
+          const parsed = JSON.parse(value) as { type?: string };
+          if (typeof parsed?.type === "string" && parsed.type.trim()) {
+            out = `event: ${parsed.type.trim()}\n${line}`;
+          }
+        } catch {
+          // not JSON or no type; leave as-is
+        }
+      }
+      lastLineWasEvent = false;
+      return out;
+    }
+    lastLineWasEvent = false;
+    return line;
+  }
+
+  return new TransformStream({
+    transform(chunk, controller) {
+      buffer += new TextDecoder().decode(chunk);
+      const lines = buffer.split(/\r\n|\n/);
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        const flushed = flushLine(line + "\n");
+        controller.enqueue(encoder.encode(flushed));
+      }
+    },
+    flush(controller) {
+      if (buffer) {
+        controller.enqueue(encoder.encode(buffer));
+      }
+    },
+  });
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -32,6 +32,10 @@ import { resolveOpenClawAgentDir } from "../../agent-paths.js";
 import { resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
 import {
+  isCustomAnthropicBaseUrl,
+  runWithAnthropicSSEEventInject,
+} from "../../anthropic-sse-event-inject.js";
+import {
   analyzeBootstrapBudget,
   buildBootstrapPromptWarning,
   buildBootstrapTruncationReportMeta,
@@ -1167,8 +1171,17 @@ export async function runEmbeddedAttempt(
           activeSession.agent.streamFn = streamSimple;
         }
       } else {
-        // Force a stable streamFn reference so vitest can reliably mock @mariozechner/pi-ai.
-        activeSession.agent.streamFn = streamSimple;
+        // anthropic-messages with custom baseUrl (proxy): inject SSE event lines so SDK gets events (#37571).
+        if (
+          params.model.api === "anthropic-messages" &&
+          isCustomAnthropicBaseUrl(params.model.baseUrl)
+        ) {
+          const baseUrl = params.model.baseUrl;
+          activeSession.agent.streamFn = (model, context, options) =>
+            runWithAnthropicSSEEventInject(baseUrl, () => streamSimple(model, context, options));
+        } else {
+          activeSession.agent.streamFn = streamSimple;
+        }
       }
 
       // Ollama with OpenAI-compatible API needs num_ctx in payload.options.


### PR DESCRIPTION
Fixes #37571

### Problem

When using `api: "anthropic-messages"` with a **third-party proxy** (custom `baseUrl`, i.e. not `https://api.anthropic.com`), if the proxy returns only SSE `data:` lines and **omits `event:` lines**, the run fails with:

Users cannot use anthropic-messages streaming through proxies (e.g. LiteLLM, custom gateways) that forward only `data:` lines.

### Root cause

- The `@anthropic-ai/sdk` SSE parser relies on **`event:`** lines (e.g. `event: message_start`) to identify event types and emit callbacks.
- If the proxy sends only `data: {"type":"message_start",...}` with no preceding `event: message_start`, the SDK keeps `sse.event` as `null`, drops all events, and the stream appears empty to the consumer, leading to the error above.

### Approach

- **Minimal impact:** No patch or fork of pi-ai; no new custom anthropic streaming path.
- In OpenClaw we transform the **response body** of requests to a custom anthropic baseUrl: for each `data:` line whose JSON has a `type` field and is not preceded by an `event:` line, we prepend `event: <type>\n`. The SDK then parses the stream correctly.
- We use **AsyncLocalStorage** and a **single global fetch wrapper** installed once. Only requests issued during a run that uses anthropic-messages with a custom baseUrl get the transform; the wrapper runs only when `getStore()?.anthropicProxyBaseUrl` is set and the request URL starts with that baseUrl. All other traffic uses the real `fetch` unchanged.

### Implementation

1. **`src/agents/anthropic-sse-event-inject.ts`** (new)
   - `isCustomAnthropicBaseUrl(baseUrl)`: returns true when baseUrl is set and not the official Anthropic API URL (used to decide whether to apply injection).
   - `createSSEEventInjectTransform()`: a `TransformStream<Uint8Array, Uint8Array>` that buffers SSE by line and, for `data:` lines with no preceding `event:` and with JSON containing `type`, outputs `event: <type>\n` before the line.
   - `runWithAnthropicSSEEventInject(baseUrl, fn)`: runs `fn` inside `AsyncLocalStorage.run({ anthropicProxyBaseUrl: baseUrl }, fn)` so only requests in that context to that baseUrl are handled by the wrapper.
   - Global fetch wrapper: installed on first use. It delegates to the real fetch; only when the store has `anthropicProxyBaseUrl`, the request URL starts with it, and the response has a body, the body is piped through `createSSEEventInjectTransform()` and returned in a new `Response`; otherwise the original response is returned.
   - `__testingResetInstall()` is exported for tests to reset the install state.

2. **`src/agents/pi-embedded-runner/run/attempt.ts`**
   - Where the default `streamFn = streamSimple` is set, add a branch: if `params.model.api === "anthropic-messages"` and `isCustomAnthropicBaseUrl(params.model.baseUrl)`, set `streamFn` to a function that calls `runWithAnthropicSSEEventInject(baseUrl, () => streamSimple(model, context, options))` with the same arguments. All other cases (official Anthropic, openai-responses, etc.) keep `streamFn = streamSimple`.

3. **Tests**
   - `src/agents/anthropic-sse-event-inject.test.ts`: tests `isCustomAnthropicBaseUrl` for various baseUrls, and via a mocked fetch verifies that inside `runWithAnthropicSSEEventInject` the consumed response body has `event: message_start` (etc.) injected when the proxy sends only `data:` lines, and that existing `event:` lines are not duplicated.

4. **Docs**
   - In `docs/providers/anthropic.md`, under Troubleshooting, add an entry for **"request ended without sending any chunks" with custom baseUrl (proxy)**: describe the symptom, that OpenClaw auto-injects `event:` when using anthropic-messages with a custom baseUrl, and suggest checking model config or trying `openai-completions` if the issue persists.

### Scope

- **Injection is applied only when:** the model is configured with `api: "anthropic-messages"` and a custom `baseUrl` (not `https://api.anthropic.com`).
- **Unaffected:** Official Anthropic, Bedrock, OpenAI, Ollama, and all other APIs/providers; anthropic-messages without a custom baseUrl are unchanged.