### PR TITLE
fix(discord): process forwarded-only messages

### DIFF
--- a/src/discord/monitor/message-handler.queue.test.ts
+++ b/src/discord/monitor/message-handler.queue.test.ts
@@ -84,6 +84,36 @@ function createMessageData(messageId: string, channelId = "ch-1") {
   };
 }
 
+function createForwardedOnlyMessageData(messageId: string, channelId = "ch-1") {
+  return {
+    channel_id: channelId,
+    author: { id: "user-1" },
+    message: {
+      id: messageId,
+      author: { id: "user-1", bot: false },
+      content: "",
+      channel_id: channelId,
+      attachments: [],
+      rawData: {
+        message_snapshots: [
+          {
+            message: {
+              content: "forwarded hello",
+              embeds: [],
+              attachments: [],
+              author: {
+                id: "u2",
+                username: "Bob",
+                discriminator: "0",
+              },
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
 function createPreflightContext(channelId = "ch-1") {
   return {
     data: {
@@ -108,6 +138,26 @@ function createPreflightContext(channelId = "ch-1") {
 }
 
 describe("createDiscordMessageHandler queue behavior", () => {
+  it("does not drop forwarded-only messages at the debounce layer", async () => {
+    preflightDiscordMessageMock.mockReset();
+    processDiscordMessageMock.mockReset();
+
+    preflightDiscordMessageMock.mockImplementation(async () => createPreflightContext("ch-1"));
+
+    const params = createHandlerParams();
+    // Ensure the debounce layer is exercised (it would be bypassed with debounceMs=0).
+    params.cfg.messages = { inbound: { debounceMs: 10 } };
+    const handler = createDiscordMessageHandler(params);
+
+    await expect(
+      handler(createForwardedOnlyMessageData("m-fwd") as never, {} as never),
+    ).resolves.toBeUndefined();
+
+    await vi.waitFor(() => {
+      expect(preflightDiscordMessageMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("resets busy counters when the handler is created", () => {
     preflightDiscordMessageMock.mockReset();
     processDiscordMessageMock.mockReset();

--- a/src/discord/monitor/message-handler.ts
+++ b/src/discord/monitor/message-handler.ts
@@ -76,9 +76,9 @@ export function createDiscordMessageHandler(
       if (!message) {
         return false;
       }
-      const baseText = resolveDiscordMessageText(message, { includeForwarded: false });
+      const text = resolveDiscordMessageText(message, { includeForwarded: true });
       return shouldDebounceTextInbound({
-        text: baseText,
+        text,
         cfg: params.cfg,
         hasMedia: Boolean(
           (message.attachments && message.attachments.length > 0) ||
@@ -110,13 +110,13 @@ export function createDiscordMessageHandler(
         inboundWorker.enqueue(buildDiscordInboundJob(ctx));
         return;
       }
-      const combinedBaseText = entries
-        .map((entry) => resolveDiscordMessageText(entry.data.message, { includeForwarded: false }))
+      const combinedText = entries
+        .map((entry) => resolveDiscordMessageText(entry.data.message, { includeForwarded: true }))
         .filter(Boolean)
         .join("\n");
       const syntheticMessage = {
         ...last.data.message,
-        content: combinedBaseText,
+        content: combinedText,
         attachments: [],
         message_snapshots: (last.data.message as { message_snapshots?: unknown }).message_snapshots,
         messageSnapshots: (last.data.message as { messageSnapshots?: unknown }).messageSnapshots,


### PR DESCRIPTION
Fixes debounce text extraction to include forwarded message snapshots so forwarded text-only messages (with empty user content) aren't dropped before preflight.

Closes #37983