### PR TITLE
fix(sandbox-paths): guard decodeURIComponent against malformed percent-encoded file URIs

### DIFF
--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -149,7 +149,12 @@ function mapContainerWorkspaceFileUrl(params: {
   }
   // Sandbox paths are Linux-style (/workspace/*). Parse the URL path directly so
   // Windows hosts can still accept file:///workspace/... media references.
-  const normalizedPathname = decodeURIComponent(parsed.pathname).replace(/\\/g, "/");
+  let normalizedPathname: string;
+  try {
+    normalizedPathname = decodeURIComponent(parsed.pathname).replace(/\\/g, "/");
+  } catch {
+    return undefined;
+  }
   if (
     normalizedPathname !== SANDBOX_CONTAINER_WORKDIR &&
     !normalizedPathname.startsWith(`${SANDBOX_CONTAINER_WORKDIR}/`)


### PR DESCRIPTION
## Problem
`sandboxFileUriToHostPath()` calls `decodeURIComponent(parsed.pathname)` without a try/catch. If a sandbox tool emits a malformed percent-encoded file URI (e.g. `file:///workspace/%ZZ`), this throws an unhandled `URIError` and crashes the path resolution pipeline.

## Fix
Wrap in try/catch and return `undefined` on failure — consistent with the other early-return guards in the same function.

## Risk
Minimal — only adds a safety net around an existing call. No behavior change for valid URIs.