### PR TITLE
fix: sanitize API error messages to prevent leaking raw details to users

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -117,6 +117,43 @@ describe("formatAssistantErrorText", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");
   });
+
+  // --- API error leakage prevention (Issue #22665) ---
+
+  it("returns a friendly message for auth permanent errors instead of raw text", () => {
+    const msg = makeAssistantError("invalid_api_key: The API key you provided is invalid.");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("Authentication failed");
+    expect(result).toContain("invalid or revoked");
+    expect(result).not.toContain("invalid_api_key");
+  });
+
+  it("returns a friendly message for auth errors instead of leaking credentials", () => {
+    const msg = makeAssistantError("401 Unauthorized: Invalid token for organization org-abc123");
+    const result = formatAssistantErrorText(msg);
+    expect(result).toContain("Authentication error");
+    expect(result).not.toContain("org-abc123");
+  });
+
+  it("never returns raw unclassified error text to the user", () => {
+    const msg = makeAssistantError(
+      "Internal failure at gateway-east-2.internal:8443 — request_id: req_abc123, trace: span_xyz",
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).not.toContain("gateway-east-2");
+    expect(result).not.toContain("req_abc123");
+    expect(result).not.toContain("span_xyz");
+    expect(result).toContain("unexpected error");
+  });
+
+  it("does not leak long raw error payloads even when truncated", () => {
+    const longError = "x".repeat(1000) + " secret_key=sk-abc123";
+    const msg = makeAssistantError(longError);
+    const result = formatAssistantErrorText(msg);
+    expect(result).not.toContain("sk-abc123");
+    expect(result).not.toContain("xxxx");
+    expect(result).toContain("unexpected error");
+  });
 });
 
 describe("formatRawAssistantErrorForUi", () => {
@@ -151,5 +188,24 @@ describe("formatRawAssistantErrorForUi", () => {
     expect(formatRawAssistantErrorForUi(htmlError)).toBe(
       "The AI service is temporarily unavailable (HTTP 521). Please try again in a moment.",
     );
+  });
+
+  // --- API error leakage prevention (Issue #22665) ---
+
+  it("returns a safe generic message for unparseable raw errors", () => {
+    const rawError =
+      "Connection refused at provider-internal.east-2:8080 (credentials: sk-ant-xxx, trace_id: t_123)";
+    const result = formatRawAssistantErrorForUi(rawError);
+    expect(result).not.toContain("sk-ant-xxx");
+    expect(result).not.toContain("provider-internal");
+    expect(result).not.toContain("t_123");
+    expect(result).toContain("LLM request failed");
+  });
+
+  it("returns a safe message for very long unparseable errors", () => {
+    const longError = "Some internal error: " + "a]".repeat(500);
+    const result = formatRawAssistantErrorForUi(longError);
+    expect(result).not.toContain("a]a]");
+    expect(result).toContain("LLM request failed");
   });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -624,7 +624,11 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
     return `${prefix}${type}: ${info.message}${requestId}`;
   }
 
-  return trimmed.length > 600 ? `${trimmed.slice(0, 600)}…` : trimmed;
+  // Never return raw unhandled error text to the user — it may contain
+  // internal infrastructure details, API keys, or request metadata.
+  // Log the raw error for debugging and return a safe generic message.
+  log.warn(`Raw API error not parsed (not shown to user): ${trimmed.slice(0, 500)}`);
+  return "LLM request failed. Check `openclaw logs` for details.";
 }
 
 export function formatAssistantErrorText(
@@ -706,15 +710,23 @@ export function formatAssistantErrorText(
     return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
   }
 
+  if (isAuthPermanentErrorMessage(raw)) {
+    return "⚠️ Authentication failed — your API key appears to be invalid or revoked. Please check your API key configuration.";
+  }
+
+  if (isAuthErrorMessage(raw)) {
+    return "⚠️ Authentication error — please verify your API key or credentials are correct and not expired.";
+  }
+
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {
     return formatRawAssistantErrorForUi(raw);
   }
 
-  // Never return raw unhandled errors - log for debugging but return safe message
-  if (raw.length > 600) {
-    log.warn(`Long error truncated: ${raw.slice(0, 200)}`);
-  }
-  return raw.length > 600 ? `${raw.slice(0, 600)}…` : raw;
+  // Never return raw unhandled errors to the user — they may contain
+  // internal API details, request IDs, or infrastructure metadata.
+  // Log the full error for debugging and return a safe generic message.
+  log.warn(`Unclassified API error (not shown to user): ${raw.slice(0, 500)}`);
+  return "⚠️ An unexpected error occurred. Check `openclaw logs` for details.";
 }
 
 export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boolean }): string {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -10,6 +10,12 @@ import {
   isContextOverflowError,
   isLikelyContextOverflowError,
   isTransientHttpError,
+  isRateLimitErrorMessage,
+  isOverloadedErrorMessage,
+  isBillingErrorMessage,
+  isAuthErrorMessage,
+  isAuthPermanentErrorMessage,
+  isTimeoutErrorMessage,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
@@ -606,15 +612,27 @@ export async function runAgentTurnWithFallback(params: {
       }
 
       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
-      const safeMessage = isTransientHttp
-        ? sanitizeUserFacingText(message, { errorContext: true })
-        : message;
-      const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
+
+      // Classify the error to provide a user-friendly message instead of
+      // leaking raw API error details (rate limits, billing info, auth
+      // tokens, internal request IDs, etc.) into the chat.
       const fallbackText = isContextOverflow
         ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
         : isRoleOrderingError
           ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-          : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+          : isRateLimitErrorMessage(message) || isOverloadedErrorMessage(message)
+            ? "⚠️ API rate limit reached. Please try again later."
+            : isBillingErrorMessage(message)
+              ? "⚠️ API billing error — your API key has run out of credits. Check your provider's billing dashboard."
+              : isAuthPermanentErrorMessage(message)
+                ? "⚠️ Authentication failed — your API key appears to be invalid or revoked. Please check your configuration."
+                : isAuthErrorMessage(message)
+                  ? "⚠️ Authentication error — please verify your API key or credentials."
+                  : isTimeoutErrorMessage(message)
+                    ? "⚠️ LLM request timed out. Please try again."
+                    : isTransientHttp
+                      ? `⚠️ AI service temporarily unavailable. Please try again in a moment.`
+                      : "⚠️ An unexpected error occurred. Check `openclaw logs --follow` for details.";
 
       return {
         kind: "final",


### PR DESCRIPTION
## Summary

Closes #22665.

API errors (rate limit, usage limit, auth failures, billing errors, and unclassified provider errors) were being forwarded as-is to end-user chats (Telegram/WhatsApp/Discord), potentially exposing:
- Internal infrastructure hostnames and ports
- Request IDs and trace identifiers
- API keys and authentication tokens
- Provider-specific error metadata

This PR adds comprehensive error sanitization across three leakage points:

### Changes

**`src/agents/pi-embedded-helpers/errors.ts`**
- `formatRawAssistantErrorForUi()`: Replaced the raw-text fallback (which returned up to 600 chars of unfiltered error text) with a safe generic message. Raw errors are logged for debugging.
- `formatAssistantErrorText()`: Added auth error classification (`isAuthPermanentErrorMessage` + `isAuthErrorMessage`) before the generic fallback. Replaced the raw-text truncation fallback with a safe generic message.

**`src/auto-reply/reply/agent-runner-execution.ts`**
- The catch block's fallback previously embedded raw `${trimmedMessage}` directly in the user-facing response. Now it classifies errors through the full chain (rate-limit → billing → auth → timeout → transient HTTP) and returns appropriate user-friendly messages. No raw error text ever reaches the chat.

**Tests** (`pi-embedded-helpers.formatassistanterrortext.test.ts`)
- 6 new tests verifying that internal details (infrastructure hosts, request IDs, API keys, trace IDs) are never returned to users

### Error Classification Coverage

| Error Type | User-Facing Message |
|---|---|
| Rate limit / Overloaded | "API rate limit reached. Please try again later." |
| Billing / Insufficient credits | "API billing error — your API key has run out of credits." |
| Auth permanent (revoked key) | "Authentication failed — your API key appears to be invalid or revoked." |
| Auth transient (expired token) | "Authentication error — please verify your API key or credentials." |
| Timeout | "LLM request timed out. Please try again." |
| Transient HTTP (502/521) | "AI service temporarily unavailable. Please try again in a moment." |
| Unclassified | "An unexpected error occurred. Check `openclaw logs` for details." |

All raw errors continue to be logged via the subsystem logger for debugging.

## Test plan

- [x] All 93 existing + new tests pass (`vitest run`)
- [x] TypeScript type-check clean (`tsc --noEmit`)
- [x] Lint passes (biome)
- [ ] Manual test: trigger rate limit → verify friendly message in Telegram
- [ ] Manual test: use invalid API key → verify no key leakage in chat

## Notes

- AI-assisted: This PR was authored with Claude assistance
- Testing level: Unit tests added and passing; manual testing recommended for channel-specific behavior
- The existing error classification functions (`isRateLimitErrorMessage`, `isBillingErrorMessage`, etc.) were already exported but unused in the `agent-runner-execution.ts` catch block — this PR connects them

🤖 Generated with [Claude Code](https://claude.com/claude-code)