### PR TITLE
feat(matrix): auto cross-sign device via recovery key at startup

### DIFF
--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -139,13 +139,26 @@ To get your recovery key: log into Element (or any Matrix client that supports c
 as the bot account and complete any cross-signing or secure backup setup it prompts you with.
 Save the recovery key phrase it generates — that is the value to use here.
 
-Use an environment variable to avoid storing the key in plain config:
+Store the key in an environment variable to avoid putting it in plain config:
 
 ```bash
 MATRIX_RECOVERY_KEY="EsTc LdvM MrJj zsCE DLbK Pjgs DcVT sj8p nRV2 EW5r"
 ```
 
-Or directly in config:
+Then reference it from config:
+
+```json5
+{
+  channels: {
+    matrix: {
+      encryption: true,
+      recoveryKey: "${MATRIX_RECOVERY_KEY}",
+    },
+  },
+}
+```
+
+Or directly in config (not recommended — treat the recovery key like a password):
 
 ```json5
 {

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -102,6 +102,7 @@ E2EE config (end to end encryption enabled):
       homeserver: "https://matrix.example.org",
       accessToken: "syt_***",
       encryption: true,
+      recoveryKey: { source: "env", provider: "default", id: "MATRIX_RECOVERY_KEY" },
       dm: { policy: "pairing" },
     },
   },
@@ -116,8 +117,6 @@ Enable with `channels.matrix.encryption: true`:
 
 - If the crypto module loads, encrypted rooms are decrypted automatically.
 - Outbound media is encrypted when sending to encrypted rooms.
-- On first connection, OpenClaw requests device verification from your other sessions.
-- Verify the device in another Matrix client (Element, etc.) to enable key sharing.
 - If the crypto module cannot be loaded, E2EE is disabled and encrypted rooms will not decrypt;
   OpenClaw logs a warning.
 - If you see missing crypto module errors (for example, `@matrix-org/matrix-sdk-crypto-nodejs-*`),
@@ -131,10 +130,36 @@ Crypto state is stored per account + access token in
 If the access token (device) changes, a new store is created and the bot must be
 re-verified for encrypted rooms.
 
-**Device verification:**
-When E2EE is enabled, the bot will request verification from your other sessions on startup.
-Open Element (or another client) and approve the verification request to establish trust.
-Once verified, the bot can decrypt messages in encrypted rooms.
+**Automatic device verification via recovery key:**
+Set `channels.matrix.recoveryKey` to your Matrix recovery key and OpenClaw will automatically
+cross-sign its own device at startup — no interactive verification needed. The device will
+appear as **Verified** in other Matrix clients.
+
+To get your recovery key: log into Element (or any Matrix client that supports cross-signing)
+as the bot account and complete any cross-signing or secure backup setup it prompts you with.
+Save the recovery key phrase it generates — that is the value to use here.
+
+Use an environment variable to avoid storing the key in plain config:
+
+```bash
+MATRIX_RECOVERY_KEY="EsTc LdvM MrJj zsCE DLbK Pjgs DcVT sj8p nRV2 EW5r"
+```
+
+Or directly in config:
+
+```json5
+{
+  channels: {
+    matrix: {
+      encryption: true,
+      recoveryKey: "EsTc LdvM MrJj zsCE DLbK Pjgs DcVT sj8p nRV2 EW5r",
+    },
+  },
+}
+```
+
+If `recoveryKey` is not configured, the device will show as unverified in other clients until
+manually verified.
 
 ## Multi-account
 
@@ -284,6 +309,7 @@ Provider options:
 - `channels.matrix.password`: password for login (token stored).
 - `channels.matrix.deviceName`: device display name.
 - `channels.matrix.encryption`: enable E2EE (default: false).
+- `channels.matrix.recoveryKey`: Matrix recovery key phrase for automatic cross-signing at startup. Supports SecretRef (env var recommended).
 - `channels.matrix.initialSyncLimit`: initial sync limit.
 - `channels.matrix.threadReplies`: `off | inbound | always` (default: inbound).
 - `channels.matrix.textChunkLimit`: outbound text chunk size (chars).

--- a/extensions/matrix/src/config-schema.test.ts
+++ b/extensions/matrix/src/config-schema.test.ts
@@ -2,6 +2,26 @@ import { describe, expect, it } from "vitest";
 import { MatrixConfigSchema } from "./config-schema.js";
 
 describe("MatrixConfigSchema SecretInput", () => {
+  it("accepts string recoveryKey at top-level", () => {
+    const result = MatrixConfigSchema.safeParse({
+      homeserver: "https://matrix.example.org",
+      userId: "@bot:example.org",
+      encryption: true,
+      recoveryKey: "EsTc LdvM MrJj zsCE DLbK Pjgs DcVT sj8p nRV2 EW5r",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts SecretRef recoveryKey at top-level", () => {
+    const result = MatrixConfigSchema.safeParse({
+      homeserver: "https://matrix.example.org",
+      userId: "@bot:example.org",
+      encryption: true,
+      recoveryKey: { source: "env", provider: "default", id: "MATRIX_RECOVERY_KEY" },
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("accepts SecretRef password at top-level", () => {
     const result = MatrixConfigSchema.safeParse({
       homeserver: "https://matrix.example.org",

--- a/extensions/matrix/src/config-schema.ts
+++ b/extensions/matrix/src/config-schema.ts
@@ -48,6 +48,7 @@ export const MatrixConfigSchema = z.object({
   deviceName: z.string().optional(),
   initialSyncLimit: z.number().optional(),
   encryption: z.boolean().optional(),
+  recoveryKey: buildSecretInputSchema().optional(),
   allowlistOnly: z.boolean().optional(),
   groupPolicy: z.enum(["open", "disabled", "allowlist"]).optional(),
   replyToMode: z.enum(["off", "first", "all"]).optional(),

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -79,6 +79,10 @@ export function resolveMatrixConfigForAccount(
       ? Math.max(0, Math.floor(matrix.initialSyncLimit))
       : undefined;
   const encryption = matrix.encryption ?? false;
+  const recoveryKey =
+    clean(matrix.recoveryKey, "channels.matrix.recoveryKey") ||
+    clean(env.MATRIX_RECOVERY_KEY, "MATRIX_RECOVERY_KEY") ||
+    undefined;
   return {
     homeserver,
     userId,
@@ -87,6 +91,7 @@ export function resolveMatrixConfigForAccount(
     deviceName,
     initialSyncLimit,
     encryption,
+    recoveryKey,
   };
 }
 
@@ -160,6 +165,7 @@ export async function resolveMatrixAuth(params?: {
       deviceName: resolved.deviceName,
       initialSyncLimit: resolved.initialSyncLimit,
       encryption: resolved.encryption,
+      recoveryKey: resolved.recoveryKey,
     };
   }
 
@@ -172,6 +178,7 @@ export async function resolveMatrixAuth(params?: {
       deviceName: resolved.deviceName,
       initialSyncLimit: resolved.initialSyncLimit,
       encryption: resolved.encryption,
+      recoveryKey: resolved.recoveryKey,
     };
   }
 
@@ -228,6 +235,7 @@ export async function resolveMatrixAuth(params?: {
     deviceName: resolved.deviceName,
     initialSyncLimit: resolved.initialSyncLimit,
     encryption: resolved.encryption,
+    recoveryKey: resolved.recoveryKey,
   };
 
   saveMatrixCredentials(

--- a/extensions/matrix/src/matrix/client/cross-signing.test.ts
+++ b/extensions/matrix/src/matrix/client/cross-signing.test.ts
@@ -1,0 +1,145 @@
+import crypto from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { decodeRecoveryKey, decryptSSSSSecret } from "./cross-signing.js";
+
+// ---------------------------------------------------------------------------
+// Helpers to produce valid test vectors
+// ---------------------------------------------------------------------------
+
+const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+function base58Encode(bytes: Uint8Array): string {
+  let num = BigInt(0);
+  for (const b of bytes) num = num * BigInt(256) + BigInt(b);
+  let encoded = "";
+  while (num > 0n) {
+    const rem = Number(num % 58n);
+    num = num / 58n;
+    encoded = BASE58_ALPHABET[rem] + encoded;
+  }
+  for (const b of bytes) {
+    if (b === 0) encoded = "1" + encoded;
+    else break;
+  }
+  return encoded;
+}
+
+function makeRecoveryKey(seed: Uint8Array): string {
+  // 2-byte prefix + 32-byte seed + 1-byte XOR parity
+  const raw = new Uint8Array(35);
+  raw[0] = 0x8b;
+  raw[1] = 0x01;
+  raw.set(seed, 2);
+  let parity = 0;
+  for (let i = 0; i < 34; i++) parity ^= raw[i];
+  raw[34] = parity;
+  return base58Encode(raw);
+}
+
+function encryptSSSSSecret(
+  plaintext: string,
+  rawKey: Uint8Array,
+  secretName: string,
+  keyId: string,
+): { encrypted: Record<string, { iv: string; ciphertext: string; mac: string }> } {
+  // Derive AES/HMAC keys using the same HKDF params as the production code
+  const salt = Buffer.alloc(32, 0);
+  const derived = crypto.hkdfSync("sha256", rawKey, salt, Buffer.from(secretName, "utf8"), 64) as ArrayBuffer;
+  const keyBuf = Buffer.from(derived);
+  const aesKey = keyBuf.subarray(0, 32);
+  const hmacKey = keyBuf.subarray(32, 64);
+
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv("aes-256-ctr", aesKey, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(Buffer.from(plaintext, "utf8")),
+    cipher.final(),
+  ]);
+  const mac = crypto.createHmac("sha256", hmacKey).update(ciphertext).digest("base64");
+
+  return {
+    encrypted: {
+      [keyId]: {
+        iv: iv.toString("base64"),
+        ciphertext: ciphertext.toString("base64"),
+        mac,
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("decodeRecoveryKey", () => {
+  it("decodes a valid recovery key and returns 32 raw bytes", () => {
+    const seed = crypto.randomBytes(32);
+    const key = makeRecoveryKey(seed);
+    const decoded = decodeRecoveryKey(key);
+    expect(decoded).toHaveLength(32);
+    expect(Buffer.from(decoded)).toEqual(seed);
+  });
+
+  it("strips spaces before decoding", () => {
+    const seed = crypto.randomBytes(32);
+    const key = makeRecoveryKey(seed);
+    // Add spaces as Element would display them
+    const spaced = key.match(/.{1,4}/g)?.join(" ") ?? key;
+    const decoded = decodeRecoveryKey(spaced);
+    expect(Buffer.from(decoded)).toEqual(seed);
+  });
+
+  it("throws on wrong prefix", () => {
+    // Build a key with wrong prefix bytes (0x00, 0x00 instead of 0x8B, 0x01)
+    const raw = new Uint8Array(35);
+    raw[0] = 0x00;
+    raw[1] = 0x00;
+    const seedBytes = crypto.randomBytes(32);
+    for (let i = 0; i < 32; i++) raw[i + 2] = seedBytes[i];
+    let parity = 0;
+    for (let i = 0; i < 34; i++) parity ^= raw[i];
+    raw[34] = parity;
+    const encoded = base58Encode(raw);
+    expect(() => decodeRecoveryKey(encoded)).toThrow(/prefix/);
+  });
+
+  it("throws on bad checksum", () => {
+    const seed = crypto.randomBytes(32);
+    const key = makeRecoveryKey(seed);
+    // Corrupt the last character
+    const corrupted = key.slice(0, -1) + (key[key.length - 1] === "A" ? "B" : "A");
+    expect(() => decodeRecoveryKey(corrupted)).toThrow();
+  });
+});
+
+describe("decryptSSSSSecret", () => {
+  it("decrypts a secret encrypted with the same key", () => {
+    const rawKey = crypto.randomBytes(32);
+    const keyId = "test-key-id";
+    const secretName = "m.cross_signing.self_signing";
+    const plaintext = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="; // fake base64 seed
+
+    const encrypted = encryptSSSSSecret(plaintext, rawKey, secretName, keyId);
+    const result = decryptSSSSSecret(encrypted, rawKey, secretName, keyId);
+    expect(result).toBe(plaintext);
+  });
+
+  it("throws if the key ID is not present in encrypted data", () => {
+    const rawKey = crypto.randomBytes(32);
+    const encrypted = { encrypted: { "other-key": { iv: "aaa=", ciphertext: "bbb=", mac: "ccc=" } } };
+    expect(() =>
+      decryptSSSSSecret(encrypted, rawKey, "m.cross_signing.self_signing", "missing-key"),
+    ).toThrow(/missing-key/);
+  });
+
+  it("throws on MAC mismatch (wrong key)", () => {
+    const rawKey = crypto.randomBytes(32);
+    const wrongKey = crypto.randomBytes(32);
+    const keyId = "test-key-id";
+    const encrypted = encryptSSSSSecret("secret", rawKey, "m.cross_signing.self_signing", keyId);
+    expect(() =>
+      decryptSSSSSecret(encrypted, wrongKey, "m.cross_signing.self_signing", keyId),
+    ).toThrow(/MAC/);
+  });
+});

--- a/extensions/matrix/src/matrix/client/cross-signing.test.ts
+++ b/extensions/matrix/src/matrix/client/cross-signing.test.ts
@@ -44,17 +44,20 @@ function encryptSSSSSecret(
 ): { encrypted: Record<string, { iv: string; ciphertext: string; mac: string }> } {
   // Derive AES/HMAC keys using the same HKDF params as the production code
   const salt = Buffer.alloc(32, 0);
-  const derived = crypto.hkdfSync("sha256", rawKey, salt, Buffer.from(secretName, "utf8"), 64) as ArrayBuffer;
+  const derived = crypto.hkdfSync(
+    "sha256",
+    rawKey,
+    salt,
+    Buffer.from(secretName, "utf8"),
+    64,
+  ) as ArrayBuffer;
   const keyBuf = Buffer.from(derived);
   const aesKey = keyBuf.subarray(0, 32);
   const hmacKey = keyBuf.subarray(32, 64);
 
   const iv = crypto.randomBytes(16);
   const cipher = crypto.createCipheriv("aes-256-ctr", aesKey, iv);
-  const ciphertext = Buffer.concat([
-    cipher.update(Buffer.from(plaintext, "utf8")),
-    cipher.final(),
-  ]);
+  const ciphertext = Buffer.concat([cipher.update(Buffer.from(plaintext, "utf8")), cipher.final()]);
   const mac = crypto.createHmac("sha256", hmacKey).update(ciphertext).digest("base64");
 
   return {
@@ -127,7 +130,9 @@ describe("decryptSSSSSecret", () => {
 
   it("throws if the key ID is not present in encrypted data", () => {
     const rawKey = crypto.randomBytes(32);
-    const encrypted = { encrypted: { "other-key": { iv: "aaa=", ciphertext: "bbb=", mac: "ccc=" } } };
+    const encrypted = {
+      encrypted: { "other-key": { iv: "aaa=", ciphertext: "bbb=", mac: "ccc=" } },
+    };
     expect(() =>
       decryptSSSSSecret(encrypted, rawKey, "m.cross_signing.self_signing", "missing-key"),
     ).toThrow(/missing-key/);

--- a/extensions/matrix/src/matrix/client/cross-signing.ts
+++ b/extensions/matrix/src/matrix/client/cross-signing.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/matrix";
 
 // Base58 alphabet used by Matrix recovery keys (standard Bitcoin alphabet)
-const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"; // pragma: allowlist secret
 
 /** Decode a base58 string to bytes. */
 function base58Decode(input: string): Uint8Array {
@@ -66,10 +66,7 @@ export function decodeRecoveryKey(recoveryKey: string): Uint8Array {
  * Derive AES and HMAC keys from a raw 32-byte SSSS key using HKDF-SHA256.
  * Per Matrix spec: salt = 32 zero bytes, info = utf8(name), output = 64 bytes.
  */
-function deriveKeyMaterial(
-  rawKey: Uint8Array,
-  info: string,
-): { aesKey: Buffer; hmacKey: Buffer } {
+function deriveKeyMaterial(rawKey: Uint8Array, info: string): { aesKey: Buffer; hmacKey: Buffer } {
   const salt = Buffer.alloc(32, 0);
   const infoBuffer = Buffer.from(info, "utf8");
   const derived = crypto.hkdfSync("sha256", rawKey, salt, infoBuffer, 64) as ArrayBuffer;
@@ -128,8 +125,7 @@ function canonicalJson(obj: unknown): string {
   if (Array.isArray(obj)) return `[${obj.map(canonicalJson).join(",")}]`;
   const keys = Object.keys(obj as Record<string, unknown>).sort();
   const pairs = keys.map(
-    (k) =>
-      `${JSON.stringify(k)}:${canonicalJson((obj as Record<string, unknown>)[k])}`,
+    (k) => `${JSON.stringify(k)}:${canonicalJson((obj as Record<string, unknown>)[k])}`,
   );
   return `{${pairs.join(",")}}`;
 }
@@ -270,12 +266,18 @@ export async function bootstrapCrossSigningFromRecoveryKey(params: {
       keyId = defaultKeyData.key;
     } catch {
       const keys = Object.keys(sskEncrypted.encrypted ?? {});
-      if (keys.length === 0) throw new Error("No encrypted entries found in m.cross_signing.self_signing");
+      if (keys.length === 0)
+        throw new Error("No encrypted entries found in m.cross_signing.self_signing");
       keyId = keys[0];
     }
 
     // 3. Decrypt the self-signing key seed
-    const sskSeedBase64 = decryptSSSSSecret(sskEncrypted, rawKey, "m.cross_signing.self_signing", keyId);
+    const sskSeedBase64 = decryptSSSSSecret(
+      sskEncrypted,
+      rawKey,
+      "m.cross_signing.self_signing",
+      keyId,
+    );
     const sskSeed = Buffer.from(sskSeedBase64, "base64");
 
     // 4. Import SSK as an Ed25519 private key and derive its public key
@@ -312,7 +314,11 @@ export async function bootstrapCrossSigningFromRecoveryKey(params: {
 
     // 8. Sign the canonical device key object (without existing signatures)
     const { signatures: _omit, unsigned: _unsigned, ...deviceKeyWithoutSigs } = deviceKey;
-    const signature = crypto.sign(null, Buffer.from(canonicalJson(deviceKeyWithoutSigs)), sskPrivKey);
+    const signature = crypto.sign(
+      null,
+      Buffer.from(canonicalJson(deviceKeyWithoutSigs)),
+      sskPrivKey,
+    );
 
     // 9. Upload the signature to the homeserver
     await matrixPost<unknown>({

--- a/extensions/matrix/src/matrix/client/cross-signing.ts
+++ b/extensions/matrix/src/matrix/client/cross-signing.ts
@@ -210,6 +210,7 @@ type DeviceKeys = {
   device_id: string;
   keys: Record<string, string>;
   signatures?: Record<string, Record<string, string>>;
+  unsigned?: Record<string, unknown>;
   user_id: string;
 };
 
@@ -226,9 +227,9 @@ export async function bootstrapCrossSigningFromRecoveryKey(params: {
   accessToken: string;
   recoveryKey: string;
   logger: {
-    info: (msg: string, ...args: unknown[]) => void;
-    warn: (msg: string, ...args: unknown[]) => void;
-    debug?: (msg: string, ...args: unknown[]) => void;
+    info: (msg: string, meta?: Record<string, unknown>) => void;
+    warn: (msg: string, meta?: Record<string, unknown>) => void;
+    debug?: (msg: string, meta?: Record<string, unknown>) => void;
   };
 }): Promise<void> {
   const { homeserver, userId, accessToken, logger } = params;

--- a/extensions/matrix/src/matrix/client/cross-signing.ts
+++ b/extensions/matrix/src/matrix/client/cross-signing.ts
@@ -1,0 +1,344 @@
+import crypto from "node:crypto";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/matrix";
+
+// Base58 alphabet used by Matrix recovery keys (standard Bitcoin alphabet)
+const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+/** Decode a base58 string to bytes. */
+function base58Decode(input: string): Uint8Array {
+  const alphabet = BASE58_ALPHABET;
+  let result = BigInt(0);
+  for (const char of input) {
+    const index = alphabet.indexOf(char);
+    if (index < 0) throw new Error(`Invalid base58 character: ${char}`);
+    result = result * BigInt(58) + BigInt(index);
+  }
+  // Convert BigInt to bytes
+  const hex = result.toString(16);
+  const padded = hex.length % 2 === 0 ? hex : "0" + hex;
+  const bytes = new Uint8Array(padded.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(padded.slice(i * 2, i * 2 + 2), 16);
+  }
+  // Account for leading '1's in base58 (each '1' = 0x00 byte)
+  let leadingZeros = 0;
+  for (const char of input) {
+    if (char === "1") leadingZeros++;
+    else break;
+  }
+  if (leadingZeros === 0) return bytes;
+  const result2 = new Uint8Array(leadingZeros + bytes.length);
+  result2.set(bytes, leadingZeros);
+  return result2;
+}
+
+/**
+ * Decode a Matrix recovery key (base58 + 2-byte prefix 0x8B,0x01 + 32-byte key + XOR parity).
+ * Returns the raw 32-byte key material.
+ */
+export function decodeRecoveryKey(recoveryKey: string): Uint8Array {
+  // Strip spaces and dashes (visual separators)
+  const cleaned = recoveryKey.replace(/[\s-]/g, "");
+  let bytes: Uint8Array;
+  try {
+    bytes = base58Decode(cleaned);
+  } catch (err) {
+    throw new Error(
+      `Recovery key base58 decode failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (bytes.length !== 35) {
+    throw new Error(`Recovery key has wrong length: expected 35 bytes, got ${bytes.length}`);
+  }
+  if (bytes[0] !== 0x8b || bytes[1] !== 0x01) {
+    throw new Error("Recovery key has wrong prefix: expected 0x8B 0x01");
+  }
+  // Verify XOR parity
+  let parity = 0;
+  for (let i = 0; i < 34; i++) parity ^= bytes[i];
+  if (parity !== bytes[34]) {
+    throw new Error("Recovery key checksum mismatch — key may be mistyped");
+  }
+  return bytes.slice(2, 34);
+}
+
+/**
+ * Derive AES and HMAC keys from a raw 32-byte SSSS key using HKDF-SHA256.
+ * Per Matrix spec: salt = 32 zero bytes, info = utf8(name), output = 64 bytes.
+ */
+function deriveKeyMaterial(
+  rawKey: Uint8Array,
+  info: string,
+): { aesKey: Buffer; hmacKey: Buffer } {
+  const salt = Buffer.alloc(32, 0);
+  const infoBuffer = Buffer.from(info, "utf8");
+  const derived = crypto.hkdfSync("sha256", rawKey, salt, infoBuffer, 64) as ArrayBuffer;
+  const keyBuf = Buffer.from(derived);
+  return {
+    aesKey: keyBuf.subarray(0, 32),
+    hmacKey: keyBuf.subarray(32, 64),
+  };
+}
+
+type SSSSEncryptedSecret = {
+  encrypted?: Record<string, { iv: string; ciphertext: string; mac: string }>;
+};
+
+/**
+ * Decrypt a Matrix SSSS secret (m.secret_storage.v1.aes-hmac-sha2).
+ * Returns the plaintext as a UTF-8 string.
+ */
+export function decryptSSSSSecret(
+  secretData: SSSSEncryptedSecret,
+  rawKey: Uint8Array,
+  secretName: string,
+  keyId: string,
+): string {
+  const entry = secretData.encrypted?.[keyId];
+  if (!entry) {
+    throw new Error(`Secret "${secretName}" has no entry for key ID "${keyId}"`);
+  }
+  const { aesKey, hmacKey } = deriveKeyMaterial(rawKey, secretName);
+
+  const iv = Buffer.from(entry.iv, "base64");
+  const ciphertext = Buffer.from(entry.ciphertext, "base64");
+  const storedMac = entry.mac.replace(/=+$/, "");
+
+  // Verify MAC (HMAC-SHA256 of ciphertext only, per matrix-js-sdk behaviour)
+  const computedMac = crypto
+    .createHmac("sha256", hmacKey)
+    .update(ciphertext)
+    .digest("base64")
+    .replace(/=+$/, "");
+  if (computedMac !== storedMac) {
+    throw new Error(
+      `MAC verification failed for secret "${secretName}" — wrong recovery key or corrupted secret`,
+    );
+  }
+
+  // Decrypt AES-256-CTR
+  const decipher = crypto.createDecipheriv("aes-256-ctr", aesKey, iv);
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return plaintext.toString("utf8");
+}
+
+/** Canonical JSON for Matrix: keys sorted lexicographically, no whitespace. */
+function canonicalJson(obj: unknown): string {
+  if (typeof obj !== "object" || obj === null) return JSON.stringify(obj);
+  if (Array.isArray(obj)) return `[${obj.map(canonicalJson).join(",")}]`;
+  const keys = Object.keys(obj as Record<string, unknown>).sort();
+  const pairs = keys.map(
+    (k) =>
+      `${JSON.stringify(k)}:${canonicalJson((obj as Record<string, unknown>)[k])}`,
+  );
+  return `{${pairs.join(",")}}`;
+}
+
+/** Ed25519 PKCS#8 DER header — prepend to a 32-byte seed to get a valid DER key. */
+const ED25519_PKCS8_HEADER = Buffer.from("302e020100300506032b657004220420", "hex");
+
+/** Create a Node.js KeyObject from a 32-byte Ed25519 seed via PKCS#8 DER encoding. */
+function privateKeyFromSeed(seed: Uint8Array): crypto.KeyObject {
+  if (seed.length !== 32) throw new Error(`Ed25519 seed must be 32 bytes, got ${seed.length}`);
+  const pkcs8 = Buffer.concat([ED25519_PKCS8_HEADER, Buffer.from(seed)]);
+  return crypto.createPrivateKey({ key: pkcs8, format: "der", type: "pkcs8" });
+}
+
+/** Extract raw 32-byte Ed25519 public key from an Ed25519 private KeyObject. */
+function publicKeyBytes(privKey: crypto.KeyObject): Buffer {
+  const pub = crypto.createPublicKey(privKey);
+  // Ed25519 SPKI DER: 30 2a 30 05 06 03 2b 65 70 03 21 00 <32 bytes pubkey>
+  const spki = pub.export({ format: "der", type: "spki" }) as Buffer;
+  return spki.subarray(spki.length - 32);
+}
+
+/** Authenticated GET request to the Matrix homeserver, returning parsed JSON. */
+async function matrixGet<T>(params: {
+  homeserver: string;
+  accessToken: string;
+  path: string;
+  auditContext: string;
+}): Promise<T> {
+  const { response, release } = await fetchWithSsrFGuard({
+    url: `${params.homeserver}${params.path}`,
+    init: {
+      method: "GET",
+      headers: { Authorization: `Bearer ${params.accessToken}` },
+    },
+    auditContext: params.auditContext,
+  });
+  try {
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Matrix HTTP ${response.status}: ${body}`);
+    }
+    return (await response.json()) as T;
+  } finally {
+    await release();
+  }
+}
+
+/** Authenticated POST request to the Matrix homeserver, returning parsed JSON. */
+async function matrixPost<T>(params: {
+  homeserver: string;
+  accessToken: string;
+  path: string;
+  body: unknown;
+  auditContext: string;
+}): Promise<T> {
+  const { response, release } = await fetchWithSsrFGuard({
+    url: `${params.homeserver}${params.path}`,
+    init: {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${params.accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(params.body),
+    },
+    auditContext: params.auditContext,
+  });
+  try {
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Matrix HTTP ${response.status}: ${body}`);
+    }
+    return (await response.json()) as T;
+  } finally {
+    await release();
+  }
+}
+
+type DeviceKeys = {
+  algorithms: string[];
+  device_id: string;
+  keys: Record<string, string>;
+  signatures?: Record<string, Record<string, string>>;
+  user_id: string;
+};
+
+/**
+ * Attempt to bootstrap cross-signing by signing the bot's own device key with the
+ * self-signing key loaded from Matrix secret storage (SSSS) via the provided recovery key.
+ *
+ * Runs at gateway startup when `encryption: true` and `recoveryKey` are both configured.
+ * Fails gracefully: logs warnings on any error and never throws.
+ */
+export async function bootstrapCrossSigningFromRecoveryKey(params: {
+  homeserver: string;
+  userId: string;
+  accessToken: string;
+  recoveryKey: string;
+  logger: {
+    info: (msg: string, ...args: unknown[]) => void;
+    warn: (msg: string, ...args: unknown[]) => void;
+    debug?: (msg: string, ...args: unknown[]) => void;
+  };
+}): Promise<void> {
+  const { homeserver, userId, accessToken, logger } = params;
+  const http = { homeserver, accessToken };
+
+  let rawKey: Uint8Array;
+  try {
+    rawKey = decodeRecoveryKey(params.recoveryKey);
+  } catch (err) {
+    logger.warn("matrix: cross-signing bootstrap skipped — could not decode recovery key", {
+      error: String(err),
+    });
+    return;
+  }
+
+  try {
+    // 1. Fetch the encrypted self-signing key secret from SSSS first so we can extract
+    //    the keyId from it when m.secret_storage.default is absent (partial SSSS setups).
+    const sskEncrypted = await matrixGet<SSSSEncryptedSecret>({
+      ...http,
+      path: `/_matrix/client/v3/user/${encodeURIComponent(userId)}/account_data/m.cross_signing.self_signing`,
+      auditContext: "matrix.ssss.selfSigningKey",
+    });
+
+    // 2. Resolve the SSSS key ID: prefer m.secret_storage.default, fall back to the
+    //    first key present in the encrypted secret itself.
+    let keyId: string;
+    try {
+      const defaultKeyData = await matrixGet<{ key: string }>({
+        ...http,
+        path: `/_matrix/client/v3/user/${encodeURIComponent(userId)}/account_data/m.secret_storage.default`,
+        auditContext: "matrix.ssss.defaultKey",
+      });
+      if (!defaultKeyData.key) throw new Error("m.secret_storage.default has no 'key' field");
+      keyId = defaultKeyData.key;
+    } catch {
+      const keys = Object.keys(sskEncrypted.encrypted ?? {});
+      if (keys.length === 0) throw new Error("No encrypted entries found in m.cross_signing.self_signing");
+      keyId = keys[0];
+    }
+
+    // 3. Decrypt the self-signing key seed
+    const sskSeedBase64 = decryptSSSSSecret(sskEncrypted, rawKey, "m.cross_signing.self_signing", keyId);
+    const sskSeed = Buffer.from(sskSeedBase64, "base64");
+
+    // 4. Import SSK as an Ed25519 private key and derive its public key
+    const sskPrivKey = privateKeyFromSeed(sskSeed);
+    const sskPubKeyBase64 = publicKeyBytes(sskPrivKey).toString("base64").replace(/=+$/, "");
+
+    // 5. Discover our current device ID via whoami
+    const whoami = await matrixGet<{ user_id: string; device_id: string }>({
+      ...http,
+      path: "/_matrix/client/v3/account/whoami",
+      auditContext: "matrix.whoami",
+    });
+    const deviceId = whoami.device_id;
+    if (!deviceId) throw new Error("whoami response missing device_id");
+
+    // 6. Fetch our own device key from the homeserver
+    const keysResult = await matrixPost<{
+      device_keys: Record<string, Record<string, DeviceKeys>>;
+    }>({
+      ...http,
+      path: "/_matrix/client/v3/keys/query",
+      body: { device_keys: { [userId]: [deviceId] } },
+      auditContext: "matrix.keys.query",
+    });
+    const deviceKey = keysResult.device_keys?.[userId]?.[deviceId];
+    if (!deviceKey) throw new Error(`Could not find own device key for ${userId}/${deviceId}`);
+
+    // 7. Skip if the device already bears a signature from this SSK
+    const sskSigKey = `ed25519:${sskPubKeyBase64}`;
+    if (deviceKey.signatures?.[userId]?.[sskSigKey]) {
+      logger.info(`matrix: device ${deviceId} is already cross-signed — skipping bootstrap`);
+      return;
+    }
+
+    // 8. Sign the canonical device key object (without existing signatures)
+    const { signatures: _omit, unsigned: _unsigned, ...deviceKeyWithoutSigs } = deviceKey;
+    const signature = crypto.sign(null, Buffer.from(canonicalJson(deviceKeyWithoutSigs)), sskPrivKey);
+
+    // 9. Upload the signature to the homeserver
+    await matrixPost<unknown>({
+      ...http,
+      path: "/_matrix/client/v3/keys/signatures/upload",
+      auditContext: "matrix.keys.signatures.upload",
+      body: {
+        [userId]: {
+          [deviceId]: {
+            ...deviceKeyWithoutSigs,
+            signatures: {
+              ...(deviceKey.signatures ?? {}),
+              [userId]: {
+                ...(deviceKey.signatures?.[userId] ?? {}),
+                [sskSigKey]: signature.toString("base64"),
+              },
+            },
+          },
+        },
+      },
+    });
+
+    logger.info(`matrix: device ${deviceId} successfully cross-signed via recovery key`);
+  } catch (err) {
+    logger.warn("matrix: cross-signing bootstrap failed (non-fatal)", {
+      error: String(err),
+    });
+  }
+}

--- a/extensions/matrix/src/matrix/client/cross-signing.ts
+++ b/extensions/matrix/src/matrix/client/cross-signing.ts
@@ -265,7 +265,10 @@ export async function bootstrapCrossSigningFromRecoveryKey(params: {
       });
       if (!defaultKeyData.key) throw new Error("m.secret_storage.default has no 'key' field");
       keyId = defaultKeyData.key;
-    } catch {
+    } catch (err) {
+      // Only fall back to extracting keyId from the secret if the account data is truly absent
+      // (HTTP 404). Propagate network errors, 5xx, etc. so they aren't silently hidden.
+      if (!(err instanceof Error && /HTTP 404/.test(err.message))) throw err;
       const keys = Object.keys(sskEncrypted.encrypted ?? {});
       if (keys.length === 0)
         throw new Error("No encrypted entries found in m.cross_signing.self_signing");
@@ -334,7 +337,7 @@ export async function bootstrapCrossSigningFromRecoveryKey(params: {
               ...(deviceKey.signatures ?? {}),
               [userId]: {
                 ...(deviceKey.signatures?.[userId] ?? {}),
-                [sskSigKey]: signature.toString("base64"),
+                [sskSigKey]: signature.toString("base64").replace(/=+$/, ""),
               },
             },
           },

--- a/extensions/matrix/src/matrix/client/types.ts
+++ b/extensions/matrix/src/matrix/client/types.ts
@@ -6,6 +6,7 @@ export type MatrixResolvedConfig = {
   deviceName?: string;
   initialSyncLimit?: number;
   encryption?: boolean;
+  recoveryKey?: string;
 };
 
 /**
@@ -22,6 +23,7 @@ export type MatrixAuth = {
   deviceName?: string;
   initialSyncLimit?: number;
   encryption?: boolean;
+  recoveryKey?: string;
 };
 
 export type MatrixStoragePaths = {

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -19,6 +19,7 @@ import {
   resolveSharedMatrixClient,
   stopSharedClientForAccount,
 } from "../client.js";
+import { bootstrapCrossSigningFromRecoveryKey } from "../client/cross-signing.js";
 import { normalizeMatrixUserId } from "./allowlist.js";
 import { registerMatrixAutoJoin } from "./auto-join.js";
 import { createDirectRoomTracker } from "./direct.js";
@@ -379,21 +380,16 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   // @vector-im/matrix-bot-sdk client is already started via resolveSharedMatrixClient
   logger.info(`matrix: logged in as ${auth.userId}`);
 
-  // If E2EE is enabled, trigger device verification
-  if (auth.encryption && client.crypto) {
-    try {
-      // Request verification from other sessions
-      const verificationRequest = await (
-        client.crypto as { requestOwnUserVerification?: () => Promise<unknown> }
-      ).requestOwnUserVerification?.();
-      if (verificationRequest) {
-        logger.info("matrix: device verification requested - please verify in another client");
-      }
-    } catch (err) {
-      logger.debug?.("Device verification request failed (may already be verified)", {
-        error: String(err),
-      });
-    }
+  // If E2EE is enabled and a recovery key is configured, bootstrap cross-signing so
+  // the bot's device shows as verified without any interactive emoji/QR flow.
+  if (auth.encryption && auth.recoveryKey) {
+    await bootstrapCrossSigningFromRecoveryKey({
+      homeserver: auth.homeserver,
+      userId: auth.userId,
+      accessToken: auth.accessToken,
+      recoveryKey: auth.recoveryKey,
+      logger,
+    });
   }
 
   await new Promise<void>((resolve) => {

--- a/extensions/matrix/src/types.ts
+++ b/extensions/matrix/src/types.ts
@@ -65,6 +65,8 @@ export type MatrixConfig = {
   initialSyncLimit?: number;
   /** Enable end-to-end encryption (E2EE). Default: false. */
   encryption?: boolean;
+  /** Matrix recovery key phrase for automatic cross-signing at startup. Supports SecretRef. */
+  recoveryKey?: SecretInput;
   /** If true, enforce allowlists for groups + DMs regardless of policy. */
   allowlistOnly?: boolean;
   /** Group message policy (default: allowlist). */


### PR DESCRIPTION
## Summary

- Replaces the dead `requestOwnUserVerification()` stub with a working cross-signing bootstrap that runs at gateway startup when `channels.matrix.recoveryKey` is configured
- Decrypts the self-signing key from Matrix SSSS (AES-256-CTR + HMAC-SHA256 via HKDF), derives the Ed25519 key pair, and uploads a signature for the bot's own device key — causing it to appear as **Verified** in Element and other Matrix clients without any interactive emoji/QR flow
- Handles partial SSSS setups where `m.secret_storage.default` is absent by extracting the key ID directly from the encrypted self-signing secret
- Uses unpadded base64 for key IDs per Matrix spec; excludes `unsigned` from canonical JSON when signing
- Adds `recoveryKey` config option (supports SecretRef/env var) to `config-schema.ts`, `types.ts`, and `config.ts`
- Adds unit tests for recovery key decoding and SSSS decryption
- Updates `docs/channels/matrix.md` with setup instructions and config reference

## Test plan

- [ ] Unit tests pass: `pnpm test cross-signing` and `pnpm test config-schema`
- [ ] Gateway starts with `encryption: true` and `recoveryKey` set — log shows `matrix: device XXXXX successfully cross-signed via recovery key`
- [ ] On subsequent restarts, log shows `matrix: device XXXXX is already cross-signed — skipping bootstrap`
- [ ] Device appears as **Verified** in Element after first startup
- [ ] Gateway starts normally without `recoveryKey` set (no regression)

## Notes

Tested end-to-end against a self-hosted Synapse server. The `m.secret_storage.default` fallback was necessary because Element does not always write this account data entry even when cross-signing is fully initialized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)