### PR TITLE
fix(feishu): disable block streaming to prevent silent reply drops

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -571,6 +571,17 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
   });
 
+  it("sets disableBlockStreaming in replyOptions to prevent silent reply drops", () => {
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    expect(result.replyOptions).toHaveProperty("disableBlockStreaming", true);
+  });
+
   it("passes replyInThread to media attachments", async () => {
     createFeishuReplyDispatcher({
       cfg: {} as never,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -382,6 +382,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
+      disableBlockStreaming: true,
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
             if (!payload.text) {


### PR DESCRIPTION
## Problem

When `blockStreamingDefault` is set to `"on"` (the default after setup wizard), Feishu channels receive messages and dispatch to the agent, but **no reply is ever delivered** to the user.

The block streaming pipeline sends `block` chunks to Feishu's `deliver()`. For plain-text messages (`renderMode: "auto"`, no code blocks/tables), `shouldUseCard` returns false, so `!(streamingEnabled && useCard)` is true and the block is silently dropped. The pipeline still marks `didStream = true`, then filters out the final reply → 0 replies sent.

## Fix

Set `disableBlockStreaming: true` in the returned `replyOptions`. This bypasses the agent-level block streaming pipeline entirely. Feishu's own streaming-card mechanism (via `onPartialReply`) is unaffected and continues to work.

## Test

Added a test asserting `disableBlockStreaming` is set in replyOptions. All 22 existing tests pass.

Closes #38258