### PR TITLE
[Issue #38133] CC Chat: /usage footer and responseUsage line not appearing in agent replies

### DIFF
--- a/automation/issue-38133.md
+++ b/automation/issue-38133.md
@@ -1,0 +1,7 @@
+# Issue 38133 Tracking
+
+- Source issue: https://github.com/openclaw/openclaw/issues/38133
+- Title: CC Chat: /usage footer and responseUsage line not appearing in agent replies
+
+## Extracted Description
+CC Chat agent replies omit usage footer due to split finalization paths.


### PR DESCRIPTION
## Original Issue
- Number: #38133
- Link: https://github.com/openclaw/openclaw/issues/38133

## Original Issue Description
CC Chat agent replies omit `/usage` footer because usage text is appended on a different path than the one used for agent-run final emission.

Closes #38133