### PR TITLE
[Issue #38061] [Bug]: [Bug]: Webchat shows duplicate assistant messages because chat.history returns delivery-mirror transcript entries as normal assistant messages

### DIFF
--- a/.github/issue-bootstrap/issue-38061.md
+++ b/.github/issue-bootstrap/issue-38061.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #38061
+- Title: [Bug]: [Bug]: Webchat shows duplicate assistant messages because chat.history returns delivery-mirror transcript entries as normal assistant messages
+- Source: https://github.com/openclaw/openclaw/issues/38061


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/38061

## Original Issue Description
See source issue body for the full description.
Title: [Bug]: [Bug]: Webchat shows duplicate assistant messages because chat.history returns delivery-mirror transcript entries as normal assistant messages

## Linkage
Refs #38061