### PR TITLE
[Issue #37982] Telegram long-polling stale-socket recovery silently fails — gateway stops receiving messages

### DIFF
--- a/.github/issue-bootstrap/issue-37982.md
+++ b/.github/issue-bootstrap/issue-37982.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37982
+- Title: Telegram long-polling stale-socket recovery silently fails — gateway stops receiving messages
+- Source: https://github.com/openclaw/openclaw/issues/37982


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37982

## Original Issue Description
See source issue body for the full description.
Title: Telegram long-polling stale-socket recovery silently fails — gateway stops receiving messages

## Linkage
Refs #37982