### PR TITLE
fix(feishu): disable block streaming to prevent silent reply drops

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -106,6 +106,17 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("sets disableBlockStreaming in replyOptions", () => {
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    expect(result.replyOptions).toHaveProperty("disableBlockStreaming", true);
+  });
+
   it("skips typing indicator when account typingIndicator is disabled", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -382,6 +382,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
+      disableBlockStreaming: true,
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
             if (!payload.text) {


### PR DESCRIPTION
## Summary

Fixes #38258 — Feishu messages silently dropped when `blockStreamingDefault` is `"on"` (the default after setup wizard).

## Root Cause

When `blockStreamingDefault` is enabled, the agent-level block streaming pipeline calls `deliver({kind: "block"})`. Feishu's deliver silently `return`s for block chunks when `renderMode` is `"auto"` and text contains no code blocks/tables (`!(streamingEnabled && useCard)`).

The pipeline still marks `didStream = true` (the callback returned without error), then `shouldDropFinalPayloads = blockStreamingEnabled && didStream() = true`, so the final reply array is filtered to `[]`. No message is ever sent.

## Fix

Set `disableBlockStreaming: true` in `replyOptions` returned by `createFeishuReplyDispatcher()`. This bypasses the agent-level block streaming pipeline entirely for Feishu, while Feishu's own streaming card mechanism (`onPartialReply`) continues to work independently.

One-line change + test.

## Testing

- Added test verifying `disableBlockStreaming` is set in replyOptions
- All 22 existing tests pass
- Matches the approach used by IRC, Nextcloud Talk, BlueBubbles, and Mattermost extensions