### PR TITLE
Telegram: add pinned-message reads for agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,13 @@ jobs:
         with:
           submodules: false
 
+      - name: Ensure secrets base commit (PR fast path)
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -398,15 +398,19 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     - `sendMessage` (`to`, `content`, optional `mediaUrl`, `replyToMessageId`, `messageThreadId`)
     - `react` (`chatId`, `messageId`, `emoji`)
+    - `listPins` (`chatId`)
     - `deleteMessage` (`chatId`, `messageId`)
     - `editMessage` (`chatId`, `messageId`, `content`)
     - `createForumTopic` (`chatId`, `name`, optional `iconColor`, `iconCustomEmojiId`)
 
-    Channel message actions expose ergonomic aliases (`send`, `react`, `delete`, `edit`, `sticker`, `sticker-search`, `topic-create`).
+    Channel message actions expose ergonomic aliases (`send`, `react`, `list-pins`, `delete`, `edit`, `sticker`, `sticker-search`, `topic-create`).
+
+    Telegram currently exposes the chat-level `pinned_message` via `getChat`, so `listPins` returns zero or one pinned messages for the target chat.
 
     Gating controls:
 
     - `channels.telegram.actions.sendMessage`
+    - `channels.telegram.actions.pins`
     - `channels.telegram.actions.deleteMessage`
     - `channels.telegram.actions.reactions`
     - `channels.telegram.actions.sticker` (default: disabled)
@@ -884,6 +888,7 @@ Primary reference:
 - `channels.telegram.webhookHost`: local webhook bind host (default `127.0.0.1`).
 - `channels.telegram.webhookPort`: local webhook bind port (default `8787`).
 - `channels.telegram.actions.reactions`: gate Telegram tool reactions.
+- `channels.telegram.actions.pins`: gate Telegram pinned-message reads.
 - `channels.telegram.actions.sendMessage`: gate Telegram tool message sends.
 - `channels.telegram.actions.deleteMessage`: gate Telegram tool message deletes.
 - `channels.telegram.actions.sticker`: gate Telegram sticker actions — send and search (default: false).
@@ -902,7 +907,7 @@ Telegram-specific high-signal fields:
 - formatting/delivery: `textChunkLimit`, `chunkMode`, `linkPreview`, `responsePrefix`
 - media/network: `mediaMaxMb`, `timeoutSeconds`, `retry`, `network.autoSelectFamily`, `proxy`
 - webhook: `webhookUrl`, `webhookSecret`, `webhookPath`, `webhookHost`
-- actions/capabilities: `capabilities.inlineButtons`, `actions.sendMessage|editMessage|deleteMessage|reactions|sticker`
+- actions/capabilities: `capabilities.inlineButtons`, `actions.sendMessage|editMessage|deleteMessage|reactions|pins|sticker`
 - reactions: `reactionNotifications`, `reactionLevel`
 - writes/history: `configWrites`, `historyLimit`, `dmHistoryLimit`, `dms.*.historyLimit`
 

--- a/src/agents/tools/telegram-actions.test.ts
+++ b/src/agents/tools/telegram-actions.test.ts
@@ -18,6 +18,7 @@ const sendStickerTelegram = vi.fn(async () => ({
   chatId: "123",
 }));
 const deleteMessageTelegram = vi.fn(async () => ({ ok: true }));
+const listPinsTelegram = vi.fn(async () => []);
 let envSnapshot: ReturnType<typeof captureEnv>;
 
 vi.mock("../../telegram/send.js", () => ({
@@ -30,6 +31,7 @@ vi.mock("../../telegram/send.js", () => ({
     sendStickerTelegram(...args),
   deleteMessageTelegram: (...args: Parameters<typeof deleteMessageTelegram>) =>
     deleteMessageTelegram(...args),
+  listPinsTelegram: (...args: Parameters<typeof listPinsTelegram>) => listPinsTelegram(...args),
 }));
 
 describe("handleTelegramAction", () => {
@@ -90,6 +92,7 @@ describe("handleTelegramAction", () => {
     sendPollTelegram.mockClear();
     sendStickerTelegram.mockClear();
     deleteMessageTelegram.mockClear();
+    listPinsTelegram.mockClear();
     process.env.TELEGRAM_BOT_TOKEN = "tok";
   });
 
@@ -497,6 +500,61 @@ describe("handleTelegramAction", () => {
       456,
       expect.objectContaining({ token: "tok" }),
     );
+  });
+
+  it("lists pinned messages and normalizes Telegram timestamps", async () => {
+    listPinsTelegram.mockResolvedValueOnce([
+      {
+        message_id: 77,
+        text: "Pinned build status",
+        date: 1_736_942_400,
+      },
+    ]);
+
+    const result = await handleTelegramAction(
+      {
+        action: "listPins",
+        chatId: "123",
+      },
+      telegramConfig(),
+    );
+
+    expect(listPinsTelegram).toHaveBeenCalledWith(
+      "123",
+      expect.objectContaining({ accountId: undefined }),
+    );
+    expect(result.details).toMatchObject({
+      ok: true,
+      pins: [
+        {
+          message_id: 77,
+          text: "Pinned build status",
+        },
+      ],
+    });
+    const payload = result.details as {
+      pins: Array<{ timestampMs?: number; timestampUtc?: string }>;
+    };
+    expect(payload.pins[0]?.timestampMs).toBe(1_736_942_400_000);
+    expect(payload.pins[0]?.timestampUtc).toBe("2025-01-15T12:00:00.000Z");
+  });
+
+  it("respects listPins gating", async () => {
+    const cfg = {
+      channels: {
+        telegram: { botToken: "tok", actions: { pins: false } },
+      },
+    } as OpenClawConfig;
+
+    await expect(
+      handleTelegramAction(
+        {
+          action: "listPins",
+          chatId: "123",
+        },
+        cfg,
+      ),
+    ).rejects.toThrow(/pinned-message reads are disabled/i);
   });
 
   it("respects deleteMessage gating", async () => {

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -1,5 +1,6 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
+import { withNormalizedTimestamp } from "../date-time.js";
 import { readBooleanParam } from "../../plugin-sdk/boolean-param.js";
 import { resolvePollMaxSelections } from "../../polls.js";
 import {
@@ -16,6 +17,7 @@ import {
   createForumTopicTelegram,
   deleteMessageTelegram,
   editMessageTelegram,
+  listPinsTelegram,
   reactMessageTelegram,
   sendMessageTelegram,
   sendPollTelegram,
@@ -33,6 +35,16 @@ import {
 } from "./common.js";
 
 const TELEGRAM_BUTTON_STYLES: readonly TelegramButtonStyle[] = ["danger", "success", "primary"];
+
+function normalizeTelegramPinnedMessage(message: unknown) {
+  if (!message || typeof message !== "object") {
+    return message;
+  }
+  return withNormalizedTimestamp(
+    message as Record<string, unknown>,
+    (message as { date?: unknown }).date,
+  );
+}
 
 export function readTelegramButtons(
   params: Record<string, unknown>,
@@ -331,6 +343,22 @@ export async function handleTelegramAction(
       accountId: accountId ?? undefined,
     });
     return jsonResult({ ok: true, deleted: true });
+  }
+
+  if (action === "listPins") {
+    if (!isActionEnabled("pins")) {
+      throw new Error("Telegram pinned-message reads are disabled.");
+    }
+    const chatId = readStringOrNumberParam(params, "chatId", {
+      required: true,
+    });
+    const pins = await listPinsTelegram(chatId ?? "", {
+      accountId: accountId ?? undefined,
+    });
+    return jsonResult({
+      ok: true,
+      pins: pins.map((pin) => normalizeTelegramPinnedMessage(pin)),
+    });
   }
 
   if (action === "editMessage") {

--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -1,6 +1,5 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
-import { withNormalizedTimestamp } from "../date-time.js";
 import { readBooleanParam } from "../../plugin-sdk/boolean-param.js";
 import { resolvePollMaxSelections } from "../../polls.js";
 import {
@@ -25,6 +24,7 @@ import {
 } from "../../telegram/send.js";
 import { getCacheStats, searchStickers } from "../../telegram/sticker-cache.js";
 import { resolveTelegramToken } from "../../telegram/token.js";
+import { withNormalizedTimestamp } from "../date-time.js";
 import {
   jsonResult,
   readNumberParam,

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -538,6 +538,7 @@ describe("telegramMessageActions", () => {
     const actions = telegramMessageActions.listActions?.({ cfg: telegramCfg() }) ?? [];
 
     expect(actions).toContain("poll");
+    expect(actions).toContain("list-pins");
   });
 
   it("omits poll when sendMessage is disabled", () => {
@@ -568,6 +569,21 @@ describe("telegramMessageActions", () => {
     const actions = telegramMessageActions.listActions?.({ cfg }) ?? [];
 
     expect(actions).not.toContain("poll");
+  });
+
+  it("omits list-pins when pin reads are disabled", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          botToken: "tok",
+          actions: { pins: false },
+        },
+      },
+    } as OpenClawConfig;
+
+    const actions = telegramMessageActions.listActions?.({ cfg }) ?? [];
+
+    expect(actions).not.toContain("list-pins");
   });
 
   it("omits poll when sendMessage and poll are split across accounts", () => {
@@ -695,6 +711,18 @@ describe("telegramMessageActions", () => {
           messageId: 42,
           content: "Updated",
           buttons: [],
+          accountId: undefined,
+        },
+      },
+      {
+        name: "list-pins maps to listPins",
+        action: "list-pins" as const,
+        params: {
+          to: "telegram:group:-1001234567890:topic:271",
+        },
+        expectedPayload: {
+          action: "listPins",
+          chatId: "telegram:group:-1001234567890:topic:271",
           accountId: undefined,
         },
       },

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -94,6 +94,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     if (isEnabled("reactions")) {
       actions.add("react");
     }
+    if (isEnabled("pins")) {
+      actions.add("list-pins");
+    }
     if (isEnabled("deleteMessage")) {
       actions.add("delete");
     }
@@ -200,6 +203,19 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           action: "deleteMessage",
           chatId,
           messageId,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    if (action === "list-pins") {
+      const chatId = readTelegramChatIdParam(params);
+      return await handleTelegramAction(
+        {
+          action: "listPins",
+          chatId,
           accountId: accountId ?? undefined,
         },
         cfg,

--- a/src/config/telegram-actions-poll.test.ts
+++ b/src/config/telegram-actions-poll.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { validateConfigObject } from "./config.js";
 
-describe("telegram poll action config", () => {
+describe("telegram action config", () => {
   it("accepts channels.telegram.actions.poll", () => {
     const res = validateConfigObject({
       channels: {
@@ -24,6 +24,38 @@ describe("telegram poll action config", () => {
             ops: {
               actions: {
                 poll: false,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts channels.telegram.actions.pins", () => {
+    const res = validateConfigObject({
+      channels: {
+        telegram: {
+          actions: {
+            pins: false,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts channels.telegram.accounts.<id>.actions.pins", () => {
+    const res = validateConfigObject({
+      channels: {
+        telegram: {
+          accounts: {
+            ops: {
+              actions: {
+                pins: false,
               },
             },
           },

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -17,6 +17,8 @@ export type TelegramActionConfig = {
   sendMessage?: boolean;
   /** Enable poll creation. Requires sendMessage to also be enabled. */
   poll?: boolean;
+  /** Enable pinned-message reads via getChat. */
+  pins?: boolean;
   deleteMessage?: boolean;
   editMessage?: boolean;
   /** Enable sticker actions (send and search). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -226,6 +226,7 @@ export const TelegramAccountSchemaBase = z
         reactions: z.boolean().optional(),
         sendMessage: z.boolean().optional(),
         poll: z.boolean().optional(),
+        pins: z.boolean().optional(),
         deleteMessage: z.boolean().optional(),
         sticker: z.boolean().optional(),
       })

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -15,6 +15,7 @@ const {
   buildInlineKeyboard,
   createForumTopicTelegram,
   editMessageTelegram,
+  listPinsTelegram,
   reactMessageTelegram,
   sendMessageTelegram,
   sendPollTelegram,
@@ -1303,6 +1304,68 @@ describe("reactMessageTelegram", () => {
         resolvedChatId: "-100123",
       }),
     );
+  });
+});
+
+describe("listPinsTelegram", () => {
+  it("returns the pinned message from getChat as a pins array", async () => {
+    const pinnedMessage = {
+      message_id: 77,
+      text: "Pinned build status",
+      date: 1_736_942_400,
+    };
+    const getChat = vi.fn().mockResolvedValue({
+      id: -100123,
+      pinned_message: pinnedMessage,
+    });
+    const api = { getChat } as unknown as {
+      getChat: typeof getChat;
+    };
+
+    const pins = await listPinsTelegram("telegram:group:-100123:topic:42", {
+      token: "tok",
+      api,
+    });
+
+    expect(getChat).toHaveBeenCalledWith("-100123");
+    expect(pins).toEqual([pinnedMessage]);
+  });
+
+  it("resolves legacy targets before listing pins", async () => {
+    const getChat = vi
+      .fn()
+      .mockResolvedValueOnce({ id: -100123 })
+      .mockResolvedValueOnce({
+        id: -100123,
+        pinned_message: { message_id: 1, text: "Pinned" },
+      });
+    const api = { getChat } as unknown as {
+      getChat: typeof getChat;
+    };
+
+    const pins = await listPinsTelegram("@mychannel", {
+      token: "tok",
+      api,
+    });
+
+    expect(getChat).toHaveBeenNthCalledWith(1, "@mychannel");
+    expect(getChat).toHaveBeenNthCalledWith(2, "-100123");
+    expect(maybePersistResolvedTelegramTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rawTarget: "@mychannel",
+        resolvedChatId: "-100123",
+      }),
+    );
+    expect(pins).toEqual([{ message_id: 1, text: "Pinned" }]);
+  });
+
+  it("returns an empty array when the chat has no pinned message", async () => {
+    const getChat = vi.fn().mockResolvedValue({ id: "123" });
+    const api = { getChat } as unknown as {
+      getChat: typeof getChat;
+    };
+
+    await expect(listPinsTelegram("123", { token: "tok", api })).resolves.toEqual([]);
   });
 });
 

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -855,6 +855,8 @@ function extractTelegramPinnedMessages(chat: unknown): unknown[] {
     pinned_messages?: unknown;
   };
   if (Array.isArray(chatRecord.pinned_messages)) {
+    // NOTE: Telegram Bot API does not currently return `pinned_messages` from getChat.
+    // This branch is a forward-compatibility stub only.
     return chatRecord.pinned_messages.filter((message) => message != null);
   }
   return chatRecord.pinned_message == null ? [] : [chatRecord.pinned_message];

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -837,6 +837,65 @@ export async function deleteMessageTelegram(
   return { ok: true };
 }
 
+type TelegramListPinsOpts = {
+  token?: string;
+  accountId?: string;
+  verbose?: boolean;
+  api?: TelegramApiOverride;
+  retry?: RetryConfig;
+  cfg?: ReturnType<typeof loadConfig>;
+};
+
+function extractTelegramPinnedMessages(chat: unknown): unknown[] {
+  if (!chat || typeof chat !== "object") {
+    return [];
+  }
+  const chatRecord = chat as {
+    pinned_message?: unknown;
+    pinned_messages?: unknown;
+  };
+  if (Array.isArray(chatRecord.pinned_messages)) {
+    return chatRecord.pinned_messages.filter((message) => message != null);
+  }
+  return chatRecord.pinned_message == null ? [] : [chatRecord.pinned_message];
+}
+
+export async function listPinsTelegram(
+  chatIdInput: string | number,
+  opts: TelegramListPinsOpts = {},
+): Promise<unknown[]> {
+  const rawTarget = String(chatIdInput);
+  const { cfg, account, api } = resolveTelegramApiContext({
+    ...opts,
+    cfg: opts.cfg,
+  });
+  if (typeof api.getChat !== "function") {
+    throw new Error("Telegram pinned-message reads are unavailable in this bot API.");
+  }
+  const target = parseTelegramTarget(rawTarget);
+  const chatId = await resolveAndPersistChatId({
+    cfg,
+    api,
+    lookupTarget: target.chatId,
+    persistTarget: rawTarget,
+    verbose: opts.verbose,
+  });
+  const requestWithDiag = createTelegramRequestWithDiag({
+    cfg,
+    account,
+    retry: opts.retry,
+    verbose: opts.verbose,
+    shouldRetry: (err) => isRecoverableTelegramNetworkError(err, { context: "unknown" }),
+  });
+  const requestWithChatNotFound = createRequestWithChatNotFound({
+    requestWithDiag,
+    chatId,
+    input: rawTarget,
+  });
+  const chat = await requestWithChatNotFound(() => api.getChat(chatId), "getChat");
+  return extractTelegramPinnedMessages(chat);
+}
+
 type TelegramEditOpts = {
   token?: string;
   accountId?: string;


### PR DESCRIPTION
## Summary

- Problem: Telegram agents could not read pinned chat context on demand.
- Why it matters: pinned messages are a lightweight way to carry persistent context across sessions.
- What changed: added Telegram `list-pins` / `listPins` action plumbing backed by Bot API `getChat`, plus config/schema/docs/tests.
- What did NOT change (scope boundary): no automatic session-start pin fetch, and no topic-specific pin history beyond what Telegram exposes from `getChat`.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38580
- Related #

## User-visible / Behavior Changes

- Telegram agents can now invoke `message` with `action: "list-pins"` in the current chat or with an explicit Telegram target.
- The result returns a `pins` array containing the current pinned message exposed by Telegram.
- New config gate: `channels.telegram.actions.pins` (default enabled).

## Security Impact (required)

- New permissions/capabilities? Yes
- Secrets/tokens handling changed? No
- New/changed network calls? Yes
- Command/tool execution surface changed? Yes
- Data access scope changed? Yes
- If any `Yes`, explain risk + mitigation:

Adds read access to the current chat's pinned message through the existing Telegram tool surface. The action is account-scoped, uses the existing bot token, and can be disabled with `channels.telegram.actions.pins`.

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: Node v20.15.1 locally (repo warns on Node < 22)
- Model/provider: N/A
- Integration/channel (if any): Telegram Bot API
- Relevant config (redacted): `channels.telegram.botToken`, optional `channels.telegram.actions.pins`

### Steps

1. Pin a message in a Telegram chat the bot can access.
2. Ask the agent to read pinned messages, or invoke `message` with `action: "list-pins"`.
3. Verify the returned `pins` array contains the pinned message.

### Expected

- Telegram returns the current pinned message in `pins`.
- `channels.telegram.actions.pins=false` disables the action.

### Actual

- Fixed.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted Telegram tool/helper/action/config tests for pinned-message reads.
- Edge cases checked: no pin returns `[]`; legacy targets resolve through `getChat`; action gate disables access.
- What you did **not** verify: live Telegram Bot API call against a real bot/chat.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: set `channels.telegram.actions.pins=false` or revert this PR.
- Files/config to restore: `src/telegram/send.ts`, `src/agents/tools/telegram-actions.ts`, `src/channels/plugins/actions/telegram.ts`
- Known bad symptoms reviewers should watch for: `list-pins` rejected for Telegram, or `getChat` failures for invalid targets.

## Risks and Mitigations

- Risk:
  - Telegram Bot API currently exposes only the chat-level `pinned_message`, so this action returns zero or one pinned messages rather than a richer history.
- Mitigation:
  - The docs and implementation explicitly scope the feature to what `getChat` exposes today.