### PR TITLE
[Issue #37655] Cron Jobs page: New Job panel overlaps Jobs list columns

### DIFF
--- a/.github/issue-bootstrap/issue-37655.md
+++ b/.github/issue-bootstrap/issue-37655.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37655
+- Title: Cron Jobs page: New Job panel overlaps Jobs list columns
+- Source: https://github.com/openclaw/openclaw/issues/37655


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37655

## Original Issue Description
Bug report: On Control UI Cron Jobs page, the right-side “New Job” panel overlaps and covers Jobs table columns (Enabled/Schedule/Last run/Sort/Direction/Reset), making them unreadable and non-interactive.

Environment from issue:
- OpenClaw 2026.2.25
- macOS arm64, Safari/Chrome
- Dashboard at localhost:18789

Expected behavior:
- No overlap; responsive stacking or width constraints so both panels remain usable.

## Linkage
Refs #37655