### PR TITLE
fix(subagents): decouple announce injection from channel delivery

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -602,6 +602,7 @@ async function sendAnnounce(item: AnnounceQueueItem) {
       to: requesterIsSubagent ? undefined : origin?.to,
       threadId: requesterIsSubagent ? undefined : threadId,
       deliver: !requesterIsSubagent,
+      bestEffortDeliver: !requesterIsSubagent,
       internalEvents: item.internalEvents,
       inputProvenance: {
         kind: "inter_session",
@@ -781,6 +782,11 @@ async function sendSubagentAnnounceDirectly(params: {
         path: "none",
       };
     }
+    // Decouple session injection from channel delivery: when delivering externally,
+    // force bestEffortDeliver so channel failures (e.g. Telegram unreachable) don't
+    // prevent the announce event from being injected into the parent session.
+    // The agent turn (session injection) always completes; delivery is best-effort.
+    const effectiveBestEffortDeliver = shouldDeliverExternally || params.bestEffortDeliver;
     await runAnnounceDeliveryWithRetry({
       operation: params.expectsCompletionMessage
         ? "completion direct announce agent call"
@@ -793,7 +799,7 @@ async function sendSubagentAnnounceDirectly(params: {
             sessionKey: canonicalRequesterSessionKey,
             message: params.triggerMessage,
             deliver: shouldDeliverExternally,
-            bestEffortDeliver: params.bestEffortDeliver,
+            bestEffortDeliver: effectiveBestEffortDeliver,
             internalEvents: params.internalEvents,
             channel: shouldDeliverExternally ? directChannel : undefined,
             accountId: shouldDeliverExternally ? effectiveDirectOrigin?.accountId : undefined,


### PR DESCRIPTION
## Summary

Fixes #38055

When a subagent completion announce is delivered externally (e.g. to Telegram), the `callGateway({method: "agent", deliver: true})` call couples session injection with channel delivery. If the channel is temporarily unreachable (DNS failure, API timeout), the entire call fails and after `MAX_ANNOUNCE_RETRY_COUNT` (3) retries the completion event is **permanently lost** — the parent session is never notified.

This PR sets `bestEffortDeliver: true` alongside `deliver: true` on both announce delivery paths so that channel delivery failures are logged but non-fatal. The agent turn (session injection into the parent session context) always completes; only the outbound channel delivery becomes best-effort.

### Changes

- **`sendSubagentAnnounceDirectly`** (direct path): Force `bestEffortDeliver: true` when `shouldDeliverExternally` is true, preserving any existing `bestEffortDeliver` from the caller via OR.
- **`sendAnnounce`** (queue drain path): Add `bestEffortDeliver: !requesterIsSubagent` to mirror the existing `deliver: !requesterIsSubagent` flag.

### Why `bestEffortDeliver` is the right fix

The `bestEffortDeliver` flag already exists in the delivery pipeline (`src/commands/agent/delivery.ts`) and does exactly what's needed: when delivery encounters a missing/unreachable channel, it logs the error instead of throwing, so the agent command completes successfully. This is the same durability guarantee that normal messages already receive.

## Test plan

- [x] All 23 existing subagent announce tests pass (`pnpm test -- src/agents/subagent-announce`)
- [x] Lint/format clean (`pnpm check`)
- [ ] CI passes