### PR TITLE
[Issue #38141] Discord thread-bound subagent session binding fails (session mode unavailable)

### DIFF
--- a/automation/issue-38141.md
+++ b/automation/issue-38141.md
@@ -1,0 +1,7 @@
+# Issue 38141 Tracking
+
+- Source issue: https://github.com/openclaw/openclaw/issues/38141
+- Title: Discord thread-bound subagent session binding fails (session mode unavailable)
+
+## Extracted Description
+Issue reports Discord thread-bound subagent session binding failure.


### PR DESCRIPTION
## Original Issue
- Number: #38141
- Link: https://github.com/openclaw/openclaw/issues/38141

## Original Issue Description
Discord thread-bound subagent session binding fails with session mode unavailable behavior.

Closes #38141