### PR TITLE
[Issue #37696] unclosed <think> tags silently drop entire response on all channels

### DIFF
--- a/.github/issue-bootstrap/issue-37696.md
+++ b/.github/issue-bootstrap/issue-37696.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37696
+- Title: unclosed <think> tags silently drop entire response on all channels
+- Source: https://github.com/openclaw/openclaw/issues/37696


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37696

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37696