### PR TITLE
Agents: add skill API rate-limit guardrail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,7 @@ Docs: https://docs.openclaw.ai
 - PI embedded runner/Feishu docs: propagate sender identity into embedded attempts so Feishu doc auto-grant restores requester access for embedded-runner executions. (#32915) thanks @cszhouwei.
 - Agents/usage normalization: normalize missing or partial assistant usage snapshots before compaction accounting so `openclaw agent --json` no longer crashes when provider payloads omit `totalTokens` or related usage fields. (#34977) thanks @sp-hk2ldn.
 - Venice/default model refresh: switch the built-in Venice default to `kimi-k2-5`, update onboarding aliasing, and refresh Venice provider docs/recommendations to match the current private and anonymized catalog. (from #12964) Fixes #20156. Thanks @sabrinaaquino and @vincentkoc.
+- Agents/skill API write pacing: add a global prompt guardrail that treats skill-driven external API writes as rate-limited by default, so runners prefer batched writes, avoid tight request loops, and respect `429`/`Retry-After`. Thanks @vincentkoc.
 
 ## 2026.3.2
 

--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -168,5 +168,7 @@ Common property formats for database items:
 
 - Page/database IDs are UUIDs (with or without dashes)
 - The API cannot set database view filters — that's UI-only
-- Rate limit: ~3 requests/second average
+- Rate limit: ~3 requests/second average, with `429 rate_limited` responses using `Retry-After`
+- Append block children: up to 100 children per request, up to two levels of nesting in a single append request
+- Payload size limits: up to 1000 block elements and 500KB overall
 - Use `is_inline: true` when creating data sources to embed them in pages

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -144,6 +144,9 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("## Skills (mandatory)");
     expect(prompt).toContain("<available_skills>");
+    expect(prompt).toContain(
+      "When a skill drives external API writes, assume rate limits: prefer fewer larger writes, avoid tight one-item loops, serialize bursts when possible, and respect 429/Retry-After.",
+    );
   });
 
   it("omits skills in minimal prompt mode when skillsPrompt is absent", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -29,6 +29,7 @@ function buildSkillsSection(params: { skillsPrompt?: string; readToolName: strin
     "- If multiple could apply: choose the most specific one, then read/follow it.",
     "- If none clearly apply: do not read any SKILL.md.",
     "Constraints: never read more than one skill up front; only read after selecting.",
+    "- When a skill drives external API writes, assume rate limits: prefer fewer larger writes, avoid tight one-item loops, serialize bursts when possible, and respect 429/Retry-After.",
     trimmed,
     "",
   ];


### PR DESCRIPTION
## Summary

- Problem: skill-driven API writes did not have a runner-level guardrail for external service rate limits.
- Why it matters: agents could fall into chatty write loops against APIs like Notion and hit avoidable 429s.
- What changed: added a single system-prompt rule telling agents to batch skill-driven API writes, avoid tight request loops, and respect `429`/`Retry-After`; added a changelog note.
- What did NOT change (scope boundary): no Notion-specific runtime/client was added and no skill metadata/prompt plumbing was introduced.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Agents now treat skill-driven external API writes as rate-limited by default, preferring larger batched writes and honoring `429` / `Retry-After` guidance.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local workspace
- Model/provider: n/a
- Integration/channel (if any): skills prompt pipeline
- Relevant config (redacted): default repo config

### Steps

1. Build the agent system prompt with a populated `skillsPrompt`.
2. Verify the Skills section includes the new rate-limit guardrail.
3. Run the focused agent/skills test suite.

### Expected

- The runner receives a single generic rate-limit instruction for skill-driven external API writes.
- Focused tests pass.

### Actual

- The prompt includes the new guardrail and focused tests passed locally.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: inspected the generated system prompt expectations in `src/agents/system-prompt.test.ts` and ran the focused prompt/skills test suite.
- Edge cases checked: ensured the change stays global and does not add new skill-specific metadata plumbing.
- What you did **not** verify: no live external API traffic was exercised.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the system-prompt guardrail commit.
- Files/config to restore: `src/agents/system-prompt.ts`, `src/agents/system-prompt.test.ts`
- Known bad symptoms reviewers should watch for: none beyond unexpected prompt wording regressions.

## Risks and Mitigations

- Risk: the generic prompt hint could be too broad for purely local skill work.
- Mitigation: the wording is limited to skill-driven external API writes only.
