### PR TITLE
[Issue #37832] WhatsApp/web-outbound: message tool media from workspace- rejected (path-not-allowed)

### DIFF
--- a/.github/issue-bootstrap/issue-37832.md
+++ b/.github/issue-bootstrap/issue-37832.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37832
+- Title: WhatsApp/web-outbound: message tool media from workspace-<agentId> rejected (path-not-allowed)
+- Source: https://github.com/openclaw/openclaw/issues/37832


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37832

## Original Issue Description
## Summary

When running an untrusted agent in Docker sandbox mode, media files generated in the agent workspace are blocked on WhatsApp outbound send with:

`LocalMediaAccessError: Local media path is not under an allowed directory`

Main error code is `path-not-allowed`.

## Context

Goal is to keep `tools.exec` sandboxed in Docker (for ffmpeg/media processing) while still allowing normal channel delivery (WhatsApp/Telegram) of generated attachments.

Important clarification: with OpenClaw tool sandboxing, Docker does not need direct TCP access to gateway. Gateway still owns messaging; only tools run in Docker.

## Repro template

- Agent workspace (host): `~/.openclaw/workspace-`
- Sandbox mount: `/workspace -> ~/.openclaw/workspace-`
- Generated media in sandbox: `/workspace/media/ (e.g., pigeon1.mp4)`
- Host file path: `~/.openclaw/workspace-/media/ (e.g., pigeon1.mp4)`
- Send that media via WhatsApp using message/send tool
- Observe failure: `LocalMediaAccessError` with `code=path-not-allowed`
- Telegram works for same setup

## Log template

```text
... errorCode=UNAVAILABLE errorMessage=LocalMediaAccessError: Local media path is not under an allowed directory: /home//.openclaw/workspace-/media/ (e.g., pigeon1.mp4) ... code=path-not-allowed ... channel=whatsapp
```

## Root cause hypothesis

This appears to be a gateway-side local media allowlist issue (not file existence).

`src/web/media.ts` hardening intentionally blocks default allowlist reads for `workspace-*` state roots unless explicit local roots are provided. In this send path, explicit agent-scoped roots seem not to be applied consistently for WhatsApp outbound, so it falls back to default roots and rejects `workspace-`.

## Expected behavior

When send path has agent context, outbound media reads should apply agent-scoped local roots (or equivalent sandbox-validated read policy), so media generated in `workspace-` can be sent without requiring insecure workarounds.

## Security note

Please do not recommend `tools.exec.host=gateway` as workaround, since that defeats sandbox isolation for untrusted agents.

## Related issues

- #30871
- #28802
- #20029

## Linkage
Refs #37832