### PR TITLE
fix(cli): guard against undefined schedule and payload in cron list/run

### DIFF
--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -166,4 +166,18 @@ describe("printCronList", () => {
     printCronList([job], runtime);
     expect(logs.some((line) => line.includes("(exact)"))).toBe(true);
   });
+
+  it("handles jobs with undefined schedule and payload without TypeError", () => {
+    const { logs, runtime } = createRuntimeLogCapture();
+    const job = createBaseJob({
+      id: "broken-job",
+      name: "Broken",
+      schedule: undefined as never,
+      payload: undefined as never,
+      state: {},
+    });
+
+    expect(() => printCronList([job], runtime)).not.toThrow();
+    expect(logs.length).toBeGreaterThan(0);
+  });
 });

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -149,7 +149,10 @@ const formatRelative = (ms: number | null | undefined, nowMs: number) => {
   return delta >= 0 ? `in ${label}` : `${label} ago`;
 };
 
-const formatSchedule = (schedule: CronSchedule) => {
+const formatSchedule = (schedule: CronSchedule | undefined) => {
+  if (!schedule || !schedule.kind) {
+    return "-";
+  }
   if (schedule.kind === "at") {
     return `at ${formatIsoMinute(schedule.at)}`;
   }
@@ -214,7 +217,7 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
     const agentLabel = pad(truncate(job.agentId ?? "-", CRON_AGENT_PAD), CRON_AGENT_PAD);
     const modelLabel = pad(
       truncate(
-        (job.payload.kind === "agentTurn" ? job.payload.model : undefined) ?? "-",
+        (job.payload?.kind === "agentTurn" ? job.payload.model : undefined) ?? "-",
         CRON_MODEL_PAD,
       ),
       CRON_MODEL_PAD,
@@ -253,7 +256,7 @@ export function printCronList(jobs: CronJob[], runtime = defaultRuntime) {
       coloredStatus,
       coloredTarget,
       coloredAgent,
-      job.payload.kind === "agentTurn" && job.payload.model
+      job.payload?.kind === "agentTurn" && job.payload.model
         ? colorize(rich, theme.info, modelLabel)
         : colorize(rich, theme.muted, modelLabel),
     ].join(" ");

--- a/ui/src/ui/presenter.ts
+++ b/ui/src/ui/presenter.ts
@@ -53,6 +53,9 @@ export function formatCronState(job: CronJob) {
 
 export function formatCronSchedule(job: CronJob) {
   const s = job.schedule;
+  if (!s?.kind) {
+    return "Unknown";
+  }
   if (s.kind === "at") {
     const atMs = Date.parse(s.at);
     return Number.isFinite(atMs) ? `At ${formatMs(atMs)}` : `At ${s.at}`;
@@ -65,6 +68,9 @@ export function formatCronSchedule(job: CronJob) {
 
 export function formatCronPayload(job: CronJob) {
   const p = job.payload;
+  if (!p?.kind) {
+    return "Unknown";
+  }
   if (p.kind === "systemEvent") {
     return `System: ${p.text}`;
   }


### PR DESCRIPTION
## Summary

Fixes TypeError crash in `openclaw cron list` and `openclaw cron run` when jobs have missing or malformed `schedule` or `payload` objects.

## Problem

Jobs with undefined `schedule` or `payload` cause `TypeError: Cannot read properties of undefined (reading 'kind')` in both the CLI (`shared.ts`) and WebUI (`presenter.ts`) formatting code. The cron system itself works correctly — jobs run on schedule — but the CLI display crashes. This affects `cron list`, `cron run`, and the WebUI cron panel.

## Changes

| File | Change |
|------|--------|
| `src/cli/cron-cli/shared.ts` | `formatSchedule` now accepts `undefined` and returns `"-"`; `job.payload.kind` → `job.payload?.kind` (2 occurrences) |
| `ui/src/ui/presenter.ts` | `formatCronSchedule` and `formatCronPayload` guard `s?.kind` and `p?.kind` with early return of `"Unknown"` |
| `src/cli/cron-cli/shared.test.ts` | New test verifying `printCronList` handles jobs with `undefined` schedule and payload without throwing |

## How it works

All four formatting functions now check for `undefined`/`null` schedule or payload before accessing `.kind`. When the value is missing, they return a safe fallback string (`"-"` in CLI, `"Unknown"` in WebUI) instead of crashing.

## Test plan

- [x] 10 tests pass in `shared.test.ts` (9 existing + 1 new)
- [x] New test: job with `undefined` schedule and payload does not throw TypeError
- [ ] Manual: create a cron job, corrupt its `schedule` field in `jobs.json`, run `openclaw cron list`

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Run `openclaw cron list` with existing cron jobs — verify all jobs display correctly
2. Manually edit `jobs.json` to remove the `schedule` field from one job
3. Run `openclaw cron list` again — verify it displays without crashing (shows "-" for the broken job's schedule)
4. Open the WebUI cron panel — verify it displays without errors

## Failure Recovery

Remove the null guards to restore the original strict behavior. Jobs with missing fields will crash the CLI again.

## Risks and Mitigations

- **Risk**: Silently hiding malformed jobs instead of surfacing the error. **Mitigation**: The fallback labels (`"-"`, `"Unknown"`) are visible in the output, signaling that something is wrong with the job's configuration. The underlying cron system logs warnings for malformed jobs separately.