### PR TITLE
[Issue #37841] [Bug]: Session text invisible to user when message tool sends media on WhatsApp

### DIFF
--- a/.github/issue-bootstrap/issue-37841.md
+++ b/.github/issue-bootstrap/issue-37841.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37841
+- Title: [Bug]: Session text invisible to user when message tool sends media on WhatsApp
+- Source: https://github.com/openclaw/openclaw/issues/37841


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37841

## Original Issue Description
See source issue body for the full description.
Title: [Bug]: Session text invisible to user when message tool sends media on WhatsApp

## Linkage
Refs #37841