### PR TITLE
fix(bonjour): truncate mDNS labels to 63 bytes to prevent gateway crash

### DIFF
--- a/src/gateway/server-discovery.test.ts
+++ b/src/gateway/server-discovery.test.ts
@@ -40,7 +40,7 @@ describe("formatBonjourInstanceName", () => {
   test("handles multi-byte UTF-8 characters without splitting them", () => {
     // Each CJK character is 3 bytes in UTF-8; create a name that would
     // exceed 63 bytes when suffixed.
-    const cjkName = "测".repeat(20); // 60 bytes as raw, 70 with suffix
+    const cjkName = "测".repeat(20); // 60 bytes as raw, 71 with suffix
     const result = formatBonjourInstanceName(cjkName);
     const byteLength = new TextEncoder().encode(result).byteLength;
     expect(byteLength).toBeLessThanOrEqual(63);

--- a/src/gateway/server-discovery.test.ts
+++ b/src/gateway/server-discovery.test.ts
@@ -4,7 +4,52 @@ const getTailnetHostname = vi.hoisted(() => vi.fn());
 
 vi.mock("../infra/tailscale.js", () => ({ getTailnetHostname }));
 
-import { resolveTailnetDnsHint } from "./server-discovery.js";
+import { formatBonjourInstanceName, resolveTailnetDnsHint } from "./server-discovery.js";
+
+describe("formatBonjourInstanceName", () => {
+  test("returns OpenClaw for empty input", () => {
+    expect(formatBonjourInstanceName("")).toBe("OpenClaw");
+    expect(formatBonjourInstanceName("  ")).toBe("OpenClaw");
+  });
+
+  test("appends (OpenClaw) suffix for plain names", () => {
+    expect(formatBonjourInstanceName("MyMac")).toBe("MyMac (OpenClaw)");
+  });
+
+  test("does not append suffix if name already contains openclaw", () => {
+    expect(formatBonjourInstanceName("Studio OpenClaw")).toBe("Studio OpenClaw");
+  });
+
+  test("truncates long hostnames to fit 63-byte mDNS label limit", () => {
+    // Kubernetes-style pod name (55 chars + " (OpenClaw)" = 66 bytes)
+    const longPodName = "app-41627eae5842473f9e05f139ea307277-7f9477f4d6-lqqzf";
+    const result = formatBonjourInstanceName(longPodName);
+    const byteLength = new TextEncoder().encode(result).byteLength;
+    expect(byteLength).toBeLessThanOrEqual(63);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  test("preserves names that are exactly 63 bytes", () => {
+    // 52 chars + " (OpenClaw)" [11 chars] = 63 bytes exactly
+    const name = "a".repeat(52);
+    const result = formatBonjourInstanceName(name);
+    expect(result).toBe(`${"a".repeat(52)} (OpenClaw)`);
+    expect(new TextEncoder().encode(result).byteLength).toBe(63);
+  });
+
+  test("handles multi-byte UTF-8 characters without splitting them", () => {
+    // Each CJK character is 3 bytes in UTF-8; create a name that would
+    // exceed 63 bytes when suffixed.
+    const cjkName = "测".repeat(20); // 60 bytes as raw, 70 with suffix
+    const result = formatBonjourInstanceName(cjkName);
+    const byteLength = new TextEncoder().encode(result).byteLength;
+    expect(byteLength).toBeLessThanOrEqual(63);
+    // Should not end with a partial UTF-8 sequence
+    expect(() =>
+      new TextDecoder("utf-8", { fatal: true }).decode(new TextEncoder().encode(result)),
+    ).not.toThrow();
+  });
+});
 
 describe("resolveTailnetDnsHint", () => {
   const prevTailnetDns = { value: undefined as string | undefined };

--- a/src/gateway/server-discovery.ts
+++ b/src/gateway/server-discovery.ts
@@ -19,7 +19,7 @@ export type ResolveBonjourCliPathOptions = {
  */
 const MAX_MDNS_LABEL_BYTES = 63;
 
-function truncateToMdnsLabel(name: string): string {
+export function truncateToMdnsLabel(name: string): string {
   const encoder = new TextEncoder();
   if (encoder.encode(name).byteLength <= MAX_MDNS_LABEL_BYTES) {
     return name;

--- a/src/gateway/server-discovery.ts
+++ b/src/gateway/server-discovery.ts
@@ -11,15 +11,35 @@ export type ResolveBonjourCliPathOptions = {
   statSync?: (path: string) => fs.Stats;
 };
 
+/**
+ * mDNS service instance names are single DNS labels limited to 63 bytes
+ * (RFC 6763 §4.1.1). Exceeding this causes @homebridge/ciao to throw an
+ * AssertionError and crash the gateway — common in container environments
+ * where hostnames can be very long (e.g. Kubernetes pod names).
+ */
+const MAX_MDNS_LABEL_BYTES = 63;
+
+function truncateToMdnsLabel(name: string): string {
+  const encoder = new TextEncoder();
+  if (encoder.encode(name).byteLength <= MAX_MDNS_LABEL_BYTES) {
+    return name;
+  }
+  // Trim characters from the end until we fit within the byte budget.
+  // This handles multi-byte (UTF-8) characters correctly.
+  let truncated = name;
+  while (encoder.encode(truncated).byteLength > MAX_MDNS_LABEL_BYTES) {
+    truncated = truncated.slice(0, -1);
+  }
+  return truncated.trimEnd();
+}
+
 export function formatBonjourInstanceName(displayName: string) {
   const trimmed = displayName.trim();
   if (!trimmed) {
     return "OpenClaw";
   }
-  if (/openclaw/i.test(trimmed)) {
-    return trimmed;
-  }
-  return `${trimmed} (OpenClaw)`;
+  const raw = /openclaw/i.test(trimmed) ? trimmed : `${trimmed} (OpenClaw)`;
+  return truncateToMdnsLabel(raw);
 }
 
 export function resolveBonjourCliPath(opts: ResolveBonjourCliPathOptions = {}): string | undefined {

--- a/src/infra/bonjour.ts
+++ b/src/infra/bonjour.ts
@@ -1,3 +1,4 @@
+import { truncateToMdnsLabel } from "../gateway/server-discovery.js";
 import { logDebug, logWarn } from "../logger.js";
 import { getLogger } from "../logging.js";
 import { ignoreCiaoCancellationRejection } from "./bonjour-ciao.js";
@@ -106,12 +107,7 @@ export async function startGatewayBonjourAdvertiser(
   // mDNS hostnames are single DNS labels limited to 63 bytes (RFC 1035 §2.3.4).
   // Container environments (e.g. Kubernetes) can produce hostnames that exceed
   // this limit, causing @homebridge/ciao to throw and crash the gateway.
-  const encoder = new TextEncoder();
-  let hostname = hostnameLabel;
-  while (encoder.encode(hostname).byteLength > 63) {
-    hostname = hostname.slice(0, -1);
-  }
-  hostname = hostname.trimEnd() || "openclaw";
+  const hostname = truncateToMdnsLabel(hostnameLabel) || "openclaw";
   const instanceName =
     typeof opts.instanceName === "string" && opts.instanceName.trim()
       ? opts.instanceName.trim()

--- a/src/infra/bonjour.ts
+++ b/src/infra/bonjour.ts
@@ -98,11 +98,20 @@ export async function startGatewayBonjourAdvertiser(
     process.env.OPENCLAW_MDNS_HOSTNAME?.trim() ||
     process.env.CLAWDBOT_MDNS_HOSTNAME?.trim() ||
     "openclaw";
-  const hostname =
+  const hostnameLabel =
     hostnameRaw
       .replace(/\.local$/i, "")
       .split(".")[0]
       .trim() || "openclaw";
+  // mDNS hostnames are single DNS labels limited to 63 bytes (RFC 1035 §2.3.4).
+  // Container environments (e.g. Kubernetes) can produce hostnames that exceed
+  // this limit, causing @homebridge/ciao to throw and crash the gateway.
+  const encoder = new TextEncoder();
+  let hostname = hostnameLabel;
+  while (encoder.encode(hostname).byteLength > 63) {
+    hostname = hostname.slice(0, -1);
+  }
+  hostname = hostname.trimEnd() || "openclaw";
   const instanceName =
     typeof opts.instanceName === "string" && opts.instanceName.trim()
       ? opts.instanceName.trim()


### PR DESCRIPTION
## Problem

Fixes #37705

Long hostnames — common in Kubernetes/container environments (e.g. `app-41627eae5842473f9e05f139ea307277-7f9477f4d6-lqqzf`) — cause `@homebridge/ciao` to throw an `AssertionError: Label cannot be longer than 63 bytes` when the mDNS service instance name exceeds the 63-byte DNS label limit (RFC 6763 §4.1.1), crashing the gateway on startup.

## Root Cause

`formatBonjourInstanceName()` appends ` (OpenClaw)` to the machine display name without checking the resulting byte length. On Linux, `getMachineDisplayName()` falls back to `os.hostname()`, which in container environments can produce names that push the total well past 63 bytes.

The same issue applies to the `hostname` variable in `bonjour.ts`, which is used as the mDNS hostname label.

## Fix

- Truncate the output of `formatBonjourInstanceName()` to ≤63 bytes, handling multi-byte UTF-8 characters correctly (no partial sequences)
- Truncate the mDNS hostname in `bonjour.ts` to ≤63 bytes using the same approach
- Added tests covering truncation, exact-fit boundary, and multi-byte (CJK) edge cases

## Changes

- `src/gateway/server-discovery.ts` — add `truncateToMdnsLabel()` helper, apply in `formatBonjourInstanceName()`
- `src/infra/bonjour.ts` — truncate `hostname` to 63 bytes before passing to ciao
- `src/gateway/server-discovery.test.ts` — 6 new tests for `formatBonjourInstanceName`

**Size: XS** (78 lines added across 3 files, mostly tests)