### PR TITLE
fix(agents): wire authHeader flag to send Bearer token for anthropic-messages providers

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1556,4 +1556,78 @@ describe("applyExtraParamsToAgent", () => {
       expect(run().store).toBe(false);
     },
   );
+
+  it("applies Authorization Bearer header when provider has authHeader: true", () => {
+    const calls: Array<SimpleStreamOptions | undefined> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push(options);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const cfg = {
+      models: {
+        providers: {
+          minimax: {
+            api: "anthropic-messages",
+            authHeader: true,
+            baseUrl: "https://api.minimaxi.com/anthropic",
+            models: [],
+          },
+        },
+      },
+    };
+    applyExtraParamsToAgent(
+      agent,
+      cfg as Parameters<typeof applyExtraParamsToAgent>[1],
+      "minimax",
+      "MiniMax-M1",
+    );
+    const model = {
+      api: "anthropic-messages" as const,
+      provider: "minimax",
+      id: "MiniMax-M1",
+      baseUrl: "https://api.minimaxi.com/anthropic",
+    };
+    void agent.streamFn?.(model, { messages: [] }, { apiKey: "test-key-123" });
+    expect(calls.length).toBe(1);
+    const opts = calls[0] as SimpleStreamOptions & { headers?: Record<string, string> };
+    expect(opts?.headers?.Authorization).toBe("Bearer test-key-123");
+    expect(opts?.apiKey).toBeFalsy();
+  });
+
+  it("does not apply Authorization Bearer when authHeader is not set", () => {
+    const calls: Array<SimpleStreamOptions | undefined> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push(options);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const cfg = {
+      models: {
+        providers: {
+          anthropic: {
+            api: "anthropic-messages",
+            baseUrl: "https://api.anthropic.com",
+            models: [],
+          },
+        },
+      },
+    };
+    applyExtraParamsToAgent(
+      agent,
+      cfg as Parameters<typeof applyExtraParamsToAgent>[1],
+      "anthropic",
+      "claude-sonnet-4-6",
+    );
+    const model = {
+      api: "anthropic-messages" as const,
+      provider: "anthropic",
+      id: "claude-sonnet-4-6",
+    };
+    void agent.streamFn?.(model, { messages: [] }, { apiKey: "test-key-456" });
+    expect(calls.length).toBe(1);
+    const opts = calls[0] as SimpleStreamOptions & { headers?: Record<string, string> };
+    expect(opts?.headers?.Authorization).toBeUndefined();
+    expect(opts?.apiKey).toBe("test-key-456");
+  });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -3,6 +3,7 @@ import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
 import { streamSimple } from "@mariozechner/pi-ai";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { findNormalizedProviderValue } from "../model-selection.js";
 import { log } from "./logger.js";
 
 const OPENROUTER_APP_HEADERS: Record<string, string> = {
@@ -1033,6 +1034,33 @@ function createZaiToolStreamWrapper(
   };
 }
 
+function resolveProviderAuthHeader(cfg: OpenClawConfig | undefined, provider: string): boolean {
+  const providerConfig = findNormalizedProviderValue(cfg?.models?.providers, provider);
+  return providerConfig?.authHeader === true;
+}
+
+/**
+ * Wraps a streamFn so that for anthropic-messages models the API key is sent
+ * via `Authorization: Bearer` instead of the default `x-api-key` header.
+ */
+function createAuthHeaderBearerWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (model.api !== "anthropic-messages" || !options?.apiKey) {
+      return underlying(model, context, options);
+    }
+    const modifiedOptions: typeof options = {
+      ...options,
+      apiKey: undefined as unknown as string,
+      headers: {
+        ...options?.headers,
+        Authorization: `Bearer ${options.apiKey}`,
+      },
+    };
+    return underlying(model, context, modifiedOptions);
+  };
+}
+
 /**
  * Apply extra params (like temperature) to an agent's streamFn.
  * Also adds OpenRouter app attribution headers when using the OpenRouter provider.
@@ -1048,6 +1076,10 @@ export function applyExtraParamsToAgent(
   thinkingLevel?: ThinkLevel,
   agentId?: string,
 ): void {
+  if (resolveProviderAuthHeader(cfg, provider)) {
+    log.debug(`applying authHeader Bearer wrapper for ${provider}/${modelId}`);
+    agent.streamFn = createAuthHeaderBearerWrapper(agent.streamFn);
+  }
   const extraParams = resolveExtraParams({
     cfg,
     provider,


### PR DESCRIPTION
## Summary

Implements the `authHeader: true` provider config flag so that providers using `anthropic-messages` API (like MiniMax) send credentials via `Authorization: Bearer` instead of the default `x-api-key` header.

## Problem

MiniMax and MiniMax Portal providers have `authHeader: true` in their config, but this flag was never read or acted upon anywhere in the codebase. The pi-ai Anthropic SDK always sends API keys via `x-api-key` (Anthropic's native header), but MiniMax's anthropic-compatible endpoint expects `Authorization: Bearer <key>`. This caused HTTP 401 errors despite valid API keys, while the same key worked perfectly with `curl`.

## Changes

| File | Change |
|------|--------|
| `src/agents/pi-embedded-runner/extra-params.ts` | Added `resolveProviderAuthHeader()` to check the `authHeader` flag from provider config, and `createAuthHeaderBearerWrapper()` that converts `apiKey` to `Authorization: Bearer` header for `anthropic-messages` models. Applied early in `applyExtraParamsToAgent` before other wrappers. |
| `src/agents/pi-embedded-runner-extraparams.test.ts` | 2 new test cases: verifies Bearer header is set when `authHeader: true`, and verifies no modification when `authHeader` is not set. |

## Test plan

- [x] `npx vitest run src/agents/pi-embedded-runner-extraparams.test.ts` — 58/58 passing (56 existing + 2 new)
- [x] Provider with `authHeader: true` + `anthropic-messages` model → `Authorization: Bearer <key>` set, `apiKey` cleared
- [x] Provider without `authHeader` → `apiKey` passed through unchanged (no regression)
- [ ] Manual: configure MiniMax provider, send a message, verify 200 response instead of 401

## Security Impact

- Does this change handle user input? **No** — reads from provider config
- Does this change affect authentication/authorization? **Yes** — changes how auth credentials are passed to upstream providers. Only affects providers that explicitly opt in via `authHeader: true`.
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **Yes** — changes the HTTP header used for authentication. The API key is the same; only the header name changes from `x-api-key` to `Authorization: Bearer`.
- Does this change introduce new dependencies? **No**

## Human Verification

1. Configure MiniMax provider with a valid API key
2. Send a message to the agent
3. Verify the request succeeds (no 401 error)
4. Check gateway logs for `applying authHeader Bearer wrapper` debug line

## Failure Recovery

Remove the `resolveProviderAuthHeader` and `createAuthHeaderBearerWrapper` functions and their call in `applyExtraParamsToAgent` to restore the previous behavior.

## Risks and Mitigations

- **Risk**: Providers with `authHeader: true` that also need `x-api-key` would break
  **Mitigation**: The wrapper only applies to `anthropic-messages` API models, and only when the provider explicitly sets `authHeader: true`. Currently only MiniMax and MiniMax Portal use this flag. Standard Anthropic providers do not have `authHeader: true`.