### PR TITLE
[Issue #38054] [Bug]: Windows install fails and immediately closes Powershell

### DIFF
--- a/.github/issue-bootstrap/issue-38054.md
+++ b/.github/issue-bootstrap/issue-38054.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #38054
+- Title: [Bug]: Windows install fails and immediately closes Powershell
+- Source: https://github.com/openclaw/openclaw/issues/38054


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/38054

## Original Issue Description
See source issue body for the full description.
Title: [Bug]: Windows install fails and immediately closes Powershell

## Linkage
Refs #38054