### PR TITLE
[Issue #37716] [Bug] 心跳间隔无法配置，实际频率远高于文档说明的 30 分钟

### DIFF
--- a/.github/issue-bootstrap/issue-37716.md
+++ b/.github/issue-bootstrap/issue-37716.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37716
+- Title: [Bug] 心跳间隔无法配置，实际频率远高于文档说明的 30 分钟
+- Source: https://github.com/openclaw/openclaw/issues/37716


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37716

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37716