### PR TITLE
model-usage: parse numeric-string costs and skip non-finite values

### DIFF
--- a/skills/model-usage/scripts/model_usage.py
+++ b/skills/model-usage/scripts/model_usage.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import subprocess
 import sys
@@ -108,6 +109,27 @@ def filter_by_days(entries: List[Dict[str, Any]], days: Optional[int]) -> List[D
     return filtered
 
 
+def parse_cost(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        parsed = float(value)
+    elif isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return None
+        try:
+            parsed = float(stripped)
+        except ValueError:
+            return None
+    else:
+        return None
+
+    if not math.isfinite(parsed):
+        return None
+    return parsed
+
+
 def aggregate_costs(entries: Iterable[Dict[str, Any]]) -> Dict[str, float]:
     totals: Dict[str, float] = {}
     for entry in entries:
@@ -120,12 +142,12 @@ def aggregate_costs(entries: Iterable[Dict[str, Any]]) -> Dict[str, float]:
             if not isinstance(item, dict):
                 continue
             model = item.get("modelName")
-            cost = item.get("cost")
+            cost = parse_cost(item.get("cost"))
             if not isinstance(model, str):
                 continue
-            if not isinstance(cost, (int, float)):
+            if cost is None:
                 continue
-            totals[model] = totals.get(model, 0.0) + float(cost)
+            totals[model] = totals.get(model, 0.0) + cost
     return totals
 
 
@@ -144,9 +166,9 @@ def pick_current_model(entries: List[Dict[str, Any]]) -> Tuple[Optional[str], Op
                 if not isinstance(item, dict):
                     continue
                 model = item.get("modelName")
-                cost = item.get("cost")
-                if isinstance(model, str) and isinstance(cost, (int, float)):
-                    scored.append(ModelCost(model=model, cost=float(cost)))
+                cost = parse_cost(item.get("cost"))
+                if isinstance(model, str) and cost is not None:
+                    scored.append(ModelCost(model=model, cost=cost))
             if scored:
                 scored.sort(key=lambda item: item.cost, reverse=True)
                 return scored[0].model, entry.get("date") if isinstance(entry.get("date"), str) else None
@@ -179,9 +201,9 @@ def latest_day_cost(entries: List[Dict[str, Any]], model: str) -> Tuple[Optional
             if not isinstance(item, dict):
                 continue
             if item.get("modelName") == model:
-                cost = item.get("cost") if isinstance(item.get("cost"), (int, float)) else None
+                cost = parse_cost(item.get("cost"))
                 day = entry.get("date") if isinstance(entry.get("date"), str) else None
-                return day, float(cost) if cost is not None else None
+                return day, cost
     return None, None
 
 

--- a/skills/model-usage/scripts/test_model_usage.py
+++ b/skills/model-usage/scripts/test_model_usage.py
@@ -7,7 +7,7 @@ import argparse
 from datetime import date, timedelta
 from unittest import TestCase, main
 
-from model_usage import filter_by_days, positive_int
+from model_usage import aggregate_costs, filter_by_days, latest_day_cost, positive_int
 
 
 class TestModelUsage(TestCase):
@@ -34,6 +34,34 @@ class TestModelUsage(TestCase):
         self.assertEqual(len(filtered), 2)
         self.assertEqual(filtered[0]["date"], (today - timedelta(days=1)).strftime("%Y-%m-%d"))
         self.assertEqual(filtered[1]["date"], today.strftime("%Y-%m-%d"))
+
+    def test_aggregate_costs_accepts_numeric_strings_and_skips_non_finite_values(self):
+        entries = [
+            {
+                "modelBreakdowns": [
+                    {"modelName": "gpt-5", "cost": "1.25"},
+                    {"modelName": "gpt-5", "cost": "nan"},
+                    {"modelName": "gpt-5", "cost": True},
+                    {"modelName": "gpt-5-mini", "cost": 0.75},
+                ]
+            }
+        ]
+
+        totals = aggregate_costs(entries)
+
+        self.assertEqual(totals["gpt-5"], 1.25)
+        self.assertEqual(totals["gpt-5-mini"], 0.75)
+
+    def test_latest_day_cost_parses_numeric_string(self):
+        entries = [
+            {"date": "2026-03-04", "modelBreakdowns": [{"modelName": "gpt-5", "cost": 0.5}]},
+            {"date": "2026-03-05", "modelBreakdowns": [{"modelName": "gpt-5", "cost": "1.75"}]},
+        ]
+
+        latest_date, latest_cost = latest_day_cost(entries, "gpt-5")
+
+        self.assertEqual(latest_date, "2026-03-05")
+        self.assertEqual(latest_cost, 1.75)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed
- Added a `parse_cost()` helper in `skills/model-usage/scripts/model_usage.py`.
- `aggregate_costs()`, `pick_current_model()`, and `latest_day_cost()` now use `parse_cost()` so they:
  - accept numeric string costs (for example `"1.75"`),
  - ignore boolean values,
  - ignore non-finite values (`NaN`, `Infinity`).
- Extended `skills/model-usage/scripts/test_model_usage.py` with coverage for:
  - numeric-string cost aggregation,
  - skipping non-finite/bool costs,
  - parsing numeric-string latest-day cost.

## Why
- Some cost payloads can contain numeric values serialized as strings.
- The previous logic only accepted `int`/`float`, so valid string costs were silently dropped.
- Filtering non-finite and boolean values makes output more robust and avoids propagating invalid totals.

## Testing
- ✅ `source .venv/bin/activate && pytest -q skills/model-usage/scripts/test_model_usage.py`
- ✅ `scripts/clone_and_test.sh openclaw/openclaw`
