### PR TITLE
fix(extensions/tlon): add type check before string operations on hostname

### DIFF
--- a/extensions/tlon/src/urbit/base-url.ts
+++ b/extensions/tlon/src/urbit/base-url.ts
@@ -48,14 +48,14 @@ export function validateUrbitBaseUrl(raw: string): UrbitBaseUrlValidation {
   return { ok: true, baseUrl: `${parsed.protocol}//${host}`, hostname };
 }
 
-    export function isBlockedUrbitHostname(hostname: string): boolean {
-      if (typeof hostname !== 'string') {
-        return false;
-      }
+export function isBlockedUrbitHostname(hostname: string): boolean {
+  if (typeof hostname !== 'string') {
+    return false;
+  }
 
-      const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
-      if (!normalized) {
-        return false;
-      }
-      return isBlockedHostnameOrIp(normalized);
-    }
+  const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
+  if (!normalized) {
+    return false;
+  }
+  return isBlockedHostnameOrIp(normalized);
+}

--- a/extensions/tlon/src/urbit/base-url.ts
+++ b/extensions/tlon/src/urbit/base-url.ts
@@ -48,10 +48,14 @@ export function validateUrbitBaseUrl(raw: string): UrbitBaseUrlValidation {
   return { ok: true, baseUrl: `${parsed.protocol}//${host}`, hostname };
 }
 
-export function isBlockedUrbitHostname(hostname: string): boolean {
-  const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
-  if (!normalized) {
-    return false;
-  }
-  return isBlockedHostnameOrIp(normalized);
-}
+    export function isBlockedUrbitHostname(hostname: string): boolean {
+      if (typeof hostname !== 'string') {
+        return false;
+      }
+
+      const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
+      if (!normalized) {
+        return false;
+      }
+      return isBlockedHostnameOrIp(normalized);
+    }


### PR DESCRIPTION
## Problem
The `isBlockedUrbitHostname` function assumes the `hostname` parameter is a string and directly calls String.prototype methods (`.trim()`, `.toLowerCase()`, `.replace()`) on it without type validation. When external input contains non-string values (objects, arrays, etc.) for hostname properties, this causes a runtime crash.

## Root Cause
Code called prototype methods directly on object properties without verifying the type. The function signature accepts `string` but TypeScript doesn't enforce this at runtime for external input.

## Fix
Add explicit type check `typeof hostname !== 'string'` at the start of the function. If hostname is not a string, return `false` immediately instead of attempting string operations.

## Impact
- Prevents runtime crashes when processing malformed plugin specifications
- Ensures robust input validation for hostname checking
- Maintains backward compatibility (valid strings work as before)

---
**Pattern from PR #31997**