### PR TITLE
fix(feishu): prevent silent send failure when streaming card close fails

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -365,5 +365,10 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
         accountId: ctx.accountId,
       });
     },
+    stopAccount: async (ctx) => {
+      const { stopFeishuMonitor } = await import("./monitor.js");
+      ctx.log?.info(`stopping feishu[${ctx.accountId}]`);
+      stopFeishuMonitor(ctx.accountId);
+    },
   },
 };

--- a/extensions/feishu/src/monitor.startup.test.ts
+++ b/extensions/feishu/src/monitor.startup.test.ts
@@ -6,6 +6,11 @@ const probeFeishuMock = vi.hoisted(() => vi.fn());
 const feishuClientMockModule = vi.hoisted(() => ({
   createFeishuWSClient: vi.fn(() => ({ start: vi.fn() })),
   createEventDispatcher: vi.fn(() => ({ register: vi.fn() })),
+  clearClientCache: vi.fn(),
+}));
+
+vi.mock("./streaming-card.js", () => ({
+  clearStreamingTokenCache: vi.fn(),
 }));
 const feishuRuntimeMockModule = vi.hoisted(() => ({
   getFeishuRuntime: () => ({

--- a/extensions/feishu/src/monitor.state.ts
+++ b/extensions/feishu/src/monitor.state.ts
@@ -7,6 +7,8 @@ import {
   WEBHOOK_ANOMALY_COUNTER_DEFAULTS as WEBHOOK_ANOMALY_COUNTER_DEFAULTS_FROM_SDK,
   WEBHOOK_RATE_LIMIT_DEFAULTS as WEBHOOK_RATE_LIMIT_DEFAULTS_FROM_SDK,
 } from "openclaw/plugin-sdk/feishu";
+import { clearClientCache } from "./client.js";
+import { clearStreamingTokenCache } from "./streaming-card.js";
 
 export const wsClients = new Map<string, Lark.WSClient>();
 export const httpServers = new Map<string, http.Server>();
@@ -133,6 +135,11 @@ export function recordWebhookStatus(
 }
 
 export function stopFeishuMonitorState(accountId?: string): void {
+  // Clear HTTP client and streaming token caches so a restarted channel
+  // gets fresh credentials instead of potentially stale/broken ones.
+  clearClientCache(accountId);
+  clearStreamingTokenCache(accountId);
+
   if (accountId) {
     wsClients.delete(accountId);
     const server = httpServers.get(accountId);

--- a/extensions/feishu/src/monitor.test-mocks.ts
+++ b/extensions/feishu/src/monitor.test-mocks.ts
@@ -3,10 +3,20 @@ import { vi } from "vitest";
 export function createFeishuClientMockModule(): {
   createFeishuWSClient: () => { start: () => void };
   createEventDispatcher: () => { register: () => void };
+  clearClientCache: () => void;
 } {
   return {
     createFeishuWSClient: vi.fn(() => ({ start: vi.fn() })),
     createEventDispatcher: vi.fn(() => ({ register: vi.fn() })),
+    clearClientCache: vi.fn(),
+  };
+}
+
+export function createStreamingCardMockModule(): {
+  clearStreamingTokenCache: () => void;
+} {
+  return {
+    clearStreamingTokenCache: vi.fn(),
   };
 }
 

--- a/extensions/feishu/src/monitor.webhook-security.test.ts
+++ b/extensions/feishu/src/monitor.webhook-security.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createFeishuClientMockModule,
   createFeishuRuntimeMockModule,
+  createStreamingCardMockModule,
 } from "./monitor.test-mocks.js";
 
 const probeFeishuMock = vi.hoisted(() => vi.fn());
@@ -14,6 +15,7 @@ vi.mock("./probe.js", () => ({
 }));
 
 vi.mock("./client.js", () => createFeishuClientMockModule());
+vi.mock("./streaming-card.js", () => createStreamingCardMockModule());
 vi.mock("./runtime.js", () => createFeishuRuntimeMockModule());
 
 vi.mock("@larksuiteoapi/node-sdk", () => ({

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -588,4 +588,99 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       }),
     );
   });
+
+  it("falls back to non-streaming send when streaming close fails", async () => {
+    const errorFn = vi.fn();
+    const logFn = vi.fn();
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: logFn, error: errorFn } as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+
+    // Pre-configure the first streaming session's close to throw
+    // The mock class pushes instances to streamingInstances on construction,
+    // but we need to intercept before deliver() is called.
+    // Use a one-shot close override via the mock class.
+    let closeCallCount = 0;
+    const origMockModule = vi.mocked(await import("./streaming-card.js"));
+    // Instead, we can intercept: the first instance created will have its
+    // close mock. We set it to fail before deliver triggers it.
+
+    // Deliver a markdown final — this creates a streaming session, starts it,
+    // then calls close. We need close to fail.
+    // Since the mock class creates instances synchronously on `new`, we can
+    // intercept after the streaming session is created but before close is called
+    // by making startStreaming trigger instance creation, then patching close.
+    //
+    // Simpler approach: Use onReplyStart to trigger streaming creation for
+    // card mode, then patch the instance's close before final delivery.
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: { renderMode: "card", streaming: true },
+    });
+
+    // Re-create dispatcher with card mode to get onReplyStart streaming
+    streamingInstances.length = 0;
+    vi.clearAllMocks();
+    resolveReceiveIdTypeMock.mockReturnValue("chat_id");
+    createFeishuClientMock.mockReturnValue({});
+    getFeishuRuntimeMock.mockReturnValue({
+      channel: {
+        text: {
+          resolveTextChunkLimit: vi.fn(() => 4000),
+          resolveChunkMode: vi.fn(() => "line"),
+          resolveMarkdownTableMode: vi.fn(() => "preserve"),
+          convertMarkdownTables: vi.fn((text: string) => text),
+          chunkTextWithMode: vi.fn((text: string) => [text]),
+        },
+        reply: {
+          createReplyDispatcherWithTyping: createReplyDispatcherWithTypingMock,
+          resolveHumanDelayConfig: vi.fn(() => undefined),
+        },
+      },
+    });
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: { renderMode: "card", streaming: true },
+    });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: logFn, error: errorFn } as never,
+      chatId: "oc_chat",
+    });
+
+    const opts = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+
+    // onReplyStart triggers startStreaming for card mode
+    await opts.onReplyStart?.();
+    expect(streamingInstances).toHaveLength(1);
+
+    // Patch close to throw before delivering the final payload
+    streamingInstances[0].close.mockRejectedValueOnce(
+      new Error("Streaming card close failed with HTTP 401"),
+    );
+
+    await opts.deliver({ text: "fallback content" }, { kind: "final" });
+
+    // Streaming close failed, so it should fall back to sendMarkdownCardFeishu
+    expect(errorFn).toHaveBeenCalledWith(expect.stringContaining("streaming close failed"));
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "fallback content",
+      }),
+    );
+  });
 });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -206,22 +206,32 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     })();
   };
 
-  const closeStreaming = async () => {
+  /** Close streaming card. Returns true if closed successfully, false on error. */
+  const closeStreaming = async (): Promise<boolean> => {
     if (streamingStartPromise) {
       await streamingStartPromise;
     }
     await partialUpdateQueue;
+    let ok = true;
     if (streaming?.isActive()) {
       let text = streamText;
       if (mentionTargets?.length) {
         text = buildMentionedCardContent(mentionTargets, text);
       }
-      await streaming.close(text);
+      try {
+        await streaming.close(text);
+      } catch (error) {
+        params.runtime.error?.(
+          `feishu[${account.accountId}] streaming close failed, will fallback: ${String(error)}`,
+        );
+        ok = false;
+      }
     }
     streaming = null;
     streamingStartPromise = null;
     streamText = "";
     lastPartial = "";
+    return ok;
   };
 
   const { dispatcher, replyOptions, markDispatchIdle } =
@@ -284,23 +294,50 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             }
             if (info?.kind === "final") {
               streamText = mergeStreamingText(streamText, text);
-              await closeStreaming();
-              deliveredFinalTexts.add(text);
-            }
-            // Send media even when streaming handled the text
-            if (hasMedia) {
-              for (const mediaUrl of mediaList) {
-                await sendMediaFeishu({
-                  cfg,
-                  to: chatId,
-                  mediaUrl,
-                  replyToMessageId: sendReplyToMessageId,
-                  replyInThread: effectiveReplyInThread,
-                  accountId,
-                });
+              const closeOk = await closeStreaming();
+              if (closeOk) {
+                deliveredFinalTexts.add(text);
+              } else {
+                // Streaming close failed — fall through to non-streaming send
+                // path below so the message is not silently lost.
+                params.runtime.log?.(
+                  `feishu[${account.accountId}] falling back to non-streaming send for final reply`,
+                );
               }
+              if (closeOk) {
+                // Send media even when streaming handled the text
+                if (hasMedia) {
+                  for (const mediaUrl of mediaList) {
+                    await sendMediaFeishu({
+                      cfg,
+                      to: chatId,
+                      mediaUrl,
+                      replyToMessageId: sendReplyToMessageId,
+                      replyInThread: effectiveReplyInThread,
+                      accountId,
+                    });
+                  }
+                }
+                return;
+              }
+              // Fall through: streaming failed, deliver via non-streaming path
+            } else {
+              // block kind: stay in streaming path
+              // Send media even when streaming handled the text
+              if (hasMedia) {
+                for (const mediaUrl of mediaList) {
+                  await sendMediaFeishu({
+                    cfg,
+                    to: chatId,
+                    mediaUrl,
+                    replyToMessageId: sendReplyToMessageId,
+                    replyInThread: effectiveReplyInThread,
+                    accountId,
+                  });
+                }
+              }
+              return;
             }
-            return;
           }
 
           let first = true;

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -26,6 +26,15 @@ type StreamingStartOptions = {
 // Token cache (keyed by domain + appId)
 const tokenCache = new Map<string, { token: string; expiresAt: number }>();
 
+/**
+ * Clear the streaming card token cache.
+ * Token cache keys are `${domain}|${appId}` (not account-scoped), so we
+ * always clear all entries to avoid stale tokens after channel restart.
+ */
+export function clearStreamingTokenCache(_accountId?: string): void {
+  tokenCache.clear();
+}
+
 function resolveApiBase(domain?: FeishuDomain): string {
   if (domain === "lark") {
     return "https://open.larksuite.com/open-apis";
@@ -339,9 +348,10 @@ export class FeishuStreamingSession {
       this.state.currentText = text;
     }
 
-    // Close streaming mode
+    // Close streaming mode — propagate errors so callers can fall back to
+    // non-streaming delivery instead of silently losing the message.
     this.state.sequence += 1;
-    await fetchWithSsrFGuard({
+    const { response: closeRes, release } = await fetchWithSsrFGuard({
       url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/settings`,
       init: {
         method: "PATCH",
@@ -359,11 +369,13 @@ export class FeishuStreamingSession {
       },
       policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
       auditContext: "feishu.streaming-card.close",
-    })
-      .then(async ({ release }) => {
-        await release();
-      })
-      .catch((e) => this.log?.(`Close failed: ${String(e)}`));
+    });
+    await release();
+    if (!closeRes.ok) {
+      const errMsg = `Streaming card close failed with HTTP ${closeRes.status} (cardId=${this.state.cardId})`;
+      this.log?.(errMsg);
+      throw new Error(errMsg);
+    }
 
     this.log?.(`Closed streaming: cardId=${this.state.cardId}`);
   }


### PR DESCRIPTION
## Problem

Feishu channel silently drops replies after health-monitor restarts the channel. The agent generates replies (`dispatch complete (queuedFinal=true, replies=1)`), but messages never reach users. No ERROR/WARN logs are produced. Only a full gateway restart recovers the send pipeline.

### Timeline from actual incident

- 17:12:59 — Last successful send (WebSocket layer confirmed)
- 17:13:18 — New message received, dispatched to agent
- 17:13:36/39 — Dispatch complete, replies=1, but no corresponding send log
- 17:14:01 — Health-monitor detects stale-socket, restarts feishu[default]
- 17:14:20 — After restart: new message, dispatch, replies=1, still no send
- 17:37:27 — Manual gateway restart finally recovers

## Root Causes

### 1. Streaming card `close()` swallows errors
When the streaming card API close call fails (token expired, network error, etc.), the error was caught and only logged via `.catch()`, never propagated to the caller. The deliver callback treated the message as successfully sent and returned without attempting a fallback.

### 2. `deliveredFinalTexts` tracking is unconditional
Text was added to the dedup set (`deliveredFinalTexts.add(text)`) even when streaming close failed, preventing any retry of the same content.

### 3. Client/token caches persist across channel restart
When health-monitor restarts the feishu channel (`stopChannel` → `startChannel`), the Lark SDK client cache (`clientCache` in `client.ts`) and the streaming card token cache (`tokenCache` in `streaming-card.ts`) were never cleared. If the SDK client's internal state was corrupted (e.g., stale/expired token), the restart could not fix it — explaining why only a full gateway restart worked.

### 4. No `stopAccount` gateway hook
The feishu channel plugin only defined `startAccount` but no `stopAccount`, so no cleanup ran during channel stop/restart.

## Fixes

| File | Change |
|------|--------|
| `streaming-card.ts` | Make `close()` propagate HTTP errors instead of silently catching. Export `clearStreamingTokenCache()`. |
| `reply-dispatcher.ts` | When streaming close fails, fall through to non-streaming send path instead of returning silently. Only mark text as delivered on success. |
| `channel.ts` | Add `stopAccount` gateway hook calling `stopFeishuMonitor()`. |
| `monitor.state.ts` | Clear `clientCache` and streaming `tokenCache` in `stopFeishuMonitorState()` so restarted channels get fresh credentials. |

## Testing

- Added: `falls back to non-streaming send when streaming close fails` test
- Updated test mocks for monitor tests to include new imports
- All 336 feishu tests pass (4 pre-existing failures in media.test.ts unrelated to this PR)

Refs: #34093