### PR TITLE
fix(feishu): extract content from interactive card variants when quoting

### DIFF
--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -138,6 +138,148 @@ describe("getMessageFeishu", () => {
     );
   });
 
+  it("extracts header + elements from interactive card with header", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_card_header",
+            chat_id: "oc_1",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                header: { title: { content: "Card Title", tag: "plain_text" } },
+                elements: [{ tag: "markdown", content: "body text" }],
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_card_header",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        content: "Card Title\nbody text",
+      }),
+    );
+  });
+
+  it("extracts content from i18n_elements when top-level elements is absent", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_i18n",
+            chat_id: "oc_1",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                i18n_elements: {
+                  zh_cn: [{ tag: "markdown", content: "中文内容" }],
+                },
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_i18n",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        content: "中文内容",
+      }),
+    );
+  });
+
+  it("extracts template_variable values from template cards", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_tpl",
+            chat_id: "oc_1",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                type: "template",
+                data: {
+                  template_id: "tpl_xxx",
+                  template_variable: {
+                    title: "Alert Title",
+                    content: "Something happened",
+                  },
+                },
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_tpl",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        content: "Alert Title\nSomething happened",
+      }),
+    );
+  });
+
+  it("extracts content from column_set elements", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_cols",
+            chat_id: "oc_1",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                elements: [
+                  {
+                    tag: "column_set",
+                    columns: [
+                      { elements: [{ tag: "markdown", content: "col1 text" }] },
+                      { elements: [{ tag: "div", text: { content: "col2 text" } }] },
+                    ],
+                  },
+                ],
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_cols",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        content: "col1 text\ncol2 text",
+      }),
+    );
+  });
+
   it("supports single-object response shape from Feishu API", async () => {
     mockClientGet.mockResolvedValueOnce({
       code: 0,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -85,25 +85,23 @@ export type FeishuMessageInfo = {
   createTime?: number;
 };
 
-function parseInteractiveCardContent(parsed: unknown): string {
-  if (!parsed || typeof parsed !== "object") {
-    return "[Interactive Card]";
-  }
-
-  const candidate = parsed as { elements?: unknown };
-  if (!Array.isArray(candidate.elements)) {
-    return "[Interactive Card]";
-  }
-
+/**
+ * Extract readable text from an array of Feishu card elements.
+ * Handles div (plain_text/lark_md), markdown, column_set, and other
+ * common interactive card element types.
+ */
+function extractTextsFromElements(elements: unknown[]): string[] {
   const texts: string[] = [];
-  for (const element of candidate.elements) {
+  for (const element of elements) {
     if (!element || typeof element !== "object") {
       continue;
     }
     const item = element as {
       tag?: string;
       content?: string;
-      text?: { content?: string };
+      text?: { content?: string; tag?: string };
+      columns?: unknown[];
+      elements?: unknown[];
     };
     if (item.tag === "div" && typeof item.text?.content === "string") {
       texts.push(item.text.content);
@@ -111,8 +109,89 @@ function parseInteractiveCardContent(parsed: unknown): string {
     }
     if (item.tag === "markdown" && typeof item.content === "string") {
       texts.push(item.content);
+      continue;
+    }
+    // column_set → recurse into each column's elements
+    if (item.tag === "column_set" && Array.isArray(item.columns)) {
+      for (const col of item.columns) {
+        if (
+          col &&
+          typeof col === "object" &&
+          Array.isArray((col as { elements?: unknown[] }).elements)
+        ) {
+          texts.push(...extractTextsFromElements((col as { elements: unknown[] }).elements));
+        }
+      }
+      continue;
+    }
+    // Generic nested elements (e.g. form, collapsible)
+    if (Array.isArray(item.elements)) {
+      texts.push(...extractTextsFromElements(item.elements));
     }
   }
+  return texts;
+}
+
+/**
+ * Parse interactive card (message_type=interactive) into readable text.
+ *
+ * Feishu interactive cards come in several shapes:
+ * 1. Flat v1: `{ "elements": [...] }`
+ * 2. With header: `{ "header": { "title": { "content": "..." } }, "elements": [...] }`
+ * 3. i18n: `{ "i18n_elements": { "zh_cn": [...] } }`
+ * 4. Template: `{ "type": "template", "data": { "template_variable": {...} } }`
+ * 5. Body wrapper (card kit v2): `{ "body": { "elements": [...] } }`
+ */
+function parseInteractiveCardContent(parsed: unknown): string {
+  if (!parsed || typeof parsed !== "object") {
+    return "[Interactive Card]";
+  }
+
+  const card = parsed as {
+    header?: { title?: { content?: string } };
+    elements?: unknown[];
+    i18n_elements?: Record<string, unknown[]>;
+    body?: { elements?: unknown[] };
+    type?: string;
+    data?: { template_variable?: Record<string, unknown> };
+  };
+
+  const texts: string[] = [];
+
+  // Extract header title if present
+  if (typeof card.header?.title?.content === "string" && card.header.title.content.trim()) {
+    texts.push(card.header.title.content);
+  }
+
+  // Resolve the elements array from multiple possible locations
+  let elements: unknown[] | undefined = card.elements;
+  if (!Array.isArray(elements)) {
+    // Try body.elements (card kit v2)
+    elements = card.body?.elements;
+  }
+  if (!Array.isArray(elements)) {
+    // Try i18n_elements — pick zh_cn first, then first available locale
+    if (card.i18n_elements && typeof card.i18n_elements === "object") {
+      elements =
+        card.i18n_elements.zh_cn ??
+        (Object.values(card.i18n_elements).find((v) => Array.isArray(v)) as unknown[] | undefined);
+    }
+  }
+
+  if (Array.isArray(elements)) {
+    texts.push(...extractTextsFromElements(elements));
+  }
+
+  // Template cards: extract template_variable values as last resort
+  if (texts.length === 0 && card.type === "template" && card.data?.template_variable) {
+    const vars = card.data.template_variable;
+    for (const val of Object.values(vars)) {
+      if (typeof val === "string" && val.trim()) {
+        texts.push(val);
+      }
+    }
+  }
+
   return texts.join("\n").trim() || "[Interactive Card]";
 }
 


### PR DESCRIPTION
## Summary

Fix quoted interactive card messages showing only `[Interactive Card]` instead of actual content.

Closes #32712

## Problem

When a user quotes a Feishu interactive card and @mentions the bot, the bot only receives:
`[Replying to: "[Interactive Card]"]`

This is because `parseInteractiveCardContent` only handled flat v1 cards with top-level `elements`. Feishu cards come in many shapes (with headers, i18n, templates, column layouts, body wrappers) and those all fell through to the fallback.

## Changes

**`extensions/feishu/src/send.ts`:**
- Extract header title when present
- Support `body.elements` (card kit v2 wrapper)
- Support `i18n_elements` with locale fallback (`zh_cn` preferred)
- Support template cards (`template_variable` extraction)
- Recurse into `column_set` columns and nested `elements` (form, collapsible)
- Extract helper `extractTextsFromElements` for recursive traversal

**`extensions/feishu/src/send.test.ts`:**
- Add tests for card with header
- Add tests for i18n_elements
- Add tests for template cards
- Add tests for column_set nested elements

## Testing

All 345 existing feishu extension tests pass, plus 4 new tests for the card variants.