### PR TITLE
[Issue #37813] [Bug]: Unrecognised model IDs silently fall back to primary default — bypasses configured fallback chain and tool permissions

### DIFF
--- a/.github/issue-bootstrap/issue-37813.md
+++ b/.github/issue-bootstrap/issue-37813.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37813
+- Title: [Bug]: Unrecognised model IDs silently fall back to primary default — bypasses configured fallback chain and tool permissions
+- Source: https://github.com/openclaw/openclaw/issues/37813


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37813

## Original Issue Description
Issue reports that unknown or non-registry model IDs silently fall back to the primary default model, bypass configured fallback chains, and inherit fallback-model permissions. Reported impact includes security risk (tool permission escalation), cost impact (unexpected Opus fallback), status-surface inconsistency (`/status` vs `session_status`), and missing user-visible warninging for resolution failures.

## Linkage
Refs #37813