### PR TITLE
fix(macos): set speech recognition taskHint for Talk Mode mic capture

### DIFF
--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -178,6 +178,7 @@ actor TalkModeRuntime {
 
         self.recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
         self.recognitionRequest?.shouldReportPartialResults = true
+        self.recognitionRequest?.taskHint = .dictation
         guard let request = self.recognitionRequest else { return }
 
         if self.audioEngine == nil {


### PR DESCRIPTION
## Summary
Set the `taskHint` property on the speech recognition request for Talk Mode on macOS. This improves recognition accuracy by telling the system the audio is coming from a dictation/conversation context.

## Motivation
Without the task hint, macOS speech recognition may optimize for the wrong use case (e.g., search queries vs. dictation), resulting in lower transcription quality during Talk Mode sessions.

## Changes
- Added `taskHint` configuration to the speech recognition request