### PR TITLE
fix(model-compat): correct openai-codex/gpt-5.4 forward-compat limits

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -363,8 +363,23 @@ describe("resolveForwardCompatModel", () => {
     expectResolvedForwardCompat(model, { provider: "openai-codex", id: "gpt-5.4" });
     expect(model?.api).toBe("openai-codex-responses");
     expect(model?.baseUrl).toBe("https://chatgpt.com/backend-api");
-    expect(model?.contextWindow).toBe(272_000);
+    expect(model?.contextWindow).toBe(1_050_000);
     expect(model?.maxTokens).toBe(128_000);
+  });
+
+  it("resolves openai-codex gpt-5.4 without templates using gpt-5.4 defaults", () => {
+    const registry = createRegistry({});
+
+    const model = resolveForwardCompatModel("openai-codex", "gpt-5.4", registry);
+
+    expectResolvedForwardCompat(model, { provider: "openai-codex", id: "gpt-5.4" });
+    expect(model?.api).toBe("openai-codex-responses");
+    expect(model?.baseUrl).toBe("https://chatgpt.com/backend-api");
+    expect(model?.input).toEqual(["text", "image"]);
+    expect(model?.reasoning).toBe(true);
+    expect(model?.contextWindow).toBe(1_050_000);
+    expect(model?.maxTokens).toBe(128_000);
+    expect(model?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
   });
 
   it("resolves anthropic opus 4.6 via 4.5 template", () => {

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -12,6 +12,8 @@ const OPENAI_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.2"] as const;
 const OPENAI_GPT_54_PRO_TEMPLATE_MODEL_IDS = ["gpt-5.2-pro", "gpt-5.2"] as const;
 
 const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
+const OPENAI_CODEX_GPT_54_CONTEXT_TOKENS = 1_050_000;
+const OPENAI_CODEX_GPT_54_MAX_TOKENS = 128_000;
 const OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex", "gpt-5.2-codex"] as const;
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
@@ -146,9 +148,16 @@ function resolveOpenAICodexForwardCompatModel(
       ...template,
       id: trimmedModelId,
       name: trimmedModelId,
+      ...(lower === OPENAI_CODEX_GPT_54_MODEL_ID
+        ? {
+            contextWindow: OPENAI_CODEX_GPT_54_CONTEXT_TOKENS,
+            maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
+          }
+        : {}),
     } as Model<Api>);
   }
 
+  const usesGpt54Defaults = lower === OPENAI_CODEX_GPT_54_MODEL_ID;
   return normalizeModelCompat({
     id: trimmedModelId,
     name: trimmedModelId,
@@ -158,8 +167,8 @@ function resolveOpenAICodexForwardCompatModel(
     reasoning: true,
     input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_TOKENS,
-    maxTokens: DEFAULT_CONTEXT_TOKENS,
+    contextWindow: usesGpt54Defaults ? OPENAI_CODEX_GPT_54_CONTEXT_TOKENS : DEFAULT_CONTEXT_TOKENS,
+    maxTokens: usesGpt54Defaults ? OPENAI_CODEX_GPT_54_MAX_TOKENS : DEFAULT_CONTEXT_TOKENS,
   } as Model<Api>);
 }
 


### PR DESCRIPTION
## Summary
- set `openai-codex/gpt-5.4` forward-compat fallback to GPT-5.4 limits (`contextWindow=1_050_000`, `maxTokens=128_000`)
- apply the same limits when cloning codex templates, so template metadata cannot keep stale 272k context
- add coverage for both template-backed and no-template codex fallback paths

Closes #37875

## Validation
- `bun test src/agents/model-compat.test.ts` (pass: 33 passed, 0 failed)
- `bun run lint src/agents/model-forward-compat.ts src/agents/model-compat.test.ts` (pass: 0 warnings, 0 errors)