### PR TITLE
Slack: support per-account native command prefixes for slash commands

### DIFF
--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -132,6 +132,15 @@ describe("commands registry", () => {
     expect(native.find((spec) => spec.name === "agentstatus")).toBeFalsy();
   });
 
+  it("normalizes mixed-case nativePrefix for slack command specs", () => {
+    const native = listNativeCommandSpecsForConfig(
+      { commands: { native: true } },
+      { provider: "slack", nativePrefix: "AcCt1" },
+    );
+    expect(native.find((spec) => spec.name === "acct1-help")).toBeTruthy();
+    expect(native.find((spec) => spec.name === "acct1-agentstatus")).toBeTruthy();
+  });
+
   it("finds slack commands by prefixed native names", () => {
     expect(
       findCommandByNativeName("acct1-agentstatus", "slack", { nativePrefix: "acct1" })?.key,
@@ -140,6 +149,19 @@ describe("commands registry", () => {
     expect(findCommandByNativeName("agentstatus", "slack", { nativePrefix: "acct1" })?.key).toBe(
       "status",
     );
+  });
+
+  it("ignores invalid hyphenated nativePrefix values", () => {
+    const native = listNativeCommandSpecsForConfig(
+      { commands: { native: true } },
+      { provider: "slack", nativePrefix: "acct-1" },
+    );
+    expect(native.find((spec) => spec.name === "help")).toBeTruthy();
+    expect(native.find((spec) => spec.name === "agentstatus")).toBeTruthy();
+    expect(native.find((spec) => spec.name === "acct-1-help")).toBeFalsy();
+    expect(
+      findCommandByNativeName("acct-1-agentstatus", "slack", { nativePrefix: "acct-1" }),
+    ).toBeUndefined();
   });
 
   it("keeps discord native command specs within slash-command limits", () => {

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -121,6 +121,27 @@ describe("commands registry", () => {
     expect(findCommandByNativeName("status", "slack")).toBeUndefined();
   });
 
+  it("prefixes slack native command specs when nativePrefix is set", () => {
+    const native = listNativeCommandSpecsForConfig(
+      { commands: { native: true } },
+      { provider: "slack", nativePrefix: "acct1" },
+    );
+    expect(native.find((spec) => spec.name === "acct1-help")).toBeTruthy();
+    expect(native.find((spec) => spec.name === "acct1-agentstatus")).toBeTruthy();
+    expect(native.find((spec) => spec.name === "help")).toBeFalsy();
+    expect(native.find((spec) => spec.name === "agentstatus")).toBeFalsy();
+  });
+
+  it("finds slack commands by prefixed native names", () => {
+    expect(
+      findCommandByNativeName("acct1-agentstatus", "slack", { nativePrefix: "acct1" })?.key,
+    ).toBe("status");
+    expect(findCommandByNativeName("acct1-agentstatus", "slack")?.key).toBe("status");
+    expect(findCommandByNativeName("agentstatus", "slack", { nativePrefix: "acct1" })?.key).toBe(
+      "status",
+    );
+  });
+
   it("keeps discord native command specs within slash-command limits", () => {
     const cfg = { commands: { native: true } };
     const native = listNativeCommandSpecsForConfig(cfg, { provider: "discord" });

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -143,9 +143,26 @@ function resolveNativeName(command: ChatCommandDefinition, provider?: string): s
   return command.nativeName;
 }
 
-function toNativeCommandSpec(command: ChatCommandDefinition, provider?: string): NativeCommandSpec {
+function normalizeNativePrefix(nativePrefix?: string): string | undefined {
+  const trimmed = nativePrefix?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.replace(/^-+|-+$/g, "");
+}
+
+function withNativePrefix(name: string, nativePrefix?: string): string {
+  const prefix = normalizeNativePrefix(nativePrefix);
+  return prefix ? `${prefix}-${name}` : name;
+}
+
+function toNativeCommandSpec(
+  command: ChatCommandDefinition,
+  provider?: string,
+  nativePrefix?: string,
+): NativeCommandSpec {
   return {
-    name: resolveNativeName(command, provider) ?? command.key,
+    name: withNativePrefix(resolveNativeName(command, provider) ?? command.key, nativePrefix),
     description: command.description,
     acceptsArgs: Boolean(command.acceptsArgs),
     args: command.args,
@@ -155,39 +172,77 @@ function toNativeCommandSpec(command: ChatCommandDefinition, provider?: string):
 function listNativeSpecsFromCommands(
   commands: ChatCommandDefinition[],
   provider?: string,
+  nativePrefix?: string,
 ): NativeCommandSpec[] {
   return commands
     .filter((command) => command.scope !== "text" && command.nativeName)
-    .map((command) => toNativeCommandSpec(command, provider));
+    .map((command) => toNativeCommandSpec(command, provider, nativePrefix));
 }
 
 export function listNativeCommandSpecs(params?: {
   skillCommands?: SkillCommandSpec[];
   provider?: string;
+  nativePrefix?: string;
 }): NativeCommandSpec[] {
   return listNativeSpecsFromCommands(
     listChatCommands({ skillCommands: params?.skillCommands }),
     params?.provider,
+    params?.nativePrefix,
   );
 }
 
 export function listNativeCommandSpecsForConfig(
   cfg: OpenClawConfig,
-  params?: { skillCommands?: SkillCommandSpec[]; provider?: string },
+  params?: { skillCommands?: SkillCommandSpec[]; provider?: string; nativePrefix?: string },
 ): NativeCommandSpec[] {
-  return listNativeSpecsFromCommands(listChatCommandsForConfig(cfg, params), params?.provider);
+  return listNativeSpecsFromCommands(
+    listChatCommandsForConfig(cfg, params),
+    params?.provider,
+    params?.nativePrefix,
+  );
+}
+
+function stripNativePrefixCandidate(name: string, nativePrefix?: string): string | undefined {
+  const prefix = normalizeNativePrefix(nativePrefix)?.toLowerCase();
+  if (!prefix) {
+    return undefined;
+  }
+  const token = `${prefix}-`;
+  if (!name.startsWith(token)) {
+    return undefined;
+  }
+  const stripped = name.slice(token.length).trim();
+  return stripped || undefined;
 }
 
 export function findCommandByNativeName(
   name: string,
   provider?: string,
+  params?: { nativePrefix?: string; nativePrefixes?: string[] },
 ): ChatCommandDefinition | undefined {
   const normalized = name.trim().toLowerCase();
-  return getChatCommands().find(
-    (command) =>
-      command.scope !== "text" &&
-      resolveNativeName(command, provider)?.toLowerCase() === normalized,
-  );
+  const candidates = new Set<string>([normalized]);
+  const configuredPrefixes = [params?.nativePrefix, ...(params?.nativePrefixes ?? [])];
+  for (const prefix of configuredPrefixes) {
+    const stripped = stripNativePrefixCandidate(normalized, prefix);
+    if (stripped) {
+      candidates.add(stripped);
+    }
+  }
+  // Slack native commands can be account-prefixed. If account context is not available,
+  // fall back to stripping one leading "<prefix>-" segment and retrying.
+  const dynamicDashIndex = normalized.indexOf("-");
+  if (provider === "slack" && dynamicDashIndex > 0 && dynamicDashIndex < normalized.length - 1) {
+    candidates.add(normalized.slice(dynamicDashIndex + 1));
+  }
+
+  return getChatCommands().find((command) => {
+    if (command.scope === "text") {
+      return false;
+    }
+    const resolved = resolveNativeName(command, provider)?.toLowerCase();
+    return Boolean(resolved && candidates.has(resolved));
+  });
 }
 
 export function buildCommandText(commandName: string, args?: string): string {

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -148,7 +148,13 @@ function normalizeNativePrefix(nativePrefix?: string): string | undefined {
   if (!trimmed) {
     return undefined;
   }
-  return trimmed.replace(/^-+|-+$/g, "");
+  const normalized = trimmed.toLowerCase();
+  // Native slash command prefix is a single segment prepended as "<prefix>-<command>".
+  // Restrict to lowercase alphanumeric to avoid ambiguous multi-segment matching.
+  if (!/^[a-z0-9]+$/.test(normalized)) {
+    return undefined;
+  }
+  return normalized;
 }
 
 function withNativePrefix(name: string, nativePrefix?: string): string {

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -64,7 +64,7 @@ export type SlackSlashCommandConfig = {
   enabled?: boolean;
   /** Slash command name (default: "openclaw"). */
   name?: string;
-  /** Optional per-account prefix for native slash commands (e.g. "acct-help"). */
+  /** Optional per-account prefix for native slash commands; must be one lowercase alphanumeric word (e.g. "acct1"). */
   nativePrefix?: string;
   /** Session key prefix for slash commands (default: "slack:slash"). */
   sessionPrefix?: string;

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -64,6 +64,8 @@ export type SlackSlashCommandConfig = {
   enabled?: boolean;
   /** Slash command name (default: "openclaw"). */
   name?: string;
+  /** Optional per-account prefix for native slash commands (e.g. "acct-help"). */
+  nativePrefix?: string;
   /** Session key prefix for slash commands (default: "slack:slash"). */
   sessionPrefix?: string;
   /** Reply ephemerally (default: true). */

--- a/src/slack/monitor/commands.ts
+++ b/src/slack/monitor/commands.ts
@@ -1,5 +1,12 @@
 import type { SlackSlashCommandConfig } from "../../config/config.js";
 
+export type ResolvedSlackSlashCommandConfig = Omit<
+  Required<SlackSlashCommandConfig>,
+  "nativePrefix"
+> & {
+  nativePrefix?: string;
+};
+
 /**
  * Strip Slack mentions (<@U123>, <@U123|name>) so command detection works on
  * normalized text. Use in both prepare and debounce gate for consistency.
@@ -17,12 +24,14 @@ export function normalizeSlackSlashCommandName(raw: string) {
 
 export function resolveSlackSlashCommandConfig(
   raw?: SlackSlashCommandConfig,
-): Required<SlackSlashCommandConfig> {
+): ResolvedSlackSlashCommandConfig {
   const normalizedName = normalizeSlackSlashCommandName(raw?.name?.trim() || "openclaw");
   const name = normalizedName || "openclaw";
+  const nativePrefix = raw?.nativePrefix?.trim();
   return {
     enabled: raw?.enabled === true,
     name,
+    nativePrefix: nativePrefix || undefined,
     sessionPrefix: raw?.sessionPrefix?.trim() || "slack:slash",
     ephemeral: raw?.ephemeral !== false,
   };

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -14,6 +14,7 @@ import { normalizeAllowList, normalizeAllowListLower, normalizeSlackSlug } from 
 import type { SlackChannelConfigEntries } from "./channel-config.js";
 import { resolveSlackChannelConfig } from "./channel-config.js";
 import { normalizeSlackChannelType } from "./channel-type.js";
+import type { ResolvedSlackSlashCommandConfig } from "./commands.js";
 import { isSlackChannelAllowedByPolicy } from "./policy.js";
 
 export { inferSlackChannelType, normalizeSlackChannelType } from "./channel-type.js";
@@ -50,7 +51,7 @@ export type SlackMonitorContext = {
   replyToMode: "off" | "first" | "all";
   threadHistoryScope: "thread" | "channel";
   threadInheritParent: boolean;
-  slashCommand: Required<import("../../config/config.js").SlackSlashCommandConfig>;
+  slashCommand: ResolvedSlackSlashCommandConfig;
   textLimit: number;
   ackReactionScope: string;
   typingReaction: string;

--- a/src/slack/monitor/slash.test.ts
+++ b/src/slack/monitor/slash.test.ts
@@ -37,6 +37,29 @@ vi.mock("../../auto-reply/commands-registry.js", () => {
     return { arg: periodArg, choices };
   };
 
+  const normalizePrefix = (prefix?: string) => {
+    const trimmed = prefix?.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    return trimmed.replace(/^-+|-+$/g, "").toLowerCase() || undefined;
+  };
+  const withPrefix = (name: string, prefix?: string) => {
+    const normalizedPrefix = normalizePrefix(prefix);
+    return normalizedPrefix ? `${normalizedPrefix}-${name}` : name;
+  };
+  const stripPrefix = (name: string, prefix?: string) => {
+    const normalizedPrefix = normalizePrefix(prefix);
+    if (!normalizedPrefix) {
+      return name;
+    }
+    const token = `${normalizedPrefix}-`;
+    if (!name.startsWith(token)) {
+      return name;
+    }
+    return name.slice(token.length) || name;
+  };
+
   return {
     buildCommandTextFromArgs: (
       cmd: { nativeName?: string; key: string },
@@ -54,8 +77,12 @@ vi.mock("../../auto-reply/commands-registry.js", () => {
             : "";
       return selected ? `/${name} ${selected}` : `/${name}`;
     },
-    findCommandByNativeName: (name: string) => {
-      const normalized = name.trim().toLowerCase();
+    findCommandByNativeName: (
+      name: string,
+      _provider?: string,
+      params?: { nativePrefix?: string },
+    ) => {
+      const normalized = stripPrefix(name.trim().toLowerCase(), params?.nativePrefix);
       if (normalized === "usage") {
         return usageCommand;
       }
@@ -79,45 +106,45 @@ vi.mock("../../auto-reply/commands-registry.js", () => {
       }
       return undefined;
     },
-    listNativeCommandSpecsForConfig: () => [
+    listNativeCommandSpecsForConfig: (_cfg?: unknown, params?: { nativePrefix?: string }) => [
       {
-        name: "usage",
+        name: withPrefix("usage", params?.nativePrefix),
         description: "Usage",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: "report",
+        name: withPrefix("report", params?.nativePrefix),
         description: "Report",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: "reportcompact",
+        name: withPrefix("reportcompact", params?.nativePrefix),
         description: "ReportCompact",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: "reportexternal",
+        name: withPrefix("reportexternal", params?.nativePrefix),
         description: "ReportExternal",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: "reportlong",
+        name: withPrefix("reportlong", params?.nativePrefix),
         description: "ReportLong",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: "unsafeconfirm",
+        name: withPrefix("unsafeconfirm", params?.nativePrefix),
         description: "UnsafeConfirm",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: "agentstatus",
+        name: withPrefix("agentstatus", params?.nativePrefix),
         description: "Status",
         acceptsArgs: false,
         args: [],
@@ -222,7 +249,10 @@ function createDeferred<T>() {
   return { promise, resolve };
 }
 
-function createArgMenusHarness() {
+function createArgMenusHarness(overrides?: {
+  nativePrefix?: string;
+  accountNativePrefix?: string;
+}) {
   const commands = new Map<string, (args: unknown) => Promise<void>>();
   const actions = new Map<string, (args: unknown) => Promise<void>>();
   const options = new Map<string, (args: unknown) => Promise<void>>();
@@ -263,6 +293,7 @@ function createArgMenusHarness() {
       name: "openclaw",
       ephemeral: true,
       sessionPrefix: "slack:slash",
+      nativePrefix: overrides?.nativePrefix,
     },
     textLimit: 4000,
     app,
@@ -273,7 +304,13 @@ function createArgMenusHarness() {
 
   const account = {
     accountId: "acct",
-    config: { commands: { native: true, nativeSkills: false } },
+    config: {
+      commands: { native: true, nativeSkills: false },
+      slashCommand:
+        overrides?.accountNativePrefix === undefined
+          ? undefined
+          : { nativePrefix: overrides.accountNativePrefix },
+    },
   } as unknown;
 
   return {
@@ -690,6 +727,59 @@ describe("Slack native command argument menus", () => {
         text: "Sorry, that button is no longer valid.",
       }),
     );
+  });
+});
+
+describe("Slack native command prefix wiring", () => {
+  it("registers prefixed native slash commands using account nativePrefix", async () => {
+    const harness = createArgMenusHarness({
+      nativePrefix: "ctxprefix",
+      accountNativePrefix: "acctprefix",
+    });
+    await registerCommands(harness.ctx, harness.account);
+
+    expect(harness.commands.has("/acctprefix-usage")).toBe(true);
+    expect(harness.commands.has("/acctprefix-agentstatus")).toBe(true);
+    expect(harness.commands.has("/ctxprefix-usage")).toBe(false);
+  });
+
+  it("dispatches prefixed native slash commands to internal command keys", async () => {
+    const harness = createArgMenusHarness({ accountNativePrefix: "acctprefix" });
+    await registerCommands(harness.ctx, harness.account);
+
+    const statusHandler = requireHandler(
+      harness.commands,
+      "/acctprefix-agentstatus",
+      "/acctprefix-agentstatus",
+    );
+    await runCommandHandler(statusHandler);
+    expectSingleDispatchedSlashBody("/status");
+  });
+
+  it("resolves prefixed arg-menu command names during dispatch", async () => {
+    const harness = createArgMenusHarness({ accountNativePrefix: "acctprefix" });
+    await registerCommands(harness.ctx, harness.account);
+
+    const argMenuHandler = requireHandler(harness.actions, "openclaw_cmdarg", "arg-menu action");
+    await runArgMenuAction(argMenuHandler, {
+      action: {
+        value: encodeValue({
+          command: "acctprefix-usage",
+          arg: "mode",
+          value: "tokens",
+          userId: "U1",
+        }),
+      },
+    });
+    expectSingleDispatchedSlashBody("/usage tokens");
+  });
+
+  it("keeps no-prefix native slash behavior unchanged", async () => {
+    const harness = createArgMenusHarness();
+    await registerCommands(harness.ctx, harness.account);
+
+    expect(harness.commands.has("/usage")).toBe(true);
+    expect(harness.commands.has("/agentstatus")).toBe(true);
   });
 });
 

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -669,6 +669,7 @@ export async function registerSlackMonitorSlashCommands(params: {
     nativeCommands = slashCommandsRuntime.listNativeCommandSpecsForConfig(cfg, {
       skillCommands,
       provider: "slack",
+      nativePrefix: slashCommand.nativePrefix,
     });
   }
 
@@ -683,6 +684,7 @@ export async function registerSlackMonitorSlashCommands(params: {
           const commandDefinition = slashCommandsRuntime.findCommandByNativeName(
             command.name,
             "slack",
+            { nativePrefix: slashCommand.nativePrefix },
           );
           const rawText = cmd.text?.trim() ?? "";
           const commandArgs = commandDefinition
@@ -837,7 +839,9 @@ export async function registerSlackMonitorSlashCommands(params: {
       }
       const { buildCommandTextFromArgs, findCommandByNativeName } =
         await loadSlashCommandsRuntime();
-      const commandDefinition = findCommandByNativeName(parsed.command, "slack");
+      const commandDefinition = findCommandByNativeName(parsed.command, "slack", {
+        nativePrefix: slashCommand.nativePrefix,
+      });
       const commandArgs: CommandArgs = {
         values: { [parsed.arg]: parsed.value },
       };

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -295,6 +295,7 @@ export async function registerSlackMonitorSlashCommands(params: {
   const slashCommand = resolveSlackSlashCommandConfig(
     ctx.slashCommand ?? account.config.slashCommand,
   );
+  const nativePrefix = account.config.slashCommand?.nativePrefix ?? slashCommand.nativePrefix;
 
   const handleSlashCommand = async (p: {
     command: SlackCommandMiddlewareArgs["command"];
@@ -669,7 +670,7 @@ export async function registerSlackMonitorSlashCommands(params: {
     nativeCommands = slashCommandsRuntime.listNativeCommandSpecsForConfig(cfg, {
       skillCommands,
       provider: "slack",
-      nativePrefix: slashCommand.nativePrefix,
+      nativePrefix,
     });
   }
 
@@ -684,7 +685,7 @@ export async function registerSlackMonitorSlashCommands(params: {
           const commandDefinition = slashCommandsRuntime.findCommandByNativeName(
             command.name,
             "slack",
-            { nativePrefix: slashCommand.nativePrefix },
+            { nativePrefix },
           );
           const rawText = cmd.text?.trim() ?? "";
           const commandArgs = commandDefinition
@@ -840,7 +841,7 @@ export async function registerSlackMonitorSlashCommands(params: {
       const { buildCommandTextFromArgs, findCommandByNativeName } =
         await loadSlashCommandsRuntime();
       const commandDefinition = findCommandByNativeName(parsed.command, "slack", {
-        nativePrefix: slashCommand.nativePrefix,
+        nativePrefix,
       });
       const commandArgs: CommandArgs = {
         values: { [parsed.arg]: parsed.value },


### PR DESCRIPTION
## Summary
- add `nativePrefix?: string` to `SlackSlashCommandConfig`
- thread `nativePrefix` through command registry native spec generation and native-name lookup for Slack commands
- wire Slack slash registration and dispatch to use account-level `nativePrefix` and add prefix-focused slash tests

Closes #38302

## Testing
- `pnpm test src/auto-reply/commands-registry.test.ts src/slack/monitor/slash.test.ts`
