### PR TITLE
fix(agents): prevent session freeze on compaction timeout

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -65,6 +65,11 @@ import {
 } from "../skills.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
 import {
+  isCompactionCircuitOpen,
+  recordCompactionFailure,
+  recordCompactionSuccess,
+} from "./compaction-circuit-breaker.js";
+import {
   compactWithSafetyTimeout,
   EMBEDDED_COMPACTION_TIMEOUT_MS,
 } from "./compaction-safety-timeout.js";
@@ -131,6 +136,8 @@ export type CompactEmbeddedPiSessionParams = {
   enqueue?: typeof enqueueCommand;
   extraSystemPrompt?: string;
   ownerNumbers?: string[];
+  /** External abort signal to cancel compaction immediately. */
+  abortSignal?: AbortSignal;
 };
 
 type CompactionMessageMetrics = {
@@ -268,6 +275,21 @@ export async function compactEmbeddedPiSessionDirect(
   const runId = params.runId ?? params.sessionId;
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);
   const prevCwd = process.cwd();
+  const sessionKey = params.sessionKey ?? params.sessionId;
+
+  // Circuit breaker: skip compaction if too many recent consecutive failures
+  if (isCompactionCircuitOpen(sessionKey)) {
+    log.warn(
+      `[compaction-circuit-breaker] skipping compaction: sessionKey=${sessionKey} ` +
+        `diagId=${diagId} trigger=${trigger} — circuit open due to repeated failures`,
+    );
+    return {
+      ok: false,
+      compacted: false,
+      reason:
+        "Compaction circuit breaker open — too many consecutive failures. Will retry after cooldown.",
+    };
+  }
 
   const provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
   const modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
@@ -533,10 +555,14 @@ export async function compactEmbeddedPiSessionDirect(
     });
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
 
+    // Resolve compaction timeout: config > default constant
+    const compactionTimeoutMs =
+      params.config?.agents?.defaults?.compaction?.timeoutMs ?? EMBEDDED_COMPACTION_TIMEOUT_MS;
+
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
       maxHoldMs: resolveSessionLockMaxHoldFromTimeout({
-        timeoutMs: EMBEDDED_COMPACTION_TIMEOUT_MS,
+        timeoutMs: compactionTimeoutMs,
       }),
     });
     try {
@@ -734,8 +760,13 @@ export async function compactEmbeddedPiSessionDirect(
         // Measure compactedCount from the original pre-limiting transcript so compaction
         // lifecycle metrics represent total reduction through the compaction pipeline.
         const messageCountCompactionInput = messageCountOriginal;
-        const result = await compactWithSafetyTimeout(() =>
-          session.compact(params.customInstructions),
+        // Note: session.compact() does not accept an abort signal directly,
+        // but the merged signal ensures Promise.race resolves immediately
+        // on external abort, and the caller's session.abort() handles cleanup.
+        const result = await compactWithSafetyTimeout(
+          () => session.compact(params.customInstructions),
+          compactionTimeoutMs,
+          params.abortSignal,
         );
         // Estimate tokens after compaction by summing token estimates for remaining messages
         let tokensAfter: number | undefined;
@@ -813,6 +844,7 @@ export async function compactEmbeddedPiSessionDirect(
             });
           }
         }
+        recordCompactionSuccess(sessionKey);
         return {
           ok: true,
           compacted: true,
@@ -837,6 +869,16 @@ export async function compactEmbeddedPiSessionDirect(
     }
   } catch (err) {
     const reason = describeUnknownError(err);
+    // Only record as circuit breaker failure for actual execution errors
+    // (timeouts, provider errors), not for benign skip conditions.
+    const skipReason = classifyCompactionReason(reason);
+    const isExecutionFailure =
+      skipReason !== "no_compactable_entries" &&
+      skipReason !== "below_threshold" &&
+      skipReason !== "already_compacted_recently";
+    if (isExecutionFailure) {
+      recordCompactionFailure(sessionKey);
+    }
     return fail(reason);
   } finally {
     restoreSkillEnv?.();

--- a/src/agents/pi-embedded-runner/compaction-circuit-breaker.test.ts
+++ b/src/agents/pi-embedded-runner/compaction-circuit-breaker.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getCompactionCircuitState,
+  isCompactionCircuitOpen,
+  recordCompactionFailure,
+  recordCompactionSuccess,
+  resetCompactionCircuit,
+  __testing,
+} from "./compaction-circuit-breaker.js";
+
+const { DEFAULT_MAX_CONSECUTIVE_FAILURES, DEFAULT_COOLDOWN_MS } = __testing;
+
+describe("compaction-circuit-breaker", () => {
+  afterEach(() => {
+    resetCompactionCircuit("test-session");
+  });
+
+  it("circuit is closed with zero failures", () => {
+    expect(isCompactionCircuitOpen("test-session")).toBe(false);
+  });
+
+  it("circuit stays closed below threshold", () => {
+    for (let i = 0; i < DEFAULT_MAX_CONSECUTIVE_FAILURES - 1; i++) {
+      recordCompactionFailure("test-session", { nowMs: 1000 });
+    }
+    expect(isCompactionCircuitOpen("test-session", { nowMs: 1000 })).toBe(false);
+  });
+
+  it("circuit opens at threshold during cooldown", () => {
+    const now = 100_000;
+    for (let i = 0; i < DEFAULT_MAX_CONSECUTIVE_FAILURES; i++) {
+      recordCompactionFailure("test-session", { nowMs: now });
+    }
+    // Still in cooldown
+    expect(isCompactionCircuitOpen("test-session", { nowMs: now + 1000 })).toBe(true);
+  });
+
+  it("circuit half-opens after cooldown expires", () => {
+    const now = 100_000;
+    for (let i = 0; i < DEFAULT_MAX_CONSECUTIVE_FAILURES; i++) {
+      recordCompactionFailure("test-session", { nowMs: now, cooldownMs: 1000 });
+    }
+    // After cooldown (exponential: 1000 * 2^(3-1) = 4000ms for 3rd failure)
+    expect(isCompactionCircuitOpen("test-session", { nowMs: now + 5000 })).toBe(false);
+  });
+
+  it("success resets the circuit", () => {
+    for (let i = 0; i < DEFAULT_MAX_CONSECUTIVE_FAILURES; i++) {
+      recordCompactionFailure("test-session", { nowMs: 1000 });
+    }
+    recordCompactionSuccess("test-session");
+    const state = getCompactionCircuitState("test-session");
+    expect(state.consecutiveFailures).toBe(0);
+    expect(state.cooldownUntil).toBe(0);
+    expect(isCompactionCircuitOpen("test-session")).toBe(false);
+  });
+
+  it("exponential backoff increases cooldown with each failure", () => {
+    const now = 100_000;
+    recordCompactionFailure("test-session", { nowMs: now, cooldownMs: 1000 });
+    const state1 = getCompactionCircuitState("test-session");
+    // 1st failure: 1000 * 2^0 = 1000
+    expect(state1.cooldownUntil).toBe(now + 1000);
+
+    recordCompactionFailure("test-session", { nowMs: now, cooldownMs: 1000 });
+    const state2 = getCompactionCircuitState("test-session");
+    // 2nd failure: 1000 * 2^1 = 2000
+    expect(state2.cooldownUntil).toBe(now + 2000);
+
+    recordCompactionFailure("test-session", { nowMs: now, cooldownMs: 1000 });
+    const state3 = getCompactionCircuitState("test-session");
+    // 3rd failure: 1000 * 2^2 = 4000
+    expect(state3.cooldownUntil).toBe(now + 4000);
+  });
+
+  it("backoff is capped at 30 minutes", () => {
+    const now = 100_000;
+    // Simulate many failures with large base cooldown
+    for (let i = 0; i < 20; i++) {
+      recordCompactionFailure("test-session", { nowMs: now, cooldownMs: DEFAULT_COOLDOWN_MS });
+    }
+    const state = getCompactionCircuitState("test-session");
+    expect(state.cooldownUntil).toBeLessThanOrEqual(now + 30 * 60 * 1000);
+  });
+
+  it("different sessions have independent circuits", () => {
+    recordCompactionFailure("session-a", { nowMs: 1000 });
+    recordCompactionFailure("session-a", { nowMs: 1000 });
+    recordCompactionFailure("session-a", { nowMs: 1000 });
+    expect(isCompactionCircuitOpen("session-a", { nowMs: 1001 })).toBe(true);
+    expect(isCompactionCircuitOpen("session-b", { nowMs: 1001 })).toBe(false);
+    resetCompactionCircuit("session-a");
+    resetCompactionCircuit("session-b");
+  });
+});

--- a/src/agents/pi-embedded-runner/compaction-circuit-breaker.ts
+++ b/src/agents/pi-embedded-runner/compaction-circuit-breaker.ts
@@ -1,0 +1,97 @@
+import { resolveProcessScopedMap } from "../../shared/process-scoped-map.js";
+import { log } from "./logger.js";
+
+const CIRCUIT_BREAKER_KEY = Symbol.for("openclaw.compactionCircuitBreaker");
+
+type CircuitState = {
+  consecutiveFailures: number;
+  lastFailureAt: number;
+  cooldownUntil: number;
+};
+
+const DEFAULT_MAX_CONSECUTIVE_FAILURES = 3;
+const DEFAULT_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+
+const states = resolveProcessScopedMap<CircuitState>(CIRCUIT_BREAKER_KEY);
+
+function getState(sessionKey: string): CircuitState {
+  const existing = states.get(sessionKey);
+  if (existing) {
+    return existing;
+  }
+  const created: CircuitState = {
+    consecutiveFailures: 0,
+    lastFailureAt: 0,
+    cooldownUntil: 0,
+  };
+  states.set(sessionKey, created);
+  return created;
+}
+
+export function isCompactionCircuitOpen(
+  sessionKey: string,
+  opts?: { maxConsecutiveFailures?: number; nowMs?: number },
+): boolean {
+  const state = getState(sessionKey);
+  const max = opts?.maxConsecutiveFailures ?? DEFAULT_MAX_CONSECUTIVE_FAILURES;
+  const now = opts?.nowMs ?? Date.now();
+
+  if (state.consecutiveFailures < max) {
+    return false;
+  }
+  // Still in cooldown?
+  if (now < state.cooldownUntil) {
+    return true;
+  }
+  // Cooldown expired — half-open: allow one attempt
+  return false;
+}
+
+export function recordCompactionSuccess(sessionKey: string): void {
+  const state = getState(sessionKey);
+  if (state.consecutiveFailures > 0) {
+    log.info(
+      `[compaction-circuit-breaker] reset after success: sessionKey=${sessionKey} priorFailures=${state.consecutiveFailures}`,
+    );
+  }
+  state.consecutiveFailures = 0;
+  state.lastFailureAt = 0;
+  state.cooldownUntil = 0;
+}
+
+export function recordCompactionFailure(
+  sessionKey: string,
+  opts?: { cooldownMs?: number; nowMs?: number },
+): void {
+  const state = getState(sessionKey);
+  const now = opts?.nowMs ?? Date.now();
+  const cooldownMs = opts?.cooldownMs ?? DEFAULT_COOLDOWN_MS;
+
+  state.consecutiveFailures += 1;
+  state.lastFailureAt = now;
+  // Exponential backoff: cooldown doubles each consecutive failure, capped at 30 min
+  const backoffMs = Math.min(
+    cooldownMs * Math.pow(2, state.consecutiveFailures - 1),
+    30 * 60 * 1000,
+  );
+  state.cooldownUntil = now + backoffMs;
+
+  log.warn(
+    `[compaction-circuit-breaker] failure recorded: sessionKey=${sessionKey} ` +
+      `consecutiveFailures=${state.consecutiveFailures} cooldownMs=${backoffMs}`,
+  );
+}
+
+export function getCompactionCircuitState(sessionKey: string): Readonly<CircuitState> {
+  return getState(sessionKey);
+}
+
+export function resetCompactionCircuit(sessionKey: string): void {
+  states.delete(sessionKey);
+}
+
+export const __testing = {
+  states,
+  DEFAULT_MAX_CONSECUTIVE_FAILURES,
+  DEFAULT_COOLDOWN_MS,
+};

--- a/src/agents/pi-embedded-runner/compaction-safety-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/compaction-safety-timeout.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { compactWithSafetyTimeout } from "./compaction-safety-timeout.js";
+
+describe("compactWithSafetyTimeout", () => {
+  it("resolves normally when work completes in time", async () => {
+    const result = await compactWithSafetyTimeout(async () => "done", 5000);
+    expect(result).toBe("done");
+  });
+
+  it("rejects with timeout error when work exceeds timeout", async () => {
+    await expect(
+      compactWithSafetyTimeout(() => new Promise((resolve) => setTimeout(resolve, 5000)), 50),
+    ).rejects.toThrow(/timed out/i);
+  });
+
+  it("aborts immediately when external signal is already aborted", async () => {
+    const ctrl = new AbortController();
+    ctrl.abort(new Error("cancelled externally"));
+
+    await expect(
+      compactWithSafetyTimeout(
+        async (signal) => {
+          // Signal should be aborted
+          if (signal?.aborted) {
+            throw signal.reason;
+          }
+          return "should not reach";
+        },
+        5000,
+        ctrl.signal,
+      ),
+    ).rejects.toThrow(/cancelled externally/);
+  });
+
+  it("aborts when external signal fires during work", async () => {
+    const ctrl = new AbortController();
+
+    const workPromise = compactWithSafetyTimeout(
+      (signal) =>
+        new Promise((resolve, reject) => {
+          const onAbort = () => reject(signal?.reason ?? new Error("aborted"));
+          signal?.addEventListener("abort", onAbort, { once: true });
+          // Work that would take too long
+          setTimeout(resolve, 10_000);
+        }),
+      5000,
+      ctrl.signal,
+    );
+
+    // Abort externally after 50ms
+    setTimeout(() => ctrl.abort(new Error("run cancelled")), 50);
+
+    await expect(workPromise).rejects.toThrow(/run cancelled/);
+  });
+
+  it("passes merged signal to work function", async () => {
+    let receivedSignal: AbortSignal | undefined;
+    await compactWithSafetyTimeout(async (signal) => {
+      receivedSignal = signal;
+      return "ok";
+    }, 5000);
+    // Should receive a signal from the timeout mechanism
+    expect(receivedSignal).toBeDefined();
+  });
+});

--- a/src/agents/pi-embedded-runner/compaction-safety-timeout.ts
+++ b/src/agents/pi-embedded-runner/compaction-safety-timeout.ts
@@ -3,8 +3,59 @@ import { withTimeout } from "../../node-host/with-timeout.js";
 export const EMBEDDED_COMPACTION_TIMEOUT_MS = 300_000;
 
 export async function compactWithSafetyTimeout<T>(
-  compact: () => Promise<T>,
+  compact: (signal?: AbortSignal) => Promise<T>,
   timeoutMs: number = EMBEDDED_COMPACTION_TIMEOUT_MS,
+  externalSignal?: AbortSignal,
 ): Promise<T> {
-  return await withTimeout(() => compact(), timeoutMs, "Compaction");
+  let cleanupMerge: (() => void) | undefined;
+  try {
+    return await withTimeout(
+      (signal) => {
+        // Merge the timeout-internal signal with an external abort signal
+        // so that callers (e.g. run-level abort) can cancel compaction immediately.
+        const { merged, cleanup } = mergeAbortSignals(signal, externalSignal);
+        cleanupMerge = cleanup;
+        return compact(merged);
+      },
+      timeoutMs,
+      "Compaction",
+    );
+  } finally {
+    cleanupMerge?.();
+  }
+}
+
+function mergeAbortSignals(
+  a: AbortSignal | undefined,
+  b: AbortSignal | undefined,
+): { merged: AbortSignal | undefined; cleanup: () => void } {
+  const noop = () => {};
+  if (!a && !b) {
+    return { merged: undefined, cleanup: noop };
+  }
+  if (!a) {
+    return { merged: b, cleanup: noop };
+  }
+  if (!b) {
+    return { merged: a, cleanup: noop };
+  }
+  // If either is already aborted, return that one immediately
+  if (a.aborted) {
+    return { merged: a, cleanup: noop };
+  }
+  if (b.aborted) {
+    return { merged: b, cleanup: noop };
+  }
+  const ctrl = new AbortController();
+  const onAbort = () => {
+    ctrl.abort(a.aborted ? a.reason : b.reason);
+    cleanup();
+  };
+  const cleanup = () => {
+    a.removeEventListener("abort", onAbort);
+    b.removeEventListener("abort", onAbort);
+  };
+  a.addEventListener("abort", onAbort, { once: true });
+  b.addEventListener("abort", onAbort, { once: true });
+  return { merged: ctrl.signal, cleanup };
 }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1040,6 +1040,7 @@ export async function runEmbeddedPiAgent(
                   diagId: overflowDiagId,
                   attempt: overflowCompactionAttempts,
                   maxAttempts: MAX_OVERFLOW_COMPACTION_ATTEMPTS,
+                  abortSignal: params.abortSignal,
                 },
               });
               if (compactResult.compacted) {

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -211,8 +211,9 @@ describe("acquireSessionWriteLock", () => {
   });
 
   it("derives max hold from timeout plus grace", () => {
-    expect(resolveSessionLockMaxHoldFromTimeout({ timeoutMs: 600_000 })).toBe(720_000);
-    expect(resolveSessionLockMaxHoldFromTimeout({ timeoutMs: 1_000, minMs: 5_000 })).toBe(121_000);
+    // Grace period is 15s (DEFAULT_TIMEOUT_GRACE_MS)
+    expect(resolveSessionLockMaxHoldFromTimeout({ timeoutMs: 600_000 })).toBe(615_000);
+    expect(resolveSessionLockMaxHoldFromTimeout({ timeoutMs: 1_000, minMs: 5_000 })).toBe(16_000);
   });
 
   it("clamps max hold for effectively no-timeout runs", () => {

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -43,8 +43,8 @@ const WATCHDOG_STATE_KEY = Symbol.for("openclaw.sessionWriteLockWatchdogState");
 
 const DEFAULT_STALE_MS = 30 * 60 * 1000;
 const DEFAULT_MAX_HOLD_MS = 5 * 60 * 1000;
-const DEFAULT_WATCHDOG_INTERVAL_MS = 60_000;
-const DEFAULT_TIMEOUT_GRACE_MS = 2 * 60 * 1000;
+const DEFAULT_WATCHDOG_INTERVAL_MS = 10_000;
+const DEFAULT_TIMEOUT_GRACE_MS = 15_000;
 const MAX_LOCK_HOLD_MS = 2_147_000_000;
 
 type CleanupState = {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1007,6 +1007,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Maximum number of regeneration retries after a failed safeguard summary quality audit. Use small values to bound extra latency and token cost.",
   "agents.defaults.compaction.postCompactionSections":
     'AGENTS.md H2/H3 section names re-injected after compaction so the agent reruns critical startup guidance. Leave unset to use "Session Startup"/"Red Lines" with legacy fallback to "Every Session"/"Safety"; set to [] to disable reinjection entirely.',
+  "agents.defaults.compaction.timeoutMs":
+    "Maximum time in milliseconds allowed for a single compaction operation (range 30000-1800000, default 300000). Increase for slow local models or very large contexts; decrease for tighter channel timeout windows.",
   "agents.defaults.compaction.memoryFlush":
     "Pre-compaction memory flush settings that run an agentic memory write before heavy compaction. Keep enabled for long sessions so salient context is persisted before aggressive trimming.",
   "agents.defaults.compaction.memoryFlush.enabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -456,6 +456,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.compaction.qualityGuard.enabled": "Compaction Quality Guard Enabled",
   "agents.defaults.compaction.qualityGuard.maxRetries": "Compaction Quality Guard Max Retries",
   "agents.defaults.compaction.postCompactionSections": "Post-Compaction Context Sections",
+  "agents.defaults.compaction.timeoutMs": "Compaction Timeout (ms)",
   "agents.defaults.compaction.memoryFlush": "Compaction Memory Flush",
   "agents.defaults.compaction.memoryFlush.enabled": "Compaction Memory Flush Enabled",
   "agents.defaults.compaction.memoryFlush.softThresholdTokens":

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -312,6 +312,8 @@ export type AgentCompactionConfig = {
   identifierInstructions?: string;
   /** Optional quality-audit retries for safeguard compaction summaries. */
   qualityGuard?: AgentCompactionQualityGuardConfig;
+  /** Compaction timeout in milliseconds (default 300000 = 5 min). */
+  timeoutMs?: number;
   /** Pre-compaction memory flush (agentic turn). Default: enabled. */
   memoryFlush?: AgentCompactionMemoryFlushConfig;
   /**

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -103,6 +103,8 @@ export const AgentDefaultsSchema = z
           .strict()
           .optional(),
         postCompactionSections: z.array(z.string()).optional(),
+        /** Compaction timeout in milliseconds. Defaults to 300000 (5 min). */
+        timeoutMs: z.number().int().min(30_000).max(1_800_000).optional(),
         memoryFlush: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
## Summary

Resolves #38233 and the recurring compaction timeout freeze pattern reported across #17444, #25272, #27595, and #30116.

Previous fixes addressed individual symptoms (aggregate retry timeout in #17445, thinking override in #34554, drain timeouts) but the core issue persisted: when compaction times out, the
session write lock is held too long, the watchdog reacts too slowly, there is no mechanism to stop repeated freeze cycles, and the timeout is not configurable for slow models or large
contexts.

This PR addresses all four root causes:

- **Circuit breaker** — Per-session compaction circuit breaker with exponential backoff cooldown. After 3 consecutive failures, compaction is skipped for a cooldown period (5min → 10min →
20min → 30min cap). Benign skip reasons (nothing to compact, below threshold, already compacted) are filtered out so they do not trip the breaker. Success resets the circuit immediately.

- **Configurable timeout** — New `agents.defaults.compaction.timeoutMs` config field (range 30s–30min, default 300s). Users with slow local models (Ollama, etc.) or very large contexts can
increase the timeout; users with tight channel timeouts (Discord 30s, Telegram 240s) can decrease it.

- **Faster lock release** — Session write lock grace period reduced from 120s to 15s, and watchdog check interval reduced from 60s to 10s. Worst-case freeze window drops from ~180s to ~25s
after timeout.

- **Abort signal propagation** — External `AbortSignal` is merged with the internal timeout signal via `mergeAbortSignals()`, with proper listener cleanup in `finally` to prevent leaks.
Overflow compaction in `run.ts` now passes the run-level abort signal through `legacyParams` so compaction is cancelled immediately when the run is aborted.

## Changes

| File | Change |
|------|--------|
| `compaction-circuit-breaker.ts` | New: per-session circuit breaker with exponential backoff |
| `compaction-circuit-breaker.test.ts` | New: 8 tests covering all circuit breaker branches |
| `compaction-safety-timeout.ts` | Rewrite: external AbortSignal merge with listener cleanup |
| `compaction-safety-timeout.test.ts` | New: 5 tests covering timeout and abort signal paths |
| `compact.ts` | Integrate circuit breaker, configurable timeout, abort signal |
| `run.ts` | Pass `abortSignal` through `legacyParams` to overflow compaction |
| `session-write-lock.ts` | Grace period 120s→15s, watchdog interval 60s→10s |
| `session-write-lock.test.ts` | Update expected values for new grace period |
| `zod-schema.agent-defaults.ts` | Add `timeoutMs` to compaction config schema |
| `types.agent-defaults.ts` | Add `timeoutMs` to `AgentCompactionConfig` type |
| `schema.help.ts` | Add help text for `compaction.timeoutMs` |
| `schema.labels.ts` | Add label for `compaction.timeoutMs` |

## Test plan

- [x] 17 new unit tests (circuit breaker: 8, safety timeout: 5, existing compaction-timeout: 4)
- [x] All 58 affected tests pass after rebase onto latest main
- [x] TypeScript type check: zero errors
- [x] Lint: zero warnings
- [ ] Manual: trigger compaction timeout with a slow model, verify session unfreezes within ~25s
- [ ] Manual: set `compaction.timeoutMs` to a custom value, verify it takes effect
- [ ] Manual: trigger 3+ consecutive failures, verify circuit breaker skips with log message

Closes  #38233