### PR TITLE
fix(cron): persist cron state before gateway shutdown

### DIFF
--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -18,6 +18,10 @@ export class CronService {
     ops.stop(this.state);
   }
 
+  async flush() {
+    await ops.flush(this.state);
+  }
+
   async status() {
     return await ops.status(this.state);
   }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -131,6 +131,12 @@ export function stop(state: CronServiceState) {
   stopTimer(state);
 }
 
+export async function flush(state: CronServiceState) {
+  await locked(state, async () => {
+    await persist(state);
+  });
+}
+
 export async function status(state: CronServiceState) {
   return await locked(state, async () => {
     await ensureLoadedForRead(state);

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -13,7 +13,7 @@ export function createGatewayCloseHandler(params: {
   canvasHostServer: CanvasHostServer | null;
   stopChannel: (name: ChannelId, accountId?: string) => Promise<void>;
   pluginServices: PluginServicesHandle | null;
-  cron: { stop: () => void };
+  cron: { flush: () => Promise<void>; stop: () => void };
   heartbeatRunner: HeartbeatRunner;
   updateCheckStop?: (() => void) | null;
   nodePresenceTimers: Map<string, ReturnType<typeof setInterval>>;
@@ -69,7 +69,12 @@ export function createGatewayCloseHandler(params: {
       await params.pluginServices.stop().catch(() => {});
     }
     await stopGmailWatcher();
-    params.cron.stop();
+    try {
+    await params.cron.flush();
+  } catch {
+    // best-effort flush
+  }
+  params.cron.stop();
     params.heartbeatRunner.stop();
     try {
       params.updateCheckStop?.();


### PR DESCRIPTION
## Summary
Fixes #38137

Flushes cron job state to disk before gateway shutdown, preventing jobs created shortly before a restart from being silently lost.

## Changes
- **src/cron/service/ops.ts**: Added `flush()` function that acquires lock and calls `persist()`
- **src/cron/service.ts**: Exposed `flush()` as public method on CronService
- **src/gateway/server-close.ts**: 
  - Added `flush: () => Promise<void>` to cron type definition
  - Call `await params.cron.flush()` (best-effort, try/catch) before `cron.stop()`

## Test Plan
- TypeScript compilation passes
- Job added → flush → stop → loadCronStore → job exists on disk
- Manual: create cron job, immediately restart gateway, verify job survives

## Security Impact
- Does not affect authentication/authorization
- Writes to existing `jobs.json` file during shutdown (same write path as normal operation)
- No new dependencies

🤖 Generated by ql-agent