### PR TITLE
fix: return undefined for non-string apiKey (PR #37643)

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -437,8 +437,14 @@ function resolveSearchApiKey(search?: WebSearchConfig): string | undefined {
           path: "tools.web.search.apiKey",
         })
       : undefined;
-  const fromConfig = normalizeSecretInput(fromConfigRaw);
-  const fromEnv = normalizeSecretInput(process.env.BRAVE_API_KEY);
+  // Handle both string and SecretRef - dont normalize non-string values
+  const fromConfig =
+    fromConfigRaw !== undefined && typeof fromConfigRaw === "string"
+      ? normalizeSecretInput(fromConfigRaw)
+      : fromConfigRaw;
+  const fromEnvRaw = process.env.BRAVE_API_KEY;
+  const fromEnv =
+    fromEnvRaw !== undefined ? normalizeSecretInput(fromEnvRaw) : undefined;
   return fromConfig || fromEnv || undefined;
 }
 
@@ -565,12 +571,19 @@ function resolvePerplexityApiKey(perplexity?: PerplexityConfig): {
   apiKey?: string;
   source: PerplexityApiKeySource;
 } {
-  const fromConfig = normalizeApiKey(perplexity?.apiKey);
+  const apiKey = perplexity?.apiKey;
+  // Handle both string and SecretRef - dont normalize non-string values
+  const fromConfig =
+    apiKey !== undefined && typeof apiKey === "string"
+      ? normalizeSecretInput(apiKey)
+      : apiKey;
   if (fromConfig) {
     return { apiKey: fromConfig, source: "config" };
   }
 
-  const fromEnvPerplexity = normalizeApiKey(process.env.PERPLEXITY_API_KEY);
+  const fromEnvRaw = process.env.PERPLEXITY_API_KEY;
+  const fromEnvPerplexity =
+    fromEnvRaw !== undefined ? normalizeSecretInput(fromEnvRaw) : undefined;
   if (fromEnvPerplexity) {
     return { apiKey: fromEnvPerplexity, source: "perplexity_env" };
   }
@@ -578,9 +591,6 @@ function resolvePerplexityApiKey(perplexity?: PerplexityConfig): {
   return { apiKey: undefined, source: "none" };
 }
 
-function normalizeApiKey(key: unknown): string {
-  return normalizeSecretInput(key);
-}
 
 function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
   if (!search || typeof search !== "object") {
@@ -594,11 +604,18 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
 }
 
 function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
-  const fromConfig = normalizeApiKey(grok?.apiKey);
+  const apiKey = grok?.apiKey;
+  // Handle both string and SecretRef - dont normalize non-string values
+  const fromConfig =
+    apiKey !== undefined && typeof apiKey === "string"
+      ? normalizeSecretInput(apiKey)
+      : apiKey;
   if (fromConfig) {
     return fromConfig;
   }
-  const fromEnv = normalizeApiKey(process.env.XAI_API_KEY);
+  const fromEnvRaw = process.env.XAI_API_KEY;
+  const fromEnv =
+    fromEnvRaw !== undefined ? normalizeSecretInput(fromEnvRaw) : undefined;
   return fromEnv || undefined;
 }
 
@@ -660,11 +677,18 @@ function resolveGeminiConfig(search?: WebSearchConfig): GeminiConfig {
 }
 
 function resolveGeminiApiKey(gemini?: GeminiConfig): string | undefined {
-  const fromConfig = normalizeApiKey(gemini?.apiKey);
+  const apiKey = gemini?.apiKey;
+  // Handle both string and SecretRef - dont normalize non-string values
+  const fromConfig =
+    apiKey !== undefined && typeof apiKey === "string"
+      ? normalizeSecretInput(apiKey)
+      : apiKey;
   if (fromConfig) {
     return fromConfig;
   }
-  const fromEnv = normalizeApiKey(process.env.GEMINI_API_KEY);
+  const fromEnvRaw = process.env.GEMINI_API_KEY;
+  const fromEnv =
+    fromEnvRaw !== undefined ? normalizeSecretInput(fromEnvRaw) : undefined;
   return fromEnv || undefined;
 }
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -641,15 +641,24 @@ function resolveKimiConfig(search?: WebSearchConfig): KimiConfig {
 }
 
 function resolveKimiApiKey(kimi?: KimiConfig): string | undefined {
-  const fromConfig = normalizeApiKey(kimi?.apiKey);
+  const apiKey = kimi?.apiKey;
+  // Handle both string and SecretRef - dont normalize non-string values
+  const fromConfig =
+    apiKey !== undefined && typeof apiKey === "string"
+      ? normalizeSecretInput(apiKey)
+      : apiKey;
   if (fromConfig) {
     return fromConfig;
   }
-  const fromEnvKimi = normalizeApiKey(process.env.KIMI_API_KEY);
+  const fromEnvKimiRaw = process.env.KIMI_API_KEY;
+  const fromEnvKimi =
+    fromEnvKimiRaw !== undefined ? normalizeSecretInput(fromEnvKimiRaw) : undefined;
   if (fromEnvKimi) {
     return fromEnvKimi;
   }
-  const fromEnvMoonshot = normalizeApiKey(process.env.MOONSHOT_API_KEY);
+  const fromEnvMoonshotRaw = process.env.MOONSHOT_API_KEY;
+  const fromEnvMoonshot =
+    fromEnvMoonshotRaw !== undefined ? normalizeSecretInput(fromEnvMoonshotRaw) : undefined;
   return fromEnvMoonshot || undefined;
 }
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -437,11 +437,11 @@ function resolveSearchApiKey(search?: WebSearchConfig): string | undefined {
           path: "tools.web.search.apiKey",
         })
       : undefined;
-  // Handle both string and SecretRef - dont normalize non-string values
+  // Only return string values - SecretRef objects should return undefined
   const fromConfig =
     fromConfigRaw !== undefined && typeof fromConfigRaw === "string"
       ? normalizeSecretInput(fromConfigRaw)
-      : fromConfigRaw;
+      : undefined;
   const fromEnvRaw = process.env.BRAVE_API_KEY;
   const fromEnv =
     fromEnvRaw !== undefined ? normalizeSecretInput(fromEnvRaw) : undefined;
@@ -572,11 +572,11 @@ function resolvePerplexityApiKey(perplexity?: PerplexityConfig): {
   source: PerplexityApiKeySource;
 } {
   const apiKey = perplexity?.apiKey;
-  // Handle both string and SecretRef - dont normalize non-string values
+  // Only return string values - SecretRef objects should return undefined
   const fromConfig =
     apiKey !== undefined && typeof apiKey === "string"
       ? normalizeSecretInput(apiKey)
-      : apiKey;
+      : undefined;
   if (fromConfig) {
     return { apiKey: fromConfig, source: "config" };
   }
@@ -605,11 +605,11 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
 
 function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
   const apiKey = grok?.apiKey;
-  // Handle both string and SecretRef - dont normalize non-string values
+  // Only return string values - SecretRef objects should return undefined
   const fromConfig =
     apiKey !== undefined && typeof apiKey === "string"
       ? normalizeSecretInput(apiKey)
-      : apiKey;
+      : undefined;
   if (fromConfig) {
     return fromConfig;
   }
@@ -642,11 +642,11 @@ function resolveKimiConfig(search?: WebSearchConfig): KimiConfig {
 
 function resolveKimiApiKey(kimi?: KimiConfig): string | undefined {
   const apiKey = kimi?.apiKey;
-  // Handle both string and SecretRef - dont normalize non-string values
+  // Only return string values - SecretRef objects should return undefined
   const fromConfig =
     apiKey !== undefined && typeof apiKey === "string"
       ? normalizeSecretInput(apiKey)
-      : apiKey;
+      : undefined;
   if (fromConfig) {
     return fromConfig;
   }
@@ -687,11 +687,11 @@ function resolveGeminiConfig(search?: WebSearchConfig): GeminiConfig {
 
 function resolveGeminiApiKey(gemini?: GeminiConfig): string | undefined {
   const apiKey = gemini?.apiKey;
-  // Handle both string and SecretRef - dont normalize non-string values
+  // Only return string values - SecretRef objects should return undefined
   const fromConfig =
     apiKey !== undefined && typeof apiKey === "string"
       ? normalizeSecretInput(apiKey)
-      : apiKey;
+      : undefined;
   if (fromConfig) {
     return fromConfig;
   }


### PR DESCRIPTION
Updates PR #37643 based on review feedback.

Change: Return undefined for non-string apiKey values (including SecretRef objects) to prevent downstream using "[object Object]" string.