### PR TITLE
[Issue #37865] [Bug]: TUI and web UI: streaming text does not actually stream when using tools, it only shows up when finalized

### DIFF
--- a/.github/issue-bootstrap/issue-37865.md
+++ b/.github/issue-bootstrap/issue-37865.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37865
+- Title: [Bug]: TUI and web UI: streaming text does not actually stream when using tools, it only shows up when finalized
+- Source: https://github.com/openclaw/openclaw/issues/37865


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37865

## Original Issue Description
See source issue body for the full description.
Title: [Bug]: TUI and web UI: streaming text does not actually stream when using tools, it only shows up when finalized

## Linkage
Refs #37865