### PR TITLE
fix(web-search): fallback to BRAVE_API_KEY env var when config secret input cannot be resolved

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -430,13 +430,21 @@ function resolveSearchEnabled(params: { search?: WebSearchConfig; sandboxed?: bo
 }
 
 function resolveSearchApiKey(search?: WebSearchConfig): string | undefined {
-  const fromConfigRaw =
-    search && "apiKey" in search
-      ? normalizeResolvedSecretInputString({
-          value: search.apiKey,
-          path: "tools.web.search.apiKey",
-        })
-      : undefined;
+  let fromConfigRaw: string | undefined;
+  if (search && "apiKey" in search) {
+    try {
+      fromConfigRaw = normalizeResolvedSecretInputString({
+        value: search.apiKey,
+        path: "tools.web.search.apiKey",
+      });
+    } catch {
+      // If secret input cannot be resolved (e.g., missing refValue/defaults in runtime),
+      // fall back to environment variable instead of failing.
+      // This handles cases where config was saved with secret input format but
+      // the gateway runtime cannot resolve it (e.g., different env context).
+      fromConfigRaw = undefined;
+    }
+  }
   const fromConfig = normalizeSecretInput(fromConfigRaw);
   const fromEnv = normalizeSecretInput(process.env.BRAVE_API_KEY);
   return fromConfig || fromEnv || undefined;


### PR DESCRIPTION
## Problem

When \	ools.web.search.apiKey\ is saved as a secret input reference but cannot be resolved at runtime (e.g., missing refValue/defaults or different environment context), \
ormalizeResolvedSecretInputString\ throws an error, causing the tool to fail with \missing_brave_api_key\ even though \BRAVE_API_KEY\ may be available in the environment.

This affects users who:
- Configure API key via \openclaw configure --section web\ but gateway runtime cannot resolve the secret input (different env context)
- Run gateway service that relies on \~/.openclaw/.env\ for secrets instead of config file secret input resolution

## Solution

Fix \esolveSearchApiKey\ to catch errors from secret input resolution and fall back to the \BRAVE_API_KEY\ environment variable, ensuring the tool works when either config or env var is available.

## Changes

- Modified \esolveSearchApiKey\ in \src/agents/tools/web-search.ts\ to wrap \
ormalizeResolvedSecretInputString\ in try-catch
- When secret input resolution fails, fall back to \BRAVE_API_KEY\ environment variable instead of failing

## Testing

- Linting passed
- Manual testing: when config secret input cannot be resolved, tool should fall back to env var

Fixes #23058