### PR TITLE
fix(synology-chat): load runtime config for outbound recovery sends

### DIFF
--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -45,8 +45,14 @@ vi.mock("zod", () => ({
 
 const { createSynologyChatPlugin } = await import("./channel.js");
 const { registerPluginHttpRoute } = await import("openclaw/plugin-sdk/synology-chat");
+const { sendMessage, sendFileUrl } = await import("./client.js");
+const { getSynologyRuntime } = await import("./runtime.js");
 
 describe("createSynologyChatPlugin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("returns a plugin object with all required sections", () => {
     const plugin = createSynologyChatPlugin();
     expect(plugin.id).toBe("synology-chat");
@@ -313,6 +319,70 @@ describe("createSynologyChatPlugin", () => {
           to: "user1",
         }),
       ).rejects.toThrow("not configured");
+    });
+
+    it("sendText loads runtime config when cfg is missing", async () => {
+      const loadConfig = vi.fn().mockResolvedValue({
+        channels: {
+          "synology-chat": {
+            enabled: true,
+            token: "t",
+            incomingUrl: "https://nas/incoming",
+            allowInsecureSsl: false,
+          },
+        },
+      });
+      vi.mocked(getSynologyRuntime).mockReturnValue({
+        config: { loadConfig },
+        channel: {
+          reply: {
+            dispatchReplyWithBufferedBlockDispatcher: vi.fn().mockResolvedValue({ counts: {} }),
+          },
+        },
+      } as any);
+
+      const plugin = createSynologyChatPlugin();
+      await plugin.outbound.sendText({ text: "hello", to: "user1" });
+
+      expect(loadConfig).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(sendMessage)).toHaveBeenCalledWith(
+        "https://nas/incoming",
+        "hello",
+        "user1",
+        false,
+      );
+    });
+
+    it("sendMedia loads runtime config when cfg is missing", async () => {
+      const loadConfig = vi.fn().mockResolvedValue({
+        channels: {
+          "synology-chat": {
+            enabled: true,
+            token: "t",
+            incomingUrl: "https://nas/incoming",
+            allowInsecureSsl: true,
+          },
+        },
+      });
+      vi.mocked(getSynologyRuntime).mockReturnValue({
+        config: { loadConfig },
+        channel: {
+          reply: {
+            dispatchReplyWithBufferedBlockDispatcher: vi.fn().mockResolvedValue({ counts: {} }),
+          },
+        },
+      } as any);
+
+      const plugin = createSynologyChatPlugin();
+      await plugin.outbound.sendMedia({ mediaUrl: "https://example.com/img.png", to: "user1" });
+
+      expect(loadConfig).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(sendFileUrl)).toHaveBeenCalledWith(
+        "https://nas/incoming",
+        "https://example.com/img.png",
+        "user1",
+        true,
+      );
     });
   });
 

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -44,8 +44,7 @@ export function createSynologyChatPlugin() {
     cfg: any,
     accountId?: string,
   ): Promise<ResolvedSynologyChatAccount> => {
-    const rt = getSynologyRuntime();
-    const effectiveCfg = cfg ?? (await rt.config.loadConfig());
+    const effectiveCfg = cfg ?? (await getSynologyRuntime().config.loadConfig());
     return resolveAccount(effectiveCfg ?? {}, accountId);
   };
 

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -40,6 +40,15 @@ function waitUntilAbort(signal?: AbortSignal, onAbort?: () => void): Promise<voi
 }
 
 export function createSynologyChatPlugin() {
+  const resolveOutboundAccount = async (
+    cfg: any,
+    accountId?: string,
+  ): Promise<ResolvedSynologyChatAccount> => {
+    const rt = getSynologyRuntime();
+    const effectiveCfg = cfg ?? (await rt.config.loadConfig());
+    return resolveAccount(effectiveCfg ?? {}, accountId);
+  };
+
   return {
     id: CHANNEL_ID,
 
@@ -196,7 +205,7 @@ export function createSynologyChatPlugin() {
       textChunkLimit: 2000,
 
       sendText: async ({ to, text, accountId, cfg }: any) => {
-        const account: ResolvedSynologyChatAccount = resolveAccount(cfg ?? {}, accountId);
+        const account = await resolveOutboundAccount(cfg, accountId);
 
         if (!account.incomingUrl) {
           throw new Error("Synology Chat incoming URL not configured");
@@ -210,7 +219,7 @@ export function createSynologyChatPlugin() {
       },
 
       sendMedia: async ({ to, mediaUrl, accountId, cfg }: any) => {
-        const account: ResolvedSynologyChatAccount = resolveAccount(cfg ?? {}, accountId);
+        const account = await resolveOutboundAccount(cfg, accountId);
 
         if (!account.incomingUrl) {
           throw new Error("Synology Chat incoming URL not configured");


### PR DESCRIPTION
## Summary
- fix Synology Chat outbound fallback when `cfg` is missing (e.g. delivery recovery path)
- load current runtime config via `getSynologyRuntime().config.loadConfig()` before resolving account
- apply the same fallback logic to both `sendText` and `sendMedia`
- add regression tests proving runtime config fallback is used for both outbound methods

Closes #37852

## Validation
- `pnpm vitest run extensions/synology-chat/src/channel.test.ts extensions/synology-chat/src/accounts.test.ts` ✅
  - `extensions/synology-chat/src/channel.test.ts`: 26 passed
  - `extensions/synology-chat/src/accounts.test.ts`: 11 passed
  - Total: 37 passed, 0 failed