### PR TITLE
fix(tools): surface detailed error diagnostics for web_search fetch failures

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -15,6 +15,7 @@ const {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  summarizeNetworkError,
 } = __testing;
 
 describe("web_search brave language param normalization", () => {
@@ -269,5 +270,47 @@ describe("extractKimiCitations", () => {
         ],
       }).toSorted(),
     ).toEqual(["https://example.com/a", "https://example.com/b", "https://example.com/c"]);
+  });
+});
+
+describe("summarizeNetworkError", () => {
+  it("extracts code and cause from Node.js fetch errors", () => {
+    const cause = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:7890"), {
+      code: "ECONNREFUSED",
+    });
+    const err = new Error("fetch failed", { cause });
+    const result = summarizeNetworkError(err);
+    expect(result.message).toBe("fetch failed: connect ECONNREFUSED 127.0.0.1:7890");
+    expect(result.code).toBe("ECONNREFUSED");
+    expect(result.hint).toContain("proxy");
+  });
+
+  it("provides DNS hint for ENOTFOUND", () => {
+    const cause = Object.assign(new Error("getaddrinfo ENOTFOUND api.search.brave.com"), {
+      code: "ENOTFOUND",
+    });
+    const result = summarizeNetworkError(new Error("fetch failed", { cause }));
+    expect(result.code).toBe("ENOTFOUND");
+    expect(result.hint).toContain("DNS");
+  });
+
+  it("provides timeout hint for ETIMEDOUT", () => {
+    const cause = Object.assign(new Error("connect ETIMEDOUT"), { code: "ETIMEDOUT" });
+    const result = summarizeNetworkError(new Error("fetch failed", { cause }));
+    expect(result.code).toBe("ETIMEDOUT");
+    expect(result.hint).toContain("timed out");
+  });
+
+  it("provides generic hint for bare 'fetch failed' with no cause", () => {
+    const result = summarizeNetworkError(new Error("fetch failed"));
+    expect(result.message).toBe("fetch failed");
+    expect(result.code).toBeUndefined();
+    expect(result.hint).toContain("Generic fetch failure");
+  });
+
+  it("handles non-Error values gracefully", () => {
+    const result = summarizeNetworkError("something broke");
+    expect(result.message).toBe("something broke");
+    expect(result.code).toBeUndefined();
   });
 });

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -2,7 +2,8 @@ import { Type } from "@sinclair/typebox";
 import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
-import { logVerbose } from "../../globals.js";
+import { logVerbose, logWarn } from "../../globals.js";
+import { SsrFBlockedError } from "../../infra/net/ssrf.js";
 import { wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import type { AnyAgentTool } from "./common.js";
@@ -20,6 +21,41 @@ import {
   resolveTimeoutSeconds,
   writeCache,
 } from "./web-shared.js";
+
+function summarizeNetworkError(err: unknown): {
+  message: string;
+  code?: string;
+  hint?: string;
+} {
+  const msg = err instanceof Error ? err.message : String(err);
+  const cause = err instanceof Error ? (err.cause as Error | undefined) : undefined;
+  const causeMsg = cause instanceof Error ? cause.message : undefined;
+  const code =
+    cause && typeof cause === "object" && "code" in cause && typeof cause.code === "string"
+      ? cause.code
+      : undefined;
+
+  const detail = causeMsg ? `${msg}: ${causeMsg}` : msg;
+
+  let hint: string | undefined;
+  if (code === "ECONNREFUSED" || code === "ECONNRESET") {
+    hint =
+      "Connection refused or reset. If you use an HTTP proxy (HTTP_PROXY / HTTPS_PROXY env), ensure it is running and reachable.";
+  } else if (code === "ENOTFOUND") {
+    hint = "DNS lookup failed. Check that the host is reachable and DNS is configured correctly.";
+  } else if (code === "ETIMEDOUT" || code === "UND_ERR_CONNECT_TIMEOUT") {
+    hint =
+      "Connection timed out. Try increasing tools.web.search.timeoutSeconds or check network connectivity.";
+  } else if (/proxy/i.test(detail)) {
+    hint =
+      "The error mentions a proxy. Check HTTP_PROXY / HTTPS_PROXY environment variables and ensure the proxy is accessible.";
+  } else if (msg === "fetch failed" && !causeMsg) {
+    hint =
+      "Generic fetch failure. If you use a system proxy (e.g., Clash, Surge), ensure it is running. Set HTTPS_PROXY or HTTP_PROXY if direct access is available, or unset them if the proxy is down.";
+  }
+
+  return { message: detail, code, hint };
+}
 
 const SEARCH_PROVIDERS = ["brave", "perplexity", "grok", "gemini", "kimi"] as const;
 const DEFAULT_SEARCH_COUNT = 5;
@@ -1638,30 +1674,48 @@ export function createWebSearchTool(options?: {
       const maxTokens = readNumberParam(params, "max_tokens", { integer: true });
       const maxTokensPerPage = readNumberParam(params, "max_tokens_per_page", { integer: true });
 
-      const result = await runWebSearch({
-        query,
-        count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
-        apiKey,
-        timeoutSeconds: resolveTimeoutSeconds(search?.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS),
-        cacheTtlMs: resolveCacheTtlMs(search?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
-        provider,
-        country,
-        language,
-        search_lang: resolvedSearchLang,
-        ui_lang: resolvedUiLang,
-        freshness,
-        dateAfter,
-        dateBefore,
-        searchDomainFilter: domainFilter,
-        maxTokens: maxTokens ?? undefined,
-        maxTokensPerPage: maxTokensPerPage ?? undefined,
-        grokModel: resolveGrokModel(grokConfig),
-        grokInlineCitations: resolveGrokInlineCitations(grokConfig),
-        geminiModel: resolveGeminiModel(geminiConfig),
-        kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
-        kimiModel: resolveKimiModel(kimiConfig),
-      });
-      return jsonResult(result);
+      try {
+        const result = await runWebSearch({
+          query,
+          count: resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
+          apiKey,
+          timeoutSeconds: resolveTimeoutSeconds(search?.timeoutSeconds, DEFAULT_TIMEOUT_SECONDS),
+          cacheTtlMs: resolveCacheTtlMs(search?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
+          provider,
+          country,
+          language,
+          search_lang: resolvedSearchLang,
+          ui_lang: resolvedUiLang,
+          freshness,
+          dateAfter,
+          dateBefore,
+          searchDomainFilter: domainFilter,
+          maxTokens: maxTokens ?? undefined,
+          maxTokensPerPage: maxTokensPerPage ?? undefined,
+          grokModel: resolveGrokModel(grokConfig),
+          grokInlineCitations: resolveGrokInlineCitations(grokConfig),
+          geminiModel: resolveGeminiModel(geminiConfig),
+          kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
+          kimiModel: resolveKimiModel(kimiConfig),
+        });
+        return jsonResult(result);
+      } catch (err) {
+        if (err instanceof SsrFBlockedError) {
+          throw err;
+        }
+        const summary = summarizeNetworkError(err);
+        logWarn(
+          `web_search (${provider}): network error for query="${query}": ${summary.message}${summary.code ? ` [${summary.code}]` : ""}`,
+        );
+        return jsonResult({
+          error: "fetch_failed",
+          provider,
+          message: summary.message,
+          ...(summary.code ? { code: summary.code } : {}),
+          ...(summary.hint ? { hint: summary.hint } : {}),
+          docs: "https://docs.openclaw.ai/tools/web",
+        });
+      }
     },
   };
 }
@@ -1684,4 +1738,5 @@ export const __testing = {
   resolveKimiBaseUrl,
   extractKimiCitations,
   resolveRedirectUrl: resolveCitationRedirectUrl,
+  summarizeNetworkError,
 } as const;


### PR DESCRIPTION
## Summary

- **Problem:** `web_search` tool returns a bare "fetch failed" error when the underlying HTTP request fails (e.g., proxy misconfiguration, DNS failure, connection timeout), providing no diagnostic context for users to troubleshoot.
- **Why it matters:** Users cannot determine whether the failure is due to a broken proxy, DNS misconfiguration, network timeout, or other connectivity issue. The `web_fetch` tool works fine while `web_search` fails, and the error message gives no clue why.
- **What changed:** Added a `summarizeNetworkError` helper that extracts the error cause chain from Node.js fetch errors (including `cause.code` like `ECONNREFUSED`, `ENOTFOUND`, `ETIMEDOUT`) and provides actionable hints. Wrapped the `runWebSearch` call in the tool's `execute` function with a try/catch that returns a structured JSON error response instead of letting the raw error propagate.
- **What did NOT change:** No changes to the actual fetch/proxy/SSRF logic. `SsrFBlockedError` is re-thrown as before. All existing behavior is preserved — only the error reporting path is improved.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38155

## User-visible / Behavior Changes

- `web_search` now returns a structured JSON error with `error: "fetch_failed"`, the provider name, detailed error message, error code (if available), and an actionable hint instead of a raw "fetch failed" string.
- Gateway log now includes a `warn` entry with the provider, query, and error details when a web search network failure occurs.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+
- Integration/channel: Any (web_search tool)

### Steps

1. Configure `tools.web.search.provider: "brave"` with a valid API key
2. Set `HTTP_PROXY` to a non-running proxy (e.g., `http://127.0.0.1:9999`)
3. Ask the agent to use `web_search`

### Expected

- Structured error response with error code, message, and hint about proxy configuration

### Actual

- Before fix: Raw "fetch failed" with no context
- After fix: `{ error: "fetch_failed", provider: "brave", message: "fetch failed: connect ECONNREFUSED 127.0.0.1:9999", code: "ECONNREFUSED", hint: "Connection refused or reset. If you use an HTTP proxy..." }`

## Evidence

```typescript
// New error response format:
{
  error: "fetch_failed",
  provider: "brave",
  message: "fetch failed: connect ECONNREFUSED 127.0.0.1:7890",
  code: "ECONNREFUSED",
  hint: "Connection refused or reset. If you use an HTTP proxy (HTTP_PROXY / HTTPS_PROXY env), ensure it is running and reachable.",
  docs: "https://docs.openclaw.ai/tools/web"
}
```

Test results: 33/33 tests pass (5 new tests for `summarizeNetworkError`).

## Human Verification (required)

- Verified scenarios: ECONNREFUSED, ENOTFOUND, ETIMEDOUT, bare "fetch failed", non-Error values
- Edge cases checked: SsrFBlockedError is re-thrown (not caught), cause chain extraction with missing fields
- What I did **not** verify: End-to-end with actual broken proxy (unit tests mock the error shapes)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; the error will propagate as before
- Files/config to restore: `src/agents/tools/web-search.ts`
- Known bad symptoms: None — this only adds error handling, does not change success paths

## Risks and Mitigations

None — purely additive error handling improvement.
