### PR TITLE
feat(agents): graph-aware cycle detection for sessions_send

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { resolvePluginTools } from "../plugins/tools.js";
+import type { InputProvenance } from "../sessions/input-provenance.js";
 import type { GatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveSessionAgentId } from "./agent-scope.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
@@ -74,6 +75,8 @@ export function createOpenClawTools(options?: {
   senderIsOwner?: boolean;
   /** Ephemeral session UUID — regenerated on /new and /reset. */
   sessionId?: string;
+  /** Input provenance of the triggering message (for chain cycle detection). */
+  inputProvenance?: InputProvenance;
 }): AnyAgentTool[] {
   const workspaceDir = resolveWorkspaceRoot(options?.workspaceDir);
   const imageTool = options?.agentDir?.trim()
@@ -170,6 +173,7 @@ export function createOpenClawTools(options?: {
       agentSessionKey: options?.agentSessionKey,
       agentChannel: options?.agentChannel,
       sandboxed: options?.sandboxed,
+      inputProvenance: options?.inputProvenance,
     }),
     createSessionsSpawnTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -877,6 +877,7 @@ export async function runEmbeddedAttempt(
           requireExplicitMessageTarget:
             params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
           disableMessageTool: params.disableMessageTool,
+          inputProvenance: params.inputProvenance,
         });
     const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider: params.provider });
     const allowedToolNames = collectAllowedToolNames({

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
 import { resolveMergedSafeBinProfileFixtures } from "../infra/exec-safe-bin-runtime-policy.js";
 import { logWarn } from "../logger.js";
+import type { InputProvenance } from "../sessions/input-provenance.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { isSubagentSessionKey } from "../routing/session-key.js";
 import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
@@ -255,6 +256,8 @@ export function createOpenClawCodingTools(options?: {
   disableMessageTool?: boolean;
   /** Whether the sender is an owner (required for owner-only tools). */
   senderIsOwner?: boolean;
+  /** Input provenance of the message that triggered this agent run (for chain cycle detection). */
+  inputProvenance?: InputProvenance;
 }): AnyAgentTool[] {
   const execToolName = "exec";
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;
@@ -513,6 +516,7 @@ export function createOpenClawCodingTools(options?: {
       requesterSenderId: options?.senderId,
       senderIsOwner: options?.senderIsOwner,
       sessionId: options?.sessionId,
+      inputProvenance: options?.inputProvenance,
     }),
   ];
   const toolsForMessageProvider = applyMessageProviderToolPolicy(tools, options?.messageProvider);

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -2,7 +2,12 @@ import crypto from "node:crypto";
 import { Type } from "@sinclair/typebox";
 import { loadConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
-import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import {
+  normalizeAgentId,
+  parseAgentSessionKey,
+  resolveAgentIdFromSessionKey,
+} from "../../routing/session-key.js";
+import type { InputProvenance } from "../../sessions/input-provenance.js";
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
 import {
   type GatewayMessageChannel,
@@ -36,6 +41,7 @@ export function createSessionsSendTool(opts?: {
   agentSessionKey?: string;
   agentChannel?: GatewayMessageChannel;
   sandboxed?: boolean;
+  inputProvenance?: InputProvenance;
 }): AnyAgentTool {
   return {
     label: "Session Send",
@@ -212,6 +218,23 @@ export function createSessionsSendTool(opts?: {
         });
       }
 
+      const requesterParsed = parseAgentSessionKey(opts?.agentSessionKey);
+      const targetParsed = parseAgentSessionKey(resolvedKey);
+      const requesterAgentId = requesterParsed?.agentId;
+      const targetAgentId = targetParsed?.agentId;
+      const incomingChain = opts?.inputProvenance?.chainAgentIds ?? [];
+      const updatedChain = requesterAgentId
+        ? [...incomingChain, requesterAgentId]
+        : incomingChain;
+      if (targetAgentId && updatedChain.length > 0 && updatedChain.includes(targetAgentId)) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error: `Cycle detected: agent "${targetAgentId}" already appears in the inter-session chain [${updatedChain.join(" → ")}]. Stopping to prevent an infinite loop.`,
+          sessionKey: displayKey,
+        });
+      }
+
       const agentMessageContext = buildAgentToAgentMessageContext({
         requesterSessionKey: opts?.agentSessionKey,
         requesterChannel: opts?.agentChannel,
@@ -230,6 +253,7 @@ export function createSessionsSendTool(opts?: {
           sourceSessionKey: opts?.agentSessionKey,
           sourceChannel: opts?.agentChannel,
           sourceTool: "sessions_send",
+          chainAgentIds: updatedChain.length > 0 ? updatedChain : undefined,
         },
       };
       const requesterSessionKey = opts?.agentSessionKey;

--- a/src/sessions/input-provenance.ts
+++ b/src/sessions/input-provenance.ts
@@ -13,6 +13,8 @@ export type InputProvenance = {
   sourceSessionKey?: string;
   sourceChannel?: string;
   sourceTool?: string;
+  /** Agent IDs that have participated in this inter-session message chain (cycle detection). */
+  chainAgentIds?: string[];
 };
 
 function normalizeOptionalString(value: unknown): string | undefined {
@@ -37,11 +39,17 @@ export function normalizeInputProvenance(value: unknown): InputProvenance | unde
   if (!isInputProvenanceKind(record.kind)) {
     return undefined;
   }
+  const chainAgentIds = Array.isArray(record.chainAgentIds)
+    ? (record.chainAgentIds as unknown[]).filter(
+        (entry): entry is string => typeof entry === "string" && entry.length > 0,
+      )
+    : undefined;
   return {
     kind: record.kind,
     sourceSessionKey: normalizeOptionalString(record.sourceSessionKey),
     sourceChannel: normalizeOptionalString(record.sourceChannel),
     sourceTool: normalizeOptionalString(record.sourceTool),
+    chainAgentIds: chainAgentIds && chainAgentIds.length > 0 ? chainAgentIds : undefined,
   };
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** `maxPingPongTurns` only guards direct A<>B message exchanges. Triangular or polygonal loops (A→B→C→A) bypass the counter because each leg appears as "turn 1" from its pairwise perspective. In a 17-agent deployment, this caused a 398-message echo storm over 10 hours (~$19 token burn).
- **Why it matters:** Multi-agent topologies with `agentToAgent` enabled can enter infinite circular message cascades that burn tokens, saturate resources, and produce no useful work.
- **What changed:** Added `chainAgentIds` to `InputProvenance` and threaded it through the tool creation chain. `sessions_send` now appends the requester's agent ID to the chain before sending and blocks delivery if the target agent already appears in the chain.
- **What did NOT change:** The existing `maxPingPongTurns` behavior for direct A<>B exchanges is untouched. Legacy/alias session keys without explicit `agent:` prefixes are not tracked (prevents false positives). The A2A ping-pong flow within `runSessionsSendA2AFlow` is unchanged — it's already bounded by `maxPingPongTurns`.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37842

## User-visible / Behavior Changes

- When an inter-session message chain forms a cycle (e.g. A→B→C→A), the `sessions_send` tool now returns a descriptive error: `Cycle detected: agent "X" already appears in the inter-session chain [A → B → C]. Stopping to prevent an infinite loop.`
- New optional field `chainAgentIds` in `InputProvenance` — backward compatible, ignored when absent.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — only adds a pre-send guard
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Any (inter-agent `sessions_send`)

### Steps

1. Configure 3+ agents with `tools.agentToAgent.enabled: true`
2. Agent A sends to Agent B via `sessions_send`
3. Agent B's response triggers `sessions_send` to Agent C
4. Agent C's response triggers `sessions_send` back to Agent A

### Expected

- Step 4 is blocked with a cycle detection error instead of entering an infinite loop

### Actual

- Before fix: Each leg has `turn 1` from its pairwise perspective; loop continues indefinitely
- After fix: `sessions_send` at step 4 detects Agent A is already in the chain `[A, B, C]` and returns an error

## Evidence

**Implementation approach:**

```
InputProvenance {
  kind: "inter_session"
  chainAgentIds?: string[]    // NEW: tracks participating agents
}

sessions_send execution:
  1. Parse requester agent ID from agentSessionKey (parseAgentSessionKey)
  2. Parse target agent ID from resolved session key
  3. Build chain = incoming provenance chain + requester ID
  4. If target ID is in chain → cycle → block with error
  5. Include updated chain in outgoing inputProvenance
```

**Thread path:**

```
pi-embedded-runner/attempt.ts (params.inputProvenance)
  └─► pi-tools.ts (createOpenClawCodingTools)
        └─► openclaw-tools.ts (createOpenClawTools)
              └─► sessions-send-tool.ts (createSessionsSendTool)
                    └─► inputProvenance.chainAgentIds checked at send time
```

**Tests:** 23 tests pass (openclaw-tools.sessions: 21, server.sessions-send: 2)

## Human Verification (required)

- Verified scenarios: Traced the full chain propagation path; confirmed cycle detection only fires for agent-prefixed session keys
- Edge cases checked: Legacy session keys (`main`, `discord:group:req`) don't trigger false positives; empty chains are handled; self-sends (same agent ID) are correctly detected as cycles
- What I did **not** verify: Live multi-agent deployment with >3 agents

## Compatibility / Migration

- Backward compatible? `Yes` — `chainAgentIds` is optional in `InputProvenance`; when absent, no cycle detection occurs
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this PR; cycle detection simply stops — `maxPingPongTurns` still guards A<>B exchanges
- Files/config to restore: None
- Known bad symptoms: If cycle detection has false positives, legitimate multi-agent chains would be blocked. Mitigated by only tracking agent-prefixed session keys.

## Risks and Mitigations

- **Risk:** Legitimate deep chains (A→B→C→D→…→A) could be blocked if they intentionally revisit an agent → **Mitigation:** This is intentionally blocked — revisiting an agent in a chain is the definition of a cycle. If needed in the future, a config option could set a "max revisits" threshold.
- **Risk:** `chainAgentIds` array grows unbounded in very long chains → **Mitigation:** Agent topologies are finite (typically <20 agents); the array is bounded by the number of distinct agents.

