### PR TITLE
fix(daemon): truncate overlong launchd labels to 63 bytes

### DIFF
--- a/src/daemon/constants.test.ts
+++ b/src/daemon/constants.test.ts
@@ -4,12 +4,14 @@ import {
   GATEWAY_LAUNCH_AGENT_LABEL,
   GATEWAY_SYSTEMD_SERVICE_NAME,
   GATEWAY_WINDOWS_TASK_NAME,
+  LAUNCHD_LABEL_MAX_BYTES,
   LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES,
   normalizeGatewayProfile,
   resolveGatewayLaunchAgentLabel,
   resolveGatewayProfileSuffix,
   resolveGatewayServiceDescription,
   resolveGatewaySystemdServiceName,
+  truncateLaunchdLabel,
   resolveGatewayWindowsTaskName,
 } from "./constants.js";
 
@@ -38,6 +40,28 @@ describe("resolveGatewayLaunchAgentLabel", () => {
   it("returns profile-specific label when profile is set", () => {
     const result = resolveGatewayLaunchAgentLabel("dev");
     expect(result).toBe("ai.openclaw.dev");
+  });
+
+  it("truncates long profile labels to launchd byte limit", () => {
+    const longProfile = "x".repeat(120);
+    const result = resolveGatewayLaunchAgentLabel(longProfile);
+    expect(Buffer.byteLength(result, "utf8")).toBeLessThanOrEqual(LAUNCHD_LABEL_MAX_BYTES);
+    expect(result).toMatch(/^ai\.openclaw\./);
+  });
+});
+
+describe("truncateLaunchdLabel", () => {
+  it("keeps short labels unchanged", () => {
+    expect(truncateLaunchdLabel("ai.openclaw.gateway")).toBe("ai.openclaw.gateway");
+  });
+
+  it("truncates long labels deterministically with hash suffix", () => {
+    const longLabel = "ai.openclaw." + "x".repeat(200);
+    const resultA = truncateLaunchdLabel(longLabel);
+    const resultB = truncateLaunchdLabel(longLabel);
+    expect(resultA).toBe(resultB);
+    expect(Buffer.byteLength(resultA, "utf8")).toBeLessThanOrEqual(LAUNCHD_LABEL_MAX_BYTES);
+    expect(resultA).toMatch(/-[0-9a-f]{8}$/);
   });
 });
 

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 // Default service labels (canonical + legacy compatibility)
 export const GATEWAY_LAUNCH_AGENT_LABEL = "ai.openclaw.gateway";
 export const GATEWAY_SYSTEMD_SERVICE_NAME = "openclaw-gateway";
@@ -16,6 +18,31 @@ export const LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES: string[] = [
   "moltbot-gateway",
 ];
 export const LEGACY_GATEWAY_WINDOWS_TASK_NAMES: string[] = [];
+export const LAUNCHD_LABEL_MAX_BYTES = 63;
+
+function truncateUtf8ToByteLength(value: string, maxBytes: number): string {
+  let truncated = "";
+  let usedBytes = 0;
+  for (const char of value) {
+    const charBytes = Buffer.byteLength(char, "utf8");
+    if (usedBytes + charBytes > maxBytes) {
+      break;
+    }
+    truncated += char;
+    usedBytes += charBytes;
+  }
+  return truncated;
+}
+
+export function truncateLaunchdLabel(label: string): string {
+  const trimmed = label.trim();
+  if (Buffer.byteLength(trimmed, "utf8") <= LAUNCHD_LABEL_MAX_BYTES) {
+    return trimmed;
+  }
+  const hashSuffix = `-${createHash("sha256").update(trimmed).digest("hex").slice(0, 8)}`;
+  const maxPrefixBytes = Math.max(0, LAUNCHD_LABEL_MAX_BYTES - Buffer.byteLength(hashSuffix, "utf8"));
+  return `${truncateUtf8ToByteLength(trimmed, maxPrefixBytes)}${hashSuffix}`;
+}
 
 export function normalizeGatewayProfile(profile?: string): string | null {
   const trimmed = profile?.trim();
@@ -35,7 +62,7 @@ export function resolveGatewayLaunchAgentLabel(profile?: string): string {
   if (!normalized) {
     return GATEWAY_LAUNCH_AGENT_LABEL;
   }
-  return `ai.openclaw.${normalized}`;
+  return truncateLaunchdLabel(`ai.openclaw.${normalized}`);
 }
 
 export function resolveLegacyGatewayLaunchAgentLabels(profile?: string): string[] {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -344,4 +344,16 @@ describe("resolveLaunchAgentPlistPath", () => {
   ])("$name", ({ env, expected }) => {
     expect(resolveLaunchAgentPlistPath(env)).toBe(expected);
   });
+
+  it("truncates overlong OPENCLAW_LAUNCHD_LABEL values to launchd-safe length", () => {
+    const longLabel = `com.custom.${"x".repeat(200)}`;
+    const resolved = resolveLaunchAgentPlistPath({
+      HOME: "/Users/test",
+      OPENCLAW_LAUNCHD_LABEL: longLabel,
+    });
+    const fileName = resolved.split("/").at(-1) ?? "";
+    const label = fileName.replace(/\.plist$/, "");
+    expect(Buffer.byteLength(label, "utf8")).toBeLessThanOrEqual(63);
+    expect(label).toMatch(/-[0-9a-f]{8}$/);
+  });
 });

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -5,6 +5,7 @@ import {
   resolveGatewayServiceDescription,
   resolveGatewayLaunchAgentLabel,
   resolveLegacyGatewayLaunchAgentLabels,
+  truncateLaunchdLabel,
 } from "./constants.js";
 import { execFileUtf8 } from "./exec-file.js";
 import {
@@ -27,7 +28,7 @@ import type {
 function resolveLaunchAgentLabel(args?: { env?: Record<string, string | undefined> }): string {
   const envLabel = args?.env?.OPENCLAW_LAUNCHD_LABEL?.trim();
   if (envLabel) {
-    return envLabel;
+    return truncateLaunchdLabel(envLabel);
   }
   return resolveGatewayLaunchAgentLabel(args?.env?.OPENCLAW_PROFILE);
 }


### PR DESCRIPTION
## Summary
Gateway launch fails with label > 63 bytes.

Fixes #37705