### PR TITLE
fix(avatar): accept Windows namespaced workspace paths

### DIFF
--- a/src/shared/avatar-policy.test.ts
+++ b/src/shared/avatar-policy.test.ts
@@ -23,6 +23,18 @@ describe("avatar policy", () => {
     expect(isPathWithinRoot(root, path.resolve("/tmp/root/../outside.png"))).toBe(false);
   });
 
+  it("accepts mixed Windows namespaced paths under the same workspace", () => {
+    const namespacedRoot = "\\\\?\\C:\\Users\\me\\workspace-gaia";
+    const driveRoot = "C:\\Users\\me\\workspace-gaia";
+    const insidePath = "C:\\Users\\me\\workspace-gaia\\avatars\\gaia.png";
+    const namespacedInsidePath = "\\\\?\\C:\\Users\\me\\workspace-gaia\\avatars\\gaia.png";
+    const outsidePath = "C:\\Users\\me\\outside.png";
+
+    expect(isPathWithinRoot(namespacedRoot, insidePath)).toBe(true);
+    expect(isPathWithinRoot(driveRoot, namespacedInsidePath)).toBe(true);
+    expect(isPathWithinRoot(namespacedRoot, outsidePath)).toBe(false);
+  });
+
   it("detects avatar-like path strings", () => {
     expect(looksLikeAvatarPath("avatars/openclaw.svg")).toBe(true);
     expect(looksLikeAvatarPath("openclaw.webp")).toBe(true);

--- a/src/shared/avatar-policy.ts
+++ b/src/shared/avatar-policy.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { normalizeWindowsPathForComparison } from "../infra/path-guards.js";
 
 export const AVATAR_MAX_BYTES = 2 * 1024 * 1024;
 
@@ -21,6 +22,7 @@ export const AVATAR_IMAGE_DATA_RE = /^data:image\//i;
 export const AVATAR_HTTP_RE = /^https?:\/\//i;
 export const AVATAR_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
 export const WINDOWS_ABS_RE = /^[a-zA-Z]:[\\/]/;
+export const WINDOWS_NAMESPACE_PREFIX_RE = /^\\\\\?\\/;
 
 const AVATAR_PATH_EXT_RE = /\.(png|jpe?g|gif|webp|svg|ico)$/i;
 
@@ -49,6 +51,10 @@ export function isWindowsAbsolutePath(value: string): boolean {
   return WINDOWS_ABS_RE.test(value);
 }
 
+function usesWindowsPathSemantics(value: string): boolean {
+  return WINDOWS_NAMESPACE_PREFIX_RE.test(value) || isWindowsAbsolutePath(value);
+}
+
 export function isWorkspaceRelativeAvatarPath(value: string): boolean {
   if (!value) {
     return false;
@@ -63,6 +69,20 @@ export function isWorkspaceRelativeAvatarPath(value: string): boolean {
 }
 
 export function isPathWithinRoot(rootDir: string, targetPath: string): boolean {
+  if (
+    process.platform === "win32" ||
+    usesWindowsPathSemantics(rootDir) ||
+    usesWindowsPathSemantics(targetPath)
+  ) {
+    const rootForCompare = normalizeWindowsPathForComparison(path.win32.resolve(rootDir));
+    const targetForCompare = normalizeWindowsPathForComparison(path.win32.resolve(targetPath));
+    const relative = path.win32.relative(rootForCompare, targetForCompare);
+    if (relative === "") {
+      return true;
+    }
+    return !relative.startsWith("..") && !path.win32.isAbsolute(relative);
+  }
+
   const relative = path.relative(rootDir, targetPath);
   if (relative === "") {
     return true;


### PR DESCRIPTION
## Summary

- normalize mixed Windows namespaced and drive-letter paths before avatar workspace-boundary checks
- add regression coverage for `\\?\C:\...` and `C:\...` path pairs under the same workspace

## Why

On Windows, `fs.realpathSync()` can return a namespaced path like `\\?\C:\Users\...` while the resolved avatar candidate stays in normal drive-letter form. `isPathWithinRoot()` compared those raw forms directly, so avatar files inside the workspace could be misclassified as `outside_workspace` and `/avatar/{agentId}` returned 404.

## Validation

- `pnpm exec vitest run --config vitest.unit.config.ts src/shared/avatar-policy.test.ts`
- `pnpm exec vitest run src/agents/identity-avatar.test.ts`

## Notes

- Local git hooks could not run `oxlint` in this environment because the native binding for the installed Node/arch combination is missing; targeted tests above passed.
- Related issue: #38439
