### PR TITLE
[Issue #37846] EROFS: Isolated cron session sandbox tries to write /file.lock at root (read-only), crashes before script executes

### DIFF
--- a/.github/issue-bootstrap/issue-37846.md
+++ b/.github/issue-bootstrap/issue-37846.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37846
+- Title: EROFS: Isolated cron session sandbox tries to write /file.lock at root (read-only), crashes before script executes
+- Source: https://github.com/openclaw/openclaw/issues/37846


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37846

## Original Issue Description
See source issue body for the full description.
Title: EROFS: Isolated cron session sandbox tries to write /file.lock at root (read-only), crashes before script executes

## Linkage
Refs #37846