### PR TITLE
fix(gateway): bypass streaming throttle when character growth exceeds threshold

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -441,6 +441,45 @@ describe("agent event handler", () => {
     nowSpy.mockRestore();
   });
 
+  it("bypasses time throttle when character growth exceeds threshold", () => {
+    let now = 12_000;
+    const nowSpy2 = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const { broadcast, chatRunState, handler } = createHarness();
+    chatRunState.registry.add("run-char-growth", {
+      sessionKey: "session-char-growth",
+      clientRunId: "client-char-growth",
+    });
+
+    handler({
+      runId: "run-char-growth",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: "A" },
+    });
+
+    // Within 150ms window but with 30+ chars of growth — should still broadcast
+    now = 12_050;
+    const longText = "A" + "x".repeat(40);
+    handler({
+      runId: "run-char-growth",
+      seq: 1,
+      stream: "assistant",
+      ts: Date.now(),
+      data: { text: longText },
+    });
+
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(chatCalls).toHaveLength(2);
+    const secondPayload = chatCalls[1]?.[1] as {
+      state?: string;
+      message?: { content?: Array<{ text?: string }> };
+    };
+    expect(secondPayload.state).toBe("delta");
+    expect(secondPayload.message?.content?.[0]?.text).toBe(longText);
+    nowSpy2.mockRestore();
+  });
+
   it("cleans up agent run sequence tracking when lifecycle completes", () => {
     const { agentRunSeq, chatRunState, handler, nowSpy } = createHarness({ now: 2_500 });
     chatRunState.registry.add("run-cleanup", {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -370,7 +370,9 @@ export function createAgentEventHandler({
     }
     const now = Date.now();
     const last = chatRunState.deltaSentAt.get(clientRunId) ?? 0;
-    if (now - last < 150) {
+    const lastLen = chatRunState.deltaLastBroadcastLen.get(clientRunId) ?? 0;
+    const charGrowth = mergedText.length - lastLen;
+    if (now - last < 150 && charGrowth < 30) {
       return;
     }
     chatRunState.deltaSentAt.set(clientRunId, now);


### PR DESCRIPTION
## Summary

- **Problem:** Streaming text in TUI and web UI does not actually stream — text only appears when the response is finalized. The 150ms time-based throttle in `emitChatDelta` drops most deltas when events arrive rapidly (e.g., with tool calls every few words).
- **Why it matters:** Users see a "streaming" indicator but no content for the entire duration of the response. This makes the UI feel broken and provides no feedback during long responses.
- **What changed:** Added a character-growth bypass to the throttle: if the merged buffer has grown by 30+ characters since the last broadcast, emit the delta regardless of time elapsed. The condition is now `timeElapsed < 150 && charGrowth < 30` (both must be true to suppress).
- **What did NOT change:** The existing `resolveMergedAssistantText` merge logic (d326861), the final flush mechanism, or any UI-side event handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37865

## User-visible / Behavior Changes

- Streaming text now appears progressively in both TUI and web UI, even during responses with frequent tool calls
- Small deltas (< 30 chars within 150ms) are still throttled to avoid excessive traffic

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — same broadcast mechanism, slightly more frequent
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js 22+
- Integration/channel: TUI, web UI

### Steps

1. Ask assistant: "please print the FULL lorem ipsum while using a tool call every 3 words"
2. Observe streaming behavior

### Expected

- Text appears progressively as it is generated

### Actual

- Before fix: "streaming" status shows but no text until response finalizes
- After fix: text streams visibly with updates whenever 30+ new characters accumulate

## Evidence

```
 ✓ src/gateway/server-chat.agent-events.test.ts (23 tests) 7ms

 Test Files  1 passed (1)
      Tests  23 passed (23)
```

New test verifies: within 150ms window, delta with 40+ char growth is broadcast (not suppressed).

## Human Verification (required)

- Verified scenarios: rapid deltas with large growth, small deltas within throttle window, tool boundary text preservation
- Edge cases checked: all 22 existing streaming/throttle tests still pass
- What I did **not** verify: live TUI/web UI streaming with frequent tool calls

## Compatibility / Migration

- Backward compatible? `Yes` — only changes broadcast frequency, not content
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit; streaming returns to previous behavior
- Files/config to restore: `src/gateway/server-chat.ts`
- Known bad symptoms: slightly more WebSocket messages during streaming (bounded by char growth threshold)

## Risks and Mitigations

- Risk: more broadcasts increase network traffic → mitigated by 30-char minimum growth threshold

