### PR TITLE
Media: reject spoofed input_image MIME payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,7 @@ Docs: https://docs.openclaw.ai
 - Plugin runtime/events: expose `runtime.events.onAgentEvent` and `runtime.events.onSessionTranscriptUpdate` for extension-side subscriptions, and isolate transcript-listener failures so one faulty listener cannot break the entire update fanout. (#16044) Thanks @scifantastic.
 - CLI/Banner taglines: add `cli.banner.taglineMode` (`random` | `default` | `off`) to control funny tagline behavior in startup output, with docs + FAQ guidance and regression tests for config override behavior.
 - Agents/compaction safeguard quality-audit rollout: keep summary quality audits disabled by default unless `agents.defaults.compaction.qualityGuard` is explicitly enabled, and add config plumbing for bounded retry control. (#25556) thanks @rodrigouroz.
+- Gateway/input_image MIME validation: sniff uploaded image bytes before MIME allowlist enforcement again so declared image types cannot mask concrete non-image payloads, while keeping HEIC/HEIF normalization behavior scoped to actual HEIC inputs. Thanks @vincentkoc.
 
 ### Breaking
 

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -99,7 +99,9 @@ describe("HEIC input image normalization", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps declared MIME for non-HEIC images without sniffing", async () => {
+  it("keeps declared MIME for non-HEIC images after validation", async () => {
+    detectMimeMock.mockResolvedValueOnce("image/png");
+
     const image = await extractImageContentFromSource(
       {
         type: "base64",
@@ -115,13 +117,66 @@ describe("HEIC input image normalization", () => {
       },
     );
 
-    expect(detectMimeMock).not.toHaveBeenCalled();
+    expect(detectMimeMock).toHaveBeenCalledTimes(1);
     expect(convertHeicToJpegMock).not.toHaveBeenCalled();
     expect(image).toEqual({
       type: "image",
       data: Buffer.from("png-like").toString("base64"),
       mimeType: "image/png",
     });
+  });
+
+  it("rejects spoofed base64 images when detected bytes are not an image", async () => {
+    detectMimeMock.mockResolvedValueOnce("application/pdf");
+
+    await expect(
+      extractImageContentFromSource(
+        {
+          type: "base64",
+          data: Buffer.from("%PDF-1.4\n").toString("base64"),
+          mediaType: "image/png",
+        },
+        {
+          allowUrl: false,
+          allowedMimes: new Set(["image/png", "image/jpeg"]),
+          maxBytes: 1024 * 1024,
+          maxRedirects: 0,
+          timeoutMs: 1,
+        },
+      ),
+    ).rejects.toThrow("Unsupported image MIME type: application/pdf");
+    expect(convertHeicToJpegMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects spoofed URL images when detected bytes are not an image", async () => {
+    const release = vi.fn(async () => {});
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(Buffer.from("%PDF-1.4\n"), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      }),
+      release,
+      finalUrl: "https://example.com/photo.png",
+    });
+    detectMimeMock.mockResolvedValueOnce("application/pdf");
+
+    await expect(
+      extractImageContentFromSource(
+        {
+          type: "url",
+          url: "https://example.com/photo.png",
+        },
+        {
+          allowUrl: true,
+          allowedMimes: new Set(["image/png", "image/jpeg"]),
+          maxBytes: 1024 * 1024,
+          maxRedirects: 0,
+          timeoutMs: 1000,
+        },
+      ),
+    ).rejects.toThrow("Unsupported image MIME type: application/pdf");
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(convertHeicToJpegMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -235,11 +235,17 @@ async function normalizeInputImage(params: {
   limits: InputImageLimits;
 }): Promise<InputImageContent> {
   const declaredMime = normalizeMimeType(params.mimeType) ?? "application/octet-stream";
-  const sourceMime = HEIC_INPUT_IMAGE_MIMES.has(declaredMime)
-    ? (normalizeMimeType(
-        await detectMime({ buffer: params.buffer, headerMime: params.mimeType }),
-      ) ?? declaredMime)
-    : declaredMime;
+  const detectedMime = normalizeMimeType(
+    await detectMime({ buffer: params.buffer, headerMime: params.mimeType }),
+  );
+  if (declaredMime.startsWith("image/") && detectedMime && !detectedMime.startsWith("image/")) {
+    throw new Error(`Unsupported image MIME type: ${detectedMime}`);
+  }
+  const sourceMime =
+    (detectedMime && HEIC_INPUT_IMAGE_MIMES.has(detectedMime)) ||
+    (HEIC_INPUT_IMAGE_MIMES.has(declaredMime) && !detectedMime)
+      ? (detectedMime ?? declaredMime)
+      : declaredMime;
   if (!params.limits.allowedMimes.has(sourceMime)) {
     throw new Error(`Unsupported image MIME type: ${sourceMime}`);
   }


### PR DESCRIPTION
## Summary

- Problem: `normalizeInputImage` trusted caller-declared non-HEIC image MIME types before the allowlist check, so a request could claim `image/png` while supplying concrete non-image bytes.
- Why it matters: that let spoofed `input_image` payloads bypass the intended image MIME validation boundary on Gateway HTTP APIs.
- What changed: image inputs now sniff bytes again before allowlist enforcement, reject concrete non-image detections for declared `image/*` payloads, and still keep HEIC/HEIF normalization scoped to actual HEIC inputs.
- What did NOT change (scope boundary): this does not expand accepted MIME types, relax URL fetching policy, or change the existing HEIC -> JPEG normalization path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #38122
- Related #38146

## User-visible / Behavior Changes

- Gateway `input_image` requests now reject spoofed non-image payloads even when the request declares an allowed image MIME type.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: n/a
- Integration/channel (if any): Gateway HTTP APIs
- Relevant config (redacted): defaults

### Steps

1. Send an `input_image` base64 or URL request that declares `image/png`.
2. Provide bytes that detect as `application/pdf` instead of an image.
3. Observe Gateway validation.

### Expected

- Spoofed payloads are rejected before provider delivery.

### Actual

- The previous merged follow-up trusted declared non-HEIC MIME types and could accept spoofed payloads.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: HEIC base64 normalization, HEIC URL normalization, spoofed base64 image rejection, spoofed URL image rejection, OpenAI chat completions gateway path, OpenResponses parity validation.
- Edge cases checked: non-HEIC images keep declared MIME after validation; HEIC image budget tests remain green.
- What you did **not** verify: install smoke locally in Docker.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/media/input-files.ts`, `src/media/input-files.fetch-guard.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: valid image inputs getting rejected due to incorrect MIME detection.

## Risks and Mitigations

- Risk: MIME sniffing could reintroduce non-HEIC behavior drift.
  - Mitigation: tests assert non-HEIC images keep their declared MIME after validation while concrete non-image detections are rejected.

## AI Assistance

- AI-assisted: yes
- Testing: fully tested on the focused Gateway/media suites listed below

Verification:
- `pnpm vitest run src/media/input-files.fetch-guard.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-parity.test.ts src/gateway/openai-http.image-budget.test.ts`
- `pnpm exec oxfmt --check src/media/input-files.ts src/media/input-files.fetch-guard.test.ts CHANGELOG.md`
