### PR TITLE
fix(feishu): ignore @all broadcast mentions

### DIFF
--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -92,6 +92,12 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     expect(ctx.mentionedBot).toBe(false);
   });
 
+  it("returns mentionedBot=false for Feishu @all broadcasts", () => {
+    const event = makeEvent("group", [], "@_all");
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
   it("returns mentionedBot=false when botOpenId is undefined (unknown bot)", () => {
     const event = makeEvent("group", [
       { key: "@_user_1", name: "Alice", id: { open_id: "ou_alice" } },

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -452,9 +452,6 @@ function formatSubMessageContent(content: string, contentType: string): string {
 
 function checkBotMentioned(event: FeishuMessageEvent, botOpenId?: string): boolean {
   if (!botOpenId) return false;
-  // Check for @all (@_all in Feishu) — treat as mentioning every bot
-  const rawContent = event.message.content ?? "";
-  if (rawContent.includes("@_all")) return true;
   const mentions = event.message.mentions ?? [];
   if (mentions.length > 0) {
     // Rely on Feishu mention IDs; display names can vary by alias/context.


### PR DESCRIPTION
## Summary
Fixes #37706.

Feishu group-wide broadcasts (`@_all`) were treated as direct bot mentions, so mention-gated group handlers replied to `@all` notifications.

## Changes
- remove the `@_all` shortcut from `checkBotMentioned()`
- keep mention detection on actual mention metadata and post mention parsing
- add regression coverage for `@_all` broadcast payloads

## Testing
- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/feishu/src/bot.checkBotMentioned.test.ts`
- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/feishu/src/monitor.reaction.test.ts`
