### PR TITLE
feat(gateway): add explicit post-restart continuation prompts

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1403,6 +1403,7 @@ public struct ConfigApplyParams: Codable, Sendable {
     public let basehash: String?
     public let sessionkey: String?
     public let note: String?
+    public let continueprompt: String?
     public let restartdelayms: Int?
 
     public init(
@@ -1410,12 +1411,14 @@ public struct ConfigApplyParams: Codable, Sendable {
         basehash: String?,
         sessionkey: String?,
         note: String?,
+        continueprompt: String?,
         restartdelayms: Int?)
     {
         self.raw = raw
         self.basehash = basehash
         self.sessionkey = sessionkey
         self.note = note
+        self.continueprompt = continueprompt
         self.restartdelayms = restartdelayms
     }
 
@@ -1424,6 +1427,7 @@ public struct ConfigApplyParams: Codable, Sendable {
         case basehash = "baseHash"
         case sessionkey = "sessionKey"
         case note
+        case continueprompt = "continuePrompt"
         case restartdelayms = "restartDelayMs"
     }
 }
@@ -1433,6 +1437,7 @@ public struct ConfigPatchParams: Codable, Sendable {
     public let basehash: String?
     public let sessionkey: String?
     public let note: String?
+    public let continueprompt: String?
     public let restartdelayms: Int?
 
     public init(
@@ -1440,12 +1445,14 @@ public struct ConfigPatchParams: Codable, Sendable {
         basehash: String?,
         sessionkey: String?,
         note: String?,
+        continueprompt: String?,
         restartdelayms: Int?)
     {
         self.raw = raw
         self.basehash = basehash
         self.sessionkey = sessionkey
         self.note = note
+        self.continueprompt = continueprompt
         self.restartdelayms = restartdelayms
     }
 
@@ -1454,6 +1461,7 @@ public struct ConfigPatchParams: Codable, Sendable {
         case basehash = "baseHash"
         case sessionkey = "sessionKey"
         case note
+        case continueprompt = "continuePrompt"
         case restartdelayms = "restartDelayMs"
     }
 }
@@ -3311,17 +3319,20 @@ public struct ChatEvent: Codable, Sendable {
 public struct UpdateRunParams: Codable, Sendable {
     public let sessionkey: String?
     public let note: String?
+    public let continueprompt: String?
     public let restartdelayms: Int?
     public let timeoutms: Int?
 
     public init(
         sessionkey: String?,
         note: String?,
+        continueprompt: String?,
         restartdelayms: Int?,
         timeoutms: Int?)
     {
         self.sessionkey = sessionkey
         self.note = note
+        self.continueprompt = continueprompt
         self.restartdelayms = restartdelayms
         self.timeoutms = timeoutms
     }
@@ -3329,6 +3340,7 @@ public struct UpdateRunParams: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case note
+        case continueprompt = "continuePrompt"
         case restartdelayms = "restartDelayMs"
         case timeoutms = "timeoutMs"
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1403,6 +1403,7 @@ public struct ConfigApplyParams: Codable, Sendable {
     public let basehash: String?
     public let sessionkey: String?
     public let note: String?
+    public let continueprompt: String?
     public let restartdelayms: Int?
 
     public init(
@@ -1410,12 +1411,14 @@ public struct ConfigApplyParams: Codable, Sendable {
         basehash: String?,
         sessionkey: String?,
         note: String?,
+        continueprompt: String?,
         restartdelayms: Int?)
     {
         self.raw = raw
         self.basehash = basehash
         self.sessionkey = sessionkey
         self.note = note
+        self.continueprompt = continueprompt
         self.restartdelayms = restartdelayms
     }
 
@@ -1424,6 +1427,7 @@ public struct ConfigApplyParams: Codable, Sendable {
         case basehash = "baseHash"
         case sessionkey = "sessionKey"
         case note
+        case continueprompt = "continuePrompt"
         case restartdelayms = "restartDelayMs"
     }
 }
@@ -1433,6 +1437,7 @@ public struct ConfigPatchParams: Codable, Sendable {
     public let basehash: String?
     public let sessionkey: String?
     public let note: String?
+    public let continueprompt: String?
     public let restartdelayms: Int?
 
     public init(
@@ -1440,12 +1445,14 @@ public struct ConfigPatchParams: Codable, Sendable {
         basehash: String?,
         sessionkey: String?,
         note: String?,
+        continueprompt: String?,
         restartdelayms: Int?)
     {
         self.raw = raw
         self.basehash = basehash
         self.sessionkey = sessionkey
         self.note = note
+        self.continueprompt = continueprompt
         self.restartdelayms = restartdelayms
     }
 
@@ -1454,6 +1461,7 @@ public struct ConfigPatchParams: Codable, Sendable {
         case basehash = "baseHash"
         case sessionkey = "sessionKey"
         case note
+        case continueprompt = "continuePrompt"
         case restartdelayms = "restartDelayMs"
     }
 }
@@ -3311,17 +3319,20 @@ public struct ChatEvent: Codable, Sendable {
 public struct UpdateRunParams: Codable, Sendable {
     public let sessionkey: String?
     public let note: String?
+    public let continueprompt: String?
     public let restartdelayms: Int?
     public let timeoutms: Int?
 
     public init(
         sessionkey: String?,
         note: String?,
+        continueprompt: String?,
         restartdelayms: Int?,
         timeoutms: Int?)
     {
         self.sessionkey = sessionkey
         self.note = note
+        self.continueprompt = continueprompt
         self.restartdelayms = restartdelayms
         self.timeoutms = timeoutms
     }
@@ -3329,6 +3340,7 @@ public struct UpdateRunParams: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case note
+        case continueprompt = "continuePrompt"
         case restartdelayms = "restartDelayMs"
         case timeoutms = "timeoutMs"
     }

--- a/src/agents/openclaw-gateway-tool.test.ts
+++ b/src/agents/openclaw-gateway-tool.test.ts
@@ -37,6 +37,7 @@ function expectConfigMutationCall(params: {
   action: "config.apply" | "config.patch";
   raw: string;
   sessionKey: string;
+  continuePrompt?: string;
 }) {
   expect(params.callGatewayTool).toHaveBeenCalledWith("config.get", expect.any(Object), {});
   expect(params.callGatewayTool).toHaveBeenCalledWith(
@@ -46,6 +47,7 @@ function expectConfigMutationCall(params: {
       raw: params.raw.trim(),
       baseHash: "hash-1",
       sessionKey: params.sessionKey,
+      ...(params.continuePrompt ? { continuePrompt: params.continuePrompt } : {}),
     }),
   );
 }
@@ -70,6 +72,7 @@ describe("gateway tool", () => {
           const result = await tool.execute("call1", {
             action: "restart",
             delayMs: 0,
+            continuePrompt: "resume after restart",
           });
           expect(result.details).toMatchObject({
             ok: true,
@@ -81,12 +84,20 @@ describe("gateway tool", () => {
           const sentinelPath = path.join(stateDir, "restart-sentinel.json");
           const raw = await fs.readFile(sentinelPath, "utf-8");
           const parsed = JSON.parse(raw) as {
-            payload?: { kind?: string; doctorHint?: string | null };
+            payload?: {
+              kind?: string;
+              doctorHint?: string | null;
+              continuation?: { kind?: string; prompt?: string };
+            };
           };
           expect(parsed.payload?.kind).toBe("restart");
           expect(parsed.payload?.doctorHint).toBe(
             "Run: openclaw --profile isolated doctor --non-interactive",
           );
+          expect(parsed.payload?.continuation).toEqual({
+            kind: "agent-turn",
+            prompt: "resume after restart",
+          });
 
           expect(kill).not.toHaveBeenCalled();
           await vi.runAllTimersAsync();
@@ -104,11 +115,13 @@ describe("gateway tool", () => {
     const { callGatewayTool } = await import("./tools/gateway.js");
     const sessionKey = "agent:main:whatsapp:dm:+15555550123";
     const tool = requireGatewayTool(sessionKey);
+    const continuePrompt = "re-run smoke tests after restart";
 
     const raw = '{\n  agents: { defaults: { workspace: "~/openclaw" } }\n}\n';
     await tool.execute("call2", {
       action: "config.apply",
       raw,
+      continuePrompt,
     });
 
     expectConfigMutationCall({
@@ -116,6 +129,7 @@ describe("gateway tool", () => {
       action: "config.apply",
       raw,
       sessionKey,
+      continuePrompt,
     });
   });
 
@@ -142,10 +156,12 @@ describe("gateway tool", () => {
     const { callGatewayTool } = await import("./tools/gateway.js");
     const sessionKey = "agent:main:whatsapp:dm:+15555550123";
     const tool = requireGatewayTool(sessionKey);
+    const continuePrompt = "verify update health";
 
     await tool.execute("call3", {
       action: "update.run",
       note: "test update",
+      continuePrompt,
     });
 
     expect(callGatewayTool).toHaveBeenCalledWith(
@@ -153,6 +169,7 @@ describe("gateway tool", () => {
       expect.any(Object),
       expect.objectContaining({
         note: "test update",
+        continuePrompt,
         sessionKey,
       }),
     );

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { resolveConfigSnapshotHash } from "../../config/io.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
 import {
+  buildRestartSentinelContinuation,
   formatDoctorNonInteractiveHint,
   type RestartSentinelPayload,
   writeRestartSentinel,
@@ -58,6 +59,7 @@ const GatewayToolSchema = Type.Object({
   // config.apply, config.patch, update.run
   sessionKey: Type.Optional(Type.String()),
   note: Type.Optional(Type.String()),
+  continuePrompt: Type.Optional(Type.String()),
   restartDelayMs: Type.Optional(Type.Number()),
 });
 // NOTE: We intentionally avoid top-level `allOf`/`anyOf`/`oneOf` conditionals here:
@@ -74,7 +76,7 @@ export function createGatewayTool(opts?: {
     name: "gateway",
     ownerOnly: true,
     description:
-      "Restart, apply config, or update the gateway in-place (SIGUSR1). Use config.patch for safe partial config updates (merges with existing). Use config.apply only when replacing entire config. Both trigger restart after writing. Always pass a human-readable completion message via the `note` parameter so the system can deliver it to the user after restart.",
+      "Restart, apply config, or update the gateway in-place (SIGUSR1). Use config.patch for safe partial config updates (merges with existing). Use config.apply only when replacing entire config. Both trigger restart after writing. Always pass a human-readable completion message via the `note` parameter so the system can deliver it to the user after restart. Pass `continuePrompt` when restart should automatically resume work with a fresh agent turn after startup.",
     parameters: GatewayToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -97,6 +99,10 @@ export function createGatewayTool(opts?: {
             : undefined;
         const note =
           typeof params.note === "string" && params.note.trim() ? params.note.trim() : undefined;
+        const continuePrompt =
+          typeof params.continuePrompt === "string" && params.continuePrompt.trim()
+            ? params.continuePrompt.trim()
+            : undefined;
         // Extract channel + threadId for routing after restart
         // Supports both :thread: (most channels) and :topic: (Telegram)
         const { deliveryContext, threadId } = extractDeliveryInfo(sessionKey);
@@ -108,6 +114,7 @@ export function createGatewayTool(opts?: {
           deliveryContext,
           threadId,
           message: note ?? reason ?? null,
+          continuation: buildRestartSentinelContinuation(continuePrompt) ?? null,
           doctorHint: formatDoctorNonInteractiveHint(),
           stats: {
             mode: "gateway.restart",
@@ -134,6 +141,7 @@ export function createGatewayTool(opts?: {
       const resolveGatewayWriteMeta = (): {
         sessionKey: string | undefined;
         note: string | undefined;
+        continuePrompt: string | undefined;
         restartDelayMs: number | undefined;
       } => {
         const sessionKey =
@@ -142,11 +150,15 @@ export function createGatewayTool(opts?: {
             : opts?.agentSessionKey?.trim() || undefined;
         const note =
           typeof params.note === "string" && params.note.trim() ? params.note.trim() : undefined;
+        const continuePrompt =
+          typeof params.continuePrompt === "string" && params.continuePrompt.trim()
+            ? params.continuePrompt.trim()
+            : undefined;
         const restartDelayMs =
           typeof params.restartDelayMs === "number" && Number.isFinite(params.restartDelayMs)
             ? Math.floor(params.restartDelayMs)
             : undefined;
-        return { sessionKey, note, restartDelayMs };
+        return { sessionKey, note, continuePrompt, restartDelayMs };
       };
 
       const resolveConfigWriteParams = async (): Promise<{
@@ -154,6 +166,7 @@ export function createGatewayTool(opts?: {
         baseHash: string;
         sessionKey: string | undefined;
         note: string | undefined;
+        continuePrompt: string | undefined;
         restartDelayMs: number | undefined;
       }> => {
         const raw = readStringParam(params, "raw", { required: true });
@@ -177,31 +190,33 @@ export function createGatewayTool(opts?: {
         return jsonResult({ ok: true, result });
       }
       if (action === "config.apply") {
-        const { raw, baseHash, sessionKey, note, restartDelayMs } =
+        const { raw, baseHash, sessionKey, note, continuePrompt, restartDelayMs } =
           await resolveConfigWriteParams();
         const result = await callGatewayTool("config.apply", gatewayOpts, {
           raw,
           baseHash,
           sessionKey,
           note,
+          continuePrompt,
           restartDelayMs,
         });
         return jsonResult({ ok: true, result });
       }
       if (action === "config.patch") {
-        const { raw, baseHash, sessionKey, note, restartDelayMs } =
+        const { raw, baseHash, sessionKey, note, continuePrompt, restartDelayMs } =
           await resolveConfigWriteParams();
         const result = await callGatewayTool("config.patch", gatewayOpts, {
           raw,
           baseHash,
           sessionKey,
           note,
+          continuePrompt,
           restartDelayMs,
         });
         return jsonResult({ ok: true, result });
       }
       if (action === "update.run") {
-        const { sessionKey, note, restartDelayMs } = resolveGatewayWriteMeta();
+        const { sessionKey, note, continuePrompt, restartDelayMs } = resolveGatewayWriteMeta();
         const updateTimeoutMs = gatewayOpts.timeoutMs ?? DEFAULT_UPDATE_TIMEOUT_MS;
         const updateGatewayOpts = {
           ...gatewayOpts,
@@ -210,6 +225,7 @@ export function createGatewayTool(opts?: {
         const result = await callGatewayTool("update.run", updateGatewayOpts, {
           sessionKey,
           note,
+          continuePrompt,
           restartDelayMs,
           timeoutMs: updateTimeoutMs,
         });

--- a/src/gateway/protocol/schema/config.ts
+++ b/src/gateway/protocol/schema/config.ts
@@ -17,6 +17,7 @@ const ConfigApplyLikeParamsSchema = Type.Object(
     baseHash: Type.Optional(NonEmptyString),
     sessionKey: Type.Optional(Type.String()),
     note: Type.Optional(Type.String()),
+    continuePrompt: Type.Optional(Type.String()),
     restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
   },
   { additionalProperties: false },
@@ -31,6 +32,7 @@ export const UpdateRunParamsSchema = Type.Object(
   {
     sessionKey: Type.Optional(Type.String()),
     note: Type.Optional(Type.String()),
+    continuePrompt: Type.Optional(Type.String()),
     restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
     timeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
   },

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -21,6 +21,7 @@ import { buildConfigSchema, type ConfigSchemaResponse } from "../../config/schem
 import { extractDeliveryInfo } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
+  buildRestartSentinelContinuation,
   formatDoctorNonInteractiveHint,
   type RestartSentinelPayload,
   writeRestartSentinel,
@@ -155,11 +156,12 @@ function parseValidateConfigFromRawOrRespond(
 function resolveConfigRestartRequest(params: unknown): {
   sessionKey: string | undefined;
   note: string | undefined;
+  continuePrompt: string | undefined;
   restartDelayMs: number | undefined;
   deliveryContext: ReturnType<typeof extractDeliveryInfo>["deliveryContext"];
   threadId: ReturnType<typeof extractDeliveryInfo>["threadId"];
 } {
-  const { sessionKey, note, restartDelayMs } = parseRestartRequestParams(params);
+  const { sessionKey, note, continuePrompt, restartDelayMs } = parseRestartRequestParams(params);
 
   // Extract deliveryContext + threadId for routing after restart
   // Supports both :thread: (most channels) and :topic: (Telegram)
@@ -168,6 +170,7 @@ function resolveConfigRestartRequest(params: unknown): {
   return {
     sessionKey,
     note,
+    continuePrompt,
     restartDelayMs,
     deliveryContext,
     threadId,
@@ -181,6 +184,7 @@ function buildConfigRestartSentinelPayload(params: {
   deliveryContext: ReturnType<typeof extractDeliveryInfo>["deliveryContext"];
   threadId: ReturnType<typeof extractDeliveryInfo>["threadId"];
   note: string | undefined;
+  continuePrompt: string | undefined;
 }): RestartSentinelPayload {
   return {
     kind: params.kind,
@@ -190,6 +194,7 @@ function buildConfigRestartSentinelPayload(params: {
     deliveryContext: params.deliveryContext,
     threadId: params.threadId,
     message: params.note ?? null,
+    continuation: buildRestartSentinelContinuation(params.continuePrompt) ?? null,
     doctorHint: formatDoctorNonInteractiveHint(),
     stats: {
       mode: params.mode,
@@ -362,7 +367,7 @@ export const configHandlers: GatewayRequestHandlers = {
     );
     await writeConfigFile(validated.config, writeOptions);
 
-    const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
+    const { sessionKey, note, continuePrompt, restartDelayMs, deliveryContext, threadId } =
       resolveConfigRestartRequest(params);
     const payload = buildConfigRestartSentinelPayload({
       kind: "config-patch",
@@ -371,6 +376,7 @@ export const configHandlers: GatewayRequestHandlers = {
       deliveryContext,
       threadId,
       note,
+      continuePrompt,
     });
     const sentinelPath = await tryWriteRestartSentinelPayload(payload);
     const restart = scheduleGatewaySigusr1Restart({
@@ -422,7 +428,7 @@ export const configHandlers: GatewayRequestHandlers = {
     );
     await writeConfigFile(parsed.config, writeOptions);
 
-    const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
+    const { sessionKey, note, continuePrompt, restartDelayMs, deliveryContext, threadId } =
       resolveConfigRestartRequest(params);
     const payload = buildConfigRestartSentinelPayload({
       kind: "config-apply",
@@ -431,6 +437,7 @@ export const configHandlers: GatewayRequestHandlers = {
       deliveryContext,
       threadId,
       note,
+      continuePrompt,
     });
     const sentinelPath = await tryWriteRestartSentinelPayload(payload);
     const restart = scheduleGatewaySigusr1Restart({

--- a/src/gateway/server-methods/restart-request.ts
+++ b/src/gateway/server-methods/restart-request.ts
@@ -1,6 +1,7 @@
 export function parseRestartRequestParams(params: unknown): {
   sessionKey: string | undefined;
   note: string | undefined;
+  continuePrompt: string | undefined;
   restartDelayMs: number | undefined;
 } {
   const sessionKey =
@@ -11,10 +12,14 @@ export function parseRestartRequestParams(params: unknown): {
     typeof (params as { note?: unknown }).note === "string"
       ? (params as { note?: string }).note?.trim() || undefined
       : undefined;
+  const continuePrompt =
+    typeof (params as { continuePrompt?: unknown }).continuePrompt === "string"
+      ? (params as { continuePrompt?: string }).continuePrompt?.trim() || undefined
+      : undefined;
   const restartDelayMsRaw = (params as { restartDelayMs?: unknown }).restartDelayMs;
   const restartDelayMs =
     typeof restartDelayMsRaw === "number" && Number.isFinite(restartDelayMsRaw)
       ? Math.max(0, Math.floor(restartDelayMsRaw))
       : undefined;
-  return { sessionKey, note, restartDelayMs };
+  return { sessionKey, note, continuePrompt, restartDelayMs };
 }

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -67,6 +67,7 @@ vi.mock("./restart-request.js", () => ({
   parseRestartRequestParams: (params: Record<string, unknown>) => ({
     sessionKey: params.sessionKey,
     note: params.note,
+    continuePrompt: params.continuePrompt,
     restartDelayMs: undefined,
   }),
 }));
@@ -140,6 +141,21 @@ describe("update.run sentinel deliveryContext", () => {
       accountId: "workspace-1",
     });
     expect(capturedPayload!.threadId).toBe("1234567890.123456");
+  });
+
+  it("includes continuation when continuePrompt is provided", async () => {
+    capturedPayload = undefined;
+
+    await invokeUpdateRun({
+      sessionKey: "agent:main:webchat:dm:user-123",
+      continuePrompt: "resume validation after restart",
+    });
+
+    expect(capturedPayload).toBeDefined();
+    expect(capturedPayload!.continuation).toEqual({
+      kind: "agent-turn",
+      prompt: "resume validation after restart",
+    });
   });
 });
 

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -2,6 +2,7 @@ import { loadConfig } from "../../config/config.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import {
+  buildRestartSentinelContinuation,
   formatDoctorNonInteractiveHint,
   type RestartSentinelPayload,
   writeRestartSentinel,
@@ -21,7 +22,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       return;
     }
     const actor = resolveControlPlaneActor(client);
-    const { sessionKey, note, restartDelayMs } = parseRestartRequestParams(params);
+    const { sessionKey, note, continuePrompt, restartDelayMs } = parseRestartRequestParams(params);
     const { deliveryContext, threadId } = extractDeliveryInfo(sessionKey);
     const timeoutMsRaw = (params as { timeoutMs?: unknown }).timeoutMs;
     const timeoutMs =
@@ -63,6 +64,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       deliveryContext,
       threadId,
       message: note ?? null,
+      continuation: buildRestartSentinelContinuation(continuePrompt) ?? null,
       doctorHint: formatDoctorNonInteractiveHint(),
       stats: {
         mode: result.mode,

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -5,6 +5,10 @@ const mocks = vi.hoisted(() => ({
   consumeRestartSentinel: vi.fn(async () => ({
     payload: {
       sessionKey: "agent:main:main",
+      continuation: {
+        kind: "agent-turn",
+        prompt: "continue testing",
+      },
       deliveryContext: {
         channel: "whatsapp",
         to: "+15550002",
@@ -27,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   resolveOutboundTarget: vi.fn(() => ({ ok: true as const, to: "+15550002" })),
   deliverOutboundPayloads: vi.fn(async () => []),
   enqueueSystemEvent: vi.fn(),
+  agentCommandFromIngress: vi.fn(async () => ({ payloads: [], meta: {} })),
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
@@ -76,10 +81,14 @@ vi.mock("../infra/system-events.js", () => ({
   enqueueSystemEvent: mocks.enqueueSystemEvent,
 }));
 
+vi.mock("../commands/agent.js", () => ({
+  agentCommandFromIngress: mocks.agentCommandFromIngress,
+}));
+
 const { scheduleRestartSentinelWake } = await import("./server-restart-sentinel.js");
 
 describe("scheduleRestartSentinelWake", () => {
-  it("forwards session context to outbound delivery", async () => {
+  it("forwards session context to outbound delivery and starts restart continuation", async () => {
     await scheduleRestartSentinelWake({ deps: {} as never });
 
     expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
@@ -88,6 +97,25 @@ describe("scheduleRestartSentinelWake", () => {
         to: "+15550002",
         session: { key: "agent:main:main", agentId: "agent-from-key" },
       }),
+    );
+    expect(mocks.agentCommandFromIngress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "continue testing",
+        sessionKey: "agent:main:main",
+        channel: "whatsapp",
+        to: "+15550002",
+        deliver: true,
+        messageChannel: "whatsapp",
+        bestEffortDeliver: true,
+        senderIsOwner: true,
+        inputProvenance: {
+          kind: "internal_system",
+          sourceChannel: "whatsapp",
+          sourceTool: "gateway.restart.continuation",
+        },
+      }),
+      expect.any(Object),
+      expect.any(Object),
     );
     expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
   });

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -1,6 +1,7 @@
 import { resolveAnnounceTargetFromKey } from "../agents/tools/sessions-send-helpers.js";
 import { normalizeChannelId } from "../channels/plugins/index.js";
 import type { CliDeps } from "../cli/deps.js";
+import { agentCommandFromIngress } from "../commands/agent.js";
 import { resolveMainSessionKeyFromConfig } from "../config/sessions.js";
 import { parseSessionThreadInfo } from "../config/sessions/delivery-info.js";
 import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
@@ -9,11 +10,64 @@ import { resolveOutboundTarget } from "../infra/outbound/targets.js";
 import {
   consumeRestartSentinel,
   formatRestartSentinelMessage,
+  type RestartSentinelPayload,
   summarizeRestartSentinel,
 } from "../infra/restart-sentinel.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
+import { defaultRuntime } from "../runtime.js";
 import { deliveryContextFromSession, mergeDeliveryContext } from "../utils/delivery-context.js";
 import { loadSessionEntry } from "./session-utils.js";
+
+function buildRestartContinuationRequest(params: {
+  payload: RestartSentinelPayload;
+  sessionKey: string;
+  channel?: string | null;
+  to?: string;
+  accountId?: string;
+  threadId?: string | number;
+}) {
+  const prompt =
+    params.payload.continuation?.kind === "agent-turn"
+      ? params.payload.continuation.prompt.trim()
+      : "";
+  if (!prompt) {
+    return null;
+  }
+  const hasDeliveryTarget = Boolean(params.channel && params.to);
+  const runContext = {
+    ...(params.channel ? { messageChannel: params.channel } : {}),
+    ...(params.accountId ? { accountId: params.accountId } : {}),
+    ...(params.to ? { currentChannelId: params.to } : {}),
+    ...(params.threadId != null && params.threadId !== ""
+      ? { currentThreadTs: String(params.threadId) }
+      : {}),
+  };
+  return {
+    message: prompt,
+    sessionKey: params.sessionKey,
+    ...(hasDeliveryTarget
+      ? {
+          deliver: true,
+          channel: params.channel,
+          to: params.to,
+          deliveryTargetMode: "explicit" as const,
+        }
+      : {}),
+    ...(params.channel ? { messageChannel: params.channel } : {}),
+    ...(params.accountId ? { accountId: params.accountId } : {}),
+    ...(params.threadId != null && params.threadId !== ""
+      ? { threadId: String(params.threadId) }
+      : {}),
+    ...(Object.keys(runContext).length > 0 ? { runContext } : {}),
+    bestEffortDeliver: true,
+    inputProvenance: {
+      kind: "internal_system" as const,
+      ...(params.channel ? { sourceChannel: params.channel } : {}),
+      sourceTool: "gateway.restart.continuation",
+    },
+    senderIsOwner: true,
+  };
+}
 
 export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
   const sentinel = await consumeRestartSentinel();
@@ -53,21 +107,23 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
   const channelRaw = origin?.channel;
   const channel = channelRaw ? normalizeChannelId(channelRaw) : null;
   const to = origin?.to;
+  let continuationTo = to;
   if (!channel || !to) {
     enqueueSystemEvent(message, { sessionKey });
-    return;
-  }
-
-  const resolved = resolveOutboundTarget({
-    channel,
-    to,
-    cfg,
-    accountId: origin?.accountId,
-    mode: "implicit",
-  });
-  if (!resolved.ok) {
-    enqueueSystemEvent(message, { sessionKey });
-    return;
+  } else {
+    const resolved = resolveOutboundTarget({
+      channel,
+      to,
+      cfg,
+      accountId: origin?.accountId,
+      mode: "implicit",
+    });
+    if (!resolved.ok) {
+      continuationTo = undefined;
+      enqueueSystemEvent(message, { sessionKey });
+    } else {
+      continuationTo = resolved.to;
+    }
   }
 
   const threadId =
@@ -88,21 +144,39 @@ export async function scheduleRestartSentinelWake(_params: { deps: CliDeps }) {
     sessionKey,
   });
 
-  try {
-    await deliverOutboundPayloads({
-      cfg,
-      channel,
-      to: resolved.to,
-      accountId: origin?.accountId,
-      replyToId,
-      threadId: resolvedThreadId,
-      payloads: [{ text: message }],
-      session: outboundSession,
-      bestEffort: true,
-    });
-  } catch (err) {
-    enqueueSystemEvent(`${summary}\n${String(err)}`, { sessionKey });
+  if (channel && continuationTo) {
+    try {
+      await deliverOutboundPayloads({
+        cfg,
+        channel,
+        to: continuationTo,
+        accountId: origin?.accountId,
+        replyToId,
+        threadId: resolvedThreadId,
+        payloads: [{ text: message }],
+        session: outboundSession,
+        bestEffort: true,
+      });
+    } catch (err) {
+      enqueueSystemEvent(`${summary}\n${String(err)}`, { sessionKey });
+    }
   }
+
+  const continuationRequest = buildRestartContinuationRequest({
+    payload,
+    sessionKey,
+    channel,
+    to: continuationTo,
+    accountId: origin?.accountId,
+    threadId,
+  });
+  if (!continuationRequest) {
+    return;
+  }
+
+  void agentCommandFromIngress(continuationRequest, defaultRuntime, _params.deps).catch((err) => {
+    enqueueSystemEvent(`Restart continuation failed: ${String(err)}`, { sessionKey });
+  });
 }
 
 export function shouldWakeFromRestartSentinel() {

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
 import {
+  buildRestartSentinelContinuation,
   consumeRestartSentinel,
   formatRestartSentinelMessage,
   readRestartSentinel,
@@ -33,6 +34,10 @@ describe("restart sentinel", () => {
       status: "ok" as const,
       ts: Date.now(),
       sessionKey: "agent:main:whatsapp:dm:+15555550123",
+      continuation: {
+        kind: "agent-turn" as const,
+        prompt: "resume after restart",
+      },
       stats: { mode: "git" },
     };
     const filePath = await writeRestartSentinel(payload);
@@ -98,6 +103,14 @@ describe("restart sentinel", () => {
     const trimmed = trimLogTail(text, 8000);
     expect(trimmed?.length).toBeLessThanOrEqual(8001);
     expect(trimmed?.startsWith("…")).toBe(true);
+  });
+
+  it("builds continuation from a non-empty prompt", () => {
+    expect(buildRestartSentinelContinuation("  continue after restart  ")).toEqual({
+      kind: "agent-turn",
+      prompt: "continue after restart",
+    });
+    expect(buildRestartSentinelContinuation("   ")).toBeUndefined();
   });
 
   it("formats restart messages without volatile timestamps", () => {

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -27,6 +27,11 @@ export type RestartSentinelStats = {
   durationMs?: number | null;
 };
 
+export type RestartSentinelContinuation = {
+  kind: "agent-turn";
+  prompt: string;
+};
+
 export type RestartSentinelPayload = {
   kind: "config-apply" | "config-patch" | "update" | "restart";
   status: "ok" | "error" | "skipped";
@@ -41,6 +46,7 @@ export type RestartSentinelPayload = {
   /** Thread ID for reply threading (e.g., Slack thread_ts). */
   threadId?: string;
   message?: string | null;
+  continuation?: RestartSentinelContinuation | null;
   doctorHint?: string | null;
   stats?: RestartSentinelStats | null;
 };
@@ -52,10 +58,31 @@ export type RestartSentinel = {
 
 const SENTINEL_FILENAME = "restart-sentinel.json";
 
+function normalizeOptionalString(value?: string | null): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 export function formatDoctorNonInteractiveHint(
   env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
 ): string {
   return `Run: ${formatCliCommand("openclaw doctor --non-interactive", env)}`;
+}
+
+export function buildRestartSentinelContinuation(
+  prompt?: string | null,
+): RestartSentinelContinuation | undefined {
+  const normalizedPrompt = normalizeOptionalString(prompt);
+  if (!normalizedPrompt) {
+    return undefined;
+  }
+  return {
+    kind: "agent-turn",
+    prompt: normalizedPrompt,
+  };
 }
 
 export function resolveRestartSentinelPath(env: NodeJS.ProcessEnv = process.env): string {


### PR DESCRIPTION
## Summary

- Problem: self-initiated gateway restarts only send a notification after restart and do not resume the intended follow-up work.
- Why it matters: config/update/restart flows that know exactly what should happen next still leave the user waiting for a manual prompt.
- What changed: added an explicit `continuePrompt` path that is persisted in the restart sentinel and replayed as a fresh ingress agent turn after startup.
- What did NOT change (scope boundary): this does not persist or replay arbitrary in-flight runs, and it does not attempt crash recovery.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #26872
- Related #34747
- Related #36070

## User-visible / Behavior Changes

- `gateway restart`, `config.apply`, `config.patch`, and `update.run` now accept `continuePrompt`.
- When `continuePrompt` is present, startup wake sends the usual restart notification and then starts a new agent turn with that prompt.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  - This adds one explicit post-restart execution path, but only when a caller intentionally supplies `continuePrompt`.
  - Scope is constrained to self-authored restart flows; no generic replay of arbitrary in-flight work is attempted.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm checkout
- Model/provider: n/a
- Integration/channel (if any): mocked gateway/unit coverage
- Relevant config (redacted): default local test config

### Steps

1. Trigger a restart-producing flow with `continuePrompt`.
2. Persist restart sentinel.
3. Simulate startup wake.

### Expected

- Restart notification is delivered.
- A new ingress agent turn is started with the stored prompt.

### Actual

- Verified by targeted tests below.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `restart-sentinel` payload now stores optional continuation.
  - `update.run` writes continuation into sentinel.
  - `gateway` tool forwards `continuePrompt`.
  - startup wake sends restart notice and starts a continuation turn.
  - gateway `config.apply` test still passes with schema changes.
- Edge cases checked:
  - blank `continuePrompt` is ignored.
  - continuation path is best-effort and does not block restart notice delivery.
- What you did **not** verify:
  - full crash recovery / persisted in-flight run replay.
  - live end-to-end delivery on a real channel.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Stop passing `continuePrompt`.
  - Revert this PR.
- Files/config to restore:
  - restart sentinel payload/schema and startup wake handling.
- Known bad symptoms reviewers should watch for:
  - duplicate post-restart turns.
  - continuation turn starting without an explicit prompt.

## Risks and Mitigations

- Risk:
  - This may overlap conceptually with broader restart recovery work.
  - Mitigation:
    - Scope is intentionally narrow: explicit continuation only, no generic run replay.

## AI Assistance

- AI-assisted: yes
- Testing level: lightly tested to targeted-tested
- Session log available on request
