### PR TITLE
fix(discord): absorb reconnect stall timeout to prevent full gateway restart

### DIFF
--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -371,7 +371,7 @@ describe("runDiscordGatewayLifecycle", () => {
       emitter.emit("debug", "WebSocket connection closed with code 1006");
 
       await vi.advanceTimersByTimeAsync(5 * 60_000 + 1_000);
-      await expect(lifecyclePromise).rejects.toThrow("reconnect watchdog timeout");
+      await expect(lifecyclePromise).resolves.toBeUndefined();
     } finally {
       vi.useRealTimers();
     }

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -67,8 +67,9 @@ export async function runDiscordGatewayLifecycle(params: {
         return;
       }
       const at = Date.now();
-      const error = new Error(
-        `discord reconnect watchdog timeout after ${RECONNECT_STALL_TIMEOUT_MS}ms`,
+      const error = Object.assign(
+        new Error(`discord reconnect watchdog timeout after ${RECONNECT_STALL_TIMEOUT_MS}ms`),
+        { __reconnectStallTimeout: true },
       );
       pushStatus({
         connected: false,
@@ -323,7 +324,12 @@ export async function runDiscordGatewayLifecycle(params: {
       },
     });
   } catch (err) {
-    if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {
+    const isReconnectStall =
+      err instanceof Error &&
+      (err as { __reconnectStallTimeout?: boolean }).__reconnectStallTimeout;
+    if (isReconnectStall) {
+      params.runtime.log?.(`discord: reconnect stall resolved; channel will auto-restart`);
+    } else if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {
       throw err;
     }
   } finally {


### PR DESCRIPTION
## Summary

Prevents the Discord reconnect stall watchdog timeout from propagating as an unrecoverable error that triggers a full gateway restart, confining the failure to the Discord channel's auto-restart cycle.

## Problem

When a Discord WebSocket connection closes (code 1006, network interruption), the reconnect stall watchdog starts a 5-minute timer. If reconnection doesn't complete in time, `triggerForceStop` is called, which rejects the `waitForDiscordGatewayStop` promise. The rejection propagates through `runDiscordGatewayLifecycle` and re-throws at the catch block (since it's not a disallowed-intents error). This error propagates out of `monitorDiscordProvider`, and while the channel management system catches it, the force-stop rejection pattern causes the gateway process manager to detect a stale process and restart the entire gateway — disrupting all channels (Feishu, Slack, etc.).

## Changes

| File | Change |
|------|--------|
| `src/discord/monitor/provider.lifecycle.ts` | Tagged the reconnect stall error with `__reconnectStallTimeout: true`; added a check in the lifecycle catch block to absorb this error instead of re-throwing |
| `src/discord/monitor/provider.lifecycle.test.ts` | Updated test: reconnect stall now resolves (graceful exit) instead of rejecting |

## How it works

The reconnect stall watchdog error is now tagged with `__reconnectStallTimeout: true` using `Object.assign`. The lifecycle's catch block checks for this tag and, when found, logs a message and swallows the error instead of re-throwing. The lifecycle function then exits normally through the `finally` block, which cleans up resources. The channel management system in `server-channels.ts` sees a normal exit and initiates auto-restart with backoff, keeping other channels unaffected.

## Test plan

- [x] 17 tests pass across `provider.lifecycle.test.ts` (11) and `monitor.gateway.test.ts` (6)
- [x] Updated test: reconnect stall timeout resolves lifecycle gracefully instead of rejecting
- [x] Existing test: reconnect that resumes before timeout still works correctly
- [ ] Manual: simulate Discord disconnect (disable network), wait 5+ minutes, verify only Discord channel restarts

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **No** — reconnection behavior is unchanged
- Does this change introduce new dependencies? **No**

## Human Verification

1. Start gateway with Discord and at least one other channel (e.g. Feishu)
2. Temporarily block Discord WebSocket traffic (firewall rule or disconnect network)
3. Wait 5+ minutes for the reconnect stall watchdog to fire
4. Verify Discord channel logs show "reconnect stall resolved; channel will auto-restart"
5. Verify other channels (Feishu) continue operating normally
6. Verify Discord auto-restarts and reconnects when network is restored

## Failure Recovery

Remove the `__reconnectStallTimeout` tag and the catch block check to restore the original throw behavior. The reconnect stall error will once again propagate as an unrecoverable error.

## Risks and Mitigations

- **Risk**: Silently absorbing the reconnect stall error could mask persistent network issues. **Mitigation**: The error is still logged via `runtime.error` in the watchdog callback and the status is updated with `lastError`. The channel management's auto-restart with backoff provides visibility through restart attempt logs. After `MAX_RESTART_ATTEMPTS` (10), the channel gives up and logs a final error.