### PR TITLE
[Issue #37815] Feature Request: Native prompt scrubbing / PII redaction before sending to LLM providers

### DIFF
--- a/.github/issue-bootstrap/issue-37815.md
+++ b/.github/issue-bootstrap/issue-37815.md
@@ -1,0 +1,5 @@
+# Issue Bootstrap
+
+- Issue: #37815
+- Title: Feature Request: Native prompt scrubbing / PII redaction before sending to LLM providers
+- Source: https://github.com/openclaw/openclaw/issues/37815


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37815

## Original Issue Description
Feature request for configurable pre-provider prompt scrubbing with reversible substitutions on responses, so sensitive business terms are transformed before leaving the machine. Proposal includes dictionary-based replacement/redaction, optional per-agent overrides, and rationale around enterprise privacy and operational simplicity.

## Linkage
Refs #37815