### PR TITLE
skill-creator: make .skill archive entry order deterministic

### DIFF
--- a/skills/skill-creator/scripts/package_skill.py
+++ b/skills/skill-creator/scripts/package_skill.py
@@ -77,8 +77,10 @@ def package_skill(skill_path, output_dir=None):
     # Create the .skill file (zip format)
     try:
         with zipfile.ZipFile(skill_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
-            # Walk through the skill directory
-            for file_path in skill_path.rglob("*"):
+            # Walk through the skill directory in a stable order so archives are reproducible.
+            for file_path in sorted(
+                skill_path.rglob("*"), key=lambda path: path.relative_to(skill_path).as_posix()
+            ):
                 # Security: never follow or package symlinks.
                 if file_path.is_symlink():
                     print(f"[WARN] Skipping symlink: {file_path}")

--- a/skills/skill-creator/scripts/test_package_skill.py
+++ b/skills/skill-creator/scripts/test_package_skill.py
@@ -155,6 +155,26 @@ class TestPackageSkillSecurity(TestCase):
         self.assertIn("self-output-skill/script.py", names)
         self.assertNotIn("self-output-skill/self-output-skill.skill", names)
 
+    def test_writes_archive_entries_in_stable_sorted_order(self):
+        skill_dir = self.create_skill("sorted-skill")
+        (skill_dir / "z-last.py").write_text("print('z')\n")
+        (skill_dir / "a-first.py").write_text("print('a')\n")
+        nested = skill_dir / "nested"
+        nested.mkdir(parents=True, exist_ok=True)
+        (nested / "middle.py").write_text("print('m')\n")
+
+        out_dir = self.temp_dir / "out"
+        out_dir.mkdir()
+
+        result = package_skill(str(skill_dir), str(out_dir))
+
+        self.assertIsNotNone(result)
+        skill_file = out_dir / "sorted-skill.skill"
+        with zipfile.ZipFile(skill_file, "r") as archive:
+            names = archive.namelist()
+
+        self.assertEqual(names, sorted(names))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## What changed
- Updated `skills/skill-creator/scripts/package_skill.py` to iterate files in a stable sorted order before writing them to the `.skill` archive.
- Added a regression test in `skills/skill-creator/scripts/test_package_skill.py` that verifies archive entry order is deterministic.

## Why
- `Path.rglob()` traversal order can vary by filesystem/environment.
- Sorting archive entries makes generated `.skill` bundles reproducible and easier to diff/review across machines and runs.

## Testing
- ✅ `source .venv/bin/activate && pytest -q skills/skill-creator/scripts/test_package_skill.py`
  - 7 passed
- ✅ `scripts/clone_and_test.sh openclaw/openclaw`
  - 17 passed
