### PR TITLE
fix(acp): canonicalize aliased session keys on restart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,13 @@ jobs:
         with:
           submodules: false
 
+      - name: Ensure secrets base commit (PR fast path)
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,21 +320,25 @@ jobs:
           python -m pip install pre-commit
 
       - name: Detect secrets
+        env:
+          GHA_REF: ${{ github.ref }}
+          GHA_EVENT_NAME: ${{ github.event_name }}
+          GHA_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
 
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "$GHA_REF" = "refs/heads/main" ]; then
             echo "Skipping detect-secrets on main until the allowlist cleanup lands."
             exit 0
           fi
 
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "$GHA_EVENT_NAME" = "push" ]; then
             echo "Running full detect-secrets scan on push."
             pre-commit run --all-files detect-secrets
             exit 0
           fi
 
-          BASE="${{ github.event.pull_request.base.sha }}"
+          BASE="$GHA_PR_BASE_SHA"
           changed_files=()
           if git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1; then
             while IFS= read -r path; do
@@ -356,13 +360,17 @@ jobs:
         run: pre-commit run --all-files detect-private-key
 
       - name: Audit changed GitHub workflows with zizmor
+        env:
+          GHA_EVENT_NAME: ${{ github.event_name }}
+          GHA_PUSH_BEFORE: ${{ github.event.before }}
+          GHA_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
 
-          if [ "${{ github.event_name }}" = "push" ]; then
-            BASE="${{ github.event.before }}"
+          if [ "$GHA_EVENT_NAME" = "push" ]; then
+            BASE="$GHA_PUSH_BEFORE"
           else
-            BASE="${{ github.event.pull_request.base.sha }}"
+            BASE="$GHA_PR_BASE_SHA"
           fi
 
           mapfile -t workflow_files < <(git diff --name-only "$BASE" HEAD -- '.github/workflows/*.yml' '.github/workflows/*.yaml')

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -36,6 +36,7 @@ import {
   type AcpSessionResolution,
   type AcpSessionRuntimeOptions,
   type AcpSessionStatus,
+  type AcpSessionStoreTarget,
   type AcpStartupIdentityReconcileResult,
   type ActiveTurnState,
   DEFAULT_DEPS,
@@ -194,14 +195,12 @@ export class AcpSessionManager {
           }
           const { runtime, handle, meta } = await this.ensureRuntimeHandle({
             cfg: params.cfg,
-            sessionKey: canonicalSessionKey,
-            storeSessionKey: resolution.storeSessionKey,
+            target: resolution,
             meta: resolution.meta,
           });
           const reconciled = await this.reconcileRuntimeSessionIdentifiers({
             cfg: params.cfg,
-            sessionKey: canonicalSessionKey,
-            storeSessionKey: resolution.storeSessionKey,
+            target: resolution,
             runtime,
             handle,
             meta,
@@ -294,7 +293,7 @@ export class AcpSessionManager {
       try {
         const persisted = await this.writeSessionMeta({
           cfg: input.cfg,
-          sessionKey,
+          target: { sessionKey },
           mutate: () => meta,
           failOnError: true,
         });
@@ -368,8 +367,7 @@ export class AcpSessionManager {
           meta: ensuredMeta,
         } = await this.ensureRuntimeHandle({
           cfg: params.cfg,
-          sessionKey,
-          storeSessionKey: resolution.storeSessionKey,
+          target: resolution,
           meta: resolution.meta,
         });
         let handle = ensuredHandle;
@@ -393,8 +391,7 @@ export class AcpSessionManager {
         }
         ({ handle, meta, runtimeStatus } = await this.reconcileRuntimeSessionIdentifiers({
           cfg: params.cfg,
-          sessionKey,
-          storeSessionKey: resolution.storeSessionKey,
+          target: resolution,
           runtime,
           handle,
           meta,
@@ -449,8 +446,7 @@ export class AcpSessionManager {
       }
       const { runtime, handle, meta } = await this.ensureRuntimeHandle({
         cfg: params.cfg,
-        sessionKey,
-        storeSessionKey: resolution.storeSessionKey,
+        target: resolution,
         meta: resolution.meta,
       });
       const capabilities = await this.resolveRuntimeCapabilities({ runtime, handle });
@@ -477,8 +473,7 @@ export class AcpSessionManager {
       });
       await this.persistRuntimeOptions({
         cfg: params.cfg,
-        sessionKey,
-        storeSessionKey: resolution.storeSessionKey,
+        target: resolution,
         options: nextOptions,
       });
       return nextOptions;
@@ -517,8 +512,7 @@ export class AcpSessionManager {
       }
       const { runtime, handle, meta } = await this.ensureRuntimeHandle({
         cfg: params.cfg,
-        sessionKey,
-        storeSessionKey: resolution.storeSessionKey,
+        target: resolution,
         meta: resolution.meta,
       });
       const inferredPatch = inferRuntimeOptionPatchFromConfigOption(key, value);
@@ -562,8 +556,7 @@ export class AcpSessionManager {
       });
       await this.persistRuntimeOptions({
         cfg: params.cfg,
-        sessionKey,
-        storeSessionKey: resolution.storeSessionKey,
+        target: resolution,
         options: nextOptions,
       });
       return nextOptions;
@@ -603,8 +596,7 @@ export class AcpSessionManager {
       });
       await this.persistRuntimeOptions({
         cfg: params.cfg,
-        sessionKey,
-        storeSessionKey: resolution.storeSessionKey,
+        target: resolution,
         options: nextOptions,
       });
       return nextOptions;
@@ -637,8 +629,7 @@ export class AcpSessionManager {
       }
       const { runtime, handle } = await this.ensureRuntimeHandle({
         cfg: params.cfg,
-        sessionKey,
-        storeSessionKey: resolution.storeSessionKey,
+        target: resolution,
         meta: resolution.meta,
       });
       await withAcpRuntimeErrorBoundary({
@@ -653,8 +644,7 @@ export class AcpSessionManager {
       this.clearCachedRuntimeState(sessionKey);
       await this.persistRuntimeOptions({
         cfg: params.cfg,
-        sessionKey,
-        storeSessionKey: resolution.storeSessionKey,
+        target: resolution,
         options: {},
       });
       return {};
@@ -693,8 +683,7 @@ export class AcpSessionManager {
         meta: ensuredMeta,
       } = await this.ensureRuntimeHandle({
         cfg: input.cfg,
-        sessionKey,
-        storeSessionKey: resolution.storeSessionKey,
+        target: resolution,
         meta: resolution.meta,
       });
       let handle = ensuredHandle;
@@ -710,8 +699,7 @@ export class AcpSessionManager {
 
       await this.setSessionState({
         cfg: input.cfg,
-        sessionKey,
-        storeSessionKey: resolution.storeSessionKey,
+        target: resolution,
         state: "running",
         clearLastError: true,
       });
@@ -764,8 +752,7 @@ export class AcpSessionManager {
         });
         await this.setSessionState({
           cfg: input.cfg,
-          sessionKey,
-          storeSessionKey: resolution.storeSessionKey,
+          target: resolution,
           state: "idle",
           clearLastError: true,
         });
@@ -781,8 +768,7 @@ export class AcpSessionManager {
         });
         await this.setSessionState({
           cfg: input.cfg,
-          sessionKey,
-          storeSessionKey: resolution.storeSessionKey,
+          target: resolution,
           state: "error",
           lastError: acpError.message,
         });
@@ -797,8 +783,7 @@ export class AcpSessionManager {
         if (meta.mode !== "oneshot") {
           ({ handle } = await this.reconcileRuntimeSessionIdentifiers({
             cfg: input.cfg,
-            sessionKey,
-            storeSessionKey: resolution.storeSessionKey,
+            target: resolution,
             runtime,
             handle,
             meta,
@@ -866,8 +851,7 @@ export class AcpSessionManager {
       }
       const { runtime, handle } = await this.ensureRuntimeHandle({
         cfg: params.cfg,
-        sessionKey,
-        storeSessionKey: resolution.storeSessionKey,
+        target: resolution,
         meta: resolution.meta,
       });
       try {
@@ -882,8 +866,7 @@ export class AcpSessionManager {
         });
         await this.setSessionState({
           cfg: params.cfg,
-          sessionKey,
-          storeSessionKey: resolution.storeSessionKey,
+          target: resolution,
           state: "idle",
           clearLastError: true,
         });
@@ -895,8 +878,7 @@ export class AcpSessionManager {
         });
         await this.setSessionState({
           cfg: params.cfg,
-          sessionKey,
-          storeSessionKey: resolution.storeSessionKey,
+          target: resolution,
           state: "error",
           lastError: acpError.message,
         });
@@ -947,8 +929,7 @@ export class AcpSessionManager {
       try {
         const { runtime, handle } = await this.ensureRuntimeHandle({
           cfg: input.cfg,
-          sessionKey,
-          storeSessionKey: resolution.storeSessionKey,
+          target: resolution,
           meta: resolution.meta,
         });
         await withAcpRuntimeErrorBoundary({
@@ -985,8 +966,7 @@ export class AcpSessionManager {
       if (input.clearMeta) {
         await this.writeSessionMeta({
           cfg: input.cfg,
-          sessionKey,
-          storeSessionKey: resolution.storeSessionKey,
+          target: resolution,
           mutate: (_current, entry) => {
             if (!entry) {
               return null;
@@ -1008,17 +988,16 @@ export class AcpSessionManager {
 
   private async ensureRuntimeHandle(params: {
     cfg: OpenClawConfig;
-    sessionKey: string;
-    storeSessionKey?: string;
+    target: AcpSessionStoreTarget;
     meta: SessionAcpMeta;
   }): Promise<{ runtime: AcpRuntime; handle: AcpRuntimeHandle; meta: SessionAcpMeta }> {
-    const agent =
-      params.meta.agent?.trim() || resolveAcpAgentFromSessionKey(params.sessionKey, "main");
+    const sessionKey = params.target.sessionKey;
+    const agent = params.meta.agent?.trim() || resolveAcpAgentFromSessionKey(sessionKey, "main");
     const mode = params.meta.mode;
     const runtimeOptions = resolveRuntimeOptionsFromMeta(params.meta);
     const cwd = runtimeOptions.cwd ?? normalizeText(params.meta.cwd);
     const configuredBackend = (params.meta.backend || params.cfg.acp?.backend || "").trim();
-    const cached = this.getCachedRuntimeState(params.sessionKey);
+    const cached = this.getCachedRuntimeState(sessionKey);
     if (cached) {
       const backendMatches = !configuredBackend || cached.backend === configuredBackend;
       const agentMatches = cached.agent === agent;
@@ -1031,12 +1010,12 @@ export class AcpSessionManager {
           meta: params.meta,
         };
       }
-      this.clearCachedRuntimeState(params.sessionKey);
+      this.clearCachedRuntimeState(sessionKey);
     }
 
     this.enforceConcurrentSessionLimit({
       cfg: params.cfg,
-      sessionKey: params.sessionKey,
+      sessionKey,
     });
 
     const backend = this.deps.requireRuntimeBackend(configuredBackend || undefined);
@@ -1044,7 +1023,7 @@ export class AcpSessionManager {
     const ensured = await withAcpRuntimeErrorBoundary({
       run: async () =>
         await runtime.ensureSession({
-          sessionKey: params.sessionKey,
+          sessionKey,
           agent,
           mode,
           cwd,
@@ -1103,8 +1082,7 @@ export class AcpSessionManager {
     if (shouldPersistMeta) {
       await this.writeSessionMeta({
         cfg: params.cfg,
-        sessionKey: params.sessionKey,
-        storeSessionKey: params.storeSessionKey,
+        target: params.target,
         mutate: (_current, entry) => {
           if (!entry) {
             return null;
@@ -1113,7 +1091,7 @@ export class AcpSessionManager {
         },
       });
     }
-    this.setCachedRuntimeState(params.sessionKey, {
+    this.setCachedRuntimeState(sessionKey, {
       runtime,
       handle: nextHandle,
       backend: ensured.backend || backend.id,
@@ -1131,16 +1109,14 @@ export class AcpSessionManager {
 
   private async persistRuntimeOptions(params: {
     cfg: OpenClawConfig;
-    sessionKey: string;
-    storeSessionKey?: string;
+    target: AcpSessionStoreTarget;
     options: AcpSessionRuntimeOptions;
   }): Promise<void> {
     const normalized = normalizeRuntimeOptions(params.options);
     const hasOptions = Object.keys(normalized).length > 0;
     await this.writeSessionMeta({
       cfg: params.cfg,
-      sessionKey: params.sessionKey,
-      storeSessionKey: params.storeSessionKey,
+      target: params.target,
       mutate: (current, entry) => {
         if (!entry) {
           return null;
@@ -1165,12 +1141,12 @@ export class AcpSessionManager {
       failOnError: true,
     });
 
-    const cached = this.getCachedRuntimeState(params.sessionKey);
+    const cached = this.getCachedRuntimeState(params.target.sessionKey);
     if (!cached) {
       return;
     }
     if ((cached.cwd ?? "") !== (normalized.cwd ?? "")) {
-      this.clearCachedRuntimeState(params.sessionKey);
+      this.clearCachedRuntimeState(params.target.sessionKey);
       return;
     }
     // Persisting options does not guarantee this process pushed all controls to the runtime.
@@ -1279,16 +1255,14 @@ export class AcpSessionManager {
 
   private async setSessionState(params: {
     cfg: OpenClawConfig;
-    sessionKey: string;
-    storeSessionKey?: string;
+    target: AcpSessionStoreTarget;
     state: SessionAcpMeta["state"];
     lastError?: string;
     clearLastError?: boolean;
   }): Promise<void> {
     await this.writeSessionMeta({
       cfg: params.cfg,
-      sessionKey: params.sessionKey,
-      storeSessionKey: params.storeSessionKey,
+      target: params.target,
       mutate: (current, entry) => {
         if (!entry) {
           return null;
@@ -1321,8 +1295,7 @@ export class AcpSessionManager {
 
   private async reconcileRuntimeSessionIdentifiers(params: {
     cfg: OpenClawConfig;
-    sessionKey: string;
-    storeSessionKey?: string;
+    target: AcpSessionStoreTarget;
     runtime: AcpRuntime;
     handle: AcpRuntimeHandle;
     meta: SessionAcpMeta;
@@ -1347,8 +1320,7 @@ export class AcpSessionManager {
 
   private async writeSessionMeta(params: {
     cfg: OpenClawConfig;
-    sessionKey: string;
-    storeSessionKey?: string;
+    target: AcpSessionStoreTarget;
     mutate: (
       current: SessionAcpMeta | undefined,
       entry: SessionEntry | undefined,
@@ -1358,8 +1330,8 @@ export class AcpSessionManager {
     try {
       return await this.deps.upsertSessionMeta({
         cfg: params.cfg,
-        sessionKey: params.sessionKey,
-        rawSessionKey: params.storeSessionKey,
+        sessionKey: params.target.sessionKey,
+        rawSessionKey: params.target.storeSessionKey,
         mutate: params.mutate,
       });
     } catch (error) {
@@ -1367,7 +1339,7 @@ export class AcpSessionManager {
         throw error;
       }
       logVerbose(
-        `acp-manager: failed persisting ACP metadata for ${params.sessionKey}: ${String(error)}`,
+        `acp-manager: failed persisting ACP metadata for ${params.target.sessionKey}: ${String(error)}`,
       );
       return null;
     }

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -518,6 +518,7 @@ export class AcpSessionManager {
       const { runtime, handle, meta } = await this.ensureRuntimeHandle({
         cfg: params.cfg,
         sessionKey,
+        storeSessionKey: resolution.storeSessionKey,
         meta: resolution.meta,
       });
       const inferredPatch = inferRuntimeOptionPatchFromConfigOption(key, value);

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -650,6 +650,7 @@ export class AcpSessionManager {
   }
 
   async runTurn(input: AcpRunTurnInput): Promise<void> {
+    const rawSessionKey = input.rawSessionKey ?? input.sessionKey;
     const sessionKey = canonicalizeAcpSessionKey({
       cfg: input.cfg,
       sessionKey: input.sessionKey,
@@ -662,7 +663,7 @@ export class AcpSessionManager {
       const resolution = this.resolveSession({
         cfg: input.cfg,
         sessionKey,
-        rawSessionKey: input.sessionKey,
+        rawSessionKey,
       });
       if (resolution.kind === "none") {
         throw new AcpRuntimeError(

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -44,11 +44,11 @@ import {
   type TurnLatencyStats,
 } from "./manager.types.js";
 import {
+  canonicalizeAcpSessionKey,
   createUnsupportedControlError,
   hasLegacyAcpIdentityProjection,
   normalizeAcpErrorCode,
   normalizeActorKey,
-  normalizeSessionKey,
   resolveAcpAgentFromSessionKey,
   resolveMissingMetaError,
   resolveRuntimeIdleTtlMs,
@@ -85,7 +85,7 @@ export class AcpSessionManager {
   constructor(private readonly deps: AcpSessionManagerDeps = DEFAULT_DEPS) {}
 
   resolveSession(params: { cfg: OpenClawConfig; sessionKey: string }): AcpSessionResolution {
-    const sessionKey = normalizeSessionKey(params.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey(params);
     if (!sessionKey) {
       return {
         kind: "none",
@@ -211,7 +211,10 @@ export class AcpSessionManager {
     handle: AcpRuntimeHandle;
     meta: SessionAcpMeta;
   }> {
-    const sessionKey = normalizeSessionKey(input.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey({
+      cfg: input.cfg,
+      sessionKey: input.sessionKey,
+    });
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
@@ -318,7 +321,7 @@ export class AcpSessionManager {
     sessionKey: string;
     signal?: AbortSignal;
   }): Promise<AcpSessionStatus> {
-    const sessionKey = normalizeSessionKey(params.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey(params);
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
@@ -402,7 +405,7 @@ export class AcpSessionManager {
     sessionKey: string;
     runtimeMode: string;
   }): Promise<AcpSessionRuntimeOptions> {
-    const sessionKey = normalizeSessionKey(params.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey(params);
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
@@ -465,7 +468,7 @@ export class AcpSessionManager {
     key: string;
     value: string;
   }): Promise<AcpSessionRuntimeOptions> {
-    const sessionKey = normalizeSessionKey(params.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey(params);
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
@@ -546,7 +549,7 @@ export class AcpSessionManager {
     sessionKey: string;
     patch: Partial<AcpSessionRuntimeOptions>;
   }): Promise<AcpSessionRuntimeOptions> {
-    const sessionKey = normalizeSessionKey(params.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey(params);
     const validatedPatch = validateRuntimeOptionPatch(params.patch);
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
@@ -584,7 +587,7 @@ export class AcpSessionManager {
     cfg: OpenClawConfig;
     sessionKey: string;
   }): Promise<AcpSessionRuntimeOptions> {
-    const sessionKey = normalizeSessionKey(params.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey(params);
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
@@ -628,7 +631,10 @@ export class AcpSessionManager {
   }
 
   async runTurn(input: AcpRunTurnInput): Promise<void> {
-    const sessionKey = normalizeSessionKey(input.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey({
+      cfg: input.cfg,
+      sessionKey: input.sessionKey,
+    });
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
@@ -782,7 +788,7 @@ export class AcpSessionManager {
     sessionKey: string;
     reason?: string;
   }): Promise<void> {
-    const sessionKey = normalizeSessionKey(params.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey(params);
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }
@@ -858,7 +864,10 @@ export class AcpSessionManager {
   }
 
   async closeSession(input: AcpCloseSessionInput): Promise<AcpCloseSessionResult> {
-    const sessionKey = normalizeSessionKey(input.sessionKey);
+    const sessionKey = canonicalizeAcpSessionKey({
+      cfg: input.cfg,
+      sessionKey: input.sessionKey,
+    });
     if (!sessionKey) {
       throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "ACP session key is required.");
     }

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -84,7 +84,12 @@ export class AcpSessionManager {
 
   constructor(private readonly deps: AcpSessionManagerDeps = DEFAULT_DEPS) {}
 
-  resolveSession(params: { cfg: OpenClawConfig; sessionKey: string }): AcpSessionResolution {
+  resolveSession(params: {
+    cfg: OpenClawConfig;
+    sessionKey: string;
+    rawSessionKey?: string;
+  }): AcpSessionResolution {
+    const rawSessionKey = params.rawSessionKey ?? params.sessionKey;
     const sessionKey = canonicalizeAcpSessionKey(params);
     if (!sessionKey) {
       return {
@@ -95,6 +100,7 @@ export class AcpSessionManager {
     const acp = this.deps.readSessionEntry({
       cfg: params.cfg,
       sessionKey,
+      rawSessionKey,
     })?.acp;
     if (acp) {
       return {
@@ -334,6 +340,7 @@ export class AcpSessionManager {
         const resolution = this.resolveSession({
           cfg: params.cfg,
           sessionKey,
+          rawSessionKey: params.sessionKey,
         });
         if (resolution.kind === "none") {
           throw new AcpRuntimeError(
@@ -416,6 +423,7 @@ export class AcpSessionManager {
       const resolution = this.resolveSession({
         cfg: params.cfg,
         sessionKey,
+        rawSessionKey: params.sessionKey,
       });
       if (resolution.kind === "none") {
         throw new AcpRuntimeError(
@@ -481,6 +489,7 @@ export class AcpSessionManager {
       const resolution = this.resolveSession({
         cfg: params.cfg,
         sessionKey,
+        rawSessionKey: params.sessionKey,
       });
       if (resolution.kind === "none") {
         throw new AcpRuntimeError(
@@ -560,6 +569,7 @@ export class AcpSessionManager {
       const resolution = this.resolveSession({
         cfg: params.cfg,
         sessionKey,
+        rawSessionKey: params.sessionKey,
       });
       if (resolution.kind === "none") {
         throw new AcpRuntimeError(
@@ -596,6 +606,7 @@ export class AcpSessionManager {
       const resolution = this.resolveSession({
         cfg: params.cfg,
         sessionKey,
+        rawSessionKey: params.sessionKey,
       });
       if (resolution.kind === "none") {
         throw new AcpRuntimeError(
@@ -643,6 +654,7 @@ export class AcpSessionManager {
       const resolution = this.resolveSession({
         cfg: input.cfg,
         sessionKey,
+        rawSessionKey: input.sessionKey,
       });
       if (resolution.kind === "none") {
         throw new AcpRuntimeError(
@@ -815,6 +827,7 @@ export class AcpSessionManager {
       const resolution = this.resolveSession({
         cfg: params.cfg,
         sessionKey,
+        rawSessionKey: params.sessionKey,
       });
       if (resolution.kind === "none") {
         throw new AcpRuntimeError(
@@ -876,6 +889,7 @@ export class AcpSessionManager {
       const resolution = this.resolveSession({
         cfg: input.cfg,
         sessionKey,
+        rawSessionKey: input.sessionKey,
       });
       if (resolution.kind === "none") {
         if (input.requireAcpSession ?? true) {

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -101,12 +101,13 @@ export class AcpSessionManager {
       cfg: params.cfg,
       sessionKey,
       rawSessionKey,
-    })?.acp;
-    if (acp) {
+    });
+    if (acp?.acp) {
       return {
         kind: "ready",
         sessionKey,
-        meta: acp,
+        storeSessionKey: acp.storeSessionKey,
+        meta: acp.acp,
       };
     }
     if (isAcpSessionKey(sessionKey)) {
@@ -194,11 +195,13 @@ export class AcpSessionManager {
           const { runtime, handle, meta } = await this.ensureRuntimeHandle({
             cfg: params.cfg,
             sessionKey: canonicalSessionKey,
+            storeSessionKey: resolution.storeSessionKey,
             meta: resolution.meta,
           });
           const reconciled = await this.reconcileRuntimeSessionIdentifiers({
             cfg: params.cfg,
             sessionKey: canonicalSessionKey,
+            storeSessionKey: resolution.storeSessionKey,
             runtime,
             handle,
             meta,
@@ -366,6 +369,7 @@ export class AcpSessionManager {
         } = await this.ensureRuntimeHandle({
           cfg: params.cfg,
           sessionKey,
+          storeSessionKey: resolution.storeSessionKey,
           meta: resolution.meta,
         });
         let handle = ensuredHandle;
@@ -390,6 +394,7 @@ export class AcpSessionManager {
         ({ handle, meta, runtimeStatus } = await this.reconcileRuntimeSessionIdentifiers({
           cfg: params.cfg,
           sessionKey,
+          storeSessionKey: resolution.storeSessionKey,
           runtime,
           handle,
           meta,
@@ -445,6 +450,7 @@ export class AcpSessionManager {
       const { runtime, handle, meta } = await this.ensureRuntimeHandle({
         cfg: params.cfg,
         sessionKey,
+        storeSessionKey: resolution.storeSessionKey,
         meta: resolution.meta,
       });
       const capabilities = await this.resolveRuntimeCapabilities({ runtime, handle });
@@ -472,6 +478,7 @@ export class AcpSessionManager {
       await this.persistRuntimeOptions({
         cfg: params.cfg,
         sessionKey,
+        storeSessionKey: resolution.storeSessionKey,
         options: nextOptions,
       });
       return nextOptions;
@@ -555,6 +562,7 @@ export class AcpSessionManager {
       await this.persistRuntimeOptions({
         cfg: params.cfg,
         sessionKey,
+        storeSessionKey: resolution.storeSessionKey,
         options: nextOptions,
       });
       return nextOptions;
@@ -628,6 +636,7 @@ export class AcpSessionManager {
       const { runtime, handle } = await this.ensureRuntimeHandle({
         cfg: params.cfg,
         sessionKey,
+        storeSessionKey: resolution.storeSessionKey,
         meta: resolution.meta,
       });
       await withAcpRuntimeErrorBoundary({
@@ -643,6 +652,7 @@ export class AcpSessionManager {
       await this.persistRuntimeOptions({
         cfg: params.cfg,
         sessionKey,
+        storeSessionKey: resolution.storeSessionKey,
         options: {},
       });
       return {};
@@ -682,6 +692,7 @@ export class AcpSessionManager {
       } = await this.ensureRuntimeHandle({
         cfg: input.cfg,
         sessionKey,
+        storeSessionKey: resolution.storeSessionKey,
         meta: resolution.meta,
       });
       let handle = ensuredHandle;
@@ -698,6 +709,7 @@ export class AcpSessionManager {
       await this.setSessionState({
         cfg: input.cfg,
         sessionKey,
+        storeSessionKey: resolution.storeSessionKey,
         state: "running",
         clearLastError: true,
       });
@@ -751,6 +763,7 @@ export class AcpSessionManager {
         await this.setSessionState({
           cfg: input.cfg,
           sessionKey,
+          storeSessionKey: resolution.storeSessionKey,
           state: "idle",
           clearLastError: true,
         });
@@ -767,6 +780,7 @@ export class AcpSessionManager {
         await this.setSessionState({
           cfg: input.cfg,
           sessionKey,
+          storeSessionKey: resolution.storeSessionKey,
           state: "error",
           lastError: acpError.message,
         });
@@ -782,6 +796,7 @@ export class AcpSessionManager {
           ({ handle } = await this.reconcileRuntimeSessionIdentifiers({
             cfg: input.cfg,
             sessionKey,
+            storeSessionKey: resolution.storeSessionKey,
             runtime,
             handle,
             meta,
@@ -850,6 +865,7 @@ export class AcpSessionManager {
       const { runtime, handle } = await this.ensureRuntimeHandle({
         cfg: params.cfg,
         sessionKey,
+        storeSessionKey: resolution.storeSessionKey,
         meta: resolution.meta,
       });
       try {
@@ -865,6 +881,7 @@ export class AcpSessionManager {
         await this.setSessionState({
           cfg: params.cfg,
           sessionKey,
+          storeSessionKey: resolution.storeSessionKey,
           state: "idle",
           clearLastError: true,
         });
@@ -877,6 +894,7 @@ export class AcpSessionManager {
         await this.setSessionState({
           cfg: params.cfg,
           sessionKey,
+          storeSessionKey: resolution.storeSessionKey,
           state: "error",
           lastError: acpError.message,
         });
@@ -928,6 +946,7 @@ export class AcpSessionManager {
         const { runtime, handle } = await this.ensureRuntimeHandle({
           cfg: input.cfg,
           sessionKey,
+          storeSessionKey: resolution.storeSessionKey,
           meta: resolution.meta,
         });
         await withAcpRuntimeErrorBoundary({
@@ -965,6 +984,7 @@ export class AcpSessionManager {
         await this.writeSessionMeta({
           cfg: input.cfg,
           sessionKey,
+          storeSessionKey: resolution.storeSessionKey,
           mutate: (_current, entry) => {
             if (!entry) {
               return null;
@@ -987,6 +1007,7 @@ export class AcpSessionManager {
   private async ensureRuntimeHandle(params: {
     cfg: OpenClawConfig;
     sessionKey: string;
+    storeSessionKey?: string;
     meta: SessionAcpMeta;
   }): Promise<{ runtime: AcpRuntime; handle: AcpRuntimeHandle; meta: SessionAcpMeta }> {
     const agent =
@@ -1081,6 +1102,7 @@ export class AcpSessionManager {
       await this.writeSessionMeta({
         cfg: params.cfg,
         sessionKey: params.sessionKey,
+        storeSessionKey: params.storeSessionKey,
         mutate: (_current, entry) => {
           if (!entry) {
             return null;
@@ -1108,6 +1130,7 @@ export class AcpSessionManager {
   private async persistRuntimeOptions(params: {
     cfg: OpenClawConfig;
     sessionKey: string;
+    storeSessionKey?: string;
     options: AcpSessionRuntimeOptions;
   }): Promise<void> {
     const normalized = normalizeRuntimeOptions(params.options);
@@ -1115,6 +1138,7 @@ export class AcpSessionManager {
     await this.writeSessionMeta({
       cfg: params.cfg,
       sessionKey: params.sessionKey,
+      storeSessionKey: params.storeSessionKey,
       mutate: (current, entry) => {
         if (!entry) {
           return null;
@@ -1254,6 +1278,7 @@ export class AcpSessionManager {
   private async setSessionState(params: {
     cfg: OpenClawConfig;
     sessionKey: string;
+    storeSessionKey?: string;
     state: SessionAcpMeta["state"];
     lastError?: string;
     clearLastError?: boolean;
@@ -1261,6 +1286,7 @@ export class AcpSessionManager {
     await this.writeSessionMeta({
       cfg: params.cfg,
       sessionKey: params.sessionKey,
+      storeSessionKey: params.storeSessionKey,
       mutate: (current, entry) => {
         if (!entry) {
           return null;
@@ -1294,6 +1320,7 @@ export class AcpSessionManager {
   private async reconcileRuntimeSessionIdentifiers(params: {
     cfg: OpenClawConfig;
     sessionKey: string;
+    storeSessionKey?: string;
     runtime: AcpRuntime;
     handle: AcpRuntimeHandle;
     meta: SessionAcpMeta;
@@ -1319,6 +1346,7 @@ export class AcpSessionManager {
   private async writeSessionMeta(params: {
     cfg: OpenClawConfig;
     sessionKey: string;
+    storeSessionKey?: string;
     mutate: (
       current: SessionAcpMeta | undefined,
       entry: SessionEntry | undefined,
@@ -1329,6 +1357,7 @@ export class AcpSessionManager {
       return await this.deps.upsertSessionMeta({
         cfg: params.cfg,
         sessionKey: params.sessionKey,
+        rawSessionKey: params.storeSessionKey,
         mutate: params.mutate,
       });
     } catch (error) {

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -168,6 +168,13 @@ export class AcpSessionManager {
       if (!session.acp || !session.sessionKey) {
         continue;
       }
+      const canonicalSessionKey = canonicalizeAcpSessionKey({
+        cfg: params.cfg,
+        sessionKey: session.sessionKey,
+      });
+      if (!canonicalSessionKey) {
+        continue;
+      }
       const currentIdentity = resolveSessionIdentityFromMeta(session.acp);
       if (!isSessionIdentityPending(currentIdentity)) {
         continue;
@@ -175,22 +182,23 @@ export class AcpSessionManager {
 
       checked += 1;
       try {
-        const becameResolved = await this.withSessionActor(session.sessionKey, async () => {
+        const becameResolved = await this.withSessionActor(canonicalSessionKey, async () => {
           const resolution = this.resolveSession({
             cfg: params.cfg,
-            sessionKey: session.sessionKey,
+            sessionKey: canonicalSessionKey,
+            rawSessionKey: session.sessionKey,
           });
           if (resolution.kind !== "ready") {
             return false;
           }
           const { runtime, handle, meta } = await this.ensureRuntimeHandle({
             cfg: params.cfg,
-            sessionKey: session.sessionKey,
+            sessionKey: canonicalSessionKey,
             meta: resolution.meta,
           });
           const reconciled = await this.reconcileRuntimeSessionIdentifiers({
             cfg: params.cfg,
-            sessionKey: session.sessionKey,
+            sessionKey: canonicalSessionKey,
             runtime,
             handle,
             meta,

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -603,6 +603,7 @@ export class AcpSessionManager {
       await this.persistRuntimeOptions({
         cfg: params.cfg,
         sessionKey,
+        storeSessionKey: resolution.storeSessionKey,
         options: nextOptions,
       });
       return nextOptions;

--- a/src/acp/control-plane/manager.identity-reconcile.ts
+++ b/src/acp/control-plane/manager.identity-reconcile.ts
@@ -9,13 +9,12 @@ import {
   resolveSessionIdentityFromMeta,
 } from "../runtime/session-identity.js";
 import type { AcpRuntime, AcpRuntimeHandle, AcpRuntimeStatus } from "../runtime/types.js";
-import type { SessionAcpMeta, SessionEntry } from "./manager.types.js";
+import type { AcpSessionStoreTarget, SessionAcpMeta, SessionEntry } from "./manager.types.js";
 import { hasLegacyAcpIdentityProjection } from "./manager.utils.js";
 
 export async function reconcileManagerRuntimeSessionIdentifiers(params: {
   cfg: OpenClawConfig;
-  sessionKey: string;
-  storeSessionKey?: string;
+  target: AcpSessionStoreTarget;
   runtime: AcpRuntime;
   handle: AcpRuntimeHandle;
   meta: SessionAcpMeta;
@@ -24,8 +23,7 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
   setCachedHandle: (sessionKey: string, handle: AcpRuntimeHandle) => void;
   writeSessionMeta: (params: {
     cfg: OpenClawConfig;
-    sessionKey: string;
-    storeSessionKey?: string;
+    target: AcpSessionStoreTarget;
     mutate: (
       current: SessionAcpMeta | undefined,
       entry: SessionEntry | undefined,
@@ -53,7 +51,7 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
         throw error;
       }
       logVerbose(
-        `acp-manager: failed to refresh ACP runtime status for ${params.sessionKey}: ${String(error)}`,
+        `acp-manager: failed to refresh ACP runtime status for ${params.target.sessionKey}: ${String(error)}`,
       );
       return {
         handle: params.handle,
@@ -90,7 +88,7 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
       }
     : params.handle;
   if (handleChanged) {
-    params.setCachedHandle(params.sessionKey, nextHandle);
+    params.setCachedHandle(params.target.sessionKey, nextHandle);
   }
 
   const metaChanged =
@@ -122,7 +120,7 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
     const currentAcpxRecordId = currentIdentity?.acpxRecordId ?? "<none>";
     const nextAcpxRecordId = nextIdentity?.acpxRecordId ?? "<none>";
     logVerbose(
-      `acp-manager: session identity updated for ${params.sessionKey} ` +
+      `acp-manager: session identity updated for ${params.target.sessionKey} ` +
         `(agentSessionId ${currentAgentSessionId} -> ${nextAgentSessionId}, ` +
         `acpxSessionId ${currentAcpxSessionId} -> ${nextAcpxSessionId}, ` +
         `acpxRecordId ${currentAcpxRecordId} -> ${nextAcpxRecordId})`,
@@ -130,8 +128,7 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
   }
   await params.writeSessionMeta({
     cfg: params.cfg,
-    sessionKey: params.sessionKey,
-    storeSessionKey: params.storeSessionKey,
+    target: params.target,
     mutate: (current, entry) => {
       if (!entry) {
         return null;

--- a/src/acp/control-plane/manager.identity-reconcile.ts
+++ b/src/acp/control-plane/manager.identity-reconcile.ts
@@ -15,6 +15,7 @@ import { hasLegacyAcpIdentityProjection } from "./manager.utils.js";
 export async function reconcileManagerRuntimeSessionIdentifiers(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
+  storeSessionKey?: string;
   runtime: AcpRuntime;
   handle: AcpRuntimeHandle;
   meta: SessionAcpMeta;
@@ -24,6 +25,7 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
   writeSessionMeta: (params: {
     cfg: OpenClawConfig;
     sessionKey: string;
+    storeSessionKey?: string;
     mutate: (
       current: SessionAcpMeta | undefined,
       entry: SessionEntry | undefined,
@@ -129,6 +131,7 @@ export async function reconcileManagerRuntimeSessionIdentifiers(params: {
   await params.writeSessionMeta({
     cfg: params.cfg,
     sessionKey: params.sessionKey,
+    storeSessionKey: params.storeSessionKey,
     mutate: (current, entry) => {
       if (!entry) {
         return null;

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1035,6 +1035,89 @@ describe("AcpSessionManager", () => {
     );
   });
 
+  it("preserves legacy store keys when updating config options", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.ensureSession.mockResolvedValue({
+      sessionKey: "agent:helper:desk",
+      backend: "acpx",
+      runtimeSessionName: "canonical-helper-runtime",
+    });
+    runtimeState.getCapabilities.mockResolvedValue({
+      controls: ["session/set_config_option"],
+      configOptionKeys: ["model"],
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    let currentMeta: SessionAcpMeta = {
+      ...readySessionMeta(),
+      agent: "helper",
+      runtimeSessionName: "legacy-helper-main",
+    };
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const params = paramsUnknown as { sessionKey?: string; rawSessionKey?: string };
+      if (
+        params.sessionKey !== "agent:helper:desk" ||
+        params.rawSessionKey !== "agent:helper:main"
+      ) {
+        return null;
+      }
+      return {
+        sessionKey: "agent:helper:desk",
+        storeSessionKey: "agent:helper:main",
+        acp: currentMeta,
+      };
+    });
+    hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
+      const params = paramsUnknown as {
+        sessionKey?: string;
+        rawSessionKey?: string;
+        mutate: (
+          current: SessionAcpMeta | undefined,
+          entry: { acp?: SessionAcpMeta } | undefined,
+        ) => SessionAcpMeta | null | undefined;
+      };
+      if (
+        params.sessionKey !== "agent:helper:desk" ||
+        params.rawSessionKey !== "agent:helper:main"
+      ) {
+        throw new Error("expected config-option writes to preserve the legacy helper alias");
+      }
+      const next = params.mutate(currentMeta, { acp: currentMeta });
+      if (next) {
+        currentMeta = next;
+      }
+      return {
+        sessionId: "session-helper-main",
+        updatedAt: Date.now(),
+        acp: currentMeta,
+      };
+    });
+
+    const manager = new AcpSessionManager();
+    const cfg = {
+      ...baseCfg,
+      session: { mainKey: "desk" },
+      agents: { list: [{ id: "main", default: true }, { id: "helper" }] },
+    } as OpenClawConfig;
+
+    await manager.setSessionConfigOption({
+      cfg,
+      sessionKey: "agent:helper:main",
+      key: "model",
+      value: "openai/gpt-5.3-codex",
+    });
+
+    expect(hoisted.upsertAcpSessionMetaMock).toHaveBeenCalled();
+    expect(
+      hoisted.upsertAcpSessionMetaMock.mock.calls.every(
+        ([firstArg]) =>
+          (firstArg as { rawSessionKey?: string }).rawSessionKey === "agent:helper:main",
+      ),
+    ).toBe(true);
+  });
+
   it("reapplies persisted controls on next turn after runtime option updates", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -205,6 +205,7 @@ describe("AcpSessionManager", () => {
     expect(hoisted.readAcpSessionEntryMock).toHaveBeenCalledWith(
       expect.objectContaining({
         cfg,
+        rawSessionKey: "main",
         sessionKey: "agent:main:main",
       }),
     );

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -271,6 +271,81 @@ describe("AcpSessionManager", () => {
     );
   });
 
+  it("reuses legacy store keys for ACP metadata writes after canonical dispatch", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    let currentMeta: SessionAcpMeta = {
+      ...readySessionMeta(),
+      agent: "helper",
+      runtimeSessionName: "legacy-helper-main",
+    };
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const params = paramsUnknown as { sessionKey?: string; rawSessionKey?: string };
+      if (
+        params.sessionKey !== "agent:helper:desk" ||
+        params.rawSessionKey !== "agent:helper:main"
+      ) {
+        return null;
+      }
+      return {
+        sessionKey: "agent:helper:desk",
+        storeSessionKey: "agent:helper:main",
+        acp: currentMeta,
+      };
+    });
+    hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
+      const params = paramsUnknown as {
+        sessionKey?: string;
+        rawSessionKey?: string;
+        mutate: (
+          current: SessionAcpMeta | undefined,
+          entry: { acp?: SessionAcpMeta } | undefined,
+        ) => SessionAcpMeta | null | undefined;
+      };
+      if (
+        params.sessionKey !== "agent:helper:desk" ||
+        params.rawSessionKey !== "agent:helper:main"
+      ) {
+        throw new Error("expected ACP metadata writes to preserve the legacy helper alias");
+      }
+      const next = params.mutate(currentMeta, { acp: currentMeta });
+      if (next) {
+        currentMeta = next;
+      }
+      return {
+        sessionId: "session-helper-main",
+        updatedAt: Date.now(),
+        acp: currentMeta,
+      };
+    });
+    const manager = new AcpSessionManager();
+    const cfg = {
+      ...baseCfg,
+      session: { mainKey: "desk" },
+      agents: { list: [{ id: "main", default: true }, { id: "helper" }] },
+    } as OpenClawConfig;
+
+    await manager.runTurn({
+      cfg,
+      sessionKey: "agent:helper:desk",
+      rawSessionKey: "agent:helper:main",
+      text: "persist helper alias",
+      mode: "prompt",
+      requestId: "r-helper-write",
+    });
+
+    expect(hoisted.upsertAcpSessionMetaMock).toHaveBeenCalled();
+    expect(
+      hoisted.upsertAcpSessionMetaMock.mock.calls.every(
+        ([firstArg]) =>
+          (firstArg as { rawSessionKey?: string }).rawSessionKey === "agent:helper:main",
+      ),
+    ).toBe(true);
+  });
+
   it("serializes concurrent turns for the same ACP session", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -216,6 +216,61 @@ describe("AcpSessionManager", () => {
     );
   });
 
+  it("preserves explicit raw alias keys when ACP turn dispatch is already canonicalized", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const params = paramsUnknown as { sessionKey?: string; rawSessionKey?: string };
+      if (
+        params.sessionKey !== "agent:helper:desk" ||
+        params.rawSessionKey !== "agent:helper:main"
+      ) {
+        return null;
+      }
+      return {
+        sessionKey: "agent:helper:desk",
+        storeSessionKey: "agent:helper:main",
+        acp: {
+          ...readySessionMeta(),
+          agent: "helper",
+          runtimeSessionName: "legacy-helper-main",
+        },
+      };
+    });
+    const manager = new AcpSessionManager();
+    const cfg = {
+      ...baseCfg,
+      session: { mainKey: "desk" },
+      agents: { list: [{ id: "main", default: true }, { id: "helper" }] },
+    } as OpenClawConfig;
+
+    await manager.runTurn({
+      cfg,
+      sessionKey: "agent:helper:desk",
+      rawSessionKey: "agent:helper:main",
+      text: "after alias preserve",
+      mode: "prompt",
+      requestId: "r-helper-main",
+    });
+
+    expect(hoisted.readAcpSessionEntryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg,
+        rawSessionKey: "agent:helper:main",
+        sessionKey: "agent:helper:desk",
+      }),
+    );
+    expect(runtimeState.ensureSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: "helper",
+        sessionKey: "agent:helper:desk",
+      }),
+    );
+  });
+
   it("serializes concurrent turns for the same ACP session", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -959,6 +959,82 @@ describe("AcpSessionManager", () => {
     );
   });
 
+  it("preserves legacy store keys when updating runtime options", async () => {
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const params = paramsUnknown as { sessionKey?: string; rawSessionKey?: string };
+      if (
+        params.sessionKey !== "agent:helper:desk" ||
+        params.rawSessionKey !== "agent:helper:main"
+      ) {
+        return null;
+      }
+      return {
+        sessionKey: "agent:helper:desk",
+        storeSessionKey: "agent:helper:main",
+        acp: {
+          ...readySessionMeta(),
+          agent: "helper",
+          runtimeSessionName: "legacy-helper-main",
+        },
+      };
+    });
+    hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
+      const params = paramsUnknown as {
+        sessionKey?: string;
+        rawSessionKey?: string;
+        mutate: (
+          current: SessionAcpMeta | undefined,
+          entry: { acp?: SessionAcpMeta } | undefined,
+        ) => SessionAcpMeta | null | undefined;
+      };
+      if (
+        params.sessionKey !== "agent:helper:desk" ||
+        params.rawSessionKey !== "agent:helper:main"
+      ) {
+        throw new Error("expected runtime option writes to preserve the legacy helper alias");
+      }
+      return {
+        sessionId: "session-helper-main",
+        updatedAt: Date.now(),
+        acp:
+          params.mutate(
+            {
+              ...readySessionMeta(),
+              agent: "helper",
+              runtimeSessionName: "legacy-helper-main",
+            },
+            {
+              acp: {
+                ...readySessionMeta(),
+                agent: "helper",
+                runtimeSessionName: "legacy-helper-main",
+              },
+            },
+          ) ?? undefined,
+      };
+    });
+
+    const manager = new AcpSessionManager();
+    const cfg = {
+      ...baseCfg,
+      session: { mainKey: "desk" },
+      agents: { list: [{ id: "main", default: true }, { id: "helper" }] },
+    } as OpenClawConfig;
+
+    await manager.updateSessionRuntimeOptions({
+      cfg,
+      sessionKey: "agent:helper:main",
+      patch: { cwd: "/tmp/helper" },
+    });
+
+    expect(hoisted.upsertAcpSessionMetaMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rawSessionKey: "agent:helper:main",
+        sessionKey: "agent:helper:desk",
+      }),
+    );
+  });
+
   it("reapplies persisted controls on next turn after runtime option updates", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1038,6 +1038,97 @@ describe("AcpSessionManager", () => {
     expect(currentMeta.identity?.agentSessionId).toBe("agent-session-1");
   });
 
+  it("reuses canonical runtime handles after startup reconcile of legacy alias keys", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.getStatus.mockResolvedValue({
+      summary: "status=alive",
+      acpxRecordId: "acpx-record-1",
+      backendSessionId: "acpx-session-1",
+      agentSessionId: "agent-session-1",
+      details: { status: "alive" },
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+
+    const cfg = {
+      ...baseCfg,
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    let currentMeta: SessionAcpMeta = {
+      ...readySessionMeta(),
+      agent: "main",
+      identity: {
+        state: "pending",
+        source: "ensure",
+        acpxSessionId: "acpx-stale",
+        lastUpdatedAt: Date.now(),
+      },
+    };
+    hoisted.listAcpSessionEntriesMock.mockResolvedValue([
+      {
+        cfg,
+        storePath: "/tmp/sessions-acp.json",
+        sessionKey: "main",
+        storeSessionKey: "main",
+        entry: {
+          sessionId: "session-main",
+          updatedAt: Date.now(),
+          acp: currentMeta,
+        },
+        acp: currentMeta,
+      },
+    ]);
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const params = paramsUnknown as { sessionKey?: string; rawSessionKey?: string };
+      if (params.sessionKey !== "agent:main:main" || params.rawSessionKey !== "main") {
+        return null;
+      }
+      return {
+        sessionKey: "agent:main:main",
+        storeSessionKey: "main",
+        acp: currentMeta,
+      };
+    });
+    hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
+      const params = paramsUnknown as {
+        mutate: (
+          current: SessionAcpMeta | undefined,
+          entry: { acp?: SessionAcpMeta } | undefined,
+        ) => SessionAcpMeta | null | undefined;
+      };
+      const next = params.mutate(currentMeta, { acp: currentMeta });
+      if (next) {
+        currentMeta = next;
+      }
+      return {
+        sessionId: "session-main",
+        updatedAt: Date.now(),
+        acp: currentMeta,
+      };
+    });
+
+    const manager = new AcpSessionManager();
+    const reconcile = await manager.reconcilePendingSessionIdentities({ cfg });
+    await manager.runTurn({
+      cfg,
+      sessionKey: "main",
+      text: "after startup",
+      mode: "prompt",
+      requestId: "run-main",
+    });
+
+    expect(reconcile).toEqual({ checked: 1, resolved: 1, failed: 0 });
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(1);
+    expect(runtimeState.ensureSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+      }),
+    );
+  });
+
   it("skips startup identity reconciliation for already resolved sessions", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -170,6 +170,51 @@ describe("AcpSessionManager", () => {
     expect(resolved.error.message).toContain("ACP metadata is missing");
   });
 
+  it("canonicalizes main alias session keys before ACP lookup and runtime rehydrate", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
+      if (sessionKey !== "agent:main:main") {
+        return null;
+      }
+      return {
+        sessionKey,
+        storeSessionKey: sessionKey,
+        acp: readySessionMeta(),
+      };
+    });
+    const manager = new AcpSessionManager();
+    const cfg = {
+      ...baseCfg,
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+
+    await manager.runTurn({
+      cfg,
+      sessionKey: "main",
+      text: "after restart",
+      mode: "prompt",
+      requestId: "r-main",
+    });
+
+    expect(hoisted.readAcpSessionEntryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg,
+        sessionKey: "agent:main:main",
+      }),
+    );
+    expect(runtimeState.ensureSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+      }),
+    );
+  });
+
   it("serializes concurrent turns for the same ACP session", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({

--- a/src/acp/control-plane/manager.types.ts
+++ b/src/acp/control-plane/manager.types.ts
@@ -39,6 +39,13 @@ export type AcpSessionResolution =
       meta: SessionAcpMeta;
     };
 
+export type AcpSessionStoreTarget = {
+  sessionKey: string;
+  storeSessionKey?: string;
+};
+
+export type AcpReadySessionResolution = Extract<AcpSessionResolution, { kind: "ready" }>;
+
 export type AcpInitializeSessionInput = {
   cfg: OpenClawConfig;
   sessionKey: string;

--- a/src/acp/control-plane/manager.types.ts
+++ b/src/acp/control-plane/manager.types.ts
@@ -50,6 +50,7 @@ export type AcpInitializeSessionInput = {
 export type AcpRunTurnInput = {
   cfg: OpenClawConfig;
   sessionKey: string;
+  rawSessionKey?: string;
   text: string;
   mode: AcpRuntimePromptMode;
   requestId: string;

--- a/src/acp/control-plane/manager.types.ts
+++ b/src/acp/control-plane/manager.types.ts
@@ -35,6 +35,7 @@ export type AcpSessionResolution =
   | {
       kind: "ready";
       sessionKey: string;
+      storeSessionKey: string;
       meta: SessionAcpMeta;
     };
 

--- a/src/acp/control-plane/manager.utils.ts
+++ b/src/acp/control-plane/manager.utils.ts
@@ -1,5 +1,8 @@
 import type { OpenClawConfig } from "../../config/config.js";
-import { canonicalizeMainSessionAlias, resolveMainSessionKey } from "../../config/sessions.js";
+import {
+  canonicalizeMainSessionAlias,
+  resolveMainSessionKey,
+} from "../../config/sessions/main-session.js";
 import type { SessionAcpMeta } from "../../config/sessions/types.js";
 import {
   normalizeAgentId,

--- a/src/acp/control-plane/manager.utils.ts
+++ b/src/acp/control-plane/manager.utils.ts
@@ -1,6 +1,11 @@
 import type { OpenClawConfig } from "../../config/config.js";
+import { canonicalizeMainSessionAlias, resolveMainSessionKey } from "../../config/sessions.js";
 import type { SessionAcpMeta } from "../../config/sessions/types.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
+import {
+  normalizeAgentId,
+  normalizeMainKey,
+  parseAgentSessionKey,
+} from "../../routing/session-key.js";
 import { ACP_ERROR_CODES, AcpRuntimeError } from "../runtime/errors.js";
 
 export function resolveAcpAgentFromSessionKey(sessionKey: string, fallback = "main"): string {
@@ -17,6 +22,33 @@ export function resolveMissingMetaError(sessionKey: string): AcpRuntimeError {
 
 export function normalizeSessionKey(sessionKey: string): string {
   return sessionKey.trim();
+}
+
+export function canonicalizeAcpSessionKey(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+}): string {
+  const normalized = normalizeSessionKey(params.sessionKey);
+  if (!normalized) {
+    return "";
+  }
+  const lowered = normalized.toLowerCase();
+  if (lowered === "global" || lowered === "unknown") {
+    return lowered;
+  }
+  const parsed = parseAgentSessionKey(lowered);
+  if (parsed) {
+    return canonicalizeMainSessionAlias({
+      cfg: params.cfg,
+      agentId: parsed.agentId,
+      sessionKey: lowered,
+    });
+  }
+  const mainKey = normalizeMainKey(params.cfg.session?.mainKey);
+  if (lowered === "main" || lowered === mainKey) {
+    return resolveMainSessionKey(params.cfg);
+  }
+  return lowered;
 }
 
 export function normalizeActorKey(sessionKey: string): string {

--- a/src/acp/persistent-bindings.test.ts
+++ b/src/acp/persistent-bindings.test.ts
@@ -446,6 +446,7 @@ describe("ensureConfiguredAcpBindingSession", () => {
     managerMocks.resolveSession.mockReturnValue({
       kind: "ready",
       sessionKey,
+      storeSessionKey: sessionKey,
       meta: {
         backend: "acpx",
         agent: "codex",
@@ -480,6 +481,7 @@ describe("ensureConfiguredAcpBindingSession", () => {
     managerMocks.resolveSession.mockReturnValue({
       kind: "ready",
       sessionKey,
+      storeSessionKey: sessionKey,
       meta: {
         backend: "acpx",
         agent: "codex",

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -230,6 +230,12 @@ export async function upsertAcpSessionMeta(params: {
     sessionKey,
     cfg,
   });
+  const activeStoreSessionKey =
+    readAcpSessionEntry({
+      cfg,
+      sessionKey,
+      rawSessionKey: params.rawSessionKey,
+    })?.storeSessionKey ?? sessionKey;
   return await updateSessionStore(
     storePath,
     (store) => {
@@ -260,7 +266,7 @@ export async function upsertAcpSessionMeta(params: {
       return nextEntry;
     },
     {
-      activeSessionKey: sessionKey.toLowerCase(),
+      activeSessionKey: activeStoreSessionKey.toLowerCase(),
     },
   );
 }

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -26,24 +26,35 @@ export type AcpSessionStoreEntry = {
   storeReadFailed?: boolean;
 };
 
-function resolveStoreSessionKey(store: Record<string, SessionEntry>, sessionKey: string): string {
-  const normalized = sessionKey.trim();
-  if (!normalized) {
-    return "";
+function resolveStoreSessionKey(
+  store: Record<string, SessionEntry>,
+  sessionKeys: string[],
+): string {
+  const lookupKeys: string[] = [];
+  const seen = new Set<string>();
+  for (const key of sessionKeys) {
+    const normalized = key.trim();
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    lookupKeys.push(normalized);
   }
-  if (store[normalized]) {
-    return normalized;
-  }
-  const lower = normalized.toLowerCase();
-  if (store[lower]) {
-    return lower;
-  }
-  for (const key of Object.keys(store)) {
-    if (key.toLowerCase() === lower) {
-      return key;
+  for (const lookupKey of lookupKeys) {
+    if (store[lookupKey]) {
+      return lookupKey;
+    }
+    const lower = lookupKey.toLowerCase();
+    if (store[lower]) {
+      return lower;
+    }
+    for (const key of Object.keys(store)) {
+      if (key.toLowerCase() === lower) {
+        return key;
+      }
     }
   }
-  return lower;
+  return lookupKeys[0]?.toLowerCase() ?? "";
 }
 
 function canonicalizeAcpSessionKey(params: { cfg: OpenClawConfig; sessionKey: string }): string {
@@ -88,9 +99,11 @@ export function resolveSessionStorePathForAcp(params: {
 
 export function readAcpSessionEntry(params: {
   sessionKey: string;
+  rawSessionKey?: string;
   cfg?: OpenClawConfig;
 }): AcpSessionStoreEntry | null {
   const cfg = params.cfg ?? loadConfig();
+  const rawSessionKey = params.rawSessionKey ?? params.sessionKey;
   const sessionKey = canonicalizeAcpSessionKey({
     cfg,
     sessionKey: params.sessionKey,
@@ -110,7 +123,7 @@ export function readAcpSessionEntry(params: {
     storeReadFailed = true;
     store = {};
   }
-  const storeSessionKey = resolveStoreSessionKey(store, sessionKey);
+  const storeSessionKey = resolveStoreSessionKey(store, [sessionKey, rawSessionKey]);
   const entry = store[storeSessionKey];
   return {
     cfg,
@@ -180,7 +193,7 @@ export async function upsertAcpSessionMeta(params: {
   return await updateSessionStore(
     storePath,
     (store) => {
-      const storeSessionKey = resolveStoreSessionKey(store, sessionKey);
+      const storeSessionKey = resolveStoreSessionKey(store, [sessionKey]);
       const currentEntry = store[storeSessionKey];
       const nextMeta = params.mutate(currentEntry?.acp, currentEntry);
       if (nextMeta === undefined) {

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -211,6 +211,7 @@ export async function listAcpSessionEntries(params: {
 
 export async function upsertAcpSessionMeta(params: {
   sessionKey: string;
+  rawSessionKey?: string;
   cfg?: OpenClawConfig;
   mutate: (
     current: SessionAcpMeta | undefined,
@@ -237,6 +238,7 @@ export async function upsertAcpSessionMeta(params: {
         resolveStoreLookupKeys({
           cfg,
           sessionKey,
+          rawSessionKey: params.rawSessionKey,
         }),
       );
       const currentEntry = store[storeSessionKey];

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -26,6 +26,38 @@ export type AcpSessionStoreEntry = {
   storeReadFailed?: boolean;
 };
 
+function resolveStoreLookupKeys(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  rawSessionKey?: string;
+}): string[] {
+  const lookupKeys: string[] = [];
+  const seen = new Set<string>();
+  const pushKey = (key?: string) => {
+    const normalized = key?.trim();
+    if (!normalized || seen.has(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+    lookupKeys.push(normalized);
+  };
+
+  pushKey(params.sessionKey);
+  pushKey(params.rawSessionKey);
+
+  const mainSessionKey = resolveMainSessionKey(params.cfg);
+  if (params.sessionKey === mainSessionKey) {
+    pushKey("main");
+    pushKey(normalizeMainKey(params.cfg.session?.mainKey));
+    const parsed = parseAgentSessionKey(params.sessionKey);
+    if (parsed) {
+      pushKey(`agent:${parsed.agentId}:main`);
+    }
+  }
+
+  return lookupKeys;
+}
+
 function resolveStoreSessionKey(
   store: Record<string, SessionEntry>,
   sessionKeys: string[],
@@ -123,7 +155,14 @@ export function readAcpSessionEntry(params: {
     storeReadFailed = true;
     store = {};
   }
-  const storeSessionKey = resolveStoreSessionKey(store, [sessionKey, rawSessionKey]);
+  const storeSessionKey = resolveStoreSessionKey(
+    store,
+    resolveStoreLookupKeys({
+      cfg,
+      sessionKey,
+      rawSessionKey,
+    }),
+  );
   const entry = store[storeSessionKey];
   return {
     cfg,
@@ -193,7 +232,13 @@ export async function upsertAcpSessionMeta(params: {
   return await updateSessionStore(
     storePath,
     (store) => {
-      const storeSessionKey = resolveStoreSessionKey(store, [sessionKey]);
+      const storeSessionKey = resolveStoreSessionKey(
+        store,
+        resolveStoreLookupKeys({
+          cfg,
+          sessionKey,
+        }),
+      );
       const currentEntry = store[storeSessionKey];
       const nextMeta = params.mutate(currentEntry?.acp, currentEntry);
       if (nextMeta === undefined) {

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -5,11 +5,10 @@ import { loadConfig } from "../../config/config.js";
 import { resolveStateDir } from "../../config/paths.js";
 import {
   canonicalizeMainSessionAlias,
-  loadSessionStore,
   resolveMainSessionKey,
-  resolveStorePath,
-  updateSessionStore,
-} from "../../config/sessions.js";
+} from "../../config/sessions/main-session.js";
+import { resolveStorePath } from "../../config/sessions/paths.js";
+import { loadSessionStore, updateSessionStore } from "../../config/sessions/store.js";
 import {
   mergeSessionEntry,
   type SessionAcpMeta,

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -3,13 +3,19 @@ import { resolveAgentSessionDirs } from "../../agents/session-dirs.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import { resolveStateDir } from "../../config/paths.js";
-import { loadSessionStore, resolveStorePath, updateSessionStore } from "../../config/sessions.js";
+import {
+  canonicalizeMainSessionAlias,
+  loadSessionStore,
+  resolveMainSessionKey,
+  resolveStorePath,
+  updateSessionStore,
+} from "../../config/sessions.js";
 import {
   mergeSessionEntry,
   type SessionAcpMeta,
   type SessionEntry,
 } from "../../config/sessions/types.js";
-import { parseAgentSessionKey } from "../../routing/session-key.js";
+import { normalizeMainKey, parseAgentSessionKey } from "../../routing/session-key.js";
 
 export type AcpSessionStoreEntry = {
   cfg: OpenClawConfig;
@@ -41,12 +47,40 @@ function resolveStoreSessionKey(store: Record<string, SessionEntry>, sessionKey:
   return lower;
 }
 
+function canonicalizeAcpSessionKey(params: { cfg: OpenClawConfig; sessionKey: string }): string {
+  const normalized = params.sessionKey.trim();
+  if (!normalized) {
+    return "";
+  }
+  const lowered = normalized.toLowerCase();
+  if (lowered === "global" || lowered === "unknown") {
+    return lowered;
+  }
+  const parsed = parseAgentSessionKey(lowered);
+  if (parsed) {
+    return canonicalizeMainSessionAlias({
+      cfg: params.cfg,
+      agentId: parsed.agentId,
+      sessionKey: lowered,
+    });
+  }
+  const mainKey = normalizeMainKey(params.cfg.session?.mainKey);
+  if (lowered === "main" || lowered === mainKey) {
+    return resolveMainSessionKey(params.cfg);
+  }
+  return lowered;
+}
+
 export function resolveSessionStorePathForAcp(params: {
   sessionKey: string;
   cfg?: OpenClawConfig;
 }): { cfg: OpenClawConfig; storePath: string } {
   const cfg = params.cfg ?? loadConfig();
-  const parsed = parseAgentSessionKey(params.sessionKey);
+  const canonicalKey = canonicalizeAcpSessionKey({
+    cfg,
+    sessionKey: params.sessionKey,
+  });
+  const parsed = parseAgentSessionKey(canonicalKey);
   const storePath = resolveStorePath(cfg.session?.store, {
     agentId: parsed?.agentId,
   });
@@ -57,13 +91,17 @@ export function readAcpSessionEntry(params: {
   sessionKey: string;
   cfg?: OpenClawConfig;
 }): AcpSessionStoreEntry | null {
-  const sessionKey = params.sessionKey.trim();
+  const cfg = params.cfg ?? loadConfig();
+  const sessionKey = canonicalizeAcpSessionKey({
+    cfg,
+    sessionKey: params.sessionKey,
+  });
   if (!sessionKey) {
     return null;
   }
-  const { cfg, storePath } = resolveSessionStorePathForAcp({
+  const { storePath } = resolveSessionStorePathForAcp({
     sessionKey,
-    cfg: params.cfg,
+    cfg,
   });
   let store: Record<string, SessionEntry>;
   let storeReadFailed = false;
@@ -128,13 +166,17 @@ export async function upsertAcpSessionMeta(params: {
     entry: SessionEntry | undefined,
   ) => SessionAcpMeta | null | undefined;
 }): Promise<SessionEntry | null> {
-  const sessionKey = params.sessionKey.trim();
+  const cfg = params.cfg ?? loadConfig();
+  const sessionKey = canonicalizeAcpSessionKey({
+    cfg,
+    sessionKey: params.sessionKey,
+  });
   if (!sessionKey) {
     return null;
   }
   const { storePath } = resolveSessionStorePathForAcp({
     sessionKey,
-    cfg: params.cfg,
+    cfg,
   });
   return await updateSessionStore(
     storePath,

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -50,6 +50,7 @@ const acpManagerMocks = vi.hoisted(() => ({
       | {
           kind: "ready";
           sessionKey: string;
+          storeSessionKey: string;
           meta: unknown;
         }
   >(() => ({ kind: "none" })),
@@ -399,6 +400,7 @@ describe("abort detection", () => {
     acpManagerMocks.resolveSession.mockReturnValue({
       kind: "ready",
       sessionKey,
+      storeSessionKey: sessionKey,
       meta: {} as never,
     });
 
@@ -428,6 +430,7 @@ describe("abort detection", () => {
     acpManagerMocks.resolveSession.mockReturnValue({
       kind: "ready",
       sessionKey,
+      storeSessionKey: sessionKey,
       meta: {} as never,
     });
     acpManagerMocks.cancelSession.mockRejectedValueOnce(new Error("cancel failed"));

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -107,6 +107,7 @@ function setReadyAcpResolution() {
   managerMocks.resolveSession.mockReturnValue({
     kind: "ready",
     sessionKey,
+    storeSessionKey: sessionKey,
     meta: createAcpSessionMeta(),
   });
 }

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -393,6 +393,73 @@ describe("agentCommand ACP runtime routing", () => {
     });
   });
 
+  it("keeps legacy alias entries active during ACP upserts under disk-budget enforcement", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+      const now = Date.now();
+      fs.writeFileSync(
+        storePath,
+        JSON.stringify(
+          {
+            "agent:helper:main": {
+              sessionId: "acp-helper-budget",
+              updatedAt: now - 60_000,
+              displayName: "x".repeat(4096),
+              acp: {
+                backend: "acpx",
+                agent: "helper",
+                runtimeSessionName: "legacy-helper-main",
+                mode: "persistent",
+                state: "idle",
+                lastActivityAt: now - 60_000,
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const cfg = createAcpEnabledConfig(home, storePath);
+      cfg.session = {
+        store: storePath,
+        mainKey: "desk",
+        maintenance: {
+          mode: "enforce",
+          maxDiskBytes: "300b",
+          highWaterBytes: "200b",
+        },
+      };
+      cfg.acp = {
+        ...cfg.acp,
+        allowedAgents: ["helper"],
+      };
+      loadConfigSpy.mockReturnValue(cfg);
+
+      await upsertAcpSessionMeta({
+        cfg,
+        sessionKey: "agent:helper:desk",
+        rawSessionKey: "agent:helper:main",
+        mutate: (current, entry) => ({
+          ...(current ?? entry?.acp),
+          backend: "acpx",
+          agent: "helper",
+          runtimeSessionName: "legacy-helper-main",
+          mode: "persistent",
+          state: "running",
+          lastActivityAt: now + 1,
+        }),
+      });
+
+      const store = JSON.parse(fs.readFileSync(storePath, "utf-8")) as Record<
+        string,
+        { acp?: { state?: string } }
+      >;
+      expect(Object.keys(store)).toEqual(["agent:helper:main"]);
+      expect(store["agent:helper:main"]?.acp?.state).toBe("running");
+    });
+  });
+
   it("suppresses ACP NO_REPLY lead fragments before emitting assistant text", async () => {
     await withTempHome(async (home) => {
       const storePath = path.join(home, "sessions.json");

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -196,6 +196,32 @@ describe("agentCommand ACP runtime routing", () => {
     });
   });
 
+  it("uses canonical ACP session keys returned by the manager", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+      writeAcpSessionStore(storePath, "main");
+      mockConfigWithAcpOverrides(home, storePath, {
+        allowedAgents: ["main"],
+      });
+
+      const runTurn = vi.fn(async (_params: unknown) => {});
+      mockAcpManager({
+        runTurn: (params: unknown) => runTurn(params),
+        resolveSession: () => resolveReadySession("agent:main:acp:test", "main"),
+      });
+
+      await agentCommand({ message: "ping", sessionKey: "main" }, runtime);
+
+      expect(runTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: "agent:main:acp:test",
+          text: "ping",
+        }),
+      );
+      expect(runEmbeddedPiAgentSpy).not.toHaveBeenCalled();
+    });
+  });
+
   it("suppresses ACP NO_REPLY lead fragments before emitting assistant text", async () => {
     await withTempHome(async (home) => {
       const storePath = path.join(home, "sessions.json");

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
 import * as acpManagerModule from "../acp/control-plane/manager.js";
 import { AcpRuntimeError } from "../acp/runtime/errors.js";
-import { readAcpSessionEntry } from "../acp/runtime/session-meta.js";
+import { readAcpSessionEntry, upsertAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import * as embeddedModule from "../agents/pi-embedded.js";
 import type { OpenClawConfig } from "../config/config.js";
 import * as configModule from "../config/config.js";
@@ -258,6 +258,46 @@ describe("agentCommand ACP runtime routing", () => {
       expect(entry?.sessionKey).toBe("agent:main:main");
       expect(entry?.storeSessionKey).toBe("main");
       expect(entry?.acp?.backend).toBe("acpx");
+    });
+  });
+
+  it("clears ACP metadata stored under legacy main alias keys", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+      const now = Date.now();
+      fs.writeFileSync(
+        storePath,
+        JSON.stringify(
+          {
+            main: {
+              sessionId: "acp-main-legacy",
+              updatedAt: now,
+              acp: {
+                backend: "acpx",
+                agent: "main",
+                runtimeSessionName: "legacy-main",
+                mode: "persistent",
+                state: "idle",
+                lastActivityAt: now,
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      const cfg = createAcpEnabledConfig(home, storePath);
+
+      await upsertAcpSessionMeta({
+        cfg,
+        sessionKey: "main",
+        mutate: () => null,
+      });
+
+      const store = JSON.parse(fs.readFileSync(storePath, "utf-8")) as {
+        main?: { acp?: unknown };
+      };
+      expect(store.main?.acp).toBeUndefined();
     });
   });
 

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -215,7 +215,41 @@ describe("agentCommand ACP runtime routing", () => {
 
       expect(runTurn).toHaveBeenCalledWith(
         expect.objectContaining({
+          rawSessionKey: "main",
           sessionKey: "agent:main:acp:test",
+          text: "ping",
+        }),
+      );
+      expect(runEmbeddedPiAgentSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("preserves raw non-default agent aliases when the manager resolves a canonical ACP key", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+      fs.mkdirSync(path.dirname(storePath), { recursive: true });
+      fs.writeFileSync(storePath, JSON.stringify({}, null, 2));
+
+      const cfg = createAcpEnabledConfig(home, storePath);
+      cfg.session = { store: storePath, mainKey: "desk" };
+      cfg.acp = {
+        ...cfg.acp,
+        allowedAgents: ["helper"],
+      };
+      loadConfigSpy.mockReturnValue(cfg);
+
+      const runTurn = vi.fn(async (_params: unknown) => {});
+      mockAcpManager({
+        runTurn: (params: unknown) => runTurn(params),
+        resolveSession: () => resolveReadySession("agent:helper:desk", "helper"),
+      });
+
+      await agentCommand({ message: "ping", sessionKey: "agent:helper:main" }, runtime);
+
+      expect(runTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rawSessionKey: "agent:helper:main",
+          sessionKey: "agent:helper:desk",
           text: "ping",
         }),
       );

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -97,6 +97,7 @@ function resolveReadySession(
   return {
     kind: "ready",
     sessionKey,
+    storeSessionKey: sessionKey,
     meta: {
       backend: "acpx",
       agent,
@@ -332,6 +333,63 @@ describe("agentCommand ACP runtime routing", () => {
         main?: { acp?: unknown };
       };
       expect(store.main?.acp).toBeUndefined();
+    });
+  });
+
+  it("updates ACP metadata in place for legacy non-default main aliases", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+      const now = Date.now();
+      fs.writeFileSync(
+        storePath,
+        JSON.stringify(
+          {
+            "agent:helper:main": {
+              sessionId: "acp-helper-legacy",
+              updatedAt: now,
+              acp: {
+                backend: "acpx",
+                agent: "helper",
+                runtimeSessionName: "legacy-helper-main",
+                mode: "persistent",
+                state: "idle",
+                lastActivityAt: now,
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      const cfg = createAcpEnabledConfig(home, storePath);
+      cfg.session = { store: storePath, mainKey: "desk" };
+      cfg.acp = {
+        ...cfg.acp,
+        allowedAgents: ["helper"],
+      };
+
+      await upsertAcpSessionMeta({
+        cfg,
+        sessionKey: "agent:helper:desk",
+        rawSessionKey: "agent:helper:main",
+        mutate: (current, entry) => ({
+          ...(current ?? entry?.acp),
+          backend: "acpx",
+          agent: "helper",
+          runtimeSessionName: "legacy-helper-main",
+          mode: "persistent",
+          state: "running",
+          lastActivityAt: now + 1,
+        }),
+      });
+
+      const store = JSON.parse(fs.readFileSync(storePath, "utf-8")) as Record<
+        string,
+        { acp?: { state?: string } }
+      >;
+      expect(Object.keys(store)).toEqual(["agent:helper:main"]);
+      expect(store["agent:helper:main"]?.acp?.state).toBe("running");
+      expect(store["agent:helper:desk"]).toBeUndefined();
     });
   });
 

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
 import * as acpManagerModule from "../acp/control-plane/manager.js";
 import { AcpRuntimeError } from "../acp/runtime/errors.js";
+import { readAcpSessionEntry } from "../acp/runtime/session-meta.js";
 import * as embeddedModule from "../agents/pi-embedded.js";
 import type { OpenClawConfig } from "../config/config.js";
 import * as configModule from "../config/config.js";
@@ -219,6 +220,44 @@ describe("agentCommand ACP runtime routing", () => {
         }),
       );
       expect(runEmbeddedPiAgentSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("reads ACP metadata from legacy main alias keys before canonical migration", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+      const now = Date.now();
+      fs.writeFileSync(
+        storePath,
+        JSON.stringify(
+          {
+            main: {
+              sessionId: "acp-main-legacy",
+              updatedAt: now,
+              acp: {
+                backend: "acpx",
+                agent: "main",
+                runtimeSessionName: "legacy-main",
+                mode: "persistent",
+                state: "idle",
+                lastActivityAt: now,
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      const cfg = createAcpEnabledConfig(home, storePath);
+
+      const entry = readAcpSessionEntry({
+        cfg,
+        sessionKey: "main",
+      });
+
+      expect(entry?.sessionKey).toBe("agent:main:main");
+      expect(entry?.storeSessionKey).toBe("main");
+      expect(entry?.acp?.backend).toBe("acpx");
     });
   });
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -591,6 +591,7 @@ async function agentCommandInternal(
         await acpManager.runTurn({
           cfg,
           sessionKey: acpSessionKey,
+          rawSessionKey: sessionKey,
           text: body,
           mode: "prompt",
           requestId: runId,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -559,9 +559,10 @@ async function agentCommandInternal(
     }
 
     if (acpResolution?.kind === "ready" && sessionKey) {
+      const acpSessionKey = acpResolution.sessionKey;
       const startedAt = Date.now();
       registerAgentRunContext(runId, {
-        sessionKey,
+        sessionKey: acpSessionKey,
       });
       emitAgentEvent({
         runId,
@@ -580,7 +581,7 @@ async function agentCommandInternal(
           throw dispatchPolicyError;
         }
         const acpAgent = normalizeAgentId(
-          acpResolution.meta.agent || resolveAgentIdFromSessionKey(sessionKey),
+          acpResolution.meta.agent || resolveAgentIdFromSessionKey(acpSessionKey),
         );
         const agentPolicyError = resolveAcpAgentPolicyError(cfg, acpAgent);
         if (agentPolicyError) {
@@ -589,7 +590,7 @@ async function agentCommandInternal(
 
         await acpManager.runTurn({
           cfg,
-          sessionKey,
+          sessionKey: acpSessionKey,
           text: body,
           mode: "prompt",
           requestId: runId,


### PR DESCRIPTION
## Problem

After a gateway restart, ACP callers can still use aliased session keys like `main`, but ACP metadata/runtime lookups expect the canonical stored key. That drift can route the session through the wrong tool profile and surface as `Tool not found` for agent tools after restart.

## Fix

- canonicalize ACP session keys before metadata lookup and runtime rehydrate
- thread the manager-returned canonical `sessionKey` through the agent command path
- apply the same canonicalization in ACP session metadata read/write helpers
- add regressions for aliased-session restart lookup and canonical key propagation

## Validation

- `pnpm vitest src/acp/control-plane/manager.test.ts src/commands/agent.acp.test.ts src/acp/persistent-bindings.test.ts`
- `pnpm tsgo`
- `pnpm check`

Closes #25692
