### PR TITLE
fix(gateway): chat.abort RPC now aborts Pi agent, sub-agents, and queues

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -3,8 +3,11 @@ import path from "node:path";
 import { CURRENT_SESSION_VERSION } from "@mariozechner/pi-coding-agent";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveThinkingDefault } from "../../agents/model-selection.js";
+import { abortEmbeddedPiRun } from "../../agents/pi-embedded.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
+import { stopSubagentsForRequester } from "../../auto-reply/reply/abort.js";
+import { clearSessionQueues } from "../../auto-reply/reply/queue.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
@@ -683,6 +686,17 @@ export const chatHandlers: GatewayRequestHandlers = {
         abortOrigin: "rpc",
         stopReason: "rpc",
       });
+      // Also abort the Pi coding agent, clear follow-up queues, and stop
+      // sub-agents, matching what the /stop text command does via
+      // tryFastAbortFromMessage. Without this, clicking the UI Stop button
+      // left spawned sub-agents and embedded Pi runs still running.
+      const { cfg, entry } = loadSessionEntry(rawSessionKey);
+      const sessionId = entry?.sessionId;
+      if (sessionId) {
+        abortEmbeddedPiRun(sessionId);
+      }
+      clearSessionQueues([rawSessionKey, sessionId]);
+      stopSubagentsForRequester({ cfg, requesterSessionKey: rawSessionKey });
       respond(true, { ok: true, aborted: res.aborted, runIds: res.runIds });
       return;
     }
@@ -720,6 +734,17 @@ export const chatHandlers: GatewayRequestHandlers = {
           },
         ],
       });
+    }
+    // Also abort the Pi coding agent, clear follow-up queues, and stop
+    // sub-agents, matching what the /stop text command does via
+    // tryFastAbortFromMessage. Without this, clicking the UI Stop button
+    // left spawned sub-agents and embedded Pi runs still running.
+    if (res.aborted) {
+      const { cfg, entry } = loadSessionEntry(rawSessionKey);
+      const sessionId = entry?.sessionId ?? active.sessionId;
+      abortEmbeddedPiRun(sessionId);
+      clearSessionQueues([rawSessionKey, sessionId]);
+      stopSubagentsForRequester({ cfg, requesterSessionKey: rawSessionKey });
     }
     respond(true, {
       ok: true,


### PR DESCRIPTION
## Problem

The webchat Stop button triggers `chat.abort`, which only aborted HTTP streaming connections tracked in `chatAbortControllers`. It did **not**:

1. Call `abortEmbeddedPiRun()` to stop the Pi coding agent
2. Call `stopSubagentsForRequester()` to stop spawned sub-agents
3. Call `clearSessionQueues()` to drain follow-up message queues

As a result, clicking Stop left sub-agents and Pi runs still running in the background, while the `/stop` text command (via `tryFastAbortFromMessage`) correctly performed all three steps.

## Fix

After aborting HTTP runs in both code paths (`chat.abort` by sessionKey and by runId), replicate the same cleanup that `/stop` performs:

- Load session entry to obtain `sessionId`
- `abortEmbeddedPiRun(sessionId)`
- `clearSessionQueues([rawSessionKey, sessionId])`
- `stopSubagentsForRequester({ cfg, requesterSessionKey: rawSessionKey })`

The runId-specific branch only performs cleanup when the abort actually succeeded (`res.aborted`).

## Testing

Existing tests in `src/gateway/server-methods/` and `src/auto-reply/reply/` all pass (858 tests).

Fixes #38277