### PR TITLE
fix(feishu): pin DM sessions to current route

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -19,7 +19,7 @@ const {
   mockCreateFeishuClient,
   mockResolveAgentRoute,
   mockResolveStorePath,
-  mockUpdateLastRoute,
+  mockRecordInboundSession,
 } = vi.hoisted(() => ({
   mockCreateFeishuReplyDispatcher: vi.fn(() => ({
     dispatcher: vi.fn(),
@@ -43,7 +43,7 @@ const {
     matchedBy: "default",
   })),
   mockResolveStorePath: vi.fn(() => "/tmp/openclaw-feishu-session-store.json"),
-  mockUpdateLastRoute: vi.fn().mockResolvedValue(undefined),
+  mockRecordInboundSession: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("./reply-dispatcher.js", () => ({
@@ -144,7 +144,7 @@ describe("handleFeishuMessage command authorization", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockResolveStorePath.mockReturnValue("/tmp/openclaw-feishu-session-store.json");
-    mockUpdateLastRoute.mockResolvedValue(undefined);
+    mockRecordInboundSession.mockResolvedValue(undefined);
     mockShouldComputeCommandAuthorized.mockReset().mockReturnValue(true);
     mockResolveAgentRoute.mockReturnValue({
       agentId: "main",
@@ -198,7 +198,7 @@ describe("handleFeishuMessage command authorization", () => {
           },
           session: {
             resolveStorePath: mockResolveStorePath,
-            updateLastRoute: mockUpdateLastRoute,
+            recordInboundSession: mockRecordInboundSession,
           },
         },
         media: {
@@ -1723,7 +1723,11 @@ describe("handleFeishuMessage command authorization", () => {
       channels: {
         feishu: {
           dmPolicy: "open",
+          allowFrom: ["ou-dm-last-route"],
         },
+      },
+      session: {
+        dmScope: "main",
       },
     } as ClawdbotConfig;
 
@@ -1752,14 +1756,91 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockResolveStorePath).toHaveBeenCalledWith(cfg.session?.store, {
       agentId: "main",
     });
-    expect(mockUpdateLastRoute).toHaveBeenCalledWith({
+    expect(mockRecordInboundSession).toHaveBeenCalledWith({
       storePath: "/tmp/openclaw-feishu-session-store.json",
       sessionKey: "agent:main:main",
-      deliveryContext: {
+      ctx: expect.objectContaining({
+        SessionKey: "agent:main:main",
+        AccountId: "default",
+        OriginatingChannel: "feishu",
+        OriginatingTo: "user:ou-dm-last-route",
+      }),
+      updateLastRoute: {
+        sessionKey: "agent:main:main",
         channel: "feishu",
         to: "user:ou-dm-last-route",
         accountId: "default",
+        mainDmOwnerPin: {
+          ownerRecipient: "ou-dm-last-route",
+          senderRecipient: "ou-dm-last-route",
+          onSkip: expect.any(Function),
+        },
       },
+      onRecordError: expect.any(Function),
+    });
+  });
+
+  it("does not let paired Feishu users overwrite a pinned main-session owner route", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+          allowFrom: ["ou-main-owner"],
+        },
+      },
+      session: {
+        dmScope: "main",
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-paired-user" } },
+      message: {
+        message_id: "msg-dm-paired-user",
+        chat_id: "oc-dm-paired-user",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello from paired user" }),
+      },
+    };
+
+    mockResolveAgentRoute.mockReturnValue({
+      agentId: "main",
+      channel: "feishu",
+      accountId: "default",
+      sessionKey: "agent:main:main",
+      mainSessionKey: "agent:main:main",
+      matchedBy: "default",
+    });
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockResolveStorePath).toHaveBeenCalledWith(cfg.session?.store, {
+      agentId: "main",
+    });
+    expect(mockRecordInboundSession).toHaveBeenCalledWith({
+      storePath: "/tmp/openclaw-feishu-session-store.json",
+      sessionKey: "agent:main:main",
+      ctx: expect.objectContaining({
+        SessionKey: "agent:main:main",
+        AccountId: "default",
+        OriginatingChannel: "feishu",
+        OriginatingTo: "user:ou-paired-user",
+      }),
+      updateLastRoute: {
+        sessionKey: "agent:main:main",
+        channel: "feishu",
+        to: "user:ou-paired-user",
+        accountId: "default",
+        mainDmOwnerPin: {
+          ownerRecipient: "ou-main-owner",
+          senderRecipient: "ou-paired-user",
+          onSkip: expect.any(Function),
+        },
+      },
+      onRecordError: expect.any(Function),
     });
   });
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1844,6 +1844,70 @@ describe("handleFeishuMessage command authorization", () => {
     });
   });
 
+  it("uses the owner-matching user_id for main-session pinning when allowFrom is not open_id", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+          allowFrom: ["user:cli-owner"],
+        },
+      },
+      session: {
+        dmScope: "main",
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-owner-open-id",
+          user_id: "cli-owner",
+        },
+      },
+      message: {
+        message_id: "msg-dm-user-id-owner",
+        chat_id: "oc-dm-user-id-owner",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello from owner via user id" }),
+      },
+    };
+
+    mockResolveAgentRoute.mockReturnValue({
+      agentId: "main",
+      channel: "feishu",
+      accountId: "default",
+      sessionKey: "agent:main:main",
+      mainSessionKey: "agent:main:main",
+      matchedBy: "default",
+    });
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockRecordInboundSession).toHaveBeenCalledWith({
+      storePath: "/tmp/openclaw-feishu-session-store.json",
+      sessionKey: "agent:main:main",
+      ctx: expect.objectContaining({
+        SessionKey: "agent:main:main",
+        OriginatingTo: "user:ou-owner-open-id",
+      }),
+      updateLastRoute: {
+        sessionKey: "agent:main:main",
+        channel: "feishu",
+        to: "user:ou-owner-open-id",
+        accountId: "default",
+        mainDmOwnerPin: {
+          ownerRecipient: "cli-owner",
+          senderRecipient: "cli-owner",
+          onSkip: expect.any(Function),
+        },
+      },
+      onRecordError: expect.any(Function),
+    });
+  });
+
   it("does not dispatch twice for the same image message_id (concurrent dedupe)", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -18,6 +18,8 @@ const {
   mockDownloadMessageResourceFeishu,
   mockCreateFeishuClient,
   mockResolveAgentRoute,
+  mockResolveStorePath,
+  mockUpdateLastRoute,
 } = vi.hoisted(() => ({
   mockCreateFeishuReplyDispatcher: vi.fn(() => ({
     dispatcher: vi.fn(),
@@ -40,6 +42,8 @@ const {
     mainSessionKey: "agent:main:main",
     matchedBy: "default",
   })),
+  mockResolveStorePath: vi.fn(() => "/tmp/openclaw-feishu-session-store.json"),
+  mockUpdateLastRoute: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("./reply-dispatcher.js", () => ({
@@ -139,6 +143,8 @@ describe("handleFeishuMessage command authorization", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockResolveStorePath.mockReturnValue("/tmp/openclaw-feishu-session-store.json");
+    mockUpdateLastRoute.mockResolvedValue(undefined);
     mockShouldComputeCommandAuthorized.mockReset().mockReturnValue(true);
     mockResolveAgentRoute.mockReturnValue({
       agentId: "main",
@@ -189,6 +195,10 @@ describe("handleFeishuMessage command authorization", () => {
             readAllowFromStore: mockReadAllowFromStore,
             upsertPairingRequest: mockUpsertPairingRequest,
             buildPairingReply: mockBuildPairingReply,
+          },
+          session: {
+            resolveStorePath: mockResolveStorePath,
+            updateLastRoute: mockUpdateLastRoute,
           },
         },
         media: {
@@ -1704,6 +1714,53 @@ describe("handleFeishuMessage command authorization", () => {
         threadReply: true,
       }),
     );
+  });
+
+  it("pins main-session lastRoute to Feishu for direct messages", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-dm-last-route" } },
+      message: {
+        message_id: "msg-dm-last-route",
+        chat_id: "oc-dm-last-route",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello" }),
+      },
+    };
+
+    mockResolveAgentRoute.mockReturnValue({
+      agentId: "main",
+      channel: "feishu",
+      accountId: "default",
+      sessionKey: "agent:main:main",
+      mainSessionKey: "agent:main:main",
+      matchedBy: "default",
+    });
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockResolveStorePath).toHaveBeenCalledWith(cfg.session?.store, {
+      agentId: "main",
+    });
+    expect(mockUpdateLastRoute).toHaveBeenCalledWith({
+      storePath: "/tmp/openclaw-feishu-session-store.json",
+      sessionKey: "agent:main:main",
+      deliveryContext: {
+        channel: "feishu",
+        to: "user:ou-dm-last-route",
+        accountId: "default",
+      },
+    });
   });
 
   it("does not dispatch twice for the same image message_id (concurrent dedupe)", async () => {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1908,6 +1908,65 @@ describe("handleFeishuMessage command authorization", () => {
     });
   });
 
+  it("does not pin a wildcard allowFrom entry as a fake owner", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+          allowFrom: ["feishu:*"],
+        },
+      },
+      session: {
+        dmScope: "main",
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-wildcard-owner",
+        },
+      },
+      message: {
+        message_id: "msg-dm-wildcard-owner",
+        chat_id: "oc-dm-wildcard-owner",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello from wildcard sender" }),
+      },
+    };
+
+    mockResolveAgentRoute.mockReturnValue({
+      agentId: "main",
+      channel: "feishu",
+      accountId: "default",
+      sessionKey: "agent:main:main",
+      mainSessionKey: "agent:main:main",
+      matchedBy: "default",
+    });
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockRecordInboundSession).toHaveBeenCalledWith({
+      storePath: "/tmp/openclaw-feishu-session-store.json",
+      sessionKey: "agent:main:main",
+      ctx: expect.objectContaining({
+        SessionKey: "agent:main:main",
+        OriginatingTo: "user:ou-wildcard-owner",
+      }),
+      updateLastRoute: {
+        sessionKey: "agent:main:main",
+        channel: "feishu",
+        to: "user:ou-wildcard-owner",
+        accountId: "default",
+        mainDmOwnerPin: undefined,
+      },
+      onRecordError: expect.any(Function),
+    });
+  });
+
   it("does not dispatch twice for the same image message_id (concurrent dedupe)", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -247,6 +247,39 @@ function resolvePinnedFeishuMainDmOwner(params: {
   return normalizedOwners.length === 1 ? normalizedOwners[0] : null;
 }
 
+function resolveNormalizedFeishuSenderCandidates(
+  senderIds: Array<string | null | undefined>,
+): string[] {
+  return Array.from(
+    new Set(
+      senderIds
+        .map((entry) => {
+          const trimmed = String(entry ?? "").trim();
+          if (!trimmed) {
+            return "";
+          }
+          const normalized = normalizeFeishuTarget(trimmed) ?? trimmed;
+          return normalized.trim().toLowerCase();
+        })
+        .filter(Boolean),
+    ),
+  );
+}
+
+function resolveFeishuPinnedSenderRecipient(params: {
+  ownerRecipient: string | null;
+  senderIds: Array<string | null | undefined>;
+}): string | null {
+  const normalizedCandidates = resolveNormalizedFeishuSenderCandidates(params.senderIds);
+  if (normalizedCandidates.length === 0) {
+    return null;
+  }
+  if (params.ownerRecipient && normalizedCandidates.includes(params.ownerRecipient)) {
+    return params.ownerRecipient;
+  }
+  return normalizedCandidates[0];
+}
+
 type GroupSessionScope = "group" | "group_sender" | "group_topic" | "group_topic_sender";
 
 type ResolvedFeishuGroupSession = {
@@ -1550,11 +1583,10 @@ export async function handleFeishuMessage(params: {
           dmScope: cfg.session?.dmScope,
           allowFrom: configAllowFrom,
         });
-        const normalizedSenderRecipient = (
-          normalizeFeishuTarget(ctx.senderOpenId) ?? ctx.senderOpenId
-        )
-          .trim()
-          .toLowerCase();
+        const normalizedSenderRecipient = resolveFeishuPinnedSenderRecipient({
+          ownerRecipient: pinnedMainDmOwner,
+          senderIds: [ctx.senderOpenId, senderUserId],
+        });
         const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
           agentId: route.agentId,
         });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1513,6 +1513,20 @@ export async function handleFeishuMessage(params: {
         messageCreateTimeMs,
       });
 
+      // Keep DM sessions pinned to Feishu so later replies do not reuse a stale
+      // route from another channel that last touched the shared session.
+      if (!isGroup && route.sessionKey === route.mainSessionKey) {
+        core.channel.session.updateLastRoute({
+          agentId: route.agentId,
+          sessionKey: route.mainSessionKey,
+          channel: "feishu",
+          to: feishuTo,
+          accountId: route.accountId,
+        }).catch((err: unknown) => {
+          log(`feishu[${account.accountId}]: updateLastRoute failed: ${String(err)}`);
+        });
+      }
+
       log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
       const { queuedFinal, counts } = await core.channel.reply.withReplyDispatcher({
         dispatcher,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -29,6 +29,7 @@ import { parsePostContent } from "./post.js";
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu, sendMessageFeishu } from "./send.js";
+import { normalizeFeishuTarget } from "./targets.js";
 import type { FeishuMessageContext, FeishuMediaInfo, ResolvedFeishuAccount } from "./types.js";
 import type { DynamicAgentCreationConfig } from "./types.js";
 
@@ -216,6 +217,35 @@ export type FeishuBotAddedEvent = {
   external: boolean;
   operator_tenant_key?: string;
 };
+
+function resolvePinnedFeishuMainDmOwner(params: {
+  dmScope?: string | null;
+  allowFrom?: Array<string | number> | null;
+}): string | null {
+  if ((params.dmScope ?? "main") !== "main") {
+    return null;
+  }
+  const rawAllowFrom = Array.isArray(params.allowFrom) ? params.allowFrom : [];
+  if (rawAllowFrom.some((entry) => String(entry).trim() === "*")) {
+    return null;
+  }
+  const normalizedOwners = Array.from(
+    new Set(
+      rawAllowFrom
+        .map((entry) => {
+          const trimmed = String(entry).trim();
+          if (!trimmed) {
+            return "";
+          }
+          const withoutProviderPrefix = trimmed.replace(/^feishu:/i, "");
+          const normalized = normalizeFeishuTarget(withoutProviderPrefix) ?? withoutProviderPrefix;
+          return normalized.trim().toLowerCase();
+        })
+        .filter(Boolean),
+    ),
+  );
+  return normalizedOwners.length === 1 ? normalizedOwners[0] : null;
+}
 
 type GroupSessionScope = "group" | "group_sender" | "group_topic" | "group_topic_sender";
 
@@ -1516,21 +1546,47 @@ export async function handleFeishuMessage(params: {
       // Keep DM sessions pinned to Feishu so later replies do not reuse a stale
       // route from another channel that last touched the shared session.
       if (!isGroup && route.sessionKey === route.mainSessionKey) {
+        const pinnedMainDmOwner = resolvePinnedFeishuMainDmOwner({
+          dmScope: cfg.session?.dmScope,
+          allowFrom: configAllowFrom,
+        });
+        const normalizedSenderRecipient = (
+          normalizeFeishuTarget(ctx.senderOpenId) ?? ctx.senderOpenId
+        )
+          .trim()
+          .toLowerCase();
         const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
           agentId: route.agentId,
         });
         core.channel.session
-          .updateLastRoute({
+          .recordInboundSession({
             storePath,
-            sessionKey: route.mainSessionKey,
-            deliveryContext: {
+            sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+            ctx: ctxPayload,
+            updateLastRoute: {
+              sessionKey: route.mainSessionKey,
               channel: "feishu",
               to: feishuTo,
               accountId: route.accountId,
+              mainDmOwnerPin:
+                pinnedMainDmOwner && normalizedSenderRecipient
+                  ? {
+                      ownerRecipient: pinnedMainDmOwner,
+                      senderRecipient: normalizedSenderRecipient,
+                      onSkip: ({ ownerRecipient, senderRecipient }) => {
+                        log(
+                          `feishu[${account.accountId}]: skip main-session last route for ${senderRecipient} (pinned owner ${ownerRecipient})`,
+                        );
+                      },
+                    }
+                  : undefined,
+            },
+            onRecordError: (err: unknown) => {
+              log(`feishu[${account.accountId}]: recordInboundSession failed: ${String(err)}`);
             },
           })
           .catch((err: unknown) => {
-            log(`feishu[${account.accountId}]: updateLastRoute failed: ${String(err)}`);
+            log(`feishu[${account.accountId}]: recordInboundSession failed: ${String(err)}`);
           });
       }
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1516,15 +1516,22 @@ export async function handleFeishuMessage(params: {
       // Keep DM sessions pinned to Feishu so later replies do not reuse a stale
       // route from another channel that last touched the shared session.
       if (!isGroup && route.sessionKey === route.mainSessionKey) {
-        core.channel.session.updateLastRoute({
+        const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
           agentId: route.agentId,
-          sessionKey: route.mainSessionKey,
-          channel: "feishu",
-          to: feishuTo,
-          accountId: route.accountId,
-        }).catch((err: unknown) => {
-          log(`feishu[${account.accountId}]: updateLastRoute failed: ${String(err)}`);
         });
+        core.channel.session
+          .updateLastRoute({
+            storePath,
+            sessionKey: route.mainSessionKey,
+            deliveryContext: {
+              channel: "feishu",
+              to: feishuTo,
+              accountId: route.accountId,
+            },
+          })
+          .catch((err: unknown) => {
+            log(`feishu[${account.accountId}]: updateLastRoute failed: ${String(err)}`);
+          });
       }
 
       log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -226,9 +226,6 @@ function resolvePinnedFeishuMainDmOwner(params: {
     return null;
   }
   const rawAllowFrom = Array.isArray(params.allowFrom) ? params.allowFrom : [];
-  if (rawAllowFrom.some((entry) => String(entry).trim() === "*")) {
-    return null;
-  }
   const normalizedOwners = Array.from(
     new Set(
       rawAllowFrom
@@ -244,6 +241,9 @@ function resolvePinnedFeishuMainDmOwner(params: {
         .filter(Boolean),
     ),
   );
+  if (normalizedOwners.includes("*")) {
+    return null;
+  }
   return normalizedOwners.length === 1 ? normalizedOwners[0] : null;
 }
 


### PR DESCRIPTION
## Summary
- update `lastRoute` before single-agent Feishu DM dispatches that reuse the main session
- keep follow-up replies on Feishu instead of reusing a stale route from another channel

## Test plan
- [x] Build and validate the same fix in the local source checkout with `pnpm build`
- [x] Confirm `openclaw gateway status`, `openclaw status`, and `openclaw models status` are healthy after applying the fix locally
- [ ] Send a live Feishu DM that reuses a shared session and verify replies stay on Feishu

Made with [Cursor](https://cursor.com)