### PR TITLE
fix: preserve text after unclosed <think> tags

### DIFF
--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -187,8 +187,10 @@ describe("stripReasoningTagsFromText", () => {
   describe("strict vs preserve mode", () => {
     it("applies strict and preserve modes to unclosed tags", () => {
       const input = "Before <think>unclosed content after";
+      // After fix for Issue #37696, both modes preserve trailing text
+      // to prevent silent message loss when models forget </think>
       const cases = [
-        { mode: "strict" as const, expected: "Before" },
+        { mode: "strict" as const, expected: "Before unclosed content after" },
         { mode: "preserve" as const, expected: "Before unclosed content after" },
       ];
       for (const { mode, expected } of cases) {

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -84,9 +84,13 @@ export function stripReasoningTagsFromText(
     lastIndex = idx + match[0].length;
   }
 
-  if (!inThinking || mode === "preserve") {
-    result += cleaned.slice(lastIndex);
-  }
+  // Fix for Issue #37696: Always preserve trailing text, even after unclosed tags
+  // When a model forgets </think>, we still want to show the visible response
+  // (only properly closed <think>...</think> blocks are stripped)
+  // Security note: This may expose reasoning text after unclosed <think>, but
+  // that's preferable to silently dropping the entire response (common with
+  // Qwen 3.5 and other models that occasionally forget closing tags)
+  result += cleaned.slice(lastIndex);
 
   return applyTrim(result, trimMode);
 }


### PR DESCRIPTION
Fixes #37696

## Problem

When models emit `<think>` without closing `</think>` (common with Qwen 3.5), users receive **NOTHING** - the entire response is silently dropped.

**Affected**: ALL channels (Telegram, Discord, Slack, Signal, etc.)  
**Severity**: Critical — complete message loss  
**Frequency**: Intermittent (common on short casual responses)  
**Web UI**: Not affected (uses mode="preserve")

### Before
```
User: "Hello"
Model: "<think>Hello! How are you?"  (no </think>)
User sees: (nothing - silence)
Session logs: Response exists but never delivered
```

### After
```
User: "Hello"
Model: "<think>Hello! How are you?"  (no </think>)
User sees: "Hello! How are you?"  ✅
```

---

## Solution

### Root Cause
`src/shared/text/reasoning-tags.ts` line 87-89:
```typescript
if (!inThinking || mode === "preserve") {
  result += cleaned.slice(lastIndex);
}
// When inThinking=true (unclosed tag), trailing text is dropped
```

**Why it fails**:
1. Model emits: `<think>Hello! How are you?` (no `</think>`)
2. Parser sets `inThinking=true` at `<think>`
3. No closing tag found → `inThinking` stays `true`
4. Line 87: `!inThinking` is `false` → text NOT appended
5. Result: `""` → delivery layer has nothing to send

**Why Web UI works**: Uses `mode="preserve"` → always appends text

### Implementation
```typescript
// OLD (drops text after unclosed tags)
if (!inThinking || mode === "preserve") {
  result += cleaned.slice(lastIndex);
}

// NEW (always preserves trailing text)
result += cleaned.slice(lastIndex);
```

**Behavior**:
- ✅ Properly closed `<think>...</think>`: Still stripped
- ✅ Unclosed `<think>...`: Text preserved (instead of dropped)
- ✅ `mode="preserve"`: Unchanged
- ✅ `mode="strict"`: Now preserves text after unclosed tags

---

## Security Trade-off

### Risk
May expose reasoning text after unclosed `<think>` tags.

### Justification
- **Better to show reasoning than drop entire response**
- Users expect to see SOMETHING, not silence
- Model forgetting `</think>` is common (Qwen 3.5, others)
- Web UI already exposes this (mode="preserve")
- Alternative (auto-close tags) more complex and error-prone

---

## Testing

### Manual Test Plan
**Qwen 3.5 or similar model**:
1. Send short casual message: `"Hello"`
2. Model sometimes responds: `<think>Hello! How are you?` (no closing)
3. Before fix: User sees nothing
4. After fix: User sees `"Hello! How are you?"`

### Verification
- ✅ Properly closed tags still stripped correctly
- ✅ Unclosed tags now preserve visible text
- ✅ No change to mode="preserve" behavior
- ✅ All channels now consistent with Web UI

---

## Impact

### Affected
- ✅ All channels using mode="strict" (Telegram, Discord, etc.)
- ✅ Models that forget closing tags (Qwen 3.5, others)

### Unaffected
- ✅ Web UI (already uses mode="preserve")
- ✅ Properly closed `<think>...</think>` blocks
- ✅ Models that always close tags correctly

### Benefits
- 🎉 No more silent response drops
- 🎉 Users always see their response
- 🎉 Consistent behavior across all channels
- 🎉 Simple 1-line fix

---

## AI Assistance

- **Tool**: Claude 4.5 Sonnet (Agent C)
- **Degree**: AI-assisted (implemented fix from user's analysis)
- **Testing**: Logic verified
- **Understanding**: ✅ I fully understand how this code works

---

## Related

- Issue credit: #37696 reporter (detailed root cause analysis)
- User prepared branch: `druide67:fix/reasoning-tags-unclosed-think`
- Affects: Qwen 3.5 and other models that occasionally forget `</think>`
