### PR TITLE
fix(agents): apply cache_control injection for LiteLLM-proxied Anthropic models

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.litellm-cache-control.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.litellm-cache-control.test.ts
@@ -1,0 +1,150 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model } from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+type StreamPayload = {
+  messages: Array<{
+    role: string;
+    content: unknown;
+  }>;
+};
+
+function runLiteLLMPayload(
+  payload: StreamPayload,
+  modelId: string,
+  cacheRetention?: "none" | "short" | "long",
+) {
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    options?.onPayload?.(payload);
+    return createAssistantMessageEventStream();
+  };
+  const agent = { streamFn: baseStreamFn };
+
+  const cfg = cacheRetention
+    ? {
+        agents: {
+          defaults: {
+            models: {
+              [`litellm/${modelId}`]: {
+                params: { cacheRetention },
+              },
+            },
+          },
+        },
+      }
+    : undefined;
+
+  applyExtraParamsToAgent(agent, cfg as never, "litellm", modelId);
+
+  const model = {
+    api: "openai-completions",
+    provider: "litellm",
+    id: modelId,
+  } as Model<"openai-completions">;
+  const context: Context = { messages: [] };
+
+  void agent.streamFn?.(model, context, {});
+}
+
+describe("extra-params: LiteLLM Anthropic cache_control (refs #37966)", () => {
+  it("injects cache_control when cacheRetention is explicitly configured for a claude-* model", () => {
+    const payload = {
+      messages: [
+        { role: "system", content: "You are a helpful assistant." },
+        { role: "user", content: "Hello" },
+      ],
+    };
+
+    runLiteLLMPayload(payload, "claude-opus-4-6", "long");
+
+    expect(payload.messages[0].content).toEqual([
+      { type: "text", text: "You are a helpful assistant.", cache_control: { type: "ephemeral" } },
+    ]);
+    expect(payload.messages[1].content).toBe("Hello");
+  });
+
+  it("injects cache_control for anthropic/claude-* model IDs", () => {
+    const payload = {
+      messages: [{ role: "system", content: "System prompt." }],
+    };
+
+    runLiteLLMPayload(payload, "anthropic/claude-3-5-sonnet", "short");
+
+    expect(payload.messages[0].content).toEqual([
+      { type: "text", text: "System prompt.", cache_control: { type: "ephemeral" } },
+    ]);
+  });
+
+  it("injects cache_control for anthropic.claude-* (Bedrock-style) model IDs via LiteLLM", () => {
+    const payload = {
+      messages: [{ role: "system", content: "Bedrock-style prompt." }],
+    };
+
+    runLiteLLMPayload(payload, "anthropic.claude-3-5-sonnet-20241022-v2:0", "short");
+
+    expect(payload.messages[0].content).toEqual([
+      {
+        type: "text",
+        text: "Bedrock-style prompt.",
+        cache_control: { type: "ephemeral" },
+      },
+    ]);
+  });
+
+  it("does NOT inject cache_control when cacheRetention is not configured", () => {
+    const payload = {
+      messages: [{ role: "system", content: "You are a helpful assistant." }],
+    };
+
+    // No cacheRetention config — wrapper should not be applied
+    runLiteLLMPayload(payload, "claude-opus-4-6", undefined);
+
+    expect(payload.messages[0].content).toBe("You are a helpful assistant.");
+  });
+
+  it("does NOT inject cache_control for non-Anthropic LiteLLM models", () => {
+    const payload = {
+      messages: [{ role: "system", content: "You are a helpful assistant." }],
+    };
+
+    runLiteLLMPayload(payload, "gpt-4o", "short");
+
+    expect(payload.messages[0].content).toBe("You are a helpful assistant.");
+  });
+
+  it("adds cache_control to last block when system message content is already an array", () => {
+    const payload = {
+      messages: [
+        {
+          role: "system",
+          content: [
+            { type: "text", text: "Part 1" },
+            { type: "text", text: "Part 2" },
+          ],
+        },
+      ],
+    };
+
+    runLiteLLMPayload(payload, "claude-opus-4-6", "long");
+
+    const content = payload.messages[0].content as Array<Record<string, unknown>>;
+    expect(content[0]).toEqual({ type: "text", text: "Part 1" });
+    expect(content[1]).toEqual({
+      type: "text",
+      text: "Part 2",
+      cache_control: { type: "ephemeral" },
+    });
+  });
+
+  it("leaves payload unchanged when there is no system message", () => {
+    const payload = {
+      messages: [{ role: "user", content: "Hello" }],
+    };
+
+    runLiteLLMPayload(payload, "claude-opus-4-6", "long");
+
+    expect(payload.messages[0].content).toBe("Hello");
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.litellm-cache-control.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.litellm-cache-control.test.ts
@@ -104,6 +104,17 @@ describe("extra-params: LiteLLM Anthropic cache_control (refs #37966)", () => {
     expect(payload.messages[0].content).toBe("You are a helpful assistant.");
   });
 
+  it("does NOT inject cache_control when cacheRetention is explicitly 'none'", () => {
+    const payload = {
+      messages: [{ role: "system", content: "You are a helpful assistant." }],
+    };
+
+    // cacheRetention: "none" means the user opted out — must not inject cache_control
+    runLiteLLMPayload(payload, "claude-opus-4-6", "none");
+
+    expect(payload.messages[0].content).toBe("You are a helpful assistant.");
+  });
+
   it("does NOT inject cache_control for non-Anthropic LiteLLM models", () => {
     const payload = {
       messages: [{ role: "system", content: "You are a helpful assistant." }],

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -1190,7 +1190,8 @@ export function applyExtraParamsToAgent(
   // param — payload injection is the correct mechanism here.  Fixes #37966.
   if (provider === "litellm" && isLiteLLMAnthropicModel(modelId)) {
     const hasExplicitCacheRetention =
-      extraParams?.cacheRetention !== undefined || extraParams?.cacheControlTtl !== undefined;
+      (extraParams?.cacheRetention !== undefined && extraParams.cacheRetention !== "none") ||
+      extraParams?.cacheControlTtl !== undefined;
     if (hasExplicitCacheRetention) {
       log.debug(
         `applying system-prompt cache_control for LiteLLM Anthropic model ${provider}/${modelId} (refs #37966)`,

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -529,10 +529,50 @@ function isOpenRouterAnthropicModel(provider: string, modelId: string): boolean 
   return provider.toLowerCase() === "openrouter" && modelId.toLowerCase().startsWith("anthropic/");
 }
 
+/**
+ * Returns true when a LiteLLM model ID refers to an Anthropic Claude model.
+ * LiteLLM natively passes through Anthropic's cache_control field, so
+ * payload-level injection (same as OpenRouter) restores prompt caching.
+ * Recognized patterns: "claude-*", "anthropic/claude-*", "anthropic.claude-*".
+ */
+function isLiteLLMAnthropicModel(modelId: string): boolean {
+  const normalized = modelId.toLowerCase();
+  return (
+    normalized.startsWith("claude-") ||
+    normalized.startsWith("anthropic/claude") ||
+    normalized.startsWith("anthropic.claude")
+  );
+}
+
 type PayloadMessage = {
   role?: string;
   content?: unknown;
 };
+
+/**
+ * Inject cache_control: { type: "ephemeral" } into the last content block of
+ * every system/developer message in the payload.  Used by both the OpenRouter
+ * and LiteLLM Anthropic cache wrappers.
+ */
+function injectSystemPromptCacheControl(payload: unknown): void {
+  const messages = (payload as Record<string, unknown>)?.messages;
+  if (!Array.isArray(messages)) {
+    return;
+  }
+  for (const msg of messages as PayloadMessage[]) {
+    if (msg.role !== "system" && msg.role !== "developer") {
+      continue;
+    }
+    if (typeof msg.content === "string") {
+      msg.content = [{ type: "text", text: msg.content, cache_control: { type: "ephemeral" } }];
+    } else if (Array.isArray(msg.content) && msg.content.length > 0) {
+      const last = msg.content[msg.content.length - 1];
+      if (last && typeof last === "object") {
+        (last as Record<string, unknown>).cache_control = { type: "ephemeral" };
+      }
+    }
+  }
+}
 
 /**
  * Inject cache_control into the system message for OpenRouter Anthropic models.
@@ -554,24 +594,36 @@ function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | undefined):
     return underlying(model, context, {
       ...options,
       onPayload: (payload) => {
-        const messages = (payload as Record<string, unknown>)?.messages;
-        if (Array.isArray(messages)) {
-          for (const msg of messages as PayloadMessage[]) {
-            if (msg.role !== "system" && msg.role !== "developer") {
-              continue;
-            }
-            if (typeof msg.content === "string") {
-              msg.content = [
-                { type: "text", text: msg.content, cache_control: { type: "ephemeral" } },
-              ];
-            } else if (Array.isArray(msg.content) && msg.content.length > 0) {
-              const last = msg.content[msg.content.length - 1];
-              if (last && typeof last === "object") {
-                (last as Record<string, unknown>).cache_control = { type: "ephemeral" };
-              }
-            }
-          }
-        }
+        injectSystemPromptCacheControl(payload);
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}
+
+/**
+ * Inject cache_control into the system message for LiteLLM-proxied Anthropic models.
+ * LiteLLM natively passes through Anthropic's cache_control field — caching the
+ * system prompt avoids re-processing it on every request.  Applied only when the
+ * caller has explicitly configured cacheRetention for the model.  Fixes #37966.
+ */
+function createLiteLLMAnthropicCacheWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (
+      typeof model.provider !== "string" ||
+      typeof model.id !== "string" ||
+      model.provider !== "litellm" ||
+      !isLiteLLMAnthropicModel(model.id)
+    ) {
+      return underlying(model, context, options);
+    }
+
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        injectSystemPromptCacheControl(payload);
         originalOnPayload?.(payload);
       },
     });
@@ -1127,6 +1179,24 @@ export function applyExtraParamsToAgent(
   if (provider === "amazon-bedrock" && !isAnthropicBedrockModel(modelId)) {
     log.debug(`disabling prompt caching for non-Anthropic Bedrock model ${provider}/${modelId}`);
     agent.streamFn = createBedrockNoCacheWrapper(agent.streamFn);
+  }
+
+  // LiteLLM passes through Anthropic's cache_control field to the upstream
+  // provider.  When the user explicitly configures cacheRetention for a
+  // LiteLLM Anthropic model, apply payload-level cache_control injection
+  // (same approach as OpenRouter) so prompt caching is actually activated.
+  // resolveCacheRetention() intentionally returns undefined for "litellm"
+  // because the openai-completions adapter ignores the cacheRetention stream
+  // param — payload injection is the correct mechanism here.  Fixes #37966.
+  if (provider === "litellm" && isLiteLLMAnthropicModel(modelId)) {
+    const hasExplicitCacheRetention =
+      extraParams?.cacheRetention !== undefined || extraParams?.cacheControlTtl !== undefined;
+    if (hasExplicitCacheRetention) {
+      log.debug(
+        `applying system-prompt cache_control for LiteLLM Anthropic model ${provider}/${modelId} (refs #37966)`,
+      );
+      agent.streamFn = createLiteLLMAnthropicCacheWrapper(agent.streamFn);
+    }
   }
 
   // Enable Z.AI tool_stream for real-time tool call streaming.


### PR DESCRIPTION
## Summary

Fixes #37966

When users configure `cacheRetention` for a LiteLLM model proxying Anthropic (e.g. `litellm/claude-opus-4-6`), the setting was silently ignored — no `cache_control` markers were injected, so prompt caching never activated.

## Root cause

`resolveCacheRetention()` correctly skips the `cacheRetention` stream param for LiteLLM (the `openai-completions` adapter ignores it). However, the payload-level `cache_control` injection — used by OpenRouter for the same purpose — was never applied for LiteLLM. Result: `cacheRetention` on any `litellm/*` Anthropic model was a complete no-op.

## Fix

1. **Extract** shared `injectSystemPromptCacheControl()` helper from `createOpenRouterSystemCacheWrapper` to eliminate duplicated payload mutation logic.
2. **Add** `isLiteLLMAnthropicModel()` — recognises `claude-*`, `anthropic/claude-*`, and `anthropic.claude-*` model IDs.
3. **Add** `createLiteLLMAnthropicCacheWrapper()` — applies the same `cache_control: { type: "ephemeral" }` injection as the OpenRouter wrapper.
4. **Wire** in `applyExtraParamsToAgent()`: when `provider === "litellm"`, the model ID looks like Anthropic Claude, **and** `cacheRetention` is explicitly configured, the wrapper is applied.

LiteLLM natively passes through Anthropic's `cache_control` field, so payload-level injection is sufficient.

## Tests

New file `extra-params.litellm-cache-control.test.ts` (7 tests):
- Injects for `claude-*`, `anthropic/claude-*`, `anthropic.claude-*` when `cacheRetention` is configured
- Does **not** inject when `cacheRetention` is absent
- Does **not** inject for non-Anthropic LiteLLM models (e.g. `gpt-4o`)
- Handles string and array system message content correctly