### PR TITLE
fix(media): re-apply media file mode after writes

### DIFF
--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -278,6 +278,7 @@ export async function saveMediaSource(
     const id = ext ? `${baseId}${ext}` : baseId;
     const finalDest = path.join(dir, id);
     await fs.rename(tempDest, finalDest);
+    await fs.chmod(finalDest, MEDIA_FILE_MODE);
     return { id, path: finalDest, size, contentType: mime };
   }
   // local path
@@ -288,6 +289,7 @@ export async function saveMediaSource(
     const id = ext ? `${baseId}${ext}` : baseId;
     const dest = path.join(dir, id);
     await fs.writeFile(dest, buffer, { mode: MEDIA_FILE_MODE });
+    await fs.chmod(dest, MEDIA_FILE_MODE);
     return { id, path: dest, size: stat.size, contentType: mime };
   } catch (err) {
     if (err instanceof SafeOpenError) {
@@ -327,5 +329,6 @@ export async function saveMediaBuffer(
 
   const dest = path.join(dir, id);
   await fs.writeFile(dest, buffer, { mode: MEDIA_FILE_MODE });
+  await fs.chmod(dest, MEDIA_FILE_MODE);
   return { id, path: dest, size: buffer.byteLength, contentType: mime };
 }


### PR DESCRIPTION
## Summary
- apply `fs.chmod(..., MEDIA_FILE_MODE)` after URL downloads are renamed into place
- apply the same chmod step after local-path and buffer writes
- keep media files readable for non-owner UIDs even when the process umask is restrictive

## Testing
- `pnpm test -- src/media/store.redirect.test.ts`
- `bash /Users/newdldewdl/.openclaw/workspace/skills/openclaw-autonomous-contributor/scripts/quality_gate.sh /tmp/openclaw-baseline-debug-4a80d48ea9c4-63193`

## AI-assisted disclosure
This PR was prepared with AI assistance and validated with the tests above.