### PR TITLE
fix: per-agent heartbeat model override ignored on hot reload

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -65,7 +65,7 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     kind: "hot",
     actions: ["restart-heartbeat"],
   },
-  { prefix: "agent.heartbeat", kind: "hot", actions: ["restart-heartbeat"] },
+  { prefix: "agents.list", kind: "hot", actions: ["restart-heartbeat", "restart-cron"] },
   { prefix: "cron", kind: "hot", actions: ["restart-cron"] },
   {
     prefix: "browser",
@@ -83,7 +83,6 @@ const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
   { prefix: "tools", kind: "none" },
   { prefix: "bindings", kind: "none" },
   { prefix: "audio", kind: "none" },
-  { prefix: "agent", kind: "none" },
   { prefix: "routing", kind: "none" },
   { prefix: "messages", kind: "none" },
   { prefix: "session", kind: "none" },

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -167,6 +167,41 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.noopPaths).toEqual([]);
   });
 
+  it("restarts heartbeat and cron when agents.list changes", () => {
+    const plan = buildGatewayReloadPlan(["agents.list"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartHeartbeat).toBe(true);
+    expect(plan.restartCron).toBe(true);
+    expect(plan.hotReasons).toContain("agents.list");
+  });
+
+  it("restarts heartbeat when per-agent heartbeat model changes via agents.list diff", () => {
+    const prev = {
+      agents: {
+        defaults: { heartbeat: { every: "30m" } },
+        list: [
+          { id: "main", default: true },
+          { id: "ops", heartbeat: { model: "openai/gpt-4o-mini" } },
+        ],
+      },
+    };
+    const next = {
+      agents: {
+        defaults: { heartbeat: { every: "30m" } },
+        list: [
+          { id: "main", default: true },
+          { id: "ops", heartbeat: { model: "anthropic/claude-haiku-4-5" } },
+        ],
+      },
+    };
+    const changedPaths = diffConfigPaths(prev, next);
+    expect(changedPaths).toContain("agents.list");
+    const plan = buildGatewayReloadPlan(changedPaths);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartHeartbeat).toBe(true);
+    expect(plan.restartCron).toBe(true);
+  });
+
   it("hot-reloads health monitor when channelHealthCheckMinutes changes", () => {
     const plan = buildGatewayReloadPlan(["gateway.channelHealthCheckMinutes"]);
     expect(plan.restartGateway).toBe(false);

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -175,7 +175,7 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.hotReasons).toContain("agents.list");
   });
 
-  it("restarts heartbeat when per-agent heartbeat model changes via agents.list diff", () => {
+  it("restarts heartbeat and cron when per-agent heartbeat model changes via agents.list diff", () => {
     const prev = {
       agents: {
         defaults: { heartbeat: { every: "30m" } },


### PR DESCRIPTION
Replace dead 'agent.heartbeat' reload rule with 'agents.list' so per-agent heartbeat.model changes trigger restart-heartbeat (and restart-cron) on config hot reload.

The old rule used singular 'agent' which never matched any config path -- the schema uses 'agents' (plural). diffConfigPaths emits 'agents.list' when any array element changes, so the new prefix correctly catches per-agent heartbeat model overrides.

Also removed dead 'agent' (singular) tail rule that could never match.

Fixes #9556, #14279, #13009, #21144, #22133, #30894

## Summary

- Problem: The `agent.heartbeat` reload rule in `config-reload-plan.ts` used singular `agent`, but the config schema only uses `agents` (plural). `diffConfigPaths` never emits paths starting with `agent.`, so per-agent heartbeat config changes were silently ignored on hot reload. Users had to fully restart the gateway for heartbeat model overrides to take effect.
- Why it matters: Users configuring `heartbeat.model` to use cheaper models for background checks were still billed for expensive primary model calls. Reported across six issues over 6+ weeks.
- What changed: Replaced dead `agent.heartbeat` rule with `agents.list` (matching what `diffConfigPaths` actually emits for array changes). Added `restart-cron` alongside `restart-heartbeat` since `agents.list` entries contain both. Removed orphaned `agent` (singular) tail rule.
- What did NOT change (scope boundary): No changes to heartbeat runner logic, model resolution, session handling, or the downstream `hasResolvedHeartbeatModelOverride` guard chain. The model override flow itself is correct; only the reload trigger was broken.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #9556
- Closes #14279
- Closes #13009
- Closes #21144
- Closes #22133
- Closes #30894
- Related #9742 (per-agent heartbeat.model ignored, marked stale)
- Related #32046 (prior fix that added models.* reload triggers but missed agents.list)

## User-visible / Behavior Changes

Changing `agents.list[N].heartbeat.model` in a running gateway now triggers a heartbeat restart, applying the new model without requiring a full gateway restart. Previously this change was silently ignored until manual restart.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows 11 (WSL2 compatible)
- Runtime/container: Node 22.x
- Model/provider: Any (reproducible with any heartbeat.model override)
- Integration/channel (if any): Telegram (but affects all channels)
- Relevant config (redacted):

```json
{
  "agents": {
    "defaults": {
      "model": { "primary": "anthropic/claude-sonnet-4-6" },
      "heartbeat": { "every": "30m", "target": "last" }
    },
    "list": [
      { "id": "main", "default": true },
      { "id": "ops", "heartbeat": { "model": "google/gemini-2.5-flash" } }
    ]
  }
}
```

### Steps

1. Set `agents.list[].heartbeat.model` to a different model than the primary
2. Start the gateway, observe heartbeat uses the correct override model
3. Change the heartbeat model in config while gateway is running
4. Observe config hot reload triggers

### Expected

Config change to `agents.list[N].heartbeat.model` triggers `restart-heartbeat` action, heartbeat runner picks up the new model.

### Actual (before fix)

Config change falls through to `agents` tail rule with `kind: "none"`. Heartbeat runner keeps stale config snapshot, continues using old model until full gateway restart.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Two new tests in `config-reload.test.ts`:
1. Direct path test: `buildGatewayReloadPlan(["agents.list"])` sets `restartHeartbeat: true` and `restartCron: true`
2. End-to-end diff test: changing per-agent `heartbeat.model` from `openai/gpt-4o-mini` to `anthropic/claude-haiku-4-5`, verifying `diffConfigPaths` emits `agents.list` and the plan triggers both restarts

All 24 tests pass (22 existing + 2 new).

## Human Verification (required)

- Verified scenarios: All 24 tests pass including 2 new regression tests. Confirmed `diffConfigPaths` emits `agents.list` (not element-level paths) for array changes. Verified `agent.heartbeat` (singular) rule was dead code that never matched any config path.
- Edge cases checked: Confirmed the `agents` (plural) catch-all tail rule at line 82 still handles any `agents.*` path not matched by more specific rules. Verified no other rules depend on the removed `agent` (singular) prefix.
- What you did **not** verify: Live gateway hot-reload with actual LLM calls (test-only verification). Did not test with every supported model provider.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `02e8bf675` or restore line 68 to `{ prefix: "agent.heartbeat", kind: "hot", actions: ["restart-heartbeat"] }` and re-add `{ prefix: "agent", kind: "none" }` to tail rules
- Files/config to restore: `src/gateway/config-reload-plan.ts`
- Known bad symptoms reviewers should watch for: Unexpected heartbeat or cron restarts when unrelated `agents.list` fields change (e.g., agent name or workspace). This is a broader trigger than the original rule, but matches how `diffConfigPaths` reports array changes (whole-array, not element-level).

## Risks and Mitigations

- Risk: The `agents.list` prefix is broader than `agent.heartbeat` -- any change to the agents list (not just heartbeat fields) will now trigger `restart-heartbeat` and `restart-cron`.
  - Mitigation: This matches the actual granularity of `diffConfigPaths`, which compares arrays as wholes and emits `agents.list` for any element change. Both restarts are lightweight (re-resolve config, reschedule timers) with no user-visible side effects. The alternative (element-level path matching) would require changes to `diffConfigPaths` itself, which is out of scope.