### PR TITLE
fix: downgrade cross-origin duplicate plugin warning to info

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -130,7 +130,7 @@ afterEach(() => {
 });
 
 describe("loadPluginManifestRegistry", () => {
-  it("emits duplicate warning for truly distinct plugins with same id", () => {
+  it("emits info (not warn) for distinct plugins with same id but different origins", () => {
     const dirA = makeTempDir();
     const dirB = makeTempDir();
     const manifest = { id: "test-plugin", configSchema: { type: "object" } };
@@ -150,7 +150,44 @@ describe("loadPluginManifestRegistry", () => {
       }),
     ];
 
-    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
+    const registry = loadRegistry(candidates);
+    // No warn-level duplicate diagnostics — cross-origin duplicates are info.
+    expect(countDuplicateWarnings(registry)).toBe(0);
+    // Both records are kept (the loader handles final dedup).
+    expect(registry.plugins.filter((p) => p.id === "test-plugin")).toHaveLength(2);
+    // An info-level diagnostic is emitted.
+    expect(
+      registry.diagnostics.some(
+        (d) =>
+          d.level === "info" &&
+          d.pluginId === "test-plugin" &&
+          d.message?.includes("multiple locations"),
+      ),
+    ).toBe(true);
+  });
+
+  it("emits warn for distinct plugins with same id and same origin", () => {
+    const dirA = makeTempDir();
+    const dirB = makeTempDir();
+    const manifest = { id: "dup-origin", configSchema: { type: "object" } };
+    writeManifest(dirA, manifest);
+    writeManifest(dirB, manifest);
+
+    const candidates: PluginCandidate[] = [
+      createPluginCandidate({
+        idHint: "dup-origin",
+        rootDir: dirA,
+        origin: "global",
+      }),
+      createPluginCandidate({
+        idHint: "dup-origin",
+        rootDir: dirB,
+        origin: "global",
+      }),
+    ];
+
+    const registry = loadRegistry(candidates);
+    expect(countDuplicateWarnings(registry)).toBe(1);
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -229,11 +229,20 @@ export function loadPluginManifestRegistry(params: {
         }
         continue;
       }
+
+      // Different directories, same plugin id.  When the duplicates come
+      // from different origin tiers (e.g. bundled + global installed via
+      // `openclaw configure`) this is expected — the loader will pick the
+      // right one.  Only warn when both share the *same* origin, which
+      // signals an actual misconfiguration.
+      const sameOriginTier = candidate.origin === existing.candidate.origin;
       diagnostics.push({
-        level: "warn",
+        level: sameOriginTier ? "warn" : "info",
         pluginId: manifest.id,
         source: candidate.source,
-        message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
+        message: sameOriginTier
+          ? `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`
+          : `plugin "${manifest.id}" found in multiple locations (${existing.candidate.origin} + ${candidate.origin}); the loader will resolve precedence`,
       });
     } else {
       seenIds.set(manifest.id, { candidate, recordIndex: records.length });

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -302,7 +302,7 @@ export type OpenClawPluginApi = {
 export type PluginOrigin = "bundled" | "global" | "workspace" | "config";
 
 export type PluginDiagnostic = {
-  level: "warn" | "error";
+  level: "info" | "warn" | "error";
   message: string;
   pluginId?: string;
   source?: string;


### PR DESCRIPTION
## Summary

Fixes #38437

When a plugin is installed both as a bundled package and via `openclaw configure` (global extensions dir), the manifest registry emits a **warn-level** diagnostic:

> duplicate plugin id detected; later plugin may be overridden

This is confusing because the loader already handles cross-origin dedup correctly (preferring the appropriate origin). The warning implies misconfiguration when there is none.

## Changes

- **Downgrade to info** when duplicates come from different origin tiers (e.g. bundled + global). This is expected and resolved by the loader.
- **Keep warn** when duplicates share the same origin tier, which signals an actual misconfiguration.
- Updated tests to verify both behaviors.

## Testing

- `manifest-registry.test.ts`: 8/8 pass — new tests for cross-origin (info) and same-origin (warn)
- `loader.test.ts`: 38/38 pass — existing dedup behavior unchanged