### PR TITLE
fix(skill-creator): make .skill package file order deterministic

### DIFF
--- a/skills/skill-creator/scripts/package_skill.py
+++ b/skills/skill-creator/scripts/package_skill.py
@@ -76,32 +76,40 @@ def package_skill(skill_path, output_dir=None):
 
     # Create the .skill file (zip format)
     try:
+        # Collect all files first, then sort for deterministic ordering
+        files_to_package = []
+        for file_path in skill_path.rglob("*"):
+            # Security: never follow or package symlinks.
+            if file_path.is_symlink():
+                print(f"[WARN] Skipping symlink: {file_path}")
+                continue
+
+            rel_parts = file_path.relative_to(skill_path).parts
+            if any(part in EXCLUDED_DIRS for part in rel_parts):
+                continue
+
+            if file_path.is_file():
+                resolved_file = file_path.resolve()
+                if not _is_within(resolved_file, skill_path):
+                    print(f"[ERROR] File escapes skill root: {file_path}")
+                    return None
+                # If output lives under skill_path, avoid writing archive into itself.
+                if resolved_file == skill_filename.resolve():
+                    print(f"[WARN] Skipping output archive: {file_path}")
+                    continue
+
+                files_to_package.append(file_path)
+
+        # Sort files deterministically by their relative path using posix separators
+        # to ensure cross-platform consistency (Windows uses backslashes in str())
+        files_to_package.sort(key=lambda p: p.relative_to(skill_path).as_posix())
+
         with zipfile.ZipFile(skill_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
-            # Walk through the skill directory
-            for file_path in skill_path.rglob("*"):
-                # Security: never follow or package symlinks.
-                if file_path.is_symlink():
-                    print(f"[WARN] Skipping symlink: {file_path}")
-                    continue
-
-                rel_parts = file_path.relative_to(skill_path).parts
-                if any(part in EXCLUDED_DIRS for part in rel_parts):
-                    continue
-
-                if file_path.is_file():
-                    resolved_file = file_path.resolve()
-                    if not _is_within(resolved_file, skill_path):
-                        print(f"[ERROR] File escapes skill root: {file_path}")
-                        return None
-                    # If output lives under skill_path, avoid writing archive into itself.
-                    if resolved_file == skill_filename.resolve():
-                        print(f"[WARN] Skipping output archive: {file_path}")
-                        continue
-
-                    # Calculate the relative path within the zip.
-                    arcname = Path(skill_name) / file_path.relative_to(skill_path)
-                    zipf.write(file_path, arcname)
-                    print(f"  Added: {arcname}")
+            for file_path in files_to_package:
+                # Calculate the relative path within the zip.
+                arcname = Path(skill_name) / file_path.relative_to(skill_path)
+                zipf.write(file_path, arcname)
+                print(f"  Added: {arcname}")
 
         print(f"\n[OK] Successfully packaged skill to: {skill_filename}")
         return skill_filename

--- a/skills/skill-creator/scripts/test_package_skill.py
+++ b/skills/skill-creator/scripts/test_package_skill.py
@@ -155,6 +155,52 @@ class TestPackageSkillSecurity(TestCase):
         self.assertIn("self-output-skill/script.py", names)
         self.assertNotIn("self-output-skill/self-output-skill.skill", names)
 
+    def test_deterministic_file_order(self):
+        """Test that files are packaged in deterministic (sorted) order."""
+        skill_dir = self.create_skill("deterministic-skill")
+
+        # Create multiple files with names that would sort differently
+        # if ordering was non-deterministic
+        (skill_dir / "zebra.py").write_text("print('z')\n")
+        (skill_dir / "alpha.py").write_text("print('a')\n")
+        (skill_dir / "beta.py").write_text("print('b')\n")
+        nested = skill_dir / "subdir"
+        nested.mkdir()
+        (nested / "gamma.py").write_text("print('g')\n")
+        (nested / "delta.py").write_text("print('d')\n")
+
+        out_dir = self.temp_dir / "out"
+        out_dir.mkdir()
+
+        # Package multiple times and verify order is consistent
+        results = []
+        for _ in range(3):
+            result = package_skill(str(skill_dir), str(out_dir))
+            self.assertIsNotNone(result)
+            skill_file = out_dir / "deterministic-skill.skill"
+            with zipfile.ZipFile(skill_file, "r") as archive:
+                # Get ordered list (not set) to preserve order
+                names = archive.namelist()
+            results.append(names)
+            # Remove the .skill file for next iteration
+            skill_file.unlink()
+
+        # All runs should produce identical ordering
+        self.assertEqual(results[0], results[1], "First two runs produced different order")
+        self.assertEqual(results[1], results[2], "Second and third runs produced different order")
+
+        # Verify the order is alphabetically sorted by relative path
+        expected_order = [
+            "deterministic-skill/SKILL.md",
+            "deterministic-skill/alpha.py",
+            "deterministic-skill/beta.py",
+            "deterministic-skill/script.py",
+            "deterministic-skill/subdir/delta.py",
+            "deterministic-skill/subdir/gamma.py",
+            "deterministic-skill/zebra.py",
+        ]
+        self.assertEqual(results[0], expected_order, "Files not in expected sorted order")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

Fixes non-deterministic file ordering when packaging .skill files, which caused inconsistent builds/hashes for the same skill.

## Problem

The `package_skill()` function used `skill_path.rglob("*")` to iterate over files, which returns files in non-deterministic filesystem order. This caused:
- Inconsistent .skill file hashes across builds
- Unreliable caching/validation
- Confusing diff noise in version control

## Solution

Modified the packaging logic to:
1. Collect all files into a list first (instead of iterating directly)
2. Sort the list deterministically by relative path (alphabetically) before adding to the zip archive

## Changes

**File:** `skills/skill-creator/scripts/package_skill.py`
- Collect files into `files_to_package` list
- Sort by relative path string before zipping
- Preserves all existing security checks (symlink skipping, path validation)

**File:** `skills/skill-creator/scripts/test_package_skill.py`
- Added `test_deterministic_file_order()` test
- Creates files with names that would expose non-deterministic ordering (zebra, alpha, beta, etc.)
- Packages skill 3 times and verifies identical file ordering
- Verifies order is alphabetically sorted

## Testing

✅ All 7 existing tests pass
✅ New test verifies deterministic ordering across multiple runs
✅ Verified with real skill: packaging `skills/skill-creator` 3 times produces identical MD5 hash: `d8495647d02b85a0142773cafbb5af80`
✅ Ruff linting passes

## Impact

- **Backward compatible:** Existing .skill files work unchanged
- **Breaking change:** None - only affects build reproducibility
- **Security:** No changes to security model (symlink checks, path validation preserved)

Fixes #37748