### PR TITLE
fix: use static import for resolveContextTokensForModel (PR #35500)

### DIFF
--- a/src/auto-reply/reply/directive-handling.persist.test.ts
+++ b/src/auto-reply/reply/directive-handling.persist.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { persistInlineDirectives } from "./directive-handling.persist.js";
+import type { InlineDirectives } from "./directive-handling.parse.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SessionEntry } from "../../config/sessions.js";
+
+describe("persistInlineDirectives", () => {
+  it("recalculates contextTokens when model changes (fixes #35372)", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+        },
+      },
+    };
+
+    const sessionEntry: SessionEntry = {
+      sessionId: "test-session",
+      updatedAt: Date.now(),
+      modelOverride: "claude-haiku-4-5",
+      providerOverride: "anthropic",
+      contextTokens: 160000, // Stuck at haiku's limit
+    };
+
+    const sessionStore = {
+      "test-key": sessionEntry,
+    };
+
+    const directives: InlineDirectives = {
+      hasModelDirective: true,
+      rawModelDirective: "claude-sonnet-4-6",
+      cleaned: "",
+      hasThinkDirective: false,
+      hasVerboseDirective: false,
+      hasReasoningDirective: false,
+      hasElevatedDirective: false,
+      hasExecDirective: false,
+      hasExecOptions: false,
+      hasQueueDirective: false,
+      queueReset: false,
+      hasStatusDirective: false,
+    };
+
+    const aliasIndex = {
+      byKey: new Map(),
+      byAlias: new Map(),
+    };
+
+    const result = await persistInlineDirectives({
+      directives,
+      effectiveModelDirective: "claude-sonnet-4-6",
+      cfg,
+      sessionEntry,
+      sessionStore,
+      sessionKey: "test-key",
+      storePath: undefined,
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-sonnet-4-6",
+      aliasIndex,
+      allowedModelKeys: new Set([
+        "anthropic/claude-sonnet-4-6",
+        "anthropic/claude-haiku-4-5",
+      ]),
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      initialModelLabel: "anthropic/claude-haiku-4-5",
+      formatModelSwitchEvent: (label) => `Switched to ${label}`,
+      agentCfg: cfg.agents?.defaults,
+    });
+
+    // contextTokens should be recalculated for the new model (sonnet-4-6)
+    // and not stuck at the old model's limit (160k from haiku)
+    expect(result.contextTokens).toBeGreaterThan(160000);
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-sonnet-4-6");
+  });
+
+  it("uses agentCfg.contextTokens override when provided", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          contextTokens: 100000, // Override
+        },
+      },
+    };
+
+    const directives: InlineDirectives = {
+      hasModelDirective: false,
+      cleaned: "",
+      hasThinkDirective: false,
+      hasVerboseDirective: false,
+      hasReasoningDirective: false,
+      hasElevatedDirective: false,
+      hasExecDirective: false,
+      hasExecOptions: false,
+      hasQueueDirective: false,
+      queueReset: false,
+      hasStatusDirective: false,
+    };
+
+    const aliasIndex = {
+      byKey: new Map(),
+      byAlias: new Map(),
+    };
+
+    const result = await persistInlineDirectives({
+      directives,
+      cfg,
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      defaultProvider: "anthropic",
+      defaultModel: "claude-sonnet-4-6",
+      aliasIndex,
+      allowedModelKeys: new Set(),
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      initialModelLabel: "anthropic/claude-sonnet-4-6",
+      formatModelSwitchEvent: (label) => `Switched to ${label}`,
+      agentCfg: cfg.agents?.defaults,
+    });
+
+    // Should use the override value
+    expect(result.contextTokens).toBe(100000);
+  });
+});

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -3,7 +3,6 @@ import {
   resolveDefaultAgentId,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
-import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import {
   buildModelAliasIndex,
@@ -210,10 +209,24 @@ export async function persistInlineDirectives(params: {
     }
   }
 
+  // Recalculate contextTokens using the newly selected model to ensure the
+  // session's stored contextTokens reflects the current model's actual limit.
+  // This prevents contextTokens from getting stuck at a lower model's limit
+  // after switching models (fixes #35372).
+  const { resolveContextTokensForModel } = await import("../../agents/context.js");
+  const contextTokens =
+    resolveContextTokensForModel({
+      cfg,
+      provider,
+      model,
+      contextTokensOverride: agentCfg?.contextTokens,
+      fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
+    }) ?? DEFAULT_CONTEXT_TOKENS;
+
   return {
     provider,
     model,
-    contextTokens: agentCfg?.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
+    contextTokens,
   };
 }
 

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -3,6 +3,7 @@ import {
   resolveDefaultAgentId,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import {
   buildModelAliasIndex,
@@ -213,7 +214,6 @@ export async function persistInlineDirectives(params: {
   // session's stored contextTokens reflects the current model's actual limit.
   // This prevents contextTokens from getting stuck at a lower model's limit
   // after switching models (fixes #35372).
-  const { resolveContextTokensForModel } = await import("../../agents/context.js");
   const contextTokens =
     resolveContextTokensForModel({
       cfg,

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -85,4 +85,56 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(entry.model).toBe("gpt-5.2");
     expect(entry.updatedAt).toBe(before);
   });
+
+  it("clears stale contextTokens when model selection changes (fixes #35372)", () => {
+    const before = Date.now() - 5_000;
+    const entry: SessionEntry = {
+      sessionId: "sess-4",
+      updatedAt: before,
+      modelProvider: "anthropic",
+      model: "claude-haiku-4-5",
+      providerOverride: "anthropic",
+      modelOverride: "claude-haiku-4-5",
+      contextTokens: 160000, // Stuck at haiku's limit
+    };
+
+    const result = applyModelOverrideToSessionEntry({
+      entry,
+      selection: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      },
+    });
+
+    expect(result.updated).toBe(true);
+    expect(entry.providerOverride).toBe("anthropic");
+    expect(entry.modelOverride).toBe("claude-sonnet-4-6");
+    expect(entry.contextTokens).toBeUndefined();
+    expect((entry.updatedAt ?? 0) > before).toBe(true);
+  });
+
+  it("does not clear contextTokens when model selection is unchanged", () => {
+    const before = Date.now() - 5_000;
+    const entry: SessionEntry = {
+      sessionId: "sess-5",
+      updatedAt: before,
+      modelProvider: "anthropic",
+      model: "claude-sonnet-4-6",
+      providerOverride: "anthropic",
+      modelOverride: "claude-sonnet-4-6",
+      contextTokens: 200000,
+    };
+
+    const result = applyModelOverrideToSessionEntry({
+      entry,
+      selection: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      },
+    });
+
+    expect(result.updated).toBe(false);
+    expect(entry.contextTokens).toBe(200000);
+    expect(entry.updatedAt).toBe(before);
+  });
 });

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -61,6 +61,14 @@ export function applyModelOverrideToSessionEntry(params: {
     }
   }
 
+  // Clear stale contextTokens when model selection changes so the new model's
+  // context window will be looked up fresh. This prevents contextTokens from
+  // getting stuck at a previous model's limit (fixes #35372).
+  if (selectionUpdated && entry.contextTokens !== undefined) {
+    delete entry.contextTokens;
+    updated = true;
+  }
+
   if (profileOverride) {
     if (entry.authProfileOverride !== profileOverride) {
       entry.authProfileOverride = profileOverride;

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -411,7 +411,7 @@ export function buildModelOptions(
       <option value="" disabled>No configured models</option>
     `;
   }
-  return options.map((option) => html`<option value=${option.value}>${option.label}</option>`);
+  return options.map((option) => html`<option value=${option.value} ?selected=${current === option.value}>${option.label}</option>`);
 }
 
 type CompiledPattern =


### PR DESCRIPTION
Updates PR #35500 based on review feedback.

Change: Use static import instead of dynamic import to match other code in the codebase (src/commands/status.summary.ts, src/commands/agent/session-store.ts, src/auto-reply/status.ts).