### PR TITLE
fix(onboard): use inspection instead of resolution for Telegram SecretRef tokens

### DIFF
--- a/src/channels/plugins/onboarding/discord.ts
+++ b/src/channels/plugins/onboarding/discord.ts
@@ -5,7 +5,6 @@ import { inspectDiscordAccount } from "../../../discord/account-inspect.js";
 import {
   listDiscordAccountIds,
   resolveDefaultDiscordAccountId,
-  resolveDiscordAccount,
 } from "../../../discord/accounts.js";
 import { normalizeDiscordSlug } from "../../../discord/monitor/allow-list.js";
 import {
@@ -89,8 +88,8 @@ async function promptDiscordAllowFrom(params: {
     accountId: params.accountId,
     defaultAccountId: resolveDefaultDiscordAccountId(params.cfg),
   });
-  const resolved = resolveDiscordAccount({ cfg: params.cfg, accountId });
-  const token = resolved.token;
+  const inspected = inspectDiscordAccount({ cfg: params.cfg, accountId });
+  const token = inspected.token;
   const existing =
     params.cfg.channels?.discord?.allowFrom ?? params.cfg.channels?.discord?.dm?.allowFrom ?? [];
   const parseId = (value: string) =>
@@ -173,10 +172,12 @@ export const discordOnboardingAdapter: ChannelOnboardingAdapter = {
     });
 
     let next = cfg;
-    const resolvedAccount = resolveDiscordAccount({
+    const inspectedAccount = inspectDiscordAccount({
       cfg: next,
       accountId: discordAccountId,
     });
+    const hasConfigToken = hasConfiguredSecretInput(inspectedAccount.config.token);
+    const accountConfigured = inspectedAccount.configured;
     const allowEnv = discordAccountId === DEFAULT_ACCOUNT_ID;
     const tokenStep = await runSingleChannelSecretStep({
       cfg: next,
@@ -184,8 +185,8 @@ export const discordOnboardingAdapter: ChannelOnboardingAdapter = {
       providerHint: "discord",
       credentialLabel: "Discord bot token",
       secretInputMode: options?.secretInputMode,
-      accountConfigured: Boolean(resolvedAccount.token),
-      hasConfigToken: hasConfiguredSecretInput(resolvedAccount.config.token),
+      accountConfigured,
+      hasConfigToken,
       allowEnv,
       envValue: process.env.DISCORD_BOT_TOKEN,
       envPrompt: "DISCORD_BOT_TOKEN detected. Use env var?",
@@ -212,7 +213,7 @@ export const discordOnboardingAdapter: ChannelOnboardingAdapter = {
     });
     next = tokenStep.cfg;
 
-    const currentEntries = Object.entries(resolvedAccount.config.guilds ?? {}).flatMap(
+    const currentEntries = Object.entries(inspectedAccount.config.guilds ?? {}).flatMap(
       ([guildKey, value]) => {
         const channels = value?.channels ?? {};
         const channelKeys = Object.keys(channels);
@@ -227,10 +228,10 @@ export const discordOnboardingAdapter: ChannelOnboardingAdapter = {
       cfg: next,
       prompter,
       label: "Discord channels",
-      currentPolicy: resolvedAccount.config.groupPolicy ?? "allowlist",
+      currentPolicy: inspectedAccount.config.groupPolicy ?? "allowlist",
       currentEntries,
       placeholder: "My Server/#general, guildId/channelId, #support",
-      updatePrompt: Boolean(resolvedAccount.config.guilds),
+      updatePrompt: Boolean(inspectedAccount.config.guilds),
       setPolicy: (cfg, policy) =>
         setAccountGroupPolicyForChannel({
           cfg,
@@ -239,7 +240,7 @@ export const discordOnboardingAdapter: ChannelOnboardingAdapter = {
           groupPolicy: policy,
         }),
       resolveAllowlist: async ({ cfg, entries }) => {
-        const accountWithTokens = resolveDiscordAccount({
+        const accountWithTokens = inspectDiscordAccount({
           cfg,
           accountId: discordAccountId,
         });

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -2,11 +2,7 @@ import type { OpenClawConfig } from "../../../config/config.js";
 import { hasConfiguredSecretInput } from "../../../config/types.secrets.js";
 import { DEFAULT_ACCOUNT_ID } from "../../../routing/session-key.js";
 import { inspectSlackAccount } from "../../../slack/account-inspect.js";
-import {
-  listSlackAccountIds,
-  resolveDefaultSlackAccountId,
-  resolveSlackAccount,
-} from "../../../slack/accounts.js";
+import { listSlackAccountIds, resolveDefaultSlackAccountId } from "../../../slack/accounts.js";
 import { resolveSlackChannelAllowlist } from "../../../slack/resolve-channels.js";
 import { resolveSlackUserAllowlist } from "../../../slack/resolve-users.js";
 import { formatDocsLink } from "../../../terminal/links.js";
@@ -140,8 +136,8 @@ async function promptSlackAllowFrom(params: {
     accountId: params.accountId,
     defaultAccountId: resolveDefaultSlackAccountId(params.cfg),
   });
-  const resolved = resolveSlackAccount({ cfg: params.cfg, accountId });
-  const token = resolved.userToken ?? resolved.botToken ?? "";
+  const inspected = inspectSlackAccount({ cfg: params.cfg, accountId });
+  const token = inspected.userToken ?? inspected.botToken ?? "";
   const existing =
     params.cfg.channels?.slack?.allowFrom ?? params.cfg.channels?.slack?.dm?.allowFrom ?? [];
   const parseId = (value: string) =>
@@ -224,17 +220,15 @@ export const slackOnboardingAdapter: ChannelOnboardingAdapter = {
     });
 
     let next = cfg;
-    const resolvedAccount = resolveSlackAccount({
+    const inspectedAccount = inspectSlackAccount({
       cfg: next,
       accountId: slackAccountId,
     });
-    const hasConfiguredBotToken = hasConfiguredSecretInput(resolvedAccount.config.botToken);
-    const hasConfiguredAppToken = hasConfiguredSecretInput(resolvedAccount.config.appToken);
-    const hasConfigTokens = hasConfiguredBotToken && hasConfiguredAppToken;
-    const accountConfigured =
-      Boolean(resolvedAccount.botToken && resolvedAccount.appToken) || hasConfigTokens;
+    const hasConfiguredBotToken = hasConfiguredSecretInput(inspectedAccount.config.botToken);
+    const hasConfiguredAppToken = hasConfiguredSecretInput(inspectedAccount.config.appToken);
+    const accountConfigured = inspectedAccount.configured;
     const allowEnv = slackAccountId === DEFAULT_ACCOUNT_ID;
-    let resolvedBotTokenForAllowlist = resolvedAccount.botToken;
+    let resolvedBotTokenForAllowlist = inspectedAccount.botToken;
     const slackBotName = String(
       await prompter.text({
         message: "Slack bot display name (used for manifest)",
@@ -250,7 +244,7 @@ export const slackOnboardingAdapter: ChannelOnboardingAdapter = {
       providerHint: "slack-bot",
       credentialLabel: "Slack bot token",
       secretInputMode: options?.secretInputMode,
-      accountConfigured: Boolean(resolvedAccount.botToken) || hasConfiguredBotToken,
+      accountConfigured: Boolean(inspectedAccount.botToken) || hasConfiguredBotToken,
       hasConfigToken: hasConfiguredBotToken,
       allowEnv,
       envValue: process.env.SLACK_BOT_TOKEN,
@@ -277,7 +271,7 @@ export const slackOnboardingAdapter: ChannelOnboardingAdapter = {
       providerHint: "slack-app",
       credentialLabel: "Slack app token",
       secretInputMode: options?.secretInputMode,
-      accountConfigured: Boolean(resolvedAccount.appToken) || hasConfiguredAppToken,
+      accountConfigured: Boolean(inspectedAccount.appToken) || hasConfiguredAppToken,
       hasConfigToken: hasConfiguredAppToken,
       allowEnv,
       envValue: process.env.SLACK_APP_TOKEN,
@@ -299,12 +293,12 @@ export const slackOnboardingAdapter: ChannelOnboardingAdapter = {
       cfg: next,
       prompter,
       label: "Slack channels",
-      currentPolicy: resolvedAccount.config.groupPolicy ?? "allowlist",
-      currentEntries: Object.entries(resolvedAccount.config.channels ?? {})
+      currentPolicy: inspectedAccount.config.groupPolicy ?? "allowlist",
+      currentEntries: Object.entries(inspectedAccount.config.channels ?? {})
         .filter(([, value]) => value?.allow !== false && value?.enabled !== false)
         .map(([key]) => key),
       placeholder: "#general, #private, C123",
-      updatePrompt: Boolean(resolvedAccount.config.channels),
+      updatePrompt: Boolean(inspectedAccount.config.channels),
       setPolicy: (cfg, policy) =>
         setAccountGroupPolicyForChannel({
           cfg,
@@ -314,7 +308,7 @@ export const slackOnboardingAdapter: ChannelOnboardingAdapter = {
         }),
       resolveAllowlist: async ({ cfg, entries }) => {
         let keys = entries;
-        const accountWithTokens = resolveSlackAccount({
+        const accountWithTokens = inspectSlackAccount({
           cfg,
           accountId: slackAccountId,
         });

--- a/src/channels/plugins/onboarding/telegram.ts
+++ b/src/channels/plugins/onboarding/telegram.ts
@@ -6,7 +6,6 @@ import { inspectTelegramAccount } from "../../../telegram/account-inspect.js";
 import {
   listTelegramAccountIds,
   resolveDefaultTelegramAccountId,
-  resolveTelegramAccount,
 } from "../../../telegram/accounts.js";
 import { formatDocsLink } from "../../../terminal/links.js";
 import type { WizardPrompter } from "../../../wizard/prompts.js";
@@ -72,11 +71,11 @@ async function promptTelegramAllowFrom(params: {
   tokenOverride?: string;
 }): Promise<OpenClawConfig> {
   const { cfg, prompter, accountId } = params;
-  const resolved = resolveTelegramAccount({ cfg, accountId });
-  const existingAllowFrom = resolved.config.allowFrom ?? [];
+  const inspected = inspectTelegramAccount({ cfg, accountId });
+  const existingAllowFrom = inspected.config.allowFrom ?? [];
   await noteTelegramUserIdHelp(prompter);
 
-  const token = params.tokenOverride?.trim() || resolved.token;
+  const token = params.tokenOverride?.trim() || inspected.token;
   if (!token) {
     await prompter.note("Telegram token missing; username lookup is unavailable.", "Telegram");
   }
@@ -185,13 +184,14 @@ export const telegramOnboardingAdapter: ChannelOnboardingAdapter = {
     });
 
     let next = cfg;
-    const resolvedAccount = resolveTelegramAccount({
+    const inspectedAccount = inspectTelegramAccount({
       cfg: next,
       accountId: telegramAccountId,
     });
-    const hasConfiguredBotToken = hasConfiguredSecretInput(resolvedAccount.config.botToken);
+    const hasConfiguredBotToken = hasConfiguredSecretInput(inspectedAccount.config.botToken);
     const hasConfigToken =
-      hasConfiguredBotToken || Boolean(resolvedAccount.config.tokenFile?.trim());
+      hasConfiguredBotToken || Boolean(inspectedAccount.config.tokenFile?.trim());
+    const accountConfigured = inspectedAccount.configured;
     const allowEnv = telegramAccountId === DEFAULT_ACCOUNT_ID;
     const tokenStep = await runSingleChannelSecretStep({
       cfg: next,
@@ -199,7 +199,7 @@ export const telegramOnboardingAdapter: ChannelOnboardingAdapter = {
       providerHint: "telegram",
       credentialLabel: "Telegram bot token",
       secretInputMode: options?.secretInputMode,
-      accountConfigured: Boolean(resolvedAccount.token) || hasConfigToken,
+      accountConfigured,
       hasConfigToken,
       allowEnv,
       envValue: process.env.TELEGRAM_BOT_TOKEN,


### PR DESCRIPTION
Ran into this while testing exec secret providers for Telegram onboarding — the wizard crashes right after validating the reference:

```
Error: channels.telegram.botToken: unresolved SecretRef "exec:xxx:telegram/apiKey".
Resolve this command against an active gateway runtime snapshot before reading it.
```

The `configure` and `promptAllowFrom` paths in all three channel onboarding adapters (Telegram, Slack, Discord) call their respective `resolve*Account()` functions, which throw on unresolved SecretRefs. The `getStatus` methods already use the safe `inspect*Account()` variants, but `configure` was missed.

Switched all call sites to `inspect*Account()` and derived `accountConfigured` from the inspector's `.configured` flag.

Closes #37303