### PR TITLE
[Issue #37697] [Bug] Telegram: duplicate message delivery — same response sent twice

### DIFF
--- a/.github/issue-bootstrap/issue-37697.md
+++ b/.github/issue-bootstrap/issue-37697.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37697
+- Title: [Bug] Telegram: duplicate message delivery — same response sent twice
+- Source: https://github.com/openclaw/openclaw/issues/37697


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37697

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37697