### PR TITLE
cron: support human-readable at with optional tz

### DIFF
--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -179,8 +179,10 @@ JOB SCHEMA (for add action):
 }
 
 SCHEDULE TYPES (schedule.kind):
-- "at": One-shot at absolute time
-  { "kind": "at", "atMs": <unix-ms-timestamp> }
+- "at": One-shot at absolute time. Prefer human-readable "at" (with optional "tz") so the model does not compute Unix timestamps:
+  { "kind": "at", "at": "2026-02-01T23:00:00+08:00" }
+  { "kind": "at", "at": "2026-02-01 23:00:00", "tz": "Asia/Shanghai" }
+  Legacy: { "kind": "at", "atMs": <unix-ms-timestamp> }
 - "every": Recurring interval
   { "kind": "every", "everyMs": <interval-ms>, "anchorMs": <optional-start-ms> }
 - "cron": Cron expression

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -22,11 +22,12 @@ function coerceSchedule(schedule: UnknownRecord) {
   const kind = typeof schedule.kind === "string" ? schedule.kind : undefined;
   const atMsRaw = schedule.atMs;
   const atRaw = schedule.at;
+  const tzRaw = typeof schedule.tz === "string" ? schedule.tz.trim() || undefined : undefined;
   const parsedAtMs =
     typeof atMsRaw === "string"
-      ? parseAbsoluteTimeMs(atMsRaw)
+      ? parseAbsoluteTimeMs(atMsRaw, tzRaw)
       : typeof atRaw === "string"
-        ? parseAbsoluteTimeMs(atRaw)
+        ? parseAbsoluteTimeMs(atRaw, tzRaw)
         : null;
 
   if (!kind) {
@@ -49,6 +50,9 @@ function coerceSchedule(schedule: UnknownRecord) {
 
   if ("at" in next) {
     delete next.at;
+  }
+  if (next.kind === "at" && "tz" in next) {
+    delete next.tz;
   }
 
   return next;

--- a/src/cron/parse.test.ts
+++ b/src/cron/parse.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { parseAbsoluteTimeMs } from "./parse.js";
+
+describe("parseAbsoluteTimeMs", () => {
+  it("returns null for empty or whitespace", () => {
+    expect(parseAbsoluteTimeMs("")).toBeNull();
+    expect(parseAbsoluteTimeMs("   ")).toBeNull();
+  });
+
+  it("parses epoch milliseconds", () => {
+    const ms = 1769871600000;
+    expect(parseAbsoluteTimeMs(String(ms))).toBe(ms);
+  });
+
+  it("parses ISO date (UTC midnight)", () => {
+    expect(parseAbsoluteTimeMs("2026-01-12")).toBe(Date.parse("2026-01-12T00:00:00Z"));
+  });
+
+  it("parses ISO datetime without TZ (coerced to UTC)", () => {
+    expect(parseAbsoluteTimeMs("2026-01-12T18:00:00")).toBe(Date.parse("2026-01-12T18:00:00Z"));
+  });
+
+  it("parses ISO datetime with Z", () => {
+    expect(parseAbsoluteTimeMs("2026-01-12T18:00:00Z")).toBe(Date.parse("2026-01-12T18:00:00Z"));
+  });
+
+  it("parses ISO datetime with offset", () => {
+    expect(parseAbsoluteTimeMs("2026-02-01T23:00:00+08:00")).toBe(
+      Date.parse("2026-02-01T15:00:00Z"),
+    );
+  });
+
+  it("parses local time in IANA timezone when tz provided", () => {
+    const ms = parseAbsoluteTimeMs("2026-02-01 23:00:00", "Asia/Shanghai");
+    expect(ms).not.toBeNull();
+    expect(new Date(ms!).toISOString()).toBe("2026-02-01T15:00:00.000Z");
+  });
+
+  it("parses local time with T separator when tz provided", () => {
+    const ms = parseAbsoluteTimeMs("2026-02-01T23:00:00", "Asia/Shanghai");
+    expect(ms).not.toBeNull();
+    expect(new Date(ms!).toISOString()).toBe("2026-02-01T15:00:00.000Z");
+  });
+
+  it("ignores tz when string has explicit offset", () => {
+    const ms = parseAbsoluteTimeMs("2026-02-01T23:00:00+08:00", "America/New_York");
+    expect(ms).toBe(Date.parse("2026-02-01T15:00:00Z"));
+  });
+
+  it("returns null for invalid timezone", () => {
+    expect(parseAbsoluteTimeMs("2026-02-01 23:00:00", "Invalid/Zone")).toBeNull();
+  });
+
+  it("returns null for date-only when tz provided (avoid silent UTC midnight)", () => {
+    expect(parseAbsoluteTimeMs("2026-02-01", "Asia/Shanghai")).toBeNull();
+  });
+});

--- a/src/cron/parse.ts
+++ b/src/cron/parse.ts
@@ -1,6 +1,7 @@
 const ISO_TZ_RE = /(Z|[+-]\d{2}:?\d{2})$/i;
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const ISO_DATE_TIME_RE = /^\d{4}-\d{2}-\d{2}T/;
+const ISO_DATE_TIME_SPACE_RE = /^\d{4}-\d{2}-\d{2}[T\s]\d{1,2}:\d{2}(:\d{2})?(\.\d+)?$/;
 
 function normalizeUtcIso(raw: string) {
   if (ISO_TZ_RE.test(raw)) {
@@ -15,7 +16,92 @@ function normalizeUtcIso(raw: string) {
   return raw;
 }
 
-export function parseAbsoluteTimeMs(input: string): number | null {
+function formatUtcMsInZone(ms: number, timeZone: string): string {
+  const date = new Date(ms);
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(date);
+
+  const partMap: Record<string, string> = {};
+  for (const part of parts) {
+    if (part.type !== "literal") {
+      partMap[part.type] = part.value;
+    }
+  }
+
+  const year = partMap.year ?? "0000";
+  const month = partMap.month ?? "01";
+  const day = partMap.day ?? "01";
+  const hour = partMap.hour ?? "00";
+  const minute = partMap.minute ?? "00";
+  const second = partMap.second ?? "00";
+  return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
+}
+
+function parseLocalTimeInZone(localStr: string, timeZone: string): number | null {
+  const normalized = localStr.trim().replace(/[T\s]+/, " ");
+  const match = normalized.match(
+    /^(\d{4})-(\d{2})-(\d{2})\s+(\d{1,2}):(\d{2})(?::(\d{2}))?(?:\.(\d+))?$/,
+  );
+  if (!match) {
+    return null;
+  }
+
+  const [, year, month, day, hour, minute, secondPart, fractionPart] = match;
+  const second = secondPart ? Number(secondPart) : 0;
+  const millisecond = fractionPart ? Math.floor(Number(`0.${fractionPart}`) * 1000) : 0;
+  const target = `${year}-${month}-${day} ${hour.padStart(2, "0")}:${minute}:${String(second).padStart(2, "0")}`;
+
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone }).format(new Date());
+  } catch {
+    return null;
+  }
+
+  const trialMs = Date.parse(
+    `${year}-${month}-${day}T${hour.padStart(2, "0")}:${minute}:${String(second).padStart(2, "0")}.${String(
+      millisecond,
+    ).padStart(3, "0")}Z`,
+  );
+  if (!Number.isFinite(trialMs)) {
+    return null;
+  }
+
+  const halfDayMs = 12 * 60 * 60 * 1000;
+  let low = trialMs - halfDayMs;
+  let high = trialMs + halfDayMs;
+  const roundToSecond = (value: number) =>
+    millisecond === 0 ? Math.floor(value / 1000) * 1000 : value;
+
+  for (let i = 0; i < 30; i++) {
+    const mid = Math.floor((low + high) / 2);
+    const formatted = formatUtcMsInZone(mid, timeZone);
+    if (formatted === target) {
+      return roundToSecond(mid);
+    }
+    if (formatted < target) {
+      low = mid;
+    } else {
+      high = mid;
+    }
+  }
+
+  const mid = Math.floor((low + high) / 2);
+  const result = formatUtcMsInZone(mid, timeZone) === target ? mid : null;
+  if (result === null) {
+    return null;
+  }
+  return roundToSecond(result);
+}
+
+export function parseAbsoluteTimeMs(input: string, tz?: string): number | null {
   const raw = input.trim();
   if (!raw) {
     return null;
@@ -26,6 +112,18 @@ export function parseAbsoluteTimeMs(input: string): number | null {
       return Math.floor(n);
     }
   }
+
+  if (ISO_TZ_RE.test(raw)) {
+    const parsed = Date.parse(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  if (tz && ISO_DATE_TIME_SPACE_RE.test(raw)) {
+    return parseLocalTimeInZone(raw, tz);
+  }
+  if (tz && ISO_DATE_RE.test(raw)) {
+    return null;
+  }
+
   const parsed = Date.parse(normalizeUtcIso(raw));
   return Number.isFinite(parsed) ? parsed : null;
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
