### PR TITLE
fix(telegram): use runtime config snapshot for SecretRef botToken

### DIFF
--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -5,7 +5,7 @@ import type {
   ReactionTypeEmoji,
 } from "@grammyjs/types";
 import { type ApiClientOptions, Bot, HttpError, InputFile } from "grammy";
-import { loadConfig } from "../config/config.js";
+import { getRuntimeConfigSnapshot, loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
@@ -326,7 +326,10 @@ function resolveTelegramApiContext(opts: {
   api?: TelegramApiOverride;
   cfg?: ReturnType<typeof loadConfig>;
 }): TelegramApiContext {
-  const cfg = opts.cfg ?? loadConfig();
+  // Prefer the active secrets runtime snapshot when available so SecretRef-backed
+  // tokens (channels.telegram.botToken) resolve consistently across startup, bot
+  // handlers, and tool-driven outbound sends.
+  const cfg = opts.cfg ?? getRuntimeConfigSnapshot() ?? loadConfig();
   const account = resolveTelegramAccount({
     cfg,
     accountId: opts.accountId,


### PR DESCRIPTION
This fixes a mismatch where Telegram sends triggered via tool-driven paths (e.g. `message` tool or other outbound helpers) could read `channels.telegram.botToken` from the raw config and fail when it is configured as a SecretRef.

Instead, prefer the active secrets runtime snapshot config when available, so SecretRef-backed tokens resolve consistently across startup/bot handlers and tool-driven outbound sends.

Closes #37909