### PR TITLE
fix(sessions): clear stale contextTokens on model switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - macOS release packaging: default `scripts/package-mac-app.sh` to universal binaries for `BUILD_CONFIG=release`, and clarify that `scripts/package-mac-dist.sh` already produces the release zip + DMG. (#33891) Thanks @cgdusek.
 - Tools/web search: restore Perplexity OpenRouter/Sonar compatibility for legacy `OPENROUTER_API_KEY`, `sk-or-...`, and explicit `perplexity.baseUrl` / `model` setups while keeping direct Perplexity keys on the native Search API path. (#39937) Thanks @obviyus.
 - Hooks/session-memory: keep `/new` and `/reset` memory artifacts in the bound agent workspace and align saved reset session keys with that workspace when stale main-agent keys leak into the hook path. (#39875) thanks @rbutera.
+- Sessions/model switch: clear stale cached `contextTokens` when a session changes models so status and runtime paths recompute against the active model window. (#38044) thanks @yuweuii.
 
 ## 2026.3.7
 

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -31,6 +31,8 @@ const unitIsolatedFilesRaw = [
   "src/commands/doctor.runs-legacy-state-migrations-yes-mode-without.test.ts",
   // Setup-heavy CLI update flow suite; move off unit-fast critical path.
   "src/cli/update-cli.test.ts",
+  // Uses temp repos + module cache resets; keep it off vmForks to avoid ref-resolution flakes.
+  "src/infra/git-commit.test.ts",
   // Expensive schema build/bootstrap checks; keep coverage but run in isolated lane.
   "src/config/schema.test.ts",
   "src/config/schema.tags.test.ts",

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { normalizeTestText } from "../../test/helpers/normalize-text.js";
 import { withTempHome } from "../../test/helpers/temp-home.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
 import { createSuccessfulImageMediaDecision } from "./media-understanding.test-fixtures.js";
 import {
   buildCommandsMessage,
@@ -170,6 +171,39 @@ describe("buildStatusMessage", () => {
     });
 
     expect(normalizeTestText(text)).toContain("Context: 200k/1.0m");
+  });
+
+  it("recomputes context window from the active model after switching away from a smaller session override", () => {
+    const sessionEntry = {
+      sessionId: "switch-back",
+      updatedAt: 0,
+      providerOverride: "local",
+      modelOverride: "small-model",
+      contextTokens: 4_096,
+      totalTokens: 1_024,
+    };
+
+    applyModelOverrideToSessionEntry({
+      entry: sessionEntry,
+      selection: {
+        provider: "local",
+        model: "large-model",
+        isDefault: true,
+      },
+    });
+
+    const text = buildStatusMessage({
+      agent: {
+        model: "local/large-model",
+        contextTokens: 65_536,
+      },
+      sessionEntry,
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    expect(normalizeTestText(text)).toContain("Context: 1.0k/66k");
   });
 
   it("uses per-agent sandbox config when config and session key are provided", () => {

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,16 +36,17 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway = vi.fn<
-  (opts: {
-    url: string;
-    auth?: { token?: string; password?: string };
-    timeoutMs: number;
-  }) => Promise<{
-    ok: boolean;
-    configSnapshot: unknown;
-  }>
->();
+const probeGateway =
+  vi.fn<
+    (opts: {
+      url: string;
+      auth?: { token?: string; password?: string };
+      timeoutMs: number;
+    }) => Promise<{
+      ok: boolean;
+      configSnapshot: unknown;
+    }>
+  >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/src/infra/git-commit.test.ts
+++ b/src/infra/git-commit.test.ts
@@ -43,6 +43,9 @@ describe("git commit resolution", () => {
 
   afterEach(() => {
     process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    vi.doUnmock("node:fs");
+    vi.doUnmock("node:module");
     vi.resetModules();
   });
 

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -1,7 +1,7 @@
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { spawnWithFallbackMock, killProcessTreeMock } = vi.hoisted(() => ({
   spawnWithFallbackMock: vi.fn(),
@@ -58,6 +58,10 @@ describe("createChildAdapter", () => {
   beforeEach(() => {
     spawnWithFallbackMock.mockClear();
     killProcessTreeMock.mockClear();
+    delete process.env.OPENCLAW_SERVICE_MARKER;
+  });
+
+  afterAll(() => {
     if (originalServiceMarker === undefined) {
       delete process.env.OPENCLAW_SERVICE_MARKER;
     } else {

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -30,6 +30,7 @@ describe("applyModelOverrideToSessionEntry", () => {
       model: "claude-sonnet-4-6",
       providerOverride: "anthropic",
       modelOverride: "claude-sonnet-4-6",
+      contextTokens: 160_000,
       fallbackNoticeSelectedModel: "anthropic/claude-sonnet-4-6",
       fallbackNoticeActiveModel: "anthropic/claude-sonnet-4-6",
       fallbackNoticeReason: "provider temporary failure",
@@ -39,6 +40,7 @@ describe("applyModelOverrideToSessionEntry", () => {
 
     expect(result.updated).toBe(true);
     expectRuntimeModelFieldsCleared(entry, before);
+    expect(entry.contextTokens).toBeUndefined();
     expect(entry.fallbackNoticeSelectedModel).toBeUndefined();
     expect(entry.fallbackNoticeActiveModel).toBeUndefined();
     expect(entry.fallbackNoticeReason).toBeUndefined();
@@ -53,12 +55,14 @@ describe("applyModelOverrideToSessionEntry", () => {
       model: "claude-sonnet-4-6",
       providerOverride: "openai",
       modelOverride: "gpt-5.2",
+      contextTokens: 160_000,
     };
 
     const result = applyOpenAiSelection(entry);
 
     expect(result.updated).toBe(true);
     expectRuntimeModelFieldsCleared(entry, before);
+    expect(entry.contextTokens).toBeUndefined();
   });
 
   it("retains aligned runtime model fields when selection and runtime already match", () => {
@@ -84,5 +88,31 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(entry.modelProvider).toBe("openai");
     expect(entry.model).toBe("gpt-5.2");
     expect(entry.updatedAt).toBe(before);
+  });
+
+  it("clears stale contextTokens when switching back to the default model", () => {
+    const before = Date.now() - 5_000;
+    const entry: SessionEntry = {
+      sessionId: "sess-4",
+      updatedAt: before,
+      providerOverride: "local",
+      modelOverride: "sunapi386/llama-3-lexi-uncensored:8b",
+      contextTokens: 4_096,
+    };
+
+    const result = applyModelOverrideToSessionEntry({
+      entry,
+      selection: {
+        provider: "local",
+        model: "llama3.1:8b",
+        isDefault: true,
+      },
+    });
+
+    expect(result.updated).toBe(true);
+    expect(entry.providerOverride).toBeUndefined();
+    expect(entry.modelOverride).toBeUndefined();
+    expect(entry.contextTokens).toBeUndefined();
+    expect((entry.updatedAt ?? 0) > before).toBe(true);
   });
 });

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -74,6 +74,7 @@ describe("applyModelOverrideToSessionEntry", () => {
       model: "gpt-5.2",
       providerOverride: "openai",
       modelOverride: "gpt-5.2",
+      contextTokens: 200_000,
     };
 
     const result = applyModelOverrideToSessionEntry({
@@ -87,6 +88,7 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(result.updated).toBe(false);
     expect(entry.modelProvider).toBe("openai");
     expect(entry.model).toBe("gpt-5.2");
+    expect(entry.contextTokens).toBe(200_000);
     expect(entry.updatedAt).toBe(before);
   });
 

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -61,6 +61,17 @@ export function applyModelOverrideToSessionEntry(params: {
     }
   }
 
+  // contextTokens are derived from the active session model. When the selected
+  // model changes (or runtime model is already stale), the cached window can
+  // pin the session to an older/smaller limit until another run refreshes it.
+  if (
+    entry.contextTokens !== undefined &&
+    (selectionUpdated || (runtimePresent && !runtimeAligned))
+  ) {
+    delete entry.contextTokens;
+    updated = true;
+  }
+
   if (profileOverride) {
     if (entry.authProfileOverride !== profileOverride) {
       entry.authProfileOverride = profileOverride;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: session-scoped `contextTokens` can stay pinned to an older/smaller model window after a model switch in the same session.
- Why it matters: switching back to a larger-context model can still report and budget against the stale smaller window, causing premature compaction and incorrect status output.
- What changed: clear cached `contextTokens` when a model override/default-model selection changes (or when stored runtime model identity is already stale), so status/runtime paths recompute from the newly active model.
- What did NOT change (scope boundary): this does not change model selection itself, model discovery, or compaction thresholds; it only invalidates stale cached context-window state on model switch.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35372
- Related #27394

## User-visible / Behavior Changes

- After switching from a smaller-context model back to a larger-context model in the same session, `/status` and related session views now reflect the larger window again instead of staying pinned to the old smaller value.
- Existing sessions no longer need a `/new` just to recover the correct context window after a model switch.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3
- Runtime/container: Node.js workspace / local source checkout
- Model/provider: local provider models with different configured context windows
- Integration/channel (if any): session store + status output
- Relevant config (redacted): one small-window local model (`4096`) and one larger-window local model (`65536`)

### Steps

1. Start with a session entry that has a small-model override and persisted `contextTokens = 4096`.
2. Switch that same session back to a larger model/default selection.
3. Inspect the resulting session state / status output.

### Expected

- The session should recompute `contextTokens` from the currently active model, so the larger window is restored.

### Actual

- Before this patch, the session kept the stale `4096` override even after the active model switched back to the larger one.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Minimal local repro before fix:

```json
before {"resolved":{"provider":"sunapi386","model":"llama-3-lexi-uncensored:8b"},"context":4096,"rawContextTokens":4096}
after {"resolved":{"provider":"local","model":"llama3.1:8b"},"context":4096,"rawContextTokens":4096}
```

Control check for the larger model window:

```text
65536
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - reproduced the bug locally with a minimal session-entry script (small-window override -> switch back to larger model -> stale `contextTokens` remained)
  - verified that clearing stale `contextTokens` fixes the reproduced case
  - verified status output now re-resolves to the larger window after the switch
- Edge cases checked:
  - switching between two explicit overrides
  - switching back to the default model
  - unchanged/already-aligned runtime model does not clear state unnecessarily
- What you did **not** verify:
  - full end-to-end interactive TUI reproduction on every provider family
  - multi-process races involving concurrent session-store writers

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR commit
- Files/config to restore:
  - `src/sessions/model-overrides.ts`
  - `src/sessions/model-overrides.test.ts`
  - `src/auto-reply/status.test.ts`
- Known bad symptoms reviewers should watch for:
  - model switch stops invalidating stale session context windows
  - `/status` remains pinned to the previous smaller window after switching back to a larger model

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Clearing `contextTokens` on model switch could briefly remove a cached window until the new model is re-resolved.
  - Mitigation:
    - all affected read paths already have normal fallbacks (`agent.contextTokens`, configured model windows, discovered windows, or `DEFAULT_CONTEXT_TOKENS`), so the state becomes recomputed rather than empty/broken.
