### PR TITLE
fix(feishu): disable block streaming to prevent silent reply drops

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -591,4 +591,15 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       }),
     );
   });
+
+  it("sets disableBlockStreaming in replyOptions to prevent silent block-chunk drops", () => {
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as any,
+      agentId: "agent1",
+      runtime: { log: vi.fn(), error: vi.fn() } as any,
+      chatId: "oc_chat_1",
+    });
+
+    expect(result.replyOptions.disableBlockStreaming).toBe(true);
+  });
 });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -382,6 +382,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
+      disableBlockStreaming: true,
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
             if (!payload.text) {


### PR DESCRIPTION
## Summary

- **Problem:** When `blockStreamingDefault` is `"on"` (the default after setup wizard), Feishu agents receive and process messages but **no reply is ever delivered** to the client. The block streaming pipeline's `deliver({kind: "block"})` is silently dropped by Feishu when `renderMode` is `"auto"` and text has no code blocks/tables, but the pipeline still marks `didStream = true`, causing the final reply to also be filtered out.
- **Why it matters:** This silently breaks all Feishu channels using default config — agents appear completely unresponsive.
- **What changed:** Set `disableBlockStreaming: true` in Feishu's `replyOptions` so the agent-level block streaming pipeline is bypassed entirely. Feishu's own streaming-card path (`onPartialReply`) remains fully functional and unaffected.
- **What did NOT change:** No changes to block streaming logic itself, no changes to other channels, no changes to Feishu streaming cards.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #38258

## User-visible / Behavior Changes

- Feishu channels with `blockStreamingDefault: "on"` now correctly deliver replies.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Channel: Feishu
- Config: `agents.defaults.blockStreamingDefault: "on"`

### Steps

1. Configure Feishu channel with default settings
2. Send a message to the agent
3. Observe reply is delivered (`queuedFinal=true, replies=1`)

### Expected

Reply delivered to Feishu client.

### Actual (before fix)

`dispatch complete (queuedFinal=false, replies=0)` — no reply delivered.

## Evidence

- [x] Failing test/log before + passing after
- Test added: verifies `disableBlockStreaming` is set in replyOptions

## Human Verification

- Verified: test suite passes (22/22 tests)
- Edge cases: streaming cards still work via `onPartialReply` path

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- Revert this PR to restore previous behavior.

## Risks and Mitigations

- Risk: Block streaming content lost for Feishu users who relied on it.
  - Mitigation: Feishu's deliver already silently dropped block chunks in auto/raw mode, so no functional regression.

## AI Assistance

- AI-assisted: yes
- Testing: `pnpm vitest run extensions/feishu/src/reply-dispatcher.test.ts` (22/22 pass)