### PR TITLE
[Issue #37635] models list --all omits config-injected models from models.providers

### DIFF
--- a/.github/issue-bootstrap/issue-37635.md
+++ b/.github/issue-bootstrap/issue-37635.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37635
+- Title: models list --all omits config-injected models from models.providers
+- Source: https://github.com/openclaw/openclaw/issues/37635


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37635

## Original Issue Description
Issue summary: `openclaw models list --all` omits provider models injected via `models.providers.<provider>.models` when not present in underlying registry.

Reported behavior:
- Non-`--all` path can show configured model.
- `--all` path omits config-only model (example: `openai-codex/gpt-5.4`) despite runtime being able to resolve/call it in specific setups.

Expected:
- `models list --all` should be superset and include config-injected provider models.

Suggested direction from issue:
- Merge configured entries missing from discovered registry before rendering `--all` rows.

## Linkage
Refs #37635