### PR TITLE
[Issue #37711] [Bug]: Hostinger Docker template deploys successfully, but OpenClaw web UI stays black due to /assets/index-*.js ERR_CONTENT_LENGTH_MISMATCH

### DIFF
--- a/.github/issue-bootstrap/issue-37711.md
+++ b/.github/issue-bootstrap/issue-37711.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37711
+- Title: [Bug]: Hostinger Docker template deploys successfully, but OpenClaw web UI stays black due to /assets/index-*.js ERR_CONTENT_LENGTH_MISMATCH
+- Source: https://github.com/openclaw/openclaw/issues/37711


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37711

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37711