### PR TITLE
feat(hooks): add agent-scoped internal hook policy overrides

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -477,6 +477,56 @@ Hooks can have custom configuration:
 }
 ```
 
+### Agent-Scoped Internal Hook Policy
+
+You can further restrict internal hooks per agent without changing the global handler protocol:
+
+```json
+{
+  "hooks": {
+    "internal": {
+      "enabled": true,
+      "events": ["command:new", "message:received"],
+      "entries": {
+        "command-logger": { "enabled": true }
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "hooks": {
+        "events": ["command:new"]
+      }
+    },
+    "list": [
+      {
+        "id": "work",
+        "hooks": {
+          "enabled": false,
+          "entries": {
+            "command-logger": { "enabled": false }
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+Effective policy is resolved in this order for the runtime agent id:
+
+- `hooks.internal`
+- `agents.defaults.hooks`
+- `agents.list[].hooks`
+
+Agent-scoped policy fields:
+
+- `enabled`: disable all internal hooks for that agent when `false`
+- `events`: allowlist of registration event keys such as `command:new` or `message`
+- `entries.<hookName>.enabled`: disable one discovered hook without changing others
+
+If these fields are omitted, behavior stays the same as before.
+
 ### Extra Directories
 
 Load hooks from additional directories:

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -993,6 +993,30 @@ Periodic heartbeat runs.
 - Per-agent: set `agents.list[].heartbeat`. When any agent defines `heartbeat`, **only those agents** run heartbeats.
 - Heartbeats run full agent turns — shorter intervals burn more tokens.
 
+### `agents.defaults.hooks`
+
+Optional internal-hook policy overlay applied after `hooks.internal` and before `agents.list[].hooks`.
+
+```json5
+{
+  agents: {
+    defaults: {
+      hooks: {
+        enabled: true,
+        events: ["command:new", "message:received"],
+        entries: {
+          "command-logger": { enabled: false },
+        },
+      },
+    },
+  },
+}
+```
+
+- `enabled: false` disables all internal hooks for that agent scope.
+- `events`: allowlist of internal hook registration keys (`command:new`, `message`, `session:compact:after`, etc.).
+- `entries.<hookName>.enabled: false` disables a specific discovered hook.
+
 ### `agents.defaults.compaction`
 
 ```json5
@@ -1280,6 +1304,12 @@ scripts/sandbox-browser-setup.sh   # optional browser image
           avatar: "avatars/samantha.png",
         },
         groupChat: { mentionPatterns: ["@openclaw"] },
+        hooks: {
+          events: ["command:new"],
+          entries: {
+            "command-logger": { enabled: false },
+          },
+        },
         sandbox: { mode: "off" },
         runtime: {
           type: "acp",
@@ -1308,6 +1338,7 @@ scripts/sandbox-browser-setup.sh   # optional browser image
 - `model`: string form overrides `primary` only; object form `{ primary, fallbacks }` overrides both (`[]` disables global fallbacks). Cron jobs that only override `primary` still inherit default fallbacks unless you set `fallbacks: []`.
 - `params`: per-agent stream params merged over the selected model entry in `agents.defaults.models`. Use this for agent-specific overrides like `cacheRetention`, `temperature`, or `maxTokens` without duplicating the whole model catalog.
 - `runtime`: optional per-agent runtime descriptor. Use `type: "acp"` with `runtime.acp` defaults (`agent`, `backend`, `mode`, `cwd`) when the agent should default to ACP harness sessions.
+- `hooks`: optional internal-hook policy overlay for that agent. Precedence is `hooks.internal` → `agents.defaults.hooks` → `agents.list[].hooks`.
 - `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI.
 - `identity` derives defaults: `ackReaction` from `emoji`, `mentionPatterns` from `name`/`emoji`.
 - `subagents.allowAgents`: allowlist of agent ids for `sessions_spawn` (`["*"]` = any; default: same agent only).

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -16,12 +16,12 @@ import { resolveDefaultAgentWorkspaceDir } from "./workspace.js";
 const log = createSubsystemLogger("agent-scope");
 
 /** Strip null bytes from paths to prevent ENOTDIR errors. */
+export { resolveAgentIdFromSessionKey };
+
 function stripNullBytes(s: string): string {
   // eslint-disable-next-line no-control-regex
   return s.replace(/\0/g, "");
 }
-
-export { resolveAgentIdFromSessionKey };
 
 type AgentEntry = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[number];
 

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -34,6 +34,7 @@ type ResolvedAgentConfig = {
   memorySearch?: AgentEntry["memorySearch"];
   humanDelay?: AgentEntry["humanDelay"];
   heartbeat?: AgentEntry["heartbeat"];
+  hooks?: AgentEntry["hooks"];
   identity?: AgentEntry["identity"];
   groupChat?: AgentEntry["groupChat"];
   subagents?: AgentEntry["subagents"];
@@ -136,6 +137,7 @@ export function resolveAgentConfig(
     memorySearch: entry.memorySearch,
     humanDelay: entry.humanDelay,
     heartbeat: entry.heartbeat,
+    hooks: entry.hooks,
     identity: entry.identity,
     groupChat: entry.groupChat,
     subagents: typeof entry.subagents === "object" && entry.subagents ? entry.subagents : undefined,

--- a/src/agents/bootstrap-hooks.ts
+++ b/src/agents/bootstrap-hooks.ts
@@ -25,7 +25,7 @@ export async function applyBootstrapHookOverrides(params: {
     agentId,
   };
   const event = createInternalHookEvent("agent", "bootstrap", sessionKey, context);
-  await triggerInternalHook(event);
+  await triggerInternalHook(event, { config: params.config, agentId });
   const updated = (event.context as AgentBootstrapHookContext).bootstrapFiles;
   return Array.isArray(updated) ? updated : params.files;
 }

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -703,8 +703,13 @@ export async function compactEmbeddedPiSessionDirect(
             tokenCount: tokenCountBefore,
             messageCountOriginal,
             tokenCountOriginal,
+            cfg: params.config,
+            agentId: sessionAgentId,
           });
-          await triggerInternalHook(hookEvent);
+          await triggerInternalHook(hookEvent, {
+            config: params.config,
+            agentId: sessionAgentId,
+          });
         } catch (err) {
           log.warn("session:compact:before hook failed", {
             errorMessage: err instanceof Error ? err.message : String(err),
@@ -811,8 +816,13 @@ export async function compactEmbeddedPiSessionDirect(
             tokensBefore: result.tokensBefore,
             tokensAfter,
             firstKeptEntryId: result.firstKeptEntryId,
+            cfg: params.config,
+            agentId: sessionAgentId,
           });
-          await triggerInternalHook(hookEvent);
+          await triggerInternalHook(hookEvent, {
+            config: params.config,
+            agentId: sessionAgentId,
+          });
         } catch (err) {
           log.warn("session:compact:after hook failed", {
             errorMessage: err instanceof Error ? err.message : String(err),

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -65,7 +65,7 @@ export async function emitResetCommandHooks(params: {
     senderId: params.command.senderId,
     cfg: params.cfg, // Pass config for LLM slug generation
   });
-  await triggerInternalHook(hookEvent);
+  await triggerInternalHook(hookEvent, { config: params.cfg });
   params.command.resetHookTriggered = true;
 
   // Send hook messages immediately if present

--- a/src/auto-reply/reply/commands-session-abort.ts
+++ b/src/auto-reply/reply/commands-session-abort.ts
@@ -131,9 +131,10 @@ export const handleStopCommand: CommandHandler = async (params, allowTextCommand
       sessionId: abortTarget.sessionId,
       commandSource: params.command.surface,
       senderId: params.command.senderId,
+      cfg: params.cfg,
     },
   );
-  await triggerInternalHook(hookEvent);
+  await triggerInternalHook(hookEvent, { config: params.cfg });
 
   const { stopped } = stopSubagentsForRequester({
     cfg: params.cfg,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -201,7 +201,9 @@ export async function dispatchReplyFromConfig(params: {
         createInternalHookEvent("message", "received", sessionKey, {
           ...toInternalMessageReceivedContext(hookContext),
           timestamp,
+          cfg,
         }),
+        { config: cfg },
       ),
       "dispatch-from-config: message_received internal hook failed",
     );

--- a/src/auto-reply/reply/message-preprocess-hooks.ts
+++ b/src/auto-reply/reply/message-preprocess-hooks.ts
@@ -31,6 +31,7 @@ export function emitPreAgentMessageHooks(params: {
           sessionKey,
           toInternalMessageTranscribedContext(canonical, params.cfg),
         ),
+        { config: params.cfg },
       ),
       "get-reply: message:transcribed internal hook failed",
     );
@@ -44,6 +45,7 @@ export function emitPreAgentMessageHooks(params: {
         sessionKey,
         toInternalMessagePreprocessedContext(canonical, params.cfg),
       ),
+      { config: params.cfg },
     ),
     "get-reply: message:preprocessed internal hook failed",
   );

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -184,4 +184,51 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it("accepts agent-scoped internal hook policy overrides", () => {
+    const res = validateConfigObject({
+      hooks: {
+        internal: {
+          enabled: true,
+          events: ["command:new"],
+          entries: {
+            "command-logger": {
+              enabled: true,
+              env: {
+                LOG_PATH: "/tmp/openclaw-hooks.log",
+              },
+            },
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          hooks: {
+            events: ["message:received"],
+            entries: {
+              "command-logger": {
+                enabled: false,
+              },
+            },
+          },
+        },
+        list: [
+          {
+            id: "work",
+            hooks: {
+              enabled: true,
+              events: ["session:compact:after"],
+              entries: {
+                "session-memory": {
+                  enabled: false,
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -6,6 +6,7 @@ import type {
   HumanDelayConfig,
   TypingMode,
 } from "./types.base.js";
+import type { InternalHookPolicyConfig } from "./types.hooks.js";
 import type { MemorySearchConfig } from "./types.tools.js";
 
 export type AgentModelEntryConfig = {
@@ -261,6 +262,8 @@ export type AgentDefaultsConfig = {
      */
     includeReasoning?: boolean;
   };
+  /** Optional agent-scoped internal hook policy overrides. */
+  hooks?: InternalHookPolicyConfig;
   /** Max concurrent agent runs across all conversations. Default: 1 (sequential). */
   maxConcurrent?: number;
   /** Sub-agent defaults (spawned via sessions_spawn). */

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -2,6 +2,7 @@ import type { ChatType } from "../channels/chat-type.js";
 import type { AgentDefaultsConfig } from "./types.agent-defaults.js";
 import type { AgentModelConfig, AgentSandboxConfig } from "./types.agents-shared.js";
 import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
+import type { InternalHookPolicyConfig } from "./types.hooks.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
 
@@ -72,6 +73,8 @@ export type AgentConfig = {
   humanDelay?: HumanDelayConfig;
   /** Optional per-agent heartbeat overrides. */
   heartbeat?: AgentDefaultsConfig["heartbeat"];
+  /** Optional per-agent internal hook policy overrides. */
+  hooks?: InternalHookPolicyConfig;
   identity?: IdentityConfig;
   groupChat?: GroupChatConfig;
   subagents?: {

--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -87,16 +87,25 @@ export type HookConfig = {
   [key: string]: unknown;
 };
 
+export type InternalHookEntryPolicyConfig = {
+  enabled?: boolean;
+};
+
+export type InternalHookPolicyConfig = {
+  enabled?: boolean;
+  /** Allowlist of registration event keys (for example "command:new" or "message"). */
+  events?: string[];
+  entries?: Record<string, InternalHookEntryPolicyConfig>;
+};
+
 export type HookInstallRecord = InstallRecordBase & {
   hooks?: string[];
 };
 
-export type InternalHooksConfig = {
-  /** Enable hooks system */
-  enabled?: boolean;
+export type InternalHooksConfig = InternalHookPolicyConfig & {
   /** Legacy: List of internal hook handlers to register (still supported) */
   handlers?: InternalHookHandlerConfig[];
-  /** Per-hook configuration overrides */
+  /** Per-hook configuration overrides (global baseline; supports additional hook-specific keys). */
   entries?: Record<string, HookConfig>;
   /** Load configuration */
   load?: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -13,6 +13,7 @@ import {
   HumanDelaySchema,
   TypingModeSchema,
 } from "./zod-schema.core.js";
+import { InternalHookPolicySchema } from "./zod-schema.hooks.js";
 
 export const AgentDefaultsSchema = z
   .object({
@@ -158,6 +159,7 @@ export const AgentDefaultsSchema = z
     typingIntervalSeconds: z.number().int().positive().optional(),
     typingMode: TypingModeSchema.optional(),
     heartbeat: HeartbeatSchema,
+    hooks: InternalHookPolicySchema,
     maxConcurrent: z.number().int().positive().optional(),
     subagents: z
       .object({

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -10,6 +10,7 @@ import {
   ToolsLinksSchema,
   ToolsMediaSchema,
 } from "./zod-schema.core.js";
+import { InternalHookPolicySchema } from "./zod-schema.hooks.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
 export const HeartbeatSchema = z
@@ -718,6 +719,7 @@ export const AgentEntrySchema = z
     memorySearch: MemorySearchSchema,
     humanDelay: HumanDelaySchema.optional(),
     heartbeat: HeartbeatSchema,
+    hooks: InternalHookPolicySchema,
     identity: IdentitySchema,
     groupChat: GroupChatSchema,
     subagents: z

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -95,6 +95,21 @@ const HookConfigSchema = z
   // whole config invalid (which triggers doctor/best-effort loads).
   .passthrough();
 
+export const InternalHookEntryPolicySchema = z
+  .object({
+    enabled: z.boolean().optional(),
+  })
+  .strict();
+
+export const InternalHookPolicySchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    events: z.array(z.string()).optional(),
+    entries: z.record(z.string(), InternalHookEntryPolicySchema).optional(),
+  })
+  .strict()
+  .optional();
+
 const HookInstallRecordSchema = z
   .object({
     ...InstallRecordShape,
@@ -105,6 +120,7 @@ const HookInstallRecordSchema = z
 export const InternalHooksSchema = z
   .object({
     enabled: z.boolean().optional(),
+    events: z.array(z.string()).optional(),
     handlers: z.array(InternalHookHandlerSchema).optional(),
     entries: z.record(z.string(), HookConfigSchema).optional(),
     load: z

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -488,7 +488,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         cfg,
       },
     );
-    await triggerInternalHook(hookEvent);
+    await triggerInternalHook(hookEvent, { config: cfg });
     const mutationCleanupError = await cleanupSessionBeforeMutation({
       cfg,
       key,

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -146,7 +146,7 @@ export async function startGatewaySidecars(params: {
         deps: params.deps,
         workspaceDir: params.defaultWorkspaceDir,
       });
-      void triggerInternalHook(hookEvent);
+      void triggerInternalHook(hookEvent, { config: params.cfg });
     }, 250);
   }
 

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -8,6 +8,7 @@ import {
   isMessageReceivedEvent,
   isMessageSentEvent,
   registerInternalHook,
+  resolveEffectiveInternalHookPolicy,
   triggerInternalHook,
   unregisterInternalHook,
   type AgentBootstrapHookContext,
@@ -145,7 +146,17 @@ describe("hooks", () => {
 
     it("stores handlers in the global singleton registry", async () => {
       const globalHooks = globalThis as typeof globalThis & {
-        __openclaw_internal_hook_handlers__?: Map<string, Array<(event: unknown) => unknown>>;
+        __openclaw_internal_hook_handlers__?: Map<
+          string,
+          Array<
+            | ((event: unknown) => unknown)
+            | {
+                handler: (event: unknown) => unknown;
+                eventKey: string;
+                hookName?: string;
+              }
+          >
+        >;
       };
       const handler = vi.fn();
       registerInternalHook("command:new", handler);
@@ -160,6 +171,138 @@ describe("hooks", () => {
       globalHooks.__openclaw_internal_hook_handlers__?.set("command:new", [injectedHandler]);
       await triggerInternalHook(event);
       expect(injectedHandler).toHaveBeenCalledWith(event);
+    });
+
+    it("skips all internal hooks when effective policy is disabled for the runtime agent", async () => {
+      const handler = vi.fn();
+      registerInternalHook("command:new", handler, { hookName: "command-logger" });
+
+      const cfg = {
+        hooks: { internal: { enabled: true } },
+        agents: {
+          list: [
+            {
+              id: "work",
+              hooks: {
+                enabled: false,
+              },
+            },
+          ],
+        },
+      };
+      const event = createInternalHookEvent("command", "new", "work:thread-1", { cfg });
+
+      await triggerInternalHook(event, { config: cfg, agentId: "work" });
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it("filters handlers by effective events allowlist", async () => {
+      const generalHandler = vi.fn();
+      const specificHandler = vi.fn();
+      registerInternalHook("command", generalHandler, { hookName: "all-commands" });
+      registerInternalHook("command:new", specificHandler, { hookName: "new-command" });
+
+      const cfg = {
+        hooks: { internal: { enabled: true } },
+        agents: {
+          list: [
+            {
+              id: "work",
+              hooks: {
+                events: ["command:new"],
+              },
+            },
+          ],
+        },
+      };
+      const event = createInternalHookEvent("command", "new", "work:thread-1", { cfg });
+
+      await triggerInternalHook(event, { config: cfg, agentId: "work" });
+
+      expect(generalHandler).not.toHaveBeenCalled();
+      expect(specificHandler).toHaveBeenCalledWith(event);
+    });
+
+    it("filters handlers by effective per-hook entry policy", async () => {
+      const disabledHandler = vi.fn();
+      const enabledHandler = vi.fn();
+      registerInternalHook("command:new", disabledHandler, { hookName: "command-logger" });
+      registerInternalHook("command:new", enabledHandler, { hookName: "session-memory" });
+
+      const cfg = {
+        hooks: {
+          internal: {
+            enabled: true,
+            entries: {
+              "command-logger": { enabled: true },
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            hooks: {
+              entries: {
+                "command-logger": { enabled: false },
+              },
+            },
+          },
+        },
+      };
+      const event = createInternalHookEvent("command", "new", "main", { cfg });
+
+      await triggerInternalHook(event, { config: cfg, agentId: "main" });
+
+      expect(disabledHandler).not.toHaveBeenCalled();
+      expect(enabledHandler).toHaveBeenCalledWith(event);
+    });
+  });
+
+  describe("resolveEffectiveInternalHookPolicy", () => {
+    it("applies global baseline then defaults then agent overrides", () => {
+      const cfg = {
+        hooks: {
+          internal: {
+            enabled: true,
+            events: ["command:new"],
+            entries: {
+              "command-logger": { enabled: true },
+              "session-memory": { enabled: true },
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            hooks: {
+              events: ["message:received"],
+              entries: {
+                "command-logger": { enabled: false },
+              },
+            },
+          },
+          list: [
+            {
+              id: "work",
+              hooks: {
+                enabled: false,
+                events: ["session:compact:after"],
+                entries: {
+                  "session-memory": { enabled: false },
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      expect(resolveEffectiveInternalHookPolicy({ config: cfg, agentId: "work" })).toEqual({
+        enabled: false,
+        events: ["session:compact:after"],
+        entries: {
+          "command-logger": { enabled: false },
+          "session-memory": { enabled: false },
+        },
+      });
     });
   });
 

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -5,7 +5,6 @@
  * like command processing, session lifecycle, etc.
  */
 
-import { resolveAgentConfig, resolveSessionAgentId } from "../agents/agent-scope.js";
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -15,6 +14,12 @@ import type {
   InternalHookPolicyConfig,
 } from "../config/types.hooks.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  DEFAULT_AGENT_ID,
+  normalizeAgentId,
+  parseAgentSessionKey,
+  resolveAgentIdFromSessionKey,
+} from "../routing/session-key.js";
 
 export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
 
@@ -300,7 +305,7 @@ export function resolveEffectiveInternalHookPolicy(params: {
     return undefined;
   }
   const defaultsPolicy = cfg.agents?.defaults?.hooks;
-  const agentPolicy = params.agentId ? resolveAgentConfig(cfg, params.agentId)?.hooks : undefined;
+  const agentPolicy = params.agentId ? resolveAgentHookPolicy(cfg, params.agentId) : undefined;
 
   const enabled = pickLastDefined(
     cfg.hooks?.internal?.enabled,
@@ -523,12 +528,60 @@ function getConfigFromEvent(event: InternalHookEvent): OpenClawConfig | undefine
 function getAgentIdForEvent(event: InternalHookEvent, config?: OpenClawConfig): string | undefined {
   const context = event.context as { agentId?: string } | undefined;
   if (typeof context?.agentId === "string" && context.agentId.trim()) {
-    return context.agentId;
+    return normalizeAgentId(context.agentId);
   }
   if (!config || !event.sessionKey?.trim()) {
     return undefined;
   }
-  return resolveSessionAgentId({ config, sessionKey: event.sessionKey });
+  return resolveSessionAgentIdFromConfig(config, event.sessionKey);
+}
+
+function resolveSessionAgentIdFromConfig(config: OpenClawConfig, sessionKey: string): string {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (parsed?.agentId) {
+    return normalizeAgentId(parsed.agentId);
+  }
+  const resolved = resolveAgentIdFromSessionKey(sessionKey);
+  if (resolved !== DEFAULT_AGENT_ID) {
+    return resolved;
+  }
+  return resolveDefaultAgentIdFromConfig(config);
+}
+
+function resolveDefaultAgentIdFromConfig(config: OpenClawConfig): string {
+  const list = config.agents?.list;
+  if (!Array.isArray(list) || list.length === 0) {
+    return DEFAULT_AGENT_ID;
+  }
+  const entries = list.filter((entry): entry is NonNullable<(typeof list)[number]> =>
+    Boolean(entry && typeof entry === "object"),
+  );
+  if (entries.length === 0) {
+    return DEFAULT_AGENT_ID;
+  }
+  const defaults = entries.filter((entry) => entry.default);
+  const chosen = (defaults[0] ?? entries[0])?.id;
+  return normalizeAgentId(typeof chosen === "string" ? chosen : DEFAULT_AGENT_ID);
+}
+
+function resolveAgentHookPolicy(
+  config: OpenClawConfig,
+  agentId: string,
+): InternalHookPolicyConfig | undefined {
+  const target = normalizeAgentId(agentId);
+  const list = config.agents?.list;
+  if (!Array.isArray(list)) {
+    return undefined;
+  }
+  for (const entry of list) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    if (normalizeAgentId(entry.id) === target) {
+      return entry.hooks;
+    }
+  }
+  return undefined;
 }
 
 function pickLastDefined<T>(...values: Array<T | undefined>): T | undefined {

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -5,9 +5,15 @@
  * like command processing, session lifecycle, etc.
  */
 
+import { resolveAgentConfig, resolveSessionAgentId } from "../agents/agent-scope.js";
 import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
+import type {
+  HookConfig,
+  InternalHookEntryPolicyConfig,
+  InternalHookPolicyConfig,
+} from "../config/types.hooks.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
@@ -173,6 +179,14 @@ export interface InternalHookEvent {
 
 export type InternalHookHandler = (event: InternalHookEvent) => Promise<void> | void;
 
+type InternalHookRegistration = {
+  handler: InternalHookHandler;
+  eventKey: string;
+  hookName?: string;
+};
+
+type InternalHookRegistryEntry = InternalHookHandler | InternalHookRegistration;
+
 /**
  * Registry of hook handlers by event key.
  *
@@ -184,11 +198,11 @@ export type InternalHookHandler = (event: InternalHookEvent) => Promise<void> | 
  * to silently fire with zero handlers.
  */
 const _g = globalThis as typeof globalThis & {
-  __openclaw_internal_hook_handlers__?: Map<string, InternalHookHandler[]>;
+  __openclaw_internal_hook_handlers__?: Map<string, InternalHookRegistryEntry[]>;
 };
 const handlers = (_g.__openclaw_internal_hook_handlers__ ??= new Map<
   string,
-  InternalHookHandler[]
+  InternalHookRegistryEntry[]
 >());
 const log = createSubsystemLogger("internal-hooks");
 
@@ -211,11 +225,21 @@ const log = createSubsystemLogger("internal-hooks");
  * });
  * ```
  */
-export function registerInternalHook(eventKey: string, handler: InternalHookHandler): void {
+export function registerInternalHook(
+  eventKey: string,
+  handler: InternalHookHandler,
+  opts?: {
+    hookName?: string;
+  },
+): void {
   if (!handlers.has(eventKey)) {
     handlers.set(eventKey, []);
   }
-  handlers.get(eventKey)!.push(handler);
+  handlers.get(eventKey)!.push({
+    handler,
+    eventKey,
+    hookName: opts?.hookName,
+  });
 }
 
 /**
@@ -230,7 +254,7 @@ export function unregisterInternalHook(eventKey: string, handler: InternalHookHa
     return;
   }
 
-  const index = eventHandlers.indexOf(handler);
+  const index = eventHandlers.findIndex((entry) => getRegisteredHandler(entry) === handler);
   if (index !== -1) {
     eventHandlers.splice(index, 1);
   }
@@ -267,9 +291,57 @@ export function getRegisteredEventKeys(): string[] {
  *
  * @param event - The event to trigger
  */
-export async function triggerInternalHook(event: InternalHookEvent): Promise<void> {
-  const typeHandlers = handlers.get(event.type) ?? [];
-  const specificHandlers = handlers.get(`${event.type}:${event.action}`) ?? [];
+export function resolveEffectiveInternalHookPolicy(params: {
+  config?: OpenClawConfig;
+  agentId?: string;
+}): InternalHookPolicyConfig | undefined {
+  const cfg = params.config;
+  if (!cfg) {
+    return undefined;
+  }
+  const defaultsPolicy = cfg.agents?.defaults?.hooks;
+  const agentPolicy = params.agentId ? resolveAgentConfig(cfg, params.agentId)?.hooks : undefined;
+
+  const enabled = pickLastDefined(
+    cfg.hooks?.internal?.enabled,
+    defaultsPolicy?.enabled,
+    agentPolicy?.enabled,
+  );
+  const events = pickLastDefined(
+    cfg.hooks?.internal?.events,
+    defaultsPolicy?.events,
+    agentPolicy?.events,
+  );
+  const entries = mergeInternalHookPolicyEntries(
+    toInternalHookPolicyEntries(cfg.hooks?.internal?.entries),
+    defaultsPolicy?.entries,
+    agentPolicy?.entries,
+  );
+
+  if (enabled === undefined && events === undefined && entries === undefined) {
+    return undefined;
+  }
+
+  return {
+    ...(enabled === undefined ? {} : { enabled }),
+    ...(events === undefined ? {} : { events }),
+    ...(entries === undefined ? {} : { entries }),
+  };
+}
+
+export async function triggerInternalHook(
+  event: InternalHookEvent,
+  opts?: {
+    config?: OpenClawConfig;
+    agentId?: string;
+  },
+): Promise<void> {
+  const typeHandlers = normalizeRegistrations(event.type, handlers.get(event.type) ?? []);
+  const specificEventKey = `${event.type}:${event.action}`;
+  const specificHandlers = normalizeRegistrations(
+    specificEventKey,
+    handlers.get(specificEventKey) ?? [],
+  );
 
   const allHandlers = [...typeHandlers, ...specificHandlers];
 
@@ -277,9 +349,19 @@ export async function triggerInternalHook(event: InternalHookEvent): Promise<voi
     return;
   }
 
-  for (const handler of allHandlers) {
+  const config = opts?.config ?? getConfigFromEvent(event);
+  const agentId = opts?.agentId ?? getAgentIdForEvent(event, config);
+  const policy = resolveEffectiveInternalHookPolicy({ config, agentId });
+  if (policy?.enabled === false) {
+    return;
+  }
+
+  for (const registration of allHandlers) {
+    if (!shouldRunRegistration(registration, policy)) {
+      continue;
+    }
     try {
-      await handler(event);
+      await registration.handler(event);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.error(`Hook error [${event.type}:${event.action}]: ${message}`);
@@ -418,4 +500,92 @@ export function isMessagePreprocessedEvent(
     return false;
   }
   return hasStringContextField(context, "channelId");
+}
+
+function getRegisteredHandler(entry: InternalHookRegistryEntry): InternalHookHandler {
+  return typeof entry === "function" ? entry : entry.handler;
+}
+
+function normalizeRegistrations(
+  eventKey: string,
+  entries: InternalHookRegistryEntry[],
+): InternalHookRegistration[] {
+  return entries.map((entry) =>
+    typeof entry === "function" ? { handler: entry, eventKey } : entry,
+  );
+}
+
+function getConfigFromEvent(event: InternalHookEvent): OpenClawConfig | undefined {
+  const context = event.context as { cfg?: OpenClawConfig } | undefined;
+  return context?.cfg;
+}
+
+function getAgentIdForEvent(event: InternalHookEvent, config?: OpenClawConfig): string | undefined {
+  const context = event.context as { agentId?: string } | undefined;
+  if (typeof context?.agentId === "string" && context.agentId.trim()) {
+    return context.agentId;
+  }
+  if (!config || !event.sessionKey?.trim()) {
+    return undefined;
+  }
+  return resolveSessionAgentId({ config, sessionKey: event.sessionKey });
+}
+
+function pickLastDefined<T>(...values: Array<T | undefined>): T | undefined {
+  for (let index = values.length - 1; index >= 0; index -= 1) {
+    if (values[index] !== undefined) {
+      return values[index];
+    }
+  }
+  return undefined;
+}
+
+function toInternalHookPolicyEntries(
+  entries: Record<string, HookConfig> | undefined,
+): Record<string, InternalHookEntryPolicyConfig> | undefined {
+  if (!entries) {
+    return undefined;
+  }
+  const normalized: Record<string, InternalHookEntryPolicyConfig> = {};
+  for (const [hookName, entry] of Object.entries(entries)) {
+    normalized[hookName] = {
+      enabled: typeof entry?.enabled === "boolean" ? entry.enabled : undefined,
+    };
+  }
+  return normalized;
+}
+
+function mergeInternalHookPolicyEntries(
+  ...sources: Array<Record<string, InternalHookEntryPolicyConfig> | undefined>
+): Record<string, InternalHookEntryPolicyConfig> | undefined {
+  let merged: Record<string, InternalHookEntryPolicyConfig> | undefined;
+  for (const source of sources) {
+    if (!source) {
+      continue;
+    }
+    merged ??= {};
+    for (const [hookName, entry] of Object.entries(source)) {
+      merged[hookName] = {
+        ...merged[hookName],
+        ...entry,
+      };
+    }
+  }
+  return merged;
+}
+
+function shouldRunRegistration(
+  registration: InternalHookRegistration,
+  policy: InternalHookPolicyConfig | undefined,
+): boolean {
+  if (!policy) {
+    return true;
+  }
+  if (policy.events && !policy.events.includes(registration.eventKey)) {
+    return false;
+  }
+  if (registration.hookName && policy.entries?.[registration.hookName]?.enabled === false) {
+    return false;
+  }
+  return true;
 }

--- a/src/hooks/loader.ts
+++ b/src/hooks/loader.ts
@@ -113,7 +113,7 @@ export async function loadInternalHooks(
         }
 
         for (const event of events) {
-          registerInternalHook(event, handler);
+          registerInternalHook(event, handler, { hookName: entry.hook.name });
         }
 
         log.info(

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -373,12 +373,11 @@ function createMessageSentEmitter(params: {
     }
     fireAndForgetHook(
       triggerInternalHook(
-        createInternalHookEvent(
-          "message",
-          "sent",
-          params.sessionKeyForInternalHooks!,
-          toInternalMessageSentContext(canonical),
-        ),
+        createInternalHookEvent("message", "sent", params.sessionKeyForInternalHooks!, {
+          ...toInternalMessageSentContext(canonical),
+          cfg: params.cfg,
+        }),
+        { config: params.cfg },
       ),
       "deliverOutboundPayloads: message:sent internal hook failed",
       (message) => {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -337,6 +337,7 @@ function createMessageSentEmitter(params: {
   sessionKeyForInternalHooks?: string;
   mirrorIsGroup?: boolean;
   mirrorGroupId?: string;
+  cfg?: OpenClawConfig;
 }): { emitMessageSent: (event: MessageSentEvent) => void; hasMessageSentHooks: boolean } {
   const hasMessageSentHooks = params.hookRunner?.hasHooks("message_sent") ?? false;
   const canEmitInternalHook = Boolean(params.sessionKeyForInternalHooks);
@@ -674,6 +675,7 @@ async function deliverOutboundPayloadsCore(
     sessionKeyForInternalHooks,
     mirrorIsGroup,
     mirrorGroupId,
+    cfg,
   });
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
   if (hasMessageSentHooks && params.session?.agentId && !sessionKeyForInternalHooks) {


### PR DESCRIPTION
## Summary
- add optional agent-scoped internal hook policy config at `agents.defaults.hooks` and `agents.list[].hooks`
- add runtime policy resolution precedence `hooks.internal -> agents.defaults.hooks -> agents.list[].hooks`
- gate internal hook dispatch by effective `enabled`, `events`, and `entries.<hookName>.enabled`
- keep backward compatibility when new fields are absent
- thread config/agent metadata through internal hook trigger call-sites so policy can resolve against runtime agent
- document new config in hooks and configuration reference docs

## Config shape (MVP)
```json
{
  "agents": {
    "defaults": {
      "hooks": { "enabled": true, "events": ["command:new"], "entries": { "command-logger": { "enabled": true } } }
    },
    "list": [
      { "id": "work", "hooks": { "enabled": false, "entries": { "command-logger": { "enabled": false } } } }
    ]
  }
}
```

## Tests
- `pnpm test src/hooks/internal-hooks.test.ts src/hooks/loader.test.ts src/config/config.schema-regressions.test.ts`

## Notes
- no hook handler protocol changes
- existing behavior is preserved when `agents.*.hooks` is omitted
