### PR TITLE
[Issue #38045] feat(slack): Add `mode: "mux"` for WebSocket-based event delivery via external multiplexer

### DIFF
--- a/.github/issue-bootstrap/issue-38045.md
+++ b/.github/issue-bootstrap/issue-38045.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #38045
+- Title: feat(slack): Add `mode: "mux"` for WebSocket-based event delivery via external multiplexer
+- Source: https://github.com/openclaw/openclaw/issues/38045


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/38045

## Original Issue Description
See source issue body for the full description.
Title: feat(slack): Add `mode: "mux"` for WebSocket-based event delivery via external multiplexer

## Linkage
Refs #38045