### PR TITLE
fix(telegram): add isSilentReplyText guard to sendMessageTelegram

### DIFF
--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -90,6 +90,69 @@ describe("sent-message-cache", () => {
   });
 });
 
+describe("sendMessageTelegram NO_REPLY guard", () => {
+  it("suppresses NO_REPLY before any Telegram API call", async () => {
+    const result = await sendMessageTelegram("123", "NO_REPLY");
+
+    expect(botApi.sendMessage).not.toHaveBeenCalled();
+    expect(result.messageId).toBe("suppressed");
+  });
+
+  it("suppresses NO_REPLY with surrounding whitespace", async () => {
+    const result = await sendMessageTelegram("123", "  NO_REPLY  ");
+
+    expect(botApi.sendMessage).not.toHaveBeenCalled();
+    expect(result.messageId).toBe("suppressed");
+  });
+
+  it("does not suppress substantive text containing NO_REPLY", async () => {
+    botApi.sendMessage.mockResolvedValue({
+      message_id: 42,
+      chat: { id: 123 },
+      date: 0,
+    });
+
+    await sendMessageTelegram("123", "This is not a NO_REPLY situation", { token: "tok" });
+
+    expect(botApi.sendMessage).toHaveBeenCalled();
+  });
+
+  it("does not suppress NO_REPLY when media is attached", async () => {
+    loadWebMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("img"),
+      contentType: "image/png",
+    });
+    botApi.sendPhoto.mockResolvedValue({
+      message_id: 43,
+      chat: { id: 123 },
+      date: 0,
+    });
+
+    const result = await sendMessageTelegram("123", "NO_REPLY", {
+      token: "tok",
+      mediaUrl: "https://example.com/img.png",
+    });
+
+    expect(result.messageId).not.toBe("suppressed");
+  });
+
+  it("does not suppress NO_REPLY when buttons are attached", async () => {
+    botApi.sendMessage.mockResolvedValue({
+      message_id: 44,
+      chat: { id: 123 },
+      date: 0,
+    });
+
+    const result = await sendMessageTelegram("123", "NO_REPLY", {
+      token: "tok",
+      buttons: [[{ text: "Click", callback_data: "cb" }]],
+    });
+
+    expect(botApi.sendMessage).toHaveBeenCalled();
+    expect(result.messageId).not.toBe("suppressed");
+  });
+});
+
 describe("buildInlineKeyboard", () => {
   it("normalizes keyboard inputs", () => {
     const cases: Array<{

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -5,6 +5,7 @@ import type {
   ReactionTypeEmoji,
 } from "@grammyjs/types";
 import { type ApiClientOptions, Bot, HttpError, InputFile } from "grammy";
+import { isSilentReplyText } from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
@@ -549,6 +550,11 @@ export async function sendMessageTelegram(
   text: string,
   opts: TelegramSendOpts = {},
 ): Promise<TelegramSendResult> {
+  const trimmedText = text?.trim() ?? "";
+  if (isSilentReplyText(trimmedText) && !opts.mediaUrl && !opts.buttons?.length) {
+    logVerbose("telegram send: suppressed NO_REPLY token before API call");
+    return { messageId: "suppressed", chatId: "" };
+  }
   const { cfg, account, api } = resolveTelegramApiContext(opts);
   const target = parseTelegramTarget(to);
   const chatId = await resolveAndPersistChatId({


### PR DESCRIPTION
Slack's `sendMessageSlack` already suppresses `NO_REPLY` tokens before calling the API — if the trimmed message is a silent reply and there's no media or blocks, it returns early with a `suppressed` result.

The Telegram adapter didn't have this check. When an agent emits text before a trailing `NO_REPLY`, the stream handler forwards those deltas to Telegram as a live preview. By the time the sentinel is recognized and the message deleted, the user has already seen a brief flash of text (often just "NO").

This adds the same early-return guard to `sendMessageTelegram`: if the text is a silent reply token and there's no media or inline buttons, skip the API call entirely.

**Changes:**
- Import `isSilentReplyText` from `auto-reply/tokens`
- Add early return at the top of `sendMessageTelegram` matching Slack's pattern
- Use `opts.buttons?.length` instead of `opts.blocks` since Telegram uses buttons, not blocks

Closes #38603