### PR TITLE
fix(discord): reconnect stall triggers channel-level recovery instead of gateway crash

### DIFF
--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -352,26 +352,44 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
-  it("force-stops when reconnect stalls after a close event", async () => {
+  it("attempts channel-level reconnect when reconnect stalls after a close event", async () => {
     vi.useFakeTimers();
     try {
       const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
-      const { emitter, gateway } = createGatewayHarness();
+      const { emitter, gateway } = createGatewayHarness({
+        state: { sessionId: "old-session", resumeGatewayUrl: "wss://old", sequence: 42 },
+        sequence: 42,
+      });
       getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+      let resolveWait: (() => void) | undefined;
       waitForDiscordGatewayStopMock.mockImplementationOnce(
-        (waitParams: WaitForDiscordGatewayStopParams) =>
-          new Promise<void>((_resolve, reject) => {
-            waitParams.registerForceStop?.((err) => reject(err));
+        () =>
+          new Promise<void>((resolve) => {
+            resolveWait = resolve;
           }),
       );
-      const { lifecycleParams } = createLifecycleHarness({ gateway });
+      const { lifecycleParams, runtimeError } = createLifecycleHarness({ gateway });
 
       const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
-      lifecyclePromise.catch(() => {});
       emitter.emit("debug", "WebSocket connection closed with code 1006");
 
       await vi.advanceTimersByTimeAsync(5 * 60_000 + 1_000);
-      await expect(lifecyclePromise).rejects.toThrow("reconnect watchdog timeout");
+
+      // Should attempt channel-level reconnect instead of force-stopping
+      expect(gateway.disconnect).toHaveBeenCalled();
+      expect(gateway.connect).toHaveBeenCalledWith(false);
+      expect(runtimeError).toHaveBeenCalledWith(
+        expect.stringContaining("attempting channel-level reconnect"),
+      );
+
+      // Resume state should be cleared
+      expect(gateway.state.sessionId).toBeNull();
+      expect(gateway.state.resumeGatewayUrl).toBeNull();
+      expect(gateway.state.sequence).toBeNull();
+
+      // Lifecycle should still be running (not rejected)
+      resolveWait?.();
+      await expect(lifecyclePromise).resolves.toBeUndefined();
     } finally {
       vi.useRealTimers();
     }
@@ -385,10 +403,9 @@ describe("runDiscordGatewayLifecycle", () => {
       getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
       let resolveWait: (() => void) | undefined;
       waitForDiscordGatewayStopMock.mockImplementationOnce(
-        (waitParams: WaitForDiscordGatewayStopParams) =>
-          new Promise<void>((resolve, reject) => {
+        () =>
+          new Promise<void>((resolve) => {
             resolveWait = resolve;
-            waitParams.registerForceStop?.((err) => reject(err));
           }),
       );
       const { lifecycleParams, runtimeLog } = createLifecycleHarness({ gateway });

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -42,19 +42,9 @@ export async function runDiscordGatewayLifecycle(params: {
     runtime: params.runtime,
   });
   let lifecycleStopping = false;
-  let forceStopHandler: ((err: unknown) => void) | undefined;
-  let queuedForceStopError: unknown;
 
   const pushStatus = (patch: Parameters<DiscordMonitorStatusSink>[0]) => {
     params.statusSink?.(patch);
-  };
-
-  const triggerForceStop = (err: unknown) => {
-    if (forceStopHandler) {
-      forceStopHandler(err);
-      return;
-    }
-    queuedForceStopError = err;
   };
 
   const reconnectStallWatchdog = createArmableStallWatchdog({
@@ -81,10 +71,12 @@ export async function runDiscordGatewayLifecycle(params: {
       });
       params.runtime.error?.(
         danger(
-          `discord: reconnect watchdog timeout after ${RECONNECT_STALL_TIMEOUT_MS}ms; force-stopping monitor task`,
+          `discord: reconnect watchdog timeout after ${RECONNECT_STALL_TIMEOUT_MS}ms; attempting channel-level reconnect`,
         ),
       );
-      triggerForceStop(error);
+      clearResumeState();
+      gateway?.disconnect();
+      gateway?.connect(false);
     },
   });
 
@@ -313,14 +305,6 @@ export async function runDiscordGatewayLifecycle(params: {
       abortSignal: params.abortSignal,
       onGatewayError: logGatewayError,
       shouldStopOnError: shouldStopOnGatewayError,
-      registerForceStop: (forceStop) => {
-        forceStopHandler = forceStop;
-        if (queuedForceStopError !== undefined) {
-          const queued = queuedForceStopError;
-          queuedForceStopError = undefined;
-          forceStop(queued);
-        }
-      },
     });
   } catch (err) {
     if (!sawDisallowedIntents && !params.isDisallowedIntentsError(err)) {


### PR DESCRIPTION
## Summary
- **Problem:** When Discord's WebSocket reconnect stalls (no activity for 5 minutes after a close event), the `reconnectStallWatchdog.onTimeout` handler calls `triggerForceStop()`, which rejects the `waitForDiscordGatewayStop` promise and propagates as a fatal error through `runDiscordGatewayLifecycle`. The gateway process crashes and the daemon triggers a full restart, killing all other channels (Telegram, Lark, Slack, etc.).
- **Why it matters:** A transient Discord API outage takes down every channel in the gateway. Users on non-Discord channels lose service for no reason.
- **What changed:** Replaced `triggerForceStop(error)` with `clearResumeState(); gateway?.disconnect(); gateway?.connect(false)`, matching the existing hello-timeout recovery pattern (lines 235-240). This keeps the recovery scoped to the Discord channel. Removed the now-unused `triggerForceStop` function, `forceStopHandler` variable, `queuedForceStopError` variable, and `registerForceStop` callback.
- **What did NOT change:** The hello-timeout handler, abort handling, gateway error classification, or any other lifecycle flow.

## Change Type
- [x] Bug fix

## Scope
- [x] Discord channel / provider
- [x] Gateway lifecycle

## Linked Issue/PR
- Fixes #37752

## User-visible / Behavior Changes
Discord reconnect stalls now trigger a channel-level reconnect instead of crashing the entire gateway. Other channels remain unaffected during Discord outages.

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
Any OpenClaw instance with Discord channel configured alongside other channels.

### Steps
1. Discord API becomes unreachable (e.g., network partition, API outage)
2. WebSocket closes with code 1006
3. Reconnect stalls for 5 minutes (RECONNECT_STALL_TIMEOUT_MS)
4. Before fix: gateway crashes, daemon restarts everything
5. After fix: Discord channel does `disconnect()/connect(false)`, other channels unaffected

### Expected
Discord channel attempts a fresh reconnect; gateway and other channels remain operational.

### Actual (before fix)
`triggerForceStop` rejects the lifecycle promise, crashing the gateway process.

## Evidence
- [x] Updated test: "attempts channel-level reconnect when reconnect stalls after a close event" verifies `disconnect()` and `connect(false)` are called, resume state is cleared, and the lifecycle promise resolves (does not reject)
- [x] All 11 existing tests pass

## Human Verification (required)
- Verified scenarios: Traced the full error propagation chain: `triggerForceStop` → `forceStopHandler` → `finishReject` (in `monitor.gateway.ts`) → rejected promise → `runDiscordGatewayLifecycle` throw → gateway crash. Confirmed the new path follows the hello-timeout pattern: `clearResumeState()` clears stale session data, `gateway?.disconnect()` tears down the dead connection, `gateway?.connect(false)` starts a fresh identify (no resume attempt since the session is stale after 5 minutes).
- Edge cases checked: (1) `gateway` is null/undefined: safe due to optional chaining. (2) Repeated stalls in a loop: watchdog re-arms on the next "WebSocket connection closed" debug event, providing repeated recovery attempts. (3) Concurrent abort: guard at line 66 checks `abortSignal?.aborted || lifecycleStopping` before acting.
- What I did **not** verify: Actual Discord API outage behavior in a live deployment. The channel health monitor (`maxRestartsPerHour` cap) provides a backstop for infinite reconnect loops, but I did not test that integration path.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)
- How to disable/revert quickly: `git revert <commit>` on `src/discord/monitor/provider.lifecycle.ts`
- Files/config to restore: `src/discord/monitor/provider.lifecycle.ts`, `src/discord/monitor/provider.lifecycle.test.ts`
- Known bad symptoms: If reverted, Discord reconnect stalls will again crash the entire gateway

## Risks and Mitigations
If Discord is permanently unreachable, the channel will cycle through disconnect/connect attempts every 5 minutes. The existing channel health monitor (`maxRestartsPerHour`) provides a backstop to prevent infinite rapid cycling.