### PR TITLE
fix(chatui): show stdout for structured tool results

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ToolResultTextFormatter.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ToolResultTextFormatter.swift
@@ -35,6 +35,7 @@ enum ToolResultTextFormatter {
     private static func renderDictionary(_ dict: [String: Any], toolName: String?) -> String {
         let status = (dict["status"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
         let errorText = self.firstString(in: dict, keys: ["error", "reason"])
+        let stdoutText = self.firstString(in: dict, keys: ["stdout"])
         let messageText = self.firstString(in: dict, keys: ["message", "result", "detail"])
 
         if status?.lowercased() == "error" || errorText != nil {
@@ -49,6 +50,10 @@ enum ToolResultTextFormatter {
 
         if toolName == "nodes", let summary = self.renderNodesSummary(dict) {
             return summary
+        }
+
+        if let stdoutText, !stdoutText.isEmpty {
+            return stdoutText
         }
 
         if let message = messageText {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ToolResultTextFormatterTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ToolResultTextFormatterTests.swift
@@ -65,4 +65,17 @@ struct ToolResultTextFormatterTests {
         let result = ToolResultTextFormatter.format(text: json, toolName: "bash")
         #expect(result == "test output\nsecond line")
     }
+
+    @Test func prefersStdoutWhenStdoutAndStderrAreBothPresent() {
+        let json = """
+        {
+          "stdout": "primary output",
+          "stderr": "warning output",
+          "exitCode": 0
+        }
+        """
+
+        let result = ToolResultTextFormatter.format(text: json, toolName: "bash")
+        #expect(result == "primary output")
+    }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ToolResultTextFormatterTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ToolResultTextFormatterTests.swift
@@ -51,4 +51,18 @@ struct ToolResultTextFormatterTests {
         let result = ToolResultTextFormatter.format(text: json, toolName: "nodes")
         #expect(result.isEmpty)
     }
+
+    @Test func surfacesStdoutFromSuccessfulExecPayload() {
+        let json = """
+        {
+          "message": "tool completed successfully",
+          "stdout": "test output\\nsecond line",
+          "stderr": "",
+          "exitCode": 0
+        }
+        """
+
+        let result = ToolResultTextFormatter.format(text: json, toolName: "bash")
+        #expect(result == "test output\nsecond line")
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #38223.

Structured tool results can carry a generic success message plus the real command output in `stdout`. `ToolResultTextFormatter` only looked at `message`, `result`, and `detail`, so successful exec payloads were rendered as if there was no output.

## Changes
- prefer `stdout` when formatting successful structured tool payloads
- add regression coverage for successful exec payloads that include `stdout`

## Testing
- Not run locally: this machine only has Apple Swift 5.3.1 and does not provide `xctest`, so the OpenClawKit Swift tests cannot execute here.
