### PR TITLE
[Issue #37804] RFC: treat models.providers-injected models as first-class forward-compat models

### DIFF
--- a/.github/issue-bootstrap/issue-37804.md
+++ b/.github/issue-bootstrap/issue-37804.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37804
+- Title: RFC: treat models.providers-injected models as first-class forward-compat models
+- Source: https://github.com/openclaw/openclaw/issues/37804


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37804

## Original Issue Description
RFC proposes making `models.providers.*.models` injections first-class across all relevant surfaces (status, list, runtime, auth/availability heuristics, capability gates, and docs), rather than partially supported. Core motivation: provider model releases outpace registry updates, and users need a consistent forward-compat path when configured models are valid but not yet in upstream catalogs.

## Linkage
Refs #37804