### PR TITLE
[Issue #37875] openai-codex/gpt-5.4 forward-compat fallback still uses 272k context

### DIFF
--- a/.github/issue-bootstrap/issue-37875.md
+++ b/.github/issue-bootstrap/issue-37875.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37875
+- Title: openai-codex/gpt-5.4 forward-compat fallback still uses 272k context
+- Source: https://github.com/openclaw/openclaw/issues/37875


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37875

## Original Issue Description
See source issue body for the full description.
Title: openai-codex/gpt-5.4 forward-compat fallback still uses 272k context

## Linkage
Refs #37875