### PR TITLE
fix(telegram): suppress bare Reasoning: prefix leak in draft streaming

### DIFF
--- a/src/telegram/reasoning-lane-coordinator.test.ts
+++ b/src/telegram/reasoning-lane-coordinator.test.ts
@@ -26,4 +26,18 @@ describe("splitTelegramReasoningText", () => {
   it("does not emit partial reasoning tag prefixes", () => {
     expect(splitTelegramReasoningText("  <thi")).toEqual({});
   });
+
+  it("suppresses bare 'Reasoning:\\n' prefix before content arrives", () => {
+    expect(splitTelegramReasoningText("Reasoning:\n")).toEqual({});
+  });
+
+  it("suppresses trimmed 'Reasoning:' prefix", () => {
+    expect(splitTelegramReasoningText("  Reasoning:  ")).toEqual({});
+  });
+
+  it("keeps full reasoning message with content after prefix", () => {
+    expect(splitTelegramReasoningText("Reasoning:\nActual reasoning here")).toEqual({
+      reasoningText: "Reasoning:\nActual reasoning here",
+    });
+  });
 });

--- a/src/telegram/reasoning-lane-coordinator.ts
+++ b/src/telegram/reasoning-lane-coordinator.ts
@@ -68,6 +68,10 @@ export function splitTelegramReasoningText(text?: string): TelegramReasoningSpli
   if (isPartialReasoningTagPrefix(trimmed)) {
     return {};
   }
+  const prefixTrimmed = REASONING_MESSAGE_PREFIX.trim();
+  if (trimmed === prefixTrimmed) {
+    return {};
+  }
   if (
     trimmed.startsWith(REASONING_MESSAGE_PREFIX) &&
     trimmed.length > REASONING_MESSAGE_PREFIX.length


### PR DESCRIPTION
## Summary

- **Problem:** During Telegram DM draft streaming with Gemini models, a partial chunk containing just `"Reasoning:
"` leaks to the user as visible answer text `"Reasoning:"`.
- **Why it matters:** Users see raw reasoning prefix text in their chat, which is confusing and breaks the clean streaming experience.
- **What changed:**
  - `src/telegram/reasoning-lane-coordinator.ts`: Added check in `splitTelegramReasoningText` — if the trimmed text equals the trimmed `REASONING_MESSAGE_PREFIX` (bare `"Reasoning:"` with no content after it), return `{}` to suppress it.
  - `src/telegram/reasoning-lane-coordinator.test.ts`: Added 3 test cases covering the bare prefix, whitespace-padded prefix, and full reasoning message with content.
- **What did NOT change:** The handling of complete reasoning messages with content after the prefix, or tagged reasoning (`<think>...</think>`).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #37890

## User-visible / Behavior Changes

Bare `Reasoning:` prefix no longer leaks into Telegram DM streaming output during Gemini model reasoning.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js
- Integration/channel: Telegram DM with Gemini model

### Steps

1. Configure a Gemini model with Telegram DM and draft streaming
2. Send a prompt that triggers reasoning
3. During streaming, observe the partial chunks

### Expected

- No raw `Reasoning:` text visible in the chat

### Actual

- Before fix: `Reasoning:` appears as answer text
- After fix: Bare prefix is suppressed; only reasoning with actual content is shown

## Evidence

```
 ✓ src/telegram/reasoning-lane-coordinator.test.ts (7 tests) 3ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

## Human Verification (required)

- Verified scenarios: Bare prefix, padded prefix, full reasoning with content, existing tag-based reasoning
- Edge cases checked: Whitespace-only around prefix, prefix with trailing newline
- What I did **not** verify: E2E with live Gemini streaming on Telegram

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the 4-line change in `reasoning-lane-coordinator.ts`
- Files/config to restore: Single file
- Known bad symptoms: If reverted, bare Reasoning: prefix leaks again

## Risks and Mitigations

None — the check only suppresses the exact bare prefix text that should never be visible to users.
