### PR TITLE
fix(telegram): suppress JSON NO_REPLY action payload

### DIFF
--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -2,6 +2,24 @@ import { splitMediaFromOutput } from "../../media/parse.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 
+type NoReplyActionEnvelope = { action?: unknown };
+
+function isNoReplyActionEnvelope(raw: string, token: string): boolean {
+  // Some run paths may emit an object directive like {"action":"NO_REPLY"}
+  // instead of the raw token. That payload must never reach user-visible
+  // channels; treat it as silent.
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as NoReplyActionEnvelope;
+    return typeof parsed?.action === "string" && parsed.action.trim() === token;
+  } catch {
+    return false;
+  }
+}
+
 export type ReplyDirectiveParseResult = {
   text: string;
   mediaUrls?: string[];
@@ -31,7 +49,7 @@ export function parseReplyDirectives(
   }
 
   const silentToken = options.silentToken ?? SILENT_REPLY_TOKEN;
-  const isSilent = isSilentReplyText(text, silentToken);
+  const isSilent = isSilentReplyText(text, silentToken) || isNoReplyActionEnvelope(text, silentToken);
   if (isSilent) {
     text = "";
   }

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
+
+describe("normalizeReplyPayloadsForDelivery", () => {
+  it("suppresses NO_REPLY even when delivered as a JSON action payload", () => {
+    const normalized = normalizeReplyPayloadsForDelivery([
+      { text: "{\"action\":\"NO_REPLY\"}" },
+      { text: "{\n  \"action\": \"NO_REPLY\"\n}" },
+    ]);
+    expect(normalized).toEqual([]);
+  });
+
+  it("does not suppress arbitrary JSON that is not a NO_REPLY action", () => {
+    const normalized = normalizeReplyPayloadsForDelivery([
+      { text: "{\"action\":\"SOMETHING_ELSE\"}" },
+    ]);
+    expect(normalized).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ text: "{\"action\":\"SOMETHING_ELSE\"}" }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
Closes #37727

Fixes a Telegram UX bug where an internal silent-reply control payload like {"action":"NO_REPLY"} could be serialized and delivered as literal text.

Changes:
- Treat JSON action envelopes containing action=NO_REPLY as silent in reply directive parsing
- Add regression unit tests for outbound payload normalization

Validation:
- vitest: src/infra/outbound/payloads.test.ts