### PR TITLE
[Issue #37748] skill-creator: make .skill package file order deterministic

### DIFF
--- a/.github/issue-bootstrap/issue-37748.md
+++ b/.github/issue-bootstrap/issue-37748.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37748
+- Title: skill-creator: make .skill package file order deterministic
+- Source: https://github.com/openclaw/openclaw/issues/37748


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37748

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37748