### PR TITLE
fix(agents): strip parallel_tool_calls for models that reject it

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -1556,4 +1556,46 @@ describe("applyExtraParamsToAgent", () => {
       expect(run().store).toBe(false);
     },
   );
+
+  it("strips parallel_tool_calls from payload when parallelToolCalls: false", () => {
+    const payload: Record<string, unknown> = { parallel_tool_calls: true, model: "test" };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    applyExtraParamsToAgent(
+      agent,
+      {
+        agents: {
+          defaults: {
+            models: {
+              "custom/kimi-k2.5": {
+                params: { parallelToolCalls: false },
+              },
+            },
+          },
+        },
+      },
+      "custom",
+      "kimi-k2.5",
+    );
+    const context: Context = { messages: [] };
+    void agent.streamFn?.({} as Model<"openai-completions">, context, {});
+    expect(payload).not.toHaveProperty("parallel_tool_calls");
+    expect(payload.model).toBe("test");
+  });
+
+  it("does not strip parallel_tool_calls when parallelToolCalls is not configured", () => {
+    const payload: Record<string, unknown> = { parallel_tool_calls: true, model: "test" };
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      options?.onPayload?.(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    applyExtraParamsToAgent(agent, undefined, "custom", "some-model");
+    const context: Context = { messages: [] };
+    void agent.streamFn?.({} as Model<"openai-completions">, context, {});
+    expect(payload.parallel_tool_calls).toBe(true);
+  });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -384,6 +384,32 @@ function createOpenAIServiceTierWrapper(
   };
 }
 
+function resolveParallelToolCalls(
+  extraParams: Record<string, unknown> | undefined,
+): boolean | undefined {
+  const value = extraParams?.parallelToolCalls ?? extraParams?.parallel_tool_calls;
+  if (typeof value === "boolean") {
+    return value;
+  }
+  return undefined;
+}
+
+function createParallelToolCallsGuard(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          delete (payload as Record<string, unknown>).parallel_tool_calls;
+        }
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}
+
 function createCodexDefaultTransportWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) =>
@@ -1147,6 +1173,12 @@ export function applyExtraParamsToAgent(
   if (openAIServiceTier) {
     log.debug(`applying OpenAI service_tier=${openAIServiceTier} for ${provider}/${modelId}`);
     agent.streamFn = createOpenAIServiceTierWrapper(agent.streamFn, openAIServiceTier);
+  }
+
+  const parallelToolCalls = resolveParallelToolCalls(merged);
+  if (parallelToolCalls === false) {
+    log.debug(`stripping parallel_tool_calls from payload for ${provider}/${modelId}`);
+    agent.streamFn = createParallelToolCallsGuard(agent.streamFn);
   }
 
   // Work around upstream pi-ai hardcoding `store: false` for Responses API.


### PR DESCRIPTION
## Summary

Adds a config-driven guard to strip `parallel_tool_calls` from outgoing API payloads for models/providers that don't support the parameter.

## Problem

The Pi SDK (via OpenAI SDK internals) injects `parallel_tool_calls: true` into chat completion requests by default. Custom OpenAI-compatible providers like NVIDIA NIM (e.g. `moonshotai/kimi-k2.5`) do not support this parameter and return HTTP 400 errors, breaking all tool execution for the agent. There was no way to disable it.

## Changes

| File | Change |
|------|--------|
| `src/agents/pi-embedded-runner/extra-params.ts` | Added `resolveParallelToolCalls()` to read `parallelToolCalls` (or `parallel_tool_calls`) from model params, and `createParallelToolCallsGuard()` onPayload wrapper that deletes the field from outgoing payloads |
| `src/agents/pi-embedded-runner-extraparams.test.ts` | 2 new tests: verifies field is stripped when `parallelToolCalls: false`, and preserved when not configured |

## Usage

Add to `openclaw.json`:

```json
{
  "agents": {
    "defaults": {
      "models": {
        "custom-nim/kimi-k2.5": {
          "params": {
            "parallelToolCalls": false
          }
        }
      }
    }
  }
}
```

## Test plan

- [x] `npx vitest run src/agents/pi-embedded-runner-extraparams.test.ts` — 58/58 passing
- [ ] Manual: configure a custom provider that rejects `parallel_tool_calls`, set `parallelToolCalls: false`, verify tool calls succeed
- [ ] Manual: verify no change in behavior for providers that support the parameter (default: not configured)

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **Yes** — removes a field from outgoing API requests when configured. Only affects the request body, not headers or auth.
- Does this change introduce new dependencies? **No**

## Human Verification

1. Configure NVIDIA NIM with `moonshotai/kimi-k2.5` and set `parallelToolCalls: false` in model params
2. Send a message that triggers tool use
3. Verify the tool call succeeds without HTTP 400
4. Remove the `parallelToolCalls: false` config and verify the default behavior is unchanged

## Failure Recovery

Remove the `parallelToolCalls: false` from model params to restore the default behavior (Pi SDK sends `parallel_tool_calls: true`).

## Risks and Mitigations

- **Risk**: Users may not discover this config option when encountering 400 errors
  **Mitigation**: The parameter name matches the OpenAI API field name, and can be documented in the model configuration guide