### PR TITLE
[Issue #38052] bug: `openclaw gateway install` fails on Linux when service not yet installed

### DIFF
--- a/.github/issue-bootstrap/issue-38052.md
+++ b/.github/issue-bootstrap/issue-38052.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #38052
+- Title: bug: `openclaw gateway install` fails on Linux when service not yet installed
+- Source: https://github.com/openclaw/openclaw/issues/38052


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/38052

## Original Issue Description
See source issue body for the full description.
Title: bug: `openclaw gateway install` fails on Linux when service not yet installed

## Linkage
Refs #38052