### PR TITLE
fix(telegram): suppress bare Reasoning: prefix leak during Gemini streaming

### DIFF
--- a/src/telegram/reasoning-lane-coordinator.test.ts
+++ b/src/telegram/reasoning-lane-coordinator.test.ts
@@ -26,4 +26,19 @@ describe("splitTelegramReasoningText", () => {
   it("does not emit partial reasoning tag prefixes", () => {
     expect(splitTelegramReasoningText("  <thi")).toEqual({});
   });
+
+  it("suppresses bare 'Reasoning:\\n' prefix chunk", () => {
+    expect(splitTelegramReasoningText("Reasoning:\n")).toEqual({});
+  });
+
+  it("suppresses bare 'Reasoning:' without newline", () => {
+    expect(splitTelegramReasoningText("Reasoning:")).toEqual({});
+  });
+
+  it("keeps full reasoning message with content after prefix", () => {
+    const text = "Reasoning:\nThis is the reasoning content";
+    expect(splitTelegramReasoningText(text)).toEqual({
+      reasoningText: text,
+    });
+  });
 });

--- a/src/telegram/reasoning-lane-coordinator.ts
+++ b/src/telegram/reasoning-lane-coordinator.ts
@@ -68,6 +68,12 @@ export function splitTelegramReasoningText(text?: string): TelegramReasoningSpli
   if (isPartialReasoningTagPrefix(trimmed)) {
     return {};
   }
+  // Suppress bare "Reasoning:" / "Reasoning:\n" prefix chunks that arrive
+  // before actual reasoning content — trim() strips the trailing newline so
+  // the startsWith(REASONING_MESSAGE_PREFIX) check below would miss them.
+  if (trimmed === REASONING_MESSAGE_PREFIX.trim()) {
+    return {};
+  }
   if (
     trimmed.startsWith(REASONING_MESSAGE_PREFIX) &&
     trimmed.length > REASONING_MESSAGE_PREFIX.length


### PR DESCRIPTION
## Summary

- **Problem:** When Gemini streams a partial chunk containing just `"Reasoning:
"`, `trim()` collapses it to `"Reasoning:"` which no longer matches `REASONING_MESSAGE_PREFIX` (`"Reasoning:
"`). The text falls through all checks and leaks to the user as `answerText`.
- **Why it matters:** Users see raw `"Reasoning:"` text in their Telegram DM instead of it being suppressed as a reasoning prefix.
- **What changed:** Added an explicit check in `splitTelegramReasoningText` for the trimmed reasoning prefix (`trimmed === REASONING_MESSAGE_PREFIX.trim()`), returning `{}` to suppress it. Added 3 test cases.
- **What did NOT change:** Full reasoning message handling, tagged reasoning extraction, `formatReasoningMessage`, answer text passthrough.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37890

## User-visible / Behavior Changes

- Bare `"Reasoning:"` / `"Reasoning:
"` chunks are suppressed during Gemini streaming on Telegram DM, preventing the reasoning prefix from appearing in user-visible output.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0 (arm64)
- Runtime: Node v25.6.1
- Channel: Telegram DM with draft streaming
- Model: Gemini 3 Flash / Gemini 3.1 Pro

### Steps

1. Configure Gemini model with Telegram DM channel and reasoning level display
2. Send a prompt that triggers reasoning output
3. Observe streaming output

### Expected

- Reasoning prefix is suppressed; user sees only formatted reasoning content or answer

### Actual

- Before fix: `"Reasoning:"` appears as answer text in chat
- After fix: Bare prefix suppressed, only actual content is delivered

## Evidence

```
 ✓ src/telegram/reasoning-lane-coordinator.test.ts (7 tests) 2ms
   ✓ suppresses bare 'Reasoning:
' prefix chunk
   ✓ suppresses bare 'Reasoning:' without newline
   ✓ keeps full reasoning message with content after prefix
   ... (4 existing tests still pass)
```

## Human Verification (required)

- Verified scenarios: Bare prefix with newline, without newline, full reasoning with content
- Edge cases checked: Whitespace-only after prefix, empty string, non-string input
- What I did **not** verify: Live Gemini streaming on Telegram

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; bare prefix will leak again (original behavior)
- Files/config to restore: `src/telegram/reasoning-lane-coordinator.ts`
- Known bad symptoms: None — suppressing a bare prefix is always safe

## Risks and Mitigations

None — the bare prefix contains no user content and should never be delivered.
