### PR TITLE
fix(agents): add gpt-5.4-pro to openai-codex forward-compat resolution

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -363,7 +363,28 @@ describe("resolveForwardCompatModel", () => {
     expectResolvedForwardCompat(model, { provider: "openai-codex", id: "gpt-5.4" });
     expect(model?.api).toBe("openai-codex-responses");
     expect(model?.baseUrl).toBe("https://chatgpt.com/backend-api");
-    expect(model?.contextWindow).toBe(272_000);
+    expect(model?.contextWindow).toBe(1_050_000);
+    expect(model?.maxTokens).toBe(128_000);
+  });
+
+  it("resolves openai-codex gpt-5.4-pro via codex template fallback", () => {
+    const registry = createRegistry({
+      "openai-codex/gpt-5.2-codex": createOpenAICodexTemplateModel("gpt-5.2-codex"),
+    });
+    const model = resolveForwardCompatModel("openai-codex", "gpt-5.4-pro", registry);
+    expectResolvedForwardCompat(model, { provider: "openai-codex", id: "gpt-5.4-pro" });
+    expect(model?.api).toBe("openai-codex-responses");
+    expect(model?.baseUrl).toBe("https://chatgpt.com/backend-api");
+    expect(model?.contextWindow).toBe(1_050_000);
+    expect(model?.maxTokens).toBe(128_000);
+  });
+
+  it("resolves openai-codex gpt-5.4-pro without templates using gpt-5.4 context window", () => {
+    const registry = createRegistry({});
+    const model = resolveForwardCompatModel("openai-codex", "gpt-5.4-pro", registry);
+    expectResolvedForwardCompat(model, { provider: "openai-codex", id: "gpt-5.4-pro" });
+    expect(model?.api).toBe("openai-codex-responses");
+    expect(model?.contextWindow).toBe(1_050_000);
     expect(model?.maxTokens).toBe(128_000);
   });
 

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -12,6 +12,7 @@ const OPENAI_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.2"] as const;
 const OPENAI_GPT_54_PRO_TEMPLATE_MODEL_IDS = ["gpt-5.2-pro", "gpt-5.2"] as const;
 
 const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
+const OPENAI_CODEX_GPT_54_PRO_MODEL_ID = "gpt-5.4-pro";
 const OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex", "gpt-5.2-codex"] as const;
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
@@ -123,7 +124,8 @@ function resolveOpenAICodexForwardCompatModel(
 
   let templateIds: readonly string[];
   let eligibleProviders: Set<string>;
-  if (lower === OPENAI_CODEX_GPT_54_MODEL_ID) {
+  const isGpt54Family = lower === OPENAI_CODEX_GPT_54_MODEL_ID || lower === OPENAI_CODEX_GPT_54_PRO_MODEL_ID;
+  if (isGpt54Family) {
     templateIds = OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS;
     eligibleProviders = CODEX_GPT54_ELIGIBLE_PROVIDERS;
   } else if (lower === OPENAI_CODEX_GPT_53_MODEL_ID) {
@@ -146,6 +148,9 @@ function resolveOpenAICodexForwardCompatModel(
       ...template,
       id: trimmedModelId,
       name: trimmedModelId,
+      ...(isGpt54Family
+        ? { contextWindow: OPENAI_GPT_54_CONTEXT_TOKENS, maxTokens: OPENAI_GPT_54_MAX_TOKENS }
+        : {}),
     } as Model<Api>);
   }
 
@@ -158,8 +163,8 @@ function resolveOpenAICodexForwardCompatModel(
     reasoning: true,
     input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_TOKENS,
-    maxTokens: DEFAULT_CONTEXT_TOKENS,
+    contextWindow: isGpt54Family ? OPENAI_GPT_54_CONTEXT_TOKENS : DEFAULT_CONTEXT_TOKENS,
+    maxTokens: isGpt54Family ? OPENAI_GPT_54_MAX_TOKENS : DEFAULT_CONTEXT_TOKENS,
   } as Model<Api>);
 }
 

--- a/src/agents/pi-embedded-runner/model.test-harness.ts
+++ b/src/agents/pi-embedded-runner/model.test-harness.ts
@@ -36,13 +36,14 @@ export function mockOpenAICodexTemplateModel(): void {
 export function buildOpenAICodexForwardCompatExpectation(
   id: string = "gpt-5.3-codex",
 ): Partial<typeof OPENAI_CODEX_TEMPLATE_MODEL> & { provider: string; id: string } {
+  const isGpt54Family = id.toLowerCase() === "gpt-5.4" || id.toLowerCase() === "gpt-5.4-pro";
   return {
     provider: "openai-codex",
     id,
     api: "openai-codex-responses",
     baseUrl: "https://chatgpt.com/backend-api",
     reasoning: true,
-    contextWindow: 272000,
+    contextWindow: isGpt54Family ? 1_050_000 : 272000,
     maxTokens: 128000,
   };
 }


### PR DESCRIPTION
## Summary

- **Problem:** Compaction (and all `resolveModel` callers) fails with `Unknown model: openai-codex/gpt-5.4-pro` because the codex forward-compat path only handles `gpt-5.4` and `gpt-5.3-codex`, not `gpt-5.4-pro`.
- **Why it matters:** Users running GPT-5.4 Pro via the openai-codex OAuth provider cannot use compaction, context management, or any feature that requires model resolution.
- **What changed:** Added `gpt-5.4-pro` to the codex forward-compat resolution alongside `gpt-5.4`, using the same template chain (`gpt-5.3-codex`, `gpt-5.2-codex`) and the correct 1,050,000 token context window. Also applied `OPENAI_GPT_54_CONTEXT_TOKENS` to both gpt-5.4 and gpt-5.4-pro in the template-clone and no-template fallback paths. Added 2 test cases, updated test harness.
- **What did NOT change:** Non-codex gpt-5.4/gpt-5.4-pro resolution (already correct), gpt-5.3-codex resolution, template lookup logic, provider eligibility checks.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38120

## User-visible / Behavior Changes

- `openai-codex/gpt-5.4-pro` is now resolved correctly with 1,050,000 token context window, enabling compaction and all model-dependent features.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0 (arm64)
- Runtime: Node v25.6.1

### Steps

1. Configure `openai-codex/gpt-5.4-pro` as primary model
2. Use the agent until compaction triggers

### Expected

- Compaction succeeds using the 1M token context window

### Actual

- Before fix: `Compaction failed: Unknown model: openai-codex/gpt-5.4-pro`
- After fix: Compaction succeeds

## Evidence

```
 ✓ src/agents/model-compat.test.ts (34 tests) 4ms
   ✓ resolves openai-codex gpt-5.4-pro via codex template fallback
   ✓ resolves openai-codex gpt-5.4-pro without templates using gpt-5.4 context window
```

## Human Verification (required)

- Verified scenarios: codex gpt-5.4-pro with template, codex gpt-5.4-pro without template, codex gpt-5.4 (updated), codex gpt-5.3 (unchanged), openai gpt-5.4 variants (unchanged)
- Edge cases checked: gpt-5.3-codex still uses DEFAULT_CONTEXT_TOKENS, template-found vs no-template paths both correct for gpt-5.4-pro
- What I did **not** verify: Live codex API call with gpt-5.4-pro model

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/agents/model-forward-compat.ts`
- Known bad symptoms: If gpt-5.4-pro has a different context window than 1,050,000, requests could exceed the real limit

## Risks and Mitigations

None — aligns codex gpt-5.4-pro with the already-correct non-codex gpt-5.4-pro resolution.
