### PR TITLE
fix(agents): use gpt-5.4 context window for openai-codex forward-compat resolution

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -363,7 +363,16 @@ describe("resolveForwardCompatModel", () => {
     expectResolvedForwardCompat(model, { provider: "openai-codex", id: "gpt-5.4" });
     expect(model?.api).toBe("openai-codex-responses");
     expect(model?.baseUrl).toBe("https://chatgpt.com/backend-api");
-    expect(model?.contextWindow).toBe(272_000);
+    expect(model?.contextWindow).toBe(1_050_000);
+    expect(model?.maxTokens).toBe(128_000);
+  });
+
+  it("resolves openai-codex gpt-5.4 without templates using gpt-5.4 context window", () => {
+    const registry = createRegistry({});
+    const model = resolveForwardCompatModel("openai-codex", "gpt-5.4", registry);
+    expectResolvedForwardCompat(model, { provider: "openai-codex", id: "gpt-5.4" });
+    expect(model?.api).toBe("openai-codex-responses");
+    expect(model?.contextWindow).toBe(1_050_000);
     expect(model?.maxTokens).toBe(128_000);
   });
 

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -123,7 +123,8 @@ function resolveOpenAICodexForwardCompatModel(
 
   let templateIds: readonly string[];
   let eligibleProviders: Set<string>;
-  if (lower === OPENAI_CODEX_GPT_54_MODEL_ID) {
+  const isGpt54 = lower === OPENAI_CODEX_GPT_54_MODEL_ID;
+  if (isGpt54) {
     templateIds = OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS;
     eligibleProviders = CODEX_GPT54_ELIGIBLE_PROVIDERS;
   } else if (lower === OPENAI_CODEX_GPT_53_MODEL_ID) {
@@ -146,6 +147,9 @@ function resolveOpenAICodexForwardCompatModel(
       ...template,
       id: trimmedModelId,
       name: trimmedModelId,
+      ...(isGpt54
+        ? { contextWindow: OPENAI_GPT_54_CONTEXT_TOKENS, maxTokens: OPENAI_GPT_54_MAX_TOKENS }
+        : {}),
     } as Model<Api>);
   }
 
@@ -158,8 +162,8 @@ function resolveOpenAICodexForwardCompatModel(
     reasoning: true,
     input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_TOKENS,
-    maxTokens: DEFAULT_CONTEXT_TOKENS,
+    contextWindow: isGpt54 ? OPENAI_GPT_54_CONTEXT_TOKENS : DEFAULT_CONTEXT_TOKENS,
+    maxTokens: isGpt54 ? OPENAI_GPT_54_MAX_TOKENS : DEFAULT_CONTEXT_TOKENS,
   } as Model<Api>);
 }
 

--- a/src/agents/pi-embedded-runner/model.test-harness.ts
+++ b/src/agents/pi-embedded-runner/model.test-harness.ts
@@ -36,13 +36,14 @@ export function mockOpenAICodexTemplateModel(): void {
 export function buildOpenAICodexForwardCompatExpectation(
   id: string = "gpt-5.3-codex",
 ): Partial<typeof OPENAI_CODEX_TEMPLATE_MODEL> & { provider: string; id: string } {
+  const isGpt54 = id.toLowerCase() === "gpt-5.4";
   return {
     provider: "openai-codex",
     id,
     api: "openai-codex-responses",
     baseUrl: "https://chatgpt.com/backend-api",
     reasoning: true,
-    contextWindow: 272000,
+    contextWindow: isGpt54 ? 1_050_000 : 272000,
     maxTokens: 128000,
   };
 }


### PR DESCRIPTION
## Summary

- **Problem:** The codex forward-compat resolution path for `gpt-5.4` uses `DEFAULT_CONTEXT_TOKENS` (272k) instead of the model-specific 1,050,000 token context window, causing premature context truncation.
- **Why it matters:** Users running gpt-5.4 via openai-codex provider get a context window 4x smaller than the model supports, leading to unnecessarily truncated conversations and degraded agent performance.
- **What changed:** Applied `OPENAI_GPT_54_CONTEXT_TOKENS` (1,050,000) and `OPENAI_GPT_54_MAX_TOKENS` (128,000) to both the template-clone path and the no-template fallback path in `resolveOpenAICodexForwardCompatModel`. Updated test harness and added a new test case.
- **What did NOT change:** Non-codex gpt-5.4 resolution (already correct), gpt-5.3-codex resolution, template lookup logic, provider eligibility checks.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37875

## User-visible / Behavior Changes

- `openai-codex` provider with `gpt-5.4` model now resolves to 1,050,000 token context window (was 272,000).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0 (arm64)
- Runtime: Node v25.6.1

### Steps

1. Configure agent with `provider: openai-codex`, `model: gpt-5.4`
2. Check resolved model's `contextWindow`

### Expected

- `contextWindow` is 1,050,000

### Actual

- Before fix: `contextWindow` is 272,000 (DEFAULT_CONTEXT_TOKENS)
- After fix: `contextWindow` is 1,050,000

## Evidence

```
 ✓ src/agents/model-compat.test.ts (33 tests) 4ms
   ✓ resolves openai-codex gpt-5.4 via codex template fallback
   ✓ resolves openai-codex gpt-5.4 without templates using gpt-5.4 context window
```

## Human Verification (required)

- Verified scenarios: codex gpt-5.4 with template, codex gpt-5.4 without template, codex gpt-5.3 (unchanged), openai gpt-5.4 (unchanged)
- Edge cases checked: gpt-5.3-codex still uses DEFAULT_CONTEXT_TOKENS, template-found vs no-template paths both correct
- What I did **not** verify: Live codex API call with gpt-5.4 model

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/agents/model-forward-compat.ts`
- Known bad symptoms: If gpt-5.4 actually has a smaller context window than 1,050,000, requests could exceed the real limit

## Risks and Mitigations

None — aligns codex path with the already-correct non-codex gpt-5.4 resolution.
