### PR TITLE
[Issue #38076] skill-creator: make init_skill --resources parsing case-insensitive

### DIFF
--- a/.github/issue-bootstrap/issue-38076.md
+++ b/.github/issue-bootstrap/issue-38076.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #38076
+- Title: skill-creator: make init_skill --resources parsing case-insensitive
+- Source: https://github.com/openclaw/openclaw/issues/38076


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/38076

## Original Issue Description
See source issue body for the full description.
Title: skill-creator: make init_skill --resources parsing case-insensitive

## Linkage
Refs #38076