### PR TITLE
fix(hooks): pass session key to outbound delivery for message:sent hook dispatch

### DIFF
--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -525,6 +525,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
       channel,
       params,
       agentId,
+      sessionKey: outboundRoute?.sessionKey,
       accountId: accountId ?? undefined,
       gateway,
       toolContext: input.toolContext,

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -16,6 +16,7 @@ vi.mock("../../channels/plugins/index.js", () => ({
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveDefaultAgentId: () => "main",
   resolveAgentWorkspaceDir: () => "/tmp/openclaw-test-workspace",
+  resolveSessionAgentId: () => "main",
 }));
 
 vi.mock("../../config/plugin-auto-enable.js", () => ({
@@ -67,6 +68,44 @@ describe("sendMessage", () => {
         session: expect.objectContaining({ agentId: "work" }),
         channel: "telegram",
         to: "123456",
+      }),
+    );
+  });
+
+  it("passes standalone sessionKey to outbound session context for hook dispatch", async () => {
+    await sendMessage({
+      cfg: {},
+      channel: "telegram",
+      to: "123456",
+      content: "hi",
+      agentId: "work",
+      sessionKey: "agent:work:main",
+    });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({ key: "agent:work:main", agentId: "work" }),
+      }),
+    );
+  });
+
+  it("prefers standalone sessionKey over mirror sessionKey for outbound session context", async () => {
+    await sendMessage({
+      cfg: {},
+      channel: "telegram",
+      to: "123456",
+      content: "hi",
+      agentId: "work",
+      sessionKey: "agent:work:main",
+      mirror: {
+        sessionKey: "agent:work:mirror",
+        agentId: "work",
+      },
+    });
+
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: expect.objectContaining({ key: "agent:work:main" }),
       }),
     );
   });

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -34,6 +34,8 @@ type MessageSendParams = {
   content: string;
   /** Active agent id for per-agent outbound media root scoping. */
   agentId?: string;
+  /** Session key for internal hook dispatch (independent of mirror). */
+  sessionKey?: string;
   channel?: string;
   mediaUrl?: string;
   mediaUrls?: string[];
@@ -211,7 +213,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
     const outboundSession = buildOutboundSessionContext({
       cfg,
       agentId: params.agentId,
-      sessionKey: params.mirror?.sessionKey,
+      sessionKey: params.sessionKey ?? params.mirror?.sessionKey,
     });
     const results = await deliverOutboundPayloads({
       cfg,

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -26,6 +26,8 @@ export type OutboundSendContext = {
   params: Record<string, unknown>;
   /** Active agent id for per-agent outbound media root scoping. */
   agentId?: string;
+  /** Session key for internal hook dispatch (independent of mirror). */
+  sessionKey?: string;
   accountId?: string | null;
   gateway?: OutboundGatewayContext;
   toolContext?: ChannelThreadingToolContext;
@@ -128,6 +130,7 @@ export async function executeSendAction(params: {
     to: params.to,
     content: params.message,
     agentId: params.ctx.agentId,
+    sessionKey: params.ctx.sessionKey ?? params.ctx.mirror?.sessionKey,
     mediaUrl: params.mediaUrl || undefined,
     mediaUrls: params.mediaUrls,
     channel: params.ctx.channel || undefined,


### PR DESCRIPTION
## Summary

When agents send messages via the `message` tool without mirroring, `buildOutboundSessionContext` received no `sessionKey`, causing `session.key` to be undefined. This meant the `message:sent` internal hook was silently skipped for direct agent responses.

## Root Cause

In `sendMessage()` (`message.ts`), the session key was derived exclusively from `params.mirror?.sessionKey`. When `mirror` was not set (direct sends without mirroring), no session key reached `buildOutboundSessionContext`, so the outbound session context had no `key` property. The hook dispatch in `deliverOutboundPayloads` then skipped the `message:sent` internal hook because `sessionKeyForInternalHooks` was undefined.

## Fix

- Add a standalone `sessionKey` field to `MessageSendParams` and `OutboundSendContext`
- Use `params.sessionKey ?? params.mirror?.sessionKey` in `buildOutboundSessionContext` 
- Pass the resolved session key from `message-action-runner`'s outbound route into the send context

## Changes (4 files, ~46 lines)

- `src/infra/outbound/message.ts` — accept `sessionKey` param, prefer it over mirror
- `src/infra/outbound/outbound-send-service.ts` — add `sessionKey` to `OutboundSendContext`, forward to `sendMessage`
- `src/infra/outbound/message-action-runner.ts` — pass `outboundRoute.sessionKey` to ctx
- `src/infra/outbound/message.test.ts` — 2 new tests: standalone sessionKey works, standalone sessionKey takes precedence over mirror

Closes #35557