### PR TITLE
fix(session): tighten direct-session webchat routing matching

### DIFF
--- a/src/auto-reply/reply/session-delivery.test.ts
+++ b/src/auto-reply/reply/session-delivery.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { resolveLastChannelRaw, resolveLastToRaw } from "./session-delivery.js";
+
+describe("session delivery direct-session routing overrides", () => {
+  it.each([
+    "agent:main:direct:user-1",
+    "agent:main:telegram:direct:123456",
+    "agent:main:telegram:account-a:direct:123456",
+    "agent:main:telegram:dm:123456",
+    "agent:main:telegram:direct:123456:thread:99",
+    "agent:main:telegram:account-a:direct:123456:topic:ops",
+  ])("lets webchat override persisted routes for strict direct key %s", (sessionKey) => {
+    expect(
+      resolveLastChannelRaw({
+        originatingChannelRaw: "webchat",
+        persistedLastChannel: "telegram",
+        sessionKey,
+      }),
+    ).toBe("webchat");
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: "webchat",
+        originatingToRaw: "session:dashboard",
+        persistedLastChannel: "telegram",
+        persistedLastTo: "123456",
+        sessionKey,
+      }),
+    ).toBe("session:dashboard");
+  });
+
+  it.each([
+    "agent:main:main:direct",
+    "agent:main:cron:job-1:dm",
+    "agent:main:subagent:worker:direct:user-1",
+    "agent:main:telegram:channel:direct",
+    "agent:main:telegram:account-a:direct",
+    "agent:main:telegram:direct:123456:cron:job-1",
+  ])("keeps persisted external routes for malformed direct-like key %s", (sessionKey) => {
+    expect(
+      resolveLastChannelRaw({
+        originatingChannelRaw: "webchat",
+        persistedLastChannel: "telegram",
+        sessionKey,
+      }),
+    ).toBe("telegram");
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: "webchat",
+        originatingToRaw: "session:dashboard",
+        persistedLastChannel: "telegram",
+        persistedLastTo: "group:12345",
+        sessionKey,
+      }),
+    ).toBe("group:12345");
+  });
+});

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -1,6 +1,6 @@
 import type { SessionEntry } from "../../config/sessions.js";
 import { buildAgentMainSessionKey } from "../../routing/session-key.js";
-import { deriveSessionChatType, parseAgentSessionKey } from "../../sessions/session-key-utils.js";
+import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import {
   deliveryContextFromSession,
   deliveryContextKey,
@@ -38,8 +38,44 @@ function isMainSessionKey(sessionKey?: string): boolean {
   return parsed.rest.trim().toLowerCase() === "main";
 }
 
+const DIRECT_SESSION_MARKERS = new Set(["direct", "dm"]);
+const THREAD_SESSION_MARKERS = new Set(["thread", "topic"]);
+
+function hasStrictDirectSessionTail(parts: string[], markerIndex: number): boolean {
+  const peerId = parts[markerIndex + 1]?.trim();
+  if (!peerId) {
+    return false;
+  }
+  const tail = parts.slice(markerIndex + 2);
+  if (tail.length === 0) {
+    return true;
+  }
+  return tail.length === 2 && THREAD_SESSION_MARKERS.has(tail[0] ?? "") && Boolean(tail[1]?.trim());
+}
+
 function isDirectSessionKey(sessionKey?: string): boolean {
-  return deriveSessionChatType(sessionKey) === "direct";
+  const raw = (sessionKey ?? "").trim().toLowerCase();
+  if (!raw) {
+    return false;
+  }
+  const scoped = parseAgentSessionKey(raw)?.rest ?? raw;
+  const parts = scoped.split(":").filter(Boolean);
+  if (parts.length < 2) {
+    return false;
+  }
+  if (DIRECT_SESSION_MARKERS.has(parts[0] ?? "")) {
+    return hasStrictDirectSessionTail(parts, 0);
+  }
+  const channel = normalizeMessageChannel(parts[0]);
+  if (!channel || !isDeliverableMessageChannel(channel)) {
+    return false;
+  }
+  if (DIRECT_SESSION_MARKERS.has(parts[1] ?? "")) {
+    return hasStrictDirectSessionTail(parts, 1);
+  }
+  return Boolean(parts[1]?.trim()) && DIRECT_SESSION_MARKERS.has(parts[2] ?? "")
+    ? hasStrictDirectSessionTail(parts, 2)
+    : false;
 }
 
 function isExternalRoutingChannel(channel?: string): channel is string {


### PR DESCRIPTION
## Summary

- Problem: `session-delivery.ts` treated any session key containing `:direct:` or `:dm:` as eligible for WebChat route override, even when the key shape was malformed.
- Why it matters: malformed or non-chat session keys could poison persisted `lastChannel` / `lastTo` routing state during internal WebChat turns.
- What changed: the routing override now accepts only strict supported direct-session shapes, including legacy `:dm:` keys and direct thread/topic descendants.
- What did NOT change (scope boundary): `deriveSessionChatType()` remains best-effort for broader classification; this PR only hardens the routing-affecting override path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #37135

## User-visible / Behavior Changes

WebChat route overrides now apply only to canonical direct-session keys instead of any key that happens to contain a `direct` / `dm` token.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): WebChat / session routing
- Relevant config (redacted): default session store, `dmScope` coverage via tests

### Steps

1. Persist an external `lastChannel` / `lastTo` for a session.
2. Send a WebChat-originated turn with a malformed session key like `agent:main:cron:job-1:dm` or `agent:main:main:direct`.
3. Confirm the persisted external route is preserved.
4. Repeat with valid direct-session keys such as `agent:main:telegram:direct:123456` and confirm WebChat still overrides routing.

### Expected

- Valid direct-session keys continue to let WebChat own direct-session UI routing.
- Malformed direct-like keys do not override persisted external routing.

### Actual

- Verified by targeted unit coverage and existing session routing tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: strict direct keys, legacy `:dm:` keys, per-account direct keys, direct thread/topic keys, and malformed direct-like keys.
- Edge cases checked: `main`, `cron`, `subagent`, missing peer ids, and unsupported suffixes no longer qualify for WebChat override.
- What you did **not** verify: live Gateway/WebSocket repro against a running external deployment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/auto-reply/reply/session-delivery.ts`
- Known bad symptoms reviewers should watch for: valid direct-session WebChat turns unexpectedly preserving stale external routes.

## Risks and Mitigations

- Risk: strict matching could reject a valid direct-session variant that was previously accepted implicitly.
  - Mitigation: test coverage includes supported canonical, legacy, per-account, and thread/topic direct shapes.
