### PR TITLE
fix(gateway): keep probe routes reachable with root-mounted control ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,7 +205,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp media upload caps: make outbound media sends and auto-replies honor `channels.whatsapp.mediaMaxMb` with per-account overrides so inbound and outbound limits use the same channel config. Thanks @vincentkoc.
 - Windows/Plugin install: when OpenClaw runs on Windows via Bun and `npm-cli.js` is not colocated with the runtime binary, fall back to `npm.cmd`/`npx.cmd` through the existing `cmd.exe` wrapper so `openclaw plugins install` no longer fails with `spawn EINVAL`. (#38056) Thanks @0xlin2023.
 - Telegram/send retry classification: retry grammY `Network request ... failed after N attempts` envelopes in send flows without reclassifying plain `Network request ... failed!` wrappers as transient, restoring the intended retry path while keeping broad send-context message matching tight. (#38056) Thanks @0xlin2023.
-- Gateway/probe route precedence: keep `/health`, `/healthz`, `/ready`, and `/readyz` reachable when the Control UI is mounted at `/`, so root-mounted SPA fallbacks no longer swallow machine probe routes while plugin-owned routes on those paths still keep precedence. (#18446) Thanks @vibecodooor.
+- Gateway/probe route precedence: keep `/health`, `/healthz`, `/ready`, and `/readyz` reachable when the Control UI is mounted at `/`, so root-mounted SPA fallbacks no longer swallow machine probe routes while plugin-owned routes on those paths still keep precedence. (#18446) Thanks @vibecodooor and @vincentkoc.
 
 ## 2026.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp media upload caps: make outbound media sends and auto-replies honor `channels.whatsapp.mediaMaxMb` with per-account overrides so inbound and outbound limits use the same channel config. Thanks @vincentkoc.
 - Windows/Plugin install: when OpenClaw runs on Windows via Bun and `npm-cli.js` is not colocated with the runtime binary, fall back to `npm.cmd`/`npx.cmd` through the existing `cmd.exe` wrapper so `openclaw plugins install` no longer fails with `spawn EINVAL`. (#38056) Thanks @0xlin2023.
 - Telegram/send retry classification: retry grammY `Network request ... failed after N attempts` envelopes in send flows without reclassifying plain `Network request ... failed!` wrappers as transient, restoring the intended retry path while keeping broad send-context message matching tight. (#38056) Thanks @0xlin2023.
+- Gateway/probe route precedence: keep `/health`, `/healthz`, `/ready`, and `/readyz` reachable when the Control UI is mounted at `/`, so root-mounted SPA fallbacks no longer swallow machine probe routes while plugin-owned routes on those paths still keep precedence. (#18446) Thanks @vibecodooor.
 
 ## 2026.3.2
 

--- a/src/gateway/control-ui-routing.ts
+++ b/src/gateway/control-ui-routing.ts
@@ -6,6 +6,8 @@ export type ControlUiRequestClassification =
   | { kind: "redirect"; location: string }
   | { kind: "serve" };
 
+const ROOT_MOUNTED_GATEWAY_PROBE_PATHS = new Set(["/health", "/healthz", "/ready", "/readyz"]);
+
 export function classifyControlUiRequest(params: {
   basePath: string;
   pathname: string;
@@ -16,6 +18,11 @@ export function classifyControlUiRequest(params: {
   if (!basePath) {
     if (pathname === "/ui" || pathname.startsWith("/ui/")) {
       return { kind: "not-found" };
+    }
+    // Keep core probe routes outside the root-mounted SPA catch-all so the
+    // gateway probe handler can answer them even when the Control UI owns `/`.
+    if (ROOT_MOUNTED_GATEWAY_PROBE_PATHS.has(pathname)) {
+      return { kind: "not-control-ui" };
     }
     // Keep plugin-owned HTTP routes outside the root-mounted Control UI SPA
     // fallback so untrusted plugins cannot claim arbitrary UI paths.

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -494,6 +494,58 @@ describe("gateway plugin HTTP auth boundary", () => {
     });
   });
 
+  test("root-mounted control ui does not swallow gateway probe routes", async () => {
+    const handlePluginRequest = vi.fn(async () => false);
+
+    await withRootMountedControlUiServer({
+      prefix: "openclaw-plugin-http-control-ui-probes-test-",
+      handlePluginRequest,
+      run: async (server) => {
+        const probeCases = [
+          { path: "/health", status: "live" },
+          { path: "/healthz", status: "live" },
+          { path: "/ready", status: "ready" },
+          { path: "/readyz", status: "ready" },
+        ] as const;
+
+        for (const probeCase of probeCases) {
+          const response = await sendRequest(server, { path: probeCase.path });
+          expect(response.res.statusCode, probeCase.path).toBe(200);
+          expect(response.getBody(), probeCase.path).toBe(
+            JSON.stringify({ ok: true, status: probeCase.status }),
+          );
+        }
+
+        expect(handlePluginRequest).toHaveBeenCalledTimes(probeCases.length);
+      },
+    });
+  });
+
+  test("root-mounted control ui still lets plugins claim probe paths first", async () => {
+    const handlePluginRequest = vi.fn(async (req: IncomingMessage, res: ServerResponse) => {
+      const pathname = new URL(req.url ?? "/", "http://localhost").pathname;
+      if (pathname !== "/healthz") {
+        return false;
+      }
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.end(JSON.stringify({ ok: true, route: "plugin-health" }));
+      return true;
+    });
+
+    await withRootMountedControlUiServer({
+      prefix: "openclaw-plugin-http-control-ui-probe-shadow-test-",
+      handlePluginRequest,
+      run: async (server) => {
+        const response = await sendRequest(server, { path: "/healthz" });
+
+        expect(response.res.statusCode).toBe(200);
+        expect(response.getBody()).toBe(JSON.stringify({ ok: true, route: "plugin-health" }));
+        expect(handlePluginRequest).toHaveBeenCalledTimes(1);
+      },
+    });
+  });
+
   test("requires gateway auth for canonicalized /api/channels variants", async () => {
     const handlePluginRequest = createCanonicalizedChannelPluginHandler();
 


### PR DESCRIPTION
## Summary

- Problem: when the Control UI is mounted at `/`, the SPA request classifier can still claim `/health`, `/healthz`, `/ready`, and `/readyz` before the gateway probe handler runs.
- Why it matters: deployment probes can receive Control UI fallback responses instead of the machine probe payload, which keeps #18446 reproducible even after #31272 landed.
- What changed: root-mounted Control UI classification now explicitly leaves the four probe routes outside the SPA catch-all, and regression tests cover both probe reachability and plugin precedence on probe paths.
- What did NOT change (scope boundary): no deep readiness semantics, no auth model changes, and no route-order reversal that would shadow plugin-owned probe paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #18446
- Related #31272

## User-visible / Behavior Changes

- `/health`, `/healthz`, `/ready`, and `/readyz` stay reachable even when the Control UI is mounted at `/`.
- Plugin-owned routes mounted on probe paths still keep precedence, matching the compatibility behavior from #31272.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): gateway HTTP server
- Relevant config (redacted): root-mounted Control UI (`gateway.controlUi.basePath = "/"` equivalent normalization to empty base path)

### Steps

1. Start the gateway with Control UI mounted at `/`.
2. Request `/healthz` and `/readyz`.
3. Mount a plugin handler on `/healthz` and request it again.

### Expected

- Probe paths return the gateway probe JSON when unclaimed.
- Plugin handlers on probe paths still win when explicitly registered.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Root-mounted Control UI no longer swallows `/health`, `/healthz`, `/ready`, or `/readyz`.
  - Plugin handlers mounted on `/healthz` still keep precedence.
- Edge cases checked:
  - Existing non-probe root-mounted Control UI fallthrough behavior remains intact.
- What you did **not** verify:
  - Full end-to-end deploy on Render/Kubernetes in this PR.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the two commits in this PR.
- Files/config to restore:
  - `src/gateway/control-ui-routing.ts`
  - `src/gateway/server.plugin-http-auth.test.ts`
  - `CHANGELOG.md`
- Known bad symptoms reviewers should watch for:
  - Root-mounted Control UI starts serving probe paths again.
  - Plugin routes mounted on `/healthz` stop taking precedence.

## Risks and Mitigations

- Risk: root-mounted Control UI path classification grows another special-case allowlist.
  - Mitigation: keep the allowlist limited to the four built-in probe paths and cover it with regression tests.
