### PR TITLE
fix(plugins): enforce length limits on hook-injected prompt context

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -9,6 +9,7 @@ import { resolveChannelCapabilities } from "../../../config/channel-capabilities
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
+import { clampHookString } from "../../../plugins/hooks.js";
 import {
   isCronSessionKey,
   isSubagentSessionKey,
@@ -905,9 +906,15 @@ export async function runEmbeddedAttempt(
           : undefined;
         const hookResult = {
           systemPrompt: promptBuildResult?.systemPrompt ?? legacyResult?.systemPrompt,
-          prependContext: [promptBuildResult?.prependContext, legacyResult?.prependContext]
-            .filter((value): value is string => Boolean(value))
-            .join("\n\n"),
+          // Clamp combined context: each hook is individually clamped, but
+          // legacy + phase hooks can concatenate to exceed the limit.
+          prependContext: clampHookString(
+            [promptBuildResult?.prependContext, legacyResult?.prependContext]
+              .filter((value): value is string => Boolean(value))
+              .join("\n\n") || undefined,
+            "combined prependContext",
+            log.warn.bind(log),
+          ),
         };
         {
           if (hookResult?.prependContext) {

--- a/src/plugins/hooks.before-agent-start.test.ts
+++ b/src/plugins/hooks.before-agent-start.test.ts
@@ -5,8 +5,8 @@
  * propagated through the hook merger, including priority ordering and
  * backward compatibility.
  */
-import { beforeEach, describe, expect, it } from "vitest";
-import { createHookRunner } from "./hooks.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createHookRunner, MAX_HOOK_CONTEXT_LENGTH } from "./hooks.js";
 import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
 import type { PluginHookBeforeAgentStartResult, PluginHookRegistration } from "./types.js";
 
@@ -184,5 +184,39 @@ describe("before_agent_start hook merger", () => {
     expect(result?.systemPrompt).toBe("You are a helpful assistant");
     expect(result?.modelOverride).toBe("llama3.3:8b");
     expect(result?.providerOverride).toBe("ollama");
+  });
+
+  it("truncates oversized prependContext while preserving model overrides", async () => {
+    const oversized = "x".repeat(MAX_HOOK_CONTEXT_LENGTH + 500);
+    addBeforeAgentStartHook(registry, "big-plugin", () => ({
+      prependContext: oversized,
+      modelOverride: "llama3.3:8b",
+      providerOverride: "ollama",
+    }));
+
+    const warn = vi.fn();
+    const runner = createHookRunner(registry, { logger: { warn, error: vi.fn() } });
+    const result = await runner.runBeforeAgentStart({ prompt: "hello" }, stubCtx);
+
+    expect(result?.prependContext?.length).toBeLessThanOrEqual(MAX_HOOK_CONTEXT_LENGTH);
+    expect(result?.prependContext).toContain("[…truncated by openclaw]");
+    expect(result?.modelOverride).toBe("llama3.3:8b");
+    expect(result?.providerOverride).toBe("ollama");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("prependContext"));
+  });
+
+  it("truncates oversized systemPrompt via legacy hook path", async () => {
+    const oversized = "s".repeat(MAX_HOOK_CONTEXT_LENGTH + 100);
+    addBeforeAgentStartHook(registry, "big-plugin", () => ({
+      systemPrompt: oversized,
+    }));
+
+    const warn = vi.fn();
+    const runner = createHookRunner(registry, { logger: { warn, error: vi.fn() } });
+    const result = await runner.runBeforeAgentStart({ prompt: "hello" }, stubCtx);
+
+    expect(result?.systemPrompt?.length).toBeLessThanOrEqual(MAX_HOOK_CONTEXT_LENGTH);
+    expect(result?.systemPrompt).toContain("[…truncated by openclaw]");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("systemPrompt"));
   });
 });

--- a/src/plugins/hooks.phase-hooks.test.ts
+++ b/src/plugins/hooks.phase-hooks.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { createHookRunner } from "./hooks.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createHookRunner, MAX_HOOK_CONTEXT_LENGTH } from "./hooks.js";
 import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
 import type {
   PluginHookBeforeModelResolveResult,
@@ -71,5 +71,61 @@ describe("phase hooks merger", () => {
 
     expect(result?.prependContext).toBe("context A\n\ncontext B");
     expect(result?.systemPrompt).toBe("system A");
+  });
+
+  it("truncates prependContext that exceeds MAX_HOOK_CONTEXT_LENGTH", async () => {
+    const oversized = "x".repeat(MAX_HOOK_CONTEXT_LENGTH + 500);
+    addTypedHook(
+      registry,
+      "before_prompt_build",
+      "big",
+      () => ({ prependContext: oversized }),
+      10,
+    );
+
+    const warn = vi.fn();
+    const runner = createHookRunner(registry, { logger: { warn, error: vi.fn() } });
+    const result = await runner.runBeforePromptBuild({ prompt: "test", messages: [] }, {});
+
+    expect(result?.prependContext?.length).toBeLessThan(oversized.length);
+    expect(result?.prependContext).toContain("[…truncated by openclaw]");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("prependContext"));
+  });
+
+  it("truncates systemPrompt that exceeds MAX_HOOK_CONTEXT_LENGTH", async () => {
+    const oversized = "s".repeat(MAX_HOOK_CONTEXT_LENGTH + 100);
+    addTypedHook(
+      registry,
+      "before_prompt_build",
+      "big",
+      () => ({ systemPrompt: oversized }),
+      10,
+    );
+
+    const warn = vi.fn();
+    const runner = createHookRunner(registry, { logger: { warn, error: vi.fn() } });
+    const result = await runner.runBeforePromptBuild({ prompt: "test", messages: [] }, {});
+
+    expect(result?.systemPrompt?.length).toBeLessThan(oversized.length);
+    expect(result?.systemPrompt).toContain("[…truncated by openclaw]");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("systemPrompt"));
+  });
+
+  it("does not truncate context within the length limit", async () => {
+    const normalContext = "a".repeat(1000);
+    addTypedHook(
+      registry,
+      "before_prompt_build",
+      "normal",
+      () => ({ prependContext: normalContext }),
+      10,
+    );
+
+    const warn = vi.fn();
+    const runner = createHookRunner(registry, { logger: { warn, error: vi.fn() } });
+    const result = await runner.runBeforePromptBuild({ prompt: "test", messages: [] }, {});
+
+    expect(result?.prependContext).toBe(normalContext);
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/hooks.phase-hooks.test.ts
+++ b/src/plugins/hooks.phase-hooks.test.ts
@@ -87,7 +87,7 @@ describe("phase hooks merger", () => {
     const runner = createHookRunner(registry, { logger: { warn, error: vi.fn() } });
     const result = await runner.runBeforePromptBuild({ prompt: "test", messages: [] }, {});
 
-    expect(result?.prependContext?.length).toBeLessThan(oversized.length);
+    expect(result?.prependContext?.length).toBeLessThanOrEqual(MAX_HOOK_CONTEXT_LENGTH);
     expect(result?.prependContext).toContain("[…truncated by openclaw]");
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("prependContext"));
   });
@@ -106,7 +106,7 @@ describe("phase hooks merger", () => {
     const runner = createHookRunner(registry, { logger: { warn, error: vi.fn() } });
     const result = await runner.runBeforePromptBuild({ prompt: "test", messages: [] }, {});
 
-    expect(result?.systemPrompt?.length).toBeLessThan(oversized.length);
+    expect(result?.systemPrompt?.length).toBeLessThanOrEqual(MAX_HOOK_CONTEXT_LENGTH);
     expect(result?.systemPrompt).toContain("[…truncated by openclaw]");
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("systemPrompt"));
   });

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -106,6 +106,32 @@ function getHooksForName<K extends PluginHookName>(
 }
 
 /**
+ * Maximum length (in characters) for plugin-injected prompt context.
+ * Prevents a single plugin from consuming the entire context window.
+ * Generous enough for legitimate use (documentation, code snippets)
+ * while guarding against accidental or malicious prompt inflation.
+ */
+export const MAX_HOOK_CONTEXT_LENGTH = 50_000;
+
+/**
+ * Clamp a string to `MAX_HOOK_CONTEXT_LENGTH`, appending a truncation
+ * marker so the model (and operators) can see that content was cut.
+ */
+function clampHookString(
+  value: string | undefined,
+  label: string,
+  warn: ((msg: string) => void) | undefined,
+): string | undefined {
+  if (!value) return value;
+  if (value.length <= MAX_HOOK_CONTEXT_LENGTH) return value;
+  warn?.(
+    `[hooks] ${label} from plugin exceeded ${MAX_HOOK_CONTEXT_LENGTH} chars ` +
+      `(${value.length}) and was truncated`,
+  );
+  return value.slice(0, MAX_HOOK_CONTEXT_LENGTH) + "\n[…truncated by openclaw]";
+}
+
+/**
  * Create a hook runner for a specific registry.
  */
 export function createHookRunner(registry: PluginRegistry, options: HookRunnerOptions = {}) {
@@ -232,28 +258,35 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
   /**
    * Run before_prompt_build hook.
    * Allows plugins to inject context and system prompt before prompt submission.
+   * Applies length limits to prevent a plugin from consuming the context window.
    */
   async function runBeforePromptBuild(
     event: PluginHookBeforePromptBuildEvent,
     ctx: PluginHookAgentContext,
   ): Promise<PluginHookBeforePromptBuildResult | undefined> {
-    return runModifyingHook<"before_prompt_build", PluginHookBeforePromptBuildResult>(
+    const raw = await runModifyingHook<"before_prompt_build", PluginHookBeforePromptBuildResult>(
       "before_prompt_build",
       event,
       ctx,
       mergeBeforePromptBuild,
     );
+    if (!raw) return raw;
+    return {
+      systemPrompt: clampHookString(raw.systemPrompt, "systemPrompt", logger?.warn),
+      prependContext: clampHookString(raw.prependContext, "prependContext", logger?.warn),
+    };
   }
 
   /**
    * Run before_agent_start hook.
    * Legacy compatibility hook that combines model resolve + prompt build phases.
+   * Applies the same length limits as runBeforePromptBuild.
    */
   async function runBeforeAgentStart(
     event: PluginHookBeforeAgentStartEvent,
     ctx: PluginHookAgentContext,
   ): Promise<PluginHookBeforeAgentStartResult | undefined> {
-    return runModifyingHook<"before_agent_start", PluginHookBeforeAgentStartResult>(
+    const raw = await runModifyingHook<"before_agent_start", PluginHookBeforeAgentStartResult>(
       "before_agent_start",
       event,
       ctx,
@@ -262,6 +295,12 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
         ...mergeBeforeModelResolve(acc, next),
       }),
     );
+    if (!raw) return raw;
+    return {
+      ...raw,
+      systemPrompt: clampHookString(raw.systemPrompt, "systemPrompt", logger?.warn),
+      prependContext: clampHookString(raw.prependContext, "prependContext", logger?.warn),
+    };
   }
 
   /**

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -113,9 +113,11 @@ function getHooksForName<K extends PluginHookName>(
  */
 export const MAX_HOOK_CONTEXT_LENGTH = 50_000;
 
+const TRUNCATION_MARKER = "\n[…truncated by openclaw]";
+
 /**
- * Clamp a string to `MAX_HOOK_CONTEXT_LENGTH`, appending a truncation
- * marker so the model (and operators) can see that content was cut.
+ * Clamp a string to `MAX_HOOK_CONTEXT_LENGTH` (inclusive of the
+ * truncation marker), so the returned value never exceeds the limit.
  */
 function clampHookString(
   value: string | undefined,
@@ -125,10 +127,10 @@ function clampHookString(
   if (!value) return value;
   if (value.length <= MAX_HOOK_CONTEXT_LENGTH) return value;
   warn?.(
-    `[hooks] ${label} from plugin exceeded ${MAX_HOOK_CONTEXT_LENGTH} chars ` +
+    `[hooks] ${label} from plugin hooks exceeded ${MAX_HOOK_CONTEXT_LENGTH} chars ` +
       `(${value.length}) and was truncated`,
   );
-  return value.slice(0, MAX_HOOK_CONTEXT_LENGTH) + "\n[…truncated by openclaw]";
+  return value.slice(0, MAX_HOOK_CONTEXT_LENGTH - TRUNCATION_MARKER.length) + TRUNCATION_MARKER;
 }
 
 /**

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -119,7 +119,7 @@ const TRUNCATION_MARKER = "\n[…truncated by openclaw]";
  * Clamp a string to `MAX_HOOK_CONTEXT_LENGTH` (inclusive of the
  * truncation marker), so the returned value never exceeds the limit.
  */
-function clampHookString(
+export function clampHookString(
   value: string | undefined,
   label: string,
   warn: ((msg: string) => void) | undefined,


### PR DESCRIPTION
## Summary

- Plugin hooks (`before_prompt_build`, `before_agent_start`) can inject arbitrary content into LLM prompts via `prependContext` and `systemPrompt` with no length validation
- A single plugin can consume the entire context window or inject excessive content that degrades model performance
- Adds `MAX_HOOK_CONTEXT_LENGTH` (50,000 chars) with truncation + warning log when exceeded
- Applied as post-processing after hook merge, catching both single-plugin and multi-plugin cases

**Found via automated security scan** — the scanner flagged template literal prompt construction at `attempt.ts:914` where `hookResult.prependContext` is interpolated directly into the LLM prompt without bounds checking.

## Details

The `before_prompt_build` hook allows plugins to return `prependContext` and `systemPrompt` strings that are concatenated into the LLM prompt. Without bounds:

1. A misbehaving plugin can inflate the prompt beyond the model's context window
2. Multiple plugins accumulating context via `mergeBeforePromptBuild` can exceed limits cumulatively
3. A compromised plugin processing untrusted external data (e.g., channel messages) could inject unbounded content

The fix adds a `clampHookString()` helper (following the existing `MAX_ARGS_LENGTH` pattern in `commands.ts`) that truncates oversized strings and appends a `[…truncated by openclaw]` marker visible to both the model and operators.

## Test plan

- [x] New test: oversized `prependContext` is truncated with warning
- [x] New test: oversized `systemPrompt` is truncated with warning  
- [x] New test: normal-length context passes through unchanged
- [x] Existing tests pass (21/21 across all hook test files)
- [x] TypeScript type check passes (`tsc --noEmit`)