### PR TITLE
fix(session): avoid Discord channel key poisoning from sender-shaped From

### DIFF
--- a/src/config/sessions/group.test.ts
+++ b/src/config/sessions/group.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { MsgContext } from "../../auto-reply/templating.js";
+import { resolveGroupSessionKey } from "./group.js";
+
+describe("resolveGroupSessionKey", () => {
+  it("uses OriginatingTo channel id when Discord channel chats provide sender-shaped From", () => {
+    const ctx = {
+      Provider: "discord",
+      ChatType: "channel",
+      From: "discord:657229412030480397",
+      OriginatingTo: "channel:1476858065914695741",
+      To: "slash:657229412030480397",
+    } as MsgContext;
+
+    expect(resolveGroupSessionKey(ctx)).toEqual({
+      key: "discord:channel:1476858065914695741",
+      channel: "discord",
+      id: "1476858065914695741",
+      chatType: "channel",
+    });
+  });
+
+  it("falls back to To when OriginatingTo is absent", () => {
+    const ctx = {
+      Provider: "discord",
+      ChatType: "channel",
+      From: "discord:657229412030480397",
+      To: "discord:channel:1476858065914695741",
+    } as MsgContext;
+
+    expect(resolveGroupSessionKey(ctx)).toEqual({
+      key: "discord:channel:1476858065914695741",
+      channel: "discord",
+      id: "1476858065914695741",
+      chatType: "channel",
+    });
+  });
+
+  it("keeps legacy behavior when no Discord channel hint is available", () => {
+    const ctx = {
+      Provider: "discord",
+      ChatType: "channel",
+      From: "discord:657229412030480397",
+    } as MsgContext;
+
+    expect(resolveGroupSessionKey(ctx)).toEqual({
+      key: "discord:channel:657229412030480397",
+      channel: "discord",
+      id: "657229412030480397",
+      chatType: "channel",
+    });
+  });
+});

--- a/src/config/sessions/group.ts
+++ b/src/config/sessions/group.ts
@@ -20,6 +20,35 @@ function shortenGroupId(value?: string) {
   return `${trimmed.slice(0, 6)}...${trimmed.slice(-4)}`;
 }
 
+function resolveDiscordChannelIdFromTarget(raw?: string): string | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const withoutProvider = trimmed.replace(/^discord:/i, "").trim();
+  if (!withoutProvider) {
+    return undefined;
+  }
+  const withoutChannelPrefix = withoutProvider.replace(/^channel:/i, "").trim();
+  if (!withoutChannelPrefix) {
+    return undefined;
+  }
+  // Accept bare numeric IDs and channel-prefixed numeric IDs.
+  return /^\d+$/.test(withoutChannelPrefix) ? withoutChannelPrefix : undefined;
+}
+
+function resolveGroupIdHintFromTargets(ctx: MsgContext, provider?: string): string | undefined {
+  if (provider !== "discord") {
+    return undefined;
+  }
+  return (
+    resolveDiscordChannelIdFromTarget(ctx.ThreadParentId) ??
+    resolveDiscordChannelIdFromTarget(ctx.NativeChannelId) ??
+    resolveDiscordChannelIdFromTarget(ctx.OriginatingTo) ??
+    resolveDiscordChannelIdFromTarget(ctx.To)
+  );
+}
+
 export function buildGroupDisplayName(params: {
   provider?: string;
   subject?: string;
@@ -88,10 +117,13 @@ export function resolveGroupSessionKey(ctx: MsgContext): GroupKeyResolution | nu
     : from.includes(":channel:") || normalizedChatType === "channel"
       ? "channel"
       : "group";
+  const targetHintId = resolveGroupIdHintFromTargets(ctx, provider);
   const id = headIsSurface
     ? secondIsKind
       ? parts.slice(2).join(":")
-      : parts.slice(1).join(":")
+      : kind === "channel"
+        ? (targetHintId ?? parts.slice(1).join(":"))
+        : parts.slice(1).join(":")
     : from;
   const finalId = id.trim().toLowerCase();
   if (!finalId) {


### PR DESCRIPTION
## Summary
- fix Discord group-session key derivation for channel chats when synthetic/internal contexts provide sender-shaped `From` (e.g. `discord:<userId>`)
- prefer concrete Discord channel targets from `ThreadParentId` / `NativeChannelId` / `OriginatingTo` / `To` before falling back to `From`
- keep legacy fallback behavior unchanged when no channel hint exists

## Root cause
`resolveGroupSessionKey()` previously derived the channel id from `From` whenever `From` lacked an explicit `:channel:` segment but `ChatType=channel`. For Discord synthetic/internal contexts, `From` can carry sender identity while the real channel id is present in routing targets, causing poisoned keys like `discord:channel:<userId>`.

## Test plan
- `pnpm build`
- `pnpm check`
- `pnpm test`
- Added `src/config/sessions/group.test.ts` regression coverage for:
  - `OriginatingTo` channel hint precedence
  - `To` fallback when `OriginatingTo` missing
  - legacy fallback when no hint exists

Fixes #38487

---
This PR is AI-assisted. Code has been fully tested locally. I understand what this code does.
