### PR TITLE
Fix systemd daemon install failing when user session bus not active

### DIFF
--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -159,7 +159,8 @@ function isSystemctlMissing(detail: string): boolean {
     normalized.includes("not found") ||
     normalized.includes("no such file or directory") ||
     normalized.includes("spawn systemctl enoent") ||
-    normalized.includes("spawn systemctl eacces")
+    normalized.includes("spawn systemctl eacces") ||
+    normalized.includes("failed to connect to bus")
   );
 }
 


### PR DESCRIPTION
Fixes #38379. When running `openclaw onboard --install-daemon` on a fresh system (e.g., via sudo -u openclaw or Ansible), the command fails with "systemctl is-enabled unavailable" because the systemd user session bus is not yet active.

The error occurs because `isSystemctlMissing()` did not recognize "Failed to connect to bus" as a missing/indeterminate systemctl state, causing `isSystemdServiceEnabled()` to throw instead of returning false.

The fix adds "failed to connect to bus" to the pattern list in `isSystemctlMissing()`, matching the existing behavior in `shouldFallbackToMachineUserScope()` which already recognizes this pattern.