### PR TITLE
feat: CLI flags, config overlays, and MagicForm channel plugin

### DIFF
--- a/extensions/magicform/index.ts
+++ b/extensions/magicform/index.ts
@@ -1,0 +1,17 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/magicform";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/magicform";
+import { createMagicFormPlugin } from "./src/channel.js";
+import { setMagicFormRuntime } from "./src/runtime.js";
+
+const plugin = {
+  id: "magicform",
+  name: "MagicForm",
+  description: "Native MagicForm channel plugin for OpenClaw",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setMagicFormRuntime(api.runtime);
+    api.registerChannel({ plugin: createMagicFormPlugin() });
+  },
+};
+
+export default plugin;

--- a/extensions/magicform/package.json
+++ b/extensions/magicform/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@openclaw/magicform",
+  "version": "2026.3.2",
+  "description": "MagicForm channel plugin for OpenClaw",
+  "type": "module",
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "channel": {
+      "id": "magicform",
+      "label": "MagicForm",
+      "selectionLabel": "MagicForm (Webhook)",
+      "docsPath": "/channels/magicform",
+      "docsLabel": "magicform",
+      "blurb": "Connect MagicForm to OpenClaw for agentic task processing.",
+      "order": 91
+    },
+    "install": {
+      "npmSpec": "@openclaw/magicform",
+      "localPath": "extensions/magicform",
+      "defaultChoice": "local"
+    }
+  }
+}

--- a/extensions/magicform/src/accounts.ts
+++ b/extensions/magicform/src/accounts.ts
@@ -1,0 +1,77 @@
+/**
+ * Account resolution: reads config from channels.magicform,
+ * merges per-account overrides, falls back to environment variables.
+ */
+
+import type { MagicFormChannelConfig, ResolvedMagicFormAccount } from "./types.js";
+
+/** Extract the channel config from the full OpenClaw config object. */
+function getChannelConfig(cfg: any): MagicFormChannelConfig | undefined {
+  return cfg?.channels?.magicform;
+}
+
+/** Parse allow_from from string or array to string[]. */
+function parseAllowFrom(raw: string | string[] | undefined): string[] {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw.filter(Boolean);
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * List all configured account IDs for this channel.
+ * Returns ["default"] if there's a base config, plus any named accounts.
+ */
+export function listAccountIds(cfg: any): string[] {
+  const channelCfg = getChannelConfig(cfg);
+  if (!channelCfg) return [];
+
+  const ids = new Set<string>();
+
+  const hasBaseToken = channelCfg.api_token || process.env.MAGICFORM_API_TOKEN;
+  if (hasBaseToken) {
+    ids.add("default");
+  }
+
+  if (channelCfg.accounts) {
+    for (const id of Object.keys(channelCfg.accounts)) {
+      ids.add(id);
+    }
+  }
+
+  return Array.from(ids);
+}
+
+/**
+ * Resolve a specific account by ID with full defaults applied.
+ * Falls back to env vars for the "default" account.
+ */
+export function resolveAccount(cfg: any, accountId?: string | null): ResolvedMagicFormAccount {
+  const channelCfg = getChannelConfig(cfg) ?? {};
+  const id = accountId || "default";
+
+  const accountOverride = channelCfg.accounts?.[id] ?? {};
+
+  const envApiToken = process.env.MAGICFORM_API_TOKEN ?? "";
+  const envBackendUrl = process.env.MAGICFORM_BACKEND_URL ?? "";
+  const envRateLimit = process.env.MAGICFORM_RATE_LIMIT;
+
+  return {
+    accountId: id,
+    enabled: accountOverride.enabled ?? channelCfg.enabled ?? true,
+    backendUrl: accountOverride.backend_url ?? channelCfg.backend_url ?? envBackendUrl,
+    apiToken: accountOverride.api_token ?? channelCfg.api_token ?? envApiToken,
+    callbackPath: accountOverride.callback_path ?? channelCfg.callback_path ?? "/claw-agent/callback",
+    webhookPath: accountOverride.webhookPath ?? channelCfg.webhookPath ?? "/webhook/magicform",
+    dmPolicy: accountOverride.dmPolicy ?? channelCfg.dmPolicy ?? "open",
+    allowFrom: parseAllowFrom(
+      accountOverride.allow_from ?? channelCfg.allow_from,
+    ),
+    rateLimitPerMinute:
+      accountOverride.rateLimitPerMinute ??
+      channelCfg.rateLimitPerMinute ??
+      (envRateLimit ? parseInt(envRateLimit, 10) || 60 : 60),
+  };
+}

--- a/extensions/magicform/src/channel.ts
+++ b/extensions/magicform/src/channel.ts
@@ -252,10 +252,19 @@ export function createMagicFormPlugin() {
               CommandAuthorized: true,
             });
 
-            // Dispatch via the SDK's buffered block dispatcher
+            // Dispatch via the SDK's buffered block dispatcher.
+            // Pass per-request overrides from the webhook payload through replyOptions
+            // so they reach getReplyFromConfig → workspace/config-dir/tool resolution.
             await rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
               ctx: msgCtx,
               cfg: currentCfg,
+              replyOptions: {
+                workspaceOverride: msg.workspaceOverride,
+                configDirOverride: msg.configDirOverride,
+                toolsProfileOverride: msg.toolsProfileOverride,
+                toolsAllowOverride: msg.toolsAllowOverride,
+                toolsDenyOverride: msg.toolsDenyOverride,
+              },
               dispatcherOptions: {
                 deliver: async (payload: { text?: string; body?: string }) => {
                   const text = payload?.text ?? payload?.body;

--- a/extensions/magicform/src/channel.ts
+++ b/extensions/magicform/src/channel.ts
@@ -1,0 +1,341 @@
+/**
+ * MagicForm Channel Plugin for OpenClaw.
+ *
+ * Implements the ChannelPlugin interface following the synology-chat pattern.
+ * Webhook inbound, HTTP callback outbound, no persistent connection.
+ */
+
+import {
+  DEFAULT_ACCOUNT_ID,
+  setAccountEnabledInConfigSection,
+  registerPluginHttpRoute,
+  buildChannelConfigSchema,
+} from "openclaw/plugin-sdk/magicform";
+import { z } from "zod";
+import { listAccountIds, resolveAccount } from "./accounts.js";
+import { sendCallback } from "./client.js";
+import { getMagicFormRuntime } from "./runtime.js";
+import type { ResolvedMagicFormAccount } from "./types.js";
+import { createWebhookHandler } from "./webhook-handler.js";
+
+const CHANNEL_ID = "magicform";
+const MagicFormConfigSchema = buildChannelConfigSchema(z.object({}).passthrough());
+
+const activeRouteUnregisters = new Map<string, () => void>();
+
+function waitUntilAbort(signal?: AbortSignal, onAbort?: () => void): Promise<void> {
+  return new Promise((resolve) => {
+    const complete = () => {
+      onAbort?.();
+      resolve();
+    };
+    if (!signal) {
+      return;
+    }
+    if (signal.aborted) {
+      complete();
+      return;
+    }
+    signal.addEventListener("abort", complete, { once: true });
+  });
+}
+
+export function createMagicFormPlugin() {
+  return {
+    id: CHANNEL_ID,
+
+    meta: {
+      id: CHANNEL_ID,
+      label: "MagicForm",
+      selectionLabel: "MagicForm (Webhook)",
+      detailLabel: "MagicForm (Webhook)",
+      docsPath: "/channels/magicform",
+      blurb: "Connect MagicForm to OpenClaw for agentic task processing.",
+      order: 91,
+    },
+
+    capabilities: {
+      chatTypes: ["direct" as const],
+      media: false,
+      threads: false,
+      reactions: false,
+      edit: false,
+      unsend: false,
+      reply: false,
+      effects: false,
+      blockStreaming: false,
+    },
+
+    reload: { configPrefixes: [`channels.${CHANNEL_ID}`] },
+
+    configSchema: MagicFormConfigSchema,
+
+    config: {
+      listAccountIds: (cfg: any) => listAccountIds(cfg),
+
+      resolveAccount: (cfg: any, accountId?: string | null) => resolveAccount(cfg, accountId),
+
+      defaultAccountId: (_cfg: any) => DEFAULT_ACCOUNT_ID,
+
+      setAccountEnabled: ({ cfg, accountId, enabled }: any) => {
+        const channelConfig = cfg?.channels?.[CHANNEL_ID] ?? {};
+        if (accountId === DEFAULT_ACCOUNT_ID) {
+          return {
+            ...cfg,
+            channels: {
+              ...cfg.channels,
+              [CHANNEL_ID]: { ...channelConfig, enabled },
+            },
+          };
+        }
+        return setAccountEnabledInConfigSection({
+          cfg,
+          sectionKey: `channels.${CHANNEL_ID}`,
+          accountId,
+          enabled,
+        });
+      },
+    },
+
+    pairing: {
+      idLabel: "magicformUserId",
+      normalizeAllowEntry: (entry: string) => entry.toLowerCase().trim(),
+    },
+
+    security: {
+      resolveDmPolicy: ({
+        cfg,
+        accountId,
+        account,
+      }: {
+        cfg: any;
+        accountId?: string | null;
+        account: ResolvedMagicFormAccount;
+      }) => {
+        const resolvedAccountId = accountId ?? account.accountId ?? DEFAULT_ACCOUNT_ID;
+        const channelCfg = (cfg as any).channels?.[CHANNEL_ID];
+        const useAccountPath = Boolean(channelCfg?.accounts?.[resolvedAccountId]);
+        const basePath = useAccountPath
+          ? `channels.${CHANNEL_ID}.accounts.${resolvedAccountId}.`
+          : `channels.${CHANNEL_ID}.`;
+        return {
+          policy: account.dmPolicy ?? "open",
+          allowFrom: account.allowFrom ?? [],
+          policyPath: `${basePath}dmPolicy`,
+          allowFromPath: basePath,
+          approveHint: `openclaw pairing approve ${CHANNEL_ID} <code>`,
+          normalizeEntry: (raw: string) => raw.toLowerCase().trim(),
+        };
+      },
+      collectWarnings: ({ account }: { account: ResolvedMagicFormAccount }) => {
+        const warnings: string[] = [];
+        if (!account.apiToken) {
+          warnings.push(
+            "- MagicForm: api_token is not configured. The webhook will reject all requests.",
+          );
+        }
+        if (!account.backendUrl) {
+          warnings.push(
+            "- MagicForm: backend_url is not configured. The bot cannot send callback responses.",
+          );
+        }
+        if (account.dmPolicy === "open" && account.allowFrom.length === 0) {
+          warnings.push(
+            '- MagicForm: dmPolicy="open" with empty allow_from allows any stack to message the bot.',
+          );
+        }
+        return warnings;
+      },
+    },
+
+    messaging: {
+      normalizeTarget: (target: string) => {
+        const trimmed = target.trim();
+        if (!trimmed) return undefined;
+        return trimmed.replace(/^magicform:/i, "").trim();
+      },
+      targetResolver: {
+        looksLikeId: (id: string) => {
+          const trimmed = id?.trim();
+          if (!trimmed) return false;
+          // MagicForm targets are encoded as stack_id:conversation_id:user_id
+          return /^magicform:/i.test(trimmed) || trimmed.includes(":");
+        },
+        hint: "<stack_id>:<conversation_id>:<user_id>",
+      },
+    },
+
+    directory: {
+      self: async () => null,
+      listPeers: async () => [],
+      listGroups: async () => [],
+    },
+
+    outbound: {
+      deliveryMode: "gateway" as const,
+      textChunkLimit: 4000,
+
+      sendText: async ({ to, text, accountId, cfg }: any) => {
+        const account: ResolvedMagicFormAccount = resolveAccount(cfg ?? {}, accountId);
+
+        if (!account.backendUrl) {
+          throw new Error("MagicForm backend_url not configured");
+        }
+
+        // Parse the `to` field: stack_id:conversation_id:user_id
+        const parts = to.split(":");
+        if (parts.length < 3) {
+          throw new Error(`Invalid MagicForm target format: ${to} (expected stack_id:conversation_id:user_id)`);
+        }
+        const [stackId, conversationId, userId] = parts;
+
+        const ok = await sendCallback(account.backendUrl, account.callbackPath, {
+          stack_id: stackId,
+          conversation_id: conversationId,
+          user_id: userId,
+          response: text,
+          status: "success",
+        }, account.apiToken);
+
+        if (!ok) {
+          throw new Error("Failed to send callback to MagicForm");
+        }
+        return { channel: CHANNEL_ID, messageId: `mf-${Date.now()}`, chatId: to };
+      },
+    },
+
+    gateway: {
+      startAccount: async (ctx: any) => {
+        const { cfg, accountId, log } = ctx;
+        const account = resolveAccount(cfg, accountId);
+
+        if (!account.enabled) {
+          log?.info?.(`MagicForm account ${accountId} is disabled, skipping`);
+          return waitUntilAbort(ctx.abortSignal);
+        }
+
+        if (!account.apiToken || !account.backendUrl) {
+          log?.warn?.(
+            `MagicForm account ${accountId} not fully configured (missing api_token or backend_url)`,
+          );
+          return waitUntilAbort(ctx.abortSignal);
+        }
+
+        log?.info?.(
+          `Starting MagicForm channel (account: ${accountId}, path: ${account.webhookPath})`,
+        );
+
+        const handler = createWebhookHandler({
+          account,
+          deliver: async (msg) => {
+            const rt = getMagicFormRuntime();
+            const currentCfg = await rt.config.loadConfig();
+
+            // Build MsgContext using SDK's finalizeInboundContext
+            const msgCtx = rt.channel.reply.finalizeInboundContext({
+              Body: msg.body,
+              RawBody: msg.body,
+              CommandBody: msg.body,
+              From: `magicform:${msg.from}`,
+              To: `magicform:${msg.from}`,
+              SessionKey: msg.sessionKey,
+              AccountId: account.accountId,
+              OriginatingChannel: CHANNEL_ID,
+              OriginatingTo: `magicform:${msg.from}`,
+              ChatType: msg.chatType,
+              SenderName: msg.senderName,
+              SenderId: msg.from,
+              Provider: CHANNEL_ID,
+              Surface: CHANNEL_ID,
+              ConversationLabel: msg.senderName || msg.from,
+              Timestamp: Date.now(),
+              CommandAuthorized: true,
+            });
+
+            // Dispatch via the SDK's buffered block dispatcher
+            await rt.channel.reply.dispatchReplyWithBufferedBlockDispatcher({
+              ctx: msgCtx,
+              cfg: currentCfg,
+              dispatcherOptions: {
+                deliver: async (payload: { text?: string; body?: string }) => {
+                  const text = payload?.text ?? payload?.body;
+                  if (text) {
+                    // Parse from field for callback routing
+                    const parts = msg.from.split(":");
+                    if (parts.length >= 3) {
+                      const [stackId, conversationId, userId] = parts;
+                      await sendCallback(
+                        account.backendUrl,
+                        account.callbackPath,
+                        {
+                          stack_id: stackId,
+                          conversation_id: conversationId,
+                          user_id: userId,
+                          response: text,
+                          status: "success",
+                        },
+                        account.apiToken,
+                      );
+                    }
+                  }
+                },
+                onReplyStart: () => {
+                  log?.info?.(`Agent reply started for ${msg.from}`);
+                },
+              },
+            });
+
+            return null;
+          },
+          log,
+        });
+
+        // Deregister any stale route from a previous start
+        const routeKey = `${accountId}:${account.webhookPath}`;
+        const prevUnregister = activeRouteUnregisters.get(routeKey);
+        if (prevUnregister) {
+          log?.info?.(`Deregistering stale route before re-registering: ${account.webhookPath}`);
+          prevUnregister();
+          activeRouteUnregisters.delete(routeKey);
+        }
+
+        const unregister = registerPluginHttpRoute({
+          path: account.webhookPath,
+          auth: "plugin",
+          replaceExisting: true,
+          pluginId: CHANNEL_ID,
+          accountId: account.accountId,
+          log: (msg: string) => log?.info?.(msg),
+          handler,
+        });
+        activeRouteUnregisters.set(routeKey, unregister);
+
+        log?.info?.(`Registered HTTP route: ${account.webhookPath} for MagicForm`);
+
+        return waitUntilAbort(ctx.abortSignal, () => {
+          log?.info?.(`Stopping MagicForm channel (account: ${accountId})`);
+          if (typeof unregister === "function") unregister();
+          activeRouteUnregisters.delete(routeKey);
+        });
+      },
+
+      stopAccount: async (ctx: any) => {
+        ctx.log?.info?.(`MagicForm account ${ctx.accountId} stopped`);
+      },
+    },
+
+    agentPrompt: {
+      messageToolHints: () => [
+        "",
+        "### MagicForm Formatting",
+        "MagicForm supports markdown formatting in responses.",
+        "",
+        "**Best practices**:",
+        "- Use clear, structured responses",
+        "- Use markdown headers, lists, and code blocks as needed",
+        "- Keep responses focused and actionable",
+        "- Responses over 4000 characters will be chunked",
+      ],
+    },
+  };
+}

--- a/extensions/magicform/src/client.ts
+++ b/extensions/magicform/src/client.ts
@@ -1,0 +1,92 @@
+/**
+ * MagicForm HTTP callback client.
+ * Sends agent responses back to MagicForm's POST /claw-agent/callback endpoint.
+ */
+
+import * as http from "node:http";
+import * as https from "node:https";
+import type { MagicFormCallbackPayload } from "./types.js";
+
+/**
+ * Send an agent response back to MagicForm via the callback endpoint.
+ *
+ * @param backendUrl - MagicForm backend base URL (e.g., "https://api.magicform.ai")
+ * @param callbackPath - Callback path (e.g., "/claw-agent/callback")
+ * @param payload - The callback payload
+ * @param apiToken - Bearer token for authentication
+ * @returns true if sent successfully
+ */
+export async function sendCallback(
+  backendUrl: string,
+  callbackPath: string,
+  payload: MagicFormCallbackPayload,
+  apiToken: string,
+): Promise<boolean> {
+  const url = `${backendUrl.replace(/\/$/, "")}${callbackPath}`;
+  const body = JSON.stringify(payload);
+
+  const maxRetries = 3;
+  const baseDelay = 300;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const ok = await doPost(url, body, apiToken);
+      if (ok) return true;
+    } catch {
+      // will retry
+    }
+
+    if (attempt < maxRetries - 1) {
+      await sleep(baseDelay * Math.pow(2, attempt));
+    }
+  }
+
+  return false;
+}
+
+function doPost(url: string, body: string, apiToken: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      reject(new Error(`Invalid URL: ${url}`));
+      return;
+    }
+    const transport = parsedUrl.protocol === "https:" ? https : http;
+
+    const req = transport.request(
+      url,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(body),
+          Authorization: `Bearer ${apiToken}`,
+        },
+        timeout: 30_000,
+      },
+      (res) => {
+        let data = "";
+        res.on("data", (chunk: Buffer) => {
+          data += chunk.toString();
+        });
+        res.on("end", () => {
+          resolve(res.statusCode !== undefined && res.statusCode >= 200 && res.statusCode < 300);
+        });
+      },
+    );
+
+    req.on("error", reject);
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error("Request timeout"));
+    });
+    req.write(body);
+    req.end();
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/extensions/magicform/src/runtime.ts
+++ b/extensions/magicform/src/runtime.ts
@@ -1,0 +1,20 @@
+/**
+ * Plugin runtime singleton.
+ * Stores the PluginRuntime from api.runtime (set during register()).
+ * Used by channel.ts to access dispatch functions.
+ */
+
+import type { PluginRuntime } from "openclaw/plugin-sdk/magicform";
+
+let runtime: PluginRuntime | null = null;
+
+export function setMagicFormRuntime(r: PluginRuntime): void {
+  runtime = r;
+}
+
+export function getMagicFormRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("MagicForm runtime not initialized - plugin not registered");
+  }
+  return runtime;
+}

--- a/extensions/magicform/src/security.ts
+++ b/extensions/magicform/src/security.ts
@@ -1,0 +1,101 @@
+/**
+ * Security module: token validation, rate limiting, input sanitization, allowlist.
+ */
+
+import * as crypto from "node:crypto";
+import {
+  createFixedWindowRateLimiter,
+  type FixedWindowRateLimiter,
+} from "openclaw/plugin-sdk/magicform";
+
+export type AuthorizationResult =
+  | { allowed: true }
+  | { allowed: false; reason: "disabled" | "not-allowlisted" };
+
+/**
+ * Validate webhook token using constant-time comparison.
+ * Prevents timing attacks that could leak token bytes.
+ */
+export function validateToken(received: string, expected: string): boolean {
+  if (!received || !expected) return false;
+
+  const key = "openclaw-token-cmp";
+  const a = crypto.createHmac("sha256", key).update(received).digest();
+  const b = crypto.createHmac("sha256", key).update(expected).digest();
+
+  return crypto.timingSafeEqual(a, b);
+}
+
+/**
+ * Check if a stack ID is in the allow_from list.
+ * Empty allowFrom means allow all.
+ */
+export function authorizeStackId(
+  stackId: string,
+  allowFrom: string[],
+): AuthorizationResult {
+  if (allowFrom.length === 0) {
+    return { allowed: true };
+  }
+  if (allowFrom.includes(stackId)) {
+    return { allowed: true };
+  }
+  return { allowed: false, reason: "not-allowlisted" };
+}
+
+/**
+ * Sanitize user input to prevent prompt injection attacks.
+ */
+export function sanitizeInput(text: string): string {
+  const dangerousPatterns = [
+    /ignore\s+(all\s+)?(previous|prior|above)\s+(instructions?|prompts?)/gi,
+    /you\s+are\s+now\s+/gi,
+    /system:\s*/gi,
+    /<\|.*?\|>/g,
+  ];
+
+  let sanitized = text;
+  for (const pattern of dangerousPatterns) {
+    sanitized = sanitized.replace(pattern, "[FILTERED]");
+  }
+
+  const maxLength = 4000;
+  if (sanitized.length > maxLength) {
+    sanitized = sanitized.slice(0, maxLength) + "... [truncated]";
+  }
+
+  return sanitized;
+}
+
+/**
+ * Fixed window rate limiter per key.
+ */
+export class RateLimiter {
+  private readonly limiter: FixedWindowRateLimiter;
+  private readonly limit: number;
+
+  constructor(limit = 60, windowSeconds = 60, maxTrackedKeys = 10_000) {
+    this.limit = limit;
+    this.limiter = createFixedWindowRateLimiter({
+      windowMs: Math.max(1, Math.floor(windowSeconds * 1000)),
+      maxRequests: Math.max(1, Math.floor(limit)),
+      maxTrackedKeys: Math.max(1, Math.floor(maxTrackedKeys)),
+    });
+  }
+
+  check(key: string): boolean {
+    return !this.limiter.isRateLimited(key);
+  }
+
+  size(): number {
+    return this.limiter.size();
+  }
+
+  clear(): void {
+    this.limiter.clear();
+  }
+
+  maxRequests(): number {
+    return this.limit;
+  }
+}

--- a/extensions/magicform/src/types.ts
+++ b/extensions/magicform/src/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Type definitions for the MagicForm channel plugin.
+ */
+
+/** Raw channel config from openclaw.json channels.magicform */
+export interface MagicFormChannelConfig {
+  enabled?: boolean;
+  backend_url?: string;
+  api_token?: string;
+  callback_path?: string;
+  webhookPath?: string;
+  dmPolicy?: "open" | "allowlist" | "disabled";
+  allow_from?: string[];
+  rateLimitPerMinute?: number;
+  accounts?: Record<string, MagicFormAccountRaw>;
+}
+
+/** Raw per-account config (overrides base config) */
+export interface MagicFormAccountRaw {
+  enabled?: boolean;
+  backend_url?: string;
+  api_token?: string;
+  callback_path?: string;
+  webhookPath?: string;
+  dmPolicy?: "open" | "allowlist" | "disabled";
+  allow_from?: string[];
+  rateLimitPerMinute?: number;
+}
+
+/** Fully resolved account config with defaults applied */
+export interface ResolvedMagicFormAccount {
+  accountId: string;
+  enabled: boolean;
+  backendUrl: string;
+  apiToken: string;
+  callbackPath: string;
+  webhookPath: string;
+  dmPolicy: "open" | "allowlist" | "disabled";
+  allowFrom: string[];
+  rateLimitPerMinute: number;
+}
+
+/** Inbound webhook payload (MagicForm → OpenClaw) */
+export interface MagicFormWebhookPayload {
+  message: string;
+  stack_id: string;
+  conversation_id: string;
+  user_id: string;
+  user_name?: string;
+  workspace?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/** Outbound callback payload (OpenClaw → MagicForm) */
+export interface MagicFormCallbackPayload {
+  stack_id: string;
+  conversation_id: string;
+  user_id: string;
+  response: string;
+  status: "success" | "error";
+  error?: string;
+  metadata?: Record<string, unknown>;
+}

--- a/extensions/magicform/src/types.ts
+++ b/extensions/magicform/src/types.ts
@@ -47,7 +47,16 @@ export interface MagicFormWebhookPayload {
   conversation_id: string;
   user_id: string;
   user_name?: string;
+  /** Workspace directory for agent-generated files (scoped by memory_scope). */
   workspace?: string;
+  /** Directory containing bootstrap .md config files (AGENTS.md, IDENTITY.md, SOUL.md, etc.). */
+  config_dir?: string;
+  /** Tool profile override (minimal | coding | messaging | full). */
+  tools_profile?: string;
+  /** Tool allowlist override. */
+  tools_allow?: string[];
+  /** Tool denylist override. */
+  tools_deny?: string[];
   metadata?: Record<string, unknown>;
 }
 

--- a/extensions/magicform/src/webhook-handler.ts
+++ b/extensions/magicform/src/webhook-handler.ts
@@ -1,0 +1,232 @@
+/**
+ * Inbound webhook handler for MagicForm.
+ * Parses JSON body, validates token, delivers to agent, sends callback.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  isRequestBodyLimitError,
+  readRequestBodyWithLimit,
+  requestBodyErrorToText,
+} from "openclaw/plugin-sdk/magicform";
+import { sendCallback } from "./client.js";
+import { validateToken, authorizeStackId, sanitizeInput, RateLimiter } from "./security.js";
+import type { ResolvedMagicFormAccount, MagicFormWebhookPayload } from "./types.js";
+
+const rateLimiters = new Map<string, RateLimiter>();
+
+function getRateLimiter(account: ResolvedMagicFormAccount): RateLimiter {
+  let rl = rateLimiters.get(account.accountId);
+  if (!rl || rl.maxRequests() !== account.rateLimitPerMinute) {
+    rl?.clear();
+    rl = new RateLimiter(account.rateLimitPerMinute);
+    rateLimiters.set(account.accountId, rl);
+  }
+  return rl;
+}
+
+export function clearMagicFormWebhookRateLimiterStateForTest(): void {
+  for (const limiter of rateLimiters.values()) {
+    limiter.clear();
+  }
+  rateLimiters.clear();
+}
+
+async function readBody(req: IncomingMessage): Promise<
+  | { ok: true; body: string }
+  | { ok: false; statusCode: number; error: string }
+> {
+  try {
+    const body = await readRequestBodyWithLimit(req, {
+      maxBytes: 1_048_576,
+      timeoutMs: 30_000,
+    });
+    return { ok: true, body };
+  } catch (err) {
+    if (isRequestBodyLimitError(err)) {
+      return {
+        ok: false,
+        statusCode: err.statusCode,
+        error: requestBodyErrorToText(err.code),
+      };
+    }
+    return { ok: false, statusCode: 400, error: "Invalid request body" };
+  }
+}
+
+function extractBearerToken(req: IncomingMessage): string | undefined {
+  const auth = req.headers.authorization;
+  if (!auth) return undefined;
+  const headerValue = Array.isArray(auth) ? auth[0] : auth;
+  const match = headerValue?.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim();
+}
+
+function parsePayload(body: string): MagicFormWebhookPayload | null {
+  const parsed = JSON.parse(body);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+
+  const message = typeof parsed.message === "string" ? parsed.message.trim() : "";
+  const stackId = typeof parsed.stack_id === "string" ? parsed.stack_id.trim() : "";
+  const conversationId = typeof parsed.conversation_id === "string" ? parsed.conversation_id.trim() : "";
+  const userId = typeof parsed.user_id === "string" ? parsed.user_id.trim() : "";
+
+  if (!message || !stackId || !conversationId || !userId) return null;
+
+  return {
+    message,
+    stack_id: stackId,
+    conversation_id: conversationId,
+    user_id: userId,
+    user_name: typeof parsed.user_name === "string" ? parsed.user_name.trim() : undefined,
+    workspace: typeof parsed.workspace === "string" ? parsed.workspace.trim() : undefined,
+    metadata: typeof parsed.metadata === "object" && parsed.metadata ? parsed.metadata : undefined,
+  };
+}
+
+function respondJson(res: ServerResponse, statusCode: number, body: Record<string, unknown>) {
+  res.writeHead(statusCode, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+export interface WebhookHandlerDeps {
+  account: ResolvedMagicFormAccount;
+  deliver: (msg: {
+    body: string;
+    from: string;
+    senderName: string;
+    provider: string;
+    chatType: string;
+    sessionKey: string;
+    accountId: string;
+  }) => Promise<string | null>;
+  log?: {
+    info: (...args: unknown[]) => void;
+    warn: (...args: unknown[]) => void;
+    error: (...args: unknown[]) => void;
+  };
+}
+
+/**
+ * Create an HTTP request handler for MagicForm inbound webhooks.
+ *
+ * This handler:
+ * 1. Parses JSON payload
+ * 2. Validates Bearer token
+ * 3. Checks stack_id against allow_from
+ * 4. Rate limits by stack_id:conversation_id
+ * 5. ACKs immediately (202)
+ * 6. Delivers to agent asynchronously
+ * 7. Sends response back to MagicForm callback
+ */
+export function createWebhookHandler(deps: WebhookHandlerDeps) {
+  const { account, deliver, log } = deps;
+  const rateLimiter = getRateLimiter(account);
+
+  return async (req: IncomingMessage, res: ServerResponse) => {
+    if (req.method !== "POST") {
+      respondJson(res, 405, { error: "Method not allowed" });
+      return;
+    }
+
+    const bodyResult = await readBody(req);
+    if (!bodyResult.ok) {
+      log?.error("Failed to read request body", bodyResult.error);
+      respondJson(res, bodyResult.statusCode, { error: bodyResult.error });
+      return;
+    }
+
+    // Validate Bearer token
+    const token = extractBearerToken(req);
+    if (!token || !validateToken(token, account.apiToken)) {
+      log?.warn(`Invalid token from ${req.socket?.remoteAddress}`);
+      respondJson(res, 401, { error: "Unauthorized" });
+      return;
+    }
+
+    // Parse payload
+    let payload: MagicFormWebhookPayload | null = null;
+    try {
+      payload = parsePayload(bodyResult.body);
+    } catch (err) {
+      log?.warn("Failed to parse webhook payload", err);
+      respondJson(res, 400, { error: "Invalid JSON body" });
+      return;
+    }
+    if (!payload) {
+      respondJson(res, 400, { error: "Missing required fields (message, stack_id, conversation_id, user_id)" });
+      return;
+    }
+
+    // Check stack_id against allow_from
+    const auth = authorizeStackId(payload.stack_id, account.allowFrom);
+    if (!auth.allowed) {
+      log?.warn(`Stack ${payload.stack_id} not in allow_from`);
+      respondJson(res, 403, { error: "Stack not authorized" });
+      return;
+    }
+
+    // Rate limit
+    const rateLimitKey = `${payload.stack_id}:${payload.conversation_id}`;
+    if (!rateLimiter.check(rateLimitKey)) {
+      log?.warn(`Rate limit exceeded for ${rateLimitKey}`);
+      respondJson(res, 429, { error: "Rate limit exceeded" });
+      return;
+    }
+
+    // Sanitize input
+    const cleanMessage = sanitizeInput(payload.message);
+    if (!cleanMessage) {
+      respondJson(res, 202, { ok: true });
+      return;
+    }
+
+    const preview = cleanMessage.length > 100 ? `${cleanMessage.slice(0, 100)}...` : cleanMessage;
+    log?.info(`Message from ${payload.user_name ?? payload.user_id} (stack: ${payload.stack_id}): ${preview}`);
+
+    // ACK immediately
+    respondJson(res, 202, { ok: true });
+
+    // Deliver to agent asynchronously.
+    // The dispatcher's deliver callback (in channel.ts) handles sending responses
+    // back to MagicForm via sendCallback. This handler only needs to handle errors.
+    const sessionKey = `magicform:${payload.stack_id}:${payload.conversation_id}`;
+    const toField = `${payload.stack_id}:${payload.conversation_id}:${payload.user_id}`;
+
+    try {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error("Agent response timeout (300s)")), 300_000);
+      });
+
+      try {
+        await Promise.race([
+          deliver({
+            body: cleanMessage,
+            from: toField,
+            senderName: payload.user_name ?? payload.user_id,
+            provider: "magicform",
+            chatType: "direct",
+            sessionKey,
+            accountId: account.accountId,
+          }),
+          timeoutPromise,
+        ]);
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      log?.error(`Failed to process message for ${payload.conversation_id}: ${errMsg}`);
+      await sendCallback(account.backendUrl, account.callbackPath, {
+        stack_id: payload.stack_id,
+        conversation_id: payload.conversation_id,
+        user_id: payload.user_id,
+        response: "",
+        status: "error",
+        error: errMsg,
+        metadata: payload.metadata,
+      }, account.apiToken);
+    }
+  };
+}

--- a/extensions/magicform/src/webhook-handler.ts
+++ b/extensions/magicform/src/webhook-handler.ts
@@ -80,6 +80,14 @@ function parsePayload(body: string): MagicFormWebhookPayload | null {
     user_id: userId,
     user_name: typeof parsed.user_name === "string" ? parsed.user_name.trim() : undefined,
     workspace: typeof parsed.workspace === "string" ? parsed.workspace.trim() : undefined,
+    config_dir: typeof parsed.config_dir === "string" ? parsed.config_dir.trim() : undefined,
+    tools_profile: typeof parsed.tools_profile === "string" ? parsed.tools_profile.trim() : undefined,
+    tools_allow: Array.isArray(parsed.tools_allow)
+      ? parsed.tools_allow.filter((s: unknown): s is string => typeof s === "string")
+      : undefined,
+    tools_deny: Array.isArray(parsed.tools_deny)
+      ? parsed.tools_deny.filter((s: unknown): s is string => typeof s === "string")
+      : undefined,
     metadata: typeof parsed.metadata === "object" && parsed.metadata ? parsed.metadata : undefined,
   };
 }
@@ -99,6 +107,12 @@ export interface WebhookHandlerDeps {
     chatType: string;
     sessionKey: string;
     accountId: string;
+    /** Per-request overrides from webhook payload. */
+    workspaceOverride?: string;
+    configDirOverride?: string;
+    toolsProfileOverride?: string;
+    toolsAllowOverride?: string[];
+    toolsDenyOverride?: string[];
   }) => Promise<string | null>;
   log?: {
     info: (...args: unknown[]) => void;
@@ -209,6 +223,11 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
             chatType: "direct",
             sessionKey,
             accountId: account.accountId,
+            workspaceOverride: payload.workspace,
+            configDirOverride: payload.config_dir,
+            toolsProfileOverride: payload.tools_profile,
+            toolsAllowOverride: payload.tools_allow,
+            toolsDenyOverride: payload.tools_deny,
           }),
           timeoutPromise,
         ]);

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -81,6 +81,8 @@ const requiredPathGroups = [
   "dist/plugin-sdk/qwen-portal-auth.d.ts",
   "dist/plugin-sdk/synology-chat.js",
   "dist/plugin-sdk/synology-chat.d.ts",
+  "dist/plugin-sdk/magicform.js",
+  "dist/plugin-sdk/magicform.d.ts",
   "dist/plugin-sdk/talk-voice.js",
   "dist/plugin-sdk/talk-voice.d.ts",
   "dist/plugin-sdk/test-utils.js",

--- a/scripts/write-plugin-sdk-entry-dts.ts
+++ b/scripts/write-plugin-sdk-entry-dts.ts
@@ -41,6 +41,7 @@ const entrypoints = [
   "phone-control",
   "qwen-portal-auth",
   "synology-chat",
+  "magicform",
   "talk-voice",
   "test-utils",
   "thread-ownership",

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1,3 +1,5 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
@@ -11,6 +13,7 @@ import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
 import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
 import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import { resolveCommandAuthorization } from "../command-auth.js";
 import type { MsgContext } from "../templating.js";
@@ -101,12 +104,91 @@ export async function getReplyFromConfig(
     }
   }
 
-  const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, agentId) ?? DEFAULT_AGENT_WORKSPACE_DIR;
+  // Apply channel/webhook overrides for workspace, config-dir, and tool policy.
+  // These mirror the CLI override logic in agentCommandInternal (commands/agent.ts).
+  const workspaceBaseDir = cfg.agents?.defaults?.workspaceBaseDir?.trim();
+
+  const workspaceDirRaw = opts?.workspaceOverride?.trim()
+    || resolveAgentWorkspaceDir(cfg, agentId)
+    || DEFAULT_AGENT_WORKSPACE_DIR;
+
+  if (opts?.workspaceOverride?.trim() && workspaceBaseDir) {
+    const resolved = path.resolve(opts.workspaceOverride.trim());
+    const base = path.resolve(workspaceBaseDir);
+    if (!resolved.startsWith(base + path.sep) && resolved !== base) {
+      throw new Error(
+        `workspace override must be under workspaceBaseDir (${base}), got: ${resolved}`,
+      );
+    }
+  }
+
   const workspace = await ensureAgentWorkspace({
     dir: workspaceDirRaw,
     ensureBootstrapFiles: !agentCfg?.skipBootstrap && !isFastTestEnv,
   });
   const workspaceDir = workspace.dir;
+
+  // Copy bootstrap .md files from configDirOverride into workspace
+  if (opts?.configDirOverride) {
+    const configDir = path.resolve(opts.configDirOverride.trim());
+
+    if (workspaceBaseDir) {
+      const base = path.resolve(workspaceBaseDir);
+      if (!configDir.startsWith(base + path.sep) && configDir !== base) {
+        throw new Error(
+          `config-dir override must be under workspaceBaseDir (${base}), got: ${configDir}`,
+        );
+      }
+    }
+
+    try {
+      await fs.access(configDir);
+    } catch {
+      defaultRuntime.error?.(`config-dir path does not exist: ${configDir}`);
+    }
+    const bootstrapFileNames = [
+      "AGENTS.md", "IDENTITY.md", "SOUL.md", "TOOLS.md",
+      "USER.md", "HEARTBEAT.md", "BOOTSTRAP.md",
+    ];
+    for (const filename of bootstrapFileNames) {
+      const srcPath = path.join(configDir, filename);
+      try {
+        const content = await fs.readFile(srcPath, "utf-8");
+        await fs.writeFile(path.join(workspaceDir, filename), content, "utf-8");
+      } catch (err: any) {
+        if (err.code !== "ENOENT") throw err;
+      }
+    }
+  }
+
+  // Apply tool policy overrides
+  const VALID_TOOL_PROFILES = ["minimal", "coding", "messaging", "full"];
+  if (opts?.toolsProfileOverride && !VALID_TOOL_PROFILES.includes(opts.toolsProfileOverride)) {
+    throw new Error(
+      `Invalid tools-profile "${opts.toolsProfileOverride}". Use one of: ${VALID_TOOL_PROFILES.join(", ")}`,
+    );
+  }
+  if (opts?.toolsProfileOverride || opts?.toolsAllowOverride || opts?.toolsDenyOverride) {
+    const agentEntry = cfg.agents?.list?.find(
+      (a: any) => normalizeAgentId(a.id) === agentId,
+    );
+    const toolsOverride: Record<string, unknown> = { ...(agentEntry?.tools ?? {}) };
+    if (opts.toolsProfileOverride) toolsOverride.profile = opts.toolsProfileOverride;
+    if (opts.toolsAllowOverride) toolsOverride.allow = opts.toolsAllowOverride;
+    if (opts.toolsDenyOverride) toolsOverride.deny = opts.toolsDenyOverride;
+
+    if (agentEntry) {
+      agentEntry.tools = toolsOverride as any;
+    } else {
+      cfg.agents = cfg.agents ?? {};
+      cfg.agents.list = cfg.agents.list ?? [];
+      cfg.agents.list.push({
+        id: agentId,
+        tools: toolsOverride,
+      } as any);
+    }
+  }
+
   const agentDir = resolveAgentDir(cfg, agentId);
   const timeoutMs = resolveAgentTimeoutMs({ cfg, overrideSeconds: opts?.timeoutOverrideSeconds });
   const configuredTypingSeconds =

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -10,7 +10,9 @@ import { resolveModelRefFromString } from "../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
-import { type OpenClawConfig, loadConfig } from "../../config/config.js";
+import { type OpenClawConfig, loadConfig, parseConfigJson5 } from "../../config/config.js";
+import { MissingEnvVarError, resolveConfigEnvVars } from "../../config/env-substitution.js";
+import { applyMergePatch } from "../../config/merge-patch.js";
 import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
 import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
@@ -158,6 +160,30 @@ export async function getReplyFromConfig(
       } catch (err: any) {
         if (err.code !== "ENOENT") throw err;
       }
+    }
+
+    // Load and merge per-stack openclaw.json overlay from config directory.
+    const overlayPath = path.join(configDir, "openclaw.json");
+    try {
+      const overlayRaw = await fs.readFile(overlayPath, "utf-8");
+      const parseResult = parseConfigJson5(overlayRaw);
+      if (
+        parseResult.ok &&
+        parseResult.parsed &&
+        typeof parseResult.parsed === "object" &&
+        !Array.isArray(parseResult.parsed)
+      ) {
+        const resolved = resolveConfigEnvVars(parseResult.parsed);
+        const merged = applyMergePatch(cfg, resolved, { mergeObjectArraysById: true });
+        Object.assign(cfg, merged);
+      } else if (!parseResult.ok) {
+        defaultRuntime.error?.(`Failed to parse ${overlayPath}: ${parseResult.error}`);
+      }
+    } catch (err: any) {
+      if (err instanceof MissingEnvVarError) {
+        throw new Error(`Config overlay ${overlayPath}: ${err.message}`);
+      }
+      if (err.code !== "ENOENT") throw err;
     }
   }
 

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -65,6 +65,45 @@ export async function getReplyFromConfig(
 ): Promise<ReplyPayload | ReplyPayload[] | undefined> {
   const isFastTestEnv = process.env.OPENCLAW_TEST_FAST === "1";
   const cfg = configOverride ?? loadConfig();
+
+  // Load and merge per-stack openclaw.json overlay from config directory early,
+  // before model/agent/timeout resolution so the overlay can influence all of them.
+  // The workspaceBaseDir security boundary comes from the base config (not the overlay).
+  if (opts?.configDirOverride) {
+    const configDir = path.resolve(opts.configDirOverride.trim());
+    const workspaceBaseDirForValidation = cfg.agents?.defaults?.workspaceBaseDir?.trim();
+    if (workspaceBaseDirForValidation) {
+      const base = path.resolve(workspaceBaseDirForValidation);
+      if (!configDir.startsWith(base + path.sep) && configDir !== base) {
+        throw new Error(
+          `config-dir override must be under workspaceBaseDir (${base}), got: ${configDir}`,
+        );
+      }
+    }
+    const overlayPath = path.join(configDir, "openclaw.json");
+    try {
+      const overlayRaw = await fs.readFile(overlayPath, "utf-8");
+      const parseResult = parseConfigJson5(overlayRaw);
+      if (
+        parseResult.ok &&
+        parseResult.parsed &&
+        typeof parseResult.parsed === "object" &&
+        !Array.isArray(parseResult.parsed)
+      ) {
+        const resolved = resolveConfigEnvVars(parseResult.parsed);
+        const merged = applyMergePatch(cfg, resolved, { mergeObjectArraysById: true });
+        Object.assign(cfg, merged);
+      } else if (!parseResult.ok) {
+        defaultRuntime.error?.(`Failed to parse ${overlayPath}: ${parseResult.error}`);
+      }
+    } catch (err: any) {
+      if (err instanceof MissingEnvVarError) {
+        throw new Error(`Config overlay ${overlayPath}: ${err.message}`);
+      }
+      if (err.code !== "ENOENT") throw err;
+    }
+  }
+
   const targetSessionKey =
     ctx.CommandSource === "native" ? ctx.CommandTargetSessionKey?.trim() : undefined;
   const agentSessionKey = targetSessionKey || ctx.SessionKey;
@@ -130,18 +169,10 @@ export async function getReplyFromConfig(
   });
   const workspaceDir = workspace.dir;
 
-  // Copy bootstrap .md files from configDirOverride into workspace
+  // Copy bootstrap .md files from configDirOverride into workspace.
+  // Note: workspaceBaseDir boundary was already validated in the early overlay block above.
   if (opts?.configDirOverride) {
     const configDir = path.resolve(opts.configDirOverride.trim());
-
-    if (workspaceBaseDir) {
-      const base = path.resolve(workspaceBaseDir);
-      if (!configDir.startsWith(base + path.sep) && configDir !== base) {
-        throw new Error(
-          `config-dir override must be under workspaceBaseDir (${base}), got: ${configDir}`,
-        );
-      }
-    }
 
     try {
       await fs.access(configDir);
@@ -160,30 +191,6 @@ export async function getReplyFromConfig(
       } catch (err: any) {
         if (err.code !== "ENOENT") throw err;
       }
-    }
-
-    // Load and merge per-stack openclaw.json overlay from config directory.
-    const overlayPath = path.join(configDir, "openclaw.json");
-    try {
-      const overlayRaw = await fs.readFile(overlayPath, "utf-8");
-      const parseResult = parseConfigJson5(overlayRaw);
-      if (
-        parseResult.ok &&
-        parseResult.parsed &&
-        typeof parseResult.parsed === "object" &&
-        !Array.isArray(parseResult.parsed)
-      ) {
-        const resolved = resolveConfigEnvVars(parseResult.parsed);
-        const merged = applyMergePatch(cfg, resolved, { mergeObjectArraysById: true });
-        Object.assign(cfg, merged);
-      } else if (!parseResult.ok) {
-        defaultRuntime.error?.(`Failed to parse ${overlayPath}: ${parseResult.error}`);
-      }
-    } catch (err: any) {
-      if (err instanceof MissingEnvVarError) {
-        throw new Error(`Config overlay ${overlayPath}: ${err.message}`);
-      }
-      if (err.code !== "ENOENT") throw err;
     }
   }
 

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -66,6 +66,16 @@ export type GetReplyOptions = {
   hasRepliedRef?: { value: boolean };
   /** Override agent timeout in seconds (0 = no timeout). Threads through to resolveAgentTimeoutMs. */
   timeoutOverrideSeconds?: number;
+  /** Override workspace directory for this invocation (channel webhook use case). */
+  workspaceOverride?: string;
+  /** Directory containing bootstrap .md config files to copy into workspace. */
+  configDirOverride?: string;
+  /** Tool profile override (minimal | coding | messaging | full). */
+  toolsProfileOverride?: string;
+  /** Tool allowlist override. */
+  toolsAllowOverride?: string[];
+  /** Tool denylist override. */
+  toolsDenyOverride?: string[];
 };
 
 export type ReplyPayload = {

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -47,6 +47,14 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
       "--timeout <seconds>",
       "Override agent command timeout (seconds, default 600 or config value)",
     )
+    .option("--workspace <dir>", "Override agent workspace directory (agent-generated files)")
+    .option(
+      "--config-dir <dir>",
+      "Directory containing bootstrap .md files (AGENTS.md, IDENTITY.md, SOUL.md, etc.)",
+    )
+    .option("--tools-profile <profile>", "Tool profile: minimal | coding | messaging | full")
+    .option("--tools-allow <tools>", "Comma-separated tool allowlist (overrides profile)")
+    .option("--tools-deny <tools>", "Comma-separated tool denylist")
     .addHelpText(
       "after",
       () =>

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -51,6 +51,11 @@ export type AgentCliOpts = {
   runId?: string;
   extraSystemPrompt?: string;
   local?: boolean;
+  workspace?: string;
+  configDir?: string;
+  toolsProfile?: string;
+  toolsAllow?: string;
+  toolsDeny?: string;
 };
 
 function parseTimeoutSeconds(opts: { cfg: ReturnType<typeof loadConfig>; timeout?: string }) {
@@ -146,6 +151,11 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
           lane: opts.lane,
           extraSystemPrompt: opts.extraSystemPrompt,
           idempotencyKey,
+          workspace: opts.workspace,
+          configDir: opts.configDir,
+          toolsProfile: opts.toolsProfile,
+          toolsAllow: opts.toolsAllow?.split(",").map((s) => s.trim()).filter(Boolean),
+          toolsDeny: opts.toolsDeny?.split(",").map((s) => s.trim()).filter(Boolean),
         },
         expectFinal: true,
         timeoutMs: gatewayTimeoutMs,
@@ -182,6 +192,11 @@ export async function agentCliCommand(opts: AgentCliOpts, runtime: RuntimeEnv, d
     ...opts,
     agentId: opts.agent,
     replyAccountId: opts.replyAccount,
+    workspaceOverride: opts.workspace,
+    configDirOverride: opts.configDir,
+    toolsProfileOverride: opts.toolsProfile,
+    toolsAllowOverride: opts.toolsAllow?.split(",").map((s) => s.trim()).filter(Boolean),
+    toolsDenyOverride: opts.toolsDeny?.split(",").map((s) => s.trim()).filter(Boolean),
   };
   if (opts.local === true) {
     return await agentCommand(localOpts, runtime, deps);

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -53,7 +53,9 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { resolveCommandSecretRefsViaGateway } from "../cli/command-secret-gateway.js";
 import { getAgentRuntimeCommandSecretTargetIds } from "../cli/command-secret-targets.js";
 import { type CliDeps, createDefaultDeps } from "../cli/deps.js";
-import { loadConfig } from "../config/config.js";
+import { loadConfig, parseConfigJson5 } from "../config/config.js";
+import { MissingEnvVarError, resolveConfigEnvVars } from "../config/env-substitution.js";
+import { applyMergePatch } from "../config/merge-patch.js";
 import {
   mergeSessionEntry,
   parseSessionThreadInfo,
@@ -507,6 +509,30 @@ async function agentCommandInternal(
     }
     if (copiedCount === 0) {
       log.warn(`--config-dir ${configDir} contains no bootstrap .md files`);
+    }
+
+    // Load and merge per-stack openclaw.json overlay from config directory.
+    const overlayPath = path.join(configDir, "openclaw.json");
+    try {
+      const overlayRaw = await fs.readFile(overlayPath, "utf-8");
+      const parseResult = parseConfigJson5(overlayRaw);
+      if (
+        parseResult.ok &&
+        parseResult.parsed &&
+        typeof parseResult.parsed === "object" &&
+        !Array.isArray(parseResult.parsed)
+      ) {
+        const resolved = resolveConfigEnvVars(parseResult.parsed);
+        const merged = applyMergePatch(cfg, resolved, { mergeObjectArraysById: true });
+        Object.assign(cfg, merged);
+      } else if (!parseResult.ok) {
+        log.error(`Failed to parse ${overlayPath}: ${parseResult.error}`);
+      }
+    } catch (err: any) {
+      if (err instanceof MissingEnvVarError) {
+        throw new Error(`Config overlay ${overlayPath}: ${err.message}`);
+      }
+      if (err.code !== "ENOENT") throw err;
     }
   }
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -359,6 +359,45 @@ async function agentCommandInternal(
   for (const entry of diagnostics) {
     runtime.log(`[secrets] ${entry}`);
   }
+
+  // Load and merge per-stack openclaw.json overlay from --config-dir early,
+  // before model/agent/timeout resolution so the overlay can influence all of them.
+  // The workspaceBaseDir security boundary comes from the base config (not the overlay).
+  if (opts.configDirOverride) {
+    const configDir = path.resolve(opts.configDirOverride.trim());
+    const workspaceBaseDirForValidation = cfg.agents?.defaults?.workspaceBaseDir?.trim();
+    if (workspaceBaseDirForValidation) {
+      const base = path.resolve(workspaceBaseDirForValidation);
+      if (!configDir.startsWith(base + path.sep) && configDir !== base) {
+        throw new Error(
+          `--config-dir must be under workspaceBaseDir (${base}), got: ${configDir}`,
+        );
+      }
+    }
+    const overlayPath = path.join(configDir, "openclaw.json");
+    try {
+      const overlayRaw = await fs.readFile(overlayPath, "utf-8");
+      const parseResult = parseConfigJson5(overlayRaw);
+      if (
+        parseResult.ok &&
+        parseResult.parsed &&
+        typeof parseResult.parsed === "object" &&
+        !Array.isArray(parseResult.parsed)
+      ) {
+        const resolved = resolveConfigEnvVars(parseResult.parsed);
+        const merged = applyMergePatch(cfg, resolved, { mergeObjectArraysById: true });
+        Object.assign(cfg, merged);
+      } else if (!parseResult.ok) {
+        log.error(`Failed to parse ${overlayPath}: ${parseResult.error}`);
+      }
+    } catch (err: any) {
+      if (err instanceof MissingEnvVarError) {
+        throw new Error(`Config overlay ${overlayPath}: ${err.message}`);
+      }
+      if (err.code !== "ENOENT") throw err;
+    }
+  }
+
   const agentIdOverrideRaw = opts.agentId?.trim();
   const agentIdOverride = agentIdOverrideRaw ? normalizeAgentId(agentIdOverrideRaw) : undefined;
   if (agentIdOverride) {
@@ -474,18 +513,10 @@ async function agentCommandInternal(
   });
   const workspaceDir = workspace.dir;
 
-  // Copy bootstrap .md files from --config-dir into workspace (overwriting defaults)
+  // Copy bootstrap .md files from --config-dir into workspace (overwriting defaults).
+  // Note: workspaceBaseDir boundary was already validated in the early overlay block above.
   if (opts.configDirOverride) {
     const configDir = path.resolve(opts.configDirOverride.trim());
-
-    if (workspaceBaseDir) {
-      const base = path.resolve(workspaceBaseDir);
-      if (!configDir.startsWith(base + path.sep) && configDir !== base) {
-        throw new Error(
-          `--config-dir must be under workspaceBaseDir (${base}), got: ${configDir}`,
-        );
-      }
-    }
 
     try {
       await fs.access(configDir);
@@ -511,29 +542,6 @@ async function agentCommandInternal(
       log.warn(`--config-dir ${configDir} contains no bootstrap .md files`);
     }
 
-    // Load and merge per-stack openclaw.json overlay from config directory.
-    const overlayPath = path.join(configDir, "openclaw.json");
-    try {
-      const overlayRaw = await fs.readFile(overlayPath, "utf-8");
-      const parseResult = parseConfigJson5(overlayRaw);
-      if (
-        parseResult.ok &&
-        parseResult.parsed &&
-        typeof parseResult.parsed === "object" &&
-        !Array.isArray(parseResult.parsed)
-      ) {
-        const resolved = resolveConfigEnvVars(parseResult.parsed);
-        const merged = applyMergePatch(cfg, resolved, { mergeObjectArraysById: true });
-        Object.assign(cfg, merged);
-      } else if (!parseResult.ok) {
-        log.error(`Failed to parse ${overlayPath}: ${parseResult.error}`);
-      }
-    } catch (err: any) {
-      if (err instanceof MissingEnvVarError) {
-        throw new Error(`Config overlay ${overlayPath}: ${err.message}`);
-      }
-      if (err.code !== "ENOENT") throw err;
-    }
   }
 
   // Apply --tools-* overrides to config

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -1,3 +1,5 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import { getAcpSessionManager } from "../acp/control-plane/manager.js";
 import { resolveAcpAgentPolicyError, resolveAcpDispatchPolicyError } from "../acp/policy.js";
 import { toAcpRuntimeError } from "../acp/runtime/errors.js";
@@ -443,13 +445,99 @@ async function agentCommandInternal(
     agentId: sessionAgentId,
     sessionKey,
   });
-  const workspaceDirRaw = resolveAgentWorkspaceDir(cfg, sessionAgentId);
+  // agents.defaults.workspaceBaseDir — optional security boundary for all CLI path
+  // overrides (--workspace, --config-dir). When set, both must resolve under this
+  // directory. Recommended for deployments where paths arrive via RPC (e.g. MagicForm
+  // channel plugin). Example: "workspaceBaseDir": "/data"
+  const workspaceBaseDir = cfg.agents?.defaults?.workspaceBaseDir?.trim();
+
+  const workspaceDirRaw = opts.workspaceOverride?.trim()
+    || resolveAgentWorkspaceDir(cfg, sessionAgentId);
+
+  // When workspaceBaseDir is configured, --workspace and --config-dir must resolve under it
+  if (opts.workspaceOverride?.trim() && workspaceBaseDir) {
+    const resolved = path.resolve(opts.workspaceOverride.trim());
+    const base = path.resolve(workspaceBaseDir);
+    if (!resolved.startsWith(base + path.sep) && resolved !== base) {
+      throw new Error(
+        `--workspace must be under workspaceBaseDir (${base}), got: ${resolved}`,
+      );
+    }
+  }
+
   const agentDir = resolveAgentDir(cfg, sessionAgentId);
   const workspace = await ensureAgentWorkspace({
     dir: workspaceDirRaw,
     ensureBootstrapFiles: !agentCfg?.skipBootstrap,
   });
   const workspaceDir = workspace.dir;
+
+  // Copy bootstrap .md files from --config-dir into workspace (overwriting defaults)
+  if (opts.configDirOverride) {
+    const configDir = path.resolve(opts.configDirOverride.trim());
+
+    if (workspaceBaseDir) {
+      const base = path.resolve(workspaceBaseDir);
+      if (!configDir.startsWith(base + path.sep) && configDir !== base) {
+        throw new Error(
+          `--config-dir must be under workspaceBaseDir (${base}), got: ${configDir}`,
+        );
+      }
+    }
+
+    try {
+      await fs.access(configDir);
+    } catch {
+      throw new Error(`--config-dir path does not exist: ${configDir}`);
+    }
+    const bootstrapFileNames = [
+      "AGENTS.md", "IDENTITY.md", "SOUL.md", "TOOLS.md",
+      "USER.md", "HEARTBEAT.md", "BOOTSTRAP.md",
+    ];
+    let copiedCount = 0;
+    for (const filename of bootstrapFileNames) {
+      const srcPath = path.join(configDir, filename);
+      try {
+        const content = await fs.readFile(srcPath, "utf-8");
+        await fs.writeFile(path.join(workspaceDir, filename), content, "utf-8");
+        copiedCount++;
+      } catch (err: any) {
+        if (err.code !== "ENOENT") throw err;
+      }
+    }
+    if (copiedCount === 0) {
+      log.warn(`--config-dir ${configDir} contains no bootstrap .md files`);
+    }
+  }
+
+  // Apply --tools-* overrides to config
+  const VALID_TOOL_PROFILES = ["minimal", "coding", "messaging", "full"];
+  if (opts.toolsProfileOverride && !VALID_TOOL_PROFILES.includes(opts.toolsProfileOverride)) {
+    throw new Error(
+      `Invalid --tools-profile "${opts.toolsProfileOverride}". Use one of: ${VALID_TOOL_PROFILES.join(", ")}`,
+    );
+  }
+
+  if (opts.toolsProfileOverride || opts.toolsAllowOverride || opts.toolsDenyOverride) {
+    const agentEntry = cfg.agents?.list?.find(
+      (a: any) => normalizeAgentId(a.id) === sessionAgentId,
+    );
+    const toolsOverride: Record<string, unknown> = { ...(agentEntry?.tools ?? {}) };
+    if (opts.toolsProfileOverride) toolsOverride.profile = opts.toolsProfileOverride;
+    if (opts.toolsAllowOverride) toolsOverride.allow = opts.toolsAllowOverride;
+    if (opts.toolsDenyOverride) toolsOverride.deny = opts.toolsDenyOverride;
+
+    if (agentEntry) {
+      agentEntry.tools = toolsOverride as any;
+    } else {
+      cfg.agents = cfg.agents ?? {};
+      cfg.agents.list = cfg.agents.list ?? [];
+      cfg.agents.list.push({
+        id: sessionAgentId,
+        tools: toolsOverride,
+      } as any);
+    }
+  }
   let sessionEntry = resolvedSessionEntry;
   const runId = opts.runId?.trim() || sessionId;
   const acpManager = getAcpSessionManager();

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -80,6 +80,16 @@ export type AgentCommandOpts = {
   inputProvenance?: InputProvenance;
   /** Per-call stream param overrides (best-effort). */
   streamParams?: AgentStreamParams;
+  /** Override workspace directory for this invocation. */
+  workspaceOverride?: string;
+  /** Directory containing bootstrap .md config files (AGENTS.md, IDENTITY.md, SOUL.md, etc.). */
+  configDirOverride?: string;
+  /** Tool profile override. */
+  toolsProfileOverride?: string;
+  /** Tool allowlist override. */
+  toolsAllowOverride?: string[];
+  /** Tool denylist override. */
+  toolsDenyOverride?: string[];
 };
 
 export type AgentCommandIngressOpts = Omit<AgentCommandOpts, "senderIsOwner"> & {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -132,6 +132,13 @@ export type AgentDefaultsConfig = {
   models?: Record<string, AgentModelEntryConfig>;
   /** Agent working directory (preferred). Used as the default cwd for agent runs. */
   workspace?: string;
+  /**
+   * Optional security boundary for CLI path overrides (--workspace, --config-dir).
+   * When set, both must resolve under this directory. Recommended for deployments
+   * where paths arrive via RPC (e.g. MagicForm channel plugin).
+   * Example: "/data"
+   */
+  workspaceBaseDir?: string;
   /** Optional repository root for system prompt runtime line (overrides auto-detect). */
   repoRoot?: string;
   /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -110,6 +110,11 @@ export const AgentParamsSchema = Type.Object(
     idempotencyKey: NonEmptyString,
     label: Type.Optional(SessionLabelString),
     spawnedBy: Type.Optional(Type.String()),
+    workspace: Type.Optional(Type.String()),
+    configDir: Type.Optional(Type.String()),
+    toolsProfile: Type.Optional(Type.String()),
+    toolsAllow: Type.Optional(Type.Array(Type.String())),
+    toolsDeny: Type.Optional(Type.Array(Type.String())),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -211,6 +211,11 @@ export const agentHandlers: GatewayRequestHandlers = {
       label?: string;
       spawnedBy?: string;
       inputProvenance?: InputProvenance;
+      workspace?: string;
+      configDir?: string;
+      toolsProfile?: string;
+      toolsAllow?: string[];
+      toolsDeny?: string[];
     };
     const senderIsOwner = resolveSenderIsOwnerFromClient(client);
     const cfg = loadConfig();
@@ -646,6 +651,11 @@ export const agentHandlers: GatewayRequestHandlers = {
         internalEvents: request.internalEvents,
         inputProvenance,
         senderIsOwner,
+        workspaceOverride: request.workspace?.trim() || undefined,
+        configDirOverride: request.configDir?.trim() || undefined,
+        toolsProfileOverride: request.toolsProfile?.trim() || undefined,
+        toolsAllowOverride: request.toolsAllow,
+        toolsDenyOverride: request.toolsDeny,
       },
       defaultRuntime,
       context.deps,

--- a/src/plugin-sdk/magicform.ts
+++ b/src/plugin-sdk/magicform.ts
@@ -1,0 +1,17 @@
+// Narrow plugin-sdk surface for the bundled magicform plugin.
+// Keep this list additive and scoped to symbols used under extensions/magicform.
+
+export { setAccountEnabledInConfigSection } from "../channels/plugins/config-helpers.js";
+export { buildChannelConfigSchema } from "../channels/plugins/config-schema.js";
+export {
+  isRequestBodyLimitError,
+  readRequestBodyWithLimit,
+  requestBodyErrorToText,
+} from "../infra/http-body.js";
+export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
+export { registerPluginHttpRoute } from "../plugins/http-registry.js";
+export type { PluginRuntime } from "../plugins/runtime/types.js";
+export type { OpenClawPluginApi } from "../plugins/types.js";
+export { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
+export type { FixedWindowRateLimiter } from "./webhook-memory-guards.js";
+export { createFixedWindowRateLimiter } from "./webhook-memory-guards.js";

--- a/src/plugin-sdk/subpaths.test.ts
+++ b/src/plugin-sdk/subpaths.test.ts
@@ -39,6 +39,7 @@ const bundledExtensionSubpathLoaders = [
   { id: "phone-control", load: () => import("openclaw/plugin-sdk/phone-control") },
   { id: "qwen-portal-auth", load: () => import("openclaw/plugin-sdk/qwen-portal-auth") },
   { id: "synology-chat", load: () => import("openclaw/plugin-sdk/synology-chat") },
+  { id: "magicform", load: () => import("openclaw/plugin-sdk/magicform") },
   { id: "talk-voice", load: () => import("openclaw/plugin-sdk/talk-voice") },
   { id: "test-utils", load: () => import("openclaw/plugin-sdk/test-utils") },
   { id: "thread-ownership", load: () => import("openclaw/plugin-sdk/thread-ownership") },

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -159,6 +159,7 @@ const pluginSdkScopedAliasEntries = [
     srcFile: "synology-chat.ts",
     distFile: "synology-chat.js",
   },
+  { subpath: "magicform", srcFile: "magicform.ts", distFile: "magicform.js" },
   { subpath: "talk-voice", srcFile: "talk-voice.ts", distFile: "talk-voice.js" },
   { subpath: "test-utils", srcFile: "test-utils.ts", distFile: "test-utils.js" },
   {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -39,6 +39,7 @@ const pluginSdkEntrypoints = [
   "phone-control",
   "qwen-portal-auth",
   "synology-chat",
+  "magicform",
   "talk-voice",
   "test-utils",
   "thread-ownership",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,6 +43,7 @@ const pluginSdkSubpaths = [
   "phone-control",
   "qwen-portal-auth",
   "synology-chat",
+  "magicform",
   "talk-voice",
   "test-utils",
   "thread-ownership",


### PR DESCRIPTION
## Summary

- **CLI flags**: Add `--workspace`, `--config-dir`, `--tools-profile/allow/deny` flags to the `agent` command
- **MagicForm channel plugin**: New channel plugin for MagicForm integration (accounts, webhook handler, security, client)
- **Config overlays**: Wire workspace/config-dir/tools overrides through webhook dispatcher; support loading and merging `openclaw.json` overlays from config directory
- **Fix**: Load config-dir overlay before model/agent resolution to ensure overrides take effect

## Commits
- `47786617a` feat(agent): add --workspace, --config-dir, --tools-profile/allow/deny CLI flags
- `f03d7fda7` feat(channel): add MagicForm channel plugin
- `444c3f3f2` feat(channel): wire workspace/config-dir/tools overrides through webhook dispatcher
- `e33ff1dc3` feat(config): add support for loading and merging openclaw.json overlays from config directory
- `6b8918342` fix(config): load config-dir overlay before model/agent resolution

## Test plan
- [ ] Verify CLI flags parse correctly with `openclaw agent --workspace ./test --config-dir ./conf`
- [ ] Test MagicForm webhook handler receives and processes events
- [ ] Confirm config-dir overlays merge correctly and override defaults
- [ ] Run existing test suite to check for regressions