### PR TITLE
[Issue #38069] [Feature]: cron job execution retry with configurable delay after transient failure

### DIFF
--- a/.github/issue-bootstrap/issue-38069.md
+++ b/.github/issue-bootstrap/issue-38069.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #38069
+- Title: [Feature]: cron job execution retry with configurable delay after transient failure
+- Source: https://github.com/openclaw/openclaw/issues/38069


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/38069

## Original Issue Description
See source issue body for the full description.
Title: [Feature]: cron job execution retry with configurable delay after transient failure

## Linkage
Refs #38069