### PR TITLE
fix(agents): let config baseUrl override cached models.json value

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -207,7 +207,7 @@ describe("models-config", () => {
     });
   });
 
-  it("preserves non-empty agent apiKey/baseUrl for matching providers in merge mode", async () => {
+  it("config baseUrl overrides stale agent baseUrl in merge mode", async () => {
     await withTempHome(async () => {
       const parsed = await runCustomProviderMergeTest({
         baseUrl: "https://agent.example/v1",
@@ -216,7 +216,7 @@ describe("models-config", () => {
         models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
       });
       expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
-      expect(parsed.providers.custom?.baseUrl).toBe("https://agent.example/v1");
+      expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
     });
   });
 

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -158,11 +158,16 @@ function mergeWithExistingProviderSecrets(params: {
       mergedProviders[key] = newEntry;
       continue;
     }
+    const newRecord = newEntry as Record<string, unknown>;
     const preserved: Record<string, unknown> = {};
     if (typeof existing.apiKey === "string" && existing.apiKey) {
       preserved.apiKey = existing.apiKey;
     }
-    if (typeof existing.baseUrl === "string" && existing.baseUrl) {
+    if (
+      typeof existing.baseUrl === "string" &&
+      existing.baseUrl &&
+      !(typeof newRecord.baseUrl === "string" && newRecord.baseUrl.trim())
+    ) {
       preserved.baseUrl = existing.baseUrl;
     }
     mergedProviders[key] = { ...newEntry, ...preserved };


### PR DESCRIPTION
## Summary

Fixes stale `baseUrl` caching in the agent's `models.json` by letting `openclaw.json` config values take precedence when non-empty.

## Problem

When a user corrects a `baseUrl` in `openclaw.json` and restarts the gateway, the agent continues using the old URL from `.openclaw/agent/main/agent/models.json`. The `mergeWithExistingProviderSecrets` function unconditionally preserves the existing `baseUrl` from `models.json`, overriding the config value. Users must manually edit the hidden `models.json` file — an unintuitive and error-prone workaround.

## Changes

| File | Change |
|------|--------|
| `src/agents/models-config.ts` | `mergeWithExistingProviderSecrets`: only preserve existing `baseUrl` from `models.json` when the config entry does not provide a non-empty `baseUrl`. `apiKey` preservation is unchanged (keeps resolved credentials). |
| `src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts` | Updated merge test: config `baseUrl` now takes precedence over the stale agent value |

## How it works

In the `mergeWithExistingProviderSecrets` function, the `baseUrl` from the existing `models.json` is now only carried forward when the new config entry's `baseUrl` is empty or missing. When the config provides a non-empty `baseUrl`, it wins. The `apiKey` field is still unconditionally preserved from `models.json` to avoid losing resolved API key credentials that may have been set during onboarding.

## Test plan

- [x] 70 tests pass across 17 `models-config*.test.ts` files
- [x] Updated test verifies config `baseUrl` overrides stale agent value
- [x] Existing test confirms empty config falls back to preserved agent values
- [ ] Manual: set wrong `baseUrl` in `openclaw.json`, start gateway, correct `baseUrl`, restart gateway — agent should use new URL

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication/authorization? **No** — apiKey preservation is unchanged
- Does this change affect data storage or retrieval? **Yes** — the `models.json` written to disk may now contain a different `baseUrl`. No sensitive data is affected.
- Does this change affect network communication? **Yes** — the agent will connect to the updated `baseUrl` instead of the cached one. This is the intended fix.
- Does this change introduce new dependencies? **No**

## Human Verification

1. Set up a vLLM/llama.cpp provider with an intentionally wrong `baseUrl` (e.g. `127.0.0.1/completion`)
2. Start the gateway — requests fail as expected
3. Fix `baseUrl` to the correct path (e.g. `127.0.0.1/v1`) in `openclaw.json`
4. Restart the gateway
5. Verify requests now go to the correct endpoint
6. Check `.openclaw/agent/main/agent/models.json` — `baseUrl` should reflect the new value

## Failure Recovery

Revert the change in `mergeWithExistingProviderSecrets` to restore unconditional `baseUrl` preservation. Users will need to manually edit `models.json` when changing `baseUrl`.

## Risks and Mitigations

- **Risk**: Users who intentionally set a different `baseUrl` in `models.json` (for testing/override) will have it overwritten on restart. **Mitigation**: The `models.json` override pattern was never officially supported. The config should be the single source of truth. Users can use `mode: "replace"` for full control.