### PR TITLE
[Issue #37634] sandbox: keep workspaceAccess none workspaces writable

### DIFF
--- a/.github/issue-bootstrap/issue-37634.md
+++ b/.github/issue-bootstrap/issue-37634.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37634
+- Title: sandbox: keep workspaceAccess none workspaces writable
+- Source: https://github.com/openclaw/openclaw/issues/37634


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37634

## Original Issue Description
When `agents.defaults.sandbox.workspaceAccess` is set to `"none"`, OpenClaw isolates workspace under `~/.openclaw/sandboxes/...` as expected, but mounts `/workspace` read-only.

Expected from issue:
- `workspaceAccess: "none"` should isolate from the main workspace while keeping isolated sandbox workspace writable.

Actual:
- `/workspace` maps to sandbox path but is mounted `rw=false`, which breaks write-reliant tools.

The issue notes likely regression tied to commit `903e4dff3` and requests keeping `ro` read-only while `none` remains isolated but writable.

## Linkage
Refs #37634