### PR TITLE
[Issue #37910] message tool cannot resolve SecretRef for channels.telegram.botToken at tool-call time

### DIFF
--- a/.github/issue-bootstrap/issue-37910.md
+++ b/.github/issue-bootstrap/issue-37910.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37910
+- Title: message tool cannot resolve SecretRef for channels.telegram.botToken at tool-call time
+- Source: https://github.com/openclaw/openclaw/issues/37910


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37910

## Original Issue Description
See source issue body for the full description.
Title: message tool cannot resolve SecretRef for channels.telegram.botToken at tool-call time

## Linkage
Refs #37910