### PR TITLE
fix(process): quote spaced Windows node executable path

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -38,6 +38,19 @@ function buildCmdExeCommandLine(resolvedCommand: string, args: string[]): string
   return [escapeForCmdExe(resolvedCommand), ...args.map(escapeForCmdExe)].join(" ");
 }
 
+function quoteWindowsExecutablePath(command: string): string {
+  if (process.platform !== "win32") {
+    return command;
+  }
+  if (!command.includes(" ")) {
+    return command;
+  }
+  if (command.startsWith('"') && command.endsWith('"')) {
+    return command;
+  }
+  return `"${command}"`;
+}
+
 /**
  * On Windows, Node 18.20.2+ (CVE-2024-27980) rejects spawning .cmd/.bat directly
  * without shell, causing EINVAL. Resolve npm/npx to node + cli script so we
@@ -224,9 +237,13 @@ export async function runCommandWithTimeout(
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
   const finalArgv = process.platform === "win32" ? (resolveNpmArgvForWindows(argv) ?? argv) : argv;
   const resolvedCommand = finalArgv !== argv ? (finalArgv[0] ?? "") : resolveCommand(argv[0] ?? "");
+  const spawnCommand =
+    process.platform === "win32" && finalArgv !== argv
+      ? quoteWindowsExecutablePath(resolvedCommand)
+      : resolvedCommand;
   const useCmdWrapper = isWindowsBatchCommand(resolvedCommand);
   const child = spawn(
-    useCmdWrapper ? (process.env.ComSpec ?? "cmd.exe") : resolvedCommand,
+    useCmdWrapper ? (process.env.ComSpec ?? "cmd.exe") : spawnCommand,
     useCmdWrapper
       ? ["/d", "/s", "/c", buildCmdExeCommandLine(resolvedCommand, finalArgv.slice(1))]
       : finalArgv.slice(1),

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const spawnMock = vi.hoisted(() => vi.fn());
@@ -108,6 +109,31 @@ describe("windows command wrapper behavior", () => {
       const captured = execFileMock.mock.calls[0] as ExecCall | undefined;
       expectCmdWrappedInvocation({ captured, expectedComSpec });
     } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("quotes spaced node executable path when spawning npm-cli on Windows", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const execPathSpy = vi
+      .spyOn(process, "execPath", "get")
+      .mockReturnValue("C:/Program Files/nodejs/node.exe");
+    const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(true);
+
+    spawnMock.mockImplementation(
+      (_command: string, _args: string[], _options: Record<string, unknown>) => createMockChild(),
+    );
+
+    try {
+      const result = await runCommandWithTimeout(["npm", "--version"], { timeoutMs: 1000 });
+      expect(result.code).toBe(0);
+      const captured = spawnMock.mock.calls[0] as SpawnCall | undefined;
+      expect(captured).toBeDefined();
+      expect(captured?.[0]).toBe('"C:/Program Files/nodejs/node.exe"');
+      expect(captured?.[1][0]).toBe("C:/Program Files/nodejs/node_modules/npm/bin/npm-cli.js");
+    } finally {
+      existsSpy.mockRestore();
+      execPathSpy.mockRestore();
       platformSpy.mockRestore();
     }
   });


### PR DESCRIPTION
## Summary
Plugin install fails on Windows with spaced Node.js path.

Fixes #37563