### PR TITLE
fix(gateway): restart on provider transport reload changes

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -100,6 +100,10 @@ const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
 let cachedReloadRules: ReloadRule[] | null = null;
 let cachedRegistry: ReturnType<typeof getActivePluginRegistry> | null = null;
 
+function isProviderTransportRestartPath(path: string): boolean {
+  return /^models\.providers\.[^.]+\.(api|baseUrl)$/.test(path);
+}
+
 function listReloadRules(): ReloadRule[] {
   const registry = getActivePluginRegistry();
   if (registry !== cachedRegistry) {
@@ -186,6 +190,11 @@ export function buildGatewayReloadPlan(changedPaths: string[]): GatewayReloadPla
   };
 
   for (const path of changedPaths) {
+    if (isProviderTransportRestartPath(path)) {
+      plan.restartGateway = true;
+      plan.restartReasons.push(path);
+      continue;
+    }
     const rule = matchRule(path);
     if (!rule) {
       plan.restartGateway = true;

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -167,6 +167,21 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.noopPaths).toEqual([]);
   });
 
+  it("requires a gateway restart when provider transport identity changes", () => {
+    const plan = buildGatewayReloadPlan([
+      "models.providers.kimi-coding.api",
+      "models.providers.kimi-coding.baseUrl",
+    ]);
+    expect(plan.restartGateway).toBe(true);
+    expect(plan.restartReasons).toEqual(
+      expect.arrayContaining([
+        "models.providers.kimi-coding.api",
+        "models.providers.kimi-coding.baseUrl",
+      ]),
+    );
+    expect(plan.hotReasons).toEqual([]);
+  });
+
   it("hot-reloads health monitor when channelHealthCheckMinutes changes", () => {
     const plan = buildGatewayReloadPlan(["gateway.channelHealthCheckMinutes"]);
     expect(plan.restartGateway).toBe(false);
@@ -220,6 +235,11 @@ describe("buildGatewayReloadPlan", () => {
       path: "unknownField",
       expectRestartGateway: true,
       expectRestartReason: "unknownField",
+    },
+    {
+      path: "models.providers.kimi-coding.api",
+      expectRestartGateway: true,
+      expectRestartReason: "models.providers.kimi-coding.api",
     },
   ])("classifies reload path: $path", (testCase) => {
     const plan = buildGatewayReloadPlan([testCase.path]);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `models.providers.<id>.api` and `.baseUrl` changes currently fall through the generic model hot-reload path even though they change provider transport identity.
- Why it matters: hot-reloading transport identity can leave the old adapter/client alive and creates partial-reload behavior that is harder to reason about than a clean restart.
- What changed: provider transport identity changes are now classified as restart-required before the generic `models` reload logic, with regression coverage for both `api` and `baseUrl`.
- What did NOT change (scope boundary): ordinary model catalog changes and other existing hot-reload paths still behave as before.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38298
- Related #38354

## User-visible / Behavior Changes

- Editing `models.providers.<id>.api` or `models.providers.<id>.baseUrl` now plans a gateway restart instead of attempting an in-place hot reload.
- Other model catalog edits remain hot-reloadable.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) `No`
- Secrets/tokens handling changed? (`Yes/No`) `No`
- New/changed network calls? (`Yes/No`) `No`
- Command/tool execution surface changed? (`Yes/No`) `No`
- Data access scope changed? (`Yes/No`) `No`
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: macOS local dev environment
- Runtime/container: Node + pnpm
- Model/provider: provider transport reload path
- Integration/channel (if any): N/A
- Relevant config (redacted): `models.providers.kimi-coding.api`, `models.providers.kimi-coding.baseUrl`

### Steps

1. Start from a config reload scenario where only `models.providers.<id>.api` or `.baseUrl` changes.
2. Build the gateway reload plan.
3. Compare the plan before and after this patch.

### Expected

- Transport identity changes require a restart.
- Non-transport model changes continue to hot reload.

### Actual

- Before this patch, transport identity changes could fall through the generic model hot-reload path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added regression coverage in `src/gateway/config-reload.test.ts` and verified the targeted suite passes locally.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm exec vitest run src/gateway/config-reload.test.ts` and checked restart-required classification for provider transport identity changes.
- Edge cases checked: both `api` and `baseUrl` changes restart; existing hot-reload coverage for ordinary model changes still passes.
- What you did **not** verify: no full end-to-end gateway process reload against a live provider.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) `Yes`
- Config/env changes? (`Yes/No`) `No`
- Migration needed? (`Yes/No`) `No`
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit to restore the previous generic hot-reload behavior.
- Files/config to restore: none.
- Known bad symptoms reviewers should watch for: unnecessary gateway restarts on non-transport model edits.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the restart rule could be broader than intended and restart on edits that do not actually change transport identity.
  - Mitigation: the matcher is intentionally narrow and only targets `models.providers.<id>.api` and `.baseUrl`; regression tests cover both paths.

## AI Assistance

- AI-assisted: `Yes`
- Testing level: `Targeted local tests run`
- I reviewed the generated changes and understand the code paths involved.
- Session logs/prompts: available on request, not attached here.
