### PR TITLE
fix(agents): inline Session Startup section into bare session reset prompt

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -43,7 +43,7 @@ import type { createModelSelectionState } from "./model-selection.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { resolveQueueSettings } from "./queue.js";
 import { routeReply } from "./route-reply.js";
-import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
+import { buildBareSessionResetPrompt, readStartupSection } from "./session-reset-prompt.js";
 import { drainFormattedSystemEvents, ensureSkillSnapshot } from "./session-updates.js";
 import { resolveTypingMode } from "./typing-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
@@ -290,7 +290,9 @@ export async function runPreparedReply(
   const isBareSessionReset =
     isNewSession &&
     ((baseBodyTrimmedRaw.length === 0 && rawBodyTrimmed.length > 0) || isBareNewOrReset);
-  const baseBodyFinal = isBareSessionReset ? buildBareSessionResetPrompt(cfg) : baseBody;
+  const baseBodyFinal = isBareSessionReset
+    ? buildBareSessionResetPrompt(cfg, undefined, readStartupSection(workspaceDir))
+    : baseBody;
   const inboundUserContext = buildInboundUserContextPrefix(
     isNewSession
       ? {

--- a/src/auto-reply/reply/session-reset-prompt.test.ts
+++ b/src/auto-reply/reply/session-reset-prompt.test.ts
@@ -1,6 +1,9 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, it, expect } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
+import { buildBareSessionResetPrompt, readStartupSection } from "./session-reset-prompt.js";
 
 describe("buildBareSessionResetPrompt", () => {
   it("includes the core session startup instruction", () => {
@@ -31,5 +34,57 @@ describe("buildBareSessionResetPrompt", () => {
     const nowMs = Date.UTC(2026, 2, 3, 14, 0, 0);
     const prompt = buildBareSessionResetPrompt(undefined, nowMs);
     expect(prompt).toContain("Current time:");
+  });
+
+  it("inlines startup section when provided", () => {
+    const section =
+      "## Session Startup\n\n1. Read /workspace/BOOTSTRAP.md\n2. Read /workspace/persona.md";
+    const prompt = buildBareSessionResetPrompt(undefined, undefined, section);
+    expect(prompt).toContain("Your Session Startup instructions from AGENTS.md:");
+    expect(prompt).toContain("Read /workspace/BOOTSTRAP.md");
+    expect(prompt).toContain("Read /workspace/persona.md");
+    expect(prompt).toContain("Execute your Session Startup sequence now");
+  });
+
+  it("does not include startup section header when no section provided", () => {
+    const prompt = buildBareSessionResetPrompt();
+    expect(prompt).not.toContain("Your Session Startup instructions from AGENTS.md:");
+  });
+});
+
+describe("readStartupSection", () => {
+  function makeTmpWorkspace(agentsMd: string): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "reset-prompt-test-"));
+    fs.writeFileSync(path.join(dir, "AGENTS.md"), agentsMd, "utf-8");
+    return dir;
+  }
+
+  it("extracts Session Startup section from AGENTS.md", () => {
+    const dir = makeTmpWorkspace(
+      "# Agent\n\n## Session Startup\n\n1. Read BOOTSTRAP.md\n2. Greet user\n\n## Red Lines\n\nDo not lie.\n",
+    );
+    const section = readStartupSection(dir);
+    expect(section).toBeDefined();
+    expect(section).toContain("Read BOOTSTRAP.md");
+    expect(section).not.toContain("Do not lie");
+  });
+
+  it("returns undefined when no AGENTS.md exists", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "reset-prompt-test-"));
+    const section = readStartupSection(dir);
+    expect(section).toBeUndefined();
+  });
+
+  it("returns undefined when AGENTS.md has no Session Startup section", () => {
+    const dir = makeTmpWorkspace("# Agent\n\n## Red Lines\n\nDo not lie.\n");
+    const section = readStartupSection(dir);
+    expect(section).toBeUndefined();
+  });
+
+  it("falls back to Every Session legacy name", () => {
+    const dir = makeTmpWorkspace("# Agent\n\n## Every Session\n\n1. Read config.md\n");
+    const section = readStartupSection(dir);
+    expect(section).toBeDefined();
+    expect(section).toContain("Read config.md");
   });
 });

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -1,20 +1,70 @@
+import fs from "node:fs";
+import path from "node:path";
 import { appendCronStyleCurrentTimeLine } from "../../agents/current-time.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { openBoundaryFileSync } from "../../infra/boundary-file-read.js";
+import { extractSections } from "./post-compaction-context.js";
 
 const BARE_SESSION_RESET_PROMPT_BASE =
   "A new session was started via /new or /reset. Execute your Session Startup sequence now - read the required files before responding to the user. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
+
+const MAX_STARTUP_SECTION_CHARS = 3000;
+
+/**
+ * Read the "## Session Startup" section from AGENTS.md in the workspace.
+ * Returns the section content or undefined if not found / unreadable.
+ */
+export function readStartupSection(workspaceDir: string): string | undefined {
+  const agentsPath = path.join(workspaceDir, "AGENTS.md");
+  try {
+    const opened = openBoundaryFileSync({
+      absolutePath: agentsPath,
+      rootPath: workspaceDir,
+      boundaryLabel: "workspace root",
+    });
+    if (!opened.ok) {
+      return undefined;
+    }
+    let content: string;
+    try {
+      content = fs.readFileSync(opened.fd, "utf-8");
+    } finally {
+      fs.closeSync(opened.fd);
+    }
+    let sections = extractSections(content, ["Session Startup"]);
+    if (sections.length === 0) {
+      sections = extractSections(content, ["Every Session"]);
+    }
+    if (sections.length === 0) {
+      return undefined;
+    }
+    const combined = sections.join("\n\n");
+    return combined.length > MAX_STARTUP_SECTION_CHARS
+      ? combined.slice(0, MAX_STARTUP_SECTION_CHARS) + "\n...[truncated]..."
+      : combined;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Build the bare session reset prompt, appending the current date/time so agents
  * know which daily memory files to read during their Session Startup sequence.
  * Without this, agents on /new or /reset guess the date from their training cutoff.
+ *
+ * When `startupSection` is provided (extracted from AGENTS.md), it is inlined
+ * into the prompt so the model has concrete file paths instead of hallucinating
+ * them from training data.
  */
-export function buildBareSessionResetPrompt(cfg?: OpenClawConfig, nowMs?: number): string {
-  return appendCronStyleCurrentTimeLine(
-    BARE_SESSION_RESET_PROMPT_BASE,
-    cfg ?? {},
-    nowMs ?? Date.now(),
-  );
+export function buildBareSessionResetPrompt(
+  cfg?: OpenClawConfig,
+  nowMs?: number,
+  startupSection?: string,
+): string {
+  const base = startupSection
+    ? `${BARE_SESSION_RESET_PROMPT_BASE}\n\nYour Session Startup instructions from AGENTS.md:\n\n${startupSection}`
+    : BARE_SESSION_RESET_PROMPT_BASE;
+  return appendCronStyleCurrentTimeLine(base, cfg ?? {}, nowMs ?? Date.now());
 }
 
 /** @deprecated Use buildBareSessionResetPrompt(cfg) instead */

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { listAgentIds } from "../../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import type { AgentInternalEvent } from "../../agents/internal-events.js";
-import { buildBareSessionResetPrompt } from "../../auto-reply/reply/session-reset-prompt.js";
+import {
+  buildBareSessionResetPrompt,
+  readStartupSection,
+} from "../../auto-reply/reply/session-reset-prompt.js";
 import { agentCommandFromIngress } from "../../commands/agent.js";
 import { loadConfig } from "../../config/config.js";
 import {
@@ -359,7 +363,12 @@ export const agentHandlers: GatewayRequestHandlers = {
         // reset first, then run a fresh-session greeting prompt in-place.
         // Date is embedded in the prompt so agents read the correct daily
         // memory files; skip further timestamp injection to avoid duplication.
-        message = buildBareSessionResetPrompt(cfg);
+        const resetWorkspaceDir = agentId ? resolveAgentWorkspaceDir(cfg, agentId) : undefined;
+        message = buildBareSessionResetPrompt(
+          cfg,
+          undefined,
+          resetWorkspaceDir ? readStartupSection(resetWorkspaceDir) : undefined,
+        );
         skipTimestampInjection = true;
       }
     }


### PR DESCRIPTION
## Summary

Fixes large models (Sonnet) hallucinating file paths like `/app/config/persona.md` on `/new` or `/reset` instead of following the `## Session Startup` section from AGENTS.md.

## Problem

`buildBareSessionResetPrompt` generates a vague instruction: *"Execute your Session Startup sequence now - read the required files before responding to the user."* This relies on the model finding the `## Session Startup` section in the system prompt context. Smaller models (Haiku) correctly follow the section, but larger models like Sonnet consistently ignore it and hallucinate paths inferred from training data (`/app/config/persona.md`, `/project/config/persona.md`, `~/persona.md`), causing ENOENT errors and a fallback to the default Claude persona.

## Changes

| File | Change |
|------|--------|
| `src/auto-reply/reply/session-reset-prompt.ts` | Added `readStartupSection()` to extract `## Session Startup` from workspace AGENTS.md; updated `buildBareSessionResetPrompt` to accept and inline a `startupSection` parameter |
| `src/auto-reply/reply/get-reply-run.ts` | Pass `readStartupSection(workspaceDir)` to `buildBareSessionResetPrompt` on bare `/new`/`/reset` |
| `src/gateway/server-methods/agent.ts` | Same pattern for the gateway agent handler; resolve workspace dir and pass startup section |
| `src/auto-reply/reply/session-reset-prompt.test.ts` | 6 new tests for startup section inlining and `readStartupSection` extraction |

## How it works

On `/new` or `/reset`, the reset prompt now reads AGENTS.md from the workspace, extracts the `## Session Startup` section (falling back to legacy `## Every Session`), and appends it directly to the prompt:

```
A new session was started via /new or /reset. Execute your Session Startup sequence now...

Your Session Startup instructions from AGENTS.md:

## Session Startup

1. Read BOOTSTRAP.md
2. Read persona.md
...
```

This mirrors the pattern already used by `readPostCompactionContext()` for post-compaction recovery, which inlines AGENTS.md sections and works reliably across all model sizes.

## Test plan

- [x] 10 tests pass in `session-reset-prompt.test.ts` (4 existing + 6 new)
- [x] New tests verify: startup section inlining, no header when absent, extraction from AGENTS.md, missing file handling, missing section handling, legacy name fallback
- [ ] Manual: configure a Sonnet agent with custom `## Session Startup` files, send `/new`, verify it reads the correct files instead of hallucinating

## Security Impact

- Does this change handle user input? **No** (reads workspace AGENTS.md only)
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Configure an agent with a custom workspace and `## Session Startup` section in AGENTS.md listing specific files
2. Set primary model to `claude-sonnet-4-6` (or any large model)
3. Send `/new` to the agent
4. Verify the agent reads the files listed in AGENTS.md instead of hallucinating `/app/config/persona.md`
5. Verify Haiku still works correctly (no regression)

## Failure Recovery

Revert the three source files; `buildBareSessionResetPrompt` falls back to the original vague prompt when no `startupSection` is provided.

## Risks and Mitigations

- **Risk**: Startup section content increases prompt token count. **Mitigation**: Content is capped at 3000 characters (matching post-compaction context limit) and only injected on `/new`/`/reset`.
- **Risk**: Reading AGENTS.md synchronously on the reset path. **Mitigation**: `openBoundaryFileSync` is already used in the post-compaction path; reset is infrequent and the file is small.