### PR TITLE
fix(docs): remove broken FAQ link to non-existent troubleshooting anchor

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -448,9 +448,7 @@ section is the latest shipped version. Entries are grouped by **Highlights**, **
 ### I can't access docs.openclaw.ai SSL error What now
 
 Some Comcast/Xfinity connections incorrectly block `docs.openclaw.ai` via Xfinity
-Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry. More
-detail above.
-Please help us unblock it by reporting here: [https://spa.xfinity.com/check_url_status](https://spa.xfinity.com/check_url_status).
+Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry. Please help us unblock it by reporting here: [https://spa.xfinity.com/check_url_status](https://spa.xfinity.com/check_url_status).
 
 If you still can't reach the site, the docs are mirrored on GitHub:
 [https://github.com/openclaw/openclaw/tree/main/docs](https://github.com/openclaw/openclaw/tree/main/docs)

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -449,7 +449,7 @@ section is the latest shipped version. Entries are grouped by **Highlights**, **
 
 Some Comcast/Xfinity connections incorrectly block `docs.openclaw.ai` via Xfinity
 Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry. More
-detail: [Troubleshooting](/help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity).
+detail above.
 Please help us unblock it by reporting here: [https://spa.xfinity.com/check_url_status](https://spa.xfinity.com/check_url_status).
 
 If you still can't reach the site, the docs are mirrored on GitHub:


### PR DESCRIPTION
Fixes #36970

The link to /help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity does not exist in the troubleshooting page. The FAQ section already contains the full workaround, so this cross-reference is redundant.