### PR TITLE
[Issue #37571] [Bug]: Custom anthropic-messages providers fail when proxy omits SSE event: field

### DIFF
--- a/.github/issue-bootstrap/issue-37571.md
+++ b/.github/issue-bootstrap/issue-37571.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37571
+- Title: [Bug]: Custom anthropic-messages providers fail when proxy omits SSE event: field
+- Source: https://github.com/openclaw/openclaw/issues/37571


### PR DESCRIPTION
## Issue Bootstrap

- Issue: #37571
- Source: https://github.com/openclaw/openclaw/issues/37571

## Original issue description

### Bug type

Behavior bug (incorrect output/state without crash)

### Summary

Custom providers using `api: &#34;anthropic-messages&#34;` with a third-party proxy that returns SSE streams without `event:` field lines fail with `&#34;request ended without sending any chunks&#34;`. The `@anthropic-ai/sdk` SSE parser requires the `event:` field to dispatch events — when it&#39;s missing, all SSE events are silently dropped.

### Steps to reproduce

1. Configure a custom provider with `api: &#34;anthropic-messages&#34;` pointing to a third-party Anthropic-compatible proxy
2. The proxy returns valid SSE data but omits `event:` lines (only sends `data:` lines with `{&#34;type&#34;:&#34;message_start&#34;,...}`)
3. Send any message using this provider

**Standard Anthropic SSE format:**
```
event: message_start
data: {&#34;type&#34;:&#34;message_start&#34;,&#34;message&#34;:{...}}
```

**Proxy SSE format (missing `event:` lines):**
```
data: {&#34;type&#34;:&#34;message_start&#34;,&#34;message&#34;:{...}}
```

The JSON payload is identical and valid — only the SSE `event:` field is missing.

### Expected behavior

The SSE stream should be parsed successfully and the model should respond normally, regardless of whether the proxy includes `event:` field lines — the event type is already available in `data.type`.

### Actual behavior

Error: `&#34;request ended without sending any chunks&#34;` (from `@anthropic-ai/sdk/lib/BetaMessageStream.js:436`)

**Root cause trace:**
1. `@anthropic-ai/sdk` SSE parser (`core/streaming.js:242`) initializes `this.event = null`
2. Without `event:` lines, `sse.event` stays `null` for all events
3. `core/streaming.js:44-49` only yields events when `sse.event === &#39;message_start&#39;` etc. — `null` matches nothing
4. All events silently dropped → `#currentMessageSnapshot` stays `undefined`
5. `BetaMessageStream.js:436` throws when stream ends with no snapshot

### OpenClaw version

2026.3.2

### Operating system

macOS 15.3.2

### Install method

npm global

### Logs, screenshots, and evidence

```shell

```

### Impact and severity

Affected: All users with custom anthropic-messages providers behind third-party proxies that don&#39;t emit SSE event: lines
Severity: High (completely blocks usage of custom anthropic-messages providers with non-conformant proxies)
Frequency: 100% repro with affected proxies
Consequence: Cannot use prompt caching or native Anthropic features through custom providers; forced to use openai-completions API as workaround

### Additional information

**Suggested fix:** In `pi-ai`&#39;s `streamAnthropic`, pass a custom `fetch` to the Anthropic client that wraps the response body with a TransformStream. The transform would detect `data:` lines containing `{&#34;type&#34;:&#34;&#34;,...}` and inject the corresponding `event: \n` line before each `data:` line when no `event:` line is present.

Alternatively, this could be fixed upstream in `@anthropic-ai/sdk` by falling back to `JSON.parse(data).type` when `sse.event` is `null`.

**Workaround:** Use `api: &#34;openai-completions&#34;` instead of `api: &#34;anthropic-messages&#34;` for custom providers (loses native prompt caching support).

Closes #37571