### PR TITLE
[Issue #37902] sessions_spawn: model overrides runTimeoutSeconds with decreasing values across retries; no config minimum enforced

### DIFF
--- a/.github/issue-bootstrap/issue-37902.md
+++ b/.github/issue-bootstrap/issue-37902.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37902
+- Title: sessions_spawn: model overrides runTimeoutSeconds with decreasing values across retries; no config minimum enforced
+- Source: https://github.com/openclaw/openclaw/issues/37902


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37902

## Original Issue Description
See source issue body for the full description.
Title: sessions_spawn: model overrides runTimeoutSeconds with decreasing values across retries; no config minimum enforced

## Linkage
Refs #37902