### PR TITLE
fix(discord): prevent uncaught error crash when gateway shuts down with maxAttempts=0

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1460,6 +1460,20 @@ public struct ConfigPatchParams: Codable, Sendable {
 
 public struct ConfigSchemaParams: Codable, Sendable {}
 
+public struct ConfigSchemaLookupParams: Codable, Sendable {
+    public let path: String
+
+    public init(
+        path: String)
+    {
+        self.path = path
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+    }
+}
+
 public struct ConfigSchemaResponse: Codable, Sendable {
     public let schema: AnyCodable
     public let uihints: [String: AnyCodable]
@@ -1483,6 +1497,36 @@ public struct ConfigSchemaResponse: Codable, Sendable {
         case uihints = "uiHints"
         case version
         case generatedat = "generatedAt"
+    }
+}
+
+public struct ConfigSchemaLookupResult: Codable, Sendable {
+    public let path: String
+    public let schema: AnyCodable
+    public let hint: [String: AnyCodable]?
+    public let hintpath: String?
+    public let children: [[String: AnyCodable]]
+
+    public init(
+        path: String,
+        schema: AnyCodable,
+        hint: [String: AnyCodable]?,
+        hintpath: String?,
+        children: [[String: AnyCodable]])
+    {
+        self.path = path
+        self.schema = schema
+        self.hint = hint
+        self.hintpath = hintpath
+        self.children = children
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+        case schema
+        case hint
+        case hintpath = "hintPath"
+        case children
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1460,6 +1460,20 @@ public struct ConfigPatchParams: Codable, Sendable {
 
 public struct ConfigSchemaParams: Codable, Sendable {}
 
+public struct ConfigSchemaLookupParams: Codable, Sendable {
+    public let path: String
+
+    public init(
+        path: String)
+    {
+        self.path = path
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+    }
+}
+
 public struct ConfigSchemaResponse: Codable, Sendable {
     public let schema: AnyCodable
     public let uihints: [String: AnyCodable]
@@ -1483,6 +1497,36 @@ public struct ConfigSchemaResponse: Codable, Sendable {
         case uihints = "uiHints"
         case version
         case generatedat = "generatedAt"
+    }
+}
+
+public struct ConfigSchemaLookupResult: Codable, Sendable {
+    public let path: String
+    public let schema: AnyCodable
+    public let hint: [String: AnyCodable]?
+    public let hintpath: String?
+    public let children: [[String: AnyCodable]]
+
+    public init(
+        path: String,
+        schema: AnyCodable,
+        hint: [String: AnyCodable]?,
+        hintpath: String?,
+        children: [[String: AnyCodable]])
+    {
+        self.path = path
+        self.schema = schema
+        self.hint = hint
+        self.hintpath = hintpath
+        self.children = children
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+        case schema
+        case hint
+        case hintpath = "hintPath"
+        case children
     }
 }
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -65,7 +65,9 @@ export async function runGatewayLoop(params: {
       const modeLabel =
         respawn.mode === "spawned"
           ? `spawned pid ${respawn.pid ?? "unknown"}`
-          : "supervisor restart";
+          : respawn.detail
+            ? `supervisor restart; ${respawn.detail}`
+            : "supervisor restart";
       gatewayLog.info(`restart mode: full process restart (${modeLabel})`);
       exitProcess(0);
       return;

--- a/src/discord/monitor.gateway.ts
+++ b/src/discord/monitor.gateway.ts
@@ -24,19 +24,20 @@ export async function waitForDiscordGatewayStop(
   const emitter = gateway?.emitter;
   return await new Promise<void>((resolve, reject) => {
     let settled = false;
-    const cleanup = () => {
-      abortSignal?.removeEventListener("abort", onAbort);
-      emitter?.removeListener("error", onGatewayErrorEvent);
-    };
     const finishResolve = () => {
       if (settled) {
         return;
       }
       settled = true;
-      cleanup();
+      // Remove abort listener first, but keep the error listener alive across
+      // gateway.disconnect() so Carbon's synchronous "max reconnect attempts"
+      // error (emitted when maxAttempts=0 is set before shutdown) is absorbed
+      // rather than crashing Node with an unhandled 'error' event.
+      abortSignal?.removeEventListener("abort", onAbort);
       try {
         gateway?.disconnect?.();
       } finally {
+        emitter?.removeListener("error", onGatewayErrorEvent);
         resolve();
       }
     };
@@ -45,10 +46,11 @@ export async function waitForDiscordGatewayStop(
         return;
       }
       settled = true;
-      cleanup();
+      abortSignal?.removeEventListener("abort", onAbort);
       try {
         gateway?.disconnect?.();
       } finally {
+        emitter?.removeListener("error", onGatewayErrorEvent);
         reject(err);
       }
     };
@@ -56,6 +58,12 @@ export async function waitForDiscordGatewayStop(
       finishResolve();
     };
     const onGatewayErrorEvent = (err: unknown) => {
+      // If already settled (e.g. shutting down), absorb the error silently so
+      // Carbon's reconnect-exhausted error during intentional disconnect does
+      // not surface as an unhandled rejection or spurious onGatewayError call.
+      if (settled) {
+        return;
+      }
       onGatewayError?.(err);
       const shouldStop = shouldStopOnError?.(err) ?? true;
       if (shouldStop) {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -424,7 +424,10 @@ function appendAssistantTranscriptMessage(params: {
 
   if (!fs.existsSync(transcriptPath)) {
     if (!params.createIfMissing) {
-      return { ok: false, error: "transcript file not found" };
+      return {
+        ok: false,
+        error: `session does not exist: no transcript found for session "${params.sessionId}"`,
+      };
     }
     const ensured = ensureTranscriptFile({
       transcriptPath,

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -95,6 +95,25 @@ describe("restartGatewayProcessWithFreshPid", () => {
     expect(result.detail).toContain("spawn failed");
   });
 
+  it("returns supervised when launchd kickstart times out (ETIMEDOUT) to avoid degraded state (#36822)", () => {
+    setPlatform("darwin");
+    process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
+    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+    triggerOpenClawRestartMock.mockReturnValue({
+      ok: false,
+      method: "launchctl",
+      detail: "spawnSync launchctl ETIMEDOUT",
+    });
+
+    const result = restartGatewayProcessWithFreshPid();
+
+    // ETIMEDOUT means launchctl timed out but the restart may be in-flight.
+    // Return "supervised" so the gateway exits cleanly and launchd KeepAlive
+    // restarts it, rather than falling back to a degraded in-process restart.
+    expect(result.mode).toBe("supervised");
+    expect(result.detail).toContain("ETIMEDOUT");
+  });
+
   it("does not schedule kickstart on non-darwin platforms", () => {
     setPlatform("linux");
     process.env.INVOCATION_ID = "abc123";

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -38,6 +38,17 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
     if (process.platform === "darwin" && process.env.OPENCLAW_LAUNCHD_LABEL?.trim()) {
       const restart = triggerOpenClawRestart();
       if (!restart.ok) {
+        // When launchctl kickstart times out (ETIMEDOUT), the command was still
+        // dispatched to launchd and the restart may be in-flight. Rather than
+        // falling back to an in-process restart (which leaves the gateway in a
+        // degraded state), exit cleanly so launchd's KeepAlive can start a
+        // fresh process. (#36822)
+        if (restart.detail?.includes("ETIMEDOUT")) {
+          return {
+            mode: "supervised",
+            detail: `launchctl kickstart timed out; trusting launchd KeepAlive to restart (${restart.detail})`,
+          };
+        }
         return {
           mode: "failed",
           detail: restart.detail ?? "launchctl kickstart failed",

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -31,7 +31,8 @@ function warnInvalidAllowFromEntries(entries: string[]) {
       [
         "Invalid allowFrom entry:",
         JSON.stringify(entry),
-        "- allowFrom/groupAllowFrom authorization requires numeric Telegram sender IDs only.",
+        "- allowFrom/groupAllowFrom authorization requires numeric Telegram IDs only",
+        "(positive for users/senders, negative for group/chat IDs like -100xxxxxxxxxx).",
         'If you had "@username" entries, re-run onboarding (it resolves @username to IDs) or replace them manually.',
       ].join(" "),
     );
@@ -44,11 +45,12 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  // Accept both positive IDs (user/sender IDs) and negative IDs (group/chat IDs like -100xxxxxxxxxx).
+  const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => /^-?\d+$/.test(value));
   return {
     entries: ids,
     hasWildcard,

--- a/src/telegram/group-access.ts
+++ b/src/telegram/group-access.ts
@@ -126,6 +126,8 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
   effectiveGroupAllow: NormalizedAllowFrom;
   senderId?: string;
   senderUsername?: string;
+  /** Chat/group ID as a string, used to match group IDs in groupAllowFrom. */
+  chatIdStr?: string;
   resolveGroupPolicy: (chatId: string | number) => ChannelGroupPolicy;
   enforcePolicy: boolean;
   useTopicAndGroupOverrides: boolean;
@@ -192,6 +194,18 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
       return { allowed: true, groupPolicy };
     }
     const senderUsername = params.senderUsername ?? "";
+    // For group messages, check the chat/group ID against the allowlist so that
+    // entries like "-100xxxxxxxxxx" in groupAllowFrom correctly allow a group.
+    // If the chat ID matches, the group itself is authorized; otherwise fall
+    // through to the per-sender check.
+    const chatIdStr = params.chatIdStr ?? String(params.chatId);
+    if (
+      params.isGroup &&
+      chatIdStr &&
+      isSenderAllowed({ allow: params.effectiveGroupAllow, senderId: chatIdStr, senderUsername: "" })
+    ) {
+      return { allowed: true, groupPolicy };
+    }
     if (
       !isSenderAllowed({
         allow: params.effectiveGroupAllow,

--- a/src/telegram/group-access.ts
+++ b/src/telegram/group-access.ts
@@ -202,7 +202,11 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
     if (
       params.isGroup &&
       chatIdStr &&
-      isSenderAllowed({ allow: params.effectiveGroupAllow, senderId: chatIdStr, senderUsername: "" })
+      isSenderAllowed({
+        allow: params.effectiveGroupAllow,
+        senderId: chatIdStr,
+        senderUsername: "",
+      })
     ) {
       return { allowed: true, groupPolicy };
     }


### PR DESCRIPTION
Fixes #36055

## Root cause

When OpenClaw shuts down a Discord account, `provider.lifecycle.ts` sets
`gateway.options.reconnect = { maxAttempts: 0 }` to prevent reconnects and
then calls `gateway.disconnect()`. Carbon's `GatewayPlugin.handleClose` fires
**synchronously** on the WS close event and calls `handleReconnectionAttempt`,
which immediately emits `new Error('Max reconnect attempts (0) reached')` because
`reconnectAttempts(0) >= maxAttempts(0)`.

Previously, `waitForDiscordGatewayStop.finishResolve()` removed the error
listener **before** calling `disconnect()`, leaving no listener to absorb that
error. Node.js then threw an uncaught `'error'` event and crashed the gateway
process.

## Fix

- In `finishResolve` and `finishReject`: remove the abort listener first, then
  call `gateway.disconnect()` while the error listener is **still active**, and
  only remove the error listener in the `finally` block after `disconnect()` returns.
- Guard `onGatewayErrorEvent` with a `settled` check so Carbon's
  reconnect-exhausted error emitted during intentional shutdown is silently
  dropped — no spurious `onGatewayError` call, no unhandled rejection.

The `once("error", () => {})` workaround in `provider.lifecycle.ts` was
insufficient because it raced with `waitForDiscordGatewayStop`'s abort handler
(registered earlier, called first), which removed the real error listener before
`disconnect()` ran.