### PR TITLE
docs(docker): add DinD sidecar guide for sandbox in Docker-in-Docker …

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -113,6 +113,88 @@ Notes:
 - For non-local `OPENCLAW_IMAGE` values, the image must already contain Docker
   CLI support for sandbox execution.
 
+### DinD sidecar (Docker-in-Docker alternative)
+
+The default sandbox approach mounts the host's `docker.sock` to create sibling
+containers. This works when the Gateway runs directly on a Linux host, but
+**breaks on Docker Desktop** (macOS/Windows) or when the Gateway itself runs
+inside a container, because bind-mount paths inside the Gateway container don't
+exist on the host filesystem (causes `Mounts denied` errors).
+
+A **Docker-in-Docker (DinD) sidecar** solves this by running a dedicated Docker
+daemon that shares a volume with the Gateway. Sandbox containers are created
+inside the DinD daemon where paths are consistent.
+
+```
+Gateway container ──(DOCKER_HOST=tcp://dind:2375)──▶ DinD container
+       │                                                    │
+       └── openclaw-state volume (shared) ──────────────────┘
+```
+
+Example `docker-compose.yml`:
+
+```yaml
+services:
+  dind:
+    image: docker:dind
+    privileged: true
+    restart: unless-stopped
+    environment:
+      DOCKER_TLS_CERTDIR: ""
+    volumes:
+      - openclaw-state:/home/node/.openclaw
+      - dind-storage:/var/lib/docker
+    networks:
+      - openclaw-net
+    healthcheck:
+      test: ["CMD", "docker", "info"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  openclaw-gateway:
+    image: ${OPENCLAW_IMAGE:-openclaw:local}
+    environment:
+      DOCKER_HOST: tcp://dind:2375
+    depends_on:
+      dind:
+        condition: service_healthy
+    volumes:
+      - openclaw-state:/home/node/.openclaw
+    networks:
+      - openclaw-net
+    # ... rest of your gateway config
+
+volumes:
+  openclaw-state:
+  dind-storage:
+
+networks:
+  openclaw-net:
+    driver: bridge
+```
+
+Key points:
+
+- The Gateway image must include Docker CLI (`docker-ce-cli`). Build with
+  `--build-arg OPENCLAW_INSTALL_DOCKER_CLI=1` or install it in your Dockerfile.
+- Both containers mount `openclaw-state` at `/home/node/.openclaw` so sandbox
+  bind-mount paths resolve correctly inside the DinD daemon.
+- `dind-storage` persists the DinD daemon's image cache across restarts (avoids
+  rebuilding the sandbox image every time).
+- Set `agents.defaults.sandbox.docker.network` to `"bridge"` (the DinD daemon's
+  default network) since the default `"none"` prevents network access inside
+  the sandbox.
+- The sandbox image (`openclaw-sandbox:bookworm-slim`) must be built inside the
+  DinD daemon. Run `scripts/sandbox-setup.sh` with `DOCKER_HOST=tcp://dind:2375`
+  after the DinD container is healthy, or build it in a startup script.
+
+Security note: `privileged: true` on the DinD container grants elevated host
+access. This is required for nested Docker and is standard for DinD deployments.
+Keep the DinD container on an internal network and restrict access to the
+Gateway only.
+
 ### Automation/CI (non-interactive, no TTY noise)
 
 For scripts and CI, disable Compose pseudo-TTY allocation with `-T`:

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -126,9 +126,9 @@ daemon that shares a volume with the Gateway. Sandbox containers are created
 inside the DinD daemon where paths are consistent.
 
 ```
-Gateway container ──(DOCKER_HOST=tcp://dind:2375)──▶ DinD container
-       │                                                    │
-       └── openclaw-state volume (shared) ──────────────────┘
+Gateway container ──(DOCKER_HOST=tcp://dind:2376, TLS)──▶ DinD container
+       │                                                          │
+       └── openclaw-state volume (shared) ────────────────────────┘
 ```
 
 Example `docker-compose.yml`:
@@ -136,14 +136,16 @@ Example `docker-compose.yml`:
 ```yaml
 services:
   dind:
-    image: docker:dind
+    image: docker:27-dind
     privileged: true
     restart: unless-stopped
     environment:
-      DOCKER_TLS_CERTDIR: ""
+      DOCKER_TLS_CERTDIR: /certs
     volumes:
       - openclaw-state:/home/node/.openclaw
       - dind-storage:/var/lib/docker
+      - dind-certs-ca:/certs/ca
+      - dind-certs-client:/certs/client
     networks:
       - openclaw-net
     healthcheck:
@@ -156,12 +158,15 @@ services:
   openclaw-gateway:
     image: ${OPENCLAW_IMAGE:-openclaw:local}
     environment:
-      DOCKER_HOST: tcp://dind:2375
+      DOCKER_HOST: tcp://dind:2376
+      DOCKER_TLS_VERIFY: "1"
+      DOCKER_CERT_PATH: /certs/client
     depends_on:
       dind:
         condition: service_healthy
     volumes:
       - openclaw-state:/home/node/.openclaw
+      - dind-certs-client:/certs/client:ro
     networks:
       - openclaw-net
     # ... rest of your gateway config
@@ -169,6 +174,8 @@ services:
 volumes:
   openclaw-state:
   dind-storage:
+  dind-certs-ca:
+  dind-certs-client:
 
 networks:
   openclaw-net:
@@ -183,17 +190,26 @@ Key points:
   bind-mount paths resolve correctly inside the DinD daemon.
 - `dind-storage` persists the DinD daemon's image cache across restarts (avoids
   rebuilding the sandbox image every time).
-- Set `agents.defaults.sandbox.docker.network` to `"bridge"` (the DinD daemon's
-  default network) since the default `"none"` prevents network access inside
-  the sandbox.
+- Only if sandbox containers need network access (for example, `setupCommand`
+  installs packages), set `agents.defaults.sandbox.docker.network` to `"bridge"`
+  (the DinD daemon's default network). Otherwise, keep the default `"none"` for
+  a tighter security posture. In the DinD context `"bridge"` connects sandbox
+  containers to the DinD daemon's internal network, which can reach the internet.
 - The sandbox image (`openclaw-sandbox:bookworm-slim`) must be built inside the
-  DinD daemon. Run `scripts/sandbox-setup.sh` with `DOCKER_HOST=tcp://dind:2375`
-  after the DinD container is healthy, or build it in a startup script.
+  DinD daemon. After the DinD container is healthy, run:
+
+  ```bash
+  docker compose exec openclaw-gateway scripts/sandbox-setup.sh
+  ```
+
+  The gateway already has `DOCKER_HOST` and TLS cert env vars set, so the build
+  targets the DinD daemon automatically.
 
 Security note: `privileged: true` on the DinD container grants elevated host
 access. This is required for nested Docker and is standard for DinD deployments.
-Keep the DinD container on an internal network and restrict access to the
-Gateway only.
+Keep the DinD container on an isolated internal network. The example above
+enables TLS (`DOCKER_TLS_CERTDIR=/certs`) so only clients with the shared
+certificate can talk to the DinD daemon.
 
 ### Automation/CI (non-interactive, no TTY noise)
 


### PR DESCRIPTION
…deployments

The default sandbox approach (docker.sock mount) breaks when the Gateway runs inside a container on Docker Desktop (macOS/Windows) because bind-mount paths inside the Gateway container don't exist on the host filesystem ("Mounts denied" errors).

This adds documentation for a Docker-in-Docker (DinD) sidecar alternative that runs a dedicated Docker daemon sharing a volume with the Gateway, so sandbox container paths resolve correctly.

lobster-biscuit

Made-with: Cursor

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
