### PR TITLE
fix(tui): guard runTui against non-TTY environments (#32900)

### DIFF
--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { getSlashCommands, parseCommand } from "./commands.js";
 import {
+  assertTty,
   createBackspaceDeduper,
   isIgnorableTuiStopError,
   resolveCtrlCAction,
@@ -214,5 +215,58 @@ describe("TUI shutdown safety", () => {
         throw new Error("boom");
       });
     }).toThrow("boom");
+  });
+});
+
+describe("assertTty", () => {
+  it("is exported as a function", () => {
+    expect(typeof assertTty).toBe("function");
+  });
+
+  it("calls process.exit(1) and writes to stderr when stdout is not a TTY", () => {
+    const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {}) as () => never);
+    const mockStderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const origStdoutTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+    const origStdinTTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+    Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+    try {
+      assertTty();
+      // assertions before restore so spy call history is intact
+      expect(mockExit).toHaveBeenCalledWith(1);
+      expect(mockStderr).toHaveBeenCalledWith(
+        expect.stringContaining("TUI requires an interactive terminal"),
+      );
+    } finally {
+      if (origStdoutTTY) {
+        Object.defineProperty(process.stdout, "isTTY", origStdoutTTY);
+      }
+      if (origStdinTTY) {
+        Object.defineProperty(process.stdin, "isTTY", origStdinTTY);
+      }
+      mockExit.mockRestore();
+      mockStderr.mockRestore();
+    }
+  });
+
+  it("does not call process.exit when both stdout and stdin are TTYs", () => {
+    const mockExit = vi.spyOn(process, "exit").mockImplementation((() => {}) as () => never);
+    const origStdoutTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+    const origStdinTTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    try {
+      assertTty();
+      // assertion before restore so spy call history is intact
+      expect(mockExit).not.toHaveBeenCalled();
+    } finally {
+      if (origStdoutTTY) {
+        Object.defineProperty(process.stdout, "isTTY", origStdoutTTY);
+      }
+      if (origStdinTTY) {
+        Object.defineProperty(process.stdin, "isTTY", origStdinTTY);
+      }
+      mockExit.mockRestore();
+    }
   });
 });

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -297,7 +297,18 @@ export function resolveCtrlCAction(params: {
   };
 }
 
+export function assertTty(): void {
+  if (!process.stdout.isTTY || !process.stdin.isTTY) {
+    process.stderr.write(
+      "TUI requires an interactive terminal; stdout/stdin must be a TTY.\n" +
+        "Tip: use `openclaw chat` or start the gateway with --deliver mode instead.\n",
+    );
+    process.exit(1);
+  }
+}
+
 export async function runTui(opts: TuiOptions) {
+  assertTty();
   const config = loadConfig();
   const initialSessionInput = (opts.session ?? "").trim();
   let sessionScope: SessionScope = (config.session?.scope ?? "per-sender") as SessionScope;


### PR DESCRIPTION
## Problem
When `openclaw tui` is invoked in an environment where stdout or stdin is not a real TTY (piped output, non-interactive shell, tmux with wrong `$TERM`, certain CI environments), the TUI starts but renders nothing. The terminal appears completely blank with no output and no error messages, while messages continue to be processed in gateway logs.

## Root cause
`src/tui/tui.ts` — `runTui()` calls `new TUI(new ProcessTerminal())` and `tui.start()` unconditionally. `ProcessTerminal` calls `process.stdout.setRawMode()` which silently fails when stdout is not a true TTY, leaving the TUI event loop running but producing no visible output.

## Fix
Added exported `assertTty()` function that checks `process.stdout.isTTY && process.stdin.isTTY`. If either is falsy, writes a clear error to stderr and exits with code 1 with a helpful tip. Called as the first statement in `runTui()`.

## Verification
- **Test:** `src/tui/tui.test.ts` — 3 new `assertTty` tests fail on unpatched main, pass on fix
- **Build:** clean compile (`build-output.log`)
- **Test suite:** no new regressions (`test-output.log`)
- **Code proof:** `assertTty` exported + called at start of `runTui` (`step6-verify.log`)

Closes #32900