### PR TITLE
fix(feishu): disable block streaming to prevent silent reply drops

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -591,4 +591,16 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       }),
     );
   });
+
+  it("sets disableBlockStreaming to true in replyOptions", async () => {
+    const result = await createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_123",
+      replyToMessageId: "om_456",
+    });
+
+    expect(result.replyOptions.disableBlockStreaming).toBe(true);
+  });
 });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -382,6 +382,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
+      disableBlockStreaming: true,
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
             if (!payload.text) {


### PR DESCRIPTION
## Summary

- **Problem:** When `blockStreamingDefault` is `"on"` (the default after the setup wizard), Feishu messages are dispatched to the agent successfully but **no reply is ever delivered** to the Feishu client. Logs show `dispatch complete (queuedFinal=false, replies=0)`.
- **Root cause:** Feishu's `deliver()` silently drops block chunks when `renderMode` is `"auto"` and text contains no code blocks/tables. The block streaming pipeline marks `didStream=true` (callback returned without error), then filters out the final reply payload → zero replies sent.
- **Fix:** Set `disableBlockStreaming: true` in Feishu's `replyOptions`, matching how WhatsApp, Telegram, Slack, Signal, and iMessage already handle this. Feishu's own streaming card mechanism (`onPartialReply`) is unaffected.

## Test plan

- [x] Added test asserting `disableBlockStreaming` is `true` in returned `replyOptions`
- [x] All 340 Feishu extension tests pass
- [x] `pnpm vitest run extensions/feishu/src/`

## Verification

```
# Before fix:
feishu[invest]: dispatch complete (queuedFinal=false, replies=0)

# After fix:
feishu[default]: dispatch complete (queuedFinal=true, replies=1) ✅
feishu[invest]: dispatch complete (queuedFinal=true, replies=1) ✅
```

Closes #38258