### PR TITLE
fix(agents): re-sanitize tool pairing after orphaned user message removal

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1681,7 +1681,10 @@ export async function runEmbeddedAttempt(
             sessionManager.resetLeaf();
           }
           const sessionContext = sessionManager.buildSessionContext();
-          activeSession.agent.replaceMessages(sessionContext.messages);
+          const repairedMessages = transcriptPolicy.repairToolUseResultPairing
+            ? sanitizeToolUseResultPairing(sessionContext.messages)
+            : sessionContext.messages;
+          activeSession.agent.replaceMessages(repairedMessages);
           log.warn(
             `Removed orphaned user message to prevent consecutive user turns. ` +
               `runId=${params.runId} sessionId=${params.sessionId}`,

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -488,3 +488,29 @@ describe("stripToolResultDetails", () => {
     expect(out).toBe(input);
   });
 });
+
+describe("sanitizeToolUseResultPairing – orphaned tool_result after session rebuild", () => {
+  it("drops tool_result whose matching tool_use assistant message was removed during session rebuild", () => {
+    const messages = castAgentMessages([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: [{ type: "text", text: "sure" }] },
+      {
+        role: "toolResult",
+        toolCallId: "callfunction91b6mt5824h61",
+        toolName: "bash",
+        content: [{ type: "text", text: "done" }],
+      },
+      { role: "user", content: "thanks" },
+    ]);
+
+    const repaired = sanitizeToolUseResultPairing(messages);
+
+    const hasOrphanedResult = repaired.some(
+      (m) =>
+        (m as { role: string }).role === "toolResult" &&
+        (m as { toolCallId?: string }).toolCallId === "callfunction91b6mt5824h61",
+    );
+    expect(hasOrphanedResult).toBe(false);
+    expect(repaired).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes WebUI error 2013 ("tool result's tool id not found") and infinite spinner by re-applying `sanitizeToolUseResultPairing` after the session manager rebuilds messages following orphaned user message removal.

## Problem

When an orphaned trailing user message is detected and removed in `attempt.ts`, `sessionManager.buildSessionContext()` rebuilds the entire message array from the session tree. This rebuild happens *after* the initial `sanitizeToolUseResultPairing` call (line ~1404) and does **not** re-apply it. The rebuilt array can contain `tool_result` messages whose matching `tool_use` blocks were dropped during the tree rebuild, leaving orphaned results that cause LLM API validation errors.

Reproduction path:
1. User sends a message in WebUI
2. Agent executes a tool (e.g., bash) and produces a `tool_use` + `tool_result` pair
3. An orphaned trailing user message is detected (logged as "Removed orphaned user message")
4. `sessionManager.buildSessionContext()` rebuilds messages — the `tool_use` assistant message is pruned but the `tool_result` survives
5. The next API call fails with error 2013: `tool_result` references a `tool_call_id` (`callfunction91b6mt5824h61`) with no corresponding `tool_use` block

## Changes

| File | Change |
|------|--------|
| `src/agents/pi-embedded-runner/run/attempt.ts` | Re-apply `sanitizeToolUseResultPairing` to the rebuilt messages after orphaned user message removal |
| `src/agents/session-transcript-repair.test.ts` | New test verifying orphaned `tool_result` messages (missing `tool_use` counterpart) are dropped |

## How it works

After the orphaned user message removal rebuilds the session messages via `sessionManager.buildSessionContext()`, the fix passes the rebuilt array through `sanitizeToolUseResultPairing` — the same function already used at line ~1404 — before calling `activeSession.agent.replaceMessages()`. This ensures any `tool_result` referencing a now-missing `tool_use` is dropped or paired with a synthetic error, preventing the API validation error.

## Test plan

- [x] 24 tests pass in `session-transcript-repair.test.ts` (23 existing + 1 new)
- [x] New test: orphaned `tool_result` with ID `callfunction91b6mt5824h61` and no matching `tool_use` assistant message is dropped
- [ ] Manual: reproduce in WebUI by triggering orphaned user message removal during a tool-heavy conversation; verify no error 2013 or spinner

## Security Impact

- Does this change handle user input? **No** (operates on internal session messages)
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No** (session state only)
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Open WebUI and start a conversation with tool use enabled
2. Trigger multiple tool calls in rapid succession
3. Verify no error 2013 or infinite spinner appears
4. Check logs for "Removed orphaned user message" — if it appears, verify the subsequent turn completes normally

## Failure Recovery

Revert the single conditional wrapping `sanitizeToolUseResultPairing` around `sessionContext.messages` in the orphaned user message removal block (~line 1684 of `attempt.ts`) to restore the original `activeSession.agent.replaceMessages(sessionContext.messages)` call.

## Risks and Mitigations

- **Risk**: Minor performance overhead from running `sanitizeToolUseResultPairing` a second time. **Mitigation**: The function is O(n) over messages and only runs in the rare orphaned-user-message code path, not on every turn.
- **Risk**: `sanitizeToolUseResultPairing` drops valid `tool_result` messages. **Mitigation**: It only drops results whose `tool_call_id` has no matching `tool_use` in any assistant message — these are already invalid per the API contract.