### PR TITLE
[Issue #37843] Cron Job Model Should Support default as Special Value for Runtime Resolution

### DIFF
--- a/.github/issue-bootstrap/issue-37843.md
+++ b/.github/issue-bootstrap/issue-37843.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37843
+- Title: Cron Job Model Should Support default as Special Value for Runtime Resolution
+- Source: https://github.com/openclaw/openclaw/issues/37843


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37843

## Original Issue Description
See source issue body for the full description.
Title: Cron Job Model Should Support default as Special Value for Runtime Resolution

## Linkage
Refs #37843