### PR TITLE
fix(tui): omit channel field for webchat messages to prevent cross-delivery

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -99,6 +99,25 @@ describe("buildInboundMetaSystemPrompt", () => {
     const payload = parseInboundMetaPayload(prompt);
     expect(payload["sender_id"]).toBeUndefined();
   });
+
+  it("omits channel field for TUI/webchat messages even when OriginatingChannel is set", () => {
+    // TUI messages have Surface=webchat and Provider=webchat, but may inherit
+    // OriginatingChannel from session delivery context (e.g., "telegram").
+    // The channel field should be omitted to prevent cross-delivery.
+    const prompt = buildInboundMetaSystemPrompt({
+      MessageSid: "tui-123",
+      OriginatingTo: "telegram:5494292670",
+      OriginatingChannel: "telegram", // Stale from session delivery context
+      Provider: "webchat",
+      Surface: "webchat",
+      ChatType: "direct",
+    } as TemplateContext);
+
+    const payload = parseInboundMetaPayload(prompt);
+    expect(payload["channel"]).toBeUndefined();
+    expect(payload["provider"]).toBe("webchat");
+    expect(payload["surface"]).toBe("webchat");
+  });
 });
 
 describe("buildInboundUserContextPrefix", () => {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -32,10 +32,19 @@ function formatConversationTimestamp(value: unknown): string | undefined {
 }
 
 function resolveInboundChannel(ctx: TemplateContext): string | undefined {
-  let channelValue = safeTrim(ctx.OriginatingChannel) ?? safeTrim(ctx.Surface);
+  // For webchat/Hub Chat sessions (when Surface is 'webchat'), prioritize Surface
+  // over OriginatingChannel to prevent TUI/webchat messages from being incorrectly
+  // tagged with a different channel (e.g., 'telegram') from session delivery context.
+  const surface = safeTrim(ctx.Surface);
+  if (surface === "webchat") {
+    // For webchat sessions, omit the channel field entirely rather than falling
+    // back to an unrelated provider or stale OriginatingChannel.
+    return undefined;
+  }
+  let channelValue = safeTrim(ctx.OriginatingChannel) ?? surface;
   if (!channelValue) {
     const provider = safeTrim(ctx.Provider);
-    if (provider !== "webchat" && ctx.Surface !== "webchat") {
+    if (provider !== "webchat") {
       channelValue = provider;
     }
   }


### PR DESCRIPTION
## Problem

When TUI sends messages via \chat.send\, the session may have stale \OriginatingChannel\ from previous delivery context (e.g., 'telegram'). This caused TUI messages to be incorrectly tagged with \channel: telegram\ instead of omitting the channel field, leading to replies being delivered to both TUI and Telegram.

## Solution

Fix \esolveInboundChannel\ to prioritize \Surface=webchat\ over \OriginatingChannel\. When \Surface\ is 'webchat', return \undefined\ to omit the channel field entirely, preventing cross-delivery.

## Changes

- Modified \esolveInboundChannel\ in \src/auto-reply/reply/inbound-meta.ts\ to check \Surface\ first and return \undefined\ when \Surface\ is 'webchat'
- Added test case to verify TUI messages omit channel field even when \OriginatingChannel\ is set

## Testing

- Added unit test to verify the fix
- Linting passed

Fixes #37874