### PR TITLE
fix(discord): add early message-ID deduplication to prevent duplicate replies

### DIFF
--- a/src/discord/monitor/message-handler.queue.test.ts
+++ b/src/discord/monitor/message-handler.queue.test.ts
@@ -516,4 +516,26 @@ describe("createDiscordMessageHandler queue behavior", () => {
       );
     });
   });
+
+  it("deduplicates messages with the same message ID", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+
+    const ctx = createPreflightContext("ch-dedup");
+    preflightDiscordMessageMock.mockResolvedValue(ctx);
+    processDiscordMessageMock.mockResolvedValue(undefined);
+    eventualReplyDeliveredMock.mockResolvedValue(undefined);
+
+    const handler = createDiscordMessageHandler(createHandlerParams());
+
+    const data = createMessageData("msg-same-id", "ch-dedup");
+    const client = {} as never;
+
+    await handler(data as never, client);
+    await handler(data as never, client);
+
+    await vi.waitFor(() => {
+      expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -5,6 +5,7 @@ import {
 } from "../../channels/inbound-debounce-policy.js";
 import { resolveOpenProviderRuntimeGroupPolicy } from "../../config/runtime-group-policy.js";
 import { danger } from "../../globals.js";
+import { createDedupeCache } from "../../infra/dedupe.js";
 import { buildDiscordInboundJob } from "./inbound-job.js";
 import { createDiscordInboundWorker } from "./inbound-worker.js";
 import type { DiscordMessageEvent, DiscordMessageHandler } from "./listeners.js";
@@ -159,18 +160,20 @@ export function createDiscordMessageHandler(
     },
   });
 
+  const seenMessageIds = createDedupeCache({ ttlMs: 120_000, maxSize: 2000 });
+
   const handler: DiscordMessageHandlerWithLifecycle = async (data, client, options) => {
     try {
       if (options?.abortSignal?.aborted) {
         return;
       }
-      // Filter bot-own messages before they enter the debounce queue.
-      // The same check exists in preflightDiscordMessage(), but by that point
-      // the message has already consumed debounce capacity and blocked
-      // legitimate user messages. On active servers this causes cumulative
-      // slowdown (see #15874).
       const msgAuthorId = data.message?.author?.id ?? data.author?.id;
       if (params.botUserId && msgAuthorId === params.botUserId) {
+        return;
+      }
+
+      const msgId = data.message?.id;
+      if (typeof msgId === "string" && msgId && seenMessageIds.check(msgId)) {
         return;
       }
 


### PR DESCRIPTION
## Summary

- **Problem:** Discord bot sends duplicate replies to the same message. Both replies have the same message_id, with tools executed twice within 2-4ms. This is caused by Discord resending MESSAGE_CREATE events on reconnect or internal retries.
- **Why it matters:** Users receive confusing duplicate responses, and tool side effects (exec, write, etc.) are executed twice.
- **What changed:** Added a `createDedupeCache` (120s TTL, 2000 entries) keyed by `message.id` in the Discord message handler, checked before `debouncer.enqueue()`. Duplicate events for the same message ID are silently dropped.
- **What did NOT change:** The existing dispatch-level dedupe in `shouldSkipDuplicateInbound`, debouncer logic, or any other message processing steps.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37844

## User-visible / Behavior Changes

- Discord bot no longer sends duplicate replies to the same message
- Duplicate MESSAGE_CREATE events from reconnects/retries are silently dropped at the handler level

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 25.3.0 (arm64) - Apple M2
- Runtime: Node.js 22+
- Integration/channel: Discord (DM or group)

### Steps

1. Configure Discord as a messaging channel
2. Send a message to the bot
3. Observe response count

### Expected

- One reply per message

### Actual

- Before fix: two replies (duplicate tool execution within 2-4ms)
- After fix: one reply (duplicate MESSAGE_CREATE silently dropped)

## Evidence

```
 ✓ src/discord/monitor/message-handler.queue.test.ts (11 tests) 268ms

 Test Files  1 passed (1)
      Tests  11 passed (11)
```

New test verifies: sending the same message data twice results in only one preflight call.

## Human Verification (required)

- Verified scenarios: duplicate messages with same ID, different messages with different IDs, bot-own message filtering
- Edge cases checked: messages without ID (not deduped), TTL expiry (120s)
- What I did **not** verify: live Discord reconnect scenario

## Compatibility / Migration

- Backward compatible? `Yes` — only adds an early filter; existing downstream dedupe still active
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit; duplicate replies return but downstream dedupe may catch some
- Files/config to restore: `src/discord/monitor/message-handler.ts`
- Known bad symptoms: if cache size is too small for high-traffic servers, some dedup misses (fall through to existing dispatch-level dedupe)

## Risks and Mitigations

- Risk: legitimate rapid messages from same user dropped → mitigated by keying on message.id (unique per message), not user/channel

