### PR TITLE
[Issue #37630] feat(cron): hierarchical job store — one file per cron job in cron/jobs/ directory

### DIFF
--- a/.github/issue-bootstrap/issue-37630.md
+++ b/.github/issue-bootstrap/issue-37630.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37630
+- Title: feat(cron): hierarchical job store — one file per cron job in cron/jobs/ directory
+- Source: https://github.com/openclaw/openclaw/issues/37630


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37630

## Original Issue Description
The issue requests replacing/augmenting monolithic `~/.openclaw/cron/jobs.json` with a directory-based store (`cron/jobs/*.json`) where each job is one file.

Key points from the issue:
- Better readability/diffs and easier enable/disable by filename prefix.
- Backward compatibility with `jobs.json`.
- Optional migration command (`openclaw cron migrate-to-dir`).
- Conflict/overlap diagnostics when both stores exist.
- Acceptance criteria include loading precedence, ID inference from filename, and update/remove behavior against per-job files.

## Linkage
Refs #37630