### PR TITLE
fix/gateway token mismatch 38617

### DIFF
--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -395,10 +395,12 @@ describe("GatewayClient connect auth payload", () => {
     ws.emitOpen();
     emitConnectChallenge(ws);
 
+    // Device token is now always included when available, even when shared token is provided.
+    // This ensures the gateway can verify device identity in addition to main authentication.
     expect(connectFrameFrom(ws)).toMatchObject({
       token: "shared-token",
+      deviceToken: "stored-device-token",
     });
-    expect(connectFrameFrom(ws).deviceToken).toBeUndefined();
     client.stop();
   });
 

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -255,8 +255,9 @@ export class GatewayClient {
       : null;
     // Keep shared gateway credentials explicit. Persisted per-device tokens only
     // participate when no explicit shared token is provided.
-    const resolvedDeviceToken =
-      explicitDeviceToken ?? (!explicitGatewayToken ? (storedToken ?? undefined) : undefined);
+    // Always include device token when available - it will be used for device identity
+    // verification in addition to the gateway token for main authentication.
+    const resolvedDeviceToken = explicitDeviceToken ?? storedToken ?? undefined;
     // Legacy compatibility: keep `auth.token` populated for device-token auth when
     // no explicit shared token is present.
     const authToken = explicitGatewayToken ?? resolvedDeviceToken;


### PR DESCRIPTION
- **Mattermost: honor onmessage mention override and add gating diagnostics tests (#27160)**
- **fix(subagents): strip leaked [[reply_to]] tags from completion announces (#34503)**
- **fix(cron): restore direct fallback after announce failure in best-effort mode (openclaw#36177)**
- **test(cron): add cross-channel announce fallback regression coverage (openclaw#36197)**
- **feat(mattermost): add interactive buttons support (#19957)**
- **fix(browser): remove deprecated --disable-blink-features=AutomationControlled flag**
- **fix(feishu): add HTTP timeout to prevent per-chat queue deadlocks (#36430)**
- **fix(feishu): use probed botName for mention checks (#36391)**
- **Feishu: honor bot mentions by ID despite aliases (Fixes #36317) (#36333)**
- **Mattermost: switch plugin-sdk imports to scoped subpaths (openclaw#36480)**
- **fix(feishu): accept groupPolicy "allowall" as alias for "open" (#36358)**
- **synthesis: fix Feishu group mention slash parsing**
- **Feishu: normalize group slash command probing**
- **add prependSystemContext and appendSystemContext to before_prompt_build (fixes #35131) (#35177)**
- **fix(feishu): avoid media regressions from global HTTP timeout (#36500)**
- **Gateway: add SecretRef support for gateway.auth.token with auth-mode guardrails (#35094)**
- **fix(embedded): classify model_context_window_exceeded as context overflow, trigger compaction (#35934)**
- **fix(agents): skip compaction API call when session has no real messages (#36451)**
- **fix(ui): catch marked.js parse errors to prevent Control UI crash (#36445)**
- **fix(session): archive old transcript on daily/scheduled reset to prevent orphaned files (#35493)**
- **fix(agents): set preserveSignatures to isAnthropic in resolveTranscriptPolicy (#32813)**
- **fix: avoid false global rate-limit classification from generic cooldown text (#32972)**
- **refactor(agents): share failover HTTP status classification (#36615)**
- **fix(failover): narrow service-unavailable to require overload indicator (#32828) (#36646)**
- **Compaction/Safeguard: add summary quality audit retries (#25556)**
- **test(agents): add provider-backed failover regressions (#36735)**
- **Docs: add Slack typing reaction fallback**
- **Docs: update gateway config reference for Slack and TTS**
- **Docs: clarify OpenAI-compatible TTS endpoints**
- **Docs: document Control UI locale support**
- **Docs: cover heartbeat, cron, and plugin route updates**
- **fix(ui): bump dompurify to 3.3.2 (#36781)**
- **UI: hoist lifecycle connect test mocks (#36788)**
- **fix(agents): classify insufficient_quota 400s as billing (#36783)**
- **feat: append UTC time alongside local time in shared Current time lines (#32423)**
- **fix(auth): grant senderIsOwner for internal channels with operator.admin scope (openclaw#35704)**
- **fix(config): prevent RangeError in merged schema cache key generation**
- **fix(slack): propagate mediaLocalRoots through Slack send path**
- **fix(slack): preserve dedupe while recovering dropped app_mention (#34937)**
- **README: add algal to contributors list (#2046)**
- **fix: decouple Discord inbound worker timeout from listener timeout (#36602) (thanks @dutifulbob) (#36602)**
- **plugins: enforce prompt hook policy with runtime validation (#36567)**
- **fix(memory): avoid destructive qmd collection rebinds**
- **Harden Telegram poll gating and schema consistency (#36547)**
- **fix(browser): close tracked tabs on session cleanup (#36666)**
- **Diffs: restore system prompt guidance (#36904)**
- **fix(routing): avoid full binding rescans in resolveAgentRoute (#36915)**
- **fix(gateway): honor insecure ws override for remote hostnames**
- **fix(llm-task): load runEmbeddedPiAgent from dist/extensionAPI in installs**
- **fix(auth): harden openai-codex oauth login path**
- **feat(telegram/acp): Topic Binding, Pin Binding Message, Fix Spawn Param Parsing (#36683)**
- **fix(gateway): preserve streamed prefixes across tool boundaries**
- **fix(tui): prevent stale model indicator after /model**
- **Memory: handle SecretRef keys in doctor embeddings (#36835)**
- **fix(openai-codex): request required oauth api scopes (#24720)**
- **fix(memory-flush): ban timestamped variant files in default flush prompt (#34951)**
- **fix(tui): render final event error when assistant output is empty (#14687)**
- **feat(agents): flush reply pipeline before compaction wait (#35489)**
- **fix(secrets): harden api key normalization for ByteString headers**
- **fix(slack): remove double mrkdwn conversion in native streaming path**
- **fix(kimi-coding): normalize anthropic tool payload format**
- **fix(slack): thread channel ID through inbound context for reactions (#34831)**
- **fix(heartbeat): pin HEARTBEAT.md reads to workspace path**
- **fix(subagents): recover announce cleanup after kill/complete race**
- **feat(hooks): emit compaction lifecycle hooks (#16788)**
- **fix(auth): harden openai-codex oauth refresh fallback**
- **fix(subagents): announce delivery with descendant gating, frozen result refresh, and cron retry (#35080)**
- **fix(agents): avoid synthetic tool-result writes on idle-timeout cleanup**
- **fix(agent): harden undici stream timeouts for long openai-completions runs**
- **fix(slack): record app_mention retry key before dedupe check (#37033)**
- **fix(agents): honor explicit rate-limit cooldown probes in fallback runs**
- **fix(agents): allow configured ollama endpoints without dummy api keys**
- **fix(memory): recover qmd updates from duplicate document constraints**
- **Doctor: warn on implicit heartbeat directPolicy (#36789)**
- **Plugins: clarify registerHttpHandler migration errors (#36794)**
- **fix(memory): repair qmd collection name conflicts during ensure**
- **fix(memory): handle qmd search results without docid**
- **Plugins: avoid false integrity drift prompts on unpinned updates (#37179)**
- **Changelog: add #37179 release note**
- **Delete changelog/fragments directory**
- **Update CHANGELOG.md**
- **fix(whatsapp): remove implicit [openclaw] self-chat prefix**
- **fix: remove config.schema from agent gateway tool (#7382)**
- **feat(openai): add gpt-5.4 support for API and Codex OAuth (#36590)**
- **fix(tui): preserve credential-like tokens in render sanitization**
- **CLI: make read-only SecretRef status flows degrade safely (#37023)**
- **chore(changelog): update for #37023**
- **fix(agents): disable usage streaming chunks on non-native openai-completions**
- **feat(nano-banana-pro): add --aspect-ratio flag to generate_image.py (#28159)**
- **fix(gateway): support image_url in OpenAI chat completions (#34068)**
- **fix(agents): avoid xAI web_search tool-name collisions**
- **fix: clear Telegram DM draft after materialize (#36746) (thanks @joelnishanth)**
- **Fix Control UI duplicate iMessage replies for internal webchat turns (#36151)**
- **fix: enforce 600 perms for cron store and run logs (#36078)**
- **fix(tui): accept canonical session-key aliases in chat event routing**
- **Gateway: normalize OpenAI stream chunk text**
- **Gateway: coerce chat deliverable route boolean**
- **fix(web_search): align brave language codes with API**
- **Respect source channel for agent event surfacing (#36030)**
- **fix(session): prefer webchat routes for direct ui turns (#37135)**
- **Gateway: discriminate input sources**
- **Cron: migrate legacy provider delivery hints**
- **Cron: stabilize runs-one-shot migration tests**
- **fix(memory): retry mcporter after Windows EINVAL spawn**
- **fix(onboarding): guard daemon status probe on headless linux**
- **Gateway: add path-scoped config schema lookup (#37266)**
- **docs(changelog): add pr entry**
- **fix(ci): restore protocol and schema checks (#37470)**
- **Fix failover for zhipuai 1310 Weekly/Monthly Limit Exhausted (#33813)**
- **fix(openai-codex-oauth): stop mutating authorize url scopes**
- **Update CHANGELOG.md**
- **fix(auth): remove bogus codex oauth responses probe**
- **docs(changelog): fold codex oauth fix notes**
- **docs(changelog): add codex oauth pr reference (#37558)**
- **fix(failover): classify HTTP 402 as rate_limit when payload indicates usage limit (#30484) (#36802)**
- **fix(mattermost): allow reachable interaction callback URLs (#37543)**
- **Gateway: allow slash-delimited schema lookup paths**
- **feature(context): extend plugin system to support custom context management (#22201)**
- **fix(session): tighten direct-session webchat routing matching (#37867)**
- **docs(tools): document slash-delimited config schema lookup paths**
- **docs(protocol): document slash-delimited schema lookup plugin ids**
- **docs(plugins): document context engine slots and registration**
- **docs(plugins): add context-engine manifest kind example**
- **docs(config): list the context engine plugin slot**
- **docs: context engine**
- **fix(nano-banana-pro): remove space after MEDIA: token in generate_image.py (#18706)**
- **CI: drop unused install-smoke bootstrap**
- **nano-banana-pro: respect explicit --resolution when editing images (#36880)**
- **Skills/nano-banana-pro: clarify MEDIA token comment (#38063)**
- **CI: run changed-scope on main pushes**
- **Telegram/Discord: honor outbound mediaMaxMb uploads (#38065)**
- **Docs: align BlueBubbles media cap wording**
- **openai-image-gen: validate --background and --style options (#36762)**
- **WhatsApp: honor outbound mediaMaxMb (#38097)**
- **Mattermost: harden interaction callback binding (#38057)**
- **Infra: require explicit opt-in for prerelease npm installs (#38117)**
- **openai-image-gen: validate and normalize --output-format (#36648)**
- **Gateway: normalize HEIC input_image sources (#38122)**
- **CI: cover skill and extension tests**
- **fix: Windows: openclaw plugins install fails with spawn EINVAL**
- **fix: Telegram API requests fail with Network request failed after**
- **fix: narrow Telegram failed-after retry match**
- **chore: prep #38056 for landing (thanks @0xlin2023)**
- **Gateway: follow up HEIC input image handling (#38146)**
- **fix(feishu): restore explicit media request timeouts**
- **chore(extensions): sync plugin versions**
- **fix(gateway): keep probe routes reachable with root-mounted control ui (#38199)**
- **container builds: opt-in extension deps via OPENCLAW_EXTENSIONS build arg (#32223)**
- **CI: add Barnacle r: too-many-prs guard**
- **fix: tune stale workflow limits**
- **fix: add stale workflow fallback run**
- **chore: update X handle**
- **chore: disable contributor labels**
- **feat(onboarding): add web search to onboarding flow (#34009)**
- **CI: shallow scope checkouts**
- **Install Smoke: shallow docs-scope checkout**
- **Install Smoke: allow reusing prebuilt test images**
- **Install Smoke: cache docker smoke builds**
- **chore: code/dead tests cleanup (#38286)**
- **Media: reject spoofed input_image MIME payloads (#38289)**
- **CI: scope secret scans to changed files**
- **Docs: update secret scan reproduction steps**
- **CI: keep full secret scans on main**
- **Docs: clarify main secret scan behavior**
- **CI: add base-commit fetch helper**
- **CI: fetch base history on demand**
- **Install Smoke: fetch docs base on demand**
- **CI: skip detect-secrets on main temporarily**
- **Tooling: add Knip workspace config**
- **Tooling: wire deadcode scripts to Knip**
- **CI: enable report-only Knip deadcode job**
- **feat(gateway): add channel-backed readiness probes (#38285)**
- **docs: fix broken dashboard image on i18n pages (#38031)**
- **fix(feishu): remove invalid timeout properties from SDK method calls (#38267)**
- **docs: add changelog entry for Feishu timeouts (#38356)**
- **fix: add no-ci-pr auto-response label**
- **fix: repair auto-response workflow YAML**
- **fix(pi-embedded-runner): propagate sender identity to fix Feishu doc create auto-grant (#32915)**
- **Feishu: update media timeout tests**
- **fix(agents): handle overloaded failover separately (#38301)**
- **Tests: serialize low-memory test runner lanes**
- **Dead code: remove unused helper modules (#38318)**
- **feat(compaction): make post-compaction context sections configurable (#34556)**
- **fix: strip skill-injected env vars from ACP harness spawn env (#36280) (#36316)**
- **fix(auth): treat unconfigured-owner sessions as owner for ownerOnly tools (#26331)**
- **fix(agents): prevent totalTokens crash when assistant usage is missing (#34977)**
- **fix(venice): harden discovery limits and tool support (#38306)**
- **fix(imessage): prevent echo loop from leaking internal metadata and amplifying NO_REPLY into queue overflow (#33295)**
- **fix(venice): switch default model to kimi-k2-5 (#38423)**
- **Secrets: add inline allowlist review set (#38314)**
- **fix: xxxxx**
- **Dependencies: remove unused core and UI packages (#38316)**
- **fix(podman): stop assuming /tmp is disk-backed (#38296)**
- **Dependencies: remove unused extension packages (#38317)**
- **Agents: add skill API rate-limit guardrail (#38452)**
- **fix(gateway): stop shared-main chat.send from inheriting stale external routes (#38418)**
- **fix(media): retain inbound media with recursive cleanup TTL (#38292)**
- **fix(googlechat): inherit shared defaults for multi-account webhook auth (#38492)**
- **fix: increase maxTokens for tool probe to support reasoning models**
- **fix(gateway): classify wrapped "fetch failed" messages as transient network errors (openclaw#38530)**
- **Web: add HEIC media regression and doc fix (#38294)**
- **fix: suppress ACP NO_REPLY fragments in console output (#38436)**
- **fix(feishu): disable block streaming to prevent silent reply drops (openclaw#38422)**
- **Fix owner-only auth and overlapping skill env regressions (#38548)**
- **fix: normalize reply media paths**
- **fix: contain block reply media failures**
- **fix: contain final reply media normalization failures**
- **docs: update changelog for reply media delivery (#38572)**
- **fix(gateway): invalidate bootstrap cache on session rollover (openclaw#38535)**
- **fix(gateway): skip stale-socket restarts for Telegram polling (openclaw#38405)**
- **fix(gateway): stop stale-socket restarts before first event (#38643)**
- **fix: always send device token when paired, regardless of gateway.auth.token**
