### PR TITLE
fix(agents): warn on unrecognised model ID instead of silently falling back

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 import { saveAuthProfileStore } from "./auth-profiles.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
@@ -487,6 +488,34 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledTimes(2);
     expect(run.mock.calls[1]?.[0]).toBe("anthropic");
     expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
+  });
+
+  it("warns when falling back due to model_not_found", async () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const cfg = makeCfg();
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Model not found: openai/gpt-6"))
+        .mockResolvedValueOnce("ok");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-6",
+        run,
+      });
+
+      expect(result.result).toBe("ok");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Model "openai/gpt-6" not found'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+      setLoggerOverride(null);
+      resetLogger();
+    }
   });
 
   it("skips providers when all profiles are in cooldown", async () => {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -3,6 +3,7 @@ import {
   resolveAgentModelFallbackValues,
   resolveAgentModelPrimaryValue,
 } from "../config/model-input.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   ensureAuthProfileStore,
   getSoonestCooldownExpiry,
@@ -27,6 +28,8 @@ import {
 } from "./model-selection.js";
 import type { FailoverReason } from "./pi-embedded-helpers.js";
 import { isLikelyContextOverflowError } from "./pi-embedded-helpers.js";
+
+const log = createSubsystemLogger("model-fallback");
 
 type ModelCandidate = {
   provider: string;
@@ -527,6 +530,11 @@ export async function runWithModelFallback<T>(params: {
       options: runOptions,
     });
     if ("success" in attemptRun) {
+      if (i > 0 && attempts[0]?.reason === "model_not_found") {
+        log.warn(
+          `Model "${attempts[0].provider}/${attempts[0].model}" not found. Fell back to "${candidate.provider}/${candidate.model}".`,
+        );
+      }
       return attemptRun.success;
     }
     const err = attemptRun.error;

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -4,6 +4,7 @@ import {
   resolveAgentModelPrimaryValue,
 } from "../config/model-input.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { stripAnsi } from "../terminal/ansi.js";
 import {
   ensureAuthProfileStore,
   getSoonestCooldownExpiry,
@@ -531,8 +532,16 @@ export async function runWithModelFallback<T>(params: {
     });
     if ("success" in attemptRun) {
       if (i > 0 && attempts[0]?.reason === "model_not_found") {
+        // Sanitize to prevent log forging / terminal escape injection (CWE-117).
+        const sanitize = (v: string) => {
+          let out = stripAnsi(v);
+          for (let c = 0; c <= 0x1f; c++) {
+            out = out.replaceAll(String.fromCharCode(c), "");
+          }
+          return out.replaceAll(String.fromCharCode(0x7f), "");
+        };
         log.warn(
-          `Model "${attempts[0].provider}/${attempts[0].model}" not found. Fell back to "${candidate.provider}/${candidate.model}".`,
+          `Model "${sanitize(attempts[0].provider)}/${sanitize(attempts[0].model)}" not found. Fell back to "${sanitize(candidate.provider)}/${sanitize(candidate.model)}".`,
         );
       }
       return attemptRun.success;

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -558,6 +558,35 @@ describe("model-selection", () => {
       });
       expect(result).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
     });
+
+    it("should warn when specified model cannot be resolved and falls back to default", () => {
+      setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const cfg: Partial<OpenClawConfig> = {
+          agents: {
+            defaults: {
+              model: { primary: "openai/" },
+            },
+          },
+        };
+
+        const result = resolveConfiguredModelRef({
+          cfg: cfg as OpenClawConfig,
+          defaultProvider: "anthropic",
+          defaultModel: "claude-opus-4-6",
+        });
+
+        expect(result).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Falling back to default "anthropic/claude-opus-4-6"'),
+        );
+      } finally {
+        warnSpy.mockRestore();
+        setLoggerOverride(null);
+        resetLogger();
+      }
+    });
   });
 
   describe("resolveThinkingDefault", () => {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveAgentModelPrimaryValue, toAgentModelListLike } from "../config/model-input.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { stripAnsi } from "../terminal/ansi.js";
 import { resolveAgentConfig, resolveAgentEffectiveModelPrimary } from "./agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import type { ModelCatalogEntry } from "./model-catalog.js";
@@ -318,9 +319,18 @@ export function resolveConfiguredModelRef(params: {
     }
 
     // User specified a model but it could not be resolved — warn before falling back.
-    log.warn(
-      `Model "${trimmed}" could not be resolved. Falling back to default "${params.defaultProvider}/${params.defaultModel}".`,
-    );
+    // Sanitize to prevent log forging / terminal escape injection (CWE-117).
+    const sanitizeLog = (v: string) => {
+      let out = stripAnsi(v);
+      // Strip C0 control chars (U+0000–U+001F) and DEL (U+007F).
+      for (let c = 0; c <= 0x1f; c++) {
+        out = out.replaceAll(String.fromCharCode(c), "");
+      }
+      return out.replaceAll(String.fromCharCode(0x7f), "");
+    };
+    const safe = sanitizeLog(trimmed);
+    const safeFallback = sanitizeLog(`${params.defaultProvider}/${params.defaultModel}`);
+    log.warn(`Model "${safe}" could not be resolved. Falling back to default "${safeFallback}".`);
   }
   // Before falling back to the hardcoded default, check if the default provider
   // is actually available. If it isn't but other providers are configured, prefer

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -316,6 +316,11 @@ export function resolveConfiguredModelRef(params: {
     if (resolved) {
       return resolved.ref;
     }
+
+    // User specified a model but it could not be resolved — warn before falling back.
+    log.warn(
+      `Model "${trimmed}" could not be resolved. Falling back to default "${params.defaultProvider}/${params.defaultModel}".`,
+    );
   }
   // Before falling back to the hardcoded default, check if the default provider
   // is actually available. If it isn't but other providers are configured, prefer

--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -413,6 +413,7 @@ describe("models-config", () => {
           models: {
             providers: {
               openai: {
+                baseUrl: "",
                 apiKey: "sk-plaintext-should-not-appear", // already resolved by loadConfig
                 api: "openai-completions",
                 models: [

--- a/src/agents/models-config.providers.normalize-keys.test.ts
+++ b/src/agents/models-config.providers.normalize-keys.test.ts
@@ -81,6 +81,7 @@ describe("normalizeProviders", () => {
     try {
       const providers: NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]> = {
         openai: {
+          baseUrl: "",
           apiKey: "sk-test-secret-value-12345", // simulates resolved ${OPENAI_API_KEY}
           api: "openai-completions",
           models: [


### PR DESCRIPTION
## Summary
- **Problem**: When a user specifies a model ID that doesn't match any configured provider/model (e.g. typo like `openai/gpt-5.4-pro`), the agent silently falls back to the primary default model with no warning.
- **Why it matters**: Users unknowingly use the wrong model, with billing implications, capability differences, and hard-to-debug "off" responses.
- **What changed**: Added warning logs in two places:
  1. `src/agents/model-fallback.ts`: Runtime fallback. When `runWithModelFallback` succeeds on a later candidate after the user's primary model fails with `model_not_found`, a warning is logged.
  2. `src/agents/model-selection.ts`: Config-level. When a malformed model string (e.g. `"openai/"`) can't be parsed into a valid ModelRef, a warning is logged before falling back to defaults.
- **What did NOT change**: Fallback behaviour itself is unchanged. This is strictly additive logging.

## Change Type
- [x] Bug fix

## Scope
- [x] Agents / subagents

## Linked Issue/PR
- Closes #37813

## User-visible / Behavior Changes
Users will now see a warning log when their specified model ID is not found and the system falls back to the default model: `Model "openai/gpt-6" not found. Fell back to "openai/gpt-4.1-mini".`

## Security Impact
- [x] None of the above

## Evidence
- [x] Unit/integration test added or updated (2 new tests, 97/97 passing)

## Human Verification
- **Verified scenarios**: Unrecognised model ID triggers warning; valid model ID produces no warning; malformed config string triggers config-level warning.
- **Edge cases checked**: `attempts[0]` precision. Only warns when user's primary model (always candidate 0) has `model_not_found`, not when a fallback model is unrecognised.
- **What was NOT verified**: `runWithImageModelFallback` (same pattern but doesn't extract `reason` into `attempts`, separate concern and out of scope).

## Compatibility / Migration
- Backward compatible: yes
- Config changes: none
- Migration needed: none

## Failure Recovery
- **Revert**: `git revert <sha>`
- **Bad symptoms**: Unexpected warning logs appearing in normal model resolution (would indicate the check is too broad, but the `model_not_found` reason gating prevents this).

## Risks and Mitigations
| Risk | Mitigation |
|------|-----------|
| Duplicate warning for malformed config strings (resolveConfiguredModelRef called twice) | Minor noise, not worth adding dedup complexity for an uncommon edge case |
| Warning not emitted for `runWithImageModelFallback` | Out of scope. Image model fallback is a separate concern |
