### PR TITLE
feat(feishu): add share_chat_id param to feishu_doc create

### DIFF
--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -49,6 +49,12 @@ export const FeishuDocSchema = Type.Union([
           "Grant edit permission to the trusted requesting Feishu user from runtime context (default: true).",
       }),
     ),
+    share_chat_id: Type.Optional(
+      Type.String({
+        description:
+          "Grant edit permission to all members of this group chat (openchat). The chat_id (e.g. oc_xxx). Link sharing stays closed — only chat members can edit.",
+      }),
+    ),
   }),
   Type.Object({
     action: Type.Literal("list_blocks"),

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -751,7 +751,7 @@ async function createDoc(
   client: Lark.Client,
   title: string,
   folderToken?: string,
-  options?: { grantToRequester?: boolean; requesterOpenId?: string },
+  options?: { grantToRequester?: boolean; requesterOpenId?: string; shareChatId?: string },
 ) {
   const res = await client.docx.document.create({
     data: { title, folder_token: folderToken },
@@ -793,6 +793,28 @@ async function createDoc(
     }
   }
 
+  // Grant edit permission to a group chat (openchat) if requested
+  const shareChatId = options?.shareChatId?.trim();
+  let chatPermissionAdded = false;
+  let chatPermissionError: string | undefined;
+
+  if (shareChatId) {
+    try {
+      await client.drive.permissionMember.create({
+        path: { token: docToken },
+        params: { type: "docx", need_notification: false },
+        data: {
+          member_type: "openchat",
+          member_id: shareChatId,
+          perm: "edit",
+        },
+      });
+      chatPermissionAdded = true;
+    } catch (err) {
+      chatPermissionError = err instanceof Error ? err.message : String(err);
+    }
+  }
+
   return {
     document_id: docToken,
     title: doc?.title,
@@ -805,6 +827,11 @@ async function createDoc(
         requester_permission_skipped_reason: requesterPermissionSkippedReason,
       }),
       ...(requesterPermissionError && { requester_permission_error: requesterPermissionError }),
+    }),
+    ...(shareChatId && {
+      chat_permission_added: chatPermissionAdded,
+      share_chat_id: shareChatId,
+      ...(chatPermissionError && { chat_permission_error: chatPermissionError }),
     }),
   };
 }
@@ -1313,6 +1340,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                     await createDoc(client, p.title, p.folder_token, {
                       grantToRequester: p.grant_to_requester,
                       requesterOpenId: trustedRequesterOpenId,
+                      shareChatId: p.share_chat_id,
                     }),
                   );
                 case "list_blocks":


### PR DESCRIPTION
## What

Add an optional `share_chat_id` parameter to the `feishu_doc create` action that grants edit permission to all members of a Feishu group chat (`openchat`) during document creation — in a single tool call.

## Why

Currently, creating a document and granting group chat permissions requires two separate steps:
1. `feishu_doc create` to create the document
2. A manual API call to `drive.permissionMember.create` with `member_type: openchat`

This is a common pattern when agents create documents for group collaboration. Making it a single call is simpler and more reliable.

## How

- Added `share_chat_id` optional field to the `create` action in `doc-schema.ts`
- Extended `createDoc()` in `docx.ts` to call `drive.permissionMember.create` with `member_type: 'openchat'` when `share_chat_id` is provided
- Link sharing stays closed — only chat members can edit
- Returns `chat_permission_added: true/false` and `chat_permission_error` in the response
- No breaking changes: the parameter is optional, existing behavior is unchanged

## Usage

```json
{
  "action": "create",
  "title": "Team Document",
  "share_chat_id": "oc_xxx"
}
```

Response includes:
```json
{
  "document_id": "...",
  "chat_permission_added": true,
  "share_chat_id": "oc_xxx"
}
```

## Testing

Verified manually against Feishu API:
- Document created successfully
- Group chat added as editor collaborator (`member_type: openchat`, `perm: edit`)
- Group members can edit; non-members cannot access