### PR TITLE
feat(config): support per-agent thinkingDefault configuration

### DIFF
--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -61,7 +61,18 @@ describe("resolveAgentConfig", () => {
       subagents: undefined,
       sandbox: undefined,
       tools: undefined,
+      thinkingDefault: undefined,
     });
+  });
+
+  it("returns per-agent thinkingDefault when configured", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "coder", thinkingDefault: "high" }],
+      },
+    };
+    const result = resolveAgentConfig(cfg, "coder");
+    expect(result?.thinkingDefault).toBe("high");
   });
 
   it("resolves explicit and effective model primary separately", () => {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -38,6 +38,7 @@ type ResolvedAgentConfig = {
   subagents?: AgentEntry["subagents"];
   sandbox?: AgentEntry["sandbox"];
   tools?: AgentEntry["tools"];
+  thinkingDefault?: AgentEntry["thinkingDefault"];
 };
 
 let defaultAgentWarned = false;
@@ -140,6 +141,7 @@ export function resolveAgentConfig(
     subagents: typeof entry.subagents === "object" && entry.subagents ? entry.subagents : undefined,
     sandbox: entry.sandbox,
     tools: entry.tools,
+    thinkingDefault: entry.thinkingDefault,
   };
 }
 

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1,4 +1,5 @@
 import {
+  resolveAgentConfig,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveSessionAgentId,
@@ -73,7 +74,10 @@ export async function getReplyFromConfig(
   );
   const resolvedOpts =
     mergedSkillFilter !== undefined ? { ...opts, skillFilter: mergedSkillFilter } : opts;
-  const agentCfg = cfg.agents?.defaults;
+  const resolvedAgent = resolveAgentConfig(cfg, agentId);
+  const agentCfg = resolvedAgent?.thinkingDefault
+    ? { ...cfg.agents?.defaults, thinkingDefault: resolvedAgent.thinkingDefault }
+    : cfg.agents?.defaults;
   const sessionCfg = cfg.session;
   const { defaultProvider, defaultModel, aliasIndex } = resolveDefaultModel({
     cfg,

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -87,6 +87,8 @@ export type AgentConfig = {
   tools?: AgentToolsConfig;
   /** Optional runtime descriptor for this agent. */
   runtime?: AgentRuntimeConfig;
+  /** Per-agent thinking default (overrides agents.defaults.thinkingDefault). */
+  thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
 };
 
 export type AgentsConfig = {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -741,6 +741,17 @@ export const AgentEntrySchema = z
     sandbox: AgentSandboxSchema,
     tools: AgentToolsSchema,
     runtime: AgentRuntimeSchema,
+    thinkingDefault: z
+      .union([
+        z.literal("off"),
+        z.literal("minimal"),
+        z.literal("low"),
+        z.literal("medium"),
+        z.literal("high"),
+        z.literal("xhigh"),
+        z.literal("adaptive"),
+      ])
+      .optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary

Adds `thinkingDefault` to the per-agent config schema so each agent in `agents.list` can override the global `agents.defaults.thinkingDefault` value.

## Problem

Thinking level can only be configured globally (`agents.defaults.thinkingDefault`) or per-session (`/think`). In mixed-provider setups (e.g. Anthropic + OpenAI agents), there is no way to set different thinking defaults per agent. Setting a global value overrides Anthropic's `adaptive` behavior for all agents.

## Changes

| File | Change |
|------|--------|
| `src/config/zod-schema.agent-runtime.ts` | Add `thinkingDefault` (same union as `AgentDefaultsSchema`) to `AgentEntrySchema` |
| `src/config/types.agents.ts` | Add `thinkingDefault` to `AgentConfig` type |
| `src/agents/agent-scope.ts` | Add `thinkingDefault` to `ResolvedAgentConfig` type and `resolveAgentConfig()` |
| `src/auto-reply/reply/get-reply.ts` | Import `resolveAgentConfig`; merge per-agent `thinkingDefault` over `agents.defaults` when present |
| `src/agents/agent-scope.test.ts` | Update existing test expectation; add new test for per-agent `thinkingDefault` resolution |

## Usage

```json
{
  "agents": {
    "defaults": {
      "thinkingDefault": "low"
    },
    "list": [
      {
        "id": "coder",
        "model": "anthropic/claude-sonnet-4",
        "thinkingDefault": "adaptive"
      },
      {
        "id": "assistant",
        "model": "openai/gpt-5.2",
        "thinkingDefault": "low"
      }
    ]
  }
}
```

## Test plan

- [x] `npx vitest run src/agents/agent-scope.test.ts` — 16/16 passing
- [ ] Manual: configure two agents with different `thinkingDefault` values, verify each uses its own default
- [ ] Manual: verify global `thinkingDefault` still works when no per-agent value is set
- [ ] Manual: verify `/think` command still overrides per-agent default at runtime

## Security Impact

- Does this change handle user input? **No** — only reads validated config
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Set `agents.defaults.thinkingDefault: "low"`, set agent `coder` to `thinkingDefault: "adaptive"` → verify coder agent uses adaptive, other agents use low
2. Remove per-agent `thinkingDefault` → verify agent falls back to global default
3. Use `/think high` in a session → verify it overrides per-agent default

## Failure Recovery

Revert the commit. Per-agent `thinkingDefault` will be rejected by `.strict()` schema validation, so stale configs will produce a clear validation error on startup.

## Risks and Mitigations

- **Risk**: Users may set conflicting values between global and per-agent thinking defaults
  **Mitigation**: Per-agent always wins over global, matching the established override pattern for other fields like `model` and `humanDelay`.