### PR TITLE
[Issue #38169] ugc-factory-01 node cannot connect: DNS resolution failure for Tailscale MagicDNS

### DIFF
--- a/automation/issue-38169.md
+++ b/automation/issue-38169.md
@@ -1,0 +1,7 @@
+# Issue 38169 Tracking
+
+- Source issue: https://github.com/openclaw/openclaw/issues/38169
+- Title: ugc-factory-01 node cannot connect: DNS resolution failure for Tailscale MagicDNS
+
+## Extracted Description
+Node connectivity fails due to MagicDNS resolution errors.


### PR DESCRIPTION
## Original Issue
- Number: #38169
- Link: https://github.com/openclaw/openclaw/issues/38169

## Original Issue Description
Node host cannot connect because the machine cannot resolve Tailscale MagicDNS hostname (`getaddrinfo ENOTFOUND`) and enters a restart loop despite Tailscale showing the peer online.

Closes #38169