### PR TITLE
fix(agents): extend gemini-3.1 forward-compat to google-vertex and google providers

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -241,15 +241,22 @@ function resolveAnthropicSonnet46ForwardCompatModel(
   });
 }
 
-// gemini-3.1-pro-preview / gemini-3.1-flash-preview are not present in pi-ai's built-in
-// google-gemini-cli catalog yet. Clone the nearest gemini-3 template so users don't get
-// "Unknown model" errors when Google Gemini CLI gains new minor-version models.
-function resolveGoogleGeminiCli31ForwardCompatModel(
+// gemini-3.1-pro-preview / gemini-3.1-flash-preview may not be present in pi-ai's
+// built-in catalog for every Google provider. Clone the nearest gemini-3 template so
+// users don't get "Unknown model" errors across all Google provider variants.
+const GOOGLE_GEMINI_31_ELIGIBLE_PROVIDERS = new Set([
+  "google-gemini-cli",
+  "google-vertex",
+  "google",
+]);
+
+function resolveGoogleGemini31ForwardCompatModel(
   provider: string,
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
-  if (normalizeProviderId(provider) !== "google-gemini-cli") {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (!GOOGLE_GEMINI_31_ELIGIBLE_PROVIDERS.has(normalizedProvider)) {
     return undefined;
   }
   const trimmed = modelId.trim();
@@ -265,7 +272,7 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
   }
 
   return cloneFirstTemplateModel({
-    normalizedProvider: "google-gemini-cli",
+    normalizedProvider,
     trimmedModelId: trimmed,
     templateIds: [...templateIds],
     modelRegistry,
@@ -326,6 +333,6 @@ export function resolveForwardCompatModel(
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveZaiGlm5ForwardCompatModel(provider, modelId, modelRegistry) ??
-    resolveGoogleGeminiCli31ForwardCompatModel(provider, modelId, modelRegistry)
+    resolveGoogleGemini31ForwardCompatModel(provider, modelId, modelRegistry)
   );
 }

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -10,9 +10,11 @@ import {
   buildOpenAICodexForwardCompatExpectation,
   GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
   GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+  GOOGLE_VERTEX_PRO_TEMPLATE_MODEL,
   makeModel,
   mockGoogleGeminiCliFlashTemplateModel,
   mockGoogleGeminiCliProTemplateModel,
+  mockGoogleVertexProTemplateModel,
   mockOpenAICodexTemplateModel,
   resetMockDiscoverModels,
 } from "./model.test-harness.js";
@@ -93,5 +95,18 @@ describe("pi embedded model e2e smoke", () => {
     const result = resolveModel("google-gemini-cli", "gemini-4-unknown", "/tmp/agent");
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: google-gemini-cli/gemini-4-unknown");
+  });
+
+  it("builds a google-vertex forward-compat fallback for gemini-3.1-pro-preview", () => {
+    mockGoogleVertexProTemplateModel();
+
+    const result = resolveModel("google-vertex", "gemini-3.1-pro-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      ...GOOGLE_VERTEX_PRO_TEMPLATE_MODEL,
+      id: "gemini-3.1-pro-preview",
+      name: "gemini-3.1-pro-preview",
+      reasoning: true,
+    });
   });
 });

--- a/src/agents/pi-embedded-runner/model.test-harness.ts
+++ b/src/agents/pi-embedded-runner/model.test-harness.ts
@@ -73,6 +73,19 @@ export const GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL = {
   maxTokens: 64000,
 };
 
+export const GOOGLE_VERTEX_PRO_TEMPLATE_MODEL = {
+  id: "gemini-3-pro-preview",
+  name: "Gemini 3 Pro Preview",
+  provider: "google-vertex",
+  api: "google-vertex",
+  baseUrl: "https://us-central1-aiplatform.googleapis.com/v1beta1",
+  reasoning: true,
+  input: ["text", "image"] as const,
+  cost: { input: 1.25, output: 10, cacheRead: 0.315, cacheWrite: 0 },
+  contextWindow: 200000,
+  maxTokens: 64000,
+};
+
 export function mockGoogleGeminiCliProTemplateModel(): void {
   mockDiscoveredModel({
     provider: "google-gemini-cli",
@@ -86,6 +99,14 @@ export function mockGoogleGeminiCliFlashTemplateModel(): void {
     provider: "google-gemini-cli",
     modelId: "gemini-3-flash-preview",
     templateModel: GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
+  });
+}
+
+export function mockGoogleVertexProTemplateModel(): void {
+  mockDiscoveredModel({
+    provider: "google-vertex",
+    modelId: "gemini-3-pro-preview",
+    templateModel: GOOGLE_VERTEX_PRO_TEMPLATE_MODEL,
   });
 }
 


### PR DESCRIPTION
## Problem

The forward-compat fallback for `gemini-3.1-pro-preview` / `gemini-3.1-flash-preview` only handled the `google-gemini-cli` provider. Users configuring `google-vertex/gemini-3.1-pro-preview` got `FailoverError: Unknown model` because `resolveGoogleGeminiCli31ForwardCompatModel` rejected any provider that wasn't `google-gemini-cli`.

## Fix

- Rename function to `resolveGoogleGemini31ForwardCompatModel`
- Add a `GOOGLE_GEMINI_31_ELIGIBLE_PROVIDERS` set containing `google-gemini-cli`, `google-vertex`, and `google`
- Use the actual normalized provider when cloning the template (so `google-vertex` looks up its own template, not `google-gemini-cli`'s)
- Add test coverage for `google-vertex/gemini-3.1-pro-preview`

## Testing

All 8 forward-compat tests pass including the new google-vertex case.

Fixes #38273