### PR TITLE
[Issue #37844] [Bug]: Discord bot sends duplicate replies to the same message

### DIFF
--- a/.github/issue-bootstrap/issue-37844.md
+++ b/.github/issue-bootstrap/issue-37844.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37844
+- Title: [Bug]: Discord bot sends duplicate replies to the same message
+- Source: https://github.com/openclaw/openclaw/issues/37844


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37844

## Original Issue Description
See source issue body for the full description.
Title: [Bug]: Discord bot sends duplicate replies to the same message

## Linkage
Refs #37844