### PR TITLE
fix(agents): prevent file path hallucination in session reset prompt

### DIFF
--- a/src/auto-reply/reply/session-reset-prompt.test.ts
+++ b/src/auto-reply/reply/session-reset-prompt.test.ts
@@ -7,6 +7,8 @@ describe("buildBareSessionResetPrompt", () => {
     const prompt = buildBareSessionResetPrompt();
     expect(prompt).toContain("Execute your Session Startup sequence now");
     expect(prompt).toContain("read the required files before responding to the user");
+    expect(prompt).toContain("Never invent file names or paths");
+    expect(prompt).toContain("never claim to have read a file you did not read");
   });
 
   it("appends current time line so agents know the date", () => {

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -2,7 +2,7 @@ import { appendCronStyleCurrentTimeLine } from "../../agents/current-time.js";
 import type { OpenClawConfig } from "../../config/config.js";
 
 const BARE_SESSION_RESET_PROMPT_BASE =
-  "A new session was started via /new or /reset. Execute your Session Startup sequence now - read the required files before responding to the user. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
+  "A new session was started via /new or /reset. Execute your Session Startup sequence now - read the required files before responding to the user. Only use startup files explicitly listed in your instructions and files that actually exist in this workspace. Never invent file names or paths, and never claim to have read a file you did not read. If a startup file is unavailable, continue without guessing its contents. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
 
 /**
  * Build the bare session reset prompt, appending the current date/time so agents


### PR DESCRIPTION
## Summary
Session reset prompt causes models to hallucinate startup file paths.

## Changes
- session-reset-prompt.ts: Add anti-hallucination constraints

## Testing
- 4/4 tests passed

Fixes #37889