### PR TITLE
fix(agents): use per-model maxCompletionTokens from Venice API instead of hardcoded 8192

### DIFF
--- a/src/agents/venice-models.test.ts
+++ b/src/agents/venice-models.test.ts
@@ -3,7 +3,10 @@ import {
   buildVeniceModelDefinition,
   discoverVeniceModels,
   VENICE_MODEL_CATALOG,
+  __testing,
 } from "./venice-models.js";
+
+const { resolveApiMaxCompletionTokens, VENICE_DEFAULT_MAX_TOKENS } = __testing;
 
 const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
 const ORIGINAL_VITEST = process.env.VITEST;
@@ -32,7 +35,7 @@ async function runWithDiscoveryEnabled<T>(operation: () => Promise<T>): Promise<
   }
 }
 
-function makeModelsResponse(id: string): Response {
+function makeModelsResponse(id: string, opts?: { maxCompletionTokens?: number }): Response {
   return new Response(
     JSON.stringify({
       data: [
@@ -42,6 +45,9 @@ function makeModelsResponse(id: string): Response {
             name: id,
             privacy: "private",
             availableContextTokens: 131072,
+            ...(opts?.maxCompletionTokens !== undefined && {
+              maxCompletionTokens: opts.maxCompletionTokens,
+            }),
             capabilities: {
               supportsReasoning: false,
               supportsVision: false,
@@ -94,6 +100,40 @@ describe("venice-models", () => {
     expect(models.map((m) => m.id)).toContain("llama-3.3-70b");
   });
 
+  it("uses API maxCompletionTokens for catalog models when present", async () => {
+    const fetchMock = vi.fn(async () =>
+      makeModelsResponse("llama-3.3-70b", { maxCompletionTokens: 4096 }),
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const models = await runWithDiscoveryEnabled(() => discoverVeniceModels());
+    const llama = models.find((m) => m.id === "llama-3.3-70b");
+    expect(llama).toBeDefined();
+    expect(llama!.maxTokens).toBe(4096);
+  });
+
+  it("uses API maxCompletionTokens for non-catalog models", async () => {
+    const fetchMock = vi.fn(async () =>
+      makeModelsResponse("new-model-2026", { maxCompletionTokens: 2048 }),
+    );
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const models = await runWithDiscoveryEnabled(() => discoverVeniceModels());
+    const newModel = models.find((m) => m.id === "new-model-2026");
+    expect(newModel).toBeDefined();
+    expect(newModel!.maxTokens).toBe(2048);
+  });
+
+  it("falls back to conservative default when API omits maxCompletionTokens for non-catalog models", async () => {
+    const fetchMock = vi.fn(async () => makeModelsResponse("unknown-model"));
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const models = await runWithDiscoveryEnabled(() => discoverVeniceModels());
+    const unknownModel = models.find((m) => m.id === "unknown-model");
+    expect(unknownModel).toBeDefined();
+    expect(unknownModel!.maxTokens).toBe(VENICE_DEFAULT_MAX_TOKENS);
+  });
+
   it("falls back to static catalog after retry budget is exhausted", async () => {
     const fetchMock = vi.fn(async () => {
       throw Object.assign(new TypeError("fetch failed"), {
@@ -106,5 +146,41 @@ describe("venice-models", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(models).toHaveLength(VENICE_MODEL_CATALOG.length);
     expect(models.map((m) => m.id)).toEqual(VENICE_MODEL_CATALOG.map((m) => m.id));
+  });
+});
+
+describe("resolveApiMaxCompletionTokens", () => {
+  const makeModel = (maxCompletionTokens?: number | null) =>
+    ({
+      id: "test",
+      model_spec: {
+        name: "test",
+        privacy: "private" as const,
+        availableContextTokens: 128000,
+        ...(maxCompletionTokens !== null && { maxCompletionTokens }),
+        capabilities: {
+          supportsReasoning: false,
+          supportsVision: false,
+          supportsFunctionCalling: true,
+        },
+      },
+    }) as Parameters<typeof resolveApiMaxCompletionTokens>[0];
+
+  it("returns the value when present and valid", () => {
+    expect(resolveApiMaxCompletionTokens(makeModel(4096))).toBe(4096);
+  });
+
+  it("returns undefined when missing", () => {
+    expect(resolveApiMaxCompletionTokens(makeModel(null))).toBeUndefined();
+  });
+
+  it("returns undefined for non-finite values", () => {
+    expect(resolveApiMaxCompletionTokens(makeModel(NaN))).toBeUndefined();
+    expect(resolveApiMaxCompletionTokens(makeModel(Infinity))).toBeUndefined();
+  });
+
+  it("returns undefined for zero or negative", () => {
+    expect(resolveApiMaxCompletionTokens(makeModel(0))).toBeUndefined();
+    expect(resolveApiMaxCompletionTokens(makeModel(-1))).toBeUndefined();
   });
 });

--- a/src/agents/venice-models.ts
+++ b/src/agents/venice-models.ts
@@ -17,6 +17,7 @@ export const VENICE_DEFAULT_COST = {
   cacheWrite: 0,
 };
 
+const VENICE_DEFAULT_MAX_TOKENS = 4096;
 const VENICE_DISCOVERY_TIMEOUT_MS = 10_000;
 const VENICE_DISCOVERY_RETRYABLE_HTTP_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
 const VENICE_DISCOVERY_RETRYABLE_NETWORK_CODES = new Set([
@@ -60,7 +61,7 @@ export const VENICE_MODEL_CATALOG = [
     reasoning: false,
     input: ["text"],
     contextWindow: 131072,
-    maxTokens: 8192,
+    maxTokens: 4096,
     privacy: "private",
   },
   {
@@ -69,7 +70,7 @@ export const VENICE_MODEL_CATALOG = [
     reasoning: false,
     input: ["text"],
     contextWindow: 131072,
-    maxTokens: 8192,
+    maxTokens: 4096,
     privacy: "private",
   },
   {
@@ -78,7 +79,7 @@ export const VENICE_MODEL_CATALOG = [
     reasoning: false,
     input: ["text"],
     contextWindow: 131072,
-    maxTokens: 8192,
+    maxTokens: 4096,
     privacy: "private",
   },
 
@@ -156,7 +157,7 @@ export const VENICE_MODEL_CATALOG = [
     reasoning: false,
     input: ["text"],
     contextWindow: 32768,
-    maxTokens: 8192,
+    maxTokens: 4096,
     privacy: "private",
   },
   {
@@ -165,7 +166,7 @@ export const VENICE_MODEL_CATALOG = [
     reasoning: false,
     input: ["text", "image"],
     contextWindow: 131072,
-    maxTokens: 8192,
+    maxTokens: 4096,
     privacy: "private",
   },
 
@@ -176,7 +177,7 @@ export const VENICE_MODEL_CATALOG = [
     reasoning: false,
     input: ["text", "image"],
     contextWindow: 202752,
-    maxTokens: 8192,
+    maxTokens: 4096,
     privacy: "private",
   },
   {
@@ -335,6 +336,7 @@ interface VeniceModelSpec {
   name: string;
   privacy: "private" | "anonymized";
   availableContextTokens: number;
+  maxCompletionTokens?: number;
   capabilities: {
     supportsReasoning: boolean;
     supportsVision: boolean;
@@ -412,6 +414,14 @@ function isRetryableVeniceDiscoveryError(err: unknown): boolean {
   return hasRetryableNetworkCode(err);
 }
 
+function resolveApiMaxCompletionTokens(apiModel: VeniceModel): number | undefined {
+  const raw = apiModel.model_spec.maxCompletionTokens;
+  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+    return raw;
+  }
+  return undefined;
+}
+
 /**
  * Discover models from Venice API with fallback to static catalog.
  * The /models endpoint is public and doesn't require authentication.
@@ -468,11 +478,14 @@ export async function discoverVeniceModels(): Promise<ModelDefinitionConfig[]> {
 
     for (const apiModel of data.data) {
       const catalogEntry = catalogById.get(apiModel.id);
+      const apiMaxTokens = resolveApiMaxCompletionTokens(apiModel);
       if (catalogEntry) {
-        // Use catalog metadata for known models
-        models.push(buildVeniceModelDefinition(catalogEntry));
+        const def = buildVeniceModelDefinition(catalogEntry);
+        if (apiMaxTokens !== undefined) {
+          def.maxTokens = apiMaxTokens;
+        }
+        models.push(def);
       } else {
-        // Create definition for newly discovered models not in catalog
         const isReasoning =
           apiModel.model_spec.capabilities.supportsReasoning ||
           apiModel.id.toLowerCase().includes("thinking") ||
@@ -488,8 +501,7 @@ export async function discoverVeniceModels(): Promise<ModelDefinitionConfig[]> {
           input: hasVision ? ["text", "image"] : ["text"],
           cost: VENICE_DEFAULT_COST,
           contextWindow: apiModel.model_spec.availableContextTokens || 128000,
-          maxTokens: 8192,
-          // Avoid usage-only streaming chunks that can break OpenAI-compatible parsers.
+          maxTokens: apiMaxTokens ?? VENICE_DEFAULT_MAX_TOKENS,
           compat: {
             supportsUsageInStreaming: false,
           },
@@ -507,3 +519,8 @@ export async function discoverVeniceModels(): Promise<ModelDefinitionConfig[]> {
     return staticVeniceModelDefinitions();
   }
 }
+
+export const __testing = {
+  resolveApiMaxCompletionTokens,
+  VENICE_DEFAULT_MAX_TOKENS,
+} as const;


### PR DESCRIPTION
## Summary

Reads `maxCompletionTokens` from the Venice `/models` API response and uses per-model values in the static catalog instead of blanket `8192`, preventing HTTP 400 errors on models with lower limits.

## Problem

The Venice model catalog hardcoded `maxTokens: 8192` for all 26 models. Several models (e.g. `llama-3.3-70b`, `mistral-31-24b`) only allow `max_completion_tokens` up to 4096. Venice returns:

```
400 "max_completion_tokens (8192) exceeds the maximum allowed for model 'llama-3.3-70b' (4096)"
```

This breaks the default onboarding experience for all Venice.ai users.

## Changes

| File | Change |
|------|--------|
| `src/agents/venice-models.ts` | Add `maxCompletionTokens?: number` to `VeniceModelSpec`; add `resolveApiMaxCompletionTokens()` helper; lower static catalog `maxTokens` to 4096 for Llama, Hermes, Mistral, Gemma, and Venice Uncensored models; use API-reported `maxCompletionTokens` in discovery for both catalog and non-catalog models; default to 4096 for unknown models |
| `src/agents/venice-models.test.ts` | Add 3 tests for API discovery with `maxCompletionTokens`; add 4 tests for `resolveApiMaxCompletionTokens` edge cases |

## Test plan

- [x] `npx vitest run src/agents/venice-models.test.ts` — 10/10 passing
- [ ] Manual: configure Venice provider with `llama-3.3-70b`, verify no 400 error
- [ ] Manual: verify models with higher limits still work (e.g. `qwen3-235b-a22b-instruct-2507`)
- [ ] Manual: verify API discovery overrides catalog defaults when `maxCompletionTokens` is present

## Security Impact

- Does this change handle user input? **No**
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **No** — only the `max_completion_tokens` value in the request body changes
- Does this change introduce new dependencies? **No**

## Human Verification

1. Onboard with Venice API key, send a message using `llama-3.3-70b` → verify no 400 error
2. Send a message using `qwen3-235b-a22b-instruct-2507` → verify normal operation
3. Restart gateway → verify API discovery picks up `maxCompletionTokens` from Venice API

## Failure Recovery

Revert the commit to restore the previous hardcoded values. Users can also override `maxTokens` per model in their config.

## Risks and Mitigations

- **Risk**: Some catalog models may have the wrong `maxTokens` cap in the static fallback
  **Mitigation**: API discovery overrides static values when `maxCompletionTokens` is present. The static catalog uses a conservative 4096 default for models known to have lower limits. Users can always override via config.