### PR TITLE
fix(webchat): preserve draft while background announce messages arrive

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -277,7 +277,9 @@ function handleTerminalChatEvent(
 }
 
 function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | undefined) {
-  if (payload?.sessionKey) {
+  const isCurrentSessionEvent =
+    Boolean(payload?.sessionKey) && payload?.sessionKey === host.sessionKey;
+  if (isCurrentSessionEvent && payload?.sessionKey) {
     setLastActiveSessionKey(
       host as unknown as Parameters<typeof setLastActiveSessionKey>[0],
       payload.sessionKey,


### PR DESCRIPTION
## Summary
- stop updating `lastActiveSessionKey` for chat events from other sessions
- keep active chat session anchored to the currently opened session in Control UI
- avoid side effects from background cron/subagent announce events while typing in webchat

Closes #37675

## Validation
- `pnpm exec vitest run ui/src/ui/controllers/chat.test.ts`
  - Result: 1 test file passed, 25 tests passed
- `pnpm exec oxlint --type-aware ui/src/ui/app-gateway.ts ui/src/ui/controllers/chat.ts`
  - Result: 0 warnings, 0 errors