### PR TITLE
fix(feishu): allow plugin status with unresolved SecretRefs during inspect

### DIFF
--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -325,6 +325,28 @@ describe("resolveFeishuAccount", () => {
     ).toThrow(/unresolved SecretRef/i);
   });
 
+  it("supports read-only account inspection with unresolved refs allowed", () => {
+    const account = resolveFeishuAccount({
+      cfg: {
+        channels: {
+          feishu: {
+            accounts: {
+              main: {
+                appId: "cli_123",
+                appSecret: { source: "file", provider: "default", id: "path/to/secret" },
+              } as never,
+            },
+          },
+        },
+      } as never,
+      accountId: "main",
+      allowUnresolvedSecretRef: true,
+    });
+
+    expect(account.accountId).toBe("main");
+    expect(account.configured).toBe(false);
+  });
+
   it("does not throw when account name is non-string", () => {
     expect(() =>
       resolveFeishuAccount({

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -187,6 +187,7 @@ export function resolveFeishuCredentials(
 export function resolveFeishuAccount(params: {
   cfg: ClawdbotConfig;
   accountId?: string | null;
+  allowUnresolvedSecretRef?: boolean;
 }): ResolvedFeishuAccount {
   const hasExplicitAccountId =
     typeof params.accountId === "string" && params.accountId.trim() !== "";
@@ -212,7 +213,9 @@ export function resolveFeishuAccount(params: {
   const enabled = baseEnabled && accountEnabled;
 
   // Resolve credentials from merged config
-  const creds = resolveFeishuCredentials(merged);
+  const creds = resolveFeishuCredentials(merged, {
+    allowUnresolvedSecretRef: params.allowUnresolvedSecretRef,
+  });
   const accountName = (merged as FeishuAccountConfig).name;
 
   return {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -158,6 +158,12 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
   config: {
     listAccountIds: (cfg) => listFeishuAccountIds(cfg),
     resolveAccount: (cfg, accountId) => resolveFeishuAccount({ cfg, accountId }),
+    inspectAccount: (cfg, accountId) =>
+      resolveFeishuAccount({
+        cfg,
+        accountId,
+        allowUnresolvedSecretRef: true,
+      }),
     defaultAccountId: (cfg) => resolveDefaultFeishuAccountId(cfg),
     setAccountEnabled: ({ cfg, accountId, enabled }) => {
       const account = resolveFeishuAccount({ cfg, accountId });


### PR DESCRIPTION
## Summary
- add `allowUnresolvedSecretRef` option to Feishu account resolution path
- wire Feishu channel `config.inspectAccount` to use relaxed secret-ref handling for read-only inspection/status flows
- keep strict `resolveAccount` behavior unchanged for runtime paths
- add regression coverage for relaxed inspection mode with unresolved refs

## Why
Issue #37633 reports `openclaw plugins list` failing when Feishu credentials use SecretRef objects (e.g. env refs). Read-only status/inspection should not crash plugin registration.

## Validation
- pnpm -s test extensions/feishu/src/accounts.test.ts
- pnpm -s test src/channels/plugins/plugins-core.test.ts

Fixes #37633
