### PR TITLE
fix(plugins): resolve secrets for CLI plugin status

### DIFF
--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+const loadConfigMock = vi.fn();
+const loadOpenClawPluginsMock = vi.fn();
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: (...args: unknown[]) => loadConfigMock(...args),
+}));
+
+vi.mock("./loader.js", () => ({
+  loadOpenClawPlugins: (...args: unknown[]) => loadOpenClawPluginsMock(...args),
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock("./logger.js", () => ({
+  createPluginLoaderLogger: (logger: unknown) => logger,
+}));
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDir: () => "/tmp/workspace",
+  resolveDefaultAgentId: () => "default",
+}));
+
+vi.mock("../agents/workspace.js", () => ({
+  resolveDefaultAgentWorkspaceDir: () => "/tmp/workspace-default",
+}));
+
+import { buildPluginStatusReport } from "./status.js";
+
+describe("buildPluginStatusReport", () => {
+  it("loads config with secret resolution enabled", () => {
+    loadConfigMock.mockReturnValue({});
+    loadOpenClawPluginsMock.mockReturnValue({
+      plugins: [],
+      tools: [],
+      hooks: [],
+      typedHooks: [],
+      channels: [],
+      providers: [],
+      gatewayHandlers: {},
+      httpRoutes: [],
+      cliRegistrars: [],
+      services: [],
+      commands: [],
+      diagnostics: [],
+    });
+
+    buildPluginStatusReport();
+
+    expect(loadConfigMock).toHaveBeenCalledTimes(1);
+    expect(loadConfigMock).toHaveBeenCalledWith({ resolveSecrets: true });
+  });
+});

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -16,7 +16,17 @@ export function buildPluginStatusReport(params?: {
   config?: ReturnType<typeof loadConfig>;
   workspaceDir?: string;
 }): PluginStatusReport {
-  const config = params?.config ?? loadConfig();
+  // Plugin status commands (like `openclaw plugins list`) run in a standalone CLI
+  // process and do not have access to a gateway runtime snapshot.
+  //
+  // Some plugins evaluate whether they're "configured" during registration by
+  // reading channel credentials. When credentials are supplied via SecretRef
+  // objects (env/file/exec), they may intentionally remain unresolved in the CLI
+  // context.
+  //
+  // Load config with secret resolution enabled so env-backed SecretRefs are
+  // normalized where possible (and we don't falsely mark plugins as errored).
+  const config = params?.config ?? loadConfig({ resolveSecrets: true });
   const workspaceDir = params?.workspaceDir
     ? params.workspaceDir
     : (resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config)) ??


### PR DESCRIPTION
Closes #37633

`openclaw plugins list`/`plugins info` uses the plugin status report, which loads config in a standalone CLI context.
When channel credentials are supplied via SecretRef (e.g. env-backed appSecret), plugins can throw `unresolved SecretRef` during registration and get marked as errored.

This change loads config with secret resolution enabled when building the plugin status report, matching the expectations of status-style commands.

Tests:
- Added unit test to ensure buildPluginStatusReport calls loadConfig with `{ resolveSecrets: true }`.
