### PR TITLE
Add a Crust local gateway provider plugin

### DIFF
--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -154,7 +154,8 @@ authoring plugins:
 - `openclaw/plugin-sdk/msteams` for the bundled Microsoft Teams plugin surface.
 - Bundled extension-specific subpaths are also available:
   `openclaw/plugin-sdk/acpx`, `openclaw/plugin-sdk/bluebubbles`,
-  `openclaw/plugin-sdk/copilot-proxy`, `openclaw/plugin-sdk/device-pair`,
+  `openclaw/plugin-sdk/copilot-proxy`, `openclaw/plugin-sdk/crust-proxy`,
+  `openclaw/plugin-sdk/device-pair`,
   `openclaw/plugin-sdk/diagnostics-otel`, `openclaw/plugin-sdk/diffs`,
   `openclaw/plugin-sdk/feishu`,
   `openclaw/plugin-sdk/google-gemini-cli-auth`, `openclaw/plugin-sdk/googlechat`,

--- a/extensions/crust-proxy/README.md
+++ b/extensions/crust-proxy/README.md
@@ -1,0 +1,42 @@
+# Crust Proxy (OpenClaw plugin)
+
+Provider plugin for routing model traffic through a local **Crust** gateway.
+
+The OpenAI-compatible flow ships with a small starter set of models, including
+`gpt-5.2`, `claude-sonnet-4.5`, `gemini-3-flash`, and `kimi-k2.5`. You can also
+enter any other model IDs that your Crust gateway exposes.
+
+## Enable
+
+Bundled plugins are disabled by default. Enable this one:
+
+```bash
+openclaw plugins enable crust-proxy
+```
+
+Restart the Gateway after enabling.
+
+## Authenticate
+
+OpenAI-compatible routing:
+
+```bash
+openclaw models auth login --provider crust-openai --set-default
+```
+
+Anthropic Messages routing:
+
+```bash
+openclaw models auth login --provider crust-anthropic --set-default
+```
+
+## Requirements
+
+- Crust must be running locally.
+- The default gateway URL is `http://localhost:9090`.
+- This plugin is intended for API-key based routing through Crust.
+
+## Notes
+
+- If you already manage a custom provider in `openclaw.json`, pointing that provider's `baseUrl` at Crust is still a valid alternative.
+- OpenClaw's official OpenAI and Anthropic OAuth flows may bypass custom `baseUrl` handling, so they are not the primary integration path for this plugin.

--- a/extensions/crust-proxy/index.test.ts
+++ b/extensions/crust-proxy/index.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import plugin from "./index.js";
+
+type TextPromptConfig = {
+  message: string;
+  initialValue?: string;
+  placeholder?: string;
+  validate?: (value: string) => string | undefined;
+};
+
+function createApi() {
+  const providers: any[] = [];
+  const api = {
+    registerProvider(provider: any) {
+      providers.push(provider);
+    },
+  };
+  plugin.register(api as any);
+  return providers;
+}
+
+function createContext(answers: string[]) {
+  const prompts: TextPromptConfig[] = [];
+  let index = 0;
+  return {
+    ctx: {
+      prompter: {
+        text: async (config: TextPromptConfig) => {
+          prompts.push(config);
+          return answers[index++] ?? "";
+        },
+      },
+    },
+    prompts,
+  };
+}
+
+describe("crust-proxy plugin", () => {
+  it("registers OpenAI-compatible and Anthropic providers", () => {
+    const providers = createApi();
+
+    expect(providers.map((provider) => provider.id)).toEqual(["crust-openai", "crust-anthropic"]);
+  });
+
+  it("configures OpenAI-compatible routing with Kimi available in defaults", async () => {
+    const providers = createApi();
+    const provider = providers.find((entry) => entry.id === "crust-openai");
+    expect(provider).toBeTruthy();
+
+    const { ctx, prompts } = createContext(["http://localhost:9090", "sk-openai-test", ""]);
+    const result = await provider.auth[0].run(ctx as any);
+
+    expect(prompts[2]?.placeholder).toContain("kimi-k2.5");
+    expect(result.defaultModel).toBe("crust-openai/gpt-5.2");
+    expect(
+      result.configPatch.models.providers["crust-openai"].models.map((m: any) => m.id),
+    ).toEqual([
+      "gpt-5.2",
+      "gpt-5.2-codex",
+      "gpt-5-mini",
+      "claude-sonnet-4.5",
+      "gemini-3-flash",
+      "kimi-k2.5",
+    ]);
+  });
+
+  it("supports custom OpenAI-compatible model lists", async () => {
+    const providers = createApi();
+    const provider = providers.find((entry) => entry.id === "crust-openai");
+    const { ctx } = createContext([
+      "http://localhost:9090",
+      "sk-openai-test",
+      "kimi-k2.5, qwen3-coder",
+    ]);
+    const result = await provider.auth[0].run(ctx as any);
+
+    expect(result.defaultModel).toBe("crust-openai/kimi-k2.5");
+    expect(
+      result.configPatch.models.providers["crust-openai"].models.map((m: any) => m.id),
+    ).toEqual(["kimi-k2.5", "qwen3-coder"]);
+  });
+
+  it("falls back to default Anthropic routing values", async () => {
+    const providers = createApi();
+    const provider = providers.find((entry) => entry.id === "crust-anthropic");
+    const { ctx } = createContext(["", "sk-anthropic-test", ""]);
+    const result = await provider.auth[0].run(ctx as any);
+
+    expect(result.defaultModel).toBe("crust-anthropic/claude-sonnet-4.5");
+    expect(result.configPatch.models.providers["crust-anthropic"].baseUrl).toBe(
+      "http://localhost:9090",
+    );
+    expect(
+      result.configPatch.models.providers["crust-anthropic"].models.map((m: any) => m.id),
+    ).toEqual(["claude-sonnet-4.5", "claude-opus-4.5", "claude-haiku-4.5"]);
+  });
+});

--- a/extensions/crust-proxy/index.test.ts
+++ b/extensions/crust-proxy/index.test.ts
@@ -62,6 +62,8 @@ describe("crust-proxy plugin", () => {
       "gemini-3-flash",
       "kimi-k2.5",
     ]);
+    expect(prompts[2]?.validate?.(" , , ")).toBe("Enter at least one model id");
+    expect(prompts[2]?.validate?.("")).toBeUndefined();
   });
 
   it("supports custom OpenAI-compatible model lists", async () => {
@@ -78,6 +80,21 @@ describe("crust-proxy plugin", () => {
     expect(
       result.configPatch.models.providers["crust-openai"].models.map((m: any) => m.id),
     ).toEqual(["kimi-k2.5", "qwen3-coder"]);
+  });
+
+  it("marks reasoning models conservatively for custom model ids", async () => {
+    const providers = createApi();
+    const provider = providers.find((entry) => entry.id === "crust-openai");
+    const { ctx } = createContext([
+      "http://localhost:9090",
+      "sk-openai-test",
+      "proto3-demo, o3-mini",
+    ]);
+    const result = await provider.auth[0].run(ctx as any);
+    const models = result.configPatch.models.providers["crust-openai"].models;
+
+    expect(models.find((model: any) => model.id === "proto3-demo")?.reasoning).toBe(false);
+    expect(models.find((model: any) => model.id === "o3-mini")?.reasoning).toBe(true);
   });
 
   it("falls back to default Anthropic routing values", async () => {

--- a/extensions/crust-proxy/index.ts
+++ b/extensions/crust-proxy/index.ts
@@ -67,13 +67,16 @@ function parseModelIds(input: string, fallback: readonly string[]): string[] {
   return deduped.length > 0 ? deduped : Array.from(fallback);
 }
 
+function hasExplicitModelIds(input: string): boolean {
+  return input.split(/[\n,]/).some((modelId) => modelId.trim().length > 0);
+}
+
 function inferReasoning(modelId: string): boolean {
   const normalized = modelId.toLowerCase();
+  const tokenizedReasoningPattern = /(^|[/:._-])(o1|o3|o4)(?=($|[/:._-]))/;
   return (
     normalized.includes("gpt-5") ||
-    normalized.includes("o1") ||
-    normalized.includes("o3") ||
-    normalized.includes("o4") ||
+    tokenizedReasoningPattern.test(normalized) ||
     normalized.includes("reason")
   );
 }
@@ -124,9 +127,7 @@ async function runApiKeyFlow(
     message: `${flavor.label} model IDs (comma-separated)`,
     placeholder: `${flavor.modelInputHint} (blank keeps: ${flavor.defaultModels.join(", ")})`,
     validate: (value: string) =>
-      parseModelIds(value, flavor.defaultModels).length > 0
-        ? undefined
-        : "Enter at least one model id",
+      !value.trim() || hasExplicitModelIds(value) ? undefined : "Enter at least one model id",
   });
 
   const baseUrl = normalizeBaseUrl(baseUrlInput);

--- a/extensions/crust-proxy/index.ts
+++ b/extensions/crust-proxy/index.ts
@@ -1,0 +1,231 @@
+import {
+  emptyPluginConfigSchema,
+  type OpenClawPluginApi,
+  type ProviderAuthContext,
+  type ProviderAuthResult,
+} from "openclaw/plugin-sdk/crust-proxy";
+
+const DEFAULT_BASE_URL = "http://localhost:9090";
+const PLACEHOLDER_API_KEY = "crust-managed";
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const DEFAULT_MAX_TOKENS = 8192;
+
+const OPENAI_PROVIDER_ID = "crust-openai";
+const OPENAI_DEFAULT_MODELS = [
+  "gpt-5.2",
+  "gpt-5.2-codex",
+  "gpt-5-mini",
+  "claude-sonnet-4.5",
+  "gemini-3-flash",
+  "kimi-k2.5",
+] as const;
+
+const ANTHROPIC_PROVIDER_ID = "crust-anthropic";
+const ANTHROPIC_DEFAULT_MODELS = [
+  "claude-sonnet-4.5",
+  "claude-opus-4.5",
+  "claude-haiku-4.5",
+] as const;
+
+type ProviderFlavor = {
+  providerId: string;
+  label: string;
+  docsPath: string;
+  api: "openai-completions" | "anthropic-messages";
+  defaultModels: readonly string[];
+  defaultAlias: string;
+  modelInputHint: string;
+};
+
+function normalizeBaseUrl(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return DEFAULT_BASE_URL;
+  }
+  return trimmed.replace(/\/+$/, "");
+}
+
+function validateBaseUrl(value: string): string | undefined {
+  try {
+    new URL(normalizeBaseUrl(value));
+  } catch {
+    return "Enter a valid URL";
+  }
+  return undefined;
+}
+
+function validateApiKey(value: string): string | undefined {
+  return value.trim() ? undefined : "Enter an API key";
+}
+
+function parseModelIds(input: string, fallback: readonly string[]): string[] {
+  const parsed = input
+    .split(/[\n,]/)
+    .map((modelId) => modelId.trim())
+    .filter(Boolean);
+  const deduped = Array.from(new Set(parsed));
+  return deduped.length > 0 ? deduped : Array.from(fallback);
+}
+
+function inferReasoning(modelId: string): boolean {
+  const normalized = modelId.toLowerCase();
+  return (
+    normalized.includes("gpt-5") ||
+    normalized.includes("o1") ||
+    normalized.includes("o3") ||
+    normalized.includes("o4") ||
+    normalized.includes("reason")
+  );
+}
+
+function buildModelDefinition(modelId: string, api: ProviderFlavor["api"]) {
+  return {
+    id: modelId,
+    name: modelId,
+    api,
+    reasoning: inferReasoning(modelId),
+    input: ["text", "image"] as Array<"text" | "image">,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    maxTokens: DEFAULT_MAX_TOKENS,
+  };
+}
+
+function buildAgentDefaults(
+  providerId: string,
+  modelIds: string[],
+  defaultAlias: string,
+): Record<string, { alias?: string }> {
+  return Object.fromEntries(
+    modelIds.map((modelId, index) => [
+      `${providerId}/${modelId}`,
+      index === 0 ? { alias: defaultAlias } : {},
+    ]),
+  );
+}
+
+async function runApiKeyFlow(
+  ctx: ProviderAuthContext,
+  flavor: ProviderFlavor,
+): Promise<ProviderAuthResult> {
+  const baseUrlInput = await ctx.prompter.text({
+    message: `${flavor.label} base URL`,
+    initialValue: DEFAULT_BASE_URL,
+    validate: validateBaseUrl,
+  });
+
+  const apiKey = await ctx.prompter.text({
+    message: `${flavor.label} upstream API key`,
+    placeholder: "Paste the upstream API key that Crust should forward",
+    validate: validateApiKey,
+  });
+
+  const modelInput = await ctx.prompter.text({
+    message: `${flavor.label} model IDs (comma-separated)`,
+    placeholder: `${flavor.modelInputHint} (blank keeps: ${flavor.defaultModels.join(", ")})`,
+    validate: (value: string) =>
+      parseModelIds(value, flavor.defaultModels).length > 0
+        ? undefined
+        : "Enter at least one model id",
+  });
+
+  const baseUrl = normalizeBaseUrl(baseUrlInput);
+  const modelIds = parseModelIds(modelInput, flavor.defaultModels);
+  const defaultModelRef = `${flavor.providerId}/${modelIds[0]}`;
+
+  return {
+    profiles: [
+      {
+        profileId: `${flavor.providerId}:default`,
+        credential: {
+          type: "api_key",
+          provider: flavor.providerId,
+          key: apiKey.trim(),
+        },
+      },
+    ],
+    configPatch: {
+      models: {
+        providers: {
+          [flavor.providerId]: {
+            baseUrl,
+            apiKey: PLACEHOLDER_API_KEY,
+            api: flavor.api,
+            models: modelIds.map((modelId) => buildModelDefinition(modelId, flavor.api)),
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          models: buildAgentDefaults(flavor.providerId, modelIds, flavor.defaultAlias),
+        },
+      },
+    },
+    defaultModel: defaultModelRef,
+    notes: [
+      "Start Crust before using these models.",
+      `Crust base URL defaults to ${DEFAULT_BASE_URL}.`,
+      "This flow is intended for API-key based routing through Crust.",
+    ],
+  };
+}
+
+const crustProxyPlugin = {
+  id: "crust-proxy",
+  name: "Crust Proxy",
+  description: "Provider plugin for routing model traffic through a local Crust gateway",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    api.registerProvider({
+      id: OPENAI_PROVIDER_ID,
+      label: "Crust (OpenAI-compatible)",
+      docsPath: "/providers/models",
+      aliases: ["crust-openai", "crust"],
+      auth: [
+        {
+          id: "api-key",
+          label: "API key via Crust",
+          hint: "Configure OpenAI-compatible routing through a local Crust gateway",
+          kind: "api_key",
+          run: (ctx: ProviderAuthContext) =>
+            runApiKeyFlow(ctx, {
+              providerId: OPENAI_PROVIDER_ID,
+              label: "Crust (OpenAI-compatible)",
+              docsPath: "/providers/models",
+              api: "openai-completions",
+              defaultModels: OPENAI_DEFAULT_MODELS,
+              defaultAlias: "crust",
+              modelInputHint: "gpt-5.2-codex, claude-sonnet-4.5, gemini-3-flash, kimi-k2.5",
+            }),
+        },
+      ],
+    });
+
+    api.registerProvider({
+      id: ANTHROPIC_PROVIDER_ID,
+      label: "Crust (Anthropic Messages)",
+      docsPath: "/providers/anthropic",
+      aliases: ["crust-anthropic"],
+      auth: [
+        {
+          id: "api-key",
+          label: "API key via Crust",
+          hint: "Configure Anthropic Messages routing through a local Crust gateway",
+          kind: "api_key",
+          run: (ctx: ProviderAuthContext) =>
+            runApiKeyFlow(ctx, {
+              providerId: ANTHROPIC_PROVIDER_ID,
+              label: "Crust (Anthropic Messages)",
+              docsPath: "/providers/anthropic",
+              api: "anthropic-messages",
+              defaultModels: ANTHROPIC_DEFAULT_MODELS,
+              defaultAlias: "crust-anthropic",
+              modelInputHint: "claude-sonnet-4.5, claude-opus-4.5",
+            }),
+        },
+      ],
+    });
+  },
+};
+
+export default crustProxyPlugin;

--- a/extensions/crust-proxy/openclaw.plugin.json
+++ b/extensions/crust-proxy/openclaw.plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "crust-proxy",
+  "providers": ["crust-openai", "crust-anthropic"],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/crust-proxy/package.json
+++ b/extensions/crust-proxy/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/crust-proxy",
+  "version": "2026.3.3",
+  "private": true,
+  "description": "OpenClaw Crust provider plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -92,6 +92,10 @@
       "types": "./dist/plugin-sdk/copilot-proxy.d.ts",
       "default": "./dist/plugin-sdk/copilot-proxy.js"
     },
+    "./plugin-sdk/crust-proxy": {
+      "types": "./dist/plugin-sdk/crust-proxy.d.ts",
+      "default": "./dist/plugin-sdk/crust-proxy.js"
+    },
     "./plugin-sdk/device-pair": {
       "types": "./dist/plugin-sdk/device-pair.d.ts",
       "default": "./dist/plugin-sdk/device-pair.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,6 +269,8 @@ importers:
 
   extensions/copilot-proxy: {}
 
+  extensions/crust-proxy: {}
+
   extensions/diagnostics-otel:
     dependencies:
       '@opentelemetry/api':

--- a/scripts/check-plugin-sdk-exports.mjs
+++ b/scripts/check-plugin-sdk-exports.mjs
@@ -55,6 +55,7 @@ const requiredSubpathEntries = [
   "acpx",
   "bluebubbles",
   "copilot-proxy",
+  "crust-proxy",
   "device-pair",
   "diagnostics-otel",
   "diffs",

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -41,6 +41,8 @@ const requiredPathGroups = [
   "dist/plugin-sdk/bluebubbles.d.ts",
   "dist/plugin-sdk/copilot-proxy.js",
   "dist/plugin-sdk/copilot-proxy.d.ts",
+  "dist/plugin-sdk/crust-proxy.js",
+  "dist/plugin-sdk/crust-proxy.d.ts",
   "dist/plugin-sdk/device-pair.js",
   "dist/plugin-sdk/device-pair.d.ts",
   "dist/plugin-sdk/diagnostics-otel.js",

--- a/scripts/write-plugin-sdk-entry-dts.ts
+++ b/scripts/write-plugin-sdk-entry-dts.ts
@@ -21,6 +21,7 @@ const entrypoints = [
   "acpx",
   "bluebubbles",
   "copilot-proxy",
+  "crust-proxy",
   "device-pair",
   "diagnostics-otel",
   "diffs",

--- a/src/plugin-sdk/crust-proxy.ts
+++ b/src/plugin-sdk/crust-proxy.ts
@@ -1,0 +1,9 @@
+// Narrow plugin-sdk surface for the bundled crust-proxy plugin.
+// Keep this list additive and scoped to symbols used under extensions/crust-proxy.
+
+export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
+export type {
+  OpenClawPluginApi,
+  ProviderAuthContext,
+  ProviderAuthResult,
+} from "../plugins/types.js";

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -13,6 +13,7 @@ const bundledExtensionSubpathLoaders = [
   { id: "acpx", load: () => import("openclaw/plugin-sdk/acpx") },
   { id: "bluebubbles", load: () => import("openclaw/plugin-sdk/bluebubbles") },
   { id: "copilot-proxy", load: () => import("openclaw/plugin-sdk/copilot-proxy") },
+  { id: "crust-proxy", load: () => import("openclaw/plugin-sdk/crust-proxy") },
   { id: "device-pair", load: () => import("openclaw/plugin-sdk/device-pair") },
   { id: "diagnostics-otel", load: () => import("openclaw/plugin-sdk/diagnostics-otel") },
   { id: "diffs", load: () => import("openclaw/plugin-sdk/diffs") },

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -106,6 +106,11 @@ const pluginSdkScopedAliasEntries = [
     srcFile: "copilot-proxy.ts",
     distFile: "copilot-proxy.js",
   },
+  {
+    subpath: "crust-proxy",
+    srcFile: "crust-proxy.ts",
+    distFile: "crust-proxy.js",
+  },
   { subpath: "device-pair", srcFile: "device-pair.ts", distFile: "device-pair.js" },
   {
     subpath: "diagnostics-otel",

--- a/tsconfig.plugin-sdk.dts.json
+++ b/tsconfig.plugin-sdk.dts.json
@@ -27,6 +27,7 @@
     "src/plugin-sdk/acpx.ts",
     "src/plugin-sdk/bluebubbles.ts",
     "src/plugin-sdk/copilot-proxy.ts",
+    "src/plugin-sdk/crust-proxy.ts",
     "src/plugin-sdk/device-pair.ts",
     "src/plugin-sdk/diagnostics-otel.ts",
     "src/plugin-sdk/diffs.ts",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -19,6 +19,7 @@ const pluginSdkEntrypoints = [
   "acpx",
   "bluebubbles",
   "copilot-proxy",
+  "crust-proxy",
   "device-pair",
   "diagnostics-otel",
   "diffs",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,7 @@ const pluginSdkSubpaths = [
   "acpx",
   "bluebubbles",
   "copilot-proxy",
+  "crust-proxy",
   "device-pair",
   "diagnostics-otel",
   "diffs",


### PR DESCRIPTION
## Summary

This PR adds a bundled `crust-proxy` extension that lets OpenClaw users route
model traffic through a local Crust gateway.

It registers two provider flows:

- `crust-openai`
- `crust-anthropic`

The integration is intentionally plugin-first and keeps scope limited to local
provider configuration. It does not change core provider behavior or OpenClaw's
existing OAuth flows.

## What this adds

- bundled `extensions/crust-proxy` plugin
- `crust-openai` provider auth flow for OpenAI-compatible routing through Crust
- `crust-anthropic` provider auth flow for Anthropic Messages routing through Crust
- narrow `openclaw/plugin-sdk/crust-proxy` subpath
- loader / plugin-sdk / release-check wiring for the new bundled extension
- plugin docs and regression tests

## Notes

- default Crust gateway URL is `http://localhost:9090`
- the OpenAI-compatible flow includes a starter model set with:
  - `gpt-5.2`
  - `gpt-5.2-codex`
  - `gpt-5-mini`
  - `claude-sonnet-4.5`
  - `gemini-3-flash`
  - `kimi-k2.5`
- users can also enter any other model IDs exposed by their Crust gateway

## Validation

Passed locally:

- `pnpm exec vitest run src/plugin-sdk/subpaths.test.ts extensions/crust-proxy/index.test.ts src/plugins/loader.test.ts`
- `pnpm exec oxfmt --check docs/tools/plugin.md extensions/crust-proxy/README.md extensions/crust-proxy/index.ts extensions/crust-proxy/index.test.ts extensions/crust-proxy/package.json extensions/crust-proxy/openclaw.plugin.json`

Validated behavior includes:

- bundled plugin-sdk subpath resolution
- loader alias resolution
- provider registration for `crust-openai` and `crust-anthropic`
- default model and config patch generation
- custom model list support
- default OpenAI-compatible model list includes `kimi-k2.5`

## Scope

This PR is intentionally limited to a bundled provider plugin and its required
wiring. It does not attempt to embed the Crust runtime into OpenClaw core.
