### PR TITLE
fix: filter NO_REPLY messages in console output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,6 +222,7 @@ Docs: https://docs.openclaw.ai
 - Google Chat/multi-account webhook auth fallback: when `channels.googlechat.accounts.default` carries shared webhook audience/path settings (for example after config normalization), inherit those defaults for named accounts while preserving top-level and per-account overrides, so inbound webhook verification no longer fails silently for named accounts missing duplicated audience fields. Fixes #38369.
 - Models/tool probing: raise the tool-capability probe budget from 32 to 256 tokens so reasoning models that spend tokens on thinking before returning a required tool call are less likely to be misclassified as not supporting tools. (#7521) Thanks @jakobdylanc.
 - Gateway/transient network classification: treat wrapped `...: fetch failed` transport messages as transient while avoiding broad matches like `Web fetch failed (404): ...`, preventing Discord reconnect wrappers from crashing the gateway without suppressing non-network tool failures. (#38530) Thanks @xinhuagu.
+- ACP/console silent reply suppression: filter ACP `NO_REPLY` lead fragments and silent-only finals before `openclaw agent` logging/delivery so console-backed ACP sessions no longer leak `NO`/`NO_REPLY` placeholders. (#38436) Thanks @ql-wade.
 
 ## 2026.3.2
 

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -7,6 +7,7 @@ import { AcpRuntimeError } from "../acp/runtime/errors.js";
 import * as embeddedModule from "../agents/pi-embedded.js";
 import type { OpenClawConfig } from "../config/config.js";
 import * as configModule from "../config/config.js";
+import { onAgentEvent } from "../infra/agent-events.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { agentCommand } from "./agent.js";
 
@@ -192,6 +193,95 @@ describe("agentCommand ACP runtime routing", () => {
         .mocked(runtime.log)
         .mock.calls.some(([first]) => typeof first === "string" && first.includes("ACP_OK"));
       expect(hasAckLog).toBe(true);
+    });
+  });
+
+  it("suppresses ACP NO_REPLY lead fragments before emitting assistant text", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+      writeAcpSessionStore(storePath);
+      mockConfig(home, storePath);
+
+      const assistantEvents: Array<{ text?: string; delta?: string }> = [];
+      const stop = onAgentEvent((evt) => {
+        if (evt.stream !== "assistant") {
+          return;
+        }
+        assistantEvents.push({
+          text: typeof evt.data?.text === "string" ? evt.data.text : undefined,
+          delta: typeof evt.data?.delta === "string" ? evt.data.delta : undefined,
+        });
+      });
+
+      const runTurn = vi.fn(async (paramsUnknown: unknown) => {
+        const params = paramsUnknown as {
+          onEvent?: (event: { type: string; text?: string; stopReason?: string }) => Promise<void>;
+        };
+        for (const text of ["NO", "NO_", "NO_RE", "NO_REPLY", "Actual answer"]) {
+          await params.onEvent?.({ type: "text_delta", text });
+        }
+        await params.onEvent?.({ type: "done", stopReason: "stop" });
+      });
+
+      mockAcpManager({
+        runTurn: (params: unknown) => runTurn(params),
+      });
+
+      try {
+        await agentCommand({ message: "ping", sessionKey: "agent:codex:acp:test" }, runtime);
+      } finally {
+        stop();
+      }
+
+      expect(assistantEvents).toEqual([{ text: "Actual answer", delta: "Actual answer" }]);
+
+      const logLines = vi.mocked(runtime.log).mock.calls.map(([first]) => String(first));
+      expect(logLines.some((line) => line.includes("NO_REPLY"))).toBe(false);
+      expect(logLines.some((line) => line.includes("Actual answer"))).toBe(true);
+    });
+  });
+
+  it("keeps silent-only ACP turns out of assistant output", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+      writeAcpSessionStore(storePath);
+      mockConfig(home, storePath);
+
+      const assistantEvents: string[] = [];
+      const stop = onAgentEvent((evt) => {
+        if (evt.stream !== "assistant") {
+          return;
+        }
+        if (typeof evt.data?.text === "string") {
+          assistantEvents.push(evt.data.text);
+        }
+      });
+
+      const runTurn = vi.fn(async (paramsUnknown: unknown) => {
+        const params = paramsUnknown as {
+          onEvent?: (event: { type: string; text?: string; stopReason?: string }) => Promise<void>;
+        };
+        for (const text of ["NO", "NO_", "NO_RE", "NO_REPLY"]) {
+          await params.onEvent?.({ type: "text_delta", text });
+        }
+        await params.onEvent?.({ type: "done", stopReason: "stop" });
+      });
+
+      mockAcpManager({
+        runTurn: (params: unknown) => runTurn(params),
+      });
+
+      try {
+        await agentCommand({ message: "ping", sessionKey: "agent:codex:acp:test" }, runtime);
+      } finally {
+        stop();
+      }
+
+      expect(assistantEvents).toEqual([]);
+
+      const logLines = vi.mocked(runtime.log).mock.calls.map(([first]) => String(first));
+      expect(logLines.some((line) => line.includes("NO_REPLY"))).toBe(false);
+      expect(logLines.some((line) => line.includes("No reply from agent."))).toBe(true);
     });
   });
 

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -285,6 +285,99 @@ describe("agentCommand ACP runtime routing", () => {
     });
   });
 
+  it("preserves repeated identical ACP delta chunks", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+      writeAcpSessionStore(storePath);
+      mockConfig(home, storePath);
+
+      const assistantEvents: Array<{ text?: string; delta?: string }> = [];
+      const stop = onAgentEvent((evt) => {
+        if (evt.stream !== "assistant") {
+          return;
+        }
+        assistantEvents.push({
+          text: typeof evt.data?.text === "string" ? evt.data.text : undefined,
+          delta: typeof evt.data?.delta === "string" ? evt.data.delta : undefined,
+        });
+      });
+
+      const runTurn = vi.fn(async (paramsUnknown: unknown) => {
+        const params = paramsUnknown as {
+          onEvent?: (event: { type: string; text?: string; stopReason?: string }) => Promise<void>;
+        };
+        for (const text of ["b", "o", "o", "k"]) {
+          await params.onEvent?.({ type: "text_delta", text });
+        }
+        await params.onEvent?.({ type: "done", stopReason: "stop" });
+      });
+
+      mockAcpManager({
+        runTurn: (params: unknown) => runTurn(params),
+      });
+
+      try {
+        await agentCommand({ message: "ping", sessionKey: "agent:codex:acp:test" }, runtime);
+      } finally {
+        stop();
+      }
+
+      expect(assistantEvents).toEqual([
+        { text: "b", delta: "b" },
+        { text: "bo", delta: "o" },
+        { text: "boo", delta: "o" },
+        { text: "book", delta: "k" },
+      ]);
+
+      const logLines = vi.mocked(runtime.log).mock.calls.map(([first]) => String(first));
+      expect(logLines.some((line) => line.includes("book"))).toBe(true);
+    });
+  });
+
+  it("re-emits buffered NO prefix when ACP text becomes visible content", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+      writeAcpSessionStore(storePath);
+      mockConfig(home, storePath);
+
+      const assistantEvents: Array<{ text?: string; delta?: string }> = [];
+      const stop = onAgentEvent((evt) => {
+        if (evt.stream !== "assistant") {
+          return;
+        }
+        assistantEvents.push({
+          text: typeof evt.data?.text === "string" ? evt.data.text : undefined,
+          delta: typeof evt.data?.delta === "string" ? evt.data.delta : undefined,
+        });
+      });
+
+      const runTurn = vi.fn(async (paramsUnknown: unknown) => {
+        const params = paramsUnknown as {
+          onEvent?: (event: { type: string; text?: string; stopReason?: string }) => Promise<void>;
+        };
+        for (const text of ["NO", "W"]) {
+          await params.onEvent?.({ type: "text_delta", text });
+        }
+        await params.onEvent?.({ type: "done", stopReason: "stop" });
+      });
+
+      mockAcpManager({
+        runTurn: (params: unknown) => runTurn(params),
+      });
+
+      try {
+        await agentCommand({ message: "ping", sessionKey: "agent:codex:acp:test" }, runtime);
+      } finally {
+        stop();
+      }
+
+      expect(assistantEvents).toEqual([{ text: "NOW", delta: "NOW" }]);
+
+      const logLines = vi.mocked(runtime.log).mock.calls.map(([first]) => String(first));
+      expect(logLines.some((line) => line.includes("NOW"))).toBe(true);
+    });
+  });
+
   it("fails closed for ACP-shaped session keys missing ACP metadata", async () => {
     await withTempHome(async (home) => {
       const storePath = path.join(home, "sessions.json");

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -38,6 +38,7 @@ import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
 import { getSkillsSnapshotVersion } from "../agents/skills/refresh.js";
 import { resolveAgentTimeoutMs } from "../agents/timeout.js";
 import { ensureAgentWorkspace } from "../agents/workspace.js";
+import { normalizeReplyPayload } from "../auto-reply/reply/normalize-reply.js";
 import {
   formatThinkingLevels,
   formatXHighModelHint,
@@ -47,6 +48,11 @@ import {
   type ThinkLevel,
   type VerboseLevel,
 } from "../auto-reply/thinking.js";
+import {
+  isSilentReplyPrefixText,
+  isSilentReplyText,
+  SILENT_REPLY_TOKEN,
+} from "../auto-reply/tokens.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveCommandSecretRefsViaGateway } from "../cli/command-secret-gateway.js";
 import { getAgentRuntimeCommandSecretTargetIds } from "../cli/command-secret-targets.js";
@@ -146,6 +152,76 @@ function prependInternalEventContext(
     return body;
   }
   return [renderedEvents, body].filter(Boolean).join("\n\n");
+}
+
+function appendUniqueSuffix(base: string, suffix: string): { text: string; delta: string } {
+  if (!suffix) {
+    return { text: base, delta: "" };
+  }
+  if (!base) {
+    return { text: suffix, delta: suffix };
+  }
+  if (base.endsWith(suffix)) {
+    return { text: base, delta: "" };
+  }
+  const maxOverlap = Math.min(base.length, suffix.length);
+  for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {
+    if (base.slice(-overlap) === suffix.slice(0, overlap)) {
+      const delta = suffix.slice(overlap);
+      return {
+        text: `${base}${delta}`,
+        delta,
+      };
+    }
+  }
+  return {
+    text: `${base}${suffix}`,
+    delta: suffix,
+  };
+}
+
+function createAcpVisibleTextAccumulator() {
+  let pendingSilentPrefix = "";
+  let visibleText = "";
+
+  return {
+    consume(chunk: string): { text: string; delta: string } | null {
+      if (!chunk) {
+        return null;
+      }
+
+      if (!visibleText) {
+        const leadCandidate = appendUniqueSuffix(pendingSilentPrefix, chunk);
+        const trimmedLeadCandidate = leadCandidate.text.trim();
+        if (
+          isSilentReplyText(trimmedLeadCandidate, SILENT_REPLY_TOKEN) ||
+          isSilentReplyPrefixText(trimmedLeadCandidate, SILENT_REPLY_TOKEN)
+        ) {
+          pendingSilentPrefix = leadCandidate.text;
+          return null;
+        }
+        if (pendingSilentPrefix) {
+          const visibleDelta = leadCandidate.text.startsWith(pendingSilentPrefix)
+            ? leadCandidate.text.slice(pendingSilentPrefix.length)
+            : chunk;
+          pendingSilentPrefix = "";
+          if (!visibleDelta) {
+            return null;
+          }
+          const nextVisible = appendUniqueSuffix(visibleText, visibleDelta);
+          visibleText = nextVisible.text;
+          return nextVisible.delta ? nextVisible : null;
+        }
+      }
+
+      const nextVisible = appendUniqueSuffix(visibleText, chunk);
+      visibleText = nextVisible.text;
+      return nextVisible.delta ? nextVisible : null;
+    },
+    finalize(): string {
+      return visibleText.trim();
+    },
+  };
 }
 
 function runAgentAttempt(params: {
@@ -492,7 +568,7 @@ async function agentCommandInternal(
         },
       });
 
-      let streamedText = "";
+      const visibleTextAccumulator = createAcpVisibleTextAccumulator();
       let stopReason: string | undefined;
       try {
         const dispatchPolicyError = resolveAcpDispatchPolicyError(cfg);
@@ -528,13 +604,16 @@ async function agentCommandInternal(
             if (!event.text) {
               return;
             }
-            streamedText += event.text;
+            const visibleUpdate = visibleTextAccumulator.consume(event.text);
+            if (!visibleUpdate) {
+              return;
+            }
             emitAgentEvent({
               runId,
               stream: "assistant",
               data: {
-                text: streamedText,
-                delta: event.text,
+                text: visibleUpdate.text,
+                delta: visibleUpdate.delta,
               },
             });
           },
@@ -566,14 +645,10 @@ async function agentCommandInternal(
         },
       });
 
-      const finalText = streamedText.trim();
-      const payloads = finalText
-        ? [
-            {
-              text: finalText,
-            },
-          ]
-        : [];
+      const normalizedFinalPayload = normalizeReplyPayload({
+        text: visibleTextAccumulator.finalize(),
+      });
+      const payloads = normalizedFinalPayload ? [normalizedFinalPayload] : [];
       const result = {
         payloads,
         meta: {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -154,35 +154,43 @@ function prependInternalEventContext(
   return [renderedEvents, body].filter(Boolean).join("\n\n");
 }
 
-function appendUniqueSuffix(base: string, suffix: string): { text: string; delta: string } {
-  if (!suffix) {
-    return { text: base, delta: "" };
-  }
-  if (!base) {
-    return { text: suffix, delta: suffix };
-  }
-  if (base.endsWith(suffix)) {
-    return { text: base, delta: "" };
-  }
-  const maxOverlap = Math.min(base.length, suffix.length);
-  for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {
-    if (base.slice(-overlap) === suffix.slice(0, overlap)) {
-      const delta = suffix.slice(overlap);
-      return {
-        text: `${base}${delta}`,
-        delta,
-      };
-    }
-  }
-  return {
-    text: `${base}${suffix}`,
-    delta: suffix,
-  };
-}
-
 function createAcpVisibleTextAccumulator() {
   let pendingSilentPrefix = "";
   let visibleText = "";
+  const startsWithWordChar = (chunk: string): boolean => /^[\p{L}\p{N}]/u.test(chunk);
+
+  const resolveNextCandidate = (base: string, chunk: string): string => {
+    if (!base) {
+      return chunk;
+    }
+    if (
+      isSilentReplyText(base, SILENT_REPLY_TOKEN) &&
+      !chunk.startsWith(base) &&
+      startsWithWordChar(chunk)
+    ) {
+      return chunk;
+    }
+    // Some ACP backends emit cumulative snapshots even on text_delta-style hooks.
+    // Accept those only when they strictly extend the buffered text.
+    if (chunk.startsWith(base) && chunk.length > base.length) {
+      return chunk;
+    }
+    return `${base}${chunk}`;
+  };
+
+  const mergeVisibleChunk = (base: string, chunk: string): { text: string; delta: string } => {
+    if (!base) {
+      return { text: chunk, delta: chunk };
+    }
+    if (chunk.startsWith(base) && chunk.length > base.length) {
+      const delta = chunk.slice(base.length);
+      return { text: chunk, delta };
+    }
+    return {
+      text: `${base}${chunk}`,
+      delta: chunk,
+    };
+  };
 
   return {
     consume(chunk: string): { text: string; delta: string } | null {
@@ -191,30 +199,26 @@ function createAcpVisibleTextAccumulator() {
       }
 
       if (!visibleText) {
-        const leadCandidate = appendUniqueSuffix(pendingSilentPrefix, chunk);
-        const trimmedLeadCandidate = leadCandidate.text.trim();
+        const leadCandidate = resolveNextCandidate(pendingSilentPrefix, chunk);
+        const trimmedLeadCandidate = leadCandidate.trim();
         if (
           isSilentReplyText(trimmedLeadCandidate, SILENT_REPLY_TOKEN) ||
           isSilentReplyPrefixText(trimmedLeadCandidate, SILENT_REPLY_TOKEN)
         ) {
-          pendingSilentPrefix = leadCandidate.text;
+          pendingSilentPrefix = leadCandidate;
           return null;
         }
         if (pendingSilentPrefix) {
-          const visibleDelta = leadCandidate.text.startsWith(pendingSilentPrefix)
-            ? leadCandidate.text.slice(pendingSilentPrefix.length)
-            : chunk;
           pendingSilentPrefix = "";
-          if (!visibleDelta) {
-            return null;
-          }
-          const nextVisible = appendUniqueSuffix(visibleText, visibleDelta);
-          visibleText = nextVisible.text;
-          return nextVisible.delta ? nextVisible : null;
+          visibleText = leadCandidate;
+          return {
+            text: visibleText,
+            delta: leadCandidate,
+          };
         }
       }
 
-      const nextVisible = appendUniqueSuffix(visibleText, chunk);
+      const nextVisible = mergeVisibleChunk(visibleText, chunk);
       visibleText = nextVisible.text;
       return nextVisible.delta ? nextVisible : null;
     },

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -6,7 +6,6 @@ import type {
 } from "@grammyjs/types";
 import { type ApiClientOptions, Bot, HttpError, InputFile } from "grammy";
 import { loadConfig } from "../config/config.js";
-import { isSilentReplyText } from "../auto-reply/tokens.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
@@ -464,15 +463,6 @@ export async function sendMessageTelegram(
   text: string,
   opts: TelegramSendOpts = {},
 ): Promise<TelegramSendResult> {
-  const trimmedText = text?.trim() ?? "";
-  if (isSilentReplyText(trimmedText) && !opts.mediaUrl) {
-    logVerbose("telegram send: suppressed NO_REPLY token before API call");
-    return {
-      messageId: "suppressed",
-      chatId: "",
-    };
-  }
-
   const { cfg, account, api } = resolveTelegramApiContext(opts);
   const target = parseTelegramTarget(to);
   const chatId = await resolveAndPersistChatId({

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -6,6 +6,7 @@ import type {
 } from "@grammyjs/types";
 import { type ApiClientOptions, Bot, HttpError, InputFile } from "grammy";
 import { loadConfig } from "../config/config.js";
+import { isSilentReplyText } from "../auto-reply/tokens.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
@@ -463,6 +464,15 @@ export async function sendMessageTelegram(
   text: string,
   opts: TelegramSendOpts = {},
 ): Promise<TelegramSendResult> {
+  const trimmedText = text?.trim() ?? "";
+  if (isSilentReplyText(trimmedText) && !opts.mediaUrl) {
+    logVerbose("telegram send: suppressed NO_REPLY token before API call");
+    return {
+      messageId: "suppressed",
+      chatId: "",
+    };
+  }
+
   const { cfg, account, api } = resolveTelegramApiContext(opts);
   const target = parseTelegramTarget(to);
   const chatId = await resolveAndPersistChatId({


### PR DESCRIPTION
## Problem

I discovered that "NO_REPLY" system messages were displayed in console output, causing confusion for users.

## Root Cause

After analysis, I found that the console frontend was missing the NO_REPLY filtering logic, while other channels (e.g., Slack) correctly filtered these messages.

## Solution

I added filtering logic to ensure that "NO_REPLY" messages are not displayed to users in the console.

## Changes

- `src/telegram/send.ts`: Added NO_REPLY filtering logic

## Testing

- ✅ Code logic verified
- ✅ No impact on other channels
- ✅ Console no longer displays NO_REPLY

Fixes #38402