### PR TITLE
fix(canvas): catch URIError from malformed percent-encoded paths

### DIFF
--- a/src/canvas-host/file-resolver.ts
+++ b/src/canvas-host/file-resolver.ts
@@ -3,7 +3,13 @@ import path from "node:path";
 import { SafeOpenError, openFileWithinRoot, type SafeOpenResult } from "../infra/fs-safe.js";
 
 export function normalizeUrlPath(rawPath: string): string {
-  const decoded = decodeURIComponent(rawPath || "/");
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(rawPath || "/");
+  } catch {
+    // Malformed percent-encoding (e.g. %ZZ) – treat as literal path
+    decoded = rawPath || "/";
+  }
   const normalized = path.posix.normalize(decoded);
   return normalized.startsWith("/") ? normalized : `/${normalized}`;
 }


### PR DESCRIPTION
## Problem
`decodeURIComponent` in `normalizeUrlPath` throws `URIError` on malformed percent-encoded sequences (e.g. `%ZZ`, `%G1`). This crashes the canvas file-resolver request handler with an unhandled exception.

## Fix
Wrap in try-catch; fall back to the raw path on failure. Same pattern used elsewhere in the codebase (e.g. browser dispatcher).

## Impact
Prevents canvas host from crashing on crafted/corrupted URL paths. One-line semantic change, zero risk.