### PR TITLE
[Issue #37869] [Bug] ACP/acpx session accepted but never closes the loop; no history, no announce, no stream log

### DIFF
--- a/.github/issue-bootstrap/issue-37869.md
+++ b/.github/issue-bootstrap/issue-37869.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37869
+- Title: [Bug] ACP/acpx session accepted but never closes the loop; no history, no announce, no stream log
+- Source: https://github.com/openclaw/openclaw/issues/37869


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37869

## Original Issue Description
See source issue body for the full description.
Title: [Bug] ACP/acpx session accepted but never closes the loop; no history, no announce, no stream log

## Linkage
Refs #37869