### PR TITLE
[Issue #37966] [Bug]: cacheRetention ignored for LiteLLM-proxied Anthropic models

### DIFF
--- a/.github/issue-bootstrap/issue-37966.md
+++ b/.github/issue-bootstrap/issue-37966.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37966
+- Title: [Bug]: cacheRetention ignored for LiteLLM-proxied Anthropic models
+- Source: https://github.com/openclaw/openclaw/issues/37966


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37966

## Original Issue Description
See source issue body for the full description.
Title: [Bug]: cacheRetention ignored for LiteLLM-proxied Anthropic models

## Linkage
Refs #37966