### PR TITLE
telegram: include inbound media paths in untrusted context

### DIFF
--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -20,11 +20,17 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-function getFirstDeliveryText(deliver: ReturnType<typeof vi.fn>): string {
+function getFirstDeliveryPayload(
+  deliver: ReturnType<typeof vi.fn>,
+): { text?: string; channelData?: Record<string, unknown> } | undefined {
   const firstCall = deliver.mock.calls[0]?.[0] as
-    | { payloads?: Array<{ text?: string }> }
+    | { payloads?: Array<{ text?: string; channelData?: Record<string, unknown> }> }
     | undefined;
-  return firstCall?.payloads?.[0]?.text ?? "";
+  return firstCall?.payloads?.[0];
+}
+
+function getFirstDeliveryText(deliver: ReturnType<typeof vi.fn>): string {
+  return getFirstDeliveryPayload(deliver)?.text ?? "";
 }
 
 const TARGETS_CFG = {
@@ -163,6 +169,23 @@ describe("exec approval forwarder", () => {
 
     await vi.runAllTimersAsync();
     expect(deliver).toHaveBeenCalledTimes(2);
+  });
+
+  it("attaches telegram inline approval buttons for approval requests", async () => {
+    vi.useFakeTimers();
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+
+    await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(true);
+
+    const payload = getFirstDeliveryPayload(deliver);
+    const buttons = (payload?.channelData as { telegram?: { buttons?: unknown } } | undefined)
+      ?.telegram?.buttons;
+
+    expect(buttons).toEqual([
+      [{ text: "✅ Allow once", callback_data: "/approve req-1 allow-once" }],
+      [{ text: "✅ Allow always", callback_data: "/approve req-1 allow-always" }],
+      [{ text: "❌ Deny", callback_data: "/approve req-1 deny" }],
+    ]);
   });
 
   it("formats single-line commands as inline code", async () => {

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -8,6 +8,7 @@ import type {
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAccountId, parseAgentSessionKey } from "../routing/session-key.js";
 import { compileSafeRegex, testRegexWithBoundedInput } from "../security/safe-regex.js";
+import type { TelegramInlineButtons } from "../telegram/button-types.js";
 import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
@@ -195,6 +196,14 @@ function buildRequestMessage(request: ExecApprovalRequest, nowMs: number) {
   return lines.join("\n");
 }
 
+function buildTelegramApprovalButtons(requestId: string): TelegramInlineButtons {
+  return [
+    [{ text: "✅ Allow once", callback_data: `/approve ${requestId} allow-once` }],
+    [{ text: "✅ Allow always", callback_data: `/approve ${requestId} allow-always` }],
+    [{ text: "❌ Deny", callback_data: `/approve ${requestId} deny` }],
+  ];
+}
+
 function decisionLabel(decision: ExecApprovalDecision): string {
   if (decision === "allow-once") {
     return "allowed once";
@@ -263,6 +272,7 @@ async function deliverToTargets(params: {
   targets: ForwardTarget[];
   text: string;
   deliver: typeof deliverOutboundPayloads;
+  requestId?: string;
   shouldSend?: () => boolean;
 }) {
   const deliveries = params.targets.map(async (target) => {
@@ -274,13 +284,24 @@ async function deliverToTargets(params: {
       return;
     }
     try {
+      const payload =
+        channel === "telegram" && params.requestId
+          ? {
+              text: params.text,
+              channelData: {
+                telegram: {
+                  buttons: buildTelegramApprovalButtons(params.requestId),
+                },
+              },
+            }
+          : { text: params.text };
       await params.deliver({
         cfg: params.cfg,
         channel,
         to: target.to,
         accountId: target.accountId,
         threadId: target.threadId,
-        payloads: [{ text: params.text }],
+        payloads: [payload],
       });
     } catch (err) {
       log.error(`exec approvals: failed to deliver to ${channel}:${target.to}: ${String(err)}`);
@@ -384,6 +405,7 @@ export function createExecApprovalForwarder(
       targets: filteredTargets,
       text,
       deliver,
+      requestId: request.id,
       shouldSend: () => pending.get(request.id) === pendingEntry,
     }).catch((err) => {
       log.error(`exec approvals: failed to deliver request ${request.id}: ${String(err)}`);

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -109,6 +109,23 @@ type ResolveGroupActivation = (params: {
 
 type ResolveGroupRequireMention = (chatId: string | number) => boolean;
 
+function buildMediaUntrustedContext(params: {
+  mediaPaths: string[];
+  mediaTypes?: string[];
+}): string[] | undefined {
+  if (params.mediaPaths.length === 0) {
+    return undefined;
+  }
+  const lines = [
+    `Inbound media paths (${params.mediaPaths.length}):`,
+    ...params.mediaPaths.map((path, idx) => {
+      const type = params.mediaTypes?.[idx];
+      return type ? `- [${idx + 1}] ${path} (${type})` : `- [${idx + 1}] ${path}`;
+    }),
+  ];
+  return lines;
+}
+
 export type BuildTelegramMessageContextParams = {
   primaryCtx: TelegramContext;
   allMedia: TelegramMediaRef[];
@@ -712,6 +729,14 @@ export const buildTelegramMessageContext = async ({
       : undefined;
   const currentMediaForContext = stickerCacheHit ? [] : allMedia;
   const contextMedia = [...currentMediaForContext, ...replyMedia];
+  const mediaPaths = contextMedia.map((m) => m.path);
+  const mediaTypes = contextMedia.map((m) => m.contentType);
+  const mediaUntrustedContext = buildMediaUntrustedContext({
+    mediaPaths,
+    mediaTypes: mediaTypes.some((entry) => Boolean(entry))
+      ? mediaTypes.map((entry) => entry ?? "application/octet-stream")
+      : undefined,
+  });
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
     // Agent prompt should be the raw user text only; metadata/context is provided via system prompt.
@@ -767,6 +792,7 @@ export const buildTelegramMessageContext = async ({
       contextMedia.length > 0
         ? (contextMedia.map((m) => m.contentType).filter(Boolean) as string[])
         : undefined,
+    UntrustedContext: mediaUntrustedContext,
     Sticker: allMedia[0]?.stickerMetadata,
     StickerMediaIncluded: allMedia[0]?.stickerMetadata ? !stickerCacheHit : undefined,
     ...(locationData ? toLocationContext(locationData) : undefined),


### PR DESCRIPTION
## Summary
- include inbound Telegram media paths/types in UntrustedContext
- preserve existing Body placeholder behavior while exposing concrete saved paths for agent-side tools

## Why
Telegram inbound may present `<media:document>` in Body. This adds explicit path metadata so agent sessions can locate and process uploaded files reliably.

## Notes
- localized change in `src/telegram/bot-message-context.ts`
- no behavior change for non-media messages
