### PR TITLE
fix(ui): suppress partial NO_REPLY prefix "NO" leaking into console stream

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -105,7 +105,24 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBeNull();
   });
 
-  it("does not suppress lowercase 'no' or 'Nothing' as delta prefix", () => {
+  it("does not suppress lowercase 'no' as delta prefix", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: null,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      message: { role: "assistant", content: [{ type: "text", text: "no" }] },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("delta");
+    expect(state.chatStream).toBe("no");
+  });
+
+  it("does not suppress mixed-case 'Nothing' as delta prefix", () => {
     const state = createState({
       sessionKey: "main",
       chatRunId: "run-1",
@@ -119,7 +136,6 @@ describe("handleChatEvent", () => {
     };
 
     expect(handleChatEvent(state, payload)).toBe("delta");
-    // Real content should still flow through
     expect(state.chatStream).toBe("Nothing to report");
   });
 

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -70,6 +70,59 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe("Hello");
   });
 
+  it("ignores partial NO_REPLY prefix 'NO' during delta streaming", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: null,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      message: { role: "assistant", content: [{ type: "text", text: "NO" }] },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("delta");
+    // "NO" should not leak into the stream — it's a prefix of NO_REPLY
+    expect(state.chatStream).toBeNull();
+  });
+
+  it("ignores partial NO_REPLY prefix 'NO_R' during delta streaming", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: null,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      message: { role: "assistant", content: [{ type: "text", text: "NO_R" }] },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("delta");
+    expect(state.chatStream).toBeNull();
+  });
+
+  it("does not suppress lowercase 'no' or 'Nothing' as delta prefix", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: null,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      message: { role: "assistant", content: [{ type: "text", text: "Nothing to report" }] },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("delta");
+    // Real content should still flow through
+    expect(state.chatStream).toBe("Nothing to report");
+  });
+
   it("appends final payload from another run without clearing active stream", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -4,9 +4,33 @@ import type { ChatAttachment } from "../ui-types.ts";
 import { generateUUID } from "../uuid.ts";
 
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
+const SILENT_REPLY_TOKEN = "NO_REPLY";
 
 function isSilentReplyStream(text: string): boolean {
   return SILENT_REPLY_PATTERN.test(text);
+}
+
+/**
+ * Detect partial silent-reply tokens during streaming (e.g. "NO" before "NO_REPLY" arrives).
+ * Mirrors the server-side `isSilentReplyPrefixText` logic from `auto-reply/tokens.ts`.
+ */
+function isSilentReplyPrefix(text: string): boolean {
+  const trimmed = text.trimStart();
+  if (!trimmed || trimmed.length < 2) {
+    return false;
+  }
+  // Only suppress uppercase fragments to avoid hiding natural language like "No..."
+  if (trimmed !== trimmed.toUpperCase()) {
+    return false;
+  }
+  if (/[^A-Z_]/.test(trimmed)) {
+    return false;
+  }
+  if (trimmed.includes("_")) {
+    return SILENT_REPLY_TOKEN.startsWith(trimmed);
+  }
+  // Allow bare "NO" as a known prefix of NO_REPLY
+  return trimmed === "NO";
 }
 /** Client-side defense-in-depth: detect assistant messages whose text is purely NO_REPLY. */
 function isAssistantSilentReply(message: unknown): boolean {
@@ -265,7 +289,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
 
   if (payload.state === "delta") {
     const next = extractText(payload.message);
-    if (typeof next === "string" && !isSilentReplyStream(next)) {
+    if (typeof next === "string" && !isSilentReplyStream(next) && !isSilentReplyPrefix(next)) {
       const current = state.chatStream ?? "";
       if (!current || next.length >= current.length) {
         state.chatStream = next;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -32,6 +32,7 @@ function isSilentReplyPrefix(text: string): boolean {
   // Allow bare "NO" as a known prefix of NO_REPLY
   return trimmed === "NO";
 }
+
 /** Client-side defense-in-depth: detect assistant messages whose text is purely NO_REPLY. */
 function isAssistantSilentReply(message: unknown): boolean {
   if (!message || typeof message !== "object") {
@@ -299,7 +300,11 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
     if (finalMessage && !isAssistantSilentReply(finalMessage)) {
       state.chatMessages = [...state.chatMessages, finalMessage];
-    } else if (state.chatStream?.trim() && !isSilentReplyStream(state.chatStream)) {
+    } else if (
+      state.chatStream?.trim() &&
+      !isSilentReplyStream(state.chatStream) &&
+      !isSilentReplyPrefix(state.chatStream)
+    ) {
       state.chatMessages = [
         ...state.chatMessages,
         {


### PR DESCRIPTION
## Problem

During streaming, when the model outputs `NO_REPLY`, the first delta token `"NO"` does not match the exact `/^\s*NO_REPLY\s*$/` pattern in the webchat/console UI. This causes a brief `"NO"` flash in the chat stream before the final handler filters it out.

**Telegram and other messaging channels are unaffected** because the server-side `isSilentReplyPrefixText()` in `auto-reply/tokens.ts` already catches these partial prefixes. The webchat console lacks this check.

## Fix

Add `isSilentReplyPrefix()` to the client-side chat controller (`ui/src/ui/controllers/chat.ts`), mirroring the server-side logic:
- Only suppresses uppercase-only fragments (won't hide natural language like "Nothing to report")
- Catches `"NO"` and partial underscore-delimited prefixes like `"NO_R"`, `"NO_RE"`, etc.
- Applied to delta events so partial tokens never leak into `chatStream`

## Tests

3 new tests in `chat.test.ts`:
- `"NO"` prefix suppressed during delta streaming
- `"NO_R"` prefix suppressed during delta streaming  
- Lowercase `"Nothing to report"` NOT suppressed (defense against false positives)

All 28 tests pass.

Fixes #38402