### PR TITLE
fix(nextcloud-talk): resolve missing abort-signal module

### DIFF
--- a/extensions/nextcloud-talk/src/abort-signal.ts
+++ b/extensions/nextcloud-talk/src/abort-signal.ts
@@ -1,0 +1,12 @@
+export async function waitForAbortSignal(signal?: AbortSignal): Promise<void> {
+  if (!signal || signal.aborted) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -12,7 +12,7 @@ import {
   type OpenClawConfig,
   type ChannelSetupInput,
 } from "openclaw/plugin-sdk/nextcloud-talk";
-import { waitForAbortSignal } from "../../../src/infra/abort-signal.js";
+import { waitForAbortSignal } from "./abort-signal.js";
 import {
   listNextcloudTalkAccountIds,
   resolveDefaultNextcloudTalkAccountId,


### PR DESCRIPTION
## Summary
nextcloud-talk plugin fails to load: Cannot find module

## Root Cause
Plugin was importing from relative path that didn't exist in bundled package.

## Changes
- Added missing abort-signal.ts to plugin

## Testing
- pnpm test: 2/2 passed

Fixes #37915