### PR TITLE
[Issue #37761] [Bug]: Opus 4.6 via GitHub Copilot on Raspberry Pi producing nonsensical output — possible misconfiguration?

### DIFF
--- a/.github/issue-bootstrap/issue-37761.md
+++ b/.github/issue-bootstrap/issue-37761.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37761
+- Title: [Bug]: Opus 4.6 via GitHub Copilot on Raspberry Pi producing nonsensical output — possible misconfiguration?
+- Source: https://github.com/openclaw/openclaw/issues/37761


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37761

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37761