### PR TITLE
[Issue #37705] [Bug]: Gateway Launch Failure:  Label cannot be longer than 63 bytes

### DIFF
--- a/.github/issue-bootstrap/issue-37705.md
+++ b/.github/issue-bootstrap/issue-37705.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37705
+- Title: [Bug]: Gateway Launch Failure:  Label cannot be longer than 63 bytes
+- Source: https://github.com/openclaw/openclaw/issues/37705


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37705

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37705