### PR TITLE
feat(cron): support "default" as special model value for runtime resolution

### DIFF
--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -234,6 +234,24 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
     );
   });
 
+  it("treats payload model 'default' as no-override, uses agent default model", async () => {
+    const jobWithDefaultModel = makeJob({
+      payload: { kind: "agentTurn", message: "run daily digest", model: "default" },
+    });
+
+    runWithModelFallbackMock.mockResolvedValueOnce(makeSuccessfulRunResult());
+
+    const result = await runCronIsolatedAgentTurn(makeParams({ job: jobWithDefaultModel }));
+
+    expect(result.status).toBe("ok");
+    // "default" should be treated as "use agent defaults" — the resolved
+    // default model (Opus) should be used, not "default" passed to
+    // resolveAllowedModelRef.
+    expect(resolveAllowedModelRefMock).not.toHaveBeenCalled();
+    expect(cronSession.sessionEntry.model).toBe("claude-opus-4-6");
+    expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
+  });
+
   it("persists default model pre-run when no payload override is present", async () => {
     // No cron payload model override
     const jobWithoutModel = makeJob({

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -219,7 +219,7 @@ export async function runCronIsolatedAgentTurn(params: {
   const modelOverrideRaw =
     params.job.payload.kind === "agentTurn" ? params.job.payload.model : undefined;
   const modelOverride = typeof modelOverrideRaw === "string" ? modelOverrideRaw.trim() : undefined;
-  if (modelOverride !== undefined && modelOverride.length > 0) {
+  if (modelOverride !== undefined && modelOverride.length > 0 && modelOverride !== "default") {
     const resolvedOverride = resolveAllowedModelRef({
       cfg: cfgWithAgentDefaults,
       catalog: await loadCatalog(),


### PR DESCRIPTION
## Summary

- **Problem:** Cron jobs with hardcoded `payload.model` break when tokens expire, providers change endpoints, or models are discontinued. Users must manually delete and recreate each job.
- **Why it matters:** Multi-environment deployments (dev/staging/prod) and model migrations require touching every cron job individually.
- **What changed:** Added `modelOverride !== "default"` guard in `src/cron/isolated-agent/run.ts` so that `payload.model: "default"` skips the override resolution and falls through to the agent's configured default model at runtime.
- **What did NOT change:** Schema types (`model?: string` already accepts any string), CLI display, UI forms, or existing behavior for specific model strings and empty/undefined values.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37843

## User-visible / Behavior Changes

- `payload.model: "default"` in cron job configuration now means "resolve model at runtime from agent defaults" instead of attempting to resolve the literal string `"default"` as a model ID
- Existing cron jobs with specific model strings (e.g., `anthropic/claude-sonnet-4-6`) continue to work identically

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js 22+
- Integration/channel: cron jobs

### Steps

1. Create a cron job with `--model default`
2. Run the cron job

### Expected

- Job uses the agent's configured default model

### Actual

- Before fix: `"default"` passed to `resolveAllowedModelRef`, likely fails or resolves incorrectly
- After fix: `"default"` treated as no-override, agent default model used

## Evidence

```
 ✓ src/cron/isolated-agent/run.cron-model-override.test.ts (7 tests) 7ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

New test verifies: `payload.model: "default"` skips `resolveAllowedModelRef` and uses agent default model (Opus).

## Human Verification (required)

- Verified scenarios: model="default", model=undefined, model="", model="anthropic/claude-sonnet-4-6", model not allowed
- Edge cases checked: whitespace around "default" (trimmed by existing `trim()` call)
- What I did **not** verify: CLI `--model default` flag parsing (only runtime resolution)

## Compatibility / Migration

- Backward compatible? `Yes` — `"default"` was not a valid model ID before, so no existing behavior changes
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit; users can omit `model` field instead
- Files/config to restore: `src/cron/isolated-agent/run.ts`
- Known bad symptoms: if someone has a model literally named "default" (extremely unlikely), it would no longer be used

## Risks and Mitigations

None — the string `"default"` is not a valid model ID in any known provider catalog

