### PR TITLE
[Issue #38059] Heartbeat 觸發後訊息跳過 (skipped) 未送到 Telegram

### DIFF
--- a/.github/issue-bootstrap/issue-38059.md
+++ b/.github/issue-bootstrap/issue-38059.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #38059
+- Title: Heartbeat 觸發後訊息跳過 (skipped) 未送到 Telegram
+- Source: https://github.com/openclaw/openclaw/issues/38059


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/38059

## Original Issue Description
See source issue body for the full description.
Title: Heartbeat 觸發後訊息跳過 (skipped) 未送到 Telegram

## Linkage
Refs #38059