### PR TITLE
[Issue #37584] feat: per-agent tool settings (e.g. tools.web.search.apiKey)

### DIFF
--- a/.github/issue-bootstrap/issue-37584.md
+++ b/.github/issue-bootstrap/issue-37584.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37584
+- Title: feat: per-agent tool settings (e.g. tools.web.search.apiKey)
+- Source: https://github.com/openclaw/openclaw/issues/37584


### PR DESCRIPTION
## Issue Bootstrap

- Issue: #37584
- Source: https://github.com/openclaw/openclaw/issues/37584

## Original issue description

## Feature Request

### Problem

In a multi-agent setup, `tools.web.search.apiKey` (and other tool-specific settings like provider, timeouts, etc.) are global — shared across all agents. There is no way to scope them per agent.

Per-agent `tools` config (`agents.list[].tools`) currently only supports:
- `profile` / `allow` / `deny`
- `elevated` / `loopDetection` / `sandbox.tools`
- `byProvider`

### Use Case

Running multiple agents that need **different API keys** for web search (e.g. separate billing/rate limits per agent, or different search providers per agent).

### Proposed Solution

Allow `agents.list[].tools.web` (and potentially other nested tool settings) to override global `tools.web` config per agent. For example:

```json5
{
  tools: {
    web: {
      search: {
        apiKey: &#34;default-brave-key&#34;,
      },
    },
  },
  agents: {
    list: [
      {
        id: &#34;work&#34;,
        tools: {
          web: {
            search: {
              apiKey: &#34;work-specific-brave-key&#34;,
            },
          },
        },
      },
      {
        id: &#34;personal&#34;,
        tools: {
          web: {
            search: {
              apiKey: &#34;personal-brave-key&#34;,
            },
          },
        },
      },
    ],
  },
}
```

### Alternatives Considered

- **Two gateway instances** with separate configs — works but heavyweight for just an API key difference
- **Env vars** — `BRAVE_API_KEY` is gateway-wide, no per-agent env support

Closes #37584