### PR TITLE
fix(cron): persist cron state before gateway shutdown

### DIFF
--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -18,6 +18,10 @@ export class CronService {
     ops.stop(this.state);
   }
 
+  async flush() {
+    await ops.flush(this.state);
+  }
+
   async status() {
     return await ops.status(this.state);
   }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -131,6 +131,12 @@ export function stop(state: CronServiceState) {
   stopTimer(state);
 }
 
+export async function flush(state: CronServiceState) {
+  await locked(state, async () => {
+    await persist(state);
+  });
+}
+
 export async function status(state: CronServiceState) {
   return await locked(state, async () => {
     await ensureLoadedForRead(state);

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -13,7 +13,7 @@ export function createGatewayCloseHandler(params: {
   canvasHostServer: CanvasHostServer | null;
   stopChannel: (name: ChannelId, accountId?: string) => Promise<void>;
   pluginServices: PluginServicesHandle | null;
-  cron: { stop: () => void };
+  cron: { flush: () => Promise<void>; stop: () => void };
   heartbeatRunner: HeartbeatRunner;
   updateCheckStop?: (() => void) | null;
   nodePresenceTimers: Map<string, ReturnType<typeof setInterval>>;
@@ -69,6 +69,11 @@ export function createGatewayCloseHandler(params: {
       await params.pluginServices.stop().catch(() => {});
     }
     await stopGmailWatcher();
+    try {
+      await params.cron.flush();
+    } catch {
+      // best-effort flush
+    }
     params.cron.stop();
     params.heartbeatRunner.stop();
     try {


### PR DESCRIPTION
Fixes #38137

- Add flush() to ops.ts and service.ts
- Call flush() before stop() in gateway close handler