### PR TITLE
fix(config): align web search apiKey types with SecretRef support

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,5 +1,7 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
+import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
+import type { SecretInput } from "../../config/types.secrets.js";
 import { SsrFBlockedError } from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
@@ -71,7 +73,7 @@ type WebFetchConfig = NonNullable<OpenClawConfig["tools"]>["web"] extends infer 
 type FirecrawlFetchConfig =
   | {
       enabled?: boolean;
-      apiKey?: string;
+      apiKey?: SecretInput;
       baseUrl?: string;
       onlyMainContent?: boolean;
       maxAgeMs?: number;
@@ -136,10 +138,14 @@ function resolveFirecrawlConfig(fetch?: WebFetchConfig): FirecrawlFetchConfig {
 }
 
 function resolveFirecrawlApiKey(firecrawl?: FirecrawlFetchConfig): string | undefined {
-  const fromConfig =
-    firecrawl && "apiKey" in firecrawl && typeof firecrawl.apiKey === "string"
-      ? normalizeSecretInput(firecrawl.apiKey)
-      : "";
+  const fromConfigRaw =
+    firecrawl && "apiKey" in firecrawl
+      ? normalizeResolvedSecretInputString({
+          value: firecrawl.apiKey,
+          path: "tools.web.fetch.firecrawl.apiKey",
+        })
+      : undefined;
+  const fromConfig = normalizeSecretInput(fromConfigRaw);
   const fromEnv = normalizeSecretInput(process.env.FIRECRAWL_API_KEY);
   return fromConfig || fromEnv || undefined;
 }

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -39,6 +39,39 @@ describe("web search provider config", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts top-level apiKey as SecretRef object", () => {
+    const res = validateConfigObject({
+      tools: {
+        web: {
+          search: {
+            provider: "brave",
+            apiKey: { source: "env", provider: "default", id: "BRAVE_API_KEY" },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts nested provider apiKey as SecretRef object", () => {
+    const res = validateConfigObject(
+      buildWebSearchProviderConfig({
+        enabled: true,
+        provider: "perplexity",
+        providerConfig: {
+          apiKey: {
+            source: "env",
+            provider: "default",
+            id: "PERPLEXITY_API_KEY",
+          },
+        },
+      }),
+    );
+
+    expect(res.ok).toBe(true);
+  });
+
   it("accepts gemini provider with no extra config", () => {
     const res = validateConfigObject(
       buildWebSearchProviderConfig({

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -444,7 +444,7 @@ export type ToolsConfig = {
       /** Search provider ("brave", "perplexity", "grok", "gemini", or "kimi"). */
       provider?: "brave" | "perplexity" | "grok" | "gemini" | "kimi";
       /** Brave Search API key (optional; defaults to BRAVE_API_KEY env var). */
-      apiKey?: string;
+      apiKey?: SecretInput;
       /** Default search results count (1-10). */
       maxResults?: number;
       /** Timeout in seconds for search requests. */
@@ -454,7 +454,7 @@ export type ToolsConfig = {
       /** Perplexity-specific configuration (used when provider="perplexity"). */
       perplexity?: {
         /** API key for Perplexity (defaults to PERPLEXITY_API_KEY env var). */
-        apiKey?: string;
+        apiKey?: SecretInput;
         /** @deprecated Legacy Sonar/OpenRouter field. Ignored by Search API. */
         baseUrl?: string;
         /** @deprecated Legacy Sonar/OpenRouter field. Ignored by Search API. */
@@ -463,7 +463,7 @@ export type ToolsConfig = {
       /** Grok-specific configuration (used when provider="grok"). */
       grok?: {
         /** API key for xAI (defaults to XAI_API_KEY env var). */
-        apiKey?: string;
+        apiKey?: SecretInput;
         /** Model to use (defaults to "grok-4-1-fast"). */
         model?: string;
         /** Include inline citations in response text as markdown links (default: false). */
@@ -472,14 +472,14 @@ export type ToolsConfig = {
       /** Gemini-specific configuration (used when provider="gemini"). */
       gemini?: {
         /** Gemini API key (defaults to GEMINI_API_KEY env var). */
-        apiKey?: string;
+        apiKey?: SecretInput;
         /** Model to use for grounded search (defaults to "gemini-2.5-flash"). */
         model?: string;
       };
       /** Kimi-specific configuration (used when provider="kimi"). */
       kimi?: {
         /** Moonshot/Kimi API key (defaults to KIMI_API_KEY or MOONSHOT_API_KEY env var). */
-        apiKey?: string;
+        apiKey?: SecretInput;
         /** Base URL for API requests (defaults to "https://api.moonshot.ai/v1"). */
         baseUrl?: string;
         /** Model to use (defaults to "moonshot-v1-128k"). */
@@ -507,7 +507,7 @@ export type ToolsConfig = {
         /** Enable Firecrawl fallback (default: true when apiKey is set). */
         enabled?: boolean;
         /** Firecrawl API key (optional; defaults to FIRECRAWL_API_KEY env var). */
-        apiKey?: string;
+        apiKey?: SecretInput;
         /** Firecrawl base URL (default: https://api.firecrawl.dev). */
         baseUrl?: string;
         /** Whether to keep only main content (default: true). */

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -473,10 +473,13 @@ export async function finalizeOnboardingWizard(
   }
 
   const webSearchProvider = nextConfig.tools?.web?.search?.provider ?? "brave";
-  const webSearchKey =
+  const rawApiKey =
     webSearchProvider === "perplexity"
-      ? (nextConfig.tools?.web?.search?.perplexity?.apiKey ?? "").trim()
-      : (nextConfig.tools?.web?.search?.apiKey ?? "").trim();
+      ? nextConfig.tools?.web?.search?.perplexity?.apiKey
+      : nextConfig.tools?.web?.search?.apiKey;
+  // apiKey may be a string or a SecretRef object; treat SecretRef as "key present"
+  const webSearchKey =
+    typeof rawApiKey === "string" ? rawApiKey.trim() : rawApiKey != null ? "secretref" : "";
   const webSearchEnv =
     webSearchProvider === "perplexity"
       ? (process.env.PERPLEXITY_API_KEY ?? "").trim()


### PR DESCRIPTION
## Summary

The Zod schema (`zod-schema.agent-runtime.ts`) already accepts `SecretRef` objects for all web search `apiKey` fields via `SecretInputSchema`, but the TypeScript type definitions in `types.tools.ts` still declared them as plain `string`. This mismatch causes config validation to reject SecretRef-formatted API keys with `"Invalid input: expected string, received object"`.

**Changes:**
- Update all `apiKey` fields in `ToolsConfig.web.search` (brave, perplexity, grok, gemini, kimi) and `web.fetch.firecrawl` from `string` to `SecretInput`
- Add tests verifying SecretRef objects are accepted for both top-level and nested provider apiKey fields

**Before:** `apiKey: { source: "env", id: "BRAVE_API_KEY" }` → validation error
**After:** Both `apiKey: "my-key"` and `apiKey: { source: "env", id: "BRAVE_API_KEY" }` accepted

Closes #37578

## Test plan
- [x] Existing web search provider tests still pass
- [x] New test: top-level apiKey accepts SecretRef object
- [x] New test: nested provider apiKey accepts SecretRef object