### PR TITLE
fix(process): wrap npm/npx .cmd via cmd.exe when npm-cli.js missing

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -77,7 +77,12 @@ function resolveCommand(command: string): string {
   if (ext) {
     return command;
   }
-  const cmdCommands = ["pnpm", "yarn"];
+  // On Windows, most package-manager CLIs are exposed as .cmd shims.
+  // Note: npm/npx are *preferably* handled by resolveNpmArgvForWindows to avoid
+  // spawn EINVAL on newer Node versions (see comment above), but when the npm
+  // cli script isn't found (alt Node installs like nvm-windows/volta/fnm), we
+  // still need to resolve to the .cmd shim so we can run it via cmd.exe wrapper.
+  const cmdCommands = ["npm", "npx", "pnpm", "yarn"];
   if (cmdCommands.includes(basename)) {
     return `${command}.cmd`;
   }

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const spawnMock = vi.hoisted(() => vi.fn());
@@ -68,6 +69,35 @@ describe("windows command wrapper behavior", () => {
     spawnMock.mockReset();
     execFileMock.mockReset();
     vi.restoreAllMocks();
+  });
+
+  it("wraps npm.cmd via cmd.exe when npm-cli.js cannot be resolved", async () => {
+    // This simulates alternative Node/npm installs on Windows where
+    // <nodeDir>/node_modules/npm/bin/npm-cli.js doesn't exist.
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    const expectedComSpec = process.env.ComSpec ?? "cmd.exe";
+
+    spawnMock.mockImplementation(
+      (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
+    );
+
+    try {
+      const result = await runCommandWithTimeout(["npm", "--version"], { timeoutMs: 1000 });
+      expect(result.code).toBe(0);
+
+      const captured = spawnMock.mock.calls[0] as SpawnCall | undefined;
+      if (!captured) {
+        throw new Error("expected spawn to be called");
+      }
+      expect(captured[0]).toBe(expectedComSpec);
+      expect(captured[1].slice(0, 3)).toEqual(["/d", "/s", "/c"]);
+      expect(captured[1][3]).toContain("npm.cmd --version");
+      expect(captured[2].windowsVerbatimArguments).toBe(true);
+    } finally {
+      existsSpy.mockRestore();
+      platformSpy.mockRestore();
+    }
   });
 
   it("wraps .cmd commands via cmd.exe in runCommandWithTimeout", async () => {


### PR DESCRIPTION
Closes #37563

On Windows, some Node/npm installs do not include <nodeDir>/node_modules/npm/bin/npm-cli.js. In that case, we must fall back to executing npm.cmd via an explicit cmd.exe wrapper (with windowsVerbatimArguments) to avoid spawn EINVAL + quoting issues when Node lives under a path with spaces.

## Validation
- node node_modules/vitest/vitest.mjs run src/process/exec.windows.test.ts