### PR TITLE
[Issue #37595] [Feature Request] Control UI: Show available skills list

### DIFF
--- a/.github/issue-bootstrap/issue-37595.md
+++ b/.github/issue-bootstrap/issue-37595.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37595
+- Title: [Feature Request] Control UI: Show available skills list
+- Source: https://github.com/openclaw/openclaw/issues/37595


### PR DESCRIPTION
## Issue Bootstrap

- Issue: #37595
- Source: https://github.com/openclaw/openclaw/issues/37595

## Original issue description

## Description

In the OpenClaw Control UI, add a section to display the agent&#39;s available skills.

Currently, users can only view skills via CLI command:
```
openclaw skills list
```

But there&#39;s no way to see this in the web UI.

## Expected Behavior

- Show a list of ready/missing skills in the Control UI
- Display skill name, status (ready/missing), description, and source
- Allow users to quickly see what capabilities the agent has

## Additional Context

This would help users understand the agent&#39;s capabilities without needing CLI access.

Closes #37595