### PR TITLE
fix(agents): sanitize tool schemas for llama.cpp GBNF grammar compat (#32916)

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -866,6 +866,7 @@ export async function runEmbeddedAttempt(
           abortSignal: runAbortController.signal,
           modelProvider: params.model.provider,
           modelId: params.modelId,
+          modelBaseUrl: typeof params.model.baseUrl === "string" ? params.model.baseUrl : undefined,
           modelContextWindowTokens: params.model.contextWindow,
           modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
           currentChannelId: params.currentChannelId,

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -1,5 +1,9 @@
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import { cleanSchemaForGemini } from "./schema/clean-for-gemini.js";
+import {
+  isLlamaCppProvider,
+  stripLlamaCppUnsupportedKeywords,
+} from "./schema/clean-for-llamacpp.js";
 import { isXaiProvider, stripXaiUnsupportedKeywords } from "./schema/clean-for-xai.js";
 
 function extractEnumValues(schema: unknown): unknown[] | undefined {
@@ -65,7 +69,7 @@ function mergePropertySchemas(existing: unknown, incoming: unknown): unknown {
 
 export function normalizeToolParameters(
   tool: AnyAgentTool,
-  options?: { modelProvider?: string; modelId?: string },
+  options?: { modelProvider?: string; modelId?: string; modelBaseUrl?: string },
 ): AnyAgentTool {
   const schema =
     tool.parameters && typeof tool.parameters === "object"
@@ -81,6 +85,8 @@ export function normalizeToolParameters(
   //   (TypeBox root unions compile to `{ anyOf: [...] }` without `type`).
   // - Anthropic expects full JSON Schema draft 2020-12 compliance.
   // - xAI rejects validation-constraint keywords (minLength, maxLength, etc.) outright.
+  // - llama.cpp GBNF grammar converter fails on $schema, additionalProperties, $ref,
+  //   and complex anyOf/oneOf — strip these for llama.cpp-compatible endpoints.
   //
   // Normalize once here so callers can always pass `tools` through unchanged.
 
@@ -89,6 +95,7 @@ export function normalizeToolParameters(
     options?.modelProvider?.toLowerCase().includes("gemini");
   const isAnthropicProvider = options?.modelProvider?.toLowerCase().includes("anthropic");
   const isXai = isXaiProvider(options?.modelProvider, options?.modelId);
+  const isLlamaCpp = isLlamaCppProvider(options?.modelProvider, options?.modelBaseUrl);
 
   function applyProviderCleaning(s: unknown): unknown {
     if (isGeminiProvider && !isAnthropicProvider) {
@@ -96,6 +103,9 @@ export function normalizeToolParameters(
     }
     if (isXai) {
       return stripXaiUnsupportedKeywords(s);
+    }
+    if (isLlamaCpp) {
+      return stripLlamaCppUnsupportedKeywords(s);
     }
     return s;
   }

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -218,6 +218,8 @@ export function createOpenClawCodingTools(options?: {
   modelProvider?: string;
   /** Model id for the current provider (used for model-specific tool gating). */
   modelId?: string;
+  /** Model base URL for the current provider (used for llama.cpp-compat detection). */
+  modelBaseUrl?: string;
   /** Model context window in tokens (used to scale read-tool output budget). */
   modelContextWindowTokens?: number;
   /**
@@ -551,6 +553,7 @@ export function createOpenClawCodingTools(options?: {
     normalizeToolParameters(tool, {
       modelProvider: options?.modelProvider,
       modelId: options?.modelId,
+      modelBaseUrl: options?.modelBaseUrl,
     }),
   );
   const withHooks = normalized.map((tool) =>

--- a/src/agents/schema/clean-for-llamacpp.test.ts
+++ b/src/agents/schema/clean-for-llamacpp.test.ts
@@ -186,4 +186,101 @@ describe("stripLlamaCppUnsupportedKeywords", () => {
     expect(result[1].additionalProperties).toBeUndefined();
     expect(result[1].type).toBe("number");
   });
+
+  it("preserves sibling keys (description, default) when collapsing anyOf", () => {
+    // Greptile-flagged bug: sibling keys on the parent were silently discarded.
+    const schema = {
+      description: "The file path to read",
+      default: "./index.ts",
+      anyOf: [{ type: "string" }, { type: "null" }],
+    };
+    const result = stripLlamaCppUnsupportedKeywords(schema) as Record<string, unknown>;
+    expect(result.anyOf).toBeUndefined();
+    expect(result.type).toBe("string");
+    expect(result.description).toBe("The file path to read");
+    expect(result.default).toBe("./index.ts");
+  });
+
+  it("preserves sibling keys when collapsing oneOf", () => {
+    const schema = {
+      title: "Count field",
+      description: "Number of items",
+      oneOf: [{ type: "null" }, { type: "integer", minimum: 0 }],
+    };
+    const result = stripLlamaCppUnsupportedKeywords(schema) as Record<string, unknown>;
+    expect(result.oneOf).toBeUndefined();
+    expect(result.type).toBe("integer");
+    expect(result.title).toBe("Count field");
+    expect(result.description).toBe("Number of items");
+  });
+
+  it("concrete branch type wins over sibling type when collapsing anyOf", () => {
+    // Concrete branch takes precedence for overlapping keys like `type`.
+    const schema = {
+      type: "object", // sibling — should be overwritten by the concrete branch type
+      anyOf: [{ type: "string" }, { type: "null" }],
+    };
+    const result = stripLlamaCppUnsupportedKeywords(schema) as Record<string, unknown>;
+    expect(result.type).toBe("string");
+  });
+
+  it("strips unsupported keywords inside $defs recursively", () => {
+    // Codex-flagged bug: only properties/items were recursed; $defs was copied verbatim.
+    const schema = {
+      type: "object",
+      $defs: {
+        Item: {
+          type: "object",
+          $schema: "http://json-schema.org/draft-07/schema#",
+          additionalProperties: false,
+          properties: { id: { type: "string" } },
+        },
+      },
+      properties: {
+        item: { $ref: "#/$defs/Item" },
+      },
+    };
+    const result = stripLlamaCppUnsupportedKeywords(schema) as {
+      $defs: { Item: Record<string, unknown> };
+    };
+    expect(result.$defs.Item.$schema).toBeUndefined();
+    expect(result.$defs.Item.additionalProperties).toBeUndefined();
+    expect(result.$defs.Item.type).toBe("object");
+  });
+
+  it("strips unsupported keywords inside allOf recursively", () => {
+    const schema = {
+      allOf: [
+        { $ref: "#/$defs/Base" },
+        { type: "object", additionalProperties: false, properties: { name: { type: "string" } } },
+      ],
+    };
+    const result = stripLlamaCppUnsupportedKeywords(schema) as {
+      allOf: Array<Record<string, unknown>>;
+    };
+    // $ref is stripped, leaving an empty object for the first branch
+    expect(result.allOf[0]).toEqual({});
+    expect(result.allOf[1].additionalProperties).toBeUndefined();
+    expect(result.allOf[1].type).toBe("object");
+  });
+
+  it("strips unsupported keywords inside definitions recursively", () => {
+    const schema = {
+      type: "object",
+      definitions: {
+        Address: {
+          type: "object",
+          additionalProperties: true,
+          $schema: "x",
+          properties: { street: { type: "string" } },
+        },
+      },
+    };
+    const result = stripLlamaCppUnsupportedKeywords(schema) as {
+      definitions: { Address: Record<string, unknown> };
+    };
+    expect(result.definitions.Address.$schema).toBeUndefined();
+    expect(result.definitions.Address.additionalProperties).toBeUndefined();
+    expect(result.definitions.Address.type).toBe("object");
+  });
 });

--- a/src/agents/schema/clean-for-llamacpp.test.ts
+++ b/src/agents/schema/clean-for-llamacpp.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import { isLlamaCppProvider, stripLlamaCppUnsupportedKeywords } from "./clean-for-llamacpp.js";
+
+describe("isLlamaCppProvider", () => {
+  it("matches llamacpp provider name", () => {
+    expect(isLlamaCppProvider("llamacpp")).toBe(true);
+  });
+
+  it("matches llama-cpp provider name", () => {
+    expect(isLlamaCppProvider("llama-cpp")).toBe(true);
+  });
+
+  it("matches llama.cpp provider name", () => {
+    expect(isLlamaCppProvider("llama.cpp")).toBe(true);
+  });
+
+  it("matches lmstudio provider name", () => {
+    expect(isLlamaCppProvider("lmstudio")).toBe(true);
+  });
+
+  it("matches lm-studio provider name", () => {
+    expect(isLlamaCppProvider("lm-studio")).toBe(true);
+  });
+
+  it("matches by localhost baseUrl on port 8080", () => {
+    expect(isLlamaCppProvider(undefined, "http://localhost:8080/v1")).toBe(true);
+  });
+
+  it("matches by 127.0.0.1 baseUrl on port 8080", () => {
+    expect(isLlamaCppProvider(undefined, "http://127.0.0.1:8080/v1")).toBe(true);
+  });
+
+  it("does not match localhost on non-8080 port", () => {
+    expect(isLlamaCppProvider(undefined, "http://localhost:11434/v1")).toBe(false);
+  });
+
+  it("does not match remote host on port 8080", () => {
+    expect(isLlamaCppProvider(undefined, "http://myserver.example.com:8080/v1")).toBe(false);
+  });
+
+  it("does not match openai provider", () => {
+    expect(isLlamaCppProvider("openai")).toBe(false);
+  });
+
+  it("does not match ollama provider", () => {
+    expect(isLlamaCppProvider("ollama")).toBe(false);
+  });
+
+  it("handles undefined provider and baseUrl", () => {
+    expect(isLlamaCppProvider(undefined, undefined)).toBe(false);
+  });
+});
+
+describe("stripLlamaCppUnsupportedKeywords", () => {
+  it("strips $schema from top-level schema", () => {
+    const schema = {
+      $schema: "http://json-schema.org/draft-07/schema#",
+      type: "object",
+      properties: { name: { type: "string" } },
+    };
+    const result = stripLlamaCppUnsupportedKeywords(schema) as Record<string, unknown>;
+    expect(result.$schema).toBeUndefined();
+    expect(result.type).toBe("object");
+  });
+
+  it("strips additionalProperties from schemas", () => {
+    const schema = {
+      type: "object",
+      properties: { name: { type: "string" } },
+      additionalProperties: true,
+    };
+    const result = stripLlamaCppUnsupportedKeywords(schema) as Record<string, unknown>;
+    expect(result.additionalProperties).toBeUndefined();
+    expect(result.type).toBe("object");
+    expect(result.properties).toBeDefined();
+  });
+
+  it("strips $ref from schemas", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        item: { $ref: "#/definitions/Item" },
+      },
+    };
+    const result = stripLlamaCppUnsupportedKeywords(schema) as {
+      properties: { item: Record<string, unknown> };
+    };
+    expect(result.properties.item.$ref).toBeUndefined();
+  });
+
+  it("collapses anyOf to first non-null concrete branch", () => {
+    const schema = {
+      anyOf: [{ type: "string", description: "a text value" }, { type: "null" }],
+    };
+    const result = stripLlamaCppUnsupportedKeywords(schema) as Record<string, unknown>;
+    expect(result.anyOf).toBeUndefined();
+    expect(result.type).toBe("string");
+    expect(result.description).toBe("a text value");
+  });
+
+  it("collapses oneOf to first non-null concrete branch", () => {
+    const schema = {
+      oneOf: [{ type: "null" }, { type: "number" }],
+    };
+    const result = stripLlamaCppUnsupportedKeywords(schema) as Record<string, unknown>;
+    expect(result.oneOf).toBeUndefined();
+    // first non-null is "number"
+    expect(result.type).toBe("number");
+  });
+
+  it("strips keywords recursively inside nested properties", () => {
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        nested: {
+          type: "object",
+          $schema: "http://json-schema.org/draft-07/schema#",
+          additionalProperties: true,
+          properties: {
+            value: { type: "string" },
+          },
+        },
+      },
+    };
+    const result = stripLlamaCppUnsupportedKeywords(schema) as {
+      additionalProperties?: unknown;
+      properties: {
+        nested: Record<string, unknown>;
+      };
+    };
+    expect(result.additionalProperties).toBeUndefined();
+    expect(result.properties.nested.$schema).toBeUndefined();
+    expect(result.properties.nested.additionalProperties).toBeUndefined();
+    expect(result.properties.nested.type).toBe("object");
+  });
+
+  it("strips keywords inside array item schemas", () => {
+    const schema = {
+      type: "array",
+      items: {
+        type: "object",
+        $schema: "http://json-schema.org/draft-07/schema#",
+        additionalProperties: false,
+        properties: { id: { type: "string" } },
+      },
+    };
+    const result = stripLlamaCppUnsupportedKeywords(schema) as {
+      items: Record<string, unknown>;
+    };
+    expect(result.items.$schema).toBeUndefined();
+    expect(result.items.additionalProperties).toBeUndefined();
+    expect(result.items.type).toBe("object");
+  });
+
+  it("preserves required, type, description, and other safe keywords", () => {
+    const schema = {
+      type: "object",
+      description: "A tool schema",
+      required: ["name"],
+      properties: {
+        name: { type: "string", description: "The name" },
+      },
+    };
+    const result = stripLlamaCppUnsupportedKeywords(schema) as Record<string, unknown>;
+    expect(result.type).toBe("object");
+    expect(result.description).toBe("A tool schema");
+    expect(result.required).toEqual(["name"]);
+    expect(result.properties as Record<string, unknown>).toBeDefined();
+  });
+
+  it("passes through primitives and null unchanged", () => {
+    expect(stripLlamaCppUnsupportedKeywords(null)).toBeNull();
+    expect(stripLlamaCppUnsupportedKeywords("string")).toBe("string");
+    expect(stripLlamaCppUnsupportedKeywords(42)).toBe(42);
+  });
+
+  it("passes through arrays recursively", () => {
+    const schemas = [
+      { type: "string", $schema: "x" },
+      { type: "number", additionalProperties: true },
+    ];
+    const result = stripLlamaCppUnsupportedKeywords(schemas) as Array<Record<string, unknown>>;
+    expect(result[0].$schema).toBeUndefined();
+    expect(result[0].type).toBe("string");
+    expect(result[1].additionalProperties).toBeUndefined();
+    expect(result[1].type).toBe("number");
+  });
+});

--- a/src/agents/schema/clean-for-llamacpp.ts
+++ b/src/agents/schema/clean-for-llamacpp.ts
@@ -1,0 +1,90 @@
+// llama.cpp's GBNF grammar converter crashes on several JSON Schema keywords that
+// became common after the 2026.3.2 SecretRef expansion and zod schema deduplication.
+// Tool definitions forwarded to llama.cpp-compatible endpoints now include
+// $schema, additionalProperties, and complex anyOf/oneOf structures that the GBNF
+// converter cannot handle, producing degenerate grammars that match fewer tool calls.
+// Strip these before sending tool schemas to llama.cpp-compatible endpoints.
+
+export const LLAMACPP_UNSUPPORTED_SCHEMA_KEYWORDS = new Set([
+  "$schema",
+  "additionalProperties",
+  "$ref",
+]);
+
+export function stripLlamaCppUnsupportedKeywords(schema: unknown): unknown {
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+  if (Array.isArray(schema)) {
+    return schema.map(stripLlamaCppUnsupportedKeywords);
+  }
+  const obj = schema as Record<string, unknown>;
+
+  // Collapse anyOf/oneOf to the first concrete (non-null) branch.
+  // llama.cpp's GBNF grammar converter fails on complex union types.
+  for (const key of ["anyOf", "oneOf"] as const) {
+    if (Array.isArray(obj[key])) {
+      const variants = obj[key] as unknown[];
+      const concrete =
+        variants.find(
+          (v) => v && typeof v === "object" && (v as Record<string, unknown>).type !== "null",
+        ) ?? variants[0];
+      return stripLlamaCppUnsupportedKeywords(concrete);
+    }
+  }
+
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (LLAMACPP_UNSUPPORTED_SCHEMA_KEYWORDS.has(key)) {
+      continue;
+    }
+    if (key === "properties" && value && typeof value === "object" && !Array.isArray(value)) {
+      cleaned[key] = Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([k, v]) => [
+          k,
+          stripLlamaCppUnsupportedKeywords(v),
+        ]),
+      );
+    } else if (key === "items" && value && typeof value === "object") {
+      cleaned[key] = Array.isArray(value)
+        ? value.map(stripLlamaCppUnsupportedKeywords)
+        : stripLlamaCppUnsupportedKeywords(value);
+    } else {
+      cleaned[key] = value;
+    }
+  }
+  return cleaned;
+}
+
+export function isLlamaCppProvider(modelProvider?: string, modelBaseUrl?: string): boolean {
+  const provider = modelProvider?.toLowerCase().trim() ?? "";
+  if (
+    provider.includes("llamacpp") ||
+    provider.includes("llama-cpp") ||
+    provider.includes("llama.cpp") ||
+    provider.includes("lmstudio") ||
+    provider.includes("lm-studio")
+  ) {
+    return true;
+  }
+  if (!modelBaseUrl) {
+    return false;
+  }
+  try {
+    const parsed = new URL(modelBaseUrl);
+    // llama.cpp server default port is 8080; only trust localhost to avoid
+    // false-positives for remote services that happen to run on 8080.
+    if (parsed.port === "8080") {
+      const hostname = parsed.hostname.toLowerCase();
+      const isLocalhost =
+        hostname === "localhost" ||
+        hostname === "127.0.0.1" ||
+        hostname === "::1" ||
+        hostname === "[::1]";
+      return isLocalhost;
+    }
+  } catch {
+    // ignore invalid URLs
+  }
+  return false;
+}

--- a/src/agents/schema/clean-for-llamacpp.ts
+++ b/src/agents/schema/clean-for-llamacpp.ts
@@ -22,6 +22,9 @@ export function stripLlamaCppUnsupportedKeywords(schema: unknown): unknown {
 
   // Collapse anyOf/oneOf to the first concrete (non-null) branch.
   // llama.cpp's GBNF grammar converter fails on complex union types.
+  // Preserve sibling keys (description, title, default, etc.) from the parent
+  // object — they are metadata about the field, not part of the union itself,
+  // and losing them silently degrades tool-call quality.
   for (const key of ["anyOf", "oneOf"] as const) {
     if (Array.isArray(obj[key])) {
       const variants = obj[key] as unknown[];
@@ -29,25 +32,35 @@ export function stripLlamaCppUnsupportedKeywords(schema: unknown): unknown {
         variants.find(
           (v) => v && typeof v === "object" && (v as Record<string, unknown>).type !== "null",
         ) ?? variants[0];
-      return stripLlamaCppUnsupportedKeywords(concrete);
+      // Collect sibling keys that are safe to keep (not anyOf/oneOf and not
+      // one of the unsupported keywords we strip globally).
+      const siblings: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(obj)) {
+        if (k !== "anyOf" && k !== "oneOf" && !LLAMACPP_UNSUPPORTED_SCHEMA_KEYWORDS.has(k)) {
+          siblings[k] = v;
+        }
+      }
+      // Resolved concrete branch wins over siblings for overlapping keys so that
+      // the concrete type information is always authoritative.
+      const resolvedConcrete = stripLlamaCppUnsupportedKeywords(concrete) as Record<
+        string,
+        unknown
+      >;
+      return { ...siblings, ...resolvedConcrete };
     }
   }
 
+  // Recursively clean all object-valued properties, not just `properties` and
+  // `items`. This handles $defs, definitions, allOf, and any future containers
+  // so that nested $ref/$schema/additionalProperties are stripped as well.
   const cleaned: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
     if (LLAMACPP_UNSUPPORTED_SCHEMA_KEYWORDS.has(key)) {
       continue;
     }
-    if (key === "properties" && value && typeof value === "object" && !Array.isArray(value)) {
-      cleaned[key] = Object.fromEntries(
-        Object.entries(value as Record<string, unknown>).map(([k, v]) => [
-          k,
-          stripLlamaCppUnsupportedKeywords(v),
-        ]),
-      );
-    } else if (key === "items" && value && typeof value === "object") {
+    if (value && typeof value === "object") {
       cleaned[key] = Array.isArray(value)
-        ? value.map(stripLlamaCppUnsupportedKeywords)
+        ? (value as unknown[]).map(stripLlamaCppUnsupportedKeywords)
         : stripLlamaCppUnsupportedKeywords(value);
     } else {
       cleaned[key] = value;


### PR DESCRIPTION
## Problem
After the 2026.3.2 SecretRef expansion and zod schema deduplication, tool definitions forwarded to llama.cpp-compatible endpoints began including JSON Schema keywords that llama.cpp's GBNF grammar converter cannot handle: `$schema`, `additionalProperties`, `$ref`, and complex `anyOf/oneOf` structures. The converter produces degenerate grammars that match fewer or zero tool calls, causing tool use to silently fail.

## Root cause
`normalizeToolParameters` in `src/agents/pi-tools.schema.ts` already handles Gemini and xAI provider-specific schema quirks, but had no equivalent sanitizer for llama.cpp-compatible providers. The `flattenedSchema` path explicitly sets `additionalProperties: true`, and `$schema`/`$ref` keywords flow through unchecked. Additionally, `modelBaseUrl` was not threaded from `attempt.ts` through `createOpenClawCodingTools` to `normalizeToolParameters`.

## Fix
- Added `src/agents/schema/clean-for-llamacpp.ts` with `isLlamaCppProvider()` (detects by provider name hints or localhost:8080 baseUrl) and `stripLlamaCppUnsupportedKeywords()` (strips `$schema`, `additionalProperties`, `$ref`, collapses `anyOf/oneOf` to first concrete branch)
- Updated `normalizeToolParameters` in `pi-tools.schema.ts` to accept `modelBaseUrl` and apply llama.cpp sanitization
- Threaded `modelBaseUrl` from `attempt.ts` → `createOpenClawCodingTools` → `normalizeToolParameters`

## Verification
- **Test:** `src/agents/schema/clean-for-llamacpp.test.ts` (22 tests) — fails on main, passes on fix
- **Build:** clean compile (`build-output.log`)
- **Test suite:** no new regressions (`test-output.log`)
- **Code proof:** old pattern removed, new pattern confirmed (`step6-verify.log`)

Closes #32916