### PR TITLE
fix(plugins): handle symlinked plugin directories

### DIFF
--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -436,14 +436,34 @@ function discoverInDirectory(params: {
 
     // Handle symlinks: resolve to target type
     let isDir = entry.isDirectory();
-    if (!isDir && entry.isSymbolicLink()) {
+    let isFile = entry.isFile();
+    if (entry.isSymbolicLink()) {
       try {
         const stat = fs.statSync(fullPath); // follows symlinks
         isDir = stat.isDirectory();
+        isFile = stat.isFile();
       } catch {
         // broken symlink — skip
         continue;
       }
+    }
+
+    // Handle extension files (including file symlinks)
+    if (isFile) {
+      if (!isExtensionFile(fullPath)) {
+        continue;
+      }
+      addCandidate({
+        candidates: params.candidates,
+        diagnostics: params.diagnostics,
+        seen: params.seen,
+        idHint: path.basename(entry.name, path.extname(entry.name)),
+        source: fullPath,
+        rootDir: path.dirname(fullPath),
+        origin: params.origin,
+        ownershipUid: params.ownershipUid,
+        workspaceDir: params.workspaceDir,
+      });
     }
 
     if (!isDir) {

--- a/src/plugins/discovery.ts
+++ b/src/plugins/discovery.ts
@@ -433,7 +433,20 @@ function discoverInDirectory(params: {
         workspaceDir: params.workspaceDir,
       });
     }
-    if (!entry.isDirectory()) {
+
+    // Handle symlinks: resolve to target type
+    let isDir = entry.isDirectory();
+    if (!isDir && entry.isSymbolicLink()) {
+      try {
+        const stat = fs.statSync(fullPath); // follows symlinks
+        isDir = stat.isDirectory();
+      } catch {
+        // broken symlink — skip
+        continue;
+      }
+    }
+
+    if (!isDir) {
       continue;
     }
     if (shouldIgnoreScannedDirectory(entry.name)) {


### PR DESCRIPTION
## Summary

Fix plugin directory discovery to properly handle symbolic links, including broken symlinks.

## Changes

- Use fs.statSync() to resolve symlink target type
- Skip broken symlinks with continue
- Properly detect directory symlinks for plugin discovery

## Why

entry.isDirectory() returns false for symlinks, causing valid plugin directories to be skipped.

## Testing

Tested with various symlink configurations.

## Related Issues

Fixes #36754
