### PR TITLE
fix(synology-chat): remove redundant 120s agent response timeout

### DIFF
--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -336,7 +336,7 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
     // Default to webhook user_id; may be replaced with Chat API user_id below.
     let replyUserId = payload.user_id;
 
-    // Deliver to agent asynchronously (with 120s timeout to match nginx proxy_read_timeout)
+    // Deliver to agent asynchronously (relies on the core agent timeout)
     try {
       // Resolve the Chat-internal user_id for sending replies.
       // Synology Chat outgoing webhooks use a per-integration user_id that may

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -369,11 +369,7 @@ export function createWebhookHandler(deps: WebhookHandlerDeps) {
         chatUserId: replyUserId,
       });
 
-      const timeoutPromise = new Promise<null>((_, reject) =>
-        setTimeout(() => reject(new Error("Agent response timeout (120s)")), 120_000),
-      );
-
-      const reply = await Promise.race([deliverPromise, timeoutPromise]);
+      const reply = await deliverPromise;
 
       // Send reply back to Synology Chat using the resolved Chat user_id
       if (reply) {


### PR DESCRIPTION
## Summary
- Remove the custom 120s `Promise.race` timeout in the webhook handler
- Rely on the core agent timeout (`agents.defaults.timeoutSeconds`, default 600s) like all other channel plugins (Slack, Discord, Telegram, etc.)
- Fixes agent responses being cut off when they legitimately take longer than 120s

## Test plan
- [ ] Verify existing unit tests pass
- [ ] Send a message via Synology Chat that triggers a slow agent response (>120s)
- [ ] Confirm the response is delivered instead of timing out

🤖 Generated with [Claude Code](https://claude.com/claude-code)