### PR TITLE
[Issue #37579] [Bug] Compaction safeguard 频繁触发导致消息丢失

### DIFF
--- a/.github/issue-bootstrap/issue-37579.md
+++ b/.github/issue-bootstrap/issue-37579.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37579
+- Title: [Bug] Compaction safeguard 频繁触发导致消息丢失
+- Source: https://github.com/openclaw/openclaw/issues/37579


### PR DESCRIPTION
## Issue Bootstrap

- Issue: #37579
- Source: https://github.com/openclaw/openclaw/issues/37579

## Original issue description

## 问题描述

当对话历史较长时，UI 显示 &#34;context compacted&#34;，但实际 compaction 被 safeguard 取消。在此期间，用户发送的消息无法被 AI 接收/响应。

## 日志证据

```
WARN: Compaction safeguard: cancelling compaction with no real conversation messages to summarize
```

这个警告在短时间内频繁出现（每分钟多次），说明：
1. compact 流程被触发
2. safeguard 判断&#34;没有真正的对话消息&#34;后取消
3. 但 UI 可能已经显示 compacting/compacted 状态
4. 消息处理可能在此期间被阻塞

## 环境信息

- OpenClaw: 2026.3.2
- Node: v22.22.0
- 系统: macOS Darwin 25.3.0 arm64
- 通道: webchat (openclaw-control-ui)

## 复现步骤

1. 进行较长的对话（触发 compact 阈值）
2. 观察日志中的 safeguard 警告
3. 在 compact 尝试期间发送消息
4. 消息可能丢失或延迟响应

## 期望行为

1. 如果 safeguard 取消 compact，UI 不应显示 &#34;context compacted&#34;
2. compact 流程不应阻塞消息处理
3. safeguard 的判断逻辑可能需要调整（为什么会认为没有&#34;真正的对话消息&#34;？）

## 临时解决方案

使用 `/new` 新开对话，避免长历史触发 compact。

## 相关代码

`subsystem-BfkFJ4uQ.js:427` - compaction safeguard 逻辑

---

感谢排查！🙏

Closes #37579