### PR TITLE
fix(auto-reply): fix model resolution

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -15,14 +15,9 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
-import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
 import { logVerbose } from "../../globals.js";
-import { resolveSessionModelRef } from "../../gateway/session-utils.js";
 import { clearCommandLane, getQueueSize } from "../../process/command-queue.js";
-import {
-  normalizeMainKey,
-  resolveAgentIdFromSessionKey,
-} from "../../routing/session-key.js";
+import { normalizeMainKey } from "../../routing/session-key.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { hasControlCommand } from "../command-detection.js";
 import { buildInboundMediaNote } from "../media-note.js";
@@ -98,7 +93,10 @@ async function sendResetSessionNotice(params: {
   cfg: OpenClawConfig;
   accountId: string | undefined;
   threadId: string | number | undefined;
-  sessionEntry?: SessionEntry;
+  provider: string;
+  model: string;
+  defaultProvider: string;
+  defaultModel: string;
 }): Promise<void> {
   const route = resolveResetSessionNoticeRoute({
     ctx: params.ctx,
@@ -107,24 +105,13 @@ async function sendResetSessionNotice(params: {
   if (!route) {
     return;
   }
-  const noticeAgentId = resolveAgentIdFromSessionKey(params.sessionKey);
-  // Current model: what will be used (session override / runtime model / agent default).
-  const currentModel = resolveSessionModelRef(
-    params.cfg,
-    params.sessionEntry,
-    noticeAgentId,
-  );
-  const defaultModel = resolveDefaultModelForAgent({
-    cfg: params.cfg,
-    agentId: noticeAgentId,
-  });
   await routeReply({
     payload: {
       text: buildResetSessionNoticeText({
-        provider: currentModel.provider,
-        model: currentModel.model,
-        defaultProvider: defaultModel.provider,
-        defaultModel: defaultModel.model,
+        provider: params.provider,
+        model: params.model,
+        defaultProvider: params.defaultProvider,
+        defaultModel: params.defaultModel,
       }),
     },
     channel: route.channel,
@@ -430,7 +417,10 @@ export async function runPreparedReply(
       cfg,
       accountId: ctx.AccountId,
       threadId: ctx.MessageThreadId,
-      sessionEntry,
+      provider,
+      model,
+      defaultProvider,
+      defaultModel,
     });
   }
   const sessionIdFinal = sessionId ?? crypto.randomUUID();

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -15,9 +15,14 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
 import { logVerbose } from "../../globals.js";
+import { resolveSessionModelRef } from "../../gateway/session-utils.js";
 import { clearCommandLane, getQueueSize } from "../../process/command-queue.js";
-import { normalizeMainKey } from "../../routing/session-key.js";
+import {
+  normalizeMainKey,
+  resolveAgentIdFromSessionKey,
+} from "../../routing/session-key.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { hasControlCommand } from "../command-detection.js";
 import { buildInboundMediaNote } from "../media-note.js";
@@ -93,10 +98,7 @@ async function sendResetSessionNotice(params: {
   cfg: OpenClawConfig;
   accountId: string | undefined;
   threadId: string | number | undefined;
-  provider: string;
-  model: string;
-  defaultProvider: string;
-  defaultModel: string;
+  sessionEntry?: SessionEntry;
 }): Promise<void> {
   const route = resolveResetSessionNoticeRoute({
     ctx: params.ctx,
@@ -105,13 +107,24 @@ async function sendResetSessionNotice(params: {
   if (!route) {
     return;
   }
+  const noticeAgentId = resolveAgentIdFromSessionKey(params.sessionKey);
+  // Current model: what will be used (session override / runtime model / agent default).
+  const currentModel = resolveSessionModelRef(
+    params.cfg,
+    params.sessionEntry,
+    noticeAgentId,
+  );
+  const defaultModel = resolveDefaultModelForAgent({
+    cfg: params.cfg,
+    agentId: noticeAgentId,
+  });
   await routeReply({
     payload: {
       text: buildResetSessionNoticeText({
-        provider: params.provider,
-        model: params.model,
-        defaultProvider: params.defaultProvider,
-        defaultModel: params.defaultModel,
+        provider: currentModel.provider,
+        model: currentModel.model,
+        defaultProvider: defaultModel.provider,
+        defaultModel: defaultModel.model,
       }),
     },
     channel: route.channel,
@@ -417,10 +430,7 @@ export async function runPreparedReply(
       cfg,
       accountId: ctx.AccountId,
       threadId: ctx.MessageThreadId,
-      provider,
-      model,
-      defaultProvider,
-      defaultModel,
+      sessionEntry,
     });
   }
   const sessionIdFinal = sessionId ?? crypto.randomUUID();

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -1589,6 +1589,8 @@ async function dispatchDiscordCommandInteraction(params: {
     sender: { id: sender.id, name: sender.name, tag: sender.tag },
     allowNameMatching,
   });
+  // Use the resolved route's session key so get-reply receives correct agent (channel/thread binding).
+  const routeSessionKey = effectiveRoute.sessionKey;
   const ctxPayload = finalizeInboundContext({
     Body: prompt,
     BodyForAgent: prompt,
@@ -1601,8 +1603,8 @@ async function dispatchDiscordCommandInteraction(params: {
         ? `discord:group:${channelId}`
         : `discord:channel:${channelId}`,
     To: `slash:${user.id}`,
-    SessionKey: boundSessionKey ?? `agent:${effectiveRoute.agentId}:${sessionPrefix}:${user.id}`,
-    CommandTargetSessionKey: boundSessionKey ?? effectiveRoute.sessionKey,
+    SessionKey: routeSessionKey || `agent:${effectiveRoute.agentId}:${sessionPrefix}:${user.id}`,
+    CommandTargetSessionKey: routeSessionKey,
     AccountId: effectiveRoute.accountId,
     ChatType: isDirectMessage ? "direct" : isGroupDm ? "group" : "channel",
     ConversationLabel: conversationLabel,


### PR DESCRIPTION
## Summary

As per https://github.com/openclaw/openclaw/blob/main/CONTRIBUTING.md - this was fixed with the help of cursor editor and LLM agent.

Describe the problem and fix in 2–5 bullets:

- Problem: after `/new` command on discord channel with specific agent binded to it the response message returns wrong model info
- Why it matters: this confuses openclaw users into thinking the agent is using different model than it actually is using
- What changed: SessionKey and CommandTargetSessionKey used to created context in  `dispatchDiscordCommandInteraction`
- What did NOT change (scope boundary): anything outside `dispatchDiscordCommandInteraction` method

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

Not sure

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

Agents config:
<img width="1153" height="1106" alt="image" src="https://github.com/user-attachments/assets/2b0ba87f-07ac-4fc4-ac69-c861b40a2094" />

Bindings:
<img width="574" height="913" alt="image" src="https://github.com/user-attachments/assets/2830777a-2e2f-4407-a407-c32ab9709afd" />

Before the fix the personal-unsafe agent in the channel binded to it was returning:
✅ New session started · model: google/gemini-2.5-flash-lite

instead of:
✅ New session started · model: anthropic/claude-opus-4-6

After proposed changes the agent properly returns:
 ✅ New session started · model: anthropic/claude-opus-4-6

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: I don't think there is any, I think this i the intended behavior 

## Repro + Verification

Use config that is visible in the "Behavior Changes description" section and run `/new` in channel bound to `personal-unsafe` agent

### Environment

- OS: Omarchy
- Runtime/container: local
- Model/provider: n/a
- Integration/channel (if any): seen in discord but could affect others
- Relevant config (redacted):

### Steps

Use this config:

Agents config:
<img width="1153" height="1106" alt="image" src="https://github.com/user-attachments/assets/2b0ba87f-07ac-4fc4-ac69-c861b40a2094" />

Bindings:
<img width="574" height="913" alt="image" src="https://github.com/user-attachments/assets/db478616-8a3c-4a28-ab34-4e076bf536c8" />


### Expected

 ✅ New session started · model: anthropic/claude-opus-4-6

### Actual

 ✅ New session started · model: google/gemini-2.5-flash-lite

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

<img width="540" height="358" alt="image" src="https://github.com/user-attachments/assets/86d63f55-149c-44a2-84a8-615ce9b8e595" />

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: as shown in the screenshot, tested the `/new` command 
- Edge cases checked: none
- What you did **not** verify: i only checked how `/new` behaves

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert PR
- Files/config to restore: `src/discord/monitor/native-command.ts`
- Known bad symptoms reviewers should watch for: wrong model in 
✅ New session started · model: anthropic/claude-opus-4-6 message

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: none
- Mitigation:
