### PR TITLE
fix(cron): exclude sandbox from shallow Object.assign in isolated agent config merge

### DIFF
--- a/src/cron/isolated-agent/run.sandbox-merge.test.ts
+++ b/src/cron/isolated-agent/run.sandbox-merge.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  clearFastTestEnv,
+  loadRunCronIsolatedAgentTurn,
+  makeCronSession,
+  makeCronSessionEntry,
+  resolveAgentConfigMock,
+  resolveAllowedModelRefMock,
+  resolveConfiguredModelRefMock,
+  resolveCronSessionMock,
+  resetRunCronIsolatedAgentTurnHarness,
+  restoreFastTestEnv,
+  runWithModelFallbackMock,
+  updateSessionStoreMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+function makeJob(overrides?: Record<string, unknown>) {
+  return {
+    id: "sandbox-job",
+    name: "Sandbox test",
+    schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+    sessionTarget: "isolated",
+    payload: { kind: "agentTurn", message: "run" },
+    ...overrides,
+  } as never;
+}
+
+describe("runCronIsolatedAgentTurn — sandbox shallow-merge guard (#38067)", () => {
+  let previousFastTestEnv: string | undefined;
+
+  beforeEach(() => {
+    previousFastTestEnv = clearFastTestEnv();
+    resetRunCronIsolatedAgentTurnHarness();
+  });
+
+  afterEach(() => {
+    restoreFastTestEnv(previousFastTestEnv);
+  });
+
+  it("preserves defaults.sandbox when agent config has its own sandbox", async () => {
+    const cfg: Partial<OpenClawConfig> = {
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              dangerouslyAllowExternalBindSources: true,
+              network: "host",
+            },
+          } as never,
+        },
+      },
+    };
+
+    resolveAgentConfigMock.mockReturnValue({
+      sandbox: {
+        docker: {
+          binds: ["/data/shared:/mnt/shared"],
+        },
+      },
+    });
+
+    resolveCronSessionMock.mockReturnValue(
+      makeCronSession({ sessionEntry: makeCronSessionEntry() }),
+    );
+    resolveConfiguredModelRefMock.mockReturnValue({ provider: "openai", model: "gpt-4" });
+    resolveAllowedModelRefMock.mockReturnValue({ ref: { provider: "openai", model: "gpt-4" } });
+    updateSessionStoreMock.mockResolvedValue(undefined);
+    runWithModelFallbackMock.mockResolvedValue({
+      result: {
+        payloads: [{ text: "done" }],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      },
+      provider: "openai",
+      model: "gpt-4",
+    });
+
+    await runCronIsolatedAgentTurn({
+      cfg: cfg as OpenClawConfig,
+      deps: {} as never,
+      job: makeJob({ agentId: "kotik" }),
+      message: "run",
+    } as never);
+
+    const fallbackCall = runWithModelFallbackMock.mock.calls[0];
+    expect(fallbackCall).toBeDefined();
+
+    const runCallback = fallbackCall[0].run;
+    expect(runCallback).toBeInstanceOf(Function);
+
+    const mergedCfg = fallbackCall[0].cfg as OpenClawConfig;
+    const mergedSandbox = mergedCfg.agents?.defaults?.sandbox as Record<string, unknown>;
+
+    expect(mergedSandbox?.docker).toEqual(
+      expect.objectContaining({
+        dangerouslyAllowExternalBindSources: true,
+        network: "host",
+      }),
+    );
+  });
+
+  it("does not lose defaults.sandbox when agent has no sandbox override", async () => {
+    const cfg: Partial<OpenClawConfig> = {
+      agents: {
+        defaults: {
+          sandbox: {
+            docker: {
+              dangerouslyAllowExternalBindSources: true,
+            },
+          } as never,
+        },
+      },
+    };
+
+    resolveAgentConfigMock.mockReturnValue({ model: "anthropic/claude-sonnet-4-6" });
+
+    resolveCronSessionMock.mockReturnValue(
+      makeCronSession({ sessionEntry: makeCronSessionEntry() }),
+    );
+    resolveConfiguredModelRefMock.mockReturnValue({ provider: "openai", model: "gpt-4" });
+    resolveAllowedModelRefMock.mockReturnValue({ ref: { provider: "openai", model: "gpt-4" } });
+    updateSessionStoreMock.mockResolvedValue(undefined);
+    runWithModelFallbackMock.mockResolvedValue({
+      result: {
+        payloads: [{ text: "done" }],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      },
+      provider: "openai",
+      model: "gpt-4",
+    });
+
+    await runCronIsolatedAgentTurn({
+      cfg: cfg as OpenClawConfig,
+      deps: {} as never,
+      job: makeJob({ agentId: "other" }),
+      message: "run",
+    } as never);
+
+    const mergedCfg = runWithModelFallbackMock.mock.calls[0][0].cfg as OpenClawConfig;
+    const mergedSandbox = mergedCfg.agents?.defaults?.sandbox as Record<string, unknown>;
+
+    expect(mergedSandbox?.docker).toEqual(
+      expect.objectContaining({ dangerouslyAllowExternalBindSources: true }),
+    );
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -125,11 +125,19 @@ export async function runCronIsolatedAgentTurn(params: {
   const agentConfigOverride = normalizedRequested
     ? resolveAgentConfig(params.cfg, normalizedRequested)
     : undefined;
-  const { model: overrideModel, ...agentOverrideRest } = agentConfigOverride ?? {};
+  const {
+    model: overrideModel,
+    sandbox: _sandboxOverride,
+    ...agentOverrideRest
+  } = agentConfigOverride ?? {};
   // Use the requested agentId even when there is no explicit agent config entry.
   // This ensures auth-profiles, workspace, and agentDir all resolve to the
   // correct per-agent paths (e.g. ~/.openclaw/agents/<agentId>/agent/).
   const agentId = normalizedRequested ?? defaultAgentId;
+  // Exclude `sandbox` from the shallow merge — resolveSandboxConfigForAgent
+  // already deep-merges defaults.sandbox with the per-agent sandbox config,
+  // including dangerouslyAllow* flags.  Shallow-assigning sandbox here would
+  // replace the entire defaults.sandbox object and drop nested properties.
   const agentCfg: AgentDefaultsConfig = Object.assign(
     {},
     params.cfg.agents?.defaults,


### PR DESCRIPTION
## Summary

- **Problem:** `runCronIsolatedAgentTurn` uses `Object.assign` to shallow-merge per-agent config on top of `agents.defaults`. When an agent has its own `sandbox` config (e.g. custom `docker.binds`), the entire `defaults.sandbox` object is replaced, dropping nested properties like `dangerouslyAllowExternalBindSources`, `dangerouslyAllowReadOnlyRoot`, and `docker.network`.
- **Why it matters:** Cron isolated sessions targeting agents with custom sandbox binds fail with "Sandbox security: bind mount source is outside allowed roots" even when `dangerouslyAllowExternalBindSources: true` is set in `agents.defaults.sandbox.docker`.
- **What changed:**
  - `src/cron/isolated-agent/run.ts`: Exclude `sandbox` from the destructured `agentOverrideRest` so it does not participate in the shallow `Object.assign`. `resolveSandboxConfigForAgent` already correctly deep-merges defaults with per-agent sandbox config.
  - `src/cron/isolated-agent/run.sandbox-merge.test.ts`: New test file with 2 cases verifying that defaults sandbox properties survive the config merge both when the agent has its own sandbox section and when it doesn't.
- **What did NOT change:** The `resolveSandboxConfigForAgent` merge logic; the model override deep-merge; any other `agents.defaults` properties.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38067

## User-visible / Behavior Changes

Cron isolated sessions for agents with custom `sandbox.docker.binds` now correctly inherit `dangerouslyAllowExternalBindSources` and other nested sandbox flags from `agents.defaults`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js
- Integration/channel: Cron isolated sessions

### Steps

1. Set `agents.defaults.sandbox.docker.dangerouslyAllowExternalBindSources: true`
2. Configure an agent with `sandbox.docker.binds` containing paths outside workspace/sandbox roots, but WITHOUT setting `dangerouslyAllowExternalBindSources` on the agent
3. Run a cron job targeting that agent with `sessionTarget: "isolated"`

### Expected

- Cron job starts and bind mounts are allowed

### Actual

- Before fix: Fails with "Sandbox security: bind mount source is outside allowed roots"
- After fix: Bind mounts are allowed (inheriting the defaults flag)

## Evidence

```
 ✓ src/cron/isolated-agent/run.sandbox-merge.test.ts (2 tests) 5ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Test cases:
- `preserves defaults.sandbox when agent config has its own sandbox`
- `does not lose defaults.sandbox when agent has no sandbox override`

## Human Verification (required)

- Verified scenarios: Agent with own sandbox, agent without sandbox override, model override still works
- Edge cases checked: No agent config at all (resolveAgentConfigMock returns undefined)
- What I did **not** verify: E2E with actual Docker sandbox execution

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the one-line change in `run.ts`; set `dangerouslyAllowExternalBindSources` explicitly in per-agent sandbox config as workaround
- Files/config to restore: `src/cron/isolated-agent/run.ts`
- Known bad symptoms: If reverted, cron isolated sessions with custom sandbox binds would fail again

## Risks and Mitigations

- Risk: Other nested properties in agent config besides `sandbox` and `model` may also need exclusion from shallow merge. Mitigation: The issue explicitly calls out `sandbox` as the problematic property; `model` already has its own deep-merge logic. Other flat properties work correctly with Object.assign.
