### PR TITLE
[Issue #37765] Document previous_response_id behavior in OpenResponses API — silently ignored

### DIFF
--- a/.github/issue-bootstrap/issue-37765.md
+++ b/.github/issue-bootstrap/issue-37765.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37765
+- Title: Document previous_response_id behavior in OpenResponses API — silently ignored
+- Source: https://github.com/openclaw/openclaw/issues/37765


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37765

## Original Issue Description
See the linked source issue body.

## Linkage
Refs #37765