### PR TITLE
fix(feishu): deduplicate inbound events by event_id

### DIFF
--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -20,7 +20,7 @@ import {
 } from "./dedup.js";
 import { isMentionForwardRequest } from "./mention.js";
 import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
-import { botNames, botOpenIds } from "./monitor.state.js";
+import { botNames, botOpenIds, isDuplicateFeishuInboundEventId } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu } from "./send.js";
@@ -133,6 +133,34 @@ type RegisterEventHandlersContext = {
   chatHistories: Map<string, HistoryEntry[]>;
   fireAndForget?: boolean;
 };
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function unwrapFeishuEventEnvelope<T>(payload: unknown): { event: T; eventId?: string } {
+  const record = asRecord(payload);
+  if (!record) {
+    return { event: payload as T };
+  }
+
+  const header = asRecord(record.header);
+  const headerEventId = header?.event_id;
+  const topEventId = record.event_id;
+  const eventIdRaw =
+    typeof headerEventId === "string"
+      ? headerEventId
+      : typeof topEventId === "string"
+        ? topEventId
+        : undefined;
+  const eventId = eventIdRaw?.trim() || undefined;
+
+  const eventPayload = asRecord(record.event);
+  if (eventPayload) {
+    return { event: eventPayload as T, eventId };
+  }
+  return { event: payload as T, eventId };
+}
 
 /**
  * Per-chat serial queue that ensures messages from the same chat are processed
@@ -379,7 +407,11 @@ function registerEventHandlers(
   eventDispatcher.register({
     "im.message.receive_v1": async (data) => {
       const processMessage = async () => {
-        const event = data as unknown as FeishuMessageEvent;
+        const { event, eventId } = unwrapFeishuEventEnvelope<FeishuMessageEvent>(data);
+        if (eventId && isDuplicateFeishuInboundEventId(accountId, eventId)) {
+          log(`feishu[${accountId}]: skipping duplicate event_id ${eventId}`);
+          return;
+        }
         await inboundDebouncer.enqueue(event);
       };
       if (fireAndForget) {
@@ -399,7 +431,11 @@ function registerEventHandlers(
     },
     "im.chat.member.bot.added_v1": async (data) => {
       try {
-        const event = data as unknown as FeishuBotAddedEvent;
+        const { event, eventId } = unwrapFeishuEventEnvelope<FeishuBotAddedEvent>(data);
+        if (eventId && isDuplicateFeishuInboundEventId(accountId, eventId)) {
+          log(`feishu[${accountId}]: skipping duplicate event_id ${eventId}`);
+          return;
+        }
         log(`feishu[${accountId}]: bot added to chat ${event.chat_id}`);
       } catch (err) {
         error(`feishu[${accountId}]: error handling bot added event: ${String(err)}`);
@@ -407,7 +443,11 @@ function registerEventHandlers(
     },
     "im.chat.member.bot.deleted_v1": async (data) => {
       try {
-        const event = data as unknown as { chat_id: string };
+        const { event, eventId } = unwrapFeishuEventEnvelope<{ chat_id: string }>(data);
+        if (eventId && isDuplicateFeishuInboundEventId(accountId, eventId)) {
+          log(`feishu[${accountId}]: skipping duplicate event_id ${eventId}`);
+          return;
+        }
         log(`feishu[${accountId}]: bot removed from chat ${event.chat_id}`);
       } catch (err) {
         error(`feishu[${accountId}]: error handling bot removed event: ${String(err)}`);
@@ -415,7 +455,11 @@ function registerEventHandlers(
     },
     "im.message.reaction.created_v1": async (data) => {
       const processReaction = async () => {
-        const event = data as FeishuReactionCreatedEvent;
+        const { event, eventId } = unwrapFeishuEventEnvelope<FeishuReactionCreatedEvent>(data);
+        if (eventId && isDuplicateFeishuInboundEventId(accountId, eventId)) {
+          log(`feishu[${accountId}]: skipping duplicate event_id ${eventId}`);
+          return;
+        }
         const myBotId = botOpenIds.get(accountId);
         const syntheticEvent = await resolveReactionSyntheticEvent({
           cfg,
@@ -463,7 +507,11 @@ function registerEventHandlers(
     },
     "card.action.trigger": async (data: unknown) => {
       try {
-        const event = data as unknown as FeishuCardActionEvent;
+        const { event, eventId } = unwrapFeishuEventEnvelope<FeishuCardActionEvent>(data);
+        if (eventId && isDuplicateFeishuInboundEventId(accountId, eventId)) {
+          log(`feishu[${accountId}]: skipping duplicate event_id ${eventId}`);
+          return;
+        }
         const promise = handleFeishuCardAction({
           cfg,
           event,

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -613,4 +613,50 @@ describe("Feishu inbound debounce regressions", () => {
     expect(recordSpy).toHaveBeenCalledWith("default:om_old");
     expect(recordSpy).not.toHaveBeenCalledWith("default:om_new");
   });
+
+  it("drops duplicate inbound envelopes with the same event_id", async () => {
+    const onMessage = await setupDebounceMonitor();
+
+    await onMessage({
+      header: { event_id: "evt_same" },
+      event: createTextEvent({ messageId: "om_evt_1", text: "first" }),
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(25);
+
+    await onMessage({
+      header: { event_id: "evt_same" },
+      event: createTextEvent({ messageId: "om_evt_2", text: "retry payload" }),
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(handleFeishuMessageMock).toHaveBeenCalledTimes(1);
+    const dispatched = getFirstDispatchedEvent();
+    expect(dispatched.message.message_id).toBe("om_evt_1");
+  });
+
+  it("accepts distinct inbound envelopes when event_id differs", async () => {
+    const onMessage = await setupDebounceMonitor();
+
+    await onMessage({
+      header: { event_id: "evt_1" },
+      event: createTextEvent({ messageId: "om_evt_1", text: "first" }),
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(25);
+
+    await onMessage({
+      header: { event_id: "evt_2" },
+      event: createTextEvent({ messageId: "om_evt_2", text: "second" }),
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(handleFeishuMessageMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/extensions/feishu/src/monitor.state.ts
+++ b/extensions/feishu/src/monitor.state.ts
@@ -1,6 +1,7 @@
 import * as http from "http";
 import * as Lark from "@larksuiteoapi/node-sdk";
 import {
+  createDedupeCache,
   createFixedWindowRateLimiter,
   createWebhookAnomalyTracker,
   type RuntimeEnv,
@@ -15,6 +16,8 @@ export const botNames = new Map<string, string>();
 
 export const FEISHU_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 export const FEISHU_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
+const FEISHU_EVENT_DEDUP_TTL_MS = 60_000;
+const FEISHU_EVENT_DEDUP_MAX_SIZE = 8_192;
 
 type WebhookRateLimitDefaults = {
   windowMs: number;
@@ -104,9 +107,15 @@ const feishuWebhookAnomalyTracker = createWebhookAnomalyTracker({
   logEvery: feishuWebhookAnomalyDefaults.logEvery,
 });
 
+const recentFeishuEventIds = createDedupeCache({
+  ttlMs: FEISHU_EVENT_DEDUP_TTL_MS,
+  maxSize: FEISHU_EVENT_DEDUP_MAX_SIZE,
+});
+
 export function clearFeishuWebhookRateLimitStateForTest(): void {
   feishuWebhookRateLimiter.clear();
   feishuWebhookAnomalyTracker.clear();
+  recentFeishuEventIds.clear();
 }
 
 export function getFeishuWebhookRateLimitStateSizeForTest(): number {
@@ -115,6 +124,18 @@ export function getFeishuWebhookRateLimitStateSizeForTest(): number {
 
 export function isWebhookRateLimitedForTest(key: string, nowMs: number): boolean {
   return feishuWebhookRateLimiter.isRateLimited(key, nowMs);
+}
+
+export function isDuplicateFeishuInboundEventId(
+  accountId: string,
+  eventId: string,
+  nowMs = Date.now(),
+): boolean {
+  const normalizedEventId = eventId.trim();
+  if (!normalizedEventId) {
+    return false;
+  }
+  return recentFeishuEventIds.check(`${accountId}:${normalizedEventId}`, nowMs);
 }
 
 export function recordWebhookStatus(


### PR DESCRIPTION
## Summary
Feishu produces duplicate messages.

## Changes
- monitor.account.ts: Add event_id dedup
- monitor.state.ts: Add 60s TTL

Fixes #37477