### PR TITLE
[Issue #38058] WhatsApp: messages lost during WebSocket reconnect — no retry after connection recovery

### DIFF
--- a/.github/issue-bootstrap/issue-38058.md
+++ b/.github/issue-bootstrap/issue-38058.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #38058
+- Title: WhatsApp: messages lost during WebSocket reconnect — no retry after connection recovery
+- Source: https://github.com/openclaw/openclaw/issues/38058


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/38058

## Original Issue Description
See source issue body for the full description.
Title: WhatsApp: messages lost during WebSocket reconnect — no retry after connection recovery

## Linkage
Refs #38058