### PR TITLE
[Issue #37659] docs: improve safe-mode agent instructions for token updates and OAuth re-auth

### DIFF
--- a/.github/issue-bootstrap/issue-37659.md
+++ b/.github/issue-bootstrap/issue-37659.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37659
+- Title: docs: improve safe-mode agent instructions for token updates and OAuth re-auth
+- Source: https://github.com/openclaw/openclaw/issues/37659


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37659

## Original Issue Description
Documentation improvement request based on a real safe-mode recovery session.

Two gaps identified:
1) Token updates:
- `TOOLS.md` mentions `/etc/habitat-parsed.env` but does not explain this file is read by recovery scripts.
- Updating only `~/.openclaw/openclaw.full.json` leaves stale token behavior.

2) OAuth re-auth flow:
- Current guidance uses detached tmux (`-d`), hiding wizard UI from RDP desktop.
- Request clarifies terminal must be visible on `DISPLAY=:10` and warns against detached flow.

Issue requests updates to safe-mode workspace templates / generation scripts accordingly.

## Linkage
Refs #37659