### PR TITLE
[Issue #37718] [Bug]: Gateway health check fails when using secrets reference format for channel credentials (cfg?.appId?.trim is not a function)

### DIFF
--- a/.github/issue-bootstrap/issue-37718.md
+++ b/.github/issue-bootstrap/issue-37718.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37718
+- Title: [Bug]: Gateway health check fails when using secrets reference format for channel credentials (cfg?.appId?.trim is not a function)
+- Source: https://github.com/openclaw/openclaw/issues/37718


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37718

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37718