### PR TITLE
[Issue #38124] [Bug]: Node host cannot pair: "pairing required" while "openclaw nodes pending" is always empty (Oracle Cloud Ubuntu)

### DIFF
--- a/automation/issue-38124.md
+++ b/automation/issue-38124.md
@@ -1,0 +1,7 @@
+# Issue 38124 Tracking
+
+- Source issue: https://github.com/openclaw/openclaw/issues/38124
+- Title: [Bug]: Node host cannot pair: "pairing required" while "openclaw nodes pending" is always empty (Oracle Cloud Ubuntu)
+
+## Extracted Description
+Node host pairing fails with code 1008 while pending pairing list remains empty.


### PR DESCRIPTION
## Original Issue
- Number: #38124
- Link: https://github.com/openclaw/openclaw/issues/38124

## Original Issue Description
Node host pairing consistently fails with `pairing required` and websocket code 1008 while `openclaw nodes pending` remains empty, blocking approval flow.

Closes #38124