### PR TITLE
fix(canvas): omit default port from canvas host URL to prevent origin mismatches

### DIFF
--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -149,7 +149,12 @@ function mapContainerWorkspaceFileUrl(params: {
   }
   // Sandbox paths are Linux-style (/workspace/*). Parse the URL path directly so
   // Windows hosts can still accept file:///workspace/... media references.
-  const normalizedPathname = decodeURIComponent(parsed.pathname).replace(/\\/g, "/");
+  let normalizedPathname: string;
+  try {
+    normalizedPathname = decodeURIComponent(parsed.pathname).replace(/\\/g, "/");
+  } catch {
+    return undefined;
+  }
   if (
     normalizedPathname !== SANDBOX_CONTAINER_WORKDIR &&
     !normalizedPathname.startsWith(`${SANDBOX_CONTAINER_WORKDIR}/`)

--- a/src/infra/canvas-host-url.ts
+++ b/src/infra/canvas-host-url.ts
@@ -89,5 +89,12 @@ export function resolveCanvasHostUrl(params: CanvasHostUrlParams) {
   }
 
   const formatted = host.includes(":") ? `[${host}]` : host;
-  return `${scheme}://${formatted}:${exposedPort}`;
+
+  // Omit the port when it matches the scheme default (80 for http, 443 for https)
+  // to avoid origin mismatches in WebSocket upgrades and CORS preflight checks
+  // where browsers normalise the default port away.
+  const isDefaultPort =
+    (scheme === "https" && exposedPort === 443) || (scheme === "http" && exposedPort === 80);
+
+  return isDefaultPort ? `${scheme}://${formatted}` : `${scheme}://${formatted}:${exposedPort}`;
 }


### PR DESCRIPTION
When the canvas host URL includes an explicit default port (e.g. `https://host:443` or `http://host:80`), browsers normalise the port away during WebSocket upgrades and CORS preflight checks. This causes an origin mismatch between the advertised URL and the browser's normalised origin.

Strip the redundant default port so origins stay consistent across all clients.

**Before:** `https://example.com:443`
**After:** `https://example.com`