### PR TITLE
fix(process): use globalThis to deduplicate command-queue lanes Map

### DIFF
--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -335,3 +335,20 @@ describe("command queue", () => {
     await expect(enqueueCommand(async () => "ok")).resolves.toBe("ok");
   });
 });
+
+describe("globalThis lane state sharing", () => {
+  it("stores lanes Map on globalThis for cross-chunk deduplication", () => {
+    const g = globalThis as Record<string, unknown>;
+    const lanesMap = g.__openclaw_command_lanes__;
+    expect(lanesMap).toBeInstanceOf(Map);
+  });
+
+  it("setCommandLaneConcurrency affects shared globalThis lanes Map", () => {
+    setCommandLaneConcurrency("main", 6);
+    const g = globalThis as Record<string, unknown>;
+    const lanesMap = g.__openclaw_command_lanes__ as Map<string, { maxConcurrent: number }>;
+    const mainLane = lanesMap.get("main");
+    expect(mainLane).toBeDefined();
+    expect(mainLane!.maxConcurrent).toBe(6);
+  });
+});

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -49,8 +49,23 @@ type LaneState = {
   generation: number;
 };
 
-const lanes = new Map<string, LaneState>();
-let nextTaskId = 1;
+const LANES_KEY = "__openclaw_command_lanes__" as const;
+const TASK_ID_KEY = "__openclaw_command_task_id__" as const;
+
+type GlobalLaneRegistry = {
+  [LANES_KEY]?: Map<string, LaneState>;
+  [TASK_ID_KEY]?: { value: number };
+};
+
+const g = globalThis as unknown as GlobalLaneRegistry;
+if (!g[LANES_KEY]) {
+  g[LANES_KEY] = new Map<string, LaneState>();
+}
+if (!g[TASK_ID_KEY]) {
+  g[TASK_ID_KEY] = { value: 1 };
+}
+
+const lanes: Map<string, LaneState> = g[LANES_KEY];
 
 function getLaneState(lane: string): LaneState {
   const existing = lanes.get(lane);
@@ -105,7 +120,7 @@ function drainLane(lane: string) {
           );
         }
         logLaneDequeue(lane, waitedMs, state.queue.length);
-        const taskId = nextTaskId++;
+        const taskId = g[TASK_ID_KEY]!.value++;
         const taskGeneration = state.generation;
         state.activeTaskIds.add(taskId);
         void (async () => {


### PR DESCRIPTION
## Summary

Stores the command-queue `lanes` Map on `globalThis` so that code-splitting cannot produce duplicate instances, ensuring `setCommandLaneConcurrency` always affects the same Map that `enqueueCommandInLane` reads from.

## Problem

When the bundler splits `command-queue.ts` into separate output chunks (e.g. `pi-embedded-*.js` and `subagent-registry-*.js`), each chunk gets its own copy of the module-level `lanes` Map. `setCommandLaneConcurrency` modifies the Map in one chunk, but Telegram message processing reads from the Map in the other chunk — so `maxConcurrent` has no effect and every lane defaults to 1.

## Changes

| File | Change |
|------|--------|
| `src/process/command-queue.ts` | Store `lanes` Map and `nextTaskId` counter on `globalThis` behind well-known symbol keys; initialize lazily so the first import wins and subsequent imports reuse the same instance |
| `src/process/command-queue.test.ts` | Add two tests verifying the `globalThis` registry is used and that `setCommandLaneConcurrency` mutates the shared Map |

## Test plan

- [x] `npx vitest run src/process/command-queue.test.ts` — 18/18 passing
- [ ] Manual: set `agents.defaults.maxConcurrent: 4`, send 4 Telegram messages simultaneously → verify all 4 process concurrently instead of queuing
- [ ] Manual: verify default behavior (no config) still queues with concurrency 1

## Security Impact

- Does this change handle user input? **No** — only affects internal process scheduling
- Does this change affect authentication/authorization? **No**
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Deploy with `maxConcurrent: 4` for Telegram, send 4 messages rapidly → all should process in parallel
2. Remove `maxConcurrent` config → verify default concurrency of 1 is restored
3. Verify other channels (Discord, Control UI) still respect their lane concurrency settings

## Failure Recovery

Revert the commit. The `lanes` Map reverts to module-level scope; Telegram concurrency will fall back to the previous broken behavior (always 1) but no data loss or crashes.

## Risks and Mitigations

- **Risk**: Polluting `globalThis` with well-known keys
  **Mitigation**: Keys use a namespaced prefix (`__openclaw_command_lanes__`, `__openclaw_command_task_id__`) that is unlikely to collide with other libraries or user code.