### PR TITLE
fix(agents): allow all configured agents by default when allowAgents is not set

### DIFF
--- a/src/agents/openclaw-tools.agents.test.ts
+++ b/src/agents/openclaw-tools.agents.test.ts
@@ -50,9 +50,30 @@ describe("agents_list", () => {
     };
   });
 
-  it("defaults to the requester agent only", async () => {
+  it("defaults to all configured agents when allowAgents is not set", async () => {
+    setConfigWithAgentList([
+      { id: "main", name: "Main" },
+      { id: "research", name: "Research" },
+    ]);
+
     const tool = requireAgentsListTool();
     const result = await tool.execute("call1", {});
+    expect(result.details).toMatchObject({
+      requester: "main",
+      allowAny: true,
+    });
+    const agents = readAgentList(result);
+    expect(agents?.map((agent) => agent.id)).toEqual(["main", "research"]);
+  });
+
+  it("restricts to requester only when allowAgents is explicitly empty", async () => {
+    setConfigWithAgentList([
+      { id: "main", name: "Main", subagents: { allowAgents: [] } },
+      { id: "research", name: "Research" },
+    ]);
+
+    const tool = requireAgentsListTool();
+    const result = await tool.execute("call1b", {});
     expect(result.details).toMatchObject({
       requester: "main",
       allowAny: false,

--- a/src/agents/openclaw-tools.agents.test.ts
+++ b/src/agents/openclaw-tools.agents.test.ts
@@ -130,6 +130,43 @@ describe("agents_list", () => {
     expect(agents?.map((agent) => agent.id)).toEqual(["main", "coder", "research"]);
   });
 
+  it("returns only requester when agents.list is an empty array", async () => {
+    configOverride = {
+      session: createPerSenderSessionConfig(),
+      agents: {
+        list: [],
+      },
+    };
+
+    const tool = requireAgentsListTool();
+    const result = await tool.execute("call-empty-list", {});
+    const agents = readAgentList(result);
+    // Even with an empty list, the requester's own id should be present
+    expect(agents?.length).toBeLessThanOrEqual(1);
+  });
+
+  it("handles case-insensitive agent id matching in allowAgents", async () => {
+    setConfigWithAgentList([
+      {
+        id: "main",
+        name: "Main",
+        subagents: {
+          allowAgents: ["RESEARCH"],
+        },
+      },
+      {
+        id: "research",
+        name: "Research",
+      },
+    ]);
+
+    const tool = requireAgentsListTool();
+    const result = await tool.execute("call-case", {});
+    const agents = readAgentList(result);
+    const ids = agents?.map((agent) => agent.id) ?? [];
+    expect(ids).toContain("research");
+  });
+
   it("marks allowlisted-but-unconfigured agents", async () => {
     setConfigWithAgentList([
       {

--- a/src/agents/openclaw-tools.agents.test.ts
+++ b/src/agents/openclaw-tools.agents.test.ts
@@ -29,9 +29,9 @@ describe("agents_list", () => {
     };
   }
 
-  function requireAgentsListTool() {
+  function requireAgentsListTool(requesterAgentId = "main") {
     const tool = createOpenClawTools({
-      agentSessionKey: "main",
+      agentSessionKey: requesterAgentId,
     }).find((candidate) => candidate.name === "agents_list");
     if (!tool) {
       throw new Error("missing agents_list tool");
@@ -183,5 +183,22 @@ describe("agents_list", () => {
     expect(agents?.map((agent) => agent.id)).toEqual(["main", "research"]);
     const research = agents?.find((agent) => agent.id === "research");
     expect(research?.configured).toBe(false);
+  });
+
+  it("denies implicit allow when requester agent has no config entry", async () => {
+    setConfigWithAgentList([
+      {
+        id: "configured-agent",
+        name: "Configured",
+      },
+    ]);
+
+    // Requester "unknown-agent" has no config entry — should NOT get implicit
+    // allow-any, so configured-agent should not appear in its list.
+    const tool = requireAgentsListTool("unknown-agent");
+    const result = await tool.execute("call-unknown", {});
+    const agents = readAgentList(result);
+    const ids = agents?.map((agent) => agent.id) ?? [];
+    expect(ids).not.toContain("configured-agent");
   });
 });

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -352,10 +352,20 @@ export async function spawnSubagentDirect(
         .map((value) => normalizeAgentId(value).toLowerCase()),
     );
     if (!allowAny && !implicitAllow && !allowSet.has(normalizedTargetId)) {
-      const allowedText = allowSet.size > 0 ? Array.from(allowSet).join(", ") : "none";
+      const effectiveAllowed =
+        allowAgentsRaw === undefined
+          ? configuredIds
+          : allowSet.size > 0
+            ? Array.from(allowSet)
+            : [];
+      const allowedText = effectiveAllowed.length > 0 ? effectiveAllowed.join(", ") : "none";
+      const hint =
+        allowAgentsRaw === undefined
+          ? ` (no allowAgents configured — only configured agents are allowed: ${allowedText})`
+          : ` (allowed: ${allowedText})`;
       return {
         status: "forbidden",
-        error: `agentId is not allowed for sessions_spawn (allowed: ${allowedText})`,
+        error: `Agent "${targetAgentId}" is not allowed for sessions_spawn${hint}`,
       };
     }
   }

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -335,15 +335,23 @@ export async function spawnSubagentDirect(
   );
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
   if (targetAgentId !== requesterAgentId) {
-    const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
+    const allowAgentsRaw = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents;
+    const allowAgents = allowAgentsRaw ?? [];
     const allowAny = allowAgents.some((value) => value.trim() === "*");
     const normalizedTargetId = targetAgentId.toLowerCase();
+    // When allowAgents is not configured (undefined), allow all configured agents
+    // so they are discoverable out-of-the-box.
+    const configuredIds = Array.isArray(cfg.agents?.list)
+      ? cfg.agents.list.map((entry) => normalizeAgentId(entry.id).toLowerCase())
+      : [];
+    const implicitAllow =
+      allowAgentsRaw === undefined && configuredIds.includes(normalizedTargetId);
     const allowSet = new Set(
       allowAgents
         .filter((value) => value.trim() && value.trim() !== "*")
         .map((value) => normalizeAgentId(value).toLowerCase()),
     );
-    if (!allowAny && !allowSet.has(normalizedTargetId)) {
+    if (!allowAny && !implicitAllow && !allowSet.has(normalizedTargetId)) {
       const allowedText = allowSet.size > 0 ? Array.from(allowSet).join(", ") : "none";
       return {
         status: "forbidden",

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -335,17 +335,22 @@ export async function spawnSubagentDirect(
   );
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
   if (targetAgentId !== requesterAgentId) {
-    const allowAgentsRaw = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents;
+    const requesterConfig = resolveAgentConfig(cfg, requesterAgentId);
+    const allowAgentsRaw = requesterConfig?.subagents?.allowAgents;
     const allowAgents = allowAgentsRaw ?? [];
     const allowAny = allowAgents.some((value) => value.trim() === "*");
     const normalizedTargetId = targetAgentId.toLowerCase();
     // When allowAgents is not configured (undefined), allow all configured agents
-    // so they are discoverable out-of-the-box.
+    // so they are discoverable out-of-the-box — but only when the requester
+    // agent itself has a config entry.  Unknown/unconfigured requesters must
+    // not receive implicit allow.
     const configuredIds = Array.isArray(cfg.agents?.list)
       ? cfg.agents.list.map((entry) => normalizeAgentId(entry.id).toLowerCase())
       : [];
     const implicitAllow =
-      allowAgentsRaw === undefined && configuredIds.includes(normalizedTargetId);
+      allowAgentsRaw === undefined &&
+      requesterConfig !== undefined &&
+      configuredIds.includes(normalizedTargetId);
     const allowSet = new Set(
       allowAgents
         .filter((value) => value.trim() && value.trim() !== "*")

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -362,17 +362,22 @@ export async function spawnSubagentDirect(
       );
     }
     if (!allowAny && !implicitAllow && !allowSet.has(normalizedTargetId)) {
-      const effectiveAllowed =
-        allowAgentsRaw === undefined
+      // Only reveal the allowlist to configured requesters to avoid
+      // agent inventory disclosure to unknown/unconfigured callers (CWE-200).
+      const canRevealAllowlist = requesterConfig !== undefined;
+      const effectiveAllowed = canRevealAllowlist
+        ? allowAgentsRaw === undefined
           ? configuredIds
           : allowSet.size > 0
             ? Array.from(allowSet)
-            : [];
+            : []
+        : [];
       const allowedText = effectiveAllowed.length > 0 ? effectiveAllowed.join(", ") : "none";
-      const hint =
-        allowAgentsRaw === undefined
+      const hint = canRevealAllowlist
+        ? allowAgentsRaw === undefined
           ? ` (no allowAgents configured — only configured agents are allowed: ${allowedText})`
-          : ` (allowed: ${allowedText})`;
+          : ` (allowed: ${allowedText})`
+        : "";
       return {
         status: "forbidden",
         error: `Agent "${targetAgentId}" is not allowed for sessions_spawn${hint}`,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -356,6 +356,11 @@ export async function spawnSubagentDirect(
         .filter((value) => value.trim() && value.trim() !== "*")
         .map((value) => normalizeAgentId(value).toLowerCase()),
     );
+    if (implicitAllow) {
+      runtime.warn(
+        `[subagent-spawn] No explicit allowAgents configured for "${requesterAgentId}" — implicitly allowing spawn of configured agent "${normalizedTargetId}". Set subagents.allowAgents to restrict access.`,
+      );
+    }
     if (!allowAny && !implicitAllow && !allowSet.has(normalizedTargetId)) {
       const effectiveAllowed =
         allowAgentsRaw === undefined

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -357,7 +357,7 @@ export async function spawnSubagentDirect(
         .map((value) => normalizeAgentId(value).toLowerCase()),
     );
     if (implicitAllow) {
-      runtime.warn(
+      console.warn(
         `[subagent-spawn] No explicit allowAgents configured for "${requesterAgentId}" — implicitly allowing spawn of configured agent "${normalizedTargetId}". Set subagents.allowAgents to restrict access.`,
       );
     }

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -46,8 +46,14 @@ export function createAgentsListTool(opts?: {
           DEFAULT_AGENT_ID,
       );
 
-      const allowAgents = resolveAgentConfig(cfg, requesterAgentId)?.subagents?.allowAgents ?? [];
-      const allowAny = allowAgents.some((value) => value.trim() === "*");
+      const agentCfg = resolveAgentConfig(cfg, requesterAgentId);
+      const allowAgentsRaw = agentCfg?.subagents?.allowAgents;
+      // When allowAgents is not configured (undefined), default to allowing all
+      // configured agents so they are discoverable out-of-the-box.
+      // Only an explicit empty array restricts to requester-only.
+      const allowAgentsNotSet = allowAgentsRaw === undefined;
+      const allowAgents = allowAgentsRaw ?? [];
+      const allowAny = allowAgentsNotSet || allowAgents.some((value) => value.trim() === "*");
       const allowSet = new Set(
         allowAgents
           .filter((value) => value.trim() && value.trim() !== "*")

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -51,7 +51,9 @@ export function createAgentsListTool(opts?: {
       // When allowAgents is not configured (undefined), default to allowing all
       // configured agents so they are discoverable out-of-the-box.
       // Only an explicit empty array restricts to requester-only.
-      const allowAgentsNotSet = allowAgentsRaw === undefined;
+      // Only grant implicit allow-any when the requester agent itself has a
+      // config entry — unknown/unconfigured requesters must not receive it.
+      const allowAgentsNotSet = allowAgentsRaw === undefined && agentCfg !== undefined;
       const allowAgents = allowAgentsRaw ?? [];
       const allowAny = allowAgentsNotSet || allowAgents.some((value) => value.trim() === "*");
       const allowSet = new Set(


### PR DESCRIPTION
## Problem

When `subagents.allowAgents` is not explicitly configured, `agents_list` only returns the requester agent ("main") and `sessions_spawn` rejects cross-agent spawning. Users with multiple configured agents cannot discover or spawn them without manually adding `allowAgents: ["*"]` to every agent config.

## Root Cause

Both `agents-list-tool.ts` and `subagent-spawn.ts` use `?? []` fallback when `allowAgents` is undefined, treating "not configured" the same as "explicitly empty". This was introduced during security hardening.

## Fix

- **`agents-list-tool.ts`**: When `allowAgents` is undefined (not set), treat as `allowAny = true` so all configured agents are returned.
- **`subagent-spawn.ts`**: When `allowAgents` is undefined, implicitly allow spawning any *configured* agent (but not arbitrary unconfigured agent IDs).
- An explicit empty array (`allowAgents: []`) still restricts to requester-only, preserving the opt-in lockdown path.

## Tests

- Updated existing test to reflect new default behavior
- Added test for explicit empty array restriction
- All 17 tests pass

Fixes #36634