### PR TITLE
fix(agents): let codex-cli provider reuse openai-codex forward-compat, auth, and xhigh support

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -109,8 +109,8 @@ function cloneFirstTemplateModel(params: {
   return undefined;
 }
 
-const CODEX_GPT54_ELIGIBLE_PROVIDERS = new Set(["openai-codex"]);
-const CODEX_GPT53_ELIGIBLE_PROVIDERS = new Set(["openai-codex", "github-copilot"]);
+const CODEX_GPT54_ELIGIBLE_PROVIDERS = new Set(["openai-codex", "codex-cli"]);
+const CODEX_GPT53_ELIGIBLE_PROVIDERS = new Set(["openai-codex", "codex-cli", "github-copilot"]);
 
 function resolveOpenAICodexForwardCompatModel(
   provider: string,
@@ -137,8 +137,10 @@ function resolveOpenAICodexForwardCompatModel(
     return undefined;
   }
 
+  const catalogProvider = normalizedProvider === "codex-cli" ? "openai-codex" : normalizedProvider;
+
   for (const templateId of templateIds) {
-    const template = modelRegistry.find(normalizedProvider, templateId) as Model<Api> | null;
+    const template = modelRegistry.find(catalogProvider, templateId) as Model<Api> | null;
     if (!template) {
       continue;
     }
@@ -153,7 +155,7 @@ function resolveOpenAICodexForwardCompatModel(
     id: trimmedModelId,
     name: trimmedModelId,
     api: "openai-codex-responses",
-    provider: normalizedProvider,
+    provider: catalogProvider,
     baseUrl: "https://chatgpt.com/backend-api",
     reasoning: true,
     input: ["text", "image"],

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -71,6 +71,10 @@ describe("model-selection", () => {
       expect(normalizeProviderIdForAuth("byteplus-plan")).toBe("byteplus");
       expect(normalizeProviderIdForAuth("openai")).toBe("openai");
     });
+
+    it("maps codex-cli to openai-codex for auth lookup", () => {
+      expect(normalizeProviderIdForAuth("codex-cli")).toBe("openai-codex");
+    });
   });
 
   describe("parseModelRef", () => {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -70,6 +70,9 @@ export function normalizeProviderIdForAuth(provider: string): string {
   if (normalized === "byteplus-plan") {
     return "byteplus";
   }
+  if (normalized === "codex-cli") {
+    return "openai-codex";
+  }
   return normalized;
 }
 

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -57,6 +57,22 @@ describe("pi embedded model e2e smoke", () => {
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
   });
 
+  it("builds a codex-cli forward-compat fallback for gpt-5.4", () => {
+    mockOpenAICodexTemplateModel();
+
+    const result = resolveModel("codex-cli", "gpt-5.4", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
+  });
+
+  it("builds a codex-cli forward-compat fallback for gpt-5.3-codex", () => {
+    mockOpenAICodexTemplateModel();
+
+    const result = resolveModel("codex-cli", "gpt-5.3-codex", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.3-codex"));
+  });
+
   it("keeps unknown-model errors for non-forward-compat IDs", () => {
     const result = resolveModel("openai-codex", "gpt-4.1-mini", "/tmp/agent");
     expect(result.model).toBeUndefined();

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -58,6 +58,11 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("openai-codex", "gpt-5.4")).toContain("xhigh");
   });
 
+  it("includes xhigh for codex-cli gpt-5.4 and gpt-5.3-codex", () => {
+    expect(listThinkingLevels("codex-cli", "gpt-5.4")).toContain("xhigh");
+    expect(listThinkingLevels("codex-cli", "gpt-5.3-codex")).toContain("xhigh");
+  });
+
   it("includes xhigh for github-copilot gpt-5.2 refs", () => {
     expect(listThinkingLevels("github-copilot", "gpt-5.2")).toContain("xhigh");
     expect(listThinkingLevels("github-copilot", "gpt-5.2-codex")).toContain("xhigh");

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -30,6 +30,8 @@ export const XHIGH_MODEL_REFS = [
   "openai-codex/gpt-5.3-codex-spark",
   "openai-codex/gpt-5.2-codex",
   "openai-codex/gpt-5.1-codex",
+  "codex-cli/gpt-5.4",
+  "codex-cli/gpt-5.3-codex",
   "github-copilot/gpt-5.2-codex",
   "github-copilot/gpt-5.2",
 ] as const;


### PR DESCRIPTION
## Summary

Adds `codex-cli` to the three resolution layers that previously only recognized `openai-codex`, so that `codex-cli/gpt-5.4` works in embedded/helper paths (e.g. `session-memory -> llm-slug-generator`).

## Problem

When the primary model is configured as `codex-cli/gpt-5.4`, embedded runner helper paths fail with `FailoverError: Unknown model: codex-cli/gpt-5.4` because:

1. **Forward-compat model resolution** — `CODEX_GPT54_ELIGIBLE_PROVIDERS` only contains `openai-codex`, so `codex-cli` is rejected.
2. **Auth profile lookup** — `normalizeProviderIdForAuth("codex-cli")` returns `"codex-cli"` instead of `"openai-codex"`, so stored OAuth credentials are not found.
3. **xhigh thinking support** — `XHIGH_MODEL_REFS` only lists `openai-codex/gpt-5.4`, so `codex-cli` models cannot use the xhigh thinking level.

## Changes

| File | Change |
|------|--------|
| `src/agents/model-forward-compat.ts` | Add `codex-cli` to `CODEX_GPT54_ELIGIBLE_PROVIDERS` and `CODEX_GPT53_ELIGIBLE_PROVIDERS`; use `openai-codex` as catalog provider for template lookup when provider is `codex-cli` |
| `src/agents/model-selection.ts` | Map `codex-cli` → `openai-codex` in `normalizeProviderIdForAuth()` |
| `src/auto-reply/thinking.ts` | Add `codex-cli/gpt-5.4` and `codex-cli/gpt-5.3-codex` to `XHIGH_MODEL_REFS` |
| `src/agents/pi-embedded-runner/model.forward-compat.test.ts` | Add two tests: `codex-cli` forward-compat for `gpt-5.4` and `gpt-5.3-codex` |
| `src/agents/model-selection.test.ts` | Add test: `normalizeProviderIdForAuth("codex-cli")` returns `"openai-codex"` |
| `src/auto-reply/thinking.test.ts` | Add test: `listThinkingLevels("codex-cli", "gpt-5.4")` includes xhigh |

## Test plan

- [x] `npx vitest run src/agents/pi-embedded-runner/model.forward-compat.test.ts` — 9/9 passing
- [x] `npx vitest run src/agents/model-selection.test.ts` — 41/41 passing
- [x] `npx vitest run src/auto-reply/thinking.test.ts` — 18/18 passing
- [ ] Manual: configure `codex-cli/gpt-5.4` as primary model, trigger `/new` → verify slug generator completes without `FailoverError`
- [ ] Manual: verify `openai-codex/gpt-5.4` still works unchanged

## Security Impact

- Does this change handle user input? **No** — only affects internal model/auth resolution
- Does this change affect authentication/authorization? **Yes** — `codex-cli` now shares the `openai-codex` auth namespace, which matches the existing `CODEX_CLI_PROFILE_ID = "openai-codex:codex-cli"` convention in `auth-profiles/constants.ts`
- Does this change affect data storage or retrieval? **No**
- Does this change affect network communication? **No**
- Does this change introduce new dependencies? **No**

## Human Verification

1. Set `agents.defaults.model.primary: "codex-cli/gpt-5.4"` with `session-memory` hook enabled → trigger `/new` → slug generator should complete without errors
2. Set `agents.defaults.model.primary: "openai-codex/gpt-5.4"` → same test → still works
3. Use `/think xhigh` with `codex-cli/gpt-5.4` → should be accepted (previously rejected)

## Failure Recovery

Revert the commit. `codex-cli` forward-compat reverts to "Unknown model" errors — the same behavior as before this fix. No data loss or side effects.

## Risks and Mitigations

- **Risk**: `codex-cli` and `openai-codex` may diverge in future API behavior
  **Mitigation**: The mapping is minimal (auth normalization + eligible provider set); if APIs diverge, the forward-compat function can be split into a separate `codex-cli`-specific path without affecting other providers.