### PR TITLE
fix: respect session modelOverride in followup/auto-reply fallback resolution

### DIFF
--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -2,13 +2,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { FollowupRun } from "./queue.js";
 
 const hoisted = vi.hoisted(() => {
-  const resolveRunModelFallbacksOverrideMock = vi.fn();
-  return { resolveRunModelFallbacksOverrideMock };
+  const resolveEffectiveModelFallbacksMock = vi.fn();
+  const resolveFallbackAgentIdMock = vi.fn();
+  const resolveDefaultModelForAgentMock = vi.fn();
+  return {
+    resolveEffectiveModelFallbacksMock,
+    resolveFallbackAgentIdMock,
+    resolveDefaultModelForAgentMock,
+  };
 });
 
 vi.mock("../../agents/agent-scope.js", () => ({
-  resolveRunModelFallbacksOverride: (...args: unknown[]) =>
-    hoisted.resolveRunModelFallbacksOverrideMock(...args),
+  resolveEffectiveModelFallbacks: (...args: unknown[]) =>
+    hoisted.resolveEffectiveModelFallbacksMock(...args),
+  resolveFallbackAgentId: (...args: unknown[]) => hoisted.resolveFallbackAgentIdMock(...args),
+}));
+
+vi.mock("../../agents/model-selection.js", () => ({
+  resolveDefaultModelForAgent: (...args: unknown[]) =>
+    hoisted.resolveDefaultModelForAgentMock(...args),
 }));
 
 const {
@@ -44,19 +56,31 @@ function makeRun(overrides: Partial<FollowupRun["run"]> = {}): FollowupRun["run"
 
 describe("agent-runner-utils", () => {
   beforeEach(() => {
-    hoisted.resolveRunModelFallbacksOverrideMock.mockClear();
+    hoisted.resolveEffectiveModelFallbacksMock.mockClear();
+    hoisted.resolveFallbackAgentIdMock.mockClear();
+    hoisted.resolveDefaultModelForAgentMock.mockClear();
+    // Default: configured primary matches run model (no session override).
+    hoisted.resolveFallbackAgentIdMock.mockReturnValue("agent-1");
+    hoisted.resolveDefaultModelForAgentMock.mockReturnValue({
+      provider: "openai",
+      model: "gpt-4.1",
+    });
   });
 
   it("resolves model fallback options from run context", () => {
-    hoisted.resolveRunModelFallbacksOverrideMock.mockReturnValue(["fallback-model"]);
+    hoisted.resolveEffectiveModelFallbacksMock.mockReturnValue(["fallback-model"]);
     const run = makeRun();
 
     const resolved = resolveModelFallbackOptions(run);
 
-    expect(hoisted.resolveRunModelFallbacksOverrideMock).toHaveBeenCalledWith({
-      cfg: run.config,
+    expect(hoisted.resolveFallbackAgentIdMock).toHaveBeenCalledWith({
       agentId: run.agentId,
       sessionKey: run.sessionKey,
+    });
+    expect(hoisted.resolveEffectiveModelFallbacksMock).toHaveBeenCalledWith({
+      cfg: run.config,
+      agentId: "agent-1",
+      hasSessionModelOverride: false,
     });
     expect(resolved).toEqual({
       cfg: run.config,
@@ -68,17 +92,106 @@ describe("agent-runner-utils", () => {
   });
 
   it("passes through missing agentId for helper-based fallback resolution", () => {
-    hoisted.resolveRunModelFallbacksOverrideMock.mockReturnValue(["fallback-model"]);
+    hoisted.resolveEffectiveModelFallbacksMock.mockReturnValue(["fallback-model"]);
+    hoisted.resolveFallbackAgentIdMock.mockReturnValue("default");
     const run = makeRun({ agentId: undefined });
 
     const resolved = resolveModelFallbackOptions(run);
 
-    expect(hoisted.resolveRunModelFallbacksOverrideMock).toHaveBeenCalledWith({
-      cfg: run.config,
+    expect(hoisted.resolveFallbackAgentIdMock).toHaveBeenCalledWith({
       agentId: undefined,
       sessionKey: run.sessionKey,
     });
     expect(resolved.fallbacksOverride).toEqual(["fallback-model"]);
+  });
+
+  it("detects session model override when provider differs from agent-aware primary", () => {
+    hoisted.resolveEffectiveModelFallbacksMock.mockReturnValue(["anthropic/claude-haiku-3-5"]);
+    hoisted.resolveDefaultModelForAgentMock.mockReturnValue({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+    });
+    const run = makeRun({
+      provider: "openrouter",
+      model: "meta-llama/llama-3.3-70b-instruct:free",
+    });
+
+    resolveModelFallbackOptions(run);
+
+    expect(hoisted.resolveEffectiveModelFallbacksMock).toHaveBeenCalledWith(
+      expect.objectContaining({ hasSessionModelOverride: true }),
+    );
+  });
+
+  it("detects session model override when model differs from agent-aware primary", () => {
+    hoisted.resolveEffectiveModelFallbacksMock.mockReturnValue(["anthropic/claude-haiku-3-5"]);
+    hoisted.resolveDefaultModelForAgentMock.mockReturnValue({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+    });
+    const run = makeRun({
+      provider: "openai",
+      model: "gpt-5.3-codex",
+    });
+
+    resolveModelFallbackOptions(run);
+
+    expect(hoisted.resolveEffectiveModelFallbacksMock).toHaveBeenCalledWith(
+      expect.objectContaining({ hasSessionModelOverride: true }),
+    );
+  });
+
+  it("does not flag session model override when run matches agent-aware primary", () => {
+    hoisted.resolveEffectiveModelFallbacksMock.mockReturnValue(undefined);
+    hoisted.resolveDefaultModelForAgentMock.mockReturnValue({
+      provider: "openai",
+      model: "gpt-4.1",
+    });
+    const run = makeRun({
+      provider: "openai",
+      model: "gpt-4.1",
+    });
+
+    resolveModelFallbackOptions(run);
+
+    expect(hoisted.resolveEffectiveModelFallbacksMock).toHaveBeenCalledWith(
+      expect.objectContaining({ hasSessionModelOverride: false }),
+    );
+  });
+
+  it("does not flag per-agent model.primary as a session override", () => {
+    // Simulate an agent configured with its own model.primary (anthropic/claude-sonnet-4)
+    // that differs from the global default (openai/gpt-4.1).
+    // resolveDefaultModelForAgent returns the per-agent primary, so the run model
+    // should match and hasSessionModelOverride should be false.
+    hoisted.resolveEffectiveModelFallbacksMock.mockReturnValue(undefined);
+    hoisted.resolveDefaultModelForAgentMock.mockReturnValue({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+    });
+    const run = makeRun({
+      provider: "anthropic",
+      model: "claude-sonnet-4-20250514",
+    });
+
+    resolveModelFallbackOptions(run);
+
+    expect(hoisted.resolveDefaultModelForAgentMock).toHaveBeenCalledWith({
+      cfg: run.config,
+      agentId: run.agentId,
+    });
+    expect(hoisted.resolveEffectiveModelFallbacksMock).toHaveBeenCalledWith(
+      expect.objectContaining({ hasSessionModelOverride: false }),
+    );
+  });
+
+  it("returns undefined fallbacksOverride when cfg is falsy", () => {
+    const run = makeRun({ config: undefined } as unknown as Partial<FollowupRun["run"]>);
+
+    const resolved = resolveModelFallbackOptions(run);
+
+    expect(resolved.fallbacksOverride).toBeUndefined();
+    expect(hoisted.resolveEffectiveModelFallbacksMock).not.toHaveBeenCalled();
   });
 
   it("builds embedded run base params with auth profile and run metadata", () => {

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -1,4 +1,8 @@
-import { resolveRunModelFallbacksOverride } from "../../agents/agent-scope.js";
+import {
+  resolveEffectiveModelFallbacks,
+  resolveFallbackAgentId,
+} from "../../agents/agent-scope.js";
+import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
 import type { NormalizedUsage } from "../../agents/usage.js";
 import { getChannelDock } from "../../channels/dock.js";
 import type { ChannelId, ChannelThreadingToolContext } from "../../channels/plugins/types.js";
@@ -147,16 +151,36 @@ export const resolveEnforceFinalTag = (run: FollowupRun["run"], provider: string
   Boolean(run.enforceFinalTag || isReasoningTagProvider(provider));
 
 export function resolveModelFallbackOptions(run: FollowupRun["run"]) {
+  const cfg = run.config;
+  const agentId = resolveFallbackAgentId({
+    agentId: run.agentId,
+    sessionKey: run.sessionKey,
+  });
+
+  // Detect whether the run's model differs from the agent-aware configured
+  // primary.  `resolveDefaultModelForAgent` factors in per-agent
+  // `model.primary` entries under `agents.list[n]` before falling back to
+  // the global `agents.defaults.model`, so agents with their own primary
+  // are not incorrectly flagged as having a session override.
+  // This mirrors the intent of `commands/agent.ts` which reads
+  // `sessionEntry.modelOverride` directly.
+  const configuredPrimary = cfg ? resolveDefaultModelForAgent({ cfg, agentId: run.agentId }) : null;
+  const hasSessionModelOverride = configuredPrimary
+    ? run.provider !== configuredPrimary.provider || run.model !== configuredPrimary.model
+    : false;
+
   return {
-    cfg: run.config,
+    cfg,
     provider: run.provider,
     model: run.model,
     agentDir: run.agentDir,
-    fallbacksOverride: resolveRunModelFallbacksOverride({
-      cfg: run.config,
-      agentId: run.agentId,
-      sessionKey: run.sessionKey,
-    }),
+    fallbacksOverride: cfg
+      ? resolveEffectiveModelFallbacks({
+          cfg,
+          agentId,
+          hasSessionModelOverride,
+        })
+      : undefined,
   };
 }
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import { resolveRunModelFallbacksOverride } from "../../agents/agent-scope.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
@@ -15,7 +14,7 @@ import { stripHeartbeatToken } from "../heartbeat.js";
 import type { OriginatingChannelType } from "../templating.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
-import { resolveRunAuthProfile } from "./agent-runner-utils.js";
+import { resolveModelFallbackOptions, resolveRunAuthProfile } from "./agent-runner-utils.js";
 import {
   resolveOriginAccountId,
   resolveOriginMessageProvider,
@@ -156,15 +155,7 @@ export function createFollowupRunner(params: {
       );
       try {
         const fallbackResult = await runWithModelFallback({
-          cfg: queued.run.config,
-          provider: queued.run.provider,
-          model: queued.run.model,
-          agentDir: queued.run.agentDir,
-          fallbacksOverride: resolveRunModelFallbacksOverride({
-            cfg: queued.run.config,
-            agentId: queued.run.agentId,
-            sessionKey: queued.run.sessionKey,
-          }),
+          ...resolveModelFallbackOptions(queued.run),
           run: async (provider, model, runOptions) => {
             const authProfile = resolveRunAuthProfile(queued.run, provider);
             const result = await runEmbeddedPiAgent({


### PR DESCRIPTION
## What

Fixes #38394.

Replace `resolveRunModelFallbacksOverride` with `resolveEffectiveModelFallbacks` in the auto-reply and followup code paths so that session model overrides are respected during 429 fallback retries.

### Changes

- **`agent-runner-utils.ts`** — `resolveModelFallbackOptions` now calls `resolveEffectiveModelFallbacks` (instead of `resolveRunModelFallbacksOverride`). It detects session model overrides by comparing the run's `provider`/`model` against `resolveDefaultModelForAgent` (which correctly factors in per-agent `model.primary` entries) rather than `resolveConfiguredModelRef` (which only reads the global default). This avoids false positives for agents with per-agent model configurations.
- **`followup-runner.ts`** — The duplicated fallback-resolution logic is replaced by reusing `resolveModelFallbackOptions` from `agent-runner-utils.ts`, keeping both paths in sync and preventing future drift.
- **`agent-runner-utils.test.ts`** — Updated mocks to use `resolveDefaultModelForAgentMock` and added 4 new test cases covering cross-provider override detection, same-provider model override detection, no-override baseline, and specifically verifying that per-agent `model.primary` configurations are not incorrectly flagged as session overrides.

## Why

When a session has a model override (e.g., set via `sessions.patch` or `sessions_spawn model=...`), and the overridden model hits a 429 rate limit, the followup retry mechanism was selecting a different model from `agents.defaults.model.fallbacks` instead of retrying with the session's configured override.

This occurred because the auto-reply and followup paths used `resolveRunModelFallbacksOverride`, which is unaware of session model overrides. When the session model override differed from the agent's configured primary model (cross-provider), `resolveFallbackCandidates` returned an empty fallback list, causing the system to fall through to the default fallback chain.

The CLI path (`commands/agent.ts`) already handled this correctly via `resolveEffectiveModelFallbacks`. This PR brings the auto-reply/followup paths into alignment while ensuring multi-agent setups with per-agent model configurations are not negatively impacted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- Updated existing unit tests in `agent-runner-utils.test.ts` to verify session model override detection and correct fallback resolution (10 tests, 5 new).
- All related test suites pass: `agent-runner-utils.test.ts` (10/10), `model-fallback.test.ts` (56/56), `agent-scope.test.ts` (15/15).
- Linting (`oxlint`) and formatting (`oxfmt`) pass with zero warnings and zero errors.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## AI Disclosure

This PR was developed with AI assistance. Degree of testing: **fully tested** — all unit tests pass, lint and format checks pass. I confirm I understand what the code does: the fix replaces `resolveRunModelFallbacksOverride` with `resolveEffectiveModelFallbacks` in two call sites, passing `hasSessionModelOverride` so `resolveFallbackCandidates` correctly includes the configured fallback models when a session model override is active. It uses `resolveDefaultModelForAgent` to ensure per-agent model configurations are not misidentified as session overrides.
