### PR TITLE
[Issue #37647] [Bug]: TUI doesn't display assistant replies, but webchat works fine

### DIFF
--- a/.github/issue-bootstrap/issue-37647.md
+++ b/.github/issue-bootstrap/issue-37647.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37647
+- Title: [Bug]: TUI doesn't display assistant replies, but webchat works fine
+- Source: https://github.com/openclaw/openclaw/issues/37647


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37647

## Original Issue Description
Regression report: assistant replies are not displayed in terminal TUI, while webchat shows replies correctly.

Issue details:
- OpenClaw 2026.3.2 on Linux systemd service.
- `openclaw tui` sends user messages and session logs contain assistant messages.
- Webchat (`http://127.0.0.1:18789/chat`) shows assistant responses.
- TUI does not display assistant responses and shows no explicit error.

Impact: TUI users cannot see assistant output despite successful processing.

## Linkage
Refs #37647