### PR TITLE
fix: deduplicate snapshot field reads and add test coverage

### DIFF
--- a/src/agents/anthropic-payload-log.test.ts
+++ b/src/agents/anthropic-payload-log.test.ts
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { AgentMessage, StreamFn } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import { createAnthropicPayloadLogger } from "./anthropic-payload-log.js";
 
@@ -45,5 +45,92 @@ describe("createAnthropicPayloadLogger", () => {
     expect(source.bytes).toBe(4);
     expect(source.sha256).toBe(crypto.createHash("sha256").update("QUJDRA==").digest("hex"));
     expect(event.payloadDigest).toBeDefined();
+  });
+
+  it("returns null when payload logging is disabled", () => {
+    const logger = createAnthropicPayloadLogger({
+      env: { OPENCLAW_ANTHROPIC_PAYLOAD_LOG: "0" },
+    });
+    expect(logger).toBeNull();
+  });
+
+  it("does not log when OPENCLAW_ANTHROPIC_PAYLOAD_LOG is not set", () => {
+    const logger = createAnthropicPayloadLogger({ env: {} });
+    expect(logger).toBeNull();
+  });
+
+  it("passes through calls for non-Anthropic models without logging", async () => {
+    const lines: string[] = [];
+    const logger = createAnthropicPayloadLogger({
+      env: { OPENCLAW_ANTHROPIC_PAYLOAD_LOG: "1" },
+      writer: {
+        filePath: "memory",
+        write: (line) => lines.push(line),
+      },
+    });
+
+    const streamFn: StreamFn = ((_, __, options) => {
+      options?.onPayload?.({ type: "request" });
+      return {} as never;
+    }) as StreamFn;
+
+    const wrapped = logger?.wrapStreamFn(streamFn);
+    await wrapped?.({ api: "openai" } as never, { messages: [] } as never, {});
+
+    expect(lines).toHaveLength(0);
+  });
+
+  it("recordUsage does not write when there is no assistant message and no error", () => {
+    const lines: string[] = [];
+    const logger = createAnthropicPayloadLogger({
+      env: { OPENCLAW_ANTHROPIC_PAYLOAD_LOG: "1" },
+      writer: {
+        filePath: "memory",
+        write: (line) => lines.push(line),
+      },
+    });
+
+    logger?.recordUsage([] as AgentMessage[]);
+    expect(lines).toHaveLength(0);
+  });
+
+  it("recordUsage writes error line when error is provided but no assistant message", () => {
+    const lines: string[] = [];
+    const logger = createAnthropicPayloadLogger({
+      env: { OPENCLAW_ANTHROPIC_PAYLOAD_LOG: "1" },
+      writer: {
+        filePath: "memory",
+        write: (line) => lines.push(line),
+      },
+    });
+
+    logger?.recordUsage([] as AgentMessage[], new Error("quota exceeded"));
+
+    expect(lines).toHaveLength(1);
+    const event = JSON.parse(lines[0]?.trim() ?? "{}") as Record<string, unknown>;
+    expect(event.stage).toBe("usage");
+    expect(event.error).toBe("quota exceeded");
+  });
+
+  it("recordUsage writes usage fields from the last assistant message", () => {
+    const lines: string[] = [];
+    const logger = createAnthropicPayloadLogger({
+      env: { OPENCLAW_ANTHROPIC_PAYLOAD_LOG: "1" },
+      writer: {
+        filePath: "memory",
+        write: (line) => lines.push(line),
+      },
+    });
+
+    const messages = [
+      { role: "assistant", usage: { input_tokens: 10, output_tokens: 5 } },
+    ] as unknown as AgentMessage[];
+
+    logger?.recordUsage(messages);
+
+    expect(lines).toHaveLength(1);
+    const event = JSON.parse(lines[0]?.trim() ?? "{}") as Record<string, unknown>;
+    expect(event.stage).toBe("usage");
+    expect((event.usage as { input_tokens?: number } | undefined)?.input_tokens).toBe(10);
   });
 });

--- a/src/agents/cache-trace.test.ts
+++ b/src/agents/cache-trace.test.ts
@@ -192,7 +192,7 @@ describe("createCacheTrace", () => {
     const innerStreamFn: import("@mariozechner/pi-agent-core").StreamFn = (() =>
       ({}) as never) as import("@mariozechner/pi-agent-core").StreamFn;
     const wrapped = trace?.wrapStreamFn(innerStreamFn);
-    wrapped?.(
+    void wrapped?.(
       { id: "claude-opus", provider: "anthropic", api: "anthropic-messages" } as never,
       { messages: [{ role: "user" } as never], system: "you are helpful" } as never,
       {},

--- a/src/agents/cache-trace.test.ts
+++ b/src/agents/cache-trace.test.ts
@@ -144,4 +144,64 @@ describe("createCacheTrace", () => {
     expect(source.bytes).toBe(6);
     expect(source.sha256).toBe(crypto.createHash("sha256").update("U0VDUkVU").digest("hex"));
   });
+
+  it("suppresses message content when includeMessages is false", () => {
+    const lines: string[] = [];
+    const trace = createCacheTrace({
+      cfg: {
+        diagnostics: {
+          cacheTrace: {
+            enabled: true,
+            includeMessages: false,
+          },
+        },
+      },
+      env: {},
+      writer: {
+        filePath: "memory",
+        write: (line) => lines.push(line),
+      },
+    });
+
+    trace?.recordStage("session:loaded", {
+      messages: [{ role: "user" } as never],
+    });
+
+    const event = JSON.parse(lines[0]?.trim() ?? "{}") as Record<string, unknown>;
+    expect(event.messageCount).toBe(1);
+    expect(event).not.toHaveProperty("messages");
+  });
+
+  it("wrapStreamFn records a stream:context stage event with model and message info", () => {
+    const lines: string[] = [];
+    const trace = createCacheTrace({
+      cfg: {
+        diagnostics: {
+          cacheTrace: {
+            enabled: true,
+          },
+        },
+      },
+      env: {},
+      writer: {
+        filePath: "memory",
+        write: (line) => lines.push(line),
+      },
+    });
+
+    const innerStreamFn: import("@mariozechner/pi-agent-core").StreamFn = (() =>
+      ({}) as never) as import("@mariozechner/pi-agent-core").StreamFn;
+    const wrapped = trace?.wrapStreamFn(innerStreamFn);
+    wrapped?.(
+      { id: "claude-opus", provider: "anthropic", api: "anthropic-messages" } as never,
+      { messages: [{ role: "user" } as never], system: "you are helpful" } as never,
+      {},
+    );
+
+    expect(lines).toHaveLength(1);
+    const event = JSON.parse(lines[0]?.trim() ?? "{}") as Record<string, unknown>;
+    expect(event.stage).toBe("stream:context");
+    expect((event.model as { id?: string } | undefined)?.id).toBe("claude-opus");
+    expect(event.messageCount).toBe(1);
+  });
 });

--- a/src/agents/payload-redaction.test.ts
+++ b/src/agents/payload-redaction.test.ts
@@ -1,0 +1,84 @@
+import crypto from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { REDACTED_IMAGE_DATA, redactImageDataForDiagnostics } from "./payload-redaction.js";
+
+describe("redactImageDataForDiagnostics", () => {
+  it("passes through null and primitive values unchanged", () => {
+    expect(redactImageDataForDiagnostics(null)).toBeNull();
+    expect(redactImageDataForDiagnostics(42)).toBe(42);
+    expect(redactImageDataForDiagnostics("hello")).toBe("hello");
+    expect(redactImageDataForDiagnostics(true)).toBe(true);
+  });
+
+  it("passes through objects with no image data unchanged", () => {
+    const input = { role: "user", content: "hello" };
+    expect(redactImageDataForDiagnostics(input)).toEqual(input);
+  });
+
+  it("redacts image data identified by type field", () => {
+    const data = "QUJDRA==";
+    const result = redactImageDataForDiagnostics({
+      type: "image",
+      data,
+    }) as Record<string, unknown>;
+    expect(result.data).toBe(REDACTED_IMAGE_DATA);
+    expect(result.bytes).toBe(4);
+    expect(result.sha256).toBe(crypto.createHash("sha256").update(data).digest("hex"));
+  });
+
+  it("redacts image data identified by mimeType field", () => {
+    const data = "U0VDUkVU";
+    const result = redactImageDataForDiagnostics({
+      mimeType: "image/jpeg",
+      data,
+    }) as Record<string, unknown>;
+    expect(result.data).toBe(REDACTED_IMAGE_DATA);
+    expect(result.bytes).toBe(6);
+  });
+
+  it("redacts image data identified by media_type field", () => {
+    const data = "QUJDRA==";
+    const result = redactImageDataForDiagnostics({
+      media_type: "image/png",
+      data,
+    }) as Record<string, unknown>;
+    expect(result.data).toBe(REDACTED_IMAGE_DATA);
+  });
+
+  it("does not redact records with image type but no data field", () => {
+    const input = { type: "image" };
+    const result = redactImageDataForDiagnostics(input) as Record<string, unknown>;
+    expect(result).not.toHaveProperty("sha256");
+    expect(result).not.toHaveProperty("bytes");
+  });
+
+  it("recurses into arrays and nested objects", () => {
+    const input = {
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: { media_type: "image/png", data: "QUJDRA==" },
+            },
+          ],
+        },
+      ],
+    };
+    const result = redactImageDataForDiagnostics(input) as {
+      messages: Array<{
+        content: Array<{ source: Record<string, unknown> }>;
+      }>;
+    };
+    expect(result.messages[0]?.content[0]?.source.data).toBe(REDACTED_IMAGE_DATA);
+  });
+
+  it("handles circular references without throwing", () => {
+    const obj: Record<string, unknown> = { key: "value" };
+    obj.self = obj;
+    const result = redactImageDataForDiagnostics(obj) as Record<string, unknown>;
+    expect(result.self).toBe("[Circular]");
+    expect(result.key).toBe("value");
+  });
+});

--- a/src/channels/account-snapshot-fields.test.ts
+++ b/src/channels/account-snapshot-fields.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { projectSafeChannelAccountSnapshotFields } from "./account-snapshot-fields.js";
+import {
+  hasConfiguredUnavailableCredentialStatus,
+  hasResolvedCredentialValue,
+  projectCredentialSnapshotFields,
+  projectSafeChannelAccountSnapshotFields,
+  resolveConfiguredFromCredentialStatuses,
+  resolveConfiguredFromRequiredCredentialStatuses,
+} from "./account-snapshot-fields.js";
 
 describe("projectSafeChannelAccountSnapshotFields", () => {
   it("omits webhook and public-key style fields from generic snapshots", () => {
@@ -23,5 +30,164 @@ describe("projectSafeChannelAccountSnapshotFields", () => {
       signingSecretSource: "config",
       signingSecretStatus: "configured_unavailable",
     });
+  });
+
+  it("returns empty object for null or non-object input", () => {
+    expect(projectSafeChannelAccountSnapshotFields(null)).toEqual({});
+    expect(projectSafeChannelAccountSnapshotFields(undefined)).toEqual({});
+    expect(projectSafeChannelAccountSnapshotFields("string")).toEqual({});
+    expect(projectSafeChannelAccountSnapshotFields([])).toEqual({});
+  });
+
+  it("includes numeric and boolean fields when present", () => {
+    const snapshot = projectSafeChannelAccountSnapshotFields({
+      linked: true,
+      running: false,
+      connected: true,
+      reconnectAttempts: 3,
+      port: 8080,
+      allowUnmentionedGroups: false,
+    });
+    expect(snapshot.linked).toBe(true);
+    expect(snapshot.running).toBe(false);
+    expect(snapshot.connected).toBe(true);
+    expect(snapshot.reconnectAttempts).toBe(3);
+    expect(snapshot.port).toBe(8080);
+    expect(snapshot.allowUnmentionedGroups).toBe(false);
+  });
+
+  it("normalizes allowFrom to non-empty trimmed strings only", () => {
+    const snapshot = projectSafeChannelAccountSnapshotFields({
+      allowFrom: ["  valid  ", "", 42, null, "another"],
+    });
+    expect(snapshot.allowFrom).toEqual(["valid", "42", "another"]);
+  });
+
+  it("omits fields with empty or whitespace-only string values", () => {
+    const snapshot = projectSafeChannelAccountSnapshotFields({
+      name: "   ",
+      mode: "",
+      dmPolicy: " ",
+    });
+    expect(snapshot).not.toHaveProperty("name");
+    expect(snapshot).not.toHaveProperty("mode");
+    expect(snapshot).not.toHaveProperty("dmPolicy");
+  });
+});
+
+describe("resolveConfiguredFromCredentialStatuses", () => {
+  it("returns undefined for null or non-object input", () => {
+    expect(resolveConfiguredFromCredentialStatuses(null)).toBeUndefined();
+    expect(resolveConfiguredFromCredentialStatuses("x")).toBeUndefined();
+  });
+
+  it("returns undefined when no recognized credential status keys are present", () => {
+    expect(resolveConfiguredFromCredentialStatuses({ other: "value" })).toBeUndefined();
+  });
+
+  it("returns false when all credential statuses are missing", () => {
+    expect(resolveConfiguredFromCredentialStatuses({ tokenStatus: "missing" })).toBe(false);
+  });
+
+  it("returns true when any credential status is not missing", () => {
+    expect(resolveConfiguredFromCredentialStatuses({ tokenStatus: "available" })).toBe(true);
+    expect(
+      resolveConfiguredFromCredentialStatuses({ botTokenStatus: "configured_unavailable" }),
+    ).toBe(true);
+  });
+});
+
+describe("resolveConfiguredFromRequiredCredentialStatuses", () => {
+  it("returns undefined when none of the required keys are present", () => {
+    expect(resolveConfiguredFromRequiredCredentialStatuses({}, ["tokenStatus"])).toBeUndefined();
+  });
+
+  it("returns false when a required key is missing", () => {
+    expect(
+      resolveConfiguredFromRequiredCredentialStatuses({ tokenStatus: "missing" }, ["tokenStatus"]),
+    ).toBe(false);
+  });
+
+  it("returns true when required keys are configured or available", () => {
+    expect(
+      resolveConfiguredFromRequiredCredentialStatuses(
+        { botTokenStatus: "available", signingSecretStatus: "configured_unavailable" },
+        ["botTokenStatus", "signingSecretStatus"],
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("hasConfiguredUnavailableCredentialStatus", () => {
+  it("returns false for null input", () => {
+    expect(hasConfiguredUnavailableCredentialStatus(null)).toBe(false);
+  });
+
+  it("returns false when no credential status is configured_unavailable", () => {
+    expect(hasConfiguredUnavailableCredentialStatus({ tokenStatus: "available" })).toBe(false);
+  });
+
+  it("returns true when any credential status is configured_unavailable", () => {
+    expect(
+      hasConfiguredUnavailableCredentialStatus({ appTokenStatus: "configured_unavailable" }),
+    ).toBe(true);
+  });
+});
+
+describe("hasResolvedCredentialValue", () => {
+  it("returns false for null input", () => {
+    expect(hasResolvedCredentialValue(null)).toBe(false);
+  });
+
+  it("returns false when no token or available status is present", () => {
+    expect(hasResolvedCredentialValue({ tokenStatus: "missing" })).toBe(false);
+    expect(hasResolvedCredentialValue({ token: "   " })).toBe(false);
+  });
+
+  it("returns true when a token string is non-empty", () => {
+    expect(hasResolvedCredentialValue({ token: "tok-123" })).toBe(true);
+    expect(hasResolvedCredentialValue({ botToken: "xoxb-1" })).toBe(true);
+  });
+
+  it("returns true when any credential status is available", () => {
+    expect(hasResolvedCredentialValue({ userTokenStatus: "available" })).toBe(true);
+  });
+});
+
+describe("projectCredentialSnapshotFields", () => {
+  it("returns empty object for non-object input", () => {
+    expect(projectCredentialSnapshotFields(null)).toEqual({});
+  });
+
+  it("includes only recognized source and status fields", () => {
+    const result = projectCredentialSnapshotFields({
+      tokenSource: "config",
+      botTokenSource: "env",
+      appTokenSource: "config",
+      signingSecretSource: "config",
+      tokenStatus: "available",
+      botTokenStatus: "missing",
+      appTokenStatus: "configured_unavailable",
+      signingSecretStatus: "available",
+      userTokenStatus: "missing",
+      webhookUrl: "https://example.com",
+    });
+    expect(result).toEqual({
+      tokenSource: "config",
+      botTokenSource: "env",
+      appTokenSource: "config",
+      signingSecretSource: "config",
+      tokenStatus: "available",
+      botTokenStatus: "missing",
+      appTokenStatus: "configured_unavailable",
+      signingSecretStatus: "available",
+      userTokenStatus: "missing",
+    });
+    expect(result).not.toHaveProperty("webhookUrl");
+  });
+
+  it("omits status fields with unrecognized values", () => {
+    const result = projectCredentialSnapshotFields({ tokenStatus: "unknown-value" });
+    expect(result).not.toHaveProperty("tokenStatus");
   });
 });

--- a/src/channels/account-snapshot-fields.test.ts
+++ b/src/channels/account-snapshot-fields.test.ts
@@ -14,21 +14,21 @@ describe("projectSafeChannelAccountSnapshotFields", () => {
       name: "Primary",
       tokenSource: "config",
       tokenStatus: "configured_unavailable",
-      signingSecretSource: "config",
-      signingSecretStatus: "configured_unavailable",
+      signingSecretSource: "config", // pragma: allowlist secret
+      signingSecretStatus: "configured_unavailable", // pragma: allowlist secret
       webhookUrl: "https://example.com/webhook",
       webhookPath: "/webhook",
       audienceType: "project-number",
       audience: "1234567890",
-      publicKey: "pk_live_123",
+      publicKey: "pk_live_123", // pragma: allowlist secret
     });
 
     expect(snapshot).toEqual({
       name: "Primary",
       tokenSource: "config",
       tokenStatus: "configured_unavailable",
-      signingSecretSource: "config",
-      signingSecretStatus: "configured_unavailable",
+      signingSecretSource: "config", // pragma: allowlist secret
+      signingSecretStatus: "configured_unavailable", // pragma: allowlist secret
     });
   });
 
@@ -111,7 +111,7 @@ describe("resolveConfiguredFromRequiredCredentialStatuses", () => {
   it("returns true when required keys are configured or available", () => {
     expect(
       resolveConfiguredFromRequiredCredentialStatuses(
-        { botTokenStatus: "available", signingSecretStatus: "configured_unavailable" },
+        { botTokenStatus: "available", signingSecretStatus: "configured_unavailable" }, // pragma: allowlist secret
         ["botTokenStatus", "signingSecretStatus"],
       ),
     ).toBe(true);
@@ -164,11 +164,11 @@ describe("projectCredentialSnapshotFields", () => {
       tokenSource: "config",
       botTokenSource: "env",
       appTokenSource: "config",
-      signingSecretSource: "config",
+      signingSecretSource: "config", // pragma: allowlist secret
       tokenStatus: "available",
       botTokenStatus: "missing",
       appTokenStatus: "configured_unavailable",
-      signingSecretStatus: "available",
+      signingSecretStatus: "available", // pragma: allowlist secret
       userTokenStatus: "missing",
       webhookUrl: "https://example.com",
     });
@@ -176,11 +176,11 @@ describe("projectCredentialSnapshotFields", () => {
       tokenSource: "config",
       botTokenSource: "env",
       appTokenSource: "config",
-      signingSecretSource: "config",
+      signingSecretSource: "config", // pragma: allowlist secret
       tokenStatus: "available",
       botTokenStatus: "missing",
       appTokenStatus: "configured_unavailable",
-      signingSecretStatus: "available",
+      signingSecretStatus: "available", // pragma: allowlist secret
       userTokenStatus: "missing",
     });
     expect(result).not.toHaveProperty("webhookUrl");

--- a/src/channels/account-snapshot-fields.ts
+++ b/src/channels/account-snapshot-fields.ts
@@ -141,34 +141,25 @@ export function projectCredentialSnapshotFields(
     return {};
   }
 
+  const tokenSource = readTrimmedString(record, "tokenSource");
+  const botTokenSource = readTrimmedString(record, "botTokenSource");
+  const appTokenSource = readTrimmedString(record, "appTokenSource");
+  const signingSecretSource = readTrimmedString(record, "signingSecretSource");
+  const tokenStatus = readCredentialStatus(record, "tokenStatus");
+  const botTokenStatus = readCredentialStatus(record, "botTokenStatus");
+  const appTokenStatus = readCredentialStatus(record, "appTokenStatus");
+  const signingSecretStatus = readCredentialStatus(record, "signingSecretStatus");
+  const userTokenStatus = readCredentialStatus(record, "userTokenStatus");
   return {
-    ...(readTrimmedString(record, "tokenSource")
-      ? { tokenSource: readTrimmedString(record, "tokenSource") }
-      : {}),
-    ...(readTrimmedString(record, "botTokenSource")
-      ? { botTokenSource: readTrimmedString(record, "botTokenSource") }
-      : {}),
-    ...(readTrimmedString(record, "appTokenSource")
-      ? { appTokenSource: readTrimmedString(record, "appTokenSource") }
-      : {}),
-    ...(readTrimmedString(record, "signingSecretSource")
-      ? { signingSecretSource: readTrimmedString(record, "signingSecretSource") }
-      : {}),
-    ...(readCredentialStatus(record, "tokenStatus")
-      ? { tokenStatus: readCredentialStatus(record, "tokenStatus") }
-      : {}),
-    ...(readCredentialStatus(record, "botTokenStatus")
-      ? { botTokenStatus: readCredentialStatus(record, "botTokenStatus") }
-      : {}),
-    ...(readCredentialStatus(record, "appTokenStatus")
-      ? { appTokenStatus: readCredentialStatus(record, "appTokenStatus") }
-      : {}),
-    ...(readCredentialStatus(record, "signingSecretStatus")
-      ? { signingSecretStatus: readCredentialStatus(record, "signingSecretStatus") }
-      : {}),
-    ...(readCredentialStatus(record, "userTokenStatus")
-      ? { userTokenStatus: readCredentialStatus(record, "userTokenStatus") }
-      : {}),
+    ...(tokenSource ? { tokenSource } : {}),
+    ...(botTokenSource ? { botTokenSource } : {}),
+    ...(appTokenSource ? { appTokenSource } : {}),
+    ...(signingSecretSource ? { signingSecretSource } : {}),
+    ...(tokenStatus ? { tokenStatus } : {}),
+    ...(botTokenStatus ? { botTokenStatus } : {}),
+    ...(appTokenStatus ? { appTokenStatus } : {}),
+    ...(signingSecretStatus ? { signingSecretStatus } : {}),
+    ...(userTokenStatus ? { userTokenStatus } : {}),
   };
 }
 
@@ -180,38 +171,33 @@ export function projectSafeChannelAccountSnapshotFields(
     return {};
   }
 
+  const name = readTrimmedString(record, "name");
+  const linked = readBoolean(record, "linked");
+  const running = readBoolean(record, "running");
+  const connected = readBoolean(record, "connected");
+  const reconnectAttempts = readNumber(record, "reconnectAttempts");
+  const mode = readTrimmedString(record, "mode");
+  const dmPolicy = readTrimmedString(record, "dmPolicy");
+  const allowFrom = readStringArray(record, "allowFrom");
+  const baseUrl = readTrimmedString(record, "baseUrl");
+  const allowUnmentionedGroups = readBoolean(record, "allowUnmentionedGroups");
+  const cliPath = readTrimmedString(record, "cliPath");
+  const dbPath = readTrimmedString(record, "dbPath");
+  const port = readNumber(record, "port");
   return {
-    ...(readTrimmedString(record, "name") ? { name: readTrimmedString(record, "name") } : {}),
-    ...(readBoolean(record, "linked") !== undefined
-      ? { linked: readBoolean(record, "linked") }
-      : {}),
-    ...(readBoolean(record, "running") !== undefined
-      ? { running: readBoolean(record, "running") }
-      : {}),
-    ...(readBoolean(record, "connected") !== undefined
-      ? { connected: readBoolean(record, "connected") }
-      : {}),
-    ...(readNumber(record, "reconnectAttempts") !== undefined
-      ? { reconnectAttempts: readNumber(record, "reconnectAttempts") }
-      : {}),
-    ...(readTrimmedString(record, "mode") ? { mode: readTrimmedString(record, "mode") } : {}),
-    ...(readTrimmedString(record, "dmPolicy")
-      ? { dmPolicy: readTrimmedString(record, "dmPolicy") }
-      : {}),
-    ...(readStringArray(record, "allowFrom")
-      ? { allowFrom: readStringArray(record, "allowFrom") }
-      : {}),
+    ...(name ? { name } : {}),
+    ...(linked !== undefined ? { linked } : {}),
+    ...(running !== undefined ? { running } : {}),
+    ...(connected !== undefined ? { connected } : {}),
+    ...(reconnectAttempts !== undefined ? { reconnectAttempts } : {}),
+    ...(mode ? { mode } : {}),
+    ...(dmPolicy ? { dmPolicy } : {}),
+    ...(allowFrom ? { allowFrom } : {}),
     ...projectCredentialSnapshotFields(account),
-    ...(readTrimmedString(record, "baseUrl")
-      ? { baseUrl: readTrimmedString(record, "baseUrl") }
-      : {}),
-    ...(readBoolean(record, "allowUnmentionedGroups") !== undefined
-      ? { allowUnmentionedGroups: readBoolean(record, "allowUnmentionedGroups") }
-      : {}),
-    ...(readTrimmedString(record, "cliPath")
-      ? { cliPath: readTrimmedString(record, "cliPath") }
-      : {}),
-    ...(readTrimmedString(record, "dbPath") ? { dbPath: readTrimmedString(record, "dbPath") } : {}),
-    ...(readNumber(record, "port") !== undefined ? { port: readNumber(record, "port") } : {}),
+    ...(baseUrl ? { baseUrl } : {}),
+    ...(allowUnmentionedGroups !== undefined ? { allowUnmentionedGroups } : {}),
+    ...(cliPath ? { cliPath } : {}),
+    ...(dbPath ? { dbPath } : {}),
+    ...(port !== undefined ? { port } : {}),
   };
 }

--- a/src/channels/read-only-account-inspect.test.ts
+++ b/src/channels/read-only-account-inspect.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { inspectReadOnlyChannelAccount } from "./read-only-account-inspect.js";
+
+const emptyConfig = {} as OpenClawConfig;
+
+describe("inspectReadOnlyChannelAccount", () => {
+  it("returns null for unknown channel ids", () => {
+    expect(
+      inspectReadOnlyChannelAccount({
+        channelId: "msteams" as never,
+        cfg: emptyConfig,
+      }),
+    ).toBeNull();
+  });
+
+  it("dispatches to discord for discord channel id", () => {
+    const result = inspectReadOnlyChannelAccount({
+      channelId: "discord",
+      cfg: emptyConfig,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.accountId).toBeDefined();
+  });
+
+  it("dispatches to slack for slack channel id", () => {
+    const result = inspectReadOnlyChannelAccount({
+      channelId: "slack",
+      cfg: emptyConfig,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.accountId).toBeDefined();
+  });
+
+  it("dispatches to telegram for telegram channel id", () => {
+    const result = inspectReadOnlyChannelAccount({
+      channelId: "telegram",
+      cfg: emptyConfig,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.accountId).toBeDefined();
+  });
+
+  it("passes accountId to channel inspection", () => {
+    const result = inspectReadOnlyChannelAccount({
+      channelId: "discord",
+      cfg: emptyConfig,
+      accountId: "secondary",
+    });
+    expect(result?.accountId).toBe("secondary");
+  });
+
+  it("handles null accountId by using the default account", () => {
+    const result = inspectReadOnlyChannelAccount({
+      channelId: "discord",
+      cfg: emptyConfig,
+      accountId: null,
+    });
+    expect(result?.accountId).toBeDefined();
+  });
+});

--- a/src/cron/run-log.test.ts
+++ b/src/cron/run-log.test.ts
@@ -8,6 +8,8 @@ import {
   DEFAULT_CRON_RUN_LOG_MAX_BYTES,
   getPendingCronRunLogWriteCountForTests,
   readCronRunLogEntries,
+  readCronRunLogEntriesPage,
+  readCronRunLogEntriesPageAll,
   resolveCronRunLogPruneOptions,
   resolveCronRunLogPath,
 } from "./run-log.js";
@@ -310,6 +312,141 @@ describe("cron run log", () => {
 
       // Clean up
       await writePromise.catch(() => undefined);
+    });
+  });
+
+  it("readCronRunLogEntriesPage filters by query text", async () => {
+    await withRunLogDir("openclaw-cron-log-query-", async (dir) => {
+      const logPath = path.join(dir, "runs", "job-1.jsonl");
+      await appendCronRunLog(logPath, {
+        ts: 1,
+        jobId: "job-1",
+        action: "finished",
+        status: "ok",
+        summary: "all done",
+      });
+      await appendCronRunLog(logPath, {
+        ts: 2,
+        jobId: "job-1",
+        action: "finished",
+        status: "error",
+        error: "quota exceeded",
+      });
+
+      const page = await readCronRunLogEntriesPage(logPath, { query: "quota", limit: 10 });
+      expect(page.total).toBe(1);
+      expect(page.entries[0]?.ts).toBe(2);
+    });
+  });
+
+  it("readCronRunLogEntriesPage sorts ascending when sortDir is asc", async () => {
+    await withRunLogDir("openclaw-cron-log-sortdir-", async (dir) => {
+      const logPath = path.join(dir, "runs", "job-1.jsonl");
+      for (const ts of [3, 1, 2]) {
+        await appendCronRunLog(logPath, {
+          ts,
+          jobId: "job-1",
+          action: "finished",
+          status: "ok",
+        });
+      }
+
+      const page = await readCronRunLogEntriesPage(logPath, { sortDir: "asc", limit: 10 });
+      expect(page.entries.map((e) => e.ts)).toEqual([1, 2, 3]);
+    });
+  });
+
+  it("readCronRunLogEntriesPage filters by deliveryStatus", async () => {
+    await withRunLogDir("openclaw-cron-log-delivery-", async (dir) => {
+      const logPath = path.join(dir, "runs", "job-1.jsonl");
+      await appendCronRunLog(logPath, {
+        ts: 1,
+        jobId: "job-1",
+        action: "finished",
+        status: "ok",
+        delivered: true,
+        deliveryStatus: "delivered",
+      });
+      await appendCronRunLog(logPath, {
+        ts: 2,
+        jobId: "job-1",
+        action: "finished",
+        status: "ok",
+        delivered: false,
+        deliveryStatus: "not-delivered",
+      });
+
+      const page = await readCronRunLogEntriesPage(logPath, {
+        deliveryStatus: "delivered",
+        limit: 10,
+      });
+      expect(page.total).toBe(1);
+      expect(page.entries[0]?.ts).toBe(1);
+    });
+  });
+
+  it("readCronRunLogEntriesPage paginates with offset", async () => {
+    await withRunLogDir("openclaw-cron-log-offset-", async (dir) => {
+      const logPath = path.join(dir, "runs", "job-1.jsonl");
+      for (let i = 0; i < 5; i++) {
+        await appendCronRunLog(logPath, {
+          ts: i,
+          jobId: "job-1",
+          action: "finished",
+          status: "ok",
+        });
+      }
+
+      const page = await readCronRunLogEntriesPage(logPath, {
+        sortDir: "asc",
+        limit: 2,
+        offset: 2,
+      });
+      expect(page.entries).toHaveLength(2);
+      expect(page.offset).toBe(2);
+      expect(page.hasMore).toBe(true);
+      expect(page.nextOffset).toBe(4);
+    });
+  });
+
+  it("readCronRunLogEntriesPageAll merges entries from multiple job files", async () => {
+    await withRunLogDir("openclaw-cron-log-all-", async (dir) => {
+      const storePath = path.join(dir, "jobs.json");
+      await fs.mkdir(path.join(dir, "runs"), { recursive: true });
+      const logPathA = path.join(dir, "runs", "a.jsonl");
+      const logPathB = path.join(dir, "runs", "b.jsonl");
+
+      await appendCronRunLog(logPathA, {
+        ts: 10,
+        jobId: "a",
+        action: "finished",
+        status: "ok",
+      });
+      await appendCronRunLog(logPathB, {
+        ts: 20,
+        jobId: "b",
+        action: "finished",
+        status: "error",
+        error: "oops",
+      });
+
+      const page = await readCronRunLogEntriesPageAll({
+        storePath,
+        sortDir: "asc",
+        limit: 50,
+      });
+      expect(page.total).toBe(2);
+      expect(page.entries.map((e) => e.jobId)).toEqual(["a", "b"]);
+    });
+  });
+
+  it("readCronRunLogEntriesPageAll returns empty result when runs dir is missing", async () => {
+    await withRunLogDir("openclaw-cron-log-nodir-", async (dir) => {
+      const storePath = path.join(dir, "jobs.json");
+      const page = await readCronRunLogEntriesPageAll({ storePath });
+      expect(page.entries).toEqual([]);
+      expect(page.total).toBe(0);
+      expect(page.hasMore).toBe(false);
     });
   });
 });

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -170,4 +170,43 @@ describe("saveCronStore", () => {
 
     spy.mockRestore();
   });
+
+  it("skips backup file when skipBackup is true", async () => {
+    const { storePath } = await makeStorePath();
+    const first = makeStore("job-1", true);
+    const second = makeStore("job-2", false);
+
+    await saveCronStore(storePath, first);
+    await saveCronStore(storePath, second, { skipBackup: true });
+
+    await expect(fs.stat(`${storePath}.bak`)).rejects.toThrow();
+    const loaded = await loadCronStore(storePath);
+    expect(loaded).toEqual(second);
+  });
+});
+
+describe("loadCronStore edge cases", () => {
+  it("returns empty store when root JSON is an array", async () => {
+    const { storePath } = await makeStorePath();
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(storePath, JSON.stringify([{ id: "job-1" }]), "utf-8");
+    const store = await loadCronStore(storePath);
+    expect(store).toEqual({ version: 1, jobs: [] });
+  });
+
+  it("returns empty store when root JSON is null", async () => {
+    const { storePath } = await makeStorePath();
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(storePath, "null", "utf-8");
+    const store = await loadCronStore(storePath);
+    expect(store).toEqual({ version: 1, jobs: [] });
+  });
+
+  it("returns empty store when jobs field is missing", async () => {
+    const { storePath } = await makeStorePath();
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(storePath, JSON.stringify({ version: 1 }), "utf-8");
+    const store = await loadCronStore(storePath);
+    expect(store.jobs).toEqual([]);
+  });
 });

--- a/src/infra/channel-summary.ts
+++ b/src/infra/channel-summary.ts
@@ -14,7 +14,7 @@ import { inspectReadOnlyChannelAccount } from "../channels/read-only-account-ins
 import { type OpenClawConfig, loadConfig } from "../config/config.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import { theme } from "../terminal/theme.js";
-import { formatTimeAgo } from "./format-time/format-relative.ts";
+import { formatTimeAgo } from "./format-time/format-relative.js";
 
 export type ChannelSummaryOptions = {
   colorize?: boolean;


### PR DESCRIPTION
## Summary

- Problem: projectCredentialSnapshotFields called eadTrimmedString and eadCredentialStatus twice per field, and channel-summary.ts used a .ts ESM import extension
- Why it matters: Redundant reads add unnecessary overhead; .ts imports fail at runtime in ESM mode
- What changed: Cache intermediate values in projectCredentialSnapshotFields; fix import extension to .js; add test coverage for snapshot field utilities, cron store/run-log, cache-trace, payload-redaction, and anthropic-payload-log
- What did NOT change: All existing behavior, guard conditions, and return values are preserved

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

No security impact. No behavioral changes; refactor only caches intermediate values that were already being read from the same source record.

## Testing

- All existing tests pass (pnpm test)
- New tests added for ccount-snapshot-fields, cron/run-log, cron/store, cache-trace, payload-redaction, nthropic-payload-log, ead-only-account-inspect
- pnpm check passes with 0 warnings