### PR TITLE
test(session): cover short dm direct-session key

### DIFF
--- a/src/auto-reply/reply/session-delivery.test.ts
+++ b/src/auto-reply/reply/session-delivery.test.ts
@@ -4,6 +4,7 @@ import { resolveLastChannelRaw, resolveLastToRaw } from "./session-delivery.js";
 describe("session delivery direct-session routing overrides", () => {
   it.each([
     "agent:main:direct:user-1",
+    "agent:main:dm:user-1",
     "agent:main:telegram:direct:123456",
     "agent:main:telegram:account-a:direct:123456",
     "agent:main:telegram:dm:123456",


### PR DESCRIPTION
## Summary

- add the missing positive coverage for the legacy short-form direct-session key `agent:main:dm:user-1`
- keep the direct-session routing matrix aligned with current `isDirectSessionKey()` behavior
- make no production-code changes

## Why

Greptile's review on #37867 noted that the short `dm:peerId` form is supported but missing from the positive test matrix. This follow-up closes that coverage gap without changing runtime behavior.

## Testing

- `bunx vitest run --config vitest.config.ts src/auto-reply/reply/session-delivery.test.ts`

## AI-assisted

- yes; prepared with Codex, reviewed before submission
