### PR TITLE
fix(test): update Telegram DM auth assertion after #34873

### DIFF
--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -1243,6 +1243,7 @@ describe("createTelegramBot", () => {
     expect(sendMessageSpy).toHaveBeenCalledWith(
       12345,
       "You are not authorized to use this command.",
+      {},
     );
   });
 


### PR DESCRIPTION
## Summary

- **Problem:** #34873 added `threadParams` to `sendAuthMessage` in `bot-native-commands.ts` but did not update the test assertion in `bot.test.ts`, causing the "blocks native DM commands for unpaired users" test to fail on main.
- **Why it matters:** Broken test on main; CI may mask real regressions.
- **What changed:** Updated `sendMessageSpy` assertion to expect the third `threadParams` argument (`{}`).
- **What did NOT change (scope boundary):** No runtime behavior change. Test-only fix.

## AI Assistance

- AI-assisted: yes (implemented with OpenCode / Claude Code assistance, then manually reviewed)
- Testing: locally validated and CI passed as noted below
- I understand what the code does and reviewed the final changes before submitting

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related #34873

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. `git checkout main`
2. `npx vitest run src/telegram/bot.test.ts`
3. "blocks native DM commands for unpaired users" fails

### Expected

Test passes.

### Actual

Test passes after this fix.

## Evidence

- [x] Failing test before + passing after

## Human Verification (required)

- Verified scenarios: Ran `npx vitest run src/telegram/bot.test.ts` — all 59 tests pass.
- Edge cases checked: Single assertion change, no other tests affected.
- What I did **not** verify: Full CI suite (deferred to CI).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this single-line change.

