### PR TITLE
fix(auto-reply): suppress JSON-wrapped NO_REPLY leaking to end users

### DIFF
--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -34,6 +34,18 @@ describe("isSilentReplyText", () => {
     expect(isSilentReplyText("HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(true);
     expect(isSilentReplyText("Checked inbox. HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(false);
   });
+
+  it("detects JSON-wrapped NO_REPLY (#37727)", () => {
+    expect(isSilentReplyText('{"action":"NO_REPLY"}')).toBe(true);
+    expect(isSilentReplyText('{ "action": "NO_REPLY" }')).toBe(true);
+    expect(isSilentReplyText('{"text":"NO_REPLY","action":"NO_REPLY"}')).toBe(true);
+    expect(isSilentReplyText('{"action":"NO_REPLY","extra":""}')).toBe(true);
+  });
+
+  it("does not suppress JSON with real content alongside NO_REPLY", () => {
+    expect(isSilentReplyText('{"action":"NO_REPLY","message":"Hello"}')).toBe(false);
+    expect(isSilentReplyText('{"count":42}')).toBe(false);
+  });
 });
 
 describe("stripSilentToken", () => {

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -37,7 +37,44 @@ export function isSilentReplyText(
   }
   // Match only the exact silent token with optional surrounding whitespace.
   // This prevents substantive replies ending with NO_REPLY from being suppressed (#19537).
-  return getSilentExactRegex(token).test(text);
+  if (getSilentExactRegex(token).test(text)) {
+    return true;
+  }
+  // Some models emit JSON-wrapped silent tokens like {"action":"NO_REPLY"}.
+  // Detect and suppress these to prevent raw JSON leaking to end users (#37727).
+  return isJsonWrappedSilentToken(text, token);
+}
+
+/**
+ * Detect JSON payloads whose only meaningful value is a silent reply token.
+ * Matches patterns like `{"action":"NO_REPLY"}`, `{ "text": "NO_REPLY" }`, etc.
+ */
+function isJsonWrappedSilentToken(text: string, token: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+    const values = Object.values(parsed);
+    // All string values must be the silent token (or empty); at least one must match.
+    let hasToken = false;
+    for (const v of values) {
+      if (typeof v === "string") {
+        const sv = v.trim();
+        if (sv === token) {
+          hasToken = true;
+        } else if (sv !== "") {
+          return false;
+        }
+      } else if (v !== null && v !== undefined) {
+        return false;
+      }
+    }
+    return hasToken;
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

Some models (especially during cron/heartbeat/sub-agent flows) emit JSON-wrapped silent tokens like `{"action":"NO_REPLY"}` instead of the bare `NO_REPLY` text. The existing detection in `isSilentReplyText()` only matches the exact token with optional whitespace, and `stripSilentToken()` requires whitespace/asterisk before the token — neither catches JSON-wrapped variants.

This causes raw JSON payloads to leak through to end users on Telegram and other channels.

## Fix

Add `isJsonWrappedSilentToken()` that parses the text as JSON and checks whether all string values in the object are either the silent token or empty, with at least one matching the token. Integrated into the existing `isSilentReplyText()` check.

## Tests

Added 6 test cases covering JSON-wrapped detection and non-suppression of JSON with real content.

All 21 tests in `tokens.test.ts` pass.

Fixes #37727