### PR TITLE
[Issue #38074] [Bug]: [Security/Core]: Lack of Sandbox Context Sanitization for External Data Sources Allows Prompt Injections

### DIFF
--- a/.github/issue-bootstrap/issue-38074.md
+++ b/.github/issue-bootstrap/issue-38074.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #38074
+- Title: [Bug]: [Security/Core]: Lack of Sandbox Context Sanitization for External Data Sources Allows Prompt Injections
+- Source: https://github.com/openclaw/openclaw/issues/38074


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/38074

## Original Issue Description
See source issue body for the full description.
Title: [Bug]: [Security/Core]: Lack of Sandbox Context Sanitization for External Data Sources Allows Prompt Injections

## Linkage
Refs #38074