### PR TITLE
skill-creator: accept case-insensitive --resources values

### DIFF
--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -208,13 +208,17 @@ def title_case_skill_name(skill_name):
 def parse_resources(raw_resources):
     if not raw_resources:
         return []
-    resources = [item.strip() for item in raw_resources.split(",") if item.strip()]
+
+    # Accept case-insensitive resource names while preserving input order.
+    resources = [item.strip().lower() for item in raw_resources.split(",") if item.strip()]
+
     invalid = sorted({item for item in resources if item not in ALLOWED_RESOURCES})
     if invalid:
         allowed = ", ".join(sorted(ALLOWED_RESOURCES))
         print(f"[ERROR] Unknown resource type(s): {', '.join(invalid)}")
         print(f"   Allowed: {allowed}")
         sys.exit(1)
+
     deduped = []
     seen = set()
     for resource in resources:

--- a/skills/skill-creator/scripts/test_init_skill.py
+++ b/skills/skill-creator/scripts/test_init_skill.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Tests for init_skill helpers."""
+
+from unittest import TestCase, main
+
+from init_skill import parse_resources
+
+
+class TestInitSkill(TestCase):
+    def test_parse_resources_accepts_case_insensitive_values(self):
+        parsed = parse_resources("Scripts, references,ASSETS,scripts")
+
+        self.assertEqual(parsed, ["scripts", "references", "assets"])
+
+    def test_parse_resources_rejects_unknown_values(self):
+        with self.assertRaises(SystemExit) as ctx:
+            parse_resources("scripts,unknown")
+
+        self.assertEqual(ctx.exception.code, 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed
- Updated `skills/skill-creator/scripts/init_skill.py` so `--resources` parsing is case-insensitive.
  - Example: `--resources Scripts,References,ASSETS` is now accepted.
- Kept existing behavior for order-preserving deduplication and unknown-resource validation.
- Added `skills/skill-creator/scripts/test_init_skill.py` with regression tests for:
  - mixed-case resource parsing + deduplication,
  - unknown-resource rejection.

## Why
- `init_skill.py` already normalizes the skill name for convenience, but `--resources` required exact lowercase values.
- In practice, users often type mixed-case CLI values. Treating resource names case-insensitively improves UX without changing the resulting directory names.
- The tests lock in the new behavior and guard against regressions.

## Testing
- ✅ `source .venv/bin/activate && pytest -q skills/skill-creator/scripts/test_init_skill.py skills/skill-creator/scripts/test_package_skill.py skills/skill-creator/scripts/test_quick_validate.py`
- ✅ `scripts/clone_and_test.sh openclaw/openclaw`
