### PR TITLE
[Issue #37553] [Feature]: How to automatically designate bot replies based on "@" in content in openclaw

### DIFF
--- a/.github/issue-bootstrap/issue-37553.md
+++ b/.github/issue-bootstrap/issue-37553.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37553
+- Title: [Feature]: How to automatically designate bot replies based on "@" in content in openclaw
+- Source: https://github.com/openclaw/openclaw/issues/37553


### PR DESCRIPTION
## Issue Bootstrap

- Issue: #37553
- Source: https://github.com/openclaw/openclaw/issues/37553

## Original issue description

### Summary

In openclaw, how can replies be automatically assigned to a bot when the content contains &#34;@&#34; symbols? This feature is needed for efficient bot management and response handling.


### Problem to solve

In openclaw, how can replies be automatically assigned to a bot when the content contains &#34;@&#34; symbols? This feature is needed for efficient bot management and response handling.

### Proposed solution

In openclaw, how can replies be automatically assigned to a bot when the content contains &#34;@&#34; symbols? This feature is needed for efficient bot management and response handling.

### Alternatives considered

_No response_

### Impact

.

### Evidence/examples

_No response_

### Additional information

_No response_

Closes #37553