### PR TITLE
fix(gateway): stop stale-socket restarts before first event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/Telegram stale-socket restart guard: only apply stale-socket restarts to channels that publish event-liveness timestamps, preventing Telegram providers from being misclassified as stale solely due to long uptime and avoiding restart/pairing storms after upgrade. (openclaw#38464)
 - Onboarding/headless Linux daemon probe hardening: treat `systemctl --user is-enabled` probe failures as non-fatal during daemon install flow so onboarding no longer crashes on SSH/headless VPS environments before showing install guidance. (#37297) Thanks @acarbajal-web.
 - Memory/QMD mcporter Windows spawn hardening: when `mcporter.cmd` launch fails with `spawn EINVAL`, retry via bare `mcporter` shell resolution so QMD recall can continue instead of falling back to builtin memory search. (#27402) Thanks @i0ivi0i.
 - Tools/web_search Brave language-code validation: align `search_lang` handling with Brave-supported codes (including `zh-hans`, `zh-hant`, `en-gb`, and `pt-br`), map common alias inputs (`zh`, `ja`) to valid Brave values, and reject unsupported codes before upstream requests to prevent 422 failures. (#37260) Thanks @heyanming.

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -1,6 +1,7 @@
 import type { Client } from "@buape/carbon";
 import type { GatewayPlugin } from "@buape/carbon/gateway";
 import { createArmableStallWatchdog } from "../../channels/transport/stall-watchdog.js";
+import { createConnectedChannelStatusPatch } from "../../gateway/channel-status-patches.js";
 import { danger } from "../../globals.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { attachDiscordGatewayLogging } from "../gateway-logging.js";
@@ -180,8 +181,7 @@ export async function runDiscordGatewayLifecycle(params: {
     let sawConnected = gateway?.isConnected === true;
     if (sawConnected) {
       pushStatus({
-        connected: true,
-        lastConnectedAt: at,
+        ...createConnectedChannelStatusPatch(at),
         lastDisconnect: null,
       });
     }
@@ -194,9 +194,7 @@ export async function runDiscordGatewayLifecycle(params: {
       const connectedAt = Date.now();
       reconnectStallWatchdog.disarm();
       pushStatus({
-        connected: true,
-        lastEventAt: connectedAt,
-        lastConnectedAt: connectedAt,
+        ...createConnectedChannelStatusPatch(connectedAt),
         lastDisconnect: null,
       });
       if (helloConnectedPollId) {
@@ -253,9 +251,7 @@ export async function runDiscordGatewayLifecycle(params: {
   if (gateway?.isConnected && !lifecycleStopping) {
     const at = Date.now();
     pushStatus({
-      connected: true,
-      lastEventAt: at,
-      lastConnectedAt: at,
+      ...createConnectedChannelStatusPatch(at),
       lastDisconnect: null,
     });
   }

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -36,6 +36,7 @@ import {
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "../../config/runtime-group-policy.js";
+import { createConnectedChannelStatusPatch } from "../../gateway/channel-status-patches.js";
 import { danger, logVerbose, shouldLogVerbose, warn } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createDiscordRetryRunner } from "../../infra/retry-policy.js";
@@ -752,7 +753,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
       botUserId && botUserName ? `${botUserId} (${botUserName})` : (botUserId ?? botUserName ?? "");
     runtime.log?.(`logged in to discord${botIdentity ? ` as ${botIdentity}` : ""}`);
     if (lifecycleGateway?.isConnected) {
-      opts.setStatus?.({ connected: true });
+      opts.setStatus?.(createConnectedChannelStatusPatch());
     }
 
     lifecycleStarted = true;

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -489,14 +489,32 @@ describe("channel-health-monitor", () => {
       await expectNoRestart(manager);
     });
 
-    it("restarts a channel that never received any event past the stale threshold", async () => {
+    it("restarts a channel that has seen no events since connect past the stale threshold", async () => {
       const now = Date.now();
       const manager = createSlackSnapshotManager(
         runningConnectedSlackAccount({
           lastStartAt: now - STALE_THRESHOLD - 60_000,
+          lastEventAt: now - STALE_THRESHOLD - 60_000,
         }),
       );
       await expectRestartedChannel(manager, "slack");
+    });
+
+    it("skips connected channels that do not report event liveness", async () => {
+      const now = Date.now();
+      const manager = createSnapshotManager({
+        telegram: {
+          default: {
+            running: true,
+            connected: true,
+            enabled: true,
+            configured: true,
+            lastStartAt: now - STALE_THRESHOLD - 60_000,
+            lastEventAt: null,
+          },
+        },
+      });
+      await expectNoRestart(manager);
     });
 
     it("respects custom staleEventThresholdMs", async () => {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -162,6 +162,25 @@ describe("evaluateChannelHealth", () => {
     );
     expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
   });
+
+  it("does not flag stale sockets without an active connected socket", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+        lastEventAt: 0,
+      },
+      {
+        channelId: "slack",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
 });
 
 describe("resolveChannelRestartReason", () => {

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -111,7 +111,7 @@ describe("evaluateChannelHealth", () => {
         enabled: true,
         configured: true,
         lastStartAt: 0,
-        lastEventAt: null,
+        lastEventAt: 0,
       },
       {
         channelId: "discord",
@@ -135,6 +135,26 @@ describe("evaluateChannelHealth", () => {
       },
       {
         channelId: "telegram",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
+
+  it("does not flag stale sockets for channels without event tracking", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 0,
+        lastEventAt: null,
+      },
+      {
+        channelId: "discord",
         now: 100_000,
         channelConnectGraceMs: 10_000,
         staleEventThresholdMs: 30_000,

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -181,6 +181,26 @@ describe("evaluateChannelHealth", () => {
     );
     expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
   });
+
+  it("ignores inherited event timestamps from a previous lifecycle", () => {
+    const evaluation = evaluateChannelHealth(
+      {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+        lastStartAt: 50_000,
+        lastEventAt: 10_000,
+      },
+      {
+        channelId: "slack",
+        now: 100_000,
+        channelConnectGraceMs: 10_000,
+        staleEventThresholdMs: 30_000,
+      },
+    );
+    expect(evaluation).toEqual({ healthy: true, reason: "healthy" });
+  });
 });
 
 describe("resolveChannelRestartReason", () => {

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -103,17 +103,10 @@ export function evaluateChannelHealth(
   // Skip stale-socket check for Telegram (long-polling mode). Each polling request
   // acts as a heartbeat, so the half-dead WebSocket scenario this check is designed
   // to catch does not apply to Telegram's long-polling architecture.
-  if (policy.channelId !== "telegram") {
-    if (snapshot.lastEventAt != null || snapshot.lastStartAt != null) {
-      const upSince = snapshot.lastStartAt ?? 0;
-      const upDuration = policy.now - upSince;
-      if (upDuration > policy.staleEventThresholdMs) {
-        const lastEvent = snapshot.lastEventAt ?? 0;
-        const eventAge = policy.now - lastEvent;
-        if (eventAge > policy.staleEventThresholdMs) {
-          return { healthy: false, reason: "stale-socket" };
-        }
-      }
+  if (policy.channelId !== "telegram" && snapshot.lastEventAt != null) {
+    const eventAge = policy.now - snapshot.lastEventAt;
+    if (eventAge > policy.staleEventThresholdMs) {
+      return { healthy: false, reason: "stale-socket" };
     }
   }
   return { healthy: true, reason: "healthy" };

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -103,7 +103,11 @@ export function evaluateChannelHealth(
   // Skip stale-socket check for Telegram (long-polling mode). Each polling request
   // acts as a heartbeat, so the half-dead WebSocket scenario this check is designed
   // to catch does not apply to Telegram's long-polling architecture.
-  if (policy.channelId !== "telegram" && snapshot.lastEventAt != null) {
+  if (
+    policy.channelId !== "telegram" &&
+    snapshot.connected === true &&
+    snapshot.lastEventAt != null
+  ) {
     const eventAge = policy.now - snapshot.lastEventAt;
     if (eventAge > policy.staleEventThresholdMs) {
       return { healthy: false, reason: "stale-socket" };

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -108,6 +108,9 @@ export function evaluateChannelHealth(
     snapshot.connected === true &&
     snapshot.lastEventAt != null
   ) {
+    if (lastStartAt != null && snapshot.lastEventAt < lastStartAt) {
+      return { healthy: true, reason: "healthy" };
+    }
     const eventAge = policy.now - snapshot.lastEventAt;
     if (eventAge > policy.staleEventThresholdMs) {
       return { healthy: false, reason: "stale-socket" };

--- a/src/gateway/channel-status-patches.test.ts
+++ b/src/gateway/channel-status-patches.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { createConnectedChannelStatusPatch } from "./channel-status-patches.js";
+
+describe("createConnectedChannelStatusPatch", () => {
+  it("uses one timestamp for connected event-liveness state", () => {
+    expect(createConnectedChannelStatusPatch(1234)).toEqual({
+      connected: true,
+      lastConnectedAt: 1234,
+      lastEventAt: 1234,
+    });
+  });
+});

--- a/src/gateway/channel-status-patches.ts
+++ b/src/gateway/channel-status-patches.ts
@@ -1,0 +1,15 @@
+export type ConnectedChannelStatusPatch = {
+  connected: true;
+  lastConnectedAt: number;
+  lastEventAt: number;
+};
+
+export function createConnectedChannelStatusPatch(
+  at: number = Date.now(),
+): ConnectedChannelStatusPatch {
+  return {
+    connected: true,
+    lastConnectedAt: at,
+    lastEventAt: at,
+  };
+}

--- a/src/slack/monitor/provider.reconnect.test.ts
+++ b/src/slack/monitor/provider.reconnect.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { __testing } from "./provider.js";
 
 class FakeEmitter {
@@ -22,6 +22,22 @@ class FakeEmitter {
 }
 
 describe("slack socket reconnect helpers", () => {
+  it("seeds event liveness when socket mode connects", () => {
+    const setStatus = vi.fn();
+
+    __testing.publishSlackConnectedStatus(setStatus);
+
+    expect(setStatus).toHaveBeenCalledTimes(1);
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connected: true,
+        lastConnectedAt: expect.any(Number),
+        lastEventAt: expect.any(Number),
+        lastError: null,
+      }),
+    );
+  });
+
   it("resolves disconnect waiter on socket disconnect event", async () => {
     const client = new FakeEmitter();
     const app = { receiver: { client } };

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -18,6 +18,7 @@ import {
 } from "../../config/runtime-group-policy.js";
 import type { SessionScope } from "../../config/sessions.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
+import { createConnectedChannelStatusPatch } from "../../gateway/channel-status-patches.js";
 import { warn } from "../../globals.js";
 import { computeBackoff, sleepWithAbort } from "../../infra/backoff.js";
 import { installRequestBodyLimitGuard } from "../../infra/http-body.js";
@@ -63,6 +64,17 @@ function parseApiAppIdFromAppToken(raw?: string) {
   }
   const match = /^xapp-\d-([a-z0-9]+)-/i.exec(token);
   return match?.[1]?.toUpperCase();
+}
+
+function publishSlackConnectedStatus(setStatus?: (next: Record<string, unknown>) => void) {
+  if (!setStatus) {
+    return;
+  }
+  const now = Date.now();
+  setStatus({
+    ...createConnectedChannelStatusPatch(now),
+    lastError: null,
+  });
 }
 
 export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
@@ -390,6 +402,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
         try {
           await app.start();
           reconnectAttempts = 0;
+          publishSlackConnectedStatus(opts.setStatus);
           runtime.log?.("slack socket mode connected");
         } catch (err) {
           // Auth errors (account_inactive, invalid_auth, etc.) are permanent —
@@ -481,6 +494,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
 export { isNonRecoverableSlackAuthError } from "./reconnect-policy.js";
 
 export const __testing = {
+  publishSlackConnectedStatus,
   resolveSlackRuntimeGroupPolicy: resolveOpenProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   getSocketEmitter,

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -211,10 +211,7 @@ export async function monitorWebChannel(
       },
     });
 
-    const connectedStatus = createConnectedChannelStatusPatch();
-    status.connected = connectedStatus.connected;
-    status.lastConnectedAt = connectedStatus.lastConnectedAt;
-    status.lastEventAt = connectedStatus.lastEventAt;
+    Object.assign(status, createConnectedChannelStatusPatch());
     status.lastError = null;
     emitStatus();
 

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -5,6 +5,7 @@ import { DEFAULT_GROUP_HISTORY_LIMIT } from "../../auto-reply/reply/history.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import { waitForever } from "../../cli/wait.js";
 import { loadConfig } from "../../config/config.js";
+import { createConnectedChannelStatusPatch } from "../../gateway/channel-status-patches.js";
 import { logVerbose } from "../../globals.js";
 import { formatDurationPrecise } from "../../infra/format-time/format-duration.ts";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
@@ -210,9 +211,10 @@ export async function monitorWebChannel(
       },
     });
 
-    status.connected = true;
-    status.lastConnectedAt = Date.now();
-    status.lastEventAt = status.lastConnectedAt;
+    const connectedStatus = createConnectedChannelStatusPatch();
+    status.connected = connectedStatus.connected;
+    status.lastConnectedAt = connectedStatus.lastConnectedAt;
+    status.lastEventAt = connectedStatus.lastEventAt;
     status.lastError = null;
     emitStatus();
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: gateway stale-socket health checks restarted connected channels that had never published event-liveness timestamps, which caused Telegram reconnect storms and duplicate delivery loops.
- Why it matters: quiet or freshly reconnected channels could be recycled indefinitely before their first real event, destabilizing sessions and creating duplicate downstream work.
- What changed: stale-socket recovery now requires explicit event-liveness tracking, and connect-time liveness seeding is centralized in a shared helper used by Slack, Discord, and web channel startup paths.
- What did NOT change (scope boundary): auth, transport retry policy, message parsing, and non-stale health outcomes are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38464
- Related #

## User-visible / Behavior Changes

Telegram-shaped channels no longer get restarted as `stale-socket` before they have published any event-liveness timestamp. Slack, Discord, and web channels now seed connect-time liveness consistently so stale-socket recovery still works after a real connection is established.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js via `pnpm`
- Model/provider: N/A
- Integration/channel (if any): Gateway health monitor; Telegram/Slack/Discord/Web providers
- Relevant config (redacted): default local test config; no secret/config changes required

### Steps

1. Start a channel provider that reports `connected: true` before receiving its first inbound event.
2. Let the channel health monitor evaluate a long-lived idle connection.
3. Observe whether the provider is restarted as `stale-socket` without any recorded event-liveness.

### Expected

- Channels without event-liveness tracking stay healthy, while channels that do track liveness can still be restarted when they go stale.

### Actual

- Before the fix, connected channels with `lastEventAt: null` could be restarted repeatedly, causing reconnect churn and duplicate delivery loops.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused stale-socket policy and monitor regressions, shared connect-time liveness helper coverage, Slack connect-time status seeding, full repo test suite.
- Edge cases checked: no-event channels remain healthy; Slack/Discord/web connected paths still seed stale-socket liveness; `lastError` clearing remains intact for Slack connect.
- What you did **not** verify: live production channel sessions outside automated tests.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commits `0d6110e08eac92a42124800b90a9138637f2c367` and `e5af30283abf051964a1b5f0eb8a4a734e617d08` from the branch.
- Files/config to restore: `src/gateway/channel-health-policy.ts`, provider status publishers, and `src/gateway/channel-status-patches.ts`.
- Known bad symptoms reviewers should watch for: stale-socket restarts stop firing for connected channels that should recover, or channels begin reconnecting before their first inbound event again.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: a provider path that should participate in stale-socket recovery might bypass the shared connect-time liveness helper.
  - Mitigation: the helper is covered by a focused test and adopted in the currently touched Slack, Discord, and web connected paths.
