### PR TITLE
fix(gateway): allow control-ui bypass when dangerouslyDisableDeviceAuth=true (#35944)

### DIFF
--- a/src/gateway/server/ws-connection/connect-policy.test.ts
+++ b/src/gateway/server/ws-connection/connect-policy.test.ts
@@ -238,4 +238,59 @@ describe("ws connect policy", () => {
       ).toBe(tc.expected);
     }
   });
+
+  test("dangerouslyDisableDeviceAuth allows control-ui without device identity or shared auth (issue #35944)", () => {
+    const bypassPolicy = resolveControlUiAuthPolicy({
+      isControlUi: true,
+      controlUiConfig: { dangerouslyDisableDeviceAuth: true },
+      deviceRaw: null,
+    });
+    expect(bypassPolicy.allowBypass).toBe(true);
+    expect(bypassPolicy.device).toBeNull();
+
+    // Control UI with bypass enabled and NO device identity, NO shared auth → must be allowed.
+    // Bug: without the allowBypass early-allow guard, this falls through to reject-device-required.
+    expect(
+      evaluateMissingDeviceIdentity({
+        hasDeviceIdentity: false,
+        role: "operator",
+        isControlUi: true,
+        controlUiAuthPolicy: bypassPolicy,
+        trustedProxyAuthOk: false,
+        sharedAuthOk: false,
+        authOk: false,
+        hasSharedAuth: false,
+        isLocalClient: false,
+      }).kind,
+    ).toBe("allow");
+
+    // Control UI with bypass enabled and a device payload present in raw but null in policy.
+    const bypassPolicyWithRawDevice = resolveControlUiAuthPolicy({
+      isControlUi: true,
+      controlUiConfig: { dangerouslyDisableDeviceAuth: true },
+      deviceRaw: {
+        id: "dev-bypass",
+        publicKey: "bad-key",
+        signature: "bad-sig",
+        signedAt: Date.now(),
+        nonce: "nonce-x",
+      },
+    });
+    // Policy must null-out the device so device-id-mismatch validation is skipped.
+    expect(bypassPolicyWithRawDevice.device).toBeNull();
+    // And missing-device path must still allow (no device identity because policy suppressed it).
+    expect(
+      evaluateMissingDeviceIdentity({
+        hasDeviceIdentity: false,
+        role: "operator",
+        isControlUi: true,
+        controlUiAuthPolicy: bypassPolicyWithRawDevice,
+        trustedProxyAuthOk: false,
+        sharedAuthOk: false,
+        authOk: false,
+        hasSharedAuth: false,
+        isLocalClient: false,
+      }).kind,
+    ).toBe("allow");
+  });
 });

--- a/src/gateway/server/ws-connection/connect-policy.ts
+++ b/src/gateway/server/ws-connection/connect-policy.ts
@@ -82,6 +82,9 @@ export function evaluateMissingDeviceIdentity(params: {
   if (params.isControlUi && params.trustedProxyAuthOk) {
     return { kind: "allow" };
   }
+  if (params.isControlUi && params.controlUiAuthPolicy.allowBypass) {
+    return { kind: "allow" };
+  }
   if (params.isControlUi && !params.controlUiAuthPolicy.allowBypass) {
     // Allow localhost Control UI connections when allowInsecureAuth is configured.
     // Localhost has no network interception risk, and browser SubtleCrypto


### PR DESCRIPTION
## Problem
When `dangerouslyDisableDeviceAuth: true` is set in the Control UI config, connections are still rejected with a device-related error. The setting is intended to allow Control UI connections without device authentication, but the handler rejects the connection during the missing-device-identity evaluation step.

## Root cause
`evaluateMissingDeviceIdentity()` in `src/gateway/server/ws-connection/connect-policy.ts` has no early-allow path for the `allowBypass=true` case when `hasDeviceIdentity=false`. Although the function correctly skips the `reject-control-ui-insecure-auth` block when `allowBypass=true`, it falls through to `roleCanSkipDeviceIdentity(role, sharedAuthOk)` which requires `role === 'operator' && sharedAuthOk`. A Control UI connecting without shared auth—relying entirely on the `dangerouslyDisableDeviceAuth` bypass—gets `reject-device-required` instead of being allowed.

## Fix
Added an early-allow guard in `evaluateMissingDeviceIdentity` (after the `trustedProxyAuthOk` check):
```typescript
if (params.isControlUi && params.controlUiAuthPolicy.allowBypass) {
  return { kind: 'allow' };
}
```
This ensures that when `dangerouslyDisableDeviceAuth=true` the Control UI connection is allowed regardless of whether device identity or shared auth is present.

## Verification
- **Test:** `src/gateway/server/ws-connection/connect-policy.test.ts` — new test case "dangerouslyDisableDeviceAuth allows control-ui without device identity or shared auth (issue #35944)" fails on main (`reject-device-required` instead of `allow`), passes on fix
- **Build:** clean compile (`build-output.log`)
- **Test suite:** 832/832 test files pass, zero failures (`test-output.log`)
- **Code proof:** allowBypass early-allow guard present, `reject-device-required` fallback retained (`step6-verify.log`)

Closes #35944