### PR TITLE
[Issue #37626] [feishu plugin] wiki spaceNode.list 分页不生效，只返回前20条记录

### DIFF
--- a/.github/issue-bootstrap/issue-37626.md
+++ b/.github/issue-bootstrap/issue-37626.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37626
+- Title: [feishu plugin] wiki spaceNode.list 分页不生效，只返回前20条记录
+- Source: https://github.com/openclaw/openclaw/issues/37626


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37626

## Original Issue Description
问题描述：飞书插件 `feishu_wiki` 的 `nodes` action 只能返回前 20 条记录，无法拿到完整子节点列表。

复现：对超过 20 子节点的知识库调用 `feishu_wiki({ action: "nodes", ... })`，返回始终为 20 条。

已尝试：在 `wiki-schema.ts` 添加 `page_size` / `page_token` / `fetch_all` 参数，并在 `wiki.ts` 的 `listNodes` 增加分页循环和 `has_more` 判断，但重启后仍只返回 20 条，且未出现分页信息字段。

期望：当 `fetch_all=true`（默认）时自动翻页并返回全部记录，同时返回 `total` 与 `pages_fetched` 等分页元信息。

## Linkage
Refs #37626