### PR TITLE
fix(daemon): treat systemd bus connection failure as 'not enabled' during onboard

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -124,6 +124,27 @@ describe("isSystemdServiceEnabled", () => {
     );
   });
 
+  it("returns false when both user-scope and machine-scope fail with bus connection error (refs #38379)", async () => {
+    // During initial provisioning (e.g. `sudo -u openclaw openclaw onboard --install-daemon`
+    // before the first login), the systemd user bus is not yet running.  Both the
+    // direct `--user` scope and the machine-user fallback return "Failed to connect to bus".
+    // The onboard flow should treat this as "service not yet installed" and continue.
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock
+      .mockImplementationOnce((_cmd, _args, _opts, cb) => {
+        const err = new Error("Failed to connect to bus") as Error & { code?: number };
+        err.code = 1;
+        cb(err, "", "Failed to connect to bus: No such file or directory");
+      })
+      .mockImplementationOnce((_cmd, _args, _opts, cb) => {
+        const err = new Error("Failed to connect to bus") as Error & { code?: number };
+        err.code = 1;
+        cb(err, "", "Failed to connect to bus: No such file or directory");
+      });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
+
   it("returns false when systemctl is-enabled exits with code 4 (not-found)", async () => {
     const { isSystemdServiceEnabled } = await import("./systemd.js");
     execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -130,16 +130,19 @@ describe("isSystemdServiceEnabled", () => {
     // direct `--user` scope and the machine-user fallback return "Failed to connect to bus".
     // The onboard flow should treat this as "service not yet installed" and continue.
     const { isSystemdServiceEnabled } = await import("./systemd.js");
+    // Use "Connection refused" rather than "No such file or directory" so the
+    // error does not match isSystemctlMissing() and falls through to the new
+    // bus-connection guard added for #38379.
     execFileMock
       .mockImplementationOnce((_cmd, _args, _opts, cb) => {
         const err = new Error("Failed to connect to bus") as Error & { code?: number };
         err.code = 1;
-        cb(err, "", "Failed to connect to bus: No such file or directory");
+        cb(err, "", "Failed to connect to bus: Connection refused");
       })
       .mockImplementationOnce((_cmd, _args, _opts, cb) => {
         const err = new Error("Failed to connect to bus") as Error & { code?: number };
         err.code = 1;
-        cb(err, "", "Failed to connect to bus: No such file or directory");
+        cb(err, "", "Failed to connect to bus: Connection refused");
       });
     const result = await isSystemdServiceEnabled({ env: {} });
     expect(result).toBe(false);

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -433,6 +433,18 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
   if (isSystemctlMissing(detail) || isSystemdUnitNotEnabled(detail)) {
     return false;
   }
+  // During initial provisioning (e.g. `sudo -u openclaw openclaw onboard --install-daemon`
+  // before the user's first login), the systemd user bus is not yet started and
+  // both the direct `--user` scope and the machine-user fallback fail with
+  // "Failed to connect to bus".  Treat this as "service not yet installed" so the
+  // onboard flow can proceed and install the unit.  Fixes #38379.
+  const normalizedDetail = detail.toLowerCase();
+  if (
+    normalizedDetail.includes("failed to connect to bus") ||
+    normalizedDetail.includes("failed to connect to user scope bus")
+  ) {
+    return false;
+  }
   throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());
 }
 


### PR DESCRIPTION
## Summary

Fixes #38379

`openclaw onboard --install-daemon` fails with `Error: systemctl is-enabled unavailable: Failed to connect to bus` when run as a provisioned system user (e.g. via Ansible or `sudo -u openclaw`) before the first interactive login — because the systemd user bus is not yet started.

## Root cause

When the systemd user bus is unavailable, `execSystemctlUser` correctly falls back from the direct `--user` scope to the `--machine user@` scope. However, if the machine scope also fails with a bus connection error, `isSystemdServiceEnabled` receives a result that doesn't match either `isSystemctlMissing` (handles binary-not-found) or `isSystemdUnitNotEnabled` (handles disabled/static/masked), so it **throws** and aborts the onboard flow.

## Fix

Add a check for bus-connection error strings (`failed to connect to bus`, `failed to connect to user scope bus`) in `isSystemdServiceEnabled`. When encountered, return `false` (service is not yet installed) instead of throwing, so the onboard flow can proceed to install the unit.

This matches the intent of the pre-regression behavior: any `systemctl is-enabled` failure that doesn't indicate a definitive "permission denied" or similar real error should be treated as "service not yet available".

## Tests

Added one new test case to `systemd.test.ts` (`isSystemdServiceEnabled` suite, 25 tests total):
- Both direct and machine-scope calls return "Failed to connect to bus" → `isSystemdServiceEnabled` returns `false` without throwing