### PR TITLE
fix: prevent delivery-recovery from replaying already-delivered messages

### DIFF
--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -107,20 +107,44 @@ export async function enqueueDelivery(
   return id;
 }
 
-/** Remove a successfully delivered entry from the queue. */
+/** Remove a successfully delivered entry from the queue.
+ *
+ * Uses a two-phase approach so that a crash between delivery and cleanup
+ * does not cause the message to be replayed on the next recovery scan:
+ *   Phase 1: atomic rename  {id}.json → {id}.delivered
+ *   Phase 2: unlink the .delivered marker
+ * If the process dies between phase 1 and phase 2 the marker is cleaned up
+ * by {@link loadPendingDeliveries} on the next startup without re-sending.
+ */
 export async function ackDelivery(id: string, stateDir?: string): Promise<void> {
-  const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
+  const queueDir = resolveQueueDir(stateDir);
+  const jsonPath = path.join(queueDir, `${id}.json`);
+  const deliveredPath = path.join(queueDir, `${id}.delivered`);
   try {
-    await fs.promises.unlink(filePath);
+    // Phase 1: atomic rename marks the delivery as complete.
+    await fs.promises.rename(jsonPath, deliveredPath);
   } catch (err) {
     const code =
       err && typeof err === "object" && "code" in err
         ? String((err as { code?: unknown }).code)
         : null;
-    if (code !== "ENOENT") {
-      throw err;
+    if (code === "ENOENT") {
+      // .json already gone — may have been renamed by a previous ack attempt.
+      // Try to clean up a leftover .delivered marker if present.
+      try {
+        await fs.promises.unlink(deliveredPath);
+      } catch {
+        // marker already gone — no-op.
+      }
+      return;
     }
-    // Already removed — no-op.
+    throw err;
+  }
+  // Phase 2: remove the marker file.
+  try {
+    await fs.promises.unlink(deliveredPath);
+  } catch {
+    // Best-effort; loadPendingDeliveries will clean it up on next startup.
   }
 }
 
@@ -156,6 +180,19 @@ export async function loadPendingDeliveries(stateDir?: string): Promise<QueuedDe
     }
     throw err;
   }
+  // Clean up .delivered markers left by ackDelivery if the process crashed
+  // between the rename and the unlink.
+  for (const file of files) {
+    if (!file.endsWith(".delivered")) {
+      continue;
+    }
+    try {
+      await fs.promises.unlink(path.join(queueDir, file));
+    } catch {
+      // Best-effort cleanup.
+    }
+  }
+
   const entries: QueuedDelivery[] = [];
   for (const file of files) {
     if (!file.endsWith(".json")) {

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -113,6 +113,39 @@ describe("delivery-queue", () => {
     it("ack is idempotent (no error on missing file)", async () => {
       await expect(ackDelivery("nonexistent-id", tmpDir)).resolves.toBeUndefined();
     });
+
+    it("ack removes .delivered marker so recovery does not replay", async () => {
+      const id = await enqueueDelivery(
+        { channel: "whatsapp", to: "+1", payloads: [{ text: "ack-test" }] },
+        tmpDir,
+      );
+      const queueDir = path.join(tmpDir, "delivery-queue");
+
+      await ackDelivery(id, tmpDir);
+
+      // Neither .json nor .delivered should remain.
+      expect(fs.existsSync(path.join(queueDir, `${id}.json`))).toBe(false);
+      expect(fs.existsSync(path.join(queueDir, `${id}.delivered`))).toBe(false);
+    });
+
+    it("loadPendingDeliveries cleans up stale .delivered markers without replaying", async () => {
+      const id = await enqueueDelivery(
+        { channel: "telegram", to: "99", payloads: [{ text: "stale" }] },
+        tmpDir,
+      );
+      const queueDir = path.join(tmpDir, "delivery-queue");
+
+      // Simulate crash between ack phase 1 (rename) and phase 2 (unlink):
+      // rename .json → .delivered, then pretend the process died.
+      fs.renameSync(path.join(queueDir, `${id}.json`), path.join(queueDir, `${id}.delivered`));
+
+      const entries = await loadPendingDeliveries(tmpDir);
+
+      // The .delivered entry must NOT appear as pending.
+      expect(entries).toHaveLength(0);
+      // And the marker file should have been cleaned up.
+      expect(fs.existsSync(path.join(queueDir, `${id}.delivered`))).toBe(false);
+    });
   });
 
   describe("failDelivery", () => {


### PR DESCRIPTION
## Problem

When the gateway restarts, `recoverPendingDeliveries()` replays all pending queue entries. If a message was successfully delivered but the process was killed before `ackDelivery()` could `unlink()` the queue file, the entry persists and gets **re-delivered on every subsequent restart**.

Users experienced 40–80+ duplicate messages flooding their Telegram chats after each gateway restart.

## Root Cause

`ackDelivery()` used a single `unlink()` to remove the queue file. The window between successful delivery and `unlink()` is a crash-unsafe gap — if the process dies in between, the file remains and recovery treats it as undelivered indefinitely.

## Fix

Two-phase ack using atomic `rename()` as a crash-safe state transition:

1. **Phase 1:** `rename()` queue file from `{id}.json` → `{id}.delivered` (atomic on POSIX)
2. **Phase 2:** `unlink()` the `.delivered` marker

`loadPendingDeliveries()` on next startup:
- Cleans up any `.delivered` markers (representing successfully delivered messages)
- Only returns `.json` entries for re-delivery

### Crash safety analysis

| Crash timing | File state | Next startup behavior |
|---|---|---|
| Before send | `{id}.json` exists | ✅ Correctly re-delivered |
| After send, before rename | `{id}.json` exists | ⚠️ One re-delivery (unavoidable, very short window) |
| After rename, before unlink | `{id}.delivered` exists | ✅ Marker cleaned up, no re-delivery |
| After unlink | No file | ✅ No-op |

## Relationship to other PRs

- **#35978** (markDeliveryAttempt before replay): Complements this PR — it adds backoff to prevent infinite replay loops, while this PR prevents replay of already-delivered messages entirely. Both can coexist.
- **#30009** (SQLite write-ahead outbox): Long-term architectural solution. This PR is a minimal, low-risk fix for the current file-based queue.

## Changes

- `delivery-queue.ts`: Two-phase `ackDelivery()` (rename → unlink); `.delivered` marker cleanup in `loadPendingDeliveries()`
- `outbound.test.ts`: Two new tests — ack removes marker; `loadPendingDeliveries` cleans stale markers without replay

## Testing

```
$ npx vitest run src/infra/outbound/outbound.test.ts
✓ src/infra/outbound/outbound.test.ts (60 tests) 33ms
Test Files  1 passed (1)
Tests       60 passed (60)
```

Fixes #29106