### PR TITLE
docs: clarify NVIDIA refs with slash-containing model ids

### DIFF
--- a/docs/providers/nvidia.md
+++ b/docs/providers/nvidia.md
@@ -20,6 +20,14 @@ openclaw onboard --auth-choice skip
 openclaw models set nvidia/nvidia/llama-3.1-nemotron-70b-instruct
 ```
 
+OpenClaw model refs still use `provider/model`, so NVIDIA configs should keep the
+leading `nvidia/` provider prefix. NVIDIA NIM model IDs can themselves contain
+slashes, so a valid OpenClaw ref can look doubled, such as
+`nvidia/nvidia/llama-3.1-nemotron-70b-instruct` or `nvidia/moonshotai/kimi-k2.5`.
+OpenClaw parses model refs on the first `/`, keeps `nvidia` as the provider, and
+sends the full remaining NVIDIA model ID (`nvidia/llama-3.1-nemotron-70b-instruct`,
+`moonshotai/kimi-k2.5`, and so on) to the NVIDIA API.
+
 If you still pass `--token`, remember it lands in shell history and `ps` output; prefer the env var when possible.
 
 ## Config snippet
@@ -46,6 +54,7 @@ If you still pass `--token`, remember it lands in shell history and `ps` output;
 ## Model IDs
 
 - `nvidia/llama-3.1-nemotron-70b-instruct` (default)
+- `moonshotai/kimi-k2.5`
 - `meta/llama-3.3-70b-instruct`
 - `nvidia/mistral-nemo-minitron-8b-8k-instruct`
 

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -444,6 +444,27 @@ describe("model-selection", () => {
   });
 
   describe("resolveConfiguredModelRef", () => {
+    it("preserves nested NVIDIA model ids after the provider prefix", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: "nvidia/moonshotai/kimi-k2.5" },
+          },
+        },
+      } as OpenClawConfig;
+
+      const result = resolveConfiguredModelRef({
+        cfg,
+        defaultProvider: "openai",
+        defaultModel: "gpt-4",
+      });
+
+      expect(result).toEqual({
+        provider: "nvidia",
+        model: "moonshotai/kimi-k2.5",
+      });
+    });
+
     it("should fall back to anthropic and warn if provider is missing for non-alias", () => {
       setLoggerOverride({ level: "silent", consoleLevel: "warn" });
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -182,6 +182,29 @@ describe("buildInlineProviderModels", () => {
 });
 
 describe("resolveModel", () => {
+  it("preserves slash-containing NVIDIA model ids for OpenAI-compatible requests", () => {
+    const cfg = {
+      models: {
+        providers: {
+          nvidia: {
+            baseUrl: "https://integrate.api.nvidia.com/v1",
+            api: "openai-completions",
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("nvidia", "moonshotai/kimi-k2.5", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "nvidia",
+      id: "moonshotai/kimi-k2.5",
+      api: "openai-completions",
+      baseUrl: "https://integrate.api.nvidia.com/v1",
+    });
+  });
+
   it("includes provider baseUrl in fallback model", () => {
     const cfg = {
       models: {


### PR DESCRIPTION
## Summary

- Problem: NVIDIA docs implied the doubled `nvidia/...` model ref was suspect, while the code path already parses `provider/model` on the first slash and preserves slash-containing NVIDIA model IDs.
- Why it matters: users filed bugs and worked around the documented OpenClaw ref format even though the intended behavior is already correct.
- What changed: document how NVIDIA refs are parsed, add a config-resolution regression test, and add a runner-model regression test for slash-containing NVIDIA IDs.
- What did NOT change (scope boundary): no provider runtime code changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Integrations
- [x] UI / DX

## Linked Issue/PR

- Closes #38256

## User-visible / Behavior Changes

- NVIDIA provider docs now explicitly explain why OpenClaw refs can look like `nvidia/nvidia/...` or `nvidia/moonshotai/...` and that only the leading provider segment is stripped.
- Regression tests now cover configured model resolution and embedded runner resolution for slash-containing NVIDIA model IDs.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15/26 host
- Runtime/container: local repo worktree
- Model/provider: NVIDIA NIM
- Integration/channel (if any): embedded runner model resolution
- Relevant config (redacted): `agents.defaults.model.primary = "nvidia/moonshotai/kimi-k2.5"` and `models.providers.nvidia.api = "openai-completions"`

### Steps

1. Configure an NVIDIA provider whose model ID itself contains a slash.
2. Resolve the configured OpenClaw model ref.
3. Resolve the runner model for an OpenAI-compatible NVIDIA provider.

### Expected

- Provider stays `nvidia` and the remaining model ID stays `moonshotai/kimi-k2.5`.

### Actual

- `pnpm exec vitest run src/agents/model-selection.test.ts src/agents/pi-embedded-runner/model.test.ts`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `resolveConfiguredModelRef` preserves `moonshotai/kimi-k2.5`; `resolveModel` preserves the same ID for NVIDIA OpenAI-compatible requests.
- Edge cases checked: docs now describe both `nvidia/nvidia/...` and `nvidia/moonshotai/...` OpenClaw refs.
- What you did **not** verify: a live NVIDIA API request.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `docs/providers/nvidia.md`, `src/agents/model-selection.test.ts`, `src/agents/pi-embedded-runner/model.test.ts`
- Known bad symptoms reviewers should watch for: none beyond doc/test drift.

## Risks and Mitigations

- Risk: docs could still be read as mixing OpenClaw refs and raw NVIDIA model IDs.
  - Mitigation: the new paragraph explicitly distinguishes the OpenClaw provider prefix from the model ID sent to NVIDIA, and tests lock in the current behavior.
