### PR TITLE
[Issue #37546] [Bug]: Message ordering conflict - please try again. If this persists, use /new to start a fresh session.

### DIFF
--- a/.github/issue-bootstrap/issue-37546.md
+++ b/.github/issue-bootstrap/issue-37546.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37546
+- Title: [Bug]: Message ordering conflict - please try again. If this persists, use /new to start a fresh session.
+- Source: https://github.com/openclaw/openclaw/issues/37546


### PR DESCRIPTION
## Issue Bootstrap

- Issue: #37546
- Source: https://github.com/openclaw/openclaw/issues/37546

## Original issue description

### Bug type

Regression (worked before, now fails)

### Summary

No matter what message I send, I get the same reply, and /new doesn&#39;t work either; it&#39;s always the same response.Message ordering conflict - please try again. If this persists, use /new to start a fresh session.

### Steps to reproduce

No matter what message I send, I get the same reply, and /new doesn&#39;t work either; it&#39;s always the same response.Message ordering conflict - please try again. If this persists, use /new to start a fresh session.

### Expected behavior

No matter what message I send, I get the same reply, and /new doesn&#39;t work either; it&#39;s always the same response.Message ordering conflict - please try again. If this persists, use /new to start a fresh session.

### Actual behavior

No matter what message I send, I get the same reply, and /new doesn&#39;t work either; it&#39;s always the same response.Message ordering conflict - please try again. If this persists, use /new to start a fresh session.

### OpenClaw version

2026.3.2

### Operating system

Ubuntu

### Install method

_No response_

### Logs, screenshots, and evidence

```shell

```

### Impact and severity

_No response_

### Additional information

_No response_

Closes #37546