### PR TITLE
[Issue #37915] [Bug]: nextcloud-talk plugin fails to load: Cannot find module '../../../src/infra/abort-signal.js'

### DIFF
--- a/.github/issue-bootstrap/issue-37915.md
+++ b/.github/issue-bootstrap/issue-37915.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37915
+- Title: [Bug]: nextcloud-talk plugin fails to load: Cannot find module '../../../src/infra/abort-signal.js'
+- Source: https://github.com/openclaw/openclaw/issues/37915


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37915

## Original Issue Description
See source issue body for the full description.
Title: [Bug]: nextcloud-talk plugin fails to load: Cannot find module '../../../src/infra/abort-signal.js'

## Linkage
Refs #37915