### PR TITLE
fix(auto-reply): suppress structured JSON NO_REPLY payloads

### DIFF
--- a/src/auto-reply/reply/reply-directives.test.ts
+++ b/src/auto-reply/reply/reply-directives.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { parseReplyDirectives } from "./reply-directives.js";
+
+describe("parseReplyDirectives", () => {
+  it("treats structured NO_REPLY action payload as silent", () => {
+    const parsed = parseReplyDirectives('{"action":"NO_REPLY"}');
+    expect(parsed.isSilent).toBe(true);
+    expect(parsed.text).toBe("");
+  });
+});

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -150,6 +150,16 @@ describe("normalizeReplyPayload", () => {
     expect(result!.text).toBe("");
     expect(result!.mediaUrl).toBe("https://example.com/img.png");
   });
+
+  it("suppresses structured NO_REPLY action payload", () => {
+    const reasons: string[] = [];
+    const result = normalizeReplyPayload(
+      { text: '{"action":"NO_REPLY"}' },
+      { onSkip: (reason) => reasons.push(reason) },
+    );
+    expect(result).toBeNull();
+    expect(reasons).toEqual(["silent"]);
+  });
 });
 
 describe("typing controller", () => {

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -30,9 +30,19 @@ describe("isSilentReplyText", () => {
     expect(isSilentReplyText("Please NO_REPLY to this")).toBe(false);
   });
 
+  it("returns true for structured JSON action payload", () => {
+    expect(isSilentReplyText('{"action":"NO_REPLY"}')).toBe(true);
+    expect(isSilentReplyText(' \n { "action": "NO_REPLY" } \n ')).toBe(true);
+  });
+
+  it("returns false for structured JSON with non-silent action", () => {
+    expect(isSilentReplyText('{"action":"REPLY"}')).toBe(false);
+  });
+
   it("works with custom token", () => {
     expect(isSilentReplyText("HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(true);
     expect(isSilentReplyText("Checked inbox. HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(false);
+    expect(isSilentReplyText('{"action":"HEARTBEAT_OK"}', "HEARTBEAT_OK")).toBe(true);
   });
 });
 

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -28,6 +28,23 @@ function getSilentTrailingRegex(token: string): RegExp {
   return regex;
 }
 
+function extractSilentActionDirective(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return undefined;
+    }
+    const action = (parsed as { action?: unknown }).action;
+    return typeof action === "string" ? action.trim() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function isSilentReplyText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,
@@ -37,7 +54,11 @@ export function isSilentReplyText(
   }
   // Match only the exact silent token with optional surrounding whitespace.
   // This prevents substantive replies ending with NO_REPLY from being suppressed (#19537).
-  return getSilentExactRegex(token).test(text);
+  if (getSilentExactRegex(token).test(text)) {
+    return true;
+  }
+  // Some model/tool paths emit a structured action payload instead of plain token text.
+  return extractSilentActionDirective(text) === token;
 }
 
 /**


### PR DESCRIPTION
## Summary
Telegram sends raw JSON NO_REPLY payload.

Fixes #37727