### PR TITLE
fix(gateway): add drain delay between health-monitor stop and start

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -192,7 +192,7 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(imageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        timeout: 120_000,
+        data: expect.objectContaining({ image_type: "message" }),
       }),
     );
     expect(messageCreateMock).toHaveBeenCalledWith(
@@ -320,7 +320,6 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(imageGetMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { image_key: imageKey },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toEqual(Buffer.from("image-data"));
@@ -512,7 +511,6 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_audio_msg", file_key: "file_key_audio" },
         params: { type: "file" },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);
@@ -532,7 +530,6 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_img_msg", file_key: "img_key_1" },
         params: { type: "image" },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -106,7 +106,6 @@ export async function downloadImageFeishu(params: {
 
   const response = await client.im.image.get({
     path: { image_key: normalizedImageKey },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   const buffer = await readFeishuResponseBuffer({
@@ -146,7 +145,6 @@ export async function downloadMessageResourceFeishu(params: {
   const response = await client.im.messageResource.get({
     path: { message_id: messageId, file_key: normalizedFileKey },
     params: { type },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   const buffer = await readFeishuResponseBuffer({
@@ -202,7 +200,6 @@ export async function uploadImageFeishu(params: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
       image: imageData as any,
     },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   // SDK v1.30+ returns data directly without code wrapper on success
@@ -277,7 +274,6 @@ export async function uploadFileFeishu(params: {
       file: fileData as any,
       ...(duration !== undefined && { duration }),
     },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   // SDK v1.30+ returns data directly without code wrapper on success

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -57,6 +57,7 @@ function startDefaultMonitor(
     checkIntervalMs: DEFAULT_CHECK_INTERVAL_MS,
     startupGraceMs: 0,
     ...overrides,
+    timing: { restartDrainMs: 0, ...overrides.timing },
   });
 }
 
@@ -514,6 +515,63 @@ describe("channel-health-monitor", () => {
       expect(manager.stopChannel).toHaveBeenCalledWith("slack", "default");
       expect(manager.startChannel).toHaveBeenCalledWith("slack", "default");
       monitor.stop();
+    });
+  });
+
+  describe("restart drain delay", () => {
+    it("waits restartDrainMs between stop and start", async () => {
+      const now = Date.now();
+      const manager = createSnapshotManager({
+        whatsapp: {
+          default: {
+            running: true,
+            connected: false,
+            enabled: true,
+            configured: true,
+            linked: true,
+            lastStartAt: now - 300_000,
+          },
+        },
+      });
+      const drainMs = 3_000;
+      const monitor = startDefaultMonitor(manager, {
+        timing: { restartDrainMs: drainMs },
+      });
+      // Advance past startup grace + first check interval
+      await vi.advanceTimersByTimeAsync(DEFAULT_CHECK_INTERVAL_MS + 1);
+      expect(manager.stopChannel).toHaveBeenCalledWith("whatsapp", "default");
+      // Start not yet called — drain is pending
+      expect(manager.startChannel).not.toHaveBeenCalled();
+      // Advance past drain
+      await vi.advanceTimersByTimeAsync(drainMs + 1);
+      expect(manager.startChannel).toHaveBeenCalledWith("whatsapp", "default");
+      monitor.stop();
+    });
+
+    it("skips startChannel if monitor stopped during drain", async () => {
+      const now = Date.now();
+      const manager = createSnapshotManager({
+        whatsapp: {
+          default: {
+            running: true,
+            connected: false,
+            enabled: true,
+            configured: true,
+            linked: true,
+            lastStartAt: now - 300_000,
+          },
+        },
+      });
+      const drainMs = 3_000;
+      const monitor = startDefaultMonitor(manager, {
+        timing: { restartDrainMs: drainMs },
+      });
+      await vi.advanceTimersByTimeAsync(DEFAULT_CHECK_INTERVAL_MS + 1);
+      expect(manager.stopChannel).toHaveBeenCalled();
+      // Stop monitor during drain window
+      monitor.stop();
+      await vi.advanceTimersByTimeAsync(drainMs + 1);
+      expect(manager.startChannel).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -18,15 +18,20 @@ const DEFAULT_MAX_RESTARTS_PER_HOUR = 10;
 const ONE_HOUR_MS = 60 * 60_000;
 
 /**
- * How long a connected channel can go without receiving any event before
- * the health monitor treats it as a "stale socket" and triggers a restart.
- * This catches the half-dead WebSocket scenario where the connection appears
- * alive (health checks pass) but Slack silently stops delivering events.
+ * After stopping a channel, wait this long before starting a new instance.
+ * For well-behaved channels (e.g. Telegram via grammY), stopChannel() already
+ * awaits full shutdown including the final offset-sync getUpdates that releases
+ * the server-side polling lock.  This drain is a defensive buffer for edge
+ * cases: plugin channels whose stop doesn't fully await cleanup, or network
+ * errors during shutdown that prevent proper session release.
  */
+const DEFAULT_RESTART_DRAIN_MS = 5_000;
+
 export type ChannelHealthTimingPolicy = {
   monitorStartupGraceMs: number;
   channelConnectGraceMs: number;
   staleEventThresholdMs: number;
+  restartDrainMs: number;
 };
 
 export type ChannelHealthMonitorDeps = {
@@ -70,6 +75,7 @@ function resolveTimingPolicy(
       deps.timing?.staleEventThresholdMs ??
       deps.staleEventThresholdMs ??
       DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
+    restartDrainMs: deps.timing?.restartDrainMs ?? DEFAULT_RESTART_DRAIN_MS,
   };
 }
 
@@ -103,7 +109,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
     checkInFlight = true;
 
     try {
-      const now = Date.now();
+      let now = Date.now();
       if (now - startedAt < timing.monitorStartupGraceMs) {
         return;
       }
@@ -156,6 +162,18 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           try {
             if (status.running) {
               await channelManager.stopChannel(channelId as ChannelId, accountId);
+              if (timing.restartDrainMs > 0) {
+                await new Promise((resolve) => {
+                  const t = setTimeout(resolve, timing.restartDrainMs);
+                  if (typeof t === "object" && "unref" in t) {
+                    t.unref();
+                  }
+                });
+              }
+              if (stopped) {
+                return;
+              }
+              now = Date.now();
             }
             channelManager.resetRestartAttempts(channelId as ChannelId, accountId);
             await channelManager.startChannel(channelId as ChannelId, accountId);


### PR DESCRIPTION
## Summary

- **Problem**: The channel health monitor restarts unhealthy channels by calling `stopChannel()` then immediately `startChannel()`. Plugin channels may not fully await their cleanup, and network errors during shutdown can prevent proper session release — leaving a window where the new instance races the stale server-side state (HTTP 409 Conflict).
- **Why it matters**: Without a drain buffer, edge-case shutdown failures cascade into restart loops.
- **What changed** (4 files, +83/-13):
  1. `channel-health-monitor.ts` — 5s drain delay between stop/start, `stopped` guard after drain, clock refresh (`now = Date.now()`) post-drain
  2. `channel-health-monitor.test.ts` — 2 new tests covering drain behavior and monitor-stop-during-drain
  3. `feishu/media.ts` — removed per-request `timeout` (SDK dropped from types; `httpTimeoutMs` on constructor preserves the 120s guardrail)
  4. `feishu/media.test.ts` — aligned assertions with SDK type changes
- **What did NOT change**: Health evaluation logic, channel start/stop implementations, any other restart paths, stale-socket detection (#38036)

## Review Guide

**Core change** (2min): `src/gateway/channel-health-monitor.ts` lines 165-176 — drain delay + stopped guard + clock refresh. Compare with `stopChannel()` at `server-channels.ts:327` which sets `manuallyStopped`.

**Tests** (1min): `src/gateway/channel-health-monitor.test.ts` — two new `describe("restart drain")` tests at the bottom.

**Feishu fix** (30s): Unrelated upstream type regression — Feishu SDK dropped per-request `timeout` from types (TS2353). Timeout preserved via `httpTimeoutMs` on client constructor. Needed to unblock CI `check` job.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway

## Linked Issue/PR

- Ref #37939
- Complementary to #38036 (stale-socket detection threshold)
- Related to #38405 (Takhoffman — Telegram polling restart skip, same health monitor file)
- Rebased on top of #38285 (vincentkoc — readiness probes, moved constants to channel-health-policy.ts)

## User-visible / Behavior Changes

Health-monitor restarts now include a 5s defensive pause between stopping and restarting a channel. No user-visible difference unless channels were hitting 409 Conflict on restart.

## Security Impact

- [x] None of the above

## Evidence

- [x] Unit tests added (2 new drain tests, 30 total passing)
- [x] CI green: `check`, all `checks` shards (bun/node/extensions/windows x6), `build-artifacts`, `install-smoke`
- [x] Only `secrets` fails (expected for fork PRs)

## Human Verification

- **Verified**: Drain fires only when `status.running` is true; `restartDrainMs: 0` disables it; `stopped` guard prevents restart during shutdown; clock refreshes after drain for accurate health/cooldown evaluation
- **Edge case**: `isManuallyStopped` check intentionally NOT added after drain — `stopChannel()` always sets that flag (`server-channels.ts:327`), so the check would always be true, permanently suppressing restarts. Pre-loop check at line 134 handles operator manual stops.
- **Not verified**: Production plugin channel with incomplete shutdown cleanup

## Compatibility / Migration

- Backward compatible: yes (new default adds delay; `restartDrainMs: 0` preserves old behavior)
- Config changes: none
- Migration needed: none

## Risks and Mitigations

| Risk | Mitigation |
|------|------------|
| 5s delay is a heuristic | Configurable via `restartDrainMs`; well-behaved channels already await full shutdown |
| Hot-reload during drain leaves `manuallyStopped` set | Extremely narrow race (unhealthy channel + reload during 5s window + channel config unchanged). Full restart clears all state. |