### PR TITLE
fix(matrix): exempt operator-configured homeserver from SSRF private-network block

### DIFF
--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -186,6 +186,16 @@ export async function resolveMatrixAuth(params?: {
   }
 
   // Login with password using HTTP API.
+  // The homeserver URL is operator-configured, so exempt its hostname from
+  // private-network SSRF checks.  Without this, Docker-internal hostnames
+  // (e.g. http://matrix:8888) that resolve to private IPs are blocked.
+  const homeserverHostname = (() => {
+    try {
+      return new URL(resolved.homeserver).hostname;
+    } catch {
+      return undefined;
+    }
+  })();
   const { response: loginResponse, release: releaseLoginResponse } = await fetchWithSsrFGuard({
     url: `${resolved.homeserver}/_matrix/client/v3/login`,
     init: {
@@ -198,6 +208,7 @@ export async function resolveMatrixAuth(params?: {
         initial_device_display_name: resolved.deviceName ?? "OpenClaw Gateway",
       }),
     },
+    policy: homeserverHostname ? { allowedHostnames: [homeserverHostname] } : undefined,
     auditContext: "matrix.login",
   });
   const login = await (async () => {


### PR DESCRIPTION
## Problem

The SSRF guard added in #29580 blocks Matrix homeservers that resolve to private/internal IP addresses. This is a regression for Docker Compose deployments where the Matrix homeserver runs as a sibling container (e.g. `http://matrix:8888` resolving to `172.x.x.x`).

Error:
```
[security] blocked URL fetch (matrix.login) target=http://matrix:8888/_matrix/client/v3/login reason=Blocked: resolves to private/internal/special-use IP address
[matrix] [default] channel exited: Blocked: resolves to private/internal/special-use IP address
```

## Fix

The homeserver URL is operator-configured (not user-supplied), so its hostname is passed via `allowedHostnames` in the SSRF policy. This exempts only that specific hostname from private-network checks while preserving SSRF protection for any redirected or user-controlled URLs.

## Changes

- `extensions/matrix/src/matrix/client/config.ts`: Parse the homeserver hostname and pass it as `policy.allowedHostnames` to `fetchWithSsrFGuard`

Fixes #38126