### PR TITLE
fix(nodes): remove redundant rawCommand from system.run.prepare

### DIFF
--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -7,7 +7,7 @@ const gatewayMocks = vi.hoisted(() => ({
 
 const nodeUtilsMocks = vi.hoisted(() => ({
   resolveNodeId: vi.fn(async () => "node-1"),
-  listNodes: vi.fn(async () => []),
+  listNodes: vi.fn(async () => [] as Array<{ nodeId: string; commands?: string[] }>),
   resolveNodeIdFromList: vi.fn(() => "node-1"),
 }));
 

--- a/src/agents/tools/nodes-tool.test.ts
+++ b/src/agents/tools/nodes-tool.test.ts
@@ -85,4 +85,50 @@ describe("createNodesTool screen_record duration guardrails", () => {
       }),
     );
   });
+
+  it("omits rawCommand when preparing wrapped argv execution", async () => {
+    nodeUtilsMocks.listNodes.mockResolvedValue([
+      {
+        nodeId: "node-1",
+        commands: ["system.run"],
+      },
+    ]);
+    gatewayMocks.callGatewayTool.mockImplementation(async (_method, _opts, payload) => {
+      if (payload?.command === "system.run.prepare") {
+        return {
+          payload: {
+            cmdText: "echo hi",
+            plan: {
+              argv: ["bash", "-lc", "echo hi"],
+              cwd: null,
+              rawCommand: null,
+              agentId: null,
+              sessionKey: null,
+            },
+          },
+        };
+      }
+      if (payload?.command === "system.run") {
+        return { payload: { ok: true } };
+      }
+      throw new Error(`unexpected command: ${String(payload?.command)}`);
+    });
+    const tool = createNodesTool();
+
+    await tool.execute("call-1", {
+      action: "run",
+      node: "macbook",
+      command: ["bash", "-lc", "echo hi"],
+    });
+
+    const prepareCall = gatewayMocks.callGatewayTool.mock.calls.find(
+      (call) => call[2]?.command === "system.run.prepare",
+    )?.[2];
+    expect(prepareCall).toBeTruthy();
+    expect(prepareCall?.params).toMatchObject({
+      command: ["bash", "-lc", "echo hi"],
+      agentId: "main",
+    });
+    expect(prepareCall?.params).not.toHaveProperty("rawCommand");
+  });
 });

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -18,7 +18,6 @@ import {
 import { parseDurationMs } from "../../cli/parse-duration.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { parsePreparedSystemRunPayload } from "../../infra/system-run-approval-context.js";
-import { formatExecCommand } from "../../infra/system-run-command.js";
 import { imageMimeFromFormat } from "../../media/mime.js";
 import type { GatewayMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
@@ -651,7 +650,6 @@ export function createNodesTool(options?: {
                 command: "system.run.prepare",
                 params: {
                   command,
-                  rawCommand: formatExecCommand(command),
                   cwd,
                   agentId,
                   sessionKey,


### PR DESCRIPTION
## Problem

`nodes run` is completely broken since 2026.3.2 for any command using a shell wrapper (powershell, bash, etc.). Every command fails with:

```
INVALID_REQUEST: rawCommand does not match command
```

## Root Cause

In `nodes-tool.ts`, the `system.run.prepare` call passes:
```ts
rawCommand: formatExecCommand(command)
```

This produces the full formatted argv string, e.g. `powershell -Command "echo hello"`.

However, `validateSystemRunCommandConsistency()` recognizes shell wrappers (powershell, bash, etc.) and extracts the inner command as the "inferred" value (`echo hello`). The raw vs inferred comparison then fails.

## Fix

Remove the explicit `rawCommand` parameter from the `system.run.prepare` call. When `rawCommand` is null/undefined, the validation skips the comparison and correctly infers the command text from the argv array.

## Testing

Verified on a live setup (gateway 2026.3.3, Windows node 2026.3.3):
- Before fix: every `nodes run` command fails with rawCommand mismatch
- After fix: `nodes run` works correctly for all shell wrapper commands

Fixes #33080