### PR TITLE
fix(agents): drop empty aborted assistant messages to break 400 loop

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -488,3 +488,61 @@ describe("stripToolResultDetails", () => {
     expect(out).toBe(input);
   });
 });
+
+describe("repairToolUseResultPairing — aborted empty assistant (#37834)", () => {
+  it("drops aborted assistant message with empty content", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "toolUse", id: "exec_1", name: "exec", input: { command: "ls" } }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "exec_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "file1.txt" }],
+      },
+      {
+        role: "assistant",
+        content: [],
+        stopReason: "aborted",
+      },
+      { role: "user", content: "next question" },
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+    const roles = result.messages.map((m) => (m as { role: string }).role);
+    expect(roles).not.toContain("assistant_aborted");
+    expect(result.messages).toHaveLength(3);
+    expect((result.messages[2] as { role: string }).role).toBe("user");
+  });
+
+  it("keeps aborted assistant message with non-empty content", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "partial response..." }],
+        stopReason: "aborted",
+      },
+      { role: "user", content: "try again" },
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+    expect(result.messages).toHaveLength(2);
+    expect((result.messages[0] as { role: string }).role).toBe("assistant");
+  });
+
+  it("keeps errored assistant message with content", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "error occurred" }],
+        stopReason: "error",
+      },
+      { role: "user", content: "retry" },
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+    expect(result.messages).toHaveLength(2);
+  });
+});

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -398,6 +398,14 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
     // See: https://github.com/openclaw/openclaw/issues/4597
     const stopReason = (assistant as { stopReason?: string }).stopReason;
     if (stopReason === "error" || stopReason === "aborted") {
+      // Drop aborted/errored messages with no content — they add nothing to the
+      // context and can leave orphaned tool_use blocks from the preceding
+      // assistant turn unresolved, causing permanent 400 loops (#37834).
+      const content = Array.isArray(assistant.content) ? assistant.content : [];
+      if (content.length === 0) {
+        changed = true;
+        continue;
+      }
       out.push(msg);
       continue;
     }


### PR DESCRIPTION
## Summary

- **Problem:** When an assistant turn is aborted or errored with `content: []`, the empty message stays in the session transcript. `repairToolUseResultPairing` skips tool-call extraction for these messages but still keeps them. The orphaned `tool_use` blocks from the *preceding* assistant turn then lack matching `tool_result` entries, causing the provider to reject every subsequent request with HTTP 400 — a permanent unrecoverable loop.
- **Why it matters:** Users hit an infinite 400 retry loop that can only be resolved by manually editing the session transcript or resetting the conversation.
- **What changed:** `src/agents/session-transcript-repair.ts` — inside `repairToolUseResultPairing`, aborted/errored assistant messages with empty `content` arrays are now dropped (`continue`) instead of being pushed to the output. This allows the orphaned `tool_use` IDs from the preceding turn to be resolved normally by the existing repair logic.
- **What did NOT change:** Aborted/errored messages with non-empty content are still preserved. No other repair functions were modified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37834

## User-visible / Behavior Changes

- Sessions that previously entered a permanent 400 loop due to orphaned `tool_use` IDs from aborted turns will now self-heal on the next repair pass.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js
- Integration/channel: any (agents/core)

### Steps

1. Trigger an agent turn that is aborted mid-tool-call, producing an assistant message with `content: []` and `stopReason: "aborted"`.
2. On the next turn, the session transcript contains the empty aborted message plus orphaned `tool_use` blocks from the prior assistant turn.
3. `repairToolUseResultPairing` runs but keeps the empty aborted message, leaving `tool_use` IDs unresolved.
4. The provider returns HTTP 400 (`tool_use` without matching `tool_result`), and the agent retries forever.

### Expected

- The empty aborted message is dropped during repair, orphaned `tool_use` blocks are resolved, and the session continues normally.

### Actual

- Before fix: Permanent 400 loop — the empty aborted message blocks tool_use/tool_result resolution.
- After fix: Empty aborted messages are dropped, orphaned tool_use IDs are resolved by subsequent repair logic, and the session recovers.

## Evidence

```
 ✓ src/agents/session-transcript-repair.test.ts (26 tests) 5ms
   ✓ repairToolUseResultPairing — aborted empty assistant (#37834)
     ✓ drops aborted assistant message with empty content
     ✓ keeps aborted assistant message with non-empty content
     ✓ keeps errored assistant message with content
```

## Human Verification (required)

- Verified scenarios: aborted + empty content dropped; aborted + non-empty content preserved; errored + content preserved
- Edge cases checked: `content` is not an array (treated as empty); `stopReason` is "error" (same logic applies)
- What I did **not** verify: end-to-end integration with a live provider returning 400

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the `if (content.length === 0)` check in `repairToolUseResultPairing` to restore original behavior (keep all aborted messages).
- Files/config to restore: `src/agents/session-transcript-repair.ts`
- Known bad symptoms: If reverted, sessions with aborted empty assistant messages will continue to hit 400 loops.

## Risks and Mitigations

- **Risk:** Dropping aborted messages could theoretically remove useful context. **Mitigation:** Only messages with `content: []` are dropped — they contribute zero context. Messages with any content (even partial text) are preserved.
