### PR TITLE
[Issue #37651] Feature request: Add lightweight shell payload type for cron jobs

### DIFF
--- a/.github/issue-bootstrap/issue-37651.md
+++ b/.github/issue-bootstrap/issue-37651.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37651
+- Title: Feature request: Add lightweight shell payload type for cron jobs
+- Source: https://github.com/openclaw/openclaw/issues/37651


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37651

## Original Issue Description
Feature request: add cron `payload.kind: "shell"` (or `"exec"`) for direct shell execution without LLM invocation.

Rationale from issue:
- Current `systemEvent`/`agentTurn` paths incur heavy token/time overhead for simple checks.
- Desired use cases include health checks, monitoring, API polling, and system status commands.

Issue also proposes API fields (`command`, `shell`, `timeoutSeconds`, `env`) and delivery conditions (`always`, `nonzero-output`, `nonzero-exit`, etc.), with security constraints aligned to exec policy and explicit opt-in.

## Linkage
Refs #37651