### PR TITLE
[Issue #38067] [Bug]: Cron isolated sessions lose sandbox.docker.dangerouslyAllow* flags due to shallow Object.assign on agents.defaults

### DIFF
--- a/.github/issue-bootstrap/issue-38067.md
+++ b/.github/issue-bootstrap/issue-38067.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #38067
+- Title: [Bug]: Cron isolated sessions lose sandbox.docker.dangerouslyAllow* flags due to shallow Object.assign on agents.defaults
+- Source: https://github.com/openclaw/openclaw/issues/38067


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/38067

## Original Issue Description
See source issue body for the full description.
Title: [Bug]: Cron isolated sessions lose sandbox.docker.dangerouslyAllow* flags due to shallow Object.assign on agents.defaults

## Linkage
Refs #38067