### PR TITLE
[Issue #37658] Bug: Invalid diff: now finding less tool calls!

### DIFF
--- a/.github/issue-bootstrap/issue-37658.md
+++ b/.github/issue-bootstrap/issue-37658.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37658
+- Title: Bug: Invalid diff: now finding less tool calls!
+- Source: https://github.com/openclaw/openclaw/issues/37658


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37658

## Original Issue Description
Issue reports streaming mismatch with local llama.cpp models during tool calls:

Error:
`Invalid diff: now finding less tool calls!`

Context from issue:
- Local OpenAI-compatible llama provider (`127.0.0.1:8080`).
- Model example: Qwen3.5-35B-A3B-UD-Q4_K_L.
- Tool-calling tasks intermittently fail as initial and final tool call counts diverge.

Claimed impact:
- High priority because local model tool-calling becomes unreliable.

## Linkage
Refs #37658