### PR TITLE
[Issue #37939] Telegram channel: stale-socket false positive every 30 minutes

### DIFF
--- a/.github/issue-bootstrap/issue-37939.md
+++ b/.github/issue-bootstrap/issue-37939.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37939
+- Title: Telegram channel: stale-socket false positive every 30 minutes
+- Source: https://github.com/openclaw/openclaw/issues/37939


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37939

## Original Issue Description
See source issue body for the full description.
Title: Telegram channel: stale-socket false positive every 30 minutes

## Linkage
Refs #37939