### PR TITLE
fix(dotenv): expand env references in loaded env files

### DIFF
--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -96,4 +96,45 @@ describe("loadDotEnv", () => {
       });
     });
   });
+
+  it("expands references from the shell and CWD env files", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ cwdDir, stateDir }) => {
+        process.env.OPENAI_API_KEY = "from-shell";
+        await writeEnvFile(path.join(cwdDir, ".env"), "LOCAL_BASE=from-cwd\n");
+        await writeEnvFile(
+          path.join(stateDir, ".env"),
+          "OPENAI_TRANSCRIPTION_API_KEY=${OPENAI_API_KEY}\nCHAINED_VALUE=${LOCAL_BASE}\n",
+        );
+
+        process.chdir(cwdDir);
+        delete process.env.OPENAI_TRANSCRIPTION_API_KEY;
+        delete process.env.CHAINED_VALUE;
+
+        loadDotEnv({ quiet: true });
+
+        expect(process.env.OPENAI_TRANSCRIPTION_API_KEY).toBe("from-shell");
+        expect(process.env.CHAINED_VALUE).toBe("from-cwd");
+      });
+    });
+  });
+
+  it("expands references defined earlier in the same env file", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ cwdDir, stateDir }) => {
+        await writeEnvFile(
+          path.join(stateDir, ".env"),
+          "BASE=from-global\nCOMBINED=${BASE}-suffix\n",
+        );
+        process.chdir(cwdDir);
+        delete process.env.BASE;
+        delete process.env.COMBINED;
+
+        loadDotEnv({ quiet: true });
+
+        expect(process.env.BASE).toBe("from-global");
+        expect(process.env.COMBINED).toBe("from-global-suffix");
+      });
+    });
+  });
 });

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -3,18 +3,62 @@ import path from "node:path";
 import dotenv from "dotenv";
 import { resolveConfigDir } from "../utils.js";
 
-export function loadDotEnv(opts?: { quiet?: boolean }) {
-  const quiet = opts?.quiet ?? true;
+const ENV_REFERENCE_PATTERN = /\$\{([A-Za-z0-9_]+)\}|\$([A-Za-z0-9_]+)/g;
 
-  // Load from process CWD first (dotenv default).
-  dotenv.config({ quiet });
+function expandEnvReferences(
+  parsed: Record<string, string>,
+  baseEnv: NodeJS.ProcessEnv,
+): Record<string, string> {
+  const resolved: Record<string, string> = {};
+  const resolving = new Set<string>();
+
+  const resolveValue = (key: string): string | undefined => {
+    const existing = baseEnv[key];
+    if (existing !== undefined) {
+      return existing;
+    }
+    if (Object.hasOwn(resolved, key)) {
+      return resolved[key];
+    }
+    const raw = parsed[key];
+    if (raw === undefined) {
+      return undefined;
+    }
+    if (resolving.has(key)) {
+      return "";
+    }
+
+    resolving.add(key);
+    const expanded = raw.replace(ENV_REFERENCE_PATTERN, (_, braced, bare) => {
+      const name = typeof braced === "string" && braced.length > 0 ? braced : bare;
+      return resolveValue(name) ?? "";
+    });
+    resolving.delete(key);
+    resolved[key] = expanded;
+    return expanded;
+  };
+
+  for (const key of Object.keys(parsed)) {
+    resolveValue(key);
+  }
+  return resolved;
+}
+
+function loadEnvFile(filePath: string, opts?: { override?: boolean }) {
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+  const parsed = dotenv.parse(fs.readFileSync(filePath, "utf8"));
+  const expanded = expandEnvReferences(parsed, process.env);
+  dotenv.populate(process.env, expanded, { override: opts?.override ?? false });
+}
+
+export function loadDotEnv(_opts?: { quiet?: boolean }) {
+  // Load from process CWD first so fallback expansion can reference it.
+  loadEnvFile(path.join(process.cwd(), ".env"));
 
   // Then load global fallback: ~/.openclaw/.env (or OPENCLAW_STATE_DIR/.env),
   // without overriding any env vars already present.
   const globalEnvPath = path.join(resolveConfigDir(process.env), ".env");
-  if (!fs.existsSync(globalEnvPath)) {
-    return;
-  }
-
-  dotenv.config({ quiet, path: globalEnvPath, override: false });
+  loadEnvFile(globalEnvPath, { override: false });
 }


### PR DESCRIPTION
## Summary
- expand `${VAR}` and `$VAR` references when loading CWD and global `.env` files
- preserve shell/CWD precedence so existing exported vars still win
- add coverage for shell-backed, chained, and same-file expansion

## Why
OpenClaw auto-loads `~/.openclaw/.env`, but today values like `OPENAI_TRANSCRIPTION_API_KEY=${OPENAI_API_KEY}` are loaded literally instead of being resolved. That breaks configs which reasonably expect standard env aliasing.

## Testing
- `pnpm exec vitest run src/infra/dotenv.test.ts`
- `pnpm exec oxfmt --check src/infra/dotenv.ts src/infra/dotenv.test.ts`

## Notes
- repo-wide `tsc -p tsconfig.json --noEmit` is currently red on unrelated `extensions/feishu/src/media.ts` timeout typing errors