### PR TITLE
fix(gateway): truncate mDNS labels to prevent 63-byte DNS limit crash

### DIFF
--- a/src/infra/bonjour.test.ts
+++ b/src/infra/bonjour.test.ts
@@ -307,4 +307,27 @@ describe("gateway bonjour advertiser", () => {
 
     await started.stop();
   });
+
+  it("truncates hostname exceeding 63-byte DNS label limit", async () => {
+    const longHostname = "app-41627eae5842473f9e05f139ea307277-7f9477f4d6-lqqzf";
+    enableAdvertiserUnitMode(longHostname);
+
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const advertise = vi.fn().mockResolvedValue(undefined);
+    mockCiaoService({ advertise, destroy });
+
+    const started = await startGatewayBonjourAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    const [gatewayCall] = createService.mock.calls as Array<[ServiceCall]>;
+    const hostname = gatewayCall?.[0]?.hostname as string;
+    const name = gatewayCall?.[0]?.name as string;
+
+    expect(Buffer.byteLength(hostname, "utf8")).toBeLessThanOrEqual(63);
+    expect(Buffer.byteLength(name, "utf8")).toBeLessThanOrEqual(63);
+
+    await started.stop();
+  });
 });

--- a/src/infra/bonjour.ts
+++ b/src/infra/bonjour.ts
@@ -38,9 +38,23 @@ function isDisabledByEnv() {
   return false;
 }
 
+const MAX_DNS_LABEL_BYTES = 63;
+
+function truncateToByteLimit(label: string, maxBytes: number): string {
+  if (Buffer.byteLength(label, "utf8") <= maxBytes) {
+    return label;
+  }
+  let truncated = label;
+  while (Buffer.byteLength(truncated, "utf8") > maxBytes) {
+    truncated = truncated.slice(0, -1);
+  }
+  return truncated.trimEnd() || "openclaw";
+}
+
 function safeServiceName(name: string) {
   const trimmed = name.trim();
-  return trimmed.length > 0 ? trimmed : "OpenClaw";
+  const safe = trimmed.length > 0 ? trimmed : "OpenClaw";
+  return truncateToByteLimit(safe, MAX_DNS_LABEL_BYTES);
 }
 
 function prettifyInstanceName(name: string) {
@@ -98,11 +112,13 @@ export async function startGatewayBonjourAdvertiser(
     process.env.OPENCLAW_MDNS_HOSTNAME?.trim() ||
     process.env.CLAWDBOT_MDNS_HOSTNAME?.trim() ||
     "openclaw";
-  const hostname =
+  const hostname = truncateToByteLimit(
     hostnameRaw
       .replace(/\.local$/i, "")
       .split(".")[0]
-      .trim() || "openclaw";
+      .trim() || "openclaw",
+    MAX_DNS_LABEL_BYTES,
+  );
   const instanceName =
     typeof opts.instanceName === "string" && opts.instanceName.trim()
       ? opts.instanceName.trim()


### PR DESCRIPTION
## Summary

Prevents gateway crash on Kubernetes pods (and other environments with long hostnames) by truncating mDNS hostname and service name to the 63-byte DNS label maximum before passing them to `@homebridge/ciao`.

## Problem

On Kubernetes, pod hostnames like `app-41627eae5842473f9e05f139ea307277-7f9477f4d6-lqqzf` are 53 bytes. When the `(OpenClaw)` suffix is appended to create the service instance name, the result is 64 bytes — exactly 1 byte over the 63-byte DNS label limit. The `@homebridge/ciao` library enforces this limit with an `AssertionError` that becomes an uncaught exception, crashing the entire gateway process.

The `CLAWDBOT_DISABLE_BONJOUR=1` workaround documented in a previous issue does not work because the env var name was updated to `OPENCLAW_DISABLE_BONJOUR`.

## Changes

| File | Change |
|------|--------|
| `src/infra/bonjour.ts` | Added `truncateToByteLimit` helper and `MAX_DNS_LABEL_BYTES` constant; applied truncation to both `hostname` and `safeServiceName` |
| `src/infra/bonjour.test.ts` | New test verifying Kubernetes-style long hostnames are truncated to ≤63 bytes for both hostname and service name |

## How it works

A new `truncateToByteLimit(label, maxBytes)` function iteratively removes trailing characters until the UTF-8 byte length is within the DNS label limit. It is applied in two places:

1. **`hostname`** (line ~105): The resolved hostname label is truncated to 63 bytes after splitting on dots and stripping `.local`
2. **`safeServiceName`** (line ~53): The service instance name (e.g., `hostname (OpenClaw)`) is truncated to 63 bytes before being passed to `responder.createService()`

The truncation preserves as much of the original name as possible while ensuring no `AssertionError` from ciao.

## Test plan

- [x] 8 tests pass in `src/infra/bonjour.test.ts` (7 existing + 1 new)
- [x] New test: Kubernetes-style hostname `app-41627eae5842473f9e05f139ea307277-7f9477f4d6-lqqzf` produces service name and hostname both ≤63 bytes
- [ ] Manual: deploy on Kubernetes with a long pod hostname and verify gateway starts without crash

## Security Impact

- Does this change handle user input? **No** (only processes system hostname)
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **Minimally** — truncated mDNS names may differ from full hostname, but mDNS is LAN-only service discovery
- Does this change introduce new dependencies? **No**

## Human Verification

1. Deploy OpenClaw on a Kubernetes pod with a hostname longer than 53 characters
2. Start the gateway without setting `OPENCLAW_DISABLE_BONJOUR`
3. Verify the gateway starts successfully without crashing
4. Verify mDNS discovery works from another device on the same network
5. Alternatively, set `OPENCLAW_MDNS_HOSTNAME` to a 64+ character string and verify no crash

## Failure Recovery

Remove the `truncateToByteLimit` function and its calls in `safeServiceName` and hostname resolution to restore original behavior. Users can alternatively set `OPENCLAW_DISABLE_BONJOUR=1` to skip mDNS entirely.

## Risks and Mitigations

- **Risk**: Truncated hostnames reduce discoverability when multiple pods have the same prefix. **Mitigation**: The first 63 bytes of Kubernetes hostnames typically include enough of the deployment hash and pod ID to remain unique within a LAN segment.
- **Risk**: Truncation could split a multi-byte UTF-8 character. **Mitigation**: The function removes one JS character at a time and re-checks byte length, so it never produces an invalid UTF-8 sequence.