### PR TITLE
[Issue #37727] [Bug]: Telegram: occasional raw {"action":"NO_REPLY"} payload is delivered to end user instead of being suppressed

### DIFF
--- a/.github/issue-bootstrap/issue-37727.md
+++ b/.github/issue-bootstrap/issue-37727.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37727
+- Title: [Bug]: Telegram: occasional raw {"action":"NO_REPLY"} payload is delivered to end user instead of being suppressed
+- Source: https://github.com/openclaw/openclaw/issues/37727


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37727

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37727