### PR TITLE
fix(discord): prevent channel reconnect timeout from triggering gatew…

### DIFF
--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -352,26 +352,43 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
-  it("force-stops when reconnect stalls after a close event", async () => {
+  it("does not force-stop when reconnect stalls, but updates status", async () => {
     vi.useFakeTimers();
     try {
       const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
       const { emitter, gateway } = createGatewayHarness();
       getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+      const statusSinkMock = vi.fn();
+      const runtimeMock = {
+        log: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+      };
       waitForDiscordGatewayStopMock.mockImplementationOnce(
-        (waitParams: WaitForDiscordGatewayStopParams) =>
-          new Promise<void>((_resolve, reject) => {
-            waitParams.registerForceStop?.((err) => reject(err));
-          }),
+        () => new Promise<void>(() => {}),
       );
-      const { lifecycleParams } = createLifecycleHarness({ gateway });
+      const { lifecycleParams } = createLifecycleHarness({ gateway, statusSink: statusSinkMock, runtime: runtimeMock as any });
 
       const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
-      lifecyclePromise.catch(() => {});
       emitter.emit("debug", "WebSocket connection closed with code 1006");
 
       await vi.advanceTimersByTimeAsync(5 * 60_000 + 1_000);
-      await expect(lifecyclePromise).rejects.toThrow("reconnect watchdog timeout");
+      
+      // Verify status was updated with reconnectFailed flag
+      expect(statusSinkMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          connected: false,
+          lastError: expect.stringContaining("discord reconnect watchdog timeout"),
+          reconnectFailed: true,
+        }),
+      );
+      
+      // Verify triggerForceStop was NOT called (no error logged)
+      expect(runtimeMock.error).not.toHaveBeenCalled();
+      expect(runtimeMock.log).toHaveBeenCalledWith(
+        expect.stringContaining("discord: reconnect timeout, marking channel as failed"),
+      );
     } finally {
       vi.useRealTimers();
     }

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -67,24 +67,25 @@ export async function runDiscordGatewayLifecycle(params: {
         return;
       }
       const at = Date.now();
-      const error = new Error(
-        `discord reconnect watchdog timeout after ${RECONNECT_STALL_TIMEOUT_MS}ms`,
-      );
+      const errorMsg = `discord reconnect watchdog timeout after ${RECONNECT_STALL_TIMEOUT_MS}ms`;
+      // FIX: Do not propagate error to main process (triggers gateway restart).
+      // Instead, just update status and let channel health monitor handle restart.
       pushStatus({
         connected: false,
         lastEventAt: at,
         lastDisconnect: {
           at,
-          error: error.message,
+          error: errorMsg,
         },
-        lastError: error.message,
+        lastError: errorMsg,
+        // Mark as reconnect failed, but don't force-stop the lifecycle
+        reconnectFailed: true,
       });
-      params.runtime.error?.(
-        danger(
-          `discord: reconnect watchdog timeout after ${RECONNECT_STALL_TIMEOUT_MS}ms; force-stopping monitor task`,
-        ),
+      // REMOVED: triggerForceStop(error) - this was causing gateway-wide restart
+      // The channel health monitor will detect this and restart only the Discord channel
+      params.runtime.log?.(
+        `discord: reconnect timeout, marking channel as failed (no gateway restart)`,
       );
-      triggerForceStop(error);
     },
   });
 

--- a/src/discord/monitor/status.ts
+++ b/src/discord/monitor/status.ts
@@ -16,6 +16,7 @@ export type DiscordMonitorStatusPatch = {
   busy?: boolean;
   activeRuns?: number;
   lastRunActivityAt?: number | null;
+  reconnectFailed?: boolean;
 };
 
 export type DiscordMonitorStatusSink = (patch: DiscordMonitorStatusPatch) => void;


### PR DESCRIPTION
…ay restart

- Remove triggerForceStop() call in reconnectStallWatchdog.onTimeout()
- Just update status with reconnectFailed flag instead
- Let channel health monitor handle restart决策 (channel-level, not gateway-level)

This fixes the issue where Discord WebSocket disconnection (code 1006) during reconnect would timeout after 5 minutes and propagate error to main process, causing the entire Gateway to restart and disrupting all other channels (Feishu, etc.)

Root cause: triggerForceStop() propagated error to gateway main process, which was then detected as stale gateway PID and triggered full restart.

Fix: Only update channel status, let channel health monitor decide restart.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
