### PR TITLE
fix(agents): repair structurally complete interrupted tool calls

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -581,6 +581,24 @@ describe("sanitizeSessionHistory", () => {
     expect(result[1]?.role).toBe("toolResult");
   });
 
+  it("repairs structurally complete interrupted tool calls for openai-responses", async () => {
+    const messages: AgentMessage[] = [
+      makeAssistantMessage(
+        [{ type: "toolCall", id: "call_aborted", name: "read", arguments: {} }],
+        {
+          stopReason: "aborted",
+        },
+      ),
+    ];
+
+    const result = await sanitizeOpenAIHistory(messages);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]?.role).toBe("assistant");
+    expect(result[1]?.role).toBe("toolResult");
+    expect((result[1] as { toolCallId?: string }).toolCallId).toBe("call_aborted");
+  });
+
   it.each([
     {
       name: "missing input or arguments",

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -462,14 +462,10 @@ describe("installSessionToolResultGuard", () => {
     });
   });
 
-  // When an assistant message with toolCalls is aborted, no synthetic toolResult
-  // should be created. Creating synthetic results for aborted/incomplete tool calls
-  // causes API 400 errors: "unexpected tool_use_id found in tool_result blocks".
-  it("does NOT create synthetic toolResult for aborted assistant messages with toolCalls", () => {
+  it("creates synthetic toolResult for structurally complete aborted assistant tool calls", () => {
     const sm = SessionManager.inMemory();
     installSessionToolResultGuard(sm);
 
-    // Aborted assistant message with incomplete toolCall
     sm.appendMessage(
       asAppendMessage({
         role: "assistant",
@@ -487,18 +483,16 @@ describe("installSessionToolResultGuard", () => {
       }),
     );
 
-    // Should only have assistant + user, NO synthetic toolResult
     const messages = getPersistedMessages(sm);
     const roles = messages.map((m) => m.role);
-    expect(roles).toEqual(["assistant", "user"]);
-    expect(roles).not.toContain("toolResult");
+    expect(roles).toEqual(["assistant", "toolResult", "user"]);
+    expect((messages[1] as { toolCallId?: string }).toolCallId).toBe("call_aborted");
   });
 
-  it("does NOT create synthetic toolResult for errored assistant messages with toolCalls", () => {
+  it("creates synthetic toolResult for structurally complete errored assistant tool calls", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm);
 
-    // Error assistant message with incomplete toolCall
     sm.appendMessage(
       asAppendMessage({
         role: "assistant",
@@ -507,15 +501,54 @@ describe("installSessionToolResultGuard", () => {
       }),
     );
 
-    // Explicit flush should NOT create synthetic result for errored messages
     guard.flushPendingToolResults();
 
     const messages = getPersistedMessages(sm);
     const toolResults = messages.filter((m) => m.role === "toolResult");
-    // No synthetic toolResults should exist for the errored call
     const syntheticForError = toolResults.filter(
       (m) => (m as { toolCallId?: string }).toolCallId === "call_error",
     );
-    expect(syntheticForError).toHaveLength(0);
+    expect(syntheticForError).toHaveLength(1);
+  });
+
+  it("still skips synthetic toolResult creation for incomplete aborted tool calls", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_aborted", name: "read" }],
+        stopReason: "aborted",
+      }),
+    );
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "user",
+        content: "are you stuck?",
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = getPersistedMessages(sm);
+    expect(messages.map((message) => message.role)).toEqual(["user"]);
+  });
+
+  it("still skips synthetic toolResult creation for incomplete errored tool calls", () => {
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm);
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_error", name: "exec" }],
+        stopReason: "error",
+      }),
+    );
+
+    guard.flushPendingToolResults();
+
+    expect(getPersistedMessages(sm).map((message) => message.role)).toEqual([]);
   });
 });

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -10,8 +10,12 @@ import {
   truncateToolResultMessage,
 } from "./pi-embedded-runner/tool-result-truncation.js";
 import { createPendingToolCallState } from "./session-tool-result-state.js";
-import { makeMissingToolResult, sanitizeToolCallInputs } from "./session-transcript-repair.js";
-import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-id.js";
+import {
+  extractRepairableToolCallsFromAssistant,
+  makeMissingToolResult,
+  sanitizeToolCallInputs,
+} from "./session-transcript-repair.js";
+import { extractToolResultId } from "./tool-call-id.js";
 
 const GUARD_TRUNCATION_SUFFIX =
   "\n\n⚠️ [Content truncated during persistence — original exceeded size limit. " +
@@ -209,16 +213,14 @@ export function installSessionToolResultGuard(
       return originalAppend(persisted as never);
     }
 
-    // Skip tool call extraction for aborted/errored assistant messages.
-    // When stopReason is "error" or "aborted", the tool_use blocks may be incomplete
-    // and should not have synthetic tool_results created. Creating synthetic results
-    // for incomplete tool calls causes API 400 errors:
-    // "unexpected tool_use_id found in tool_result blocks"
-    // This matches the behavior in repairToolUseResultPairing (session-transcript-repair.ts)
-    const stopReason = (nextMessage as { stopReason?: string }).stopReason;
     const toolCalls =
-      nextRole === "assistant" && stopReason !== "aborted" && stopReason !== "error"
-        ? extractToolCallsFromAssistant(nextMessage as Extract<AgentMessage, { role: "assistant" }>)
+      nextRole === "assistant"
+        ? extractRepairableToolCallsFromAssistant(
+            nextMessage as Extract<AgentMessage, { role: "assistant" }>,
+            {
+              allowedToolNames: opts?.allowedToolNames,
+            },
+          )
         : [];
 
     // Always clear pending tool call state before appending non-tool-result messages.

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -144,10 +144,7 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(out.map((m) => m.role)).toEqual(["user", "assistant"]);
   });
 
-  it("skips tool call extraction for assistant messages with stopReason 'error'", () => {
-    // When an assistant message has stopReason: "error", its tool_use blocks may be
-    // incomplete/malformed. We should NOT create synthetic tool_results for them,
-    // as this causes API 400 errors: "unexpected tool_use_id found in tool_result blocks"
+  it("repairs structurally complete tool calls even when stopReason is 'error'", () => {
     const input = castAgentMessages([
       {
         role: "assistant",
@@ -159,17 +156,16 @@ describe("sanitizeToolUseResultPairing", () => {
 
     const result = repairToolUseResultPairing(input);
 
-    // Should NOT add synthetic tool results for errored messages
-    expect(result.added).toHaveLength(0);
-    // The assistant message should be passed through unchanged
-    expect(result.messages[0]?.role).toBe("assistant");
-    expect(result.messages[1]?.role).toBe("user");
-    expect(result.messages).toHaveLength(2);
+    expect(result.added).toHaveLength(1);
+    expect(result.added[0]?.toolCallId).toBe("call_error");
+    expect(result.messages.map((message) => message.role)).toEqual([
+      "assistant",
+      "toolResult",
+      "user",
+    ]);
   });
 
-  it("skips tool call extraction for assistant messages with stopReason 'aborted'", () => {
-    // When a request is aborted mid-stream, the assistant message may have incomplete
-    // tool_use blocks (with partialJson). We should NOT create synthetic tool_results.
+  it("repairs structurally complete tool calls even when stopReason is 'aborted'", () => {
     const input = castAgentMessages([
       {
         role: "assistant",
@@ -181,12 +177,13 @@ describe("sanitizeToolUseResultPairing", () => {
 
     const result = repairToolUseResultPairing(input);
 
-    // Should NOT add synthetic tool results for aborted messages
-    expect(result.added).toHaveLength(0);
-    // Messages should be passed through without synthetic insertions
-    expect(result.messages).toHaveLength(2);
-    expect(result.messages[0]?.role).toBe("assistant");
-    expect(result.messages[1]?.role).toBe("user");
+    expect(result.added).toHaveLength(1);
+    expect(result.added[0]?.toolCallId).toBe("call_aborted");
+    expect(result.messages.map((message) => message.role)).toEqual([
+      "assistant",
+      "toolResult",
+      "user",
+    ]);
   });
 
   it("still repairs tool results for normal assistant messages with stopReason 'toolUse'", () => {
@@ -207,10 +204,7 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(result.added[0]?.toolCallId).toBe("call_normal");
   });
 
-  it("drops orphan tool results that follow an aborted assistant message", () => {
-    // When an assistant message is aborted, any tool results that follow should be
-    // dropped as orphans (since we skip extracting tool calls from aborted messages).
-    // This addresses the edge case where a partial tool result was persisted before abort.
+  it("preserves tool results that follow an aborted assistant message when the tool call is complete", () => {
     const input = castAgentMessages([
       {
         role: "assistant",
@@ -229,13 +223,29 @@ describe("sanitizeToolUseResultPairing", () => {
 
     const result = repairToolUseResultPairing(input);
 
-    // The orphan tool result should be dropped
-    expect(result.droppedOrphanCount).toBe(1);
-    expect(result.messages).toHaveLength(2);
-    expect(result.messages[0]?.role).toBe("assistant");
-    expect(result.messages[1]?.role).toBe("user");
-    // No synthetic results should be added
+    expect(result.droppedOrphanCount).toBe(0);
     expect(result.added).toHaveLength(0);
+    expect(result.messages.map((message) => message.role)).toEqual([
+      "assistant",
+      "toolResult",
+      "user",
+    ]);
+  });
+
+  it("still skips incomplete tool calls on aborted assistant messages", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_incomplete", name: "exec" }],
+        stopReason: "aborted",
+      },
+      { role: "user", content: "retrying" },
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    expect(result.added).toHaveLength(0);
+    expect(result.messages.map((message) => message.role)).toEqual(["assistant", "user"]);
   });
 });
 

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-id.js";
+import type { ToolCallLike } from "./tool-call-id.js";
+import { extractToolResultId } from "./tool-call-id.js";
 
 const TOOL_CALL_NAME_MAX_CHARS = 64;
 const TOOL_CALL_NAME_RE = /^[A-Za-z0-9_-]+$/;
@@ -130,6 +131,29 @@ function sanitizeToolCallBlock(block: RawToolCallBlock): RawToolCallBlock {
     next.input = nextInput;
   }
   return next as RawToolCallBlock;
+}
+
+function toRepairableToolCall(
+  block: RawToolCallBlock,
+  allowedToolNames: Set<string> | null,
+): ToolCallLike | null {
+  if (
+    !hasToolCallInput(block) ||
+    !hasToolCallId(block) ||
+    !hasToolCallName(block, allowedToolNames)
+  ) {
+    return null;
+  }
+
+  const id = trimNonEmptyString(block.id);
+  if (!id) {
+    return null;
+  }
+
+  return {
+    id,
+    name: trimNonEmptyString(block.name),
+  };
 }
 
 function makeMissingToolResult(params: {
@@ -327,6 +351,28 @@ export function sanitizeToolCallInputs(
   return repairToolCallInputs(messages, options).messages;
 }
 
+export function extractRepairableToolCallsFromAssistant(
+  message: Extract<AgentMessage, { role: "assistant" }>,
+  options?: ToolCallInputRepairOptions,
+): ToolCallLike[] {
+  if (!Array.isArray(message.content)) {
+    return [];
+  }
+
+  const allowedToolNames = normalizeAllowedToolNames(options?.allowedToolNames);
+  const toolCalls: ToolCallLike[] = [];
+  for (const block of message.content) {
+    if (!isRawToolCallBlock(block)) {
+      continue;
+    }
+    const next = toRepairableToolCall(block, allowedToolNames);
+    if (next) {
+      toolCalls.push(next);
+    }
+  }
+  return toolCalls;
+}
+
 export function sanitizeToolUseResultPairing(messages: AgentMessage[]): AgentMessage[] {
   return repairToolUseResultPairing(messages).messages;
 }
@@ -390,19 +436,11 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
 
     const assistant = msg as Extract<AgentMessage, { role: "assistant" }>;
 
-    // Skip tool call extraction for aborted or errored assistant messages.
-    // When stopReason is "error" or "aborted", the tool_use blocks may be incomplete
-    // (e.g., partialJson: true) and should not have synthetic tool_results created.
-    // Creating synthetic results for incomplete tool calls causes API 400 errors:
-    // "unexpected tool_use_id found in tool_result blocks"
-    // See: https://github.com/openclaw/openclaw/issues/4597
-    const stopReason = (assistant as { stopReason?: string }).stopReason;
-    if (stopReason === "error" || stopReason === "aborted") {
-      out.push(msg);
-      continue;
-    }
-
-    const toolCalls = extractToolCallsFromAssistant(assistant);
+    // Repair is based on structural completeness, not stopReason alone.
+    // Interrupted assistant turns can still contain fully-formed persisted tool calls
+    // that need synthetic tool results to keep the transcript valid, while partial
+    // streamed fragments are ignored here because they fail the structural checks.
+    const toolCalls = extractRepairableToolCallsFromAssistant(assistant);
     if (toolCalls.length === 0) {
       out.push(msg);
       continue;


### PR DESCRIPTION
Fixes #37834

## Summary
- add a shared structural completeness classifier for persisted assistant tool calls
- use that classifier in both transcript repair and session-tool-result guard paths
- repair interrupted-but-complete tool calls by synthesizing missing tool results
- keep skipping incomplete streamed fragments so we do not regress the #4597 aborted-session fix

## Why this approach
The current behavior uses `stopReason === "aborted" | "error"` as a proxy for “this tool call is unsafe to repair”. That heuristic is too coarse: it avoids creating synthetic tool results for partial streamed fragments, but it also leaves fully-formed persisted tool calls unrepaired after timeouts, aborts, and tool-incapable fallbacks.

This PR changes the invariant from **"repair unless interrupted"** to **"repair whenever the persisted tool call is structurally complete"**.

That separates two different concerns:
- interruption state (`aborted` / `error`)
- transcript validity (does a persisted tool call have a stable id/name/payload and therefore require a matching tool result?)

As a result, interrupted sessions stop getting poisoned by orphaned tool calls, while genuinely incomplete fragments still remain out of the repair path.

## Tests
Passed locally:
- `pnpm exec vitest run src/agents/session-transcript-repair.test.ts src/agents/session-tool-result-guard.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts src/agents/pi-embedded-runner.guard.test.ts`
- `pnpm exec vitest run src/agents/compaction.test.ts src/agents/pi-embedded-runner.guard.waitforidle-before-flush.test.ts`
- `pnpm exec oxfmt --check src/agents/session-transcript-repair.ts src/agents/session-tool-result-guard.ts src/agents/session-transcript-repair.test.ts src/agents/session-tool-result-guard.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts`

Note: `pnpm check` is currently failing on unrelated existing `extensions/feishu/src/media.ts` type errors on `origin/main` (`timeout` property not in SDK types), so I validated this change with focused tests plus formatting.