### PR TITLE
fix(tui): constrain alias matching to default agent only

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -231,6 +231,26 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.updateAssistant).not.toHaveBeenCalled();
   });
 
+  it("does not match bare aliases against non-default agent canonical keys", () => {
+    const { chatLog, handleChatEvent } = createHandlersHarness({
+      state: {
+        agentDefaultId: "main",
+        currentAgentId: "alpha",
+        currentSessionKey: "agent:alpha:main",
+        activeChatRunId: null,
+      },
+    });
+
+    handleChatEvent({
+      runId: "run-non-default-alias",
+      sessionKey: "main",
+      state: "delta",
+      message: { content: "should be ignored" },
+    });
+
+    expect(chatLog.updateAssistant).not.toHaveBeenCalled();
+  });
+
   it("clears run mapping when the session changes", () => {
     const { state, chatLog, tui, handleChatEvent, handleAgentEvent } = createHandlersHarness({
       state: { activeChatRunId: null },

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -150,6 +150,7 @@ export function createEventHandlers(context: EventHandlerContext) {
   const isSameSessionKey = (left: string | undefined, right: string | undefined): boolean => {
     const normalizedLeft = (left ?? "").trim().toLowerCase();
     const normalizedRight = (right ?? "").trim().toLowerCase();
+    const defaultAgentId = (state.agentDefaultId ?? "").trim().toLowerCase();
     if (!normalizedLeft || !normalizedRight) {
       return false;
     }
@@ -162,10 +163,10 @@ export function createEventHandlers(context: EventHandlerContext) {
       return parsedLeft.agentId === parsedRight.agentId && parsedLeft.rest === parsedRight.rest;
     }
     if (parsedLeft) {
-      return parsedLeft.rest === normalizedRight;
+      return parsedLeft.agentId === defaultAgentId && parsedLeft.rest === normalizedRight;
     }
     if (parsedRight) {
-      return normalizedLeft === parsedRight.rest;
+      return parsedRight.agentId === defaultAgentId && normalizedLeft === parsedRight.rest;
     }
     return false;
   };


### PR DESCRIPTION
## Summary
TUI reply goes to wrong channel after v2026.3.2 upgrade.

## Root Cause
Alias matching was too loose.

## Changes
- tui-event-handlers.ts: Add defaultAgentId check
- tui-event-handlers.test.ts: Add regression test

## Testing
- pnpm test: 17/17 passed

Fixes #37243