### PR TITLE
feat(hooks): add agent:turn:end internal hook event

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -1,5 +1,7 @@
 import type { OpenClawConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
+import { fireAndForgetHook } from "../../hooks/fire-and-forget.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { isAcpSessionKey } from "../../sessions/session-key-utils.js";
 import {
@@ -720,6 +722,7 @@ export class AcpSessionManager {
         }
         this.recordTurnCompletion({
           startedAt: turnStartedAt,
+          sessionKey,
         });
         await this.setSessionState({
           cfg: input.cfg,
@@ -735,6 +738,7 @@ export class AcpSessionManager {
         });
         this.recordTurnCompletion({
           startedAt: turnStartedAt,
+          sessionKey,
           errorCode: acpError.code,
         });
         await this.setSessionState({
@@ -1139,16 +1143,31 @@ export class AcpSessionManager {
     }
   }
 
-  private recordTurnCompletion(params: { startedAt: number; errorCode?: AcpRuntimeError["code"] }) {
+  private recordTurnCompletion(params: {
+    startedAt: number;
+    sessionKey: string;
+    errorCode?: AcpRuntimeError["code"];
+  }) {
     const durationMs = Math.max(0, Date.now() - params.startedAt);
     this.turnLatencyStats.totalMs += durationMs;
     this.turnLatencyStats.maxMs = Math.max(this.turnLatencyStats.maxMs, durationMs);
     if (params.errorCode) {
       this.turnLatencyStats.failed += 1;
       this.recordErrorCode(params.errorCode);
-      return;
+    } else {
+      this.turnLatencyStats.completed += 1;
     }
-    this.turnLatencyStats.completed += 1;
+
+    fireAndForgetHook(
+      triggerInternalHook(
+        createInternalHookEvent("agent", "turn:end", params.sessionKey, {
+          success: !params.errorCode,
+          durationMs,
+          errorCode: params.errorCode,
+        }),
+      ),
+      "acp-manager: agent:turn:end internal hook failed",
+    );
   }
 
   private recordErrorCode(code: string): void {

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -9,11 +9,13 @@ const hoisted = vi.hoisted(() => {
   const readAcpSessionEntryMock = vi.fn();
   const upsertAcpSessionMetaMock = vi.fn();
   const requireAcpRuntimeBackendMock = vi.fn();
+  const triggerInternalHookMock = vi.fn().mockResolvedValue(undefined);
   return {
     listAcpSessionEntriesMock,
     readAcpSessionEntryMock,
     upsertAcpSessionMetaMock,
     requireAcpRuntimeBackendMock,
+    triggerInternalHookMock,
   };
 });
 
@@ -29,6 +31,14 @@ vi.mock("../runtime/registry.js", async (importOriginal) => {
     ...actual,
     requireAcpRuntimeBackend: (backendId?: string) =>
       hoisted.requireAcpRuntimeBackendMock(backendId),
+  };
+});
+
+vi.mock("../../hooks/internal-hooks.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../hooks/internal-hooks.js")>();
+  return {
+    ...actual,
+    triggerInternalHook: (...args: unknown[]) => hoisted.triggerInternalHookMock(...args),
   };
 });
 
@@ -1246,5 +1256,85 @@ describe("AcpSessionManager", () => {
         clearMeta: true,
       }),
     ).rejects.toThrow("disk locked");
+  });
+
+  it("emits agent:turn:end hook on successful turn", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+    hoisted.triggerInternalHookMock.mockClear();
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: baseCfg as OpenClawConfig,
+      sessionKey: "agent:codex:acp:session-1",
+      text: "hello",
+    });
+
+    const hookCalls = hoisted.triggerInternalHookMock.mock.calls;
+    const turnEndCall = hookCalls.find(
+      (args: unknown[]) =>
+        (args[0] as { type: string; action: string }).type === "agent" &&
+        (args[0] as { type: string; action: string }).action === "turn:end",
+    );
+    expect(turnEndCall).toBeDefined();
+    const event = turnEndCall![0] as {
+      type: string;
+      action: string;
+      sessionKey: string;
+      context: { success: boolean; durationMs: number; errorCode?: string };
+    };
+    expect(event.context.success).toBe(true);
+    expect(event.context.durationMs).toBeGreaterThanOrEqual(0);
+    expect(event.context.errorCode).toBeUndefined();
+    expect(event.sessionKey).toBe("agent:codex:acp:session-1");
+  });
+
+  it("emits agent:turn:end hook with errorCode on failed turn", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+    runtimeState.runTurn.mockImplementation(async function* () {
+      yield { type: "error" as const, code: "ACP_TURN_FAILED", message: "boom" };
+    });
+    hoisted.triggerInternalHookMock.mockClear();
+
+    const manager = new AcpSessionManager();
+    await expect(
+      manager.runTurn({
+        cfg: baseCfg as OpenClawConfig,
+        sessionKey: "agent:codex:acp:session-1",
+        text: "hello",
+      }),
+    ).rejects.toThrow();
+
+    const hookCalls = hoisted.triggerInternalHookMock.mock.calls;
+    const turnEndCall = hookCalls.find(
+      (args: unknown[]) =>
+        (args[0] as { type: string; action: string }).type === "agent" &&
+        (args[0] as { type: string; action: string }).action === "turn:end",
+    );
+    expect(turnEndCall).toBeDefined();
+    const event = turnEndCall![0] as {
+      type: string;
+      action: string;
+      context: { success: boolean; durationMs: number; errorCode?: string };
+    };
+    expect(event.context.success).toBe(false);
+    expect(event.context.errorCode).toBe("ACP_TURN_FAILED");
   });
 });

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -27,6 +27,18 @@ export type AgentBootstrapHookEvent = InternalHookEvent & {
   context: AgentBootstrapHookContext;
 };
 
+export type AgentTurnEndHookContext = {
+  success: boolean;
+  durationMs: number;
+  errorCode?: string;
+};
+
+export type AgentTurnEndHookEvent = InternalHookEvent & {
+  type: "agent";
+  action: "turn:end";
+  context: AgentTurnEndHookContext;
+};
+
 export type GatewayStartupHookContext = {
   cfg?: OpenClawConfig;
   deps?: CliDeps;


### PR DESCRIPTION
## Summary

- **Problem:** No hook fires when an entire agent turn cycle completes. Sub-turn events (`agent:thinking:*`, `agent:response:*`, `agent:tool:*`) fire per LLM call, `message:sent` fires per outbound message, and `session:end` fires when the session terminates. None of these reliably indicate a complete turn boundary.
- **Why it matters:** Post-turn memory extraction, turn-level analytics, session pruning, and workflow integration all need a reliable "turn is done" signal.
- **What changed:** Extended `recordTurnCompletion` in `AcpSessionManager` to accept `sessionKey` and emit an `agent:turn:end` event via `fireAndForgetHook`. Added `AgentTurnEndHookContext`/`AgentTurnEndHookEvent` types in `internal-hooks.ts`.
- **What did NOT change:** Existing sub-turn events, session lifecycle events, `recordTurnCompletion` stats tracking, or turn execution logic.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37833

## User-visible / Behavior Changes

- HOOK.md files can now register handlers for `agent:turn:end` events
- Context includes: `success` (boolean), `durationMs` (number), `errorCode` (string, only on failure)

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js 22+
- Integration/channel: ACP sessions with HOOK.md

### Steps

1. Create a HOOK.md that registers for `agent:turn:end`
2. Send a message to an ACP session
3. Observe hook fires after turn completes

### Expected

- Hook receives event with success=true and durationMs

### Actual

- Before: no turn-level hook exists
- After: `agent:turn:end` fires on both success and error paths

## Evidence

```
 ✓ src/acp/control-plane/manager.test.ts (27 tests) 105ms

 Test Files  1 passed (1)
      Tests  27 passed (27)
```

New tests verify: (1) successful turn emits hook with success=true, durationMs>=0, no errorCode, correct sessionKey; (2) failed turn emits hook with success=false and errorCode="ACP_TURN_FAILED".

## Human Verification (required)

- Verified scenarios: successful turn, failed turn (error event), turn with error thrown
- Edge cases checked: hook error does not block turn completion (fireAndForgetHook)
- What I did **not** verify: live HOOK.md integration with ACP runtime

## Compatibility / Migration

- Backward compatible? `Yes` — purely additive event
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit; hook simply won't fire
- Files/config to restore: `src/acp/control-plane/manager.core.ts`, `src/hooks/internal-hooks.ts`
- Known bad symptoms: hook errors are logged but never block turn execution

## Risks and Mitigations

None — fire-and-forget pattern ensures hook failures cannot affect turn execution

