### PR TITLE
fix(feishu): disable block streaming to prevent silent reply drops

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -219,6 +219,17 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMediaFeishuMock).not.toHaveBeenCalled();
   });
 
+  it("sets disableBlockStreaming in replyOptions to prevent silent reply drops", async () => {
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    expect(result.replyOptions).toHaveProperty("disableBlockStreaming", true);
+  });
+
   it("uses streaming session for auto mode markdown payloads", async () => {
     createFeishuReplyDispatcher({
       cfg: {} as never,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -382,6 +382,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
+      disableBlockStreaming: true,
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
             if (!payload.text) {


### PR DESCRIPTION
## Summary

Fixes #38258

When `blockStreamingDefault` is `"on"` (the default after setup wizard), Feishu channels deliver **zero replies** — the agent processes the message but nothing reaches the user.

## Root Cause

The block streaming pipeline calls Feishu's `deliver()` with `kind: "block"`. Feishu's deliver silently drops these chunks when `renderMode` is `"auto"` and text contains no code blocks/tables. The pipeline sees no error, marks `didStream = true`, then suppresses the final reply (`shouldDropFinalPayloads = true`). Result: both block chunks AND the final reply are lost.

## Fix

Set `disableBlockStreaming: true` in Feishu's `replyOptions` so the agent bypasses the block streaming pipeline entirely. Feishu streaming cards via `onPartialReply` remain unaffected.

**One-line change** + test.

## Testing

- Added test verifying `disableBlockStreaming: true` is set in replyOptions
- All 22 existing Feishu reply-dispatcher tests pass