### PR TITLE
[Issue #38055] BUG: Subagent completion announce permanently lost when channel delivery is unavailable

### DIFF
--- a/.github/issue-bootstrap/issue-38055.md
+++ b/.github/issue-bootstrap/issue-38055.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #38055
+- Title: BUG: Subagent completion announce permanently lost when channel delivery is unavailable
+- Source: https://github.com/openclaw/openclaw/issues/38055


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/38055

## Original Issue Description
See source issue body for the full description.
Title: BUG: Subagent completion announce permanently lost when channel delivery is unavailable

## Linkage
Refs #38055