### PR TITLE
[Issue #37625] feat(workspace): lint and auto-fix code fences in markdown at write time

### DIFF
--- a/.github/issue-bootstrap/issue-37625.md
+++ b/.github/issue-bootstrap/issue-37625.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37625
+- Title: feat(workspace): lint and auto-fix code fences in markdown at write time
+- Source: https://github.com/openclaw/openclaw/issues/37625


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37625

## Original Issue Description
## Problem

Code stored in markdown workspace files (`MEMORY.md`, `AGENTS.md`, skill files, etc.) frequently appears without proper fencing, or with fencing that's missing a language tag, causing rendering/highlighting/copy issues.

## Proposal

Add a `lintMarkdownCodeFences()` pass that runs inside `writeTrackedDoc()` / `beginDocSession.commit()` when file content changes.

- Auto-fix mode (default): wrap unfenced code and infer language tags.
- Warn-only mode: configurable `workspace.codeFenceLint: "warn"`.

Suggested heuristics include shell prompt lines, long indented blocks, bare JSON, and common TS/Python starters. Language inference targets `sh`, `ts`, `python`, and `json`.

Acceptance criteria in the issue include utility integration, skip option, and tests for shell/TS/JSON/missing-language/no-op cases.

## Linkage
Refs #37625