### PR TITLE
[Issue #38040] [Bug] Cron job with kimi-coding/k2p5 model fails with "35 validation errors"

### DIFF
--- a/.github/issue-bootstrap/issue-38040.md
+++ b/.github/issue-bootstrap/issue-38040.md
@@ -1,0 +1,4 @@
+# Issue Bootstrap
+- Issue: #38040
+- Title: [Bug] Cron job with kimi-coding/k2p5 model fails with "35 validation errors"
+- Source: https://github.com/openclaw/openclaw/issues/38040


### PR DESCRIPTION
## Source Issue
- https://github.com/openclaw/openclaw/issues/38040

## Original Issue Description
See source issue body for the full description.
Title: [Bug] Cron job with kimi-coding/k2p5 model fails with "35 validation errors"

## Linkage
Refs #38040