### PR TITLE
[Issue #37623] openai-codex/gpt-5.4 is configurable but not actually supported in runtime (missing/Unknown model)

### DIFF
--- a/.github/issue-bootstrap/issue-37623.md
+++ b/.github/issue-bootstrap/issue-37623.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37623
+- Title: openai-codex/gpt-5.4 is configurable but not actually supported in runtime (missing/Unknown model)
+- Source: https://github.com/openclaw/openclaw/issues/37623


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37623

## Original Issue Description
### Summary

On OpenClaw `2026.3.2`, `openai-codex/gpt-5.4` can be added to config and appears in `models list`, but it is still treated as `missing` and fails at runtime with `Unknown model` / `HTTP 404`.

This makes it look like GPT-5.4 via `openai-codex` is supported when it is not yet wired through the runtime.

### Environment

- OpenClaw version: `2026.3.2`
- Install method: `pnpm`
- Auth: `openai-codex` OAuth profile present and valid
- Platform: macOS

### Reproduction

1. Configure the main agent or default model as:
   - `openai-codex/gpt-5.4`
   - or `openai-codex/gpt-5.4-codex`
2. Restart gateway/node.
3. Run:
   - `openclaw models list`
   - `openclaw models status --json`
   - start a fresh `main` session / normal agent turn

### Actual behavior

- `openclaw models list` shows:
  - `openai-codex/gpt-5.4 ... configured,missing`
  - `openai-codex/gpt-5.4-codex ... configured,missing`
- runtime errors include:
  - `FailoverError: Unknown model: openai-codex/gpt-5.4`
  - `FailoverError: HTTP 404: 404 page not found`

### Expected behavior

One of these should be true:

1. `openai-codex/gpt-5.4` is fully supported in runtime/catalog/forward-compat and works.
2. Or OpenClaw should reject it early and clearly, instead of allowing it into config and then failing later at runtime.

### Findings

It looks deeper than an allow-list issue. The installed runtime still appears hard-wired around `gpt-5.3-codex` for `openai-codex`.

### Suggested fix

- Add proper runtime/catalog/forward-compat support for `openai-codex/gpt-5.4` (and possibly `gpt-5.4-codex`), or
- fail validation early with a clear error if `openai-codex/gpt-5.4` is not supported yet.

## Linkage
Refs #37623