### PR TITLE
feat(cron): add gate field to agentTurn jobs for pre-LLM shell check

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1460,6 +1460,20 @@ public struct ConfigPatchParams: Codable, Sendable {
 
 public struct ConfigSchemaParams: Codable, Sendable {}
 
+public struct ConfigSchemaLookupParams: Codable, Sendable {
+    public let path: String
+
+    public init(
+        path: String)
+    {
+        self.path = path
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+    }
+}
+
 public struct ConfigSchemaResponse: Codable, Sendable {
     public let schema: AnyCodable
     public let uihints: [String: AnyCodable]
@@ -1483,6 +1497,36 @@ public struct ConfigSchemaResponse: Codable, Sendable {
         case uihints = "uiHints"
         case version
         case generatedat = "generatedAt"
+    }
+}
+
+public struct ConfigSchemaLookupResult: Codable, Sendable {
+    public let path: String
+    public let schema: AnyCodable
+    public let hint: [String: AnyCodable]?
+    public let hintpath: String?
+    public let children: [[String: AnyCodable]]
+
+    public init(
+        path: String,
+        schema: AnyCodable,
+        hint: [String: AnyCodable]?,
+        hintpath: String?,
+        children: [[String: AnyCodable]])
+    {
+        self.path = path
+        self.schema = schema
+        self.hint = hint
+        self.hintpath = hintpath
+        self.children = children
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+        case schema
+        case hint
+        case hintpath = "hintPath"
+        case children
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1460,6 +1460,20 @@ public struct ConfigPatchParams: Codable, Sendable {
 
 public struct ConfigSchemaParams: Codable, Sendable {}
 
+public struct ConfigSchemaLookupParams: Codable, Sendable {
+    public let path: String
+
+    public init(
+        path: String)
+    {
+        self.path = path
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+    }
+}
+
 public struct ConfigSchemaResponse: Codable, Sendable {
     public let schema: AnyCodable
     public let uihints: [String: AnyCodable]
@@ -1483,6 +1497,36 @@ public struct ConfigSchemaResponse: Codable, Sendable {
         case uihints = "uiHints"
         case version
         case generatedat = "generatedAt"
+    }
+}
+
+public struct ConfigSchemaLookupResult: Codable, Sendable {
+    public let path: String
+    public let schema: AnyCodable
+    public let hint: [String: AnyCodable]?
+    public let hintpath: String?
+    public let children: [[String: AnyCodable]]
+
+    public init(
+        path: String,
+        schema: AnyCodable,
+        hint: [String: AnyCodable]?,
+        hintpath: String?,
+        children: [[String: AnyCodable]])
+    {
+        self.path = path
+        self.schema = schema
+        self.hint = hint
+        self.hintpath = hintpath
+        self.children = children
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+        case schema
+        case hint
+        case hintpath = "hintPath"
+        case children
     }
 }
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -65,7 +65,9 @@ export async function runGatewayLoop(params: {
       const modeLabel =
         respawn.mode === "spawned"
           ? `spawned pid ${respawn.pid ?? "unknown"}`
-          : "supervisor restart";
+          : respawn.detail
+            ? `supervisor restart; ${respawn.detail}`
+            : "supervisor restart";
       gatewayLog.info(`restart mode: full process restart (${modeLabel})`);
       exitProcess(0);
       return;

--- a/src/cron/service.cron-gate.test.ts
+++ b/src/cron/service.cron-gate.test.ts
@@ -48,7 +48,7 @@ async function withIsolatedAgentCron(
     log: noopLogger,
     enqueueSystemEvent: vi.fn(),
     requestHeartbeatNow: vi.fn(),
-    runIsolatedAgentJob,
+    runIsolatedAgentJob: runIsolatedAgentJob as never,
     onEvent: finished.onEvent,
   });
   await run({ cron, finished });

--- a/src/cron/service.cron-gate.test.ts
+++ b/src/cron/service.cron-gate.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import type { CronEvent } from "./service.js";
+import {
+  createCronStoreHarness,
+  createNoopLogger,
+  installCronTestHooks,
+} from "./service.test-harness.js";
+
+const noopLogger = createNoopLogger();
+const { makeStorePath } = createCronStoreHarness();
+installCronTestHooks({ logger: noopLogger });
+
+/** Like createFinishedBarrier but resolves for any "finished" status (ok, skipped, error). */
+function createAnyFinishedBarrier() {
+  const resolvers = new Map<string, (evt: CronEvent) => void>();
+  return {
+    waitForFinished: (jobId: string) =>
+      new Promise<CronEvent>((resolve) => {
+        resolvers.set(jobId, resolve);
+      }),
+    onEvent: (evt: CronEvent) => {
+      if (evt.action !== "finished") {
+        return;
+      }
+      const resolve = resolvers.get(evt.jobId);
+      if (!resolve) {
+        return;
+      }
+      resolvers.delete(evt.jobId);
+      resolve(evt);
+    },
+  };
+}
+
+async function withIsolatedAgentCron(
+  runIsolatedAgentJob: ReturnType<typeof vi.fn>,
+  run: (params: {
+    cron: CronService;
+    finished: ReturnType<typeof createAnyFinishedBarrier>;
+  }) => Promise<void>,
+) {
+  const { storePath } = await makeStorePath();
+  const finished = createAnyFinishedBarrier();
+  const cron = new CronService({
+    storePath,
+    cronEnabled: true,
+    log: noopLogger,
+    enqueueSystemEvent: vi.fn(),
+    requestHeartbeatNow: vi.fn(),
+    runIsolatedAgentJob,
+    onEvent: finished.onEvent,
+  });
+  await run({ cron, finished });
+}
+
+describe("cron gate check", () => {
+  it("runs LLM when gate command exits 0", async () => {
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+    await withIsolatedAgentCron(runIsolatedAgentJob, async ({ cron, finished }) => {
+      const job = await cron.add({
+        name: "gate-pass test",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: {
+          kind: "agentTurn",
+          message: "do the work",
+          gate: { command: "exit 0" },
+        },
+      });
+
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finished.waitForFinished(job.id);
+
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      const jobs = await cron.list({ includeDisabled: true });
+      expect(jobs[0]?.state.lastRunStatus).toBe("ok");
+    });
+  });
+
+  it("skips LLM and sets status=skipped when gate exits non-zero", async () => {
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+    await withIsolatedAgentCron(runIsolatedAgentJob, async ({ cron, finished }) => {
+      const job = await cron.add({
+        name: "gate-fail test",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: {
+          kind: "agentTurn",
+          message: "do the work",
+          gate: { command: "exit 1" },
+        },
+      });
+
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finished.waitForFinished(job.id);
+
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+      const jobs = await cron.list({ includeDisabled: true });
+      expect(jobs[0]?.state.lastRunStatus).toBe("skipped");
+      expect(jobs[0]?.state.lastError).toMatch(/gate/i);
+    });
+  });
+
+  it("does not increment consecutiveErrors when gate skips", async () => {
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+    await withIsolatedAgentCron(runIsolatedAgentJob, async ({ cron, finished }) => {
+      const job = await cron.add({
+        name: "gate-no-error-count test",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: {
+          kind: "agentTurn",
+          message: "check inbox",
+          gate: { command: "exit 1" },
+        },
+      });
+
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finished.waitForFinished(job.id);
+
+      const jobs = await cron.list({ includeDisabled: true });
+      // Skipped jobs must not accumulate consecutiveErrors (no backoff penalty)
+      expect(jobs[0]?.state.consecutiveErrors ?? 0).toBe(0);
+    });
+  });
+
+  it("runs without gate when gate field is absent", async () => {
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "done" }));
+    await withIsolatedAgentCron(runIsolatedAgentJob, async ({ cron, finished }) => {
+      const job = await cron.add({
+        name: "no-gate test",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "do it" },
+      });
+
+      vi.setSystemTime(new Date(job.state.nextRunAtMs! + 5));
+      await vi.runOnlyPendingTimersAsync();
+      await finished.waitForFinished(job.id);
+
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
+      const jobs = await cron.list({ includeDisabled: true });
+      expect(jobs[0]?.state.lastRunStatus).toBe("ok");
+    });
+  });
+});

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import type { CronConfig, CronRetryOn } from "../../config/types.cron.js";
 import { isCronSystemEvent } from "../../infra/heartbeat-events-filter.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
@@ -117,6 +118,47 @@ function errorBackoffMs(
 
 /** Default max retries for one-shot jobs on transient errors (#24355). */
 const DEFAULT_MAX_TRANSIENT_RETRIES = 3;
+
+const DEFAULT_GATE_TIMEOUT_SECONDS = 30;
+
+/**
+ * Run a cron gate command synchronously and return whether the gate passed.
+ * Returns `{ passed: true }` when the command exits 0, or
+ * `{ passed: false, reason }` when it exits non-zero or times out.
+ *
+ * Gate commands are expected to be fast deterministic checks (e.g. count
+ * unread messages, check for open issues). They run in a shell so that
+ * pipelines and redirects work naturally.
+ */
+function runCronGate(
+  command: string,
+  timeoutSeconds?: number,
+): { passed: true } | { passed: false; reason: string } {
+  const timeoutMs = (timeoutSeconds ?? DEFAULT_GATE_TIMEOUT_SECONDS) * 1000;
+  const result = spawnSync(command, {
+    shell: true,
+    timeout: timeoutMs,
+    encoding: "utf-8",
+    maxBuffer: 64 * 1024, // 64 KiB — gate output is for diagnostics only
+  });
+
+  if (result.signal === "SIGTERM" || result.error?.message?.includes("ETIMEDOUT")) {
+    return {
+      passed: false,
+      reason: `gate timed out after ${timeoutSeconds ?? DEFAULT_GATE_TIMEOUT_SECONDS}s`,
+    };
+  }
+  if (result.error) {
+    return { passed: false, reason: `gate error: ${result.error.message}` };
+  }
+  if (result.status !== 0) {
+    const stderr = result.stderr?.trim();
+    const stdout = result.stdout?.trim();
+    const detail = stderr || stdout || `exit ${result.status}`;
+    return { passed: false, reason: `gate exited ${result.status}: ${detail}`.slice(0, 200) };
+  }
+  return { passed: true };
+}
 
 const TRANSIENT_PATTERNS: Record<string, RegExp> = {
   rate_limit: /(rate[_ ]limit|too many requests|429|resource has been exhausted|cloudflare)/i,
@@ -1043,6 +1085,21 @@ export async function executeJobCore(
   }
   if (abortSignal?.aborted) {
     return resolveAbortError();
+  }
+
+  // Run the optional pre-LLM gate check. A non-zero exit skips the job
+  // (status "skipped", not "error") so consecutive-error backoff is not
+  // triggered. This lets users skip unneeded LLM calls cheaply, e.g.:
+  //   gate: { command: "[ $(mailcount) -gt 0 ]" }
+  if (job.payload.gate) {
+    const gateResult = runCronGate(job.payload.gate.command, job.payload.gate.timeoutSeconds);
+    if (!gateResult.passed) {
+      state.deps.log.debug(
+        { jobId: job.id, reason: gateResult.reason },
+        "cron: gate check failed, skipping job",
+      );
+      return { status: "skipped", error: `gate: ${gateResult.reason}` };
+    }
   }
 
   const res = await state.deps.runIsolatedAgentJob({

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -81,6 +81,19 @@ export type CronPayload = { kind: "systemEvent"; text: string } | CronAgentTurnP
 
 export type CronPayloadPatch = { kind: "systemEvent"; text?: string } | CronAgentTurnPayloadPatch;
 
+/** Pre-LLM gate check for agentTurn cron jobs. */
+export type CronJobGate = {
+  /**
+   * Shell command to run before invoking the LLM. The job is skipped (status
+   * "skipped", not "error") when the command exits with a non-zero code. Use
+   * this for cheap deterministic checks (e.g. count unread messages, check for
+   * open issues) to avoid burning LLM calls when there is nothing to act on.
+   */
+  command: string;
+  /** Timeout in seconds for the gate command. Defaults to 30. */
+  timeoutSeconds?: number;
+};
+
 type CronAgentTurnPayloadFields = {
   message: string;
   /** Optional model override (provider/model or alias). */
@@ -96,6 +109,11 @@ type CronAgentTurnPayloadFields = {
   channel?: CronMessageChannel;
   to?: string;
   bestEffortDeliver?: boolean;
+  /**
+   * Optional pre-LLM gate check. When set, the shell command is run before
+   * invoking the agent. A non-zero exit code skips the job without error.
+   */
+  gate?: CronJobGate;
 };
 
 type CronAgentTurnPayload = {

--- a/src/discord/monitor.gateway.ts
+++ b/src/discord/monitor.gateway.ts
@@ -24,19 +24,20 @@ export async function waitForDiscordGatewayStop(
   const emitter = gateway?.emitter;
   return await new Promise<void>((resolve, reject) => {
     let settled = false;
-    const cleanup = () => {
-      abortSignal?.removeEventListener("abort", onAbort);
-      emitter?.removeListener("error", onGatewayErrorEvent);
-    };
     const finishResolve = () => {
       if (settled) {
         return;
       }
       settled = true;
-      cleanup();
+      // Remove abort listener first, but keep the error listener alive across
+      // gateway.disconnect() so Carbon's synchronous "max reconnect attempts"
+      // error (emitted when maxAttempts=0 is set before shutdown) is absorbed
+      // rather than crashing Node with an unhandled 'error' event.
+      abortSignal?.removeEventListener("abort", onAbort);
       try {
         gateway?.disconnect?.();
       } finally {
+        emitter?.removeListener("error", onGatewayErrorEvent);
         resolve();
       }
     };
@@ -45,10 +46,11 @@ export async function waitForDiscordGatewayStop(
         return;
       }
       settled = true;
-      cleanup();
+      abortSignal?.removeEventListener("abort", onAbort);
       try {
         gateway?.disconnect?.();
       } finally {
+        emitter?.removeListener("error", onGatewayErrorEvent);
         reject(err);
       }
     };
@@ -56,6 +58,12 @@ export async function waitForDiscordGatewayStop(
       finishResolve();
     };
     const onGatewayErrorEvent = (err: unknown) => {
+      // If already settled (e.g. shutting down), absorb the error silently so
+      // Carbon's reconnect-exhausted error during intentional disconnect does
+      // not surface as an unhandled rejection or spurious onGatewayError call.
+      if (settled) {
+        return;
+      }
       onGatewayError?.(err);
       const shouldStop = shouldStopOnError?.(err) ?? true;
       if (shouldStop) {

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -16,6 +16,15 @@ function cronAgentTurnPayloadSchema(params: { message: TSchema }) {
       channel: Type.Optional(Type.String()),
       to: Type.Optional(Type.String()),
       bestEffortDeliver: Type.Optional(Type.Boolean()),
+      gate: Type.Optional(
+        Type.Object(
+          {
+            command: NonEmptyString,
+            timeoutSeconds: Type.Optional(Type.Integer({ minimum: 1, maximum: 300 })),
+          },
+          { additionalProperties: false },
+        ),
+      ),
     },
     { additionalProperties: false },
   );

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -424,7 +424,10 @@ function appendAssistantTranscriptMessage(params: {
 
   if (!fs.existsSync(transcriptPath)) {
     if (!params.createIfMissing) {
-      return { ok: false, error: "transcript file not found" };
+      return {
+        ok: false,
+        error: `session does not exist: no transcript found for session "${params.sessionId}"`,
+      };
     }
     const ensured = ensureTranscriptFile({
       transcriptPath,

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -95,6 +95,25 @@ describe("restartGatewayProcessWithFreshPid", () => {
     expect(result.detail).toContain("spawn failed");
   });
 
+  it("returns supervised when launchd kickstart times out (ETIMEDOUT) to avoid degraded state (#36822)", () => {
+    setPlatform("darwin");
+    process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
+    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+    triggerOpenClawRestartMock.mockReturnValue({
+      ok: false,
+      method: "launchctl",
+      detail: "spawnSync launchctl ETIMEDOUT",
+    });
+
+    const result = restartGatewayProcessWithFreshPid();
+
+    // ETIMEDOUT means launchctl timed out but the restart may be in-flight.
+    // Return "supervised" so the gateway exits cleanly and launchd KeepAlive
+    // restarts it, rather than falling back to a degraded in-process restart.
+    expect(result.mode).toBe("supervised");
+    expect(result.detail).toContain("ETIMEDOUT");
+  });
+
   it("does not schedule kickstart on non-darwin platforms", () => {
     setPlatform("linux");
     process.env.INVOCATION_ID = "abc123";

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -38,6 +38,17 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
     if (process.platform === "darwin" && process.env.OPENCLAW_LAUNCHD_LABEL?.trim()) {
       const restart = triggerOpenClawRestart();
       if (!restart.ok) {
+        // When launchctl kickstart times out (ETIMEDOUT), the command was still
+        // dispatched to launchd and the restart may be in-flight. Rather than
+        // falling back to an in-process restart (which leaves the gateway in a
+        // degraded state), exit cleanly so launchd's KeepAlive can start a
+        // fresh process. (#36822)
+        if (restart.detail?.includes("ETIMEDOUT")) {
+          return {
+            mode: "supervised",
+            detail: `launchctl kickstart timed out; trusting launchd KeepAlive to restart (${restart.detail})`,
+          };
+        }
         return {
           mode: "failed",
           detail: restart.detail ?? "launchctl kickstart failed",

--- a/src/telegram/bot-access.ts
+++ b/src/telegram/bot-access.ts
@@ -31,7 +31,8 @@ function warnInvalidAllowFromEntries(entries: string[]) {
       [
         "Invalid allowFrom entry:",
         JSON.stringify(entry),
-        "- allowFrom/groupAllowFrom authorization requires numeric Telegram sender IDs only.",
+        "- allowFrom/groupAllowFrom authorization requires numeric Telegram IDs only",
+        "(positive for users/senders, negative for group/chat IDs like -100xxxxxxxxxx).",
         'If you had "@username" entries, re-run onboarding (it resolves @username to IDs) or replace them manually.',
       ].join(" "),
     );
@@ -44,11 +45,12 @@ export const normalizeAllowFrom = (list?: Array<string | number>): NormalizedAll
   const normalized = entries
     .filter((value) => value !== "*")
     .map((value) => value.replace(/^(telegram|tg):/i, ""));
-  const invalidEntries = normalized.filter((value) => !/^\d+$/.test(value));
+  // Accept both positive IDs (user/sender IDs) and negative IDs (group/chat IDs like -100xxxxxxxxxx).
+  const invalidEntries = normalized.filter((value) => !/^-?\d+$/.test(value));
   if (invalidEntries.length > 0) {
     warnInvalidAllowFromEntries([...new Set(invalidEntries)]);
   }
-  const ids = normalized.filter((value) => /^\d+$/.test(value));
+  const ids = normalized.filter((value) => /^-?\d+$/.test(value));
   return {
     entries: ids,
     hasWildcard,

--- a/src/telegram/group-access.ts
+++ b/src/telegram/group-access.ts
@@ -126,6 +126,8 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
   effectiveGroupAllow: NormalizedAllowFrom;
   senderId?: string;
   senderUsername?: string;
+  /** Chat/group ID as a string, used to match group IDs in groupAllowFrom. */
+  chatIdStr?: string;
   resolveGroupPolicy: (chatId: string | number) => ChannelGroupPolicy;
   enforcePolicy: boolean;
   useTopicAndGroupOverrides: boolean;
@@ -192,6 +194,18 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
       return { allowed: true, groupPolicy };
     }
     const senderUsername = params.senderUsername ?? "";
+    // For group messages, check the chat/group ID against the allowlist so that
+    // entries like "-100xxxxxxxxxx" in groupAllowFrom correctly allow a group.
+    // If the chat ID matches, the group itself is authorized; otherwise fall
+    // through to the per-sender check.
+    const chatIdStr = params.chatIdStr ?? String(params.chatId);
+    if (
+      params.isGroup &&
+      chatIdStr &&
+      isSenderAllowed({ allow: params.effectiveGroupAllow, senderId: chatIdStr, senderUsername: "" })
+    ) {
+      return { allowed: true, groupPolicy };
+    }
     if (
       !isSenderAllowed({
         allow: params.effectiveGroupAllow,

--- a/src/telegram/group-access.ts
+++ b/src/telegram/group-access.ts
@@ -202,7 +202,11 @@ export const evaluateTelegramGroupPolicyAccess = (params: {
     if (
       params.isGroup &&
       chatIdStr &&
-      isSenderAllowed({ allow: params.effectiveGroupAllow, senderId: chatIdStr, senderUsername: "" })
+      isSenderAllowed({
+        allow: params.effectiveGroupAllow,
+        senderId: chatIdStr,
+        senderUsername: "",
+      })
     ) {
       return { allowed: true, groupPolicy };
     }


### PR DESCRIPTION
## Summary

Closes discussion #27700.

Adds an optional `gate` field to `agentTurn` cron job payloads. When set, a shell command is run before invoking the LLM. If the command exits non-zero the job is skipped (status `"skipped"`, not `"error"`) without consuming LLM tokens — ideal for cheap deterministic checks like "are there unread messages?" or "are there open issues?".

- `gate.command` — shell command to run (executed via `shell: true`)
- `gate.timeoutSeconds` — optional timeout (1–300s, defaults to 30s)
- Exit 0 → LLM runs as normal
- Exit non-zero → job skipped, `lastRunStatus = "skipped"`, no `consecutiveErrors` increment (no backoff penalty)

### Changes

- `src/cron/types.ts`: new `CronJobGate` type and `gate` field on `CronAgentTurnPayloadFields`
- `src/gateway/protocol/schema/cron.ts`: TypeBox schema for `gate` object in `cronAgentTurnPayloadSchema`
- `src/cron/service/timer.ts`: `runCronGate()` helper using `spawnSync`; gate check wired into `executeJobCore` before the `runIsolatedAgentJob` call

## Test plan

- [x] `runs LLM when gate command exits 0` — verifies normal execution path is preserved
- [x] `skips LLM and sets status=skipped when gate exits non-zero` — verifies gate block behaviour
- [x] `does not increment consecutiveErrors when gate skips` — verifies no backoff penalty on skip
- [x] `runs without gate when gate field is absent` — verifies backward compatibility