### PR TITLE
fix(line): resolve tokenFile/secretFile relative paths using configFile dir (#10428)

### DIFF
--- a/src/line/accounts.test.ts
+++ b/src/line/accounts.test.ts
@@ -1,10 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
-  resolveLineAccount,
-  resolveDefaultLineAccountId,
-  normalizeAccountId,
   DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+  resolveDefaultLineAccountId,
+  resolveLineAccount,
 } from "./accounts.js";
 
 describe("LINE accounts", () => {
@@ -169,6 +172,95 @@ describe("LINE accounts", () => {
   describe("normalizeAccountId", () => {
     it("trims and lowercases account ids", () => {
       expect(normalizeAccountId("  Business  ")).toBe("business");
+    });
+  });
+
+  describe("resolveLineAccount – tokenFile/secretFile relative path resolution", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-line-tokenfile-"));
+    });
+
+    afterEach(() => {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("resolves tokenFile with a relative path when configFile is provided", () => {
+      fs.writeFileSync(path.join(tmpDir, "token.txt"), "rel-line-token\n", "utf-8");
+      fs.writeFileSync(path.join(tmpDir, "secret.txt"), "rel-line-secret\n", "utf-8");
+
+      const cfg: OpenClawConfig = {
+        channels: {
+          line: {
+            enabled: true,
+            tokenFile: "./token.txt",
+            secretFile: "./secret.txt",
+          },
+        },
+      };
+
+      const account = resolveLineAccount({
+        cfg,
+        configFile: path.join(tmpDir, "openclaw.json"),
+      });
+
+      expect(account.channelAccessToken).toBe("rel-line-token");
+      expect(account.channelSecret).toBe("rel-line-secret");
+      expect(account.tokenSource).toBe("file");
+    });
+
+    it("resolves per-account tokenFile with a relative path when configFile is provided", () => {
+      fs.writeFileSync(path.join(tmpDir, "biz-token.txt"), "biz-line-token\n", "utf-8");
+      fs.writeFileSync(path.join(tmpDir, "biz-secret.txt"), "biz-line-secret\n", "utf-8");
+
+      const cfg: OpenClawConfig = {
+        channels: {
+          line: {
+            enabled: true,
+            accounts: {
+              business: {
+                enabled: true,
+                tokenFile: "biz-token.txt",
+                secretFile: "biz-secret.txt",
+              },
+            },
+          },
+        },
+      };
+
+      const account = resolveLineAccount({
+        cfg,
+        accountId: "business",
+        configFile: path.join(tmpDir, "openclaw.json"),
+      });
+
+      expect(account.channelAccessToken).toBe("biz-line-token");
+      expect(account.channelSecret).toBe("biz-line-secret");
+      expect(account.tokenSource).toBe("file");
+    });
+
+    it("still resolves absolute tokenFile paths without configFile", () => {
+      const tokenFile = path.join(tmpDir, "abs-token.txt");
+      const secretFile = path.join(tmpDir, "abs-secret.txt");
+      fs.writeFileSync(tokenFile, "abs-line-token\n", "utf-8");
+      fs.writeFileSync(secretFile, "abs-line-secret\n", "utf-8");
+
+      const cfg: OpenClawConfig = {
+        channels: {
+          line: {
+            enabled: true,
+            tokenFile,
+            secretFile,
+          },
+        },
+      };
+
+      const account = resolveLineAccount({ cfg });
+
+      expect(account.channelAccessToken).toBe("abs-line-token");
+      expect(account.channelSecret).toBe("abs-line-secret");
+      expect(account.tokenSource).toBe("file");
     });
   });
 });

--- a/src/line/accounts.ts
+++ b/src/line/accounts.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   DEFAULT_ACCOUNT_ID,
@@ -15,12 +16,14 @@ import type {
 
 export { DEFAULT_ACCOUNT_ID } from "../routing/account-id.js";
 
-function readFileIfExists(filePath: string | undefined): string | undefined {
+function readFileIfExists(filePath: string | undefined, configDir?: string): string | undefined {
   if (!filePath) {
     return undefined;
   }
+  const resolvedPath =
+    configDir && !path.isAbsolute(filePath) ? path.resolve(configDir, filePath) : filePath;
   try {
-    return fs.readFileSync(filePath, "utf-8").trim();
+    return fs.readFileSync(resolvedPath, "utf-8").trim();
   } catch {
     return undefined;
   }
@@ -30,8 +33,9 @@ function resolveToken(params: {
   accountId: string;
   baseConfig?: LineConfig;
   accountConfig?: LineAccountConfig;
+  configDir?: string;
 }): { token: string; tokenSource: LineTokenSource } {
-  const { accountId, baseConfig, accountConfig } = params;
+  const { accountId, baseConfig, accountConfig, configDir } = params;
 
   // Check account-level config first
   if (accountConfig?.channelAccessToken?.trim()) {
@@ -39,7 +43,7 @@ function resolveToken(params: {
   }
 
   // Check account-level token file
-  const accountFileToken = readFileIfExists(accountConfig?.tokenFile);
+  const accountFileToken = readFileIfExists(accountConfig?.tokenFile, configDir);
   if (accountFileToken) {
     return { token: accountFileToken, tokenSource: "file" };
   }
@@ -50,7 +54,7 @@ function resolveToken(params: {
       return { token: baseConfig.channelAccessToken.trim(), tokenSource: "config" };
     }
 
-    const baseFileToken = readFileIfExists(baseConfig?.tokenFile);
+    const baseFileToken = readFileIfExists(baseConfig?.tokenFile, configDir);
     if (baseFileToken) {
       return { token: baseFileToken, tokenSource: "file" };
     }
@@ -68,8 +72,9 @@ function resolveSecret(params: {
   accountId: string;
   baseConfig?: LineConfig;
   accountConfig?: LineAccountConfig;
+  configDir?: string;
 }): string {
-  const { accountId, baseConfig, accountConfig } = params;
+  const { accountId, baseConfig, accountConfig, configDir } = params;
 
   // Check account-level config first
   if (accountConfig?.channelSecret?.trim()) {
@@ -77,7 +82,7 @@ function resolveSecret(params: {
   }
 
   // Check account-level secret file
-  const accountFileSecret = readFileIfExists(accountConfig?.secretFile);
+  const accountFileSecret = readFileIfExists(accountConfig?.secretFile, configDir);
   if (accountFileSecret) {
     return accountFileSecret;
   }
@@ -88,7 +93,7 @@ function resolveSecret(params: {
       return baseConfig.channelSecret.trim();
     }
 
-    const baseFileSecret = readFileIfExists(baseConfig?.secretFile);
+    const baseFileSecret = readFileIfExists(baseConfig?.secretFile, configDir);
     if (baseFileSecret) {
       return baseFileSecret;
     }
@@ -105,9 +110,13 @@ function resolveSecret(params: {
 export function resolveLineAccount(params: {
   cfg: OpenClawConfig;
   accountId?: string;
+  /** Path to the OpenClaw config file. When provided, relative tokenFile/secretFile
+   * paths are resolved against its parent directory instead of process.cwd(). */
+  configFile?: string;
 }): ResolvedLineAccount {
   const cfg = params.cfg;
   const accountId = normalizeSharedAccountId(params.accountId);
+  const configDir = params.configFile ? path.dirname(params.configFile) : undefined;
   const lineConfig = cfg.channels?.line as LineConfig | undefined;
   const accounts = lineConfig?.accounts;
   const accountConfig =
@@ -117,12 +126,14 @@ export function resolveLineAccount(params: {
     accountId,
     baseConfig: lineConfig,
     accountConfig,
+    configDir,
   });
 
   const secret = resolveSecret({
     accountId,
     baseConfig: lineConfig,
     accountConfig,
+    configDir,
   });
 
   const {


### PR DESCRIPTION
## Problem
When a LINE channel is configured with a relative `tokenFile` or `secretFile` path, the doctor always reports "token/secret not configured" even when the file exists. The path is resolved against `process.cwd()` rather than the config file's directory, causing a silent read failure that leaves the token empty.

## Root cause
`readFileIfExists` in `src/line/accounts.ts` (line 18) calls `fs.readFileSync(filePath)` without first resolving relative paths. When `filePath` is relative (e.g. `./line-token.txt`), it resolves against the process working directory rather than the directory that contains `openclaw.json`.

## Fix
1. Added optional `configDir?: string` to `readFileIfExists` — if provided and the path is relative, resolves via `path.resolve(configDir, filePath)`
2. Threaded `configDir` through the `resolveToken` and `resolveSecret` helpers
3. Added optional `configFile?: string` to `resolveLineAccount` — callers that know the config path can pass it, enabling correct relative path resolution

## Verification
- **Test:** `src/line/accounts.test.ts` — 3 new tests in `resolveLineAccount – tokenFile/secretFile relative path resolution`
  - ✅ Fails on unpatched main (relative paths return empty token)
  - ✅ Passes on fix (all 12 tests pass)
- **Build:** clean compile (`build-output.log`)
- **Test suite:** 6879 passed, 0 failed — better than baseline (13 pre-existing failures in `timer.test.ts`)
- **Code proof:** old signature removed, new signature + `path.resolve` + `configFile` param confirmed

Closes #10428