### PR TITLE
[Issue #37645] patchToolSchemaForClaudeCompatibility empties required[] — non-Claude models send empty arguments

### DIFF
--- a/.github/issue-bootstrap/issue-37645.md
+++ b/.github/issue-bootstrap/issue-37645.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37645
+- Title: patchToolSchemaForClaudeCompatibility empties required[] — non-Claude models send empty arguments
+- Source: https://github.com/openclaw/openclaw/issues/37645


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37645

## Original Issue Description
The issue reports that `patchToolSchemaForClaudeCompatibility()` removes original parameter names from `required[]` without inserting aliases, effectively emptying required fields for read/edit/write tools.

Consequence described:
- Non-Claude models interpret all params as optional and may send `{}` or empty values.

Proposed one-line fix in issue:
- Replace `required.splice(idx, 1)` with `required.splice(idx, 1, alias)` so alias remains required.

Issue notes runtime normalization already maps aliases back, so preserving alias in `required[]` should be compatible.

## Linkage
Refs #37645