### PR TITLE
fix(browser): recognize node-proxy stale tab errors

### DIFF
--- a/src/agents/tools/browser-tool.actions.ts
+++ b/src/agents/tools/browser-tool.actions.ts
@@ -58,8 +58,12 @@ function isChromeStaleTargetError(profile: string | undefined, err: unknown): bo
   if (profile !== "chrome") {
     return false;
   }
-  const msg = String(err);
-  return msg.includes("404:") && msg.includes("tab not found");
+  const msg = String(err).toLowerCase();
+  return (
+    msg.includes("tab not found") ||
+    msg.includes("target not found") ||
+    msg.includes("no such target")
+  );
 }
 
 function stripTargetIdFromActRequest(

--- a/src/agents/tools/browser-tool.test.ts
+++ b/src/agents/tools/browser-tool.test.ts
@@ -602,4 +602,34 @@ describe("browser tool act stale target recovery", () => {
     );
     expect(result?.details).toMatchObject({ ok: true });
   });
+
+  it("retries proxied chrome act when node proxy returns tab not found", async () => {
+    mockSingleBrowserProxyNode();
+    gatewayMocks.callGatewayTool
+      .mockRejectedValueOnce(new Error("tab not found"))
+      .mockResolvedValueOnce({ ok: true, payload: { result: { ok: true } } });
+
+    const tool = createBrowserTool();
+    const result = await tool.execute?.("call-1", {
+      action: "act",
+      target: "node",
+      profile: "chrome",
+      request: {
+        action: "click",
+        targetId: "stale-tab",
+        ref: "btn-1",
+      },
+    });
+
+    expect(gatewayMocks.callGatewayTool).toHaveBeenCalledTimes(2);
+    const firstInvoke = gatewayMocks.callGatewayTool.mock.calls[0]?.[2] as
+      | { params?: { body?: { targetId?: string } } }
+      | undefined;
+    const secondInvoke = gatewayMocks.callGatewayTool.mock.calls[1]?.[2] as
+      | { params?: { body?: { targetId?: string } } }
+      | undefined;
+    expect(firstInvoke?.params?.body?.targetId).toBe("stale-tab");
+    expect(secondInvoke?.params?.body?.targetId).toBeUndefined();
+    expect(result?.details).toMatchObject({ ok: true });
+  });
 });


### PR DESCRIPTION
## Summary
Chrome extension relay tab not found with remote gateway + macOS node proxy.

## Root Cause
isChromeStaleTargetError only matched 404 but node-proxy returns plain text.

## Changes
- browser-tool.actions.ts: Expand stale error detection
- browser-tool.test.ts: Add regression test

## Testing
- pnpm test: 24/24 passed

Fixes #37913