### PR TITLE
[Issue #38091] [Bug] OpenClaw UI WebSocket reconnect 导致会话 terminated

### DIFF
--- a/automation/issue-38091.md
+++ b/automation/issue-38091.md
@@ -1,0 +1,7 @@
+# Issue 38091 Tracking
+
+- Source issue: https://github.com/openclaw/openclaw/issues/38091
+- Title: [Bug] OpenClaw UI WebSocket reconnect 导致会话 terminated
+
+## Extracted Description
+Frequent web UI websocket reconnects terminate active sessions.


### PR DESCRIPTION
## Original Issue
- Number: #38091
- Link: https://github.com/openclaw/openclaw/issues/38091

## Original Issue Description
Frequent OpenClaw UI websocket reconnect events can terminate in-flight sessions and force users to restart the conversation.

Closes #38091