### PR TITLE
fix(sandbox-explain): resolve telegram channel from direct session keys in CLI context

### DIFF
--- a/src/commands/sandbox-explain.ts
+++ b/src/commands/sandbox-explain.ts
@@ -3,7 +3,7 @@ import {
   resolveSandboxConfigForAgent,
   resolveSandboxToolPolicyForAgent,
 } from "../agents/sandbox.js";
-import { normalizeAnyChannelId } from "../channels/registry.js";
+import { normalizeAnyChannelId, normalizeChatChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import {
@@ -83,7 +83,7 @@ function inferProviderFromSessionKey(params: {
   if (candidate === INTERNAL_MESSAGE_CHANNEL) {
     return INTERNAL_MESSAGE_CHANNEL;
   }
-  return normalizeAnyChannelId(candidate) ?? undefined;
+  return normalizeChatChannelId(candidate) ?? normalizeAnyChannelId(candidate) ?? undefined;
 }
 
 function resolveActiveChannel(params: {


### PR DESCRIPTION
## Summary
Fixes `openclaw sandbox explain` showing `channel: (unknown)` for Telegram direct session keys like `agent:main:telegram:direct:<id>`.

The issue was in `inferProviderFromSessionKey` using `normalizeAnyChannelId(candidate)` only. In CLI context the plugin registry may be empty, so this returns `null` even for core channels.

## Change
- `src/commands/sandbox-explain.ts`
  - import `normalizeChatChannelId`
  - resolve channel with:
    - `normalizeChatChannelId(candidate)` first
    - fallback to `normalizeAnyChannelId(candidate)`

This keeps plugin-channel support while ensuring built-in channels resolve without plugin-registry state.

## Repro / Verification
Command:

```bash
pnpm openclaw sandbox explain --session agent:main:telegram:direct:7680342356
```

Before (main):
- `channel: (unknown)`

After (this branch):
- `channel: telegram`
- `failing gates: allowFrom (tools.elevated.allowFrom.telegram)`

So channel resolution is fixed and allowFrom diagnostics become accurate.

## Linked issue
- Closes #38455
