### PR TITLE
[Issue #37857] feishu-plugin-onboard doctor --fix disables most stock plugins (OpenClaw 2026.3.2)

### DIFF
--- a/.github/issue-bootstrap/issue-37857.md
+++ b/.github/issue-bootstrap/issue-37857.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37857
+- Title: feishu-plugin-onboard doctor --fix disables most stock plugins (OpenClaw 2026.3.2)
+- Source: https://github.com/openclaw/openclaw/issues/37857


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37857

## Original Issue Description
See source issue body for the full description.
Title: feishu-plugin-onboard doctor --fix disables most stock plugins (OpenClaw 2026.3.2)

## Linkage
Refs #37857