### PR TITLE
[Issue #37605] [Bug]: Cron jobs lost during gateway restart (race condition in persistence)

### DIFF
--- a/.github/issue-bootstrap/issue-37605.md
+++ b/.github/issue-bootstrap/issue-37605.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37605
+- Title: [Bug]: Cron jobs lost during gateway restart (race condition in persistence)
+- Source: https://github.com/openclaw/openclaw/issues/37605


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37605

## Original Issue Description
### Bug type

Behavior bug (incorrect output/state without crash)

### Summary

Cron jobs created shortly before a gateway restart can be silently lost. The jobs exist in memory and respond to `cron list`, but are not fully persisted to `jobs.json` on disk before the process exits.

### Steps to reproduce

1. Create multiple cron jobs via the `cron` tool (e.g., 5-6 jobs in quick succession)
2. Shortly after (~2 minutes), trigger a gateway restart (e.g., via `config.apply` or config overwrite from another session)
3. After restart, `cron list` shows fewer jobs than expected — the recently created ones are gone

### Expected behavior

All cron jobs that were successfully created (and returned a valid job ID) should survive a gateway restart.

### Actual behavior

Jobs created within a short window before restart are lost. In our case:
- 8 jobs existed before restart
- Only 3 survived (the older ones)
- 5 jobs created in the ~5 minutes before restart were lost
- `jobs.json.bak` also only contained the 3 surviving jobs

### OpenClaw version

2026.3.3

### Operating system

macOS (Darwin 25.2.0 arm64)

### Install method

_No response_

### Logs, screenshots, and evidence

```shell
04:00-04:05 CST  — 5 new cron jobs created (confirmed via cron list)
04:07:52 CST     — Config overwrite detected → restart triggered
04:26:29 CST     — New gateway process starts, loads jobs.json → only 3 old jobs remain
```

### Impact and severity

- Lost 5 cron jobs silently (no error, no warning in logs)
- User-facing: scheduled tasks (daily greeting, security audit, backup) stopped running without any notification
- Difficult to detect: no indication that jobs were lost until they failed to fire

### Additional information

## Root Cause Analysis

The cron persistence layer appears to use a buffered/periodic write strategy rather than synchronous write-on-create. When a config change triggers a process restart, the in-memory cron state is not flushed to disk before shutdown.

## Suggested Fix

- **Option A**: Synchronous write — flush `jobs.json` to disk on every `cron add/update/remove`
- **Option B**: Shutdown hook — flush cron state to disk before process exit (SIGTERM handler)
- **Option C**: Both (belt and suspenders)

## Linkage
Refs #37605