### PR TITLE
[Issue #37565] Telegram: metadata leak in DMs

### DIFF
--- a/.github/issue-bootstrap/issue-37565.md
+++ b/.github/issue-bootstrap/issue-37565.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37565
+- Title: Telegram: metadata leak in DMs
+- Source: https://github.com/openclaw/openclaw/issues/37565


### PR DESCRIPTION
## Issue Bootstrap

- Issue: #37565
- Source: https://github.com/openclaw/openclaw/issues/37565

## Original issue description

Repro: Messages prefixed with &#34;Human: Conversation info (untrusted metadata): {&#34;. Config: dmPolicy=pairing, streaming=partial→off. v2026.3.2, Linux. Status clean. Screenshot repro if needed.

Closes #37565