### PR TITLE
fix(feishu): disable block streaming to prevent silent reply drop

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -106,6 +106,17 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("sets disableBlockStreaming in replyOptions to prevent silent block drop", () => {
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    expect(result.replyOptions).toHaveProperty("disableBlockStreaming", true);
+  });
+
   it("skips typing indicator when account typingIndicator is disabled", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -382,6 +382,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
+      disableBlockStreaming: true,
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
             if (!payload.text) {


### PR DESCRIPTION
## Problem

When `blockStreamingDefault` is `"on"` (the default after setup wizard), Feishu messages are dispatched to the agent successfully but **no reply is ever delivered** to the Feishu client.

Log shows:
```
feishu[invest]: dispatch complete (queuedFinal=false, replies=0)
```

## Root Cause

In `reply-dispatcher.ts`, the returned `replyOptions` does not set `disableBlockStreaming`. The agent-level block streaming pipeline sends block chunks to Feishu's `deliver()`, which silently drops them for plain text (`renderMode: "auto"` without code blocks/tables). The pipeline still marks `didStream = true`, so the final reply is also filtered out — resulting in zero replies.

## Fix

Set `disableBlockStreaming: true` in `replyOptions` so the agent-level block streaming pipeline is bypassed for Feishu. Feishu's own streaming card mechanism (`onPartialReply`) remains unaffected.

After fix: `dispatch complete (queuedFinal=true, replies=1) ✅`

## Changes
- `extensions/feishu/src/reply-dispatcher.ts`: Add `disableBlockStreaming: true` to replyOptions
- `extensions/feishu/src/reply-dispatcher.test.ts`: Add test verifying the flag is set

Closes #38258