### PR TITLE
fix(agents): default custom provider API to openai-completions

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -199,6 +199,25 @@ describe("resolveModel", () => {
     expect(result.model?.baseUrl).toBe("http://localhost:9000");
     expect(result.model?.provider).toBe("custom");
     expect(result.model?.id).toBe("missing-model");
+    expect(result.model?.api).toBe("openai-completions");
+  });
+
+  it("defaults inline provider models without api to openai-completions", () => {
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "http://localhost:9000",
+            models: [makeModel("custom-model")],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("custom", "custom-model", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model?.api).toBe("openai-completions");
   });
 
   it("includes provider headers in provider fallback model", () => {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -22,6 +22,8 @@ type InlineProviderConfig = {
   headers?: Record<string, string>;
 };
 
+const DEFAULT_CUSTOM_PROVIDER_API: ModelDefinitionConfig["api"] = "openai-completions";
+
 export { buildModelAliasLines };
 
 function resolveConfiguredProviderConfig(
@@ -126,7 +128,10 @@ export function resolveModelWithRegistry(params: {
     (entry) => normalizeProviderId(entry.provider) === normalizedProvider && entry.id === modelId,
   );
   if (inlineMatch) {
-    return normalizeModelCompat(inlineMatch as Model<Api>);
+    return normalizeModelCompat({
+      ...inlineMatch,
+      api: inlineMatch.api ?? providerConfig?.api ?? DEFAULT_CUSTOM_PROVIDER_API,
+    } as Model<Api>);
   }
 
   // Forward-compat fallbacks must be checked BEFORE the generic providerCfg fallback.
@@ -165,7 +170,7 @@ export function resolveModelWithRegistry(params: {
     return normalizeModelCompat({
       id: modelId,
       name: modelId,
-      api: providerConfig?.api ?? "openai-responses",
+      api: providerConfig?.api ?? DEFAULT_CUSTOM_PROVIDER_API,
       provider,
       baseUrl: providerConfig?.baseUrl,
       reasoning: configuredModel?.reasoning ?? false,


### PR DESCRIPTION
## Summary
TUI/Web returns 404 for custom providers.

## Root Cause
Default API was openai-responses.

## Changes
- model.ts: Add DEFAULT_CUSTOM_PROVIDER_API

## Testing
- 30 tests passed

Fixes #37322