### PR TITLE
fix(cron): exclude sandbox from shallow Object.assign to preserve dangerouslyAllow flags

### DIFF
--- a/src/cron/isolated-agent/run.sandbox-merge.test.ts
+++ b/src/cron/isolated-agent/run.sandbox-merge.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearFastTestEnv,
+  loadRunCronIsolatedAgentTurn,
+  makeCronSession,
+  makeCronSessionEntry,
+  resolveAgentConfigMock,
+  resolveAllowedModelRefMock,
+  resolveConfiguredModelRefMock,
+  resolveCronSessionMock,
+  resetRunCronIsolatedAgentTurnHarness,
+  restoreFastTestEnv,
+  runWithModelFallbackMock,
+  updateSessionStoreMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+function makeJob(overrides?: Record<string, unknown>) {
+  return {
+    id: "sandbox-test",
+    name: "Sandbox Test",
+    schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+    sessionTarget: "isolated",
+    payload: { kind: "agentTurn", message: "test" },
+    ...overrides,
+  } as never;
+}
+
+function makeParams(overrides?: Record<string, unknown>) {
+  return {
+    cfg: {},
+    deps: {} as never,
+    job: makeJob(),
+    message: "test",
+    sessionKey: "cron:sandbox-test",
+    ...overrides,
+  };
+}
+
+describe("runCronIsolatedAgentTurn — sandbox config merge (#38067)", () => {
+  let previousFastTestEnv: string | undefined;
+
+  beforeEach(() => {
+    previousFastTestEnv = process.env.FAST_TEST;
+    process.env.FAST_TEST = "1";
+    resetRunCronIsolatedAgentTurnHarness();
+
+    resolveCronSessionMock.mockReturnValue(
+      makeCronSession({ sessionEntry: makeCronSessionEntry() }),
+    );
+    resolveConfiguredModelRefMock.mockReturnValue({ provider: "openai", model: "gpt-4" });
+    resolveAllowedModelRefMock.mockReturnValue({
+      ref: { provider: "openai", model: "gpt-4" },
+    });
+    updateSessionStoreMock.mockResolvedValue(undefined);
+    runWithModelFallbackMock.mockResolvedValue({
+      result: {
+        payloads: [{ text: "ok" }],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      },
+      provider: "openai",
+      model: "gpt-4",
+      attempts: [],
+    });
+  });
+
+  afterEach(() => {
+    if (previousFastTestEnv !== undefined) {
+      restoreFastTestEnv(previousFastTestEnv);
+    } else {
+      clearFastTestEnv();
+    }
+  });
+
+  it("does not shallow-merge agent sandbox into defaults, preserving dangerouslyAllow flags", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "docker",
+            docker: {
+              dangerouslyAllowExternalBindSources: true,
+              network: "host",
+            },
+          },
+        },
+      },
+    };
+
+    resolveAgentConfigMock.mockReturnValue({
+      sandbox: {
+        docker: {
+          binds: ["/data/shared:/mnt/shared:ro"],
+        },
+      },
+    });
+
+    await runCronIsolatedAgentTurn(makeParams({ cfg, agentId: "kotik" }));
+
+    const callArgs = runWithModelFallbackMock.mock.calls[0];
+    const passedCfg = callArgs?.[0]?.cfg;
+    const defaultsSandbox = passedCfg?.agents?.defaults?.sandbox;
+
+    expect(defaultsSandbox?.docker?.dangerouslyAllowExternalBindSources).toBe(true);
+    expect(defaultsSandbox?.docker?.network).toBe("host");
+    expect(defaultsSandbox?.docker?.binds).toBeUndefined();
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -125,7 +125,8 @@ export async function runCronIsolatedAgentTurn(params: {
   const agentConfigOverride = normalizedRequested
     ? resolveAgentConfig(params.cfg, normalizedRequested)
     : undefined;
-  const { model: overrideModel, ...agentOverrideRest } = agentConfigOverride ?? {};
+  const { model: overrideModel, sandbox: _sandboxOverride, ...agentOverrideRest } =
+    agentConfigOverride ?? {};
   // Use the requested agentId even when there is no explicit agent config entry.
   // This ensures auth-profiles, workspace, and agentDir all resolve to the
   // correct per-agent paths (e.g. ~/.openclaw/agents/<agentId>/agent/).


### PR DESCRIPTION
## Summary

- **Problem:** `runCronIsolatedAgentTurn` shallow-merges the per-agent config onto `agents.defaults` with `Object.assign`. When the agent defines its own `sandbox` config (e.g. custom `docker.binds`), the entire defaults `sandbox` object is replaced, losing nested properties like `sandbox.docker.dangerouslyAllowExternalBindSources`. This causes cron isolated sessions to fail with "Sandbox security: bind mount source is outside allowed roots".
- **Why it matters:** Any agent with custom sandbox binds running cron isolated sessions cannot use external bind sources, even when `dangerouslyAllowExternalBindSources` is explicitly set in defaults.
- **What changed:** Excluded `sandbox` from the destructured agent config override so it is not shallow-merged into defaults. `resolveSandboxConfigForAgent` (called downstream) already handles the defaults-vs-agent sandbox merge correctly with deep property resolution. Added 1 test case.
- **What did NOT change:** Normal (non-cron) session sandbox resolution, `resolveSandboxConfigForAgent` logic, model merge logic, other config merging behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38067

## User-visible / Behavior Changes

- Cron isolated sessions now correctly inherit `dangerouslyAllowExternalBindSources` (and other nested sandbox docker flags) from `agents.defaults` when the per-agent config has its own `sandbox` section.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0 (arm64)
- Runtime: Node v25.6.1

### Steps

1. Set `dangerouslyAllowExternalBindSources: true` in `agents.defaults.sandbox.docker`
2. Configure an agent with its own `sandbox.docker.binds` but without explicitly setting `dangerouslyAllowExternalBindSources`
3. Create a cron job targeting that agent with `sessionTarget: "isolated"`

### Expected

- Cron job runs successfully, inheriting `dangerouslyAllowExternalBindSources` from defaults

### Actual

- Before fix: "Sandbox security: bind mount source is outside allowed roots"
- After fix: Cron job runs successfully

## Evidence

```
 ✓ src/cron/isolated-agent/run.sandbox-merge.test.ts (1 test) 4ms
   ✓ does not shallow-merge agent sandbox into defaults, preserving dangerouslyAllow flags
```

## Human Verification (required)

- Verified scenarios: Agent with custom sandbox binds + defaults dangerouslyAllow, agent without sandbox override (unchanged)
- Edge cases checked: Agent with no config override (no-op), agent with only model override (unchanged)
- What I did **not** verify: Live Docker sandbox with external bind mounts

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/cron/isolated-agent/run.ts`
- Known bad symptoms: If an agent's sandbox config was intentionally meant to fully replace defaults sandbox (unlikely given deep merge downstream), this change would preserve defaults' properties

## Risks and Mitigations

None — the downstream `resolveSandboxConfigForAgent` already performs the correct deep merge between defaults and per-agent sandbox config.
