### PR TITLE
fix(models): include config-injected models in --all list

### DIFF
--- a/src/commands/models/list.list-command.all-configured.test.ts
+++ b/src/commands/models/list.list-command.all-configured.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const printModelTable = vi.fn();
+  return {
+    loadModelsConfig: vi.fn().mockResolvedValue({
+      agents: { defaults: { model: { primary: "openai-codex/gpt-5.4" } } },
+      models: {
+        providers: {
+          "openai-codex": {
+            baseUrl: "https://chatgpt.com/backend-api",
+            api: "openai-codex-responses",
+            models: [
+              {
+                id: "gpt-5.4",
+                name: "GPT-5.4",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 272000,
+                maxTokens: 128000,
+              },
+            ],
+          },
+        },
+      },
+    }),
+    ensureAuthProfileStore: vi.fn().mockReturnValue({ version: 1, profiles: {}, order: {} }),
+    loadModelRegistry: vi.fn().mockResolvedValue({
+      models: [],
+      availableKeys: undefined,
+      availabilityErrorMessage: undefined,
+      registry: {
+        find: vi.fn().mockReturnValue(null),
+        getAll: vi.fn().mockReturnValue([]),
+        getAvailable: vi.fn().mockImplementation(() => {
+          throw new Error("availability unsupported");
+        }),
+      },
+    }),
+    resolveConfiguredEntries: vi.fn().mockReturnValue({
+      entries: [
+        {
+          key: "openai-codex/gpt-5.4",
+          ref: { provider: "openai-codex", model: "gpt-5.4" },
+          tags: new Set(["configured"]),
+          aliases: [],
+        },
+      ],
+    }),
+    printModelTable,
+  };
+});
+
+vi.mock("../../agents/auth-profiles.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/auth-profiles.js")>();
+  return {
+    ...actual,
+    ensureAuthProfileStore: mocks.ensureAuthProfileStore,
+  };
+});
+
+vi.mock("./load-config.js", () => ({
+  loadModelsConfig: mocks.loadModelsConfig,
+}));
+
+vi.mock("./list.registry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./list.registry.js")>();
+  return {
+    ...actual,
+    loadModelRegistry: mocks.loadModelRegistry,
+  };
+});
+
+vi.mock("./list.configured.js", () => ({
+  resolveConfiguredEntries: mocks.resolveConfiguredEntries,
+}));
+
+vi.mock("./list.table.js", () => ({
+  printModelTable: mocks.printModelTable,
+}));
+
+import { modelsListCommand } from "./list.list-command.js";
+
+describe("modelsListCommand --all configured models", () => {
+  it("includes config-only provider models in --all output", async () => {
+    const runtime = { log: vi.fn(), error: vi.fn() };
+
+    await modelsListCommand({ json: true, all: true }, runtime as never);
+
+    expect(mocks.printModelTable).toHaveBeenCalled();
+    const rows = mocks.printModelTable.mock.calls.at(-1)?.[0] as Array<{ key: string }>;
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        key: "openai-codex/gpt-5.4",
+      }),
+    ]);
+  });
+});

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -62,22 +62,47 @@ export async function modelsListCommand(
   const rows: ModelRow[] = [];
 
   if (opts.all) {
-    const sorted = [...models].toSorted((a, b) => {
-      const p = a.provider.localeCompare(b.provider);
-      if (p !== 0) {
-        return p;
-      }
-      return a.id.localeCompare(b.id);
-    });
+    const modelByKey = new Map(models.map((model) => [modelKey(model.provider, model.id), model]));
 
-    for (const model of sorted) {
+    // `--all` should be a superset view that includes config-only provider models.
+    // These can be resolved at runtime via models.providers.<provider>.models even when
+    // they are not present in the underlying registry.
+    const registry = modelRegistry;
+    if (registry) {
+      for (const entry of entries) {
+        if (modelByKey.has(entry.key)) {
+          continue;
+        }
+        const resolved = resolveModelWithRegistry({
+          provider: entry.ref.provider,
+          modelId: entry.ref.model,
+          modelRegistry: registry,
+          cfg,
+        });
+        if (!resolved) {
+          continue;
+        }
+        modelByKey.set(entry.key, resolved);
+      }
+    }
+
+    const sorted = [...modelByKey.entries()]
+      .map(([key, model]) => ({ key, model }))
+      .toSorted((a, b) => {
+        const p = a.model.provider.localeCompare(b.model.provider);
+        if (p !== 0) {
+          return p;
+        }
+        return a.model.id.localeCompare(b.model.id);
+      });
+
+    for (const { key, model } of sorted) {
       if (providerFilter && model.provider.toLowerCase() !== providerFilter) {
         continue;
       }
       if (opts.local && !isLocalBaseUrl(model.baseUrl)) {
         continue;
       }
-      const key = modelKey(model.provider, model.id);
       const configured = configuredByKey.get(key);
       rows.push(
         toModelRow({
@@ -88,6 +113,7 @@ export async function modelsListCommand(
           availableKeys,
           cfg,
           authStore,
+          allowProviderAvailabilityFallback: !discoveredKeys.has(key),
         }),
       );
     }


### PR DESCRIPTION
Fixes `openclaw models list --all` so it includes models defined only in config under `models.providers.<provider>.models`.

Closes #37635.