### PR TITLE
fix(matrix): add allowPrivateNetwork config for private homeservers

### DIFF
--- a/extensions/matrix/src/config-schema.test.ts
+++ b/extensions/matrix/src/config-schema.test.ts
@@ -23,4 +23,15 @@ describe("MatrixConfigSchema SecretInput", () => {
     });
     expect(result.success).toBe(true);
   });
+
+  it("accepts allowPrivateNetwork boolean", () => {
+    const result = MatrixConfigSchema.safeParse({
+      homeserver: "https://matrix.internal.local",
+      allowPrivateNetwork: true,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.allowPrivateNetwork).toBe(true);
+    }
+  });
 });

--- a/extensions/matrix/src/config-schema.ts
+++ b/extensions/matrix/src/config-schema.ts
@@ -48,6 +48,7 @@ export const MatrixConfigSchema = z.object({
   deviceName: z.string().optional(),
   initialSyncLimit: z.number().optional(),
   encryption: z.boolean().optional(),
+  allowPrivateNetwork: z.boolean().optional(),
   allowlistOnly: z.boolean().optional(),
   groupPolicy: z.enum(["open", "disabled", "allowlist"]).optional(),
   replyToMode: z.enum(["off", "first", "all"]).optional(),

--- a/extensions/matrix/src/matrix/client.test.ts
+++ b/extensions/matrix/src/matrix/client.test.ts
@@ -32,6 +32,7 @@ describe("resolveMatrixConfig", () => {
       deviceName: "CfgDevice",
       initialSyncLimit: 5,
       encryption: false,
+      allowPrivateNetwork: false,
     });
   });
 
@@ -52,5 +53,20 @@ describe("resolveMatrixConfig", () => {
     expect(resolved.deviceName).toBe("EnvDevice");
     expect(resolved.initialSyncLimit).toBeUndefined();
     expect(resolved.encryption).toBe(false);
+    expect(resolved.allowPrivateNetwork).toBe(false);
+  });
+
+  it("returns allowPrivateNetwork when configured", () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.internal.local",
+          userId: "@bot:internal.local",
+          allowPrivateNetwork: true,
+        },
+      },
+    } as CoreConfig;
+    const resolved = resolveMatrixConfig(cfg, {} as NodeJS.ProcessEnv);
+    expect(resolved.allowPrivateNetwork).toBe(true);
   });
 });

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -79,6 +79,7 @@ export function resolveMatrixConfigForAccount(
       ? Math.max(0, Math.floor(matrix.initialSyncLimit))
       : undefined;
   const encryption = matrix.encryption ?? false;
+  const allowPrivateNetwork = matrix.allowPrivateNetwork ?? false;
   return {
     homeserver,
     userId,
@@ -87,6 +88,7 @@ export function resolveMatrixConfigForAccount(
     deviceName,
     initialSyncLimit,
     encryption,
+    allowPrivateNetwork,
   };
 }
 
@@ -186,6 +188,7 @@ export async function resolveMatrixAuth(params?: {
   }
 
   // Login with password using HTTP API.
+  const ssrfPolicy = resolved.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined;
   const { response: loginResponse, release: releaseLoginResponse } = await fetchWithSsrFGuard({
     url: `${resolved.homeserver}/_matrix/client/v3/login`,
     init: {
@@ -198,6 +201,7 @@ export async function resolveMatrixAuth(params?: {
         initial_device_display_name: resolved.deviceName ?? "OpenClaw Gateway",
       }),
     },
+    policy: ssrfPolicy,
     auditContext: "matrix.login",
   });
   const login = await (async () => {

--- a/extensions/matrix/src/matrix/client/types.ts
+++ b/extensions/matrix/src/matrix/client/types.ts
@@ -6,6 +6,7 @@ export type MatrixResolvedConfig = {
   deviceName?: string;
   initialSyncLimit?: number;
   encryption?: boolean;
+  allowPrivateNetwork?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds `allowPrivateNetwork` config option to the Matrix channel, allowing connections to homeservers that resolve to private/internal IP addresses (e.g. self-hosted Matrix on a local network).

## Problem

When a Matrix homeserver URL resolves to a private/internal IP address (e.g. `192.168.x.x`, `10.x.x.x`), the SSRF guard blocks the connection with:

```
[matrix] [default] channel exited: Blocked: resolves to private/internal/special-use IP address
```

This prevents using OpenClaw with self-hosted Matrix servers on private networks, which is a common deployment scenario.

## Changes

| File | Change |
|------|--------|
| `extensions/matrix/src/config-schema.ts` | Added `allowPrivateNetwork: z.boolean().optional()` to `MatrixConfigSchema` |
| `extensions/matrix/src/matrix/client/types.ts` | Added `allowPrivateNetwork?: boolean` to `MatrixResolvedConfig` |
| `extensions/matrix/src/matrix/client/config.ts` | Read `allowPrivateNetwork` in config resolution, pass `{ allowPrivateNetwork: true }` SSRF policy to `fetchWithSsrFGuard` during login |
| `extensions/matrix/src/config-schema.test.ts` | New test: schema accepts `allowPrivateNetwork` boolean |
| `extensions/matrix/src/matrix/client.test.ts` | Updated existing test expectation, added new test for `allowPrivateNetwork: true` |

## Usage

Add to `openclaw.json`:

```json
{
  "channels": {
    "matrix": {
      "homeserver": "https://matrix.internal.local",
      "allowPrivateNetwork": true
    }
  }
}
```

## Test plan

- [x] `npx vitest run extensions/matrix/src/config-schema.test.ts` — 3/3 passing
- [x] `npx vitest run extensions/matrix/src/matrix/client.test.ts` — 3/3 passing
- [x] `npx vitest run extensions/matrix/src/matrix/accounts.test.ts` — 6/6 passing (no regression)
- [ ] Manual: configure a Matrix homeserver on a private IP, set `allowPrivateNetwork: true`, verify connection succeeds
- [ ] Manual: verify public homeservers work without the flag

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication/authorization? **No** — auth flow is unchanged; only the IP restriction is conditionally relaxed
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **Yes** — allows SSRF guard to pass through private IP addresses when explicitly opted in. This is an intentional opt-in, matching the existing pattern used by Tlon and BlueBubbles extensions.
- Does this change introduce new dependencies? **No**

## Human Verification

1. Configure Matrix with a private homeserver URL (e.g. `http://192.168.1.100:8448`) WITHOUT `allowPrivateNetwork` → verify connection is blocked
2. Add `allowPrivateNetwork: true` → verify connection succeeds
3. Use a public homeserver (e.g. `https://matrix.org`) → verify no change in behavior

## Failure Recovery

Remove `allowPrivateNetwork: true` from config to restore the default SSRF blocking behavior.

## Risks and Mitigations

- **Risk**: Users may enable `allowPrivateNetwork` without understanding the SSRF implications
  **Mitigation**: The option defaults to `false` and must be explicitly set. The name clearly communicates the intent. This follows the same pattern as Tlon and BlueBubbles.
- **Risk**: Matrix SDK internal requests (sync, send) bypass the SSRF guard
  **Mitigation**: The SDK uses unpatched `fetch` for its internal HTTP calls, which is not SSRF-guarded. This is acceptable because once the user has opted in via `allowPrivateNetwork`, the homeserver URL is trusted. A follow-up could patch the SDK's fetch for additional hardening.