### PR TITLE
fix(agents): cap Google OAuth retry delay in embedded runs

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -10,9 +10,11 @@ import {
   resolveOllamaCompatNumCtxEnabled,
   resolvePromptBuildHookResult,
   resolvePromptModeForSession,
+  shouldCapGoogleOAuthRetryDelay,
   shouldInjectOllamaCompatNumCtx,
   decodeHtmlEntitiesInObject,
   wrapOllamaCompatNumCtx,
+  wrapStreamFnCapMaxRetryDelay,
   wrapStreamFnTrimToolCallNames,
 } from "./attempt.js";
 
@@ -456,6 +458,98 @@ describe("wrapOllamaCompatNumCtx", () => {
     expect(baseFn).toHaveBeenCalledTimes(1);
     expect((payloadSeen?.options as Record<string, unknown> | undefined)?.num_ctx).toBe(202752);
     expect(downstream).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("shouldCapGoogleOAuthRetryDelay", () => {
+  it("enables cap for google-gemini-cli oauth mode", () => {
+    expect(
+      shouldCapGoogleOAuthRetryDelay({
+        provider: "google-gemini-cli",
+        modelAuthMode: "oauth",
+      }),
+    ).toBe(true);
+  });
+
+  it("enables cap for google-antigravity mixed mode", () => {
+    expect(
+      shouldCapGoogleOAuthRetryDelay({
+        provider: "google-antigravity",
+        modelAuthMode: "mixed",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not enable cap for api-key mode", () => {
+    expect(
+      shouldCapGoogleOAuthRetryDelay({
+        provider: "google-gemini-cli",
+        modelAuthMode: "api-key",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not enable cap for non-google providers", () => {
+    expect(
+      shouldCapGoogleOAuthRetryDelay({
+        provider: "openai",
+        modelAuthMode: "oauth",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("wrapStreamFnCapMaxRetryDelay", () => {
+  it("applies cap when maxRetryDelayMs is unset", () => {
+    let seenMaxRetryDelayMs: unknown;
+    const baseFn = vi.fn((_model, _context, options) => {
+      seenMaxRetryDelayMs = (options as { maxRetryDelayMs?: unknown } | undefined)?.maxRetryDelayMs;
+      return {} as never;
+    });
+
+    const wrapped = wrapStreamFnCapMaxRetryDelay(baseFn as never, 5_000);
+    void wrapped({} as never, {} as never, undefined);
+
+    expect(seenMaxRetryDelayMs).toBe(5_000);
+  });
+
+  it("caps larger caller-provided values", () => {
+    let seenMaxRetryDelayMs: unknown;
+    const baseFn = vi.fn((_model, _context, options) => {
+      seenMaxRetryDelayMs = (options as { maxRetryDelayMs?: unknown } | undefined)?.maxRetryDelayMs;
+      return {} as never;
+    });
+
+    const wrapped = wrapStreamFnCapMaxRetryDelay(baseFn as never, 5_000);
+    void wrapped({} as never, {} as never, { maxRetryDelayMs: 60_000 } as never);
+
+    expect(seenMaxRetryDelayMs).toBe(5_000);
+  });
+
+  it("preserves smaller positive caller-provided values", () => {
+    let seenMaxRetryDelayMs: unknown;
+    const baseFn = vi.fn((_model, _context, options) => {
+      seenMaxRetryDelayMs = (options as { maxRetryDelayMs?: unknown } | undefined)?.maxRetryDelayMs;
+      return {} as never;
+    });
+
+    const wrapped = wrapStreamFnCapMaxRetryDelay(baseFn as never, 5_000);
+    void wrapped({} as never, {} as never, { maxRetryDelayMs: 1_200 } as never);
+
+    expect(seenMaxRetryDelayMs).toBe(1_200);
+  });
+
+  it("respects explicit non-positive caller-provided values", () => {
+    let seenMaxRetryDelayMs: unknown;
+    const baseFn = vi.fn((_model, _context, options) => {
+      seenMaxRetryDelayMs = (options as { maxRetryDelayMs?: unknown } | undefined)?.maxRetryDelayMs;
+      return {} as never;
+    });
+
+    const wrapped = wrapStreamFnCapMaxRetryDelay(baseFn as never, 5_000);
+    void wrapped({} as never, {} as never, { maxRetryDelayMs: 0 } as never);
+
+    expect(seenMaxRetryDelayMs).toBe(0);
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -47,7 +47,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { resolveOpenClawDocsPath } from "../../docs-path.js";
 import { isTimeoutError } from "../../failover-error.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
-import { resolveModelAuthMode } from "../../model-auth.js";
+import { resolveModelAuthMode, type ModelAuthMode } from "../../model-auth.js";
 import { normalizeProviderId, resolveDefaultModelForAgent } from "../../model-selection.js";
 import { createOllamaStreamFn, OLLAMA_NATIVE_BASE_URL } from "../../ollama-stream.js";
 import { createOpenAIWebSocketStreamFn, releaseWsSession } from "../../openai-ws-stream.js";
@@ -238,6 +238,39 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
         options?.onPayload?.(payload);
       },
     });
+}
+
+const GOOGLE_OAUTH_MAX_RETRY_DELAY_MS = 5_000;
+
+function isGoogleOAuthRetryProvider(provider?: string): boolean {
+  const normalized = normalizeProviderId(provider ?? "");
+  return normalized === "google-gemini-cli" || normalized === "google-antigravity";
+}
+
+export function shouldCapGoogleOAuthRetryDelay(params: {
+  provider?: string;
+  modelAuthMode?: ModelAuthMode;
+}): boolean {
+  if (!isGoogleOAuthRetryProvider(params.provider)) {
+    return false;
+  }
+  return params.modelAuthMode === "oauth" || params.modelAuthMode === "mixed";
+}
+
+export function wrapStreamFnCapMaxRetryDelay(baseFn: StreamFn, maxRetryDelayMs: number): StreamFn {
+  const capMs = Math.max(1, Math.floor(maxRetryDelayMs));
+  return (model, context, options) => {
+    const requested =
+      typeof options?.maxRetryDelayMs === "number" && Number.isFinite(options.maxRetryDelayMs)
+        ? Math.floor(options.maxRetryDelayMs)
+        : undefined;
+    const resolvedMaxRetryDelayMs =
+      requested === undefined || requested > 0 ? Math.min(requested ?? capMs, capMs) : requested;
+    return baseFn(model, context, {
+      ...options,
+      maxRetryDelayMs: resolvedMaxRetryDelayMs,
+    });
+  };
 }
 
 function normalizeToolCallNameForDispatch(rawName: string, allowedToolNames?: Set<string>): string {
@@ -829,6 +862,7 @@ export async function runEmbeddedAttempt(
       config: params.config,
       agentId: params.agentId,
     });
+    const modelAuthMode = resolveModelAuthMode(params.model.provider, params.config);
     const effectiveFsWorkspaceOnly = resolveAttemptFsWorkspaceOnly({
       config: params.config,
       sessionAgentId,
@@ -867,7 +901,7 @@ export async function runEmbeddedAttempt(
           modelProvider: params.model.provider,
           modelId: params.modelId,
           modelContextWindowTokens: params.model.contextWindow,
-          modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
+          modelAuthMode,
           currentChannelId: params.currentChannelId,
           currentThreadTs: params.currentThreadTs,
           currentMessageId: params.currentMessageId,
@@ -1365,6 +1399,14 @@ export async function runEmbeddedAttempt(
       if (isXaiProvider(params.provider, params.modelId)) {
         activeSession.agent.streamFn = wrapStreamFnDecodeXaiToolCallArguments(
           activeSession.agent.streamFn,
+        );
+      }
+
+      if (shouldCapGoogleOAuthRetryDelay({ provider: params.provider, modelAuthMode })) {
+        // Cloud Code Assist OAuth can emit long Retry-After values that look like hard hangs.
+        activeSession.agent.streamFn = wrapStreamFnCapMaxRetryDelay(
+          activeSession.agent.streamFn,
+          GOOGLE_OAUTH_MAX_RETRY_DELAY_MS,
         );
       }
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -862,7 +862,8 @@ export async function runEmbeddedAttempt(
       config: params.config,
       agentId: params.agentId,
     });
-    const modelAuthMode = resolveModelAuthMode(params.model.provider, params.config);
+    const modelProviderId = params.model.provider ?? params.provider;
+    const modelAuthMode = resolveModelAuthMode(modelProviderId, params.config);
     const effectiveFsWorkspaceOnly = resolveAttemptFsWorkspaceOnly({
       config: params.config,
       sessionAgentId,
@@ -1402,7 +1403,7 @@ export async function runEmbeddedAttempt(
         );
       }
 
-      if (shouldCapGoogleOAuthRetryDelay({ provider: params.provider, modelAuthMode })) {
+      if (shouldCapGoogleOAuthRetryDelay({ provider: modelProviderId, modelAuthMode })) {
         // Cloud Code Assist OAuth can emit long Retry-After values that look like hard hangs.
         activeSession.agent.streamFn = wrapStreamFnCapMaxRetryDelay(
           activeSession.agent.streamFn,


### PR DESCRIPTION
## Summary

- cap `maxRetryDelayMs` to 5s for `google-gemini-cli` / `google-antigravity` runs when auth mode is OAuth or mixed
- keep existing retry behavior for API-key/token providers unchanged
- add focused unit coverage for:
  - provider/auth gating (`shouldCapGoogleOAuthRetryDelay`)
  - retry-delay cap semantics (`wrapStreamFnCapMaxRetryDelay`)

## Why

Issue #36399 reports repeated ~60s stalls between tool-call steps on OAuth-backed Google flows. Those stalls line up with long upstream retry delays. This patch keeps retries enabled but prevents single-step waits from stretching into minute-long silent pauses.

## Scope Notes

- no changes to failover classification, cooldown buckets, or provider selection
- no changes to non-Google providers
- no changes to API-key-only Google runs

## Validation

- `pnpm vitest run src/agents/pi-embedded-runner/run/attempt.test.ts`
- `pnpm check`
- `pnpm build`

Fixes #36399
