### PR TITLE
[Issue #37834] Session context corruption: orphaned tool_use ID causes permanent 400 loop after abort

### DIFF
--- a/.github/issue-bootstrap/issue-37834.md
+++ b/.github/issue-bootstrap/issue-37834.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37834
+- Title: Session context corruption: orphaned tool_use ID causes permanent 400 loop after abort
+- Source: https://github.com/openclaw/openclaw/issues/37834


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37834

## Original Issue Description
See source issue body for the full description.
Title: Session context corruption: orphaned tool_use ID causes permanent 400 loop after abort

## Linkage
Refs #37834