### PR TITLE
fix(agents): refresh bootstrap cache after session rollover

### DIFF
--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -65,6 +65,32 @@ describe("getOrLoadBootstrapFiles", () => {
     expect(r2).toBe(files2);
     expect(mockLoad).toHaveBeenCalledTimes(2);
   });
+
+  it("uses session IDs as independent cache buckets for the same session key", async () => {
+    const files2 = [makeFile("AGENTS.md", "# Agent v2")];
+    mockLoad.mockResolvedValueOnce(files).mockResolvedValueOnce(files2);
+
+    const r1 = await getOrLoadBootstrapFiles({
+      workspaceDir: "/ws",
+      sessionKey: "agent:main:main",
+      sessionId: "sess-1",
+    });
+    const r2 = await getOrLoadBootstrapFiles({
+      workspaceDir: "/ws",
+      sessionKey: "agent:main:main",
+      sessionId: "sess-2",
+    });
+    const r3 = await getOrLoadBootstrapFiles({
+      workspaceDir: "/ws",
+      sessionKey: "agent:main:main",
+      sessionId: "sess-2",
+    });
+
+    expect(r1).toBe(files);
+    expect(r2).toBe(files2);
+    expect(r3).toBe(files2);
+    expect(mockLoad).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("clearBootstrapSnapshot", () => {

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -5,14 +5,16 @@ const cache = new Map<string, WorkspaceBootstrapFile[]>();
 export async function getOrLoadBootstrapFiles(params: {
   workspaceDir: string;
   sessionKey: string;
+  sessionId?: string;
 }): Promise<WorkspaceBootstrapFile[]> {
-  const existing = cache.get(params.sessionKey);
+  const cacheKey = params.sessionId?.trim() || params.sessionKey;
+  const existing = cache.get(cacheKey);
   if (existing) {
     return existing;
   }
 
   const files = await loadWorkspaceBootstrapFiles(params.workspaceDir);
-  cache.set(params.sessionKey, files);
+  cache.set(cacheKey, files);
   return files;
 }
 

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -7,6 +7,7 @@ import {
   type AgentBootstrapHookContext,
 } from "../hooks/internal-hooks.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
+import { clearAllBootstrapSnapshots } from "./bootstrap-cache.js";
 import { resolveBootstrapContextForRun, resolveBootstrapFilesForRun } from "./bootstrap-files.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 
@@ -53,8 +54,15 @@ function registerMalformedBootstrapFileHook() {
 }
 
 describe("resolveBootstrapFilesForRun", () => {
-  beforeEach(() => clearInternalHooks());
-  afterEach(() => clearInternalHooks());
+  beforeEach(() => {
+    clearInternalHooks();
+    clearAllBootstrapSnapshots();
+  });
+
+  afterEach(() => {
+    clearInternalHooks();
+    clearAllBootstrapSnapshots();
+  });
 
   it("applies bootstrap hook overrides", async () => {
     registerExtraBootstrapFileHook();
@@ -81,11 +89,46 @@ describe("resolveBootstrapFilesForRun", () => {
     expect(warnings).toHaveLength(3);
     expect(warnings[0]).toContain('missing or invalid "path" field');
   });
+
+  it("reloads bootstrap files after a daily-reset style sessionId rollover", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await fs.writeFile(path.join(workspaceDir, "USER.md"), "first", "utf8");
+
+    const first = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      sessionKey: "agent:main:main",
+      sessionId: "sess-1",
+    });
+    expect(first.find((file) => file.name === "USER.md")?.content).toBe("first");
+
+    await fs.writeFile(path.join(workspaceDir, "USER.md"), "second", "utf8");
+
+    const sameSession = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      sessionKey: "agent:main:main",
+      sessionId: "sess-1",
+    });
+    expect(sameSession.find((file) => file.name === "USER.md")?.content).toBe("first");
+
+    const rolledSession = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      sessionKey: "agent:main:main",
+      sessionId: "sess-2",
+    });
+    expect(rolledSession.find((file) => file.name === "USER.md")?.content).toBe("second");
+  });
 });
 
 describe("resolveBootstrapContextForRun", () => {
-  beforeEach(() => clearInternalHooks());
-  afterEach(() => clearInternalHooks());
+  beforeEach(() => {
+    clearInternalHooks();
+    clearAllBootstrapSnapshots();
+  });
+
+  afterEach(() => {
+    clearInternalHooks();
+    clearAllBootstrapSnapshots();
+  });
 
   it("returns context files for hook-adjusted bootstrap files", async () => {
     registerExtraBootstrapFileHook();

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -76,6 +76,7 @@ export async function resolveBootstrapFilesForRun(params: {
     ? await getOrLoadBootstrapFiles({
         workspaceDir: params.workspaceDir,
         sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
       })
     : await loadWorkspaceBootstrapFiles(params.workspaceDir);
   const bootstrapFiles = applyContextModeFilter({

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -207,7 +207,12 @@ async function ensureSessionRuntimeCleanup(params: {
     queueKeys.add(params.sessionId);
   }
   clearSessionQueues([...queueKeys]);
-  clearBootstrapSnapshot(params.target.canonicalKey);
+  for (const key of new Set([params.key, params.target.canonicalKey, ...params.target.storeKeys])) {
+    clearBootstrapSnapshot(key);
+  }
+  if (params.sessionId) {
+    clearBootstrapSnapshot(params.sessionId);
+  }
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
   if (!params.sessionId) {
     await closeTrackedBrowserTabs();


### PR DESCRIPTION
## Summary

- Problem: bootstrap files are cached by `sessionKey`, so daily session resets keep serving stale `USER.md` / `MEMORY.md` / related workspace files until the gateway restarts.
- Why it matters: users can update workspace bootstrap files and still get old context in the next daily-reset session, which makes session resets look broken.
- What changed: bootstrap cache entries now key off `sessionId` when available, and explicit session cleanup clears both session-key and session-id cache entries.
- What did NOT change (scope boundary): this does not change bootstrap file selection, truncation rules, hook behavior, or non-session bootstrap loading.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38494
- Related #36666

## User-visible / Behavior Changes

- Daily-reset sessions now reload updated workspace bootstrap files instead of reusing stale cached content from the prior session.
- Explicit session cleanup also drops bootstrap snapshots keyed by the active session id.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu/Linux dev environment
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): session bootstrap loading
- Relevant config (redacted): default daily-reset session behavior; no special bootstrap config required

### Steps

1. Start a session so bootstrap files are loaded and cached for a stable `sessionKey`.
2. Change a workspace bootstrap file such as `USER.md`.
3. Start a new session after a daily-reset style session rollover (same `sessionKey`, new `sessionId`).

### Expected

- The new session reads the updated bootstrap file contents.

### Actual

- Before this fix, the cache reused the old contents because it only keyed by `sessionKey`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added regression coverage proving the same `sessionKey` keeps cached data within one `sessionId` but reloads after a new `sessionId`; verified explicit cleanup now clears all known bootstrap cache keys by code inspection and build/test validation.
- Edge cases checked: same-session reuse still stays cached; different session ids for the same session key do not share stale bootstrap snapshots.
- What you did **not** verify: I did not manually wait for a real 4:00 AM reset in a live gateway process.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or restart the gateway to clear in-memory bootstrap cache.
- Files/config to restore: `src/agents/bootstrap-cache.ts`, `src/agents/bootstrap-files.ts`, `src/gateway/server-methods/sessions.ts`
- Known bad symptoms reviewers should watch for: unexpected extra bootstrap disk reads only when a new session id is created.

## Risks and Mitigations

- Risk: session rollovers may reload bootstrap files more often than before.
  - Mitigation: cache reuse is still preserved within the active `sessionId`, so only genuine session rollovers incur the reload.
