### PR TITLE
[Issue #37852] [Bug] Synology Chat plugin: sendText/sendMedia fails with 'incoming URL not configured' due to empty config fallback

### DIFF
--- a/.github/issue-bootstrap/issue-37852.md
+++ b/.github/issue-bootstrap/issue-37852.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37852
+- Title: [Bug] Synology Chat plugin: sendText/sendMedia fails with 'incoming URL not configured' due to empty config fallback
+- Source: https://github.com/openclaw/openclaw/issues/37852


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37852

## Original Issue Description
See source issue body for the full description.
Title: [Bug] Synology Chat plugin: sendText/sendMedia fails with 'incoming URL not configured' due to empty config fallback

## Linkage
Refs #37852