### PR TITLE
fix(followup): keep session override fallbacks

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -191,8 +191,9 @@ export async function runAgentTurnWithFallback(params: {
       };
       const blockReplyPipeline = params.blockReplyPipeline;
       const onToolResult = params.opts?.onToolResult;
+      const activeSessionEntry = params.getActiveSessionEntry();
       const fallbackResult = await runWithModelFallback({
-        ...resolveModelFallbackOptions(params.followupRun.run),
+        ...resolveModelFallbackOptions(params.followupRun.run, activeSessionEntry),
         run: (provider, model, runOptions) => {
           // Notify that model selection is complete (including after fallback).
           // This allows responsePrefix template interpolation with the actual model.

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -473,7 +473,7 @@ export async function runMemoryFlushIfNeeded(params: {
     .join("\n\n");
   try {
     await runWithModelFallback({
-      ...resolveModelFallbackOptions(params.followupRun.run),
+      ...resolveModelFallbackOptions(params.followupRun.run, activeSessionEntry),
       run: async (provider, model, runOptions) => {
         const { authProfile, embeddedContext, senderContext } = buildEmbeddedRunContexts({
           run: params.followupRun.run,

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -4,12 +4,18 @@ import type { FollowupRun } from "./queue.js";
 const hoisted = vi.hoisted(() => {
   const resolveRunModelFallbacksOverrideMock = vi.fn();
   const resolveEffectiveModelFallbacksMock = vi.fn();
-  return { resolveRunModelFallbacksOverrideMock, resolveEffectiveModelFallbacksMock };
+  const resolveFallbackAgentIdMock = vi.fn();
+  return {
+    resolveRunModelFallbacksOverrideMock,
+    resolveEffectiveModelFallbacksMock,
+    resolveFallbackAgentIdMock,
+  };
 });
 
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveEffectiveModelFallbacks: (...args: unknown[]) =>
     hoisted.resolveEffectiveModelFallbacksMock(...args),
+  resolveFallbackAgentId: (...args: unknown[]) => hoisted.resolveFallbackAgentIdMock(...args),
   resolveRunModelFallbacksOverride: (...args: unknown[]) =>
     hoisted.resolveRunModelFallbacksOverrideMock(...args),
 }));
@@ -49,6 +55,11 @@ describe("agent-runner-utils", () => {
   beforeEach(() => {
     hoisted.resolveRunModelFallbacksOverrideMock.mockClear();
     hoisted.resolveEffectiveModelFallbacksMock.mockClear();
+    hoisted.resolveFallbackAgentIdMock.mockClear();
+    hoisted.resolveFallbackAgentIdMock.mockImplementation(
+      (params: { agentId?: string; sessionKey?: string }) =>
+        params.agentId ?? `derived:${params.sessionKey ?? ""}`,
+    );
   });
 
   it("resolves model fallback options from run context", () => {
@@ -93,6 +104,10 @@ describe("agent-runner-utils", () => {
       modelOverride: "override-model",
     });
 
+    expect(hoisted.resolveFallbackAgentIdMock).toHaveBeenCalledWith({
+      agentId: run.agentId,
+      sessionKey: run.sessionKey,
+    });
     expect(hoisted.resolveEffectiveModelFallbacksMock).toHaveBeenCalledWith({
       cfg: run.config,
       agentId: run.agentId,
@@ -100,6 +115,67 @@ describe("agent-runner-utils", () => {
     });
     expect(hoisted.resolveRunModelFallbacksOverrideMock).not.toHaveBeenCalled();
     expect(resolved.fallbacksOverride).toEqual(["default-fallback"]);
+  });
+
+  it("derives the agent id from sessionKey for effective fallback resolution", () => {
+    hoisted.resolveEffectiveModelFallbacksMock.mockReturnValue(["derived-fallback"]);
+    const run = makeRun({
+      agentId: undefined,
+      sessionKey: "agent:derived-agent:session",
+    });
+
+    const resolved = resolveModelFallbackOptions(run, {
+      modelOverride: "override-model",
+    });
+
+    expect(hoisted.resolveFallbackAgentIdMock).toHaveBeenCalledWith({
+      agentId: undefined,
+      sessionKey: "agent:derived-agent:session",
+    });
+    expect(hoisted.resolveEffectiveModelFallbacksMock).toHaveBeenCalledWith({
+      cfg: run.config,
+      agentId: "derived:agent:derived-agent:session",
+      hasSessionModelOverride: true,
+    });
+    expect(resolved.fallbacksOverride).toEqual(["derived-fallback"]);
+  });
+
+  it("uses effective fallback resolution with hasSessionModelOverride=false when session overrides are absent", () => {
+    hoisted.resolveEffectiveModelFallbacksMock.mockReturnValue(["agent-specific-fallback"]);
+    const run = makeRun();
+
+    const resolved = resolveModelFallbackOptions(run, {
+      modelOverride: "",
+      providerOverride: "",
+    });
+
+    expect(hoisted.resolveEffectiveModelFallbacksMock).toHaveBeenCalledWith({
+      cfg: run.config,
+      agentId: run.agentId,
+      hasSessionModelOverride: false,
+    });
+    expect(hoisted.resolveRunModelFallbacksOverrideMock).not.toHaveBeenCalled();
+    expect(resolved.fallbacksOverride).toEqual(["agent-specific-fallback"]);
+  });
+
+  it("falls back to safe run-based resolution when config is missing", () => {
+    hoisted.resolveRunModelFallbacksOverrideMock.mockReturnValue(undefined);
+    const run = makeRun({
+      config: undefined,
+      agentId: undefined,
+    });
+
+    const resolved = resolveModelFallbackOptions(run, {
+      modelOverride: "override-model",
+    });
+
+    expect(hoisted.resolveEffectiveModelFallbacksMock).not.toHaveBeenCalled();
+    expect(hoisted.resolveRunModelFallbacksOverrideMock).toHaveBeenCalledWith({
+      cfg: undefined,
+      agentId: undefined,
+      sessionKey: run.sessionKey,
+    });
+    expect(resolved.fallbacksOverride).toBeUndefined();
   });
 
   it("builds embedded run base params with auth profile and run metadata", () => {

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -3,10 +3,13 @@ import type { FollowupRun } from "./queue.js";
 
 const hoisted = vi.hoisted(() => {
   const resolveRunModelFallbacksOverrideMock = vi.fn();
-  return { resolveRunModelFallbacksOverrideMock };
+  const resolveEffectiveModelFallbacksMock = vi.fn();
+  return { resolveRunModelFallbacksOverrideMock, resolveEffectiveModelFallbacksMock };
 });
 
 vi.mock("../../agents/agent-scope.js", () => ({
+  resolveEffectiveModelFallbacks: (...args: unknown[]) =>
+    hoisted.resolveEffectiveModelFallbacksMock(...args),
   resolveRunModelFallbacksOverride: (...args: unknown[]) =>
     hoisted.resolveRunModelFallbacksOverrideMock(...args),
 }));
@@ -45,6 +48,7 @@ function makeRun(overrides: Partial<FollowupRun["run"]> = {}): FollowupRun["run"
 describe("agent-runner-utils", () => {
   beforeEach(() => {
     hoisted.resolveRunModelFallbacksOverrideMock.mockClear();
+    hoisted.resolveEffectiveModelFallbacksMock.mockClear();
   });
 
   it("resolves model fallback options from run context", () => {
@@ -79,6 +83,23 @@ describe("agent-runner-utils", () => {
       sessionKey: run.sessionKey,
     });
     expect(resolved.fallbacksOverride).toEqual(["fallback-model"]);
+  });
+
+  it("uses effective fallback resolution when session model override is present", () => {
+    hoisted.resolveEffectiveModelFallbacksMock.mockReturnValue(["default-fallback"]);
+    const run = makeRun();
+
+    const resolved = resolveModelFallbackOptions(run, {
+      modelOverride: "override-model",
+    });
+
+    expect(hoisted.resolveEffectiveModelFallbacksMock).toHaveBeenCalledWith({
+      cfg: run.config,
+      agentId: run.agentId,
+      hasSessionModelOverride: true,
+    });
+    expect(hoisted.resolveRunModelFallbacksOverrideMock).not.toHaveBeenCalled();
+    expect(resolved.fallbacksOverride).toEqual(["default-fallback"]);
   });
 
   it("builds embedded run base params with auth profile and run metadata", () => {

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -1,5 +1,6 @@
 import {
   resolveEffectiveModelFallbacks,
+  resolveFallbackAgentId,
   resolveRunModelFallbacksOverride,
 } from "../../agents/agent-scope.js";
 import type { NormalizedUsage } from "../../agents/usage.js";
@@ -167,17 +168,21 @@ export function resolveModelFallbackOptions(
     providerOverride?: unknown;
   },
 ) {
-  const fallbacksOverride = sessionEntry
-    ? resolveEffectiveModelFallbacks({
-        cfg: run.config,
-        agentId: run.agentId,
-        hasSessionModelOverride: hasSessionModelOverride(sessionEntry),
-      })
-    : resolveRunModelFallbacksOverride({
-        cfg: run.config,
-        agentId: run.agentId,
-        sessionKey: run.sessionKey,
-      });
+  const fallbacksOverride =
+    sessionEntry && run.config
+      ? resolveEffectiveModelFallbacks({
+          cfg: run.config,
+          agentId: resolveFallbackAgentId({
+            agentId: run.agentId,
+            sessionKey: run.sessionKey,
+          }),
+          hasSessionModelOverride: hasSessionModelOverride(sessionEntry),
+        })
+      : resolveRunModelFallbacksOverride({
+          cfg: run.config,
+          agentId: run.agentId,
+          sessionKey: run.sessionKey,
+        });
   return {
     cfg: run.config,
     provider: run.provider,

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -1,4 +1,7 @@
-import { resolveRunModelFallbacksOverride } from "../../agents/agent-scope.js";
+import {
+  resolveEffectiveModelFallbacks,
+  resolveRunModelFallbacksOverride,
+} from "../../agents/agent-scope.js";
 import type { NormalizedUsage } from "../../agents/usage.js";
 import { getChannelDock } from "../../channels/dock.js";
 import type { ChannelId, ChannelThreadingToolContext } from "../../channels/plugins/types.js";
@@ -146,17 +149,41 @@ export const appendUsageLine = (payloads: ReplyPayload[], line: string): ReplyPa
 export const resolveEnforceFinalTag = (run: FollowupRun["run"], provider: string) =>
   Boolean(run.enforceFinalTag || isReasoningTagProvider(provider));
 
-export function resolveModelFallbackOptions(run: FollowupRun["run"]) {
+function hasSessionModelOverride(sessionEntry?: {
+  modelOverride?: unknown;
+  providerOverride?: unknown;
+}) {
+  const modelOverride =
+    typeof sessionEntry?.modelOverride === "string" ? sessionEntry.modelOverride.trim() : "";
+  const providerOverride =
+    typeof sessionEntry?.providerOverride === "string" ? sessionEntry.providerOverride.trim() : "";
+  return Boolean(modelOverride || providerOverride);
+}
+
+export function resolveModelFallbackOptions(
+  run: FollowupRun["run"],
+  sessionEntry?: {
+    modelOverride?: unknown;
+    providerOverride?: unknown;
+  },
+) {
+  const fallbacksOverride = sessionEntry
+    ? resolveEffectiveModelFallbacks({
+        cfg: run.config,
+        agentId: run.agentId,
+        hasSessionModelOverride: hasSessionModelOverride(sessionEntry),
+      })
+    : resolveRunModelFallbacksOverride({
+        cfg: run.config,
+        agentId: run.agentId,
+        sessionKey: run.sessionKey,
+      });
   return {
     cfg: run.config,
     provider: run.provider,
     model: run.model,
     agentDir: run.agentDir,
-    fallbacksOverride: resolveRunModelFallbacksOverride({
-      cfg: run.config,
-      agentId: run.agentId,
-      sessionKey: run.sessionKey,
-    }),
+    fallbacksOverride,
   };
 }
 

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -6,14 +6,17 @@ import { loadSessionStore, saveSessionStore, type SessionEntry } from "../../con
 import type { FollowupRun } from "./queue.js";
 import { createMockTypingController } from "./test-helpers.js";
 
+const hoisted = vi.hoisted(() => ({
+  runWithModelFallbackMock: vi.fn(),
+}));
+
 const runEmbeddedPiAgentMock = vi.fn();
 const routeReplyMock = vi.fn();
 const isRoutableChannelMock = vi.fn();
 
-vi.mock(
-  "../../agents/model-fallback.js",
-  async () => await import("../../test-utils/model-fallback.mock.js"),
-);
+vi.mock("../../agents/model-fallback.js", () => ({
+  runWithModelFallback: (params: unknown) => hoisted.runWithModelFallbackMock(params),
+}));
 
 vi.mock("../../agents/pi-embedded.js", () => ({
   runEmbeddedPiAgent: (params: unknown) => runEmbeddedPiAgentMock(params),
@@ -41,6 +44,18 @@ const ROUTABLE_TEST_CHANNELS = new Set([
 ]);
 
 beforeEach(() => {
+  hoisted.runWithModelFallbackMock.mockReset();
+  hoisted.runWithModelFallbackMock.mockImplementation(
+    async (params: {
+      provider: string;
+      model: string;
+      run: (provider: string, model: string) => Promise<unknown>;
+    }) => ({
+      result: await params.run(params.provider, params.model),
+      provider: params.provider,
+      model: params.model,
+    }),
+  );
   routeReplyMock.mockReset();
   routeReplyMock.mockResolvedValue({ ok: true });
   isRoutableChannelMock.mockReset();
@@ -576,5 +591,55 @@ describe("createFollowupRunner agentDir forwarding", () => {
     expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
     const call = runEmbeddedPiAgentMock.mock.calls.at(-1)?.[0] as { agentDir?: string };
     expect(call?.agentDir).toBe(agentDir);
+  });
+});
+
+describe("createFollowupRunner fallback resolution", () => {
+  it("uses effective fallbacks when the active session has a model override", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      providerOverride: "openrouter",
+      modelOverride: "meta-llama/llama-3.3-70b-instruct:free",
+    };
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply: vi.fn(async () => {}) },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionEntry,
+      sessionStore: { main: sessionEntry },
+      sessionKey: "main",
+      defaultModel: "openai/gpt-4.1-mini",
+    });
+
+    await runner(
+      createQueuedRun({
+        run: {
+          config: {
+            agents: {
+              defaults: {
+                model: {
+                  primary: "openai/gpt-4.1-mini",
+                  fallbacks: ["openrouter/openrouter/free"],
+                },
+              },
+            },
+          } as FollowupRun["run"]["config"],
+          provider: "openrouter",
+          model: "meta-llama/llama-3.3-70b-instruct:free",
+        },
+      }),
+    );
+
+    const fallbackCall = hoisted.runWithModelFallbackMock.mock.calls[0]?.[0] as
+      | { fallbacksOverride?: string[] }
+      | undefined;
+    expect(fallbackCall?.fallbacksOverride).toEqual(["openrouter/openrouter/free"]);
   });
 });

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import { resolveRunModelFallbacksOverride } from "../../agents/agent-scope.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
@@ -15,7 +14,7 @@ import { stripHeartbeatToken } from "../heartbeat.js";
 import type { OriginatingChannelType } from "../templating.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
-import { resolveRunAuthProfile } from "./agent-runner-utils.js";
+import { resolveModelFallbackOptions, resolveRunAuthProfile } from "./agent-runner-utils.js";
 import {
   resolveOriginAccountId,
   resolveOriginMessageProvider,
@@ -154,17 +153,14 @@ export function createFollowupRunner(params: {
       let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
         activeSessionEntry?.systemPromptReport,
       );
+      const fallbackOptions = resolveModelFallbackOptions(queued.run, activeSessionEntry);
       try {
         const fallbackResult = await runWithModelFallback({
           cfg: queued.run.config,
-          provider: queued.run.provider,
-          model: queued.run.model,
+          provider: fallbackOptions.provider,
+          model: fallbackOptions.model,
           agentDir: queued.run.agentDir,
-          fallbacksOverride: resolveRunModelFallbacksOverride({
-            cfg: queued.run.config,
-            agentId: queued.run.agentId,
-            sessionKey: queued.run.sessionKey,
-          }),
+          fallbacksOverride: fallbackOptions.fallbacksOverride,
           run: async (provider, model, runOptions) => {
             const authProfile = resolveRunAuthProfile(queued.run, provider);
             const result = await runEmbeddedPiAgent({


### PR DESCRIPTION
## Summary

Keep followup/model-fallback resolution aligned with session model overrides so retry lanes do not drop back to agent-default fallback behavior.

Fixes #38394.

## Problem

`commands/agent.ts` already uses `resolveEffectiveModelFallbacks(...)` when a session has a stored model override.
The followup lane was still using `resolveRunModelFallbacksOverride(...)`, which ignores that session-override signal.

That means a followup retry can resolve fallbacks as if the session had no override, even though the active session is pinned to a different provider/model.

## What changed

- taught `resolveModelFallbackOptions(...)` to accept the active `sessionEntry`
- use `resolveEffectiveModelFallbacks(...)` when the active session carries `modelOverride` / `providerOverride`
- thread the active session entry through followup, execution, and memory-flush fallback setup
- added regression coverage for the helper and the followup runner path

## Verification

- `pnpm exec vitest run src/auto-reply/reply/agent-runner-utils.test.ts src/auto-reply/reply/followup-runner.test.ts`
