### PR TITLE
security: reject hostname ws targets when OPENCLAW_ALLOW_INSECURE_PRIVATE_WS is enabled

### DIFF
--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -457,7 +457,6 @@ describe("isSecureWebSocketUrl", () => {
       "ws://169.254.10.20:18789",
       "ws://[fc00::1]:18789",
       "ws://[fe80::1]:18789",
-      "ws://gateway.private.example:18789",
     ];
 
     for (const input of allowedWhenOptedIn) {
@@ -465,10 +464,16 @@ describe("isSecureWebSocketUrl", () => {
     }
   });
 
-  it("still rejects ws:// public IP literals when opt-in is enabled", () => {
-    const publicIpWsUrls = ["ws://1.1.1.1:18789", "ws://8.8.8.8:18789", "ws://203.0.113.10:18789"];
+  it("still rejects ws:// hostnames and public IP literals when opt-in is enabled", () => {
+    const rejectedWsUrls = [
+      "ws://remote.example.com:18789",
+      "ws://gateway.private.example:18789",
+      "ws://1.1.1.1:18789",
+      "ws://8.8.8.8:18789",
+      "ws://203.0.113.10:18789",
+    ];
 
-    for (const input of publicIpWsUrls) {
+    for (const input of rejectedWsUrls) {
       expect(isSecureWebSocketUrl(input, { allowPrivateWs: true }), input).toBe(false);
     }
   });

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -434,17 +434,10 @@ export function isSecureWebSocketUrl(
     return true;
   }
   // Optional break-glass for trusted private-network overlays.
+  // Keep this strict and synchronous: only private/loopback IP literals are allowed.
+  // Hostnames are rejected here because DNS resolution is not available in this validator.
   if (opts?.allowPrivateWs) {
-    if (isPrivateOrLoopbackHost(parsed.hostname)) {
-      return true;
-    }
-    // Hostnames may resolve to private networks (for example in VPN/Tailnet DNS),
-    // but resolution is not available in this synchronous validator.
-    const hostForIpCheck =
-      parsed.hostname.startsWith("[") && parsed.hostname.endsWith("]")
-        ? parsed.hostname.slice(1, -1)
-        : parsed.hostname;
-    return net.isIP(hostForIpCheck) === 0;
+    return isPrivateOrLoopbackHost(parsed.hostname);
   }
   return false;
 }


### PR DESCRIPTION
## Summary
- remove hostname pass-through in `isSecureWebSocketUrl(..., { allowPrivateWs: true })`
- keep break-glass mode limited to private/loopback IP literals only
- add regression coverage to ensure hostnames remain rejected in opted-in ws mode

## Testing
- pnpm test src/gateway/net.test.ts

Fixes #37177
