### PR TITLE
[Issue #37874] TUI incorrectly tags messages with channel: telegram causing cross-delivery

### DIFF
--- a/.github/issue-bootstrap/issue-37874.md
+++ b/.github/issue-bootstrap/issue-37874.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37874
+- Title: TUI incorrectly tags messages with channel: telegram causing cross-delivery
+- Source: https://github.com/openclaw/openclaw/issues/37874


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37874

## Original Issue Description
See source issue body for the full description.
Title: TUI incorrectly tags messages with channel: telegram causing cross-delivery

## Linkage
Refs #37874