### PR TITLE
feat: add human-readable cron state fields to cli output

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -188,7 +188,66 @@ async function runCronRunAndCaptureExit(params: { ran: boolean; args?: string[] 
   };
 }
 
+async function getRuntimeLogSpy() {
+  const runtimeModule = await import("../runtime.js");
+  return runtimeModule.defaultRuntime.log as ReturnType<typeof vi.fn>;
+}
+
 describe("cron cli", () => {
+  it("adds human-readable state fields to cron edit output", async () => {
+    const runtimeLog = await getRuntimeLogSpy();
+    runtimeLog.mockClear();
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-03-06T06:00:00.000Z"));
+    try {
+      callGatewayFromCli.mockImplementation(
+        async (method: string, _opts: unknown, params?: unknown) => {
+          if (method === "cron.status") {
+            return { enabled: true };
+          }
+          if (method === "cron.update") {
+            return {
+              id: "job-1",
+              name: "Daily March date-selection reminder",
+              enabled: true,
+              createdAtMs: 1772162768988,
+              updatedAtMs: 1772794372339,
+              schedule: { kind: "every", everyMs: 86_400_000, anchorMs: 1772668800000 },
+              sessionTarget: "main",
+              wakeMode: "now",
+              payload: { kind: "systemEvent", text: "something something" },
+              state: {
+                nextRunAtMs: Date.parse("2026-03-06T19:00:00.000Z"),
+                lastRunAtMs: Date.parse("2026-03-05T19:00:00.000Z"),
+                lastRunStatus: "ok",
+              },
+              params,
+            };
+          }
+          return { ok: true, params };
+        },
+      );
+
+      const program = buildProgram();
+      await program.parseAsync(["cron", "edit", "job-1", "--name", "Updated"], { from: "user" });
+
+      const rendered = JSON.parse(String(runtimeLog.mock.calls.at(-1)?.[0] ?? "{}")) as {
+        state?: {
+          nextRunAtIso?: string;
+          nextRunIn?: string;
+          lastRunAtIso?: string;
+          lastRunAgo?: string;
+        };
+      };
+
+      expect(rendered.state?.nextRunAtIso).toBe("2026-03-06T19:00:00.000Z");
+      expect(rendered.state?.nextRunIn).toBe("in 13h");
+      expect(rendered.state?.lastRunAtIso).toBe("2026-03-05T19:00:00.000Z");
+      expect(rendered.state?.lastRunAgo).toBe("11h ago");
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   it.each([
     {
       name: "exits 0 for cron run when job executes successfully",

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -8,7 +8,7 @@ const defaultGatewayMock = async (
   _opts: unknown,
   params?: unknown,
   _timeoutMs?: number,
-) => {
+): Promise<unknown> => {
   if (method === "cron.status") {
     return { enabled: true };
   }
@@ -246,6 +246,48 @@ describe("cron cli", () => {
     } finally {
       nowSpy.mockRestore();
     }
+  });
+
+  it("omits human-readable cron state fields when timestamps are missing", async () => {
+    const runtimeLog = await getRuntimeLogSpy();
+    runtimeLog.mockClear();
+    callGatewayFromCli.mockImplementation(
+      async (method: string, _opts: unknown, params?: unknown) => {
+        if (method === "cron.status") {
+          return { enabled: true };
+        }
+        if (method === "cron.update") {
+          return {
+            id: "job-1",
+            name: "No timestamps yet",
+            enabled: true,
+            createdAtMs: 1772162768988,
+            updatedAtMs: 1772794372339,
+            schedule: { kind: "every", everyMs: 86_400_000, anchorMs: 1772668800000 },
+            sessionTarget: "main",
+            wakeMode: "now",
+            payload: { kind: "systemEvent", text: "something something" },
+            state: {
+              lastRunStatus: "ok",
+            },
+            params,
+          };
+        }
+        return { ok: true, params };
+      },
+    );
+
+    const program = buildProgram();
+    await program.parseAsync(["cron", "edit", "job-1", "--name", "Updated"], { from: "user" });
+
+    const rendered = JSON.parse(String(runtimeLog.mock.calls.at(-1)?.[0] ?? "{}")) as {
+      state?: Record<string, unknown>;
+    };
+
+    expect(rendered.state).not.toHaveProperty("nextRunAtIso");
+    expect(rendered.state).not.toHaveProperty("nextRunIn");
+    expect(rendered.state).not.toHaveProperty("lastRunAtIso");
+    expect(rendered.state).not.toHaveProperty("lastRunAgo");
   });
 
   it.each([

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -7,6 +7,7 @@ import type { GatewayRpcOpts } from "../gateway-rpc.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
 import { parsePositiveIntOrUndefined } from "../program/helpers.js";
 import {
+  formatCronJobForDisplay,
   getCronChannelOptions,
   parseAt,
   parseCronStaggerMs,
@@ -273,7 +274,7 @@ export function registerCronAddCommand(cron: Command) {
           };
 
           const res = await callGatewayFromCli("cron.add", opts, params);
-          defaultRuntime.log(JSON.stringify(res, null, 2));
+          defaultRuntime.log(JSON.stringify(formatCronJobForDisplay(res as CronJob), null, 2));
           await warnIfCronSchedulerDisabled(opts);
         } catch (err) {
           defaultRuntime.error(danger(String(err)));

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -5,6 +5,7 @@ import { sanitizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
 import {
+  formatCronJobForDisplay,
   getCronChannelOptions,
   parseAt,
   parseCronStaggerMs,
@@ -338,7 +339,7 @@ export function registerCronEditCommand(cron: Command) {
             id,
             patch,
           });
-          defaultRuntime.log(JSON.stringify(res, null, 2));
+          defaultRuntime.log(JSON.stringify(formatCronJobForDisplay(res as CronJob), null, 2));
           await warnIfCronSchedulerDisabled(opts);
         } catch (err) {
           defaultRuntime.error(danger(String(err)));

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -1,8 +1,9 @@
 import type { Command } from "commander";
+import type { CronJob } from "../../cron/types.js";
 import { danger } from "../../globals.js";
 import { defaultRuntime } from "../../runtime.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
-import { warnIfCronSchedulerDisabled } from "./shared.js";
+import { formatCronJobForDisplay, warnIfCronSchedulerDisabled } from "./shared.js";
 
 function registerCronToggleCommand(params: {
   cron: Command;
@@ -21,7 +22,7 @@ function registerCronToggleCommand(params: {
             id,
             patch: { enabled: params.enabled },
           });
-          defaultRuntime.log(JSON.stringify(res, null, 2));
+          defaultRuntime.log(JSON.stringify(formatCronJobForDisplay(res as CronJob), null, 2));
           await warnIfCronSchedulerDisabled(opts);
         } catch (err) {
           defaultRuntime.error(danger(String(err)));

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -149,6 +149,13 @@ const formatRelative = (ms: number | null | undefined, nowMs: number) => {
   return delta >= 0 ? `in ${label}` : `${label} ago`;
 };
 
+const formatRelativeForDisplay = (ms: number | null | undefined, nowMs: number) => {
+  if (!ms) {
+    return undefined;
+  }
+  return formatRelative(ms, nowMs);
+};
+
 const formatSchedule = (schedule: CronSchedule) => {
   if (schedule.kind === "at") {
     return `at ${formatIsoMinute(schedule.at)}`;
@@ -294,9 +301,9 @@ export function formatCronJobForDisplay(value: unknown, nowMs = Date.now()): unk
     state: {
       ...job.state,
       nextRunAtIso: formatJsonDateTime(job.state.nextRunAtMs),
-      nextRunIn: job.enabled ? formatRelative(job.state.nextRunAtMs, nowMs) : undefined,
+      nextRunIn: job.enabled ? formatRelativeForDisplay(job.state.nextRunAtMs, nowMs) : undefined,
       lastRunAtIso: formatJsonDateTime(job.state.lastRunAtMs),
-      lastRunAgo: formatRelative(job.state.lastRunAtMs, nowMs),
+      lastRunAgo: formatRelativeForDisplay(job.state.lastRunAtMs, nowMs),
     },
   };
 }

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -261,3 +261,42 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
     runtime.log(line.trimEnd());
   }
 }
+
+function formatJsonDateTime(ms: number | undefined): string | undefined {
+  if (typeof ms !== "number" || !Number.isFinite(ms)) {
+    return undefined;
+  }
+  return new Date(ms).toISOString();
+}
+
+function isCronJob(value: unknown): value is CronJob {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.id === "string" &&
+    typeof record.name === "string" &&
+    record.state !== null &&
+    typeof record.state === "object" &&
+    record.schedule !== null &&
+    typeof record.schedule === "object"
+  );
+}
+
+export function formatCronJobForDisplay(value: unknown, nowMs = Date.now()): unknown {
+  if (!isCronJob(value)) {
+    return value;
+  }
+  const job = value;
+  return {
+    ...job,
+    state: {
+      ...job.state,
+      nextRunAtIso: formatJsonDateTime(job.state.nextRunAtMs),
+      nextRunIn: job.enabled ? formatRelative(job.state.nextRunAtMs, nowMs) : undefined,
+      lastRunAtIso: formatJsonDateTime(job.state.lastRunAtMs),
+      lastRunAgo: formatRelative(job.state.lastRunAtMs, nowMs),
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add human-readable `nextRunAtIso`, `nextRunIn`, `lastRunAtIso`, and `lastRunAgo` fields to cron job JSON printed by the CLI
- apply the display formatting to `cron add`, `cron edit`, and enable/disable output without changing gateway RPC responses
- cover the new edit output in `cron-cli` tests

## Testing
- pnpm exec vitest run --config vitest.unit.config.ts src/cli/cron-cli.test.ts
- pnpm exec oxfmt --check src/cli/cron-cli/shared.ts src/cli/cron-cli/register.cron-add.ts src/cli/cron-cli/register.cron-edit.ts src/cli/cron-cli/register.cron-simple.ts src/cli/cron-cli.test.ts

Closes #37672