### PR TITLE
fix(tools): surface detailed error cause in web_search fetch failures

### DIFF
--- a/src/agents/tools/web-search.test.ts
+++ b/src/agents/tools/web-search.test.ts
@@ -15,6 +15,7 @@ const {
   resolveKimiModel,
   resolveKimiBaseUrl,
   extractKimiCitations,
+  extractErrorCause,
 } = __testing;
 
 describe("web_search brave language param normalization", () => {
@@ -243,6 +244,33 @@ describe("web_search kimi config resolution", () => {
   it("resolves default model and baseUrl", () => {
     expect(resolveKimiModel({})).toBe("moonshot-v1-128k");
     expect(resolveKimiBaseUrl({})).toBe("https://api.moonshot.ai/v1");
+  });
+});
+
+describe("extractErrorCause", () => {
+  it("returns plain message for simple errors", () => {
+    expect(extractErrorCause(new Error("fetch failed"))).toBe("fetch failed");
+  });
+
+  it("includes cause code and message", () => {
+    const cause = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:7890"), {
+      code: "ECONNREFUSED",
+    });
+    const err = Object.assign(new TypeError("fetch failed"), { cause });
+    expect(extractErrorCause(err)).toBe(
+      "fetch failed — ECONNREFUSED: connect ECONNREFUSED 127.0.0.1:7890",
+    );
+  });
+
+  it("includes cause message without code", () => {
+    const cause = new Error("socket hang up");
+    const err = Object.assign(new TypeError("fetch failed"), { cause });
+    expect(extractErrorCause(err)).toBe("fetch failed — socket hang up");
+  });
+
+  it("handles non-Error values", () => {
+    expect(extractErrorCause("some string")).toBe("some string");
+    expect(extractErrorCause(42)).toBe("42");
   });
 });
 

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -3,6 +3,7 @@ import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
 import { logVerbose } from "../../globals.js";
+import { hasProxyEnvConfigured } from "../../infra/net/proxy-env.js";
 import { wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import type { AnyAgentTool } from "./common.js";
@@ -674,6 +675,23 @@ function resolveGeminiModel(gemini?: GeminiConfig): string {
   return fromConfig || DEFAULT_GEMINI_MODEL;
 }
 
+function extractErrorCause(err: unknown): string {
+  if (!(err instanceof Error)) {
+    return String(err);
+  }
+  const parts: string[] = [err.message];
+  const cause = (err as Error & { cause?: unknown }).cause;
+  if (cause instanceof Error) {
+    const code = (cause as Error & { code?: string }).code;
+    if (code) {
+      parts.push(`${code}: ${cause.message}`);
+    } else {
+      parts.push(cause.message);
+    }
+  }
+  return parts.join(" — ");
+}
+
 async function withTrustedWebSearchEndpoint<T>(
   params: {
     url: string;
@@ -682,14 +700,23 @@ async function withTrustedWebSearchEndpoint<T>(
   },
   run: (response: Response) => Promise<T>,
 ): Promise<T> {
-  return withTrustedWebToolsEndpoint(
-    {
-      url: params.url,
-      init: params.init,
-      timeoutSeconds: params.timeoutSeconds,
-    },
-    async ({ response }) => run(response),
-  );
+  try {
+    return await withTrustedWebToolsEndpoint(
+      {
+        url: params.url,
+        init: params.init,
+        timeoutSeconds: params.timeoutSeconds,
+        auditContext: "web_search",
+      },
+      async ({ response }) => run(response),
+    );
+  } catch (err) {
+    const detail = extractErrorCause(err);
+    const proxyHint = hasProxyEnvConfigured()
+      ? " (HTTP_PROXY / HTTPS_PROXY is set — verify the proxy is reachable from the gateway process)"
+      : "";
+    throw new Error(`web_search request failed: ${detail}${proxyHint}`, { cause: err });
+  }
 }
 
 async function runGeminiSearch(params: {
@@ -1684,4 +1711,5 @@ export const __testing = {
   resolveKimiBaseUrl,
   extractKimiCitations,
   resolveRedirectUrl: resolveCitationRedirectUrl,
+  extractErrorCause,
 } as const;


### PR DESCRIPTION
## Summary

Surfaces the full error cause chain in web_search fetch failures instead of the generic "fetch failed" message. Adds audit context for security logging and a diagnostic hint when proxy env vars are detected but may be misconfigured.

## Problem

When `web_search` fails (e.g. due to an unreachable `HTTP_PROXY`), users only see `"fetch failed"` with no actionable detail. Meanwhile, `web_fetch` works fine because it uses a different fetch mode. The error cause (e.g. `ECONNREFUSED`, `ETIMEDOUT`) is present in the error chain but never surfaced.

## Changes

| File | Change |
|------|--------|
| `src/agents/tools/web-search.ts` | Import `hasProxyEnvConfigured`; add `extractErrorCause()` helper to unwrap error cause chains; wrap `withTrustedWebSearchEndpoint` with try/catch that surfaces detailed error message with proxy hint when env proxy is configured; add `auditContext: "web_search"` to fetch calls; export `extractErrorCause` via `__testing` |
| `src/agents/tools/web-search.test.ts` | Add 4 tests for `extractErrorCause`: simple error, error with cause code, error with cause message only, non-Error values |

## Example

Before:
```
{ "status": "error", "tool": "web_search", "error": "fetch failed" }
```

After:
```
{ "status": "error", "tool": "web_search", "error": "web_search request failed: fetch failed — ECONNREFUSED: connect ECONNREFUSED 127.0.0.1:7890 (HTTP_PROXY / HTTPS_PROXY is set — verify the proxy is reachable from the gateway process)" }
```

## Test plan

- [x] `npx vitest run src/agents/tools/web-search.test.ts` — 32/32 passing
- [ ] Manual: set `HTTP_PROXY` to an unreachable address, trigger `web_search`, verify detailed error message
- [ ] Manual: unset proxy env vars, trigger `web_search` with valid Brave API key, verify normal operation

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **No** — fetch behavior is unchanged; only error reporting is improved
- Does this change introduce new dependencies? **No**

## Human Verification

1. Set `HTTP_PROXY=http://127.0.0.1:9999` (unreachable), run `web_search` → verify error includes cause detail and proxy hint
2. Unset `HTTP_PROXY`, run `web_search` with valid Brave API key → verify normal results
3. Set `HTTP_PROXY` to a working proxy, run `web_search` → verify results return normally

## Failure Recovery

Revert the commit — no config or schema changes involved.

## Risks and Mitigations

- **Risk**: Error messages may leak internal proxy addresses to the agent/user
  **Mitigation**: The proxy address is already visible in the process env; the error message only surfaces what the user already configured. The `auditContext` ensures security-blocked requests are properly logged server-side.