### PR TITLE
fix(slack): disable Bolt auto-reconnect to prevent retry storm

### DIFF
--- a/src/slack/monitor/provider.reconnect.test.ts
+++ b/src/slack/monitor/provider.reconnect.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { __testing } from "./provider.js";
+import { disableBoltAutoReconnect } from "./reconnect-policy.js";
 
 class FakeEmitter {
   private listeners = new Map<string, Set<(...args: unknown[]) => void>>();
@@ -55,5 +56,28 @@ describe("slack socket reconnect helpers", () => {
       event: "unable_to_socket_mode_start",
       error: err,
     });
+  });
+});
+
+describe("disableBoltAutoReconnect", () => {
+  it("sets autoReconnectEnabled to false on the socket mode client", () => {
+    const client = new FakeEmitter() as FakeEmitter & { autoReconnectEnabled: boolean };
+    client.autoReconnectEnabled = true;
+    const app = { receiver: { client } };
+
+    disableBoltAutoReconnect(app);
+
+    expect(client.autoReconnectEnabled).toBe(false);
+  });
+
+  it("does nothing when app has no socket mode client", () => {
+    const app = {};
+    expect(() => disableBoltAutoReconnect(app)).not.toThrow();
+  });
+
+  it("does nothing when client has no autoReconnectEnabled property", () => {
+    const client = new FakeEmitter();
+    const app = { receiver: { client } };
+    expect(() => disableBoltAutoReconnect(app)).not.toThrow();
   });
 });

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -35,6 +35,7 @@ import { createSlackMonitorContext } from "./context.js";
 import { registerSlackMonitorEvents } from "./events.js";
 import { createSlackMessageHandler } from "./message-handler.js";
 import {
+  disableBoltAutoReconnect,
   formatUnknownError,
   getSocketEmitter,
   isNonRecoverableSlackAuthError,
@@ -178,6 +179,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
           clientOptions,
         },
   );
+  disableBoltAutoReconnect(app);
   const slackHttpHandler =
     slackMode === "http" && receiver
       ? async (req: IncomingMessage, res: ServerResponse) => {

--- a/src/slack/monitor/reconnect-policy.ts
+++ b/src/slack/monitor/reconnect-policy.ts
@@ -93,6 +93,24 @@ export function isNonRecoverableSlackAuthError(error: unknown): boolean {
   return SLACK_AUTH_ERROR_RE.test(msg);
 }
 
+/**
+ * Disable Bolt's SocketModeClient auto-reconnect so OpenClaw's outer loop
+ * with exponential backoff is the sole retry mechanism.  The SocketModeClient
+ * defaults to `autoReconnectEnabled: true` with a tight ~1.5 s retry interval
+ * and no backoff, which floods logs and degrades other channels.
+ */
+export function disableBoltAutoReconnect(app: unknown): void {
+  const emitter = getSocketEmitter(app);
+  if (!emitter) {
+    return;
+  }
+  const receiver = (app as { receiver?: { client?: Record<string, unknown> } }).receiver;
+  const client = receiver?.client;
+  if (client && typeof client.autoReconnectEnabled === "boolean") {
+    client.autoReconnectEnabled = false;
+  }
+}
+
 export function formatUnknownError(error: unknown): string {
   if (error instanceof Error) {
     return error.message;


### PR DESCRIPTION
## Summary

Disables Bolt's internal `SocketModeClient` auto-reconnect to prevent a competing retry storm when Slack auth fails, letting OpenClaw's existing exponential backoff handle all reconnection.

## Problem

When a Slack token expires or becomes invalid, two independent retry loops compete:

1. **Bolt's SocketModeClient** (`@slack/socket-mode`): `autoReconnectEnabled = true` by default, retries at ~1.5s intervals with no backoff
2. **OpenClaw's outer loop** (`provider.ts`): `SLACK_SOCKET_RECONNECT_POLICY` with exponential backoff (2s → 30s, factor 1.8, max 12 attempts)

Bolt's tight internal retry floods logs, wastes resources, and can degrade access to other channels (webchat, TUI) while the outer loop's backoff goes unused.

## Changes

| File | Change |
|------|--------|
| `src/slack/monitor/reconnect-policy.ts` | Added `disableBoltAutoReconnect()` — accesses `app.receiver.client.autoReconnectEnabled` and sets it to `false` |
| `src/slack/monitor/provider.ts` | Calls `disableBoltAutoReconnect(app)` immediately after `App` construction |
| `src/slack/monitor/provider.reconnect.test.ts` | 3 new tests: verifies flag is set to false, gracefully handles missing client, and handles client without the property |

## Test plan

- [x] `npx vitest run src/slack/monitor/provider.reconnect.test.ts` — 6/6 passing
- [ ] Manual: revoke a Slack bot token, observe logs — retries should follow 2s → 3.6s → 6.5s → ... pattern, not ~1.5s flat
- [ ] Manual: verify normal socket mode operation (connect, send messages) is unaffected
- [ ] Manual: disconnect network briefly, verify OpenClaw reconnects with backoff

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication/authorization? **No** — only changes retry timing, not auth logic
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **Yes** — reduces the rate of reconnection attempts from ~40/min to ~12 total over ~2min (existing policy)
- Does this change introduce new dependencies? **No**

## Human Verification

1. Configure Slack channel with valid token → messages work normally
2. Invalidate the token → gateway logs show reconnect attempts with increasing delays (not tight ~1.5s loop)
3. After max attempts, channel is marked as failed, other channels remain functional

## Failure Recovery

Remove the `disableBoltAutoReconnect(app)` call to restore Bolt's default auto-reconnect behavior.

## Risks and Mitigations

- **Risk**: Brief socket disconnects may take slightly longer to recover since Bolt's immediate reconnect is disabled
  **Mitigation**: OpenClaw's first retry delay is only 2s (with jitter), which is acceptable for a non-real-time channel. The `waitForSlackSocketDisconnect` listener still detects disconnects immediately.
- **Risk**: Future Bolt versions may change `autoReconnectEnabled` to a different property name
  **Mitigation**: `disableBoltAutoReconnect` checks for property existence before setting; if the property doesn't exist, it's a no-op