### PR TITLE
[Issue #37943] [Bug]: Node Service fails to parse valid config on macOS

### DIFF
--- a/.github/issue-bootstrap/issue-37943.md
+++ b/.github/issue-bootstrap/issue-37943.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37943
+- Title: [Bug]: Node Service fails to parse valid config on macOS
+- Source: https://github.com/openclaw/openclaw/issues/37943


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37943

## Original Issue Description
See source issue body for the full description.
Title: [Bug]: Node Service fails to parse valid config on macOS

## Linkage
Refs #37943