### PR TITLE
fix(models): update default aliases for gemini and gpt

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -24,11 +24,11 @@ const DEFAULT_MODEL_ALIASES: Readonly<Record<string, string>> = {
   sonnet: "anthropic/claude-sonnet-4-6",
 
   // OpenAI
-  gpt: "openai/gpt-5.2",
+  gpt: "openai/gpt-5.4",
   "gpt-mini": "openai/gpt-5-mini",
 
   // Google Gemini (3.x are preview ids in the catalog)
-  gemini: "google/gemini-3-pro-preview",
+  gemini: "google/gemini-3.1-pro-preview",
   "gemini-flash": "google/gemini-3-flash-preview",
 };
 


### PR DESCRIPTION
## Problem
Two default model aliases in src/config/defaults.ts are stale:

1. **gemini** points to gemini-3-pro-preview which is deprecated March 9, 2026 (3 days away)
2. **gpt** points to gpt-5.2 instead of the newer gpt-5.4

## Solution
Update the default aliases:
- gemini: gemini-3-pro-preview → gemini-3.1-pro-preview
- gpt: gpt-5.2 → gpt-5.4

## Changes
- src/config/defaults.ts: Updated DEFAULT_MODEL_ALIASES

Fixes #38312

---

AI-assisted PR - Testing: untested (CI will verify)