### PR TITLE
fix(auto-reply): preserve session text when message tool sends only media

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -114,6 +114,24 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads).toHaveLength(0);
   });
 
+  it("does not suppress session text when message tool sent only media (#37841)", () => {
+    const { replyPayloads } = buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "The spike in Q3 is driven by X" }],
+      messageProvider: "whatsapp",
+      originatingChannel: "whatsapp",
+      originatingTo: "+1234567890",
+      messagingToolSentTexts: [],
+      messagingToolSentMediaUrls: ["file:///tmp/chart.png"],
+      messagingToolSentTargets: [
+        { tool: "message", provider: "whatsapp", to: "+1234567890" },
+      ],
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]?.text).toBe("The spike in Q3 is driven by X");
+  });
+
   it("does not suppress same-target replies when accountId differs", () => {
     const { replyPayloads } = buildReplyPayloads({
       ...baseParams,

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -91,19 +91,22 @@ export function buildReplyPayloads(params: {
     !params.blockReplyPipeline?.isAborted();
   const messagingToolSentTexts = params.messagingToolSentTexts ?? [];
   const messagingToolSentTargets = params.messagingToolSentTargets ?? [];
-  const suppressMessagingToolReplies = shouldSuppressMessagingToolReplies({
-    messageProvider: resolveOriginMessageProvider({
-      originatingChannel: params.originatingChannel,
-      provider: params.messageProvider,
-    }),
-    messagingToolSentTargets,
-    originatingTo: resolveOriginMessageTo({
-      originatingTo: params.originatingTo,
-    }),
-    accountId: resolveOriginAccountId({
-      originatingAccountId: params.accountId,
-    }),
-  });
+  const messagingToolSentText = messagingToolSentTexts.length > 0;
+  const suppressMessagingToolReplies =
+    messagingToolSentText &&
+    shouldSuppressMessagingToolReplies({
+      messageProvider: resolveOriginMessageProvider({
+        originatingChannel: params.originatingChannel,
+        provider: params.messageProvider,
+      }),
+      messagingToolSentTargets,
+      originatingTo: resolveOriginMessageTo({
+        originatingTo: params.originatingTo,
+      }),
+      accountId: resolveOriginAccountId({
+        originatingAccountId: params.accountId,
+      }),
+    });
   // Only dedupe against messaging tool sends for the same origin target.
   // Cross-target sends (for example posting to another channel) must not
   // suppress the current conversation's final reply.


### PR DESCRIPTION
## Summary

- **Problem:** When an agent writes session text and also calls the message tool to send media in the same turn, the session text is silently dropped on WhatsApp and other messaging channels. No error is raised.
- **Why it matters:** Users lose the agent's text explanation and only receive the media. Neither the agent nor the user knows information was lost.
- **What changed:** Gated `shouldSuppressMessagingToolReplies` on `messagingToolSentTexts.length > 0` in `buildReplyPayloads`. Media-only sends no longer trigger reply suppression, preserving the agent's session text.
- **What did NOT change:** Text deduplication behavior when the message tool sends text, cross-target suppression logic, or media URL deduplication.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37841

## User-visible / Behavior Changes

- When the message tool sends only media (no text/caption) to the same target, the agent's session text is now delivered as a separate message
- Text deduplication still suppresses replies when the message tool sends text

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node.js 22+
- Integration/channel: WhatsApp (also affects Telegram, Discord, etc.)

### Steps

1. Configure an agent on WhatsApp
2. Send a request that produces both text and media (e.g., "analyze this and send a chart")
3. Observe both text and media delivery

### Expected

- User receives both the text explanation and the media

### Actual

- Before fix: only media arrives, text silently dropped
- After fix: both text and media are delivered

## Evidence

```
 ✓ src/auto-reply/reply/agent-runner-payloads.test.ts (10 tests) 4ms

 Test Files  1 passed (1)
      Tests  10 passed (10)
```

New test verifies: media-only message tool send does not suppress session text for same-target WhatsApp delivery.

## Human Verification (required)

- Verified scenarios: media-only send (text preserved), text send (text suppressed), cross-target (text preserved), text+media send
- Edge cases checked: empty messagingToolSentTexts, empty messagingToolSentTargets
- What I did **not** verify: live WhatsApp media delivery with session text

## Compatibility / Migration

- Backward compatible? `Yes` — only un-suppresses previously dropped text
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert this commit; text is suppressed again when tool sends media
- Files/config to restore: `src/auto-reply/reply/agent-runner-payloads.ts`
- Known bad symptoms: if the agent writes the same text as the media caption, both text and caption are delivered (minor duplicate)

## Risks and Mitigations

- Risk: agents that intentionally use NO_REPLY with media-only tools may see unexpected text delivery → mitigated by: NO_REPLY produces empty text payloads which are already filtered out

