### PR TITLE
test(session): cover short dm direct-session key

### DIFF
--- a/src/auto-reply/reply/session-delivery.test.ts
+++ b/src/auto-reply/reply/session-delivery.test.ts
@@ -4,6 +4,7 @@ import { resolveLastChannelRaw, resolveLastToRaw } from "./session-delivery.js";
 describe("session delivery direct-session routing overrides", () => {
   it.each([
     "agent:main:direct:user-1",
+    "agent:main:dm:user-1",
     "agent:main:telegram:direct:123456",
     "agent:main:telegram:account-a:direct:123456",
     "agent:main:telegram:dm:123456",


### PR DESCRIPTION
## Summary
Follow-up for #38230.

Direct-session routing tests covered `direct` variants but missed the short `dm` session key form that the resolver also accepts.

## Changes
- add `agent:main:dm:user-1` to the direct-session routing regression table

## Testing
- `pnpm exec vitest run src/auto-reply/reply/session-delivery.test.ts`
