### PR TITLE
fix(feishu): disable block streaming in reply dispatcher to prevent silent message loss

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -192,7 +192,7 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(imageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        timeout: 120_000,
+        data: expect.objectContaining({ image_type: "message" }),
       }),
     );
     expect(messageCreateMock).toHaveBeenCalledWith(
@@ -320,7 +320,6 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(imageGetMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { image_key: imageKey },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toEqual(Buffer.from("image-data"));
@@ -512,7 +511,6 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_audio_msg", file_key: "file_key_audio" },
         params: { type: "file" },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);
@@ -532,7 +530,6 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_img_msg", file_key: "img_key_1" },
         params: { type: "image" },
-        timeout: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -106,7 +106,6 @@ export async function downloadImageFeishu(params: {
 
   const response = await client.im.image.get({
     path: { image_key: normalizedImageKey },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   const buffer = await readFeishuResponseBuffer({
@@ -146,7 +145,6 @@ export async function downloadMessageResourceFeishu(params: {
   const response = await client.im.messageResource.get({
     path: { message_id: messageId, file_key: normalizedFileKey },
     params: { type },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   const buffer = await readFeishuResponseBuffer({
@@ -202,7 +200,6 @@ export async function uploadImageFeishu(params: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
       image: imageData as any,
     },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   // SDK v1.30+ returns data directly without code wrapper on success
@@ -277,7 +274,6 @@ export async function uploadFileFeishu(params: {
       file: fileData as any,
       ...(duration !== undefined && { duration }),
     },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   // SDK v1.30+ returns data directly without code wrapper on success

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -106,6 +106,17 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("sets disableBlockStreaming in replyOptions", () => {
+    const result = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+    });
+
+    expect(result.replyOptions.disableBlockStreaming).toBe(true);
+  });
+
   it("skips typing indicator when account typingIndicator is disabled", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -382,6 +382,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
+      disableBlockStreaming: true,
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
             if (!payload.text) {


### PR DESCRIPTION
## Summary
- **Problem**: When `blockStreamingDefault: "on"` (the default config after setup wizard), Feishu channels silently drop all replies. The agent generates responses but they never reach users.
- **Why it matters**: Affects ALL Feishu users on default config. Zero replies delivered — complete channel failure with no error logs.
- **What changed**: Added `disableBlockStreaming: true` to `replyOptions` in `createFeishuReplyDispatcher()`. Separately, removed deprecated per-request `timeout` from 4 SDK calls that cause TS2353 in CI.
- **What did NOT change**: Streaming cards, partial replies, typing indicators, media sending — all untouched and working.

## Change Type
- [x] Bug fix

## Scope
- [x] Channels (Feishu extension)

## Linked Issue
Closes #38258

## Root Cause

```
blockStreamingDefault: "on" (default after setup wizard)
  → pipeline calls onBlockReply → dispatcher.sendBlockReply()
  → feishu deliver({kind: "block"})
  → renderMode "auto" + no code blocks/tables → silently returns (no send)
  → pipeline marks didStream = true (callback returned without error)
  → shouldDropFinalPayloads = blockStreamingEnabled && didStream() = true
  → final reply array filtered to []
  → dispatcher.sendFinalReply() never called
  → user sees nothing
```

## Fix

**Commit 1** — `extensions/feishu/src/reply-dispatcher.ts` (1 line):
```diff
  replyOptions: {
    ...replyOptions,
    onModelSelected: prefixContext.onModelSelected,
+   disableBlockStreaming: true,
    onPartialReply: streamingEnabled ? ... : undefined,
  },
```

This matches the pattern used by 6+ other channels: bluebubbles, irc, mattermost (×3), nextcloud-talk.

**Commit 2** — `extensions/feishu/src/media.ts` (CI fix):
Removed `timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS` from 4 SDK calls. The Feishu SDK dropped per-request `timeout` from its types (TS2353). The timeout is already set at client construction via `httpTimeoutMs` in `createFeishuClient()`, so per-request timeout was redundant.

## Files to Review

| File | Lines | What |
|------|-------|------|
| `extensions/feishu/src/reply-dispatcher.ts` | +1 | `disableBlockStreaming: true` |
| `extensions/feishu/src/reply-dispatcher.test.ts` | +11 | Test asserting the property is set |
| `extensions/feishu/src/media.ts` | -4 | Remove deprecated `timeout` from SDK calls |
| `extensions/feishu/src/media.test.ts` | -4 | Update test assertions to match |

## Evidence
- [x] Unit test added (`reply-dispatcher.test.ts`: "sets disableBlockStreaming in replyOptions")
- [x] All 340 Feishu extension tests pass
- [x] `pnpm tsgo` — 0 errors
- [x] `pnpm check` — all lint/format checks pass
- [x] Tested by issue author: logs change from `dispatch complete (queuedFinal=false, replies=0)` to `dispatch complete (queuedFinal=true, replies=1)`

## Compatibility
- Backward compatible: yes
- Config changes: none
- Migration needed: none

## Risks and Mitigations
| Risk | Mitigation |
|------|-----------|
| Block streaming path no longer used for Feishu | Intentional — Feishu's deliver() already silently drops block chunks for non-code text. Streaming cards (`onPartialReply`) remain unaffected. |
| Removing `timeout` from SDK calls | `createFeishuClient()` sets `httpTimeoutMs: 120_000` at construction. Client-level timeout is the correct approach per SDK API. |

## Failure Recovery
- **Revert**: `git revert <sha>` — single property removal restores previous behavior
- **Bad symptoms**: Feishu replies not delivered → check `blockStreamingDefault` config value