### PR TITLE
fix(telegram): entity-first detection in hasBotMention to prevent false positives (#28602)

### DIFF
--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -1,9 +1,11 @@
+import type { Message } from "@grammyjs/types";
 import { describe, expect, it } from "vitest";
 import {
   buildTelegramThreadParams,
   buildTypingThreadParams,
   describeReplyTarget,
   expandTextLinks,
+  hasBotMention,
   normalizeForwardedContext,
   resolveTelegramDirectPeerId,
   resolveTelegramForumThreadId,
@@ -393,5 +395,55 @@ describe("expandTextLinks", () => {
     const text = " Hello world";
     const entities = [{ type: "text_link", offset: 1, length: 5, url: "https://example.com" }];
     expect(expandTextLinks(text, entities)).toBe(" [Hello](https://example.com) world");
+  });
+});
+
+describe("hasBotMention", () => {
+  // Helper to build a minimal Message fixture with entities present.
+  const msgWithEntities = (
+    text: string,
+    entities: { type: string; offset: number; length: number }[],
+  ) => ({ text, entities }) as unknown as Message;
+
+  it("returns true for a genuine @-mention entity", () => {
+    // "@mybot" at offset 0, length 6
+    const msg = msgWithEntities("@mybot hello", [{ type: "mention", offset: 0, length: 6 }]);
+    expect(hasBotMention(msg, "mybot")).toBe(true);
+  });
+
+  it("returns false for email containing @botname but no mention entity (false-positive guard)", () => {
+    // The text contains @mybot as part of an email address, but the entity
+    // is type "email", not "mention". Entity-first detection must reject this.
+    const msg = msgWithEntities("contact user@mybot.com for help", [
+      { type: "email", offset: 8, length: 15 },
+    ]);
+    expect(hasBotMention(msg, "mybot")).toBe(false);
+  });
+
+  it("returns false when @botname appears in forwarded text but has no mention entity", () => {
+    // Forwarded message body contains @mybot as plain text, no entities.
+    // Entity array is present but empty — should NOT fall back to text.includes().
+    const msg = msgWithEntities("Forwarded: @mybot please help", []);
+    expect(hasBotMention(msg, "mybot")).toBe(false);
+  });
+
+  it("returns true for a mention entity in caption (photo/video messages)", () => {
+    const msg = {
+      caption: "@mybot look at this",
+      caption_entities: [{ type: "mention", offset: 0, length: 6 }],
+    } as unknown as Message;
+    expect(hasBotMention(msg, "mybot")).toBe(true);
+  });
+
+  it("falls back to text.includes() when entities field is absent entirely", () => {
+    // No entities field at all (old client / edge case) — substring match is the
+    // only signal available.
+    const msg = { text: "hey @mybot are you there" } as unknown as Message;
+    expect(hasBotMention(msg, "mybot")).toBe(true);
+  });
+
+  it("is case-insensitive for both entity slice and botUsername", () => {
+    const msg = msgWithEntities("@MyBot hello", [{ type: "mention", offset: 0, length: 6 }]);
+    expect(hasBotMention(msg, "MYBOT")).toBe(true);
   });
 });

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -281,21 +281,32 @@ export function buildGroupLabel(msg: Message, chatId: number | string, messageTh
 }
 
 export function hasBotMention(msg: Message, botUsername: string) {
+  const normalizedUsername = `@${botUsername.toLowerCase()}`;
+  const entities = msg.entities ?? msg.caption_entities;
+
+  // When the message has an entities field (even an empty one), use entity-first
+  // detection: only a mention-type entity whose sliced text equals @botUsername
+  // counts as a genuine @-mention. This avoids false positives from email
+  // addresses, URLs, and forwarded message text that contain @botname as a
+  // substring but without a real mention entity.
+  if (entities != null) {
+    const fullText = msg.text ?? msg.caption ?? "";
+    for (const ent of entities) {
+      if (ent.type !== "mention") {
+        continue;
+      }
+      const slice = fullText.slice(ent.offset, ent.offset + ent.length).toLowerCase();
+      if (slice === normalizedUsername) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Fall back to text substring check only when no entities field is present
+  // at all — very old clients or certain edge cases may omit the field entirely.
   const text = (msg.text ?? msg.caption ?? "").toLowerCase();
-  if (text.includes(`@${botUsername}`)) {
-    return true;
-  }
-  const entities = msg.entities ?? msg.caption_entities ?? [];
-  for (const ent of entities) {
-    if (ent.type !== "mention") {
-      continue;
-    }
-    const slice = (msg.text ?? msg.caption ?? "").slice(ent.offset, ent.offset + ent.length);
-    if (slice.toLowerCase() === `@${botUsername}`) {
-      return true;
-    }
-  }
-  return false;
+  return text.includes(normalizedUsername);
 }
 
 type TelegramTextLinkEntity = {


### PR DESCRIPTION
## Problem

In groups with `requireMention=true`, `hasBotMention()` has a fast-path `text.includes('@botUsername')` check that fires *before* entity validation. This creates false positives: email addresses (`user@mybot.com`), forwarded message text, and URLs that happen to contain `@botname` as a substring all pass the gate without a genuine @-mention entity.

Additionally, the previous entity-branch comparison lowercased the slice but not the `botUsername`, making the match case-sensitive in practice.

## Root cause

Introduced in `da6de4981` (Grammy type migration, Christian Klotz, 2026-02-04) — the entity loop was added as a *secondary* check after the substring fast-path instead of replacing it.

## Fix

`src/telegram/bot/helpers.ts` — `hasBotMention()`:

- When `entities` / `caption_entities` is present (even as an empty array), use entity-first detection exclusively: only a `mention`-type entity whose sliced text equals `@botUsername` counts as a genuine mention.
- Fall back to the substring check **only** when the `entities` field is absent entirely (very old clients or edge cases that omit the field).
- Normalize `botUsername` once at the top with `toLowerCase()` for consistent case-insensitive comparison.

## Tests

Added 6 regression tests in `src/telegram/bot/helpers.test.ts` (45 total, all passing):

- ✅ Genuine `@-mention` entity → true
- ✅ Email address containing `@botname` but entity type `email` → false (false-positive guard)
- ✅ Forwarded text with `@botname` but empty entities array → false (false-positive guard)
- ✅ Valid mention entity in `caption_entities` (photo/video message) → true
- ✅ No entities field at all → substring fallback → true
- ✅ Case-insensitive matching for both slice and `botUsername`

Fixes #28602