### PR TITLE
[Issue #37652] [Bug]: 我目前没有执行 shell 命令的工具（exec），无法直接运行 df -h。

### DIFF
--- a/.github/issue-bootstrap/issue-37652.md
+++ b/.github/issue-bootstrap/issue-37652.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37652
+- Title: [Bug]: 我目前没有执行 shell 命令的工具（exec），无法直接运行 df -h。
+- Source: https://github.com/openclaw/openclaw/issues/37652


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37652

## Original Issue Description
问题概要：升级到最新主分支后，无法调用 `exec`，导致所有命令执行失败（例如 `df -h`）。

报告内容提到：
- 重启、重装、清理空间后问题仍存在。
- 版本为 20260306。
- 系统为 Ubuntu 22（原文为 ubuniu22）。
- 安装方式为 pnpm。

Issue 被标记为 regression。

## Linkage
Refs #37652