### PR TITLE
[Issue #38138] Feature request: mention-based agent routing override

### DIFF
--- a/automation/issue-38138.md
+++ b/automation/issue-38138.md
@@ -1,0 +1,7 @@
+# Issue 38138 Tracking
+
+- Source issue: https://github.com/openclaw/openclaw/issues/38138
+- Title: Feature request: mention-based agent routing override
+
+## Extracted Description
+Request to route messages by explicit agent mention, overriding inherited peer/thread binding.


### PR DESCRIPTION
## Original Issue
- Number: #38138
- Link: https://github.com/openclaw/openclaw/issues/38138

## Original Issue Description
Feature request to prioritize explicit agent mentions for routing so mentioned agents override inherited thread/channel bindings.

Closes #38138