### PR TITLE
[Issue #37983] Discord: forwarded text-only messages dropped by batching filter (baseText empty)

### DIFF
--- a/.github/issue-bootstrap/issue-37983.md
+++ b/.github/issue-bootstrap/issue-37983.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #37983
+- Title: Discord: forwarded text-only messages dropped by batching filter (baseText empty)
+- Source: https://github.com/openclaw/openclaw/issues/37983


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/37983

## Original Issue Description
See source issue body for the full description.
Title: Discord: forwarded text-only messages dropped by batching filter (baseText empty)

## Linkage
Refs #37983