### PR TITLE
fix(i18n): guard localStorage/navigator for node test environment

### DIFF
--- a/ui/src/i18n/lib/translate.ts
+++ b/ui/src/i18n/lib/translate.ts
@@ -22,11 +22,21 @@ class I18nManager {
   }
 
   private resolveInitialLocale(): Locale {
-    const saved = localStorage.getItem("openclaw.i18n.locale");
-    if (isSupportedLocale(saved)) {
-      return saved;
+    try {
+      const saved =
+        typeof localStorage !== "undefined" && typeof localStorage.getItem === "function"
+          ? localStorage.getItem("openclaw.i18n.locale")
+          : null;
+      if (isSupportedLocale(saved)) {
+        return saved;
+      }
+    } catch {
+      // localStorage may throw in sandboxed or SSR contexts
     }
-    return resolveNavigatorLocale(navigator.language);
+    if (typeof navigator !== "undefined" && navigator.language) {
+      return resolveNavigatorLocale(navigator.language);
+    }
+    return DEFAULT_LOCALE;
   }
 
   private loadLocale() {
@@ -64,7 +74,13 @@ class I18nManager {
     }
 
     this.locale = locale;
-    localStorage.setItem("openclaw.i18n.locale", locale);
+    try {
+      if (typeof localStorage !== "undefined" && typeof localStorage.setItem === "function") {
+        localStorage.setItem("openclaw.i18n.locale", locale);
+      }
+    } catch {
+      // localStorage may throw in sandboxed or SSR contexts
+    }
     this.notify();
   }
 

--- a/ui/src/i18n/test/translate-node-safety.node.test.ts
+++ b/ui/src/i18n/test/translate-node-safety.node.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+
+describe("i18n node-mode safety", () => {
+  const origLocalStorage = globalThis.localStorage;
+  const origNavigator = globalThis.navigator;
+
+  afterAll(() => {
+    Object.defineProperty(globalThis, "localStorage", { value: origLocalStorage, configurable: true });
+    Object.defineProperty(globalThis, "navigator", { value: origNavigator, configurable: true });
+  });
+
+  it("does not throw when localStorage and navigator are missing", async () => {
+    Object.defineProperty(globalThis, "localStorage", { value: undefined, configurable: true });
+    Object.defineProperty(globalThis, "navigator", { value: undefined, configurable: true });
+
+    vi.resetModules();
+    const { i18n } = await import("../lib/translate.ts");
+    expect(i18n.getLocale()).toBe("en");
+  });
+
+  it("does not throw when localStorage exists but getItem is missing", async () => {
+    Object.defineProperty(globalThis, "localStorage", {
+      value: { length: 0 }, // no getItem/setItem
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, "navigator", { value: undefined, configurable: true });
+
+    vi.resetModules();
+    const { i18n } = await import("../lib/translate.ts");
+    expect(i18n.getLocale()).toBe("en");
+  });
+});

--- a/ui/src/i18n/test/translate-node-safety.node.test.ts
+++ b/ui/src/i18n/test/translate-node-safety.node.test.ts
@@ -1,11 +1,14 @@
-import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, vi, afterAll } from "vitest";
 
 describe("i18n node-mode safety", () => {
   const origLocalStorage = globalThis.localStorage;
   const origNavigator = globalThis.navigator;
 
   afterAll(() => {
-    Object.defineProperty(globalThis, "localStorage", { value: origLocalStorage, configurable: true });
+    Object.defineProperty(globalThis, "localStorage", {
+      value: origLocalStorage,
+      configurable: true,
+    });
     Object.defineProperty(globalThis, "navigator", { value: origNavigator, configurable: true });
   });
 


### PR DESCRIPTION
The `I18nManager` class accesses `localStorage` and `navigator` at module load time (via constructor → `resolveInitialLocale`), which throws `ReferenceError` when imported in a Node environment — specifically in `vitest.node.config.ts` test runs.

Wraps both globals with `typeof` checks so they gracefully degrade to `DEFAULT_LOCALE` when running outside a browser. Also guards the `localStorage.setItem` call in `setLocale`.

Fixes #36626
