### PR TITLE
[Issue #38171] feat: support per-agent thinkingDefault configuration

### DIFF
--- a/automation/issue-38171.md
+++ b/automation/issue-38171.md
@@ -1,0 +1,7 @@
+# Issue 38171 Tracking
+
+- Source issue: https://github.com/openclaw/openclaw/issues/38171
+- Title: feat: support per-agent thinkingDefault configuration
+
+## Extracted Description
+Request to support per-agent thinking default configuration and resolution precedence.


### PR DESCRIPTION
## Original Issue
- Number: #38171
- Link: https://github.com/openclaw/openclaw/issues/38171

## Original Issue Description
Request to support per-agent `thinkingDefault` so mixed-provider deployments can set different default thinking levels per agent, with precedence between message override, agent default, global default, and provider/model default.

Closes #38171