### PR TITLE
[Issue #37889] [Bug]: BARE_SESSION_RESET_PROMPT causes large models (Sonnet) to hallucinate startup file paths

### DIFF
--- a/.github/issue-bootstrap/issue-37889.md
+++ b/.github/issue-bootstrap/issue-37889.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37889
+- Title: [Bug]: BARE_SESSION_RESET_PROMPT causes large models (Sonnet) to hallucinate startup file paths
+- Source: https://github.com/openclaw/openclaw/issues/37889


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37889

## Original Issue Description
See source issue body for the full description.
Title: [Bug]: BARE_SESSION_RESET_PROMPT causes large models (Sonnet) to hallucinate startup file paths

## Linkage
Refs #37889