### PR TITLE
fix(telegram): prevent duplicate messages in DM streaming

### DIFF
--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -57,7 +57,10 @@ export {
   isMessagingToolDuplicate,
   isMessagingToolDuplicateNormalized,
   normalizeTextForComparison,
+  isRecentlyDelivered,
+  recordDeliveredText,
 } from "./pi-embedded-helpers/messaging-dedupe.js";
+export type { RecentDeliveredEntry } from "./pi-embedded-helpers/messaging-dedupe.js";
 
 export { pickFallbackThinkingLevel } from "./pi-embedded-helpers/thinking.js";
 

--- a/src/agents/pi-embedded-helpers/messaging-dedupe.test.ts
+++ b/src/agents/pi-embedded-helpers/messaging-dedupe.test.ts
@@ -24,9 +24,18 @@ describe("cross-turn dedup", () => {
       expect(hash).toBe("hello world!");
     });
 
-    it("truncates at 200 chars", () => {
+    it("includes length and full-text hash for strings over 200 chars", () => {
       const long = "a".repeat(300);
-      expect(buildDeliveredTextHash(long).length).toBe(200);
+      const hash = buildDeliveredTextHash(long);
+      expect(hash).toContain("|300|");
+      expect(hash.startsWith("a".repeat(200))).toBe(true);
+    });
+
+    it("produces different hashes for texts with same prefix but different tails", () => {
+      const base = "x".repeat(200);
+      const textA = base + " ending alpha with more content here";
+      const textB = base + " ending beta with different content";
+      expect(buildDeliveredTextHash(textA)).not.toBe(buildDeliveredTextHash(textB));
     });
 
     it("returns empty for very short text", () => {

--- a/src/agents/pi-embedded-helpers/messaging-dedupe.test.ts
+++ b/src/agents/pi-embedded-helpers/messaging-dedupe.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDeliveredTextHash,
+  isRecentlyDelivered,
+  normalizeTextForComparison,
+  recordDeliveredText,
+  type RecentDeliveredEntry,
+} from "./messaging-dedupe.js";
+
+describe("normalizeTextForComparison", () => {
+  it("lowercases and trims", () => {
+    expect(normalizeTextForComparison("  Hello World  ")).toBe("hello world");
+  });
+
+  it("collapses whitespace", () => {
+    expect(normalizeTextForComparison("hello   world")).toBe("hello world");
+  });
+});
+
+describe("cross-turn dedup", () => {
+  describe("buildDeliveredTextHash", () => {
+    it("returns normalized prefix up to 200 chars", () => {
+      const hash = buildDeliveredTextHash("Hello World!");
+      expect(hash).toBe("hello world!");
+    });
+
+    it("truncates at 200 chars", () => {
+      const long = "a".repeat(300);
+      expect(buildDeliveredTextHash(long).length).toBe(200);
+    });
+
+    it("returns empty for very short text", () => {
+      expect(buildDeliveredTextHash("hi")).toBe("hi");
+    });
+  });
+
+  describe("isRecentlyDelivered", () => {
+    it("returns false for empty cache", () => {
+      expect(isRecentlyDelivered("Hello world test message", [])).toBe(false);
+    });
+
+    it("returns true when text was recently recorded", () => {
+      const cache: RecentDeliveredEntry[] = [];
+      const now = Date.now();
+      recordDeliveredText("Hello world test message", cache, now);
+      expect(isRecentlyDelivered("Hello world test message", cache, now + 1000)).toBe(true);
+    });
+
+    it("returns false after TTL expires", () => {
+      const cache: RecentDeliveredEntry[] = [];
+      const now = Date.now();
+      recordDeliveredText("Hello world test message", cache, now);
+      // 1 hour + 1ms later
+      expect(isRecentlyDelivered("Hello world test message", cache, now + 3_600_001)).toBe(false);
+    });
+
+    it("returns false for text shorter than MIN_DUPLICATE_TEXT_LENGTH", () => {
+      const cache: RecentDeliveredEntry[] = [];
+      recordDeliveredText("short", cache);
+      expect(isRecentlyDelivered("short", cache)).toBe(false);
+    });
+
+    it("detects duplicates with different whitespace/casing", () => {
+      const cache: RecentDeliveredEntry[] = [];
+      const now = Date.now();
+      recordDeliveredText("  Hello   World  Test  Message  ", cache, now);
+      expect(isRecentlyDelivered("hello world test message", cache, now)).toBe(true);
+    });
+  });
+
+  describe("recordDeliveredText", () => {
+    it("evicts expired entries on record", () => {
+      const cache: RecentDeliveredEntry[] = [];
+      const now = Date.now();
+      recordDeliveredText("First message that is long enough", cache, now);
+      // Record second much later (> TTL)
+      recordDeliveredText("Second message that is long enough", cache, now + 3_700_000);
+      // First should be evicted
+      expect(cache.length).toBe(1);
+      expect(cache[0].hash).toContain("second");
+    });
+
+    it("caps at RECENT_DELIVERED_MAX entries", () => {
+      const cache: RecentDeliveredEntry[] = [];
+      const now = Date.now();
+      for (let i = 0; i < 25; i++) {
+        recordDeliveredText(`Unique message number ${i} with enough length`, cache, now + i);
+      }
+      expect(cache.length).toBe(20);
+    });
+
+    it("updates timestamp for duplicate hash instead of adding", () => {
+      const cache: RecentDeliveredEntry[] = [];
+      const now = Date.now();
+      recordDeliveredText("Same message repeated in session", cache, now);
+      recordDeliveredText("Same message repeated in session", cache, now + 5000);
+      expect(cache.length).toBe(1);
+      expect(cache[0].timestamp).toBe(now + 5000);
+    });
+  });
+});

--- a/src/agents/pi-embedded-helpers/messaging-dedupe.ts
+++ b/src/agents/pi-embedded-helpers/messaging-dedupe.ts
@@ -1,6 +1,87 @@
 const MIN_DUPLICATE_TEXT_LENGTH = 10;
 
 /**
+ * Maximum number of recent delivered text hashes to retain for cross-turn
+ * deduplication.  Keeps memory bounded while covering the typical window
+ * where context compaction may cause the model to re-emit a previous reply.
+ */
+const RECENT_DELIVERED_MAX = 20;
+
+/**
+ * TTL for entries in the cross-turn dedup cache (1 hour).
+ * After this period the entry is evicted and the same text can be delivered
+ * again (which is desirable for intentionally repeated content).
+ */
+const RECENT_DELIVERED_TTL_MS = 60 * 60_000;
+
+export type RecentDeliveredEntry = {
+  hash: string;
+  timestamp: number;
+};
+
+/**
+ * Build a lightweight hash key from the first 200 normalised characters of
+ * a delivered assistant text.  Using a prefix keeps comparison fast while
+ * still catching the most common compaction-replay duplicates (identical
+ * opening paragraphs).
+ */
+export function buildDeliveredTextHash(text: string): string {
+  const normalized = normalizeTextForComparison(text);
+  return normalized.slice(0, 200);
+}
+
+/**
+ * Check whether `text` was recently delivered (cross-turn).
+ */
+export function isRecentlyDelivered(
+  text: string,
+  recentDelivered: RecentDeliveredEntry[],
+  now?: number,
+): boolean {
+  const hash = buildDeliveredTextHash(text);
+  if (!hash || hash.length < MIN_DUPLICATE_TEXT_LENGTH) {
+    return false;
+  }
+  const currentTime = now ?? Date.now();
+  return recentDelivered.some(
+    (entry) =>
+      currentTime - entry.timestamp < RECENT_DELIVERED_TTL_MS && entry.hash === hash,
+  );
+}
+
+/**
+ * Record a delivered text in the rolling cache.
+ */
+export function recordDeliveredText(
+  text: string,
+  recentDelivered: RecentDeliveredEntry[],
+  now?: number,
+): void {
+  const hash = buildDeliveredTextHash(text);
+  if (!hash || hash.length < MIN_DUPLICATE_TEXT_LENGTH) {
+    return;
+  }
+  const currentTime = now ?? Date.now();
+  // Evict expired entries.
+  for (let i = recentDelivered.length - 1; i >= 0; i--) {
+    if (currentTime - recentDelivered[i].timestamp >= RECENT_DELIVERED_TTL_MS) {
+      recentDelivered.splice(i, 1);
+    }
+  }
+  // Avoid duplicate entries for the same hash.
+  const existing = recentDelivered.findIndex((e) => e.hash === hash);
+  if (existing >= 0) {
+    recentDelivered[existing].timestamp = currentTime;
+    return;
+  }
+  recentDelivered.push({ hash, timestamp: currentTime });
+  // Trim oldest if over capacity.
+  while (recentDelivered.length > RECENT_DELIVERED_MAX) {
+    recentDelivered.shift();
+  }
+}
+
+/**
  * Normalize text for duplicate comparison.
  * - Trims whitespace
  * - Lowercases

--- a/src/agents/pi-embedded-helpers/messaging-dedupe.ts
+++ b/src/agents/pi-embedded-helpers/messaging-dedupe.ts
@@ -44,8 +44,7 @@ export function isRecentlyDelivered(
   }
   const currentTime = now ?? Date.now();
   return recentDelivered.some(
-    (entry) =>
-      currentTime - entry.timestamp < RECENT_DELIVERED_TTL_MS && entry.hash === hash,
+    (entry) => currentTime - entry.timestamp < RECENT_DELIVERED_TTL_MS && entry.hash === hash,
   );
 }
 

--- a/src/agents/pi-embedded-helpers/messaging-dedupe.ts
+++ b/src/agents/pi-embedded-helpers/messaging-dedupe.ts
@@ -20,14 +20,26 @@ export type RecentDeliveredEntry = {
 };
 
 /**
- * Build a lightweight hash key from the first 200 normalised characters of
- * a delivered assistant text.  Using a prefix keeps comparison fast while
- * still catching the most common compaction-replay duplicates (identical
- * opening paragraphs).
+ * Build a collision-resistant hash from the full normalised text of a
+ * delivered assistant message.  Uses a fast non-cryptographic approach:
+ * the first 200 normalised chars (for quick prefix screening) combined
+ * with the total length and a simple 53-bit numeric hash of the full
+ * string.  This avoids false positives when two responses share the same
+ * opening paragraph but diverge later.
  */
 export function buildDeliveredTextHash(text: string): string {
   const normalized = normalizeTextForComparison(text);
-  return normalized.slice(0, 200);
+  if (normalized.length <= 200) {
+    return normalized;
+  }
+  // 53-bit FNV-1a-inspired hash (fits in a JS safe integer).
+  let h = 0x811c9dc5;
+  for (let i = 0; i < normalized.length; i++) {
+    h ^= normalized.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  // Combine prefix + length + full-text hash for uniqueness.
+  return `${normalized.slice(0, 200)}|${normalized.length}|${(h >>> 0).toString(36)}`;
 }
 
 /**

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -4,6 +4,7 @@ import type { ReasoningLevel } from "../auto-reply/thinking.js";
 import type { InlineCodeState } from "../markdown/code-spans.js";
 import type { HookRunner } from "../plugins/hooks.js";
 import type { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
+import type { RecentDeliveredEntry } from "./pi-embedded-helpers/messaging-dedupe.js";
 import type { MessagingToolSend } from "./pi-embedded-messaging.js";
 import type {
   BlockReplyChunking,
@@ -68,6 +69,7 @@ export type EmbeddedPiSubscribeState = {
   compactionRetryPromise: Promise<void> | null;
   unsubscribed: boolean;
 
+  recentDeliveredTexts: RecentDeliveredEntry[];
   messagingToolSentTexts: string[];
   messagingToolSentTextsNormalized: string[];
   messagingToolSentTargets: MessagingToolSend[];

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -106,12 +106,20 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   const partialReplyDirectiveAccumulator = createStreamingDirectiveAccumulator();
   const emitBlockReplySafely = (
     payload: Parameters<NonNullable<SubscribeEmbeddedPiSessionParams["onBlockReply"]>>[0],
+    opts?: { sourceText?: string },
   ) => {
     if (!params.onBlockReply) {
       return;
     }
     void Promise.resolve()
       .then(() => params.onBlockReply?.(payload))
+      .then(() => {
+        // Record in cross-turn dedup cache only after successful delivery.
+        // Recording before send would suppress retries on transient failures.
+        if (opts?.sourceText) {
+          recordDeliveredText(opts.sourceText, state.recentDeliveredTexts);
+        }
+      })
       .catch((err) => {
         log.warn(`block reply callback failed: ${String(err)}`);
       });
@@ -516,8 +524,10 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.lastBlockReplyText = chunk;
     assistantTexts.push(chunk);
     rememberAssistantText(chunk);
-    recordDeliveredText(chunk, state.recentDeliveredTexts);
     if (!params.onBlockReply) {
+      // No block reply callback — text is accumulated for final delivery.
+      // Record now since there's no async send that could fail.
+      recordDeliveredText(chunk, state.recentDeliveredTexts);
       return;
     }
     const splitResult = replyDirectiveAccumulator.consume(chunk);
@@ -536,14 +546,17 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
       return;
     }
-    emitBlockReplySafely({
-      text: cleanedText,
-      mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
-      audioAsVoice,
-      replyToId,
-      replyToTag,
-      replyToCurrent,
-    });
+    emitBlockReplySafely(
+      {
+        text: cleanedText,
+        mediaUrls: mediaUrls?.length ? mediaUrls : undefined,
+        audioAsVoice,
+        replyToId,
+        replyToTag,
+        replyToCurrent,
+      },
+      { sourceText: chunk },
+    );
   };
 
   const consumeReplyDirectives = (text: string, options?: { final?: boolean }) =>

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -202,6 +202,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
           text,
         );
         rememberAssistantText(text);
+        recordDeliveredText(text, state.recentDeliveredTexts);
       } else {
         pushAssistantText(text);
       }
@@ -515,6 +516,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.lastBlockReplyText = chunk;
     assistantTexts.push(chunk);
     rememberAssistantText(chunk);
+    recordDeliveredText(chunk, state.recentDeliveredTexts);
     if (!params.onBlockReply) {
       return;
     }

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -9,8 +9,11 @@ import { buildCodeSpanIndex, createInlineCodeState } from "../markdown/code-span
 import { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
 import {
   isMessagingToolDuplicateNormalized,
+  isRecentlyDelivered,
   normalizeTextForComparison,
+  recordDeliveredText,
 } from "./pi-embedded-helpers.js";
+import type { RecentDeliveredEntry } from "./pi-embedded-helpers.js";
 import { createEmbeddedPiSessionEventHandler } from "./pi-embedded-subscribe.handlers.js";
 import type {
   EmbeddedPiSubscribeContext,
@@ -70,6 +73,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     compactionRetryReject: undefined,
     compactionRetryPromise: null,
     unsubscribed: false,
+    recentDeliveredTexts: [] as RecentDeliveredEntry[],
     messagingToolSentTexts: [],
     messagingToolSentTextsNormalized: [],
     messagingToolSentTargets: [],
@@ -148,15 +152,21 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   };
 
   const shouldSkipAssistantText = (text: string) => {
-    if (state.lastAssistantTextMessageIndex !== state.assistantMessageIndex) {
-      return false;
+    // Same-turn dedup (existing behaviour).
+    if (state.lastAssistantTextMessageIndex === state.assistantMessageIndex) {
+      const trimmed = text.trimEnd();
+      if (trimmed && trimmed === state.lastAssistantTextTrimmed) {
+        return true;
+      }
+      const normalized = normalizeTextForComparison(text);
+      if (normalized.length > 0 && normalized === state.lastAssistantTextNormalized) {
+        return true;
+      }
     }
-    const trimmed = text.trimEnd();
-    if (trimmed && trimmed === state.lastAssistantTextTrimmed) {
-      return true;
-    }
-    const normalized = normalizeTextForComparison(text);
-    if (normalized.length > 0 && normalized === state.lastAssistantTextNormalized) {
+    // Cross-turn dedup: catch duplicates caused by context compaction replaying
+    // the same assistant text in a new turn.  Uses a rolling hash cache with a
+    // 1-hour TTL so intentionally repeated content still goes through eventually.
+    if (isRecentlyDelivered(text, state.recentDeliveredTexts)) {
       return true;
     }
     return false;
@@ -171,6 +181,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     }
     assistantTexts.push(text);
     rememberAssistantText(text);
+    // Record in cross-turn cache so post-compaction replays are caught.
+    recordDeliveredText(text, state.recentDeliveredTexts);
   };
 
   const finalizeAssistantTexts = (args: {

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -427,8 +427,25 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           `telegram: preview final too long for edit (${text.length} > ${params.draftMaxChars}); falling back to standard send`,
         );
       }
+      // Capture preview message id before stopping so we can clean it up
+      // after fallback send to avoid duplicates.
+      const previewMessageIdBeforeFallback = lane.stream?.messageId();
       await params.stopDraftLane(lane);
+      // After stop(), the stream may have flushed/created a visible preview.
+      const previewMessageIdAfterStop = previewMessageIdBeforeFallback ?? lane.stream?.messageId();
       const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
+      // Clean up the orphaned preview message to prevent the user from seeing
+      // both the preview and the final message (the core duplicate-message bug
+      // in Telegram DM streaming).
+      if (delivered && typeof previewMessageIdAfterStop === "number") {
+        try {
+          await params.deletePreviewMessage(previewMessageIdAfterStop);
+        } catch (err) {
+          params.log(
+            `telegram: ${laneName} fallback send orphaned preview cleanup failed (${previewMessageIdAfterStop}): ${String(err)}`,
+          );
+        }
+      }
       return delivered ? "sent" : "skipped";
     }
 

--- a/src/telegram/lane-delivery.ts
+++ b/src/telegram/lane-delivery.ts
@@ -437,6 +437,12 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       // Clean up the orphaned preview message to prevent the user from seeing
       // both the preview and the final message (the core duplicate-message bug
       // in Telegram DM streaming).
+      // Note: cleanup is only performed when the fallback send succeeds
+      // (delivered === true).  When the send fails, the preview is kept so the
+      // user still sees *something*.  This differs from the archived-preview
+      // path in consumeArchivedAnswerPreviewForFinal which may delete even on
+      // send failure — that path deals with boundary-rotated previews that are
+      // stale by definition.
       if (delivered && typeof previewMessageIdAfterStop === "number") {
         try {
           await params.deletePreviewMessage(previewMessageIdAfterStop);


### PR DESCRIPTION
## Problem

Telegram DM users see duplicate messages: the same reply appears twice, then one copy may disappear after ~20 seconds. This is a known regression in v2026.3.2 affecting multiple users (#37702, #38365, #38434, #33308, #33453).

**Root causes identified:**

### 1. Cross-turn dedup resets after context compaction (#37702)

`shouldSkipAssistantText()` in `pi-embedded-subscribe.ts` only deduplicates within the same `assistantMessageIndex`. After context compaction, the index resets, so when the model re-emits the same text from the compaction summary, it bypasses the dedup check and gets delivered as a new Telegram message.

### 2. Orphaned preview on fallback send (#38365)

When the answer lane in `lane-delivery.ts` fails to finalize a preview via edit and falls back to `sendPayload()`, the previously-flushed preview message is left visible. The user sees both the preview and the final message — the classic "message appears twice, one disappears" behavior.

## Solution

### Fix 1: Rolling hash cache for cross-turn dedup

Added `recentDeliveredTexts` — a bounded rolling cache (max 20 entries, 1h TTL) that persists across assistant message turns within a session. Before delivering text, the first 200 normalized characters are compared against recently delivered hashes. Matches are skipped.

**Files changed:**
- `src/agents/pi-embedded-helpers/messaging-dedupe.ts` — new exports: `buildDeliveredTextHash`, `isRecentlyDelivered`, `recordDeliveredText`, `RecentDeliveredEntry`
- `src/agents/pi-embedded-subscribe.ts` — `shouldSkipAssistantText()` now checks cross-turn cache; `pushAssistantText()` records to cache

### Fix 2: Delete orphaned preview after fallback send

The fallback send path now captures the preview message ID before stopping the draft lane and deletes it after successful delivery.

**Files changed:**
- `src/telegram/lane-delivery.ts` — capture preview ID before `stopDraftLane()`, delete after successful `sendPayload()`

## Tests

Added `src/agents/pi-embedded-helpers/messaging-dedupe.test.ts` covering:
- Hash building and truncation
- Cross-turn duplicate detection
- TTL expiration
- Whitespace/casing normalization
- Cache eviction and capacity limits
- Timestamp update on re-record

## Related Issues

Closes #37702, #38365
Related: #38434, #33308, #33453, #33592, #37697, #30316