### PR TITLE
fix(logging): rotate rolling log file on date change without restart

### DIFF
--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -11,6 +11,7 @@ import {
   setLoggerOverride,
   stripRedundantSubsystemPrefixForConsole,
 } from "./logging.js";
+import { __test__ as loggerTestExports } from "./logging/logger.js";
 import type { RuntimeEnv } from "./runtime.js";
 
 describe("logger helpers", () => {
@@ -168,3 +169,31 @@ function localDateString(date: Date) {
   const day = String(date.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 }
+
+describe("rolling log date rotation", () => {
+  it("formatLocalDate produces correct date strings across midnight", () => {
+    const day1 = new Date(2026, 2, 5);
+    const day2 = new Date(2026, 2, 6);
+
+    expect(loggerTestExports.formatLocalDate(day1)).toBe("2026-03-05");
+    expect(loggerTestExports.formatLocalDate(day2)).toBe("2026-03-06");
+  });
+
+  it("defaultRollingPathForToday returns different paths on different days", () => {
+    vi.useFakeTimers();
+
+    const march5 = new Date(2026, 2, 5, 23, 59, 59);
+    vi.setSystemTime(march5);
+    const pathDay1 = loggerTestExports.defaultRollingPathForToday();
+
+    const march6 = new Date(2026, 2, 6, 0, 0, 1);
+    vi.setSystemTime(march6);
+    const pathDay2 = loggerTestExports.defaultRollingPathForToday();
+
+    expect(pathDay1).toContain("2026-03-05");
+    expect(pathDay2).toContain("2026-03-06");
+    expect(pathDay1).not.toBe(pathDay2);
+
+    vi.useRealTimers();
+  });
+});

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -139,15 +139,26 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   }
 
   fs.mkdirSync(path.dirname(settings.file), { recursive: true });
-  // Clean up stale rolling logs when using a dated log filename.
-  if (isRollingPath(settings.file)) {
+  const rolling = isRollingPath(settings.file);
+  if (rolling) {
     pruneOldRollingLogs(path.dirname(settings.file));
   }
-  let currentFileBytes = getCurrentLogFileBytes(settings.file);
+  let currentFile = settings.file;
+  let currentFileBytes = getCurrentLogFileBytes(currentFile);
   let warnedAboutSizeCap = false;
 
   logger.attachTransport((logObj: LogObj) => {
     try {
+      if (rolling) {
+        const todayPath = defaultRollingPathForToday();
+        if (todayPath !== currentFile) {
+          currentFile = todayPath;
+          fs.mkdirSync(path.dirname(currentFile), { recursive: true });
+          currentFileBytes = getCurrentLogFileBytes(currentFile);
+          warnedAboutSizeCap = false;
+          pruneOldRollingLogs(path.dirname(currentFile));
+        }
+      }
       const time = formatLocalIsoWithOffset(logObj.date ?? new Date());
       const line = JSON.stringify({ ...logObj, time });
       const payload = `${line}\n`;
@@ -160,16 +171,16 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
             time: formatLocalIsoWithOffset(new Date()),
             level: "warn",
             subsystem: "logging",
-            message: `log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}`,
+            message: `log file size cap reached; suppressing writes file=${currentFile} maxFileBytes=${settings.maxFileBytes}`,
           });
-          appendLogLine(settings.file, `${warningLine}\n`);
+          appendLogLine(currentFile, `${warningLine}\n`);
           process.stderr.write(
-            `[openclaw] log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}\n`,
+            `[openclaw] log file size cap reached; suppressing writes file=${currentFile} maxFileBytes=${settings.maxFileBytes}\n`,
           );
         }
         return;
       }
-      if (appendLogLine(settings.file, payload)) {
+      if (appendLogLine(currentFile, payload)) {
         currentFileBytes = nextBytes;
       }
     } catch {
@@ -297,6 +308,8 @@ export function registerLogTransport(transport: LogTransport): () => void {
 
 export const __test__ = {
   shouldSkipLoadConfigFallback,
+  formatLocalDate,
+  defaultRollingPathForToday,
 };
 
 function formatLocalDate(date: Date): string {


### PR DESCRIPTION
## Summary

Fixes log files not rotating at midnight by making the file transport dynamically re-resolve the rolling path on each write instead of capturing it once at logger creation time.

## Problem

The `buildLogger` function creates a transport closure that captures `settings.file` — the date-stamped log path (e.g., `openclaw-2026-03-05.log`) — at logger creation time. After midnight, the transport keeps writing to the previous day's file because the captured path never changes. Only a full gateway restart creates a new logger with the updated date path.

Users reported that after midnight, the new day's log file is created (or remains empty) while all entries continue accumulating in the previous day's file. This makes log analysis and rotation-based cleanup unreliable.

## Changes

| File | Change |
|------|--------|
| `src/logging/logger.ts` | Transport now re-resolves `defaultRollingPathForToday()` on each write when using a rolling path; switches to the new file, resets byte counter/size-cap warning, and prunes stale logs |
| `src/logger.test.ts` | 2 new tests verifying `formatLocalDate` produces correct strings and `defaultRollingPathForToday` returns different paths across midnight boundary |

## How it works

Before writing each log line, the transport checks whether the log file uses a rolling (date-stamped) pattern. If so, it calls `defaultRollingPathForToday()` and compares the result to the current file path. When they differ (i.e., the date has changed):

1. `currentFile` is updated to the new path
2. The parent directory is ensured to exist
3. `currentFileBytes` is reset to the new file's current size (0 if new)
4. `warnedAboutSizeCap` is cleared
5. Stale rolling logs are pruned

This adds a single string comparison per log write — negligible overhead — and completely eliminates the need for a restart to rotate logs.

## Test plan

- [x] 11 tests pass in `src/logger.test.ts` (9 existing + 2 new)
- [x] New test: `formatLocalDate` returns `2026-03-05` and `2026-03-06` for March 5 and 6
- [x] New test: `defaultRollingPathForToday` returns paths containing `2026-03-05` at 23:59:59 and `2026-03-06` at 00:00:01 (using fake timers)
- [ ] Manual: run gateway continuously across midnight and verify logs appear in the new day's file

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No** (only log file path resolution)
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Start the gateway before midnight
2. Send a message or trigger any activity before midnight — verify it appears in today's log file
3. Wait for midnight to pass
4. Send another message — verify the new entry appears in the new day's log file, not the previous day's
5. Verify the previous day's log file stopped receiving new entries

## Failure Recovery

Revert the transport changes in `buildLogger()` to restore the original `settings.file` closure capture. The only functional change is the date-check logic inside the transport callback.

## Risks and Mitigations

- **Risk**: Slight per-write overhead from calling `defaultRollingPathForToday()` on every log line. **Mitigation**: The function performs a single `new Date()` + string formatting; the additional string comparison is negligible compared to the `JSON.stringify` + `fs.appendFileSync` already in the hot path.
- **Risk**: `pruneOldRollingLogs` running synchronously on the first write after midnight. **Mitigation**: It only reads the directory listing and removes files older than 24h — typically 0-1 files. Same behavior as the existing startup prune, just triggered by date change instead of restart.