### PR TITLE
fix(agents): fall back to inject-only announce when channel delivery fails

### DIFF
--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -249,4 +249,59 @@ describe("subagent announce timeout config", () => {
     expect(directAgentCall?.params?.to).toBe("chan-main");
     expect(directAgentCall?.params?.accountId).toBe("acct-main");
   });
+
+  it("falls back to deliver=false injection when channel delivery fails with transient error (#38055)", async () => {
+    const { callGateway: mockedCallGateway } = await import("../gateway/call.js");
+    const callGatewayMock = vi.mocked(mockedCallGateway);
+
+    // Make the first agent call (with deliver=true) throw a transient error,
+    // then succeed on the fallback inject-only call (deliver=false).
+    callGatewayMock.mockImplementation(async (request: GatewayCall) => {
+      gatewayCalls.push(request);
+      if (request.method === "agent" && request.params?.deliver === true) {
+        throw new Error(
+          "HttpError: Network request for 'sendMessage' failed! errorCode=UNAVAILABLE",
+        );
+      }
+      if (request.method === "chat.history") {
+        return { messages: [] };
+      }
+      return {};
+    });
+
+    const didAnnounce = await runAnnounceFlowForTest("run-transient-fallback", {
+      requesterOrigin: {
+        channel: "telegram",
+        to: "chat:123",
+      },
+    });
+
+    expect(didAnnounce).toBe(true);
+
+    // Should have agent calls including the fallback inject-only call
+    const agentCalls = gatewayCalls.filter((c) => c.method === "agent");
+
+    // The transient retry logic will retry the deliver=true call multiple times,
+    // then the outer catch triggers a deliver=false fallback injection
+    const deliverTrueCalls = agentCalls.filter((c) => c.params?.deliver === true);
+    const deliverFalseCalls = agentCalls.filter((c) => c.params?.deliver === false);
+
+    expect(deliverTrueCalls.length).toBeGreaterThanOrEqual(1);
+    expect(deliverFalseCalls.length).toBeGreaterThanOrEqual(1);
+
+    const fallbackCall = deliverFalseCalls.find(
+      (c) =>
+        typeof c.params?.idempotencyKey === "string" && c.params.idempotencyKey.includes(":inject"),
+    );
+    expect(fallbackCall).toBeDefined();
+
+    // Restore default mock
+    callGatewayMock.mockImplementation(async (request: GatewayCall) => {
+      gatewayCalls.push(request);
+      if (request.method === "chat.history") {
+        return { messages: [] };
+      }
+      return {};
+    });
+  });
 });

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -750,27 +750,23 @@ async function sendSubagentAnnounceDirectly(params: {
     cfg,
     params.targetRequesterSessionKey,
   );
+  const completionDirectOrigin = normalizeDeliveryContext(params.completionDirectOrigin);
+  const directOrigin = normalizeDeliveryContext(params.directOrigin);
+  const effectiveDirectOrigin =
+    params.expectsCompletionMessage && completionDirectOrigin
+      ? completionDirectOrigin
+      : directOrigin;
+  const directChannelRaw =
+    typeof effectiveDirectOrigin?.channel === "string" ? effectiveDirectOrigin.channel.trim() : "";
+  const directChannel =
+    directChannelRaw && isDeliverableMessageChannel(directChannelRaw) ? directChannelRaw : "";
+  const directTo =
+    typeof effectiveDirectOrigin?.to === "string" ? effectiveDirectOrigin.to.trim() : "";
+  const hasDeliverableDirectTarget =
+    !params.requesterIsSubagent && Boolean(directChannel) && Boolean(directTo);
+  const shouldDeliverExternally =
+    !params.requesterIsSubagent && (!params.expectsCompletionMessage || hasDeliverableDirectTarget);
   try {
-    const completionDirectOrigin = normalizeDeliveryContext(params.completionDirectOrigin);
-    const directOrigin = normalizeDeliveryContext(params.directOrigin);
-    const effectiveDirectOrigin =
-      params.expectsCompletionMessage && completionDirectOrigin
-        ? completionDirectOrigin
-        : directOrigin;
-    const directChannelRaw =
-      typeof effectiveDirectOrigin?.channel === "string"
-        ? effectiveDirectOrigin.channel.trim()
-        : "";
-    const directChannel =
-      directChannelRaw && isDeliverableMessageChannel(directChannelRaw) ? directChannelRaw : "";
-    const directTo =
-      typeof effectiveDirectOrigin?.to === "string" ? effectiveDirectOrigin.to.trim() : "";
-    const hasDeliverableDirectTarget =
-      !params.requesterIsSubagent && Boolean(directChannel) && Boolean(directTo);
-    const shouldDeliverExternally =
-      !params.requesterIsSubagent &&
-      (!params.expectsCompletionMessage || hasDeliverableDirectTarget);
-
     const threadId =
       effectiveDirectOrigin?.threadId != null && effectiveDirectOrigin.threadId !== ""
         ? String(effectiveDirectOrigin.threadId)
@@ -817,6 +813,45 @@ async function sendSubagentAnnounceDirectly(params: {
       path: "direct",
     };
   } catch (err) {
+    // When external delivery failed due to a transient channel error, fall
+    // back to injecting the event into the parent session *without* delivery
+    // so the completion is not permanently lost.  The LLM response will
+    // appear in the session context and can be delivered later when the
+    // channel recovers.  (#38055)
+    if (shouldDeliverExternally && isTransientAnnounceDeliveryError(err)) {
+      try {
+        defaultRuntime.log(
+          `[warn] Subagent announce delivery failed, falling back to inject-only (deliver=false): ${summarizeDeliveryError(err)}`,
+        );
+        await callGateway({
+          method: "agent",
+          params: {
+            sessionKey: canonicalRequesterSessionKey,
+            message: params.triggerMessage,
+            deliver: false,
+            internalEvents: params.internalEvents,
+            inputProvenance: {
+              kind: "inter_session",
+              sourceSessionKey: params.sourceSessionKey,
+              sourceChannel: params.sourceChannel ?? INTERNAL_MESSAGE_CHANNEL,
+              sourceTool: params.sourceTool ?? "subagent_announce",
+            },
+            idempotencyKey: `${params.directIdempotencyKey}:inject`,
+          },
+          timeoutMs: announceTimeoutMs,
+        });
+        return {
+          delivered: true,
+          path: "direct",
+        };
+      } catch (fallbackErr) {
+        return {
+          delivered: false,
+          path: "direct",
+          error: summarizeDeliveryError(fallbackErr),
+        };
+      }
+    }
     return {
       delivered: false,
       path: "direct",


### PR DESCRIPTION
## Problem

Fixes #38055

When the downstream channel (e.g. Telegram) is temporarily unreachable, subagent completion events are **permanently lost**. The `callGateway({deliver: true})` call times out because it waits for channel delivery, and after retry exhaustion the event is dropped — even though the subagent completed successfully.

The root cause is that event injection into the parent session is coupled with channel delivery: both succeed or fail together.

## Fix

When `sendSubagentAnnounceDirectly` catches a **transient** delivery error (network timeout, ECONNREFUSED, UNAVAILABLE, etc.), it now falls back to a `deliver: false` call. This injects the completion event into the parent session context without requiring channel delivery, so:

1. The parent session receives the completion event (LLM processes it)
2. The response enters the session context and can be delivered later when the channel recovers
3. The announce is not permanently lost

### Changes

- Hoist channel/delivery resolution variables out of `try` block so the `catch` block can access `shouldDeliverExternally`
- Add transient-error fallback path: retry with `deliver: false` and append `:inject` to the idempotency key to avoid collisions with the original call
- Only triggers for transient errors (matches existing `TRANSIENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS`); permanent errors (e.g. `bot was blocked`) still fail immediately

### Test

Added regression test that verifies: when the `deliver: true` agent call throws a transient UNAVAILABLE error, the fallback `deliver: false` injection fires and the announce returns `delivered: true`.