### PR TITLE
fix(daemon): resolve Homebrew Cellar paths to stable symlinks for Node

### DIFF
--- a/src/daemon/runtime-paths.ts
+++ b/src/daemon/runtime-paths.ts
@@ -122,25 +122,29 @@ export async function resolveSystemNodePath(
   return null;
 }
 
-export async function resolveSystemNodeInfo(params: {
-  env?: Record<string, string | undefined>;
-  platform?: NodeJS.Platform;
-  execFile?: ExecFileAsync;
-}): Promise<SystemNodeInfo | null> {
-  const env = params.env ?? process.env;
-  const platform = params.platform ?? process.platform;
-  const systemNode = await resolveSystemNodePath(env, platform);
-  if (!systemNode) {
-    return null;
-  }
-
-  const version = await resolveNodeVersion(systemNode, params.execFile ?? execFileAsync);
-  return {
-    path: systemNode,
-    version,
-    supported: isSupportedNodeVersion(version),
-  };
-}
+    export async function resolveSystemNodeInfo(params: {
+      env?: Record<string, string | undefined>;
+      platform?: NodeJS.Platform;
+      execFile?: ExecFileAsync;
+    }): Promise<SystemNodeInfo | null> {
+      const env = params.env ?? process.env;
+      const platform = params.platform ?? process.platform;
+      let systemNode = await resolveSystemNodePath(env, platform);
+      if (!systemNode) {
+        return null;
+      }
+    
+      // Resolve versioned Homebrew paths (e.g. Cellar/...) to stable symlinks.
+      // This prevents the daemon from breaking when Node is upgraded.
+      systemNode = await resolveStableNodePath(systemNode);
+    
+      const version = await resolveNodeVersion(systemNode, params.execFile ?? execFileAsync);
+      return {
+        path: systemNode,
+        version,
+        supported: isSupportedNodeVersion(version),
+      };
+    }
 
 export function renderSystemNodeWarning(
   systemNode: SystemNodeInfo | null,


### PR DESCRIPTION
## Problem
When Node.js is installed via Homebrew, the resolved path points to a versioned Cellar directory. When Node is upgraded, this path becomes invalid, breaking the daemon.

## Root Cause
The resolveSystemNodeInfo function uses the raw path from resolveSystemNodePath without resolving Homebrew versioned paths to stable symlinks.

## Fix
Call resolveStableNodePath after getting the system Node path to convert versioned Homebrew paths to stable symlinks.

## Impact
- Prevents daemon breakage when Homebrew Node is upgraded
- Ensures service continuity across package updates

---
Pattern from PR #32185