### PR TITLE
fix(gateway): block gateway restart from cron job sessions

### DIFF
--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { createGatewayTool } from "./gateway-tool.js";
+
+describe("createGatewayTool", () => {
+  it("rejects gateway restart from a cron session key", async () => {
+    const tool = createGatewayTool({
+      agentSessionKey: "agent:main:cron:daily-report",
+    });
+    await expect(tool.execute("call-1", { action: "restart" })).rejects.toThrow(
+      /not allowed from a cron job session/,
+    );
+  });
+
+  it("rejects gateway restart from a cron run session key", async () => {
+    const tool = createGatewayTool({
+      agentSessionKey: "agent:main:cron:job-1:run:abc123",
+    });
+    await expect(tool.execute("call-1", { action: "restart" })).rejects.toThrow(
+      /not allowed from a cron job session/,
+    );
+  });
+
+  it("does not block restart for non-cron session keys", async () => {
+    const tool = createGatewayTool({
+      agentSessionKey: "agent:main:main",
+      config: { commands: { restart: false } } as never,
+    });
+    await expect(tool.execute("call-1", { action: "restart" })).rejects.toThrow(
+      /restart is disabled/,
+    );
+  });
+});

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -10,6 +10,7 @@ import {
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { isCronSessionKey } from "../../routing/session-key.js";
 import { stringEnum } from "../schema/typebox.js";
 import { type AnyAgentTool, jsonResult, readStringParam } from "./common.js";
 import { callGatewayTool, readGatewayCallOptions } from "./gateway.js";
@@ -82,6 +83,11 @@ export function createGatewayTool(opts?: {
       const params = args as Record<string, unknown>;
       const action = readStringParam(params, "action", { required: true });
       if (action === "restart") {
+        if (isCronSessionKey(opts?.agentSessionKey)) {
+          throw new Error(
+            "Gateway restart is not allowed from a cron job session. A restart would kill the cron session itself, causing an infinite restart loop.",
+          );
+        }
         if (!isRestartEnabled(opts?.config)) {
           throw new Error("Gateway restart is disabled (commands.restart=false).");
         }


### PR DESCRIPTION
## Summary

Prevents cron job sessions from triggering `gateway restart`, which would kill the cron session itself and cause an infinite restart loop.

## Problem

When a cron job's message instructs the agent to execute `openclaw gateway restart`, the gateway restarts and terminates all sessions — including the cron session that initiated the restart. The cron job then remains stuck or re-triggers on the next gateway start, creating an infinite loop. Users have no guard or warning against this self-destructive pattern.

## Changes

| File | Change |
|------|--------|
| `src/agents/tools/gateway-tool.ts` | Added a guard that checks `isCronSessionKey(opts?.agentSessionKey)` before allowing restart; throws a descriptive error if the caller is a cron session |
| `src/agents/tools/gateway-tool.test.ts` | New test file with 3 test cases verifying the guard blocks cron sessions and allows non-cron sessions |

## Test plan

- [x] `npx vitest run src/agents/tools/gateway-tool.test.ts` — 3/3 passing
- [x] Cron session key `agent:main:cron:daily-report` → restart rejected
- [x] Cron run session key `agent:main:cron:job-1:run:abc123` → restart rejected
- [x] Non-cron session key `agent:main:main` → restart proceeds (blocked by config, not by cron guard)

## Security Impact

- Does this change handle user input? **No** — the session key is set by the system, not user-supplied
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Create a cron job with a message containing `gateway restart`
2. Trigger the job manually
3. Verify the agent receives a clear error: "Gateway restart is not allowed from a cron job session"
4. Verify the gateway does NOT restart

## Failure Recovery

Revert the single guard condition in `gateway-tool.ts` to restore the previous behavior (no cron check).

## Risks and Mitigations

- **Risk**: Legitimate use case where a cron job needs to restart the gateway (e.g., scheduled maintenance)
  **Mitigation**: Users can schedule restarts via `openclaw cron add --message "reminder: restart the gateway"` and manually execute, or use an external scheduler (systemd timer, crontab) to call `openclaw gateway restart` directly.