### PR TITLE
Web: add HEIC media regression and doc fix

### DIFF
--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -161,7 +161,7 @@ Supports base64 or URL sources:
 }
 ```
 
-Allowed MIME types (current): `image/jpeg`, `image/png`, `image/gif`, `image/webp`.
+Allowed MIME types (current): `image/jpeg`, `image/png`, `image/gif`, `image/webp`, `image/heic`, `image/heif`.
 Max size (current): 10MB.
 
 ## Files (`input_file`)

--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -16,6 +16,17 @@ import {
   optimizeImageToJpeg,
 } from "./media.js";
 
+const convertHeicToJpegMock = vi.fn();
+
+vi.mock("../media/image-ops.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../media/image-ops.js")>("../media/image-ops.js");
+  return {
+    ...actual,
+    convertHeicToJpeg: (...args: unknown[]) => convertHeicToJpegMock(...args),
+  };
+});
+
 let fixtureRoot = "";
 let fixtureFileCount = 0;
 let largeJpegBuffer: Buffer;
@@ -23,6 +34,7 @@ let largeJpegFile = "";
 let tinyPngBuffer: Buffer;
 let tinyPngFile = "";
 let tinyPngWrongExtFile = "";
+let fakeHeicFile = "";
 let alphaPngBuffer: Buffer;
 let alphaPngFile = "";
 let fallbackPngBuffer: Buffer;
@@ -76,6 +88,7 @@ beforeAll(async () => {
     .toBuffer();
   tinyPngFile = await writeTempFile(tinyPngBuffer, ".png");
   tinyPngWrongExtFile = await writeTempFile(tinyPngBuffer, ".bin");
+  fakeHeicFile = await writeTempFile(Buffer.from("fake-heic"), ".heic");
   alphaPngBuffer = await sharp({
     create: {
       width: 64,
@@ -176,6 +189,19 @@ describe("web media loading", () => {
 
     expect(result.kind).toBe("image");
     expect(result.contentType).toBe("image/jpeg");
+  });
+
+  it("normalizes HEIC local files to JPEG output", async () => {
+    convertHeicToJpegMock.mockResolvedValueOnce(tinyPngBuffer);
+
+    const result = await loadWebMedia(fakeHeicFile, 1024 * 1024);
+
+    expect(convertHeicToJpegMock).toHaveBeenCalledTimes(1);
+    expect(result.kind).toBe("image");
+    expect(result.contentType).toBe("image/jpeg");
+    expect(result.fileName).toBe(path.basename(fakeHeicFile, ".heic") + ".jpg");
+    expect(result.buffer.length).toBeGreaterThan(0);
+    expect(result.buffer.equals(tinyPngBuffer)).toBe(false);
   });
 
   it("includes URL + status in fetch errors", async () => {

--- a/src/web/media.test.ts
+++ b/src/web/media.test.ts
@@ -202,6 +202,9 @@ describe("web media loading", () => {
     expect(result.fileName).toBe(path.basename(fakeHeicFile, ".heic") + ".jpg");
     expect(result.buffer.length).toBeGreaterThan(0);
     expect(result.buffer.equals(tinyPngBuffer)).toBe(false);
+    // Confirm the output is actually JPEG (magic bytes 0xFF 0xD8)
+    expect(result.buffer[0]).toBe(0xff);
+    expect(result.buffer[1]).toBe(0xd8);
   });
 
   it("includes URL + status in fetch errors", async () => {


### PR DESCRIPTION
## Summary

- Problem: the Gateway HEIC/input-image work left one stale doc line in the OpenResponses docs and still lacked a regression for the older `src/web/media.ts` HEIC normalization path.
- Why it matters: the docs should match the current HEIC/HEIF allowlist, and the existing web/media HEIC path should stay covered so future refactors do not quietly regress it.
- What changed: added a hermetic `src/web/media.test.ts` regression that exercises local `.heic` handling through `loadWebMedia`, and updated the OpenResponses docs MIME list to include `image/heic` and `image/heif`.
- What did NOT change (scope boundary): no runtime behavior changed in this PR; this is docs + regression coverage only.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] API / contracts
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #38122
- Related #38289

## User-visible / Behavior Changes

- Docs now list `image/heic` and `image/heif` in the current `input_image` MIME allowlist.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: n/a
- Integration/channel (if any): Web media path + Gateway docs
- Relevant config (redacted): defaults

### Steps

1. Run `pnpm vitest run src/web/media.test.ts`.
2. Confirm the new HEIC local-file regression passes.
3. Confirm the docs line lists HEIC/HEIF in `docs/gateway/openresponses-http-api.md`.

### Expected

- The older `loadWebMedia` HEIC path stays covered and docs match the runtime/schema allowlist.

### Actual

- Before this PR, the docs line was stale and the HEIC web/media path did not have a dedicated regression.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `src/web/media.test.ts` including the new HEIC local-file normalization regression.
- Edge cases checked: `.heic` input maps to JPEG output and `.jpg` filename.
- What you did **not** verify: full repo test suite.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/web/media.test.ts`, `docs/gateway/openresponses-http-api.md`
- Known bad symptoms reviewers should watch for: test-only regressions or docs drift.

## Risks and Mitigations

- Risk: the HEIC regression could become platform-coupled.
  - Mitigation: the test stubs `convertHeicToJpeg` only and keeps the rest of the path real, so it stays hermetic.

## AI Assistance

- AI-assisted: yes
- Testing: focused local verification completed

Verification:
- `pnpm vitest run src/web/media.test.ts`
- `pnpm exec oxfmt --check src/web/media.test.ts docs/gateway/openresponses-http-api.md`
