### PR TITLE
fix(plugins): keep enabled bundled channels loaded with stale allowlist

### DIFF
--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -99,6 +99,14 @@ describe("resolveEffectiveEnableState", () => {
     expect(state).toEqual({ enabled: true });
   });
 
+  it("keeps bundled channels enabled when allowlist omits them", () => {
+    const state = resolveBundledTelegramState({
+      enabled: true,
+      allow: ["feishu"],
+    });
+    expect(state).toEqual({ enabled: true });
+  });
+
   it("keeps explicit plugin-level disable authoritative", () => {
     const state = resolveBundledTelegramState({
       enabled: true,

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -245,10 +245,14 @@ export function resolveEffectiveEnableState(params: {
   rootConfig?: OpenClawConfig;
 }): { enabled: boolean; reason?: string } {
   const base = resolveEnableState(params.id, params.origin, params.config);
+  const bundledChannelEnabled = isBundledChannelEnabledByChannelConfig(
+    params.rootConfig,
+    params.id,
+  );
   if (
     !base.enabled &&
-    base.reason === "bundled (disabled by default)" &&
-    isBundledChannelEnabledByChannelConfig(params.rootConfig, params.id)
+    bundledChannelEnabled &&
+    (base.reason === "bundled (disabled by default)" || base.reason === "not in allowlist")
   ) {
     return { enabled: true };
   }

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -320,6 +320,27 @@ describe("loadOpenClawPlugins", () => {
     expectTelegramLoaded(registry);
   });
 
+  it("loads bundled channel plugins when channel config is enabled but allowlist is stale", () => {
+    setupBundledTelegramPlugin();
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir: cachedBundledTelegramDir,
+      config: {
+        channels: {
+          telegram: {
+            enabled: true,
+          },
+        },
+        plugins: {
+          allow: ["feishu"],
+        },
+      },
+    });
+
+    expectTelegramLoaded(registry);
+  });
+
   it("still respects explicit disable via plugins.entries for bundled channels", () => {
     setupBundledTelegramPlugin();
 


### PR DESCRIPTION
## Summary

- Problem: external onboarding/doctor flows can narrow `plugins.allow` to explicit plugin ids like `feishu`, which makes already-enabled bundled channels show as disabled even though `channels.<id>.enabled=true` is still set.
- Why it matters: `feishu-plugin-onboard doctor --fix` can silently knock stock channels out of the loaded set, so users lose Telegram/WhatsApp/iMessage/etc. after a Feishu repair run.
- What changed: bundled channel enable-state resolution now treats `channels.<id>.enabled=true` as authoritative for stale-allowlist cases, while keeping explicit `plugins.entries.<id>.enabled=false` authoritative.
- What did NOT change (scope boundary): non-channel plugins still respect `plugins.allow`, and denylist / explicit-disable behavior is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37857
- Related #40680432b

## User-visible / Behavior Changes

Running Feishu onboarding/repair flows no longer disables previously enabled bundled stock channels just because `plugins.allow` was narrowed to the Feishu plugin.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: local Linux workspace
- Runtime/container: Node 22 + pnpm / vitest
- Model/provider: N/A
- Integration/channel (if any): bundled channel plugins + Feishu onboarding scenario
- Relevant config (redacted): `channels.telegram.enabled=true`, `plugins.allow=["feishu"]`

### Steps

1. Start with a config where a bundled channel remains enabled via `channels.<id>.enabled=true`.
2. Narrow `plugins.allow` so it only contains the Feishu plugin id (mirrors the reported `doctor --fix` fallout).
3. Load plugins or inspect plugin status.

### Expected

- Bundled channels explicitly enabled in `channels.<id>` remain loaded.

### Actual

- Before this fix, bundled channels were disabled with `not in allowlist` despite channel config still enabling them.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added/ran regression tests for effective enable-state resolution and plugin loading with a stale allowlist.
- Edge cases checked: explicit `plugins.entries.<id>.enabled=false` still disables the bundled channel.
- What you did **not** verify: end-to-end execution of the external `feishu-plugin-onboard doctor --fix` CLI against a live install.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or explicitly set `plugins.entries.<id>.enabled=false` for a bundled channel you want disabled.
- Files/config to restore: `src/plugins/config-state.ts`
- Known bad symptoms reviewers should watch for: a bundled channel loading even when a stale allowlist omits it; explicit plugin disable should still block it.

## Risks and Mitigations

- Risk: this could permit a bundled channel to load in configs that relied on `plugins.allow` alone to disable it.
  - Mitigation: the exception only applies when `channels.<id>.enabled=true`, and explicit `plugins.entries.<id>.enabled=false` still overrides it.
