### PR TITLE
fix(subagents): enforce config runTimeoutSeconds as minimum floor (#37902)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Subagents/timeout floor: enforce `agents.defaults.subagents.runTimeoutSeconds` as minimum floor when model provides `runTimeoutSeconds` in `sessions_spawn` calls, preventing models from autonomously setting too-short timeouts (especially on retry attempts where models may decrease the value). (#37902)
 - Onboarding/headless Linux daemon probe hardening: treat `systemctl --user is-enabled` probe failures as non-fatal during daemon install flow so onboarding no longer crashes on SSH/headless VPS environments before showing install guidance. (#37297) Thanks @acarbajal-web.
 - Memory/QMD mcporter Windows spawn hardening: when `mcporter.cmd` launch fails with `spawn EINVAL`, retry via bare `mcporter` shell resolution so QMD recall can continue instead of falling back to builtin memory search. (#27402) Thanks @i0ivi0i.
 - Tools/web_search Brave language-code validation: align `search_lang` handling with Brave-supported codes (including `zh-hans`, `zh-hant`, `en-gb`, and `pt-br`), map common alias inputs (`zh`, `ja`) to valid Brave values, and reject unsupported codes before upstream requests to prevent 422 failures. (#37260) Thanks @heyanming.

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts
@@ -49,12 +49,36 @@ describe("sessions_spawn default runTimeoutSeconds", () => {
     expect(getSubagentTimeout(gateway.calls)).toBe(900);
   });
 
-  it("explicit runTimeoutSeconds wins over config default", async () => {
-    applySubagentTimeoutDefault(900);
+  it("explicit runTimeoutSeconds can increase timeout above config default", async () => {
+    applySubagentTimeoutDefault(300);
     const gateway = sessionsHarness.setupSessionsSpawnGatewayMock({});
 
-    await spawnSubagent("call-2", { task: "hello", runTimeoutSeconds: 300 });
+    await spawnSubagent("call-2", { task: "hello", runTimeoutSeconds: 900 });
 
+    expect(getSubagentTimeout(gateway.calls)).toBe(900);
+  });
+
+  it("config default acts as floor when agent provides lower runTimeoutSeconds", async () => {
+    applySubagentTimeoutDefault(300);
+    const gateway = sessionsHarness.setupSessionsSpawnGatewayMock({});
+
+    await spawnSubagent("call-3", { task: "hello", runTimeoutSeconds: 60 });
+
+    // Config default (300) is enforced as minimum, agent's 60 is rejected
     expect(getSubagentTimeout(gateway.calls)).toBe(300);
+  });
+
+  it("config default prevents model from decreasing timeout on retries", async () => {
+    applySubagentTimeoutDefault(300);
+    const gateway = sessionsHarness.setupSessionsSpawnGatewayMock({});
+
+    // Simulate model decreasing timeout across retries (60 → 45 → 20)
+    await spawnSubagent("call-4a", { task: "hello", runTimeoutSeconds: 60 });
+    await spawnSubagent("call-4b", { task: "hello", runTimeoutSeconds: 45 });
+    await spawnSubagent("call-4c", { task: "hello", runTimeoutSeconds: 20 });
+
+    const calls = gateway.calls;
+    // All three spawns should use config default (300) as floor
+    expect(getSubagentTimeout(calls)).toBe(300);
   });
 });

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts
@@ -74,11 +74,17 @@ describe("sessions_spawn default runTimeoutSeconds", () => {
 
     // Simulate model decreasing timeout across retries (60 → 45 → 20)
     await spawnSubagent("call-4a", { task: "hello", runTimeoutSeconds: 60 });
-    await spawnSubagent("call-4b", { task: "hello", runTimeoutSeconds: 45 });
-    await spawnSubagent("call-4c", { task: "hello", runTimeoutSeconds: 20 });
+    const timeout1 = getSubagentTimeout(gateway.calls);
 
-    const calls = gateway.calls;
+    await spawnSubagent("call-4b", { task: "hello", runTimeoutSeconds: 45 });
+    const timeout2 = getSubagentTimeout(gateway.calls.slice(1));
+
+    await spawnSubagent("call-4c", { task: "hello", runTimeoutSeconds: 20 });
+    const timeout3 = getSubagentTimeout(gateway.calls.slice(2));
+
     // All three spawns should use config default (300) as floor
-    expect(getSubagentTimeout(calls)).toBe(300);
+    expect(timeout1).toBe(300);
+    expect(timeout2).toBe(300);
+    expect(timeout3).toBe(300);
   });
 });

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -299,9 +299,12 @@ export async function spawnSubagentDirect(
     Number.isFinite(cfg.agents.defaults.subagents.runTimeoutSeconds)
       ? Math.max(0, Math.floor(cfg.agents.defaults.subagents.runTimeoutSeconds))
       : 0;
+  // When agent provides runTimeoutSeconds, enforce config value as minimum floor.
+  // This prevents models from autonomously setting too-short timeouts that cause
+  // premature failures, especially on retry attempts where models may decrease the value.
   const runTimeoutSeconds =
     typeof params.runTimeoutSeconds === "number" && Number.isFinite(params.runTimeoutSeconds)
-      ? Math.max(0, Math.floor(params.runTimeoutSeconds))
+      ? Math.max(cfgSubagentTimeout, Math.floor(params.runTimeoutSeconds))
       : cfgSubagentTimeout;
   let modelApplied = false;
   let threadBindingReady = false;


### PR DESCRIPTION
## Summary

- **Bug**: Model-provided `runTimeoutSeconds` in `sessions_spawn` unconditionally overrides config default
- **Root cause**: [src/agents/subagent-spawn.ts:302-305](https://github.com/openclaw/openclaw/blob/main/src/agents/subagent-spawn.ts#L302-L305) - no floor enforcement
- **Fix**: Enforce `agents.defaults.subagents.runTimeoutSeconds` as minimum floor

Fixes #37902

## Problem

When an orchestrating agent calls `sessions_spawn`, it can autonomously set `runTimeoutSeconds` in the tool call. The current implementation accepts this value unconditionally, completely ignoring the configured `agents.defaults.subagents.runTimeoutSeconds`.

**Impact**:
- Models may pass too-short timeouts (e.g., 15-60 seconds)
- On retry attempts, models often **decrease** the timeout value (60 → 45 → 20 → 15), making success increasingly unlikely
- User-configured 300-second timeout is completely bypassed
- Subagents timeout prematurely even when actively making progress

**Before fix**:
```typescript
const runTimeoutSeconds =
  typeof params.runTimeoutSeconds === "number" && Number.isFinite(params.runTimeoutSeconds)
    ? Math.max(0, Math.floor(params.runTimeoutSeconds))  // Model value wins unconditionally
    : cfgSubagentTimeout;
```

## Changes

- `src/agents/subagent-spawn.ts` — Enforce config value as minimum floor when model provides `runTimeoutSeconds`
- `src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts` — Add 3 new tests covering floor enforcement

**After fix**:
```typescript
const runTimeoutSeconds =
  typeof params.runTimeoutSeconds === "number" && Number.isFinite(params.runTimeoutSeconds)
    ? Math.max(cfgSubagentTimeout, Math.floor(params.runTimeoutSeconds))  // Config is floor
    : cfgSubagentTimeout;
```

**Behavior**:
- Model can **increase** timeout above config (e.g., config=300, model=900 → use 900)
- Model **cannot decrease** timeout below config (e.g., config=300, model=60 → use 300)
- Config value acts as safety floor, preventing premature timeouts

## Test plan

- [x] New test: config default acts as floor when agent provides lower runTimeoutSeconds
- [x] New test: config default prevents model from decreasing timeout on retries
- [x] New test: explicit runTimeoutSeconds can increase timeout above config default
- [x] All 4 existing timeout tests pass
- [x] Lint passes

## Effect on User Experience

**Before**: Model autonomously sets 60-second timeout, ignoring user's 300-second config. On retry, model decreases to 45s, then 20s, then 15s. Subagent times out repeatedly despite making progress.

**After**: Model's 60-second request is raised to 300 seconds (config floor). All retries use at least 300 seconds. Subagent has adequate time to complete.