### PR TITLE
[Issue #37633] [Bug]: lark/feishu error plugin status with unresolved appsecret(using env)

### DIFF
--- a/.github/issue-bootstrap/issue-37633.md
+++ b/.github/issue-bootstrap/issue-37633.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37633
+- Title: [Bug]: lark/feishu error plugin status with unresolved appsecret(using env)
+- Source: https://github.com/openclaw/openclaw/issues/37633


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37633

## Original Issue Description
Bug report: `openclaw plugins list` shows feishu plugin registration error when `channels.feishu.appSecret` is configured via env secret ref.

Observed error:
`channels.feishu.appSecret: unresolved SecretRef "env:default:FEISHU_APP_SECRET". Resolve this command against an active gateway runtime snapshot before reading it.`

Repro in issue:
1) Configure appsecret with env variable.
2) Run setup and execute `openclaw plugins list`.
3) Error still appears in console.

Environment from issue: OpenClaw 2026.3.2 on WSL2 (Win11), npm (non-system-wide).

## Linkage
Refs #37633