### PR TITLE
fix(ui): append usage footer to CC Chat agent replies

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import { handleAgentEnd } from "./pi-embedded-subscribe.handlers.lifecycle.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
@@ -9,7 +9,10 @@ vi.mock("../infra/agent-events.js", () => ({
 
 function createContext(
   lastAssistant: unknown,
-  overrides?: { onAgentEvent?: (event: unknown) => void },
+  overrides?: {
+    onAgentEvent?: (event: unknown) => void;
+    getUsageTotals?: () => unknown;
+  },
 ): EmbeddedPiSubscribeContext {
   return {
     params: {
@@ -34,10 +37,15 @@ function createContext(
     flushBlockReplyBuffer: vi.fn(),
     resolveCompactionRetry: vi.fn(),
     maybeResolveCompactionWait: vi.fn(),
+    getUsageTotals: overrides?.getUsageTotals ?? (() => undefined),
   } as unknown as EmbeddedPiSubscribeContext;
 }
 
 describe("handleAgentEnd", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("logs the resolved error message when run ends with assistant error", () => {
     const onAgentEvent = vi.fn();
     const ctx = createContext(
@@ -72,5 +80,44 @@ describe("handleAgentEnd", () => {
 
     expect(ctx.log.warn).not.toHaveBeenCalled();
     expect(ctx.log.debug).toHaveBeenCalledWith("embedded run agent end: runId=run-1 isError=false");
+  });
+
+  it("includes usage totals in lifecycle end event when available", async () => {
+    const { emitAgentEvent } = await import("../infra/agent-events.js");
+    const onAgentEvent = vi.fn();
+    const usage = { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 };
+    const ctx = createContext(undefined, {
+      onAgentEvent,
+      getUsageTotals: () => usage,
+    });
+
+    handleAgentEnd(ctx);
+
+    const calls = vi.mocked(emitAgentEvent).mock.calls;
+    const endCall = calls.find(
+      (c) => (c[0] as { data?: { phase?: string } }).data?.phase === "end",
+    );
+    expect(endCall).toBeDefined();
+    expect((endCall![0] as { data: { usage?: unknown } }).data.usage).toEqual(usage);
+
+    expect(onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ phase: "end", usage }),
+      }),
+    );
+  });
+
+  it("omits usage from lifecycle end event when no usage data", async () => {
+    const { emitAgentEvent } = await import("../infra/agent-events.js");
+    const ctx = createContext(undefined);
+
+    handleAgentEnd(ctx);
+
+    const calls = vi.mocked(emitAgentEvent).mock.calls;
+    const endCall = calls.find(
+      (c) => (c[0] as { data?: { phase?: string } }).data?.phase === "end",
+    );
+    expect(endCall).toBeDefined();
+    expect((endCall![0] as { data: Record<string, unknown> }).data).not.toHaveProperty("usage");
   });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -58,17 +58,22 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
     });
   } else {
     ctx.log.debug(`embedded run agent end: runId=${ctx.params.runId} isError=${isError}`);
+    const usage = ctx.getUsageTotals();
     emitAgentEvent({
       runId: ctx.params.runId,
       stream: "lifecycle",
       data: {
         phase: "end",
         endedAt: Date.now(),
+        ...(usage && { usage }),
       },
     });
     void ctx.params.onAgentEvent?.({
       stream: "lifecycle",
-      data: { phase: "end" },
+      data: {
+        phase: "end",
+        ...(usage && { usage }),
+      },
     });
   }
 

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1,5 +1,7 @@
+import { hasNonzeroUsage, type NormalizedUsage } from "../agents/usage.js";
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS, stripHeartbeatToken } from "../auto-reply/heartbeat.js";
-import { normalizeVerboseLevel } from "../auto-reply/thinking.js";
+import { formatResponseUsageLine } from "../auto-reply/reply/agent-runner-utils.js";
+import { normalizeVerboseLevel, resolveResponseUsageMode } from "../auto-reply/thinking.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-events.js";
@@ -398,6 +400,7 @@ export function createAgentEventHandler({
     jobState: "done" | "error",
     error?: unknown,
     stopReason?: string,
+    usage?: NormalizedUsage,
   ) => {
     const bufferedText = stripInlineDirectiveTagsForDisplay(
       chatRunState.buffers.get(clientRunId) ?? "",
@@ -446,6 +449,22 @@ export function createAgentEventHandler({
     chatRunState.buffers.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
     if (jobState === "done") {
+      let finalText = text;
+      if (finalText && !shouldSuppressSilent && usage && hasNonzeroUsage(usage)) {
+        try {
+          const { entry } = loadSessionEntry(sessionKey);
+          const usageMode = resolveResponseUsageMode(entry?.responseUsage);
+          if (usageMode !== "off") {
+            const usageLine = formatResponseUsageLine({ usage, showCost: false });
+            if (usageLine) {
+              const suffix = usageMode === "full" ? ` · session \`${sessionKey}\`` : "";
+              finalText = `${finalText}\n${usageLine}${suffix}`;
+            }
+          }
+        } catch {
+          /* session entry not loadable — skip usage */
+        }
+      }
       const payload = {
         runId: clientRunId,
         sessionKey,
@@ -453,10 +472,10 @@ export function createAgentEventHandler({
         state: "final" as const,
         ...(stopReason && { stopReason }),
         message:
-          text && !shouldSuppressSilent
+          finalText && !shouldSuppressSilent
             ? {
                 role: "assistant",
-                content: [{ type: "text", text }],
+                content: [{ type: "text", text: finalText }],
                 timestamp: Date.now(),
               }
             : undefined,
@@ -568,6 +587,7 @@ export function createAgentEventHandler({
       } else if (!isAborted && (lifecyclePhase === "end" || lifecyclePhase === "error")) {
         const evtStopReason =
           typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
+        const evtUsage = evt.data?.usage as NormalizedUsage | undefined;
         if (chatLink) {
           const finished = chatRunState.registry.shift(evt.runId);
           if (!finished) {
@@ -582,6 +602,7 @@ export function createAgentEventHandler({
             lifecyclePhase === "error" ? "error" : "done",
             evt.data?.error,
             evtStopReason,
+            evtUsage,
           );
         } else {
           emitChatFinal(
@@ -592,6 +613,7 @@ export function createAgentEventHandler({
             lifecyclePhase === "error" ? "error" : "done",
             evt.data?.error,
             evtStopReason,
+            evtUsage,
           );
         }
       } else if (isAborted && (lifecyclePhase === "end" || lifecyclePhase === "error")) {


### PR DESCRIPTION
## Summary

Appends the `/usage` token-count footer to agent replies in CC Chat / Control UI, which previously only appeared on pre-agent command replies.

## Problem

CC Chat has two response paths: command-only replies (which included the usage footer) and agent replies (which did not). The lifecycle `"end"` event emitted by `handleAgentEnd` did not carry usage data, and `emitChatFinal` in `server-chat.ts` never attempted to format or append a usage line.

## Changes

| File | Change |
|------|--------|
| `src/agents/pi-embedded-subscribe.handlers.lifecycle.ts` | Include `ctx.getUsageTotals()` in lifecycle `"end"` event data |
| `src/gateway/server-chat.ts` | Read usage from lifecycle event, resolve session `responseUsage` mode, format and append usage line to final message text |
| `src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts` | 2 new tests: usage included when available, omitted when absent |

## Test plan

- [x] `npx vitest run src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts` — 4/4 passing
- [ ] Manual: enable `/usage tokens` in a CC Chat session, send a message, verify usage footer appears on the agent reply
- [ ] Manual: verify usage footer does NOT appear when `/usage off` is set

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No** — reads existing session entry (read-only) for usage display preference
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Open CC Chat, run `/usage tokens`, send any prompt — reply should end with `Usage: Xk in / Yk out`
2. Run `/usage full` — reply should end with `Usage: Xk in / Yk out · session \`agent:main:main\``
3. Run `/usage off` — no footer on subsequent replies
4. Channel delivery (Telegram, Discord) remains unaffected

## Failure Recovery

Revert the two source file changes; the lifecycle event will stop carrying usage and CC Chat will behave as before (no footer).

## Risks and Mitigations

- **Risk**: `loadSessionEntry` could throw for orphaned runs without a valid session key
  **Mitigation**: Wrapped in try/catch; usage line is skipped on error
- **Risk**: Cost display — agent-runner shows estimated cost for API-key auth modes
  **Mitigation**: CC Chat currently passes `showCost: false` since model auth context is not available in the chat handler; this can be enhanced later