### PR TITLE
fix(feishu): disable block streaming to prevent silent reply loss

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -591,4 +591,15 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       }),
     );
   });
+
+  it("sets disableBlockStreaming to prevent silent reply loss", () => {
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    expect(result.replyOptions.disableBlockStreaming).toBe(true);
+  });
 });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -382,6 +382,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
+      disableBlockStreaming: true,
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
             if (!payload.text) {


### PR DESCRIPTION
## Summary

- **Problem:** When `blockStreamingDefault` is `"on"` (the default), Feishu channels silently drop all replies. The block streaming pipeline sends block-kind payloads to Feishu's `deliver()`, which silently discards them (no card rendering for plain text in auto mode). The pipeline then marks `didStream=true` and suppresses the final reply → zero replies delivered.
- **Fix:** Set `disableBlockStreaming: true` in Feishu's `replyOptions` so the agent-level block streaming pipeline is bypassed entirely. Feishu's own streaming via `onPartialReply` (card-based) continues to work independently.
- **Scope:** One-line fix + one regression test.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue

- Closes #38258

## User-visible / Behavior Changes

- Feishu channels now correctly deliver replies when `blockStreamingDefault: "on"`.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Configure Feishu channel with `blockStreamingDefault: "on"` (default).
2. Send a message to the agent via Feishu.
3. Before fix: `dispatch complete (queuedFinal=false, replies=0)` — no reply delivered.
4. After fix: `dispatch complete (queuedFinal=true, replies=1)` — reply delivered correctly.

## Evidence

- [x] Failing test/log before + passing after
- All 22 tests in `reply-dispatcher.test.ts` pass.

## Human Verification

- Verified the root cause matches the issue reporter's analysis.
- Confirmed `disableBlockStreaming` is the standard opt-out mechanism used by other channels that don't support block-kind delivery.

## Compatibility / Migration

- Backward compatible: Yes
- No config changes needed.

## Failure Recovery

- Revert the single commit to restore previous behavior.
