### PR TITLE
[Issue #37749] Onboard should auto-approve local node host pairing or prompt user

### DIFF
--- a/.github/issue-bootstrap/issue-37749.md
+++ b/.github/issue-bootstrap/issue-37749.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37749
+- Title: Onboard should auto-approve local node host pairing or prompt user
+- Source: https://github.com/openclaw/openclaw/issues/37749


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37749

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37749