### PR TITLE
fix: improve session history tool result handling

### DIFF
--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -342,6 +342,7 @@ export async function summarizeInStages(params: {
   summarizationInstructions?: CompactionSummarizationInstructions;
   previousSummary?: string;
   parts?: number;
+  allowSyntheticToolResults?: boolean;
   minMessagesForSplit?: number;
 }): Promise<string> {
   const { messages } = params;
@@ -400,6 +401,7 @@ export function pruneHistoryForContextShare(params: {
   maxContextTokens: number;
   maxHistoryShare?: number;
   parts?: number;
+  allowSyntheticToolResults?: boolean;
 }): {
   messages: AgentMessage[];
   droppedMessagesList: AgentMessage[];
@@ -431,7 +433,11 @@ export function pruneHistoryForContextShare(params: {
     // orphaned tool_results (whose tool_use was in the dropped chunk).
     // repairToolUseResultPairing drops orphaned tool_results, preventing
     // "unexpected tool_use_id" errors from Anthropic's API.
-    const repairReport = repairToolUseResultPairing(flatRest);
+    // When allowSyntheticToolResults is false, don't create synthetic errors for
+    // missing tool results (they may be in progress, e.g., after gateway restarts).
+    const repairReport = repairToolUseResultPairing(flatRest, {
+      allowSyntheticToolResults: params.allowSyntheticToolResults,
+    });
     const repairedKept = repairReport.messages;
 
     // Track orphaned tool_results as dropped (they were in kept but their tool_use was dropped)

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -636,7 +636,9 @@ export async function compactEmbeddedPiSessionDirect(
         // limitHistoryTurns can orphan tool_result blocks by removing the
         // assistant message that contained the matching tool_use.
         const limited = transcriptPolicy.repairToolUseResultPairing
-          ? sanitizeToolUseResultPairing(truncated)
+          ? sanitizeToolUseResultPairing(truncated, {
+              allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
+            })
           : truncated;
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -556,7 +556,9 @@ export async function sanitizeSessionHistory(params: {
     allowedToolNames: params.allowedToolNames,
   });
   const repairedTools = policy.repairToolUseResultPairing
-    ? sanitizeToolUseResultPairing(sanitizedToolCalls)
+    ? sanitizeToolUseResultPairing(sanitizedToolCalls, {
+        allowSyntheticToolResults: policy.allowSyntheticToolResults,
+      })
     : sanitizedToolCalls;
   const sanitizedToolResults = stripToolResultDetails(repairedTools);
   const sanitizedCompactionUsage = ensureAssistantUsageSnapshots(

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1407,7 +1407,9 @@ export async function runEmbeddedAttempt(
         // limitHistoryTurns can orphan tool_result blocks by removing the
         // assistant message that contained the matching tool_use.
         const limited = transcriptPolicy.repairToolUseResultPairing
-          ? sanitizeToolUseResultPairing(truncated)
+          ? sanitizeToolUseResultPairing(truncated, {
+              allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
+            })
           : truncated;
         cacheTrace?.recordStage("session:limited", { messages: limited });
         if (limited.length > 0) {

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -258,6 +258,7 @@ function formatNonTextPlaceholder(content: unknown): string | null {
 function splitPreservedRecentTurns(params: {
   messages: AgentMessage[];
   recentTurnsPreserve: number;
+  allowSyntheticToolResults?: boolean;
 }): { summarizableMessages: AgentMessage[]; preservedMessages: AgentMessage[] } {
   const preserveTurns = Math.min(
     MAX_RECENT_TURNS_PRESERVE,
@@ -353,7 +354,11 @@ function splitPreservedRecentTurns(params: {
   const summarizableMessages = params.messages.filter((_, idx) => !preservedIndexSet.has(idx));
   // Preserving recent assistant turns can orphan downstream toolResult messages.
   // Repair pairings here so compaction summarization doesn't trip strict providers.
-  const repairedSummarizableMessages = repairToolUseResultPairing(summarizableMessages).messages;
+  // When allowSyntheticToolResults is false, don't create synthetic errors for
+  // missing tool results (they may be in progress, e.g., after gateway restarts).
+  const repairedSummarizableMessages = repairToolUseResultPairing(summarizableMessages, {
+    allowSyntheticToolResults: params.allowSyntheticToolResults,
+  }).messages;
   const preservedMessages = params.messages
     .filter((_, idx) => preservedIndexSet.has(idx))
     .filter((msg) => {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -327,8 +327,11 @@ export function sanitizeToolCallInputs(
   return repairToolCallInputs(messages, options).messages;
 }
 
-export function sanitizeToolUseResultPairing(messages: AgentMessage[]): AgentMessage[] {
-  return repairToolUseResultPairing(messages).messages;
+export function sanitizeToolUseResultPairing(
+  messages: AgentMessage[],
+  options?: { allowSyntheticToolResults?: boolean },
+): AgentMessage[] {
+  return repairToolUseResultPairing(messages, options).messages;
 }
 
 export type ToolUseRepairReport = {
@@ -339,13 +342,17 @@ export type ToolUseRepairReport = {
   moved: boolean;
 };
 
-export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRepairReport {
+export function repairToolUseResultPairing(
+  messages: AgentMessage[],
+  options?: { allowSyntheticToolResults?: boolean },
+): ToolUseRepairReport {
   // Anthropic (and Cloud Code Assist) reject transcripts where assistant tool calls are not
   // immediately followed by matching tool results. Session files can end up with results
   // displaced (e.g. after user turns) or duplicated. Repair by:
   // - moving matching toolResult messages directly after their assistant toolCall turn
-  // - inserting synthetic error toolResults for missing ids
+  // - inserting synthetic error toolResults for missing ids (when allowSyntheticToolResults is true)
   // - dropping duplicate toolResults for the same id (anywhere in the transcript)
+  const allowSyntheticToolResults = options?.allowSyntheticToolResults ?? true;
   const out: AgentMessage[] = [];
   const added: Array<Extract<AgentMessage, { role: "toolResult" }>> = [];
   const seenToolResultIds = new Set<string>();
@@ -470,7 +477,10 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
       const existing = spanResultsById.get(call.id);
       if (existing) {
         pushToolResult(existing);
-      } else {
+      } else if (allowSyntheticToolResults) {
+        // Only create synthetic tool results when explicitly allowed.
+        // During gateway restarts or with long-running commands, missing tool results
+        // may be legitimate (not yet written) rather than errors.
         const missing = makeMissingToolResult({
           toolCallId: call.id,
           toolName: call.name,
@@ -479,6 +489,8 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
         changed = true;
         pushToolResult(missing);
       }
+      // When allowSyntheticToolResults is false, we simply skip tool calls without results
+      // (they may still be in progress, especially after gateway restarts)
     }
 
     for (const rem of remainder) {


### PR DESCRIPTION
## Problem

When gateway restarts or executes long-running commands, session history shows "missing tool result in session history; inserted synthetic error result for transcript repair" error.

## Root Cause

After debugging, I found the issue in the `repairToolUseResultPairing` function in `src/agents/session-transcript-repair.ts`. The function always creates synthetic errors for tool calls without corresponding tool results, even in scenarios like gateway restarts where this is normal behavior.

## Solution

I added an optional `allowSyntheticToolResults` parameter to control whether to create synthetic errors:

- When parameter is `false`, skip creating synthetic errors
- Preserve other repair logic (move results, remove duplicates, remove orphan results)
- Maintain backward compatibility (default value is `true`)

## Modified Files

1. `src/agents/session-transcript-repair.ts` - Add `allowSyntheticToolResults` parameter
2. `src/agents/compaction.ts` - Pass the parameter
3. `src/agents/pi-embedded-runner/run/attempt.ts` - Use transcript policy flag
4. `src/agents/pi-embedded-runner/compact.ts` - Use transcript policy flag
5. `src/agents/pi-embedded-runner/google.ts` - Use transcript policy flag
6. `src/agents/pi-extensions/compaction-safeguard.ts` - Pass the parameter

## Testing

- ✅ TypeScript compilation passes
- ✅ Backward compatible (default behavior unchanged)
- ✅ 6 files modified, +39/-10 lines

Fixes #38432