### PR TITLE
[Issue #37672] [Feature]: Add Next Run Time to Editing Cron Tasks Output in Human-Readable Date Time Format

### DIFF
--- a/.github/issue-bootstrap/issue-37672.md
+++ b/.github/issue-bootstrap/issue-37672.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37672
+- Title: [Feature]: Add Next Run Time to Editing Cron Tasks Output in Human-Readable Date Time Format
+- Source: https://github.com/openclaw/openclaw/issues/37672


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37672

## Original Issue Description
(See source issue body)

## Linkage
Refs #37672