### PR TITLE
feat(hooks): add before_llm_call and before_response_emit modifying hooks [claude, human developer oversight]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ dist/protocol.schema.json
 
 # Synthing
 **/.stfolder/
+.openclaw-*/

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -11,7 +11,6 @@ import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
-import { ensureGlobalUndiciStreamTimeouts } from "../../../infra/net/undici-global-dispatcher.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import type {
@@ -20,7 +19,6 @@ import type {
   PluginHookBeforePromptBuildResult,
 } from "../../../plugins/types.js";
 import { isSubagentSessionKey } from "../../../routing/session-key.js";
-import { joinPresentTextSegments } from "../../../shared/text/join-segments.js";
 import { resolveSignalReactionLevel } from "../../../signal/reaction-level.js";
 import { resolveTelegramInlineButtonsScope } from "../../../telegram/inline-buttons.js";
 import { resolveTelegramReactionLevel } from "../../../telegram/reaction-level.js";
@@ -31,12 +29,6 @@ import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../../agent-paths.js";
 import { resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
-import {
-  analyzeBootstrapBudget,
-  buildBootstrapPromptWarning,
-  buildBootstrapTruncationReportMeta,
-  buildBootstrapInjectionStats,
-} from "../../bootstrap-budget.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../../bootstrap-files.js";
 import { createCacheTrace } from "../../cache-trace.js";
 import {
@@ -56,19 +48,16 @@ import {
   downgradeOpenAIFunctionCallReasoningPairs,
   isCloudCodeAssistFormatError,
   resolveBootstrapMaxChars,
-  resolveBootstrapPromptTruncationWarningMode,
   resolveBootstrapTotalMaxChars,
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "../../pi-embedded-helpers.js";
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settings.js";
-import { applyPiAutoCompactionGuard } from "../../pi-settings.js";
 import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
 import { resolveSandboxContext } from "../../sandbox.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
-import { isXaiProvider } from "../../schema/clean-for-xai.js";
 import { repairSessionFileIfNeeded } from "../../session-file-repair.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import { sanitizeToolUseResultPairing } from "../../session-transcript-repair.js";
@@ -91,7 +80,6 @@ import { resolveTranscriptPolicy } from "../../transcript-policy.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
 import { appendCacheTtlTimestamp, isCacheTtlEligibleProvider } from "../cache-ttl.js";
-import type { CompactEmbeddedPiSessionParams } from "../compact.js";
 import { buildEmbeddedExtensionFactories } from "../extensions.js";
 import { applyExtraParamsToAgent } from "../extra-params.js";
 import {
@@ -426,110 +414,6 @@ export function wrapStreamFnTrimToolCallNames(
   };
 }
 
-// ---------------------------------------------------------------------------
-// xAI / Grok: decode HTML entities in tool call arguments
-// ---------------------------------------------------------------------------
-
-const HTML_ENTITY_RE = /&(?:amp|lt|gt|quot|apos|#39|#x[0-9a-f]+|#\d+);/i;
-
-function decodeHtmlEntities(value: string): string {
-  return value
-    .replace(/&amp;/gi, "&")
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/gi, "'")
-    .replace(/&apos;/gi, "'")
-    .replace(/&lt;/gi, "<")
-    .replace(/&gt;/gi, ">")
-    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
-    .replace(/&#(\d+);/gi, (_, dec) => String.fromCodePoint(Number.parseInt(dec, 10)));
-}
-
-export function decodeHtmlEntitiesInObject(obj: unknown): unknown {
-  if (typeof obj === "string") {
-    return HTML_ENTITY_RE.test(obj) ? decodeHtmlEntities(obj) : obj;
-  }
-  if (Array.isArray(obj)) {
-    return obj.map(decodeHtmlEntitiesInObject);
-  }
-  if (obj && typeof obj === "object") {
-    const result: Record<string, unknown> = {};
-    for (const [key, val] of Object.entries(obj as Record<string, unknown>)) {
-      result[key] = decodeHtmlEntitiesInObject(val);
-    }
-    return result;
-  }
-  return obj;
-}
-
-function decodeXaiToolCallArgumentsInMessage(message: unknown): void {
-  if (!message || typeof message !== "object") {
-    return;
-  }
-  const content = (message as { content?: unknown }).content;
-  if (!Array.isArray(content)) {
-    return;
-  }
-  for (const block of content) {
-    if (!block || typeof block !== "object") {
-      continue;
-    }
-    const typedBlock = block as { type?: unknown; arguments?: unknown };
-    if (typedBlock.type !== "toolCall" || !typedBlock.arguments) {
-      continue;
-    }
-    if (typeof typedBlock.arguments === "object") {
-      typedBlock.arguments = decodeHtmlEntitiesInObject(typedBlock.arguments);
-    }
-  }
-}
-
-function wrapStreamDecodeXaiToolCallArguments(
-  stream: ReturnType<typeof streamSimple>,
-): ReturnType<typeof streamSimple> {
-  const originalResult = stream.result.bind(stream);
-  stream.result = async () => {
-    const message = await originalResult();
-    decodeXaiToolCallArgumentsInMessage(message);
-    return message;
-  };
-
-  const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
-  (stream as { [Symbol.asyncIterator]: typeof originalAsyncIterator })[Symbol.asyncIterator] =
-    function () {
-      const iterator = originalAsyncIterator();
-      return {
-        async next() {
-          const result = await iterator.next();
-          if (!result.done && result.value && typeof result.value === "object") {
-            const event = result.value as { partial?: unknown; message?: unknown };
-            decodeXaiToolCallArgumentsInMessage(event.partial);
-            decodeXaiToolCallArgumentsInMessage(event.message);
-          }
-          return result;
-        },
-        async return(value?: unknown) {
-          return iterator.return?.(value) ?? { done: true as const, value: undefined };
-        },
-        async throw(error?: unknown) {
-          return iterator.throw?.(error) ?? { done: true as const, value: undefined };
-        },
-      };
-    };
-  return stream;
-}
-
-function wrapStreamFnDecodeXaiToolCallArguments(baseFn: StreamFn): StreamFn {
-  return (model, context, options) => {
-    const maybeStream = baseFn(model, context, options);
-    if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
-      return Promise.resolve(maybeStream).then((stream) =>
-        wrapStreamDecodeXaiToolCallArguments(stream),
-      );
-    }
-    return wrapStreamDecodeXaiToolCallArguments(maybeStream);
-  };
-}
-
 export async function resolvePromptBuildHookResult(params: {
   prompt: string;
   messages: unknown[];
@@ -571,35 +455,10 @@ export async function resolvePromptBuildHookResult(params: {
       : undefined);
   return {
     systemPrompt: promptBuildResult?.systemPrompt ?? legacyResult?.systemPrompt,
-    prependContext: joinPresentTextSegments([
-      promptBuildResult?.prependContext,
-      legacyResult?.prependContext,
-    ]),
-    prependSystemContext: joinPresentTextSegments([
-      promptBuildResult?.prependSystemContext,
-      legacyResult?.prependSystemContext,
-    ]),
-    appendSystemContext: joinPresentTextSegments([
-      promptBuildResult?.appendSystemContext,
-      legacyResult?.appendSystemContext,
-    ]),
+    prependContext: [promptBuildResult?.prependContext, legacyResult?.prependContext]
+      .filter((value): value is string => Boolean(value))
+      .join("\n\n"),
   };
-}
-
-export function composeSystemPromptWithHookContext(params: {
-  baseSystemPrompt?: string;
-  prependSystemContext?: string;
-  appendSystemContext?: string;
-}): string | undefined {
-  const prependSystem = params.prependSystemContext?.trim();
-  const appendSystem = params.appendSystemContext?.trim();
-  if (!prependSystem && !appendSystem) {
-    return undefined;
-  }
-  return joinPresentTextSegments(
-    [params.prependSystemContext, params.baseSystemPrompt, params.appendSystemContext],
-    { trim: true },
-  );
 }
 
 export function resolvePromptModeForSession(sessionKey?: string): "minimal" | "full" {
@@ -617,60 +476,6 @@ export function resolveAttemptFsWorkspaceOnly(params: {
     cfg: params.config,
     agentId: params.sessionAgentId,
   });
-}
-
-export function prependSystemPromptAddition(params: {
-  systemPrompt: string;
-  systemPromptAddition?: string;
-}): string {
-  if (!params.systemPromptAddition) {
-    return params.systemPrompt;
-  }
-  return `${params.systemPromptAddition}\n\n${params.systemPrompt}`;
-}
-
-/** Build legacy compaction params passed into context-engine afterTurn hooks. */
-export function buildAfterTurnLegacyCompactionParams(params: {
-  attempt: Pick<
-    EmbeddedRunAttemptParams,
-    | "sessionKey"
-    | "messageChannel"
-    | "messageProvider"
-    | "agentAccountId"
-    | "config"
-    | "skillsSnapshot"
-    | "senderIsOwner"
-    | "provider"
-    | "modelId"
-    | "thinkLevel"
-    | "reasoningLevel"
-    | "bashElevated"
-    | "extraSystemPrompt"
-    | "ownerNumbers"
-    | "authProfileId"
-  >;
-  workspaceDir: string;
-  agentDir: string;
-}): Partial<CompactEmbeddedPiSessionParams> {
-  return {
-    sessionKey: params.attempt.sessionKey,
-    messageChannel: params.attempt.messageChannel,
-    messageProvider: params.attempt.messageProvider,
-    agentAccountId: params.attempt.agentAccountId,
-    authProfileId: params.attempt.authProfileId,
-    workspaceDir: params.workspaceDir,
-    agentDir: params.agentDir,
-    config: params.attempt.config,
-    skillsSnapshot: params.attempt.skillsSnapshot,
-    senderIsOwner: params.attempt.senderIsOwner,
-    provider: params.attempt.provider,
-    model: params.attempt.modelId,
-    thinkLevel: params.attempt.thinkLevel,
-    reasoningLevel: params.attempt.reasoningLevel,
-    bashElevated: params.attempt.bashElevated,
-    extraSystemPrompt: params.attempt.extraSystemPrompt,
-    ownerNumbers: params.attempt.ownerNumbers,
-  };
 }
 
 function summarizeMessagePayload(msg: AgentMessage): { textChars: number; imageBlocks: number } {
@@ -742,7 +547,6 @@ export async function runEmbeddedAttempt(
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);
   const prevCwd = process.cwd();
   const runAbortController = new AbortController();
-  ensureGlobalUndiciStreamTimeouts();
 
   log.debug(
     `embedded run start: runId=${params.runId} sessionId=${params.sessionId} provider=${params.provider} model=${params.modelId} thinking=${params.thinkLevel} messageChannel=${params.messageChannel ?? params.messageProvider ?? "unknown"}`,
@@ -799,23 +603,6 @@ export async function runEmbeddedAttempt(
         contextMode: params.bootstrapContextMode,
         runKind: params.bootstrapContextRunKind,
       });
-    const bootstrapMaxChars = resolveBootstrapMaxChars(params.config);
-    const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config);
-    const bootstrapAnalysis = analyzeBootstrapBudget({
-      files: buildBootstrapInjectionStats({
-        bootstrapFiles: hookAdjustedBootstrapFiles,
-        injectedFiles: contextFiles,
-      }),
-      bootstrapMaxChars,
-      bootstrapTotalMaxChars,
-    });
-    const bootstrapPromptWarningMode = resolveBootstrapPromptTruncationWarningMode(params.config);
-    const bootstrapPromptWarning = buildBootstrapPromptWarning({
-      analysis: bootstrapAnalysis,
-      mode: bootstrapPromptWarningMode,
-      seenSignatures: params.bootstrapPromptWarningSignaturesSeen,
-      previousSignature: params.bootstrapPromptWarningSignature,
-    });
     const workspaceNotes = hookAdjustedBootstrapFiles.some(
       (file) => file.name === DEFAULT_BOOTSTRAP_FILENAME && !file.missing,
     )
@@ -1011,7 +798,6 @@ export async function runEmbeddedAttempt(
       userTime,
       userTimeFormat,
       contextFiles,
-      bootstrapTruncationWarningLines: bootstrapPromptWarning.lines,
       memoryCitationsMode: params.config?.memory?.citations,
     });
     const systemPromptReport = buildSystemPromptReport({
@@ -1022,13 +808,8 @@ export async function runEmbeddedAttempt(
       provider: params.provider,
       model: params.modelId,
       workspaceDir: effectiveWorkspace,
-      bootstrapMaxChars,
-      bootstrapTotalMaxChars,
-      bootstrapTruncation: buildBootstrapTruncationReportMeta({
-        analysis: bootstrapAnalysis,
-        warningMode: bootstrapPromptWarningMode,
-        warning: bootstrapPromptWarning,
-      }),
+      bootstrapMaxChars: resolveBootstrapMaxChars(params.config),
+      bootstrapTotalMaxChars: resolveBootstrapTotalMaxChars(params.config),
       sandbox: (() => {
         const runtime = resolveSandboxRuntimeStatus({
           cfg: params.config,
@@ -1081,17 +862,6 @@ export async function runEmbeddedAttempt(
       });
       trackSessionManagerAccess(params.sessionFile);
 
-      if (hadSessionFile && params.contextEngine?.bootstrap) {
-        try {
-          await params.contextEngine.bootstrap({
-            sessionId: params.sessionId,
-            sessionFile: params.sessionFile,
-          });
-        } catch (bootstrapErr) {
-          log.warn(`context engine bootstrap failed: ${String(bootstrapErr)}`);
-        }
-      }
-
       await prepareSessionManagerForRun({
         sessionManager,
         sessionFile: params.sessionFile,
@@ -1104,10 +874,6 @@ export async function runEmbeddedAttempt(
         cwd: effectiveWorkspace,
         agentDir,
         cfg: params.config,
-      });
-      applyPiAutoCompactionGuard({
-        settingsManager,
-        contextEngineInfo: params.contextEngine?.info,
       });
 
       // Sets compaction/pruning runtime state and returns extension factories
@@ -1226,7 +992,7 @@ export async function runEmbeddedAttempt(
           modelBaseUrl,
           providerBaseUrl,
         });
-        activeSession.agent.streamFn = createOllamaStreamFn(ollamaBaseUrl, params.model.headers);
+        activeSession.agent.streamFn = createOllamaStreamFn(ollamaBaseUrl);
       } else if (params.model.api === "openai-responses" && params.provider === "openai") {
         const wsApiKey = await params.authStorage.getApiKey(params.provider);
         if (wsApiKey) {
@@ -1362,12 +1128,6 @@ export async function runEmbeddedAttempt(
         allowedToolNames,
       );
 
-      if (isXaiProvider(params.provider, params.modelId)) {
-        activeSession.agent.streamFn = wrapStreamFnDecodeXaiToolCallArguments(
-          activeSession.agent.streamFn,
-        );
-      }
-
       if (anthropicPayloadLogger) {
         activeSession.agent.streamFn = anthropicPayloadLogger.wrapStreamFn(
           activeSession.agent.streamFn,
@@ -1407,38 +1167,10 @@ export async function runEmbeddedAttempt(
         if (limited.length > 0) {
           activeSession.agent.replaceMessages(limited);
         }
-
-        if (params.contextEngine) {
-          try {
-            const assembled = await params.contextEngine.assemble({
-              sessionId: params.sessionId,
-              messages: activeSession.messages,
-              tokenBudget: params.contextTokenBudget,
-            });
-            if (assembled.messages !== activeSession.messages) {
-              activeSession.agent.replaceMessages(assembled.messages);
-            }
-            if (assembled.systemPromptAddition) {
-              systemPromptText = prependSystemPromptAddition({
-                systemPrompt: systemPromptText,
-                systemPromptAddition: assembled.systemPromptAddition,
-              });
-              applySystemPromptOverrideToSession(activeSession, systemPromptText);
-              log.debug(
-                `context engine: prepended system prompt addition (${assembled.systemPromptAddition.length} chars)`,
-              );
-            }
-          } catch (assembleErr) {
-            log.warn(
-              `context engine assemble failed, using pipeline messages: ${String(assembleErr)}`,
-            );
-          }
-        }
       } catch (err) {
         await flushPendingToolResultsAfterIdle({
           agent: activeSession?.agent,
           sessionManager,
-          clearPendingOnTimeout: true,
         });
         activeSession.dispose();
         throw err;
@@ -1537,6 +1269,30 @@ export async function runEmbeddedAttempt(
         getCompactionCount,
       } = subscription;
 
+      // Build hook context early so the subscription callback can close over
+      // it without a temporal dead zone forward reference.
+      const hookCtx: import("../../../plugins/hooks.js").PluginHookAgentContext = {
+        agentId: sessionAgentId,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
+        workspaceDir: params.workspaceDir,
+        messageProvider: params.messageProvider ?? undefined,
+        trigger: params.trigger,
+        channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+      };
+
+      // Subscribe for LLM hook events (iteration tracking for before_llm_call).
+      const hookIterationRefEarly = { current: 0 };
+      let hookTurnIteration = 0;
+      const hookEventUnsub = hookRunner?.hasHooks("before_llm_call")
+        ? activeSession.subscribe((event) => {
+            if (event.type === "turn_start") {
+              hookTurnIteration++;
+              hookIterationRefEarly.current = hookTurnIteration;
+            }
+          })
+        : undefined;
+
       const queueHandle: EmbeddedPiQueueHandle = {
         queueMessage: async (text: string) => {
           await activeSession.steer(text);
@@ -1609,26 +1365,26 @@ export async function runEmbeddedAttempt(
       }
 
       // Hook runner was already obtained earlier before tool creation
-      const hookAgentId = sessionAgentId;
+      // Wrap streamFn for before_llm_call hooks — must be the outermost
+      // wrapper so hooks see the full context first.
+      if (hookRunner?.hasHooks("before_llm_call")) {
+        const { wrapStreamFnWithHooks } = await import("./hook-stream-wrapper.js");
+        activeSession.agent.streamFn = wrapStreamFnWithHooks(activeSession.agent.streamFn, {
+          hookRunner,
+          agentCtx: hookCtx,
+          iterationRef: hookIterationRefEarly,
+          modelId: params.modelId,
+        });
+      }
 
       let promptError: unknown = null;
       let promptErrorSource: "prompt" | "compaction" | null = null;
-      const prePromptMessageCount = activeSession.messages.length;
       try {
         const promptStartedAt = Date.now();
 
         // Run before_prompt_build hooks to allow plugins to inject prompt context.
         // Legacy compatibility: before_agent_start is also checked for context fields.
         let effectivePrompt = params.prompt;
-        const hookCtx = {
-          agentId: hookAgentId,
-          sessionKey: params.sessionKey,
-          sessionId: params.sessionId,
-          workspaceDir: params.workspaceDir,
-          messageProvider: params.messageProvider ?? undefined,
-          trigger: params.trigger,
-          channelId: params.messageChannel ?? params.messageProvider ?? undefined,
-        };
         const hookResult = await resolvePromptBuildHookResult({
           prompt: params.prompt,
           messages: activeSession.messages,
@@ -1649,20 +1405,6 @@ export async function runEmbeddedAttempt(
             applySystemPromptOverrideToSession(activeSession, legacySystemPrompt);
             systemPromptText = legacySystemPrompt;
             log.debug(`hooks: applied systemPrompt override (${legacySystemPrompt.length} chars)`);
-          }
-          const prependedOrAppendedSystemPrompt = composeSystemPromptWithHookContext({
-            baseSystemPrompt: systemPromptText,
-            prependSystemContext: hookResult?.prependSystemContext,
-            appendSystemContext: hookResult?.appendSystemContext,
-          });
-          if (prependedOrAppendedSystemPrompt) {
-            const prependSystemLen = hookResult?.prependSystemContext?.trim().length ?? 0;
-            const appendSystemLen = hookResult?.appendSystemContext?.trim().length ?? 0;
-            applySystemPromptOverrideToSession(activeSession, prependedOrAppendedSystemPrompt);
-            systemPromptText = prependedOrAppendedSystemPrompt;
-            log.debug(
-              `hooks: applied prependSystemContext/appendSystemContext (${prependSystemLen}+${appendSystemLen} chars)`,
-            );
           }
         }
 
@@ -1750,13 +1492,7 @@ export async function runEmbeddedAttempt(
                   historyMessages: activeSession.messages,
                   imagesCount: imageResult.images.length,
                 },
-                {
-                  agentId: hookAgentId,
-                  sessionKey: params.sessionKey,
-                  sessionId: params.sessionId,
-                  workspaceDir: params.workspaceDir,
-                  messageProvider: params.messageProvider ?? undefined,
-                },
+                hookCtx,
               )
               .catch((err) => {
                 log.warn(`llm_input hook failed: ${String(err)}`);
@@ -1771,8 +1507,17 @@ export async function runEmbeddedAttempt(
             await abortable(activeSession.prompt(effectivePrompt));
           }
         } catch (err) {
-          promptError = err;
-          promptErrorSource = "prompt";
+          // BeforeLlmCallBlockError is a graceful security intervention —
+          // the run completes normally without an error, matching
+          // before_response_emit block behavior.
+          const { BeforeLlmCallBlockError } = await import("./hook-stream-wrapper.js");
+          if (err instanceof BeforeLlmCallBlockError) {
+            log.info(`LLM call blocked by before_llm_call hook: ${err.message}`);
+            // Don't set promptError — let the run complete gracefully
+          } else {
+            promptError = err;
+            promptErrorSource = "prompt";
+          }
         } finally {
           log.debug(
             `embedded run prompt end: runId=${params.runId} sessionId=${params.sessionId} durationMs=${Date.now() - promptStartedAt}`,
@@ -1790,14 +1535,6 @@ export async function runEmbeddedAttempt(
         const preCompactionSessionId = activeSession.sessionId;
 
         try {
-          // Flush buffered block replies before waiting for compaction so the
-          // user receives the assistant response immediately.  Without this,
-          // coalesced/buffered blocks stay in the pipeline until compaction
-          // finishes — which can take minutes on large contexts (#35074).
-          if (params.onBlockReplyFlush) {
-            await params.onBlockReplyFlush();
-          }
-
           await abortable(waitForCompactionRetry());
         } catch (err) {
           if (isRunnerAbortError(err)) {
@@ -1855,6 +1592,47 @@ export async function runEmbeddedAttempt(
         messagesSnapshot = snapshotSelection.messagesSnapshot;
         sessionIdUsed = snapshotSelection.sessionIdUsed;
 
+        // Emit before_response_emit hook — only when this turn produced an assistant reply.
+        // Timeout/abort turns with no new assistant message must not trigger the hook,
+        // otherwise it scans messagesSnapshot and finds a stale prior-turn response.
+        if (hookRunner?.hasHooks("before_response_emit") && assistantTexts.length > 0) {
+          try {
+            const { applyBeforeResponseEmitHook } = await import("./hook-response-emit.js");
+            const emitResult = await applyBeforeResponseEmitHook({
+              hookRunner,
+              agentCtx: hookCtx,
+              assistantTexts,
+              messagesSnapshot,
+              activeSession,
+              channel: params.messageChannel ?? params.messageProvider,
+            });
+            if (emitResult !== undefined) {
+              if (emitResult.blocked) {
+                // Blocked — suppress the entire accumulated response, not just
+                // the last chunk. Earlier tool-loop iterations may have added
+                // text that would otherwise escape the hook.
+                assistantTexts.splice(0, assistantTexts.length);
+              } else if (emitResult.allContent !== undefined) {
+                // Full multi-turn modification — replace all assistant texts.
+                // Truncate to original length to prevent plugins from expanding
+                // the response beyond what was actually produced in this run.
+                const bounded = emitResult.allContent.slice(0, assistantTexts.length);
+                assistantTexts.splice(0, assistantTexts.length, ...bounded);
+              } else if (emitResult.content !== undefined) {
+                // Single last-message modification (backward-compatible).
+                // assistantTexts.length > 0 is guaranteed by the outer guard.
+                assistantTexts[assistantTexts.length - 1] = emitResult.content;
+              }
+              // Refresh messagesSnapshot so downstream consumers (agent_end,
+              // llm_output, cache trace) see the post-redaction content, not
+              // the original pre-hook text.
+              messagesSnapshot = activeSession.messages.slice();
+            }
+          } catch (err) {
+            log.warn(`before_response_emit hook failed: ${String(err)}`);
+          }
+        }
+
         if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
           try {
             sessionManager.appendCustomEntry("openclaw:prompt-error", {
@@ -1868,56 +1646,6 @@ export async function runEmbeddedAttempt(
             });
           } catch (entryErr) {
             log.warn(`failed to persist prompt error entry: ${String(entryErr)}`);
-          }
-        }
-
-        // Let the active context engine run its post-turn lifecycle.
-        if (params.contextEngine) {
-          const afterTurnLegacyCompactionParams = buildAfterTurnLegacyCompactionParams({
-            attempt: params,
-            workspaceDir: effectiveWorkspace,
-            agentDir,
-          });
-
-          if (typeof params.contextEngine.afterTurn === "function") {
-            try {
-              await params.contextEngine.afterTurn({
-                sessionId: sessionIdUsed,
-                sessionFile: params.sessionFile,
-                messages: messagesSnapshot,
-                prePromptMessageCount,
-                tokenBudget: params.contextTokenBudget,
-                legacyCompactionParams: afterTurnLegacyCompactionParams,
-              });
-            } catch (afterTurnErr) {
-              log.warn(`context engine afterTurn failed: ${String(afterTurnErr)}`);
-            }
-          } else {
-            // Fallback: ingest new messages individually
-            const newMessages = messagesSnapshot.slice(prePromptMessageCount);
-            if (newMessages.length > 0) {
-              if (typeof params.contextEngine.ingestBatch === "function") {
-                try {
-                  await params.contextEngine.ingestBatch({
-                    sessionId: sessionIdUsed,
-                    messages: newMessages,
-                  });
-                } catch (ingestErr) {
-                  log.warn(`context engine ingest failed: ${String(ingestErr)}`);
-                }
-              } else {
-                for (const msg of newMessages) {
-                  try {
-                    await params.contextEngine.ingest({
-                      sessionId: sessionIdUsed,
-                      message: msg,
-                    });
-                  } catch (ingestErr) {
-                    log.warn(`context engine ingest failed: ${String(ingestErr)}`);
-                  }
-                }
-              }
-            }
           }
         }
 
@@ -1943,13 +1671,7 @@ export async function runEmbeddedAttempt(
                 error: promptError ? describeUnknownError(promptError) : undefined,
                 durationMs: Date.now() - promptStartedAt,
               },
-              {
-                agentId: hookAgentId,
-                sessionKey: params.sessionKey,
-                sessionId: params.sessionId,
-                workspaceDir: params.workspaceDir,
-                messageProvider: params.messageProvider ?? undefined,
-              },
+              hookCtx,
             )
             .catch((err) => {
               log.warn(`agent_end hook failed: ${err}`);
@@ -1966,6 +1688,7 @@ export async function runEmbeddedAttempt(
           );
         }
         try {
+          hookEventUnsub?.();
           unsubscribe();
         } catch (err) {
           // unsubscribe() should never throw; if it does, it indicates a serious bug.
@@ -2003,13 +1726,7 @@ export async function runEmbeddedAttempt(
               lastAssistant,
               usage: getUsageTotals(),
             },
-            {
-              agentId: hookAgentId,
-              sessionKey: params.sessionKey,
-              sessionId: params.sessionId,
-              workspaceDir: params.workspaceDir,
-              messageProvider: params.messageProvider ?? undefined,
-            },
+            hookCtx,
           )
           .catch((err) => {
             log.warn(`llm_output hook failed: ${String(err)}`);
@@ -2022,8 +1739,6 @@ export async function runEmbeddedAttempt(
         timedOutDuringCompaction,
         promptError,
         sessionIdUsed,
-        bootstrapPromptWarningSignaturesSeen: bootstrapPromptWarning.warningSignaturesSeen,
-        bootstrapPromptWarningSignature: bootstrapPromptWarning.signature,
         systemPromptReport,
         messagesSnapshot,
         assistantTexts,
@@ -2056,7 +1771,6 @@ export async function runEmbeddedAttempt(
       await flushPendingToolResultsAfterIdle({
         agent: session?.agent,
         sessionManager,
-        clearPendingOnTimeout: true,
       });
       session?.dispose();
       releaseWsSession(params.sessionId);

--- a/src/agents/pi-embedded-runner/run/hook-response-emit.test.ts
+++ b/src/agents/pi-embedded-runner/run/hook-response-emit.test.ts
@@ -1,0 +1,503 @@
+/**
+ * Tests for hook-response-emit helper.
+ *
+ * Verifies:
+ * - Text extraction from string and content-part-array messages
+ * - Hook modification applied to assistantTexts and session messages
+ * - Block results
+ * - allContent multi-turn modification
+ * - No-op when hook returns same content
+ * - No-op when no assistant message found
+ * - Hook errors propagate (caller catches)
+ */
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { describe, expect, it, vi } from "vitest";
+import type { HookRunner, PluginHookAgentContext } from "../../../plugins/hooks.js";
+import {
+  applyBeforeResponseEmitHook,
+  extractAssistantText,
+  getRunScopedMessages,
+  rewriteAllAssistantContent,
+} from "./hook-response-emit.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMsg(
+  role: string,
+  content: string | Array<{ type: string; text?: string }>,
+): AgentMessage {
+  return { role, content } as AgentMessage;
+}
+
+function makeMockHookRunner(emitResult?: {
+  content?: string;
+  allContent?: string[];
+  block?: boolean;
+  blockReason?: string;
+}): HookRunner {
+  return {
+    hasHooks: vi.fn().mockReturnValue(true),
+    runBeforeResponseEmit: vi.fn().mockResolvedValue(emitResult),
+    // Stubs for other hooks (not used)
+    runBeforeAgentStart: vi.fn(),
+    runAgentEnd: vi.fn(),
+    runBeforeCompaction: vi.fn(),
+    runAfterCompaction: vi.fn(),
+    runMessageReceived: vi.fn(),
+    runMessageSending: vi.fn(),
+    runMessageSent: vi.fn(),
+    runBeforeToolCall: vi.fn(),
+    runAfterToolCall: vi.fn(),
+    runToolResultPersist: vi.fn(),
+    runSessionStart: vi.fn(),
+    runSessionEnd: vi.fn(),
+    runGatewayStart: vi.fn(),
+    runGatewayStop: vi.fn(),
+    runBeforeLlmCall: vi.fn(),
+    runAfterLlmCall: vi.fn(),
+    runContextAssembled: vi.fn(),
+    runLoopIterationStart: vi.fn(),
+    runLoopIterationEnd: vi.fn(),
+    getHookCount: vi.fn().mockReturnValue(0),
+  } as unknown as HookRunner;
+}
+
+const dummyCtx: PluginHookAgentContext = {
+  agentId: "test-agent",
+  sessionKey: "test-session",
+};
+
+// ---------------------------------------------------------------------------
+// extractAssistantText
+// ---------------------------------------------------------------------------
+
+describe("extractAssistantText", () => {
+  it("extracts from string content", () => {
+    expect(extractAssistantText(makeMsg("assistant", "hello world"))).toBe("hello world");
+  });
+
+  it("extracts from content-part array", () => {
+    const msg = makeMsg("assistant", [
+      { type: "text", text: "hello " },
+      { type: "text", text: "world" },
+    ]);
+    expect(extractAssistantText(msg)).toBe("hello world");
+  });
+
+  it("filters non-text parts", () => {
+    const msg = makeMsg("assistant", [
+      { type: "text", text: "hello" },
+      { type: "tool_use" },
+      { type: "text", text: " world" },
+    ]);
+    expect(extractAssistantText(msg)).toBe("hello world");
+  });
+
+  it("returns empty string for non-string non-array content", () => {
+    const msg = { role: "assistant", content: 42 } as unknown as AgentMessage;
+    expect(extractAssistantText(msg)).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyBeforeResponseEmitHook
+// ---------------------------------------------------------------------------
+
+describe("applyBeforeResponseEmitHook", () => {
+  it("returns modified content when hook changes it", async () => {
+    const hookRunner = makeMockHookRunner({ content: "modified!" });
+    const activeSession = { messages: [makeMsg("assistant", "original")] };
+
+    const result = await applyBeforeResponseEmitHook({
+      hookRunner,
+      agentCtx: dummyCtx,
+      assistantTexts: ["original"],
+      messagesSnapshot: [makeMsg("assistant", "original")],
+      activeSession,
+      channel: "discord",
+    });
+
+    expect(result).toEqual({ blocked: false, content: "modified!" });
+    // Session message should also be updated
+    expect((activeSession.messages[0] as { content: unknown }).content).toBe("modified!");
+  });
+
+  it("updates content-part-array session messages", async () => {
+    const hookRunner = makeMockHookRunner({ content: "modified!" });
+    const sessionMsg = makeMsg("assistant", [{ type: "text", text: "original" }]);
+    const activeSession = { messages: [sessionMsg] };
+
+    const result = await applyBeforeResponseEmitHook({
+      hookRunner,
+      agentCtx: dummyCtx,
+      assistantTexts: ["original"],
+      messagesSnapshot: [makeMsg("assistant", [{ type: "text", text: "original" }])],
+      activeSession,
+      channel: "discord",
+    });
+
+    expect(result).toEqual({ blocked: false, content: "modified!" });
+    expect(
+      ((sessionMsg as { content: unknown }).content as Array<{ type: string; text: string }>)[0]
+        .text,
+    ).toBe("modified!");
+  });
+
+  it("returns blocked result when hook blocks", async () => {
+    const hookRunner = makeMockHookRunner({ block: true, blockReason: "policy" });
+
+    const result = await applyBeforeResponseEmitHook({
+      hookRunner,
+      agentCtx: dummyCtx,
+      assistantTexts: ["original"],
+      messagesSnapshot: [makeMsg("assistant", "original")],
+      activeSession: { messages: [makeMsg("assistant", "original")] },
+    });
+
+    expect(result).toEqual({ blocked: true });
+  });
+
+  it("returns undefined when content unchanged", async () => {
+    const hookRunner = makeMockHookRunner({ content: "original" });
+
+    const result = await applyBeforeResponseEmitHook({
+      hookRunner,
+      agentCtx: dummyCtx,
+      assistantTexts: ["original"],
+      messagesSnapshot: [makeMsg("assistant", "original")],
+      activeSession: { messages: [makeMsg("assistant", "original")] },
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when no assistant message", async () => {
+    const hookRunner = makeMockHookRunner({ content: "modified" });
+
+    const result = await applyBeforeResponseEmitHook({
+      hookRunner,
+      agentCtx: dummyCtx,
+      assistantTexts: [],
+      messagesSnapshot: [makeMsg("user", "hello")],
+      activeSession: { messages: [makeMsg("user", "hello")] },
+    });
+
+    expect(result).toBeUndefined();
+    expect(hookRunner.runBeforeResponseEmit).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined when hook returns no result", async () => {
+    const hookRunner = makeMockHookRunner(undefined);
+
+    const result = await applyBeforeResponseEmitHook({
+      hookRunner,
+      agentCtx: dummyCtx,
+      assistantTexts: ["original"],
+      messagesSnapshot: [makeMsg("assistant", "original")],
+      activeSession: { messages: [makeMsg("assistant", "original")] },
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("clears current-run assistant content on block (multi-turn)", async () => {
+    const hookRunner = makeMockHookRunner({ block: true, blockReason: "PII detected" });
+    const activeSession = {
+      messages: [
+        makeMsg("assistant", "prior history - safe"),
+        makeMsg("user", "new question"),
+        makeMsg("assistant", "turn 1 with SSN 123-45-6789"),
+        makeMsg("user", "continue"),
+        makeMsg("assistant", "turn 2 with SSN 123-45-6789"),
+      ],
+    };
+
+    await applyBeforeResponseEmitHook({
+      hookRunner,
+      agentCtx: dummyCtx,
+      assistantTexts: ["turn 1 with SSN 123-45-6789", "turn 2 with SSN 123-45-6789"],
+      messagesSnapshot: activeSession.messages.slice(),
+      activeSession,
+    });
+
+    // Prior history must be preserved
+    expect((activeSession.messages[0] as { content: unknown }).content).toBe(
+      "prior history - safe",
+    );
+    // Current-run assistant messages must be cleared
+    expect((activeSession.messages[2] as { content: unknown }).content).toBe("");
+    expect((activeSession.messages[4] as { content: unknown }).content).toBe("");
+  });
+
+  it("clears all text parts in multi-part messages on block", async () => {
+    const hookRunner = makeMockHookRunner({ block: true });
+    const sessionMsg = makeMsg("assistant", [
+      { type: "text", text: "part 1 with PII" },
+      { type: "text", text: "part 2 with PII" },
+    ]);
+    const activeSession = { messages: [sessionMsg] };
+
+    await applyBeforeResponseEmitHook({
+      hookRunner,
+      agentCtx: dummyCtx,
+      assistantTexts: ["part 1 with PII"],
+      messagesSnapshot: [
+        makeMsg("assistant", [
+          { type: "text", text: "part 1 with PII" },
+          { type: "text", text: "part 2 with PII" },
+        ]),
+      ],
+      activeSession,
+    });
+
+    // Block clears ALL content (including tool_use blocks) — content set to empty array
+    const content = (sessionMsg as { content: unknown }).content as unknown[];
+    expect(content).toEqual([]);
+  });
+
+  it("rewrites all text parts on modification (not just first)", async () => {
+    const hookRunner = makeMockHookRunner({ content: "redacted" });
+    const sessionMsg = makeMsg("assistant", [
+      { type: "text", text: "sensitive part 1" },
+      { type: "text", text: "sensitive part 2" },
+    ]);
+    const activeSession = { messages: [sessionMsg] };
+
+    await applyBeforeResponseEmitHook({
+      hookRunner,
+      agentCtx: dummyCtx,
+      assistantTexts: ["sensitive part 1sensitive part 2"],
+      messagesSnapshot: [
+        makeMsg("assistant", [
+          { type: "text", text: "sensitive part 1" },
+          { type: "text", text: "sensitive part 2" },
+        ]),
+      ],
+      activeSession,
+    });
+
+    const parts = (sessionMsg as { content: unknown }).content as Array<{
+      type: string;
+      text: string;
+    }>;
+    expect(parts[0].text).toBe("redacted");
+    // Subsequent text parts should be cleared
+    expect(parts[1].text).toBe("");
+  });
+
+  it("finds assistant message even when not the last element", async () => {
+    const hookRunner = makeMockHookRunner({ content: "modified" });
+    const assistantMsg = makeMsg("assistant", "original");
+    const toolResult = makeMsg("tool", "result");
+    const activeSession = { messages: [assistantMsg, toolResult] };
+
+    const result = await applyBeforeResponseEmitHook({
+      hookRunner,
+      agentCtx: dummyCtx,
+      assistantTexts: ["original"],
+      messagesSnapshot: [makeMsg("assistant", "original"), makeMsg("tool", "result")],
+      activeSession,
+    });
+
+    expect(result).toEqual({ blocked: false, content: "modified" });
+    expect((assistantMsg as { content: unknown }).content).toBe("modified");
+  });
+
+  it("propagates hook errors to caller", async () => {
+    const hookRunner = makeMockHookRunner(undefined);
+    (hookRunner.runBeforeResponseEmit as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("hook crashed"),
+    );
+
+    await expect(
+      applyBeforeResponseEmitHook({
+        hookRunner,
+        agentCtx: dummyCtx,
+        assistantTexts: ["original"],
+        messagesSnapshot: [makeMsg("assistant", "original")],
+        activeSession: { messages: [makeMsg("assistant", "original")] },
+      }),
+    ).rejects.toThrow("hook crashed");
+  });
+
+  it("passes allContent to hook event", async () => {
+    const hookRunner = makeMockHookRunner({ content: "modified" });
+
+    await applyBeforeResponseEmitHook({
+      hookRunner,
+      agentCtx: dummyCtx,
+      assistantTexts: ["turn 1", "turn 2", "turn 3"],
+      messagesSnapshot: [makeMsg("assistant", "turn 3")],
+      activeSession: { messages: [makeMsg("assistant", "turn 3")] },
+    });
+
+    const callArgs = (hookRunner.runBeforeResponseEmit as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(callArgs[0].allContent).toEqual(["turn 1", "turn 2", "turn 3"]);
+    expect(callArgs[0].content).toBe("turn 3");
+  });
+
+  it("applies allContent multi-turn modification scoped to current run", async () => {
+    const hookRunner = makeMockHookRunner({
+      allContent: ["[REDACTED turn 1]", "[REDACTED turn 2]"],
+    });
+    const activeSession = {
+      messages: [
+        makeMsg("assistant", "old safe history"),
+        makeMsg("user", "new question"),
+        makeMsg("assistant", "PII in turn 1"),
+        makeMsg("user", "continue"),
+        makeMsg("assistant", "PII in turn 2"),
+      ],
+    };
+
+    const result = await applyBeforeResponseEmitHook({
+      hookRunner,
+      agentCtx: dummyCtx,
+      assistantTexts: ["PII in turn 1", "PII in turn 2"],
+      messagesSnapshot: activeSession.messages.slice(),
+      activeSession,
+    });
+
+    expect(result).toEqual({
+      blocked: false,
+      allContent: ["[REDACTED turn 1]", "[REDACTED turn 2]"],
+    });
+    // Prior history preserved
+    expect((activeSession.messages[0] as { content: unknown }).content).toBe("old safe history");
+    // Current-run assistant messages rewritten
+    expect((activeSession.messages[2] as { content: unknown }).content).toBe("[REDACTED turn 1]");
+    expect((activeSession.messages[4] as { content: unknown }).content).toBe("[REDACTED turn 2]");
+  });
+
+  it("allContent takes precedence over content", async () => {
+    const hookRunner = makeMockHookRunner({
+      content: "single-message mod",
+      allContent: ["full turn 1", "full turn 2"],
+    });
+    const activeSession = {
+      messages: [
+        makeMsg("assistant", "original 1"),
+        makeMsg("user", "continue"),
+        makeMsg("assistant", "original 2"),
+      ],
+    };
+
+    const result = await applyBeforeResponseEmitHook({
+      hookRunner,
+      agentCtx: dummyCtx,
+      assistantTexts: ["original 1", "original 2"],
+      messagesSnapshot: activeSession.messages.slice(),
+      activeSession,
+    });
+
+    // allContent should win
+    expect(result?.allContent).toEqual(["full turn 1", "full turn 2"]);
+    expect(result?.content).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rewriteAllAssistantContent
+// ---------------------------------------------------------------------------
+
+describe("rewriteAllAssistantContent", () => {
+  it("rewrites all assistant messages in order", () => {
+    const messages = [
+      makeMsg("assistant", "turn 1"),
+      makeMsg("user", "question"),
+      makeMsg("assistant", "turn 2"),
+      makeMsg("tool", "result"),
+      makeMsg("assistant", "turn 3"),
+    ];
+
+    rewriteAllAssistantContent(messages, ["new 1", "new 2", "new 3"]);
+
+    expect((messages[0] as { content: unknown }).content).toBe("new 1");
+    expect((messages[2] as { content: unknown }).content).toBe("new 2");
+    expect((messages[4] as { content: unknown }).content).toBe("new 3");
+    // Non-assistant messages untouched
+    expect((messages[1] as { content: unknown }).content).toBe("question");
+  });
+
+  it("clears extra assistant messages when newContents is shorter", () => {
+    const messages = [
+      makeMsg("assistant", "turn 1"),
+      makeMsg("assistant", "turn 2"),
+      makeMsg("assistant", "turn 3"),
+    ];
+
+    rewriteAllAssistantContent(messages, ["only first"]);
+
+    expect((messages[0] as { content: unknown }).content).toBe("only first");
+    expect((messages[1] as { content: unknown }).content).toBe("");
+    expect((messages[2] as { content: unknown }).content).toBe("");
+  });
+
+  it("handles content-part arrays", () => {
+    const messages = [
+      makeMsg("assistant", [
+        { type: "text", text: "old part 1" },
+        { type: "text", text: "old part 2" },
+      ]),
+    ];
+
+    rewriteAllAssistantContent(messages, ["new content"]);
+
+    const parts = (messages[0] as { content: unknown }).content as Array<{
+      type: string;
+      text: string;
+    }>;
+    expect(parts[0].text).toBe("new content");
+    expect(parts[1].text).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getRunScopedMessages
+// ---------------------------------------------------------------------------
+
+describe("getRunScopedMessages", () => {
+  it("uses tail scan to find run-scoped messages (compaction-safe)", () => {
+    const messages = [
+      makeMsg("assistant", "old"),
+      makeMsg("user", "new q"),
+      makeMsg("assistant", "new answer"),
+    ];
+    // Tail scan finds 1 assistant message from end, returns from that point
+    const result = getRunScopedMessages(messages, 1);
+    expect(result).toHaveLength(1);
+    expect((result[0] as { content: unknown }).content).toBe("new answer");
+  });
+
+  it("handles compacted transcript correctly via tail scan", () => {
+    const messages = [
+      makeMsg("user", "compacted q"),
+      makeMsg("assistant", "run turn 1"),
+      makeMsg("assistant", "run turn 2"),
+    ];
+    const result = getRunScopedMessages(messages, 2);
+    expect(result).toHaveLength(2);
+    expect((result[0] as { content: unknown }).content).toBe("run turn 1");
+    expect((result[1] as { content: unknown }).content).toBe("run turn 2");
+  });
+
+  it("returns full array when all messages are from current run", () => {
+    const messages = [makeMsg("assistant", "a"), makeMsg("assistant", "b")];
+    const result = getRunScopedMessages(messages, 2);
+    expect(result).toStrictEqual(messages);
+  });
+
+  it("returns empty when not enough assistant messages found (defensive)", () => {
+    const messages = [makeMsg("user", "q")];
+    const result = getRunScopedMessages(messages, 2);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty when assistantTextCount is 0", () => {
+    const messages = [makeMsg("assistant", "a")];
+    const result = getRunScopedMessages(messages, 0);
+    expect(result).toHaveLength(0);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/hook-response-emit.ts
+++ b/src/agents/pi-embedded-runner/run/hook-response-emit.ts
@@ -1,0 +1,274 @@
+/**
+ * Helper for the before_response_emit hook.
+ *
+ * Extracts text content from assistant messages, runs the hook,
+ * and returns the modified content (or undefined if no modification).
+ */
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import type { HookRunner, PluginHookAgentContext } from "../../../plugins/hooks.js";
+
+const log = createSubsystemLogger("hooks/response-emit");
+
+/** Content part with optional type and text fields (assistant message content array element). */
+interface ContentPart {
+  type?: string;
+  text?: string;
+}
+
+export interface ApplyBeforeResponseEmitParams {
+  hookRunner: HookRunner;
+  agentCtx: PluginHookAgentContext;
+  assistantTexts: string[];
+  messagesSnapshot: AgentMessage[];
+  activeSession: { messages: AgentMessage[] };
+  channel?: string;
+}
+
+/** Result from applyBeforeResponseEmitHook. */
+export interface ApplyBeforeResponseEmitResult {
+  /** When true, the response was blocked (assistantTexts should be cleared). */
+  blocked: boolean;
+  /**
+   * Modified content for the last assistant message (single-message modification).
+   * Undefined when no modification was made or when allContent is provided.
+   */
+  content?: string;
+  /**
+   * Modified content for ALL assistant messages in the run (full multi-turn modification).
+   * When present, replaces the entire assistantTexts array. Enables PII redaction
+   * across all tool-loop iterations, not just the final message.
+   */
+  allContent?: string[];
+}
+
+/**
+ * Extract text content from an assistant message.
+ * Handles both string content and content-part arrays.
+ * Guards against AgentMessage union members that lack `content`.
+ */
+export function extractAssistantText(msg: AgentMessage): string {
+  if (!("content" in msg)) {
+    return "";
+  }
+  const content = (msg as { content: unknown }).content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return (content as ContentPart[])
+      .filter((c) => c?.type === "text")
+      .map((c) => c.text ?? "")
+      .join("");
+  }
+  return "";
+}
+
+/**
+ * Run the before_response_emit hook and apply modifications.
+ *
+ * Returns a result describing the hook outcome:
+ * - `blocked: true` — response should be suppressed
+ * - `content` — modified last-message content (backward-compatible single-message redaction)
+ * - `allContent` — modified content for ALL assistant turns (full multi-turn redaction)
+ * - `undefined` — no modification was made
+ *
+ * Plugins receive both `content` (last assistant message) and `allContent`
+ * (all assistant texts from the run) in the hook event. They can return
+ * either `content` for single-message modification or `allContent` for
+ * full-run redaction. `allContent` takes precedence when both are returned.
+ */
+export async function applyBeforeResponseEmitHook(
+  params: ApplyBeforeResponseEmitParams,
+): Promise<ApplyBeforeResponseEmitResult | undefined> {
+  const { hookRunner, agentCtx, assistantTexts, messagesSnapshot, activeSession, channel } = params;
+
+  // Find last assistant message
+  const lastAssistantMsg = [...messagesSnapshot].toReversed().find((m) => m.role === "assistant");
+  if (!lastAssistantMsg || !("content" in lastAssistantMsg)) {
+    // No assistant message at all — only skip if there's also no allContent.
+    // This guards against runs where the only output is in earlier turns.
+    if (assistantTexts.length === 0) {
+      return undefined;
+    }
+  }
+
+  const content = lastAssistantMsg ? extractAssistantText(lastAssistantMsg) : "";
+  // Don't skip when content is empty but allContent has entries — policy
+  // plugins need the chance to inspect/block earlier assistant turns even
+  // when the final message is tool-call-only or non-text.
+  if (!content && assistantTexts.length === 0) {
+    return undefined;
+  }
+
+  const emitResult = await hookRunner.runBeforeResponseEmit(
+    {
+      content,
+      allContent: [...assistantTexts],
+      channel,
+      messageCount: messagesSnapshot.length,
+    },
+    agentCtx,
+  );
+
+  // Scope to only current-run messages so we never corrupt prior history.
+  // Uses tail-based scan (last N assistant messages) which is compaction-safe.
+  const runMessages = getRunScopedMessages(activeSession.messages, assistantTexts.length);
+
+  if (emitResult?.block) {
+    log.warn(`response blocked: ${emitResult.blockReason ?? "no reason"}`);
+    if (runMessages.length === 0 && activeSession.messages.length > 0) {
+      // Compaction edge case: couldn't identify run-scoped messages.
+      // Fail closed: clear ALL assistant content in the session to prevent
+      // blocked/sensitive text from leaking into future turns or persistence.
+      log.warn(
+        "response blocked but run-scoped messages empty — clearing all assistant content as fail-closed fallback. " +
+          "This can occur when compaction makes run boundaries unidentifiable.",
+      );
+      clearAllAssistantContent(activeSession.messages);
+    } else {
+      // Clear blocked content from current-run session history only so it
+      // doesn't leak to subsequent turns or session persistence.
+      clearAllAssistantContent(runMessages);
+    }
+    return { blocked: true };
+  }
+
+  // Check for full multi-turn modification (allContent takes precedence)
+  if (emitResult?.allContent !== undefined) {
+    log.debug(
+      `applying allContent modification (${emitResult.allContent.length} entries, original ${assistantTexts.length})`,
+    );
+    rewriteAllAssistantContent(runMessages, emitResult.allContent);
+    return { blocked: false, allContent: emitResult.allContent };
+  }
+
+  if (emitResult?.content === undefined || emitResult.content === content) {
+    log.debug(`no modification (hasResult=${!!emitResult}, hasContent=${!!emitResult?.content})`);
+    return undefined;
+  }
+
+  log.debug(`applying modified content (len=${emitResult.content.length})`);
+
+  // Update session messages for consistency with the delivery pipeline.
+  // We update in-place because activeSession.messages is a mutable array
+  // shared with the session persistence layer. Scoped to run messages only.
+  rewriteLastAssistantContent(runMessages, emitResult.content);
+
+  return { blocked: false, content: emitResult.content };
+}
+
+/**
+ * Get the subset of session messages belonging to the current run.
+ * Uses tail-based scanning: finds the last N assistant messages (where N
+ * is the count produced in this run) and returns everything from the first
+ * match onward. This is compaction-safe — works regardless of whether
+ * compaction shifted message indices during the run.
+ */
+export function getRunScopedMessages(
+  messages: AgentMessage[],
+  assistantTextCount: number,
+): AgentMessage[] {
+  if (assistantTextCount <= 0) {
+    // No assistant texts — return empty slice to avoid touching history.
+    return [];
+  }
+  let assistantsSeen = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    // Only count text-bearing assistant messages — tool-call-only messages
+    // have content (array with tool_use blocks) but no text. assistantTextCount
+    // is derived from streamed text entries, so we must match that filter.
+    if (messages[i].role === "assistant" && extractAssistantText(messages[i]).length > 0) {
+      assistantsSeen++;
+      if (assistantsSeen >= assistantTextCount) {
+        return messages.slice(i);
+      }
+    }
+  }
+  // Couldn't find enough assistant messages — return empty to avoid
+  // corrupting pre-run history. This is a defensive fallback that
+  // should rarely occur in practice.
+  return [];
+}
+
+/**
+ * Rewrite text content in the last assistant message.
+ * Handles both string content and multi-part content arrays.
+ * For multi-part arrays, replaces the first text part with the new content
+ * and clears all subsequent text parts to prevent stale/unredacted fragments.
+ */
+export function rewriteLastAssistantContent(messages: AgentMessage[], newContent: string): void {
+  const sessionMsg = [...messages]
+    .toReversed()
+    .find((m) => m.role === "assistant" && "content" in m);
+  if (!sessionMsg) {
+    log.warn("rewriteLastAssistantContent: no assistant message found in session history");
+    return;
+  }
+  rewriteSingleAssistantMessage(sessionMsg, newContent);
+}
+
+/**
+ * Rewrite text content in ALL assistant messages in session history.
+ * Maps each entry in `newContents` to the corresponding assistant message
+ * (in chronological order). If there are more assistant messages than
+ * entries, the extra messages are cleared. If there are fewer, the extra
+ * entries are ignored (defensive).
+ */
+export function rewriteAllAssistantContent(messages: AgentMessage[], newContents: string[]): void {
+  // Only count text-bearing assistant messages — matching getRunScopedMessages
+  // and assistantTexts counting. Tool-call-only messages are skipped to keep
+  // allContent indices aligned.
+  const assistantMsgs = messages.filter(
+    (m) => m.role === "assistant" && extractAssistantText(m).length > 0,
+  );
+  if (newContents.length !== assistantMsgs.length) {
+    log.warn(
+      `rewriteAllAssistantContent: allContent length (${newContents.length}) differs from ` +
+        `assistant message count (${assistantMsgs.length}); extras will be cleared`,
+    );
+  }
+  for (let i = 0; i < assistantMsgs.length; i++) {
+    const replacement = i < newContents.length ? newContents[i] : "";
+    rewriteSingleAssistantMessage(assistantMsgs[i], replacement);
+  }
+}
+
+/**
+ * Rewrite text content of a single assistant message in-place.
+ */
+function rewriteSingleAssistantMessage(msg: AgentMessage, newContent: string): void {
+  const msgContent = (msg as { content: unknown }).content;
+  if (typeof msgContent === "string") {
+    (msg as unknown as Record<string, unknown>).content = newContent;
+  } else if (Array.isArray(msgContent)) {
+    const textParts = (msgContent as ContentPart[]).filter((c) => c?.type === "text");
+    if (textParts.length > 0) {
+      textParts[0].text = newContent;
+      for (let i = 1; i < textParts.length; i++) {
+        textParts[i].text = "";
+      }
+    }
+  }
+}
+
+/**
+ * Clear ALL content from assistant messages in session history.
+ * Used when before_response_emit blocks delivery to prevent data leaks.
+ * Clears both text parts AND tool_use blocks (which may contain sensitive
+ * data in their input arguments) to prevent exfiltration via tool calls.
+ */
+function clearAllAssistantContent(messages: AgentMessage[]): void {
+  const assistantMsgs = messages.filter((m) => m.role === "assistant" && "content" in m);
+  for (const msg of assistantMsgs) {
+    const msgContent = (msg as { content: unknown }).content;
+    if (typeof msgContent === "string") {
+      (msg as unknown as Record<string, unknown>).content = "";
+    } else if (Array.isArray(msgContent)) {
+      // Clear ALL content parts — text, tool_use, and any other types.
+      // Setting to empty array removes tool_use blocks entirely, preventing
+      // sensitive data in tool call input arguments from persisting.
+      (msg as unknown as Record<string, unknown>).content = [];
+    }
+  }
+}

--- a/src/agents/pi-embedded-runner/run/hook-stream-wrapper.test.ts
+++ b/src/agents/pi-embedded-runner/run/hook-stream-wrapper.test.ts
@@ -1,0 +1,236 @@
+import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
+import type { Model, Api, Context } from "@mariozechner/pi-ai";
+/**
+ * Integration tests for wrapStreamFnWithHooks().
+ *
+ * Verifies that the hook-aware StreamFn wrapper correctly fires
+ * before_llm_call hooks, applies modifications,
+ * blocks calls, and is resilient to hook errors.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HookRunner, PluginHookAgentContext } from "../../../plugins/hooks.js";
+import { wrapStreamFnWithHooks } from "./hook-stream-wrapper.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeMsg(role: string, content: string): AgentMessage {
+  return { role, content } as AgentMessage;
+}
+
+function makeMockHookRunner(
+  overrides: Partial<Record<keyof HookRunner, unknown>> = {},
+): HookRunner {
+  return {
+    hasHooks: vi.fn().mockReturnValue(true),
+    runBeforeAgentStart: vi.fn(),
+    runAgentEnd: vi.fn(),
+    runBeforeCompaction: vi.fn(),
+    runAfterCompaction: vi.fn(),
+    runMessageReceived: vi.fn(),
+    runMessageSending: vi.fn(),
+    runMessageSent: vi.fn(),
+    runBeforeToolCall: vi.fn(),
+    runAfterToolCall: vi.fn(),
+    runToolResultPersist: vi.fn(),
+    runSessionStart: vi.fn(),
+    runSessionEnd: vi.fn(),
+    runGatewayStart: vi.fn(),
+    runGatewayStop: vi.fn(),
+    runBeforeLlmCall: vi.fn().mockResolvedValue(undefined),
+    runAfterLlmCall: vi.fn(),
+    runLoopIterationStart: vi.fn(),
+    runLoopIterationEnd: vi.fn(),
+    runBeforeResponseEmit: vi.fn(),
+    getHookCount: vi.fn().mockReturnValue(0),
+    ...overrides,
+  } as unknown as HookRunner;
+}
+
+const agentCtx: PluginHookAgentContext = {
+  agentId: "test-agent",
+  sessionKey: "test-session",
+};
+
+const mockStream = Symbol("mock-stream");
+
+function makeBaseContext() {
+  return {
+    systemPrompt: "You are helpful.",
+    messages: [fakeMsg("user", "hello")] as unknown[],
+    tools: [
+      { name: "read", description: "Read files", parameters: {} },
+      { name: "exec", description: "Execute commands", parameters: {} },
+    ],
+  };
+}
+
+describe("wrapStreamFnWithHooks", () => {
+  let streamFn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    streamFn = vi.fn().mockReturnValue(mockStream);
+  });
+
+  it("before_llm_call fires on every call", async () => {
+    const hookRunner = makeMockHookRunner();
+    const iterationRef = { current: 0 };
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef,
+      modelId: "gpt-4",
+    });
+
+    const context = makeBaseContext() as unknown as Context;
+    await wrapped("gpt-4" as unknown as Model<Api>, context, {});
+    iterationRef.current = 1;
+    await wrapped("gpt-4" as unknown as Model<Api>, context, {});
+
+    expect(hookRunner.runBeforeLlmCall).toHaveBeenCalledTimes(2);
+
+    // First call
+    const [event1] = (hookRunner.runBeforeLlmCall as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(event1).toMatchObject({
+      model: "gpt-4",
+      iteration: 0,
+      systemPrompt: "You are helpful.",
+    });
+
+    // Second call
+    const [event2] = (hookRunner.runBeforeLlmCall as ReturnType<typeof vi.fn>).mock.calls[1];
+    expect(event2).toMatchObject({
+      model: "gpt-4",
+      iteration: 1,
+    });
+  });
+
+  it("before_llm_call can modify context", async () => {
+    const modifiedMessages = [fakeMsg("user", "sanitized")];
+    const hookRunner = makeMockHookRunner({
+      runBeforeLlmCall: vi.fn().mockResolvedValue({
+        systemPrompt: "modified prompt",
+        messages: modifiedMessages,
+      }),
+    });
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 0 },
+      modelId: "gpt-4",
+    });
+
+    await wrapped("gpt-4" as unknown as Model<Api>, makeBaseContext() as unknown as Context, {});
+
+    expect(streamFn).toHaveBeenCalledOnce();
+    const passedContext = streamFn.mock.calls[0][1];
+    expect(passedContext.systemPrompt).toBe("modified prompt");
+    expect(passedContext.messages).toBe(modifiedMessages);
+  });
+
+  it("before_llm_call can filter tools", async () => {
+    const hookRunner = makeMockHookRunner({
+      runBeforeLlmCall: vi.fn().mockResolvedValue({
+        tools: [{ name: "read" }],
+      }),
+    });
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 0 },
+      modelId: "gpt-4",
+    });
+
+    await wrapped("gpt-4" as unknown as Model<Api>, makeBaseContext() as unknown as Context, {});
+
+    expect(streamFn).toHaveBeenCalledOnce();
+    const passedContext = streamFn.mock.calls[0][1];
+    // Only the "read" tool should remain (filtered by allowed names)
+    expect(passedContext.tools).toHaveLength(1);
+    expect(passedContext.tools[0].name).toBe("read");
+  });
+
+  it("before_llm_call can block", async () => {
+    const hookRunner = makeMockHookRunner({
+      runBeforeLlmCall: vi.fn().mockResolvedValue({
+        block: true,
+        blockReason: "tainted context",
+      }),
+    });
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 0 },
+      modelId: "gpt-4",
+    });
+
+    await expect(
+      wrapped("gpt-4" as unknown as Model<Api>, makeBaseContext() as unknown as Context, {}),
+    ).rejects.toThrow("LLM call blocked by plugin: tainted context");
+    expect(streamFn).not.toHaveBeenCalled();
+  });
+
+  it("before_llm_call error does not break stream", async () => {
+    const hookRunner = makeMockHookRunner({
+      runBeforeLlmCall: vi.fn().mockRejectedValue(new Error("hook kaboom")),
+    });
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 0 },
+      modelId: "gpt-4",
+    });
+
+    const result = await wrapped(
+      "gpt-4" as unknown as Model<Api>,
+      makeBaseContext() as unknown as Context,
+      {},
+    );
+
+    // Should still call the underlying streamFn and return its result
+    expect(streamFn).toHaveBeenCalledOnce();
+    expect(result).toBe(mockStream);
+  });
+
+  it("passes through to underlying streamFn when no hooks", async () => {
+    const hookRunner = makeMockHookRunner({
+      hasHooks: vi.fn().mockReturnValue(false),
+    });
+    const wrapped = wrapStreamFnWithHooks(streamFn as unknown as StreamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 0 },
+      modelId: "gpt-4",
+    });
+
+    const context = makeBaseContext() as unknown as Context;
+    const result = await wrapped("gpt-4" as unknown as Model<Api>, context, {});
+
+    // before_llm_call should not be called when no hooks registered
+    expect(hookRunner.runBeforeLlmCall).not.toHaveBeenCalled();
+    // Underlying streamFn receives original context unchanged
+    expect(streamFn).toHaveBeenCalledWith("gpt-4", context, {});
+    expect(result).toBe(mockStream);
+  });
+
+  it("treats messages:[] as explicit override (clears history)", async () => {
+    const hookRunner = makeMockHookRunner({
+      runBeforeLlmCall: vi.fn().mockResolvedValue({ messages: [] }),
+    });
+
+    const streamFn = vi.fn().mockResolvedValue(mockStream);
+    const wrapped = wrapStreamFnWithHooks(streamFn, {
+      hookRunner,
+      agentCtx,
+      iterationRef: { current: 1 },
+      modelId: "gpt-4",
+    });
+
+    await wrapped("gpt-4" as unknown as Model<Api>, makeBaseContext() as unknown as Context, {});
+
+    // messages: [] is an explicit "clear history" — not "no change"
+    const passedContext = streamFn.mock.calls[0][1];
+    expect(passedContext.messages).toEqual([]);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/hook-stream-wrapper.ts
+++ b/src/agents/pi-embedded-runner/run/hook-stream-wrapper.ts
@@ -1,0 +1,107 @@
+/**
+ * Wraps a StreamFn to emit before_llm_call plugin hooks.
+ *
+ * Uses the same streamFn wrapping pattern as cache-trace.ts and
+ * anthropic-payload-log.ts — outermost wrapper sees the full context before
+ * delegating to the underlying (possibly wrapped) streamFn.
+ */
+import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Message } from "@mariozechner/pi-ai";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import type { HookRunner, PluginHookAgentContext } from "../../../plugins/hooks.js";
+
+const log = createSubsystemLogger("hooks/stream");
+
+/**
+ * Sentinel error thrown when before_llm_call blocks the LLM call.
+ * Distinct from generic errors so the agent loop can handle it gracefully
+ * (suppress the run without surfacing an error) rather than treating it
+ * as a run failure.
+ */
+export class BeforeLlmCallBlockError extends Error {
+  readonly isBeforeLlmCallBlock = true;
+  constructor(reason: string) {
+    super(`LLM call blocked by plugin: ${reason}`);
+    this.name = "BeforeLlmCallBlockError";
+  }
+}
+
+export interface HookStreamWrapperParams {
+  hookRunner: HookRunner;
+  agentCtx: PluginHookAgentContext;
+  /** Mutable ref so the wrapper always reads the current iteration count */
+  iterationRef: { current: number };
+  /** Model identifier string */
+  modelId: string;
+}
+
+export function wrapStreamFnWithHooks(
+  streamFn: StreamFn,
+  params: HookStreamWrapperParams,
+): StreamFn {
+  const { hookRunner, agentCtx, iterationRef, modelId } = params;
+  const wrapped: StreamFn = async (model, context, options) => {
+    // --- before_llm_call ---
+    let effectiveContext: Context = context;
+    if (hookRunner.hasHooks("before_llm_call")) {
+      try {
+        const toolDefs = (context.tools ?? []).map((t) => ({
+          name: t.name,
+          description: t.description,
+        }));
+        const result = await hookRunner.runBeforeLlmCall(
+          {
+            messages: context.messages as AgentMessage[],
+            systemPrompt: context.systemPrompt ?? "",
+            model: modelId,
+            iteration: iterationRef.current,
+            tools: toolDefs,
+          },
+          agentCtx,
+        );
+
+        if (result?.block) {
+          const reason = result.blockReason ?? "blocked by before_llm_call hook";
+          log.warn(`before_llm_call: blocked LLM call: ${reason}`);
+          throw new BeforeLlmCallBlockError(reason);
+        }
+
+        // Apply modifications — only create new context if something changed
+        // Use !== undefined consistently: any explicit value (including [] or "")
+        // means the hook wants that exact value. Return undefined for "no change".
+        if (
+          result?.messages !== undefined ||
+          result?.systemPrompt !== undefined ||
+          result?.tools !== undefined
+        ) {
+          let filteredTools = context.tools;
+          if (result.tools !== undefined) {
+            const allowedNames = new Set(result.tools.map((t) => t.name));
+            filteredTools = (context.tools ?? []).filter((t) => allowedNames.has(t.name));
+          }
+          // Spread original context to preserve any extra fields (e.g. provider
+          // metadata) that upstream wrappers may have attached. Only override
+          // the fields the hook explicitly modified.
+          effectiveContext = {
+            ...context,
+            systemPrompt: result.systemPrompt ?? context.systemPrompt,
+            messages: (result.messages ?? context.messages) as Message[],
+            tools: filteredTools,
+          };
+        }
+      } catch (err) {
+        // Re-throw explicit block errors (sentinel class, not string matching)
+        if (err instanceof BeforeLlmCallBlockError) {
+          throw err;
+        }
+        log.warn(`before_llm_call hook failed: ${String(err)}`);
+      }
+    }
+
+    // --- actual LLM call ---
+    // streamFn may return sync EventStream or Promise<EventStream>.
+    return streamFn(model, effectiveContext, options);
+  };
+
+  return wrapped;
+}

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -13,11 +13,7 @@ import type { CliDeps } from "../cli/deps.js";
 import type { loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { startGmailWatcherWithLogs } from "../hooks/gmail-watcher-lifecycle.js";
-import {
-  clearInternalHooks,
-  createInternalHookEvent,
-  triggerInternalHook,
-} from "../hooks/internal-hooks.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import { loadInternalHooks } from "../hooks/loader.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { loadOpenClawPlugins } from "../plugins/loader.js";
@@ -110,8 +106,9 @@ export async function startGatewaySidecars(params: {
 
   // Load internal hook handlers from configuration and directory discovery.
   try {
-    // Clear any previously registered hooks to ensure fresh loading
-    clearInternalHooks();
+    // NOTE: clearInternalHooks() is called earlier in server.impl.ts, before
+    // plugins register.  Do NOT clear here — plugin hooks are already registered
+    // and must be preserved.
     const loadedCount = await loadInternalHooks(params.cfg, params.defaultWorkspaceDir);
     if (loadedCount > 0) {
       params.logHooks.info(

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -21,6 +21,7 @@ import {
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
+import { clearInternalHooks } from "../hooks/internal-hooks.js";
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import {
   ensureControlUiAssetsBuilt,
@@ -89,7 +90,7 @@ import { createSecretsHandlers } from "./server-methods/secrets.js";
 import { hasConnectedMobileNode } from "./server-mobile-nodes.js";
 import { loadGatewayModelCatalog } from "./server-model-catalog.js";
 import { createNodeSubscriptionManager } from "./server-node-subscriptions.js";
-import { loadGatewayPlugins, setFallbackGatewayContext } from "./server-plugins.js";
+import { loadGatewayPlugins } from "./server-plugins.js";
 import { createGatewayReloadHandlers } from "./server-reload-handlers.js";
 import { resolveGatewayRuntimeConfig } from "./server-runtime-config.js";
 import { createGatewayRuntimeState } from "./server-runtime-state.js";
@@ -107,11 +108,7 @@ import {
   refreshGatewayHealthSnapshot,
 } from "./server/health-state.js";
 import { loadGatewayTlsRuntime } from "./server/tls.js";
-import {
-  ensureGatewayStartupAuth,
-  mergeGatewayAuthConfig,
-  mergeGatewayTailscaleConfig,
-} from "./startup-auth.js";
+import { ensureGatewayStartupAuth } from "./startup-auth.js";
 import { maybeSeedControlUiAllowedOriginsAtStartup } from "./startup-control-ui-origins.js";
 
 export { __resetModelCatalogCacheForTest } from "./server-model-catalog.js";
@@ -176,23 +173,6 @@ function logGatewayAuthSurfaceDiagnostics(prepared: {
     const details = inactiveDetails ?? state.reason;
     logSecrets.info(`[SECRETS_GATEWAY_AUTH_SURFACE] ${path} is ${stateLabel}. ${details}`);
   }
-}
-
-function applyGatewayAuthOverridesForStartupPreflight(
-  config: OpenClawConfig,
-  overrides: Pick<GatewayServerOptions, "auth" | "tailscale">,
-): OpenClawConfig {
-  if (!overrides.auth && !overrides.tailscale) {
-    return config;
-  }
-  return {
-    ...config,
-    gateway: {
-      ...config.gateway,
-      auth: mergeGatewayAuthConfig(config.gateway?.auth, overrides.auth),
-      tailscale: mergeGatewayTailscaleConfig(config.gateway?.tailscale, overrides.tailscale),
-    },
-  };
 }
 
 export type GatewayServer = {
@@ -277,18 +257,17 @@ export async function startGatewayServer(
     }
     const { config: migrated, changes } = migrateLegacyConfig(configSnapshot.parsed);
     if (!migrated) {
-      log.warn(
-        "gateway: legacy config entries detected but no auto-migration changes were produced; continuing with validation.",
+      throw new Error(
+        `Legacy config entries detected but auto-migration failed. Run "${formatCliCommand("openclaw doctor")}" to migrate.`,
       );
-    } else {
-      await writeConfigFile(migrated);
-      if (changes.length > 0) {
-        log.info(
-          `gateway: migrated legacy config entries:\n${changes
-            .map((entry) => `- ${entry}`)
-            .join("\n")}`,
-        );
-      }
+    }
+    await writeConfigFile(migrated);
+    if (changes.length > 0) {
+      log.info(
+        `gateway: migrated legacy config entries:\n${changes
+          .map((entry) => `- ${entry}`)
+          .join("\n")}`,
+      );
     }
   }
 
@@ -394,14 +373,7 @@ export async function startGatewayServer(
           : "Unknown validation issue.";
       throw new Error(`Invalid config at ${freshSnapshot.path}.\n${issues}`);
     }
-    const startupPreflightConfig = applyGatewayAuthOverridesForStartupPreflight(
-      freshSnapshot.config,
-      {
-        auth: opts.auth,
-        tailscale: opts.tailscale,
-      },
-    );
-    await activateRuntimeSecrets(startupPreflightConfig, {
+    await activateRuntimeSecrets(freshSnapshot.config, {
       reason: "startup",
       activate: false,
     });
@@ -453,6 +425,13 @@ export async function startGatewayServer(
   const defaultAgentId = resolveDefaultAgentId(cfgAtStart);
   const defaultWorkspaceDir = resolveAgentWorkspaceDir(cfgAtStart, defaultAgentId);
   const baseMethods = listGatewayMethods();
+
+  // Clear any previously registered internal hooks before plugins or bundled
+  // hooks register.  This ensures a clean slate on restart/reload.
+  // Plugins register first (during loadGatewayPlugins), then bundled hooks
+  // register later (during startGatewaySidecars → loadInternalHooks).
+  clearInternalHooks();
+
   const emptyPluginRegistry = createEmptyPluginRegistry();
   const { pluginRegistry, gatewayMethods: baseGatewayMethods } = minimalTestGateway
     ? { pluginRegistry: emptyPluginRegistry, gatewayMethods: baseMethods }
@@ -487,7 +466,6 @@ export async function startGatewayServer(
     bindHost,
     controlUiEnabled,
     openAiChatCompletionsEnabled,
-    openAiChatCompletionsConfig,
     openResponsesEnabled,
     openResponsesConfig,
     strictTransportSecurityHeader,
@@ -572,7 +550,6 @@ export async function startGatewayServer(
     controlUiBasePath,
     controlUiRoot: controlUiRootState,
     openAiChatCompletionsEnabled,
-    openAiChatCompletionsConfig,
     openResponsesEnabled,
     openResponsesConfig,
     strictTransportSecurityHeader,
@@ -779,63 +756,6 @@ export async function startGatewayServer(
 
   const canvasHostServerPort = (canvasHostServer as CanvasHostServer | null)?.port;
 
-  const gatewayRequestContext: import("./server-methods/types.js").GatewayRequestContext = {
-    deps,
-    cron,
-    cronStorePath,
-    execApprovalManager,
-    loadGatewayModelCatalog,
-    getHealthCache,
-    refreshHealthSnapshot: refreshGatewayHealthSnapshot,
-    logHealth,
-    logGateway: log,
-    incrementPresenceVersion,
-    getHealthVersion,
-    broadcast,
-    broadcastToConnIds,
-    nodeSendToSession,
-    nodeSendToAllSubscribed,
-    nodeSubscribe,
-    nodeUnsubscribe,
-    nodeUnsubscribeAll,
-    hasConnectedMobileNode: hasMobileNodeConnected,
-    hasExecApprovalClients: () => {
-      for (const gatewayClient of clients) {
-        const scopes = Array.isArray(gatewayClient.connect.scopes)
-          ? gatewayClient.connect.scopes
-          : [];
-        if (scopes.includes("operator.admin") || scopes.includes("operator.approvals")) {
-          return true;
-        }
-      }
-      return false;
-    },
-    nodeRegistry,
-    agentRunSeq,
-    chatAbortControllers,
-    chatAbortedRuns: chatRunState.abortedRuns,
-    chatRunBuffers: chatRunState.buffers,
-    chatDeltaSentAt: chatRunState.deltaSentAt,
-    addChatRun,
-    removeChatRun,
-    registerToolEventRecipient: toolEventRecipients.add,
-    dedupe,
-    wizardSessions,
-    findRunningWizard,
-    purgeWizardSession,
-    getRuntimeSnapshot,
-    startChannel,
-    stopChannel,
-    markChannelLoggedOut,
-    wizardRunner,
-    broadcastVoiceWakeChanged,
-  };
-
-  // Store the gateway context as a fallback for plugin subagent dispatch
-  // in non-WS paths (Telegram polling, WhatsApp, etc.) where no per-request
-  // scope is set via AsyncLocalStorage.
-  setFallbackGatewayContext(gatewayRequestContext);
-
   attachGatewayWsHandlers({
     wss,
     clients,
@@ -857,7 +777,57 @@ export async function startGatewayServer(
       ...secretsHandlers,
     },
     broadcast,
-    context: gatewayRequestContext,
+    context: {
+      deps,
+      cron,
+      cronStorePath,
+      execApprovalManager,
+      loadGatewayModelCatalog,
+      getHealthCache,
+      refreshHealthSnapshot: refreshGatewayHealthSnapshot,
+      logHealth,
+      logGateway: log,
+      incrementPresenceVersion,
+      getHealthVersion,
+      broadcast,
+      broadcastToConnIds,
+      nodeSendToSession,
+      nodeSendToAllSubscribed,
+      nodeSubscribe,
+      nodeUnsubscribe,
+      nodeUnsubscribeAll,
+      hasConnectedMobileNode: hasMobileNodeConnected,
+      hasExecApprovalClients: () => {
+        for (const gatewayClient of clients) {
+          const scopes = Array.isArray(gatewayClient.connect.scopes)
+            ? gatewayClient.connect.scopes
+            : [];
+          if (scopes.includes("operator.admin") || scopes.includes("operator.approvals")) {
+            return true;
+          }
+        }
+        return false;
+      },
+      nodeRegistry,
+      agentRunSeq,
+      chatAbortControllers,
+      chatAbortedRuns: chatRunState.abortedRuns,
+      chatRunBuffers: chatRunState.buffers,
+      chatDeltaSentAt: chatRunState.deltaSentAt,
+      addChatRun,
+      removeChatRun,
+      registerToolEventRecipient: toolEventRecipients.add,
+      dedupe,
+      wizardSessions,
+      findRunningWizard,
+      purgeWizardSession,
+      getRuntimeSnapshot,
+      startChannel,
+      stopChannel,
+      markChannelLoggedOut,
+      wizardRunner,
+      broadcastVoiceWakeChanged,
+    },
   });
   logGatewayStartup({
     cfg: cfgAtStart,

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -190,7 +190,7 @@ export interface InternalHookEvent {
   action: string;
   /** The session key this event relates to */
   sessionKey: string;
-  /** Additional context specific to the event */
+  /** Additional context specific to the event. */
   context: Record<string, unknown>;
   /** Timestamp when the event occurred */
   timestamp: Date;

--- a/src/plugins/hooks.extended.test.ts
+++ b/src/plugins/hooks.extended.test.ts
@@ -1,0 +1,293 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+/**
+ * Unit tests for LLM call and response emit hooks:
+ * before_llm_call, before_response_emit.
+ *
+ * See hooks.context-loop.test.ts for context_assembled and loop_iteration tests.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { createHookRunner } from "./hooks.js";
+import type { PluginRegistry } from "./registry.js";
+import type {
+  PluginHookAgentContext,
+  PluginHookBeforeLlmCallEvent,
+  PluginHookBeforeResponseEmitEvent,
+  PluginHookRegistration,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRegistry(hooks: PluginHookRegistration[]) {
+  return { typedHooks: hooks } as unknown as PluginRegistry;
+}
+
+const agentCtx: PluginHookAgentContext = {
+  agentId: "test-agent",
+  sessionKey: "test-session",
+};
+
+function fakeMsg(role: string, content: string): AgentMessage {
+  return { role, content } as AgentMessage;
+}
+
+// ---------------------------------------------------------------------------
+// before_llm_call (modifying, sequential)
+// ---------------------------------------------------------------------------
+
+describe("before_llm_call hook", () => {
+  const baseEvent: PluginHookBeforeLlmCallEvent = {
+    messages: [fakeMsg("user", "hello")],
+    systemPrompt: "You are helpful.",
+    model: "gpt-4",
+    iteration: 0,
+    tools: [{ name: "read", description: "Read files" }, { name: "exec" }],
+    tokenEstimate: 100,
+  };
+
+  it("fires handler with correct event shape", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const runner = createHookRunner(
+      makeRegistry([{ pluginId: "p1", hookName: "before_llm_call", handler, source: "test" }]),
+    );
+
+    await runner.runBeforeLlmCall(baseEvent, agentCtx);
+
+    expect(handler).toHaveBeenCalledOnce();
+    const [event, ctx] = handler.mock.calls[0];
+    expect(event).toMatchObject({
+      messages: baseEvent.messages,
+      systemPrompt: "You are helpful.",
+      model: "gpt-4",
+      iteration: 0,
+      tools: baseEvent.tools,
+      tokenEstimate: 100,
+    });
+    expect(ctx).toBe(agentCtx);
+  });
+
+  it("returns modified messages when handler provides them", async () => {
+    const newMsgs = [fakeMsg("user", "modified")];
+    const handler = vi.fn().mockResolvedValue({ messages: newMsgs });
+    const runner = createHookRunner(
+      makeRegistry([{ pluginId: "p1", hookName: "before_llm_call", handler, source: "test" }]),
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result?.messages).toBe(newMsgs);
+  });
+
+  it("returns modified systemPrompt when handler provides it", async () => {
+    const handler = vi.fn().mockResolvedValue({ systemPrompt: "new prompt" });
+    const runner = createHookRunner(
+      makeRegistry([{ pluginId: "p1", hookName: "before_llm_call", handler, source: "test" }]),
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result?.systemPrompt).toBe("new prompt");
+  });
+
+  it("returns filtered tools when handler provides them", async () => {
+    const handler = vi.fn().mockResolvedValue({ tools: [{ name: "read" }] });
+    const runner = createHookRunner(
+      makeRegistry([{ pluginId: "p1", hookName: "before_llm_call", handler, source: "test" }]),
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result?.tools).toEqual([{ name: "read" }]);
+  });
+
+  it("returns block=true and blockReason when handler blocks", async () => {
+    const handler = vi.fn().mockResolvedValue({ block: true, blockReason: "too many tokens" });
+    const runner = createHookRunner(
+      makeRegistry([{ pluginId: "p1", hookName: "before_llm_call", handler, source: "test" }]),
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe("too many tokens");
+  });
+
+  it("merges results from multiple handlers in registration order (FIFO)", async () => {
+    const first = vi
+      .fn()
+      .mockResolvedValue({ systemPrompt: "first prompt", tools: [{ name: "exec" }] });
+    const second = vi.fn().mockResolvedValue({ systemPrompt: "second prompt" });
+    const runner = createHookRunner(
+      makeRegistry([
+        {
+          pluginId: "first",
+          hookName: "before_llm_call",
+          handler: first,
+          source: "test",
+        },
+        {
+          pluginId: "second",
+          hookName: "before_llm_call",
+          handler: second,
+          source: "test",
+        },
+      ]),
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    // First-writer-wins for messages/systemPrompt: first plugin to set wins
+    expect(result?.tools).toEqual([{ name: "exec" }]);
+    // first runs first and provides systemPrompt → its value wins (security-first)
+    expect(result?.systemPrompt).toBe("first prompt");
+    // first ran before second (registration order)
+    expect(first).toHaveBeenCalledBefore(second);
+  });
+
+  it("continues on handler error when catchErrors=true", async () => {
+    const badHandler = vi.fn().mockRejectedValue(new Error("boom"));
+    const goodHandler = vi.fn().mockResolvedValue({ systemPrompt: "survived" });
+    const runner = createHookRunner(
+      makeRegistry([
+        {
+          pluginId: "bad",
+          hookName: "before_llm_call",
+          handler: badHandler,
+
+          source: "test",
+        },
+        {
+          pluginId: "good",
+          hookName: "before_llm_call",
+          handler: goodHandler,
+
+          source: "test",
+        },
+      ]),
+      { catchErrors: true },
+    );
+
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result?.systemPrompt).toBe("survived");
+  });
+
+  it("skips when no handlers registered (returns undefined)", async () => {
+    const runner = createHookRunner(makeRegistry([]));
+    const result = await runner.runBeforeLlmCall(baseEvent, agentCtx);
+    expect(result).toBeUndefined();
+  });
+});
+
+// NOTE: context_assembled and loop_iteration_start/end tests are in
+// hooks.context-loop.test.ts (feat/hook-context-assembled-loop-iteration).
+
+// ---------------------------------------------------------------------------
+// before_response_emit (modifying, sequential)
+// ---------------------------------------------------------------------------
+
+describe("before_response_emit hook", () => {
+  const baseEvent: PluginHookBeforeResponseEmitEvent = {
+    content: "Here is the answer.",
+    allContent: ["Here is the answer."],
+    channel: "discord",
+    messageCount: 5,
+  };
+
+  it("fires handler with correct event shape", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const runner = createHookRunner(
+      makeRegistry([
+        {
+          pluginId: "p1",
+          hookName: "before_response_emit",
+          handler,
+
+          source: "test",
+        },
+      ]),
+    );
+
+    await runner.runBeforeResponseEmit(baseEvent, agentCtx);
+
+    expect(handler).toHaveBeenCalledOnce();
+    const [event, ctx] = handler.mock.calls[0];
+    expect(event).toMatchObject({
+      content: "Here is the answer.",
+      channel: "discord",
+      messageCount: 5,
+    });
+    expect(ctx).toBe(agentCtx);
+  });
+
+  it("returns modified content when handler provides it", async () => {
+    const handler = vi.fn().mockResolvedValue({ content: "[REDACTED]" });
+    const runner = createHookRunner(
+      makeRegistry([
+        {
+          pluginId: "p1",
+          hookName: "before_response_emit",
+          handler,
+
+          source: "test",
+        },
+      ]),
+    );
+
+    const result = await runner.runBeforeResponseEmit(baseEvent, agentCtx);
+    expect(result?.content).toBe("[REDACTED]");
+  });
+
+  it("returns block=true when handler blocks", async () => {
+    const handler = vi.fn().mockResolvedValue({ block: true, blockReason: "PII detected" });
+    const runner = createHookRunner(
+      makeRegistry([
+        {
+          pluginId: "p1",
+          hookName: "before_response_emit",
+          handler,
+
+          source: "test",
+        },
+      ]),
+    );
+
+    const result = await runner.runBeforeResponseEmit(baseEvent, agentCtx);
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe("PII detected");
+  });
+
+  it("merges results from multiple handlers", async () => {
+    const h1 = vi.fn().mockResolvedValue({ content: "modified" });
+    const h2 = vi.fn().mockResolvedValue({ block: true, blockReason: "policy" });
+    const runner = createHookRunner(
+      makeRegistry([
+        {
+          pluginId: "p1",
+          hookName: "before_response_emit",
+          handler: h1,
+
+          source: "test",
+        },
+        {
+          pluginId: "p2",
+          hookName: "before_response_emit",
+          handler: h2,
+
+          source: "test",
+        },
+      ]),
+    );
+
+    const result = await runner.runBeforeResponseEmit(baseEvent, agentCtx);
+    // h1 runs first, h2 runs second (registration order).
+    // First-writer-wins merge: h1 runs first and sets content ("modified"),
+    // h2 doesn't provide content so h1's value survives. block uses one-way
+    // latch (h2 sets it), blockReason uses first-writer-wins (h1 doesn't set
+    // one, so h2's "policy" is the first defined value).
+    expect(result?.block).toBe(true);
+    expect(result?.blockReason).toBe("policy");
+    expect(result?.content).toBe("modified");
+  });
+
+  it("skips when no handlers registered", async () => {
+    const runner = createHookRunner(makeRegistry([]));
+    const result = await runner.runBeforeResponseEmit(baseEvent, agentCtx);
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -2,10 +2,9 @@
  * Plugin Hook Runner
  *
  * Provides utilities for executing plugin lifecycle hooks with proper
- * error handling, priority ordering, and async support.
+ * error handling, priority-sorted, registration-order (FIFO) execution, and async support.
  */
 
-import { concatOptionalTextSegments } from "../shared/text/join-segments.js";
 import type { PluginRegistry } from "./registry.js";
 import type {
   PluginHookAfterCompactionEvent,
@@ -27,6 +26,10 @@ import type {
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
+  PluginHookBeforeLlmCallEvent,
+  PluginHookBeforeLlmCallResult,
+  PluginHookBeforeResponseEmitEvent,
+  PluginHookBeforeResponseEmitResult,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
   PluginHookMessageSendingEvent,
@@ -94,6 +97,11 @@ export type {
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
+  // LLM call & response emit hooks
+  PluginHookBeforeLlmCallEvent,
+  PluginHookBeforeLlmCallResult,
+  PluginHookBeforeResponseEmitEvent,
+  PluginHookBeforeResponseEmitResult,
 };
 
 export type HookRunnerLogger = {
@@ -109,12 +117,16 @@ export type HookRunnerOptions = {
 };
 
 /**
- * Get hooks for a specific hook name, sorted by priority (higher first).
+ * Get hooks for a specific hook name in priority order (higher first), then registration order (FIFO).
  */
 function getHooksForName<K extends PluginHookName>(
   registry: PluginRegistry,
   hookName: K,
 ): PluginHookRegistration<K>[] {
+  // Hooks sorted by priority (higher first), then registration order (FIFO) within the same priority.
+  // Plugins register during loadGatewayPlugins, then bundled hooks register
+  // during loadInternalHooks, so at equal priority plugin handlers naturally
+  // run before bundled handlers.
   return (registry.typedHooks as PluginHookRegistration<K>[])
     .filter((h) => h.hookName === hookName)
     .toSorted((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
@@ -141,18 +153,10 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     next: PluginHookBeforePromptBuildResult,
   ): PluginHookBeforePromptBuildResult => ({
     systemPrompt: next.systemPrompt ?? acc?.systemPrompt,
-    prependContext: concatOptionalTextSegments({
-      left: acc?.prependContext,
-      right: next.prependContext,
-    }),
-    prependSystemContext: concatOptionalTextSegments({
-      left: acc?.prependSystemContext,
-      right: next.prependSystemContext,
-    }),
-    appendSystemContext: concatOptionalTextSegments({
-      left: acc?.appendSystemContext,
-      right: next.appendSystemContext,
-    }),
+    prependContext:
+      acc?.prependContext && next.prependContext
+        ? `${acc.prependContext}\n\n${next.prependContext}`
+        : (next.prependContext ?? acc?.prependContext),
   });
 
   const mergeSubagentSpawningResult = (
@@ -225,7 +229,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
 
   /**
    * Run a hook that can return a modifying result.
-   * Handlers are executed sequentially in priority order, and results are merged.
+   * Handlers are executed sequentially in priority order (higher first), then registration order (FIFO), and results are merged.
    */
   async function runModifyingHook<K extends PluginHookName, TResult>(
     hookName: K,
@@ -445,8 +449,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       ctx,
       (acc, next) => ({
         params: next.params ?? acc?.params,
-        block: next.block ?? acc?.block,
-        blockReason: next.blockReason ?? acc?.blockReason,
+        block: next.block || acc?.block,
+        blockReason: acc?.blockReason ?? next.blockReason,
       }),
     );
   }
@@ -468,7 +472,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
    * This hook is intentionally synchronous: it runs in hot paths where session
    * transcripts are appended synchronously.
    *
-   * Handlers are executed sequentially in priority order (higher first). Each
+   * Handlers are executed sequentially in priority order (higher first), then registration order (FIFO). Each
    * handler may return `{ message }` to replace the message passed to the next
    * handler.
    */
@@ -531,7 +535,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
    * This hook is intentionally synchronous: it runs on the hot path where
    * session transcripts are appended synchronously.
    *
-   * Handlers are executed sequentially in priority order (higher first).
+   * Handlers are executed sequentially in priority order (higher first), then registration order (FIFO).
    * If any handler returns { block: true }, the message is NOT written
    * to the session JSONL and we return immediately.
    * If a handler returns { message }, the modified message replaces the
@@ -705,6 +709,81 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   }
 
   // =========================================================================
+  // LLM Call & Response Emit Hooks
+  // =========================================================================
+
+  /**
+   * Run before_llm_call hook.
+   * Fires before every LLM API call within the agent loop.
+   * Allows plugins to inspect/modify context, filter tools, or block the call.
+   * Runs sequentially, merging results across handlers.
+   */
+  async function runBeforeLlmCall(
+    event: PluginHookBeforeLlmCallEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookBeforeLlmCallResult | undefined> {
+    return runModifyingHook<"before_llm_call", PluginHookBeforeLlmCallResult>(
+      "before_llm_call",
+      event,
+      ctx,
+      (acc, next) => ({
+        // First-writer-wins for messages/systemPrompt: once a higher-priority
+        // security plugin sanitizes inputs, later plugins cannot override them.
+        // Consistent with first-writer-wins on content/allContent in
+        // before_response_emit and the intersection latch on tools.
+        messages: acc?.messages ?? next.messages,
+        systemPrompt: acc?.systemPrompt ?? next.systemPrompt,
+        // Intersection latch: if both handlers provide tools, only keep tools
+        // present in both lists. Prevents a later handler from widening the allowlist.
+        tools:
+          acc?.tools !== undefined && next.tools !== undefined
+            ? next.tools.filter((t) => acc.tools!.some((a) => a.name === t.name))
+            : (next.tools ?? acc?.tools),
+        block: next.block || acc?.block,
+        blockReason: acc?.blockReason ?? next.blockReason,
+      }),
+    );
+  }
+
+  /**
+   * Run before_response_emit hook.
+   * Fires when the agent's final response is ready, before delivery.
+   * Allows plugins to modify content or block emission.
+   * Runs sequentially, merging results across handlers.
+   */
+  async function runBeforeResponseEmit(
+    event: PluginHookBeforeResponseEmitEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookBeforeResponseEmitResult | undefined> {
+    return runModifyingHook<"before_response_emit", PluginHookBeforeResponseEmitResult>(
+      "before_response_emit",
+      event,
+      ctx,
+      (acc, next) => ({
+        // First-writer-wins for content/allContent, treated as mutually exclusive:
+        // once a higher-priority plugin sets EITHER field, both are locked out
+        // for later plugins. This prevents a lower-priority plugin from bypassing
+        // single-message redaction (content) by supplying allContent (which takes
+        // precedence in application), or vice versa.
+        //
+        // NOTE for plugin authors: if two security plugins both need to redact,
+        // the higher-priority plugin wins. A lower-priority plugin's content or
+        // allContent is silently dropped when the cross-lock is engaged.
+        // Fix: ensure the higher-priority plugin handles all redaction, or
+        // consolidate into a single plugin.
+        content:
+          acc?.content !== undefined || acc?.allContent !== undefined ? acc?.content : next.content,
+        allContent:
+          acc?.allContent !== undefined || acc?.content !== undefined
+            ? acc?.allContent
+            : next.allContent,
+        block: next.block || acc?.block,
+        blockReason: acc?.blockReason ?? next.blockReason,
+      }),
+    );
+  }
+
+  // =========================================================================
   // Utility
   // =========================================================================
 
@@ -753,6 +832,9 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     // Gateway hooks
     runGatewayStart,
     runGatewayStop,
+    // LLM call & response emit hooks
+    runBeforeLlmCall,
+    runBeforeResponseEmit,
     // Utility
     hasHooks,
     getHookCount,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -35,7 +35,7 @@ export type PluginConfigUiHint = {
   placeholder?: string;
 };
 
-export type PluginKind = "memory" | "context-engine";
+export type PluginKind = "memory";
 
 export type PluginConfigValidation =
   | { ok: true; value?: unknown }
@@ -285,11 +285,6 @@ export type OpenClawPluginApi = {
    * Use this for simple state-toggling or status commands that don't need AI reasoning.
    */
   registerCommand: (command: OpenClawPluginCommandDefinition) => void;
-  /** Register a context engine implementation (exclusive slot — only one active at a time). */
-  registerContextEngine: (
-    id: string,
-    factory: import("../context-engine/registry.js").ContextEngineFactory,
-  ) => void;
   resolvePath: (input: string) => string;
   /** Register a lifecycle hook handler */
   on: <K extends PluginHookName>(
@@ -336,56 +331,9 @@ export type PluginHookName =
   | "subagent_spawned"
   | "subagent_ended"
   | "gateway_start"
-  | "gateway_stop";
-
-export const PLUGIN_HOOK_NAMES = [
-  "before_model_resolve",
-  "before_prompt_build",
-  "before_agent_start",
-  "llm_input",
-  "llm_output",
-  "agent_end",
-  "before_compaction",
-  "after_compaction",
-  "before_reset",
-  "message_received",
-  "message_sending",
-  "message_sent",
-  "before_tool_call",
-  "after_tool_call",
-  "tool_result_persist",
-  "before_message_write",
-  "session_start",
-  "session_end",
-  "subagent_spawning",
-  "subagent_delivery_target",
-  "subagent_spawned",
-  "subagent_ended",
-  "gateway_start",
-  "gateway_stop",
-] as const satisfies readonly PluginHookName[];
-
-type MissingPluginHookNames = Exclude<PluginHookName, (typeof PLUGIN_HOOK_NAMES)[number]>;
-type AssertAllPluginHookNamesListed = MissingPluginHookNames extends never ? true : never;
-const assertAllPluginHookNamesListed: AssertAllPluginHookNamesListed = true;
-void assertAllPluginHookNamesListed;
-
-const pluginHookNameSet = new Set<PluginHookName>(PLUGIN_HOOK_NAMES);
-
-export const isPluginHookName = (hookName: unknown): hookName is PluginHookName =>
-  typeof hookName === "string" && pluginHookNameSet.has(hookName as PluginHookName);
-
-export const PROMPT_INJECTION_HOOK_NAMES = [
-  "before_prompt_build",
-  "before_agent_start",
-] as const satisfies readonly PluginHookName[];
-
-export type PromptInjectionHookName = (typeof PROMPT_INJECTION_HOOK_NAMES)[number];
-
-const promptInjectionHookNameSet = new Set<PluginHookName>(PROMPT_INJECTION_HOOK_NAMES);
-
-export const isPromptInjectionHookName = (hookName: PluginHookName): boolean =>
-  promptInjectionHookNameSet.has(hookName);
+  | "gateway_stop"
+  | "before_llm_call"
+  | "before_response_emit";
 
 // Agent context shared across agent hooks
 export type PluginHookAgentContext = {
@@ -423,33 +371,7 @@ export type PluginHookBeforePromptBuildEvent = {
 export type PluginHookBeforePromptBuildResult = {
   systemPrompt?: string;
   prependContext?: string;
-  /**
-   * Prepended to the agent system prompt so providers can cache it (e.g. prompt caching).
-   * Use for static plugin guidance instead of prependContext to avoid per-turn token cost.
-   */
-  prependSystemContext?: string;
-  /**
-   * Appended to the agent system prompt so providers can cache it (e.g. prompt caching).
-   * Use for static plugin guidance instead of prependContext to avoid per-turn token cost.
-   */
-  appendSystemContext?: string;
 };
-
-export const PLUGIN_PROMPT_MUTATION_RESULT_FIELDS = [
-  "systemPrompt",
-  "prependContext",
-  "prependSystemContext",
-  "appendSystemContext",
-] as const satisfies readonly (keyof PluginHookBeforePromptBuildResult)[];
-
-type MissingPluginPromptMutationResultFields = Exclude<
-  keyof PluginHookBeforePromptBuildResult,
-  (typeof PLUGIN_PROMPT_MUTATION_RESULT_FIELDS)[number]
->;
-type AssertAllPluginPromptMutationResultFieldsListed =
-  MissingPluginPromptMutationResultFields extends never ? true : never;
-const assertAllPluginPromptMutationResultFieldsListed: AssertAllPluginPromptMutationResultFieldsListed = true;
-void assertAllPluginPromptMutationResultFieldsListed;
 
 // before_agent_start hook (legacy compatibility: combines both phases)
 export type PluginHookBeforeAgentStartEvent = {
@@ -460,26 +382,6 @@ export type PluginHookBeforeAgentStartEvent = {
 
 export type PluginHookBeforeAgentStartResult = PluginHookBeforePromptBuildResult &
   PluginHookBeforeModelResolveResult;
-
-export type PluginHookBeforeAgentStartOverrideResult = Omit<
-  PluginHookBeforeAgentStartResult,
-  keyof PluginHookBeforePromptBuildResult
->;
-
-export const stripPromptMutationFieldsFromLegacyHookResult = (
-  result: PluginHookBeforeAgentStartResult | void,
-): PluginHookBeforeAgentStartOverrideResult | void => {
-  if (!result || typeof result !== "object") {
-    return result;
-  }
-  const remaining: Partial<PluginHookBeforeAgentStartResult> = { ...result };
-  for (const field of PLUGIN_PROMPT_MUTATION_RESULT_FIELDS) {
-    delete remaining[field];
-  }
-  return Object.keys(remaining).length > 0
-    ? (remaining as PluginHookBeforeAgentStartOverrideResult)
-    : undefined;
-};
 
 // llm_input hook
 export type PluginHookLlmInputEvent = {
@@ -777,6 +679,55 @@ export type PluginHookGatewayStopEvent = {
   reason?: string;
 };
 
+// ============================================================================
+// LLM Call & Response Emit Hooks
+// ============================================================================
+
+// before_llm_call hook (modifying — sequential)
+export type PluginHookBeforeLlmCallEvent = {
+  messages: AgentMessage[];
+  systemPrompt: string;
+  model: string;
+  iteration: number;
+  tools: Array<{ name: string; description?: string }>;
+  tokenEstimate?: number;
+};
+
+export type PluginHookBeforeLlmCallResult = {
+  messages?: AgentMessage[];
+  systemPrompt?: string;
+  tools?: Array<{ name: string }>;
+  block?: boolean;
+  blockReason?: string;
+};
+
+// before_response_emit hook (modifying — sequential)
+export type PluginHookBeforeResponseEmitEvent = {
+  /** Text content of the last assistant message. */
+  content: string;
+  /**
+   * Text content of ALL assistant messages from the current run, in chronological
+   * order. Enables full multi-turn PII redaction across tool-loop iterations.
+   * Each entry corresponds to one assistant turn's accumulated text.
+   */
+  allContent: string[];
+  channel?: string;
+  messageCount: number;
+};
+
+export type PluginHookBeforeResponseEmitResult = {
+  /** Modified content for the last assistant message (single-message modification). */
+  content?: string;
+  /**
+   * Modified content for ALL assistant messages. When returned, replaces the
+   * entire assistantTexts array and rewrites all assistant messages in session
+   * history. Takes precedence over `content` when both are provided.
+   */
+  allContent?: string[];
+  block?: boolean;
+  blockReason?: string;
+};
+
 // Hook handler types mapped by hook name
 export type PluginHookHandlerMap = {
   before_model_resolve: (
@@ -875,6 +826,17 @@ export type PluginHookHandlerMap = {
     event: PluginHookGatewayStopEvent,
     ctx: PluginHookGatewayContext,
   ) => Promise<void> | void;
+  before_llm_call: (
+    event: PluginHookBeforeLlmCallEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookBeforeLlmCallResult | void> | PluginHookBeforeLlmCallResult | void;
+  before_response_emit: (
+    event: PluginHookBeforeResponseEmitEvent,
+    ctx: PluginHookAgentContext,
+  ) =>
+    | Promise<PluginHookBeforeResponseEmitResult | void>
+    | PluginHookBeforeResponseEmitResult
+    | void;
 };
 
 export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = {


### PR DESCRIPTION
## Summary

Split from #33916 — synchronous hooks only. The async `after_llm_call` gate bridge follows in a separate PR.

### New Hooks

**`before_llm_call`** (modifying, sequential) — fires before every LLM API call:
- Inspect/modify messages, system prompt, and tool list
- Block the LLM call entirely (graceful `BeforeLlmCallBlockError`)
- Tools use intersection latch (can only narrow, never widen)
- First-writer-wins for messages/systemPrompt

**`before_response_emit`** (modifying, sequential) — fires before final response delivery:
- Modify response content (single message or multi-turn `allContent`)
- Block emission entirely (scrubs from session history via `clearAssistantContent`)
- First-writer-wins cross-lock on content/allContent

### Security Properties

Both hooks are **synchronous and deterministic**:
- Sequential execution in priority order (FIFO within same priority)
- `block` is a one-way latch — later handlers cannot unblock
- First-writer-wins prevents lower-priority plugins from overriding security decisions
- Tool intersection prevents allowlist widening

### Files Changed

| File | Description |
|------|-------------|
| `hook-stream-wrapper.ts` | Wraps streamFn for before_llm_call interception |
| `hook-response-emit.ts` | Applies before_response_emit with history rewrite |
| `hooks.ts` | Hook runner additions (runBeforeLlmCall, runBeforeResponseEmit) |
| `types.ts` | Type definitions for both hooks |
| `attempt.ts` | Integration into agent loop |
| `hooks.extended.test.ts` | 46 tests covering merge semantics |

### Testing

- 46 unit tests covering handler execution, merge semantics, block latch, intersection, and edge cases
- Type-checks clean (no new errors)
