### PR TITLE
fix(slack): treat not_allowed_token_type as non-recoverable auth error

### DIFF
--- a/src/slack/monitor/provider.auth-errors.test.ts
+++ b/src/slack/monitor/provider.auth-errors.test.ts
@@ -7,6 +7,7 @@ describe("isNonRecoverableSlackAuthError", () => {
     "An API error occurred: invalid_auth",
     "An API error occurred: token_revoked",
     "An API error occurred: token_expired",
+    "An API error occurred: not_allowed_token_type",
     "An API error occurred: not_authed",
     "An API error occurred: org_login_required",
     "An API error occurred: team_access_not_granted",
@@ -19,6 +20,20 @@ describe("isNonRecoverableSlackAuthError", () => {
 
   it("returns true when error is a plain string", () => {
     expect(isNonRecoverableSlackAuthError("account_inactive")).toBe(true);
+  });
+
+  it("returns true when error code is in error.data.error (PlatformError)", () => {
+    const error = Object.assign(new Error("An API error occurred"), {
+      data: { error: "not_allowed_token_type" },
+    });
+    expect(isNonRecoverableSlackAuthError(error)).toBe(true);
+  });
+
+  it("returns true when only error.data.error matches (message is generic)", () => {
+    const error = Object.assign(new Error("request failed"), {
+      data: { error: "token_revoked" },
+    });
+    expect(isNonRecoverableSlackAuthError(error)).toBe(true);
   });
 
   it("matches case-insensitively", () => {

--- a/src/slack/monitor/reconnect-policy.ts
+++ b/src/slack/monitor/reconnect-policy.ts
@@ -1,5 +1,5 @@
 const SLACK_AUTH_ERROR_RE =
-  /account_inactive|invalid_auth|token_revoked|token_expired|not_authed|org_login_required|team_access_not_granted|missing_scope|cannot_find_service|invalid_token/i;
+  /account_inactive|invalid_auth|token_revoked|token_expired|not_allowed_token_type|not_authed|org_login_required|team_access_not_granted|missing_scope|cannot_find_service|invalid_token/i;
 
 export const SLACK_SOCKET_RECONNECT_POLICY = {
   initialMs: 2_000,
@@ -90,7 +90,13 @@ export function waitForSlackSocketDisconnect(
  */
 export function isNonRecoverableSlackAuthError(error: unknown): boolean {
   const msg = error instanceof Error ? error.message : typeof error === "string" ? error : "";
-  return SLACK_AUTH_ERROR_RE.test(msg);
+  if (SLACK_AUTH_ERROR_RE.test(msg)) {
+    return true;
+  }
+  // Slack PlatformError stores the API error code in error.data.error
+  const dataError =
+    error && typeof error === "object" ? (error as { data?: { error?: string } }).data?.error : undefined;
+  return typeof dataError === "string" && SLACK_AUTH_ERROR_RE.test(dataError);
 }
 
 export function formatUnknownError(error: unknown): string {


### PR DESCRIPTION
## Summary

- **Problem:** When a Slack token expires and reconnection attempts use the wrong token type, the gateway enters a tight retry loop (~1.5s intervals) for hours because `not_allowed_token_type` is not recognized as a non-recoverable auth error.
- **Why it matters:** Thousands of identical error logs flood `gateway.err.log` (2.8 MB in 9 hours), potentially triggering Slack API rate limits and degrading other channels.
- **What changed:** Added `not_allowed_token_type` to `SLACK_AUTH_ERROR_RE`. Also enhanced `isNonRecoverableSlackAuthError` to check `error.data.error` (Slack PlatformError structure) so auth codes are detected even when the error message is generic. Added 3 test cases.
- **What did NOT change:** Existing auth error patterns, backoff policy, reconnect logic, other channel retry behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38083

## User-visible / Behavior Changes

- Slack `not_allowed_token_type` errors now cause immediate channel shutdown instead of indefinite retries.
- Auth error codes embedded in `error.data.error` (PlatformError) are now detected.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0 (arm64)
- Runtime: Node v25.6.1
- Integration/channel: Slack (Socket Mode)

### Steps

1. Use an expired Slack bot token
2. Start the gateway

### Expected

- Gateway detects non-recoverable auth error and stops retrying

### Actual

- Before fix: Tight retry loop (~1.5s) for hours, ~1,700+ identical errors
- After fix: Gateway detects `not_allowed_token_type` and fails fast

## Evidence

```
 ✓ src/slack/monitor/provider.auth-errors.test.ts (23 tests) 3ms
   ✓ returns true for non-recoverable error: An API error occurred: not_allowed_token_type
   ✓ returns true when error code is in error.data.error (PlatformError)
   ✓ returns true when only error.data.error matches (message is generic)
```

## Human Verification (required)

- Verified scenarios: not_allowed_token_type in message, not_allowed_token_type in data.error, existing auth errors still detected, transient errors still return false
- Edge cases checked: PlatformError with generic message but specific data.error, null/undefined error values
- What I did **not** verify: Live Slack SocketMode with expired token

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/slack/monitor/reconnect-policy.ts`
- Known bad symptoms: If `not_allowed_token_type` is actually transient (unlikely), the channel would stop instead of retrying

## Risks and Mitigations

Low — `not_allowed_token_type` is a permanent credential error per Slack API docs. Retrying it will never succeed.
