### PR TITLE
fix(cli): add --no-validate flag to config set for incremental updates

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -420,6 +420,65 @@ describe("config cli", () => {
     });
   });
 
+  describe("config set --no-validate (issue #38022)", () => {
+    it("writes config without validation when --no-validate is passed", async () => {
+      const resolved: OpenClawConfig = { gateway: { port: 18789 } };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "secrets.providers.default.source",
+        '"file"',
+        "--no-validate",
+      ]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = mockWriteConfigFile.mock.calls[0]?.[0];
+      expect((written as Record<string, unknown>).secrets).toEqual({
+        providers: { default: { source: "file" } },
+      });
+      // skipValidation should be passed through
+      expect(mockWriteConfigFile.mock.calls[0]?.[1]).toEqual({ skipValidation: true });
+    });
+
+    it("allows set on an already-invalid config when --no-validate is passed", async () => {
+      const invalidSnapshot = makeInvalidSnapshot({
+        issues: [{ path: "secrets.providers.default", message: "missing path" }],
+      });
+      // Override resolved to have partial config
+      invalidSnapshot.resolved = {
+        secrets: { providers: { default: { source: "file" } } },
+      } as OpenClawConfig;
+      setSnapshotOnce(invalidSnapshot);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "secrets.providers.default.path",
+        '"/secure/keys.json"',
+        "--no-validate",
+      ]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = mockWriteConfigFile.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(written.secrets).toEqual({
+        providers: { default: { source: "file", path: "/secure/keys.json" } },
+      });
+    });
+
+    it("shows validation skip hint in output", async () => {
+      const resolved: OpenClawConfig = { gateway: { port: 18789 } };
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "set", "gateway.port", "9000", "--no-validate"]);
+
+      const logCalls = mockLog.mock.calls.map((c) => c.join(" ")).join("\n");
+      expect(logCalls).toContain("Validation skipped");
+      expect(logCalls).toContain("openclaw config validate");
+    });
+  });
+
   describe("config file", () => {
     it("prints the active config file path", async () => {
       const resolved: OpenClawConfig = { gateway: { port: 18789 } };

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -430,21 +430,33 @@ export function registerConfigCli(program: Command) {
     .argument("<value>", "Value (JSON5 or raw string)")
     .option("--strict-json", "Strict JSON5 parsing (error instead of raw string fallback)", false)
     .option("--json", "Legacy alias for --strict-json", false)
+    .option(
+      "--no-validate",
+      "Skip post-write schema validation (useful when setting related keys incrementally)",
+    )
     .action(async (path: string, value: string, opts) => {
       try {
         const parsedPath = parseRequiredPath(path);
         const parsedValue = parseValue(value, {
           strictJson: Boolean(opts.strictJson || opts.json),
         });
-        const snapshot = await loadValidConfig();
+        const skipValidation = opts.validate === false;
+        const snapshot = skipValidation ? await readConfigFileSnapshot() : await loadValidConfig();
+        if (!skipValidation && !snapshot.valid) {
+          // loadValidConfig already exits on invalid config; this is a safety net.
+          return;
+        }
         // Use snapshot.resolved (config after $include and ${ENV} resolution, but BEFORE runtime defaults)
         // instead of snapshot.config (runtime-merged with defaults).
         // This prevents runtime defaults from leaking into the written config file (issue #6070)
         const next = structuredClone(snapshot.resolved) as Record<string, unknown>;
         ensureValidOllamaProviderForApiKeySet(next, parsedPath);
         setAtPath(next, parsedPath, parsedValue);
-        await writeConfigFile(next);
+        await writeConfigFile(next, { skipValidation });
         defaultRuntime.log(info(`Updated ${path}. Restart the gateway to apply.`));
+        if (skipValidation) {
+          defaultRuntime.log(info("Validation skipped. Run `openclaw config validate` when done."));
+        }
       } catch (err) {
         defaultRuntime.error(danger(String(err)));
         defaultRuntime.exit(1);

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -131,6 +131,12 @@ export type ConfigWriteOptions = {
    * even if schema/default normalization reintroduces them.
    */
   unsetPaths?: string[][];
+  /**
+   * Skip post-write schema validation. Useful for incremental `config set`
+   * calls where an intermediate state would fail validation (e.g. setting
+   * `secrets.providers.default.source` to "file" before `path` exists).
+   */
+  skipValidation?: boolean;
 };
 
 export type ReadConfigFileSnapshotForWriteResult = {
@@ -1066,18 +1072,26 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       }
     }
 
-    const validated = validateConfigObjectRawWithPlugins(persistCandidate);
-    if (!validated.ok) {
-      const issue = validated.issues[0];
-      const pathLabel = issue?.path ? issue.path : "<root>";
-      const issueMessage = issue?.message ?? "invalid";
-      throw new Error(formatConfigValidationFailure(pathLabel, issueMessage));
-    }
-    if (validated.warnings.length > 0) {
-      const details = validated.warnings
-        .map((warning) => `- ${warning.path}: ${warning.message}`)
-        .join("\n");
-      deps.logger.warn(`Config warnings:\n${details}`);
+    let cfgToWrite: OpenClawConfig;
+    if (options.skipValidation) {
+      // Skip schema validation — caller is building config incrementally and
+      // intermediate states may not satisfy cross-field constraints (issue #38022).
+      cfgToWrite = persistCandidate as OpenClawConfig;
+    } else {
+      const validated = validateConfigObjectRawWithPlugins(persistCandidate);
+      if (!validated.ok) {
+        const issue = validated.issues[0];
+        const pathLabel = issue?.path ? issue.path : "<root>";
+        const issueMessage = issue?.message ?? "invalid";
+        throw new Error(formatConfigValidationFailure(pathLabel, issueMessage));
+      }
+      if (validated.warnings.length > 0) {
+        const details = validated.warnings
+          .map((warning) => `- ${warning.path}: ${warning.message}`)
+          .join("\n");
+        deps.logger.warn(`Config warnings:\n${details}`);
+      }
+      cfgToWrite = validated.config;
     }
 
     // Restore ${VAR} env var references that were resolved during config loading.
@@ -1087,9 +1101,6 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     //
     // We use only the root file's parsed content (no $include resolution) to avoid
     // pulling values from included files into the root config on write-back.
-    // Apply env restoration to validated.config (which has runtime defaults stripped
-    // per issue #6070) rather than the raw caller input.
-    let cfgToWrite = validated.config;
     try {
       if (deps.fs.existsSync(configPath)) {
         const currentRaw = await deps.fs.promises.readFile(configPath, "utf-8");


### PR DESCRIPTION
Closes #38022

## Problem

`openclaw config set` validates the entire config after each key change. When configuring options with cross-field constraints (e.g. `secrets.providers.default.source=file` requires `path`), this creates a chicken-and-egg deadlock:

1. `config set secrets.providers.default.source file` → succeeds but config is now invalid (missing `path`)
2. `config set secrets.providers.default.path /secure/keys.json` → fails because `loadValidConfig()` rejects the already-invalid config

## Solution

Add `--no-validate` flag to `config set` that:
- Skips post-write schema validation (via new `skipValidation` option in `ConfigWriteOptions`)
- Reads the config snapshot without validation gating, so it works even when current config is already invalid
- Prints a hint to run `openclaw config validate` when done

### Usage
```bash
openclaw config set secrets.providers.default.source file --no-validate
openclaw config set secrets.providers.default.path /secure/keys.json
# Second command validates normally and succeeds
```

## Changes
- `src/config/io.ts`: Add `skipValidation` to `ConfigWriteOptions`, skip `validateConfigObjectRawWithPlugins` when set
- `src/cli/config-cli.ts`: Add `--no-validate` CLI flag, bypass `loadValidConfig` gate when flag is set
- `src/cli/config-cli.test.ts`: 3 new tests covering the flag behavior

## Tests
All 22 tests pass (`npx vitest run src/cli/config-cli.test.ts`).