### PR TITLE
fix(cron): keep fallback watchdog independent from agent timeout

### DIFF
--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from "vitest";
 import type { HeartbeatRunResult } from "../infra/heartbeat-wake.js";
 import * as schedule from "./schedule.js";
 import {
-  createAbortAwareIsolatedRunner,
   createDefaultIsolatedRunner,
   createDueIsolatedJob,
   createIsolatedRegressionJob,
@@ -944,10 +943,11 @@ describe("Cron issue regressions", () => {
     expect(job?.state.lastError).toBeUndefined();
   });
 
-  it("aborts isolated runs when cron timeout fires", async () => {
+  it("does not pre-abort isolated fallback work when payload timeoutSeconds elapses (#37505)", async () => {
     vi.useRealTimers();
     const store = makeStorePath();
     const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
+    const waitPastInnerTimeoutMs = Math.ceil(FAST_TIMEOUT_SECONDS * 1_000) + 20;
     const cronJob = createIsolatedRegressionJob({
       id: "abort-on-timeout",
       name: "abort timeout",
@@ -959,7 +959,7 @@ describe("Cron issue regressions", () => {
     await writeCronJobs(store.storePath, [cronJob]);
 
     let now = scheduledAt;
-    const abortAwareRunner = createAbortAwareIsolatedRunner();
+    const attemptAbortStates: boolean[] = [];
     const state = createCronServiceState({
       cronEnabled: true,
       storePath: store.storePath,
@@ -967,26 +967,32 @@ describe("Cron issue regressions", () => {
       nowMs: () => now,
       enqueueSystemEvent: vi.fn(),
       requestHeartbeatNow: vi.fn(),
-      runIsolatedAgentJob: vi.fn(async (params) => {
-        const result = await abortAwareRunner.runIsolatedAgentJob(params);
-        now += 5;
-        return result;
+      runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        await new Promise((resolve) => setTimeout(resolve, waitPastInnerTimeoutMs));
+        attemptAbortStates.push(abortSignal?.aborted === true);
+        if (abortSignal?.aborted) {
+          return { status: "error" as const, error: String(abortSignal.reason) };
+        }
+        // Simulate a fallback provider attempt starting after the first attempt timed out.
+        attemptAbortStates.push(abortSignal?.aborted === true);
+        now += waitPastInnerTimeoutMs;
+        return { status: "ok" as const, summary: "fallback recovered" };
       }),
     });
 
     await onTimer(state);
 
-    expect(abortAwareRunner.getObservedAbortSignal()).toBeDefined();
-    expect(abortAwareRunner.getObservedAbortSignal()?.aborted).toBe(true);
+    expect(attemptAbortStates).toEqual([false, false]);
     const job = state.store?.jobs.find((entry) => entry.id === "abort-on-timeout");
-    expect(job?.state.lastStatus).toBe("error");
-    expect(job?.state.lastError).toContain("timed out");
+    expect(job?.state.lastStatus).toBe("ok");
+    expect(job?.state.lastError).toBeUndefined();
   });
 
-  it("suppresses isolated follow-up side effects after timeout", async () => {
+  it("keeps isolated follow-up side effects after payload timeoutSeconds elapses", async () => {
     vi.useRealTimers();
     const store = makeStorePath();
     const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
+    const waitPastInnerTimeoutMs = Math.ceil(FAST_TIMEOUT_SECONDS * 1_000) + 20;
     const enqueueSystemEvent = vi.fn();
 
     const cronJob = createIsolatedRegressionJob({
@@ -1007,24 +1013,14 @@ describe("Cron issue regressions", () => {
       nowMs: () => now,
       enqueueSystemEvent,
       requestHeartbeatNow: vi.fn(),
-      runIsolatedAgentJob: vi.fn(async (params) => {
-        const abortSignal = params.abortSignal;
-        await new Promise<void>((resolve, reject) => {
-          const onAbort = () => {
-            abortSignal?.removeEventListener("abort", onAbort);
-            now += 100;
-            reject(new Error("aborted"));
-          };
-          abortSignal?.addEventListener("abort", onAbort, { once: true });
-        });
+      runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        await new Promise((resolve) => setTimeout(resolve, waitPastInnerTimeoutMs));
+        now += waitPastInnerTimeoutMs;
         return {
           status: "ok" as const,
           summary: "late-summary",
           delivered: false,
-          error:
-            abortSignal?.aborted && typeof abortSignal.reason === "string"
-              ? abortSignal.reason
-              : undefined,
+          error: abortSignal?.aborted ? String(abortSignal.reason) : undefined,
         };
       }),
     });
@@ -1032,20 +1028,31 @@ describe("Cron issue regressions", () => {
     await onTimer(state);
 
     const jobAfterTimeout = state.store?.jobs.find((j) => j.id === "timeout-side-effects");
-    expect(jobAfterTimeout?.state.lastStatus).toBe("error");
-    expect(jobAfterTimeout?.state.lastError).toContain("timed out");
-    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(jobAfterTimeout?.state.lastStatus).toBe("ok");
+    expect(jobAfterTimeout?.state.lastError).toBeUndefined();
+    expect(enqueueSystemEvent).toHaveBeenCalledWith(
+      "Cron: late-summary",
+      expect.objectContaining({ contextKey: "cron:timeout-side-effects" }),
+    );
   });
 
-  it("applies timeoutSeconds to manual cron.run isolated executions", async () => {
+  it("does not apply timeoutSeconds to manual cron.run isolated outer timeouts", async () => {
     vi.useRealTimers();
     const store = makeStorePath();
-    const abortAwareRunner = createAbortAwareIsolatedRunner();
+    const waitPastInnerTimeoutMs = Math.ceil(FAST_TIMEOUT_SECONDS * 1_000) + 20;
+    let observedAbort = false;
 
     const cron = await startCronForStore({
       storePath: store.storePath,
       cronEnabled: false,
-      runIsolatedAgentJob: abortAwareRunner.runIsolatedAgentJob,
+      runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        await new Promise((resolve) => setTimeout(resolve, waitPastInnerTimeoutMs));
+        observedAbort = abortSignal?.aborted === true;
+        if (abortSignal?.aborted) {
+          return { status: "error" as const, error: String(abortSignal.reason) };
+        }
+        return { status: "ok" as const, summary: "done" };
+      }),
     });
 
     const job = await cron.add({
@@ -1060,23 +1067,23 @@ describe("Cron issue regressions", () => {
 
     const result = await cron.run(job.id, "force");
     expect(result).toEqual({ ok: true, ran: true });
-    expect(abortAwareRunner.getObservedAbortSignal()).toBeDefined();
-    expect(abortAwareRunner.getObservedAbortSignal()?.aborted).toBe(true);
+    expect(observedAbort).toBe(false);
 
     const updated = (await cron.list({ includeDisabled: true })).find(
       (entry) => entry.id === job.id,
     );
-    expect(updated?.state.lastStatus).toBe("error");
-    expect(updated?.state.lastError).toContain("timed out");
+    expect(updated?.state.lastStatus).toBe("ok");
+    expect(updated?.state.lastError).toBeUndefined();
     expect(updated?.state.runningAtMs).toBeUndefined();
 
     cron.stop();
   });
 
-  it("applies timeoutSeconds to startup catch-up isolated executions", async () => {
+  it("does not apply timeoutSeconds to startup catch-up isolated outer timeouts", async () => {
     vi.useRealTimers();
     const store = makeStorePath();
     const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
+    const waitPastInnerTimeoutMs = Math.ceil(FAST_TIMEOUT_SECONDS * 1_000) + 20;
     const cronJob = createIsolatedRegressionJob({
       id: "startup-timeout",
       name: "startup timeout",
@@ -1088,7 +1095,7 @@ describe("Cron issue regressions", () => {
     await writeCronJobs(store.storePath, [cronJob]);
 
     let now = scheduledAt;
-    const abortAwareRunner = createAbortAwareIsolatedRunner();
+    let observedAbort = false;
     const state = createCronServiceState({
       cronEnabled: true,
       storePath: store.storePath,
@@ -1096,20 +1103,23 @@ describe("Cron issue regressions", () => {
       nowMs: () => now,
       enqueueSystemEvent: vi.fn(),
       requestHeartbeatNow: vi.fn(),
-      runIsolatedAgentJob: vi.fn(async (params) => {
-        const result = await abortAwareRunner.runIsolatedAgentJob(params);
-        now += 5;
-        return result;
+      runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
+        await new Promise((resolve) => setTimeout(resolve, waitPastInnerTimeoutMs));
+        observedAbort = abortSignal?.aborted === true;
+        now += waitPastInnerTimeoutMs;
+        if (abortSignal?.aborted) {
+          return { status: "error" as const, error: String(abortSignal.reason) };
+        }
+        return { status: "ok" as const, summary: "done" };
       }),
     });
 
     await runMissedJobs(state);
 
-    expect(abortAwareRunner.getObservedAbortSignal()).toBeDefined();
-    expect(abortAwareRunner.getObservedAbortSignal()?.aborted).toBe(true);
+    expect(observedAbort).toBe(false);
     const job = state.store?.jobs.find((entry) => entry.id === "startup-timeout");
-    expect(job?.state.lastStatus).toBe("error");
-    expect(job?.state.lastError).toContain("timed out");
+    expect(job?.state.lastStatus).toBe("ok");
+    expect(job?.state.lastError).toBeUndefined();
   });
 
   it("respects abort signals while retrying main-session wake-now heartbeat runs", async () => {
@@ -1348,22 +1358,18 @@ describe("Cron issue regressions", () => {
     expect(jobs.find((job) => job.id === second.id)?.state.lastStatus).toBe("ok");
   });
 
-  // Regression: isolated cron runs must not abort at 1/3 of configured timeoutSeconds.
-  // The bug (issue #29774) caused the CLI-provider resume watchdog (ratio 0.3, maxMs 180 s)
-  // to be applied on fresh sessions because a persisted cliSessionId was passed to
-  // runCliAgent even when isNewSession=true.  At the service level this manifests as a
-  // job abort that fires much sooner than the configured outer timeout.
-  it("outer cron timeout fires at configured timeoutSeconds, not at 1/3 (#29774)", async () => {
+  // Regression: cron isolated runs must not reuse payload.timeoutSeconds as both
+  // the inner agent-attempt timeout and the outer cron watchdog.
+  it("keeps the outer cron watchdog independent from payload timeoutSeconds (#37505)", async () => {
     vi.useRealTimers();
     const store = makeStorePath();
     const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
 
-    // Keep this short for suite speed while still separating expected timeout
-    // from the 1/3-regression timeout.
     const timeoutSeconds = 0.01;
+    const waitPastInnerTimeoutMs = Math.ceil(timeoutSeconds * 1_000) + 20;
     const cronJob = createIsolatedRegressionJob({
-      id: "timeout-fraction-29774",
-      name: "timeout fraction regression",
+      id: "timeout-fallback-37505",
+      name: "timeout fallback regression",
       scheduledAt,
       schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
       payload: { kind: "agentTurn", message: "work", timeoutSeconds },
@@ -1372,9 +1378,8 @@ describe("Cron issue regressions", () => {
     await writeCronJobs(store.storePath, [cronJob]);
 
     let now = scheduledAt;
-    const wallStart = Date.now();
-    let abortWallMs: number | undefined;
-    let started = false;
+    let fallbackAttemptStarted = false;
+    let fallbackAttemptSawAbort = false;
 
     const state = createCronServiceState({
       cronEnabled: true,
@@ -1384,43 +1389,25 @@ describe("Cron issue regressions", () => {
       enqueueSystemEvent: vi.fn(),
       requestHeartbeatNow: vi.fn(),
       runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
-        started = true;
-        await new Promise<void>((resolve) => {
-          if (!abortSignal) {
-            resolve();
-            return;
-          }
-          if (abortSignal.aborted) {
-            abortWallMs = Date.now();
-            resolve();
-            return;
-          }
-          abortSignal.addEventListener(
-            "abort",
-            () => {
-              abortWallMs = Date.now();
-              resolve();
-            },
-            { once: true },
-          );
-        });
-        now += 5;
-        return { status: "ok" as const, summary: "done" };
+        await new Promise((resolve) => setTimeout(resolve, waitPastInnerTimeoutMs));
+        fallbackAttemptStarted = true;
+        fallbackAttemptSawAbort = abortSignal?.aborted === true;
+        now += waitPastInnerTimeoutMs;
+        if (abortSignal?.aborted) {
+          return { status: "error" as const, error: String(abortSignal.reason) };
+        }
+        return { status: "ok" as const, summary: "fallback completed" };
       }),
     });
 
     await onTimer(state);
 
-    expect(started).toBe(true);
+    expect(fallbackAttemptStarted).toBe(true);
+    expect(fallbackAttemptSawAbort).toBe(false);
 
-    // The abort must not fire at the old ~1/3 regression value.
-    // Keep the lower bound conservative for loaded CI runners.
-    const elapsedMs = (abortWallMs ?? Date.now()) - wallStart;
-    expect(elapsedMs).toBeGreaterThanOrEqual(timeoutSeconds * 1000 * 0.55);
-
-    const job = state.store?.jobs.find((entry) => entry.id === "timeout-fraction-29774");
-    expect(job?.state.lastStatus).toBe("error");
-    expect(job?.state.lastError).toContain("timed out");
+    const job = state.store?.jobs.find((entry) => entry.id === "timeout-fallback-37505");
+    expect(job?.state.lastStatus).toBe("ok");
+    expect(job?.state.lastError).toBeUndefined();
   });
 
   it("keeps state updates when cron next-run computation throws after a successful run (#30905)", () => {

--- a/src/cron/service/timeout-policy.test.ts
+++ b/src/cron/service/timeout-policy.test.ts
@@ -33,17 +33,17 @@ describe("timeout-policy", () => {
     expect(timeout).toBe(AGENT_TURN_SAFETY_TIMEOUT_MS);
   });
 
-  it("disables timeout when timeoutSeconds <= 0", () => {
+  it("keeps the outer safety timeout when timeoutSeconds <= 0", () => {
     const timeout = resolveCronJobTimeoutMs(
       makeJob({ kind: "agentTurn", message: "hi", timeoutSeconds: 0 }),
     );
-    expect(timeout).toBeUndefined();
+    expect(timeout).toBe(AGENT_TURN_SAFETY_TIMEOUT_MS);
   });
 
-  it("applies explicit timeoutSeconds when positive", () => {
+  it("does not reuse agent timeoutSeconds for the outer cron timeout", () => {
     const timeout = resolveCronJobTimeoutMs(
       makeJob({ kind: "agentTurn", message: "hi", timeoutSeconds: 1.9 }),
     );
-    expect(timeout).toBe(1_900);
+    expect(timeout).toBe(AGENT_TURN_SAFETY_TIMEOUT_MS);
   });
 });

--- a/src/cron/service/timeout-policy.ts
+++ b/src/cron/service/timeout-policy.ts
@@ -14,12 +14,11 @@ export const DEFAULT_JOB_TIMEOUT_MS = 10 * 60_000; // 10 minutes
 export const AGENT_TURN_SAFETY_TIMEOUT_MS = 60 * 60_000; // 60 minutes
 
 export function resolveCronJobTimeoutMs(job: CronJob): number | undefined {
-  const configuredTimeoutMs =
-    job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
-      ? Math.floor(job.payload.timeoutSeconds * 1_000)
-      : undefined;
-  if (configuredTimeoutMs === undefined) {
-    return job.payload.kind === "agentTurn" ? AGENT_TURN_SAFETY_TIMEOUT_MS : DEFAULT_JOB_TIMEOUT_MS;
+  if (job.payload.kind === "agentTurn") {
+    // payload.timeoutSeconds is enforced inside the isolated agent run.
+    // Keep the outer cron watchdog as an independent safety ceiling so it
+    // does not pre-abort provider fallback attempts via the shared signal.
+    return AGENT_TURN_SAFETY_TIMEOUT_MS;
   }
-  return configuredTimeoutMs <= 0 ? undefined : configuredTimeoutMs;
+  return DEFAULT_JOB_TIMEOUT_MS;
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: cron `agentTurn` jobs reused `payload.timeoutSeconds` as both the inner agent-attempt timeout and the outer cron watchdog timeout.
- Why it matters: when the outer watchdog fired, it aborted the shared signal passed into the isolated run, which caused later fallback-provider attempts to fail immediately instead of actually running.
- What changed: the outer cron watchdog for `agentTurn` jobs now stays on the independent `AGENT_TURN_SAFETY_TIMEOUT_MS`, while `payload.timeoutSeconds` remains an inner attempt timeout inside the isolated agent run.
- What did NOT change (scope boundary): this does not redesign fallback budgeting or provider retry policy; it only separates the outer cron safety ceiling from per-attempt timeout behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37505
- Related #29774

## User-visible / Behavior Changes

Cron `agentTurn` jobs no longer let `payload.timeoutSeconds` pre-abort the entire fallback chain. A slow primary provider can still time out per attempt, but later fallback candidates now get a live signal instead of inheriting an already-aborted one.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.3.1
- Runtime/container: local worktree (`/tmp/oc-37505-pr`)
- Model/provider: n/a
- Integration/channel (if any): cron isolated `agentTurn`
- Relevant config (redacted): cron job with `payload.timeoutSeconds` shorter than provider response time

### Steps

1. Create an isolated cron `agentTurn` job with model fallbacks configured and `payload.timeoutSeconds` set lower than the primary provider response time.
2. Run the cron job through timer execution, manual `cron.run`, or startup catch-up paths.
3. Observe whether fallback work still starts after the inner timeout window elapses.

### Expected

- `payload.timeoutSeconds` only limits the inner agent attempt.
- The outer cron watchdog remains an independent safety ceiling.
- Fallback attempts are not handed an already-aborted signal.

### Actual

- Before this change, the outer cron timeout reused `payload.timeoutSeconds`, aborted the shared signal, and later fallback attempts failed immediately.
- After this change, the regression tests complete successfully with the job finishing `ok` and no pre-aborted fallback path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm vitest run src/cron/service/timeout-policy.test.ts src/cron/service.issue-regressions.test.ts`
  - `pnpm check`
  - `pnpm build`
  - `git diff --check`
- Edge cases checked:
  - positive `timeoutSeconds` no longer shortens the outer cron watchdog
  - `timeoutSeconds <= 0` no longer disables the outer watchdog for isolated agent turns
  - manual `cron.run` and startup catch-up keep fallback work alive
  - follow-up summary behavior still executes after the inner timeout window elapses
- What you did **not** verify:
  - full `pnpm test` suite
  - live provider/network behavior against a real timed-out model chain outside the regression harness

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `e3c927af6`
- Files/config to restore: `src/cron/service/timeout-policy.ts`, `src/cron/service/timeout-policy.test.ts`, `src/cron/service.issue-regressions.test.ts`
- Known bad symptoms reviewers should watch for: cron isolated jobs running far longer than intended without the outer safety ceiling being enforced

## Risks and Mitigations

- Risk: some users may have implicitly relied on `payload.timeoutSeconds` also capping total cron wall-clock runtime.
  - Mitigation: the outer `AGENT_TURN_SAFETY_TIMEOUT_MS` watchdog still bounds total runtime, and the tests now pin that separation explicitly.
