### PR TITLE
fix(discord): preserve target session for native /voice

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -183,7 +183,7 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "appcast.xml",
-        "hashed_secret": "abb0380989460de3f211d60628b439de7ebcd482",
+        "hashed_secret": "5e1b354be110a63154f710e31bf13f2b70431217",
         "is_verified": false,
         "line_number": 364
       },
@@ -9795,63 +9795,63 @@
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "1188d5a8ed7edcff5144a9472af960243eacf12e",
         "is_verified": false,
-        "line_number": 1611
+        "line_number": 1612
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "bde4db9b4c3be4049adc3b9a69851d7c35119770",
         "is_verified": false,
-        "line_number": 1627
+        "line_number": 1628
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "7f8aaf142ce0552c260f2e546dda43ddd7c9aef3",
         "is_verified": false,
-        "line_number": 1812
+        "line_number": 1813
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "22af290a1a3d5e941193a41a3d3a9e4ca8da5e27",
         "is_verified": false,
-        "line_number": 1985
+        "line_number": 1986
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 2041
+        "line_number": 2042
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "c1e6ee547fd492df1441ac492e8bb294974712bd",
         "is_verified": false,
-        "line_number": 2273
+        "line_number": 2274
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2401
+        "line_number": 2402
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "a219d7693c25cd2d93313512e200ff3eb374d281",
         "is_verified": false,
-        "line_number": 2654
+        "line_number": 2655
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/gateway/configuration-reference.md",
         "hashed_secret": "b6f56e5e92078ed7c078c46fbfeedcbe5719bc25",
         "is_verified": false,
-        "line_number": 2656
+        "line_number": 2657
       }
     ],
     "docs/gateway/configuration.md": [
@@ -9945,7 +9945,7 @@
         "filename": "docs/help/faq.md",
         "hashed_secret": "45d676e7c6ab44cf4b8fa366ef2d8fccd3e6d6e6",
         "is_verified": false,
-        "line_number": 2489
+        "line_number": 2490
       }
     ],
     "docs/install/macos-vm.md": [
@@ -10033,14 +10033,14 @@
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 70
+        "line_number": 69
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 148
       }
     ],
     "docs/providers/moonshot.md": [
@@ -11740,6 +11740,15 @@
         "line_number": 149
       }
     ],
+    "src/auto-reply/reply/commands.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/auto-reply/reply/commands.test.ts",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 1188
+      }
+    ],
     "src/auto-reply/status.test.ts": [
       {
         "type": "Secret Keyword",
@@ -12957,35 +12966,35 @@
         "filename": "src/tts/tts.test.ts",
         "hashed_secret": "2e7a7ee14caebf378fc32d6cf6f557f347c96773",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 39
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/tts/tts.test.ts",
         "hashed_secret": "b214f706bb602c1cc2adc5c6165e73622305f4bb",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 104
       },
       {
         "type": "Secret Keyword",
         "filename": "src/tts/tts.test.ts",
         "hashed_secret": "75ddfb45216fe09680dfe70eda4f559a910c832c",
         "is_verified": false,
-        "line_number": 468
+        "line_number": 471
       },
       {
         "type": "Secret Keyword",
         "filename": "src/tts/tts.test.ts",
         "hashed_secret": "e29af93630aa18cc3457cb5b13937b7ab7c99c9b",
         "is_verified": false,
-        "line_number": 478
+        "line_number": 481
       },
       {
         "type": "Secret Keyword",
         "filename": "src/tts/tts.test.ts",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 564
+        "line_number": 582
       }
     ],
     "src/tui/gateway-chat.test.ts": [
@@ -13034,5 +13043,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T05:05:36Z"
+  "generated_at": "2026-03-08T07:06:48Z"
 }

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -72,7 +72,9 @@ export function buildSystemPrompt(params: {
       shell: detectRuntimeShell(),
     },
   });
-  const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+  const ttsHint = params.config
+    ? buildTtsSystemPromptHint(params.config, params.agentId)
+    : undefined;
   const ownerDisplay = resolveOwnerDisplaySetting(params.config);
   return buildAgentSystemPrompt({
     workspaceDir: params.workspaceDir,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -144,6 +144,7 @@ export function createOpenClawTools(
     ...(messageTool ? [messageTool] : []),
     createTtsTool({
       agentChannel: options?.agentChannel,
+      agentSessionKey: options?.agentSessionKey,
       config: options?.config,
     }),
     createGatewayTool({

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -516,7 +516,9 @@ export async function compactEmbeddedPiSessionDirect(
       cwd: process.cwd(),
       moduleUrl: import.meta.url,
     });
-    const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+    const ttsHint = params.config
+      ? buildTtsSystemPromptHint(params.config, sessionAgentId)
+      : undefined;
     const ownerDisplay = resolveOwnerDisplaySetting(params.config);
     const appendPrompt = buildEmbeddedSystemPrompt({
       workspaceDir: effectiveWorkspace,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -992,7 +992,9 @@ export async function runEmbeddedAttempt(
       cwd: process.cwd(),
       moduleUrl: import.meta.url,
     });
-    const ttsHint = params.config ? buildTtsSystemPromptHint(params.config) : undefined;
+    const ttsHint = params.config
+      ? buildTtsSystemPromptHint(params.config, sessionAgentId)
+      : undefined;
     const ownerDisplay = resolveOwnerDisplaySetting(params.config);
 
     const appendPrompt = buildEmbeddedSystemPrompt({

--- a/src/agents/tools/tts-tool.ts
+++ b/src/agents/tools/tts-tool.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import { textToSpeech } from "../../tts/tts.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
+import { resolveSessionAgentId } from "../agent-scope.js";
 import type { AnyAgentTool } from "./common.js";
 import { readStringParam } from "./common.js";
 
@@ -17,6 +18,7 @@ const TtsToolSchema = Type.Object({
 export function createTtsTool(opts?: {
   config?: OpenClawConfig;
   agentChannel?: GatewayMessageChannel;
+  agentSessionKey?: string;
 }): AnyAgentTool {
   return {
     label: "TTS",
@@ -28,9 +30,14 @@ export function createTtsTool(opts?: {
       const text = readStringParam(params, "text", { required: true });
       const channel = readStringParam(params, "channel");
       const cfg = opts?.config ?? loadConfig();
+      const agentId = resolveSessionAgentId({
+        sessionKey: opts?.agentSessionKey,
+        config: cfg,
+      });
       const result = await textToSpeech({
         text,
         cfg,
+        agentId,
         channel: channel ?? opts?.agentChannel,
       });
 

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -346,6 +346,21 @@ describe("commands registry args", () => {
     ]);
   });
 
+  it("builds internal command text from the canonical text alias instead of native alias", () => {
+    const command = {
+      key: "tts",
+      nativeName: "voice",
+      description: "tts",
+      textAliases: ["/tts"],
+      scope: "both",
+      acceptsArgs: true,
+      argsParsing: "positional",
+      args: [{ name: "action", description: "action", type: "string" }],
+    } satisfies ChatCommandDefinition;
+
+    expect(buildCommandTextFromArgs(command, { values: { action: "on" } })).toBe("/tts on");
+  });
+
   it("does not show menus when arg already provided", () => {
     const command = createUsageModeCommand();
 

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -286,7 +286,8 @@ export function buildCommandTextFromArgs(
   command: ChatCommandDefinition,
   args?: CommandArgs,
 ): string {
-  const commandName = command.nativeName ?? command.key;
+  const textAlias = command.textAliases[0]?.trim();
+  const commandName = textAlias ? textAlias.replace(/^\/+/, "") : command.key;
   return buildCommandText(commandName, serializeCommandArgs(command, args));
 }
 

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import { resetAcpSessionInPlace } from "../../acp/persistent-bindings.js";
+import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -294,9 +295,23 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
     surface: params.command.surface,
     commandSource: params.ctx.CommandSource,
   });
+  const nativeTargetSessionKey = params.ctx.CommandTargetSessionKey?.trim();
+  const effectiveCommandAgentId = resolveSessionAgentId({
+    sessionKey: nativeTargetSessionKey || params.sessionKey,
+    config: params.cfg,
+  });
+  const handlerParams =
+    effectiveCommandAgentId === params.agentId
+      ? params
+      : { ...params, agentId: effectiveCommandAgentId };
+  if (handlerParams.agentId !== params.agentId) {
+    logVerbose(
+      `commands: overriding agent from ${params.agentId ?? "<unset>"} to ${handlerParams.agentId} (session=${nativeTargetSessionKey || params.sessionKey})`,
+    );
+  }
 
   for (const handler of HANDLERS) {
-    const result = await handler(params, allowTextCommands);
+    const result = await handler(handlerParams, allowTextCommands);
     if (result) {
       return result;
     }

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -107,7 +107,7 @@ export async function resolveCommandsSystemPromptBundle(
         },
       }
     : { enabled: false };
-  const ttsHint = params.cfg ? buildTtsSystemPromptHint(params.cfg) : undefined;
+  const ttsHint = params.cfg ? buildTtsSystemPromptHint(params.cfg, sessionAgentId) : undefined;
 
   const systemPrompt = buildAgentSystemPrompt({
     workspaceDir,

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -1,4 +1,6 @@
+import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { logVerbose } from "../../globals.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   getLastTtsAttempt,
   getTtsMaxLength,
@@ -18,6 +20,8 @@ import {
 } from "../../tts/tts.js";
 import type { ReplyPayload } from "../types.js";
 import type { CommandHandler } from "./commands-types.js";
+
+const log = createSubsystemLogger("tts/command");
 
 type ParsedTtsCommand = {
   action: string;
@@ -84,8 +88,16 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
     return { shouldContinue: false };
   }
 
-  const config = resolveTtsConfig(params.cfg);
-  const prefsPath = resolveTtsPrefsPath(config);
+  const targetSessionKey = params.ctx.CommandTargetSessionKey?.trim();
+  const effectiveAgentId =
+    targetSessionKey || params.sessionKey
+      ? resolveSessionAgentId({
+          sessionKey: targetSessionKey || params.sessionKey,
+          config: params.cfg,
+        })
+      : params.agentId;
+  const config = resolveTtsConfig(params.cfg, effectiveAgentId);
+  const prefsPath = resolveTtsPrefsPath(config, effectiveAgentId);
   const action = parsed.action;
   const args = parsed.args;
 
@@ -117,11 +129,28 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
     }
 
     const start = Date.now();
+    const provider = getTtsProvider(config, prefsPath);
+    log.info("tts audio requested", {
+      surface: params.command.surface,
+      channel: params.command.channel,
+      channelId: params.command.channelId,
+      accountId: typeof params.ctx.AccountId === "string" ? params.ctx.AccountId : undefined,
+      agentId: effectiveAgentId,
+      provider,
+      elevenlabsVoiceId: provider === "elevenlabs" ? config.elevenlabs.voiceId : undefined,
+      elevenlabsModelId: provider === "elevenlabs" ? config.elevenlabs.modelId : undefined,
+      openaiVoice: provider === "openai" ? config.openai.voice : undefined,
+      openaiModel: provider === "openai" ? config.openai.model : undefined,
+      edgeVoice: provider === "edge" ? config.edge.voice : undefined,
+      textLength: args.length,
+    });
     const result = await textToSpeech({
       text: args,
       cfg: params.cfg,
+      config,
       channel: params.command.channel,
       prefsPath,
+      agentId: effectiveAgentId,
     });
 
     if (result.success && result.audioPath) {

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -27,6 +27,14 @@ import { parseInlineDirectives } from "./directive-handling.js";
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
 const validateConfigObjectWithPluginsMock = vi.hoisted(() => vi.fn());
 const writeConfigFileMock = vi.hoisted(() => vi.fn());
+const textToSpeechMock = vi.hoisted(() =>
+  vi.fn(async (_params: unknown) => ({
+    success: true as const,
+    audioPath: "/tmp/test-tts.opus",
+    provider: "elevenlabs" as const,
+    voiceCompatible: true,
+  })),
+);
 
 vi.mock("../../config/config.js", async () => {
   const actual =
@@ -62,6 +70,14 @@ vi.mock("../../channels/plugins/pairing.js", async () => {
   return {
     ...actual,
     listPairingChannels: () => ["telegram"],
+  };
+});
+
+vi.mock("../../tts/tts.js", async () => {
+  const actual = await vi.importActual<typeof import("../../tts/tts.js")>("../../tts/tts.js");
+  return {
+    ...actual,
+    textToSpeech: (params: unknown) => textToSpeechMock(params),
   };
 });
 
@@ -1141,6 +1157,68 @@ describe("handleCommands hooks", () => {
       }),
     );
     spy.mockRestore();
+  });
+
+  it("prefers CommandTargetSessionKey agent for native TTS commands when params.agentId is stale", async () => {
+    textToSpeechMock.mockClear();
+    const agentId = "voiceagent";
+    const agentVoiceId = "J0I9H8G7F6E5D4C3B2A1";
+    const globalVoiceId = "A1B2C3D4E5F6G7H8I9J0";
+    const accountId = "discord-bot-test";
+    const cfg = {
+      commands: { text: true },
+      channels: { discord: { allowFrom: ["*"] } },
+      agents: {
+        defaults: { model: { primary: "openai/gpt-4o-mini" } },
+        list: [
+          {
+            id: agentId,
+            tts: {
+              elevenlabs: {
+                voiceId: agentVoiceId,
+              },
+            },
+          },
+        ],
+      },
+      messages: {
+        tts: {
+          provider: "elevenlabs",
+          elevenlabs: {
+            apiKey: "test-key",
+            voiceId: globalVoiceId,
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildParams("/tts audio hello there", cfg, {
+      Provider: "discord",
+      Surface: "discord",
+      CommandSource: "native",
+      CommandTargetSessionKey: `agent:${agentId}:discord:channel:123`,
+      SessionKey: "agent:main:discord:slash:user-1",
+      SenderId: "user-1",
+      From: "discord:channel:123",
+      To: "slash:user-1",
+      CommandAuthorized: true,
+      AccountId: accountId,
+    });
+    params.agentId = "main";
+    params.sessionKey = "agent:main:discord:slash:user-1";
+
+    const result = await handleCommands(params);
+
+    expect(result.shouldContinue).toBe(false);
+    expect(textToSpeechMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId,
+        config: expect.objectContaining({
+          elevenlabs: expect.objectContaining({
+            voiceId: agentVoiceId,
+          }),
+        }),
+      }),
+    );
   });
 });
 

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -53,6 +53,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
   originatingChannel?: string;
   originatingTo?: string;
   onReplyStart?: () => Promise<void> | void;
+  agentId?: string;
 }): AcpDispatchDeliveryCoordinator {
   const state: AcpDispatchDeliveryState = {
     startedReplyLifecycle: false,
@@ -138,6 +139,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       kind,
       inboundAudio: params.inboundAudio,
       ttsAuto: params.sessionTtsAuto,
+      agentId: params.agentId,
     });
 
     if (params.shouldRouteToOriginating && params.originatingChannel && params.originatingTo) {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -174,6 +174,15 @@ export async function tryDispatchAcpReply(params: {
     return null;
   }
 
+  const resolvedAcpAgent =
+    acpResolution.kind === "ready"
+      ? (
+          acpResolution.meta.agent?.trim() ||
+          params.cfg.acp?.defaultAgent?.trim() ||
+          resolveAgentIdFromSessionKey(sessionKey)
+        ).trim()
+      : resolveAgentIdFromSessionKey(sessionKey);
+
   let queuedFinal = false;
   const delivery = createAcpDispatchDeliveryCoordinator({
     cfg: params.cfg,
@@ -186,6 +195,7 @@ export async function tryDispatchAcpReply(params: {
     originatingChannel: params.originatingChannel,
     originatingTo: params.originatingTo,
     onReplyStart: params.onReplyStart,
+    agentId: resolvedAcpAgent,
   });
 
   const promptText = resolveAcpPromptText(params.ctx);
@@ -208,15 +218,6 @@ export async function tryDispatchAcpReply(params: {
         channelRaw: params.ctx.OriginatingChannel ?? params.ctx.Surface ?? params.ctx.Provider,
         accountIdRaw: params.ctx.AccountId,
       }));
-
-  const resolvedAcpAgent =
-    acpResolution.kind === "ready"
-      ? (
-          acpResolution.meta.agent?.trim() ||
-          params.cfg.acp?.defaultAgent?.trim() ||
-          resolveAgentIdFromSessionKey(sessionKey)
-        ).trim()
-      : resolveAgentIdFromSessionKey(sessionKey);
   const projector = createAcpReplyProjector({
     cfg: params.cfg,
     shouldSendToolSummaries: params.shouldSendToolSummaries,
@@ -257,7 +258,7 @@ export async function tryDispatchAcpReply(params: {
     });
 
     await projector.flush(true);
-    const ttsMode = resolveTtsConfig(params.cfg).mode ?? "final";
+    const ttsMode = resolveTtsConfig(params.cfg, resolvedAcpAgent).mode ?? "final";
     const accumulatedBlockText = delivery.getAccumulatedBlockText();
     if (ttsMode === "final" && delivery.getBlockCount() > 0 && accumulatedBlockText.trim()) {
       try {
@@ -268,6 +269,7 @@ export async function tryDispatchAcpReply(params: {
           kind: "final",
           inboundAudio: params.inboundAudio,
           ttsAuto: params.sessionTtsAuto,
+          agentId: resolvedAcpAgent,
         });
         if (ttsSyntheticReply.mediaUrl) {
           const delivered = await delivery.deliver("final", {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -77,8 +77,7 @@ const resolveSessionStoreLookup = (
   sessionKey?: string;
   entry?: SessionEntry;
 } => {
-  const targetSessionKey =
-    ctx.CommandSource === "native" ? ctx.CommandTargetSessionKey?.trim() : undefined;
+  const targetSessionKey = ctx.CommandTargetSessionKey?.trim();
   const sessionKey = (targetSessionKey ?? ctx.SessionKey)?.trim();
   if (!sessionKey) {
     return {};
@@ -171,6 +170,7 @@ export async function dispatchReplyFromConfig(params: {
 
   const sessionStoreEntry = resolveSessionStoreLookup(ctx, cfg);
   const acpDispatchSessionKey = sessionStoreEntry.sessionKey ?? sessionKey;
+  const agentId = resolveSessionAgentId({ sessionKey: acpDispatchSessionKey, config: cfg });
   const inboundAudio = isInboundAudioContext(ctx);
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
   const hookRunner = getGlobalHookRunner();
@@ -398,6 +398,7 @@ export async function dispatchReplyFromConfig(params: {
               kind: "tool",
               inboundAudio,
               ttsAuto: sessionTtsAuto,
+              agentId,
             });
             const deliveryPayload = resolveToolDeliveryPayload(ttsPayload);
             if (!deliveryPayload) {
@@ -434,6 +435,7 @@ export async function dispatchReplyFromConfig(params: {
               kind: "block",
               inboundAudio,
               ttsAuto: sessionTtsAuto,
+              agentId,
             });
             if (shouldRouteToOriginating) {
               await sendPayloadAsync(ttsPayload, context?.abortSignal, false);
@@ -490,6 +492,7 @@ export async function dispatchReplyFromConfig(params: {
         kind: "final",
         inboundAudio,
         ttsAuto: sessionTtsAuto,
+        agentId,
       });
       if (shouldRouteToOriginating && originatingChannel && originatingTo) {
         // Route final reply to originating channel.
@@ -518,7 +521,7 @@ export async function dispatchReplyFromConfig(params: {
       }
     }
 
-    const ttsMode = resolveTtsConfig(cfg).mode ?? "final";
+    const ttsMode = resolveTtsConfig(cfg, agentId).mode ?? "final";
     // Generate TTS-only reply after block streaming completes (when there's no final reply).
     // This handles the case where block streaming succeeds and drops final payloads,
     // but we still want TTS audio to be generated from the accumulated block content.
@@ -536,6 +539,7 @@ export async function dispatchReplyFromConfig(params: {
           kind: "final",
           inboundAudio,
           ttsAuto: sessionTtsAuto,
+          agentId,
         });
         // Only send if TTS was actually applied (mediaUrl exists)
         if (ttsSyntheticReply.mediaUrl) {

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -61,8 +61,7 @@ export async function getReplyFromConfig(
 ): Promise<ReplyPayload | ReplyPayload[] | undefined> {
   const isFastTestEnv = process.env.OPENCLAW_TEST_FAST === "1";
   const cfg = configOverride ?? loadConfig();
-  const targetSessionKey =
-    ctx.CommandSource === "native" ? ctx.CommandTargetSessionKey?.trim() : undefined;
+  const targetSessionKey = ctx.CommandTargetSessionKey?.trim();
   const agentSessionKey = targetSessionKey || ctx.SessionKey;
   const agentId = resolveSessionAgentId({
     sessionKey: agentSessionKey,

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -195,8 +195,7 @@ export async function initSessionState(params: {
   const { ctx, cfg, commandAuthorized } = params;
   // Native slash commands (Telegram/Discord/Slack) are delivered on a separate
   // "slash session" key, but should mutate the target chat session.
-  const targetSessionKey =
-    ctx.CommandSource === "native" ? ctx.CommandTargetSessionKey?.trim() : undefined;
+  const targetSessionKey = ctx.CommandTargetSessionKey?.trim();
   const sessionCtxForState =
     targetSessionKey && targetSessionKey !== ctx.SessionKey
       ? { ...ctx, SessionKey: targetSessionKey }

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -388,12 +388,13 @@ const formatMediaUnderstandingLine = (decisions?: ReadonlyArray<MediaUnderstandi
 const formatVoiceModeLine = (
   config?: OpenClawConfig,
   sessionEntry?: SessionEntry,
+  agentId?: string,
 ): string | null => {
   if (!config) {
     return null;
   }
-  const ttsConfig = resolveTtsConfig(config);
-  const prefsPath = resolveTtsPrefsPath(ttsConfig);
+  const ttsConfig = resolveTtsConfig(config, agentId);
+  const prefsPath = resolveTtsPrefsPath(ttsConfig, agentId);
   const autoMode = resolveTtsAutoMode({
     config: ttsConfig,
     prefsPath,
@@ -663,7 +664,7 @@ export function buildStatusMessage(args: StatusArgs): string {
   const usageCostLine =
     usagePair && costLine ? `${usagePair} · ${costLine}` : (usagePair ?? costLine);
   const mediaLine = formatMediaUnderstandingLine(args.mediaDecisions);
-  const voiceLine = formatVoiceModeLine(args.config, args.sessionEntry);
+  const voiceLine = formatVoiceModeLine(args.config, args.sessionEntry, args.agentId);
 
   return [
     versionLine,

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -4,6 +4,7 @@ import type { AgentModelConfig, AgentSandboxConfig } from "./types.agents-shared
 import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
+import type { TtsConfig } from "./types.tts.js";
 
 export type AgentRuntimeAcpConfig = {
   /** ACP harness adapter id (for example codex, claude). */
@@ -85,6 +86,8 @@ export type AgentConfig = {
   /** Optional per-agent stream params (e.g. cacheRetention, temperature). */
   params?: Record<string, unknown>;
   tools?: AgentToolsConfig;
+  /** Optional per-agent TTS overrides (merged on top of global messages.tts). */
+  tts?: TtsConfig;
   /** Optional runtime descriptor for this agent. */
   runtime?: AgentRuntimeConfig;
 };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -7,6 +7,7 @@ import {
   HumanDelaySchema,
   IdentitySchema,
   SecretInputSchema,
+  TtsConfigSchema,
   ToolsLinksSchema,
   ToolsMediaSchema,
 } from "./zod-schema.core.js";
@@ -740,6 +741,7 @@ export const AgentEntrySchema = z
       .optional(),
     sandbox: AgentSandboxSchema,
     tools: AgentToolsSchema,
+    tts: TtsConfigSchema.optional(),
     runtime: AgentRuntimeSchema,
   })
   .strict();

--- a/src/discord/monitor/native-command.logging.test.ts
+++ b/src/discord/monitor/native-command.logging.test.ts
@@ -1,0 +1,133 @@
+import { ChannelType } from "discord-api-types/v10";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listNativeCommandSpecs } from "../../auto-reply/commands-registry.js";
+import * as dispatcherModule from "../../auto-reply/reply/provider-dispatcher.js";
+import type { OpenClawConfig, loadConfig } from "../../config/config.js";
+import * as pluginCommandsModule from "../../plugins/commands.js";
+import { createNoopThreadBindingManager } from "./thread-bindings.js";
+
+const { infoMock } = vi.hoisted(() => ({
+  infoMock: vi.fn(),
+}));
+
+vi.mock("../../logging/subsystem.js", () => {
+  const makeLogger = () => ({
+    subsystem: "discord/native-command",
+    isEnabled: () => true,
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: infoMock,
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: () => makeLogger(),
+  });
+  return { createSubsystemLogger: () => makeLogger() };
+});
+
+import { createDiscordNativeCommand } from "./native-command.js";
+
+type MockCommandInteraction = {
+  user: { id: string; username: string; globalName: string };
+  channel: { type: ChannelType; id: string };
+  guild: null;
+  rawData: { id: string; member: { roles: string[] } };
+  options: {
+    getString: (name: string) => string | null;
+    getNumber: ReturnType<typeof vi.fn>;
+    getBoolean: ReturnType<typeof vi.fn>;
+  };
+  reply: ReturnType<typeof vi.fn>;
+  followUp: ReturnType<typeof vi.fn>;
+  client: object;
+};
+
+function createInteraction(values: Record<string, string>): MockCommandInteraction {
+  return {
+    user: {
+      id: "owner",
+      username: "tester",
+      globalName: "Tester",
+    },
+    channel: {
+      type: ChannelType.DM,
+      id: "dm-1",
+    },
+    guild: null,
+    rawData: {
+      id: "interaction-1",
+      member: { roles: [] },
+    },
+    options: {
+      getString: (name: string) => values[name] ?? null,
+      getNumber: vi.fn().mockReturnValue(null),
+      getBoolean: vi.fn().mockReturnValue(null),
+    },
+    reply: vi.fn().mockResolvedValue({ ok: true }),
+    followUp: vi.fn().mockResolvedValue({ ok: true }),
+    client: {},
+  };
+}
+
+describe("Discord native command routing logs", () => {
+  beforeEach(() => {
+    infoMock.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it("does not include the raw prompt in info-level routing logs", async () => {
+    const command = listNativeCommandSpecs({ provider: "discord" }).find(
+      (entry) => entry.name === "config",
+    );
+    if (!command) {
+      throw new Error("missing native command: config");
+    }
+    const cfg = {
+      channels: {
+        discord: {
+          dm: { enabled: true, policy: "open" },
+        },
+      },
+    } as ReturnType<typeof loadConfig>;
+    const discordConfig = cfg.channels?.discord;
+    const nativeCommand = createDiscordNativeCommand({
+      command,
+      cfg,
+      discordConfig,
+      accountId: "default",
+      sessionPrefix: "discord:slash",
+      ephemeralDefault: true,
+      threadBindings: createNoopThreadBindingManager("default"),
+    });
+    const interaction = createInteraction({
+      action: "set",
+      path: "agents.default.token",
+      value: "super-secret-value",
+    });
+
+    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
+    vi.spyOn(dispatcherModule, "dispatchReplyWithDispatcher").mockResolvedValue({
+      counts: {
+        final: 1,
+        block: 0,
+        tool: 0,
+      },
+    } as never);
+
+    await (nativeCommand as { run: (interaction: unknown) => Promise<void> }).run(
+      interaction as unknown,
+    );
+
+    const routedCall = infoMock.mock.calls.find(([message]) => message === "native command routed");
+    const routedMeta = routedCall?.[1] as Record<string, unknown> | undefined;
+
+    expect(routedMeta).toBeDefined();
+    expect(routedMeta).not.toHaveProperty("prompt");
+    expect(routedMeta).toMatchObject({
+      commandName: "config",
+      accountId: "default",
+      channelId: "dm-1",
+    });
+  });
+});

--- a/src/discord/monitor/native-command.logging.test.ts
+++ b/src/discord/monitor/native-command.logging.test.ts
@@ -2,7 +2,7 @@ import { ChannelType } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { listNativeCommandSpecs } from "../../auto-reply/commands-registry.js";
 import * as dispatcherModule from "../../auto-reply/reply/provider-dispatcher.js";
-import type { OpenClawConfig, loadConfig } from "../../config/config.js";
+import type { loadConfig } from "../../config/config.js";
 import * as pluginCommandsModule from "../../plugins/commands.js";
 import { createNoopThreadBindingManager } from "./thread-bindings.js";
 

--- a/src/discord/monitor/native-command.plugin-dispatch.test.ts
+++ b/src/discord/monitor/native-command.plugin-dispatch.test.ts
@@ -4,6 +4,7 @@ import type { NativeCommandSpec } from "../../auto-reply/commands-registry.js";
 import * as dispatcherModule from "../../auto-reply/reply/provider-dispatcher.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import * as pluginCommandsModule from "../../plugins/commands.js";
+import { buildAgentSessionKey } from "../../routing/resolve-route.js";
 import { createDiscordNativeCommand } from "./native-command.js";
 import {
   createMockCommandInteraction,
@@ -283,6 +284,73 @@ describe("Discord native plugin command dispatch", () => {
     );
     expect(persistentBindingMocks.resolveConfiguredAcpBindingRecord).toHaveBeenCalledTimes(1);
     expect(persistentBindingMocks.ensureConfiguredAcpBindingSession).not.toHaveBeenCalled();
+  });
+
+  it("uses the routed Discord target session as SessionKey for non-ACP native commands", async () => {
+    const guildId = "guild-1";
+    const channelId = "channel-1";
+    const accountId = "discord-bot-test";
+    const agentId = "voiceagent";
+    const routedSessionKey = buildAgentSessionKey({
+      agentId,
+      channel: "discord",
+      accountId,
+      peer: { kind: "channel", id: channelId },
+    });
+    const cfg = {
+      commands: {
+        useAccessGroups: false,
+      },
+      bindings: [
+        {
+          agentId,
+          match: {
+            channel: "discord",
+            accountId,
+          },
+        },
+      ],
+    } as OpenClawConfig;
+    const commandSpec: NativeCommandSpec = {
+      name: "status",
+      description: "Status",
+      acceptsArgs: false,
+    };
+    const command = createDiscordNativeCommand({
+      command: commandSpec,
+      cfg,
+      discordConfig: cfg.channels?.discord ?? {},
+      accountId,
+      sessionPrefix: "discord:slash",
+      ephemeralDefault: true,
+      threadBindings: createNoopThreadBindingManager(accountId),
+    });
+    const interaction = createInteraction({
+      channelType: ChannelType.GuildText,
+      channelId,
+      guildId,
+      guildName: "Test Guild",
+    });
+
+    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
+    const dispatchSpy = vi
+      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
+      .mockResolvedValue({
+        counts: {
+          final: 1,
+          block: 0,
+          tool: 0,
+        },
+      } as never);
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const dispatchCall = dispatchSpy.mock.calls[0]?.[0] as {
+      ctx?: { SessionKey?: string; CommandTargetSessionKey?: string };
+    };
+    expect(dispatchCall.ctx?.SessionKey).toBe(routedSessionKey);
+    expect(dispatchCall.ctx?.CommandTargetSessionKey).toBe(routedSessionKey);
   });
 
   it("routes Discord DM native slash commands through configured ACP bindings", async () => {

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -1645,13 +1645,20 @@ async function dispatchDiscordCommandInteraction(params: {
     configuredRoute,
     matchedBy: configuredBinding ? "binding.channel" : undefined,
   });
-  const { sessionKey, commandTargetSessionKey } = resolveNativeCommandSessionTargets({
+  const defaultSessionTargets = resolveNativeCommandSessionTargets({
     agentId: effectiveRoute.agentId,
     sessionPrefix,
     userId: user.id,
     targetSessionKey: effectiveRoute.sessionKey,
     boundSessionKey,
   });
+  const useRoutedSessionKey = !boundSessionKey && effectiveRoute.matchedBy === "binding.account";
+  const sessionKey = useRoutedSessionKey
+    ? effectiveRoute.sessionKey
+    : defaultSessionTargets.sessionKey;
+  const commandTargetSessionKey = useRoutedSessionKey
+    ? effectiveRoute.sessionKey
+    : defaultSessionTargets.commandTargetSessionKey;
   const ctxPayload = buildDiscordNativeCommandContext({
     prompt,
     commandArgs: commandArgs ?? {},
@@ -1677,6 +1684,22 @@ async function dispatchDiscordCommandInteraction(params: {
       globalName: user.globalName,
     },
     sender: { id: sender.id, name: sender.name, tag: sender.tag },
+  });
+  log.info("native command routed", {
+    commandName: command.nativeName ?? command.key,
+    promptChars: prompt.length,
+    accountId,
+    applicationId:
+      typeof interaction.rawData.application_id === "string"
+        ? interaction.rawData.application_id
+        : undefined,
+    guildId: interaction.guild?.id ?? undefined,
+    channelId,
+    routeAgentId: route.agentId,
+    effectiveAgentId: effectiveRoute.agentId,
+    effectiveSessionKey: effectiveRoute.sessionKey,
+    boundSessionKey: boundSessionKey || undefined,
+    matchedBy: effectiveRoute.matchedBy,
   });
 
   const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({

--- a/src/discord/voice/manager.test.ts
+++ b/src/discord/voice/manager.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+
+vi.mock("@discordjs/voice", () => ({
+  AudioPlayerStatus: { Playing: "playing", Idle: "idle" },
+  EndBehaviorType: { AfterSilence: "AfterSilence" },
+  VoiceConnectionStatus: {
+    Ready: "ready",
+    Disconnected: "disconnected",
+    Destroyed: "destroyed",
+    Signalling: "signalling",
+    Connecting: "connecting",
+  },
+  createAudioPlayer: vi.fn(),
+  createAudioResource: vi.fn(),
+  entersState: vi.fn(),
+  joinVoiceChannel: vi.fn(),
+}));
+
+import { resolveVoiceTtsConfig } from "./manager.js";
+
+describe("resolveVoiceTtsConfig", () => {
+  it("preserves mixed-case agent TTS overrides when voice-channel TTS override is enabled", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-4o-mini" } },
+        list: [
+          {
+            id: "VoiceAgent",
+            tts: {
+              provider: "elevenlabs",
+              elevenlabs: {
+                voiceId: "A1B2C3D4E5F6G7H8I9J0",
+              },
+            },
+          },
+        ],
+      },
+      messages: {
+        tts: {
+          provider: "elevenlabs",
+          elevenlabs: {
+            voiceId: "J0I9H8G7F6E5D4C3B2A1",
+          },
+        },
+      },
+    };
+
+    const { resolved } = resolveVoiceTtsConfig({
+      cfg,
+      agentId: "voiceagent",
+      override: {
+        elevenlabs: {
+          modelId: "eleven_flash_v2_5",
+        },
+      },
+    });
+
+    expect(resolved.elevenlabs.voiceId).toBe("A1B2C3D4E5F6G7H8I9J0");
+    expect(resolved.elevenlabs.modelId).toBe("eleven_flash_v2_5");
+  });
+});

--- a/src/discord/voice/manager.ts
+++ b/src/discord/voice/manager.ts
@@ -35,7 +35,12 @@ import {
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { parseTtsDirectives } from "../../tts/tts-core.js";
-import { resolveTtsConfig, textToSpeech, type ResolvedTtsConfig } from "../../tts/tts.js";
+import {
+  mergeTtsConfig,
+  resolveTtsConfig,
+  textToSpeech,
+  type ResolvedTtsConfig,
+} from "../../tts/tts.js";
 import { formatMention } from "../mentions.js";
 import { resolveDiscordOwnerAccess } from "../monitor/allow-list.js";
 import { formatDiscordUserTag } from "../monitor/format.js";
@@ -83,44 +88,22 @@ type VoiceSessionEntry = {
   stop: () => void;
 };
 
-function mergeTtsConfig(base: TtsConfig, override?: TtsConfig): TtsConfig {
-  if (!override) {
-    return base;
-  }
-  return {
-    ...base,
-    ...override,
-    modelOverrides: {
-      ...base.modelOverrides,
-      ...override.modelOverrides,
-    },
-    elevenlabs: {
-      ...base.elevenlabs,
-      ...override.elevenlabs,
-      voiceSettings: {
-        ...base.elevenlabs?.voiceSettings,
-        ...override.elevenlabs?.voiceSettings,
-      },
-    },
-    openai: {
-      ...base.openai,
-      ...override.openai,
-    },
-    edge: {
-      ...base.edge,
-      ...override.edge,
-    },
-  };
-}
-
-function resolveVoiceTtsConfig(params: { cfg: OpenClawConfig; override?: TtsConfig }): {
+function resolveVoiceTtsConfig(params: {
+  cfg: OpenClawConfig;
+  override?: TtsConfig;
+  agentId?: string;
+}): {
   cfg: OpenClawConfig;
   resolved: ResolvedTtsConfig;
 } {
   if (!params.override) {
-    return { cfg: params.cfg, resolved: resolveTtsConfig(params.cfg) };
+    return { cfg: params.cfg, resolved: resolveTtsConfig(params.cfg, params.agentId) };
   }
-  const base = params.cfg.messages?.tts ?? {};
+  // Merge order: global → agent → voice channel override
+  const agentTts = params.agentId
+    ? params.cfg.agents?.list?.find((a) => a.id === params.agentId)?.tts
+    : undefined;
+  const base = mergeTtsConfig(params.cfg.messages?.tts ?? {}, agentTts);
   const merged = mergeTtsConfig(base, params.override);
   const messages = params.cfg.messages ?? {};
   const cfg = {
@@ -672,6 +655,7 @@ export class DiscordVoiceManager {
     const { cfg: ttsCfg, resolved: ttsConfig } = resolveVoiceTtsConfig({
       cfg: this.params.cfg,
       override: this.params.discordConfig.voice?.tts,
+      agentId: entry.route.agentId,
     });
     const directive = parseTtsDirectives(
       replyText,
@@ -689,6 +673,8 @@ export class DiscordVoiceManager {
     const ttsResult = await textToSpeech({
       text: speakText,
       cfg: ttsCfg,
+      agentId: entry.route.agentId,
+      config: ttsConfig,
       channel: "discord",
       overrides: directive.overrides,
     });

--- a/src/discord/voice/manager.ts
+++ b/src/discord/voice/manager.ts
@@ -33,6 +33,7 @@ import {
   runCapability,
 } from "../../media-understanding/runner.js";
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { parseTtsDirectives } from "../../tts/tts-core.js";
 import {
@@ -88,7 +89,7 @@ type VoiceSessionEntry = {
   stop: () => void;
 };
 
-function resolveVoiceTtsConfig(params: {
+export function resolveVoiceTtsConfig(params: {
   cfg: OpenClawConfig;
   override?: TtsConfig;
   agentId?: string;
@@ -100,8 +101,9 @@ function resolveVoiceTtsConfig(params: {
     return { cfg: params.cfg, resolved: resolveTtsConfig(params.cfg, params.agentId) };
   }
   // Merge order: global → agent → voice channel override
-  const agentTts = params.agentId
-    ? params.cfg.agents?.list?.find((a) => a.id === params.agentId)?.tts
+  const normalizedAgentId = params.agentId?.trim() ? normalizeAgentId(params.agentId) : undefined;
+  const agentTts = normalizedAgentId
+    ? params.cfg.agents?.list?.find((a) => normalizeAgentId(a.id) === normalizedAgentId)?.tts
     : undefined;
   const base = mergeTtsConfig(params.cfg.messages?.tts ?? {}, agentTts);
   const merged = mergeTtsConfig(base, params.override);

--- a/src/gateway/server-methods/tts.test.ts
+++ b/src/gateway/server-methods/tts.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+
+const loadConfig = vi.hoisted(() => vi.fn(() => ({}) as OpenClawConfig));
+const resolveSessionAgentIds = vi.hoisted(() =>
+  vi.fn(() => ({ defaultAgentId: "main", sessionAgentId: "main" })),
+);
+
+const mocks = vi.hoisted(() => ({
+  resolveTtsConfig: vi.fn(() => ({ kind: "tts-config" })),
+  resolveTtsPrefsPath: vi.fn(() => "/tmp/tts.json"),
+  getTtsProvider: vi.fn(() => "edge"),
+  isTtsEnabled: vi.fn(() => true),
+  resolveTtsAutoMode: vi.fn(() => "always"),
+  resolveTtsProviderOrder: vi.fn(() => ["edge", "openai"]),
+  isTtsProviderConfigured: vi.fn((_config, provider: string) => provider === "edge"),
+  resolveTtsApiKey: vi.fn(() => undefined),
+  setTtsEnabled: vi.fn(),
+  setTtsProvider: vi.fn(),
+  textToSpeech: vi.fn(async () => ({
+    success: true,
+    audioPath: "/tmp/audio.mp3",
+    provider: "edge",
+    outputFormat: "mp3",
+    voiceCompatible: true,
+  })),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig,
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveSessionAgentIds,
+}));
+
+vi.mock("../../tts/tts.js", () => ({
+  OPENAI_TTS_MODELS: ["gpt-4o-mini-tts"],
+  OPENAI_TTS_VOICES: ["alloy"],
+  getTtsProvider: mocks.getTtsProvider,
+  isTtsEnabled: mocks.isTtsEnabled,
+  isTtsProviderConfigured: mocks.isTtsProviderConfigured,
+  resolveTtsAutoMode: mocks.resolveTtsAutoMode,
+  resolveTtsApiKey: mocks.resolveTtsApiKey,
+  resolveTtsConfig: mocks.resolveTtsConfig,
+  resolveTtsPrefsPath: mocks.resolveTtsPrefsPath,
+  resolveTtsProviderOrder: mocks.resolveTtsProviderOrder,
+  setTtsEnabled: mocks.setTtsEnabled,
+  setTtsProvider: mocks.setTtsProvider,
+  textToSpeech: mocks.textToSpeech,
+}));
+
+import { ttsHandlers } from "./tts.js";
+
+async function invoke(
+  method: keyof typeof ttsHandlers,
+  params: Record<string, unknown> = {},
+  respond = vi.fn(),
+) {
+  await ttsHandlers[method]({
+    req: { type: "req", id: "1", method } as never,
+    params: params as never,
+    respond: respond as never,
+    context: {} as never,
+    client: null,
+    isWebchatConnect: () => false,
+  });
+  return respond;
+}
+
+describe("gateway tts handlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadConfig.mockReturnValue({} as OpenClawConfig);
+    resolveSessionAgentIds.mockReturnValue({ defaultAgentId: "main", sessionAgentId: "main" });
+    mocks.resolveTtsConfig.mockReturnValue({ kind: "tts-config" });
+    mocks.resolveTtsPrefsPath.mockReturnValue("/tmp/tts.json");
+    mocks.getTtsProvider.mockReturnValue("edge");
+    mocks.isTtsEnabled.mockReturnValue(true);
+    mocks.resolveTtsAutoMode.mockReturnValue("always");
+    mocks.resolveTtsProviderOrder.mockReturnValue(["edge", "openai"]);
+    mocks.isTtsProviderConfigured.mockImplementation(
+      (_config, provider: string) => provider === "edge",
+    );
+    mocks.resolveTtsApiKey.mockReturnValue(undefined);
+    mocks.textToSpeech.mockResolvedValue({
+      success: true,
+      audioPath: "/tmp/audio.mp3",
+      provider: "edge",
+      outputFormat: "mp3",
+      voiceCompatible: true,
+    });
+  });
+
+  it("uses explicit agentId for tts.enable prefs resolution", async () => {
+    resolveSessionAgentIds.mockReturnValue({ defaultAgentId: "main", sessionAgentId: "ops" });
+
+    await invoke("tts.enable", { agentId: "ops" });
+
+    expect(resolveSessionAgentIds).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "ops",
+        config: expect.any(Object),
+      }),
+    );
+    expect(mocks.resolveTtsConfig).toHaveBeenCalledWith(expect.any(Object), "ops");
+    expect(mocks.resolveTtsPrefsPath).toHaveBeenCalledWith({ kind: "tts-config" }, "ops");
+    expect(mocks.setTtsEnabled).toHaveBeenCalledWith("/tmp/tts.json", true);
+  });
+
+  it("falls back to sessionKey agent for tts.status", async () => {
+    resolveSessionAgentIds.mockReturnValue({ defaultAgentId: "main", sessionAgentId: "work" });
+    const respond = await invoke("tts.status", { sessionKey: "agent:work:main" });
+
+    expect(resolveSessionAgentIds).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:work:main",
+        config: expect.any(Object),
+      }),
+    );
+    expect(mocks.resolveTtsConfig).toHaveBeenCalledWith(expect.any(Object), "work");
+    expect(mocks.resolveTtsPrefsPath).toHaveBeenCalledWith({ kind: "tts-config" }, "work");
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        enabled: true,
+        provider: "edge",
+        prefsPath: "/tmp/tts.json",
+      }),
+    );
+  });
+
+  it("passes the effective agentId through tts.convert", async () => {
+    resolveSessionAgentIds.mockReturnValue({ defaultAgentId: "main", sessionAgentId: "voice" });
+
+    await invoke("tts.convert", {
+      text: "hello there",
+      sessionKey: "agent:voice:main",
+      channel: "discord",
+    });
+
+    expect(mocks.textToSpeech).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "hello there",
+        channel: "discord",
+        cfg: expect.any(Object),
+        agentId: "voice",
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -1,3 +1,4 @@
+import { resolveSessionAgentIds } from "../../agents/agent-scope.js";
 import { loadConfig } from "../../config/config.js";
 import {
   OPENAI_TTS_MODELS,
@@ -18,12 +19,26 @@ import { ErrorCodes, errorShape } from "../protocol/index.js";
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+function resolveGatewayTtsAgentId(
+  cfg: ReturnType<typeof loadConfig>,
+  params: Record<string, unknown>,
+) {
+  const sessionKey =
+    typeof params.sessionKey === "string" && params.sessionKey.trim()
+      ? params.sessionKey.trim().toLowerCase()
+      : undefined;
+  const agentId =
+    typeof params.agentId === "string" && params.agentId.trim() ? params.agentId.trim() : undefined;
+  return resolveSessionAgentIds({ config: cfg, sessionKey, agentId }).sessionAgentId;
+}
+
 export const ttsHandlers: GatewayRequestHandlers = {
-  "tts.status": async ({ respond }) => {
+  "tts.status": async ({ params, respond }) => {
     try {
       const cfg = loadConfig();
-      const config = resolveTtsConfig(cfg);
-      const prefsPath = resolveTtsPrefsPath(config);
+      const agentId = resolveGatewayTtsAgentId(cfg, params);
+      const config = resolveTtsConfig(cfg, agentId);
+      const prefsPath = resolveTtsPrefsPath(config, agentId);
       const provider = getTtsProvider(config, prefsPath);
       const autoMode = resolveTtsAutoMode({ config, prefsPath });
       const fallbackProviders = resolveTtsProviderOrder(provider)
@@ -44,22 +59,24 @@ export const ttsHandlers: GatewayRequestHandlers = {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
     }
   },
-  "tts.enable": async ({ respond }) => {
+  "tts.enable": async ({ params, respond }) => {
     try {
       const cfg = loadConfig();
-      const config = resolveTtsConfig(cfg);
-      const prefsPath = resolveTtsPrefsPath(config);
+      const agentId = resolveGatewayTtsAgentId(cfg, params);
+      const config = resolveTtsConfig(cfg, agentId);
+      const prefsPath = resolveTtsPrefsPath(config, agentId);
       setTtsEnabled(prefsPath, true);
       respond(true, { enabled: true });
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
     }
   },
-  "tts.disable": async ({ respond }) => {
+  "tts.disable": async ({ params, respond }) => {
     try {
       const cfg = loadConfig();
-      const config = resolveTtsConfig(cfg);
-      const prefsPath = resolveTtsPrefsPath(config);
+      const agentId = resolveGatewayTtsAgentId(cfg, params);
+      const config = resolveTtsConfig(cfg, agentId);
+      const prefsPath = resolveTtsPrefsPath(config, agentId);
       setTtsEnabled(prefsPath, false);
       respond(true, { enabled: false });
     } catch (err) {
@@ -78,8 +95,11 @@ export const ttsHandlers: GatewayRequestHandlers = {
     }
     try {
       const cfg = loadConfig();
+      const agentId = resolveGatewayTtsAgentId(cfg, params);
+      const config = resolveTtsConfig(cfg, agentId);
+      const prefsPath = resolveTtsPrefsPath(config, agentId);
       const channel = typeof params.channel === "string" ? params.channel.trim() : undefined;
-      const result = await textToSpeech({ text, cfg, channel });
+      const result = await textToSpeech({ text, cfg, channel, agentId, config, prefsPath });
       if (result.success && result.audioPath) {
         respond(true, {
           audioPath: result.audioPath,
@@ -113,19 +133,21 @@ export const ttsHandlers: GatewayRequestHandlers = {
     }
     try {
       const cfg = loadConfig();
-      const config = resolveTtsConfig(cfg);
-      const prefsPath = resolveTtsPrefsPath(config);
+      const agentId = resolveGatewayTtsAgentId(cfg, params);
+      const config = resolveTtsConfig(cfg, agentId);
+      const prefsPath = resolveTtsPrefsPath(config, agentId);
       setTtsProvider(prefsPath, provider);
       respond(true, { provider });
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
     }
   },
-  "tts.providers": async ({ respond }) => {
+  "tts.providers": async ({ params, respond }) => {
     try {
       const cfg = loadConfig();
-      const config = resolveTtsConfig(cfg);
-      const prefsPath = resolveTtsPrefsPath(config);
+      const agentId = resolveGatewayTtsAgentId(cfg, params);
+      const config = resolveTtsConfig(cfg, agentId);
+      const prefsPath = resolveTtsPrefsPath(config, agentId);
       respond(true, {
         providers: [
           {

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -594,6 +594,29 @@ describe("tts", () => {
       expect(agentConfig.elevenlabs.voiceId).toBe(agentVoiceId);
     });
 
+    it("applies agent overrides when the configured agent id is not normalized", () => {
+      const cfgWithMixedCaseId: OpenClawConfig = {
+        ...cfg,
+        agents: {
+          ...cfg.agents!,
+          list: [
+            {
+              id: "VoiceAgent",
+              tts: {
+                elevenlabs: {
+                  voiceId: agentVoiceId,
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      const agentConfig = resolveTtsConfig(cfgWithMixedCaseId, "voiceagent");
+
+      expect(agentConfig.elevenlabs.voiceId).toBe(agentVoiceId);
+    });
+
     it("uses the agent-specific ElevenLabs voice during synthesis", async () => {
       const originalFetch = globalThis.fetch;
       const fetchMock = vi.fn(async () => ({

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -1,3 +1,5 @@
+import { rmSync } from "node:fs";
+import path from "node:path";
 import { completeSimple, type AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { ensureCustomApiRegistered } from "../agents/custom-api-registry.js";
@@ -45,7 +47,8 @@ vi.mock("../agents/custom-api-registry.js", () => ({
   ensureCustomApiRegistered: vi.fn(),
 }));
 
-const { _test, resolveTtsConfig, maybeApplyTtsToPayload, getTtsProvider } = tts;
+const { _test, resolveTtsConfig, resolveTtsPrefsPath, maybeApplyTtsToPayload, getTtsProvider } =
+  tts;
 
 const {
   isValidVoiceId,
@@ -554,6 +557,83 @@ describe("tts", () => {
     });
   });
 
+  describe("agent-scoped TTS", () => {
+    const agentId = "voiceagent";
+    const globalVoiceId = "A1B2C3D4E5F6G7H8I9J0";
+    const agentVoiceId = "J0I9H8G7F6E5D4C3B2A1";
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { model: { primary: "openai/gpt-4o-mini" } },
+        list: [
+          {
+            id: agentId,
+            tts: {
+              elevenlabs: {
+                voiceId: agentVoiceId,
+              },
+            },
+          },
+        ],
+      },
+      messages: {
+        tts: {
+          provider: "elevenlabs",
+          elevenlabs: {
+            apiKey: "test-key",
+            voiceId: globalVoiceId,
+          },
+        },
+      },
+    };
+
+    it("merges agent TTS overrides on top of global settings", () => {
+      const globalConfig = resolveTtsConfig(cfg);
+      const agentConfig = resolveTtsConfig(cfg, agentId);
+
+      expect(globalConfig.elevenlabs.voiceId).toBe(globalVoiceId);
+      expect(agentConfig.elevenlabs.voiceId).toBe(agentVoiceId);
+    });
+
+    it("uses the agent-specific ElevenLabs voice during synthesis", async () => {
+      const originalFetch = globalThis.fetch;
+      const fetchMock = vi.fn(async () => ({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(1),
+      }));
+      const prefsPath = `/tmp/tts-agent-${Date.now()}.json`;
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      try {
+        const result = await tts.textToSpeech({
+          text: "Hello from the agent-specific voice.",
+          cfg,
+          agentId,
+          prefsPath,
+        });
+
+        expect(result.success).toBe(true);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const requestUrl = String((fetchMock.mock.calls as Array<Array<unknown>>)[0]?.[0]);
+        expect(requestUrl).toContain(`/v1/text-to-speech/${agentVoiceId}`);
+
+        if (result.success && result.audioPath) {
+          rmSync(path.dirname(result.audioPath), { recursive: true, force: true });
+        }
+      } finally {
+        globalThis.fetch = originalFetch;
+        rmSync(prefsPath, { force: true });
+      }
+    });
+
+    it("uses agent-scoped prefs files by default", () => {
+      const globalConfig = resolveTtsConfig(cfg);
+      const agentConfig = resolveTtsConfig(cfg, agentId);
+
+      expect(resolveTtsPrefsPath(globalConfig)).toMatch(/settings\/tts\.json$/);
+      expect(resolveTtsPrefsPath(agentConfig, agentId)).toMatch(/settings\/tts\.voiceagent\.json$/);
+    });
+  });
+
   describe("maybeApplyTtsToPayload", () => {
     const baseCfg: OpenClawConfig = {
       agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
@@ -661,6 +741,62 @@ describe("tts", () => {
         expect(result.mediaUrl).toBeDefined();
         expect(fetchMock).toHaveBeenCalledTimes(1);
       });
+    });
+
+    it("uses the agent-specific ElevenLabs voice for auto-TTS final replies", async () => {
+      const agentId = "voiceagent";
+      const globalVoiceId = "A1B2C3D4E5F6G7H8I9J0";
+      const agentVoiceId = "J0I9H8G7F6E5D4C3B2A1";
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: { model: { primary: "openai/gpt-4o-mini" } },
+          list: [
+            {
+              id: agentId,
+              tts: {
+                elevenlabs: {
+                  voiceId: agentVoiceId,
+                },
+              },
+            },
+          ],
+        },
+        messages: {
+          tts: {
+            auto: "always",
+            provider: "elevenlabs",
+            elevenlabs: {
+              apiKey: "test-key",
+              voiceId: globalVoiceId,
+            },
+          },
+        },
+      };
+      const originalFetch = globalThis.fetch;
+      const fetchMock = vi.fn(async () => ({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(1),
+      }));
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      try {
+        const result = await maybeApplyTtsToPayload({
+          payload: {
+            text: "This is a sufficiently long payload for automatic TTS synthesis on Discord.",
+          },
+          cfg,
+          channel: "discord",
+          kind: "final",
+          agentId,
+        });
+
+        expect(result.mediaUrl).toBeDefined();
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const requestUrl = String((fetchMock.mock.calls as Array<Array<unknown>>)[0]?.[0]);
+        expect(requestUrl).toContain(`/v1/text-to-speech/${agentVoiceId}`);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
     });
   });
 });

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -652,8 +652,10 @@ describe("tts", () => {
       const globalConfig = resolveTtsConfig(cfg);
       const agentConfig = resolveTtsConfig(cfg, agentId);
 
-      expect(resolveTtsPrefsPath(globalConfig)).toMatch(/settings\/tts\.json$/);
-      expect(resolveTtsPrefsPath(agentConfig, agentId)).toMatch(/settings\/tts\.voiceagent\.json$/);
+      expect(resolveTtsPrefsPath(globalConfig)).toMatch(/settings[\\/]+tts\.json$/);
+      expect(resolveTtsPrefsPath(agentConfig, agentId)).toMatch(
+        /settings[\\/]+tts\.voiceagent\.json$/,
+      );
     });
   });
 

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -291,7 +291,10 @@ export function mergeTtsConfig(base: TtsConfig, override?: TtsConfig): TtsConfig
 
 export function resolveTtsConfig(cfg: OpenClawConfig, agentId?: string): ResolvedTtsConfig {
   const globalRaw: TtsConfig = cfg.messages?.tts ?? {};
-  const agentTts = agentId ? cfg.agents?.list?.find((a) => a.id === agentId)?.tts : undefined;
+  const normalizedAgentId = agentId?.trim() ? normalizeAgentId(agentId) : undefined;
+  const agentTts = normalizedAgentId
+    ? cfg.agents?.list?.find((a) => normalizeAgentId(a.id) === normalizedAgentId)?.tts
+    : undefined;
   const raw = mergeTtsConfig(globalRaw, agentTts);
   const providerSource = raw.provider ? "config" : "default";
   const edgeOutputFormat = raw.edge?.outputFormat?.trim();

--- a/src/tts/tts.ts
+++ b/src/tts/tts.ts
@@ -25,7 +25,9 @@ import type {
 import { logVerbose } from "../globals.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { stripMarkdown } from "../line/markdown-to-line.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isVoiceCompatibleAudio } from "../media/audio.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import {
   DEFAULT_OPENAI_BASE_URL,
@@ -43,6 +45,8 @@ import {
   summarizeText,
 } from "./tts-core.js";
 export { OPENAI_TTS_MODELS, OPENAI_TTS_VOICES } from "./tts-core.js";
+
+const log = createSubsystemLogger("tts");
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_TTS_MAX_LENGTH = 1500;
@@ -255,8 +259,40 @@ function resolveModelOverridePolicy(
   };
 }
 
-export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
-  const raw: TtsConfig = cfg.messages?.tts ?? {};
+export function mergeTtsConfig(base: TtsConfig, override?: TtsConfig): TtsConfig {
+  if (!override) {
+    return base;
+  }
+  return {
+    ...base,
+    ...override,
+    modelOverrides: {
+      ...base.modelOverrides,
+      ...override.modelOverrides,
+    },
+    elevenlabs: {
+      ...base.elevenlabs,
+      ...override.elevenlabs,
+      voiceSettings: {
+        ...base.elevenlabs?.voiceSettings,
+        ...override.elevenlabs?.voiceSettings,
+      },
+    },
+    openai: {
+      ...base.openai,
+      ...override.openai,
+    },
+    edge: {
+      ...base.edge,
+      ...override.edge,
+    },
+  };
+}
+
+export function resolveTtsConfig(cfg: OpenClawConfig, agentId?: string): ResolvedTtsConfig {
+  const globalRaw: TtsConfig = cfg.messages?.tts ?? {};
+  const agentTts = agentId ? cfg.agents?.list?.find((a) => a.id === agentId)?.tts : undefined;
+  const raw = mergeTtsConfig(globalRaw, agentTts);
   const providerSource = raw.provider ? "config" : "default";
   const edgeOutputFormat = raw.edge?.outputFormat?.trim();
   const auto = normalizeTtsAutoMode(raw.auto) ?? (raw.enabled ? "always" : "off");
@@ -324,13 +360,31 @@ export function resolveTtsConfig(cfg: OpenClawConfig): ResolvedTtsConfig {
   };
 }
 
-export function resolveTtsPrefsPath(config: ResolvedTtsConfig): string {
+export function resolveTtsPrefsPath(config: ResolvedTtsConfig, agentId?: string): string {
   if (config.prefsPath?.trim()) {
     return resolveUserPath(config.prefsPath.trim());
   }
   const envPath = process.env.OPENCLAW_TTS_PREFS?.trim();
   if (envPath) {
     return resolveUserPath(envPath);
+  }
+  const normalizedAgentId = agentId?.trim() ? normalizeAgentId(agentId) : undefined;
+  if (normalizedAgentId) {
+    const agentPrefsPath = path.join(CONFIG_DIR, "settings", `tts.${normalizedAgentId}.json`);
+    const legacyPrefsPath = path.join(CONFIG_DIR, "settings", "tts.json");
+    const isTestEnv = process.env.VITEST === "true" || process.env.NODE_ENV === "test";
+    if (!isTestEnv && !existsSync(agentPrefsPath) && existsSync(legacyPrefsPath)) {
+      try {
+        const legacyPrefs = readFileSync(legacyPrefsPath, "utf8");
+        if (legacyPrefs.trim()) {
+          mkdirSync(path.dirname(agentPrefsPath), { recursive: true });
+          atomicWriteFileSync(agentPrefsPath, legacyPrefs);
+        }
+      } catch {
+        // Ignore migration failures and fall back to the agent path.
+      }
+    }
+    return agentPrefsPath;
   }
   return path.join(CONFIG_DIR, "settings", "tts.json");
 }
@@ -362,9 +416,12 @@ export function resolveTtsAutoMode(params: {
   return params.config.auto;
 }
 
-export function buildTtsSystemPromptHint(cfg: OpenClawConfig): string | undefined {
-  const config = resolveTtsConfig(cfg);
-  const prefsPath = resolveTtsPrefsPath(config);
+export function buildTtsSystemPromptHint(
+  cfg: OpenClawConfig,
+  agentId?: string,
+): string | undefined {
+  const config = resolveTtsConfig(cfg, agentId);
+  const prefsPath = resolveTtsPrefsPath(config, agentId);
   const autoMode = resolveTtsAutoMode({ config, prefsPath });
   if (autoMode === "off") {
     return undefined;
@@ -560,9 +617,11 @@ export async function textToSpeech(params: {
   prefsPath?: string;
   channel?: string;
   overrides?: TtsDirectiveOverrides;
+  agentId?: string;
+  config?: ResolvedTtsConfig;
 }): Promise<TtsResult> {
-  const config = resolveTtsConfig(params.cfg);
-  const prefsPath = params.prefsPath ?? resolveTtsPrefsPath(config);
+  const config = params.config ?? resolveTtsConfig(params.cfg, params.agentId);
+  const prefsPath = params.prefsPath ?? resolveTtsPrefsPath(config, params.agentId);
   const channelId = resolveChannelId(params.channel);
   const output = resolveOutputFormat(channelId);
 
@@ -588,6 +647,18 @@ export async function textToSpeech(params: {
           errors.push("edge: disabled");
           continue;
         }
+        if (channelId === "discord") {
+          log.info("synth", {
+            provider,
+            agentId: params.agentId,
+            channel: channelId,
+            voice: config.edge.voice,
+            outputFormat: config.edge.outputFormat,
+          });
+        }
+        logVerbose(
+          `TTS: synth provider=edge agent=${params.agentId ?? "-"} channel=${channelId ?? "-"} voice=${config.edge.voice} format=${config.edge.outputFormat}`,
+        );
 
         const tempRoot = resolvePreferredOpenClawTmpDir();
         mkdirSync(tempRoot, { recursive: true, mode: 0o700 });
@@ -663,6 +734,8 @@ export async function textToSpeech(params: {
       if (provider === "elevenlabs") {
         const voiceIdOverride = params.overrides?.elevenlabs?.voiceId;
         const modelIdOverride = params.overrides?.elevenlabs?.modelId;
+        const selectedVoiceId = voiceIdOverride ?? config.elevenlabs.voiceId;
+        const selectedModelId = modelIdOverride ?? config.elevenlabs.modelId;
         const voiceSettings = {
           ...config.elevenlabs.voiceSettings,
           ...params.overrides?.elevenlabs?.voiceSettings,
@@ -670,12 +743,24 @@ export async function textToSpeech(params: {
         const seedOverride = params.overrides?.elevenlabs?.seed;
         const normalizationOverride = params.overrides?.elevenlabs?.applyTextNormalization;
         const languageOverride = params.overrides?.elevenlabs?.languageCode;
+        if (channelId === "discord") {
+          log.info("synth", {
+            provider,
+            agentId: params.agentId,
+            channel: channelId,
+            voiceId: selectedVoiceId,
+            modelId: selectedModelId,
+          });
+        }
+        logVerbose(
+          `TTS: synth provider=elevenlabs agent=${params.agentId ?? "-"} channel=${channelId ?? "-"} voiceId=${selectedVoiceId} modelId=${selectedModelId}`,
+        );
         audioBuffer = await elevenLabsTTS({
           text: params.text,
           apiKey,
           baseUrl: config.elevenlabs.baseUrl,
-          voiceId: voiceIdOverride ?? config.elevenlabs.voiceId,
-          modelId: modelIdOverride ?? config.elevenlabs.modelId,
+          voiceId: selectedVoiceId,
+          modelId: selectedModelId,
           outputFormat: output.elevenlabs,
           seed: seedOverride ?? config.elevenlabs.seed,
           applyTextNormalization: normalizationOverride ?? config.elevenlabs.applyTextNormalization,
@@ -686,12 +771,26 @@ export async function textToSpeech(params: {
       } else {
         const openaiModelOverride = params.overrides?.openai?.model;
         const openaiVoiceOverride = params.overrides?.openai?.voice;
+        const selectedModel = openaiModelOverride ?? config.openai.model;
+        const selectedVoice = openaiVoiceOverride ?? config.openai.voice;
+        if (channelId === "discord") {
+          log.info("synth", {
+            provider,
+            agentId: params.agentId,
+            channel: channelId,
+            voice: selectedVoice,
+            model: selectedModel,
+          });
+        }
+        logVerbose(
+          `TTS: synth provider=openai agent=${params.agentId ?? "-"} channel=${channelId ?? "-"} voice=${selectedVoice} model=${selectedModel}`,
+        );
         audioBuffer = await openaiTTS({
           text: params.text,
           apiKey,
           baseUrl: config.openai.baseUrl,
-          model: openaiModelOverride ?? config.openai.model,
-          voice: openaiVoiceOverride ?? config.openai.voice,
+          model: selectedModel,
+          voice: selectedVoice,
           responseFormat: output.openai,
           timeoutMs: config.timeoutMs,
         });
@@ -726,9 +825,11 @@ export async function textToSpeechTelephony(params: {
   text: string;
   cfg: OpenClawConfig;
   prefsPath?: string;
+  agentId?: string;
+  config?: ResolvedTtsConfig;
 }): Promise<TtsTelephonyResult> {
-  const config = resolveTtsConfig(params.cfg);
-  const prefsPath = params.prefsPath ?? resolveTtsPrefsPath(config);
+  const config = params.config ?? resolveTtsConfig(params.cfg, params.agentId);
+  const prefsPath = params.prefsPath ?? resolveTtsPrefsPath(config, params.agentId);
 
   if (params.text.length > config.maxTextLength) {
     return {
@@ -816,9 +917,10 @@ export async function maybeApplyTtsToPayload(params: {
   kind?: "tool" | "block" | "final";
   inboundAudio?: boolean;
   ttsAuto?: string;
+  agentId?: string;
 }): Promise<ReplyPayload> {
-  const config = resolveTtsConfig(params.cfg);
-  const prefsPath = resolveTtsPrefsPath(config);
+  const config = resolveTtsConfig(params.cfg, params.agentId);
+  const prefsPath = resolveTtsPrefsPath(config, params.agentId);
   const autoMode = resolveTtsAutoMode({
     config,
     prefsPath,
@@ -916,9 +1018,11 @@ export async function maybeApplyTtsToPayload(params: {
   const result = await textToSpeech({
     text: textForAudio,
     cfg: params.cfg,
+    config,
     prefsPath,
     channel: params.channel,
     overrides: directives.overrides,
+    agentId: params.agentId,
   });
 
   if (result.success && result.audioPath) {


### PR DESCRIPTION
## Summary

- Problem: Discord native `/voice` commands routed to the correct agent, but TTS synthesis could still fall back to `main`.
- Why it matters: agent-specific voice IDs and model IDs were ignored for native Discord slash commands, so different agents could speak with the same voice/model.
- What changed: added agent-scoped TTS overrides, fixed Discord native command session targeting so empty bound session keys no longer overwrite routed target sessions, and added regression coverage for native command routing and native TTS agent resolution.
- What did NOT change (scope boundary): no changes to TTS provider behavior outside agent-scoped TTS config and native Discord command routing.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Discord native `/voice` now respects the routed agent session.
- Agent-specific TTS voices and model IDs apply correctly for native Discord slash commands.
- Agent tools and auto-TTS flows now resolve agent-scoped TTS config consistently.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local gateway
- Model/provider: ElevenLabs TTS
- Integration/channel (if any): Discord
- Relevant config (redacted): two Discord bot accounts bound to different agents with different ElevenLabs voice IDs/model IDs

### Steps

1. Configure `main` and `aventurine` with different ElevenLabs `voiceId`s and optional `modelId`s.
2. Send `/voice audio hello` from the Aventurine Discord bot/account.
3. Observe the synthesized voice and routing logs.

### Expected

- The Aventurine request uses the Aventurine agent session and Aventurine TTS config.

### Actual

- Before this fix, routing logged `aventurine` but TTS synthesis still used `main` and its TTS config.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Discord native `/voice audio hello` and `/voice summary` for Aventurine after restarting the gateway.
- Edge cases checked: non-ACP Discord native command routing; native TTS command agent resolution; agent-scoped TTS override merging for `voiceId`/`modelId`; target session propagation.
- What you did **not** verify: full multi-platform native command behavior outside Discord; full repository-wide test suite.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit and restart the gateway.
- Files/config to restore: native Discord command routing and TTS resolution files only.
- Known bad symptoms reviewers should watch for: native Discord `/voice` requests speaking with the `main` voice/model instead of the routed agent config.

## Risks and Mitigations

- Risk: native command session routing changes could affect other Discord slash commands.
  - Mitigation: added regression tests around Discord native routing and native TTS command handling.
