### PR TITLE
feat(feishu): split DM/group display names with members-only DM lookup

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -342,54 +342,17 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockCreateFeishuClient).not.toHaveBeenCalled();
   });
 
-  it("uses sender display name for direct chat labels when resolveDmDisplayNames is enabled", async () => {
-    const cfg: ClawdbotConfig = {
-      channels: {
-        feishu: {
-          appId: "cli_test",
-          appSecret: "secret_test",
-          dmPolicy: "open",
-          resolveSenderNames: true,
-          resolveDmDisplayNames: true,
-        },
-      },
-    } as ClawdbotConfig;
-
-    const event: FeishuMessageEvent = {
-      sender: {
-        sender_id: {
-          open_id: "ou-direct-review-user",
-        },
-      },
-      message: {
-        message_id: "msg-direct-display-enabled",
-        chat_id: "oc-dm-direct-display",
-        chat_type: "p2p",
-        message_type: "text",
-        content: JSON.stringify({ text: "hello dm display" }),
-      },
-    };
-
-    await dispatchMessage({ cfg, event });
-
-    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
-      expect.objectContaining({
-        SenderName: "Sender (ou-direct-review-user)",
-      }),
-    );
-  });
-
-  it("falls back to chat members API for direct display name when contact API has no name", async () => {
+  it("uses chat members API (single path) for direct display names", async () => {
     const getUser = vi
       .fn()
-      .mockResolvedValue({ code: 0, data: { user: { open_id: "ou-direct-member-fallback" } } });
+      .mockResolvedValue({ code: 0, data: { user: { name: "ShouldNotUse" } } });
     const getMembers = vi.fn().mockResolvedValue({
       code: 0,
       data: {
         items: [
           {
-            member_id: "ou-direct-member-fallback",
-            name: "SenderFromMemberList",
+            member_id: "ou-direct-review-user-members-only",
+            name: "SenderFromMembersOnly",
           },
         ],
       },
@@ -414,130 +377,86 @@ describe("handleFeishuMessage command authorization", () => {
     const event: FeishuMessageEvent = {
       sender: {
         sender_id: {
-          open_id: "ou-direct-member-fallback",
+          open_id: "ou-direct-review-user-members-only",
+          user_id: "fouser_12345",
         },
       },
       message: {
-        message_id: "msg-direct-member-fallback",
-        chat_id: "oc-dm-direct-member-fallback",
+        message_id: "msg-direct-display-enabled",
+        chat_id: "oc-dm-direct-display",
         chat_type: "p2p",
         message_type: "text",
-        content: JSON.stringify({ text: "hello dm member fallback" }),
+        content: JSON.stringify({ text: "hello dm display" }),
       },
     };
 
     await dispatchMessage({ cfg, event });
 
     expect(getMembers).toHaveBeenCalledWith({
-      path: { chat_id: "oc-dm-direct-member-fallback" },
+      path: { chat_id: "oc-dm-direct-display" },
+      params: { member_id_type: "open_id", page_size: 50 },
+    });
+    expect(getUser).not.toHaveBeenCalled();
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderName: "SenderFromMembersOnly (ou-direct-review-user-members-only)",
+      }),
+    );
+  });
+
+  it("keeps open_id when direct member lookup has no matching name", async () => {
+    const getMembers = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [
+          {
+            member_id: "ou-someone-else",
+            name: "SomeoneElse",
+          },
+        ],
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: vi.fn() } },
+      im: { chat: { members: { get: getMembers } } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          dmPolicy: "open",
+          resolveSenderNames: true,
+          resolveDmDisplayNames: true,
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-direct-no-member-name",
+        },
+      },
+      message: {
+        message_id: "msg-direct-no-member-name",
+        chat_id: "oc-dm-direct-no-member-name",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello dm no member name" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(getMembers).toHaveBeenCalledWith({
+      path: { chat_id: "oc-dm-direct-no-member-name" },
       params: { member_id_type: "open_id", page_size: 50 },
     });
     expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
       expect.objectContaining({
-        SenderName: "SenderFromMemberList (ou-direct-member-fallback)",
-      }),
-    );
-  });
-
-  it("prefers sender user_id lookup for direct display name resolution when available", async () => {
-    const getUser = vi
-      .fn()
-      .mockResolvedValue({ code: 0, data: { user: { name: "SenderByUserId" } } });
-    mockCreateFeishuClient.mockReturnValue({
-      contact: { user: { get: getUser } },
-    });
-
-    const cfg: ClawdbotConfig = {
-      channels: {
-        feishu: {
-          appId: "cli_test",
-          appSecret: "secret_test",
-          dmPolicy: "open",
-          resolveSenderNames: true,
-          resolveDmDisplayNames: true,
-        },
-      },
-    } as ClawdbotConfig;
-
-    const event: FeishuMessageEvent = {
-      sender: {
-        sender_id: {
-          open_id: "ou-direct-with-user-id",
-          user_id: "fouser_12345",
-        },
-      },
-      message: {
-        message_id: "msg-direct-display-user-id",
-        chat_id: "oc-dm-direct-display-user-id",
-        chat_type: "p2p",
-        message_type: "text",
-        content: JSON.stringify({ text: "hello dm user id" }),
-      },
-    };
-
-    await dispatchMessage({ cfg, event });
-
-    expect(getUser).toHaveBeenCalledWith({
-      path: { user_id: "fouser_12345" },
-      params: { user_id_type: "user_id" },
-    });
-    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
-      expect.objectContaining({
-        SenderName: "SenderByUserId (ou-direct-with-user-id)",
-      }),
-    );
-  });
-
-  it("falls back to open_id lookup when user_id lookup response is non-zero", async () => {
-    const getUser = vi
-      .fn()
-      .mockResolvedValueOnce({ code: 400, msg: "bad user_id" })
-      .mockResolvedValueOnce({ code: 0, data: { user: { name: "SenderByOpenId" } } });
-    mockCreateFeishuClient.mockReturnValue({
-      contact: { user: { get: getUser } },
-    });
-
-    const cfg: ClawdbotConfig = {
-      channels: {
-        feishu: {
-          appId: "cli_test",
-          appSecret: "secret_test",
-          dmPolicy: "open",
-          resolveSenderNames: true,
-          resolveDmDisplayNames: true,
-        },
-      },
-    } as ClawdbotConfig;
-
-    const event: FeishuMessageEvent = {
-      sender: {
-        sender_id: {
-          open_id: "ou_direct_fallback_open_id",
-          user_id: "fouser_bad",
-        },
-      },
-      message: {
-        message_id: "msg-direct-display-fallback-open-id",
-        chat_id: "oc-dm-direct-display-fallback-open-id",
-        chat_type: "p2p",
-        message_type: "text",
-        content: JSON.stringify({ text: "hello dm fallback" }),
-      },
-    };
-
-    await dispatchMessage({ cfg, event });
-
-    expect(getUser).toHaveBeenNthCalledWith(1, {
-      path: { user_id: "fouser_bad" },
-      params: { user_id_type: "user_id" },
-    });
-    expect(getUser).toHaveBeenNthCalledWith(2, {
-      path: { user_id: "ou_direct_fallback_open_id" },
-      params: { user_id_type: "open_id" },
-    });
-    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
-      expect.objectContaining({
-        SenderName: "SenderByOpenId (ou_direct_fallback_open_id)",
+        SenderName: "ou-direct-no-member-name",
       }),
     );
   });

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -379,6 +379,109 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("prefers sender user_id lookup for direct display name resolution when available", async () => {
+    const getUser = vi
+      .fn()
+      .mockResolvedValue({ code: 0, data: { user: { name: "SenderByUserId" } } });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: getUser } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          dmPolicy: "open",
+          resolveSenderNames: true,
+          resolveDmDisplayNames: true,
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-direct-with-user-id",
+          user_id: "fouser_12345",
+        },
+      },
+      message: {
+        message_id: "msg-direct-display-user-id",
+        chat_id: "oc-dm-direct-display-user-id",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello dm user id" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(getUser).toHaveBeenCalledWith({
+      path: { user_id: "fouser_12345" },
+      params: { user_id_type: "user_id" },
+    });
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderName: "SenderByUserId (ou-direct-with-user-id)",
+      }),
+    );
+  });
+
+  it("falls back to open_id lookup when user_id lookup response is non-zero", async () => {
+    const getUser = vi
+      .fn()
+      .mockResolvedValueOnce({ code: 400, msg: "bad user_id" })
+      .mockResolvedValueOnce({ code: 0, data: { user: { name: "SenderByOpenId" } } });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: getUser } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          dmPolicy: "open",
+          resolveSenderNames: true,
+          resolveDmDisplayNames: true,
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou_direct_fallback_open_id",
+          user_id: "fouser_bad",
+        },
+      },
+      message: {
+        message_id: "msg-direct-display-fallback-open-id",
+        chat_id: "oc-dm-direct-display-fallback-open-id",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello dm fallback" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(getUser).toHaveBeenNthCalledWith(1, {
+      path: { user_id: "fouser_bad" },
+      params: { user_id_type: "user_id" },
+    });
+    expect(getUser).toHaveBeenNthCalledWith(2, {
+      path: { user_id: "ou_direct_fallback_open_id" },
+      params: { user_id_type: "open_id" },
+    });
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderName: "SenderByOpenId (ou_direct_fallback_open_id)",
+      }),
+    );
+  });
+
   it("keeps open_id in direct chat labels when resolveDmDisplayNames is disabled", async () => {
     const cfg: ClawdbotConfig = {
       channels: {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -342,6 +342,150 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockCreateFeishuClient).not.toHaveBeenCalled();
   });
 
+  it("resolves group name via im.chat.get for display fields only", async () => {
+    const getChat = vi.fn().mockResolvedValue({ code: 0, data: { name: "FutureMind Ops" } });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: vi.fn() } },
+      im: { chat: { get: getChat } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          groupPolicy: "open",
+          requireMention: false,
+          resolveSenderNames: false,
+          resolveGroupNames: true,
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-group-user",
+        },
+      },
+      message: {
+        message_id: "msg-group-name-display",
+        chat_id: "oc-group-resolve-display",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello group" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(getChat).toHaveBeenCalledWith({ path: { chat_id: "oc-group-resolve-display" } });
+    expect(mockResolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        peer: { kind: "group", id: "oc-group-resolve-display" },
+      }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        GroupSubject: "FutureMind Ops",
+      }),
+    );
+  });
+
+  it("falls back to chat_id when group name lookup fails", async () => {
+    const getChat = vi.fn().mockResolvedValue({ code: 999, msg: "permission denied" });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: vi.fn() } },
+      im: { chat: { get: getChat } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          groupPolicy: "open",
+          requireMention: false,
+          resolveSenderNames: false,
+          resolveGroupNames: true,
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-group-user-fallback",
+        },
+      },
+      message: {
+        message_id: "msg-group-name-fallback",
+        chat_id: "oc-group-fallback-id",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello fallback" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        GroupSubject: "oc-group-fallback-id",
+      }),
+    );
+  });
+
+  it("caches resolved group names for 10 minutes", async () => {
+    const getChat = vi.fn().mockResolvedValue({ code: 0, data: { name: "Cached Group" } });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: vi.fn() } },
+      im: { chat: { get: getChat } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          groupPolicy: "open",
+          requireMention: false,
+          resolveSenderNames: false,
+          resolveGroupNames: true,
+        },
+      },
+    } as ClawdbotConfig;
+
+    const baseEvent: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-cache-user",
+        },
+      },
+      message: {
+        message_id: "msg-group-cache-1",
+        chat_id: "oc-group-cache-id-20260306",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello cache" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event: baseEvent });
+    await dispatchMessage({
+      cfg,
+      event: {
+        ...baseEvent,
+        message: {
+          ...baseEvent.message,
+          message_id: "msg-group-cache-2",
+        },
+      },
+    });
+
+    expect(getChat).toHaveBeenCalledTimes(1);
+  });
+
   it("propagates parent/root message ids into inbound context for reply reconstruction", async () => {
     mockGetMessageFeishu.mockResolvedValueOnce({
       messageId: "om_parent_001",

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -359,7 +359,7 @@ describe("handleFeishuMessage command authorization", () => {
     });
     mockCreateFeishuClient.mockReturnValue({
       contact: { user: { get: getUser } },
-      im: { chat: { members: { get: getMembers } } },
+      im: { chatMembers: { get: getMembers } },
     });
 
     const cfg: ClawdbotConfig = {
@@ -418,7 +418,7 @@ describe("handleFeishuMessage command authorization", () => {
     });
     mockCreateFeishuClient.mockReturnValue({
       contact: { user: { get: vi.fn() } },
-      im: { chat: { members: { get: getMembers } } },
+      im: { chatMembers: { get: getMembers } },
     });
 
     const cfg: ClawdbotConfig = {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -379,6 +379,66 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("falls back to chat members API for direct display name when contact API has no name", async () => {
+    const getUser = vi
+      .fn()
+      .mockResolvedValue({ code: 0, data: { user: { open_id: "ou-direct-member-fallback" } } });
+    const getMembers = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [
+          {
+            member_id: "ou-direct-member-fallback",
+            name: "SenderFromMemberList",
+          },
+        ],
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: getUser } },
+      im: { chat: { members: { get: getMembers } } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          dmPolicy: "open",
+          resolveSenderNames: true,
+          resolveDmDisplayNames: true,
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-direct-member-fallback",
+        },
+      },
+      message: {
+        message_id: "msg-direct-member-fallback",
+        chat_id: "oc-dm-direct-member-fallback",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello dm member fallback" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(getMembers).toHaveBeenCalledWith({
+      path: { chat_id: "oc-dm-direct-member-fallback" },
+      params: { member_id_type: "open_id", page_size: 50 },
+    });
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderName: "SenderFromMemberList (ou-direct-member-fallback)",
+      }),
+    );
+  });
+
   it("prefers sender user_id lookup for direct display name resolution when available", async () => {
     const getUser = vi
       .fn()

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -342,6 +342,80 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockCreateFeishuClient).not.toHaveBeenCalled();
   });
 
+  it("uses sender display name for direct chat labels when resolveDmDisplayNames is enabled", async () => {
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          dmPolicy: "open",
+          resolveSenderNames: true,
+          resolveDmDisplayNames: true,
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-direct-review-user",
+        },
+      },
+      message: {
+        message_id: "msg-direct-display-enabled",
+        chat_id: "oc-dm-direct-display",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello dm display" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderName: "Sender (ou-direct-review-user)",
+      }),
+    );
+  });
+
+  it("keeps open_id in direct chat labels when resolveDmDisplayNames is disabled", async () => {
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          dmPolicy: "open",
+          resolveSenderNames: true,
+          resolveDmDisplayNames: false,
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-direct-review-disabled",
+        },
+      },
+      message: {
+        message_id: "msg-direct-display-disabled",
+        chat_id: "oc-dm-direct-display-disabled",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello dm disabled" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderName: "ou-direct-review-disabled",
+      }),
+    );
+  });
+
   it("resolves group name via im.chat.get for display fields only", async () => {
     const getChat = vi.fn().mockResolvedValue({ code: 0, data: { name: "FutureMind Ops" } });
     mockCreateFeishuClient.mockReturnValue({
@@ -387,7 +461,7 @@ describe("handleFeishuMessage command authorization", () => {
     );
     expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
       expect.objectContaining({
-        GroupSubject: "FutureMind Ops",
+        GroupSubject: "FutureMind Ops (oc-group-resolve-display)",
       }),
     );
   });
@@ -432,6 +506,141 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
       expect.objectContaining({
         GroupSubject: "oc-group-fallback-id",
+      }),
+    );
+  });
+
+  it("does not duplicate chat_id when resolved group name already contains id", async () => {
+    const getChat = vi
+      .fn()
+      .mockResolvedValue({ code: 0, data: { name: "FutureMind Ops (oc-group-resolve-display)" } });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: vi.fn() } },
+      im: { chat: { get: getChat } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          groupPolicy: "open",
+          requireMention: false,
+          resolveSenderNames: false,
+          resolveGroupNames: true,
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-group-user-contains-id",
+        },
+      },
+      message: {
+        message_id: "msg-group-name-contains-id",
+        chat_id: "oc-group-resolve-display",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello group id" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        GroupSubject: "FutureMind Ops (oc-group-resolve-display)",
+      }),
+    );
+  });
+
+  it("skips group-name lookup when resolveGroupNames is false", async () => {
+    const getChat = vi.fn().mockResolvedValue({ code: 0, data: { name: "Should Not Be Used" } });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: vi.fn() } },
+      im: { chat: { get: getChat } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          groupPolicy: "open",
+          requireMention: false,
+          resolveSenderNames: false,
+          resolveGroupNames: false,
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-group-user-disabled",
+        },
+      },
+      message: {
+        message_id: "msg-group-name-disabled",
+        chat_id: "oc-group-disabled-id",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello disabled" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(getChat).not.toHaveBeenCalled();
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        GroupSubject: "oc-group-disabled-id",
+      }),
+    );
+  });
+
+  it("does not resolve group name in direct chat", async () => {
+    const getChat = vi.fn().mockResolvedValue({ code: 0, data: { name: "Should Not Be Used" } });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: vi.fn() } },
+      im: { chat: { get: getChat } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          dmPolicy: "open",
+          resolveSenderNames: false,
+          resolveGroupNames: true,
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-direct-user",
+        },
+      },
+      message: {
+        message_id: "msg-direct-no-group-lookup",
+        chat_id: "oc-dm-direct-id",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello dm" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(getChat).not.toHaveBeenCalled();
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ChatType: "direct",
       }),
     );
   });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -254,6 +254,71 @@ async function resolveFeishuGroupName(params: {
   return undefined;
 }
 
+async function resolveFeishuDirectNameFromChatMember(params: {
+  account: ResolvedFeishuAccount;
+  chatId: string;
+  senderOpenId: string;
+  log: (...args: any[]) => void;
+}): Promise<string | undefined> {
+  const { account, chatId, senderOpenId, log } = params;
+  if (!account.configured) return undefined;
+
+  const normalizedSenderOpenId = senderOpenId.trim();
+  const normalizedChatId = chatId.trim();
+  if (!normalizedSenderOpenId || !normalizedChatId) return undefined;
+
+  const cached = senderNameCache.get(normalizedSenderOpenId);
+  const now = Date.now();
+  if (cached && cached.expireAt > now) return cached.name;
+
+  try {
+    const client = createFeishuClient(account) as any;
+    const getChatMembers = client?.im?.chat?.members?.get;
+    if (typeof getChatMembers !== "function") {
+      return undefined;
+    }
+
+    const res: any = await getChatMembers({
+      path: { chat_id: normalizedChatId },
+      params: {
+        member_id_type: "open_id",
+        page_size: 50,
+      },
+    });
+
+    if (res?.code !== 0) {
+      log(
+        `feishu: failed to resolve direct member name for ${normalizedSenderOpenId} in ${normalizedChatId}: code=${String(
+          res?.code,
+        )} msg=${String(res?.msg ?? "")}`,
+      );
+      return undefined;
+    }
+
+    const item = Array.isArray(res?.data?.items)
+      ? res.data.items.find(
+          (entry: any) =>
+            typeof entry?.member_id === "string" && entry.member_id === normalizedSenderOpenId,
+        )
+      : undefined;
+
+    const name = typeof item?.name === "string" ? item.name.trim() : "";
+    if (name) {
+      senderNameCache.set(normalizedSenderOpenId, {
+        name,
+        expireAt: now + SENDER_NAME_TTL_MS,
+      });
+      return name;
+    }
+  } catch (err) {
+    log(
+      `feishu: failed to resolve direct member name for ${normalizedSenderOpenId} in ${normalizedChatId}: ${String(err)}`,
+    );
+  }
+
+  return undefined;
+}
+
 function buildFeishuGroupDisplayName(params: { chatId: string; groupName?: string }): string {
   const normalizedChatId = params.chatId.trim();
   const name = params.groupName?.trim();
@@ -1027,6 +1092,18 @@ export async function handleFeishuMessage(params: {
         permissionErrorNotifiedAt.set(appKey, now);
         permissionErrorForAgent = senderResult.permissionError;
       }
+    }
+  }
+
+  if (isDirect && (feishuCfg?.resolveDmDisplayNames ?? true) && !ctx.senderName) {
+    const directName = await resolveFeishuDirectNameFromChatMember({
+      account,
+      chatId: ctx.chatId,
+      senderOpenId: ctx.senderOpenId,
+      log,
+    });
+    if (directName) {
+      ctx = { ...ctx, senderName: directName };
     }
   }
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -129,37 +129,63 @@ function resolveSenderLookupIdType(senderId: string): "open_id" | "user_id" | "u
 async function resolveFeishuSenderName(params: {
   account: ResolvedFeishuAccount;
   senderId: string;
+  senderUserId?: string;
   log: (...args: any[]) => void;
 }): Promise<SenderNameResult> {
-  const { account, senderId, log } = params;
+  const { account, senderId, senderUserId, log } = params;
   if (!account.configured) return {};
 
-  const normalizedSenderId = senderId.trim();
-  if (!normalizedSenderId) return {};
+  const candidateIds = [senderUserId?.trim(), senderId.trim()].filter(
+    (v): v is string => typeof v === "string" && v.length > 0,
+  );
+  if (candidateIds.length === 0) return {};
 
-  const cached = senderNameCache.get(normalizedSenderId);
   const now = Date.now();
-  if (cached && cached.expireAt > now) return { name: cached.name };
+  for (const candidateId of candidateIds) {
+    const cached = senderNameCache.get(candidateId);
+    if (cached && cached.expireAt > now) return { name: cached.name };
+  }
 
   try {
     const client = createFeishuClient(account);
-    const userIdType = resolveSenderLookupIdType(normalizedSenderId);
 
-    // contact/v3/users/:user_id?user_id_type=<open_id|user_id|union_id>
-    const res: any = await client.contact.user.get({
-      path: { user_id: normalizedSenderId },
-      params: { user_id_type: userIdType },
-    });
+    for (const candidateId of candidateIds) {
+      const userIdType = resolveSenderLookupIdType(candidateId);
 
-    const name: string | undefined =
-      res?.data?.user?.name ||
-      res?.data?.user?.display_name ||
-      res?.data?.user?.nickname ||
-      res?.data?.user?.en_name;
+      // contact/v3/users/:user_id?user_id_type=<open_id|user_id|union_id>
+      const res: any = await client.contact.user.get({
+        path: { user_id: candidateId },
+        params: { user_id_type: userIdType },
+      });
 
-    if (name && typeof name === "string") {
-      senderNameCache.set(normalizedSenderId, { name, expireAt: now + SENDER_NAME_TTL_MS });
-      return { name };
+      if (res?.code != null && res.code !== 0) {
+        const permErr = extractPermissionError(res);
+        if (permErr) {
+          if (shouldSuppressPermissionErrorNotice(permErr)) {
+            log(`feishu: ignoring stale permission scope error: ${permErr.message}`);
+            return {};
+          }
+          log(`feishu: permission error resolving sender name: code=${permErr.code}`);
+          return { permissionError: permErr };
+        }
+        log(
+          `feishu: sender name lookup failed for ${candidateId}: code=${String(res.code)} msg=${String(res?.msg ?? "")}`,
+        );
+        continue;
+      }
+
+      const name: string | undefined =
+        res?.data?.user?.name ||
+        res?.data?.user?.display_name ||
+        res?.data?.user?.nickname ||
+        res?.data?.user?.en_name;
+
+      if (name && typeof name === "string") {
+        for (const idForCache of candidateIds) {
+          senderNameCache.set(idForCache, { name, expireAt: now + SENDER_NAME_TTL_MS });
+        }
+        return { name };
+      }
     }
 
     return {};
@@ -176,7 +202,7 @@ async function resolveFeishuSenderName(params: {
     }
 
     // Best-effort. Don't fail message handling if name lookup fails.
-    log(`feishu: failed to resolve sender name for ${normalizedSenderId}: ${String(err)}`);
+    log(`feishu: failed to resolve sender name for ${candidateIds.join(",")}: ${String(err)}`);
     return {};
   }
 }
@@ -986,6 +1012,7 @@ export async function handleFeishuMessage(params: {
     const senderResult = await resolveFeishuSenderName({
       account,
       senderId: ctx.senderOpenId,
+      senderUserId,
       log,
     });
     if (senderResult.name) ctx = { ...ctx, senderName: senderResult.name };

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1070,10 +1070,24 @@ export async function handleFeishuMessage(params: {
     }
   }
 
-  // Resolve sender display name (best-effort) so the agent can attribute messages correctly.
-  // Optimization: skip if disabled to save API quota (Feishu free tier limit).
+  // Resolve sender display name with channel-specific strategy:
+  // - direct chat: only chat.members lookup (single-path, no fallback)
+  // - group chat: contact user lookup (existing behavior)
   let permissionErrorForAgent: PermissionError | undefined;
-  if (feishuCfg?.resolveSenderNames ?? true) {
+
+  if (isDirect && (feishuCfg?.resolveDmDisplayNames ?? true)) {
+    const directName = await resolveFeishuDirectNameFromChatMember({
+      account,
+      chatId: ctx.chatId,
+      senderOpenId: ctx.senderOpenId,
+      log,
+    });
+    if (directName) {
+      ctx = { ...ctx, senderName: directName };
+    }
+  }
+
+  if (isGroup && (feishuCfg?.resolveSenderNames ?? true)) {
     const senderResult = await resolveFeishuSenderName({
       account,
       senderId: ctx.senderOpenId,
@@ -1092,18 +1106,6 @@ export async function handleFeishuMessage(params: {
         permissionErrorNotifiedAt.set(appKey, now);
         permissionErrorForAgent = senderResult.permissionError;
       }
-    }
-  }
-
-  if (isDirect && (feishuCfg?.resolveDmDisplayNames ?? true) && !ctx.senderName) {
-    const directName = await resolveFeishuDirectNameFromChatMember({
-      account,
-      chatId: ctx.chatId,
-      senderOpenId: ctx.senderOpenId,
-      log,
-    });
-    if (directName) {
-      ctx = { ...ctx, senderName: directName };
     }
   }
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -97,10 +97,13 @@ function extractPermissionError(err: unknown): PermissionError | null {
   };
 }
 
-// --- Sender name resolution (so the agent can distinguish who is speaking in group chats) ---
+// --- Sender/group display name resolution (so the agent can distinguish who is speaking and where) ---
 // Cache display names by sender id (open_id/user_id) to avoid an API call on every message.
 const SENDER_NAME_TTL_MS = 10 * 60 * 1000;
 const senderNameCache = new Map<string, { name: string; expireAt: number }>();
+// Cache group names by account+chat id; used for display fields only.
+const GROUP_NAME_TTL_MS = 10 * 60 * 1000;
+const groupNameCache = new Map<string, { name: string; expireAt: number }>();
 
 // Cache permission errors to avoid spamming the user with repeated notifications.
 // Key: appId or "default", Value: timestamp of last notification
@@ -176,6 +179,53 @@ async function resolveFeishuSenderName(params: {
     log(`feishu: failed to resolve sender name for ${normalizedSenderId}: ${String(err)}`);
     return {};
   }
+}
+
+async function resolveFeishuGroupName(params: {
+  account: ResolvedFeishuAccount;
+  chatId: string;
+  log: (...args: any[]) => void;
+}): Promise<string | undefined> {
+  const { account, chatId, log } = params;
+  if (!account.configured) return undefined;
+
+  const normalizedChatId = chatId.trim();
+  if (!normalizedChatId) return undefined;
+
+  const cacheKey = `${account.accountId}:${normalizedChatId}`;
+  const cached = groupNameCache.get(cacheKey);
+  const now = Date.now();
+  if (cached && cached.expireAt > now) return cached.name;
+
+  try {
+    const client = createFeishuClient(account) as any;
+    const getChat = client?.im?.chat?.get;
+    if (typeof getChat !== "function") {
+      return undefined;
+    }
+
+    const res: any = await getChat({ path: { chat_id: normalizedChatId } });
+    if (res?.code !== 0) {
+      log(
+        `feishu: failed to resolve group name for ${normalizedChatId}: code=${String(res?.code)} msg=${String(res?.msg ?? "")}`,
+      );
+      return undefined;
+    }
+
+    const name =
+      typeof res?.data?.name === "string" && res.data.name.trim().length > 0
+        ? res.data.name.trim()
+        : undefined;
+    if (name) {
+      groupNameCache.set(cacheKey, { name, expireAt: now + GROUP_NAME_TTL_MS });
+      return name;
+    }
+  } catch (err) {
+    // Best-effort. Don't fail message handling if group lookup fails.
+    log(`feishu: failed to resolve group name for ${normalizedChatId}: ${String(err)}`);
+  }
+
+  return undefined;
 }
 
 export type FeishuMessageEvent = {
@@ -455,7 +505,11 @@ function formatSubMessageContent(content: string, contentType: string): string {
   }
 }
 
-function checkBotMentioned(event: FeishuMessageEvent, botOpenId?: string, botName?: string): boolean {
+function checkBotMentioned(
+  event: FeishuMessageEvent,
+  botOpenId?: string,
+  botName?: string,
+): boolean {
   if (!botOpenId) return false;
   // Check for @all (@_all in Feishu) — treat as mentioning every bot
   const rawContent = event.message.content ?? "";
@@ -922,8 +976,21 @@ export async function handleFeishuMessage(params: {
     }
   }
 
+  if (isGroup && (feishuCfg?.resolveGroupNames ?? true)) {
+    const groupName = await resolveFeishuGroupName({
+      account,
+      chatId: ctx.chatId,
+      log,
+    });
+    if (groupName) {
+      ctx = { ...ctx, groupName };
+    }
+  }
+
+  const groupDisplayName = isGroup ? ctx.groupName?.trim() || ctx.chatId : undefined;
+
   log(
-    `feishu[${account.accountId}]: received message from ${ctx.senderOpenId} in ${ctx.chatId} (${ctx.chatType})`,
+    `feishu[${account.accountId}]: received message from ${ctx.senderOpenId} in ${groupDisplayName ?? ctx.chatId} (${ctx.chatType})`,
   );
 
   // Log mention targets if detected
@@ -1177,7 +1244,7 @@ export async function handleFeishuMessage(params: {
 
     const preview = ctx.content.replace(/\s+/g, " ").slice(0, 160);
     const inboundLabel = isGroup
-      ? `Feishu[${account.accountId}] message in group ${ctx.chatId}`
+      ? `Feishu[${account.accountId}] message in group ${groupDisplayName ?? ctx.chatId}`
       : `Feishu[${account.accountId}] DM from ${ctx.senderOpenId}`;
 
     // Do not enqueue inbound user previews as system events.
@@ -1287,7 +1354,7 @@ export async function handleFeishuMessage(params: {
         SessionKey: agentSessionKey,
         AccountId: agentAccountId,
         ChatType: isGroup ? "group" : "direct",
-        GroupSubject: isGroup ? ctx.chatId : undefined,
+        GroupSubject: isGroup ? groupDisplayName : undefined,
         SenderName: ctx.senderName ?? ctx.senderOpenId,
         SenderId: ctx.senderOpenId,
         Provider: "feishu" as const,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -228,6 +228,33 @@ async function resolveFeishuGroupName(params: {
   return undefined;
 }
 
+function buildFeishuGroupDisplayName(params: { chatId: string; groupName?: string }): string {
+  const normalizedChatId = params.chatId.trim();
+  const name = params.groupName?.trim();
+
+  if (!name) return normalizedChatId;
+  if (!normalizedChatId) return name;
+
+  // Keep display human-readable but globally unique across same-name groups.
+  if (name.includes(normalizedChatId)) return name;
+  return `${name} (${normalizedChatId})`;
+}
+
+function buildFeishuDirectDisplayName(params: {
+  senderOpenId: string;
+  senderName?: string;
+}): string {
+  const senderId = params.senderOpenId.trim();
+  const senderName = params.senderName?.trim();
+
+  if (!senderName) return senderId;
+  if (!senderId) return senderName;
+
+  // Keep display human-readable and traceable for auditing/review.
+  if (senderName.includes(senderId)) return senderName;
+  return `${senderName} (${senderId})`;
+}
+
 export type FeishuMessageEvent = {
   sender: {
     sender_id: {
@@ -987,10 +1014,17 @@ export async function handleFeishuMessage(params: {
     }
   }
 
-  const groupDisplayName = isGroup ? ctx.groupName?.trim() || ctx.chatId : undefined;
+  const groupDisplayName = isGroup
+    ? buildFeishuGroupDisplayName({ chatId: ctx.chatId, groupName: ctx.groupName })
+    : undefined;
+  const directDisplayName = !isGroup
+    ? (feishuCfg?.resolveDmDisplayNames ?? true)
+      ? buildFeishuDirectDisplayName({ senderOpenId: ctx.senderOpenId, senderName: ctx.senderName })
+      : ctx.senderOpenId
+    : undefined;
 
   log(
-    `feishu[${account.accountId}]: received message from ${ctx.senderOpenId} in ${groupDisplayName ?? ctx.chatId} (${ctx.chatType})`,
+    `feishu[${account.accountId}]: received message from ${ctx.senderOpenId} in ${isGroup ? groupDisplayName : (directDisplayName ?? ctx.chatId)} (${ctx.chatType})`,
   );
 
   // Log mention targets if detected
@@ -1245,7 +1279,7 @@ export async function handleFeishuMessage(params: {
     const preview = ctx.content.replace(/\s+/g, " ").slice(0, 160);
     const inboundLabel = isGroup
       ? `Feishu[${account.accountId}] message in group ${groupDisplayName ?? ctx.chatId}`
-      : `Feishu[${account.accountId}] DM from ${ctx.senderOpenId}`;
+      : `Feishu[${account.accountId}] DM from ${directDisplayName ?? ctx.senderOpenId}`;
 
     // Do not enqueue inbound user previews as system events.
     // System events are prepended to future prompts and can be misread as
@@ -1355,7 +1389,9 @@ export async function handleFeishuMessage(params: {
         AccountId: agentAccountId,
         ChatType: isGroup ? "group" : "direct",
         GroupSubject: isGroup ? groupDisplayName : undefined,
-        SenderName: ctx.senderName ?? ctx.senderOpenId,
+        SenderName: isGroup
+          ? (ctx.senderName ?? ctx.senderOpenId)
+          : (directDisplayName ?? ctx.senderName ?? ctx.senderOpenId),
         SenderId: ctx.senderOpenId,
         Provider: "feishu" as const,
         Surface: "feishu" as const,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -273,7 +273,7 @@ async function resolveFeishuDirectNameFromChatMember(params: {
 
   try {
     const client = createFeishuClient(account) as any;
-    const getChatMembers = client?.im?.chat?.members?.get;
+    const getChatMembers = client?.im?.chatMembers?.get ?? client?.im?.chat?.members?.get;
     if (typeof getChatMembers !== "function") {
       return undefined;
     }

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -131,6 +131,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
         mediaMaxMb: { type: "number", minimum: 0 },
         renderMode: { type: "string", enum: ["auto", "raw", "card"] },
         resolveGroupNames: { type: "boolean" },
+        resolveDmDisplayNames: { type: "boolean" },
         accounts: {
           type: "object",
           additionalProperties: {
@@ -148,6 +149,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
               webhookPath: { type: "string" },
               webhookPort: { type: "integer", minimum: 1 },
               resolveGroupNames: { type: "boolean" },
+              resolveDmDisplayNames: { type: "boolean" },
             },
           },
         },

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -130,6 +130,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
         chunkMode: { type: "string", enum: ["length", "newline"] },
         mediaMaxMb: { type: "number", minimum: 0 },
         renderMode: { type: "string", enum: ["auto", "raw", "card"] },
+        resolveGroupNames: { type: "boolean" },
         accounts: {
           type: "object",
           additionalProperties: {
@@ -146,6 +147,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
               webhookHost: { type: "string" },
               webhookPath: { type: "string" },
               webhookPort: { type: "integer", minimum: 1 },
+              resolveGroupNames: { type: "boolean" },
             },
           },
         },

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -138,11 +138,12 @@ describe("FeishuConfigSchema replyInThread", () => {
 });
 
 describe("FeishuConfigSchema optimization flags", () => {
-  it("defaults top-level typingIndicator, resolveSenderNames and resolveGroupNames to true", () => {
+  it("defaults top-level typingIndicator, resolveSenderNames, resolveGroupNames and resolveDmDisplayNames to true", () => {
     const result = FeishuConfigSchema.parse({});
     expect(result.typingIndicator).toBe(true);
     expect(result.resolveSenderNames).toBe(true);
     expect(result.resolveGroupNames).toBe(true);
+    expect(result.resolveDmDisplayNames).toBe(true);
   });
 
   it("accepts account-level optimization flags", () => {
@@ -152,12 +153,14 @@ describe("FeishuConfigSchema optimization flags", () => {
           typingIndicator: false,
           resolveSenderNames: false,
           resolveGroupNames: false,
+          resolveDmDisplayNames: false,
         },
       },
     });
     expect(result.accounts?.main?.typingIndicator).toBe(false);
     expect(result.accounts?.main?.resolveSenderNames).toBe(false);
     expect(result.accounts?.main?.resolveGroupNames).toBe(false);
+    expect(result.accounts?.main?.resolveDmDisplayNames).toBe(false);
   });
 });
 

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -138,10 +138,11 @@ describe("FeishuConfigSchema replyInThread", () => {
 });
 
 describe("FeishuConfigSchema optimization flags", () => {
-  it("defaults top-level typingIndicator and resolveSenderNames to true", () => {
+  it("defaults top-level typingIndicator, resolveSenderNames and resolveGroupNames to true", () => {
     const result = FeishuConfigSchema.parse({});
     expect(result.typingIndicator).toBe(true);
     expect(result.resolveSenderNames).toBe(true);
+    expect(result.resolveGroupNames).toBe(true);
   });
 
   it("accepts account-level optimization flags", () => {
@@ -150,11 +151,13 @@ describe("FeishuConfigSchema optimization flags", () => {
         main: {
           typingIndicator: false,
           resolveSenderNames: false,
+          resolveGroupNames: false,
         },
       },
     });
     expect(result.accounts?.main?.typingIndicator).toBe(false);
     expect(result.accounts?.main?.resolveSenderNames).toBe(false);
+    expect(result.accounts?.main?.resolveGroupNames).toBe(false);
   });
 });
 

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -170,6 +170,7 @@ const FeishuSharedConfigShape = {
   reactionNotifications: ReactionNotificationModeSchema,
   typingIndicator: z.boolean().optional(),
   resolveSenderNames: z.boolean().optional(),
+  resolveGroupNames: z.boolean().optional(),
 };
 
 /**
@@ -217,6 +218,7 @@ export const FeishuConfigSchema = z
     // Optimization flags
     typingIndicator: z.boolean().optional().default(true),
     resolveSenderNames: z.boolean().optional().default(true),
+    resolveGroupNames: z.boolean().optional().default(true),
     // Multi-account configuration
     accounts: z.record(z.string(), FeishuAccountConfigSchema.optional()).optional(),
   })

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -171,6 +171,7 @@ const FeishuSharedConfigShape = {
   typingIndicator: z.boolean().optional(),
   resolveSenderNames: z.boolean().optional(),
   resolveGroupNames: z.boolean().optional(),
+  resolveDmDisplayNames: z.boolean().optional(),
 };
 
 /**
@@ -215,10 +216,11 @@ export const FeishuConfigSchema = z
     topicSessionMode: TopicSessionModeSchema,
     // Dynamic agent creation for DM users
     dynamicAgentCreation: DynamicAgentCreationSchema,
-    // Optimization flags
+    // Optimization / display flags
     typingIndicator: z.boolean().optional().default(true),
     resolveSenderNames: z.boolean().optional().default(true),
     resolveGroupNames: z.boolean().optional().default(true),
+    resolveDmDisplayNames: z.boolean().optional().default(true),
     // Multi-account configuration
     accounts: z.record(z.string(), FeishuAccountConfigSchema.optional()).optional(),
   })

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -44,6 +44,7 @@ export type FeishuMessageContext = {
   senderOpenId: string;
   senderName?: string;
   chatType: "p2p" | "group" | "private";
+  groupName?: string;
   mentionedBot: boolean;
   rootId?: string;
   parentId?: string;


### PR DESCRIPTION
## Summary

- What changed:
  - Split Feishu display-name resolution into independent DM vs Group paths.
  - Added explicit config gates for DM/group display-name behavior (`resolveDmDisplayNames`, `resolveGroupNames`) while preserving `resolveSenderNames` semantics for sender-name resolution.
  - Switched DM name lookup to `im.chat.members.get` members-only path and removed DM dependence on `contact.user.get`.
  - Improved DM lookup fallback behavior and response-code handling.
- Why:
  - Avoid cross-coupling between DM and group naming behavior.
  - Reduce permission/surface mismatch for DM lookups by using chat-members API consistently.
  - Keep route/session behavior unchanged while improving display metadata quality.
- Scope:
  - Feishu extension only (`extensions/feishu/src/{bot.ts,bot.test.ts,channel.ts,config-schema.ts,config-schema.test.ts,types.ts}`).

## Behavior

- Before:
  - DM/group display-name behavior was coupled; DM resolution could still depend on broader sender-name switches and mixed lookup paths.
  - DM lookup fallback behavior had weaker error-code handling.
- After:
  - DM and group display-name resolution are explicitly split.
  - DM lookup uses members-only path (`im.chat.members.get`) with improved fallback/response handling.
  - Routing inputs (`peer`/`parentPeer`) are unchanged.

## Risk

- Runtime impact:
  - Low-to-medium; Feishu display labels/metadata path changed for DM/group name resolution.
- Backward compatibility:
  - Config semantics changed: DM display names are now controlled by `resolveDmDisplayNames` rather than implicitly by `resolveSenderNames`.
  - In DM events with only `user_id` (no `open_id`), display name may fall back to ID when member matching is not possible.
- Rollback plan:
  - Fast config rollback:
    - `resolveDmDisplayNames: false`
    - `resolveGroupNames: false`
  - Commit-level rollback (if needed): revert
    - `43a01f49cd`, `ea3a8163f7`, `edac6cd35a`, `1351950d81`, `b87d0b37fc`.

## Validation

- Tests run:
  - `pnpm exec vitest run extensions/feishu/src/bot.test.ts extensions/feishu/src/config-schema.test.ts` ✅ (73 passed)
  - `pnpm exec vitest run extensions/feishu/src/*.test.ts` ⚠️ (287 passed, 1 failed)
    - Known pre-existing unrelated failure: `extensions/feishu/src/targets.test.ts > treats explicit channel targets as chat_id` (expected `chat_id`, got `user_id`).
- Lint/build checks:
  - `pnpm build` ✅
- Manual verification:
  - N/A in this PR (no live environment verification attached).

## Notes for Reviewers

- Key files:
  - `extensions/feishu/src/bot.ts`
  - `extensions/feishu/src/bot.test.ts`
  - `extensions/feishu/src/config-schema.ts`
  - `extensions/feishu/src/config-schema.test.ts`
  - `extensions/feishu/src/channel.ts`
  - `extensions/feishu/src/types.ts`
- Non-goals:
  - No route/session-key algorithm changes.
  - No fix included for the unrelated `targets.test.ts` baseline failure.
