### PR TITLE
fix(install): keep PowerShell window open on Windows install failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -522,6 +522,7 @@ Docs: https://docs.openclaw.ai
 - Browser/config schema: accept `browser.profiles.*.driver: "openclaw"` while preserving legacy `"clawd"` compatibility in validated config. (#39374; based on #35621) Thanks @gambletan and @ingyukoh.
 - Memory flush/bootstrap file protection: restrict memory-flush runs to append-only `read`/`write` tools and route host-side memory appends through root-enforced safe file handles so flush turns cannot overwrite bootstrap files via `exec` or unsafe raw rewrites. (#38574) Thanks @frankekn.
 - Mattermost/DM media uploads: resolve bare 26-character Mattermost IDs user-first for direct messages so media sends no longer fail with `403 Forbidden` when targets are configured as unprefixed user IDs. (#29925) Thanks @teconomix.
+- Install/Windows PowerShell: keep the installer window open on failure so users can read error messages, check `$LASTEXITCODE` after native commands (`npm`, `git`, `pnpm`) to detect silent failures, rename `$ERROR` to `$CLR_ERROR` to avoid collision with PowerShell's automatic `$Error` variable, and fix the `Write-Host` module qualifier. (#38634) Thanks @ademczuk.
 
 ## 2026.3.2
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -337,7 +337,7 @@ function Main {
     } else {
         # npm method
         if (!(Ensure-Git)) {
-            Write-Host "Git is required for npm installs. Please install Git and try again." -Level warn
+            Write-Host "Git not found. OpenClaw will install via npm, but Git is recommended for updates." -Level warn
         }
         
         if ($DryRun) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -26,7 +26,7 @@ function Wait-BeforeExit {
 $ACCENT = "`e[38;2;255;77;77m"    # coral-bright
 $SUCCESS = "`e[38;2;0;229;204m"    # cyan-bright
 $WARN = "`e[38;2;255;176;32m"     # amber
-$ERROR = "`e[38;2;230;57;70m"     # coral-mid
+$CLR_ERROR = "`e[38;2;230;57;70m"   # coral-mid (avoid $ERROR — collides with PS read-only $Error)
 $MUTED = "`e[38;2;90;100;128m"    # text-muted
 $NC = "`e[0m"                     # No Color
 
@@ -35,7 +35,7 @@ function Write-Host {
     $msg = switch ($Level) {
         "success" { "$SUCCESS✓$NC $Message" }
         "warn" { "$WARN!$NC $Message" }
-        "error" { "$ERROR✗$NC $Message" }
+        "error" { "$CLR_ERROR✗$NC $Message" }
         default { "$MUTED·$NC $Message" }
     }
     Microsoft.PowerShell.Utility\Write-Host $msg
@@ -371,7 +371,7 @@ try {
     Main
 } catch {
     Microsoft.PowerShell.Utility\Write-Host ""
-    Microsoft.PowerShell.Utility\Write-Host "$ERROR✗$NC Installation failed: $_"
+    Microsoft.PowerShell.Utility\Write-Host "$CLR_ERROR✗$NC Installation failed: $_"
     Wait-BeforeExit
     exit 1
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -14,11 +14,22 @@ param(
 $ErrorActionPreference = "Stop"
 
 # Pause before exiting on error so users can read the message.
-# Only pauses in interactive windows (not CI, not piped output).
+# Guards: not a CI environment, running in a real ConsoleHost, and stdin/stdout
+# are not redirected (piped). The try/catch ensures Read-Host errors never
+# mask the original failure that brought us here.
 function Wait-BeforeExit {
-    if ([Environment]::UserInteractive -and !$env:CI) {
-        Microsoft.PowerShell.Utility\Write-Host ""
-        Read-Host "Press Enter to close this window"
+    $isCI = (Test-Path env:CI) -or (Test-Path env:GITHUB_ACTIONS) -or
+            (Test-Path env:TF_BUILD) -or (Test-Path env:BUILD_BUILDID)
+    $canPrompt = ($Host.Name -eq 'ConsoleHost') -and
+                 -not [Console]::IsInputRedirected -and
+                 -not [Console]::IsOutputRedirected
+    if (-not $isCI -and $canPrompt) {
+        try {
+            Microsoft.PowerShell.Utility\Write-Host ""
+            [void](Read-Host 'Press Enter to close this window')
+        } catch {
+            # silently skip — never obscure the original error
+        }
     }
 }
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -13,6 +13,15 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# Pause before exiting on error so users can read the message.
+# Only pauses in interactive windows (not CI, not piped output).
+function Wait-BeforeExit {
+    if ([Environment]::UserInteractive -and !$env:CI) {
+        Microsoft.PowerShell.Host\Write-Host ""
+        Read-Host "Press Enter to close this window"
+    }
+}
+
 # Colors
 $ACCENT = "`e[38;2;255;77;77m"    # coral-bright
 $SUCCESS = "`e[38;2;0;229;204m"    # cyan-bright
@@ -205,8 +214,13 @@ function Install-OpenClawNpm {
     Write-Host "Installing OpenClaw (openclaw@$Version)..." -Level info
     
     try {
-        # Use -ExecutionPolicy Bypass to handle restricted execution policy
         npm install -g openclaw@$Version --no-fund --no-audit 2>&1
+        # npm is a native command — non-zero exit codes don't throw in
+        # PowerShell, so check $LASTEXITCODE explicitly.
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "npm install failed (exit code $LASTEXITCODE)" -Level error
+            return $false
+        }
         Write-Host "OpenClaw installed" -Level success
         return $true
     } catch {
@@ -217,30 +231,50 @@ function Install-OpenClawNpm {
 
 function Install-OpenClawGit {
     param([string]$RepoDir, [switch]$Update)
-    
+
     Write-Host "Installing OpenClaw from git..." -Level info
-    
+
     if (!(Test-Path $RepoDir)) {
         Write-Host "  Cloning repository..." -Level info
         git clone https://github.com/openclaw/openclaw.git $RepoDir 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "git clone failed (exit code $LASTEXITCODE)" -Level error
+            return $false
+        }
     } elseif ($Update) {
         Write-Host "  Updating repository..." -Level info
         git -C $RepoDir pull --rebase 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "git pull failed (exit code $LASTEXITCODE)" -Level error
+            return $false
+        }
     }
-    
+
     # Install pnpm if not present
     if (!(Get-Command pnpm -ErrorAction SilentlyContinue)) {
         Write-Host "  Installing pnpm..." -Level info
         npm install -g pnpm 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "pnpm install failed (exit code $LASTEXITCODE)" -Level error
+            return $false
+        }
     }
-    
+
     # Install dependencies
     Write-Host "  Installing dependencies..." -Level info
     pnpm install --dir $RepoDir 2>&1
-    
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "pnpm install failed (exit code $LASTEXITCODE)" -Level error
+        return $false
+    }
+
     # Build
     Write-Host "  Building..." -Level info
     pnpm --dir $RepoDir build 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "build failed (exit code $LASTEXITCODE)" -Level error
+        return $false
+    }
     
     # Create wrapper
     $wrapperDir = "$env:USERPROFILE\.local\bin"
@@ -277,22 +311,28 @@ function Main {
     if (!(Ensure-ExecutionPolicy)) {
         Write-Host ""
         Write-Host "Installation cannot continue due to execution policy restrictions" -Level error
+        Wait-BeforeExit
         exit 1
     }
     
     if (!(Ensure-Node)) {
+        Wait-BeforeExit
         exit 1
     }
     
     if ($InstallMethod -eq "git") {
         if (!(Ensure-Git)) {
+            Wait-BeforeExit
             exit 1
         }
         
         if ($DryRun) {
             Write-Host "[DRY RUN] Would install OpenClaw from git to $GitDir" -Level info
         } else {
-            Install-OpenClawGit -RepoDir $GitDir -Update:(-not $NoGitUpdate)
+            if (!(Install-OpenClawGit -RepoDir $GitDir -Update:(-not $NoGitUpdate))) {
+                Wait-BeforeExit
+                exit 1
+            }
         }
     } else {
         # npm method
@@ -304,6 +344,7 @@ function Main {
             Write-Host "[DRY RUN] Would install OpenClaw via npm (tag: $Tag)" -Level info
         } else {
             if (!(Install-OpenClawNpm -Version $Tag)) {
+                Wait-BeforeExit
                 exit 1
             }
         }
@@ -326,4 +367,11 @@ function Main {
     Write-Host "🦞 OpenClaw installed successfully!" -Level success
 }
 
-Main
+try {
+    Main
+} catch {
+    Microsoft.PowerShell.Host\Write-Host ""
+    Microsoft.PowerShell.Host\Write-Host "$ERROR✗$NC Installation failed: $_"
+    Wait-BeforeExit
+    exit 1
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -17,7 +17,7 @@ $ErrorActionPreference = "Stop"
 # Only pauses in interactive windows (not CI, not piped output).
 function Wait-BeforeExit {
     if ([Environment]::UserInteractive -and !$env:CI) {
-        Microsoft.PowerShell.Host\Write-Host ""
+        Microsoft.PowerShell.Utility\Write-Host ""
         Read-Host "Press Enter to close this window"
     }
 }
@@ -38,7 +38,7 @@ function Write-Host {
         "error" { "$ERROR✗$NC $Message" }
         default { "$MUTED·$NC $Message" }
     }
-    Microsoft.PowerShell.Host\Write-Host $msg
+    Microsoft.PowerShell.Utility\Write-Host $msg
 }
 
 function Write-Banner {
@@ -370,8 +370,8 @@ function Main {
 try {
     Main
 } catch {
-    Microsoft.PowerShell.Host\Write-Host ""
-    Microsoft.PowerShell.Host\Write-Host "$ERROR✗$NC Installation failed: $_"
+    Microsoft.PowerShell.Utility\Write-Host ""
+    Microsoft.PowerShell.Utility\Write-Host "$ERROR✗$NC Installation failed: $_"
     Wait-BeforeExit
     exit 1
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -214,9 +214,12 @@ function Install-OpenClawNpm {
     Write-Host "Installing OpenClaw (openclaw@$Version)..." -Level info
     
     try {
-        npm install -g openclaw@$Version --no-fund --no-audit 2>&1
+        npm install -g openclaw@$Version --no-fund --no-audit 2>&1 | Out-Null
         # npm is a native command — non-zero exit codes don't throw in
         # PowerShell, so check $LASTEXITCODE explicitly.
+        # Out-Null prevents output from polluting the function's return
+        # pipeline (a multi-element array always evaluates as $true,
+        # silently swallowing failures in boolean checks).
         if ($LASTEXITCODE -ne 0) {
             Write-Host "npm install failed (exit code $LASTEXITCODE)" -Level error
             return $false
@@ -236,14 +239,14 @@ function Install-OpenClawGit {
 
     if (!(Test-Path $RepoDir)) {
         Write-Host "  Cloning repository..." -Level info
-        git clone https://github.com/openclaw/openclaw.git $RepoDir 2>&1
+        git clone https://github.com/openclaw/openclaw.git $RepoDir 2>&1 | Out-Null
         if ($LASTEXITCODE -ne 0) {
             Write-Host "git clone failed (exit code $LASTEXITCODE)" -Level error
             return $false
         }
     } elseif ($Update) {
         Write-Host "  Updating repository..." -Level info
-        git -C $RepoDir pull --rebase 2>&1
+        git -C $RepoDir pull --rebase 2>&1 | Out-Null
         if ($LASTEXITCODE -ne 0) {
             Write-Host "git pull failed (exit code $LASTEXITCODE)" -Level error
             return $false
@@ -253,7 +256,7 @@ function Install-OpenClawGit {
     # Install pnpm if not present
     if (!(Get-Command pnpm -ErrorAction SilentlyContinue)) {
         Write-Host "  Installing pnpm..." -Level info
-        npm install -g pnpm 2>&1
+        npm install -g pnpm 2>&1 | Out-Null
         if ($LASTEXITCODE -ne 0) {
             Write-Host "pnpm install failed (exit code $LASTEXITCODE)" -Level error
             return $false
@@ -262,7 +265,7 @@ function Install-OpenClawGit {
 
     # Install dependencies
     Write-Host "  Installing dependencies..." -Level info
-    pnpm install --dir $RepoDir 2>&1
+    pnpm install --dir $RepoDir 2>&1 | Out-Null
     if ($LASTEXITCODE -ne 0) {
         Write-Host "pnpm install failed (exit code $LASTEXITCODE)" -Level error
         return $false
@@ -270,7 +273,7 @@ function Install-OpenClawGit {
 
     # Build
     Write-Host "  Building..." -Level info
-    pnpm --dir $RepoDir build 2>&1
+    pnpm --dir $RepoDir build 2>&1 | Out-Null
     if ($LASTEXITCODE -ne 0) {
         Write-Host "build failed (exit code $LASTEXITCODE)" -Level error
         return $false

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -127,7 +127,7 @@ function Install-Node {
     if (Get-Command winget -ErrorAction SilentlyContinue) {
         Write-Host "  Using winget..." -Level info
         try {
-            winget install OpenJS.NodeJS.LTS --accept-package-agreements --accept-source-agreements 2>&1 | Out-Null
+            winget install OpenJS.NodeJS.LTS --accept-package-agreements --accept-source-agreements 2>&1 | Out-Host
             # Refresh PATH
             $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
             Write-Host "  Node.js installed via winget" -Level success
@@ -141,7 +141,7 @@ function Install-Node {
     if (Get-Command choco -ErrorAction SilentlyContinue) {
         Write-Host "  Using chocolatey..." -Level info
         try {
-            choco install nodejs-lts -y 2>&1 | Out-Null
+            choco install nodejs-lts -y 2>&1 | Out-Host
             $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
             Write-Host "  Node.js installed via chocolatey" -Level success
             return $true
@@ -154,7 +154,7 @@ function Install-Node {
     if (Get-Command scoop -ErrorAction SilentlyContinue) {
         Write-Host "  Using scoop..." -Level info
         try {
-            scoop install nodejs-lts 2>&1 | Out-Null
+            scoop install nodejs-lts 2>&1 | Out-Host
             $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
             Write-Host "  Node.js installed via scoop" -Level success
             return $true
@@ -197,7 +197,7 @@ function Install-Git {
     if (Get-Command winget -ErrorAction SilentlyContinue) {
         Write-Host "  Installing Git via winget..." -Level info
         try {
-            winget install Git.Git --accept-package-agreements --accept-source-agreements 2>&1 | Out-Null
+            winget install Git.Git --accept-package-agreements --accept-source-agreements 2>&1 | Out-Host
             $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
             Write-Host "  Git installed" -Level success
             return $true
@@ -225,12 +225,11 @@ function Install-OpenClawNpm {
     Write-Host "Installing OpenClaw (openclaw@$Version)..." -Level info
     
     try {
-        npm install -g openclaw@$Version --no-fund --no-audit 2>&1 | Out-Null
+        npm install -g openclaw@$Version --no-fund --no-audit 2>&1 | Out-Host
         # npm is a native command — non-zero exit codes don't throw in
         # PowerShell, so check $LASTEXITCODE explicitly.
-        # Out-Null prevents output from polluting the function's return
-        # pipeline (a multi-element array always evaluates as $true,
-        # silently swallowing failures in boolean checks).
+        # Out-Host sends output to the console (so users can read errors)
+        # while keeping it off the pipeline (prevents return-value pollution).
         if ($LASTEXITCODE -ne 0) {
             Write-Host "npm install failed (exit code $LASTEXITCODE)" -Level error
             return $false
@@ -250,14 +249,14 @@ function Install-OpenClawGit {
 
     if (!(Test-Path $RepoDir)) {
         Write-Host "  Cloning repository..." -Level info
-        git clone https://github.com/openclaw/openclaw.git $RepoDir 2>&1 | Out-Null
+        git clone https://github.com/openclaw/openclaw.git $RepoDir 2>&1 | Out-Host
         if ($LASTEXITCODE -ne 0) {
             Write-Host "git clone failed (exit code $LASTEXITCODE)" -Level error
             return $false
         }
     } elseif ($Update) {
         Write-Host "  Updating repository..." -Level info
-        git -C $RepoDir pull --rebase 2>&1 | Out-Null
+        git -C $RepoDir pull --rebase 2>&1 | Out-Host
         if ($LASTEXITCODE -ne 0) {
             Write-Host "git pull failed (exit code $LASTEXITCODE)" -Level error
             return $false
@@ -267,7 +266,7 @@ function Install-OpenClawGit {
     # Install pnpm if not present
     if (!(Get-Command pnpm -ErrorAction SilentlyContinue)) {
         Write-Host "  Installing pnpm..." -Level info
-        npm install -g pnpm 2>&1 | Out-Null
+        npm install -g pnpm 2>&1 | Out-Host
         if ($LASTEXITCODE -ne 0) {
             Write-Host "pnpm install failed (exit code $LASTEXITCODE)" -Level error
             return $false
@@ -276,7 +275,7 @@ function Install-OpenClawGit {
 
     # Install dependencies
     Write-Host "  Installing dependencies..." -Level info
-    pnpm install --dir $RepoDir 2>&1 | Out-Null
+    pnpm install --dir $RepoDir 2>&1 | Out-Host
     if ($LASTEXITCODE -ne 0) {
         Write-Host "pnpm install failed (exit code $LASTEXITCODE)" -Level error
         return $false
@@ -284,7 +283,7 @@ function Install-OpenClawGit {
 
     # Build
     Write-Host "  Building..." -Level info
-    pnpm --dir $RepoDir build 2>&1 | Out-Null
+    pnpm --dir $RepoDir build 2>&1 | Out-Host
     if ($LASTEXITCODE -ne 0) {
         Write-Host "build failed (exit code $LASTEXITCODE)" -Level error
         return $false

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -131,6 +131,7 @@ function Install-Node {
         Write-Host "  Using winget..." -Level info
         try {
             winget install OpenJS.NodeJS.LTS --accept-package-agreements --accept-source-agreements 2>&1 | Out-Host
+            if ($LASTEXITCODE -ne 0) { throw "winget exited with code $LASTEXITCODE" }
             # Refresh PATH
             $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
             Write-Host "  Node.js installed via winget" -Level success
@@ -145,6 +146,7 @@ function Install-Node {
         Write-Host "  Using chocolatey..." -Level info
         try {
             choco install nodejs-lts -y 2>&1 | Out-Host
+            if ($LASTEXITCODE -ne 0) { throw "choco exited with code $LASTEXITCODE" }
             $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
             Write-Host "  Node.js installed via chocolatey" -Level success
             return $true
@@ -158,6 +160,7 @@ function Install-Node {
         Write-Host "  Using scoop..." -Level info
         try {
             scoop install nodejs-lts 2>&1 | Out-Host
+            if ($LASTEXITCODE -ne 0) { throw "scoop exited with code $LASTEXITCODE" }
             $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
             Write-Host "  Node.js installed via scoop" -Level success
             return $true
@@ -201,6 +204,7 @@ function Install-Git {
         Write-Host "  Installing Git via winget..." -Level info
         try {
             winget install Git.Git --accept-package-agreements --accept-source-agreements 2>&1 | Out-Host
+            if ($LASTEXITCODE -ne 0) { throw "winget exited with code $LASTEXITCODE" }
             $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
             Write-Host "  Git installed" -Level success
             return $true

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -18,18 +18,21 @@ $ErrorActionPreference = "Stop"
 # are not redirected (piped). The try/catch ensures Read-Host errors never
 # mask the original failure that brought us here.
 function Wait-BeforeExit {
-    $isCI = (Test-Path env:CI) -or (Test-Path env:GITHUB_ACTIONS) -or
-            (Test-Path env:TF_BUILD) -or (Test-Path env:BUILD_BUILDID)
-    $canPrompt = ($Host.Name -eq 'ConsoleHost') -and
-                 -not [Console]::IsInputRedirected -and
-                 -not [Console]::IsOutputRedirected
-    if (-not $isCI -and $canPrompt) {
-        try {
+    try {
+        $isCI = (Test-Path env:CI) -or (Test-Path env:GITHUB_ACTIONS) -or
+                (Test-Path env:TF_BUILD) -or (Test-Path env:BUILD_BUILDID)
+        # [Console]::IsInputRedirected can throw on systems without a real
+        # console handle (services, scheduled tasks), so keep it inside
+        # the try/catch to avoid masking the original failure.
+        $canPrompt = ($Host.Name -eq 'ConsoleHost') -and
+                     -not [Console]::IsInputRedirected -and
+                     -not [Console]::IsOutputRedirected
+        if (-not $isCI -and $canPrompt) {
             Microsoft.PowerShell.Utility\Write-Host ""
             [void](Read-Host 'Press Enter to close this window')
-        } catch {
-            # silently skip — never obscure the original error
         }
+    } catch {
+        # silently skip — never obscure the original error
     }
 }
 
@@ -249,14 +252,14 @@ function Install-OpenClawGit {
 
     if (!(Test-Path $RepoDir)) {
         Write-Host "  Cloning repository..." -Level info
-        git clone https://github.com/openclaw/openclaw.git $RepoDir 2>&1 | Out-Host
+        git clone -- https://github.com/openclaw/openclaw.git "$RepoDir" 2>&1 | Out-Host
         if ($LASTEXITCODE -ne 0) {
             Write-Host "git clone failed (exit code $LASTEXITCODE)" -Level error
             return $false
         }
     } elseif ($Update) {
         Write-Host "  Updating repository..." -Level info
-        git -C $RepoDir pull --rebase 2>&1 | Out-Host
+        git -C "$RepoDir" pull --rebase 2>&1 | Out-Host
         if ($LASTEXITCODE -ne 0) {
             Write-Host "git pull failed (exit code $LASTEXITCODE)" -Level error
             return $false


### PR DESCRIPTION
## Summary

- **Problem**: The Windows PowerShell installer (`scripts/install.ps1`) silently swallows native command failures and closes the window before users can read error messages. `$LASTEXITCODE` from `npm`, `git`, and `pnpm` is never checked (PowerShell's `try/catch` doesn't catch native command exit codes), and the `$ERROR` colour variable collides with PowerShell's built-in `$Error` automatic variable.
- **Why it matters**: Users see a flash of red text then the window closes. They can't tell what failed or how to fix it. Silent failures mean broken installs go undiagnosed.
- **What changed**: Added `Wait-BeforeExit` pause on every error exit (interactive-only, skipped in CI), explicit `$LASTEXITCODE` checks after all native commands, renamed `$ERROR` to `$CLR_ERROR`, changed `Out-Null` to `Out-Host` so error output is visible, and fixed the `Write-Host` module qualifier from `Host` to `Utility`.
- **What did NOT change** (scope boundary): No changes to the install logic itself (npm/git/pnpm commands, package manager detection, PATH refresh). Only error handling, output visibility, and the pause-on-exit behaviour changed.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] Test
- [ ] CI / build
- [ ] Config / env

## Scope

- [ ] Gateway
- [ ] TUI / CLI
- [ ] Agents / subagents
- [ ] UI / web
- [ ] Security
- [ ] Media
- [x] Infrastructure

## Linked Issue/PR

- Closes #38054

## User-visible / Behaviour Changes

On Windows, the installer window now stays open on failure so users can read the error message. Press Enter to close. Silent native command failures (npm, git, pnpm) are now detected and reported. No change to successful installs or CI runs.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows 10/11
- Runtime: PowerShell 5.1+ or PowerShell 7+
- Relevant config: Node.js, npm, git on PATH (or missing for failure case)

### Steps

1. Uninstall Node.js or break npm (rename the binary)
2. Run `scripts/install.ps1`
3. Observe the error message

### Expected

Window stays open with a clear error message. User presses Enter to close.

### Actual (before fix)

Window flashes an error and closes immediately. User sees nothing.

## Evidence

- [x] Manual testing on Windows with broken npm, missing git, CI env var set
- [ ] Unit/integration test added or updated
- [ ] Trace/log output confirms fix
- [ ] Screenshot or recording (UI changes)

## Human Verification

- **Verified scenarios**: npm install failure (broken npm), git clone failure, successful install (no pause), CI mode ($env:CI set, no pause), piped invocation (`iwr | iex`, Read-Host reads from console host not pipeline)
- **Edge cases checked**: `$Error` variable collision (renamed to `$CLR_ERROR`), `Write-Host` module qualifier (`Microsoft.PowerShell.Utility` not `Host`), nested try/catch in `Wait-BeforeExit` so Read-Host errors never mask the original failure
- **What was NOT verified**: Every possible Windows PowerShell version (5.1 through 7.x). Tested on 5.1 and 7.4.

## Compatibility / Migration

- Backward compatible: Yes
- Config changes: None
- Migration needed: None

## Failure Recovery

- **Revert**: Revert this PR. No config or env changes to undo.
- **Files to restore**: `scripts/install.ps1`
- **Bad symptoms**: If `Wait-BeforeExit` somehow hangs in a non-interactive context, the install would block. The CI/redirection guards and try/catch prevent this, but if it happens, kill the PowerShell process.

## Risks and Mitigations

- Risk: `Read-Host` could hang in an unexpected non-interactive context not caught by the guards.
  - Mitigation: `Wait-BeforeExit` checks `$Host.Name`, `[Console]::IsInputRedirected`, `IsOutputRedirected`, `$env:CI`, and 3 other CI env vars. The entire block is wrapped in try/catch so any Read-Host error is silently swallowed.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.