### PR TITLE
fix(whatsapp): fix QR login 100% failure with Baileys v7 (getStatusCode unwrap + creds race)

### DIFF
--- a/src/web/login-qr.ts
+++ b/src/web/login-qr.ts
@@ -12,6 +12,7 @@ import {
   getStatusCode,
   logoutWeb,
   readWebSelfId,
+  waitForCredsSaveQueue,
   waitForWaConnection,
   webAuthExists,
 } from "./session.js";
@@ -88,6 +89,12 @@ async function restartLoginSocket(login: ActiveLogin, runtime: RuntimeEnv) {
     info("WhatsApp asked for a restart after pairing (code 515); retrying connection once…"),
   );
   closeSocket(login.sock);
+  // Wait for any pending creds-save operations to flush to disk before
+  // recreating the socket. createWaSocket calls useMultiFileAuthState which
+  // reads creds from disk; if the credsSaveQueue hasn't settled yet the new
+  // socket will read stale/empty creds → WhatsApp sees a conflict → 401
+  // device_removed.
+  await waitForCredsSaveQueue();
   try {
     const sock = await createWaSocket(false, login.verbose, {
       authDir: login.authDir,

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -185,9 +185,22 @@ export async function waitForWaConnection(sock: ReturnType<typeof makeWASocket>)
 
 export function getStatusCode(err: unknown) {
   return (
+    // Baileys v7 rejects with the full `lastDisconnect` object
+    // ({ error: BoomError, date: Date }) rather than the BoomError directly.
+    // Unwrap `.error` first so we see the nested statusCode/status.
+    (err as { error?: { output?: { statusCode?: number } } })?.error?.output?.statusCode ??
     (err as { output?: { statusCode?: number } })?.output?.statusCode ??
+    (err as { error?: { status?: number } })?.error?.status ??
     (err as { status?: number })?.status
   );
+}
+
+/**
+ * Resolves once all pending creds-save operations have completed.
+ * Await this before re-reading creds from disk (e.g. in restartLoginSocket).
+ */
+export async function waitForCredsSaveQueue(): Promise<void> {
+  await credsSaveQueue;
 }
 
 function safeStringify(value: unknown, limit = 800): string {


### PR DESCRIPTION
## Problem

WhatsApp QR login fails **100% of the time** with Baileys v7 due to two separate bugs. Both have been confirmed against the dist bundle in `coollabsio/openclaw:2026.3.1`.

Fixes #33961 | Related: WhiskeySockets/Baileys#2248, WhiskeySockets/Baileys#2140

---

## Bug 1 — `getStatusCode` doesn't unwrap Baileys v7 `lastDisconnect` wrapper (CRITICAL)

**File:** `src/web/session.ts`

Baileys v7 changed `waitForWaConnection` to reject with the full `update.lastDisconnect` object (`{ error: BoomError, date: Date }`) rather than the `BoomError` directly. The existing `getStatusCode` only inspects `err.output?.statusCode` and `err.status` — it never unwraps `.error`, so it always returns `undefined`.

This means `login.errorStatus` is always `undefined`, the `=== 515` check in `waitForWebLogin` never matches, and `restartLoginSocket` is never called. QR login fails on every attempt.

**Before:**
```ts
export function getStatusCode(err: unknown) {
  return (
    (err as { output?: { statusCode?: number } })?.output?.statusCode ??
    (err as { status?: number })?.status
  );
}
```

**After:**
```ts
export function getStatusCode(err: unknown) {
  return (
    // Baileys v7 rejects with the full lastDisconnect object
    // ({ error: BoomError, date: Date }) rather than the BoomError directly.
    // Unwrap .error first so we see the nested statusCode/status.
    (err as { error?: { output?: { statusCode?: number } } })?.error?.output?.statusCode ??
    (err as { output?: { statusCode?: number } })?.output?.statusCode ??
    (err as { error?: { status?: number } })?.error?.status ??
    (err as { status?: number })?.status
  );
}
```

---

## Bug 2 — Race condition in `restartLoginSocket`: creds not flushed before socket recreated

**File:** `src/web/login-qr.ts`

`restartLoginSocket` closes the old socket and immediately calls `createWaSocket`. But `createWaSocket` calls `useMultiFileAuthState(authDir)` which reads creds from disk, and the `credsSaveQueue` (async file writes triggered by `creds.update` events during the QR scan) may not have finished yet. The new socket reads stale/empty creds → WhatsApp sees a conflicting session → `device_removed` (401).

**Fix:** Export `waitForCredsSaveQueue()` from `session.ts` and await it in `restartLoginSocket` before calling `createWaSocket`.

**session.ts — new export:**
```ts
export async function waitForCredsSaveQueue(): Promise<void> {
  await credsSaveQueue;
}
```

**login-qr.ts — before:**
```ts
closeSocket(login.sock);
try {
  const sock = await createWaSocket(false, login.verbose, { authDir: login.authDir });
```

**login-qr.ts — after:**
```ts
closeSocket(login.sock);
// Wait for any pending creds-save operations to flush to disk before
// recreating the socket. createWaSocket calls useMultiFileAuthState which
// reads creds from disk; if the credsSaveQueue hasn't settled yet the new
// socket will read stale/empty creds → WhatsApp sees a conflict → 401
// device_removed.
await waitForCredsSaveQueue();
try {
  const sock = await createWaSocket(false, login.verbose, { authDir: login.authDir });
```

---

## Impact

Without fix 1, `restartLoginSocket` is **never called** — QR login cannot complete. Without fix 2, even if fix 1 is applied in isolation, the restarted socket may still fail due to the creds race. Both fixes are required together.