### PR TITLE
fix(models): extend Gemini 3.1 forward-compat to google-vertex provider

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -242,14 +242,17 @@ function resolveAnthropicSonnet46ForwardCompatModel(
 }
 
 // gemini-3.1-pro-preview / gemini-3.1-flash-preview are not present in pi-ai's built-in
-// google-gemini-cli catalog yet. Clone the nearest gemini-3 template so users don't get
-// "Unknown model" errors when Google Gemini CLI gains new minor-version models.
-function resolveGoogleGeminiCli31ForwardCompatModel(
+// model catalog yet for several Google providers. Clone the nearest gemini-3 template so
+// users don't get "Unknown model" errors when using google-gemini-cli or google-vertex.
+const GEMINI_31_ELIGIBLE_PROVIDERS = new Set(["google-gemini-cli", "google-vertex"]);
+
+function resolveGoogleGemini31ForwardCompatModel(
   provider: string,
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
-  if (normalizeProviderId(provider) !== "google-gemini-cli") {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (!GEMINI_31_ELIGIBLE_PROVIDERS.has(normalizedProvider)) {
     return undefined;
   }
   const trimmed = modelId.trim();
@@ -265,7 +268,7 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
   }
 
   return cloneFirstTemplateModel({
-    normalizedProvider: "google-gemini-cli",
+    normalizedProvider,
     trimmedModelId: trimmed,
     templateIds: [...templateIds],
     modelRegistry,
@@ -326,6 +329,6 @@ export function resolveForwardCompatModel(
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveZaiGlm5ForwardCompatModel(provider, modelId, modelRegistry) ??
-    resolveGoogleGeminiCli31ForwardCompatModel(provider, modelId, modelRegistry)
+    resolveGoogleGemini31ForwardCompatModel(provider, modelId, modelRegistry)
   );
 }

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -10,9 +10,11 @@ import {
   buildOpenAICodexForwardCompatExpectation,
   GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
   GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+  GOOGLE_VERTEX_PRO_TEMPLATE_MODEL,
   makeModel,
   mockGoogleGeminiCliFlashTemplateModel,
   mockGoogleGeminiCliProTemplateModel,
+  mockGoogleVertexProTemplateModel,
   mockOpenAICodexTemplateModel,
   resetMockDiscoverModels,
 } from "./model.test-harness.js";
@@ -85,6 +87,19 @@ describe("pi embedded model e2e smoke", () => {
       ...GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
       id: "gemini-3.1-flash-preview",
       name: "gemini-3.1-flash-preview",
+      reasoning: true,
+    });
+  });
+
+  it("builds a google-vertex forward-compat fallback for gemini-3.1-pro-preview", () => {
+    mockGoogleVertexProTemplateModel();
+
+    const result = resolveModel("google-vertex", "gemini-3.1-pro-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      ...GOOGLE_VERTEX_PRO_TEMPLATE_MODEL,
+      id: "gemini-3.1-pro-preview",
+      name: "gemini-3.1-pro-preview",
       reasoning: true,
     });
   });

--- a/src/agents/pi-embedded-runner/model.test-harness.ts
+++ b/src/agents/pi-embedded-runner/model.test-harness.ts
@@ -89,6 +89,27 @@ export function mockGoogleGeminiCliFlashTemplateModel(): void {
   });
 }
 
+export const GOOGLE_VERTEX_PRO_TEMPLATE_MODEL = {
+  id: "gemini-3-pro-preview",
+  name: "Gemini 3 Pro Preview (Vertex AI)",
+  provider: "google-vertex",
+  api: "google-genai",
+  baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+  reasoning: true,
+  input: ["text", "image"] as const,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200000,
+  maxTokens: 64000,
+};
+
+export function mockGoogleVertexProTemplateModel(): void {
+  mockDiscoveredModel({
+    provider: "google-vertex",
+    modelId: "gemini-3-pro-preview",
+    templateModel: GOOGLE_VERTEX_PRO_TEMPLATE_MODEL,
+  });
+}
+
 export function resetMockDiscoverModels(): void {
   vi.mocked(discoverModels).mockReturnValue({
     find: vi.fn(() => null),


### PR DESCRIPTION
## Summary

Extends the Gemini 3.1 forward-compat fallback to also cover the `google-vertex` provider, not just `google-gemini-cli`.

Users configuring `google-vertex/gemini-3.1-pro-preview` currently get "Unknown model" errors because the forward-compat code only checked for the `google-gemini-cli` provider. This adds `google-vertex` to the eligible provider set so the same template-cloning logic applies.

### Changes

- `model-forward-compat.ts`: Renamed `resolveGoogleGeminiCli31ForwardCompatModel` to `resolveGoogleGemini31ForwardCompatModel` and widened the provider check from a single string comparison to a `Set` containing both `google-gemini-cli` and `google-vertex`.
- `model.test-harness.ts`: Added `GOOGLE_VERTEX_PRO_TEMPLATE_MODEL` and `mockGoogleVertexProTemplateModel` helper.
- `model.forward-compat.test.ts`: Added test case verifying `google-vertex/gemini-3.1-pro-preview` resolves correctly.

Fixes #38273

## Test plan

- [x] `vitest run src/agents/pi-embedded-runner/model.forward-compat.test.ts` — all 8 tests pass (including the new google-vertex test)
- [x] Existing google-gemini-cli tests still pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)