### PR TITLE
fix(channels): gracefully handle unresolved SecretRefs in token resolution during onboarding

### DIFF
--- a/src/discord/token.test.ts
+++ b/src/discord/token.test.ts
@@ -91,7 +91,7 @@ describe("resolveDiscordToken", () => {
     expect(res.source).toBe("config");
   });
 
-  it("throws when token is an unresolved SecretRef object", () => {
+  it("returns empty token when token is an unresolved SecretRef object", () => {
     const cfg = {
       channels: {
         discord: {
@@ -100,8 +100,8 @@ describe("resolveDiscordToken", () => {
       },
     } as unknown as OpenClawConfig;
 
-    expect(() => resolveDiscordToken(cfg)).toThrow(
-      /channels\.discord\.token: unresolved SecretRef/i,
-    );
+    const res = resolveDiscordToken(cfg);
+    expect(res.token).toBe("");
+    expect(res.source).toBe("none");
   });
 });

--- a/src/discord/token.ts
+++ b/src/discord/token.ts
@@ -10,11 +10,15 @@ export type DiscordTokenResolution = BaseTokenResolution & {
 };
 
 export function normalizeDiscordToken(raw: unknown, path: string): string | undefined {
-  const trimmed = normalizeResolvedSecretInputString({ value: raw, path });
-  if (!trimmed) {
+  try {
+    const trimmed = normalizeResolvedSecretInputString({ value: raw, path });
+    if (!trimmed) {
+      return undefined;
+    }
+    return trimmed.replace(/^Bot\s+/i, "");
+  } catch {
     return undefined;
   }
-  return trimmed.replace(/^Bot\s+/i, "");
 }
 
 export function resolveDiscordToken(

--- a/src/slack/token.ts
+++ b/src/slack/token.ts
@@ -1,29 +1,34 @@
 import { normalizeResolvedSecretInputString } from "../config/types.secrets.js";
 
+function safeNormalize(value: unknown, path: string): string | undefined {
+  try {
+    return normalizeResolvedSecretInputString({ value, path });
+  } catch {
+    return undefined;
+  }
+}
+
 export function normalizeSlackToken(raw?: unknown): string | undefined {
-  return normalizeResolvedSecretInputString({
-    value: raw,
-    path: "channels.slack.*.token",
-  });
+  return safeNormalize(raw, "channels.slack.*.token");
 }
 
 export function resolveSlackBotToken(
   raw?: unknown,
   path = "channels.slack.botToken",
 ): string | undefined {
-  return normalizeResolvedSecretInputString({ value: raw, path });
+  return safeNormalize(raw, path);
 }
 
 export function resolveSlackAppToken(
   raw?: unknown,
   path = "channels.slack.appToken",
 ): string | undefined {
-  return normalizeResolvedSecretInputString({ value: raw, path });
+  return safeNormalize(raw, path);
 }
 
 export function resolveSlackUserToken(
   raw?: unknown,
   path = "channels.slack.userToken",
 ): string | undefined {
-  return normalizeResolvedSecretInputString({ value: raw, path });
+  return safeNormalize(raw, path);
 }

--- a/src/telegram/token.test.ts
+++ b/src/telegram/token.test.ts
@@ -127,7 +127,7 @@ describe("resolveTelegramToken", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
-  it("throws when botToken is an unresolved SecretRef object", () => {
+  it("returns empty token when botToken is an unresolved SecretRef object", () => {
     const cfg = {
       channels: {
         telegram: {
@@ -136,9 +136,9 @@ describe("resolveTelegramToken", () => {
       },
     } as unknown as OpenClawConfig;
 
-    expect(() => resolveTelegramToken(cfg)).toThrow(
-      /channels\.telegram\.botToken: unresolved SecretRef/i,
-    );
+    const res = resolveTelegramToken(cfg);
+    expect(res.token).toBe("");
+    expect(res.source).toBe("none");
   });
 });
 

--- a/src/telegram/token.ts
+++ b/src/telegram/token.ts
@@ -66,12 +66,16 @@ export function resolveTelegramToken(
     return { token: "", source: "none" };
   }
 
-  const accountToken = normalizeResolvedSecretInputString({
-    value: accountCfg?.botToken,
-    path: `channels.telegram.accounts.${accountId}.botToken`,
-  });
-  if (accountToken) {
-    return { token: accountToken, source: "config" };
+  try {
+    const accountToken = normalizeResolvedSecretInputString({
+      value: accountCfg?.botToken,
+      path: `channels.telegram.accounts.${accountId}.botToken`,
+    });
+    if (accountToken) {
+      return { token: accountToken, source: "config" };
+    }
+  } catch {
+    // SecretRef not yet resolved (e.g. exec provider during onboarding without a running gateway)
   }
 
   const allowEnv = accountId === DEFAULT_ACCOUNT_ID;
@@ -92,12 +96,16 @@ export function resolveTelegramToken(
     }
   }
 
-  const configToken = normalizeResolvedSecretInputString({
-    value: telegramCfg?.botToken,
-    path: "channels.telegram.botToken",
-  });
-  if (configToken) {
-    return { token: configToken, source: "config" };
+  try {
+    const configToken = normalizeResolvedSecretInputString({
+      value: telegramCfg?.botToken,
+      path: "channels.telegram.botToken",
+    });
+    if (configToken) {
+      return { token: configToken, source: "config" };
+    }
+  } catch {
+    // SecretRef not yet resolved (e.g. exec provider during onboarding without a running gateway)
   }
 
   const envToken = allowEnv ? (opts.envToken ?? process.env.TELEGRAM_BOT_TOKEN)?.trim() : "";


### PR DESCRIPTION
## Summary

Fixes onboarding crash when using exec secret providers for channel tokens (Telegram, Slack, Discord) by gracefully handling unresolved SecretRef objects in token resolution functions.

## Problem

When configuring a channel during `openclaw onboard` and choosing an exec secret provider for the bot token, the onboarding wizard crashes immediately after "Reference validated" with:

```
Error: channels.telegram.botToken: unresolved SecretRef "exec:xxx:telegram/apiKey".
Resolve this command against an active gateway runtime snapshot before reading it.
```

The root cause: after the SecretRef is validated and stored in the config, `promptTelegramAllowFrom` calls `resolveTelegramAccount` → `resolveTelegramToken` → `normalizeResolvedSecretInputString` → `assertSecretInputResolved`, which throws because the SecretRef object in the config can't be resolved without an active gateway runtime.

## Changes

| File | Change |
|------|--------|
| `src/telegram/token.ts` | Wrapped `normalizeResolvedSecretInputString` calls in try/catch, falling through to env/none on unresolved SecretRef |
| `src/discord/token.ts` | Same try/catch wrapping in `normalizeDiscordToken` |
| `src/slack/token.ts` | Added `safeNormalize` helper that catches unresolved SecretRef errors, used by all 4 token functions |
| `src/telegram/token.test.ts` | Updated test: unresolved SecretRef now returns `{ token: "", source: "none" }` instead of throwing |
| `src/discord/token.test.ts` | Updated test: unresolved SecretRef now returns `{ token: "", source: "none" }` instead of throwing |

## How it works

Token resolution functions now catch the `assertSecretInputResolved` error and fall through to the next resolution strategy (env var, token file, or `"none"`). During onboarding, the `tokenOverride` parameter carries the resolved value directly, so the unresolved SecretRef in config is never actually needed. At runtime, the gateway resolves SecretRefs before calling token resolution, so this change has no effect on normal operation.

## Test plan

- [x] 17 tests pass across `telegram/token.test.ts` and `discord/token.test.ts`
- [x] Updated tests verify unresolved SecretRef returns `{ token: "", source: "none" }` instead of throwing
- [ ] Manual: configure exec secret provider, run `openclaw onboard`, select Telegram, choose exec provider for bot token — onboarding should complete successfully

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication/authorization? **No** — token resolution at runtime is unaffected because the gateway resolves SecretRefs before channel initialization
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Configure an exec secret provider in `openclaw.json`
2. Run `openclaw onboard` and select Telegram
3. Choose "Use external secret provider" and select the exec provider
4. Enter a secret ID — should validate successfully
5. Onboarding should continue to allowFrom configuration and complete without crashing

## Failure Recovery

Remove the try/catch blocks to restore the original throw behavior. Users with exec secret providers will need to work around by configuring channels manually instead of via `openclaw onboard`.

## Risks and Mitigations

- **Risk**: Silently swallowing SecretRef errors could mask configuration issues during runtime. **Mitigation**: At runtime, the gateway resolves all SecretRefs before passing config to channel initialization. The try/catch only affects the synchronous `normalizeResolvedSecretInputString` path, not the async `resolveSecretRefString` used by the gateway's secret resolution pipeline.