### PR TITLE
fix(gateway): filter delivery-mirror transcript entries from chat.history

### DIFF
--- a/src/gateway/server-methods/chat.delivery-mirror.test.ts
+++ b/src/gateway/server-methods/chat.delivery-mirror.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./chat.js";
+
+const { isDeliveryMirrorMessage, sanitizeChatHistoryMessages } = __testing;
+
+describe("isDeliveryMirrorMessage", () => {
+  it("returns true for delivery-mirror assistant entries", () => {
+    expect(
+      isDeliveryMirrorMessage({
+        role: "assistant",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        content: [{ type: "text", text: "hello" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for normal assistant entries", () => {
+    expect(
+      isDeliveryMirrorMessage({
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "hello" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for user messages", () => {
+    expect(
+      isDeliveryMirrorMessage({
+        role: "user",
+        content: "hello",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for null/undefined", () => {
+    expect(isDeliveryMirrorMessage(null)).toBe(false);
+    expect(isDeliveryMirrorMessage(undefined)).toBe(false);
+  });
+});
+
+describe("sanitizeChatHistoryMessages filters delivery-mirror", () => {
+  it("removes delivery-mirror entries from message list", () => {
+    const messages = [
+      { role: "user", content: "hi" },
+      {
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "Hello!" }],
+      },
+      {
+        role: "assistant",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        content: [{ type: "text", text: "Hello!" }],
+      },
+    ];
+
+    const result = sanitizeChatHistoryMessages(messages);
+    expect(result).toHaveLength(2);
+    expect(result.every((m: Record<string, unknown>) => m.model !== "delivery-mirror")).toBe(true);
+  });
+
+  it("returns original array when no delivery-mirror entries exist", () => {
+    const messages = [
+      { role: "user", content: "hi" },
+      {
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "reply" }],
+      },
+    ];
+
+    const result = sanitizeChatHistoryMessages(messages);
+    expect(result).toBe(messages);
+  });
+
+  it("returns empty array unchanged", () => {
+    const result = sanitizeChatHistoryMessages([]);
+    expect(result).toHaveLength(0);
+  });
+});

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -249,6 +249,14 @@ function extractAssistantTextForSilentCheck(message: unknown): string | undefine
   return texts.length > 0 ? texts.join("\n") : undefined;
 }
 
+function isDeliveryMirrorMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as { model?: unknown; provider?: unknown };
+  return entry.model === "delivery-mirror" && entry.provider === "openclaw";
+}
+
 function sanitizeChatHistoryMessages(messages: unknown[]): unknown[] {
   if (messages.length === 0) {
     return messages;
@@ -256,6 +264,10 @@ function sanitizeChatHistoryMessages(messages: unknown[]): unknown[] {
   let changed = false;
   const next: unknown[] = [];
   for (const message of messages) {
+    if (isDeliveryMirrorMessage(message)) {
+      changed = true;
+      continue;
+    }
     const res = sanitizeChatHistoryMessage(message);
     changed ||= res.changed;
     // Drop assistant messages whose entire visible text is the silent reply token.
@@ -1173,4 +1185,9 @@ export const chatHandlers: GatewayRequestHandlers = {
 
     respond(true, { ok: true, messageId: appended.messageId });
   },
+};
+
+export const __testing = {
+  isDeliveryMirrorMessage,
+  sanitizeChatHistoryMessages,
 };


### PR DESCRIPTION
## Summary

- **Problem:** Webchat shows each assistant reply twice because `chat.history` returns both the real provider message and an internal `delivery-mirror` transcript entry. Telegram (and other channels) correctly receive only one message.
- **Why it matters:** Users see confusing duplicate messages in the webchat UI, eroding trust in the system.
- **What changed:**
  - `src/gateway/server-methods/chat.ts`: Added `isDeliveryMirrorMessage()` check that identifies entries with `provider: "openclaw"` and `model: "delivery-mirror"`. These are now filtered out in `sanitizeChatHistoryMessages()` before `chat.history` returns messages to the client.
  - `src/gateway/server-methods/chat.delivery-mirror.test.ts`: 7 unit tests covering detection of delivery-mirror entries and the filtering behavior.
- **What did NOT change:** The transcript mirror itself (`src/config/sessions/transcript.ts`) still writes delivery-mirror entries to the session JSONL for internal cross-channel bookkeeping — only `chat.history` output is filtered.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38061

## User-visible / Behavior Changes

Webchat no longer shows duplicate assistant messages. Each assistant reply appears exactly once.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Webchat + any delivery channel (e.g. Telegram)

### Steps

1. Send a message via webchat with a Telegram delivery channel enabled
2. Wait for the assistant reply
3. Refresh or inspect webchat session history

### Expected

- One assistant reply per turn

### Actual

- Before fix: Two assistant messages (real + delivery-mirror)
- After fix: One assistant message (real only)

## Evidence

```
 ✓ src/gateway/server-methods/chat.delivery-mirror.test.ts (7 tests) 2ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

## Human Verification (required)

- Verified scenarios: Messages with delivery-mirror, messages without, empty history
- Edge cases checked: null/undefined messages, user messages (not affected)
- What I did **not** verify: E2E with live webchat + Telegram delivery channel

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the filter in `sanitizeChatHistoryMessages`
- Files/config to restore: `src/gateway/server-methods/chat.ts`
- Known bad symptoms: If reverted, duplicate messages reappear in webchat

## Risks and Mitigations

None — the filter only affects chat.history output; transcript data remains intact.
