### PR TITLE
[Issue #37675] [Bug] Webchat: input field content lost when cron/subagent announce messages arrive

### DIFF
--- a/.github/issue-bootstrap/issue-37675.md
+++ b/.github/issue-bootstrap/issue-37675.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37675
+- Title: [Bug] Webchat: input field content lost when cron/subagent announce messages arrive
+- Source: https://github.com/openclaw/openclaw/issues/37675


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37675

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37675