### PR TITLE
[Issue #37706] [Bug]: Feishu/Lark group @all should not count as bot mention

### DIFF
--- a/.github/issue-bootstrap/issue-37706.md
+++ b/.github/issue-bootstrap/issue-37706.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37706
+- Title: [Bug]: Feishu/Lark group @all should not count as bot mention
+- Source: https://github.com/openclaw/openclaw/issues/37706


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37706

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37706