### PR TITLE
[Issue #37701] macOS app crashes on Talk mode launch (TalkOverlayView exclusivity violation)

### DIFF
--- a/.github/issue-bootstrap/issue-37701.md
+++ b/.github/issue-bootstrap/issue-37701.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37701
+- Title: macOS app crashes on Talk mode launch (TalkOverlayView exclusivity violation)
+- Source: https://github.com/openclaw/openclaw/issues/37701


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37701

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37701