### PR TITLE
fix(skills): test fixes for numeric skill name coercion

### DIFF
--- a/src/agents/skills/bundled-context.test.ts
+++ b/src/agents/skills/bundled-context.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { writeSkill } from "../skills.e2e-test-helpers.js";
+import { resolveBundledSkillsContext } from "./bundled-context.js";
+
+describe("resolveBundledSkillsContext", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bundled-context-"));
+    // Set environment variable to override bundled skills directory
+    process.env.OPENCLAW_BUNDLED_SKILLS_DIR = tempDir;
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+    delete process.env.OPENCLAW_BUNDLED_SKILLS_DIR;
+  });
+
+  it("handles numeric skill names without throwing TypeError", async () => {
+    // Note: The underlying @mariozechner/pi-coding-agent package also has the same bug
+    // in validateName() function. This test verifies that our fix in bundled-context.ts
+    // handles the case where skill.name might be a number type.
+
+    // For now, we use quoted YAML to ensure the skill loads successfully
+    // The real-world scenario where YAML parses unquoted numbers is handled by
+    // the String() coercion in bundled-context.ts
+    const skillDir = path.join(tempDir, "12306");
+    await fs.mkdir(skillDir, { recursive: true });
+
+    // Use quoted name to ensure it's parsed as string by YAML
+    const skillContent = `---
+name: "12306"
+description: Test skill with numeric name
+---
+
+# Test Skill
+
+This skill has a numeric name.
+`;
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), skillContent, "utf-8");
+
+    const context = resolveBundledSkillsContext();
+
+    // The fix ensures that even if skill.name is a number, it's converted to string
+    expect(context.names.has("12306")).toBe(true);
+    expect(context.dir).toBe(tempDir);
+  });
+
+  it("handles string skill names normally", async () => {
+    await writeSkill({
+      dir: path.join(tempDir, "test-skill"),
+      name: "test-skill",
+      description: "Normal string skill name",
+    });
+
+    const context = resolveBundledSkillsContext();
+
+    expect(context.names.has("test-skill")).toBe(true);
+  });
+
+  it("filters out skills with empty names after trimming", async () => {
+    const skillDir = path.join(tempDir, "empty-name");
+    await fs.mkdir(skillDir, { recursive: true });
+
+    const skillContent = `---
+name: "   "
+description: Skill with whitespace-only name
+---
+
+# Empty Name Skill
+`;
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), skillContent, "utf-8");
+
+    const context = resolveBundledSkillsContext();
+
+    // Should not include empty/whitespace-only names
+    expect(context.names.size).toBe(0);
+  });
+});

--- a/src/agents/skills/bundled-context.test.ts
+++ b/src/agents/skills/bundled-context.test.ts
@@ -4,7 +4,6 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { writeSkill } from "../skills.e2e-test-helpers.js";
 import { resolveBundledSkillsContext } from "./bundled-context.js";
-import * as skillsModule from "../skills.js";
 
 describe("resolveBundledSkillsContext", () => {
   let tempDir: string;
@@ -25,15 +24,13 @@ describe("resolveBundledSkillsContext", () => {
     // in validateName() function. This test verifies that our fix in bundled-context.ts
     // handles the case where skill.name might be a number type.
 
-    // For now, we use quoted YAML to ensure the skill loads successfully
-    // The real-world scenario where YAML parses unquoted numbers is handled by
-    // the String() coercion in bundled-context.ts
+    // Use unquoted YAML number to trigger numeric type parsing
     const skillDir = path.join(tempDir, "12306");
     await fs.mkdir(skillDir, { recursive: true });
 
-    // Use quoted name to ensure it's parsed as string by YAML
+    // Use unquoted name so YAML parses it as a number
     const skillContent = `---
-name: "12306"
+name: 12306
 description: Test skill with numeric name
 ---
 
@@ -90,7 +87,10 @@ description: Skill with whitespace-only name
       content: "# Test Skill\n\nThis skill has a numeric name.",
     };
 
-    vi.spyOn(skillsModule, "loadSkillsFromDir").mockResolvedValue([mockSkill]);
+    const piCodingAgent = await import("@mariozechner/pi-coding-agent");
+    const loadSkillsFromDirSpy = vi.spyOn(piCodingAgent, "loadSkillsFromDir").mockReturnValue({
+      skills: [mockSkill],
+    });
 
     const context = resolveBundledSkillsContext();
 
@@ -98,6 +98,6 @@ description: Skill with whitespace-only name
     expect(context.names.has("12306")).toBe(true);
     expect(typeof Array.from(context.names)[0]).toBe("string");
 
-    vi.restoreAllMocks();
+    loadSkillsFromDirSpy.mockRestore();
   });
 });

--- a/src/agents/skills/bundled-context.test.ts
+++ b/src/agents/skills/bundled-context.test.ts
@@ -1,9 +1,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { writeSkill } from "../skills.e2e-test-helpers.js";
 import { resolveBundledSkillsContext } from "./bundled-context.js";
+import * as skillsModule from "../skills.js";
 
 describe("resolveBundledSkillsContext", () => {
   let tempDir: string;
@@ -78,5 +79,25 @@ description: Skill with whitespace-only name
 
     // Should not include empty/whitespace-only names
     expect(context.names.size).toBe(0);
+  });
+
+  it("coerces numeric skill names to strings", async () => {
+    // Mock loadSkillsFromDir to return a skill with numeric name
+    // This simulates the case where YAML parses unquoted numbers as number type
+    const mockSkill = {
+      name: 12306 as any, // Simulate numeric type from YAML
+      description: "Test skill with numeric name",
+      content: "# Test Skill\n\nThis skill has a numeric name.",
+    };
+
+    vi.spyOn(skillsModule, "loadSkillsFromDir").mockResolvedValue([mockSkill]);
+
+    const context = resolveBundledSkillsContext();
+
+    // The String() coercion should convert numeric name to string
+    expect(context.names.has("12306")).toBe(true);
+    expect(typeof Array.from(context.names)[0]).toBe("string");
+
+    vi.restoreAllMocks();
   });
 });

--- a/src/agents/skills/bundled-context.ts
+++ b/src/agents/skills/bundled-context.ts
@@ -31,8 +31,10 @@ export function resolveBundledSkillsContext(
   }
   const result = loadSkillsFromDir({ dir, source: "openclaw-bundled" });
   for (const skill of result.skills) {
-    if (skill.name.trim()) {
-      names.add(skill.name);
+    // Ensure skill name is a string (YAML may parse bare numbers as integers)
+    const skillName = String(skill.name);
+    if (skillName.trim()) {
+      names.add(skillName);
     }
   }
   cachedBundledContext = { dir, names: new Set(names) };

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -64,7 +64,9 @@ export function isBundledSkillAllowed(entry: SkillEntry, allowlist?: string[]): 
     return true;
   }
   const key = resolveSkillKey(entry.skill, entry);
-  return allowlist.includes(key) || allowlist.includes(entry.skill.name);
+  // Ensure skill name is a string (YAML may parse bare numbers as integers)
+  const skillName = String(entry.skill.name);
+  return allowlist.includes(key) || allowlist.includes(skillName);
 }
 
 export function shouldIncludeSkill(params: {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -78,7 +78,8 @@ function filterSkillEntries(
     skillsLogger.debug(`Applying skill filter: ${label}`);
     filtered =
       normalized.length > 0
-        ? filtered.filter((entry) => normalized.includes(entry.skill.name))
+        ? // Ensure skill name is a string (YAML may parse bare numbers as integers)
+          filtered.filter((entry) => normalized.includes(String(entry.skill.name)))
         : [];
     skillsLogger.debug(
       `After skill filter: ${filtered.map((entry) => entry.skill.name).join(", ") || "(none)"}`,


### PR DESCRIPTION
Updates PR #35329 based on review feedback.

Changes:
- First test now uses unquoted YAML (name: 12306) to trigger numeric type parsing
- Fourth test now correctly mocks @mariozechner/pi-coding-agent loadSkillsFromDir

Both tests now properly exercise the String() coercion code path.