### PR TITLE
fix: rename web_search tool to oc_web_search to avoid collision

### DIFF
--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -21,7 +21,7 @@ import {
 } from "../plugin-sdk/windows-spawn.js";
 import { DANGEROUS_ACP_TOOLS } from "../security/dangerous-tools.js";
 
-const SAFE_AUTO_APPROVE_TOOL_IDS = new Set(["read", "search", "web_search", "memory_search"]);
+const SAFE_AUTO_APPROVE_TOOL_IDS = new Set(["read", "search", "oc_web_search", "memory_search"]);
 const TRUSTED_SAFE_TOOL_ALIASES = new Set(["search"]);
 const READ_TOOL_PATH_KEYS = ["path", "file_path", "filePath"];
 const TOOL_NAME_MAX_LENGTH = 128;
@@ -29,7 +29,7 @@ const TOOL_NAME_PATTERN = /^[a-z0-9._-]+$/;
 const TOOL_KIND_BY_ID = new Map<string, string>([
   ["read", "read"],
   ["search", "search"],
-  ["web_search", "search"],
+  ["oc_web_search", "search"],
   ["memory_search", "search"],
 ]);
 

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -156,7 +156,7 @@ const TRUSTED_TOOL_RESULT_MEDIA = new Set([
   "subagents",
   "tts",
   "web_fetch",
-  "web_search",
+  "oc_web_search",
   "write",
 ]);
 const HTTP_URL_RE = /^https?:\/\//i;

--- a/src/agents/pi-tools.model-provider-collision.test.ts
+++ b/src/agents/pi-tools.model-provider-collision.test.ts
@@ -4,7 +4,7 @@ import type { AnyAgentTool } from "./pi-tools.types.js";
 
 const baseTools = [
   { name: "read" },
-  { name: "web_search" },
+  { name: "oc_web_search" },
   { name: "exec" },
 ] as unknown as AnyAgentTool[];
 
@@ -19,7 +19,7 @@ describe("applyModelProviderToolPolicy", () => {
       modelId: "gpt-4o-mini",
     });
 
-    expect(toolNames(filtered)).toEqual(["read", "web_search", "exec"]);
+    expect(toolNames(filtered)).toEqual(["read", "oc_web_search", "exec"]);
   });
 
   it("removes web_search for OpenRouter xAI model ids", () => {

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -22,7 +22,7 @@ describe("pi-tools.policy", () => {
 
   it("supports wildcard allow/deny patterns", () => {
     expect(isToolAllowedByPolicyName("web_fetch", { allow: ["web_*"] })).toBe(true);
-    expect(isToolAllowedByPolicyName("web_search", { deny: ["web_*"] })).toBe(false);
+    expect(isToolAllowedByPolicyName("oc_web_search", { deny: ["web_*"] })).toBe(false);
   });
 
   it("keeps apply_patch when exec is allowlisted", () => {

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -66,7 +66,7 @@ function isOpenAIProvider(provider?: string) {
 const TOOL_DENY_BY_MESSAGE_PROVIDER: Readonly<Record<string, readonly string[]>> = {
   voice: ["tts"],
 };
-const TOOL_DENY_FOR_XAI_PROVIDERS = new Set(["web_search"]);
+const TOOL_DENY_FOR_XAI_PROVIDERS = new Set(["oc_web_search"]);
 
 function normalizeMessageProvider(messageProvider?: string): string | undefined {
   const normalized = messageProvider?.trim().toLowerCase();

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -281,7 +281,7 @@ export function buildAgentSystemPrompt(params: {
     "ls",
     "exec",
     "process",
-    "web_search",
+    "oc_web_search",
     "web_fetch",
     "browser",
     "canvas",

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -82,8 +82,8 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     profiles: ["coding"],
   },
   {
-    id: "web_search",
-    label: "web_search",
+    id: "oc_web_search",
+    label: "oc_web_search",
     description: "Search the web",
     sectionId: "web",
     profiles: [],

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -1170,7 +1170,7 @@ export function resolveToolVerbAndDetail(params: {
 }): { verb?: string; detail?: string } {
   const actionSpec = resolveActionSpec(params.spec, params.action);
   const fallbackVerb =
-    params.toolKey === "web_search"
+    params.toolKey === "oc_web_search"
       ? "search"
       : params.toolKey === "web_fetch"
         ? "fetch"
@@ -1190,7 +1190,7 @@ export function resolveToolVerbAndDetail(params: {
   ) {
     detail = resolveWriteDetail(params.toolKey, params.args);
   }
-  if (!detail && params.toolKey === "web_search") {
+  if (!detail && params.toolKey === "oc_web_search") {
     detail = resolveWebSearchDetail(params.args);
   }
   if (!detail && params.toolKey === "web_fetch") {

--- a/src/agents/tool-display-overrides.json
+++ b/src/agents/tool-display-overrides.json
@@ -82,7 +82,7 @@
       "title": "Memory Get",
       "detailKeys": ["path", "from", "lines"]
     },
-    "web_search": {
+    "oc_web_search": {
       "emoji": "🔎",
       "title": "Web Search",
       "detailKeys": ["query", "count"]

--- a/src/agents/tool-display.test.ts
+++ b/src/agents/tool-display.test.ts
@@ -80,7 +80,7 @@ describe("tool display details", () => {
   it("formats web_search query with quotes", () => {
     const detail = formatToolDetail(
       resolveToolDisplay({
-        name: "web_search",
+        name: "oc_web_search",
         args: { query: "OpenClaw docs", count: 3 },
       }),
     );

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1479,7 +1479,7 @@ export function createWebSearchTool(options?: {
 
   return {
     label: "Web Search",
-    name: "web_search",
+    name: "oc_web_search",
     description,
     parameters: createWebSearchSchema(provider),
     execute: async (_toolCallId, args) => {

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -994,9 +994,9 @@ async function runPerplexitySearchApi(params: {
         const url = entry.url ?? "";
         const snippet = entry.snippet ?? "";
         return {
-          title: title ? wrapWebContent(title, "web_search") : "",
+          title: title ? wrapWebContent(title, "oc_web_search") : "",
           url,
-          description: snippet ? wrapWebContent(snippet, "web_search") : "",
+          description: snippet ? wrapWebContent(snippet, "oc_web_search") : "",
           published: entry.date ?? undefined,
           siteName: resolveSiteName(url) || undefined,
         };
@@ -1024,7 +1024,7 @@ async function runGrokSearch(params: {
         content: params.query,
       },
     ],
-    tools: [{ type: "web_search" }],
+    tools: [{ type: "oc_web_search" }],
   };
 
   // Note: xAI's /v1/responses endpoint does not support the `include`
@@ -1277,7 +1277,7 @@ async function runWebSearch(params: {
       tookMs: Date.now() - start,
       externalContent: {
         untrusted: true,
-        source: "web_search",
+        source: "oc_web_search",
         provider: params.provider,
         wrapped: true,
       },
@@ -1303,7 +1303,7 @@ async function runWebSearch(params: {
       tookMs: Date.now() - start,
       externalContent: {
         untrusted: true,
-        source: "web_search",
+        source: "oc_web_search",
         provider: params.provider,
         wrapped: true,
       },
@@ -1331,7 +1331,7 @@ async function runWebSearch(params: {
       tookMs: Date.now() - start,
       externalContent: {
         untrusted: true,
-        source: "web_search",
+        source: "oc_web_search",
         provider: params.provider,
         wrapped: true,
       },
@@ -1357,7 +1357,7 @@ async function runWebSearch(params: {
       tookMs: Date.now() - start, // Includes redirect URL resolution time
       externalContent: {
         untrusted: true,
-        source: "web_search",
+        source: "oc_web_search",
         provider: params.provider,
         wrapped: true,
       },
@@ -1424,9 +1424,9 @@ async function runWebSearch(params: {
         const url = entry.url ?? "";
         const rawSiteName = resolveSiteName(url);
         return {
-          title: title ? wrapWebContent(title, "web_search") : "",
+          title: title ? wrapWebContent(title, "oc_web_search") : "",
           url, // Keep raw for tool chaining
-          description: description ? wrapWebContent(description, "web_search") : "",
+          description: description ? wrapWebContent(description, "oc_web_search") : "",
           published: entry.age || undefined,
           siteName: rawSiteName || undefined,
         };
@@ -1441,7 +1441,7 @@ async function runWebSearch(params: {
     tookMs: Date.now() - start,
     externalContent: {
       untrusted: true,
-      source: "web_search",
+      source: "oc_web_search",
       provider: params.provider,
       wrapped: true,
     },

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -136,7 +136,7 @@ describe("web tools defaults", () => {
 
   it("enables web_search by default", () => {
     const tool = createWebSearchTool({ config: {}, sandboxed: false });
-    expect(tool?.name).toBe("web_search");
+    expect(tool?.name).toBe("oc_web_search");
   });
 });
 
@@ -282,7 +282,7 @@ describe("web_search perplexity Search API", () => {
     expect(body.query).toBe("test");
     expect(result?.details).toMatchObject({
       provider: "perplexity",
-      externalContent: { untrusted: true, source: "web_search", wrapped: true },
+      externalContent: { untrusted: true, source: "oc_web_search", wrapped: true },
       results: expect.arrayContaining([
         expect.objectContaining({
           title: expect.stringContaining("Test"),
@@ -540,7 +540,7 @@ describe("web_search external content wrapping", () => {
     expect(details.results?.[0]?.description).toContain("Ignore previous instructions");
     expect(details.externalContent).toMatchObject({
       untrusted: true,
-      source: "web_search",
+      source: "oc_web_search",
       wrapped: true,
     });
   });

--- a/src/channels/status-reactions.test.ts
+++ b/src/channels/status-reactions.test.ts
@@ -74,7 +74,7 @@ describe("resolveToolEmoji", () => {
     },
     {
       name: "returns web emoji for web_search tool",
-      tool: "web_search",
+      tool: "oc_web_search",
       expected: DEFAULT_EMOJIS.web,
     },
     { name: "returns web emoji for browser tool", tool: "browser", expected: DEFAULT_EMOJIS.web },
@@ -219,7 +219,7 @@ describe("createStatusReactionController", () => {
     void controller.setThinking();
     await vi.advanceTimersByTimeAsync(100);
 
-    void controller.setTool("web_search");
+    void controller.setTool("oc_web_search");
     await vi.advanceTimersByTimeAsync(100);
 
     void controller.setTool("exec");
@@ -437,7 +437,7 @@ describe("constants", () => {
   });
 
   it("should export WEB_TOOL_TOKENS", () => {
-    for (const token of ["web_search", "browser"]) {
+    for (const token of ["oc_web_search", "browser"]) {
       expect(WEB_TOOL_TOKENS).toContain(token);
     }
   });

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -79,7 +79,7 @@ export const CODING_TOOL_TOKENS: string[] = [
 ];
 
 export const WEB_TOOL_TOKENS: string[] = [
-  "web_search",
+  "oc_web_search",
   "web-search",
   "web_fetch",
   "web-fetch",

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1224,8 +1224,8 @@ export function collectSmallModelRiskFindings(params: {
     });
     const exposed: string[] = [];
     if (isWebSearchEnabled(params.cfg, params.env)) {
-      if (isToolAllowedByPolicies("web_search", policies)) {
-        exposed.push("web_search");
+      if (isToolAllowedByPolicies("oc_web_search", policies)) {
+        exposed.push("oc_web_search");
       }
     }
     if (isWebFetchEnabled(params.cfg)) {

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -951,7 +951,7 @@ description: test skill
           browser: { enabled: true },
         },
         expectedSeverity: "critical",
-        detailIncludes: ["mistral-8b", "web_search", "web_fetch", "browser"],
+        detailIncludes: ["mistral-8b", "oc_web_search", "web_fetch", "browser"],
       },
       {
         name: "small model with sandbox all and web/browser disabled",

--- a/src/security/external-content.test.ts
+++ b/src/security/external-content.test.ts
@@ -161,7 +161,7 @@ describe("external-content security", () => {
 
   describe("wrapWebContent", () => {
     it("wraps web search content with boundaries", () => {
-      const result = wrapWebContent("Search snippet", "web_search");
+      const result = wrapWebContent("Search snippet", "oc_web_search");
 
       expect(result).toMatch(/<<<EXTERNAL_UNTRUSTED_CONTENT id="[a-f0-9]{16}">>>/);
       expect(result).toMatch(/<<<END_EXTERNAL_UNTRUSTED_CONTENT id="[a-f0-9]{16}">>>/);
@@ -170,7 +170,7 @@ describe("external-content security", () => {
     });
 
     it("includes the source label", () => {
-      const result = wrapWebContent("Snippet", "web_search");
+      const result = wrapWebContent("Snippet", "oc_web_search");
 
       expect(result).toContain("Source: Web Search");
     });
@@ -184,7 +184,7 @@ describe("external-content security", () => {
 
     it("normalizes homoglyph markers before sanitizing", () => {
       const homoglyphMarker = "\uFF1C\uFF1C\uFF1CEXTERNAL_UNTRUSTED_CONTENT\uFF1E\uFF1E\uFF1E";
-      const result = wrapWebContent(`Before ${homoglyphMarker} after`, "web_search");
+      const result = wrapWebContent(`Before ${homoglyphMarker} after`, "oc_web_search");
 
       expect(result).toContain("[[MARKER_SANITIZED]]");
       expect(result).not.toContain(homoglyphMarker);
@@ -211,7 +211,7 @@ describe("external-content security", () => {
         const endMarker = `${left}${left}${left}END_EXTERNAL_UNTRUSTED_CONTENT${right}${right}${right}`;
         const result = wrapWebContent(
           `Before ${startMarker} middle ${endMarker} after`,
-          "web_search",
+          "oc_web_search",
         );
 
         expect(result).toContain("[[MARKER_SANITIZED]]");

--- a/src/security/external-content.ts
+++ b/src/security/external-content.ts
@@ -87,7 +87,7 @@ export type ExternalContentSource =
   | "api"
   | "browser"
   | "channel_metadata"
-  | "web_search"
+  | "oc_web_search"
   | "web_fetch"
   | "unknown";
 
@@ -333,7 +333,7 @@ export function getHookType(sessionKey: string): ExternalContentSource {
  */
 export function wrapWebContent(
   content: string,
-  source: "web_search" | "web_fetch" = "web_search",
+  source: "oc_web_search" | "web_fetch" = "oc_web_search",
 ): string {
   const includeWarning = source === "web_fetch";
   // Marker sanitization happens in wrapExternalContent


### PR DESCRIPTION
## Summary

Renamed the `web_search` tool to `oc_web_search` to prevent collision with upstream provider-native `web_search` tool.

## Changes

- Modified `src/agents/tools/web-search.ts`
- Changed tool name from `web_search` to `oc_web_search`

## Problem

The original tool name `web_search` was colliding with provider-native web_search tools, causing a 500 error:

```
500: "Parameters of tool web_search must only have these properties:query"
```

## Solution

By renaming to `oc_web_search`, we avoid the naming collision while maintaining all functionality.

## Testing

This fix was identified and validated by the issue reporter after extensive debugging.

Fixes #38517