### PR TITLE
feat(msteams): add Teams reaction support

### DIFF
--- a/extensions/msteams/src/monitor-handler.file-consent.test.ts
+++ b/extensions/msteams/src/monitor-handler.file-consent.test.ts
@@ -82,6 +82,8 @@ function createActivityHandler(): MSTeamsActivityHandler {
   handler = {
     onMessage: () => handler,
     onMembersAdded: () => handler,
+    onReactionsAdded: () => handler,
+    onReactionsRemoved: () => handler,
     run: async () => {},
   };
   return handler;

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig, RuntimeEnv } from "openclaw/plugin-sdk";
+import type { OpenClawConfig, RuntimeEnv } from "openclaw/plugin-sdk/msteams";
 import type { MSTeamsConversationStore } from "./conversation-store.js";
 import { buildFileInfoCard, parseFileConsentInvoke, uploadToConsentUrl } from "./file-consent.js";
 import { normalizeMSTeamsConversationId } from "./inbound.js";

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -1,9 +1,10 @@
-import type { OpenClawConfig, RuntimeEnv } from "openclaw/plugin-sdk/msteams";
+import type { OpenClawConfig, RuntimeEnv } from "openclaw/plugin-sdk";
 import type { MSTeamsConversationStore } from "./conversation-store.js";
 import { buildFileInfoCard, parseFileConsentInvoke, uploadToConsentUrl } from "./file-consent.js";
 import { normalizeMSTeamsConversationId } from "./inbound.js";
 import type { MSTeamsAdapter } from "./messenger.js";
 import { createMSTeamsMessageHandler } from "./monitor-handler/message-handler.js";
+import { createMSTeamsReactionHandler } from "./monitor-handler/reaction-handler.js";
 import type { MSTeamsMonitorLogger } from "./monitor-types.js";
 import { getPendingUpload, removePendingUpload } from "./pending-uploads.js";
 import type { MSTeamsPollStore } from "./polls.js";
@@ -19,6 +20,12 @@ export type MSTeamsActivityHandler = {
     handler: (context: unknown, next: () => Promise<void>) => Promise<void>,
   ) => MSTeamsActivityHandler;
   onMembersAdded: (
+    handler: (context: unknown, next: () => Promise<void>) => Promise<void>,
+  ) => MSTeamsActivityHandler;
+  onReactionsAdded: (
+    handler: (context: unknown, next: () => Promise<void>) => Promise<void>,
+  ) => MSTeamsActivityHandler;
+  onReactionsRemoved: (
     handler: (context: unknown, next: () => Promise<void>) => Promise<void>,
   ) => MSTeamsActivityHandler;
   run?: (context: unknown) => Promise<void>;
@@ -182,6 +189,26 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
         deps.log.debug?.("member added", { member: member.id });
         // Don't send welcome message - let the user initiate conversation.
       }
+    }
+    await next();
+  });
+
+  const handleReaction = createMSTeamsReactionHandler(deps);
+
+  handler.onReactionsAdded(async (context, next) => {
+    try {
+      await handleReaction(context as MSTeamsTurnContext, "added");
+    } catch (err) {
+      deps.runtime.error?.(`msteams reaction handler failed: ${String(err)}`);
+    }
+    await next();
+  });
+
+  handler.onReactionsRemoved(async (context, next) => {
+    try {
+      await handleReaction(context as MSTeamsTurnContext, "removed");
+    } catch (err) {
+      deps.runtime.error?.(`msteams reaction handler failed: ${String(err)}`);
     }
     await next();
   });

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -15,7 +15,7 @@ import {
   resolveEffectiveAllowFromLists,
   resolveDmGroupAccessWithLists,
   type HistoryEntry,
-} from "openclaw/plugin-sdk/msteams";
+} from "openclaw/plugin-sdk";
 import {
   buildMSTeamsAttachmentPlaceholder,
   buildMSTeamsMediaPayload,

--- a/extensions/msteams/src/monitor-handler/reaction-handler.ts
+++ b/extensions/msteams/src/monitor-handler/reaction-handler.ts
@@ -6,7 +6,7 @@ import {
   resolveDmGroupAccessWithLists,
   resolveDefaultGroupPolicy,
   isDangerousNameMatchingEnabled,
-} from "openclaw/plugin-sdk";
+} from "openclaw/plugin-sdk/msteams";
 import { normalizeMSTeamsConversationId } from "../inbound.js";
 import type { MSTeamsMessageHandlerDeps } from "../monitor-handler.js";
 import { resolveMSTeamsAllowlistMatch, resolveMSTeamsRouteConfig } from "../policy.js";

--- a/extensions/msteams/src/monitor-handler/reaction-handler.ts
+++ b/extensions/msteams/src/monitor-handler/reaction-handler.ts
@@ -1,0 +1,157 @@
+import {
+  DEFAULT_ACCOUNT_ID,
+  createScopedPairingAccess,
+  readStoreAllowFromForDmPolicy,
+  resolveEffectiveAllowFromLists,
+  resolveDmGroupAccessWithLists,
+  isDangerousNameMatchingEnabled,
+} from "openclaw/plugin-sdk";
+import { normalizeMSTeamsConversationId } from "../inbound.js";
+import type { MSTeamsMessageHandlerDeps } from "../monitor-handler.js";
+import { resolveMSTeamsAllowlistMatch } from "../policy.js";
+import { getMSTeamsRuntime } from "../runtime.js";
+import type { MSTeamsTurnContext } from "../sdk-types.js";
+
+/**
+ * Emoji mapping for Teams reaction type names.
+ */
+const REACTION_EMOJI: Record<string, string> = {
+  like: "👍",
+  heart: "❤️",
+  laugh: "😆",
+  surprised: "😮",
+  sad: "😢",
+  angry: "😡",
+};
+
+function reactionEmoji(type: string): string {
+  return REACTION_EMOJI[type] ?? type;
+}
+
+export function createMSTeamsReactionHandler(deps: MSTeamsMessageHandlerDeps) {
+  const { cfg, log } = deps;
+  const core = getMSTeamsRuntime();
+  const pairing = createScopedPairingAccess({
+    core,
+    channel: "msteams",
+    accountId: DEFAULT_ACCOUNT_ID,
+  });
+  const msteamsCfg = cfg.channels?.msteams;
+
+  return async function handleTeamsReaction(
+    context: MSTeamsTurnContext,
+    direction: "added" | "removed",
+  ) {
+    const activity = context.activity;
+    const from = activity.from;
+    if (!from?.id) {
+      log.debug?.("skipping reaction without from.id");
+      return;
+    }
+
+    const reactions =
+      direction === "added"
+        ? (activity as unknown as { reactionsAdded?: Array<{ type: string }> }).reactionsAdded
+        : (activity as unknown as { reactionsRemoved?: Array<{ type: string }> }).reactionsRemoved;
+
+    if (!reactions || reactions.length === 0) {
+      log.debug?.("skipping reaction event with no reactions");
+      return;
+    }
+
+    const conversation = activity.conversation;
+    const rawConversationId = conversation?.id ?? "";
+    const conversationId = normalizeMSTeamsConversationId(rawConversationId);
+    const conversationType = conversation?.conversationType ?? "personal";
+    const isGroupChat = conversationType === "groupChat" || conversation?.isGroup === true;
+    const isChannel = conversationType === "channel";
+    const isDirectMessage = !isGroupChat && !isChannel;
+
+    const senderName = from.name ?? from.id;
+    const senderId = from.aadObjectId ?? from.id;
+    const replyToId = activity.replyToId ?? undefined;
+
+    // Authorization — reuse the same allowlist logic as message-handler
+    const dmPolicy = msteamsCfg?.dmPolicy ?? "pairing";
+    const storedAllowFrom = await readStoreAllowFromForDmPolicy({
+      provider: "msteams",
+      accountId: pairing.accountId,
+      dmPolicy,
+      readStore: pairing.readStoreForDmPolicy,
+    });
+
+    const dmAllowFrom = msteamsCfg?.allowFrom ?? [];
+    const configuredDmAllowFrom = dmAllowFrom.map((v) => String(v));
+    const groupAllowFrom = msteamsCfg?.groupAllowFrom;
+    const resolvedAllowFromLists = resolveEffectiveAllowFromLists({
+      allowFrom: configuredDmAllowFrom,
+      groupAllowFrom,
+      storeAllowFrom: storedAllowFrom,
+      dmPolicy,
+    });
+    const effectiveGroupAllowFrom = resolvedAllowFromLists.effectiveGroupAllowFrom;
+    const senderGroupPolicy =
+      effectiveGroupAllowFrom.length > 0 ? "allowlist" : ("open" as const);
+    const access = resolveDmGroupAccessWithLists({
+      isGroup: !isDirectMessage,
+      dmPolicy,
+      groupPolicy: isDirectMessage ? dmPolicy : senderGroupPolicy,
+      allowFrom: configuredDmAllowFrom,
+      groupAllowFrom,
+      storeAllowFrom: storedAllowFrom,
+      groupAllowFromFallbackToAllowFrom: false,
+      isSenderAllowed: (allowFrom) =>
+        resolveMSTeamsAllowlistMatch({
+          allowFrom,
+          senderId,
+          senderName,
+          allowNameMatching: isDangerousNameMatchingEnabled(msteamsCfg),
+        }).allowed,
+    });
+
+    if (access.decision !== "allow") {
+      log.debug?.("reaction from unauthorized sender, ignoring", {
+        senderId,
+        senderName,
+        decision: access.decision,
+        reason: access.reason,
+      });
+      return;
+    }
+
+    // Resolve agent route
+    const route = core.channel.routing.resolveAgentRoute({
+      cfg,
+      channel: "msteams",
+      peer: {
+        kind: isDirectMessage ? "direct" : isChannel ? "channel" : "group",
+        id: isDirectMessage ? senderId : conversationId,
+      },
+    });
+
+    // Build the reaction summary
+    const reactionTypes = reactions.map((r) => reactionEmoji(r.type)).join(", ");
+    const directionLabel = direction === "added" ? "reacted" : "removed reaction";
+    const targetLabel = replyToId ? ` on message ${replyToId}` : "";
+    const chatLabel = isDirectMessage
+      ? `Teams DM`
+      : `Teams ${conversationType}`;
+
+    const summary = `${chatLabel}: ${senderName} ${directionLabel} ${reactionTypes}${targetLabel}`;
+
+    log.info("reaction event", {
+      direction,
+      reactions: reactions.map((r) => r.type),
+      senderId,
+      senderName,
+      replyToId,
+      conversationId,
+    });
+
+    // Fire system event — agent sees this in context without triggering an LLM call
+    core.system.enqueueSystemEvent(summary, {
+      sessionKey: route.sessionKey,
+      contextKey: `msteams:reaction:${conversationId}:${direction}:${activity.id ?? Date.now()}`,
+    });
+  };
+}

--- a/extensions/msteams/src/monitor-handler/reaction-handler.ts
+++ b/extensions/msteams/src/monitor-handler/reaction-handler.ts
@@ -4,11 +4,12 @@ import {
   readStoreAllowFromForDmPolicy,
   resolveEffectiveAllowFromLists,
   resolveDmGroupAccessWithLists,
+  resolveDefaultGroupPolicy,
   isDangerousNameMatchingEnabled,
 } from "openclaw/plugin-sdk";
 import { normalizeMSTeamsConversationId } from "../inbound.js";
 import type { MSTeamsMessageHandlerDeps } from "../monitor-handler.js";
-import { resolveMSTeamsAllowlistMatch } from "../policy.js";
+import { resolveMSTeamsAllowlistMatch, resolveMSTeamsRouteConfig } from "../policy.js";
 import { getMSTeamsRuntime } from "../runtime.js";
 import type { MSTeamsTurnContext } from "../sdk-types.js";
 
@@ -71,6 +72,10 @@ export function createMSTeamsReactionHandler(deps: MSTeamsMessageHandlerDeps) {
     const senderId = from.aadObjectId ?? from.id;
     const replyToId = activity.replyToId ?? undefined;
 
+    const teamId = activity.channelData?.team?.id;
+    const teamName = activity.channelData?.team?.name;
+    const channelName = activity.channelData?.channel?.name;
+
     // Authorization — reuse the same allowlist logic as message-handler
     const dmPolicy = msteamsCfg?.dmPolicy ?? "pairing";
     const storedAllowFrom = await readStoreAllowFromForDmPolicy({
@@ -89,13 +94,29 @@ export function createMSTeamsReactionHandler(deps: MSTeamsMessageHandlerDeps) {
       storeAllowFrom: storedAllowFrom,
       dmPolicy,
     });
+    const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
+    const groupPolicy =
+      !isDirectMessage && msteamsCfg
+        ? (msteamsCfg.groupPolicy ?? defaultGroupPolicy ?? "allowlist")
+        : "disabled";
     const effectiveGroupAllowFrom = resolvedAllowFromLists.effectiveGroupAllowFrom;
+    const channelGate = resolveMSTeamsRouteConfig({
+      cfg: msteamsCfg,
+      teamId,
+      teamName,
+      conversationId,
+      channelName,
+    });
     const senderGroupPolicy =
-      effectiveGroupAllowFrom.length > 0 ? "allowlist" : ("open" as const);
+      groupPolicy === "disabled"
+        ? "disabled"
+        : effectiveGroupAllowFrom.length > 0
+          ? "allowlist"
+          : "open";
     const access = resolveDmGroupAccessWithLists({
       isGroup: !isDirectMessage,
       dmPolicy,
-      groupPolicy: isDirectMessage ? dmPolicy : senderGroupPolicy,
+      groupPolicy: senderGroupPolicy,
       allowFrom: configuredDmAllowFrom,
       groupAllowFrom,
       storeAllowFrom: storedAllowFrom,
@@ -117,6 +138,42 @@ export function createMSTeamsReactionHandler(deps: MSTeamsMessageHandlerDeps) {
         reason: access.reason,
       });
       return;
+    }
+
+    // Group policy gating — mirror message-handler logic
+    if (!isDirectMessage && msteamsCfg) {
+      if (groupPolicy === "disabled") {
+        log.debug?.("dropping group reaction (groupPolicy: disabled)", {
+          conversationId,
+        });
+        return;
+      }
+
+      if (groupPolicy === "allowlist") {
+        if (channelGate.allowlistConfigured && !channelGate.allowed) {
+          log.debug?.("dropping group reaction (not in team/channel allowlist)", {
+            conversationId,
+            teamKey: channelGate.teamKey ?? "none",
+            channelKey: channelGate.channelKey ?? "none",
+            channelMatchKey: channelGate.channelMatchKey ?? "none",
+            channelMatchSource: channelGate.channelMatchSource ?? "none",
+          });
+          return;
+        }
+        if (effectiveGroupAllowFrom.length === 0 && !channelGate.allowlistConfigured) {
+          log.debug?.("dropping group reaction (groupPolicy: allowlist, no allowlist)", {
+            conversationId,
+          });
+          return;
+        }
+        if (effectiveGroupAllowFrom.length > 0 && access.decision !== "allow") {
+          log.debug?.("dropping group reaction (not in groupAllowFrom)", {
+            senderId,
+            senderName,
+          });
+          return;
+        }
+      }
     }
 
     // Resolve agent route

--- a/extensions/msteams/src/monitor-handler/reaction-handler.ts
+++ b/extensions/msteams/src/monitor-handler/reaction-handler.ts
@@ -190,9 +190,7 @@ export function createMSTeamsReactionHandler(deps: MSTeamsMessageHandlerDeps) {
     const reactionTypes = reactions.map((r) => reactionEmoji(r.type)).join(", ");
     const directionLabel = direction === "added" ? "reacted" : "removed reaction";
     const targetLabel = replyToId ? ` on message ${replyToId}` : "";
-    const chatLabel = isDirectMessage
-      ? `Teams DM`
-      : `Teams ${conversationType}`;
+    const chatLabel = isDirectMessage ? `Teams DM` : `Teams ${conversationType}`;
 
     const summary = `${chatLabel}: ${senderName} ${directionLabel} ${reactionTypes}${targetLabel}`;
 


### PR DESCRIPTION
## Summary
Add handler for Bot Framework reaction events (`reactionsAdded`/`reactionsRemoved`) in the MSTeams extension.

## What it does
When a user reacts to a message in Teams (thumbs up, heart, etc.), the extension now:
- Extracts reaction type from `activity.reactionsAdded`/`activity.reactionsRemoved`
- Resolves sender identity and runs allowlist authorization
- Routes to the correct agent via `resolveAgentRoute()`
- Fires a system event with emoji-mapped summary (e.g. *Teams DM: Bradley reacted :thumbsup: on message 1772788362699*)

## Reaction mapping
| Teams type | Emoji |
|---|---|
| like | :thumbsup: |
| heart | :heart: |
| laugh | :laughing: |
| surprised | :open_mouth: |
| sad | :cry: |
| angry | :rage: |

## Files changed
- `extensions/msteams/src/monitor-handler.ts` — Extended `MSTeamsActivityHandler` type with `onReactionsAdded`/`onReactionsRemoved`, registered handlers
- `extensions/msteams/src/monitor-handler/reaction-handler.ts` — New file implementing reaction event handling with auth, routing, and dispatch