### PR TITLE
[Issue #38090] [Bug] OpenClaw UI WebSocket reconnect 导致会话 terminated

### DIFF
--- a/automation/issue-38090.md
+++ b/automation/issue-38090.md
@@ -1,0 +1,7 @@
+# Issue 38090 Tracking
+
+- Source issue: https://github.com/openclaw/openclaw/issues/38090
+- Title: [Bug] OpenClaw UI WebSocket reconnect 导致会话 terminated
+
+## Extracted Description
+Frequent web UI websocket reconnects terminate active sessions.


### PR DESCRIPTION
## Original Issue
- Number: #38090
- Link: https://github.com/openclaw/openclaw/issues/38090

## Original Issue Description
Frequent OpenClaw UI websocket reconnect events can terminate in-flight sessions and force users to restart the conversation.

Closes #38090