### PR TITLE
fix(cron): use per-attempt abort controller so model fallback chain survives timeout

### DIFF
--- a/src/cron/isolated-agent/run.abort-signal.test.ts
+++ b/src/cron/isolated-agent/run.abort-signal.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  makeIsolatedAgentTurnParams,
+  setupRunCronIsolatedAgentTurnSuite,
+} from "./run.suite-helpers.js";
+import {
+  loadRunCronIsolatedAgentTurn,
+  runEmbeddedPiAgentMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+describe("runCronIsolatedAgentTurn — per-attempt abort signal", () => {
+  setupRunCronIsolatedAgentTurnSuite();
+
+  it("passes a per-attempt abort signal to runEmbeddedPiAgent, not the outer signal", async () => {
+    const outerController = new AbortController();
+
+    runWithModelFallbackMock.mockImplementation(async (params: { run: Function }) => {
+      const result = await params.run("openai", "gpt-4", {});
+      return { result, provider: "openai", model: "gpt-4" };
+    });
+
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "output" }],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({ abortSignal: outerController.signal }),
+    );
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const callArgs = runEmbeddedPiAgentMock.mock.calls[0][0];
+    expect(callArgs.abortSignal).toBeDefined();
+    expect(callArgs.abortSignal).not.toBe(outerController.signal);
+    expect(callArgs.abortSignal.aborted).toBe(false);
+  });
+
+  it("forwards outer abort to the per-attempt signal", async () => {
+    const outerController = new AbortController();
+
+    runWithModelFallbackMock.mockImplementation(async (params: { run: Function }) => {
+      const result = await params.run("openai", "gpt-4", {});
+      return { result, provider: "openai", model: "gpt-4" };
+    });
+
+    runEmbeddedPiAgentMock.mockImplementation(async () => {
+      outerController.abort("timeout");
+      return {
+        payloads: [{ text: "output" }],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      };
+    });
+
+    await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({ abortSignal: outerController.signal }),
+    );
+
+    const callArgs = runEmbeddedPiAgentMock.mock.calls[0][0];
+    expect(callArgs.abortSignal).toBeDefined();
+    expect(callArgs.abortSignal.aborted).toBe(true);
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -469,8 +469,11 @@ export async function runCronIsolatedAgentTurn(params: {
         fallbacksOverride:
           payloadFallbacks ?? resolveAgentModelFallbacksOverride(params.cfg, agentId),
         run: async (providerOverride, modelOverride, runOptions) => {
-          if (abortSignal?.aborted) {
-            throw new Error(abortReason());
+          const attemptController = new AbortController();
+          const attemptSignal = attemptController.signal;
+          const forwardAbort = () => attemptController.abort(abortSignal?.reason);
+          if (abortSignal && !abortSignal.aborted) {
+            abortSignal.addEventListener("abort", forwardAbort, { once: true });
           }
           const bootstrapPromptWarningSignature =
             bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
@@ -535,13 +538,14 @@ export async function runCronIsolatedAgentTurn(params: {
             requireExplicitMessageTarget: deliveryRequested && resolvedDelivery.ok,
             disableMessageTool: deliveryRequested || deliveryPlan.mode === "none",
             allowRateLimitCooldownProbe: runOptions?.allowRateLimitCooldownProbe,
-            abortSignal,
+            abortSignal: attemptSignal,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature,
           });
           bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
             result.meta?.systemPromptReport,
           );
+          abortSignal?.removeEventListener("abort", forwardAbort);
           return result;
         },
       });


### PR DESCRIPTION
## Summary

- **Problem:** Cron job timeout aborts a shared `AbortController`. When the first model attempt times out, subsequent fallback attempts immediately fail because they receive an already-aborted signal.
- **Why it matters:** Model fallback chains become useless under cron timeout — the first timeout kills all alternatives, preventing recovery with a different (possibly faster) model.
- **What changed:** In the `run` callback passed to `runWithModelFallback`, create a fresh `AbortController` for each attempt. Forward the outer signal's abort event to the per-attempt controller, so new attempts start with a non-aborted signal while remaining cancellable. Added 2 unit tests.
- **What did NOT change:** `timer.ts` timeout logic, `runWithModelFallback` loop, CLI agent path (uses its own timeout), outer abort semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37505

## User-visible / Behavior Changes

- Cron jobs with model fallback chains now correctly try alternative models after the primary times out, instead of aborting the entire chain.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0 (arm64)
- Runtime: Node v25.6.1

### Steps

1. Configure a cron job with a slow primary model and a fallback chain
2. Set a timeout that triggers before the primary completes

### Expected

- After primary times out, fallback models are attempted

### Actual

- Before fix: All fallback attempts fail immediately with "cron: job execution timed out" because they see the aborted signal
- After fix: Each fallback attempt gets a fresh abort controller

## Evidence

```
 ✓ src/cron/isolated-agent/run.abort-signal.test.ts (2 tests) 5ms
   ✓ passes a per-attempt abort signal to runEmbeddedPiAgent, not the outer signal
   ✓ forwards outer abort to the per-attempt signal
```

## Human Verification (required)

- Verified scenarios: fresh signal per attempt, outer abort forwarded, listener cleanup on success
- Edge cases checked: outer already aborted at attempt start, multiple sequential attempts
- What I did **not** verify: Live cron job with real model timeout + fallback

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/cron/isolated-agent/run.ts`
- Known bad symptoms: If per-attempt controller leaks (unlikely — addEventListener with `once: true`), abort forwarding could be delayed

## Risks and Mitigations

Low — the change is scoped to the run callback closure. The outer abort is still forwarded, so cancellation semantics are preserved. The only behavior change is that new fallback attempts get a fresh signal.
