### PR TITLE
Daemon: treat D-Bus unavailability as not-enabled in gateway service check

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -138,6 +138,26 @@ describe("isSystemdServiceEnabled", () => {
     const result = await isSystemdServiceEnabled({ env: {} });
     expect(result).toBe(false);
   });
+
+  it("returns false when D-Bus is unavailable (e.g. container, no medium found)", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    const busError = "Failed to connect to bus: No medium found";
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        expect(args).toEqual(["--user", "is-enabled", "openclaw-gateway.service"]);
+        const err = new Error(busError) as Error & { code?: number };
+        err.code = 1;
+        cb(err, "", busError);
+      })
+      .mockImplementationOnce((_cmd, _args, _opts, cb) => {
+        // Fallback --machine user@ also fails with no D-Bus (e.g. container).
+        const err = new Error(busError) as Error & { code?: number };
+        err.code = 1;
+        cb(err, "", busError);
+      });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
 });
 
 describe("systemd runtime parsing", () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -179,6 +179,19 @@ function isSystemdUnitNotEnabled(detail: string): boolean {
   );
 }
 
+/** True when systemctl/user D-Bus is unavailable (e.g. container, chroot, no session). */
+function isSystemctlBusUnavailable(detail: string): boolean {
+  if (!detail) {
+    return false;
+  }
+  const normalized = detail.toLowerCase();
+  return (
+    normalized.includes("failed to connect to bus") ||
+    normalized.includes("no medium found") ||
+    normalized.includes("connection refused")
+  );
+}
+
 function resolveSystemctlDirectUserScopeArgs(): string[] {
   return ["--user"];
 }
@@ -430,7 +443,11 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
     return true;
   }
   const detail = readSystemctlDetail(res);
-  if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
+  if (
+    isSystemctlMissing(detail) ||
+    isSystemdUnitNotEnabled(detail) ||
+    isSystemctlBusUnavailable(detail)
+  ) {
     return false;
   }
   throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -185,11 +185,16 @@ function isSystemctlBusUnavailable(detail: string): boolean {
     return false;
   }
   const normalized = detail.toLowerCase();
-  return (
-    normalized.includes("failed to connect to bus") ||
-    normalized.includes("no medium found") ||
+  if (normalized.includes("no medium found")) {
+    return true;
+  }
+  if (
+    normalized.includes("failed to connect to bus") &&
     normalized.includes("connection refused")
-  );
+  ) {
+    return true;
+  }
+  return false;
 }
 
 function resolveSystemctlDirectUserScopeArgs(): string[] {


### PR DESCRIPTION
## Problem
`openclaw gateway install` / uninstall / reset fails with:
`Gateway service check failed: Error: systemctl is-enabled unavailable: Failed to connect to bus: No medium found`
in environments without a user D-Bus (containers, chroot, headless).

## Solution
Treat D-Bus unavailability (e.g. "Failed to connect to bus", "No medium found", "connection refused") in `isSystemdServiceEnabled` as "service not enabled" (return `false`) instead of throwing, so install/status/uninstall/reset can continue.

## Changes
- `src/daemon/systemd.ts`: add `isSystemctlBusUnavailable(detail)` and use it in `isSystemdServiceEnabled` to return false for bus errors.
- `src/daemon/systemd.test.ts`: add test for D-Bus unavailable returning false.

Made with [Cursor](https://cursor.com)