### PR TITLE
fix(agents): suppress mutating tool warning when agent recovered in same turn

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -82,4 +82,41 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
 
     expect(payloads).toHaveLength(0);
   });
+
+  it("suppresses mutating tool warning when same tool+meta succeeded later in turn", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "edit",
+        meta: "src/app.ts",
+        error: "Found 2 occurrences, must be unique",
+        mutatingAction: true,
+      },
+      toolMetas: [
+        { toolName: "read", meta: "src/app.ts" },
+        { toolName: "edit", meta: "src/app.ts" },
+      ],
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
+  it("still shows mutating tool warning when no matching success in turn", () => {
+    const payloads = buildPayloads({
+      lastToolError: {
+        toolName: "edit",
+        meta: "src/app.ts",
+        error: "permission denied",
+        mutatingAction: true,
+      },
+      toolMetas: [
+        { toolName: "read", meta: "src/app.ts" },
+        { toolName: "edit", meta: "src/other.ts" },
+      ],
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Edit",
+      absentDetail: "permission denied",
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -58,6 +58,7 @@ function resolveToolErrorWarningPolicy(params: {
   suppressToolErrors: boolean;
   suppressToolErrorWarnings?: boolean;
   verboseLevel?: VerboseLevel;
+  recoveredBySameToolInTurn?: boolean;
 }): ToolErrorWarningPolicy {
   const includeDetails = isVerboseToolDetailEnabled(params.verboseLevel);
   if (params.suppressToolErrorWarnings) {
@@ -76,6 +77,11 @@ function resolveToolErrorWarningPolicy(params: {
   const isMutatingToolError =
     params.lastToolError.mutatingAction ?? isLikelyMutatingToolName(params.lastToolError.toolName);
   if (isMutatingToolError) {
+    // Suppress warning when the same tool+target succeeded later in the turn,
+    // indicating the agent recovered from the initial failure (#37907).
+    if (params.recoveredBySameToolInTurn) {
+      return { showWarning: false, includeDetails };
+    }
     return { showWarning: true, includeDetails };
   }
   if (params.suppressToolErrors) {
@@ -276,12 +282,20 @@ export function buildEmbeddedRunPayloads(params: {
   }
 
   if (params.lastToolError) {
+    const errorToolName = params.lastToolError.toolName.trim().toLowerCase();
+    const errorMeta = (params.lastToolError.meta ?? "").trim();
+    const recoveredBySameToolInTurn = params.toolMetas.some((m) => {
+      const mName = m.toolName.trim().toLowerCase();
+      const mMeta = (m.meta ?? "").trim();
+      return mName === errorToolName && mMeta === errorMeta;
+    });
     const warningPolicy = resolveToolErrorWarningPolicy({
       lastToolError: params.lastToolError,
       hasUserFacingReply: hasUserFacingAssistantReply,
       suppressToolErrors: Boolean(params.config?.messages?.suppressToolErrors),
       suppressToolErrorWarnings: params.suppressToolErrorWarnings,
       verboseLevel: params.verboseLevel,
+      recoveredBySameToolInTurn,
     });
 
     // Always surface mutating tool failures so we do not silently confirm actions that did not happen.


### PR DESCRIPTION
## Summary

- **Problem:** When a mutating tool (e.g. `edit`) fails and the agent immediately retries with corrected arguments that succeed in the same turn, the `⚠️ Edit: <path> failed` warning is still shown to the user. This creates noise and false alarms.
- **Why it matters:** Users see failure notifications for actions that completed successfully, eroding trust in the system.
- **What changed:** Added a `recoveredBySameToolInTurn` flag to `resolveToolErrorWarningPolicy` that checks `toolMetas` for a successful call matching the failed tool's name+meta. When recovery is detected, the mutating tool warning is suppressed. Added 2 test cases.
- **What did NOT change:** The existing fingerprint-based recovery in `handlers.tools.ts` (which handles exact same-args retries), `MUTATING_TOOL_NAMES`, non-mutating tool error handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37907

## User-visible / Behavior Changes

- Mutating tool warnings (⚠️) are suppressed when the agent successfully recovered from the error in the same turn by retrying the same tool on the same target.
- Unrecovered mutating tool errors continue to show warnings as before.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0 (arm64)
- Runtime: Node v25.6.1
- Channel: Any (Slack, Telegram, etc.)

### Steps

1. Start a session with a mutating tool (edit, write)
2. Agent calls `edit` with an ambiguous search string → fails (Found 2 occurrences)
3. Agent retries with more context → succeeds
4. Observe chat output

### Expected

- No warning shown (agent recovered successfully)

### Actual

- Before fix: `⚠️ 📝 Edit: src/app.ts failed` shown despite success
- After fix: Warning suppressed; user only sees the successful result

## Evidence

```
 ✓ src/agents/pi-embedded-runner/run/payloads.test.ts (9 tests) 4ms
   ✓ suppresses mutating tool warning when same tool+meta succeeded later in turn
   ✓ still shows mutating tool warning when no matching success in turn
   ... (7 existing tests still pass)
```

## Human Verification (required)

- Verified scenarios: Recovery suppression (same tool+meta), non-recovery (different meta), all existing test cases
- Edge cases checked: Empty toolMetas, meta mismatch, case-insensitive tool name matching
- What I did **not** verify: Live gateway test with actual edit retry sequence

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; warnings will show for all mutating tool errors again (original behavior)
- Files/config to restore: `src/agents/pi-embedded-runner/run/payloads.ts`
- Known bad symptoms: If toolMetas tracking is broken, recovered warnings may not be suppressed (fails safe — shows warning)

## Risks and Mitigations

- Risk: False negative — a tool error is marked as recovered when it shouldn't be (same tool name + meta but logically different action). Mitigation: Recovery requires both tool name AND meta (target path) to match, which is the correct granularity for mutating tools like edit/write.
