### PR TITLE
fix(sessions): include requester identity in a2a prompts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,13 @@ jobs:
         with:
           submodules: false
 
+      - name: Ensure secrets base commit (PR fast path)
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
             BASE="${{ github.event.before }}"
           else
-            BASE="${{ github.event.pull_request.base.sha }}"
+            BASE="$PR_BASE_SHA"
           fi
 
           node scripts/ci-changed-scope.mjs --base "$BASE" --head HEAD
@@ -322,15 +322,17 @@ jobs:
       - name: Detect secrets
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
 
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "$GITHUB_REF" = "refs/heads/main" ]; then
             echo "Skipping detect-secrets on main until the allowlist cleanup lands."
             exit 0
           fi
 
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
             echo "Running full detect-secrets scan on push."
             pre-commit run --all-files detect-secrets
             exit 0
@@ -343,13 +345,13 @@ jobs:
             [ -f "$path" ] || continue
             changed_files+=("$path")
           done < <(
-            gh api "repos/$GITHUB_REPO_NAME/pulls/${{ github.event.pull_request.number }}/files?per_page=100" \
+            gh api "repos/$GITHUB_REPO_NAME/pulls/$PR_NUMBER/files?per_page=100" \
               --paginate \
               --jq '.[].filename'
           )
 
           if [ "${#changed_files[@]}" -eq 0 ]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
+            BASE="$PR_BASE_SHA"
             if git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1; then
               while IFS= read -r path; do
                 [ -n "$path" ] || continue
@@ -371,16 +373,31 @@ jobs:
         run: pre-commit run --all-files detect-private-key
 
       - name: Audit changed GitHub workflows with zizmor
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
 
-          if [ "${{ github.event_name }}" = "push" ]; then
-            BASE="${{ github.event.before }}"
+          workflow_files=()
+
+          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+            BASE="$PUSH_BASE_SHA"
+            mapfile -t workflow_files < <(git diff --name-only "$BASE" HEAD -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
           else
-            BASE="${{ github.event.pull_request.base.sha }}"
+            mapfile -t workflow_files < <(
+              gh api "repos/$GITHUB_REPO_NAME/pulls/$PR_NUMBER/files?per_page=100" \
+                --paginate \
+                --jq '.[] | .filename | select(test("^\.github/workflows/.*\.ya?ml$"))'
+            )
+            if [ "${#workflow_files[@]}" -eq 0 ]; then
+              BASE="$PR_BASE_SHA"
+              mapfile -t workflow_files < <(git diff --name-only "$BASE" HEAD -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
+            fi
           fi
 
-          mapfile -t workflow_files < <(git diff --name-only "$BASE" HEAD -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
           if [ "${#workflow_files[@]}" -eq 0 ]; then
             echo "No workflow changes detected; skipping zizmor."
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "push" ]; then
             BASE="${{ github.event.before }}"
           else
-            BASE="$PR_BASE_SHA"
+            BASE="${{ github.event.pull_request.base.sha }}"
           fi
 
           node scripts/ci-changed-scope.mjs --base "$BASE" --head HEAD

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,8 @@ jobs:
           python -m pip install pre-commit
 
       - name: Detect secrets
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -334,14 +336,27 @@ jobs:
             exit 0
           fi
 
-          BASE="${{ github.event.pull_request.base.sha }}"
           changed_files=()
-          if git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1; then
-            while IFS= read -r path; do
-              [ -n "$path" ] || continue
-              [ -f "$path" ] || continue
-              changed_files+=("$path")
-            done < <(git diff --name-only --diff-filter=ACMR "$BASE" HEAD)
+
+          while IFS= read -r path; do
+            [ -n "$path" ] || continue
+            [ -f "$path" ] || continue
+            changed_files+=("$path")
+          done < <(
+            gh api "repos/$GITHUB_REPO_NAME/pulls/${{ github.event.pull_request.number }}/files?per_page=100" \
+              --paginate \
+              --jq '.[].filename'
+          )
+
+          if [ "${#changed_files[@]}" -eq 0 ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            if git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1; then
+              while IFS= read -r path; do
+                [ -n "$path" ] || continue
+                [ -f "$path" ] || continue
+                changed_files+=("$path")
+              done < <(git diff --name-only --diff-filter=ACMR "$BASE" HEAD)
+            fi
           fi
 
           if [ "${#changed_files[@]}" -gt 0 ]; then

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -17,6 +17,11 @@ export type AnnounceTarget = {
   threadId?: string; // Forum topic/thread ID
 };
 
+function formatRequesterNameLine(requesterName?: string) {
+  const trimmed = requesterName?.trim();
+  return trimmed ? `Agent 1 (requester) name: ${trimmed}.` : undefined;
+}
+
 export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget | null {
   const rawParts = sessionKey.split(":").filter(Boolean);
   const parts = rawParts.length >= 3 && rawParts[0] === "agent" ? rawParts.slice(2) : rawParts;
@@ -71,12 +76,14 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
 }
 
 export function buildAgentToAgentMessageContext(params: {
+  requesterName?: string;
   requesterSessionKey?: string;
   requesterChannel?: string;
   targetSessionKey: string;
 }) {
   const lines = [
     "Agent-to-agent message context:",
+    formatRequesterNameLine(params.requesterName),
     params.requesterSessionKey
       ? `Agent 1 (requester) session: ${params.requesterSessionKey}.`
       : undefined,
@@ -89,6 +96,7 @@ export function buildAgentToAgentMessageContext(params: {
 }
 
 export function buildAgentToAgentReplyContext(params: {
+  requesterName?: string;
   requesterSessionKey?: string;
   requesterChannel?: string;
   targetSessionKey: string;
@@ -103,6 +111,7 @@ export function buildAgentToAgentReplyContext(params: {
     "Agent-to-agent reply step:",
     `Current agent: ${currentLabel}.`,
     `Turn ${params.turn} of ${params.maxTurns}.`,
+    formatRequesterNameLine(params.requesterName),
     params.requesterSessionKey
       ? `Agent 1 (requester) session: ${params.requesterSessionKey}.`
       : undefined,
@@ -117,6 +126,7 @@ export function buildAgentToAgentReplyContext(params: {
 }
 
 export function buildAgentToAgentAnnounceContext(params: {
+  requesterName?: string;
   requesterSessionKey?: string;
   requesterChannel?: string;
   targetSessionKey: string;
@@ -127,6 +137,7 @@ export function buildAgentToAgentAnnounceContext(params: {
 }) {
   const lines = [
     "Agent-to-agent announce step:",
+    formatRequesterNameLine(params.requesterName),
     params.requesterSessionKey
       ? `Agent 1 (requester) session: ${params.requesterSessionKey}.`
       : undefined,

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -21,6 +21,7 @@ export async function runSessionsSendA2AFlow(params: {
   message: string;
   announceTimeoutMs: number;
   maxPingPongTurns: number;
+  requesterName?: string;
   requesterSessionKey?: string;
   requesterChannel?: GatewayMessageChannel;
   roundOneReply?: string;
@@ -69,6 +70,7 @@ export async function runSessionsSendA2AFlow(params: {
         const currentRole =
           currentSessionKey === params.requesterSessionKey ? "requester" : "target";
         const replyPrompt = buildAgentToAgentReplyContext({
+          requesterName: params.requesterName,
           requesterSessionKey: params.requesterSessionKey,
           requesterChannel: params.requesterChannel,
           targetSessionKey: params.displayKey,
@@ -100,6 +102,7 @@ export async function runSessionsSendA2AFlow(params: {
     }
 
     const announcePrompt = buildAgentToAgentAnnounceContext({
+      requesterName: params.requesterName,
       requesterSessionKey: params.requesterSessionKey,
       requesterChannel: params.requesterChannel,
       targetSessionKey: params.displayKey,

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -8,6 +8,7 @@ import {
   type GatewayMessageChannel,
   INTERNAL_MESSAGE_CHANNEL,
 } from "../../utils/message-channel.js";
+import { resolveIdentityName } from "../identity.js";
 import { AGENT_LANE_NESTED } from "../lanes.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";
@@ -196,6 +197,11 @@ export function createSessionsSendTool(opts?: {
       const announceTimeoutMs = timeoutSeconds === 0 ? 30_000 : timeoutMs;
       const idempotencyKey = crypto.randomUUID();
       let runId: string = idempotencyKey;
+      const requesterSessionKey = opts?.agentSessionKey;
+      const requesterChannel = opts?.agentChannel;
+      const requesterName = requesterSessionKey
+        ? resolveIdentityName(cfg, resolveAgentIdFromSessionKey(requesterSessionKey))
+        : undefined;
       const visibilityGuard = await createSessionVisibilityGuard({
         action: "send",
         requesterSessionKey: effectiveRequesterKey,
@@ -213,8 +219,9 @@ export function createSessionsSendTool(opts?: {
       }
 
       const agentMessageContext = buildAgentToAgentMessageContext({
-        requesterSessionKey: opts?.agentSessionKey,
-        requesterChannel: opts?.agentChannel,
+        requesterName,
+        requesterSessionKey,
+        requesterChannel,
         targetSessionKey: displayKey,
       });
       const sendParams = {
@@ -232,8 +239,6 @@ export function createSessionsSendTool(opts?: {
           sourceTool: "sessions_send",
         },
       };
-      const requesterSessionKey = opts?.agentSessionKey;
-      const requesterChannel = opts?.agentChannel;
       const maxPingPongTurns = resolvePingPongTurns(cfg);
       const delivery = { status: "pending", mode: "announce" as const };
       const startA2AFlow = (roundOneReply?: string, waitRunId?: string) => {
@@ -243,6 +248,7 @@ export function createSessionsSendTool(opts?: {
           message,
           announceTimeoutMs,
           maxPingPongTurns,
+          requesterName,
           requesterSessionKey,
           requesterChannel,
           roundOneReply,

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -3,6 +3,10 @@ import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { extractAssistantText, sanitizeTextContent } from "./sessions-helpers.js";
+import {
+  buildAgentToAgentAnnounceContext,
+  buildAgentToAgentReplyContext,
+} from "./sessions-send-helpers.js";
 
 const callGatewayMock = vi.fn();
 vi.mock("../../gateway/call.js", () => ({
@@ -14,6 +18,10 @@ type SessionsToolTestConfig = {
   tools: {
     agentToAgent: { enabled: boolean };
     sessions?: { visibility: "all" | "own" };
+  };
+  agents?: {
+    defaults?: Record<string, unknown>;
+    list?: Array<{ id: string; default?: boolean; identity?: { name?: string } }>;
   };
 };
 
@@ -198,6 +206,36 @@ describe("extractAssistantText", () => {
     expect(extractAssistantText(message)).toBe(
       "Firebase downgraded us to the free Spark plan. Check whether billing should be re-enabled.",
     );
+  });
+});
+
+describe("agent-to-agent context helpers", () => {
+  it("includes requester identity name in reply and announce prompts", () => {
+    const requesterName = "Stevo";
+
+    const replyPrompt = buildAgentToAgentReplyContext({
+      requesterName,
+      requesterSessionKey: "agent:habit:telegram:direct:6344794319",
+      requesterChannel: "telegram",
+      targetSessionKey: "agent:story:main",
+      targetChannel: "telegram",
+      currentRole: "requester",
+      turn: 1,
+      maxTurns: 2,
+    });
+    expect(replyPrompt).toContain("Agent 1 (requester) name: Stevo.");
+
+    const announcePrompt = buildAgentToAgentAnnounceContext({
+      requesterName,
+      requesterSessionKey: "agent:habit:telegram:direct:6344794319",
+      requesterChannel: "telegram",
+      targetSessionKey: "agent:story:main",
+      targetChannel: "telegram",
+      originalMessage: "hi",
+      roundOneReply: "hello",
+      latestReply: "still hello",
+    });
+    expect(announcePrompt).toContain("Agent 1 (requester) name: Stevo.");
   });
 });
 
@@ -438,5 +476,44 @@ describe("sessions_send gating", () => {
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
     expect(callGatewayMock.mock.calls[0]?.[0]).toMatchObject({ method: "sessions.list" });
     expect(result.details).toMatchObject({ status: "forbidden" });
+  });
+
+  it("includes requester identity name in the initial agent-to-agent prompt", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: {
+        agentToAgent: { enabled: true },
+        sessions: { visibility: "all" },
+      },
+      agents: {
+        defaults: {},
+        list: [{ id: "habit", identity: { name: "Stevo" } }, { id: "other" }],
+      },
+    });
+    callGatewayMock.mockImplementation(async (opts: { method?: string }) => {
+      if (opts.method === "agent") {
+        return { runId: "run-1" };
+      }
+      if (opts.method === "agent.wait") {
+        return { status: "error", error: "stop after prompt capture" };
+      }
+      throw new Error(`Unexpected method: ${String(opts.method)}`);
+    });
+
+    const tool = createSessionsSendTool({
+      agentSessionKey: "agent:habit:telegram:direct:6344794319",
+      agentChannel: "telegram",
+    });
+    const result = await tool.execute("call-a2a", {
+      sessionKey: "agent:other:main",
+      message: "hi",
+      timeoutSeconds: 1,
+    });
+
+    const agentCall = callGatewayMock.mock.calls.find(
+      ([arg]) => (arg as { method?: string }).method === "agent",
+    )?.[0] as { params?: { extraSystemPrompt?: string } } | undefined;
+    expect(agentCall?.params?.extraSystemPrompt).toContain("Agent 1 (requester) name: Stevo.");
+    expect(result.details).toMatchObject({ status: "error", error: "stop after prompt capture" });
   });
 });


### PR DESCRIPTION
## Summary

- Problem: `sessions_send` agent-to-agent prompts only included the requester session/channel, so receivers often guessed the sender as the default/main agent instead of the configured requester identity.
- Why it matters: multi-agent handoffs lose sender attribution, which makes the receiving agent answer with the wrong persona/name.
- What changed: threaded the requester's configured `identity.name` into the initial `sessions_send` prompt plus the follow-up reply/announce prompts, and added targeted tests.
- What did NOT change (scope boundary): no routing, delivery, agent selection, or session visibility behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38570
- Related #38570

## User-visible / Behavior Changes

- `sessions_send` now includes `Agent 1 (requester) name: <identity.name>.` in agent-to-agent prompts when the requester session maps to an agent with a configured identity name.
- The same requester-name hint is now present in the ping-pong reply and final announce prompts.
- If the requester agent has no configured `identity.name`, behavior remains unchanged.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local Codex CLI dev environment
- Model/provider: N/A
- Integration/channel (if any): `sessions_send` / internal agent-to-agent flow
- Relevant config (redacted): `tools.agentToAgent.enabled=true`, `tools.sessions.visibility=all`, requester agent has `identity.name` set

### Steps

1. Configure two agents and set `agents.list[].identity.name` on the requester agent.
2. From the requester session, call `sessions_send` to another agent session.
3. Inspect the generated agent-to-agent prompt content.

### Expected

- The receiver sees the requester's configured identity name in the prompt context, instead of inferring only from the session key.

### Actual

- The prompt omitted the requester identity name, so receivers could default to the main/default agent persona.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm exec vitest run src/agents/tools/sessions.test.ts` and confirmed the initial `agent` call payload now includes `Agent 1 (requester) name: Stevo.`; helper tests cover reply + announce prompts too.
- Edge cases checked: requester identity line is only added when a configured `identity.name` exists; existing prompt content remains intact otherwise.
- What you did **not** verify: end-to-end live multi-agent behavior against a running gateway/channel.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `5b6dd8c16` or remove the requester-name plumbing from the `sessions_send` prompt builders.
- Files/config to restore: `src/agents/tools/sessions-send-helpers.ts`, `src/agents/tools/sessions-send-tool.ts`, `src/agents/tools/sessions-send-tool.a2a.ts`, `src/agents/tools/sessions.test.ts`
- Known bad symptoms reviewers should watch for: duplicated requester-name lines or an incorrect name when the requester session is mapped to the wrong agent.

## Risks and Mitigations

- Risk: a malformed requester session key could resolve to the wrong agent id and inject the wrong name.
  - Mitigation: the name is only added when the existing session-key-to-agent-id resolution succeeds and a configured `identity.name` exists; otherwise prompts fall back to the previous behavior.
