### PR TITLE
feat(hooks): extend internal hooks to support cron lifecycle events

### DIFF
--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -19,6 +19,8 @@ import {
 import { CronService } from "../cron/service.js";
 import { resolveCronStorePath } from "../cron/store.js";
 import { normalizeHttpWebhookUrl } from "../cron/webhook-url.js";
+import { fireAndForgetHook } from "../hooks/fire-and-forget.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { runHeartbeatOnce } from "../infra/heartbeat-runner.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
@@ -357,6 +359,23 @@ export function buildGatewayCronService(params: {
     log: getChildLogger({ module: "cron", storePath }),
     onEvent: (evt) => {
       params.broadcast("cron", evt, { dropIfSlow: true });
+
+      fireAndForgetHook(
+        triggerInternalHook(
+          createInternalHookEvent("cron", evt.action, evt.sessionKey ?? `cron:${evt.jobId}`, {
+            jobId: evt.jobId,
+            status: evt.status,
+            error: evt.error,
+            summary: evt.summary,
+            durationMs: evt.durationMs,
+            nextRunAtMs: evt.nextRunAtMs,
+            model: evt.model,
+            provider: evt.provider,
+          }),
+        ),
+        "server-cron: cron internal hook failed",
+      );
+
       if (evt.action === "finished") {
         const webhookToken = trimToOptionalString(params.cfg.cron?.webhookToken);
         const legacyWebhook = trimToOptionalString(params.cfg.cron?.webhook);

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -474,4 +474,67 @@ describe("hooks", () => {
       expect(keys).toEqual([]);
     });
   });
+
+  describe("cron hooks", () => {
+    it("should trigger cron:started handler", async () => {
+      const handler = vi.fn();
+      registerInternalHook("cron:started", handler);
+
+      const event = createInternalHookEvent("cron", "started", "cron:daily-digest", {
+        jobId: "daily-digest",
+        status: "ok",
+      });
+      await triggerInternalHook(event);
+
+      expect(handler).toHaveBeenCalledWith(event);
+    });
+
+    it("should trigger cron:finished handler with telemetry context", async () => {
+      const handler = vi.fn();
+      registerInternalHook("cron:finished", handler);
+
+      const event = createInternalHookEvent("cron", "finished", "cron:daily-digest", {
+        jobId: "daily-digest",
+        status: "ok",
+        durationMs: 5000,
+        summary: "Digest sent successfully",
+        model: "claude-sonnet-4-6",
+        provider: "anthropic",
+      });
+      await triggerInternalHook(event);
+
+      expect(handler).toHaveBeenCalledWith(event);
+      expect(handler.mock.calls[0][0].context.durationMs).toBe(5000);
+    });
+
+    it("should trigger general cron handler for all cron actions", async () => {
+      const handler = vi.fn();
+      registerInternalHook("cron", handler);
+
+      for (const action of ["added", "updated", "removed", "started", "finished"]) {
+        const event = createInternalHookEvent("cron", action, `cron:job-${action}`, {
+          jobId: `job-${action}`,
+        });
+        await triggerInternalHook(event);
+      }
+
+      expect(handler).toHaveBeenCalledTimes(5);
+    });
+
+    it("should trigger cron:finished with error context", async () => {
+      const handler = vi.fn();
+      registerInternalHook("cron:finished", handler);
+
+      const event = createInternalHookEvent("cron", "finished", "cron:failing-job", {
+        jobId: "failing-job",
+        status: "error",
+        error: "LLM provider timeout",
+        durationMs: 30000,
+      });
+      await triggerInternalHook(event);
+
+      expect(handler).toHaveBeenCalledWith(event);
+      expect(handler.mock.calls[0][0].context.error).toBe("LLM provider timeout");
+    });
+  });
 });

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -10,7 +10,7 @@ import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
+export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message" | "cron";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;
@@ -181,6 +181,31 @@ export type MessagePreprocessedHookEvent = InternalHookEvent & {
   type: "message";
   action: "preprocessed";
   context: MessagePreprocessedHookContext;
+};
+
+// ============================================================================
+// Cron Hook Events
+// ============================================================================
+
+export type CronHookAction = "added" | "updated" | "removed" | "started" | "finished";
+
+export type CronHookContext = {
+  jobId: string;
+  jobName?: string;
+  schedule?: Record<string, unknown>;
+  status?: string;
+  error?: string;
+  summary?: string;
+  durationMs?: number;
+  nextRunAtMs?: number;
+  model?: string;
+  provider?: string;
+};
+
+export type CronHookEvent = InternalHookEvent & {
+  type: "cron";
+  action: CronHookAction;
+  context: CronHookContext;
 };
 
 export interface InternalHookEvent {


### PR DESCRIPTION
## Summary

- **Problem:** The Internal Hooks system supports message, agent, gateway, command, and session events but not cron events. External systems cannot react to cron job lifecycle changes without a WebSocket connection.
- **Why it matters:** Users cannot build external observability/audit systems for scheduled tasks, implement post-job cleanup, or integrate with external orchestrators through the standard hook interface.
- **What changed:** Added `"cron"` to `InternalHookEventType`, defined `CronHookContext`/`CronHookEvent` types, and emitted cron lifecycle events (`added`, `updated`, `removed`, `started`, `finished`) from the gateway's `onEvent` callback using `fireAndForgetHook`.
- **What did NOT change:** Existing hook types, WebSocket broadcast, webhook delivery logic, or any other cron service internals.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37855

## User-visible / Behavior Changes

- HOOK.md files can now register handlers for `cron`, `cron:added`, `cron:updated`, `cron:removed`, `cron:started`, `cron:finished` event types
- Context includes: jobId, status, error, summary, durationMs, nextRunAtMs, model, provider

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js 22+
- Integration/channel: cron jobs with HOOK.md

### Steps

1. Create a HOOK.md that registers for `cron:finished` events
2. Configure and run a cron job
3. Observe hook fires after job completes

### Expected

- Hook handler receives event with jobId, status, durationMs, etc.

### Actual

- Before: no cron events emitted to hook system
- After: all cron lifecycle events emitted via `fireAndForgetHook`

## Evidence

```
 ✓ src/hooks/internal-hooks.test.ts (34 tests) 7ms

 Test Files  1 passed (1)
      Tests  34 passed (34)
```

New tests cover: cron:started, cron:finished (with telemetry), general cron handler for all actions, cron:finished with error context.

## Human Verification (required)

- Verified scenarios: all 5 cron actions trigger hooks, error context preserved, telemetry fields passed through
- Edge cases checked: missing sessionKey on event (falls back to cron:jobId)
- What I did **not** verify: live HOOK.md integration with cron job execution

## Compatibility / Migration

- Backward compatible? `Yes` — purely additive; no existing hooks affected
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit; hooks simply won't fire for cron events
- Files/config to restore: `src/hooks/internal-hooks.ts`, `src/gateway/server-cron.ts`
- Known bad symptoms: hook handler errors logged but never block cron execution (fireAndForgetHook)

## Risks and Mitigations

- Risk: slow hook handler delays broadcast → mitigated by using fireAndForgetHook (non-blocking)

