### PR TITLE
[Issue #38166] Bootstrap agent attempts to write local files via messaging tool

### DIFF
--- a/automation/issue-38166.md
+++ b/automation/issue-38166.md
@@ -1,0 +1,7 @@
+# Issue 38166 Tracking
+
+- Source issue: https://github.com/openclaw/openclaw/issues/38166
+- Title: Bootstrap agent attempts to write local files via messaging tool
+
+## Extracted Description
+Bootstrap flow attempted local file writes via message tool and triggered provider errors.


### PR DESCRIPTION
## Original Issue
- Number: #38166
- Link: https://github.com/openclaw/openclaw/issues/38166

## Original Issue Description
Bootstrap flow attempted local configuration file writes through the message tool using absolute paths, causing provider/API errors.

Closes #38166