### PR TITLE
fix(openai): Enable gpt-5.4 support via Chat Completions fallback on scope error

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -11,6 +11,7 @@ import {
   isFailoverErrorMessage,
   isImageDimensionErrorMessage,
   isLikelyContextOverflowError,
+  isMissingScopeResponsesWrite,
   isTimeoutErrorMessage,
   isTransientHttpError,
   parseImageDimensionError,
@@ -94,6 +95,25 @@ describe("isAuthErrorMessage", () => {
     for (const sample of samples) {
       expect(isAuthErrorMessage(sample)).toBe(true);
     }
+  });
+});
+
+describe("isMissingScopeResponsesWrite", () => {
+  it("matches missing scopes errors that mention responses.write scope", () => {
+    expect(
+      isMissingScopeResponsesWrite(
+        "HTTP 401 Unauthorized: Missing scopes: api.responses.write for this token",
+      ),
+    ).toBe(true);
+    expect(isMissingScopeResponsesWrite("missing scopes: responses.write, model.request")).toBe(
+      true,
+    );
+  });
+
+  it("does not match when either missing scopes or responses.write is absent", () => {
+    expect(isMissingScopeResponsesWrite("Missing scopes: model.request")).toBe(false);
+    expect(isMissingScopeResponsesWrite("api.responses.write is required")).toBe(false);
+    expect(isMissingScopeResponsesWrite("Unauthorized")).toBe(false);
   });
 });
 

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -35,6 +35,7 @@ export {
   isImageDimensionErrorMessage,
   isImageSizeError,
   isOverloadedErrorMessage,
+  isMissingScopeResponsesWrite,
   isRawApiErrorPayload,
   isRateLimitAssistantError,
   isRateLimitErrorMessage,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -9,6 +9,7 @@ import {
   isBillingErrorMessage,
   isOverloadedErrorMessage,
   isPeriodicUsageLimitErrorMessage,
+  isMissingScopeResponsesWrite,
   isRateLimitErrorMessage,
   isTimeoutErrorMessage,
   matchesFormatErrorPattern,
@@ -20,6 +21,7 @@ export {
   isAuthPermanentErrorMessage,
   isBillingErrorMessage,
   isOverloadedErrorMessage,
+  isMissingScopeResponsesWrite,
   isRateLimitErrorMessage,
   isTimeoutErrorMessage,
 } from "./failover-matches.js";

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -155,6 +155,17 @@ export function isAuthErrorMessage(raw: string): boolean {
   return matchesErrorPatterns(raw, ERROR_PATTERNS.auth);
 }
 
+export function isMissingScopeResponsesWrite(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  const value = raw.toLowerCase();
+  return (
+    value.includes("missing scopes") &&
+    (value.includes("api.responses.write") || value.includes("responses.write"))
+  );
+}
+
 export function isOverloadedErrorMessage(raw: string): boolean {
   return matchesErrorPatterns(raw, ERROR_PATTERNS.overloaded);
 }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -45,6 +45,7 @@ import {
   isLikelyContextOverflowError,
   isFailoverAssistantError,
   isFailoverErrorMessage,
+  isMissingScopeResponsesWrite,
   parseImageSizeError,
   parseImageDimensionError,
   isRateLimitAssistantError,
@@ -722,6 +723,8 @@ export async function runEmbeddedPiAgent(
       let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
       let autoCompactionCount = 0;
       let runLoopIterations = 0;
+      let responsesScopeFallbackRetried = false;
+      let forcedApiModelForRetry: typeof model | undefined;
       const maybeMarkAuthProfileFailure = async (failure: {
         profileId?: string;
         reason?: Parameters<typeof markAuthProfileFailure>[0]["reason"] | null;
@@ -789,6 +792,8 @@ export async function runEmbeddedPiAgent(
 
           const prompt =
             provider === "anthropic" ? scrubAnthropicRefusalMagic(params.prompt) : params.prompt;
+          const modelForAttempt = forcedApiModelForRetry ?? model;
+          forcedApiModelForRetry = undefined;
 
           const attempt = await runEmbeddedAttempt({
             sessionId: params.sessionId,
@@ -821,7 +826,7 @@ export async function runEmbeddedPiAgent(
             disableTools: params.disableTools,
             provider,
             modelId,
-            model,
+            model: modelForAttempt,
             authProfileId: lastProfileId,
             authProfileIdSource: lockedProfileId ? "user" : "auto",
             authStorage,
@@ -1160,6 +1165,22 @@ export async function runEmbeddedPiAgent(
                 },
               };
             }
+            if (
+              !responsesScopeFallbackRetried &&
+              modelForAttempt.api === "openai-responses" &&
+              isMissingScopeResponsesWrite(errorText)
+            ) {
+              responsesScopeFallbackRetried = true;
+              forcedApiModelForRetry = {
+                ...model,
+                api: "openai-completions",
+              };
+              log.warn(
+                "Retrying with Chat Completions API due to missing api.responses.write scope",
+              );
+              continue;
+            }
+
             const promptFailoverReason = classifyFailoverReason(errorText);
             await maybeMarkAuthProfileFailure({
               profileId: lastProfileId,


### PR DESCRIPTION
Resolves #24927

## Problem

Models like `openai-codex/gpt-5.4` currently fail with a `401 Unauthorized` error when used with an OAuth token (e.g., from the Codex app `app_EMoamEEZ73f0CkXaXp7hrann`).

This is because OpenClaw defaults to the newer OpenAI Responses API (`/v1/responses`), which requires an `api.responses.write` scope that is not present in existing OAuth tokens. The current system treats this as a generic authentication error and triggers a model failover, which prevents `gpt-5.4` from being used as intended.

## Solution

To provide a seamless experience and enable `gpt-5.4` support for users on existing authentication schemes, this PR introduces a more graceful fallback mechanism.

When a model using the `openai-responses` API fails specifically with a "missing scopes: api.responses.write" error, this change implements a **one-time retry**. The retry automatically uses the `openai-completions` API type for the same model, effectively routing the request to the compatible `/v1/chat/completions` endpoint.

### Key Changes:
- **Specific Error Detection**: A new matcher `isMissingScopeResponsesWrite()` precisely identifies the scope-related failure.
- **Intelligent Retry Logic**: Instead of failing immediately, the system attempts a targeted fix by switching to a compatible API for the *same model*.
- **Improved UX**: Users can now use `gpt-5.4` without interruption. A warning is logged to inform about the automatic API fallback, maintaining transparency.
