### PR TITLE
fix(sandbox-explain): resolve Telegram channel from direct session keys in CLI context

### DIFF
--- a/src/commands/sandbox-explain.ts
+++ b/src/commands/sandbox-explain.ts
@@ -3,7 +3,7 @@ import {
   resolveSandboxConfigForAgent,
   resolveSandboxToolPolicyForAgent,
 } from "../agents/sandbox.js";
-import { normalizeAnyChannelId } from "../channels/registry.js";
+import { normalizeAnyChannelId, normalizeChatChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
 import {
@@ -83,7 +83,7 @@ function inferProviderFromSessionKey(params: {
   if (candidate === INTERNAL_MESSAGE_CHANNEL) {
     return INTERNAL_MESSAGE_CHANNEL;
   }
-  return normalizeAnyChannelId(candidate) ?? undefined;
+  return normalizeChatChannelId(candidate) ?? normalizeAnyChannelId(candidate) ?? undefined;
 }
 
 function resolveActiveChannel(params: {


### PR DESCRIPTION
- Add normalizeChatChannelId in the return since it uses a hardcoded list

## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** openclaw sandbox explain reports channel: (unknown) for Telegram direct sessions (e.g. agent:main:telegram:direct:<id>), causing allowedByConfig: false even when elevated is correctly configured
- **Why it matters:** Users can't diagnose elevated exec issues from Telegram — the diagnostic tool itself is broken for the most common channel
- **What changed:** inferProviderFromSessionKey in src/commands/sandbox-explain.ts now tries normalizeChatChannelId before normalizeAnyChannelId
- **What did NOT change:** Runtime elevated exec logic is untouched — only the CLI diagnostic command is affected

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38455 

## User-visible / Behavior Changes

- openclaw sandbox explain now correctly shows channel: telegram (or other core channel names) for direct sessions instead of (unknown).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- **OS:** Linux (Ubuntu 24.04)
- **Runtime/container**: npm global install
- Model/provider:
- **Integration/channel (if any):** Telegram direct
- Relevant config (redacted):

### Steps

1. Have a Telegram direct session (session key like agent:main:telegram:direct:<sender_id>)
2. Run openclaw sandbox explain --session agent:main:telegram:direct:<sender_id>
3. Observe Elevated section

### Expected

- **channel:** telegram

### Actual

- **channel:** (unknown) / allowedByConfig: false

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

**Before (main):**
```
Elevated:
  enabled: true
  channel: (unknown)
  allowedByConfig: false
```

**After (this branch):**
```
Elevated:
  enabled: true
  channel: telegram
  allowedByConfig: false
  failing gates: allowFrom (tools.elevated.allowFrom.telegram)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

• **Verified scenarios:** Ran pnpm openclaw sandbox explain --session agent:main:telegram:direct:<id> on both main and this branch — channel resolved correctly on branch
• **Edge cases checked:** None — change is scoped to a single fallback chain in the diagnostic command
• **What I did not verify:** Other channel types (Discord, Signal, etc.) — they were not broken before and this change only adds a fallback before the existing call

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

• **How to revert:** git revert the single commit, or restore the one-line change in src/commands/sandbox-explain.ts
• **Files to restore:** src/commands/sandbox-explain.ts only
• **Bad symptoms to watch for:** channel: (unknown) returning — means the revert worked

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

• **Risk:** normalizeChatChannelId doesn't recognize a channel that normalizeAnyChannelId would have caught via plugin registry
  • **Mitigation:** normalizeAnyChannelId is still called as a fallback — behavior is identical for plugin channels
