### PR TITLE
[Issue #37842] Feature: Graph-aware loop detection for sessions_send (triangular/polygonal cascades bypass maxPingPongTurns)

### DIFF
--- a/.github/issue-bootstrap/issue-37842.md
+++ b/.github/issue-bootstrap/issue-37842.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37842
+- Title: Feature: Graph-aware loop detection for sessions_send (triangular/polygonal cascades bypass maxPingPongTurns)
+- Source: https://github.com/openclaw/openclaw/issues/37842


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37842

## Original Issue Description
See source issue body for the full description.
Title: Feature: Graph-aware loop detection for sessions_send (triangular/polygonal cascades bypass maxPingPongTurns)

## Linkage
Refs #37842