### PR TITLE
fix(cron): preserve sandbox docker dangerous flags in isolated runs

### DIFF
--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -120,7 +120,13 @@ export async function runCronIsolatedAgentTurn(params: {
   const agentConfigOverride = normalizedRequested
     ? resolveAgentConfig(params.cfg, normalizedRequested)
     : undefined;
-  const { model: overrideModel, ...agentOverrideRest } = agentConfigOverride ?? {};
+  // Avoid shallow-merging nested sandbox config into agents.defaults for isolated cron sessions.
+  // The sandbox subtree is merged later by resolveSandboxConfigForAgent().
+  const {
+    model: overrideModel,
+    sandbox: _sandboxOverride,
+    ...agentOverrideRest
+  } = agentConfigOverride ?? {};
   // Use the requested agentId even when there is no explicit agent config entry.
   // This ensures auth-profiles, workspace, and agentDir all resolve to the
   // correct per-agent paths (e.g. ~/.openclaw/agents/<agentId>/agent/).

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -258,12 +258,26 @@ function sanitizeChatHistoryMessages(messages: unknown[]): unknown[] {
   for (const message of messages) {
     const res = sanitizeChatHistoryMessage(message);
     changed ||= res.changed;
+
     // Drop assistant messages whose entire visible text is the silent reply token.
     const text = extractAssistantTextForSilentCheck(res.message);
     if (text !== undefined && isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
       changed = true;
       continue;
     }
+
+    // Hide internal transcript entries created as delivery mirrors; they are not model output.
+    if (
+      res.message &&
+      typeof res.message === "object" &&
+      (res.message as { role?: unknown }).role === "assistant" &&
+      (res.message as { provider?: unknown }).provider === "openclaw" &&
+      (res.message as { model?: unknown }).model === "delivery-mirror"
+    ) {
+      changed = true;
+      continue;
+    }
+
     next.push(res.message);
   }
   return changed ? next : messages;

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -413,6 +413,33 @@ describe("gateway server chat", () => {
     expect(textValues).toEqual(["hello", "real reply", "real text field reply", "NO_REPLY"]);
   });
 
+  test("chat.history hides internal delivery-mirror transcript entries", async () => {
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "real reply" }],
+        timestamp: 2,
+        provider: "openrouter",
+        model: "some-model",
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "real reply" }],
+        timestamp: 3,
+        provider: "openclaw",
+        model: "delivery-mirror",
+      },
+    ]);
+
+    const textValues = collectHistoryTextValues(historyMessages);
+    expect(textValues).toEqual(["hello", "real reply"]);
+  });
+
   test("routes chat.send slash commands without agent runs", async () => {
     await withMainSessionStore(async () => {
       const spy = vi.mocked(agentCommand);


### PR DESCRIPTION
Fixes an isolated-cron-only config merge bug where agent sandbox overrides could shallow-replace agents.defaults.sandbox, dropping nested defaults like sandbox.docker.dangerouslyAllowExternalBindSources.

Closes #38067

Tested: pnpm vitest run src/cron/isolated-agent/run.skill-filter.test.ts src/cron/isolated-agent/run.payload-fallbacks.test.ts src/cron/isolated-agent/run.cron-model-override.test.ts src/cron/isolated-agent/run.session-key.test.ts