### PR TITLE
community: add OpenClawDreams plugin listing

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -54,4 +54,4 @@ Use this format when adding entries:
   npm: `openclawdreams`
   repo: `https://github.com/RogueCtrl/OpenClawDreams`
   install: `openclaw plugins install openclawdreams`
-  version: `1.0.0`
+  version: `1.1.0`

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,8 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **OpenClawDreams** — A reflection and dream cycle engine that synthesizes agent-operator interactions into encrypted long-term memory using AES-256. Gives OpenClaw agents a background "dream" state for higher-order insight and continuity.
+  npm: `openclawdreams`
+  repo: `https://github.com/RogueCtrl/OpenClawDreams`
+  install: `openclaw plugins install openclawdreams`

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -54,3 +54,4 @@ Use this format when adding entries:
   npm: `openclawdreams`
   repo: `https://github.com/RogueCtrl/OpenClawDreams`
   install: `openclaw plugins install openclawdreams`
+  version: `1.0.0`


### PR DESCRIPTION
## OpenClawDreams

Adds **OpenClawDreams** to the community plugins page.

- **npm:** `openclawdreams` (published, public access)
- **repo:** https://github.com/RogueCtrl/OpenClawDreams
- **install:** `openclaw plugins install openclawdreams`

### Description
A reflection and dream cycle engine that synthesizes agent-operator interactions into encrypted long-term memory using AES-256. Gives OpenClaw agents a background "dream" state for higher-order insight and continuity across sessions.

### Quality bar checklist
- [x] Published on npmjs
- [x] Public GitHub repository
- [x] README with setup/use docs
- [x] Issue tracker enabled
- [x] Active maintainer (v0.7.0, actively developed)