### PR TITLE
[codex] Add GPT-5.4 Codex support and fix status-card reasoning defaults

### DIFF
--- a/src/agents/live-model-filter.test.ts
+++ b/src/agents/live-model-filter.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { isModernModelRef } from "./live-model-filter.js";
+
+describe("isModernModelRef", () => {
+  it("recognizes openai-codex/gpt-5.4 as a modern codex model", () => {
+    expect(isModernModelRef({ provider: "openai-codex", id: "gpt-5.4" })).toBe(true);
+  });
+});

--- a/src/agents/live-model-filter.ts
+++ b/src/agents/live-model-filter.ts
@@ -11,6 +11,7 @@ const ANTHROPIC_PREFIXES = [
 ];
 const OPENAI_MODELS = ["gpt-5.2", "gpt-5.0"];
 const CODEX_MODELS = [
+  "gpt-5.4",
   "gpt-5.2",
   "gpt-5.2-codex",
   "gpt-5.3-codex",

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -123,4 +123,38 @@ describe("loadModelCatalog", () => {
     expect(spark?.name).toBe("gpt-5.3-codex-spark");
     expect(spark?.reasoning).toBe(true);
   });
+
+  it("adds openai-codex/gpt-5.4 when base gpt-5.3-codex exists", async () => {
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          AuthStorage: class {},
+          ModelRegistry: class {
+            getAll() {
+              return [
+                {
+                  id: "gpt-5.3-codex",
+                  provider: "openai-codex",
+                  name: "GPT-5.3 Codex",
+                  reasoning: true,
+                  contextWindow: 200000,
+                  input: ["text"],
+                },
+              ];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        provider: "openai-codex",
+        id: "gpt-5.4",
+      }),
+    );
+    const gpt54 = result.find((entry) => entry.id === "gpt-5.4");
+    expect(gpt54?.name).toBe("gpt-5.4");
+    expect(gpt54?.reasoning).toBe(true);
+  });
 });

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -29,9 +29,27 @@ let importPiSdk = defaultImportPiSdk;
 
 const CODEX_PROVIDER = "openai-codex";
 const OPENAI_CODEX_GPT53_MODEL_ID = "gpt-5.3-codex";
+const OPENAI_CODEX_GPT54_MODEL_ID = "gpt-5.4";
 const OPENAI_CODEX_GPT53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 
-function applyOpenAICodexSparkFallback(models: ModelCatalogEntry[]): void {
+function applyOpenAICodexFallbacks(models: ModelCatalogEntry[]): void {
+  const hasGpt54 = models.some(
+    (entry) =>
+      entry.provider === CODEX_PROVIDER && entry.id.toLowerCase() === OPENAI_CODEX_GPT54_MODEL_ID,
+  );
+  if (!hasGpt54) {
+    const baseModel = models.find(
+      (entry) =>
+        entry.provider === CODEX_PROVIDER && entry.id.toLowerCase() === OPENAI_CODEX_GPT53_MODEL_ID,
+    );
+    if (baseModel) {
+      models.push({
+        ...baseModel,
+        id: OPENAI_CODEX_GPT54_MODEL_ID,
+        name: OPENAI_CODEX_GPT54_MODEL_ID,
+      });
+    }
+  }
   const hasSpark = models.some(
     (entry) =>
       entry.provider === CODEX_PROVIDER &&
@@ -126,7 +144,7 @@ export async function loadModelCatalog(params?: {
         const input = Array.isArray(entry?.input) ? entry.input : undefined;
         models.push({ id, name, provider, contextWindow, reasoning, input });
       }
-      applyOpenAICodexSparkFallback(models);
+      applyOpenAICodexFallbacks(models);
 
       if (models.length === 0) {
         // If we found nothing, don't cache this result so we can try again.

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -7,6 +7,7 @@ export type ModelCatalogEntry = {
   name: string;
   provider: string;
   contextWindow?: number;
+  maxTokens?: number;
   reasoning?: boolean;
   input?: Array<"text" | "image">;
 };
@@ -16,6 +17,7 @@ type DiscoveredModel = {
   name?: string;
   provider: string;
   contextWindow?: number;
+  maxTokens?: number;
   reasoning?: boolean;
   input?: Array<"text" | "image">;
 };
@@ -31,6 +33,8 @@ const CODEX_PROVIDER = "openai-codex";
 const OPENAI_CODEX_GPT53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_GPT54_MODEL_ID = "gpt-5.4";
 const OPENAI_CODEX_GPT53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
+const OPENAI_CODEX_GPT54_CONTEXT_TOKENS = 1_050_000;
+const OPENAI_CODEX_GPT54_MAX_TOKENS = 128_000;
 
 function applyOpenAICodexFallbacks(models: ModelCatalogEntry[]): void {
   const hasGpt54 = models.some(
@@ -47,6 +51,8 @@ function applyOpenAICodexFallbacks(models: ModelCatalogEntry[]): void {
         ...baseModel,
         id: OPENAI_CODEX_GPT54_MODEL_ID,
         name: OPENAI_CODEX_GPT54_MODEL_ID,
+        contextWindow: OPENAI_CODEX_GPT54_CONTEXT_TOKENS,
+        maxTokens: OPENAI_CODEX_GPT54_MAX_TOKENS,
       });
     }
   }
@@ -140,9 +146,11 @@ export async function loadModelCatalog(params?: {
           typeof entry?.contextWindow === "number" && entry.contextWindow > 0
             ? entry.contextWindow
             : undefined;
+        const maxTokens =
+          typeof entry?.maxTokens === "number" && entry.maxTokens > 0 ? entry.maxTokens : undefined;
         const reasoning = typeof entry?.reasoning === "boolean" ? entry.reasoning : undefined;
         const input = Array.isArray(entry?.input) ? entry.input : undefined;
-        models.push({ id, name, provider, contextWindow, reasoning, input });
+        models.push({ id, name, provider, contextWindow, maxTokens, reasoning, input });
       }
       applyOpenAICodexFallbacks(models);
 

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -419,6 +419,25 @@ export function resolveThinkingDefault(params: {
   return "off";
 }
 
+export function resolveReasoningDefault(params: {
+  cfg?: OpenClawConfig;
+  provider: string;
+  model: string;
+  catalog?: ModelCatalogEntry[];
+}): "on" | "off" {
+  const candidate = params.catalog?.find(
+    (entry) => entry.provider === params.provider && entry.id === params.model,
+  );
+  if (candidate?.reasoning === true) {
+    return "on";
+  }
+  const configured =
+    params.cfg?.models?.providers?.[params.provider]?.models?.find(
+      (entry) => entry.id === params.model,
+    )?.reasoning ?? false;
+  return configured ? "on" : "off";
+}
+
 /**
  * Resolve the model configured for Gmail hook processing.
  * Returns null if hooks.gmail.model is not set.

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -241,7 +241,7 @@ describe("resolveModel", () => {
       api: "openai-codex-responses",
       baseUrl: "https://chatgpt.com/backend-api",
       reasoning: true,
-      contextWindow: 272000,
+      contextWindow: 1_050_000,
       maxTokens: 128000,
     });
   });

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -209,6 +209,43 @@ describe("resolveModel", () => {
     });
   });
 
+  it("builds an openai-codex fallback for gpt-5.4", () => {
+    const templateModel = {
+      id: "gpt-5.2-codex",
+      name: "GPT-5.2 Codex",
+      provider: "openai-codex",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      reasoning: true,
+      input: ["text", "image"] as const,
+      cost: { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+      contextWindow: 272000,
+      maxTokens: 128000,
+    };
+
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn((provider: string, modelId: string) => {
+        if (provider === "openai-codex" && modelId === "gpt-5.2-codex") {
+          return templateModel;
+        }
+        return null;
+      }),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.4",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      reasoning: true,
+      contextWindow: 272000,
+      maxTokens: 128000,
+    });
+  });
+
   it("builds an anthropic forward-compat fallback for claude-opus-4-6", () => {
     const templateModel = {
       id: "claude-opus-4-5",

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -20,6 +20,7 @@ type InlineProviderConfig = {
 };
 
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
+const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
 const OPENAI_CODEX_GPT_53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
@@ -43,6 +44,7 @@ function resolveOpenAICodexGpt53FallbackModel(
   const loweredModelId = trimmedModelId.toLowerCase();
   if (
     loweredModelId !== OPENAI_CODEX_GPT_53_MODEL_ID &&
+    loweredModelId !== OPENAI_CODEX_GPT_54_MODEL_ID &&
     loweredModelId !== OPENAI_CODEX_GPT_53_SPARK_MODEL_ID
   ) {
     return undefined;

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -22,6 +22,8 @@ type InlineProviderConfig = {
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
 const OPENAI_CODEX_GPT_53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
+const OPENAI_CODEX_GPT_54_CONTEXT_TOKENS = 1_050_000;
+const OPENAI_CODEX_GPT_54_MAX_TOKENS = 128_000;
 
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
 
@@ -59,6 +61,12 @@ function resolveOpenAICodexGpt53FallbackModel(
       ...template,
       id: trimmedModelId,
       name: trimmedModelId,
+      ...(loweredModelId === OPENAI_CODEX_GPT_54_MODEL_ID
+        ? {
+            contextWindow: OPENAI_CODEX_GPT_54_CONTEXT_TOKENS,
+            maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
+          }
+        : {}),
     } as Model<Api>);
   }
 
@@ -71,8 +79,14 @@ function resolveOpenAICodexGpt53FallbackModel(
     reasoning: true,
     input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_TOKENS,
-    maxTokens: DEFAULT_CONTEXT_TOKENS,
+    contextWindow:
+      loweredModelId === OPENAI_CODEX_GPT_54_MODEL_ID
+        ? OPENAI_CODEX_GPT_54_CONTEXT_TOKENS
+        : DEFAULT_CONTEXT_TOKENS,
+    maxTokens:
+      loweredModelId === OPENAI_CODEX_GPT_54_MODEL_ID
+        ? OPENAI_CODEX_GPT_54_MAX_TOKENS
+        : DEFAULT_CONTEXT_TOKENS,
   } as Model<Api>);
 }
 

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -383,6 +383,15 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("/status shows Reasoning");
   });
 
+  it("tells agents to use session_status for thinking-state questions", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    expect(prompt).toContain("ALWAYS call session_status first");
+    expect(prompt).toContain("never use Reasoning for that answer");
+  });
+
   it("builds runtime line with agent and channel details", () => {
     const line = buildRuntimeLine(
       {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -401,6 +401,7 @@ export function buildAgentSystemPrompt(params: {
           "- sessions_history: fetch session history",
           "- sessions_send: send to another session",
           '- session_status: show usage/time/model state and answer "what model are we using?"',
+          "- for questions about current model / whether thinking is enabled / thinking level, ALWAYS call session_status first and map thinking enabled from Think/thinkingLevel only (off=no, anything else=yes); never use Reasoning for that answer",
         ].join("\n"),
     "TOOLS.md does not control tool availability; it is user guidance for how to use external tools.",
     "If a task is more complex or takes longer, spawn a sub-agent. It will do the work for you and ping you when it's done. You can always check up on it.",

--- a/src/auto-reply/reply/commands-approve.test.ts
+++ b/src/auto-reply/reply/commands-approve.test.ts
@@ -40,6 +40,7 @@ function buildParams(commandBody: string, cfg: OpenClawConfig, ctxOverrides?: Pa
     resolvedVerboseLevel: "off" as const,
     resolvedReasoningLevel: "off" as const,
     resolveDefaultThinkingLevel: async () => undefined,
+    resolveDefaultReasoningLevel: async () => "off" as const,
     provider: "whatsapp",
     model: "test-model",
     contextTokens: 0,

--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -144,6 +144,7 @@ export const handleStatusCommand: CommandHandler = async (params, allowTextComma
     resolvedReasoningLevel: params.resolvedReasoningLevel,
     resolvedElevatedLevel: params.resolvedElevatedLevel,
     resolveDefaultThinkingLevel: params.resolveDefaultThinkingLevel,
+    resolveDefaultReasoningLevel: params.resolveDefaultReasoningLevel,
     isGroup: params.isGroup,
     defaultGroupActivation: params.defaultGroupActivation,
     mediaDecisions: params.ctx.MediaUnderstandingDecisions,

--- a/src/auto-reply/reply/commands-parsing.test.ts
+++ b/src/auto-reply/reply/commands-parsing.test.ts
@@ -38,6 +38,7 @@ function buildParams(commandBody: string, cfg: OpenClawConfig, ctxOverrides?: Pa
     resolvedVerboseLevel: "off" as const,
     resolvedReasoningLevel: "off" as const,
     resolveDefaultThinkingLevel: async () => undefined,
+    resolveDefaultReasoningLevel: async () => "off" as const,
     provider: "whatsapp",
     model: "test-model",
     contextTokens: 0,

--- a/src/auto-reply/reply/commands-policy.test.ts
+++ b/src/auto-reply/reply/commands-policy.test.ts
@@ -86,6 +86,7 @@ function buildParams(commandBody: string, cfg: OpenClawConfig, ctxOverrides?: Pa
     resolvedVerboseLevel: "off" as const,
     resolvedReasoningLevel: "off" as const,
     resolveDefaultThinkingLevel: async () => undefined,
+    resolveDefaultReasoningLevel: async () => "off" as const,
     provider: "telegram",
     model: "test-model",
     contextTokens: 0,

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { buildStatusReply } from "./commands-status.js";
+import { buildCommandContext } from "./commands.js";
+
+describe("buildStatusReply", () => {
+  it("defaults reasoning to on for reasoning-capable models when the session does not override it", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      models: {
+        providers: {
+          "openai-codex": {
+            models: [
+              {
+                id: "gpt-5.4",
+                reasoning: true,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const command = buildCommandContext({
+      ctx: {
+        Body: "/status",
+        CommandBody: "/status",
+        CommandSource: "text",
+        CommandAuthorized: true,
+        Provider: "whatsapp",
+        Surface: "whatsapp",
+      } as any,
+      cfg,
+      isGroup: false,
+      triggerBodyNormalized: "/status",
+      commandAuthorized: true,
+    });
+
+    const reply = await buildStatusReply({
+      cfg,
+      command,
+      sessionEntry: { sessionId: "status-default", updatedAt: 0 },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      contextTokens: 272000,
+      resolvedThinkLevel: "medium",
+      resolvedVerboseLevel: "off",
+      resolveDefaultThinkingLevel: async () => "medium",
+      resolveDefaultReasoningLevel: async () => "on",
+      isGroup: false,
+      defaultGroupActivation: () => "mention",
+    });
+
+    expect(reply?.text).toContain("Think: medium");
+    expect(reply?.text).toContain("Reasoning: on");
+  });
+});

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -15,7 +15,7 @@ import {
   resolveAuthProfileOrder,
 } from "../../agents/auth-profiles.js";
 import { getCustomProviderApiKey, resolveEnvApiKey } from "../../agents/model-auth.js";
-import { normalizeProviderId } from "../../agents/model-selection.js";
+import { normalizeProviderId, resolveReasoningDefault } from "../../agents/model-selection.js";
 import { listSubagentRunsForRequester } from "../../agents/subagent-registry.js";
 import {
   resolveInternalSessionKey,
@@ -112,9 +112,10 @@ export async function buildStatusReply(params: {
   contextTokens: number;
   resolvedThinkLevel?: ThinkLevel;
   resolvedVerboseLevel: VerboseLevel;
-  resolvedReasoningLevel: ReasoningLevel;
+  resolvedReasoningLevel?: ReasoningLevel;
   resolvedElevatedLevel?: ElevatedLevel;
   resolveDefaultThinkingLevel: () => Promise<ThinkLevel | undefined>;
+  resolveDefaultReasoningLevel: () => Promise<ReasoningLevel>;
   isGroup: boolean;
   defaultGroupActivation: () => "always" | "mention";
   mediaDecisions?: MediaUnderstandingDecision[];
@@ -134,6 +135,7 @@ export async function buildStatusReply(params: {
     resolvedReasoningLevel,
     resolvedElevatedLevel,
     resolveDefaultThinkingLevel,
+    resolveDefaultReasoningLevel,
     isGroup,
     defaultGroupActivation,
   } = params;
@@ -232,7 +234,7 @@ export async function buildStatusReply(params: {
     groupActivation,
     resolvedThink: resolvedThinkLevel ?? (await resolveDefaultThinkingLevel()),
     resolvedVerbose: resolvedVerboseLevel,
-    resolvedReasoning: resolvedReasoningLevel,
+    resolvedReasoning: resolvedReasoningLevel ?? (await resolveDefaultReasoningLevel()),
     resolvedElevated: resolvedElevatedLevel,
     modelAuth: resolveModelAuthLabel(provider, cfg, sessionEntry, statusAgentDir),
     usageLine: usageLine ?? undefined,

--- a/src/auto-reply/reply/commands-types.ts
+++ b/src/auto-reply/reply/commands-types.ts
@@ -46,6 +46,7 @@ export type HandleCommandsParams = {
   resolvedReasoningLevel: ReasoningLevel;
   resolvedElevatedLevel?: ElevatedLevel;
   resolveDefaultThinkingLevel: () => Promise<ThinkLevel | undefined>;
+  resolveDefaultReasoningLevel: () => Promise<ReasoningLevel>;
   provider: string;
   model: string;
   contextTokens: number;

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -70,6 +70,7 @@ function buildParams(commandBody: string, cfg: OpenClawConfig, ctxOverrides?: Pa
     resolvedVerboseLevel: "off" as const,
     resolvedReasoningLevel: "off" as const,
     resolveDefaultThinkingLevel: async () => undefined,
+    resolveDefaultReasoningLevel: async () => "off" as const,
     provider: "whatsapp",
     model: "test-model",
     contextTokens: 0,

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -154,7 +154,8 @@ export async function applyInlineDirectiveOverrides(params: {
       (sessionEntry?.verboseLevel as VerboseLevel | undefined) ??
       (agentCfg?.verboseDefault as VerboseLevel | undefined);
     const currentReasoningLevel =
-      (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ?? "off";
+      (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+      (await modelState.resolveDefaultReasoningLevel());
     const currentElevatedLevel =
       (sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
       (agentCfg?.elevatedDefault as ElevatedLevel | undefined);
@@ -198,9 +199,10 @@ export async function applyInlineDirectiveOverrides(params: {
         contextTokens,
         resolvedThinkLevel: resolvedDefaultThinkLevel,
         resolvedVerboseLevel: currentVerboseLevel ?? "off",
-        resolvedReasoningLevel: currentReasoningLevel ?? "off",
+        resolvedReasoningLevel: currentReasoningLevel,
         resolvedElevatedLevel,
         resolveDefaultThinkingLevel: async () => resolvedDefaultThinkLevel,
+        resolveDefaultReasoningLevel: modelState.resolveDefaultReasoningLevel,
         isGroup,
         defaultGroupActivation: defaultActivation,
         mediaDecisions: ctx.MediaUnderstandingDecisions,

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -354,10 +354,8 @@ export async function resolveReplyDirectives(params: {
     directives.verboseLevel ??
     (sessionEntry?.verboseLevel as VerboseLevel | undefined) ??
     (agentCfg?.verboseDefault as VerboseLevel | undefined);
-  const resolvedReasoningLevel: ReasoningLevel =
-    directives.reasoningLevel ??
-    (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
-    "off";
+  let resolvedReasoningLevel =
+    directives.reasoningLevel ?? (sessionEntry?.reasoningLevel as ReasoningLevel | undefined);
   const resolvedElevatedLevel = elevatedAllowed
     ? (directives.elevatedLevel ??
       (sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
@@ -397,6 +395,7 @@ export async function resolveReplyDirectives(params: {
   });
   provider = modelState.provider;
   model = modelState.model;
+  resolvedReasoningLevel ??= await modelState.resolveDefaultReasoningLevel();
 
   let contextTokens = resolveContextTokens({
     agentCfg,

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -87,6 +87,9 @@ export async function handleInlineActions(params: {
   resolveDefaultThinkingLevel: Awaited<
     ReturnType<typeof createModelSelectionState>
   >["resolveDefaultThinkingLevel"];
+  resolveDefaultReasoningLevel: Awaited<
+    ReturnType<typeof createModelSelectionState>
+  >["resolveDefaultReasoningLevel"];
   provider: string;
   model: string;
   contextTokens: number;
@@ -124,6 +127,7 @@ export async function handleInlineActions(params: {
     resolvedReasoningLevel,
     resolvedElevatedLevel,
     resolveDefaultThinkingLevel,
+    resolveDefaultReasoningLevel,
     provider,
     model,
     contextTokens,
@@ -264,6 +268,7 @@ export async function handleInlineActions(params: {
       resolvedReasoningLevel,
       resolvedElevatedLevel,
       resolveDefaultThinkingLevel,
+      resolveDefaultReasoningLevel,
       isGroup,
       defaultGroupActivation: defaultActivation,
       mediaDecisions: ctx.MediaUnderstandingDecisions,
@@ -302,6 +307,7 @@ export async function handleInlineActions(params: {
       resolvedReasoningLevel,
       resolvedElevatedLevel,
       resolveDefaultThinkingLevel,
+      resolveDefaultReasoningLevel,
       provider,
       model,
       contextTokens,
@@ -365,6 +371,7 @@ export async function handleInlineActions(params: {
     resolvedReasoningLevel,
     resolvedElevatedLevel,
     resolveDefaultThinkingLevel,
+    resolveDefaultReasoningLevel,
     provider,
     model,
     contextTokens,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -272,6 +272,7 @@ export async function getReplyFromConfig(
     resolvedReasoningLevel,
     resolvedElevatedLevel,
     resolveDefaultThinkingLevel: modelState.resolveDefaultThinkingLevel,
+    resolveDefaultReasoningLevel: modelState.resolveDefaultReasoningLevel,
     provider,
     model,
     contextTokens,

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -9,6 +9,7 @@ import {
   type ModelAliasIndex,
   modelKey,
   normalizeProviderId,
+  resolveReasoningDefault,
   resolveModelRefFromString,
   resolveThinkingDefault,
 } from "../../agents/model-selection.js";
@@ -32,6 +33,7 @@ type ModelSelectionState = {
   allowedModelCatalog: ModelCatalog;
   resetModelOverride: boolean;
   resolveDefaultThinkingLevel: () => Promise<ThinkLevel>;
+  resolveDefaultReasoningLevel: () => Promise<"on" | "off">;
   needsModelCatalog: boolean;
 };
 
@@ -377,6 +379,7 @@ export async function createModelSelectionState(params: {
   }
 
   let defaultThinkingLevel: ThinkLevel | undefined;
+  let defaultReasoningLevel: "on" | "off" | undefined;
   const resolveDefaultThinkingLevel = async () => {
     if (defaultThinkingLevel) {
       return defaultThinkingLevel;
@@ -397,6 +400,24 @@ export async function createModelSelectionState(params: {
     return defaultThinkingLevel;
   };
 
+  const resolveDefaultReasoningLevel = async () => {
+    if (defaultReasoningLevel) {
+      return defaultReasoningLevel;
+    }
+    let catalogForReasoning = modelCatalog ?? allowedModelCatalog;
+    if (!catalogForReasoning || catalogForReasoning.length === 0) {
+      modelCatalog = await loadModelCatalog({ config: cfg });
+      catalogForReasoning = modelCatalog;
+    }
+    defaultReasoningLevel = resolveReasoningDefault({
+      cfg,
+      provider,
+      model,
+      catalog: catalogForReasoning,
+    });
+    return defaultReasoningLevel;
+  };
+
   return {
     provider,
     model,
@@ -404,6 +425,7 @@ export async function createModelSelectionState(params: {
     allowedModelCatalog,
     resetModelOverride,
     resolveDefaultThinkingLevel,
+    resolveDefaultReasoningLevel,
     needsModelCatalog,
   };
 }

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -122,6 +122,42 @@ describe("buildStatusMessage", () => {
     expect(text).toContain("elevated");
   });
 
+  it("shows reasoning as on for reasoning-capable models when not explicitly overridden", () => {
+    const text = buildStatusMessage({
+      config: {
+        models: {
+          providers: {
+            "openai-codex": {
+              models: [
+                {
+                  id: "gpt-5.4",
+                  reasoning: true,
+                  cost: {
+                    input: 0,
+                    output: 0,
+                    cacheRead: 0,
+                    cacheWrite: 0,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      } as OpenClawConfig,
+      agent: {
+        model: "openai-codex/gpt-5.4",
+      },
+      sessionEntry: { sessionId: "reasoning-default", updatedAt: 0 },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      resolvedThink: "medium",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    expect(normalizeTestText(text)).toContain("Think: medium");
+    expect(normalizeTestText(text)).toContain("Reasoning: on");
+  });
+
   it("includes media understanding decisions when present", () => {
     const text = buildStatusMessage({
       agent: { model: "anthropic/claude-opus-4-5" },

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -7,7 +7,7 @@ import type { ElevatedLevel, ReasoningLevel, ThinkLevel, VerboseLevel } from "./
 import { lookupContextTokens } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveModelAuthMode } from "../agents/model-auth.js";
-import { resolveConfiguredModelRef } from "../agents/model-selection.js";
+import { resolveConfiguredModelRef, resolveReasoningDefault } from "../agents/model-selection.js";
 import { resolveSandboxRuntimeStatus } from "../agents/sandbox.js";
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../agents/usage.js";
 import {
@@ -380,7 +380,9 @@ export function buildStatusMessage(args: StatusArgs): string {
 
   const thinkLevel = args.resolvedThink ?? args.agent?.thinkingDefault ?? "off";
   const verboseLevel = args.resolvedVerbose ?? args.agent?.verboseDefault ?? "off";
-  const reasoningLevel = args.resolvedReasoning ?? "off";
+  const reasoningLevel =
+    args.resolvedReasoning ??
+    (args.config ? resolveReasoningDefault({ cfg: args.config, provider, model }) : "off");
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -44,6 +44,7 @@ describe("listThinkingLevels", () => {
   it("includes xhigh for codex models", () => {
     expect(listThinkingLevels(undefined, "gpt-5.2-codex")).toContain("xhigh");
     expect(listThinkingLevels(undefined, "gpt-5.3-codex")).toContain("xhigh");
+    expect(listThinkingLevels(undefined, "gpt-5.4")).toContain("xhigh");
     expect(listThinkingLevels(undefined, "gpt-5.3-codex-spark")).toContain("xhigh");
   });
 

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -24,6 +24,7 @@ export function isBinaryThinkingProvider(provider?: string | null): boolean {
 export const XHIGH_MODEL_REFS = [
   "openai/gpt-5.2",
   "openai-codex/gpt-5.3-codex",
+  "openai-codex/gpt-5.4",
   "openai-codex/gpt-5.3-codex-spark",
   "openai-codex/gpt-5.2-codex",
   "openai-codex/gpt-5.1-codex",


### PR DESCRIPTION
User Impact

Users on GPT-5.4 Codex could hit split-brain behavior where OpenClaw recognized the model in some paths but not others, or `/status` reported `Think` and `Reasoning` inconsistently. This PR makes GPT-5.4 support and status reporting behave consistently across the affected paths.

This PR fixes two related issues around GPT-5.4 Codex support and status reporting.

The first issue is model support drift. Local OpenClaw installs could be patched to recognize `openai-codex/gpt-5.4`, but the source tree still lagged in the places that govern PI embedded resolution, catalog listing, modern-model filtering, and xhigh thinking capability. This branch now aligns GPT-5.4 forward-compat behavior with the newer 1.05M / 128k Codex limits that are being discussed in overlapping model-compat PRs, rather than preserving the older 272k window.

The second issue is status-card inconsistency. In the current reply/status pipeline, `Think` and `Reasoning` could come from different defaults. When `thinkingLevel` was set but `reasoningLevel` was missing, `/status` and `session_status` could report contradictory state such as `Think: medium` while `Reasoning` silently fell back to `off`. That mismatch then leaked into bot self-reports and confused operators.

This change does four things:

1. Adds `openai-codex/gpt-5.4` forward-compat support in the PI embedded model resolver.
2. Extends the model catalog fallback so GPT-5.4 is listed when GPT-5.3 Codex is present, with the GPT-5.4 window/token limits.
3. Marks GPT-5.4 as a modern Codex model and grants it xhigh thinking parity with the other modern Codex refs.
4. Introduces a shared reasoning-default resolver and threads it through the reply/status pipeline so status cards and related command flows derive reasoning defaults consistently from model capability instead of hardcoding `off`.

Validation performed:

- `corepack pnpm exec vitest run src/agents/pi-embedded-runner/model.test.ts src/agents/model-catalog.test.ts src/auto-reply/thinking.test.ts src/auto-reply/status.test.ts src/agents/system-prompt.test.ts src/agents/live-model-filter.test.ts src/auto-reply/reply/commands-status.test.ts src/auto-reply/reply/commands.test.ts src/auto-reply/reply/commands-approve.test.ts src/auto-reply/reply/commands-parsing.test.ts src/auto-reply/reply/commands-policy.test.ts`
- `corepack pnpm build`

This PR intentionally stays scoped to upstreamable source changes only. It does not include local machine-specific session-store edits or operator-specific workspace prompt hotfixes used during diagnosis.

Note: the reasoning-default unification is also available as a standalone PR in #37940 for independent review.