### PR TITLE
fix(feishu): remove per-request timeout unsupported by SDK types

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -192,7 +192,7 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(imageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        timeout: 120_000,
+        data: expect.objectContaining({ image_type: "message" }),
       }),
     );
     expect(messageCreateMock).toHaveBeenCalledWith(
@@ -320,7 +320,6 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(imageGetMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { image_key: imageKey },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toEqual(Buffer.from("image-data"));
@@ -512,7 +511,6 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_audio_msg", file_key: "file_key_audio" },
         params: { type: "file" },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);
@@ -532,7 +530,6 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_img_msg", file_key: "img_key_1" },
         params: { type: "image" },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -106,7 +106,6 @@ export async function downloadImageFeishu(params: {
 
   const response = await client.im.image.get({
     path: { image_key: normalizedImageKey },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   const buffer = await readFeishuResponseBuffer({
@@ -146,7 +145,6 @@ export async function downloadMessageResourceFeishu(params: {
   const response = await client.im.messageResource.get({
     path: { message_id: messageId, file_key: normalizedFileKey },
     params: { type },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   const buffer = await readFeishuResponseBuffer({
@@ -202,7 +200,6 @@ export async function uploadImageFeishu(params: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
       image: imageData as any,
     },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   // SDK v1.30+ returns data directly without code wrapper on success
@@ -277,7 +274,6 @@ export async function uploadFileFeishu(params: {
       file: fileData as any,
       ...(duration !== undefined && { duration }),
     },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   // SDK v1.30+ returns data directly without code wrapper on success


### PR DESCRIPTION
## Summary

- Problem: Commit b12733395 (`fix(feishu): restore explicit media request timeouts`) added `timeout` to four Feishu SDK method calls (`im.image.get`, `im.messageResource.get`, `im.image.create`, `im.file.create`), but the SDK's typed method signatures do not include `timeout` at the per-request parameter level, causing TS2353 errors that break `pnpm check` for **every PR** based on current `main`.
- Why it matters: All PRs rebased on current `main` fail the `check` CI step, blocking the entire contribution pipeline.
- What changed: Removed the four per-request `timeout` properties and updated corresponding test assertions. Timeouts are still enforced — `createFeishuClient()` already injects a 120s timeout at the HTTP transport layer via `createTimeoutHttpInstance()`, which wraps every outgoing request.
- What did NOT change (scope boundary): No timeout behavior change at runtime. The `FEISHU_MEDIA_HTTP_TIMEOUT_MS` (120s) client-level timeout remains fully active. No changes to `client.ts`, `createTimeoutHttpInstance`, or any other file.

| Location | What was removed | Why it's safe |
|----------|-----------------|---------------|
| `im.image.get()` | `timeout: 120_000` | Client HTTP instance already applies 120s |
| `im.messageResource.get()` | `timeout: 120_000` | Client HTTP instance already applies 120s |
| `im.image.create()` | `timeout: 120_000` | Client HTTP instance already applies 120s |
| `im.file.create()` | `timeout: 120_000` | Client HTTP instance already applies 120s |

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related b12733395 (the commit that introduced the type regression)

## User-visible / Behavior Changes

None. Timeout enforcement is unchanged — the 120s media timeout is applied at the HTTP transport layer by `createTimeoutHttpInstance()` in `client.ts`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps
1. Check out current `main` (4ed5febc3)
2. Run `pnpm tsgo`
3. Observe 4 × TS2353 errors in `extensions/feishu/src/media.ts`
4. Apply this patch, run `pnpm tsgo` — zero errors

### Expected
- `pnpm tsgo` passes with no errors in `extensions/feishu/src/media.ts`

### Actual (before fix)
- 4 × `error TS2353: Object literal may only specify known properties, and 'timeout' does not exist in type ...`

## Evidence

- [x] Failing test/log before + passing after
  - Before: `pnpm tsgo` shows 4 TS2353 errors; 4 tests fail on `timeout` assertion
  - After: `pnpm tsgo` clean; all 27 `media.test.ts` tests pass

## Human Verification (required)

- Verified scenarios: `pnpm tsgo` passes, all 27 tests in `media.test.ts` pass, `oxfmt` and `oxlint` clean
- Edge cases checked: Confirmed `createTimeoutHttpInstance()` in `client.ts` still wraps all HTTP methods with 120s timeout — no runtime behavior change
- What I did **not** verify: Live Feishu media upload/download (requires Feishu credentials)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit
- Files/config to restore: `extensions/feishu/src/media.ts`, `extensions/feishu/src/media.test.ts`
- Known bad symptoms reviewers should watch for: Feishu media operations timing out earlier than expected (would indicate `createTimeoutHttpInstance` is not applying the 120s timeout, but this is already verified in existing tests)

## Risks and Mitigations

- Risk: Per-request timeout was intended to override the client-level timeout for specific calls
  - Mitigation: `createTimeoutHttpInstance()` already applies `{ timeout: defaultTimeoutMs, ...opts }` to every request, and the client is created with `httpTimeoutMs: FEISHU_MEDIA_HTTP_TIMEOUT_MS` (120s) in `media.ts`. The per-request timeout was redundant.