### PR TITLE
fix(gateway): fail fast when persisted auth mode conflicts with runtime resolution

### DIFF
--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -271,4 +271,49 @@ describe("resolveGatewayRuntimeConfig", () => {
       expect(result.strictTransportSecurityHeader).toBeUndefined();
     });
   });
+
+  describe("auth config/runtime mismatch invariant", () => {
+    it("throws when config sets auth.mode=token but runtime resolves to none", async () => {
+      await expect(
+        resolveGatewayRuntimeConfig({
+          cfg: {
+            gateway: {
+              bind: "loopback",
+              auth: { mode: "token" },
+            },
+          },
+          port: 18789,
+          auth: { mode: "none" },
+        }),
+      ).rejects.toThrow(/Security.*gateway\.auth\.mode="token".*auth=none/);
+    });
+
+    it("throws when config sets auth.mode=password but runtime resolves to none", async () => {
+      await expect(
+        resolveGatewayRuntimeConfig({
+          cfg: {
+            gateway: {
+              bind: "loopback",
+              auth: { mode: "password" },
+            },
+          },
+          port: 18789,
+          auth: { mode: "none" },
+        }),
+      ).rejects.toThrow(/Security.*gateway\.auth\.mode="password".*auth=none/);
+    });
+
+    it("does not throw when config sets auth.mode=none and runtime resolves to none", async () => {
+      const result = await resolveGatewayRuntimeConfig({
+        cfg: {
+          gateway: {
+            bind: "loopback",
+            auth: { mode: "none" },
+          },
+        },
+        port: 18789,
+      });
+      expect(result.resolvedAuth.mode).toBe("none");
+    });
+  });
 });

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -121,6 +121,17 @@ export async function resolveGatewayRuntimeConfig(params: {
   const dangerouslyAllowHostHeaderOriginFallback =
     params.cfg.gateway?.controlUi?.dangerouslyAllowHostHeaderOriginFallback === true;
 
+  const configAuthMode = params.cfg.gateway?.auth?.mode;
+  if (
+    (configAuthMode === "token" || configAuthMode === "password") &&
+    resolvedAuth.mode === "none"
+  ) {
+    throw new Error(
+      `Security: gateway.auth.mode="${configAuthMode}" in config but runtime resolved to auth=none. ` +
+        "Refusing to start — check auth overrides and SecretRef resolution.",
+    );
+  }
+
   assertGatewayAuthConfigured(resolvedAuth);
   if (tailscaleMode === "funnel" && authMode !== "password") {
     throw new Error(

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -13,6 +13,8 @@ export function logGatewayStartup(params: {
   tlsEnabled?: boolean;
   log: { info: (msg: string, meta?: Record<string, unknown>) => void; warn: (msg: string) => void };
   isNixMode: boolean;
+  authMode?: string;
+  authModeSource?: string;
 }) {
   const { provider: agentProvider, model: agentModel } = resolveConfiguredModelRef({
     cfg: params.cfg,
@@ -23,6 +25,12 @@ export function logGatewayStartup(params: {
   params.log.info(`agent model: ${modelRef}`, {
     consoleMessage: `agent model: ${chalk.whiteBright(modelRef)}`,
   });
+  if (params.authMode) {
+    const sourceLabel = params.authModeSource ? ` (source: ${params.authModeSource})` : "";
+    params.log.info(`gateway auth mode resolved: ${params.authMode}${sourceLabel}`, {
+      consoleMessage: `gateway auth mode: ${chalk.whiteBright(params.authMode)}${sourceLabel}`,
+    });
+  }
   const scheme = params.tlsEnabled ? "wss" : "ws";
   const formatHost = (host: string) => (host.includes(":") ? `[${host}]` : host);
   const hosts =

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -867,6 +867,8 @@ export async function startGatewayServer(
     tlsEnabled: gatewayTls.enabled,
     log,
     isNixMode,
+    authMode: resolvedAuth.mode,
+    authModeSource: resolvedAuth.modeSource,
   });
   const stopGatewayUpdateCheck = minimalTestGateway
     ? () => {}


### PR DESCRIPTION
## Summary

- **Problem:** Gateway can start with `auth: none` even when `gateway.auth.mode: token` (or `password`) is configured, if the runtime resolves to a different auth mode due to overrides or SecretRef failures. This is a P0 auth bypass on self-hosted deployments.
- **Why it matters:** Operators expect token/password auth but the process accepts unauthenticated requests, exposing the gateway to unauthorized access.
- **What changed:** (1) Added startup invariant in `server-runtime-config.ts` that throws when persisted config expects `token`/`password` but runtime resolves to `none`. (2) Added auth mode log line at startup showing resolved mode and source. (3) Added 3 unit tests for the invariant. (4) Passed `authMode` and `authModeSource` to `logGatewayStartup`.
- **What did NOT change:** Auth resolution logic itself, existing binding checks, tailscale mode checks, other security validations.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37812

## User-visible / Behavior Changes

- Gateway now refuses to start with a clear error if `gateway.auth.mode` is `token`/`password` but runtime resolves to `none`.
- Auth mode and source are logged at startup: `gateway auth mode resolved: token (source: config)`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0 (arm64)
- Runtime: Node v25.6.1

### Steps

1. Set `gateway.auth.mode: "token"` in `openclaw.json`
2. Start gateway with `--auth none` override

### Expected

- Gateway refuses to start with security error

### Actual

- Before fix: Gateway starts with `auth=none`, bypassing configured auth
- After fix: `Error: Security: gateway.auth.mode="token" in config but runtime resolved to auth=none. Refusing to start.`

## Evidence

```
 ✓ src/gateway/server-runtime-config.test.ts (22 tests) 9ms
   ✓ throws when config sets auth.mode=token but runtime resolves to none
   ✓ throws when config sets auth.mode=password but runtime resolves to none
   ✓ does not throw when config sets auth.mode=none and runtime resolves to none
```

## Human Verification (required)

- Verified scenarios: token→none throws, password→none throws, none→none allowed, token→token works (existing tests)
- Edge cases checked: auth override to "none" with config token, mode resolved from config vs env vs default
- What I did **not** verify: Live gateway with real token/password SecretRef failure scenarios

## Compatibility / Migration

- Backward compatible? `Yes` — only rejects invalid configurations that were silently broken before
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/gateway/server-runtime-config.ts`, `server-startup-log.ts`, `server.impl.ts`
- Known bad symptoms: If someone intentionally overrides `auth=none` while having `auth.mode=token` in config, they must also update the config

## Risks and Mitigations

- Risk: Users who intentionally use `--auth none` for local testing while having `token` in config will get an error. Mitigation: Remove `gateway.auth.mode` from config or set it to `none` explicitly.
