### PR TITLE
fix: honor provider config baseUrl over model registry default

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -127,4 +127,41 @@ describe("resolveModel", () => {
     expect(result.model?.provider).toBe("custom");
     expect(result.model?.id).toBe("missing-model");
   });
+
+  it("applies provider config baseUrl over registry default when model is found in registry", async () => {
+    // Simulate a model found in the registry with a default baseUrl
+    const { discoverModels } = await import("@mariozechner/pi-coding-agent");
+    const mockedDiscover = vi.mocked(discoverModels);
+    mockedDiscover.mockReturnValueOnce({
+      find: vi.fn(() => ({
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 400000,
+        maxTokens: 32000,
+      })),
+    } as ReturnType<typeof discoverModels>);
+
+    const cfg = {
+      models: {
+        providers: {
+          "openai-codex": {
+            baseUrl: "https://chatgpt.com/backend-api",
+            api: "openai-codex-responses",
+            models: [],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent", cfg);
+
+    expect(result.model?.baseUrl).toBe("https://chatgpt.com/backend-api");
+    expect(result.model?.id).toBe("gpt-5.4");
+  });
 });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -97,5 +97,12 @@ export function resolveModel(
       modelRegistry,
     };
   }
-  return { model: normalizeModelCompat(model), authStorage, modelRegistry };
+  // When the user configures a custom baseUrl for a provider (e.g. openai-codex
+  // pointing at chatgpt.com/backend-api instead of api.openai.com), that override
+  // should win over the built-in model registry default.
+  const providerBaseUrl = cfg?.models?.providers?.[provider]?.baseUrl;
+  const resolved = providerBaseUrl
+    ? normalizeModelCompat({ ...model, baseUrl: providerBaseUrl } as Model<Api>)
+    : normalizeModelCompat(model);
+  return { model: resolved, authStorage, modelRegistry };
 }


### PR DESCRIPTION
## The Problem

When you configure a custom `baseUrl` for a provider in `openclaw.json` — say, pointing `openai-codex` at `chatgpt.com/backend-api` instead of the default `api.openai.com` — `resolveModel()` ignores your config entirely if the model is found in the built-in registry.

The registry model comes back with its hardcoded `baseUrl`, and your provider config gets thrown away. This means OAuth-based setups that rely on a different endpoint (like Codex via ChatGPT's backend API) get routed to the wrong URL and fail with 404s.

## Why This Matters

This unlocks **GPT-5.4 via Codex OAuth** for anyone with a ChatGPT Pro subscription. The Codex OAuth tokens only work against `chatgpt.com/backend-api/codex/responses` — NOT `api.openai.com`. Without this fix, even if you configure the right `baseUrl` in your provider config, OpenClaw silently overwrites it with the registry default and sends your requests to the wrong endpoint. You get a 404 and no idea why.

With this fix, you just set your `openai-codex` provider's `baseUrl` to `https://chatgpt.com/backend-api`, set `api` to `openai-codex-responses`, and it works. GPT-5.4 through OpenClaw, zero API cost, using your existing ChatGPT Pro subscription.

## The Fix

6 lines. When `resolveModel()` finds a model in the registry AND the user has a provider config with a custom `baseUrl`, the config wins. User intent over defaults.

```typescript
const providerBaseUrl = cfg?.models?.providers?.[provider]?.baseUrl;
const resolved = providerBaseUrl
  ? normalizeModelCompat({ ...model, baseUrl: providerBaseUrl })
  : normalizeModelCompat(model);
```

## Test

Added a test that mocks `discoverModels` returning a model with `baseUrl: "https://api.openai.com/v1"`, then verifies that the provider config's `baseUrl: "https://chatgpt.com/backend-api"` takes precedence.

All existing model tests pass. The 2 pre-existing failures in `bash-tools.exec.path.test.ts` are unrelated.

## Context

Hit this running GPT-5.4 via Codex OAuth — had the config right, but the registry was overriding it silently. The model *was* resolving, just with the wrong URL. Subtle and frustrating to debug.