### PR TITLE
[Issue #37550] macOS: OpenClaw.app v2026.3.2 crashes on launch (Fatal access conflict in TalkOverlayView)

### DIFF
--- a/.github/issue-bootstrap/issue-37550.md
+++ b/.github/issue-bootstrap/issue-37550.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37550
+- Title: macOS: OpenClaw.app v2026.3.2 crashes on launch (Fatal access conflict in TalkOverlayView)
+- Source: https://github.com/openclaw/openclaw/issues/37550


### PR DESCRIPTION
## Issue Bootstrap

- Issue: #37550
- Source: https://github.com/openclaw/openclaw/issues/37550

## Original issue description

## Summary
OpenClaw.app `v2026.3.2` crashes on launch on macOS (menu bar app does not stay alive).

## Environment
- OpenClaw.app: `2026.3.2` (build `2026030290`)
- OpenClaw CLI: `2026.3.2`
- macOS: `26.4 (25E5223i)`
- Hardware: Apple Silicon (`Mac16,10`)

## Repro steps
1. Install DMG release `OpenClaw-2026.3.2.dmg`.
2. Launch `/Applications/OpenClaw.app`.
3. Observe that menu bar icon does not remain visible; app process aborts.

## Expected behavior
The menu bar app should stay running and show icon/panel normally.

## Actual behavior
The app crashes with `EXC_CRASH (SIGABRT)`.

Crash report indicates Swift exclusivity conflict:
- `libswiftCore.dylib Fatal access conflict detected`
- stack includes:
  - `TalkOverlayView.body.getter`
  - `TalkOverlayController.present()`
  - `TalkModeController.setEnabled(_:)`

## Additional context
- Gateway and CLI are healthy and continue to work (`openclaw gateway status` probe OK).
- I also tried clearing app-local state (`~/Library/Application Support/OpenClaw`, app plist prefs) and relaunching; same crash.

## Attachments
I prepared a crash bundle containing:
- latest `OpenClaw-*.ips`
- repro notes (`repro.md`)
- basic diagnostics (`diagnostics.txt`)

(Will upload in issue comments if needed.)

Closes #37550