### PR TITLE
fix: suppress JSON action-object forms of NO_REPLY from reaching end users

### DIFF
--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -34,6 +34,38 @@ describe("isSilentReplyText", () => {
     expect(isSilentReplyText("HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(true);
     expect(isSilentReplyText("Checked inbox. HEARTBEAT_OK", "HEARTBEAT_OK")).toBe(false);
   });
+
+  // JSON action-object forms (#37727)
+  it("returns true for JSON action NO_REPLY object", () => {
+    expect(isSilentReplyText('{"action":"NO_REPLY"}')).toBe(true);
+  });
+
+  it("returns true for JSON action NO_REPLY with whitespace", () => {
+    expect(isSilentReplyText('  {"action":"NO_REPLY"}  ')).toBe(true);
+    expect(isSilentReplyText('{ "action": "NO_REPLY" }')).toBe(true);
+    expect(isSilentReplyText('{\n  "action": "NO_REPLY"\n}')).toBe(true);
+  });
+
+  it("returns true for JSON action with case variation", () => {
+    expect(isSilentReplyText('{"action":"no_reply"}')).toBe(true);
+    expect(isSilentReplyText('{"action":"No_Reply"}')).toBe(true);
+  });
+
+  it("returns false for JSON with extra meaningful keys", () => {
+    expect(isSilentReplyText('{"action":"NO_REPLY","text":"hello"}')).toBe(false);
+  });
+
+  it("returns false for JSON with non-silent action", () => {
+    expect(isSilentReplyText('{"action":"SEND"}')).toBe(false);
+  });
+
+  it("returns false for invalid JSON that looks like action object", () => {
+    expect(isSilentReplyText("{action: NO_REPLY}")).toBe(false);
+  });
+
+  it("returns false for text mentioning action NO_REPLY in prose", () => {
+    expect(isSilentReplyText('The action is {"action":"NO_REPLY"} here')).toBe(false);
+  });
 });
 
 describe("stripSilentToken", () => {

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -28,6 +28,39 @@ function getSilentTrailingRegex(token: string): RegExp {
   return regex;
 }
 
+/**
+ * Detect JSON-like action objects that represent a silent reply.
+ * Models sometimes emit `{"action":"NO_REPLY"}` (or variations with extra
+ * whitespace / quotes) instead of the bare sentinel string.  We parse
+ * conservatively: the text must be *only* a JSON object whose `action`
+ * value equals the silent token.  (#37727)
+ */
+function isJsonSilentAction(text: string, token: string): boolean {
+  const trimmed = text.trim();
+  // Quick guard: must look like a JSON object.
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return false;
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const obj = parsed as Record<string, unknown>;
+      // Accept both exact match and case-insensitive match of the token.
+      if (typeof obj.action === "string") {
+        const val = obj.action.trim();
+        if (val === token || val.toUpperCase() === token.toUpperCase()) {
+          // Only suppress if the object has no other meaningful keys.
+          const keys = Object.keys(obj);
+          return keys.length === 1 || keys.every((k) => k === "action" || obj[k] === undefined);
+        }
+      }
+    }
+  } catch {
+    // Not valid JSON — not a silent action payload.
+  }
+  return false;
+}
+
 export function isSilentReplyText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,
@@ -37,7 +70,13 @@ export function isSilentReplyText(
   }
   // Match only the exact silent token with optional surrounding whitespace.
   // This prevents substantive replies ending with NO_REPLY from being suppressed (#19537).
-  return getSilentExactRegex(token).test(text);
+  if (getSilentExactRegex(token).test(text)) {
+    return true;
+  }
+  // Also detect JSON action-object forms of the silent token that some models
+  // emit (e.g. {"action":"NO_REPLY"}).  These internal control payloads must
+  // never leak to end users as literal text.  (#37727)
+  return isJsonSilentAction(text, token);
 }
 
 /**


### PR DESCRIPTION
## Problem

Some models emit `{"action":"NO_REPLY"}` (a JSON object) instead of the bare `NO_REPLY` sentinel string. The existing `isSilentReplyText` check only matched the exact string form with optional whitespace (`/^\s*NO_REPLY\s*$/`), so the JSON variant passed through the outbound pipeline and was delivered as literal text to end users — most notably on Telegram.

## Root Cause

`isSilentReplyText()` in `src/auto-reply/tokens.ts` only checked for the bare sentinel string. The `stripSilentToken()` trailing-regex also could not match because `}` follows the token. Neither the normalize pipeline nor any channel adapter had a guard for JSON-serialized action objects.

## Fix

Added `isJsonSilentAction()` helper that conservatively parses JSON objects where the **only** key is `"action"` with a value matching the silent token (case-insensitive). Integrated into `isSilentReplyText()` so **all** downstream consumers (normalize-reply, typing controller, subagent announce, Slack, etc.) benefit automatically without per-channel patches.

### Safety

- Only suppresses single-key `{"action":"<token>"}` objects — objects with additional meaningful keys are **not** suppressed
- Invalid JSON is ignored (no false positives on prose containing JSON-like text)
- Case-insensitive to handle model variations (`no_reply`, `No_Reply`, etc.)

## Tests

7 new test cases covering:
- Exact JSON match (`{"action":"NO_REPLY"}`)
- Whitespace / pretty-printed variants
- Case-insensitive matching
- Objects with extra keys (not suppressed)
- Non-silent actions (not suppressed)  
- Invalid JSON (not suppressed)
- Prose containing JSON (not suppressed)

All existing tests pass (26 total in tokens.test.ts).

Closes #37727