### PR TITLE
fix(acp): canonicalize aliased session keys on restart

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -44,11 +44,11 @@ import {
   type TurnLatencyStats,
 } from "./manager.types.js";
 import {
+  canonicalizeAcpSessionKey,
   createUnsupportedControlError,
   hasLegacyAcpIdentityProjection,
   normalizeAcpErrorCode,
   normalizeActorKey,
-  normalizeSessionKey,
   resolveAcpAgentFromSessionKey,
   resolveMissingMetaError,
   resolveRuntimeIdleTtlMs,
@@ -85,7 +85,7 @@ export class AcpSessionManager {
   constructor(private readonly deps: AcpSessionManagerDeps = DEFAULT_DEPS) {}
 
   resolveSession(params: { cfg: OpenClawConfig; sessionKey: string }): AcpSessionResolution {
-    const sessionKey = normalizeSessionKey(params.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey(params);
     if (!sessionKey) {
       return {
         kind: "none",
@@ -211,7 +211,10 @@ export class AcpSessionManager {
     handle: AcpRuntimeHandle;
     meta: SessionAcpMeta;
   }> {
-    const sessionKey = normalizeSessionKey(input.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey({
+      cfg: input.cfg,
+      sessionKey: input.sessionKey,
+    });
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
@@ -318,7 +321,7 @@ export class AcpSessionManager {
     sessionKey: string;
     signal?: AbortSignal;
   }): Promise<AcpSessionStatus> {
-    const sessionKey = normalizeSessionKey(params.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey(params);
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
@@ -402,7 +405,7 @@ export class AcpSessionManager {
     sessionKey: string;
     runtimeMode: string;
   }): Promise<AcpSessionRuntimeOptions> {
-    const sessionKey = normalizeSessionKey(params.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey(params);
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
@@ -465,7 +468,7 @@ export class AcpSessionManager {
     key: string;
     value: string;
   }): Promise<AcpSessionRuntimeOptions> {
-    const sessionKey = normalizeSessionKey(params.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey(params);
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
@@ -546,7 +549,7 @@ export class AcpSessionManager {
     sessionKey: string;
     patch: Partial<AcpSessionRuntimeOptions>;
   }): Promise<AcpSessionRuntimeOptions> {
-    const sessionKey = normalizeSessionKey(params.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey(params);
     const validatedPatch = validateRuntimeOptionPatch(params.patch);
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
@@ -584,7 +587,7 @@ export class AcpSessionManager {
     cfg: OpenClawConfig;
     sessionKey: string;
   }): Promise<AcpSessionRuntimeOptions> {
-    const sessionKey = normalizeSessionKey(params.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey(params);
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
@@ -628,7 +631,10 @@ export class AcpSessionManager {
   }
 
   async runTurn(input: AcpRunTurnInput): Promise<void> {
-    const sessionKey = normalizeSessionKey(input.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey({
+      cfg: input.cfg,
+      sessionKey: input.sessionKey,
+    });
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
@@ -782,7 +788,7 @@ export class AcpSessionManager {
     sessionKey: string;
     reason?: string;
   }): Promise<void> {
-    const sessionKey = normalizeSessionKey(params.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey(params);
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
@@ -858,7 +864,10 @@ export class AcpSessionManager {
   }
 
   async closeSession(input: AcpCloseSessionInput): Promise<AcpCloseSessionResult> {
-    const sessionKey = normalizeSessionKey(input.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey({
+      cfg: input.cfg,
+      sessionKey: input.sessionKey,
+    });
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -170,6 +170,51 @@ describe("AcpSessionManager", () => {
     expect(resolved.error.message).toContain("ACP metadata is missing");
   });
 
+  it("canonicalizes main alias session keys before ACP lookup and runtime rehydrate", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
+      if (sessionKey !== "agent:main:main") {
+        return null;
+      }
+      return {
+        sessionKey,
+        storeSessionKey: sessionKey,
+        acp: readySessionMeta(),
+      };
+    });
+    const manager = new AcpSessionManager();
+    const cfg = {
+      ...baseCfg,
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+
+    await manager.runTurn({
+      cfg,
+      sessionKey: "main",
+      text: "after restart",
+      mode: "prompt",
+      requestId: "r-main",
+    });
+
+    expect(hoisted.readAcpSessionEntryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg,
+        sessionKey: "agent:main:main",
+      }),
+    );
+    expect(runtimeState.ensureSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+      }),
+    );
+  });
+
   it("serializes concurrent turns for the same ACP session", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({

--- a/src/acp/control-plane/manager.utils.ts
+++ b/src/acp/control-plane/manager.utils.ts
@@ -1,6 +1,11 @@
 import type { OpenClawConfig } from "../../config/config.js";
+import { canonicalizeMainSessionAlias, resolveMainSessionKey } from "../../config/sessions.js";
 import type { SessionAcpMeta } from "../../config/sessions/types.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
+import {
+  normalizeAgentId,
+  normalizeMainKey,
+  parseAgentSessionKey,
+} from "../../routing/session-key.js";
 import { ACP_ERROR_CODES, AcpRuntimeError } from "../runtime/errors.js";
 
 export function resolveAcpAgentFromSessionKey(sessionKey: string, fallback = "main"): string {
@@ -17,6 +22,33 @@ export function resolveMissingMetaError(sessionKey: string): AcpRuntimeError {
 
 export function normalizeSessionKey(sessionKey: string): string {
   return sessionKey.trim();
+}
+
+export function canonicalizeAcpSessionKey(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+}): string {
+  const normalized = normalizeSessionKey(params.sessionKey);
+  if (!normalized) {
+    return "";
+  }
+  const lowered = normalized.toLowerCase();
+  if (lowered === "global" || lowered === "unknown") {
+    return lowered;
+  }
+  const parsed = parseAgentSessionKey(lowered);
+  if (parsed) {
+    return canonicalizeMainSessionAlias({
+      cfg: params.cfg,
+      agentId: parsed.agentId,
+      sessionKey: lowered,
+    });
+  }
+  const mainKey = normalizeMainKey(params.cfg.session?.mainKey);
+  if (lowered === "main" || lowered === mainKey) {
+    return resolveMainSessionKey(params.cfg);
+  }
+  return lowered;
 }
 
 export function normalizeActorKey(sessionKey: string): string {

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -3,13 +3,19 @@ import { resolveAgentSessionDirs } from "../../agents/session-dirs.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import { resolveStateDir } from "../../config/paths.js";
-import { loadSessionStore, resolveStorePath, updateSessionStore } from "../../config/sessions.js";
+import {
+  canonicalizeMainSessionAlias,
+  loadSessionStore,
+  resolveMainSessionKey,
+  resolveStorePath,
+  updateSessionStore,
+} from "../../config/sessions.js";
 import {
   mergeSessionEntry,
   type SessionAcpMeta,
   type SessionEntry,
 } from "../../config/sessions/types.js";
-import { parseAgentSessionKey } from "../../routing/session-key.js";
+import { normalizeMainKey, parseAgentSessionKey } from "../../routing/session-key.js";
 
 export type AcpSessionStoreEntry = {
   cfg: OpenClawConfig;
@@ -41,12 +47,40 @@ function resolveStoreSessionKey(store: Record<string, SessionEntry>, sessionKey:
   return lower;
 }
 
+function canonicalizeAcpSessionKey(params: { cfg: OpenClawConfig; sessionKey: string }): string {
+  const normalized = params.sessionKey.trim();
+  if (!normalized) {
+    return "";
+  }
+  const lowered = normalized.toLowerCase();
+  if (lowered === "global" || lowered === "unknown") {
+    return lowered;
+  }
+  const parsed = parseAgentSessionKey(lowered);
+  if (parsed) {
+    return canonicalizeMainSessionAlias({
+      cfg: params.cfg,
+      agentId: parsed.agentId,
+      sessionKey: lowered,
+    });
+  }
+  const mainKey = normalizeMainKey(params.cfg.session?.mainKey);
+  if (lowered === "main" || lowered === mainKey) {
+    return resolveMainSessionKey(params.cfg);
+  }
+  return lowered;
+}
+
 export function resolveSessionStorePathForAcp(params: {
   sessionKey: string;
   cfg?: OpenClawConfig;
 }): { cfg: OpenClawConfig; storePath: string } {
   const cfg = params.cfg ?? loadConfig();
-  const parsed = parseAgentSessionKey(params.sessionKey);
+  const canonicalKey = canonicalizeAcpSessionKey({
+    cfg,
+    sessionKey: params.sessionKey,
+  });
+  const parsed = parseAgentSessionKey(canonicalKey);
   const storePath = resolveStorePath(cfg.session?.store, {
     agentId: parsed?.agentId,
   });
@@ -57,13 +91,17 @@ export function readAcpSessionEntry(params: {
   sessionKey: string;
   cfg?: OpenClawConfig;
 }): AcpSessionStoreEntry | null {
-  const sessionKey = params.sessionKey.trim();
+  const cfg = params.cfg ?? loadConfig();
+  const sessionKey = canonicalizeAcpSessionKey({
+    cfg,
+    sessionKey: params.sessionKey,
+  });
   if (!sessionKey) {
     return null;
   }
-  const { cfg, storePath } = resolveSessionStorePathForAcp({
+  const { storePath } = resolveSessionStorePathForAcp({
     sessionKey,
-    cfg: params.cfg,
+    cfg,
   });
   let store: Record<string, SessionEntry>;
   let storeReadFailed = false;
@@ -128,13 +166,17 @@ export async function upsertAcpSessionMeta(params: {
     entry: SessionEntry | undefined,
   ) => SessionAcpMeta | null | undefined;
 }): Promise<SessionEntry | null> {
-  const sessionKey = params.sessionKey.trim();
+  const cfg = params.cfg ?? loadConfig();
+  const sessionKey = canonicalizeAcpSessionKey({
+    cfg,
+    sessionKey: params.sessionKey,
+  });
   if (!sessionKey) {
     return null;
   }
   const { storePath } = resolveSessionStorePathForAcp({
     sessionKey,
-    cfg: params.cfg,
+    cfg,
   });
   return await updateSessionStore(
     storePath,

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -196,6 +196,32 @@ describe("agentCommand ACP runtime routing", () => {
     });
   });
 
+  it("uses canonical ACP session keys returned by the manager", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+      writeAcpSessionStore(storePath, "main");
+      mockConfigWithAcpOverrides(home, storePath, {
+        allowedAgents: ["main"],
+      });
+
+      const runTurn = vi.fn(async (_params: unknown) => {});
+      mockAcpManager({
+        runTurn: (params: unknown) => runTurn(params),
+        resolveSession: () => resolveReadySession("agent:main:acp:test", "main"),
+      });
+
+      await agentCommand({ message: "ping", sessionKey: "main" }, runtime);
+
+      expect(runTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: "agent:main:acp:test",
+          text: "ping",
+        }),
+      );
+      expect(runEmbeddedPiAgentSpy).not.toHaveBeenCalled();
+    });
+  });
+
   it("suppresses ACP NO_REPLY lead fragments before emitting assistant text", async () => {
     await withTempHome(async (home) => {
       const storePath = path.join(home, "sessions.json");

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -559,9 +559,10 @@ async function agentCommandInternal(
     }
 
     if (acpResolution?.kind === "ready" && sessionKey) {
+      const acpSessionKey = acpResolution.sessionKey;
       const startedAt = Date.now();
       registerAgentRunContext(runId, {
-        sessionKey,
+        sessionKey: acpSessionKey,
       });
       emitAgentEvent({
         runId,
@@ -580,7 +581,7 @@ async function agentCommandInternal(
           throw dispatchPolicyError;
         }
         const acpAgent = normalizeAgentId(
-          acpResolution.meta.agent || resolveAgentIdFromSessionKey(sessionKey),
+          acpResolution.meta.agent || resolveAgentIdFromSessionKey(acpSessionKey),
         );
         const agentPolicyError = resolveAcpAgentPolicyError(cfg, acpAgent);
         if (agentPolicyError) {
@@ -589,7 +590,7 @@ async function agentCommandInternal(
 
         await acpManager.runTurn({
           cfg,
-          sessionKey,
+          sessionKey: acpSessionKey,
           text: body,
           mode: "prompt",
           requestId: runId,


### PR DESCRIPTION
## Summary
- canonicalize ACP session aliases such as `main` before ACP metadata lookup and runtime rehydrate
- keep the ACP command path on the canonical session key returned by the manager after restart/rebind
- apply the same canonicalization to direct ACP session metadata reads and writes

## Testing
- `pnpm vitest src/acp/control-plane/manager.test.ts src/commands/agent.acp.test.ts src/acp/persistent-bindings.test.ts`
- `pnpm tsgo`
- `pnpm check`

Closes #25692
