### PR TITLE
fix(security): add default pidsLimit for sandbox containers

### DIFF
--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_SANDBOX_IDLE_HOURS,
   DEFAULT_SANDBOX_IMAGE,
   DEFAULT_SANDBOX_MAX_AGE_DAYS,
+  DEFAULT_SANDBOX_PIDS_LIMIT,
   DEFAULT_SANDBOX_WORKDIR,
   DEFAULT_SANDBOX_WORKSPACE_ROOT,
 } from "./constants.js";
@@ -105,7 +106,7 @@ export function resolveSandboxDockerConfig(params: {
     capDrop: agentDocker?.capDrop ?? globalDocker?.capDrop ?? ["ALL"],
     env,
     setupCommand: agentDocker?.setupCommand ?? globalDocker?.setupCommand,
-    pidsLimit: agentDocker?.pidsLimit ?? globalDocker?.pidsLimit,
+    pidsLimit: agentDocker?.pidsLimit ?? globalDocker?.pidsLimit ?? DEFAULT_SANDBOX_PIDS_LIMIT,
     memory: agentDocker?.memory ?? globalDocker?.memory,
     memorySwap: agentDocker?.memorySwap ?? globalDocker?.memorySwap,
     cpus: agentDocker?.cpus ?? globalDocker?.cpus,

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -10,6 +10,13 @@ export const DEFAULT_SANDBOX_WORKDIR = "/workspace";
 export const DEFAULT_SANDBOX_IDLE_HOURS = 24;
 export const DEFAULT_SANDBOX_MAX_AGE_DAYS = 7;
 
+/**
+ * Default PID limit for sandbox containers to prevent fork bomb attacks.
+ * A value of 1024 is reasonable for most agent workloads while preventing
+ * resource exhaustion attacks on the host system.
+ */
+export const DEFAULT_SANDBOX_PIDS_LIMIT = 1024;
+
 export const DEFAULT_TOOL_ALLOW = [
   "exec",
   "process",


### PR DESCRIPTION
## Summary

在测试 OpenClaw 沙箱功能时，我发现了一个安全隐患：沙箱容器创建时没有默认的 `pidsLimit`，容易受到 fork bomb 攻击。

## 发现过程

在分析 `src/agents/sandbox/config.ts` 源码时，我注意到其他安全相关配置都有默认值：
- `network` → `"none"`
- `capDrop` → `["ALL"]`
- `readOnlyRoot` → `true`

但 `pidsLimit` 没有默认值，这意味着容器可以无限创建进程，威胁主机安全。

## Security Impact

- **防止 fork bomb 攻击**：恶意或被攻击的 agent 无法执行 `:(){ :|:& };:` 等攻击
- **限制容器进程数**：容器最多只能创建 1024 个进程
- **保护主机系统**：防止 PID/内存耗尽

## Changes

1. 在 `src/agents/sandbox/constants.ts` 添加 `DEFAULT_SANDBOX_PIDS_LIMIT = 1024` 常量
2. 在 `src/agents/sandbox/config.ts` 使用该默认值

## Before

```typescript
pidsLimit: agentDocker?.pidsLimit ?? globalDocker?.pidsLimit,  // NO DEFAULT!
```

## After

```typescript
pidsLimit: agentDocker?.pidsLimit ?? globalDocker?.pidsLimit ?? DEFAULT_SANDBOX_PIDS_LIMIT,
```

## Testing

- ✅ 所有 CI 测试通过
- ✅ 类型检查通过
- ✅ 代码格式检查通过

Fixes #38604

---

🤖 AI 辅助代码提交