### PR TITLE
[Issue #37661] [Bug]: LLM streaming output infinite loop - same phrase repeated 40+ times

### DIFF
--- a/.github/issue-bootstrap/issue-37661.md
+++ b/.github/issue-bootstrap/issue-37661.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37661
+- Title: [Bug]: LLM streaming output infinite loop - same phrase repeated 40+ times
+- Source: https://github.com/openclaw/openclaw/issues/37661


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37661

## Original Issue Description
Behavior bug report: during subagent timeout/recovery scenarios, LLM output can enter repetition loops where the same phrase appears dozens of times and duplicate messages are sent repeatedly.

Reported pattern:
- Trigger after subagent spawn/timeout.
- Repeated phrase appears 40+ times.
- Duplicate message sends continue until session reset (`/new`).

Expected:
- Single coherent response with repetition detection/cutoff.

Impact:
- High severity from user perspective due spam output and manual reset requirement.

## Linkage
Refs #37661