### PR TITLE
[Issue #37752] [Bug]: Discord channel reconnect timeout triggers full Gateway restart

### DIFF
--- a/.github/issue-bootstrap/issue-37752.md
+++ b/.github/issue-bootstrap/issue-37752.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37752
+- Title: [Bug]: Discord channel reconnect timeout triggers full Gateway restart
+- Source: https://github.com/openclaw/openclaw/issues/37752


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37752

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37752