### PR TITLE
fix: support google-vertex gemini-3.1 forward-compat

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -18,12 +18,13 @@ const ZAI_GLM5_MODEL_ID = "glm-5";
 const ZAI_GLM5_TEMPLATE_MODEL_IDS = ["glm-4.7"] as const;
 
 // gemini-3.1-pro-preview / gemini-3.1-flash-preview are not yet in pi-ai's built-in
-// google-gemini-cli catalog. Clone the gemini-3-pro/flash-preview template so users
+// Google provider catalogs. Clone the gemini-3-pro/flash-preview template so users
 // don't get "Unknown model" errors when Google releases a new minor version.
 const GEMINI_3_1_PRO_PREFIX = "gemini-3.1-pro";
 const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";
 const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3-pro-preview"] as const;
 const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview"] as const;
+const GOOGLE_GEMINI_31_ELIGIBLE_PROVIDERS = new Set(["google-gemini-cli", "google-vertex"]);
 
 function cloneFirstTemplateModel(params: {
   normalizedProvider: string;
@@ -169,14 +170,15 @@ function resolveAnthropicSonnet46ForwardCompatModel(
 }
 
 // gemini-3.1-pro-preview / gemini-3.1-flash-preview are not present in pi-ai's built-in
-// google-gemini-cli catalog yet. Clone the nearest gemini-3 template so users don't get
-// "Unknown model" errors when Google Gemini CLI gains new minor-version models.
-function resolveGoogleGeminiCli31ForwardCompatModel(
+// Google provider catalogs yet. Clone the nearest gemini-3 template so users don't get
+// "Unknown model" errors when Google providers gain new minor-version models.
+function resolveGoogleGemini31ForwardCompatModel(
   provider: string,
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
-  if (normalizeProviderId(provider) !== "google-gemini-cli") {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (!GOOGLE_GEMINI_31_ELIGIBLE_PROVIDERS.has(normalizedProvider)) {
     return undefined;
   }
   const trimmed = modelId.trim();
@@ -192,7 +194,7 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
   }
 
   return cloneFirstTemplateModel({
-    normalizedProvider: "google-gemini-cli",
+    normalizedProvider,
     trimmedModelId: trimmed,
     templateIds: [...templateIds],
     modelRegistry,
@@ -252,6 +254,6 @@ export function resolveForwardCompatModel(
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveZaiGlm5ForwardCompatModel(provider, modelId, modelRegistry) ??
-    resolveGoogleGeminiCli31ForwardCompatModel(provider, modelId, modelRegistry)
+    resolveGoogleGemini31ForwardCompatModel(provider, modelId, modelRegistry)
   );
 }

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -10,10 +10,12 @@ import {
   buildOpenAICodexForwardCompatExpectation,
   GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
   GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+  GOOGLE_VERTEX_FLASH_TEMPLATE_MODEL,
   GOOGLE_VERTEX_PRO_TEMPLATE_MODEL,
   makeModel,
   mockGoogleGeminiCliFlashTemplateModel,
   mockGoogleGeminiCliProTemplateModel,
+  mockGoogleVertexFlashTemplateModel,
   mockGoogleVertexProTemplateModel,
   mockOpenAICodexTemplateModel,
   resetMockDiscoverModels,
@@ -90,6 +92,19 @@ describe("pi embedded model e2e smoke", () => {
     expect(result.error).toBeUndefined();
     expect(result.model).toMatchObject({
       ...GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
+      id: "gemini-3.1-flash-preview",
+      name: "gemini-3.1-flash-preview",
+      reasoning: true,
+    });
+  });
+
+  it("builds a google-vertex forward-compat fallback for gemini-3.1-flash-preview", () => {
+    mockGoogleVertexFlashTemplateModel();
+
+    const result = resolveModel("google-vertex", "gemini-3.1-flash-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      ...GOOGLE_VERTEX_FLASH_TEMPLATE_MODEL,
       id: "gemini-3.1-flash-preview",
       name: "gemini-3.1-flash-preview",
       reasoning: true,

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -10,9 +10,11 @@ import {
   buildOpenAICodexForwardCompatExpectation,
   GOOGLE_GEMINI_CLI_FLASH_TEMPLATE_MODEL,
   GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+  GOOGLE_VERTEX_PRO_TEMPLATE_MODEL,
   makeModel,
   mockGoogleGeminiCliFlashTemplateModel,
   mockGoogleGeminiCliProTemplateModel,
+  mockGoogleVertexProTemplateModel,
   mockOpenAICodexTemplateModel,
   resetMockDiscoverModels,
 } from "./model.test-harness.js";
@@ -62,6 +64,19 @@ describe("pi embedded model e2e smoke", () => {
     expect(result.error).toBeUndefined();
     expect(result.model).toMatchObject({
       ...GOOGLE_GEMINI_CLI_PRO_TEMPLATE_MODEL,
+      id: "gemini-3.1-pro-preview",
+      name: "gemini-3.1-pro-preview",
+      reasoning: true,
+    });
+  });
+
+  it("builds a google-vertex forward-compat fallback for gemini-3.1-pro-preview", () => {
+    mockGoogleVertexProTemplateModel();
+
+    const result = resolveModel("google-vertex", "gemini-3.1-pro-preview", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      ...GOOGLE_VERTEX_PRO_TEMPLATE_MODEL,
       id: "gemini-3.1-pro-preview",
       name: "gemini-3.1-pro-preview",
       reasoning: true,

--- a/src/agents/pi-embedded-runner/model.test-harness.ts
+++ b/src/agents/pi-embedded-runner/model.test-harness.ts
@@ -89,6 +89,27 @@ export function mockGoogleGeminiCliFlashTemplateModel(): void {
   });
 }
 
+export const GOOGLE_VERTEX_PRO_TEMPLATE_MODEL = {
+  id: "gemini-3-pro-preview",
+  name: "Gemini 3 Pro Preview (Vertex)",
+  provider: "google-vertex",
+  api: "openai-completions",
+  baseUrl: "https://us-central1-aiplatform.googleapis.com/v1beta/openai",
+  reasoning: true,
+  input: ["text", "image"] as const,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200000,
+  maxTokens: 64000,
+};
+
+export function mockGoogleVertexProTemplateModel(): void {
+  mockDiscoveredModel({
+    provider: "google-vertex",
+    modelId: "gemini-3-pro-preview",
+    templateModel: GOOGLE_VERTEX_PRO_TEMPLATE_MODEL,
+  });
+}
+
 export function resetMockDiscoverModels(): void {
   vi.mocked(discoverModels).mockReturnValue({
     find: vi.fn(() => null),

--- a/src/agents/pi-embedded-runner/model.test-harness.ts
+++ b/src/agents/pi-embedded-runner/model.test-harness.ts
@@ -102,11 +102,32 @@ export const GOOGLE_VERTEX_PRO_TEMPLATE_MODEL = {
   maxTokens: 64000,
 };
 
+export const GOOGLE_VERTEX_FLASH_TEMPLATE_MODEL = {
+  id: "gemini-3-flash-preview",
+  name: "Gemini 3 Flash Preview (Vertex)",
+  provider: "google-vertex",
+  api: "openai-completions",
+  baseUrl: "https://us-central1-aiplatform.googleapis.com/v1beta/openai",
+  reasoning: false,
+  input: ["text", "image"] as const,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200000,
+  maxTokens: 64000,
+};
+
 export function mockGoogleVertexProTemplateModel(): void {
   mockDiscoveredModel({
     provider: "google-vertex",
     modelId: "gemini-3-pro-preview",
     templateModel: GOOGLE_VERTEX_PRO_TEMPLATE_MODEL,
+  });
+}
+
+export function mockGoogleVertexFlashTemplateModel(): void {
+  mockDiscoveredModel({
+    provider: "google-vertex",
+    modelId: "gemini-3-flash-preview",
+    templateModel: GOOGLE_VERTEX_FLASH_TEMPLATE_MODEL,
   });
 }
 


### PR DESCRIPTION
## Summary
Fixes #38273.

`resolveForwardCompatModel` handled Gemini 3.1 preview aliases only for `google-gemini-cli`. When provider is `google-vertex`, `gemini-3.1-pro-preview` fell through to unknown-model handling.

## Root Cause
The Gemini 3.1 forward-compat resolver hard-coded a single eligible provider (`google-gemini-cli`), even though the same template-clone fallback is valid for `google-vertex`.

## What Changed
- Expanded Gemini 3.1 forward-compat eligibility to include both providers:
  - `google-gemini-cli`
  - `google-vertex`
- Reused existing template clone logic with provider-preserving resolution.
- Added regression coverage in pi-embedded model smoke tests for:
  - `resolveModel("google-vertex", "gemini-3.1-pro-preview", "/tmp/agent")`

## Files
- `src/agents/model-forward-compat.ts`
- `src/agents/pi-embedded-runner/model.test-harness.ts`
- `src/agents/pi-embedded-runner/model.forward-compat.test.ts`

## Validation
- `pnpm build && pnpm check && pnpm test` ✅

## AI Disclosure
This PR is AI-assisted. Code has been fully tested locally. I understand what this code does.
