### PR TITLE
[Issue #37893] Bug: openclaw symlink breaks on macOS when Homebrew upgrades node

### DIFF
--- a/.github/issue-bootstrap/issue-37893.md
+++ b/.github/issue-bootstrap/issue-37893.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37893
+- Title: Bug: openclaw symlink breaks on macOS when Homebrew upgrades node
+- Source: https://github.com/openclaw/openclaw/issues/37893


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37893

## Original Issue Description
See source issue body for the full description.
Title: Bug: openclaw symlink breaks on macOS when Homebrew upgrades node

## Linkage
Refs #37893