### PR TITLE
fix(feishu): tolerate unresolved SecretRefs during plugin registration

### DIFF
--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -305,24 +305,24 @@ describe("resolveFeishuAccount", () => {
     expect(account.appId).toBe("cli_default");
   });
 
-  it("surfaces unresolved SecretRef errors in account resolution", () => {
-    expect(() =>
-      resolveFeishuAccount({
-        cfg: {
-          channels: {
-            feishu: {
-              accounts: {
-                main: {
-                  appId: "cli_123",
-                  appSecret: { source: "file", provider: "default", id: "path/to/secret" },
-                } as never,
-              },
+  it("treats unresolved SecretRef as unconfigured instead of throwing", () => {
+    const account = resolveFeishuAccount({
+      cfg: {
+        channels: {
+          feishu: {
+            accounts: {
+              main: {
+                appId: "cli_123",
+                appSecret: { source: "file", provider: "default", id: "path/to/secret" },
+              } as never,
             },
           },
-        } as never,
-        accountId: "main",
-      }),
-    ).toThrow(/unresolved SecretRef/i);
+        },
+      } as never,
+      accountId: "main",
+    });
+    expect(account.configured).toBe(false);
+    expect(account.appSecret).toBeUndefined();
   });
 
   it("does not throw when account name is non-string", () => {

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -213,13 +213,18 @@ export function resolveFeishuAccount(params: {
 
   // Resolve credentials from merged config.
   // When running outside the gateway (e.g. `openclaw plugins list`), SecretRef
-  // values have not been resolved yet and `resolveFeishuCredentials` throws.
-  // Treat unresolved refs as missing credentials so the plugin can still load.
+  // values have not been resolved yet and `resolveFeishuCredentials` throws
+  // an "unresolved SecretRef" error. Treat that as missing credentials so the
+  // plugin can still load. Re-throw unexpected errors.
   let creds: ReturnType<typeof resolveFeishuCredentials>;
   try {
     creds = resolveFeishuCredentials(merged);
-  } catch {
-    creds = null;
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("unresolved SecretRef")) {
+      creds = null;
+    } else {
+      throw err;
+    }
   }
   const accountName = (merged as FeishuAccountConfig).name;
 

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -211,8 +211,16 @@ export function resolveFeishuAccount(params: {
   const accountEnabled = merged.enabled !== false;
   const enabled = baseEnabled && accountEnabled;
 
-  // Resolve credentials from merged config
-  const creds = resolveFeishuCredentials(merged);
+  // Resolve credentials from merged config.
+  // When running outside the gateway (e.g. `openclaw plugins list`), SecretRef
+  // values have not been resolved yet and `resolveFeishuCredentials` throws.
+  // Treat unresolved refs as missing credentials so the plugin can still load.
+  let creds: ReturnType<typeof resolveFeishuCredentials>;
+  try {
+    creds = resolveFeishuCredentials(merged);
+  } catch {
+    creds = null;
+  }
   const accountName = (merged as FeishuAccountConfig).name;
 
   return {


### PR DESCRIPTION
Closes #37633

## Problem

`openclaw plugins list` fails when the feishu channel uses env-based SecretRefs (e.g. `env:default:FEISHU_APP_SECRET`). The error:

```
[plugins] feishu failed during register: Error: channels.feishu.appSecret: unresolved SecretRef "env:default:FEISHU_APP_SECRET". Resolve this command against an active gateway runtime snapshot before reading it.
```

CLI commands run outside the gateway runtime, so SecretRef values haven't been resolved yet. During plugin registration, the feishu tool registration functions call `listEnabledFeishuAccounts` → `resolveFeishuAccount` → `resolveFeishuCredentials`, which throws on unresolved SecretRef objects.

## Fix

Wrap `resolveFeishuCredentials()` in `resolveFeishuAccount()` with a try-catch. When an unresolved SecretRef error is thrown, treat it as missing credentials (`configured: false`) rather than a fatal error. This way:

- The feishu plugin loads successfully in CLI context
- Tool registration gracefully skips (no configured accounts → no tools registered)
- Gateway runtime still resolves SecretRefs normally at startup
- No behavioral change for resolved configs

## Test

Updated the existing test that expected a throw to instead verify `configured: false` and `appSecret: undefined`. All 70 feishu tests pass.