### PR TITLE
fix(acp): resolve completion loop stall for opencode sessions (#37869)

### DIFF
--- a/extensions/acpx/src/runtime-internals/test-fixtures.ts
+++ b/extensions/acpx/src/runtime-internals/test-fixtures.ts
@@ -179,6 +179,7 @@ if (command === "prompt") {
     openclawShell,
   });
   const requestId = "req-1";
+  const lingerAfterDone = agent === "opencode" && stdinText.includes("slow-exit-after-done");
 
   emitJson({
     jsonrpc: "2.0",
@@ -270,7 +271,11 @@ if (command === "prompt") {
     content: { type: "text", text: "echo:" + stdinText.trim() },
   });
   emitJson({ type: "done", stopReason: "end_turn" });
-  process.exit(0);
+  if (lingerAfterDone) {
+    setTimeout(() => process.exit(0), 3000);
+  } else {
+    process.exit(0);
+  }
 }
 
 writeLog({ kind: "unknown", args });

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -194,6 +194,40 @@ describe("AcpxRuntime", () => {
     expect(doneCount).toBe(1);
   });
 
+  it("completes opencode turns even when the process lingers after done", async () => {
+    const runtime = sharedFixture?.runtime;
+    expect(runtime).toBeDefined();
+    if (!runtime) {
+      throw new Error("shared runtime fixture missing");
+    }
+    const handle = await runtime.ensureSession({
+      sessionKey: "agent:opencode:acp:linger-after-done",
+      agent: "opencode",
+      mode: "persistent",
+    });
+
+    const startedAt = Date.now();
+    const events = [];
+    for await (const event of runtime.runTurn({
+      handle,
+      text: "slow-exit-after-done",
+      mode: "prompt",
+      requestId: "req-linger-after-done",
+    })) {
+      events.push(event);
+    }
+    const durationMs = Date.now() - startedAt;
+
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "done",
+        }),
+      ]),
+    );
+    expect(durationMs).toBeLessThan(2_500);
+  });
+
   it("maps acpx error events into ACP runtime error events", async () => {
     const runtime = sharedFixture?.runtime;
     expect(runtime).toBeDefined();

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -404,6 +404,11 @@ export class AcpxRuntime implements AcpRuntime {
         }
         if (parsed.type === "error") {
           sawError = true;
+          yield parsed;
+          // Mirror done: a terminal error event should also break the readline
+          // loop so the process can be shut down via waitForPromptExit instead
+          // of blocking indefinitely on stdout if the harness keeps it open.
+          break;
         }
         yield parsed;
       }

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -1,3 +1,4 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { createInterface } from "node:readline";
 import type {
   AcpRuntimeCapabilities,
@@ -23,6 +24,7 @@ import {
   resolveSpawnFailure,
   type SpawnCommandCache,
   type SpawnCommandOptions,
+  type SpawnExit,
   type SpawnResolutionEvent,
   spawnAndCollect,
   spawnWithResolvedCommand,
@@ -43,9 +45,31 @@ export const ACPX_BACKEND_ID = "acpx";
 const ACPX_RUNTIME_HANDLE_PREFIX = "acpx:v1:";
 const DEFAULT_AGENT_FALLBACK = "codex";
 const ACPX_EXIT_CODE_PERMISSION_DENIED = 5;
+const ACPX_PROMPT_DONE_EXIT_GRACE_MS = 400;
+const ACPX_PROMPT_FORCE_EXIT_GRACE_MS = 400;
 const ACPX_CAPABILITIES: AcpRuntimeCapabilities = {
   controls: ["session/set_mode", "session/set_config_option", "session/status"],
 };
+
+async function waitWithTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | null> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return await promise;
+  }
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race<T | null>([
+      promise,
+      new Promise<null>((resolve) => {
+        timeoutHandle = setTimeout(() => resolve(null), timeoutMs);
+        timeoutHandle.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
 
 function formatPermissionModeGuidance(): string {
   return "Configure plugins.entries.acpx.config.permissionMode to one of: approve-reads, approve-all, deny-all.";
@@ -157,6 +181,60 @@ export class AcpxRuntime implements AcpRuntime {
     this.loggedSpawnResolutions.add(key);
     this.logger?.debug?.(
       `acpx spawn resolver: command=${event.command} mode=${event.strictWindowsCmdWrapper ? "strict" : "compat"} resolution=${event.resolution}`,
+    );
+  }
+
+  private async waitForPromptExit(params: {
+    child: ChildProcessWithoutNullStreams;
+    exitPromise: Promise<SpawnExit>;
+    sawTerminalEvent: boolean;
+    agent: string;
+    sessionName: string;
+  }): Promise<SpawnExit> {
+    if (!params.sawTerminalEvent) {
+      return await params.exitPromise;
+    }
+
+    const gracefulExit = await waitWithTimeout(
+      params.exitPromise,
+      ACPX_PROMPT_DONE_EXIT_GRACE_MS,
+    );
+    if (gracefulExit) {
+      return gracefulExit;
+    }
+
+    this.logger?.warn?.(
+      `acpx prompt lingered after terminal event; forcing shutdown (agent=${params.agent} session=${params.sessionName})`,
+    );
+
+    try {
+      params.child.kill("SIGTERM");
+    } catch {
+      // Ignore kill races when process already exited.
+    }
+
+    const terminatedExit = await waitWithTimeout(
+      params.exitPromise,
+      ACPX_PROMPT_FORCE_EXIT_GRACE_MS,
+    );
+    if (terminatedExit) {
+      return terminatedExit;
+    }
+
+    try {
+      params.child.kill("SIGKILL");
+    } catch {
+      // Ignore kill races when process already exited.
+    }
+
+    const killedExit = await waitWithTimeout(params.exitPromise, ACPX_PROMPT_FORCE_EXIT_GRACE_MS);
+    if (killedExit) {
+      return killedExit;
+    }
+
+    throw new AcpRuntimeError(
+      "ACP_TURN_FAILED",
+      `ACP prompt process did not exit after terminal event (agent=${params.agent}, session=${params.sessionName}).`,
     );
   }
 
@@ -322,6 +400,10 @@ export class AcpxRuntime implements AcpRuntime {
             continue;
           }
           sawDone = true;
+          yield parsed;
+          // Some harness adapters can keep the process alive after a terminal
+          // done event. Stop reading and enforce shutdown below.
+          break;
         }
         if (parsed.type === "error") {
           sawError = true;
@@ -329,7 +411,13 @@ export class AcpxRuntime implements AcpRuntime {
         yield parsed;
       }
 
-      const exit = await waitForExit(child);
+      const exit = await this.waitForPromptExit({
+        child,
+        exitPromise: waitForExit(child),
+        sawTerminalEvent: sawDone || sawError,
+        agent: state.agent,
+        sessionName: state.name,
+      });
       if (exit.error) {
         const spawnFailure = resolveSpawnFailure(exit.error, state.cwd);
         if (spawnFailure === "missing-command") {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -195,10 +195,7 @@ export class AcpxRuntime implements AcpRuntime {
       return await params.exitPromise;
     }
 
-    const gracefulExit = await waitWithTimeout(
-      params.exitPromise,
-      ACPX_PROMPT_DONE_EXIT_GRACE_MS,
-    );
+    const gracefulExit = await waitWithTimeout(params.exitPromise, ACPX_PROMPT_DONE_EXIT_GRACE_MS);
     if (gracefulExit) {
       return gracefulExit;
     }


### PR DESCRIPTION
## Summary
- treat ACP runtime terminal events (`done`/`error`) as turn completion boundaries in `acpx` prompt streaming instead of waiting indefinitely for stdout EOF
- add bounded exit grace and forced process shutdown for lingering harness processes after terminal events
- add a regression test that reproduces opencode-like delayed process exit after `done`

## Root cause
`AcpxRuntime.runTurn` waited for the prompt stream to fully close and the process to exit before finishing the turn.
For opencode sessions, the harness can emit a terminal `done` update while the process continues running, leaving ACP session state in `running` and preventing parent announce/completion flow.

## Validation
- `pnpm build`
- `pnpm test -- extensions/acpx/src/runtime.test.ts`
- `pnpm test -- src/acp/control-plane/manager.test.ts src/agents/acp-spawn.test.ts src/auto-reply/reply/dispatch-acp.test.ts src/auto-reply/reply/session-delivery.test.ts`

Fixes #37869
