### PR TITLE
[Issue #37702] Outbound Telegram dedup resets after context compaction — causes duplicate messages

### DIFF
--- a/.github/issue-bootstrap/issue-37702.md
+++ b/.github/issue-bootstrap/issue-37702.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37702
+- Title: Outbound Telegram dedup resets after context compaction — causes duplicate messages
+- Source: https://github.com/openclaw/openclaw/issues/37702


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37702

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37702