### PR TITLE
[Issue #37907] Mutating tool warning fires even when agent successfully recovered in the same turn

### DIFF
--- a/.github/issue-bootstrap/issue-37907.md
+++ b/.github/issue-bootstrap/issue-37907.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37907
+- Title: Mutating tool warning fires even when agent successfully recovered in the same turn
+- Source: https://github.com/openclaw/openclaw/issues/37907


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37907

## Original Issue Description
See source issue body for the full description.
Title: Mutating tool warning fires even when agent successfully recovered in the same turn

## Linkage
Refs #37907