### PR TITLE
fix(auth): mirror onboarding credential writes to provisioned store

### DIFF
--- a/src/agents/auth-profiles.store.save.test.ts
+++ b/src/agents/auth-profiles.store.save.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolveAuthStorePath } from "./auth-profiles/paths.js";
-import { saveAuthProfileStore } from "./auth-profiles/store.js";
+import { resolveAuthStorePath, resolveProvisionedAuthStorePath } from "./auth-profiles/paths.js";
+import { saveAuthProfileStore, saveProvisionedAuthProfileStore } from "./auth-profiles/store.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 
 describe("saveAuthProfileStore", () => {
@@ -57,6 +57,59 @@ describe("saveAuthProfileStore", () => {
       });
 
       expect(parsed.profiles["anthropic:default"]?.key).toBe("sk-anthropic-plain");
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes a canonical provisioned mirror without runtime telemetry", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-save-provisioned-"));
+    try {
+      await fs.writeFile(resolveProvisionedAuthStorePath(agentDir), "{}");
+      const store: AuthProfileStore = {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-runtime-value",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+        order: {
+          openai: ["openai:default"],
+        },
+        lastGood: {
+          openai: "openai:default",
+        },
+        usageStats: {
+          "openai:default": {
+            lastUsed: Date.now(),
+          },
+        },
+      };
+
+      const didSave = saveProvisionedAuthProfileStore(store, agentDir);
+      expect(didSave).toBe(true);
+
+      const parsed = JSON.parse(
+        await fs.readFile(resolveProvisionedAuthStorePath(agentDir), "utf8"),
+      ) as {
+        order?: Record<string, string[]>;
+        lastGood?: Record<string, string>;
+        usageStats?: Record<string, unknown>;
+        profiles: Record<string, { key?: string; keyRef?: unknown }>;
+      };
+
+      expect(parsed.order).toEqual({ openai: ["openai:default"] });
+      expect(parsed.lastGood).toBeUndefined();
+      expect(parsed.usageStats).toBeUndefined();
+      expect(parsed.profiles["openai:default"]?.key).toBeUndefined();
+      expect(parsed.profiles["openai:default"]?.keyRef).toEqual({
+        source: "env",
+        provider: "default",
+        id: "OPENAI_API_KEY",
+      });
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }

--- a/src/agents/auth-profiles/constants.ts
+++ b/src/agents/auth-profiles/constants.ts
@@ -2,6 +2,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 
 export const AUTH_STORE_VERSION = 1;
 export const AUTH_PROFILE_FILENAME = "auth-profiles.json";
+export const AUTH_PROFILE_PROVISIONED_FILENAME = "auth-profiles.provisioned.json";
 export const LEGACY_AUTH_FILENAME = "auth.json";
 
 export const CLAUDE_CLI_PROFILE_ID = "anthropic:claude-cli";

--- a/src/agents/auth-profiles/paths.ts
+++ b/src/agents/auth-profiles/paths.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 import { saveJsonFile } from "../../infra/json-file.js";
 import { resolveUserPath } from "../../utils.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
-import { AUTH_PROFILE_FILENAME, AUTH_STORE_VERSION, LEGACY_AUTH_FILENAME } from "./constants.js";
+import {
+  AUTH_PROFILE_FILENAME,
+  AUTH_PROFILE_PROVISIONED_FILENAME,
+  AUTH_STORE_VERSION,
+  LEGACY_AUTH_FILENAME,
+} from "./constants.js";
 import type { AuthProfileStore } from "./types.js";
 
 export function resolveAuthStorePath(agentDir?: string): string {
@@ -14,6 +19,11 @@ export function resolveAuthStorePath(agentDir?: string): string {
 export function resolveLegacyAuthStorePath(agentDir?: string): string {
   const resolved = resolveUserPath(agentDir ?? resolveOpenClawAgentDir());
   return path.join(resolved, LEGACY_AUTH_FILENAME);
+}
+
+export function resolveProvisionedAuthStorePath(agentDir?: string): string {
+  const resolved = resolveUserPath(agentDir ?? resolveOpenClawAgentDir());
+  return path.join(resolved, AUTH_PROFILE_PROVISIONED_FILENAME);
 }
 
 export function resolveAuthStorePathForDisplay(agentDir?: string): string {

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -3,6 +3,7 @@ import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import { normalizeProviderId, normalizeProviderIdForAuth } from "../model-selection.js";
 import {
   ensureAuthProfileStore,
+  saveProvisionedAuthProfileStore,
   saveAuthProfileStore,
   updateAuthProfileStoreWithLock,
 } from "./store.js";
@@ -46,6 +47,7 @@ export function upsertAuthProfile(params: {
   profileId: string;
   credential: AuthProfileCredential;
   agentDir?: string;
+  syncProvisionedCopy?: boolean;
 }): void {
   const credential =
     params.credential.type === "api_key"
@@ -61,6 +63,9 @@ export function upsertAuthProfile(params: {
   const store = ensureAuthProfileStore(params.agentDir);
   store.profiles[params.profileId] = credential;
   saveAuthProfileStore(store, params.agentDir);
+  if (params.syncProvisionedCopy) {
+    saveProvisionedAuthProfileStore(store, params.agentDir);
+  }
 }
 
 export async function upsertAuthProfileWithLock(params: {

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -5,7 +5,12 @@ import { withFileLock } from "../../infra/file-lock.js";
 import { loadJsonFile, saveJsonFile } from "../../infra/json-file.js";
 import { AUTH_STORE_LOCK_OPTIONS, AUTH_STORE_VERSION, log } from "./constants.js";
 import { syncExternalCliCredentials } from "./external-cli-sync.js";
-import { ensureAuthStoreFile, resolveAuthStorePath, resolveLegacyAuthStorePath } from "./paths.js";
+import {
+  ensureAuthStoreFile,
+  resolveAuthStorePath,
+  resolveLegacyAuthStorePath,
+  resolveProvisionedAuthStorePath,
+} from "./paths.js";
 import type { AuthProfileCredential, AuthProfileStore, ProfileUsageStats } from "./types.js";
 
 type LegacyAuthStore = Record<string, AuthProfileCredential>;
@@ -483,6 +488,13 @@ export function ensureAuthProfileStore(
 
 export function saveAuthProfileStore(store: AuthProfileStore, agentDir?: string): void {
   const authPath = resolveAuthStorePath(agentDir);
+  saveJsonFile(authPath, buildPersistedAuthStorePayload(store, { includeRuntimeState: true }));
+}
+
+function buildPersistedAuthStorePayload(
+  store: AuthProfileStore,
+  opts: { includeRuntimeState: boolean },
+): AuthProfileStore {
   const profiles = Object.fromEntries(
     Object.entries(store.profiles).map(([profileId, credential]) => {
       if (credential.type === "api_key" && credential.keyRef && credential.key !== undefined) {
@@ -498,12 +510,30 @@ export function saveAuthProfileStore(store: AuthProfileStore, agentDir?: string)
       return [profileId, credential];
     }),
   ) as AuthProfileStore["profiles"];
-  const payload = {
+  return {
     version: AUTH_STORE_VERSION,
     profiles,
     order: store.order ?? undefined,
-    lastGood: store.lastGood ?? undefined,
-    usageStats: store.usageStats ?? undefined,
+    ...(opts.includeRuntimeState
+      ? {
+          lastGood: store.lastGood ?? undefined,
+          usageStats: store.usageStats ?? undefined,
+        }
+      : {}),
   } satisfies AuthProfileStore;
-  saveJsonFile(authPath, payload);
+}
+
+export function saveProvisionedAuthProfileStore(
+  store: AuthProfileStore,
+  agentDir?: string,
+): boolean {
+  const provisionedPath = resolveProvisionedAuthStorePath(agentDir);
+  if (!fs.existsSync(provisionedPath)) {
+    return false;
+  }
+  saveJsonFile(
+    provisionedPath,
+    buildPersistedAuthStorePayload(store, { includeRuntimeState: false }),
+  );
+  return true;
 }

--- a/src/commands/onboard-auth.credentials.test.ts
+++ b/src/commands/onboard-auth.credentials.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   setByteplusApiKey,
@@ -48,6 +50,9 @@ describe("onboard auth credentials secret refs", () => {
     }>(agentDir);
     return parsed.profiles?.[profileId];
   }
+
+  const provisionedAuthProfilePathFor = (agentDir: string) =>
+    path.join(agentDir, "auth-profiles.provisioned.json");
 
   async function expectStoredAuthKey(params: {
     prefix: string;
@@ -182,6 +187,30 @@ describe("onboard auth credentials secret refs", () => {
       },
       absent: ["key"],
     });
+  });
+
+  it("mirrors canonical api-key updates into the provisioned auth store when present", async () => {
+    const env = await setupAuthTestEnv("openclaw-onboard-auth-credentials-provisioned-");
+    lifecycle.setStateDir(env.stateDir);
+    await fs.writeFile(
+      provisionedAuthProfilePathFor(env.agentDir),
+      JSON.stringify({
+        version: 1,
+        profiles: {},
+        usageStats: { stale: { lastUsed: 1 } },
+      }),
+    );
+
+    await setOpenaiApiKey("sk-openai-provisioned", env.agentDir);
+
+    const parsed = JSON.parse(
+      await fs.readFile(provisionedAuthProfilePathFor(env.agentDir), "utf8"),
+    ) as {
+      profiles?: Record<string, { key?: string }>;
+      usageStats?: Record<string, unknown>;
+    };
+    expect(parsed.profiles?.["openai:default"]?.key).toBe("sk-openai-provisioned");
+    expect(parsed.usageStats).toBeUndefined();
   });
 
   it("stores env-backed volcengine and byteplus keys as keyRef in ref mode", async () => {

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -103,6 +103,15 @@ export type WriteOAuthCredentialsOptions = {
   syncSiblingAgents?: boolean;
 };
 
+function upsertOnboardingAuthProfile(
+  params: Omit<Parameters<typeof upsertAuthProfile>[0], "syncProvisionedCopy">,
+): void {
+  upsertAuthProfile({
+    ...params,
+    syncProvisionedCopy: true,
+  });
+}
+
 /** Resolve real path, returning null if the target doesn't exist. */
 function safeRealpathSync(dir: string): string | null {
   try {
@@ -172,7 +181,7 @@ export async function writeOAuthCredentials(
   };
 
   // Primary write must succeed — let it throw on failure.
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId,
     credential,
     agentDir: resolvedAgentDir,
@@ -187,7 +196,7 @@ export async function writeOAuthCredentials(
         continue;
       }
       try {
-        upsertAuthProfile({
+        upsertOnboardingAuthProfile({
           profileId,
           credential,
           agentDir: targetAgentDir,
@@ -206,7 +215,7 @@ export async function setAnthropicApiKey(
   options?: ApiKeyStorageOptions,
 ) {
   // Write to resolved agent dir so gateway finds credentials on startup.
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "anthropic:default",
     credential: buildApiKeyCredential("anthropic", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -218,7 +227,7 @@ export async function setOpenaiApiKey(
   agentDir?: string,
   options?: ApiKeyStorageOptions,
 ) {
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "openai:default",
     credential: buildApiKeyCredential("openai", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -231,7 +240,7 @@ export async function setGeminiApiKey(
   options?: ApiKeyStorageOptions,
 ) {
   // Write to resolved agent dir so gateway finds credentials on startup.
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "google:default",
     credential: buildApiKeyCredential("google", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -246,7 +255,7 @@ export async function setMinimaxApiKey(
 ) {
   const provider = profileId.split(":")[0] ?? "minimax";
   // Write to resolved agent dir so gateway finds credentials on startup.
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId,
     credential: buildApiKeyCredential(provider, key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -259,7 +268,7 @@ export async function setMoonshotApiKey(
   options?: ApiKeyStorageOptions,
 ) {
   // Write to resolved agent dir so gateway finds credentials on startup.
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "moonshot:default",
     credential: buildApiKeyCredential("moonshot", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -272,7 +281,7 @@ export async function setKimiCodingApiKey(
   options?: ApiKeyStorageOptions,
 ) {
   // Write to resolved agent dir so gateway finds credentials on startup.
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "kimi-coding:default",
     credential: buildApiKeyCredential("kimi-coding", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -284,7 +293,7 @@ export async function setVolcengineApiKey(
   agentDir?: string,
   options?: ApiKeyStorageOptions,
 ) {
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "volcengine:default",
     credential: buildApiKeyCredential("volcengine", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -296,7 +305,7 @@ export async function setByteplusApiKey(
   agentDir?: string,
   options?: ApiKeyStorageOptions,
 ) {
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "byteplus:default",
     credential: buildApiKeyCredential("byteplus", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -309,7 +318,7 @@ export async function setSyntheticApiKey(
   options?: ApiKeyStorageOptions,
 ) {
   // Write to resolved agent dir so gateway finds credentials on startup.
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "synthetic:default",
     credential: buildApiKeyCredential("synthetic", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -322,7 +331,7 @@ export async function setVeniceApiKey(
   options?: ApiKeyStorageOptions,
 ) {
   // Write to resolved agent dir so gateway finds credentials on startup.
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "venice:default",
     credential: buildApiKeyCredential("venice", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -343,7 +352,7 @@ export async function setZaiApiKey(
   options?: ApiKeyStorageOptions,
 ) {
   // Write to resolved agent dir so gateway finds credentials on startup.
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "zai:default",
     credential: buildApiKeyCredential("zai", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -355,7 +364,7 @@ export async function setXiaomiApiKey(
   agentDir?: string,
   options?: ApiKeyStorageOptions,
 ) {
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "xiaomi:default",
     credential: buildApiKeyCredential("xiaomi", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -369,7 +378,7 @@ export async function setOpenrouterApiKey(
 ) {
   // Never persist the literal "undefined" (e.g. when prompt returns undefined and caller used String(key)).
   const safeKey = typeof key === "string" && key === "undefined" ? "" : key;
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "openrouter:default",
     credential: buildApiKeyCredential("openrouter", safeKey, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -385,7 +394,7 @@ export async function setCloudflareAiGatewayConfig(
 ) {
   const normalizedAccountId = accountId.trim();
   const normalizedGatewayId = gatewayId.trim();
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "cloudflare-ai-gateway:default",
     credential: buildApiKeyCredential(
       "cloudflare-ai-gateway",
@@ -405,7 +414,7 @@ export async function setLitellmApiKey(
   agentDir?: string,
   options?: ApiKeyStorageOptions,
 ) {
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "litellm:default",
     credential: buildApiKeyCredential("litellm", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -417,7 +426,7 @@ export async function setVercelAiGatewayApiKey(
   agentDir?: string,
   options?: ApiKeyStorageOptions,
 ) {
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "vercel-ai-gateway:default",
     credential: buildApiKeyCredential("vercel-ai-gateway", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -429,7 +438,7 @@ export async function setOpencodeZenApiKey(
   agentDir?: string,
   options?: ApiKeyStorageOptions,
 ) {
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "opencode:default",
     credential: buildApiKeyCredential("opencode", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -441,7 +450,7 @@ export async function setTogetherApiKey(
   agentDir?: string,
   options?: ApiKeyStorageOptions,
 ) {
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "together:default",
     credential: buildApiKeyCredential("together", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -453,7 +462,7 @@ export async function setHuggingfaceApiKey(
   agentDir?: string,
   options?: ApiKeyStorageOptions,
 ) {
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "huggingface:default",
     credential: buildApiKeyCredential("huggingface", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -465,7 +474,7 @@ export function setQianfanApiKey(
   agentDir?: string,
   options?: ApiKeyStorageOptions,
 ) {
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "qianfan:default",
     credential: buildApiKeyCredential("qianfan", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -473,7 +482,7 @@ export function setQianfanApiKey(
 }
 
 export function setXaiApiKey(key: SecretInput, agentDir?: string, options?: ApiKeyStorageOptions) {
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "xai:default",
     credential: buildApiKeyCredential("xai", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -485,7 +494,7 @@ export async function setMistralApiKey(
   agentDir?: string,
   options?: ApiKeyStorageOptions,
 ) {
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "mistral:default",
     credential: buildApiKeyCredential("mistral", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),
@@ -497,7 +506,7 @@ export async function setKilocodeApiKey(
   agentDir?: string,
   options?: ApiKeyStorageOptions,
 ) {
-  upsertAuthProfile({
+  upsertOnboardingAuthProfile({
     profileId: "kilocode:default",
     credential: buildApiKeyCredential("kilocode", key, undefined, options),
     agentDir: resolveAuthAgentDir(agentDir),

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -126,6 +126,8 @@ describe("writeOAuthCredentials", () => {
 
   let tempStateDir: string;
   const authProfilePathFor = (dir: string) => path.join(dir, "auth-profiles.json");
+  const provisionedAuthProfilePathFor = (dir: string) =>
+    path.join(dir, "auth-profiles.provisioned.json");
 
   afterEach(async () => {
     await lifecycle.cleanup();
@@ -155,6 +157,40 @@ describe("writeOAuthCredentials", () => {
     await expect(
       fs.readFile(path.join(env.stateDir, "agents", "main", "agent", "auth-profiles.json"), "utf8"),
     ).rejects.toThrow();
+  });
+
+  it("updates the provisioned auth mirror when it already exists", async () => {
+    const env = await setupAuthTestEnv("openclaw-oauth-provisioned-");
+    lifecycle.setStateDir(env.stateDir);
+    await fs.writeFile(
+      provisionedAuthProfilePathFor(env.agentDir),
+      JSON.stringify({
+        version: 1,
+        profiles: {},
+        lastGood: { stale: "value" },
+      }),
+    );
+
+    const creds = {
+      refresh: "refresh-provisioned",
+      access: "access-provisioned",
+      expires: Date.now() + 60_000,
+    } satisfies OAuthCredentials;
+
+    await writeOAuthCredentials("openai-codex", creds, env.agentDir);
+
+    const parsed = JSON.parse(
+      await fs.readFile(provisionedAuthProfilePathFor(env.agentDir), "utf8"),
+    ) as {
+      profiles?: Record<string, OAuthCredentials & { type?: string }>;
+      lastGood?: Record<string, string>;
+    };
+    expect(parsed.profiles?.["openai-codex:default"]).toMatchObject({
+      refresh: "refresh-provisioned",
+      access: "access-provisioned",
+      type: "oauth",
+    });
+    expect(parsed.lastGood).toBeUndefined();
   });
 
   it("writes OAuth credentials to all sibling agent dirs when syncSiblingAgents=true", async () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: onboarding credential writers update `auth-profiles.json` but can leave `auth-profiles.provisioned.json` stale even when a provisioned mirror already exists.
- Why it matters: live and provisioned auth stores drift, so onboarding/repair flows fix one source of truth while provisioned consumers still see old credentials.
- What changed: added a first-class provisioned-store save path and mirrored canonical onboarding credential writes into the provisioned store when that file already exists.
- What did NOT change (scope boundary): this does not create a new provisioned file automatically, and runtime-only telemetry (`lastGood`, `usageStats`) remains live-store-only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38336
- Related #38355

## User-visible / Behavior Changes

- Onboarding credential updates now keep an existing `auth-profiles.provisioned.json` mirror in sync with canonical credential changes.
- Runtime telemetry stays out of the provisioned mirror.
- If no provisioned mirror exists, behavior stays unchanged.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) `No`
- Secrets/tokens handling changed? (`Yes/No`) `Yes`
- New/changed network calls? (`Yes/No`) `No`
- Command/tool execution surface changed? (`Yes/No`) `No`
- Data access scope changed? (`Yes/No`) `Yes`
- If any `Yes`, explain risk + mitigation: canonical credential writes now update an existing provisioned mirror file in addition to the live store. The mirrored payload is intentionally limited to canonical fields (`version`, `profiles`, `order`), strips runtime telemetry, and only writes when the provisioned file already exists.

## Repro + Verification

### Environment

- OS: macOS local dev environment
- Runtime/container: Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): onboarding/auth command flows
- Relevant config (redacted): agent dir containing both `auth-profiles.json` and `auth-profiles.provisioned.json`

### Steps

1. Prepare an agent dir with both the live auth store and a provisioned mirror.
2. Run an onboarding credential write (OAuth or API key).
3. Compare the live store and provisioned mirror before and after the write.

### Expected

- Canonical credential fields stay in sync when a provisioned mirror already exists.
- Runtime telemetry remains live-store-only.

### Actual

- Before this patch, onboarding credential writes updated only the live store and left the provisioned mirror stale.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added targeted regression coverage for the store save helper plus OAuth and API-key onboarding flows.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm exec vitest run src/agents/auth-profiles.store.save.test.ts src/commands/onboard-auth.test.ts src/commands/onboard-auth.credentials.test.ts`.
- Edge cases checked: existing provisioned mirror is updated, `order` is preserved, and runtime telemetry is excluded from the mirrored payload.
- What you did **not** verify: no end-to-end interactive onboarding session against every provider/channel combination.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) `Yes`
- Config/env changes? (`Yes/No`) `No`
- Migration needed? (`Yes/No`) `No`
- If yes, exact upgrade steps: `N/A`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR/commit to restore live-store-only onboarding writes.
- Files/config to restore: restore `auth-profiles.provisioned.json` from backup/version control if an incorrect mirrored write is observed.
- Known bad symptoms reviewers should watch for: unexpected writes to a provisioned mirror or runtime telemetry appearing in the provisioned file.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: onboarding writes could accidentally propagate runtime-only fields into the provisioned mirror.
  - Mitigation: the mirror write uses a dedicated canonical save helper that excludes runtime telemetry and only runs when the provisioned file already exists.

## AI Assistance

- AI-assisted: `Yes`
- Testing level: `Targeted local tests run`
- I reviewed the generated changes and understand the code paths involved.
- Session logs/prompts: available on request, not attached here.
