### PR TITLE
fix(daemon): add missing NODE_USE_SYSTEM_CA to service environment

### DIFF
--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -241,32 +241,33 @@ export function buildMinimalServicePath(options: BuildServicePathOptions = {}): 
   return getMinimalServicePathPartsFromEnv({ ...options, env }).join(path.posix.delimiter);
 }
 
-export function buildServiceEnvironment(params: {
-  env: Record<string, string | undefined>;
-  port: number;
-  token?: string;
-  launchdLabel?: string;
-  platform?: NodeJS.Platform;
-}): Record<string, string | undefined> {
-  const { env, port, token, launchdLabel } = params;
-  const platform = params.platform ?? process.platform;
-  const sharedEnv = resolveSharedServiceEnvironmentFields(env, platform);
-  const profile = env.OPENCLAW_PROFILE;
-  const resolvedLaunchdLabel =
-    launchdLabel || (platform === "darwin" ? resolveGatewayLaunchAgentLabel(profile) : undefined);
-  const systemdUnit = `${resolveGatewaySystemdServiceName(profile)}.service`;
-  return {
-    ...buildCommonServiceEnvironment(env, sharedEnv),
-    OPENCLAW_PROFILE: profile,
-    OPENCLAW_GATEWAY_PORT: String(port),
-    OPENCLAW_GATEWAY_TOKEN: token,
-    OPENCLAW_LAUNCHD_LABEL: resolvedLaunchdLabel,
-    OPENCLAW_SYSTEMD_UNIT: systemdUnit,
-    OPENCLAW_SERVICE_MARKER: GATEWAY_SERVICE_MARKER,
-    OPENCLAW_SERVICE_KIND: GATEWAY_SERVICE_KIND,
-    OPENCLAW_SERVICE_VERSION: VERSION,
-  };
-}
+    export function buildServiceEnvironment(params: {
+      env: Record<string, string | undefined>;
+      port: number;
+      token?: string;
+      launchdLabel?: string;
+      platform?: NodeJS.Platform;
+    }): Record<string, string | undefined> {
+      const { env, port, token, launchdLabel } = params;
+      const platform = params.platform ?? process.platform;
+      const sharedEnv = resolveSharedServiceEnvironmentFields(env, platform);
+      const profile = env.OPENCLAW_PROFILE;
+      const resolvedLaunchdLabel =
+        launchdLabel || (platform === "darwin" ? resolveGatewayLaunchAgentLabel(profile) : undefined);
+      const systemdUnit = `${resolveGatewaySystemdServiceName(profile)}.service`;
+      return {
+        ...buildCommonServiceEnvironment(env, sharedEnv),
+        OPENCLAW_PROFILE: profile,
+        OPENCLAW_GATEWAY_PORT: String(port),
+        OPENCLAW_GATEWAY_TOKEN: token,
+        OPENCLAW_LAUNCHD_LABEL: resolvedLaunchdLabel,
+        OPENCLAW_SYSTEMD_UNIT: systemdUnit,
+        OPENCLAW_SERVICE_MARKER: GATEWAY_SERVICE_MARKER,
+        OPENCLAW_SERVICE_KIND: GATEWAY_SERVICE_KIND,
+        OPENCLAW_SERVICE_VERSION: VERSION,
+        NODE_USE_SYSTEM_CA: sharedEnv.NODE_USE_SYSTEM_CA,
+      };
+    }
 
 export function buildNodeServiceEnvironment(params: {
   env: Record<string, string | undefined>;


### PR DESCRIPTION
## Problem
When running a supervised service (daemon/gateway) on macOS that connects to TLS endpoints secured by a corporate root CA installed in the System Keychain, the service fails because the required NODE_USE_SYSTEM_CA environment variable is not forwarded to the service environment object.

## Root Cause
The buildServiceEnvironment function derives the NODE_USE_SYSTEM_CA value in resolveSharedServiceEnvironmentFields but fails to include it in the returned environment object.

## Fix
Add NODE_USE_SYSTEM_CA: sharedEnv.NODE_USE_SYSTEM_CA to the returned environment object.

## Impact
- Fixes TLS verification failures in enterprise environments on macOS
- Ensures services properly respect system CA certificates

---
Pattern from PR #32205