### PR TITLE
[Issue #37890] Gemini raw reasoning text leaks into answer during Telegram DM streaming

### DIFF
--- a/.github/issue-bootstrap/issue-37890.md
+++ b/.github/issue-bootstrap/issue-37890.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37890
+- Title: Gemini raw reasoning text leaks into answer during Telegram DM streaming
+- Source: https://github.com/openclaw/openclaw/issues/37890


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37890

## Original Issue Description
See source issue body for the full description.
Title: Gemini raw reasoning text leaks into answer during Telegram DM streaming

## Linkage
Refs #37890