### PR TITLE
[Issue #37564] [Bug]:  {"subsystem":"gateway/channels/feishu"} feishu[default]: dispatch complete (queuedFinal=false, replies=0)

### DIFF
--- a/.github/issue-bootstrap/issue-37564.md
+++ b/.github/issue-bootstrap/issue-37564.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37564
+- Title: [Bug]:  {"subsystem":"gateway/channels/feishu"} feishu[default]: dispatch complete (queuedFinal=false, replies=0)
+- Source: https://github.com/openclaw/openclaw/issues/37564


### PR DESCRIPTION
## Issue Bootstrap

- Issue: #37564
- Source: https://github.com/openclaw/openclaw/issues/37564

## Original issue description

### Bug type

Behavior bug (incorrect output/state without crash)

### Summary

[Bug]:  {&#34;subsystem&#34;:&#34;gateway/channels/feishu&#34;} feishu[default]: dispatch complete (queuedFinal=false, replies=0)

### Steps to reproduce

<img width="1656" height="270" alt="Image" src="https://github.com/user-attachments/assets/da5157bb-4f7b-4a53-9384-4c7396f85ad2"/>

<img width="1440" height="770" alt="Image" src="https://github.com/user-attachments/assets/e3f81d9b-1e2f-419d-9dcd-d3b727125b44"/>

### Expected behavior

[Bug]:  {&#34;subsystem&#34;:&#34;gateway/channels/feishu&#34;} feishu[default]: dispatch complete (queuedFinal=false, replies=0)

### Actual behavior

[Bug]:  {&#34;subsystem&#34;:&#34;gateway/channels/feishu&#34;} feishu[default]: dispatch complete (queuedFinal=false, replies=0)

### OpenClaw version

2026.2.25

### Operating system

openEuler 22.03 LTS

### Install method

npm全局

### Logs, screenshots, and evidence

```shell

```

### Impact and severity

_No response_

### Additional information

_No response_

Closes #37564