### PR TITLE
fix(webchat): hide delivery-mirror transcript entries from chat.history

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -258,12 +258,26 @@ function sanitizeChatHistoryMessages(messages: unknown[]): unknown[] {
   for (const message of messages) {
     const res = sanitizeChatHistoryMessage(message);
     changed ||= res.changed;
+
     // Drop assistant messages whose entire visible text is the silent reply token.
     const text = extractAssistantTextForSilentCheck(res.message);
     if (text !== undefined && isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
       changed = true;
       continue;
     }
+
+    // Hide internal transcript entries created as delivery mirrors; they are not model output.
+    if (
+      res.message &&
+      typeof res.message === "object" &&
+      (res.message as { role?: unknown }).role === "assistant" &&
+      (res.message as { provider?: unknown }).provider === "openclaw" &&
+      (res.message as { model?: unknown }).model === "delivery-mirror"
+    ) {
+      changed = true;
+      continue;
+    }
+
     next.push(res.message);
   }
   return changed ? next : messages;

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -413,6 +413,33 @@ describe("gateway server chat", () => {
     expect(textValues).toEqual(["hello", "real reply", "real text field reply", "NO_REPLY"]);
   });
 
+  test("chat.history hides internal delivery-mirror transcript entries", async () => {
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "real reply" }],
+        timestamp: 2,
+        provider: "openrouter",
+        model: "some-model",
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "real reply" }],
+        timestamp: 3,
+        provider: "openclaw",
+        model: "delivery-mirror",
+      },
+    ]);
+
+    const textValues = collectHistoryTextValues(historyMessages);
+    expect(textValues).toEqual(["hello", "real reply"]);
+  });
+
   test("routes chat.send slash commands without agent runs", async () => {
     await withMainSessionStore(async () => {
       const spy = vi.mocked(agentCommand);


### PR DESCRIPTION
Closes #38061

Webchat was showing duplicate assistant replies because `chat.history` returned internal transcript entries created by the delivery mirror (provider=openclaw, model=delivery-mirror).

This change filters those internal assistant messages server-side and adds a regression test.

Tests: `npx --no-install vitest src/gateway/server.chat.gateway-server-chat.test.ts --run`