### PR TITLE
fix(cron): exclude sandbox from shallow Object.assign agent merge

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -125,7 +125,11 @@ export async function runCronIsolatedAgentTurn(params: {
   const agentConfigOverride = normalizedRequested
     ? resolveAgentConfig(params.cfg, normalizedRequested)
     : undefined;
-  const { model: overrideModel, ...agentOverrideRest } = agentConfigOverride ?? {};
+  const {
+    model: overrideModel,
+    sandbox: _sandboxOverride,
+    ...agentOverrideRest
+  } = agentConfigOverride ?? {};
   // Use the requested agentId even when there is no explicit agent config entry.
   // This ensures auth-profiles, workspace, and agentDir all resolve to the
   // correct per-agent paths (e.g. ~/.openclaw/agents/<agentId>/agent/).


### PR DESCRIPTION
## Summary
- **Problem:** Cron isolated sessions lose `sandbox.docker.dangerouslyAllow*` flags when an agent config override contains a `sandbox` key. `Object.assign({}, defaults, agentOverrideRest)` shallow-overwrites the entire `sandbox` object, discarding nested fields from `agents.defaults`.
- **Why it matters:** Users who set `dangerouslyAllowExternalBindSources: true` in `agents.defaults.sandbox.docker` find the flag silently ignored for cron-triggered agent sessions. Docker bind mounts fail with no indication of why.
- **What changed:** Excluded `sandbox` from the `agentOverrideRest` destructuring spread so it is not part of the shallow `Object.assign`. `resolveSandboxConfigForAgent` (called downstream) already handles proper per-field fallback merging of agent-specific sandbox config with defaults.
- **What did NOT change:** Model override merging, agent ID resolution, all other agent config fields.

## Change Type
- [x] Bug fix

## Scope
- [x] Cron / scheduled jobs
- [x] Sandbox / security

## Linked Issue/PR
- Fixes #38067

## User-visible / Behavior Changes
Cron isolated sessions now correctly inherit `sandbox.docker.dangerouslyAllow*` flags from `agents.defaults` when an agent-specific config also defines sandbox settings.

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
Any OpenClaw instance with `agents.defaults.sandbox.docker.dangerouslyAllowExternalBindSources: true` and a cron job using an agent that also has `sandbox` config.

### Steps
1. Set `agents.defaults.sandbox.docker.dangerouslyAllowExternalBindSources: true`
2. Configure an agent with `sandbox.scope: "per-session"`
3. Trigger a cron job for that agent
4. Before fix: `dangerouslyAllowExternalBindSources` is `undefined` (lost)
5. After fix: `dangerouslyAllowExternalBindSources` is `true` (inherited from defaults via `resolveSandboxConfigForAgent`)

### Expected
Nested sandbox flags from `agents.defaults` survive agent config merge.

### Actual (before fix)
`Object.assign` shallow-overwrites the entire `sandbox` object, losing nested docker flags.

## Evidence
- [x] Code path analysis confirms `resolveSandboxConfigForAgent` independently reads agent sandbox config with proper fallback chains (`agentSandbox?.field ?? agent?.field`)

## Human Verification (required)
- Verified scenarios: Traced code path from `buildCfg` (line 125-149) through `Object.assign` (line 134-137) to `resolveSandboxConfigForAgent` (sandbox/config.ts:170-185). Confirmed `resolveSandboxConfigForAgent` calls `resolveAgentConfig` independently to get agent-specific sandbox, then merges per-field with defaults.
- Edge cases checked: agent with no sandbox override (no-op, spread has no sandbox key), agent with sandbox but no defaults (resolveSandboxConfigForAgent handles undefined defaults), agent with neither (no sandbox key in spread, defaults pass through).
- What I did **not** verify: Docker runtime behavior with actual bind mounts (requires Docker environment).

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)
- How to disable/revert quickly: `git revert <commit>` on `src/cron/isolated-agent/run.ts`
- Files/config to restore: `src/cron/isolated-agent/run.ts`
- Known bad symptoms: If reverted, sandbox flags from defaults will again be lost during agent config merge

## Risks and Mitigations
None. The excluded `sandbox` key was already handled by a dedicated resolver downstream.