### PR TITLE
[Issue #38077] gmail channel: allowFrom ["*"] semantics unclear — causes unintended auto-replies to all senders

### DIFF
--- a/.github/issue-bootstrap/issue-38077.md
+++ b/.github/issue-bootstrap/issue-38077.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #38077
+- Title: gmail channel: allowFrom ["*"] semantics unclear — causes unintended auto-replies to all senders
+- Source: https://github.com/openclaw/openclaw/issues/38077


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/38077

## Original Issue Description
See source issue body for the full description.
Title: gmail channel: allowFrom ["*"] semantics unclear — causes unintended auto-replies to all senders

## Linkage
Refs #38077