### PR TITLE
fix(docs): add missing SSL/Xfinity troubleshooting section for broken FAQ anchor

### DIFF
--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -65,6 +65,14 @@ Example:
 
 Reference: [/tools/plugin#distribution-npm](/tools/plugin#distribution-npm)
 
+## docs.openclaw.ai shows an SSL error (Comcast/Xfinity)
+
+Some Comcast/Xfinity connections block `docs.openclaw.ai` via Xfinity Advanced Security.
+Disable Advanced Security or add `docs.openclaw.ai` to your allowlist, then retry.
+
+- Xfinity Advanced Security help: https://www.xfinity.com/support/articles/using-xfinity-xfi-advanced-security
+- Quick check: try a mobile hotspot or VPN to confirm this is ISP-level filtering
+
 ## Decision tree
 
 ```mermaid


### PR DESCRIPTION
## Summary

Adds the missing SSL/Xfinity troubleshooting section to `docs/help/troubleshooting.md` that the FAQ page links to.

## Problem

The FAQ page at `docs/help/faq.md` line 452 contains a link to `/help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity`, but this anchor does not exist in the English `troubleshooting.md`. Clicking the link lands on the troubleshooting page with no matching section. The zh-CN version has the section (lines 70-76), but the English version was missing it.

## Changes

| File | Change |
|------|--------|
| `docs/help/troubleshooting.md` | Added "docs.openclaw.ai shows an SSL error (Comcast/Xfinity)" section before the Decision tree, with content matching the zh-CN version |

## Test plan

- [x] Anchor `#docsopenclawai-shows-an-ssl-error-comcastxfinity` now exists in troubleshooting.md
- [ ] Manual: navigate to FAQ → click "Troubleshooting" link in SSL section → verify it scrolls to the new section

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Open the FAQ page and find the "I can't access docs.openclaw.ai SSL error" section
2. Click the "Troubleshooting" link
3. Verify it navigates to the new SSL/Xfinity section in troubleshooting.md

## Failure Recovery

Remove the added section to restore the original state.

## Risks and Mitigations

None. Documentation-only change.