### PR TITLE
[Issue #37812] [SEC] P0: Gateway may start with auth=none when config is not loaded (track + harden)

### DIFF
--- a/.github/issue-bootstrap/issue-37812.md
+++ b/.github/issue-bootstrap/issue-37812.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37812
+- Title: [SEC] P0: Gateway may start with auth=none when config is not loaded (track + harden)
+- Source: https://github.com/openclaw/openclaw/issues/37812


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37812

## Original Issue Description
Security-tracking issue for potential auth bypass: gateway may run with `auth: none` despite `gateway.auth.mode: token` in config. Includes reproduction steps and hardening checklist: startup invariant, integration coverage, explicit startup auth-source logging, and CI regression guardrails.

## Linkage
Refs #37812