### PR TITLE
[Issue #38179] [Bug] Discord channel exec fails with gateway token mismatch

### DIFF
--- a/automation/issue-38179.md
+++ b/automation/issue-38179.md
@@ -1,0 +1,7 @@
+# Issue 38179 Tracking
+
+- Source issue: https://github.com/openclaw/openclaw/issues/38179
+- Title: [Bug] Discord channel exec fails with gateway token mismatch
+
+## Extracted Description
+Discord channel exec fails with gateway token mismatch while TUI works.


### PR DESCRIPTION
## Original Issue
- Number: #38179
- Link: https://github.com/openclaw/openclaw/issues/38179

## Original Issue Description
Discord channel exec fails with gateway token mismatch while TUI channel works. Repro: trigger exec in Discord with gateway auth enabled and receive unauthorized mismatch closure.

Closes #38179