### PR TITLE
fix(sandbox): redirect root-level lock files to tmpdir to avoid EROFS

### DIFF
--- a/src/plugin-sdk/file-lock.test.ts
+++ b/src/plugin-sdk/file-lock.test.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { acquireFileLock, type FileLockOptions } from "./file-lock.js";
+
+const LOCK_OPTIONS: FileLockOptions = {
+  retries: { retries: 0, factor: 1, minTimeout: 100, maxTimeout: 500 },
+  stale: 30_000,
+};
+
+describe("acquireFileLock", () => {
+  const cleanupPaths: string[] = [];
+
+  afterEach(async () => {
+    for (const p of cleanupPaths) {
+      await fs.rm(p, { force: true, recursive: true }).catch(() => undefined);
+    }
+    cleanupPaths.length = 0;
+  });
+
+  it("redirects root-level lock files to os.tmpdir()", async () => {
+    const fallbackDir = path.join(os.tmpdir(), "openclaw-locks");
+    cleanupPaths.push(fallbackDir);
+
+    const originalCwd = process.cwd();
+    try {
+      process.chdir("/");
+      const lock = await acquireFileLock("file", LOCK_OPTIONS);
+      expect(lock.lockPath).toBe(path.join(fallbackDir, "file.lock"));
+      await lock.release();
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it("creates lock in normal directory when not at root", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-test-"));
+    cleanupPaths.push(tmpDir);
+
+    const filePath = path.join(tmpDir, "state");
+    const lock = await acquireFileLock(filePath, LOCK_OPTIONS);
+    expect(lock.lockPath).toContain("state.lock");
+    expect(lock.lockPath).not.toContain("openclaw-locks");
+    await lock.release();
+  });
+});

--- a/src/plugin-sdk/file-lock.ts
+++ b/src/plugin-sdk/file-lock.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { isPidAlive } from "../shared/pid-alive.js";
 import { resolveProcessScopedMap } from "../shared/process-scoped-map.js";
@@ -53,6 +54,13 @@ async function readLockPayload(lockPath: string): Promise<LockFilePayload | null
 async function resolveNormalizedFilePath(filePath: string): Promise<string> {
   const resolved = path.resolve(filePath);
   const dir = path.dirname(resolved);
+
+  if (dir === "/" || dir === path.sep) {
+    const fallbackDir = path.join(os.tmpdir(), "openclaw-locks");
+    await fs.mkdir(fallbackDir, { recursive: true });
+    return path.join(fallbackDir, path.basename(resolved));
+  }
+
   await fs.mkdir(dir, { recursive: true });
   try {
     const realDir = await fs.realpath(dir);


### PR DESCRIPTION
## Summary

- **Problem:** Cron jobs using `sessionTarget: isolated` fail immediately (~148ms) with `EROFS: read-only file system, open '/file.lock'` before any user script executes.
- **Why it matters:** All isolated cron sessions on systems with read-only root filesystems (Docker `--read-only`) are permanently broken. No user-side config or script change can fix it.
- **What changed:** In `resolveNormalizedFilePath` (src/plugin-sdk/file-lock.ts), detect when the resolved parent directory is the filesystem root (`/`) and redirect the lock file to `os.tmpdir()/openclaw-locks/` instead.
- **What did NOT change:** Lock semantics, retry logic, stale lock handling, or any other lock paths. Only root-level paths are redirected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37846

## User-visible / Behavior Changes

- Isolated cron sessions no longer crash with EROFS on read-only root filesystems

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.2.0 arm64) / any Docker host
- Runtime: Node.js 22+
- Integration/channel: cron isolated sessions with Docker sandbox

### Steps

1. Configure a cron job with `sessionTarget: isolated` and Docker sandbox `readOnlyRoot: true`
2. Run the cron job

### Expected

- Session initializes and runs successfully (lock file created in writable tmpfs)

### Actual

- Before fix: `EROFS: read-only file system, open '/file.lock'` — crash at ~148ms
- After fix: lock file redirected to `/tmp/openclaw-locks/file.lock`, session runs normally

## Evidence

```
 ✓ src/plugin-sdk/file-lock.test.ts (2 tests) 4ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Tests verify: (1) root-level paths redirect to `os.tmpdir()/openclaw-locks/`, (2) non-root paths use normal directories.

## Human Verification (required)

- Verified scenarios: cwd=/ with relative path, absolute paths under normal dirs
- Edge cases checked: path.sep on different OS, recursive tmpdir creation
- What I did **not** verify: live Docker container with --read-only (no Docker access in test env)

## Compatibility / Migration

- Backward compatible? `Yes` — lock files at root `/` were always failing anyway
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit; workaround is `sessionTarget: main`
- Files/config to restore: `src/plugin-sdk/file-lock.ts`
- Known bad symptoms: if os.tmpdir() is not writable in the container, lock creation fails with a different error

## Risks and Mitigations

- Risk: tmpfs mount not present → mitigated by Docker sandbox defaults always including `/tmp` in tmpfs list

