### PR TITLE
[Issue #37667] Feature: Cross-channel session continuity for same-user DMs

### DIFF
--- a/.github/issue-bootstrap/issue-37667.md
+++ b/.github/issue-bootstrap/issue-37667.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37667
+- Title: Feature: Cross-channel session continuity for same-user DMs
+- Source: https://github.com/openclaw/openclaw/issues/37667


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37667

## Original Issue Description
Feature request: same human using same agent across different DM channels should maintain conversation continuity.

Problem statement from issue:
- Channel-specific sessions are isolated (e.g., WhatsApp vs webchat vs Telegram).
- Users perceive one assistant but must repeat context across channels.

Proposed direction:
- User identity binding across channels.
- Unified DM session or cross-channel rolling context injection.
- Opt-in behavior with privacy boundaries (DM-only, not group chats).

Issue includes MVP idea like `agents.defaults.dmScope: unified`.

## Linkage
Refs #37667