### PR TITLE
fix(telegram): log native command menu syncs

### DIFF
--- a/src/telegram/bot-native-command-menu.test.ts
+++ b/src/telegram/bot-native-command-menu.test.ts
@@ -136,7 +136,7 @@ describe("bot-native-command-menu", () => {
     const setMyCommands = vi.fn(async () => undefined);
     const runtimeLog = vi.fn();
 
-  syncMenuCommandsWithMocks({
+    syncMenuCommandsWithMocks({
       deleteMyCommands,
       setMyCommands,
       runtimeLog,

--- a/src/telegram/bot-native-command-menu.test.ts
+++ b/src/telegram/bot-native-command-menu.test.ts
@@ -131,6 +131,49 @@ describe("bot-native-command-menu", () => {
     expect(callOrder).toEqual(["delete", "set"]);
   });
 
+  it("logs successful native command syncs", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+    const runtimeLog = vi.fn();
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      runtimeLog,
+      commandsToRegister: [{ command: "status", description: "Show status" }],
+      accountId: `test-success-log-${Date.now()}`,
+      botIdentity: "bot-a",
+    });
+
+    await vi.waitFor(() => {
+      expect(setMyCommands).toHaveBeenCalledTimes(1);
+    });
+
+    expect(runtimeLog).toHaveBeenCalledWith("telegram: synced 1 native command");
+  });
+
+  it("logs when the Telegram native command menu is cleared", async () => {
+    const deleteMyCommands = vi.fn(async () => undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+    const runtimeLog = vi.fn();
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      runtimeLog,
+      commandsToRegister: [],
+      accountId: `test-clear-log-${Date.now()}`,
+      botIdentity: "bot-a",
+    });
+
+    await vi.waitFor(() => {
+      expect(deleteMyCommands).toHaveBeenCalledTimes(1);
+    });
+
+    expect(setMyCommands).not.toHaveBeenCalled();
+    expect(runtimeLog).toHaveBeenCalledWith("telegram: cleared native command menu");
+  });
+
   it("produces a stable hash regardless of command order (#32017)", () => {
     const commands = [
       { command: "bravo", description: "B" },

--- a/src/telegram/bot-native-command-menu.test.ts
+++ b/src/telegram/bot-native-command-menu.test.ts
@@ -136,7 +136,7 @@ describe("bot-native-command-menu", () => {
     const setMyCommands = vi.fn(async () => undefined);
     const runtimeLog = vi.fn();
 
-    syncMenuCommandsWithMocks({
+  syncMenuCommandsWithMocks({
       deleteMyCommands,
       setMyCommands,
       runtimeLog,
@@ -147,9 +147,8 @@ describe("bot-native-command-menu", () => {
 
     await vi.waitFor(() => {
       expect(setMyCommands).toHaveBeenCalledTimes(1);
+      expect(runtimeLog).toHaveBeenCalledWith("telegram: synced 1 native command");
     });
-
-    expect(runtimeLog).toHaveBeenCalledWith("telegram: synced 1 native command");
   });
 
   it("logs when the Telegram native command menu is cleared", async () => {
@@ -168,10 +167,10 @@ describe("bot-native-command-menu", () => {
 
     await vi.waitFor(() => {
       expect(deleteMyCommands).toHaveBeenCalledTimes(1);
+      expect(runtimeLog).toHaveBeenCalledWith("telegram: cleared native command menu");
     });
 
     expect(setMyCommands).not.toHaveBeenCalled();
-    expect(runtimeLog).toHaveBeenCalledWith("telegram: cleared native command menu");
   });
 
   it("produces a stable hash regardless of command order (#32017)", () => {

--- a/src/telegram/bot-native-command-menu.ts
+++ b/src/telegram/bot-native-command-menu.ts
@@ -128,6 +128,10 @@ function resolveCommandHashPath(accountId?: string, botIdentity?: string): strin
   return path.join(stateDir, "telegram", `command-hash-${normalizedAccount}-${botHash}.txt`);
 }
 
+function formatNativeCommandCount(count: number): string {
+  return `${count} native command${count === 1 ? "" : "s"}`;
+}
+
 async function readCachedCommandHash(
   accountId?: string,
   botIdentity?: string,
@@ -192,6 +196,7 @@ export function syncTelegramMenuCommands(params: {
         return;
       }
       await writeCachedCommandHash(accountId, botIdentity, currentHash);
+      runtime.log?.("telegram: cleared native command menu");
       return;
     }
 
@@ -204,6 +209,7 @@ export function syncTelegramMenuCommands(params: {
           fn: () => bot.api.setMyCommands(retryCommands),
         });
         await writeCachedCommandHash(accountId, botIdentity, currentHash);
+        runtime.log?.(`telegram: synced ${formatNativeCommandCount(retryCommands.length)}`);
         return;
       } catch (err) {
         if (!isBotCommandsTooMuchError(err)) {


### PR DESCRIPTION
## Summary
- add operator-facing logs when Telegram native command sync succeeds
- log when the native command menu is cleared successfully
- add regression coverage for both success paths

## Why
Fixes #38367's main observability gap: command sync success was silent, which made it hard to distinguish Telegram client caching from sync never happening.

## Testing
- pnpm exec vitest run src/telegram/bot-native-command-menu.test.ts