### PR TITLE
[Issue #38047] [Bug] Cron job with kimi-coding/k2p5 model fails with "35 validation errors"

### DIFF
--- a/.github/issue-bootstrap/issue-38047.md
+++ b/.github/issue-bootstrap/issue-38047.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #38047
+- Title: [Bug] Cron job with kimi-coding/k2p5 model fails with "35 validation errors"
+- Source: https://github.com/openclaw/openclaw/issues/38047


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/38047

## Original Issue Description
See source issue body for the full description.
Title: [Bug] Cron job with kimi-coding/k2p5 model fails with "35 validation errors"

## Linkage
Refs #38047