### PR TITLE
fix: unblock check and secrets CI failures

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -51,11 +51,13 @@ jobs:
               },
               {
                 label: "r: no-ci-pr",
-                message: `Please don't make PRs for test failures on main.
-
-The team is aware of those and will handle them directly on the codebase, not only fixing the tests but also investigating what the root cause is. Having to sift through test-fix-PRs (including some that have been out of date for weeks...) on top of that doesn't help. There are already way too many PRs for humans to manage; please don't make the flood worse.
-
-Thank you.`,
+                message: [
+                  "Please don't make PRs for test failures on main.",
+                  "",
+                  "The team is aware of those and will handle them directly on the codebase, not only fixing the tests but also investigating what the root cause is. Having to sift through test-fix-PRs (including some that have been out of date for weeks...) on top of that doesn't help. There are already way too many PRs for humans to manage; please don't make the flood worse.",
+                  "",
+                  "Thank you.",
+                ].join("\n"),
               },
               {
                 label: "r: too-many-prs",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,13 @@ jobs:
         with:
           submodules: false
 
+      - name: Ensure secrets base commit (PR fast path)
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,21 +320,23 @@ jobs:
           python -m pip install pre-commit
 
       - name: Detect secrets
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
 
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
             echo "Skipping detect-secrets on main until the allowlist cleanup lands."
             exit 0
           fi
 
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
             echo "Running full detect-secrets scan on push."
             pre-commit run --all-files detect-secrets
             exit 0
           fi
 
-          BASE="${{ github.event.pull_request.base.sha }}"
+          BASE="$PR_BASE_SHA"
           changed_files=()
           if git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1; then
             while IFS= read -r path; do
@@ -356,13 +358,16 @@ jobs:
         run: pre-commit run --all-files detect-private-key
 
       - name: Audit changed GitHub workflows with zizmor
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
 
-          if [ "${{ github.event_name }}" = "push" ]; then
-            BASE="${{ github.event.before }}"
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            BASE="$PUSH_BEFORE_SHA"
           else
-            BASE="${{ github.event.pull_request.base.sha }}"
+            BASE="$PR_BASE_SHA"
           fi
 
           mapfile -t workflow_files < <(git diff --name-only "$BASE" HEAD -- '.github/workflows/*.yml' '.github/workflows/*.yaml')

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -128,7 +128,7 @@
     {
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
-        "(^|/)pnpm-lock\\.yaml$"
+        "(^|/)(dist/|vendor/|pnpm-lock\\.yaml$|\\.detect-secrets\\.cfg$)"
       ]
     },
     {
@@ -11014,7 +11014,7 @@
         "filename": "extensions/feishu/src/media.test.ts",
         "hashed_secret": "f49922d511d666848f250663c4fca84074b856a8",
         "is_verified": false,
-        "line_number": 45
+        "line_number": 66
       }
     ],
     "extensions/feishu/src/reply-dispatcher.test.ts": [
@@ -13100,5 +13100,5 @@
       }
     ]
   },
-  "generated_at": "2026-02-17T13:34:38Z"
+  "generated_at": "2026-03-06T21:51:30Z"
 }

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -191,6 +191,11 @@ describe("sendMediaFeishu msg_type routing", () => {
     });
 
     expect(imageCreateMock).toHaveBeenCalled();
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpTimeoutMs: 120_000,
+      }),
+    );
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ msg_type: "image" }),
@@ -316,6 +321,11 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(imageGetMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { image_key: imageKey },
+      }),
+    );
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpTimeoutMs: 120_000,
       }),
     );
     expect(result.buffer).toEqual(Buffer.from("image-data"));
@@ -509,6 +519,11 @@ describe("downloadMessageResourceFeishu", () => {
         params: { type: "file" },
       }),
     );
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpTimeoutMs: 120_000,
+      }),
+    );
     expect(result.buffer).toBeInstanceOf(Buffer);
   });
 
@@ -526,6 +541,11 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_img_msg", file_key: "img_key_1" },
         params: { type: "image" },
+      }),
+    );
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpTimeoutMs: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);


### PR DESCRIPTION
## Summary

- Problem: `check` was failing on `main` before [`20db7afd5`](https://github.com/openclaw/openclaw/commit/20db7afd5) because Feishu media calls had invalid per-call `timeout` properties, and PR `secrets` runs were failing in two ways: first by falling back to a full-repo scan when the shallow checkout lacked the base SHA, then by requiring a refreshed `.secrets.baseline` once the scan was correctly limited to changed files.
- Why it matters: the PR could not go green while `secrets` was diffing against incomplete history or while the generated baseline update was missing from the branch.
- What changed: kept the Feishu timeout-path coverage in `extensions/feishu/src/media.test.ts`, added the shared `ensure-base-commit` step to the `secrets` job before changed-file diffing, and refreshed `.secrets.baseline` so the changed-file secret scan no longer rewrites tracked metadata.
- What did NOT change (scope boundary): no detect-secrets allowlist cleanup beyond the generated baseline refresh, no `main` push skip-policy changes, and no new Feishu runtime behavior beyond test coverage.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #38301
- Related #38267

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:
  The `secrets` CI job now fetches the PR base ref before diffing changed files. This is limited to the PR base branch on `origin` and reuses the existing shared `ensure-base-commit` action already used by other CI jobs.

## Repro + Verification

### Environment

- OS: macOS local workstation + GitHub Actions Ubuntu 24.04 failure logs
- Runtime/container: Node 22.22.0, pnpm 10.23.0
- Model/provider: N/A
- Integration/channel (if any): Feishu, GitHub Actions CI
- Relevant config (redacted): depth-1 checkout on PR CI; Feishu media timeout override set via `httpTimeoutMs: 120_000`

### Steps

1. Inspect the failing [`check` job 66086536179](https://github.com/openclaw/openclaw/actions/runs/22780295648/job/66086536179), the fallback-path PR [`secrets` job 66088689815](https://github.com/openclaw/openclaw/actions/runs/22781651238/job/66088689815), and the changed-files PR [`secrets` job 66094255246](https://github.com/openclaw/openclaw/actions/runs/22783316831/job/66094255246).
2. Re-run `pnpm tsgo` and `pnpm vitest run extensions/feishu/src/media.test.ts` locally on the rebased branch.
3. Reproduce the PR shallow-checkout path against merge commit [`645c2826414ec1cd6d60c2695304cb70ffe79dcf`](https://github.com/openclaw/openclaw/commit/645c2826414ec1cd6d60c2695304cb70ffe79dcf) with base [`ab5fcfcc01281f1f6cd6e8f43f7c302c12806feb`](https://github.com/openclaw/openclaw/commit/ab5fcfcc01281f1f6cd6e8f43f7c302c12806feb), then run `python3 -m pre_commit run detect-secrets --files .github/workflows/ci.yml extensions/feishu/src/media.test.ts extensions/feishu/src/media.ts .secrets.baseline`.

### Expected

- `check` passes TypeScript validation.
- PR `secrets` scans only changed files instead of falling back to a full-repo scan.
- The changed-file `detect-secrets` hook passes without rewriting `.secrets.baseline`.

### Actual

- Before the fixes, `check` failed with `TS2353` on Feishu media request objects.
- Before the base-fetch fix, PR `secrets` logged `Falling back to full detect-secrets scan.` because the shallow checkout did not contain the base SHA.
- Before the baseline refresh, PR `secrets` failed because `detect-secrets` rewrote `.secrets.baseline` and exited non-zero.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm tsgo`, `pnpm vitest run extensions/feishu/src/media.test.ts`, and `python3 -m pre_commit run detect-secrets --files .github/workflows/ci.yml extensions/feishu/src/media.test.ts extensions/feishu/src/media.ts .secrets.baseline` on the rebased branch.
- Edge cases checked: Feishu tests still verify the 120s timeout is applied through `createFeishuClient`; the PR diff path works once the base commit is present; the baseline no longer rewrites during the changed-file secret scan.
- What you did **not** verify: I did not wait for the fresh post-rebase GitHub Actions run to finish.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the PR commits on top of `main`.
- Files/config to restore: `extensions/feishu/src/media.test.ts`, `.github/workflows/ci.yml`, `.secrets.baseline`
- Known bad symptoms reviewers should watch for: PR `secrets` logging `Falling back to full detect-secrets scan.`, `detect-secrets` asking to stage `.secrets.baseline`, or Feishu timeout regression coverage disappearing from `media.test.ts`.

## Risks and Mitigations

- Risk: a future workflow edit could again shift baseline metadata without updating `.secrets.baseline`.
  - Mitigation: the branch now includes the refreshed baseline produced by the same `detect-secrets` hook used in CI.
- Risk: unusually deep PR ancestry could still require more history than the initial checkout contains.
  - Mitigation: `ensure-base-commit` deepens incrementally and then fetches the full base ref if needed.



## Post-rebase Follow-up

- Current PR head: [`3b13e56c6`](https://github.com/openclaw/openclaw/commit/3b13e56c651e88a2990b7be08540342bbe1bd277)
- Rebased onto current `main` commit [`c301c5d08`](https://github.com/openclaw/openclaw/commit/c301c5d08345f532e00de6b47aeecb64f25ac2c5)
- The merge-ref failures being followed here are still:
  - [`check` 66094971631](https://github.com/openclaw/openclaw/actions/runs/22783522259/job/66094971631?pr=38353)
  - [`secrets` 66094930426](https://github.com/openclaw/openclaw/actions/runs/22783522259/job/66094930426?pr=38353)
  - [`actionlint` 66094930448](https://github.com/openclaw/openclaw/actions/runs/22783522242/job/66094930448?pr=38353)
- Root causes confirmed:
  - `.github/workflows/auto-response.yml` on `main` added the new `r: no-ci-pr` reply as a multiline template literal that broke YAML parsing inside `script: |`.
  - `.github/workflows/ci.yml` interpolated `${{ github.* }}` directly inside shell `run:` blocks, which `zizmor` flagged as `template-injection`.
- Current state on this branch:
  - rewrites the `r: no-ci-pr` auto-response message in a YAML-safe JS array/join form
  - moves `github` context values into step `env` variables before shell use in the `secrets` job
  - does **not** carry the earlier inline `zizmor` ignore anymore
- Current local verification:
  - `pnpm check`
  - `pnpm vitest run extensions/feishu/src/media.test.ts`
  - `python3 -m pre_commit run actionlint --files .github/workflows/auto-response.yml .github/workflows/ci.yml`
  - `python3 -m pre_commit run detect-secrets --files .github/workflows/ci.yml .github/workflows/auto-response.yml .secrets.baseline`
  - official `zizmor` binary `v1.22.0`: `/tmp/zizmor-v1.22.0/zizmor --persona=regular --min-severity=medium --min-confidence=medium .github/workflows/ci.yml .github/workflows/auto-response.yml`
- Remaining blocker without suppression:
  - `zizmor` still reports `dangerous-triggers` on `.github/workflows/auto-response.yml` because it uses `pull_request_target`; that finding is currently unsuppressed on this branch.
