### PR TITLE
fix(gateway): use agents.list hot-reload rule for per-agent heartbeat changes

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -65,7 +65,7 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     kind: "hot",
     actions: ["restart-heartbeat"],
   },
-  { prefix: "agent.heartbeat", kind: "hot", actions: ["restart-heartbeat"] },
+  { prefix: "agents.list", kind: "hot", actions: ["restart-heartbeat", "restart-cron"] },
   { prefix: "cron", kind: "hot", actions: ["restart-cron"] },
   {
     prefix: "browser",
@@ -83,7 +83,6 @@ const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
   { prefix: "tools", kind: "none" },
   { prefix: "bindings", kind: "none" },
   { prefix: "audio", kind: "none" },
-  { prefix: "agent", kind: "none" },
   { prefix: "routing", kind: "none" },
   { prefix: "messages", kind: "none" },
   { prefix: "session", kind: "none" },

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -167,6 +167,41 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.noopPaths).toEqual([]);
   });
 
+  it("restarts heartbeat and cron when agents.list changes", () => {
+    const plan = buildGatewayReloadPlan(["agents.list"]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartHeartbeat).toBe(true);
+    expect(plan.restartCron).toBe(true);
+    expect(plan.hotReasons).toContain("agents.list");
+  });
+
+  it("restarts heartbeat and cron when per-agent heartbeat model changes via agents.list diff", () => {
+    const prev = {
+      agents: {
+        defaults: { heartbeat: { every: "30m" } },
+        list: [
+          { id: "main", default: true },
+          { id: "ops", heartbeat: { model: "openai/gpt-4o-mini" } },
+        ],
+      },
+    };
+    const next = {
+      agents: {
+        defaults: { heartbeat: { every: "30m" } },
+        list: [
+          { id: "main", default: true },
+          { id: "ops", heartbeat: { model: "anthropic/claude-haiku-4-5" } },
+        ],
+      },
+    };
+    const changedPaths = diffConfigPaths(prev, next);
+    expect(changedPaths).toContain("agents.list");
+    const plan = buildGatewayReloadPlan(changedPaths);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.restartHeartbeat).toBe(true);
+    expect(plan.restartCron).toBe(true);
+  });
+
   it("hot-reloads health monitor when channelHealthCheckMinutes changes", () => {
     const plan = buildGatewayReloadPlan(["gateway.channelHealthCheckMinutes"]);
     expect(plan.restartGateway).toBe(false);


### PR DESCRIPTION
Replace dead agent.heartbeat reload rule with agents.list so per-agent heartbeat/cron config changes trigger hot reload. Remove unused agent no-op tail rule. Adds tests.