### PR TITLE
fix(nextcloud-talk): use plugin-sdk import for waitForAbortSignal

### DIFF
--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -12,7 +12,7 @@ import {
   type OpenClawConfig,
   type ChannelSetupInput,
 } from "openclaw/plugin-sdk/nextcloud-talk";
-import { waitForAbortSignal } from "../../../src/infra/abort-signal.js";
+import { waitForAbortSignal } from "openclaw/plugin-sdk/nextcloud-talk";
 import {
   listNextcloudTalkAccountIds,
   resolveDefaultNextcloudTalkAccountId,

--- a/src/plugin-sdk/nextcloud-talk.ts
+++ b/src/plugin-sdk/nextcloud-talk.ts
@@ -90,3 +90,4 @@ export {
   resolveOutboundMediaUrls,
 } from "./reply-payload.js";
 export { createLoggerBackedRuntime } from "./runtime.js";
+export { waitForAbortSignal } from "../infra/abort-signal.js";


### PR DESCRIPTION
## Problem

The nextcloud-talk extension imported `waitForAbortSignal` via a relative path to `src/infra/abort-signal.js`:

```ts
import { waitForAbortSignal } from "../../../src/infra/abort-signal.js";
```

This path resolves during development but **does not exist in the dist bundle** shipped to users. Only the `.d.ts` type definition is present at `dist/plugin-sdk/infra/abort-signal.d.ts`. This causes a `Cannot find module` crash when installing/loading the nextcloud-talk plugin.

## Fix

1. **Export** `waitForAbortSignal` from the nextcloud-talk plugin-sdk surface (`src/plugin-sdk/nextcloud-talk.ts`)
2. **Update** the extension import to use the package path `openclaw/plugin-sdk/nextcloud-talk`

This follows the same pattern already used for all other imports in the extension (e.g. `logInboundDrop`, `resolveMentionGatingWithBypass`, etc.).

## Testing

- `tsc --noEmit`: no new errors (45 pre-existing in unrelated files)
- All 17 nextcloud-talk tests pass

Closes #37915