### PR TITLE
fix: point misplaced Feishu plugin creds to channels.feishu

### DIFF
--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -37,6 +37,7 @@ describe("config plugin validation", () => {
   let badPluginDir = "";
   let enumPluginDir = "";
   let bluebubblesPluginDir = "";
+  let feishuAliasPluginDir = "";
   const envSnapshot = {
     OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
     OPENCLAW_PLUGIN_MANIFEST_CACHE_MS: process.env.OPENCLAW_PLUGIN_MANIFEST_CACHE_MS,
@@ -51,6 +52,7 @@ describe("config plugin validation", () => {
     badPluginDir = path.join(suiteHome, "bad-plugin");
     enumPluginDir = path.join(suiteHome, "enum-plugin");
     bluebubblesPluginDir = path.join(suiteHome, "bluebubbles-plugin");
+    feishuAliasPluginDir = path.join(suiteHome, "feishu-openclaw-plugin");
     await writePluginFixture({
       dir: badPluginDir,
       id: "bad-plugin",
@@ -83,6 +85,16 @@ describe("config plugin validation", () => {
       channels: ["bluebubbles"],
       schema: { type: "object" },
     });
+    await writePluginFixture({
+      dir: feishuAliasPluginDir,
+      id: "feishu-openclaw-plugin",
+      channels: ["feishu"],
+      schema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+    });
     process.env.OPENCLAW_STATE_DIR = path.join(suiteHome, ".openclaw");
     process.env.OPENCLAW_PLUGIN_MANIFEST_CACHE_MS = "10000";
     clearPluginManifestRegistryCache();
@@ -91,7 +103,7 @@ describe("config plugin validation", () => {
     validateInSuite({
       plugins: {
         enabled: false,
-        load: { paths: [badPluginDir, bluebubblesPluginDir] },
+        load: { paths: [badPluginDir, bluebubblesPluginDir, feishuAliasPluginDir] },
       },
     });
   });
@@ -226,6 +238,57 @@ describe("config plugin validation", () => {
       expect(issue?.message).toContain('allowed: "markdown", "html"');
       expect(issue?.allowedValues).toEqual(["markdown", "html"]);
       expect(issue?.allowedValuesHiddenCount).toBe(0);
+    }
+  });
+
+  it("points misplaced Feishu credentials at channels.feishu based on plugin channel metadata", async () => {
+    const res = validateInSuite({
+      agents: { list: [{ id: "pi" }] },
+      plugins: {
+        enabled: true,
+        load: { paths: [feishuAliasPluginDir] },
+        entries: {
+          "feishu-openclaw-plugin": {
+            config: {
+              appId: "cli_top",
+              appSecret: "secret_top",
+              accounts: {
+                workspace: {
+                  appId: "cli_workspace",
+                  appSecret: "secret_workspace",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues).toEqual(
+        expect.arrayContaining([
+          {
+            path: "plugins.entries.feishu-openclaw-plugin.config.appId",
+            message:
+              "Feishu appId belongs under channels.feishu.appId or channels.feishu.accounts.<id>.appId, not plugin config",
+          },
+          {
+            path: "plugins.entries.feishu-openclaw-plugin.config.appSecret",
+            message:
+              "Feishu appSecret belongs under channels.feishu.appSecret or channels.feishu.accounts.<id>.appSecret, not plugin config",
+          },
+          {
+            path: "plugins.entries.feishu-openclaw-plugin.config.accounts.workspace.appId",
+            message:
+              'Feishu appId for account "workspace" belongs under channels.feishu.accounts.workspace.appId, not plugin config',
+          },
+          {
+            path: "plugins.entries.feishu-openclaw-plugin.config.accounts.workspace.appSecret",
+            message:
+              'Feishu appSecret for account "workspace" belongs under channels.feishu.accounts.workspace.appSecret, not plugin config',
+          },
+        ]),
+      );
     }
   });
 

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -32,6 +32,7 @@ type AllowedValuesCollection = {
   incomplete: boolean;
   hasValues: boolean;
 };
+type PluginConfigIssue = Pick<ConfigValidationIssue, "path" | "message">;
 
 function toIssueRecord(value: unknown): UnknownIssueRecord | null {
   if (!value || typeof value !== "object") {
@@ -220,6 +221,74 @@ function validateGatewayTailscaleBind(config: OpenClawConfig): ConfigValidationI
         '(use gateway.bind="loopback" or gateway.bind="custom" with gateway.customBindHost="127.0.0.1")',
     },
   ];
+}
+
+function hasOwnKey(value: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function collectMisplacedFeishuPluginConfigIssues(params: {
+  pluginId: string;
+  channels: readonly string[];
+  config: unknown;
+}): PluginConfigIssue[] {
+  const hasFeishuChannel = params.channels.some(
+    (channelId) => channelId.trim().toLowerCase() === "feishu",
+  );
+  if (!hasFeishuChannel || !isRecord(params.config)) {
+    return [];
+  }
+
+  const issues: PluginConfigIssue[] = [];
+  const basePath = `plugins.entries.${params.pluginId}.config`;
+
+  if (hasOwnKey(params.config, "appId")) {
+    issues.push({
+      path: `${basePath}.appId`,
+      message:
+        "Feishu appId belongs under channels.feishu.appId or " +
+        "channels.feishu.accounts.<id>.appId, not plugin config",
+    });
+  }
+
+  if (hasOwnKey(params.config, "appSecret")) {
+    issues.push({
+      path: `${basePath}.appSecret`,
+      message:
+        "Feishu appSecret belongs under channels.feishu.appSecret or " +
+        "channels.feishu.accounts.<id>.appSecret, not plugin config",
+    });
+  }
+
+  const accounts = params.config.accounts;
+  if (!isRecord(accounts)) {
+    return issues;
+  }
+
+  for (const [accountId, account] of Object.entries(accounts)) {
+    if (!isRecord(account)) {
+      continue;
+    }
+    // Mirror the actual Feishu channel shape so the fix points to the right destination key.
+    if (hasOwnKey(account, "appId")) {
+      issues.push({
+        path: `${basePath}.accounts.${accountId}.appId`,
+        message:
+          `Feishu appId for account "${accountId}" belongs under ` +
+          `channels.feishu.accounts.${accountId}.appId, not plugin config`,
+      });
+    }
+    if (hasOwnKey(account, "appSecret")) {
+      issues.push({
+        path: `${basePath}.accounts.${accountId}.appSecret`,
+        message:
+          `Feishu appSecret for account "${accountId}" belongs under ` +
+          `channels.feishu.accounts.${accountId}.appSecret, not plugin config`,
+      });
+    }
+  }
+
+  return issues;
 }
 
 /**
@@ -582,6 +651,13 @@ function validateConfigObjectWithPluginsBase(
 
     const shouldValidate = enabled || entryHasConfig;
     if (shouldValidate) {
+      issues.push(
+        ...collectMisplacedFeishuPluginConfigIssues({
+          pluginId,
+          channels: record.channels,
+          config: entry?.config,
+        }),
+      );
       if (record.configSchema) {
         const res = validateJsonSchemaValue({
           schema: record.configSchema,


### PR DESCRIPTION
## Summary

- Problem: Feishu users who put `appId`/`appSecret` under `plugins.entries.feishu-openclaw-plugin.config` only saw the generic JSON schema `additionalProperties` failure.
- Why it matters: the gateway fails to start, but the error does not tell users that Feishu credentials belong under `channels.feishu`.
- What changed: add Feishu-specific validation hints keyed off plugin channel metadata and cover both top-level and per-account credentials in plugin validation tests.
- What did NOT change (scope boundary): no plugin loading behavior, onboarding flow, or Feishu runtime behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Integrations
- [x] UI / DX

## Linked Issue/PR

- Closes #38217

## User-visible / Behavior Changes

- Misplaced Feishu credentials under plugin config now produce explicit validation messages pointing to `channels.feishu.appId`, `channels.feishu.appSecret`, and `channels.feishu.accounts.<id>.*` instead of only generic schema failures.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15/26 host
- Runtime/container: local repo worktree
- Model/provider: n/a
- Integration/channel (if any): Feishu plugin manifest fixture
- Relevant config (redacted): plugin fixture with `channels: ["feishu"]` and misplaced `appId` / `appSecret`

### Steps

1. Create a Feishu plugin fixture whose manifest declares `channels: ["feishu"]` and whose schema forbids additional properties.
2. Put `appId` / `appSecret` and account-scoped credentials under `plugins.entries.feishu-openclaw-plugin.config`.
3. Run config validation.

### Expected

- Validation reports targeted guidance telling the user to move credentials under `channels.feishu`.

### Actual

- `pnpm exec vitest run src/config/config.plugin-validation.test.ts`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: top-level `appId` / `appSecret` and `accounts.<id>.appId` / `appSecret` under plugin config now surface targeted diagnostics.
- Edge cases checked: validation is keyed from plugin channel metadata instead of plugin id string matching.
- What you did **not** verify: a live Feishu plugin install on Windows.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: `src/config/validation.ts`, `src/config/config.plugin-validation.test.ts`
- Known bad symptoms reviewers should watch for: unexpected extra validation issues for non-Feishu plugins declaring `feishu` in channel metadata.

## Risks and Mitigations

- Risk: Feishu-specific hints could fire for a third-party plugin that declares the `feishu` channel but uses a different config convention.
  - Mitigation: the hint only checks well-known credential key names and does not alter schema validation or runtime config behavior.
