### PR TITLE
fix(discord): honor proxy for REST via carbon dispatcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -443,6 +443,9 @@
       "node-llama-cpp",
       "protobufjs",
       "sharp"
-    ]
+    ],
+    "patchedDependencies": {
+      "@buape/carbon@0.0.0-beta-20260216184201": "patches/@buape__carbon@0.0.0-beta-20260216184201.patch"
+    }
   }
 }

--- a/patches/@buape__carbon@0.0.0-beta-20260216184201.patch
+++ b/patches/@buape__carbon@0.0.0-beta-20260216184201.patch
@@ -1,0 +1,54 @@
+diff --git a/dist/src/classes/RequestClient.d.ts b/dist/src/classes/RequestClient.d.ts
+index a45b74eed9b297db6a9b71c116298007aa585faa..e531141269c2525c6a1af5d46eaef8d473762934 100644
+--- a/dist/src/classes/RequestClient.d.ts
++++ b/dist/src/classes/RequestClient.d.ts
+@@ -42,6 +42,11 @@ export type RequestClientOptions = {
+      * @default 1000
+      */
+     maxQueueSize?: number;
++    /**
++     * Optional undici dispatcher (ProxyAgent, EnvHttpProxyAgent, etc) to use for all REST calls.
++     * When unset, RequestClient uses the runtime global fetch implementation.
++     */
++    dispatcher?: unknown;
+ };
+ export type QueuedRequest = {
+     method: string;
+diff --git a/dist/src/classes/RequestClient.js b/dist/src/classes/RequestClient.js
+index 1cd3130df8b2cd71a240f8b028a71680628cf0fd..6fc768fa1656c21431382086f25a91e609f16d25 100644
+--- a/dist/src/classes/RequestClient.js
++++ b/dist/src/classes/RequestClient.js
+@@ -1,3 +1,4 @@
++import { fetch as undiciFetch } from "undici";
+ import { DiscordError } from "../errors/DiscordError.js";
+ import { RateLimitError } from "../errors/RatelimitError.js";
+ const defaultOptions = {
+@@ -188,13 +189,22 @@ export class RequestClient {
+             }, timeoutMs);
+         }
+         let response;
++        const init = {
++            method,
++            headers,
++            body,
++            signal: this.abortController.signal
++        };
+         try {
+-            response = await fetch(url, {
+-                method,
+-                headers,
+-                body,
+-                signal: this.abortController.signal
+-            });
++            if (this.options.dispatcher) {
++                response = await undiciFetch(url, {
++                    ...init,
++                    dispatcher: this.options.dispatcher
++                });
++            }
++            else {
++                response = await fetch(url, init);
++            }
+         }
+         finally {
+             if (timeoutId) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,11 @@ overrides:
   tar: 7.5.10
   tough-cookie: 4.1.3
 
+patchedDependencies:
+  '@buape/carbon@0.0.0-beta-20260216184201':
+    hash: 0b2d3e92cf54b2467a51aba82f8080fdc5d409ec2509ddbd5eb435ee1d766845
+    path: patches/@buape__carbon@0.0.0-beta-20260216184201.patch
+
 importers:
 
   .:
@@ -30,7 +35,7 @@ importers:
         version: 3.1000.0
       '@buape/carbon':
         specifier: 0.0.0-beta-20260216184201
-        version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.5)(opusscript@0.1.1)
+        version: 0.0.0-beta-20260216184201(patch_hash=0b2d3e92cf54b2467a51aba82f8080fdc5d409ec2509ddbd5eb435ee1d766845)(@discordjs/opus@0.10.0)(hono@4.12.5)(opusscript@0.1.1)
       '@clack/prompts':
         specifier: ^1.0.1
         version: 1.0.1
@@ -6821,7 +6826,7 @@ snapshots:
 
   '@borewit/text-codec@0.2.1': {}
 
-  '@buape/carbon@0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.5)(opusscript@0.1.1)':
+  '@buape/carbon@0.0.0-beta-20260216184201(patch_hash=0b2d3e92cf54b2467a51aba82f8080fdc5d409ec2509ddbd5eb435ee1d766845)(@discordjs/opus@0.10.0)(hono@4.12.5)(opusscript@0.1.1)':
     dependencies:
       '@types/node': 25.3.3
       discord-api-types: 0.38.37
@@ -11194,7 +11199,7 @@ snapshots:
     dependencies:
       '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
       '@aws-sdk/client-bedrock': 3.1000.0
-      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.12.5)(opusscript@0.1.1)
+      '@buape/carbon': 0.0.0-beta-20260216184201(patch_hash=0b2d3e92cf54b2467a51aba82f8080fdc5d409ec2509ddbd5eb435ee1d766845)(@discordjs/opus@0.10.0)(hono@4.12.5)(opusscript@0.1.1)
       '@clack/prompts': 1.0.1
       '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
       '@grammyjs/runner': 2.0.3(grammy@1.41.0)

--- a/src/discord/client.proxy.test.ts
+++ b/src/discord/client.proxy.test.ts
@@ -6,6 +6,9 @@ const proxyAgentCtorMock = vi.fn();
 vi.mock("undici", () => ({
   ProxyAgent: class ProxyAgent {
     constructor(url: string) {
+      if (url === "bad-proxy") {
+        throw new Error("bad proxy");
+      }
       proxyAgentCtorMock(url);
     }
   },
@@ -28,6 +31,7 @@ vi.mock("../config/config.js", () => ({
         proxy: "http://127.0.0.1:7890",
         accounts: {
           default: {},
+          bad: { proxy: "bad-proxy" },
         },
       },
     },
@@ -77,5 +81,16 @@ describe("discord client proxy wiring", () => {
     const [_token, options] = requestClientCtorMock.mock.calls[0];
     expect(options).toBeTruthy();
     expect((options as { dispatcher?: unknown }).dispatcher).toBeTruthy();
+  });
+
+  it("falls back to a non-proxied RequestClient when the proxy URL is invalid", () => {
+    requestClientCtorMock.mockClear();
+    proxyAgentCtorMock.mockClear();
+
+    createDiscordRestClient({ accountId: "bad" });
+
+    expect(requestClientCtorMock).toHaveBeenCalledTimes(1);
+    const [_token, options] = requestClientCtorMock.mock.calls[0];
+    expect(options).toBeFalsy();
   });
 });

--- a/src/discord/client.proxy.test.ts
+++ b/src/discord/client.proxy.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+
+const requestClientCtorMock = vi.fn();
+const proxyAgentCtorMock = vi.fn();
+
+vi.mock("undici", () => ({
+  ProxyAgent: class ProxyAgent {
+    constructor(url: string) {
+      proxyAgentCtorMock(url);
+    }
+  },
+}));
+
+vi.mock("@buape/carbon", () => ({
+  RequestClient: class RequestClient {
+    constructor(token: string, options?: unknown) {
+      requestClientCtorMock(token, options);
+    }
+  },
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({
+    channels: {
+      discord: {
+        enabled: true,
+        token: "cfg-token",
+        proxy: "http://127.0.0.1:7890",
+        accounts: {
+          default: {},
+        },
+      },
+    },
+  })),
+}));
+
+vi.mock("./accounts.js", () => ({
+  resolveDiscordAccount: ({ cfg, accountId }: { cfg: unknown; accountId?: string }) => {
+    const base = (
+      cfg as {
+        channels: {
+          discord: {
+            token: string;
+            accounts: Record<string, unknown>;
+          };
+        };
+      }
+    ).channels.discord;
+    const account =
+      (base.accounts[accountId ?? "default"] as Record<string, unknown> | undefined) ?? {};
+    return {
+      accountId: accountId ?? "default",
+      enabled: true,
+      token: base.token,
+      tokenSource: "config",
+      config: { ...base, ...account },
+    };
+  },
+}));
+
+vi.mock("./token.js", () => ({
+  normalizeDiscordToken: (value?: string) => value,
+}));
+
+import { createDiscordRestClient } from "./client.js";
+
+describe("discord client proxy wiring", () => {
+  it("passes an undici ProxyAgent dispatcher into Carbon RequestClient when proxy is configured", () => {
+    requestClientCtorMock.mockClear();
+    proxyAgentCtorMock.mockClear();
+
+    createDiscordRestClient({ accountId: "default" });
+
+    expect(proxyAgentCtorMock).toHaveBeenCalledWith("http://127.0.0.1:7890");
+    expect(requestClientCtorMock).toHaveBeenCalledTimes(1);
+
+    const [_token, options] = requestClientCtorMock.mock.calls[0];
+    expect(options).toBeTruthy();
+    expect((options as { dispatcher?: unknown }).dispatcher).toBeTruthy();
+  });
+});

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -1,4 +1,5 @@
 import { RequestClient } from "@buape/carbon";
+import { ProxyAgent } from "undici";
 import { loadConfig } from "../config/config.js";
 import { createDiscordRetryRunner, type RetryRunner } from "../infra/retry-policy.js";
 import type { RetryConfig } from "../infra/retry.js";
@@ -27,8 +28,20 @@ function resolveToken(params: { explicit?: string; accountId: string; fallbackTo
   return fallback;
 }
 
-function resolveRest(token: string, rest?: RequestClient) {
-  return rest ?? new RequestClient(token);
+function resolveRest(params: { token: string; proxyUrl?: string; rest?: RequestClient }) {
+  if (params.rest) {
+    return params.rest;
+  }
+  const proxy = params.proxyUrl?.trim();
+  if (!proxy) {
+    return new RequestClient(params.token);
+  }
+  // Carbon's RequestClient uses global fetch by default; provide an undici dispatcher
+  // so REST calls can traverse an HTTP proxy (e.g. Clash, Squid).
+  return new RequestClient(params.token, { dispatcher: new ProxyAgent(proxy) } as unknown as Record<
+    string,
+    unknown
+  >);
 }
 
 export function createDiscordRestClient(opts: DiscordClientOpts, cfg = loadConfig()) {
@@ -38,7 +51,7 @@ export function createDiscordRestClient(opts: DiscordClientOpts, cfg = loadConfi
     accountId: account.accountId,
     fallbackToken: account.token,
   });
-  const rest = resolveRest(token, opts.rest);
+  const rest = resolveRest({ token, proxyUrl: account.config.proxy, rest: opts.rest });
   return { token, rest, account };
 }
 

--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -36,12 +36,19 @@ function resolveRest(params: { token: string; proxyUrl?: string; rest?: RequestC
   if (!proxy) {
     return new RequestClient(params.token);
   }
+
   // Carbon's RequestClient uses global fetch by default; provide an undici dispatcher
   // so REST calls can traverse an HTTP proxy (e.g. Clash, Squid).
-  return new RequestClient(params.token, { dispatcher: new ProxyAgent(proxy) } as unknown as Record<
-    string,
-    unknown
-  >);
+  //
+  // Be defensive: ProxyAgent construction can throw synchronously for malformed proxy
+  // strings. In that case, fall back to the default (non-proxied) RequestClient instead
+  // of crashing during Discord client initialization.
+  try {
+    const dispatcher = new ProxyAgent(proxy);
+    return new RequestClient(params.token, { dispatcher } as unknown as Record<string, unknown>);
+  } catch {
+    return new RequestClient(params.token);
+  }
 }
 
 export function createDiscordRestClient(opts: DiscordClientOpts, cfg = loadConfig()) {


### PR DESCRIPTION
Fixes #27409.

### Problem
- When `channels.discord.proxy` is configured, Discord Gateway/WebSocket traffic is proxied, but **Discord REST** calls can still bypass the proxy.
- In proxy-required networks this causes Discord REST operations (send message / lookups) to fail (e.g. `fetch failed`).

### Root cause
- Discord REST uses Carbon's `RequestClient`, which (upstream) uses the runtime global `fetch` and has no way to pass an `undici` dispatcher/agent.

### Changes
- Patch `@buape/carbon` `RequestClient` to accept an optional `dispatcher` option, and use `undici.fetch(..., { dispatcher })` when provided.
- Wire Discord REST client to inject `new ProxyAgent(proxyUrl)` as the Carbon `RequestClient` dispatcher when `channels.discord.proxy` is set.
- Add a unit test verifying the proxy wiring.

### Verification
```bash
pnpm lint
env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy \
  npx vitest run --config vitest.channels.config.ts src/discord
```

### Notes / Risk
- Small, contained change: only affects Discord REST behavior when a proxy is configured.
- Uses existing `pnpm patch` workflow (`patches/@buape__carbon@...patch`).
- This aligns with the maintainer suggestion on the previous attempt (#28609) to fix it at the Carbon layer (see carbon#360).
