### PR TITLE
[Issue #37955] session-memory hook: idle/daily session rollovers don't fire command:new/reset event

### DIFF
--- a/.github/issue-bootstrap/issue-37955.md
+++ b/.github/issue-bootstrap/issue-37955.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37955
+- Title: session-memory hook: idle/daily session rollovers don't fire command:new/reset event
+- Source: https://github.com/openclaw/openclaw/issues/37955


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37955

## Original Issue Description
See source issue body for the full description.
Title: session-memory hook: idle/daily session rollovers don't fire command:new/reset event

## Linkage
Refs #37955