### PR TITLE
fix: preserve text after malformed think tags

### DIFF
--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -435,7 +435,7 @@ File contents here`,
       {
         name: "unclosed think tag",
         text: "<think>Pensando sobre el problema...",
-        expected: "",
+        expected: "Pensando sobre el problema...",
       },
       {
         name: "thinking tag",

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -188,12 +188,19 @@ describe("stripReasoningTagsFromText", () => {
     it("applies strict and preserve modes to unclosed tags", () => {
       const input = "Before <think>unclosed content after";
       const cases = [
-        { mode: "strict" as const, expected: "Before" },
+        { mode: "strict" as const, expected: "Before unclosed content after" },
         { mode: "preserve" as const, expected: "Before unclosed content after" },
       ];
       for (const { mode, expected } of cases) {
         expect(stripReasoningTagsFromText(input, { mode })).toBe(expected);
       }
+    });
+
+    it("keeps visible tail text when a malformed thinking block never closes", () => {
+      const input = "<think>drafting... Final answer goes here";
+      expect(stripReasoningTagsFromText(input, { mode: "strict" })).toBe(
+        "drafting... Final answer goes here",
+      );
     });
   });
 

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -30,7 +30,6 @@ export function stripReasoningTagsFromText(
     return text;
   }
 
-  const mode = options?.mode ?? "strict";
   const trimMode = options?.trim ?? "both";
 
   let cleaned = text;
@@ -84,9 +83,9 @@ export function stripReasoningTagsFromText(
     lastIndex = idx + match[0].length;
   }
 
-  if (!inThinking || mode === "preserve") {
-    result += cleaned.slice(lastIndex);
-  }
+  // Preserve trailing text after malformed/unclosed tags so shared delivery
+  // paths do not silently drop otherwise visible assistant output.
+  result += cleaned.slice(lastIndex);
 
   return applyTrim(result, trimMode);
 }


### PR DESCRIPTION
## Summary
- preserve trailing assistant text when a `<think>` block is malformed and never closes
- update shared reasoning-tag tests to cover malformed tags in strict mode
- align `extractAssistantText` expectations with the shared sanitizer behavior

## Testing
- pnpm exec vitest run --config vitest.unit.config.ts src/shared/text/reasoning-tags.test.ts
- pnpm exec vitest run src/agents/pi-embedded-utils.test.ts
- pnpm exec oxfmt --check src/shared/text/reasoning-tags.ts src/shared/text/reasoning-tags.test.ts src/agents/pi-embedded-utils.test.ts

Closes #37696