### PR TITLE
fix(logging): rotate log file on date change

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -70,7 +70,25 @@ function canUseSilentVitestFileLogFastPath(envLevel: LogLevel | undefined): bool
   );
 }
 
+function getSettingsDateKey(settings: ResolvedSettings): string {
+  // Extract date from rolling log path, or use a fixed key for custom paths
+  const match = settings.file.match(/openclaw-(\d{4}-\d{2}-\d{2})\.log$/);
+  return match ? match[1] : "custom";
+}
+
 function resolveSettings(): ResolvedSettings {
+  // Check if cached settings are stale (date changed) - force re-resolution for daily rotation
+  const cached = loggingState.cachedSettings as ResolvedSettings | null;
+  if (cached) {
+    const cachedDate = getSettingsDateKey(cached);
+    const todayDate = formatLocalDate(new Date());
+    // If date changed (e.g., midnight rollover), force re-resolution
+    if (cachedDate !== "custom" && cachedDate !== todayDate) {
+      loggingState.cachedLogger = null;
+      loggingState.cachedSettings = null;
+    }
+  }
+
   const envLevel = resolveEnvLogLevelOverride();
   // Test runs default file logs to silent. Skip config reads and fallback load in the
   // common case to avoid pulling heavy config/schema stacks on startup.

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -71,9 +71,13 @@ function canUseSilentVitestFileLogFastPath(envLevel: LogLevel | undefined): bool
 }
 
 function getSettingsDateKey(settings: ResolvedSettings): string {
-  // Extract date from rolling log path, or use a fixed key for custom paths
-  const match = settings.file.match(/openclaw-(\d{4}-\d{2}-\d{2})\.log$/);
-  return match ? match[1] : "custom";
+  // Use isRollingPath to check and extract date consistently with other code
+  if (isRollingPath(settings.file)) {
+    const base = path.basename(settings.file);
+    // Strip "openclaw-" prefix and ".log" suffix to get the date segment
+    return base.slice(LOG_PREFIX.length + 1, base.length - LOG_SUFFIX.length);
+  }
+  return "custom";
 }
 
 function resolveSettings(): ResolvedSettings {


### PR DESCRIPTION
Fixes #37388

The logger cached the file path and never checked for date changes, causing logs to continue writing to the previous days file after midnight.

This fix checks if the cached settings date differs from today date. If so, it clears the cached logger and settings, forcing a new logger to be created with today date in the log filename.