### PR TITLE
fix(agents): add cross-turn dedup cache to prevent duplicate messages after compaction

### DIFF
--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -78,6 +78,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     pendingMessagingTargets: new Map(),
     successfulCronAdds: 0,
     pendingMessagingMediaUrls: new Map(),
+    deliveredTextHashes: [] as Array<{ hash: string; ts: number }>,
   };
   const usageTotals = {
     input: 0,
@@ -128,15 +129,42 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.assistantTextBaseline = nextAssistantTextBaseline;
   };
 
+  const CROSS_TURN_DEDUP_MAX = 20;
+  const CROSS_TURN_DEDUP_TTL_MS = 3_600_000;
+  const CROSS_TURN_DEDUP_MIN_LEN = 40;
+
+  const addToDeliveredCache = (normalized: string) => {
+    if (!normalized || normalized.length < CROSS_TURN_DEDUP_MIN_LEN) return;
+    const now = Date.now();
+    state.deliveredTextHashes.push({ hash: normalized, ts: now });
+    const cutoff = now - CROSS_TURN_DEDUP_TTL_MS;
+    state.deliveredTextHashes = state.deliveredTextHashes
+      .filter((e) => e.ts > cutoff)
+      .slice(-CROSS_TURN_DEDUP_MAX);
+  };
+
+  const isInDeliveredCache = (normalized: string): boolean => {
+    if (!normalized || normalized.length < CROSS_TURN_DEDUP_MIN_LEN) return false;
+    const cutoff = Date.now() - CROSS_TURN_DEDUP_TTL_MS;
+    return state.deliveredTextHashes.some((e) => e.ts > cutoff && e.hash === normalized);
+  };
+
   const rememberAssistantText = (text: string) => {
     state.lastAssistantTextMessageIndex = state.assistantMessageIndex;
     state.lastAssistantTextTrimmed = text.trimEnd();
     const normalized = normalizeTextForComparison(text);
     state.lastAssistantTextNormalized = normalized.length > 0 ? normalized : undefined;
+    if (normalized) {
+      addToDeliveredCache(normalized);
+    }
   };
 
   const shouldSkipAssistantText = (text: string) => {
     if (state.lastAssistantTextMessageIndex !== state.assistantMessageIndex) {
+      const normalized = normalizeTextForComparison(text);
+      if (normalized.length > 0 && isInDeliveredCache(normalized)) {
+        return true;
+      }
       return false;
     }
     const trimmed = text.trimEnd();


### PR DESCRIPTION
## Summary

- **Problem:** After context compaction, the per-turn dedup state (`lastAssistantText*`) resets via `resetForCompactionRetry`. When the model re-generates text from the compaction summary as new output, the dedup guard sees it as new text and delivers it to Telegram/Discord as a duplicate message.
- **Why it matters:** Users see the same reply twice after long conversations that trigger compaction, especially visible on Telegram where each chunk becomes a separate message.
- **What changed:** Added a rolling hash cache (`deliveredTextHashes`, last 20 entries, 1h TTL) that persists across compaction retries and assistant turn boundaries. `rememberAssistantText` adds normalized text to the cache. `shouldSkipAssistantText` checks the cache when the per-turn index doesn't match (cross-turn scenario). Only texts >= 40 normalized chars are cached to avoid false positives on short replies.
- **What did NOT change:** Per-turn dedup logic (still works as before), `resetAssistantMessageState` (doesn't clear the cache), `resetForCompactionRetry` (doesn't clear the cache), `messagingToolSentTexts` dedup (separate path).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37702

## User-visible / Behavior Changes

- After compaction, previously delivered text is no longer re-sent to the user as a duplicate message.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0 (arm64)
- Runtime: Node v25.6.1
- Integration/channel: Telegram, Discord

### Steps

1. Have a long conversation that triggers compaction
2. The compaction summary includes the assistant's previous reply text
3. Model re-outputs that same text

### Expected

- Text is deduped and not re-delivered

### Actual

- Before fix: User sees the same reply twice
- After fix: Duplicate is suppressed by cross-turn cache

## Evidence

```
 ✓ pi-embedded-subscribe...does-not-duplicate-text-end-repeats-full.test.ts (2 tests)
 ✓ pi-embedded-subscribe...does-not-emit-duplicate-block-replies-text.test.ts (5 tests)
```

Existing dedup tests pass, confirming no regression in per-turn dedup.

## Human Verification (required)

- Verified scenarios: existing per-turn dedup unchanged, cross-turn cache survives `resetForCompactionRetry`, cache survives `resetAssistantMessageState`, short texts (<40 chars) not cached
- Edge cases checked: cache TTL expiry (1h), cache size limit (20), min length threshold (40 chars)
- What I did **not** verify: Live compaction with Telegram delivery to confirm end-to-end dedup

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: `src/agents/pi-embedded-subscribe.ts`
- Known bad symptoms: If false positives occur (legitimate re-sends suppressed), lower `CROSS_TURN_DEDUP_MIN_LEN` or reduce cache TTL

## Risks and Mitigations

- Risk: False positive dedup on intentionally repeated text. Mitigation: 40-char minimum length, 1h TTL, exact normalized match only (no fuzzy).
