### PR TITLE
fix(cli): add SecretRef support for web search apiKey

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -11,6 +11,8 @@ const {
   resolveGrokModel,
   resolveGrokInlineCitations,
   extractGrokContent,
+  resolvePerplexityApiKey,
+  resolveGeminiApiKey,
   resolveKimiApiKey,
   resolveKimiModel,
   resolveKimiBaseUrl,
@@ -110,6 +112,18 @@ describe("web_search grok config resolution", () => {
       expect(resolveGrokApiKey({})).toBeUndefined();
       expect(resolveGrokApiKey(undefined)).toBeUndefined();
     });
+  });
+
+  it("throws when config apiKey is an unresolved SecretRef", () => {
+    expect(() =>
+      resolveGrokApiKey({
+        apiKey: {
+          source: "env",
+          provider: "default",
+          id: "XAI_API_KEY",
+        } as unknown as string,
+      }),
+    ).toThrow(/tools\.web\.search\.grok\.apiKey: unresolved SecretRef/i);
   });
 
   it("uses default model when not specified", () => {
@@ -240,9 +254,47 @@ describe("web_search kimi config resolution", () => {
     });
   });
 
+  it("throws when config apiKey is an unresolved SecretRef", () => {
+    expect(() =>
+      resolveKimiApiKey({
+        apiKey: {
+          source: "env",
+          provider: "default",
+          id: "KIMI_API_KEY",
+        } as unknown as string,
+      }),
+    ).toThrow(/tools\.web\.search\.kimi\.apiKey: unresolved SecretRef/i);
+  });
+
   it("resolves default model and baseUrl", () => {
     expect(resolveKimiModel({})).toBe("moonshot-v1-128k");
     expect(resolveKimiBaseUrl({})).toBe("https://api.moonshot.ai/v1");
+  });
+});
+
+describe("web_search additional provider api key resolution", () => {
+  it("throws when perplexity config apiKey is an unresolved SecretRef", () => {
+    expect(() =>
+      resolvePerplexityApiKey({
+        apiKey: {
+          source: "env",
+          provider: "default",
+          id: "PERPLEXITY_API_KEY",
+        } as unknown as string,
+      }),
+    ).toThrow(/tools\.web\.search\.perplexity\.apiKey: unresolved SecretRef/i);
+  });
+
+  it("throws when gemini config apiKey is an unresolved SecretRef", () => {
+    expect(() =>
+      resolveGeminiApiKey({
+        apiKey: {
+          source: "env",
+          provider: "default",
+          id: "GEMINI_API_KEY",
+        } as unknown as string,
+      }),
+    ).toThrow(/tools\.web\.search\.gemini\.apiKey: unresolved SecretRef/i);
   });
 });
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -565,7 +565,11 @@ function resolvePerplexityApiKey(perplexity?: PerplexityConfig): {
   apiKey?: string;
   source: PerplexityApiKeySource;
 } {
-  const fromConfig = normalizeApiKey(perplexity?.apiKey);
+  const fromConfigRaw = normalizeResolvedSecretInputString({
+    value: perplexity?.apiKey,
+    path: "tools.web.search.perplexity.apiKey",
+  });
+  const fromConfig = normalizeApiKey(fromConfigRaw);
   if (fromConfig) {
     return { apiKey: fromConfig, source: "config" };
   }
@@ -594,7 +598,11 @@ function resolveGrokConfig(search?: WebSearchConfig): GrokConfig {
 }
 
 function resolveGrokApiKey(grok?: GrokConfig): string | undefined {
-  const fromConfig = normalizeApiKey(grok?.apiKey);
+  const fromConfigRaw = normalizeResolvedSecretInputString({
+    value: grok?.apiKey,
+    path: "tools.web.search.grok.apiKey",
+  });
+  const fromConfig = normalizeApiKey(fromConfigRaw);
   if (fromConfig) {
     return fromConfig;
   }
@@ -624,7 +632,11 @@ function resolveKimiConfig(search?: WebSearchConfig): KimiConfig {
 }
 
 function resolveKimiApiKey(kimi?: KimiConfig): string | undefined {
-  const fromConfig = normalizeApiKey(kimi?.apiKey);
+  const fromConfigRaw = normalizeResolvedSecretInputString({
+    value: kimi?.apiKey,
+    path: "tools.web.search.kimi.apiKey",
+  });
+  const fromConfig = normalizeApiKey(fromConfigRaw);
   if (fromConfig) {
     return fromConfig;
   }
@@ -660,7 +672,11 @@ function resolveGeminiConfig(search?: WebSearchConfig): GeminiConfig {
 }
 
 function resolveGeminiApiKey(gemini?: GeminiConfig): string | undefined {
-  const fromConfig = normalizeApiKey(gemini?.apiKey);
+  const fromConfigRaw = normalizeResolvedSecretInputString({
+    value: gemini?.apiKey,
+    path: "tools.web.search.gemini.apiKey",
+  });
+  const fromConfig = normalizeApiKey(fromConfigRaw);
   if (fromConfig) {
     return fromConfig;
   }
@@ -1679,6 +1695,8 @@ export const __testing = {
   resolveGrokModel,
   resolveGrokInlineCitations,
   extractGrokContent,
+  resolvePerplexityApiKey,
+  resolveGeminiApiKey,
   resolveKimiApiKey,
   resolveKimiModel,
   resolveKimiBaseUrl,

--- a/src/cli/command-secret-targets.test.ts
+++ b/src/cli/command-secret-targets.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   getAgentRuntimeCommandSecretTargetIds,
   getMemoryCommandSecretTargetIds,
+  getStatusCommandSecretTargetIds,
 } from "./command-secret-targets.js";
 
 describe("command secret target ids", () => {
@@ -19,5 +20,14 @@ describe("command secret target ids", () => {
         "agents.list[].memorySearch.remote.apiKey",
       ]),
     );
+  });
+
+  it("includes web search secret targets for status commands", () => {
+    const ids = getStatusCommandSecretTargetIds();
+    expect(ids.has("tools.web.search.apiKey")).toBe(true);
+    expect(ids.has("tools.web.search.perplexity.apiKey")).toBe(true);
+    expect(ids.has("tools.web.search.grok.apiKey")).toBe(true);
+    expect(ids.has("tools.web.search.gemini.apiKey")).toBe(true);
+    expect(ids.has("tools.web.search.kimi.apiKey")).toBe(true);
   });
 });

--- a/src/cli/command-secret-targets.ts
+++ b/src/cli/command-secret-targets.ts
@@ -28,6 +28,7 @@ const COMMAND_SECRET_TARGETS = {
     "channels.",
     "agents.defaults.memorySearch.remote.",
     "agents.list[].memorySearch.remote.",
+    "tools.web.search",
   ]),
 } as const;
 


### PR DESCRIPTION
## Summary
SecretRefs not supported in web search apiKey.

Fixes #37578