### PR TITLE
refactor(agents): unify canonical codex model facts

### DIFF
--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -106,7 +106,7 @@ describe("loadModelCatalog", () => {
                   id: "gpt-5.3-codex",
                   provider: "openai-codex",
                   name: "GPT-5.3 Codex",
-                  reasoning: true,
+                  reasoning: false,
                   contextWindow: 200000,
                   input: ["text"],
                 },
@@ -131,6 +131,7 @@ describe("loadModelCatalog", () => {
     const spark = result.find((entry) => entry.id === "gpt-5.3-codex-spark");
     expect(spark?.name).toBe("gpt-5.3-codex-spark");
     expect(spark?.reasoning).toBe(true);
+    expect(spark?.input).toEqual(["text", "image"]);
   });
 
   it("matches the canonical codex facts layer for gpt-5.4", async () => {
@@ -150,8 +151,8 @@ describe("loadModelCatalog", () => {
                   id: "gpt-5.3-codex",
                   provider: "openai-codex",
                   name: "GPT-5.3 Codex",
-                  reasoning: true,
-                  input: ["text", "image"],
+                  reasoning: false,
+                  input: ["text"],
                   contextWindow: 200000,
                   maxTokens: 64000,
                 },
@@ -178,6 +179,8 @@ describe("loadModelCatalog", () => {
       provider: canonical.provider,
       id: canonical.id,
       name: canonical.name,
+      reasoning: canonical.reasoning,
+      input: canonical.input,
       contextWindow: canonical.contextWindow,
       maxTokens: canonical.maxTokens,
     });

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -8,6 +8,15 @@ import {
 
 type PiSdkModule = typeof import("./pi-model-discovery.js");
 
+async function loadCanonicalFactsModule() {
+  const module = await import("./model-facts.js").catch(() => null);
+  if (!module?.getCanonicalForwardCompatModelFacts) {
+    expect(module?.getCanonicalForwardCompatModelFacts).toBeTypeOf("function");
+    return null;
+  }
+  return module;
+}
+
 vi.mock("./models-config.js", () => ({
   ensureOpenClawModelsJson: vi.fn().mockResolvedValue({ agentDir: "/tmp", wrote: false }),
 }));
@@ -122,5 +131,55 @@ describe("loadModelCatalog", () => {
     const spark = result.find((entry) => entry.id === "gpt-5.3-codex-spark");
     expect(spark?.name).toBe("gpt-5.3-codex-spark");
     expect(spark?.reasoning).toBe(true);
+  });
+
+  it("matches the canonical codex facts layer for gpt-5.4", async () => {
+    const factsModule = await loadCanonicalFactsModule();
+    if (!factsModule) {
+      return;
+    }
+
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          AuthStorage: class {},
+          ModelRegistry: class {
+            getAll() {
+              return [
+                {
+                  id: "gpt-5.3-codex",
+                  provider: "openai-codex",
+                  name: "GPT-5.3 Codex",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  contextWindow: 200000,
+                  maxTokens: 64000,
+                },
+              ];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+
+    const canonical = factsModule.getCanonicalForwardCompatModelFacts("openai-codex", "gpt-5.4");
+    expect(canonical).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.4",
+      name: "gpt-5.4",
+      contextWindow: 1_050_000,
+      maxTokens: 128_000,
+    });
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig });
+    const gpt54 = result.find(
+      (entry) => entry.provider === "openai-codex" && entry.id === "gpt-5.4",
+    );
+    expect(gpt54).toMatchObject({
+      provider: canonical.provider,
+      id: canonical.id,
+      name: canonical.name,
+      contextWindow: canonical.contextWindow,
+      maxTokens: canonical.maxTokens,
+    });
   });
 });

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -1,5 +1,6 @@
 import { type OpenClawConfig, loadConfig } from "../config/config.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
+import { applyCanonicalForwardCompatCatalogEntries } from "./model-facts.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
 
 export type ModelCatalogEntry = {
@@ -7,6 +8,7 @@ export type ModelCatalogEntry = {
   name: string;
   provider: string;
   contextWindow?: number;
+  maxTokens?: number;
   reasoning?: boolean;
   input?: Array<"text" | "image">;
 };
@@ -16,6 +18,7 @@ type DiscoveredModel = {
   name?: string;
   provider: string;
   contextWindow?: number;
+  maxTokens?: number;
   reasoning?: boolean;
   input?: Array<"text" | "image">;
 };
@@ -26,35 +29,6 @@ let modelCatalogPromise: Promise<ModelCatalogEntry[]> | null = null;
 let hasLoggedModelCatalogError = false;
 const defaultImportPiSdk = () => import("./pi-model-discovery.js");
 let importPiSdk = defaultImportPiSdk;
-
-const CODEX_PROVIDER = "openai-codex";
-const OPENAI_CODEX_GPT53_MODEL_ID = "gpt-5.3-codex";
-const OPENAI_CODEX_GPT53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
-
-function applyOpenAICodexSparkFallback(models: ModelCatalogEntry[]): void {
-  const hasSpark = models.some(
-    (entry) =>
-      entry.provider === CODEX_PROVIDER &&
-      entry.id.toLowerCase() === OPENAI_CODEX_GPT53_SPARK_MODEL_ID,
-  );
-  if (hasSpark) {
-    return;
-  }
-
-  const baseModel = models.find(
-    (entry) =>
-      entry.provider === CODEX_PROVIDER && entry.id.toLowerCase() === OPENAI_CODEX_GPT53_MODEL_ID,
-  );
-  if (!baseModel) {
-    return;
-  }
-
-  models.push({
-    ...baseModel,
-    id: OPENAI_CODEX_GPT53_SPARK_MODEL_ID,
-    name: OPENAI_CODEX_GPT53_SPARK_MODEL_ID,
-  });
-}
 
 export function resetModelCatalogCacheForTest() {
   modelCatalogPromise = null;
@@ -122,11 +96,13 @@ export async function loadModelCatalog(params?: {
           typeof entry?.contextWindow === "number" && entry.contextWindow > 0
             ? entry.contextWindow
             : undefined;
+        const maxTokens =
+          typeof entry?.maxTokens === "number" && entry.maxTokens > 0 ? entry.maxTokens : undefined;
         const reasoning = typeof entry?.reasoning === "boolean" ? entry.reasoning : undefined;
         const input = Array.isArray(entry?.input) ? entry.input : undefined;
-        models.push({ id, name, provider, contextWindow, reasoning, input });
+        models.push({ id, name, provider, contextWindow, maxTokens, reasoning, input });
       }
-      applyOpenAICodexSparkFallback(models);
+      applyCanonicalForwardCompatCatalogEntries(models);
 
       if (models.length === 0) {
         // If we found nothing, don't cache this result so we can try again.

--- a/src/agents/model-facts.ts
+++ b/src/agents/model-facts.ts
@@ -1,0 +1,142 @@
+import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
+
+type ModelInput = "text" | "image";
+
+export type CanonicalForwardCompatModelFacts = {
+  provider: string;
+  id: string;
+  name: string;
+  reasoning: boolean;
+  input: readonly ModelInput[];
+  contextWindow?: number;
+  maxTokens?: number;
+  fallbackContextWindow: number;
+  fallbackMaxTokens: number;
+  api: string;
+  baseUrl: string;
+  cost: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+  };
+  runtimeTemplateIds: readonly string[];
+  catalogBaseModelId?: string;
+};
+
+type CatalogEntryLike = {
+  id: string;
+  name: string;
+  provider: string;
+  contextWindow?: number;
+  maxTokens?: number;
+  reasoning?: boolean;
+  input?: Array<ModelInput>;
+};
+
+const OPENAI_CODEX_PROVIDER = "openai-codex";
+const OPENAI_CODEX_GPT53_MODEL_ID = "gpt-5.3-codex";
+const OPENAI_CODEX_GPT54_MODEL_ID = "gpt-5.4";
+const OPENAI_CODEX_GPT53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
+const OPENAI_CODEX_RUNTIME_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
+const OPENAI_CODEX_DEFAULT_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+} as const;
+
+const CANONICAL_FORWARD_COMPAT_MODEL_FACTS: readonly CanonicalForwardCompatModelFacts[] = [
+  {
+    provider: OPENAI_CODEX_PROVIDER,
+    id: OPENAI_CODEX_GPT53_MODEL_ID,
+    name: OPENAI_CODEX_GPT53_MODEL_ID,
+    reasoning: true,
+    input: ["text", "image"],
+    fallbackContextWindow: DEFAULT_CONTEXT_TOKENS,
+    fallbackMaxTokens: DEFAULT_CONTEXT_TOKENS,
+    api: "openai-codex-responses",
+    baseUrl: "https://chatgpt.com/backend-api",
+    cost: OPENAI_CODEX_DEFAULT_COST,
+    runtimeTemplateIds: OPENAI_CODEX_RUNTIME_TEMPLATE_MODEL_IDS,
+  },
+  {
+    provider: OPENAI_CODEX_PROVIDER,
+    id: OPENAI_CODEX_GPT54_MODEL_ID,
+    name: OPENAI_CODEX_GPT54_MODEL_ID,
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 1_050_000,
+    maxTokens: 128_000,
+    fallbackContextWindow: 1_050_000,
+    fallbackMaxTokens: 128_000,
+    api: "openai-codex-responses",
+    baseUrl: "https://chatgpt.com/backend-api",
+    cost: OPENAI_CODEX_DEFAULT_COST,
+    runtimeTemplateIds: OPENAI_CODEX_RUNTIME_TEMPLATE_MODEL_IDS,
+    catalogBaseModelId: OPENAI_CODEX_GPT53_MODEL_ID,
+  },
+  {
+    provider: OPENAI_CODEX_PROVIDER,
+    id: OPENAI_CODEX_GPT53_SPARK_MODEL_ID,
+    name: OPENAI_CODEX_GPT53_SPARK_MODEL_ID,
+    reasoning: true,
+    input: ["text", "image"],
+    fallbackContextWindow: DEFAULT_CONTEXT_TOKENS,
+    fallbackMaxTokens: DEFAULT_CONTEXT_TOKENS,
+    api: "openai-codex-responses",
+    baseUrl: "https://chatgpt.com/backend-api",
+    cost: OPENAI_CODEX_DEFAULT_COST,
+    runtimeTemplateIds: OPENAI_CODEX_RUNTIME_TEMPLATE_MODEL_IDS,
+    catalogBaseModelId: OPENAI_CODEX_GPT53_MODEL_ID,
+  },
+];
+
+function normalizeKey(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function getCanonicalForwardCompatModelFacts(
+  provider: string,
+  modelId: string,
+): CanonicalForwardCompatModelFacts | undefined {
+  const normalizedProvider = normalizeKey(provider);
+  const normalizedModelId = normalizeKey(modelId);
+  return CANONICAL_FORWARD_COMPAT_MODEL_FACTS.find(
+    (entry) => entry.provider === normalizedProvider && entry.id === normalizedModelId,
+  );
+}
+
+export function applyCanonicalForwardCompatCatalogEntries<T extends CatalogEntryLike>(
+  models: T[],
+): void {
+  for (const facts of CANONICAL_FORWARD_COMPAT_MODEL_FACTS) {
+    if (!facts.catalogBaseModelId) {
+      continue;
+    }
+    const hasExisting = models.some(
+      (entry) =>
+        normalizeKey(entry.provider) === facts.provider && normalizeKey(entry.id) === facts.id,
+    );
+    if (hasExisting) {
+      continue;
+    }
+
+    const baseModel = models.find(
+      (entry) =>
+        normalizeKey(entry.provider) === facts.provider &&
+        normalizeKey(entry.id) === facts.catalogBaseModelId,
+    );
+    if (!baseModel) {
+      continue;
+    }
+
+    models.push({
+      ...baseModel,
+      id: facts.id,
+      name: facts.name,
+      ...(typeof facts.contextWindow === "number" ? { contextWindow: facts.contextWindow } : {}),
+      ...(typeof facts.maxTokens === "number" ? { maxTokens: facts.maxTokens } : {}),
+    } as T);
+  }
+}

--- a/src/agents/model-facts.ts
+++ b/src/agents/model-facts.ts
@@ -135,6 +135,8 @@ export function applyCanonicalForwardCompatCatalogEntries<T extends CatalogEntry
       ...baseModel,
       id: facts.id,
       name: facts.name,
+      reasoning: facts.reasoning,
+      input: [...facts.input],
       ...(typeof facts.contextWindow === "number" ? { contextWindow: facts.contextWindow } : {}),
       ...(typeof facts.maxTokens === "number" ? { maxTokens: facts.maxTokens } : {}),
     } as T);

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -271,6 +271,56 @@ describe("resolveModel", () => {
     });
   });
 
+  it("overrides stale codex template metadata with canonical facts for gpt-5.4", async () => {
+    const factsModule = await loadCanonicalFactsModule();
+    if (!factsModule) {
+      return;
+    }
+
+    const templateModel = {
+      id: "gpt-5.2-codex",
+      name: "GPT-5.2 Codex",
+      provider: "openai-codex",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      reasoning: false,
+      input: ["text"] as const,
+      cost: { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+      contextWindow: 272000,
+      maxTokens: 128000,
+    };
+
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn((provider: string, modelId: string) => {
+        if (provider === "openai-codex" && modelId === "gpt-5.2-codex") {
+          return templateModel;
+        }
+        return null;
+      }),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const canonical = factsModule.getCanonicalForwardCompatModelFacts("openai-codex", "gpt-5.4");
+    expect(canonical).toMatchObject({
+      reasoning: true,
+      input: ["text", "image"],
+    });
+
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: canonical.provider,
+      id: canonical.id,
+      name: canonical.name,
+      api: canonical.api,
+      baseUrl: canonical.baseUrl,
+      reasoning: canonical.reasoning,
+      input: canonical.input,
+      contextWindow: canonical.contextWindow,
+      maxTokens: canonical.maxTokens,
+    });
+  });
+
   it("builds an anthropic forward-compat fallback for claude-opus-4-6", () => {
     const templateModel = {
       id: "claude-opus-4-5",

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -19,6 +19,15 @@ const makeModel = (id: string) => ({
   maxTokens: 1,
 });
 
+async function loadCanonicalFactsModule() {
+  const module = await import("../model-facts.js").catch(() => null);
+  if (!module?.getCanonicalForwardCompatModelFacts) {
+    expect(module?.getCanonicalForwardCompatModelFacts).toBeTypeOf("function");
+    return null;
+  }
+  return module;
+}
+
 beforeEach(() => {
   vi.mocked(discoverModels).mockReturnValue({
     find: vi.fn(() => null),
@@ -209,6 +218,59 @@ describe("resolveModel", () => {
     });
   });
 
+  it("uses the canonical codex facts layer for gpt-5.4 fallback resolution", async () => {
+    const factsModule = await loadCanonicalFactsModule();
+    if (!factsModule) {
+      return;
+    }
+
+    const templateModel = {
+      id: "gpt-5.2-codex",
+      name: "GPT-5.2 Codex",
+      provider: "openai-codex",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      reasoning: true,
+      input: ["text", "image"] as const,
+      cost: { input: 1.75, output: 14, cacheRead: 0.175, cacheWrite: 0 },
+      contextWindow: 272000,
+      maxTokens: 128000,
+    };
+
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn((provider: string, modelId: string) => {
+        if (provider === "openai-codex" && modelId === "gpt-5.2-codex") {
+          return templateModel;
+        }
+        return null;
+      }),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const canonical = factsModule.getCanonicalForwardCompatModelFacts("openai-codex", "gpt-5.4");
+    expect(canonical).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.4",
+      name: "gpt-5.4",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      contextWindow: 1_050_000,
+      maxTokens: 128_000,
+    });
+
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent");
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: canonical.provider,
+      id: canonical.id,
+      name: canonical.name,
+      api: canonical.api,
+      baseUrl: canonical.baseUrl,
+      contextWindow: canonical.contextWindow,
+      maxTokens: canonical.maxTokens,
+    });
+  });
+
   it("builds an anthropic forward-compat fallback for claude-opus-4-6", () => {
     const templateModel = {
       id: "claude-opus-4-5",
@@ -351,5 +413,30 @@ describe("resolveModel", () => {
     expect(result.model?.api).toBe("openai-codex-responses");
     expect(result.model?.id).toBe("gpt-5.3-codex");
     expect(result.model?.provider).toBe("openai-codex");
+  });
+
+  it("uses codex fallback for gpt-5.4 even when openai-codex provider is configured", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          "openai-codex": {
+            baseUrl: "https://custom.example.com",
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    vi.mocked(discoverModels).mockReturnValue({
+      find: vi.fn(() => null),
+    } as unknown as ReturnType<typeof discoverModels>);
+
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model?.api).toBe("openai-codex-responses");
+    expect(result.model?.id).toBe("gpt-5.4");
+    expect(result.model?.provider).toBe("openai-codex");
+    expect(result.model?.contextWindow).toBe(1_050_000);
+    expect(result.model?.maxTokens).toBe(128_000);
   });
 });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -26,7 +26,7 @@ const ANTHROPIC_OPUS_46_MODEL_ID = "claude-opus-4-6";
 const ANTHROPIC_OPUS_46_DOT_MODEL_ID = "claude-opus-4.6";
 const ANTHROPIC_OPUS_TEMPLATE_MODEL_IDS = ["claude-opus-4-5", "claude-opus-4.5"] as const;
 
-function resolveOpenAICodexGpt53FallbackModel(
+function resolveOpenAICodexForwardCompatModel(
   provider: string,
   modelId: string,
   modelRegistry: ModelRegistry,
@@ -50,6 +50,8 @@ function resolveOpenAICodexGpt53FallbackModel(
       ...template,
       id: trimmedModelId,
       name: trimmedModelId,
+      reasoning: facts.reasoning,
+      input: [...facts.input],
       ...(typeof facts.contextWindow === "number" ? { contextWindow: facts.contextWindow } : {}),
       ...(typeof facts.maxTokens === "number" ? { maxTokens: facts.maxTokens } : {}),
     } as Model<Api>);
@@ -260,10 +262,10 @@ export function resolveModel(
         modelRegistry,
       };
     }
-    // Codex gpt-5.3 forward-compat fallback must be checked BEFORE the generic providerCfg fallback.
+    // Codex forward-compat fallback must be checked BEFORE the generic providerCfg fallback.
     // Otherwise, if cfg.models.providers["openai-codex"] is configured, the generic fallback fires
     // with api: "openai-responses" instead of the correct "openai-codex-responses".
-    const codexForwardCompat = resolveOpenAICodexGpt53FallbackModel(
+    const codexForwardCompat = resolveOpenAICodexForwardCompatModel(
       provider,
       modelId,
       modelRegistry,

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -4,6 +4,7 @@ import type { ModelDefinitionConfig } from "../../config/types.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { normalizeModelCompat } from "../model-compat.js";
+import { getCanonicalForwardCompatModelFacts } from "../model-facts.js";
 import { normalizeProviderId } from "../model-selection.js";
 import {
   discoverAuthStorage,
@@ -18,11 +19,6 @@ type InlineProviderConfig = {
   api?: ModelDefinitionConfig["api"];
   models?: ModelDefinitionConfig[];
 };
-
-const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
-const OPENAI_CODEX_GPT_53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
-
-const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
 
 // pi-ai's built-in Anthropic catalog can lag behind OpenClaw's defaults/docs.
 // Add forward-compat fallbacks for known-new IDs by cloning an older template model.
@@ -40,15 +36,12 @@ function resolveOpenAICodexGpt53FallbackModel(
   if (normalizedProvider !== "openai-codex") {
     return undefined;
   }
-  const loweredModelId = trimmedModelId.toLowerCase();
-  if (
-    loweredModelId !== OPENAI_CODEX_GPT_53_MODEL_ID &&
-    loweredModelId !== OPENAI_CODEX_GPT_53_SPARK_MODEL_ID
-  ) {
+  const facts = getCanonicalForwardCompatModelFacts(normalizedProvider, trimmedModelId);
+  if (!facts) {
     return undefined;
   }
 
-  for (const templateId of OPENAI_CODEX_TEMPLATE_MODEL_IDS) {
+  for (const templateId of facts.runtimeTemplateIds) {
     const template = modelRegistry.find(normalizedProvider, templateId) as Model<Api> | null;
     if (!template) {
       continue;
@@ -57,20 +50,22 @@ function resolveOpenAICodexGpt53FallbackModel(
       ...template,
       id: trimmedModelId,
       name: trimmedModelId,
+      ...(typeof facts.contextWindow === "number" ? { contextWindow: facts.contextWindow } : {}),
+      ...(typeof facts.maxTokens === "number" ? { maxTokens: facts.maxTokens } : {}),
     } as Model<Api>);
   }
 
   return normalizeModelCompat({
     id: trimmedModelId,
     name: trimmedModelId,
-    api: "openai-codex-responses",
-    provider: normalizedProvider,
-    baseUrl: "https://chatgpt.com/backend-api",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_TOKENS,
-    maxTokens: DEFAULT_CONTEXT_TOKENS,
+    api: facts.api,
+    provider: facts.provider,
+    baseUrl: facts.baseUrl,
+    reasoning: facts.reasoning,
+    input: [...facts.input],
+    cost: { ...facts.cost },
+    contextWindow: facts.fallbackContextWindow,
+    maxTokens: facts.fallbackMaxTokens,
   } as Model<Api>);
 }
 


### PR DESCRIPTION
User Impact

Users trying newer Codex models such as `openai-codex/gpt-5.4` could see capability drift between what the catalog listed and what runtime actually used, especially around reasoning/image capability and forward-compat fallback behavior. This phase makes catalog and runtime agree on the same canonical codex facts.

## Summary
- phase 1 of the RFC #37804 follow-up: unify canonical codex forward-compat facts under `src/agents`
- make `model-catalog` and embedded runtime resolution consume the same codex facts layer
- add regression coverage for shared `gpt-5.4` facts and codex transport/limit ordering

## Context
- tracking RFC: #37804
- implementation intent comment: https://github.com/openclaw/openclaw/issues/37804#issuecomment-4012460694
- this PR is intentionally limited to the `src/agents` fact-source layer; CLI / auto-reply / picker consumer migration is deferred to later phases

## Test Plan
- `pnpm exec vitest run src/agents/model-catalog.test.ts src/agents/pi-embedded-runner/model.test.ts src/agents/model-selection.test.ts`
- `pnpm tsgo`

---
Related: #37804 (RFC: treat models.providers-injected models as first-class forward-compat models)
Ref: #37623 (openai-codex/gpt-5.4 configurable but not supported in runtime)