### PR TITLE
fix(agents): follow symlinks pointing outside workspace boundary for bootstrap files

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -191,6 +191,77 @@ describe("loadWorkspaceBootstrapFiles", () => {
     expect(getMemoryEntries(files)).toHaveLength(0);
   });
 
+  it("follows symlinks pointing outside the workspace boundary", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-symlink-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const sharedDir = path.join(rootDir, "workspace-shared");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(sharedDir, { recursive: true });
+      const sharedSoul = path.join(sharedDir, "SOUL.md");
+      await fs.writeFile(sharedSoul, "shared soul content", "utf-8");
+      await fs.symlink(sharedSoul, path.join(workspaceDir, "SOUL.md"));
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir);
+      const soul = files.find((file) => file.name === "SOUL.md");
+      expect(soul?.missing).toBe(false);
+      expect(soul?.content).toBe("shared soul content");
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("follows relative symlinks to sibling workspace directories", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-symlink-rel-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const sharedDir = path.join(rootDir, "workspace-shared");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(sharedDir, { recursive: true });
+      await fs.writeFile(path.join(sharedDir, "AGENTS.md"), "shared agents", "utf-8");
+      // Create a relative symlink: workspace/AGENTS.md -> ../workspace-shared/AGENTS.md
+      await fs.symlink(
+        path.join("..", "workspace-shared", "AGENTS.md"),
+        path.join(workspaceDir, "AGENTS.md"),
+      );
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir);
+      const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
+      expect(agents?.missing).toBe(false);
+      expect(agents?.content).toBe("shared agents");
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports dangling symlinks as missing", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-symlink-dangle-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      // Symlink to a non-existent target
+      await fs.symlink(
+        path.join(rootDir, "nonexistent", "SOUL.md"),
+        path.join(workspaceDir, "SOUL.md"),
+      );
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir);
+      const soul = files.find((file) => file.name === "SOUL.md");
+      expect(soul?.missing).toBe(true);
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
   it("treats hardlinked bootstrap aliases as missing", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -53,6 +53,35 @@ function workspaceFileIdentity(stat: syncFs.Stats, canonicalPath: string): strin
   return `${canonicalPath}|${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}`;
 }
 
+/**
+ * Attempt to read a workspace file that is a symlink pointing outside the
+ * workspace boundary.  Returns the file content when the symlink target is a
+ * regular file within the size budget, or `undefined` when the path is not a
+ * symlink or any check fails.
+ */
+async function tryReadSymlinkedWorkspaceFile(
+  filePath: string,
+): Promise<{ content: string; stat: syncFs.Stats; realPath: string } | undefined> {
+  try {
+    const lstat = await fs.lstat(filePath);
+    if (!lstat.isSymbolicLink()) {
+      return undefined;
+    }
+    const realPath = await fs.realpath(filePath);
+    const stat = await fs.stat(realPath);
+    if (!stat.isFile()) {
+      return undefined;
+    }
+    if (stat.size > MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES) {
+      return undefined;
+    }
+    const content = await fs.readFile(realPath, "utf-8");
+    return { content, stat: stat, realPath };
+  } catch {
+    return undefined;
+  }
+}
+
 async function readWorkspaceFileWithGuards(params: {
   filePath: string;
   workspaceDir: string;
@@ -64,6 +93,19 @@ async function readWorkspaceFileWithGuards(params: {
     maxBytes: MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
   });
   if (!opened.ok) {
+    // Symlink targets outside the workspace boundary are rejected by the
+    // boundary-path resolver.  For workspace bootstrap files this is a
+    // legitimate use-case (e.g. shared SOUL.md across workspaces via
+    // symlink), so we fall back to resolving the symlink and reading the
+    // target directly while still enforcing the size limit.
+    if (opened.reason === "path" || opened.reason === "validation") {
+      const symlinkResult = await tryReadSymlinkedWorkspaceFile(params.filePath);
+      if (symlinkResult !== undefined) {
+        const identity = workspaceFileIdentity(symlinkResult.stat, symlinkResult.realPath);
+        workspaceFileCache.set(params.filePath, { content: symlinkResult.content, identity });
+        return { ok: true, content: symlinkResult.content };
+      }
+    }
     workspaceFileCache.delete(params.filePath);
     return opened;
   }


### PR DESCRIPTION
## Summary

- **Problem:** Workspace bootstrap files (e.g. `SOUL.md`, `AGENTS.md`) that are symlinked from outside the workspace directory are rejected by boundary checks and injected as `[MISSING]`.
- **Why it matters:** Users cannot share configuration files across workspaces using symlinks, causing agents to silently lose their persona/identity on session start.
- **What changed:** Added a symlink fallback in `readWorkspaceFileWithGuards` to resolve and read symlink targets while still enforcing the file size limit.
- **What did NOT change:** The core `openBoundaryFile` security logic is untouched; the fallback only applies to workspace bootstrap file injection.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #38622
- Related #

## User-visible / Behavior Changes

Symlinked workspace files pointing outside the workspace root are now correctly loaded instead of showing `[MISSING]`.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `Yes`
- If any `Yes`, explain risk + mitigation: Only reads files that the user explicitly symlinked into their workspace. `MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES` size limit is still enforced.

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node.js 22+
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `mkdir shared && echo "shared soul" > shared/SOUL.md`
2. `mkdir workspace && ln -s ../shared/SOUL.md workspace/SOUL.md`
3. Start a session in the workspace.

### Expected

- `SOUL.md` content is injected into the agent context.

### Actual

- Before: `[MISSING] Expected at: .../workspace/SOUL.md`
- After: Content correctly injected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Absolute and relative symlinks to outside directories load correctly.
- Edge cases checked: Dangling symlinks still report as missing; hardlinks still rejected.
- What you did **not** verify: Windows symlink behavior (skipped per existing codebase patterns).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the PR.
- Files/config to restore: `src/agents/workspace.ts`
- Known bad symptoms reviewers should watch for: Unexpected files loaded via crafted symlinks.

## Risks and Mitigations

- Risk: Arbitrary file read via malicious symlinks in the workspace.
  - Mitigation: Workspace is user-managed; the agent cannot create symlinks. File size limit still enforced.

---

**AI-Assisted PR** — Written with AI assistance. Fully tested with 3 new unit tests + existing suite (`vitest` all passing). I have reviewed the code and confirm the logic is sound.
.