### PR TITLE
fix(outbound): treat Discord unknown channel as permanent

### DIFF
--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -387,6 +387,7 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
+  /unknown channel/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -161,6 +161,7 @@ describe("delivery-queue", () => {
     it.each([
       "No conversation reference found for user:abc",
       "Telegram send failed: chat not found (chat_id=user:123)",
+      "Discord API /channels/123/messages failed (404): Unknown Channel",
       "user not found",
       "Bot was blocked by the user",
       "Forbidden: bot was kicked from the group chat",


### PR DESCRIPTION
## Summary

Treat Discord `Unknown Channel` delivery failures as permanent so queued outbound retries move to `failed/` instead of replaying on every recovery cycle.

## Problem

Discord 404 send failures surface as messages like `Discord API /channels/... failed (404): Unknown Channel`.
The delivery queue currently does not classify that error as permanent, so recovery keeps retrying entries that can never succeed.

This showed up as part of the failure chain in #38487.

## What changed

- added `Unknown Channel` to `PERMANENT_ERROR_PATTERNS`
- added a regression case to `isPermanentDeliveryError` coverage

## Why this is safe

This only changes queue handling after Discord has already returned a hard 404 for the target channel.
It does not alter normal send behavior or retry handling for transient Discord/network failures.

## Verification

- `pnpm exec vitest run src/infra/outbound/outbound.test.ts`

## Notes

- `pnpm exec oxlint src/infra/outbound/delivery-queue.ts src/infra/outbound/outbound.test.ts` could not run locally because this machine is missing the optional `@oxlint` native binding for its Node/arch combination.
