### PR TITLE
fix(auto-reply): add unified outbound text sanitizer for NO_REPLY and streaming leaks

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -167,6 +167,7 @@ describe("buildReplyPayloads media filter integration", () => {
     const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
       didStream: () => true,
       isAborted: () => false,
+      hasSentContentKey: () => false,
       hasSentPayload: () => false,
       enqueue: () => {},
       flush: async () => {},
@@ -181,6 +182,40 @@ describe("buildReplyPayloads media filter integration", () => {
       blockReplyPipeline: pipeline,
       replyToMode: "all",
       payloads: [{ text: "response", replyToId: "post-123" }],
+    });
+
+    expect(replyPayloads).toHaveLength(0);
+  });
+
+  it("deduplicates aborted streaming final payloads using the raw content key before sanitize", async () => {
+    const { createBlockReplyContentKey } = await import("./block-reply-pipeline.js");
+    const sentKeys = new Set<string>([
+      createBlockReplyContentKey({
+        text: '{"action":"NO_REPLY"}',
+        mediaUrl: "file:///tmp/photo.jpg",
+      }),
+    ]);
+    const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
+      didStream: () => true,
+      isAborted: () => true,
+      hasSentContentKey: (contentKey) => sentKeys.has(contentKey),
+      hasSentPayload: (payload) => sentKeys.has(createBlockReplyContentKey(payload)),
+      enqueue: () => {},
+      flush: async () => {},
+      stop: () => {},
+      hasBuffered: () => false,
+    };
+
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      blockStreamingEnabled: true,
+      blockReplyPipeline: pipeline,
+      payloads: [
+        {
+          text: '{"action":"NO_REPLY"}',
+          mediaUrl: "file:///tmp/photo.jpg",
+        },
+      ],
     });
 
     expect(replyPayloads).toHaveLength(0);

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -207,16 +207,17 @@ export async function buildReplyPayloads(params: {
   const dedupedPayloadEntries = replyTaggedPayloadEntries.filter((entry) =>
     dedupedPayloadSet.has(entry.payload),
   );
-  const mediaFilteredPayloads = dedupeMessagingToolPayloads
-    ? filterMessagingToolMediaDuplicates({
-        payloads: dedupedPayloads,
-        sentMediaUrls: messagingToolSentMediaUrls,
-      })
-    : dedupedPayloads;
-  const mediaFilteredPayloadSet = new Set(mediaFilteredPayloads);
-  const mediaFilteredPayloadEntries = dedupedPayloadEntries.filter((entry) =>
-    mediaFilteredPayloadSet.has(entry.payload),
-  );
+  const mediaFilteredPayloadEntries = dedupeMessagingToolPayloads
+    ? (() => {
+        const filtered = filterMessagingToolMediaDuplicates({
+          payloads: dedupedPayloadEntries.map((e) => e.payload),
+          sentMediaUrls: messagingToolSentMediaUrls,
+        });
+        return dedupedPayloadEntries
+          .map((entry, i) => ({ ...entry, payload: filtered[i] }))
+          .filter((entry) => isRenderablePayload(entry.payload));
+      })()
+    : dedupedPayloadEntries;
   // Filter out payloads already sent via pipeline or directly during tool flush.
   const filteredPayloadEntries = shouldDropFinalPayloads
     ? []

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -131,7 +131,7 @@ export async function buildReplyPayloads(params: {
         return [{ ...payload, text: stripped.text }];
       });
 
-  const replyTaggedPayloads = (
+  const replyTaggedPayloadEntries = (
     await Promise.all(
       applyReplyThreading({
         payloads: sanitizedPayloads,
@@ -145,17 +145,23 @@ export async function buildReplyPayloads(params: {
           silentToken: SILENT_REPLY_TOKEN,
           parseMode: "always",
         });
-        const text = sanitizeOutboundText(normalized.payload.text);
-        return await normalizeReplyPayloadMedia({
-          payload: {
-            ...normalized.payload,
-            text: text ? text : undefined,
-          },
+        const rawPayload = await normalizeReplyPayloadMedia({
+          payload: normalized.payload,
           normalizeMediaPaths: params.normalizeMediaPaths,
         });
+        const text = sanitizeOutboundText(rawPayload.text);
+        return {
+          // Preserve the unsanitized text so content-key dedupe can run after
+          // later media filtering without losing the original streamed key.
+          rawText: rawPayload.text,
+          payload: {
+            ...rawPayload,
+            text: text ? text : undefined,
+          },
+        };
       }),
     )
-  ).filter(isRenderablePayload);
+  ).filter((entry) => isRenderablePayload(entry.payload));
 
   // Drop final payloads only when block streaming succeeded end-to-end.
   // If streaming aborted (e.g., timeout), fall back to final payloads.
@@ -190,31 +196,57 @@ export async function buildReplyPayloads(params: {
         normalizeMediaPaths: params.normalizeMediaPaths,
       })
     : (params.messagingToolSentMediaUrls ?? []);
+  const replyTaggedPayloads = replyTaggedPayloadEntries.map((entry) => entry.payload);
   const dedupedPayloads = dedupeMessagingToolPayloads
     ? filterMessagingToolDuplicates({
         payloads: replyTaggedPayloads,
         sentTexts: messagingToolSentTexts,
       })
     : replyTaggedPayloads;
+  const dedupedPayloadSet = new Set(dedupedPayloads);
+  const dedupedPayloadEntries = replyTaggedPayloadEntries.filter((entry) =>
+    dedupedPayloadSet.has(entry.payload),
+  );
   const mediaFilteredPayloads = dedupeMessagingToolPayloads
     ? filterMessagingToolMediaDuplicates({
         payloads: dedupedPayloads,
         sentMediaUrls: messagingToolSentMediaUrls,
       })
     : dedupedPayloads;
+  const mediaFilteredPayloadEntries = dedupedPayloadEntries.flatMap((entry, index) => {
+    const payload = mediaFilteredPayloads[index];
+    if (!payload || !isRenderablePayload(payload)) {
+      return [];
+    }
+    return [{ ...entry, payload }];
+  });
   // Filter out payloads already sent via pipeline or directly during tool flush.
-  const filteredPayloads = shouldDropFinalPayloads
+  const filteredPayloadEntries = shouldDropFinalPayloads
     ? []
     : params.blockStreamingEnabled
-      ? mediaFilteredPayloads.filter(
-          (payload) => !params.blockReplyPipeline?.hasSentPayload(payload),
+      ? mediaFilteredPayloadEntries.filter(
+          (entry) =>
+            !params.blockReplyPipeline?.hasSentContentKey(
+              createBlockReplyContentKey({
+                ...entry.payload,
+                text: entry.rawText,
+              }),
+            ),
         )
       : params.directlySentBlockKeys?.size
-        ? mediaFilteredPayloads.filter(
-            (payload) => !params.directlySentBlockKeys!.has(createBlockReplyContentKey(payload)),
+        ? mediaFilteredPayloadEntries.filter(
+            (entry) =>
+              !params.directlySentBlockKeys!.has(
+                createBlockReplyContentKey({
+                  ...entry.payload,
+                  text: entry.rawText,
+                }),
+              ),
           )
-        : mediaFilteredPayloads;
-  const replyPayloads = suppressMessagingToolReplies ? [] : filteredPayloads;
+        : mediaFilteredPayloadEntries;
+  const replyPayloads = suppressMessagingToolReplies
+    ? []
+    : filteredPayloadEntries.map((entry) => entry.payload);
 
   return {
     replyPayloads,

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -213,13 +213,10 @@ export async function buildReplyPayloads(params: {
         sentMediaUrls: messagingToolSentMediaUrls,
       })
     : dedupedPayloads;
-  const mediaFilteredPayloadEntries = dedupedPayloadEntries.flatMap((entry, index) => {
-    const payload = mediaFilteredPayloads[index];
-    if (!payload || !isRenderablePayload(payload)) {
-      return [];
-    }
-    return [{ ...entry, payload }];
-  });
+  const mediaFilteredPayloadSet = new Set(mediaFilteredPayloads);
+  const mediaFilteredPayloadEntries = dedupedPayloadEntries.filter((entry) =>
+    mediaFilteredPayloadSet.has(entry.payload),
+  );
   // Filter out payloads already sent via pipeline or directly during tool flush.
   const filteredPayloadEntries = shouldDropFinalPayloads
     ? []

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -20,6 +20,7 @@ import {
   isRenderablePayload,
   shouldSuppressMessagingToolReplies,
 } from "./reply-payloads.js";
+import { sanitizeOutboundText } from "./reply-utils.js";
 
 async function normalizeReplyPayloadMedia(params: {
   payload: ReplyPayload;
@@ -138,14 +139,18 @@ export async function buildReplyPayloads(params: {
         replyToChannel: params.replyToChannel,
         currentMessageId: params.currentMessageId,
       }).map(async (payload) => {
-        const parsed = normalizeReplyPayloadDirectives({
+        const normalized = normalizeReplyPayloadDirectives({
           payload,
           currentMessageId: params.currentMessageId,
           silentToken: SILENT_REPLY_TOKEN,
           parseMode: "always",
-        }).payload;
+        });
+        const text = sanitizeOutboundText(normalized.payload.text);
         return await normalizeReplyPayloadMedia({
-          payload: parsed,
+          payload: {
+            ...normalized.payload,
+            text: text ? text : undefined,
+          },
           normalizeMediaPaths: params.normalizeMediaPaths,
         });
       }),

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -11,6 +11,7 @@ export type BlockReplyPipeline = {
   hasBuffered: () => boolean;
   didStream: () => boolean;
   isAborted: () => boolean;
+  hasSentContentKey: (contentKey: string) => boolean;
   hasSentPayload: (payload: ReplyPayload) => boolean;
 };
 
@@ -244,6 +245,7 @@ export function createBlockReplyPipeline(params: {
     hasBuffered: () => Boolean(coalescer?.hasBuffered() || bufferedPayloads.length > 0),
     didStream: () => didStream,
     isAborted: () => aborted,
+    hasSentContentKey: (contentKey) => sentContentKeys.has(contentKey),
     hasSentPayload: (payload) => {
       const payloadKey = createBlockReplyContentKey(payload);
       return sentContentKeys.has(payloadKey);

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import { parseAudioTag } from "./audio-tags.js";
+import { buildReplyPayloads } from "./agent-runner-payloads.js";
 import { createBlockReplyCoalescer } from "./block-reply-coalescer.js";
 import { matchesMentionWithExplicit } from "./mentions.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
 import { createReplyReferencePlanner } from "./reply-reference.js";
+import { sanitizeOutboundText } from "./reply-utils.js";
 import {
   extractShortModelName,
   hasTemplateVariables,
@@ -875,5 +877,132 @@ describe("hasTemplateVariables", () => {
     expect(hasTemplateVariables("[{model}]")).toBe(true);
     expect(hasTemplateVariables("[{model}]")).toBe(true);
     expect(hasTemplateVariables("[Claude]")).toBe(false);
+  });
+});
+
+describe("sanitizeOutboundText", () => {
+  it("suppresses JSON-wrapped NO_REPLY action", () => {
+    expect(sanitizeOutboundText('{"action":"NO_REPLY"}')).toBeNull();
+  });
+
+  it("suppresses lightweight JSON-wrapped NO_REPLY variants", () => {
+    expect(sanitizeOutboundText('{"action":"NO_REPLY","extra":true}')).toBeNull();
+  });
+
+  it("passes through long JSON payloads", () => {
+    const text = `{"action":"NO_REPLY","padding":"${"x".repeat(180)}"}`;
+
+    expect(text.length).toBeGreaterThan(200);
+    expect(sanitizeOutboundText(text)).toBe(text);
+  });
+
+  it("suppresses only the documented bare Reasoning leak", () => {
+    expect(sanitizeOutboundText("Reasoning:")).toBeNull();
+    expect(sanitizeOutboundText("Reasoning:\n")).toBeNull();
+    expect(sanitizeOutboundText("Reasoning:  \n")).toBeNull();
+    expect(sanitizeOutboundText("Reasoning")).toBe("Reasoning");
+    expect(sanitizeOutboundText("reasoning:")).toBe("reasoning:");
+    expect(sanitizeOutboundText("Reasoning: Here is my analysis...")).toBe(
+      "Reasoning: Here is my analysis...",
+    );
+  });
+
+  it("suppresses bare NO_REPLY and preserves normal text", () => {
+    expect(sanitizeOutboundText("NO_REPLY")).toBeNull();
+    expect(sanitizeOutboundText("Normal reply text")).toBe("Normal reply text");
+    expect(sanitizeOutboundText("")).toBe("");
+  });
+});
+
+describe("buildReplyPayloads outbound sanitizer", () => {
+  const build = (
+    payloads: Array<Record<string, unknown>>,
+    overrides: Partial<Parameters<typeof buildReplyPayloads>[0]> = {},
+  ) =>
+    buildReplyPayloads({
+      payloads: payloads as Parameters<typeof buildReplyPayloads>[0]["payloads"],
+      isHeartbeat: false,
+      didLogHeartbeatStrip: false,
+      blockStreamingEnabled: false,
+      blockReplyPipeline: null,
+      replyToMode: "first",
+      ...overrides,
+    }).replyPayloads;
+
+  it("suppresses text-only NO_REPLY payloads", () => {
+    expect(build([{ text: "NO_REPLY" }])).toEqual([]);
+    expect(build([{ text: '{"action":"NO_REPLY"}' }])).toEqual([]);
+    expect(build([{ text: '{"action":"NO_REPLY","extra":true}' }])).toEqual([]);
+  });
+
+  it("keeps media payloads when NO_REPLY text is stripped", () => {
+    const payloads = build([{ text: "NO_REPLY", mediaUrl: "https://example.com/image.jpg" }]);
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toMatchObject({
+      mediaUrl: "https://example.com/image.jpg",
+    });
+    expect(payloads[0].text).toBeUndefined();
+  });
+
+  it("keeps channelData payloads when bare Reasoning leak text is stripped", () => {
+    const payloads = build([
+      {
+        text: "Reasoning:",
+        channelData: {
+          telegram: {
+            inline_keyboard: [],
+          },
+        },
+      },
+    ]);
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0].channelData).toEqual({
+      telegram: {
+        inline_keyboard: [],
+      },
+    });
+    expect(payloads[0].text).toBeUndefined();
+  });
+
+  it("does not suppress non-documented Reasoning variants", () => {
+    expect(build([{ text: "Reasoning" }])).toMatchObject([{ text: "Reasoning" }]);
+    expect(build([{ text: "reasoning:" }])).toMatchObject([{ text: "reasoning:" }]);
+  });
+
+  it("keeps reply threading and inline directives intact for normal text", () => {
+    const payloads = build([{ text: "[[reply_to_current]]Hello there" }], {
+      currentMessageId: "42",
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]).toMatchObject({
+      text: "Hello there",
+      replyToId: "42",
+      replyToTag: true,
+    });
+  });
+
+  it("preserves duplicate suppression for normal replies", () => {
+    const payloads = build([{ text: "hello world" }], {
+      messagingToolSentTexts: ["hello world"],
+    });
+
+    expect(payloads).toEqual([]);
+  });
+
+  it("keeps heartbeat stripping behavior unchanged", () => {
+    const result = buildReplyPayloads({
+      payloads: [{ text: "HEARTBEAT_OK" }],
+      isHeartbeat: false,
+      didLogHeartbeatStrip: false,
+      blockStreamingEnabled: false,
+      blockReplyPipeline: null,
+      replyToMode: "first",
+    });
+
+    expect(result.replyPayloads).toEqual([]);
+    expect(result.didLogHeartbeatStrip).toBe(true);
   });
 });

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -916,28 +916,30 @@ describe("sanitizeOutboundText", () => {
 });
 
 describe("buildReplyPayloads outbound sanitizer", () => {
-  const build = (
+  const build = async (
     payloads: Array<Record<string, unknown>>,
     overrides: Partial<Parameters<typeof buildReplyPayloads>[0]> = {},
   ) =>
-    buildReplyPayloads({
-      payloads: payloads as Parameters<typeof buildReplyPayloads>[0]["payloads"],
-      isHeartbeat: false,
-      didLogHeartbeatStrip: false,
-      blockStreamingEnabled: false,
-      blockReplyPipeline: null,
-      replyToMode: "first",
-      ...overrides,
-    }).replyPayloads;
+    (
+      await buildReplyPayloads({
+        payloads: payloads as Parameters<typeof buildReplyPayloads>[0]["payloads"],
+        isHeartbeat: false,
+        didLogHeartbeatStrip: false,
+        blockStreamingEnabled: false,
+        blockReplyPipeline: null,
+        replyToMode: "first",
+        ...overrides,
+      })
+    ).replyPayloads;
 
-  it("suppresses text-only NO_REPLY payloads", () => {
-    expect(build([{ text: "NO_REPLY" }])).toEqual([]);
-    expect(build([{ text: '{"action":"NO_REPLY"}' }])).toEqual([]);
-    expect(build([{ text: '{"action":"NO_REPLY","extra":true}' }])).toEqual([]);
+  it("suppresses text-only NO_REPLY payloads", async () => {
+    await expect(build([{ text: "NO_REPLY" }])).resolves.toEqual([]);
+    await expect(build([{ text: '{"action":"NO_REPLY"}' }])).resolves.toEqual([]);
+    await expect(build([{ text: '{"action":"NO_REPLY","extra":true}' }])).resolves.toEqual([]);
   });
 
-  it("keeps media payloads when NO_REPLY text is stripped", () => {
-    const payloads = build([{ text: "NO_REPLY", mediaUrl: "https://example.com/image.jpg" }]);
+  it("keeps media payloads when NO_REPLY text is stripped", async () => {
+    const payloads = await build([{ text: "NO_REPLY", mediaUrl: "https://example.com/image.jpg" }]);
 
     expect(payloads).toHaveLength(1);
     expect(payloads[0]).toMatchObject({
@@ -946,8 +948,8 @@ describe("buildReplyPayloads outbound sanitizer", () => {
     expect(payloads[0].text).toBeUndefined();
   });
 
-  it("keeps channelData payloads when bare Reasoning leak text is stripped", () => {
-    const payloads = build([
+  it("keeps channelData payloads when bare Reasoning leak text is stripped", async () => {
+    const payloads = await build([
       {
         text: "Reasoning:",
         channelData: {
@@ -967,14 +969,14 @@ describe("buildReplyPayloads outbound sanitizer", () => {
     expect(payloads[0].text).toBeUndefined();
   });
 
-  it("does not suppress non-documented Reasoning variants", () => {
-    expect(build([{ text: "Reasoning" }])).toMatchObject([{ text: "Reasoning" }]);
-    expect(build([{ text: "reasoning:" }])).toMatchObject([{ text: "reasoning:" }]);
-    expect(build([{ text: "REASONING:" }])).toMatchObject([{ text: "REASONING:" }]);
+  it("does not suppress non-documented Reasoning variants", async () => {
+    await expect(build([{ text: "Reasoning" }])).resolves.toMatchObject([{ text: "Reasoning" }]);
+    await expect(build([{ text: "reasoning:" }])).resolves.toMatchObject([{ text: "reasoning:" }]);
+    await expect(build([{ text: "REASONING:" }])).resolves.toMatchObject([{ text: "REASONING:" }]);
   });
 
-  it("keeps reply threading and inline directives intact for normal text", () => {
-    const payloads = build([{ text: "[[reply_to_current]]Hello there" }], {
+  it("keeps reply threading and inline directives intact for normal text", async () => {
+    const payloads = await build([{ text: "[[reply_to_current]]Hello there" }], {
       currentMessageId: "42",
     });
 
@@ -986,17 +988,17 @@ describe("buildReplyPayloads outbound sanitizer", () => {
     });
   });
 
-  it("preserves duplicate suppression for normal replies", () => {
-    const payloads = build([{ text: "hello world" }], {
+  it("preserves duplicate suppression for normal replies", async () => {
+    const payloads = await build([{ text: "hello world" }], {
       messagingToolSentTexts: ["hello world"],
     });
 
     expect(payloads).toEqual([]);
   });
 
-  it("keeps heartbeat stripping behavior unchanged", () => {
-    const result = buildReplyPayloads({
-      payloads: [{ text: "HEARTBEAT_OK" }],
+  it("keeps heartbeat stripping behavior unchanged", async () => {
+    const result = await buildReplyPayloads({
+      payloads: [{ text: "HEARTBEAT_OK" }] as Parameters<typeof buildReplyPayloads>[0]["payloads"],
       isHeartbeat: false,
       didLogHeartbeatStrip: false,
       blockStreamingEnabled: false,

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
-import { parseAudioTag } from "./audio-tags.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
+import { parseAudioTag } from "./audio-tags.js";
 import { createBlockReplyCoalescer } from "./block-reply-coalescer.js";
 import { matchesMentionWithExplicit } from "./mentions.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
@@ -902,6 +902,7 @@ describe("sanitizeOutboundText", () => {
     expect(sanitizeOutboundText("Reasoning:  \n")).toBeNull();
     expect(sanitizeOutboundText("Reasoning")).toBe("Reasoning");
     expect(sanitizeOutboundText("reasoning:")).toBe("reasoning:");
+    expect(sanitizeOutboundText("REASONING:")).toBe("REASONING:");
     expect(sanitizeOutboundText("Reasoning: Here is my analysis...")).toBe(
       "Reasoning: Here is my analysis...",
     );
@@ -969,6 +970,7 @@ describe("buildReplyPayloads outbound sanitizer", () => {
   it("does not suppress non-documented Reasoning variants", () => {
     expect(build([{ text: "Reasoning" }])).toMatchObject([{ text: "Reasoning" }]);
     expect(build([{ text: "reasoning:" }])).toMatchObject([{ text: "reasoning:" }]);
+    expect(build([{ text: "REASONING:" }])).toMatchObject([{ text: "REASONING:" }]);
   });
 
   it("keeps reply threading and inline directives intact for normal text", () => {

--- a/src/auto-reply/reply/reply-utils.ts
+++ b/src/auto-reply/reply/reply-utils.ts
@@ -1,0 +1,55 @@
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
+
+const DOCUMENTED_REASONING_STREAM_LEAK = "Reasoning:";
+// Only inspect tiny control-like JSON blobs here. Larger JSON bodies are normal model output.
+const NO_REPLY_JSON_SENTINEL_MAX_LENGTH = 200;
+
+function isJsonWrappedNoReply(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length === 0 || trimmed.length > NO_REPLY_JSON_SENTINEL_MAX_LENGTH) {
+    return false;
+  }
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return false;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (!parsed || Array.isArray(parsed) || typeof parsed !== "object") {
+      return false;
+    }
+
+    const keys = Object.keys(parsed);
+    if (keys.length > 2) {
+      return false;
+    }
+
+    return parsed.action === SILENT_REPLY_TOKEN;
+  } catch {
+    return false;
+  }
+}
+
+function isDocumentedReasoningLeak(text: string): boolean {
+  return text.trim() === DOCUMENTED_REASONING_STREAM_LEAK;
+}
+
+export function sanitizeOutboundText(text: string | undefined): string | null | undefined {
+  if (text === undefined) {
+    return undefined;
+  }
+  if (text === "") {
+    return text;
+  }
+  if (isJsonWrappedNoReply(text)) {
+    return null;
+  }
+  if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+    return null;
+  }
+  if (isDocumentedReasoningLeak(text)) {
+    return null;
+  }
+
+  return text;
+}


### PR DESCRIPTION
## User Impact

Users on chat surfaces such as Telegram and Discord could see leaked control text like `{"action":"NO_REPLY"}` or a bare `Reasoning:` fragment show up as visible replies. This change suppresses those leaks once in the shared outbound reply path so existing and future channels inherit the same protection.

Closes #37727
Closes #37890

## What this PR does

This PR adds a unified outbound text sanitizer at the shared auto-reply reply exit, instead of adding more per-channel ad-hoc patches.

It suppresses:
- JSON-wrapped `NO_REPLY` payloads in lightweight forms
- bare `NO_REPLY` sentinels
- bare streaming `Reasoning:` leaks with no body

The sanitizer is wired into `buildReplyPayloads`, so media-only and channelData payloads are preserved while text-only silent/leaked payloads are suppressed.

Background: #37904, #37891, #37892, and #37900 addressed this in scattered places. This PR unifies the behavior at the shared outbound reply layer.
Newer overlapping fixes such as #38659 and #38689 address the same symptom in Telegram-specific paths. This PR intentionally fixes the shared outbound reply layer so the suppression rules are inherited across existing and future channels instead of being patched per channel.

## AI Disclosure

- [x] This PR was AI-assisted (Claude + Codex review)
- [x] Degree of testing: fully tested (reply-utils, agent-runner-payloads, get-reply-directives tests)
- [x] I understand what the code does
- [x] Bot review conversations have been addressed