### PR TITLE
fix(slack): thread agent identity through draft stream preview path

### DIFF
--- a/src/slack/draft-stream.test.ts
+++ b/src/slack/draft-stream.test.ts
@@ -122,6 +122,50 @@ describe("createSlackDraftStream", () => {
     expect(remove).not.toHaveBeenCalled();
   });
 
+  it("passes identity to sendMessageSlack on initial send", async () => {
+    const send = vi.fn<DraftSendFn>(async () => ({
+      channelId: "C123",
+      messageId: "111.222",
+    }));
+    const identity = { username: "Stitch", iconEmoji: ":stitch-1:" };
+    const stream = createSlackDraftStream({
+      target: "channel:C123",
+      token: "xoxb-test",
+      throttleMs: 250,
+      identity,
+      send,
+      edit: vi.fn<DraftEditFn>(async () => {}),
+      remove: vi.fn<DraftRemoveFn>(async () => {}),
+    });
+
+    stream.update("hello");
+    await stream.flush();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][2]).toMatchObject({ identity });
+  });
+
+  it("omits identity from sendMessageSlack when not provided", async () => {
+    const send = vi.fn<DraftSendFn>(async () => ({
+      channelId: "C123",
+      messageId: "111.222",
+    }));
+    const stream = createSlackDraftStream({
+      target: "channel:C123",
+      token: "xoxb-test",
+      throttleMs: 250,
+      send,
+      edit: vi.fn<DraftEditFn>(async () => {}),
+      remove: vi.fn<DraftRemoveFn>(async () => {}),
+    });
+
+    stream.update("hello");
+    await stream.flush();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][2]).not.toHaveProperty("identity");
+  });
+
   it("clear warns when cleanup fails", async () => {
     const remove = vi.fn<DraftRemoveFn>(async () => {
       throw new Error("cleanup failed");

--- a/src/slack/draft-stream.ts
+++ b/src/slack/draft-stream.ts
@@ -1,6 +1,6 @@
 import { createDraftStreamLoop } from "../channels/draft-stream-loop.js";
 import { deleteSlackMessage, editSlackMessage } from "./actions.js";
-import { sendMessageSlack } from "./send.js";
+import { sendMessageSlack, type SlackSendIdentity } from "./send.js";
 
 const SLACK_STREAM_MAX_CHARS = 4000;
 const DEFAULT_THROTTLE_MS = 1000;
@@ -25,6 +25,7 @@ export function createSlackDraftStream(params: {
   onMessageSent?: () => void;
   log?: (message: string) => void;
   warn?: (message: string) => void;
+  identity?: SlackSendIdentity;
   send?: typeof sendMessageSlack;
   edit?: typeof editSlackMessage;
   remove?: typeof deleteSlackMessage;
@@ -69,6 +70,7 @@ export function createSlackDraftStream(params: {
         token: params.token,
         accountId: params.accountId,
         threadTs: params.resolveThreadTs?.(),
+        ...(params.identity ? { identity: params.identity } : {}),
       });
       streamChannelId = sent.channelId || streamChannelId;
       streamMessageId = sent.messageId || streamMessageId;

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -81,7 +81,12 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     ? {
         username: outboundIdentity.name,
         iconUrl: outboundIdentity.avatarUrl,
-        iconEmoji: outboundIdentity.emoji,
+        // Slack API expects icon_emoji in :name: format.
+        iconEmoji: outboundIdentity.emoji
+          ? outboundIdentity.emoji.startsWith(":") && outboundIdentity.emoji.endsWith(":")
+            ? outboundIdentity.emoji
+            : `:${outboundIdentity.emoji}:`
+          : undefined,
       }
     : undefined;
 
@@ -363,6 +368,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     token: ctx.botToken,
     accountId: account.accountId,
     maxChars: Math.min(ctx.textLimit, 4000),
+    ...(slackIdentity ? { identity: slackIdentity } : {}),
     resolveThreadTs: () => {
       const ts = replyPlan.nextThreadTs();
       if (ts) {


### PR DESCRIPTION
## Summary

- Problem: Agent identity (`agents.list[].identity`) is not applied to Slack messages when the default draft-stream preview path is active. The draft stream creates initial preview messages via `sendMessageSlack` without passing the resolved `SlackSendIdentity`, so both preview and finalized messages show the bot's default name/icon.
- Why it matters: Users configure custom agent names and emojis (e.g. `"name": "Stitch"`, `"emoji": "stitch-1"`) and add the `chat:write.customize` scope, but messages still show the default bot profile — a confusing UX gap documented in the Slack setup docs.
- What changed: `createSlackDraftStream` now accepts an optional `identity` parameter and forwards it to `sendMessageSlack` on initial send. `dispatchPreparedSlackMessage` passes the resolved `slackIdentity` to the draft stream. Bare emoji aliases are normalized to Slack's colon-wrapped format.
- What did NOT change (scope boundary): The native streaming path (`chat.startStream`/`chat.appendStream`), the `chat.update` finalization path, `sendSlackMessage` in `actions.ts`, and the `deliverReplies` path (already fixed in #27134) are unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #37763
- Related #27134 (prior fix that threaded identity through the reply delivery path but missed the draft stream)

## User-visible / Behavior Changes

When `agents.list[].identity.name` and/or `identity.emoji` are configured, Slack draft-stream preview messages now display the configured identity instead of the bot's default profile. This applies to the default streaming mode (`partial`) where messages are first sent as previews and then finalized via `chat.update`.

| Scenario | Before | After |
|----------|--------|-------|
| Default streaming (`partial`) | Preview + final show bot default name | Preview + final show configured identity |
| Streaming `off` | Final shows configured identity (already worked via #27134) | No change |
| Bare emoji alias (e.g. `stitch-1`) | Silently dropped by Slack API | Normalized to `:stitch-1:` and applied |

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: Slack (socket mode)
- Relevant config:
```json
{
  "agents": {
    "list": [{
      "id": "main",
      "identity": { "name": "Stitch", "emoji": "stitch-1" }
    }]
  }
}
```

### Steps

1. Configure agent identity with custom name and emoji
2. Add `chat:write.customize` scope to Slack bot token and reinstall
3. Send a message to the bot in Slack (default streaming mode)

### Expected

- Messages show "Stitch" as username with the custom emoji icon

### Actual (before fix)

- Messages show the bot's default name ("OpenClaw-Jass")

## Evidence

- [x] Failing test/log before + passing after
  - Added 2 new test cases in `draft-stream.test.ts` verifying identity passthrough
  - All 9 draft-stream tests pass, all 3 replies tests pass, all 5 dispatch streaming tests pass

## Human Verification (required)

- Verified scenarios: Draft stream identity passthrough with and without identity, emoji colon normalization for bare aliases and pre-wrapped values
- Edge cases checked: Undefined identity (no regression), already-wrapped emoji (`:emoji:` preserved), bare alias (`emoji` → `:emoji:`)
- What you did **not** verify: Native Slack streaming (`chat.startStream`) identity support (separate API, out of scope), live Slack workspace testing

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the 3-file commit; identity behavior falls back to pre-fix (bot default)
- Files/config to restore: `src/slack/draft-stream.ts`, `src/slack/monitor/message-handler/dispatch.ts`
- Known bad symptoms reviewers should watch for: Identity applied to wrong messages, `missing_scope` errors in logs (would indicate `chat:write.customize` scope fallback regression)

## Risks and Mitigations

- Risk: `chat:write.customize` scope fallback may trigger more frequently if identity is now passed on preview messages
  - Mitigation: The existing `isSlackCustomizeScopeError` catch-and-retry in `postSlackMessageBestEffort` already handles this gracefully — it logs a verbose warning and retries without identity