### PR TITLE
feat(subagents): add minRunTimeoutSeconds config to prevent model timeout erosion

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts
@@ -5,10 +5,17 @@ import { resetSubagentRegistryForTests } from "./subagent-registry.js";
 
 const MAIN_SESSION_KEY = "agent:test:main";
 
-function applySubagentTimeoutDefault(seconds: number) {
+function applySubagentTimeoutDefault(seconds: number, minSeconds?: number) {
   sessionsHarness.setSessionsSpawnConfigOverride({
     session: { mainKey: "main", scope: "per-sender" },
-    agents: { defaults: { subagents: { runTimeoutSeconds: seconds } } },
+    agents: {
+      defaults: {
+        subagents: {
+          runTimeoutSeconds: seconds,
+          ...(minSeconds != null ? { minRunTimeoutSeconds: minSeconds } : {}),
+        },
+      },
+    },
   });
 }
 
@@ -56,5 +63,23 @@ describe("sessions_spawn default runTimeoutSeconds", () => {
     await spawnSubagent("call-2", { task: "hello", runTimeoutSeconds: 300 });
 
     expect(getSubagentTimeout(gateway.calls)).toBe(300);
+  });
+
+  it("enforces minRunTimeoutSeconds as floor when model sets lower value", async () => {
+    applySubagentTimeoutDefault(300, 120);
+    const gateway = sessionsHarness.setupSessionsSpawnGatewayMock({});
+
+    await spawnSubagent("call-3", { task: "hello", runTimeoutSeconds: 60 });
+
+    expect(getSubagentTimeout(gateway.calls)).toBe(120);
+  });
+
+  it("allows model timeout above minRunTimeoutSeconds", async () => {
+    applySubagentTimeoutDefault(300, 120);
+    const gateway = sessionsHarness.setupSessionsSpawnGatewayMock({});
+
+    await spawnSubagent("call-4", { task: "hello", runTimeoutSeconds: 200 });
+
+    expect(getSubagentTimeout(gateway.calls)).toBe(200);
   });
 });

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -299,10 +299,19 @@ export async function spawnSubagentDirect(
     Number.isFinite(cfg.agents.defaults.subagents.runTimeoutSeconds)
       ? Math.max(0, Math.floor(cfg.agents.defaults.subagents.runTimeoutSeconds))
       : 0;
-  const runTimeoutSeconds =
+  const cfgMinTimeout =
+    typeof cfg?.agents?.defaults?.subagents?.minRunTimeoutSeconds === "number" &&
+    Number.isFinite(cfg.agents.defaults.subagents.minRunTimeoutSeconds)
+      ? Math.max(0, Math.floor(cfg.agents.defaults.subagents.minRunTimeoutSeconds))
+      : 0;
+  const rawTimeout =
     typeof params.runTimeoutSeconds === "number" && Number.isFinite(params.runTimeoutSeconds)
       ? Math.max(0, Math.floor(params.runTimeoutSeconds))
       : cfgSubagentTimeout;
+  // Enforce config minimum so orchestrating models cannot autonomously
+  // decrease the timeout across retries (#37902).
+  const runTimeoutSeconds =
+    cfgMinTimeout > 0 && rawTimeout > 0 ? Math.max(cfgMinTimeout, rawTimeout) : rawTimeout;
   let modelApplied = false;
   let threadBindingReady = false;
   const { mainKey, alias } = resolveMainSessionAlias(cfg);

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -279,6 +279,13 @@ export type AgentDefaultsConfig = {
     thinking?: string;
     /** Default run timeout in seconds for spawned sub-agents (0 = no timeout). */
     runTimeoutSeconds?: number;
+    /**
+     * Minimum run timeout in seconds for spawned sub-agents.
+     * When set, the model cannot specify a timeout lower than this value.
+     * This prevents orchestrating models from autonomously decreasing
+     * the timeout across retries. Default: no minimum enforced.
+     */
+    minRunTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 60000). */
     announceTimeoutMs?: number;
   };

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -182,6 +182,7 @@ export const AgentDefaultsSchema = z
         model: AgentModelSchema.optional(),
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
+        minRunTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
       })
       .strict()


### PR DESCRIPTION
## Summary

- **Problem:** Orchestrating models autonomously set `runTimeoutSeconds` in `sessions_spawn` calls and progressively decrease the value across retries (60→45→20→15s), making success increasingly unlikely. The config `runTimeoutSeconds` only acts as a fallback default when the model omits the field — not a floor.
- **Why it matters:** Subagents reliably time out even when actively making progress, because each retry gets less time than the previous attempt.
- **What changed:** Added `agents.defaults.subagents.minRunTimeoutSeconds` config option (zod schema + type). When set, the resolution logic in `subagent-spawn.ts` clamps any model-provided timeout upward to this minimum. Added 2 test cases.
- **What did NOT change:** Default behavior (no minimum enforced), config `runTimeoutSeconds` fallback logic, tool-level timeout normalization in `sessions-spawn-tool.ts`.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37902

## User-visible / Behavior Changes

- New config option: `agents.defaults.subagents.minRunTimeoutSeconds` (integer, default: none)
- When set, model-provided `runTimeoutSeconds` values below this minimum are clamped upward
- Default behavior unchanged — no minimum enforced unless explicitly configured

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0 (arm64)
- Runtime: Node v25.6.1
- Orchestrator: claude-haiku-4-5

### Steps

1. Set `agents.defaults.subagents.minRunTimeoutSeconds: 120` in config
2. Orchestrator calls `sessions_spawn` with `runTimeoutSeconds: 60`
3. Check `subagents/runs.json` for actual timeout value

### Expected

- Timeout clamped to 120 (the configured minimum)

### Actual

- Before fix: Timeout set to 60 (model's value used unconditionally)
- After fix: Timeout clamped to 120

## Evidence

```
 ✓ sessions-spawn-default-timeout.test.ts (4 tests) 6ms
   ✓ uses config default when agent omits runTimeoutSeconds
   ✓ explicit runTimeoutSeconds wins over config default
   ✓ enforces minRunTimeoutSeconds as floor when model sets lower value
   ✓ allows model timeout above minRunTimeoutSeconds
```

## Human Verification (required)

- Verified scenarios: Model value below min (clamped), model value above min (allowed), no min configured (unchanged), model omits timeout (uses default)
- Edge cases checked: min=0 (no effect), rawTimeout=0 (no timeout, not clamped), both finite
- What I did **not** verify: Live multi-retry sessions_spawn sequence

## Compatibility / Migration

- Backward compatible? `Yes` (no minimum enforced unless explicitly configured)
- Config/env changes? `No` (optional new field)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Remove `minRunTimeoutSeconds` from config; behavior returns to original (model value wins)
- Files/config to restore: `src/agents/subagent-spawn.ts`, config types/schema
- Known bad symptoms: If set too high, all subagent runs may run longer than intended

## Risks and Mitigations

- Risk: Minimum timeout prevents the model from setting short timeouts for quick tasks. Mitigation: Only enforced when explicitly configured; users choose the minimum that makes sense for their workload.
