### PR TITLE
feat(ui): add dismissible update banner with close button

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -153,7 +153,8 @@ export function renderApp(state: AppViewState) {
     availableUpdate && state.updateDismissedVersion !== availableUpdate.latestVersion
       ? availableUpdate
       : null;
-  const versionStatusClass = effectiveUpdate ? "warn" : "ok";
+  // Keep status warning based on actual availability, not dismissal state
+  const versionStatusClass = availableUpdate ? "warn" : "ok";
   const presenceCount = state.presenceEntries.length;
   const sessionsCount = state.sessionsResult?.count ?? null;
   const cronNext = state.cronStatus?.nextWakeAtMs ?? null;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -148,7 +148,12 @@ export function renderApp(state: AppViewState) {
     state.updateAvailable.latestVersion !== state.updateAvailable.currentVersion
       ? state.updateAvailable
       : null;
-  const versionStatusClass = availableUpdate ? "warn" : "ok";
+  // Check if this version was dismissed by the user
+  const effectiveUpdate =
+    availableUpdate && state.updateDismissedVersion !== availableUpdate.latestVersion
+      ? availableUpdate
+      : null;
+  const versionStatusClass = effectiveUpdate ? "warn" : "ok";
   const presenceCount = state.presenceEntries.length;
   const sessionsCount = state.sessionsResult?.count ?? null;
   const cronNext = state.cronStatus?.nextWakeAtMs ?? null;
@@ -307,15 +312,21 @@ export function renderApp(state: AppViewState) {
       </aside>
       <main class="content ${isChat ? "content--chat" : ""}">
         ${
-          availableUpdate
+          effectiveUpdate
             ? html`<div class="update-banner callout danger" role="alert">
-              <strong>Update available:</strong> v${availableUpdate.latestVersion}
-              (running v${availableUpdate.currentVersion}).
+              <strong>Update available:</strong> v${effectiveUpdate.latestVersion}
+              (running v${effectiveUpdate.currentVersion}).
               <button
                 class="btn btn--sm update-banner__btn"
                 ?disabled=${state.updateRunning || !state.connected}
                 @click=${() => runUpdate(state)}
               >${state.updateRunning ? "Updating…" : "Update now"}</button>
+              <button
+                class="btn btn--sm update-banner__close"
+                @click=${() => {
+                  state.updateDismissedVersion = effectiveUpdate.latestVersion;
+                }}
+              >✕</button>
             </div>`
             : nothing
         }

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -129,6 +129,21 @@ export class OpenClawApp extends LitElement {
   @state() lastError: string | null = null;
   @state() lastErrorCode: string | null = null;
   @state() eventLog: EventLogEntry[] = [];
+  // Persist dismissed update banner version to localStorage for durability across refreshes
+  @state() private _updateDismissedVersion: string | null =
+    localStorage.getItem("updateBannerDismissed");
+  // eslint-disable-next-line accessor-pairs
+  set updateDismissedVersion(value: string | null) {
+    if (value !== null) {
+      localStorage.setItem("updateBannerDismissed", value);
+    } else {
+      localStorage.removeItem("updateBannerDismissed");
+    }
+    this._updateDismissedVersion = value;
+  }
+  get updateDismissedVersion(): string | null {
+    return this._updateDismissedVersion;
+  }
   private eventLogBuffer: EventLogEntry[] = [];
   private toolStreamSyncTimer: number | null = null;
   private sidebarCloseTimer: number | null = null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -130,14 +130,24 @@ export class OpenClawApp extends LitElement {
   @state() lastErrorCode: string | null = null;
   @state() eventLog: EventLogEntry[] = [];
   // Persist dismissed update banner version to localStorage for durability across refreshes
-  @state() private _updateDismissedVersion: string | null =
-    localStorage.getItem("updateBannerDismissed");
+  // Wrap in try-catch for sandboxed contexts where localStorage may be unavailable
+  @state() private _updateDismissedVersion: string | null = (() => {
+    try {
+      return localStorage.getItem("updateBannerDismissed");
+    } catch {
+      return null;
+    }
+  })();
   // eslint-disable-next-line accessor-pairs
   set updateDismissedVersion(value: string | null) {
-    if (value !== null) {
-      localStorage.setItem("updateBannerDismissed", value);
-    } else {
-      localStorage.removeItem("updateBannerDismissed");
+    try {
+      if (value !== null) {
+        localStorage.setItem("updateBannerDismissed", value);
+      } else {
+        localStorage.removeItem("updateBannerDismissed");
+      }
+    } catch {
+      // Ignore storage errors in sandboxed contexts
     }
     this._updateDismissedVersion = value;
   }


### PR DESCRIPTION
## Summary

Add a close button to the update notification banner and persist the dismissed state to localStorage so it survives page refreshes.

## Changes

- Add close button (✕) to update notification banner
- Persist dismissed version to localStorage for durability across sessions
- Use reactive state for banner visibility tracking

## Why

Previously, users had to dismiss the update banner on every page refresh. Now the dismissal is persistent.

## Testing

Manually tested banner dismissal and persistence.

## Related Issues

Fixes #32264
