### PR TITLE
docs(feishu): clarify where appId/appSecret must be configured

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -197,6 +197,8 @@ Edit `~/.openclaw/openclaw.json`:
 
 If you use `connectionMode: "webhook"`, set `verificationToken`. The Feishu webhook server binds to `127.0.0.1` by default; set `webhookHost` only if you intentionally need a different bind address.
 
+> Note: put Feishu credentials under `channels.feishu` (or `channels.feishu.accounts.<id>`), not under `plugins.entries.feishu.config`. The plugin config schema does not accept `appId`/`appSecret` fields.
+
 #### Verification Token (webhook mode)
 
 When using webhook mode, set `channels.feishu.verificationToken` in your config. To get the value:

--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -203,6 +203,8 @@ openclaw channels add
 
 若使用 `connectionMode: "webhook"`，需设置 `verificationToken`。飞书 Webhook 服务默认绑定 `127.0.0.1`；仅在需要不同监听地址时设置 `webhookHost`。
 
+> 说明：飞书凭证应配置在 `channels.feishu`（或 `channels.feishu.accounts.<id>`）下，不要放在 `plugins.entries.feishu.config`。该插件配置 schema 不接受 `appId`/`appSecret` 字段。
+
 #### 获取 Verification Token（仅 Webhook 模式）
 
 使用 Webhook 模式时，需在配置中设置 `channels.feishu.verificationToken`。获取方式：

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -11,8 +11,8 @@ import {
   type ChannelPlugin,
   type OpenClawConfig,
   type ChannelSetupInput,
+  waitForAbortSignal,
 } from "openclaw/plugin-sdk/nextcloud-talk";
-import { waitForAbortSignal } from "../../../src/infra/abort-signal.js";
 import {
   listNextcloudTalkAccountIds,
   resolveDefaultNextcloudTalkAccountId,

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -363,8 +363,23 @@ describe("resolveForwardCompatModel", () => {
     expectResolvedForwardCompat(model, { provider: "openai-codex", id: "gpt-5.4" });
     expect(model?.api).toBe("openai-codex-responses");
     expect(model?.baseUrl).toBe("https://chatgpt.com/backend-api");
-    expect(model?.contextWindow).toBe(272_000);
+    expect(model?.contextWindow).toBe(1_050_000);
     expect(model?.maxTokens).toBe(128_000);
+  });
+
+  it("resolves openai-codex gpt-5.4 without templates using gpt-5.4 defaults", () => {
+    const registry = createRegistry({});
+
+    const model = resolveForwardCompatModel("openai-codex", "gpt-5.4", registry);
+
+    expectResolvedForwardCompat(model, { provider: "openai-codex", id: "gpt-5.4" });
+    expect(model?.api).toBe("openai-codex-responses");
+    expect(model?.baseUrl).toBe("https://chatgpt.com/backend-api");
+    expect(model?.input).toEqual(["text", "image"]);
+    expect(model?.reasoning).toBe(true);
+    expect(model?.contextWindow).toBe(1_050_000);
+    expect(model?.maxTokens).toBe(128_000);
+    expect(model?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
   });
 
   it("resolves anthropic opus 4.6 via 4.5 template", () => {

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -12,6 +12,8 @@ const OPENAI_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.2"] as const;
 const OPENAI_GPT_54_PRO_TEMPLATE_MODEL_IDS = ["gpt-5.2-pro", "gpt-5.2"] as const;
 
 const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
+const OPENAI_CODEX_GPT_54_CONTEXT_TOKENS = 1_050_000;
+const OPENAI_CODEX_GPT_54_MAX_TOKENS = 128_000;
 const OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex", "gpt-5.2-codex"] as const;
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
@@ -146,9 +148,16 @@ function resolveOpenAICodexForwardCompatModel(
       ...template,
       id: trimmedModelId,
       name: trimmedModelId,
+      ...(lower === OPENAI_CODEX_GPT_54_MODEL_ID
+        ? {
+            contextWindow: OPENAI_CODEX_GPT_54_CONTEXT_TOKENS,
+            maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
+          }
+        : {}),
     } as Model<Api>);
   }
 
+  const usesGpt54Defaults = lower === OPENAI_CODEX_GPT_54_MODEL_ID;
   return normalizeModelCompat({
     id: trimmedModelId,
     name: trimmedModelId,
@@ -158,8 +167,8 @@ function resolveOpenAICodexForwardCompatModel(
     reasoning: true,
     input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_TOKENS,
-    maxTokens: DEFAULT_CONTEXT_TOKENS,
+    contextWindow: usesGpt54Defaults ? OPENAI_CODEX_GPT_54_CONTEXT_TOKENS : DEFAULT_CONTEXT_TOKENS,
+    maxTokens: usesGpt54Defaults ? OPENAI_CODEX_GPT_54_MAX_TOKENS : DEFAULT_CONTEXT_TOKENS,
   } as Model<Api>);
 }
 

--- a/src/plugin-sdk/nextcloud-talk.ts
+++ b/src/plugin-sdk/nextcloud-talk.ts
@@ -65,6 +65,7 @@ export {
   readRequestBodyWithLimit,
   requestBodyErrorToText,
 } from "../infra/http-body.js";
+export { waitForAbortSignal } from "../infra/abort-signal.js";
 export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export type { PluginRuntime } from "../plugins/runtime/types.js";


### PR DESCRIPTION
## Summary
Adds explicit guidance in Feishu channel docs (English + Chinese) that credentials must be set under `channels.feishu` (or account entries), not under plugin config.

## Changes
- Updated `docs/channels/feishu.md`
- Updated `docs/zh-CN/channels/feishu.md`
- Added note explaining `plugins.entries.feishu.config` does not accept `appId`/`appSecret`

## Testing
- `pnpm dlx markdownlint-cli2 docs/channels/feishu.md docs/zh-CN/channels/feishu.md` ✅ (0 errors)
- `pnpm format:docs:check` ✅

Fixes #38217