### PR TITLE
[Issue #37913] [Bug]: Chrome extension relay: tab not found when using remote gateway + macOS node proxy (browser.proxy)

### DIFF
--- a/.github/issue-bootstrap/issue-37913.md
+++ b/.github/issue-bootstrap/issue-37913.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37913
+- Title: [Bug]: Chrome extension relay: tab not found when using remote gateway + macOS node proxy (browser.proxy)
+- Source: https://github.com/openclaw/openclaw/issues/37913


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37913

## Original Issue Description
See source issue body for the full description.
Title: [Bug]: Chrome extension relay: tab not found when using remote gateway + macOS node proxy (browser.proxy)

## Linkage
Refs #37913