### PR TITLE
[Issue #37733] [Feature]: Prompt caching does not work for custom providers using anthropic-messages API

### DIFF
--- a/.github/issue-bootstrap/issue-37733.md
+++ b/.github/issue-bootstrap/issue-37733.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37733
+- Title: [Feature]: Prompt caching does not work for custom providers using anthropic-messages API
+- Source: https://github.com/openclaw/openclaw/issues/37733


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37733

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37733