### PR TITLE
fix(compaction): treat safeguard no-op compaction as non-compacted

### DIFF
--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -354,4 +354,48 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
       tokenCount: 0,
     });
   });
+
+  it("treats no-op compact results as not compacted", async () => {
+    const piAgent = await import("@mariozechner/pi-coding-agent");
+    const createAgentSession = vi.mocked(piAgent.createAgentSession);
+    createAgentSession.mockImplementationOnce(async () => {
+      const session = {
+        sessionId: "session-1",
+        messages: [
+          { role: "user", content: "hello", timestamp: 1 },
+          { role: "assistant", content: [{ type: "text", text: "hi" }], timestamp: 2 },
+        ],
+        agent: {
+          replaceMessages: vi.fn((messages: unknown[]) => {
+            session.messages = [...(messages as typeof session.messages)];
+          }),
+          streamFn: vi.fn(),
+        },
+        compact: vi.fn(async () => ({
+          summary: "summary",
+          firstKeptEntryId: "entry-1",
+          tokensBefore: 120,
+          details: { ok: true },
+        })),
+        dispose: vi.fn(),
+      };
+      return { session };
+    });
+
+    const result = await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      customInstructions: "focus on decisions",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      compacted: false,
+      reason: "nothing to compact",
+    });
+    expect(sessionHook("compact:after")).toBeUndefined();
+    expect(hookRunner.runAfterCompaction).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -358,7 +358,7 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
   it("treats no-op compact results as not compacted", async () => {
     const piAgent = await import("@mariozechner/pi-coding-agent");
     const createAgentSession = vi.mocked(piAgent.createAgentSession);
-    createAgentSession.mockImplementationOnce(async () => {
+    createAgentSession.mockImplementationOnce((async () => {
       const session = {
         sessionId: "session-1",
         messages: [
@@ -379,8 +379,14 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
         })),
         dispose: vi.fn(),
       };
-      return { session };
-    });
+      return {
+        session,
+        extensionsResult: {
+          successfulExtensions: [],
+          failedExtensions: [],
+        },
+      };
+    }) as never);
 
     const result = await compactEmbeddedPiSessionDirect({
       sessionId: "session-1",

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -743,6 +743,17 @@ export async function compactEmbeddedPiSessionDirect(
         }
         const messageCountAfter = session.messages.length;
         const compactedCount = Math.max(0, messageCountCompactionInput - messageCountAfter);
+        if (compactedCount === 0) {
+          log.info(
+            `[compaction] skipping — compaction returned no message reduction ` +
+              `(sessionKey=${params.sessionKey ?? params.sessionId})`,
+          );
+          return {
+            ok: true,
+            compacted: false,
+            reason: "nothing to compact",
+          };
+        }
         const postMetrics = diagEnabled ? summarizeCompactionMessages(session.messages) : undefined;
         if (diagEnabled && preMetrics && postMetrics) {
           log.debug(


### PR DESCRIPTION
## Summary
- treat compaction runs with zero message reduction as `compacted: false` instead of unconditional success
- return `reason: "nothing to compact"` for no-op runs so overflow handling can avoid false "compacted" state
- add a regression test ensuring no-op compaction does not emit post-compaction hooks

## Testing
- pnpm vitest run src/agents/pi-embedded-runner/compact.hooks.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts

Fixes #37579
