### PR TITLE
fix(mattermost): bind interaction callbacks to channel and post context

### DIFF
--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -34,10 +34,12 @@ import {
 import { monitorMattermostProvider } from "./mattermost/monitor.js";
 import { probeMattermost } from "./mattermost/probe.js";
 import { addMattermostReaction, removeMattermostReaction } from "./mattermost/reactions.js";
-import { sendMessageMattermost } from "./mattermost/send.js";
+import { resolveMattermostSendChannelId, sendMessageMattermost } from "./mattermost/send.js";
 import { looksLikeMattermostTargetId, normalizeMattermostMessagingTarget } from "./normalize.js";
 import { mattermostOnboardingAdapter } from "./onboarding.js";
 import { getMattermostRuntime } from "./runtime.js";
+
+const SIGNED_CHANNEL_ID_CONTEXT_KEY = "__openclaw_channel_id";
 
 const mattermostMessageActions: ChannelMessageActionAdapter = {
   listActions: ({ cfg }) => {
@@ -165,6 +167,10 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
     if (params.buttons && Array.isArray(params.buttons)) {
       const account = resolveMattermostAccount({ cfg, accountId: resolvedAccountId });
       if (account.botToken) setInteractionSecret(account.accountId, account.botToken);
+      const channelId = await resolveMattermostSendChannelId(to, {
+        cfg,
+        accountId: account.accountId,
+      });
       const callbackUrl = resolveInteractionCallbackUrl(account.accountId, {
         gateway: cfg.gateway,
         interactions: account.config.interactions,
@@ -184,8 +190,11 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
           style: (btn.style as "default" | "primary" | "danger") ?? "default",
           context:
             typeof btn.context === "object" && btn.context !== null
-              ? (btn.context as Record<string, unknown>)
-              : undefined,
+              ? {
+                  ...(btn.context as Record<string, unknown>),
+                  [SIGNED_CHANNEL_ID_CONTEXT_KEY]: channelId,
+                }
+              : { [SIGNED_CHANNEL_ID_CONTEXT_KEY]: channelId },
         }))
         .filter((btn) => btn.id && btn.name);
 

--- a/extensions/mattermost/src/mattermost/interactions.test.ts
+++ b/extensions/mattermost/src/mattermost/interactions.test.ts
@@ -448,7 +448,7 @@ describe("createMattermostInteractionHandler", () => {
   }
 
   it("accepts non-localhost requests when the interaction token is valid", async () => {
-    const context = { action_id: "approve" };
+    const context = { action_id: "approve", __openclaw_channel_id: "chan-1" };
     const token = generateInteractionToken(context, "acct");
     const requestLog: Array<{ path: string; method?: string }> = [];
     const handler = createMattermostInteractionHandler({
@@ -459,6 +459,7 @@ describe("createMattermostInteractionHandler", () => {
             return { id: "post-1" };
           }
           return {
+            channel_id: "chan-1",
             message: "Choose",
             props: {
               attachments: [{ actions: [{ id: "approve", name: "Approve" }] }],
@@ -515,5 +516,98 @@ describe("createMattermostInteractionHandler", () => {
 
     expect(res.statusCode).toBe(403);
     expect(res.body).toContain("Invalid token");
+  });
+
+  it("rejects requests when the signed channel does not match the callback payload", async () => {
+    const context = { action_id: "approve", __openclaw_channel_id: "chan-1" };
+    const token = generateInteractionToken(context, "acct");
+    const handler = createMattermostInteractionHandler({
+      client: {
+        request: async () => ({ message: "unused" }),
+      } as unknown as MattermostClient,
+      botUserId: "bot",
+      accountId: "acct",
+    });
+
+    const req = createReq({
+      body: {
+        user_id: "user-1",
+        channel_id: "chan-2",
+        post_id: "post-1",
+        context: { ...context, _token: token },
+      },
+    });
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toContain("Channel mismatch");
+  });
+
+  it("rejects requests when the fetched post does not belong to the callback channel", async () => {
+    const context = { action_id: "approve", __openclaw_channel_id: "chan-1" };
+    const token = generateInteractionToken(context, "acct");
+    const handler = createMattermostInteractionHandler({
+      client: {
+        request: async () => ({
+          channel_id: "chan-9",
+          message: "Choose",
+          props: {
+            attachments: [{ actions: [{ id: "approve", name: "Approve" }] }],
+          },
+        }),
+      } as unknown as MattermostClient,
+      botUserId: "bot",
+      accountId: "acct",
+    });
+
+    const req = createReq({
+      body: {
+        user_id: "user-1",
+        channel_id: "chan-1",
+        post_id: "post-1",
+        context: { ...context, _token: token },
+      },
+    });
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toContain("Post/channel mismatch");
+  });
+
+  it("rejects requests when the action is not present on the fetched post", async () => {
+    const context = { action_id: "approve", __openclaw_channel_id: "chan-1" };
+    const token = generateInteractionToken(context, "acct");
+    const handler = createMattermostInteractionHandler({
+      client: {
+        request: async () => ({
+          channel_id: "chan-1",
+          message: "Choose",
+          props: {
+            attachments: [{ actions: [{ id: "reject", name: "Reject" }] }],
+          },
+        }),
+      } as unknown as MattermostClient,
+      botUserId: "bot",
+      accountId: "acct",
+    });
+
+    const req = createReq({
+      body: {
+        user_id: "user-1",
+        channel_id: "chan-1",
+        post_id: "post-1",
+        context: { ...context, _token: token },
+      },
+    });
+    const res = createRes();
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toContain("Unknown action");
   });
 });

--- a/extensions/mattermost/src/mattermost/interactions.ts
+++ b/extensions/mattermost/src/mattermost/interactions.ts
@@ -6,6 +6,7 @@ import { updateMattermostPost, type MattermostClient } from "./client.js";
 
 const INTERACTION_MAX_BODY_BYTES = 64 * 1024;
 const INTERACTION_BODY_TIMEOUT_MS = 10_000;
+const SIGNED_CHANNEL_ID_CONTEXT_KEY = "__openclaw_channel_id";
 
 /**
  * Mattermost interactive message callback payload.
@@ -363,6 +364,69 @@ export function createMattermostInteractionHandler(params: {
       return;
     }
 
+    const signedChannelId =
+      typeof contextWithoutToken[SIGNED_CHANNEL_ID_CONTEXT_KEY] === "string"
+        ? contextWithoutToken[SIGNED_CHANNEL_ID_CONTEXT_KEY].trim()
+        : "";
+    if (signedChannelId && signedChannelId !== payload.channel_id) {
+      log?.(
+        `mattermost interaction: signed channel mismatch payload=${payload.channel_id} signed=${signedChannelId}`,
+      );
+      res.statusCode = 403;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Channel mismatch" }));
+      return;
+    }
+
+    const userName = payload.user_name ?? payload.user_id;
+    let originalMessage = "";
+    let clickedButtonName = actionId;
+    try {
+      const originalPost = await client.request<{
+        channel_id?: string | null;
+        message?: string;
+        props?: Record<string, unknown>;
+      }>(`/posts/${payload.post_id}`);
+      const postChannelId = originalPost.channel_id?.trim();
+      if (!postChannelId || postChannelId !== payload.channel_id) {
+        log?.(
+          `mattermost interaction: post channel mismatch payload=${payload.channel_id} post=${postChannelId ?? "<missing>"}`,
+        );
+        res.statusCode = 403;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ error: "Post/channel mismatch" }));
+        return;
+      }
+      originalMessage = originalPost.message ?? "";
+
+      // Ensure the callback can only target an action that exists on the original post.
+      const postAttachments = Array.isArray(originalPost?.props?.attachments)
+        ? (originalPost.props.attachments as Array<{
+            actions?: Array<{ id?: string; name?: string }>;
+          }>)
+        : [];
+      for (const att of postAttachments) {
+        const match = att.actions?.find((a) => a.id === actionId);
+        if (match?.name) {
+          clickedButtonName = match.name;
+          break;
+        }
+      }
+      if (clickedButtonName === actionId) {
+        log?.(`mattermost interaction: action ${actionId} not found in post ${payload.post_id}`);
+        res.statusCode = 403;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ error: "Unknown action" }));
+        return;
+      }
+    } catch (err) {
+      log?.(`mattermost interaction: failed to validate post ${payload.post_id}: ${String(err)}`);
+      res.statusCode = 500;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ error: "Failed to validate interaction" }));
+      return;
+    }
+
     log?.(
       `mattermost interaction: action=${actionId} user=${payload.user_name ?? payload.user_id} ` +
         `post=${payload.post_id} channel=${payload.channel_id}`,
@@ -387,34 +451,6 @@ export function createMattermostInteractionHandler(params: {
       });
     } catch (err) {
       log?.(`mattermost interaction: system event dispatch failed: ${String(err)}`);
-    }
-
-    // Fetch the original post to preserve its message and find the clicked button name.
-    const userName = payload.user_name ?? payload.user_id;
-    let originalMessage = "";
-    let clickedButtonName = actionId; // fallback to action ID if we can't find the name
-    try {
-      const originalPost = await client.request<{
-        message?: string;
-        props?: Record<string, unknown>;
-      }>(`/posts/${payload.post_id}`);
-      originalMessage = originalPost?.message ?? "";
-
-      // Find the clicked button's display name from the original attachments
-      const postAttachments = Array.isArray(originalPost?.props?.attachments)
-        ? (originalPost.props.attachments as Array<{
-            actions?: Array<{ id?: string; name?: string }>;
-          }>)
-        : [];
-      for (const att of postAttachments) {
-        const match = att.actions?.find((a) => a.id === actionId);
-        if (match?.name) {
-          clickedButtonName = match.name;
-          break;
-        }
-      }
-    } catch (err) {
-      log?.(`mattermost interaction: failed to fetch post ${payload.post_id}: ${String(err)}`);
     }
 
     // Update the post via API to replace buttons with a completion indicator.

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -544,7 +544,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           Surface: "mattermost" as const,
           MessageSid: `interaction:${opts.postId}:${opts.actionId}`,
           WasMentioned: true,
-          CommandAuthorized: true,
+          CommandAuthorized: false,
           OriginatingChannel: "mattermost" as const,
           OriginatingTo: to,
         });

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -205,13 +205,19 @@ async function resolveTargetChannelId(params: {
   return channel.id;
 }
 
-export async function sendMessageMattermost(
+type MattermostSendContext = {
+  cfg: OpenClawConfig;
+  accountId: string;
+  token: string;
+  baseUrl: string;
+  channelId: string;
+};
+
+async function resolveMattermostSendContext(
   to: string,
-  text: string,
   opts: MattermostSendOpts = {},
-): Promise<MattermostSendResult> {
+): Promise<MattermostSendContext> {
   const core = getCore();
-  const logger = core.logging.getChildLogger({ module: "mattermost" });
   const cfg = opts.cfg ?? core.config.loadConfig();
   const account = resolveMattermostAccount({
     cfg,
@@ -236,6 +242,34 @@ export async function sendMessageMattermost(
     baseUrl,
     token,
   });
+
+  return {
+    cfg,
+    accountId: account.accountId,
+    token,
+    baseUrl,
+    channelId,
+  };
+}
+
+export async function resolveMattermostSendChannelId(
+  to: string,
+  opts: MattermostSendOpts = {},
+): Promise<string> {
+  return (await resolveMattermostSendContext(to, opts)).channelId;
+}
+
+export async function sendMessageMattermost(
+  to: string,
+  text: string,
+  opts: MattermostSendOpts = {},
+): Promise<MattermostSendResult> {
+  const core = getCore();
+  const logger = core.logging.getChildLogger({ module: "mattermost" });
+  const { cfg, accountId, token, baseUrl, channelId } = await resolveMattermostSendContext(
+    to,
+    opts,
+  );
 
   const client = createMattermostClient({ baseUrl, botToken: token });
   let message = text?.trim() ?? "";
@@ -269,7 +303,7 @@ export async function sendMessageMattermost(
     const tableMode = core.channel.text.resolveMarkdownTableMode({
       cfg,
       channel: "mattermost",
-      accountId: account.accountId,
+      accountId,
     });
     message = core.channel.text.convertMarkdownTables(message, tableMode);
   }
@@ -291,7 +325,7 @@ export async function sendMessageMattermost(
 
   core.channel.activity.record({
     channel: "mattermost",
-    accountId: account.accountId,
+    accountId,
     direction: "outbound",
   });
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Mattermost interaction callbacks accepted any valid button context token even if the callback payload channel or post metadata was swapped.
- Why it matters: a leaked/replayed callback context could steer a button click into the wrong channel/post and the synthetic follow-up message was marked `CommandAuthorized: true`.
- What changed: button sends now sign the resolved channel id into the interaction context; callback handling rejects signed-channel mismatches, rejects post/channel mismatches, and rejects actions that are not present on the original post.
- What did NOT change (scope boundary): this does not change Mattermost slash command auth, gateway auth policy, or button UX for valid callbacks.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #37543

## User-visible / Behavior Changes

- Mattermost interactive button callbacks now fail closed when the callback payload channel/post/action does not match the signed button context.
- Synthetic button-click follow-up messages are no longer treated as pre-authorized text commands.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  The send path resolves the target channel id before signing button context, which can add one pre-send Mattermost lookup for name/user targets. In exchange, callbacks are bound to the intended channel and validated against the fetched original post before any synthetic follow-up dispatch.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local pnpm worktree
- Model/provider: n/a
- Integration/channel (if any): Mattermost plugin
- Relevant config (redacted): n/a

### Steps

1. Create a Mattermost interactive message with buttons.
2. Replay or tamper with the callback payload so `channel_id` or `post_id` no longer matches the original button context/post.
3. Send the callback to the interaction endpoint.

### Expected

- The callback is rejected before synthetic follow-up dispatch.

### Actual

- Before this patch, only the button context token was checked; payload channel/post metadata could diverge.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused Mattermost tests for `interactions`, `send`, and `channel` passed after the patch.
- Edge cases checked: signed channel mismatch, fetched post channel mismatch, missing action on original post, valid non-localhost callback.
- What you did **not** verify: live Mattermost end-to-end callback flow against a real server.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Mattermost: harden interaction callback binding`.
- Files/config to restore: the Mattermost interaction/send files in this PR.
- Known bad symptoms reviewers should watch for: valid button clicks unexpectedly returning `Channel mismatch`, `Post/channel mismatch`, or `Unknown action`.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: extra target-resolution lookup before sending button messages may add latency for username/channel-name targets.
  - Mitigation: limited to the button send path; existing send logic already performs the same resolution before delivery.
- Risk: stricter callback validation could surface existing broken Mattermost deployments that were relying on mismatched callback metadata.
  - Mitigation: validation is limited to signed channel id plus original-post checks, which should hold for valid Mattermost callbacks.
