### PR TITLE
fix: handle wakeOnDescendantSettle in resumeSubagentRun

### DIFF
--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -560,7 +560,16 @@ function resumeSubagentRun(runId: string) {
     return;
   }
   if (entry.cleanupCompletedAt) {
-    return;
+    // If wakeOnDescendantSettle is true, we need to send the announce
+    // even though cleanupCompletedAt is already set. This handles the case
+    // where descendant runs completed after this run was deferred.
+    if (entry.wakeOnDescendantSettle) {
+      entry.wakeOnDescendantSettle = false;
+      persistSubagentRuns();
+      // Continue to announce flow below
+    } else {
+      return;
+    }
   }
   // Skip entries that have exhausted their retry budget or expired (#18264).
   if ((entry.announceRetryCount ?? 0) >= MAX_ANNOUNCE_RETRY_COUNT) {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -564,7 +564,8 @@ function resumeSubagentRun(runId: string) {
     // even though cleanupCompletedAt is already set. This handles the case
     // where descendant runs completed after this run was deferred.
     if (entry.wakeOnDescendantSettle) {
-      entry.wakeOnDescendantSettle = false;
+      entry.wakeOnDescendantSettle = undefined;
+      entry.cleanupCompletedAt = undefined;
       persistSubagentRuns();
       // Continue to announce flow below
     } else {


### PR DESCRIPTION
## Summary

Fixes the issue where subagent completion notifications were not sent when the subagent spawned descendant (grandchild) agents and waited for them to complete.

## Problem

When a subagent spawns descendant agents and waits for them:
1. The subagent completes its task, but descendant agents are still running
2. The subagent enters `defer-descendants` state, waiting 1 second to retry
3. During this time, descendants complete and `cleanupCompletedAt` is set
4. 1 second later, `resumeSubagentRun` is called, but it checks `cleanupCompletedAt` is already set and returns early
5. The subagent's completion announcement is silently dropped

## Solution

Modified `resumeSubagentRun` in `src/agents/subagent-registry.ts` to continue to the announcement flow when `wakeOnDescendantSettle = true`, even if `cleanupCompletedAt` is already set.

## Testing

- Simple subagent task: ✅ notification sent
- Nested subagent (with grandchildren): ✅ notification sent
- Complex task: ✅ notification sent

## Related

- Fixes issue where subagent completion notifications were not sent to main conversation

## AI Assistance

- [x] This PR is AI-assisted
- [x] Testing level: fully tested
- [x] I understand what the code does