### PR TITLE
Gateway: allow extension origins in browser allowlist

### DIFF
--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -49,6 +49,24 @@ describe("checkBrowserOrigin", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("accepts allowlisted chrome extension origins", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "127.0.0.1:18789",
+      origin: "chrome-extension://abcdefghijklmnop",
+      allowedOrigins: ["chrome-extension://abcdefghijklmnop"],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects mismatched chrome extension origins", () => {
+    const result = checkBrowserOrigin({
+      requestHost: "127.0.0.1:18789",
+      origin: "chrome-extension://abcdefghijklmnop",
+      allowedOrigins: ["chrome-extension://qrstuvwxyzabcdef"],
+    });
+    expect(result.ok).toBe(false);
+  });
+
   it("accepts wildcard allowedOrigins", () => {
     const result = checkBrowserOrigin({
       requestHost: "gateway.example.com:18789",

--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -144,4 +144,33 @@ describe("checkBrowserOrigin", () => {
   ])("$name", ({ input, expected }) => {
     expect(checkBrowserOrigin(input)).toEqual(expected);
   });
+
+  it.each([
+    "chrome-extension://abcdefghijklmnop",
+    "tauri://localhost",
+    "electron://localhost",
+    "app://desktop",
+  ])("accepts an exactly allowlisted hosted app origin: %s", (origin) => {
+    expect(checkBrowserOrigin({ origin, allowedOrigins: [origin] })).toEqual({
+      ok: true,
+      matchedBy: "allowlist",
+    });
+  });
+
+  it.each([
+    "tauri://localhost/path",
+    "tauri://localhost/admin/..",
+    "tauri://localhost/%2e",
+    "https://control.example.com\\admin",
+    "tauri://localhost?mode=admin",
+    "tauri://localhost#admin",
+    "tauri://user@localhost",
+    "file:///tmp/openclaw.html",
+    "data:text/plain,hello",
+  ])("rejects a non-origin URL value: %s", (origin) => {
+    expect(checkBrowserOrigin({ origin, allowedOrigins: [origin] })).toEqual({
+      ok: false,
+      reason: "origin missing or invalid",
+    });
+  });
 });

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -7,9 +7,19 @@ type OriginCheckResult =
     }
   | { ok: false; reason: string };
 
+function normalizeOriginForMatch(url: URL): string {
+  const normalizedOrigin = url.origin.toLowerCase();
+  if (normalizedOrigin !== "null") {
+    return normalizedOrigin;
+  }
+  // Non-standard schemes like chrome-extension://<id> stringify to origin === "null",
+  // but still have a stable scheme + host that operators can allowlist exactly.
+  return `${url.protocol}//${url.host}`.toLowerCase();
+}
+
 function parseOrigin(
   originRaw?: string,
-): { origin: string; host: string; hostname: string } | null {
+): { matchOrigin: string; host: string; hostname: string } | null {
   const trimmed = (originRaw ?? "").trim();
   if (!trimmed || trimmed === "null") {
     return null;
@@ -17,13 +27,24 @@ function parseOrigin(
   try {
     const url = new URL(trimmed);
     return {
-      origin: url.origin.toLowerCase(),
+      matchOrigin: normalizeOriginForMatch(url),
       host: url.host.toLowerCase(),
       hostname: url.hostname.toLowerCase(),
     };
   } catch {
     return null;
   }
+}
+
+function normalizeAllowedOrigin(originRaw: string): string | null {
+  const trimmed = originRaw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed === "*") {
+    return "*";
+  }
+  return parseOrigin(trimmed)?.matchOrigin ?? null;
 }
 
 export function checkBrowserOrigin(params: {
@@ -39,9 +60,9 @@ export function checkBrowserOrigin(params: {
   }
 
   const allowlist = new Set(
-    (params.allowedOrigins ?? []).map((value) => value.trim().toLowerCase()).filter(Boolean),
+    (params.allowedOrigins ?? []).map(normalizeAllowedOrigin).filter(Boolean),
   );
-  if (allowlist.has("*") || allowlist.has(parsedOrigin.origin)) {
+  if (allowlist.has("*") || allowlist.has(parsedOrigin.matchOrigin)) {
     return { ok: true, matchedBy: "allowlist" };
   }
 

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -21,10 +21,20 @@ function parseOrigin(
   if (!trimmed || trimmed === "null") {
     return null;
   }
+  // URL parsing collapses dot segments. Reject non-origin suffixes before
+  // canonicalization so a path cannot inherit its authority's grant.
+  if (!/^[a-z][a-z0-9+.-]*:\/\/[^/?#\\]+\/?$/i.test(trimmed)) {
+    return null;
+  }
   try {
     const url = new URL(trimmed);
+    if (url.username || url.password || !url.protocol || !url.host) {
+      return null;
+    }
+    // Hosted app schemes have an opaque URL.origin but a stable authority.
+    const origin = url.origin === "null" ? `${url.protocol}//${url.host}` : url.origin;
     return {
-      origin: normalizeLowercaseStringOrEmpty(url.origin),
+      origin: normalizeLowercaseStringOrEmpty(origin),
       host: normalizeLowercaseStringOrEmpty(url.host),
       hostname: normalizeLowercaseStringOrEmpty(url.hostname),
     };

--- a/src/gateway/server.auth.browser-hardening.test.ts
+++ b/src/gateway/server.auth.browser-hardening.test.ts
@@ -73,6 +73,29 @@ async function createSignedDevice(params: {
 }
 
 describe("gateway auth browser hardening", () => {
+  test("accepts allowlisted chrome extension origins for browser ws clients", async () => {
+    testState.gatewayAuth = { mode: "token", token: "secret" };
+    testState.gatewayControlUi = {
+      allowedOrigins: ["chrome-extension://abcdefghijklmnop"],
+    };
+    await withGatewayServer(async ({ port }) => {
+      const ws = await openWs(port, {
+        origin: "chrome-extension://abcdefghijklmnop",
+      });
+      try {
+        const res = await connectReq(ws, {
+          token: "secret",
+          client: TEST_OPERATOR_CLIENT,
+          device: null,
+        });
+        expect(res.ok).toBe(true);
+        expect((res.payload as { type?: string } | undefined)?.type).toBe("hello-ok");
+      } finally {
+        ws.close();
+      }
+    });
+  });
+
   test("rejects non-local browser origins for non-control-ui clients", async () => {
     testState.gatewayAuth = { mode: "token", token: "secret" };
     await withGatewayServer(async ({ port }) => {

--- a/src/gateway/server.auth.browser-hardening.test.ts
+++ b/src/gateway/server.auth.browser-hardening.test.ts
@@ -308,6 +308,28 @@ describe("gateway auth browser hardening", () => {
     });
   });
 
+  test("accepts an exactly allowlisted Tauri origin", async () => {
+    const { writeConfigFile } = await import("../config/config.js");
+    const origin = "tauri://localhost";
+    testState.gatewayAuth = { mode: "token", token: "secret" };
+    await writeConfigFile({ gateway: { controlUi: { allowedOrigins: [origin] } } });
+
+    await withGatewayServer(async ({ port }) => {
+      const ws = await openWs(port, { origin });
+      try {
+        const res = await connectReq(ws, {
+          token: "secret",
+          client: TEST_OPERATOR_CLIENT,
+          device: null,
+        });
+        expect(res.ok).toBe(true);
+        expect((res.payload as { type?: string } | undefined)?.type).toBe("hello-ok");
+      } finally {
+        ws.close();
+      }
+    });
+  });
+
   test("rejects non-local browser origins for non-control-ui clients", async () => {
     await expectBrowserOriginConnectRejected({});
   });


### PR DESCRIPTION
## What Problem This Solves

Desktop shells and browser extensions send valid browser `Origin` values such as `tauri://localhost`, `electron://localhost`, `app://localhost`, or `chrome-extension://<id>`. JavaScript's URL parser reports `URL.origin === "null"` for these hosted non-standard schemes, so the Gateway could not match them against an exact `gateway.controlUi.allowedOrigins` entry. Operators were forced to choose between a broken app and the much broader `"*"` allowlist.

Fixes #46520. Also covers the root cause reported in #35035.

## Why This Change Was Made

The Gateway now derives `scheme://authority` only for hosted schemes whose parsed origin is opaque, while retaining the standard serialized origin for HTTP(S). The raw input must first be an origin and nothing more: paths, queries, fragments, credentials, hostless schemes, dot-segment normalization, and backslash path separators are rejected before URL canonicalization.

This is deliberately exact matching, not a scheme wildcard or prefix match. `tauri://localhost` grants only that origin; it does not grant `tauri://localhost/path`, another authority, `Origin: null`, or arbitrary Tauri origins. Existing wildcard, private same-origin, tailnet, host-header fallback, token/device authentication, and local-loopback rules remain unchanged.

## User Impact

- Tauri, Electron, app-protocol, and Chrome-extension clients can use a narrow exact origin allowlist.
- Users no longer need `gateway.controlUi.allowedOrigins=["*"]` solely because their desktop/browser shell uses a non-standard scheme.
- Malformed URL-like values cannot inherit an allowlisted authority through parser normalization.
- No new config key, migration, permission, or public API surface.

## Evidence

- Blacksmith Testbox `tbx_01kx3a3cqcgztce1p3rc9wrqmp` / Actions 29014889369: 146/146 origin-validator and real Gateway browser-auth tests passed.
- Real Gateway coverage connects with exact `tauri://localhost` and rejects non-matching or malformed variants.
- Focused cases cover HTTP(S), Chrome extension, Tauri, Electron, app schemes, paths, dot segments, percent-encoded dots, backslashes, query, fragment, credentials, `file:`, `data:`, wildcard, private same-origin, host fallback, and local-loopback behavior.
- Fresh autoreview: clean after fixing two canonicalization bypasses found during review (dot segments and backslashes).
- `git diff --check` and repository formatting passed.

## Compatibility / Recovery

Backward compatible for valid existing origins. Reverting the single Gateway origin-parser change restores prior behavior; no stored data or config migration is involved.

## AI Assistance

Maintainer-refactored and reviewed with Codex. Contributor credit is preserved in the commit trailer.
