### PR TITLE
fix(discovery): truncate mDNS instance name to 63-byte DNS label limit

### DIFF
--- a/src/infra/bonjour.test.ts
+++ b/src/infra/bonjour.test.ts
@@ -308,3 +308,41 @@ describe("gateway bonjour advertiser", () => {
     await started.stop();
   });
 });
+
+describe("truncateToDnsLabel", () => {
+  // Import directly — the function is a pure utility.
+  let truncateToDnsLabel: (label: string) => string;
+
+  beforeEach(async () => {
+    const mod = await import("./bonjour.js");
+    truncateToDnsLabel = mod.truncateToDnsLabel;
+  });
+
+  it("returns short labels unchanged", () => {
+    expect(truncateToDnsLabel("my-host (OpenClaw)")).toBe("my-host (OpenClaw)");
+  });
+
+  it("returns exactly-63-byte labels unchanged", () => {
+    const label = "a".repeat(63);
+    expect(truncateToDnsLabel(label)).toBe(label);
+  });
+
+  it("truncates labels longer than 63 bytes", () => {
+    const longLabel = "a".repeat(100);
+    const result = truncateToDnsLabel(longLabel);
+    expect(Buffer.byteLength(result, "utf-8")).toBeLessThanOrEqual(63);
+  });
+
+  it("truncates Kubernetes-style pod names that exceed 63 bytes", () => {
+    // Real-world case from #37705
+    const podName = "app-41627eae5842473f9e05f139ea307277-7f9477f4d6-lqqzf (OpenClaw)";
+    expect(Buffer.byteLength(podName, "utf-8")).toBeGreaterThan(63);
+    const result = truncateToDnsLabel(podName);
+    expect(Buffer.byteLength(result, "utf-8")).toBeLessThanOrEqual(63);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to 'OpenClaw' for empty input", () => {
+    expect(truncateToDnsLabel("")).toBe("OpenClaw");
+  });
+});

--- a/src/infra/bonjour.ts
+++ b/src/infra/bonjour.ts
@@ -43,6 +43,29 @@ function safeServiceName(name: string) {
   return trimmed.length > 0 ? trimmed : "OpenClaw";
 }
 
+/**
+ * DNS labels must not exceed 63 bytes (RFC 1035 §2.3.4).
+ * Truncate on a code-point boundary so multi-byte hostnames
+ * (e.g. Kubernetes pod names) don't crash ciao's DNSLabelCoder.
+ * See https://github.com/openclaw/openclaw/issues/37705
+ */
+const DNS_LABEL_MAX_BYTES = 63;
+export function truncateToDnsLabel(label: string): string {
+  if (!label) {
+    return "OpenClaw";
+  }
+  const buf = Buffer.from(label, "utf-8");
+  if (buf.length <= DNS_LABEL_MAX_BYTES) {
+    return label;
+  }
+  // Slice and decode back, which safely handles truncated multi-byte chars
+  const truncated = buf
+    .subarray(0, DNS_LABEL_MAX_BYTES)
+    .toString("utf-8")
+    .replace(/\uFFFD$/, "");
+  return truncated || "OpenClaw";
+}
+
 function prettifyInstanceName(name: string) {
   const normalized = name.trim().replace(/\s+/g, " ");
   return normalized.replace(/\s+\(OpenClaw\)\s*$/i, "").trim() || normalized;
@@ -103,10 +126,11 @@ export async function startGatewayBonjourAdvertiser(
       .replace(/\.local$/i, "")
       .split(".")[0]
       .trim() || "openclaw";
-  const instanceName =
+  const instanceName = truncateToDnsLabel(
     typeof opts.instanceName === "string" && opts.instanceName.trim()
       ? opts.instanceName.trim()
-      : `${hostname} (OpenClaw)`;
+      : `${hostname} (OpenClaw)`,
+  );
   const displayName = prettifyInstanceName(instanceName);
 
   const txtBase: Record<string, string> = {


### PR DESCRIPTION
Fixes #37705

Long hostnames (e.g. Kubernetes pod names) exceed the 63-byte DNS label limit (RFC 1035), causing ciao DNSLabelCoder to throw an uncaught AssertionError that crashes the gateway on startup.

Add truncateToDnsLabel() that safely truncates to 63 bytes on a UTF-8 code-point boundary. 2 files, +64/-2, 12 tests pass (5 new).

---

AI-assisted PR (Claude via OpenClaw agent). I understand what this code does.