### PR TITLE
docs: Add security scan workflow template (Trivy + KICS + TruffleHog)

### DIFF
--- a/docs/security/pre-commit-secrets.md
+++ b/docs/security/pre-commit-secrets.md
@@ -34,8 +34,11 @@ set -euo pipefail
 
 echo "[pre-commit] Scanning staged files for secrets..."
 
-# List staged files (added, copied, modified)
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+# List staged files (added, copied, modified, renamed)
+# -z uses NUL delimiters to handle filenames with spaces or newlines safely.
+# ACMR includes Renames — without R, renamed files that gained new secrets
+# would be silently skipped and the commit would pass.
+STAGED_FILES=$(git diff --cached --name-only -z --diff-filter=ACMR)
 
 if [ -z "$STAGED_FILES" ]; then
   echo "[pre-commit] ✅ No staged files to scan."
@@ -46,14 +49,19 @@ fi
 TH_TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TH_TMPDIR"' EXIT
 
-# Extract staged versions of each file into the temp directory
-while IFS= read -r file; do
+# Extract staged versions of each file into the temp directory.
+# read -d '' consumes NUL-delimited output from git diff -z, so filenames
+# with spaces, tabs, or newlines are handled correctly.
+while IFS= read -r -d '' file; do
   mkdir -p "$TH_TMPDIR/$(dirname "$file")"
   git show ":$file" > "$TH_TMPDIR/$file" 2>/dev/null || true
 done <<< "$STAGED_FILES"
 
-# Scan staged content — output is shown so users can see what triggered the block
-if ! trufflehog filesystem "$TH_TMPDIR" --only-verified --fail; then
+# Scan staged content — output is shown so users can see what triggered the block.
+# NOTE: --only-verified is intentionally omitted. With that flag, TruffleHog
+# silently skips secrets it cannot verify via outbound API (SSH keys, DB passwords,
+# internal tokens). Omitting it reports all detected secrets so nothing slips through.
+if ! trufflehog filesystem "$TH_TMPDIR" --fail; then
   echo ""
   echo "🚨 SECRETS DETECTED in staged files! Commit blocked."
   echo "Remove the secrets shown above before committing."
@@ -73,11 +81,11 @@ chmod +x .git/hooks/pre-commit
 
 ## How It Works
 
-1. Lists all staged files (`git diff --cached --name-only`)
+1. Lists all staged files (`git diff --cached --name-only -z --diff-filter=ACMR`) — NUL-delimited to handle special characters in filenames; includes renamed files (`R`) so secrets in renames are not missed
 2. Extracts staged file content (`git show :filename`) into a temp directory
-3. Runs TruffleHog `filesystem` scan on the staged snapshot
+3. Runs TruffleHog `filesystem` scan on the staged snapshot — without `--only-verified` so SSH keys, database passwords, and internal tokens are not silently skipped
 4. Prints findings so you can identify and remove the secret
-5. Blocks the commit if verified secrets are found
+5. Blocks the commit if any secrets are found
 6. Temp directory is cleaned up automatically
 
 This approach correctly scans **staged (uncommitted) content** — not just git history.

--- a/docs/security/pre-commit-secrets.md
+++ b/docs/security/pre-commit-secrets.md
@@ -1,0 +1,102 @@
+# Pre-Commit Hook for Secret Scanning
+
+Prevent secrets from being committed to your repository using TruffleHog.
+
+## Installation
+
+### 1. Install TruffleHog
+
+```bash
+# macOS
+brew install trufflehog
+
+# Linux (download binary)
+curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
+
+# Or via Go
+go install github.com/trufflesecurity/trufflehog/v3@latest
+```
+
+### 2. Create Pre-Commit Hook
+
+Create `.git/hooks/pre-commit` in your repository:
+
+```bash
+#!/usr/bin/env bash
+# Pre-commit hook: Secret scanning with TruffleHog
+# Scans staged files for verified secrets before each commit
+
+set -euo pipefail
+
+echo "[pre-commit] Scanning staged files for secrets..."
+
+# Write staged content to a temp directory and scan it
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+if [ -z "$STAGED_FILES" ]; then
+  echo "[pre-commit] ✅ No staged files to scan."
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Extract staged versions of each file into tmpdir
+while IFS= read -r file; do
+  mkdir -p "$TMPDIR/$(dirname "$file")"
+  git show ":$file" > "$TMPDIR/$file" 2>/dev/null || true
+done <<< "$STAGED_FILES"
+
+# Scan staged content with TruffleHog filesystem mode
+if ! trufflehog filesystem "$TMPDIR" --only-verified --fail 2>/dev/null; then
+  echo ""
+  echo "🚨 SECRETS DETECTED in staged files! Commit blocked."
+  echo "Remove secrets before committing."
+  echo ""
+  exit 1
+fi
+
+echo "[pre-commit] ✅ No secrets found."
+exit 0
+```
+
+### 3. Make it Executable
+
+```bash
+chmod +x .git/hooks/pre-commit
+```
+
+## How It Works
+
+1. Lists all staged files (`git diff --cached --name-only`)
+2. Extracts staged file content (`git show :filename`) into a temp directory
+3. Runs TruffleHog `filesystem` scan on the staged snapshot
+4. Blocks the commit if verified secrets are found
+5. Temp directory is cleaned up automatically
+
+This approach correctly scans **staged (uncommitted) content** — not just git history.
+
+## Bypassing (Emergency Only)
+
+If you need to bypass the hook (not recommended):
+
+```bash
+git commit --no-verify -m "your message"
+```
+
+## Team Setup
+
+To share the hook with your team, add it to your repo:
+
+```bash
+mkdir -p .githooks
+cp .git/hooks/pre-commit .githooks/
+git config core.hooksPath .githooks
+```
+
+Then commit `.githooks/pre-commit` to your repository.
+
+## References
+
+- [TruffleHog Documentation](https://trufflesecurity.com/trufflehog)
+- [Catena-X TRG 8.03 - Secret Scanning](https://eclipse-tractusx.github.io/docs/release/trg-8/trg-8-03)

--- a/docs/security/pre-commit-secrets.md
+++ b/docs/security/pre-commit-secrets.md
@@ -10,10 +10,14 @@ Prevent secrets from being committed to your repository using TruffleHog.
 # macOS
 brew install trufflehog
 
-# Linux (download binary)
-curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
+# Linux (verified binary — check https://github.com/trufflesecurity/trufflehog/releases for latest checksum)
+curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh \
+  -o /tmp/install-trufflehog.sh
+# Verify the script before running (recommended):
+# sha256sum /tmp/install-trufflehog.sh
+bash /tmp/install-trufflehog.sh -b /usr/local/bin
 
-# Or via Go
+# Or via Go (reproducible build)
 go install github.com/trufflesecurity/trufflehog/v3@latest
 ```
 
@@ -30,7 +34,7 @@ set -euo pipefail
 
 echo "[pre-commit] Scanning staged files for secrets..."
 
-# Write staged content to a temp directory and scan it
+# List staged files (added, copied, modified)
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
 
 if [ -z "$STAGED_FILES" ]; then
@@ -38,20 +42,21 @@ if [ -z "$STAGED_FILES" ]; then
   exit 0
 fi
 
-TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
+# Use a distinct variable name (not TMPDIR — that is a reserved OS variable)
+TH_TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TH_TMPDIR"' EXIT
 
-# Extract staged versions of each file into tmpdir
+# Extract staged versions of each file into the temp directory
 while IFS= read -r file; do
-  mkdir -p "$TMPDIR/$(dirname "$file")"
-  git show ":$file" > "$TMPDIR/$file" 2>/dev/null || true
+  mkdir -p "$TH_TMPDIR/$(dirname "$file")"
+  git show ":$file" > "$TH_TMPDIR/$file" 2>/dev/null || true
 done <<< "$STAGED_FILES"
 
-# Scan staged content with TruffleHog filesystem mode
-if ! trufflehog filesystem "$TMPDIR" --only-verified --fail 2>/dev/null; then
+# Scan staged content — output is shown so users can see what triggered the block
+if ! trufflehog filesystem "$TH_TMPDIR" --only-verified --fail; then
   echo ""
   echo "🚨 SECRETS DETECTED in staged files! Commit blocked."
-  echo "Remove secrets before committing."
+  echo "Remove the secrets shown above before committing."
   echo ""
   exit 1
 fi
@@ -71,8 +76,9 @@ chmod +x .git/hooks/pre-commit
 1. Lists all staged files (`git diff --cached --name-only`)
 2. Extracts staged file content (`git show :filename`) into a temp directory
 3. Runs TruffleHog `filesystem` scan on the staged snapshot
-4. Blocks the commit if verified secrets are found
-5. Temp directory is cleaned up automatically
+4. Prints findings so you can identify and remove the secret
+5. Blocks the commit if verified secrets are found
+6. Temp directory is cleaned up automatically
 
 This approach correctly scans **staged (uncommitted) content** — not just git history.
 
@@ -99,4 +105,5 @@ Then commit `.githooks/pre-commit` to your repository.
 ## References
 
 - [TruffleHog Documentation](https://trufflesecurity.com/trufflehog)
+- [TruffleHog Releases & Checksums](https://github.com/trufflesecurity/trufflehog/releases)
 - [Catena-X TRG 8.03 - Secret Scanning](https://eclipse-tractusx.github.io/docs/release/trg-8/trg-8-03)

--- a/docs/security/scan-workflow-template.yml
+++ b/docs/security/scan-workflow-template.yml
@@ -1,0 +1,73 @@
+# Security Scan Workflow Template
+#
+# This workflow runs security scans on your OpenClaw workspace:
+# - Trivy: Vulnerability scanning for dependencies and filesystem
+# - KICS: Infrastructure as Code security scanning
+# - TruffleHog: Secret detection in git history
+#
+# Based on Catena-X TRG 8 security guidelines (eclipse-tractusx)
+#
+# Usage: Copy this file to your repo's .github/workflows/ directory
+
+name: Security Scan
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  schedule:
+    - cron: "0 3 * * 0" # Weekly Sunday 3 AM UTC
+  workflow_dispatch: # Manual trigger
+
+jobs:
+  trivy-scan:
+    name: Trivy Vulnerability Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          scan-type: "fs"
+          scan-ref: "."
+          severity: "CRITICAL,HIGH"
+          format: "table"
+          exit-code: "0" # Set to '1' to fail on findings
+          ignore-unfixed: true
+
+  kics-scan:
+    name: KICS IaC Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run KICS scan
+        uses: Checkmarx/kics-github-action@v2.1.0
+        with:
+          path: "."
+          fail_on: "critical" # Only fail on critical issues
+          output_path: "kics-results"
+          output_formats: "json"
+          exclude_paths: "node_modules,dist,.git,tmp"
+
+  secret-scan:
+    name: TruffleHog Secret Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Full history for secret scanning
+
+      - name: Run TruffleHog
+        uses: trufflesecurity/trufflehog@v3.88.0
+        with:
+          extra_args: --only-verified

--- a/docs/security/scan-workflow-template.yml
+++ b/docs/security/scan-workflow-template.yml
@@ -8,6 +8,10 @@
 # Based on Catena-X TRG 8 security guidelines (eclipse-tractusx)
 #
 # Usage: Copy this file to your repo's .github/workflows/ directory
+#
+# Action refs are pinned to commit SHAs (supply-chain hardening).
+# To update, run: gh api repos/<owner>/<action>/git/ref/tags/<tag>
+# and replace the SHA below.
 
 name: Security Scan
 
@@ -26,12 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.29.0
+        # aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0
         with:
           scan-type: "fs"
           scan-ref: "."
@@ -45,12 +51,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 
       - name: Run KICS scan
-        uses: Checkmarx/kics-github-action@v2.1.0
+        # Checkmarx/kics-github-action@v2.1.0
+        uses: Checkmarx/kics-github-action@aacf8e81cd48e227259c937c215b352e02ad447a
         with:
           path: "."
           fail_on: "critical" # Only fail on critical issues
@@ -58,16 +66,33 @@ jobs:
           output_formats: "json"
           exclude_paths: "node_modules,dist,.git,tmp"
 
+      - name: Upload KICS results
+        # Upload findings artifact so they survive after the job ends
+        if: always() # Run even if the KICS step fails
+        uses: actions/upload-artifact@v4
+        with:
+          name: kics-results
+          path: kics-results/
+          retention-days: 30
+
   secret-scan:
     name: TruffleHog Secret Scan
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0 # Full history for secret scanning
 
       - name: Run TruffleHog
-        uses: trufflesecurity/trufflehog@v3.88.0
-        with:
-          extra_args: --only-verified
+        # trufflesecurity/trufflehog@v3.88.0
+        # NOTE: --only-verified is intentionally omitted.
+        # With --only-verified, TruffleHog only reports secrets it can confirm
+        # via outbound API calls. This silently skips entire secret classes:
+        # SSH private keys, database passwords, internal service tokens,
+        # and any credential whose service has no TruffleHog verifier.
+        # The hook also becomes a no-op in air-gapped / offline environments.
+        # Without the flag, all detected secrets are reported (verified or not),
+        # giving teams full visibility. Tune your baseline as needed.
+        uses: trufflesecurity/trufflehog@ddc015e5ed99942b2253d8ea16a0586a01ef2ab1

--- a/docs/security/scan-workflow-template.yml
+++ b/docs/security/scan-workflow-template.yml
@@ -31,13 +31,13 @@ jobs:
           fetch-depth: 0
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@v0.29.0
         with:
           scan-type: "fs"
           scan-ref: "."
           severity: "CRITICAL,HIGH"
           format: "table"
-          exit-code: "0" # Set to '1' to fail on findings
+          exit-code: "1" # Fail the build on findings (set to '0' to report-only)
           ignore-unfixed: true
 
   kics-scan:


### PR DESCRIPTION
## Summary

Adds security scanning documentation for OpenClaw workspaces.

## What's Included

### 1. Security Scan Workflow Template (`docs/security/scan-workflow-template.yml`)

GitHub Actions workflow template with:
- **Trivy** `@0.29.0` — CVE/vulnerability scanning
- **KICS** `@v2.1.0` — Infrastructure as Code scanning
- **TruffleHog** `@v3.88.0` — Secret detection in git history

All action references are pinned to exact versions.

### 2. Pre-Commit Hook Guide (`docs/security/pre-commit-secrets.md`)

Pre-commit hook that **correctly scans staged file content**:
- Uses `git show :filename` to extract staged snapshots into a temp directory
- Runs `trufflehog filesystem` on the staged snapshot (not git history)
- Fixes the Greptile review feedback: staged-but-uncommitted secrets are now caught

Based on [Catena-X TRG 8](https://eclipse-tractusx.github.io/docs/release/trg-8/) security guidelines.

## Replaces

Closes #8951 — rebased cleanly onto current main (previous branch had diverged history).

---

## AI-Assisted Disclosure

- [x] Built with AI assistance (Claude Sonnet)
- [x] Manually reviewed and validated
- [x] Docs-only change (no code modified)

## Checklist

- [x] Docs-only change (no code modified)
- [x] No personal data included
- [x] Generic, copy-paste templates only
- [x] Action versions pinned
- [x] Pre-commit hook scans staged content correctly