### PR TITLE
Fix owner-only auth and overlapping skill env regressions

### DIFF
--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -266,6 +266,38 @@ describe("applySkillEnvOverrides", () => {
     });
   });
 
+  it("keeps env keys tracked until all overlapping overrides restore", async () => {
+    const workspaceDir = await makeWorkspace();
+    const skillDir = path.join(workspaceDir, "skills", "env-skill");
+    await writeSkill({
+      dir: skillDir,
+      name: "env-skill",
+      description: "Needs env",
+      metadata: '{"openclaw":{"requires":{"env":["ENV_KEY"]},"primaryEnv":"ENV_KEY"}}',
+    });
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, resolveTestSkillDirs(workspaceDir));
+
+    withClearedEnv(["ENV_KEY"], () => {
+      const config = { skills: { entries: { "env-skill": { apiKey: "injected" } } } };
+      const restoreFirst = applySkillEnvOverrides({ skills: entries, config });
+      const restoreSecond = applySkillEnvOverrides({ skills: entries, config });
+
+      try {
+        expect(process.env.ENV_KEY).toBe("injected");
+        expect(getActiveSkillEnvKeys().has("ENV_KEY")).toBe(true);
+
+        restoreFirst();
+        expect(process.env.ENV_KEY).toBe("injected");
+        expect(getActiveSkillEnvKeys().has("ENV_KEY")).toBe(true);
+      } finally {
+        restoreSecond();
+        expect(process.env.ENV_KEY).toBeUndefined();
+        expect(getActiveSkillEnvKeys().has("ENV_KEY")).toBe(false);
+      }
+    });
+  });
+
   it("applies env overrides from snapshots", async () => {
     const workspaceDir = await makeWorkspace();
     const skillDir = path.join(workspaceDir, "skills", "env-skill");

--- a/src/agents/skills/env-overrides.ts
+++ b/src/agents/skills/env-overrides.ts
@@ -9,8 +9,13 @@ import type { SkillEntry, SkillSnapshot } from "./types.js";
 
 const log = createSubsystemLogger("env-overrides");
 
-type EnvUpdate = { key: string; prev: string | undefined };
+type EnvUpdate = { key: string };
 type SkillConfig = NonNullable<ReturnType<typeof resolveSkillConfig>>;
+type ActiveSkillEnvEntry = {
+  baseline: string | undefined;
+  value: string;
+  count: number;
+};
 
 /**
  * Tracks env var keys that are currently injected by skill overrides.
@@ -18,11 +23,51 @@ type SkillConfig = NonNullable<ReturnType<typeof resolveSkillConfig>>;
  * leak to child processes (e.g., OPENAI_API_KEY leaking to Codex CLI).
  * @see https://github.com/openclaw/openclaw/issues/36280
  */
-const activeSkillEnvKeys = new Set<string>();
+const activeSkillEnvEntries = new Map<string, ActiveSkillEnvEntry>();
 
 /** Returns a snapshot of env var keys currently injected by skill overrides. */
 export function getActiveSkillEnvKeys(): ReadonlySet<string> {
-  return activeSkillEnvKeys;
+  return new Set(activeSkillEnvEntries.keys());
+}
+
+function acquireActiveSkillEnvKey(key: string, value: string): boolean {
+  const active = activeSkillEnvEntries.get(key);
+  if (active) {
+    active.count += 1;
+    if (process.env[key] === undefined) {
+      process.env[key] = active.value;
+    }
+    return true;
+  }
+  if (process.env[key] !== undefined) {
+    return false;
+  }
+  activeSkillEnvEntries.set(key, {
+    baseline: process.env[key],
+    value,
+    count: 1,
+  });
+  return true;
+}
+
+function releaseActiveSkillEnvKey(key: string) {
+  const active = activeSkillEnvEntries.get(key);
+  if (!active) {
+    return;
+  }
+  active.count -= 1;
+  if (active.count > 0) {
+    if (process.env[key] === undefined) {
+      process.env[key] = active.value;
+    }
+    return;
+  }
+  activeSkillEnvEntries.delete(key);
+  if (active.baseline === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = active.baseline;
+  }
 }
 
 type SanitizedSkillEnvOverrides = {
@@ -112,7 +157,9 @@ function applySkillConfigEnvOverrides(params: {
   if (skillConfig.env) {
     for (const [rawKey, envValue] of Object.entries(skillConfig.env)) {
       const envKey = rawKey.trim();
-      if (!envKey || !envValue || process.env[envKey]) {
+      const hasExternallyManagedValue =
+        process.env[envKey] !== undefined && !activeSkillEnvEntries.has(envKey);
+      if (!envKey || !envValue || hasExternallyManagedValue) {
         continue;
       }
       pendingOverrides[envKey] = envValue;
@@ -124,7 +171,11 @@ function applySkillConfigEnvOverrides(params: {
       value: skillConfig.apiKey,
       path: `skills.entries.${skillKey}.apiKey`,
     }) ?? "";
-  if (normalizedPrimaryEnv && resolvedApiKey && !process.env[normalizedPrimaryEnv]) {
+  const canInjectPrimaryEnv =
+    normalizedPrimaryEnv &&
+    (process.env[normalizedPrimaryEnv] === undefined ||
+      activeSkillEnvEntries.has(normalizedPrimaryEnv));
+  if (canInjectPrimaryEnv && resolvedApiKey) {
     if (!pendingOverrides[normalizedPrimaryEnv]) {
       pendingOverrides[normalizedPrimaryEnv] = resolvedApiKey;
     }
@@ -143,24 +194,18 @@ function applySkillConfigEnvOverrides(params: {
   }
 
   for (const [envKey, envValue] of Object.entries(sanitized.allowed)) {
-    if (process.env[envKey]) {
+    if (!acquireActiveSkillEnvKey(envKey, envValue)) {
       continue;
     }
-    updates.push({ key: envKey, prev: process.env[envKey] });
-    process.env[envKey] = envValue;
-    activeSkillEnvKeys.add(envKey);
+    updates.push({ key: envKey });
+    process.env[envKey] = activeSkillEnvEntries.get(envKey)?.value ?? envValue;
   }
 }
 
 function createEnvReverter(updates: EnvUpdate[]) {
   return () => {
     for (const update of updates) {
-      activeSkillEnvKeys.delete(update.key);
-      if (update.prev === undefined) {
-        delete process.env[update.key];
-      } else {
-        process.env[update.key] = update.prev;
-      }
+      releaseActiveSkillEnvKey(update.key);
     }
   };
 }

--- a/src/auto-reply/command-auth.owner-default.test.ts
+++ b/src/auto-reply/command-auth.owner-default.test.ts
@@ -22,8 +22,8 @@ afterEach(() => {
   setActivePluginRegistry(createRegistry());
 });
 
-describe("senderIsOwner defaults to true when no owner allowlist configured (#26319)", () => {
-  it("senderIsOwner is true when no ownerAllowFrom is configured (single-user default)", () => {
+describe("senderIsOwner only reflects explicit owner authorization", () => {
+  it("does not treat direct-message senders as owners when no ownerAllowFrom is configured", () => {
     const cfg = {
       channels: { discord: {} },
     } as OpenClawConfig;
@@ -42,12 +42,11 @@ describe("senderIsOwner defaults to true when no owner allowlist configured (#26
       commandAuthorized: true,
     });
 
-    // Without an explicit ownerAllowFrom list, the sole authorized user should
-    // be treated as owner so ownerOnly tools (cron, gateway) are available.
-    expect(auth.senderIsOwner).toBe(true);
+    expect(auth.senderIsOwner).toBe(false);
+    expect(auth.isAuthorizedSender).toBe(true);
   });
 
-  it("senderIsOwner is false when no ownerAllowFrom is configured in a group chat", () => {
+  it("does not treat group-chat senders as owners when no ownerAllowFrom is configured", () => {
     const cfg = {
       channels: { discord: {} },
     } as OpenClawConfig;
@@ -67,6 +66,7 @@ describe("senderIsOwner defaults to true when no owner allowlist configured (#26
     });
 
     expect(auth.senderIsOwner).toBe(false);
+    expect(auth.isAuthorizedSender).toBe(true);
   });
 
   it("senderIsOwner is false when ownerAllowFrom is configured and sender does not match", () => {

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -351,14 +351,7 @@ export function resolveCommandAuthorization(params: {
     Array.isArray(ctx.GatewayClientScopes) &&
     ctx.GatewayClientScopes.includes("operator.admin");
   const ownerAllowlistConfigured = ownerAllowAll || explicitOwners.length > 0;
-  const isDirectChat = (ctx.ChatType ?? "").trim().toLowerCase() === "direct";
-  // In the default single-user direct-chat setup, allow an identified sender to
-  // keep ownerOnly tools even without an explicit owner allowlist.
-  const senderIsOwner =
-    senderIsOwnerByIdentity ||
-    senderIsOwnerByScope ||
-    ownerAllowAll ||
-    (!ownerAllowlistConfigured && isDirectChat && Boolean(senderId));
+  const senderIsOwner = senderIsOwnerByIdentity || senderIsOwnerByScope || ownerAllowAll;
   const requireOwner = enforceOwner || ownerAllowlistConfigured;
   const isOwnerForCommands = !requireOwner
     ? true


### PR DESCRIPTION
## Summary

- Problem: a recent auth change treated any identified direct-message sender as an owner when `commands.ownerAllowFrom` was unset, which widened access to `ownerOnly` tools.
- Why it matters: shared or misconfigured messaging surfaces could expose owner-only command/tool paths beyond explicitly authorized owners.
- What changed: owner resolution now only trusts explicit owner matches, wildcard owner config, or internal `operator.admin` sessions; overlapping skill env overrides are now reference-counted so ACP child-process env stripping remains active until all overlapping restores complete.
- What did NOT change (scope boundary): default command authorization behavior and non-skill host env handling remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Direct-message senders are no longer implicitly treated as owners when `commands.ownerAllowFrom` is unset.
- Overlapping skill env overrides keep ACP secret stripping active until all overrides have been restored.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  This narrows owner-only tool eligibility back to explicit owner signals and hardens skill env cleanup so overlapping runs cannot prematurely stop ACP env stripping for injected credentials.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local checkout with `pnpm`
- Model/provider: N/A
- Integration/channel (if any): Discord auth path and ACP harness
- Relevant config (redacted): default command auth config; skill entry with `apiKey` override

### Steps

1. Run `pnpm exec vitest run src/auto-reply/command-auth.owner-default.test.ts src/auto-reply/command-control.test.ts src/agents/skills.test.ts src/acp/client.test.ts`.
2. Run `pnpm check`.
3. Confirm direct-message senders without `ownerAllowFrom` are not owners and overlapping env restores keep `getActiveSkillEnvKeys()` populated until the final restore.

### Expected

- Owner-only gating stays tied to explicit owner authorization.
- ACP env stripping stays active across overlapping skill env overrides.

### Actual

- Verified after the fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused Vitest coverage for auth ownership, command control, skills env overrides, and ACP client spawning; full `pnpm check`.
- Edge cases checked: direct/group senders without owner allowlists, wildcard/internal admin owner resolution, overlapping env override restore ordering.
- What you did **not** verify: full `pnpm test` suite on this branch.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the two commits on this branch.
- Files/config to restore: `src/auto-reply/command-auth.ts`, `src/agents/skills/env-overrides.ts`, and their targeted tests.
- Known bad symptoms reviewers should watch for: owner-only tools becoming unavailable for explicit owners, or skill env overrides not restoring to baseline after nested use.

## Risks and Mitigations

- Risk: overlapping overrides with different values still preserve the first active injected value for the lifetime of the overlap.
  - Mitigation: current skill env injection semantics only apply when the env var is otherwise unset, and the added regression test locks the no-leak restore behavior that ACP depends on.
