### PR TITLE
fix(telegram): namespace slash SessionKey by agent

### DIFF
--- a/src/telegram/bot-native-commands.session-meta.test.ts
+++ b/src/telegram/bot-native-commands.session-meta.test.ts
@@ -265,6 +265,12 @@ describe("registerTelegramNativeCommands — session metadata", () => {
       >
     )[0]?.[0];
     expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe(boundSessionKey);
+    const sessionMetaCall = (
+      sessionMocks.recordSessionMetaFromInbound.mock.calls as unknown as Array<
+        [{ sessionKey?: string }]
+      >
+    )[0]?.[0];
+    expect(sessionMetaCall?.sessionKey).toBe("agent:codex:telegram:slash:200");
   });
 
   it("aborts native command dispatch when configured ACP topic binding cannot initialize", async () => {

--- a/src/telegram/bot-native-commands.session-meta.test.ts
+++ b/src/telegram/bot-native-commands.session-meta.test.ts
@@ -198,7 +198,7 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     )[0]?.[0];
     expect(call?.ctx?.OriginatingChannel).toBe("telegram");
     expect(call?.ctx?.Provider).toBe("telegram");
-    expect(call?.sessionKey).toBeDefined();
+    expect(call?.sessionKey).toBe("agent:main:telegram:slash:200");
   });
 
   it("awaits session metadata persistence before dispatch", async () => {

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -669,7 +669,7 @@ export const registerTelegramNativeCommands = ({
             WasMentioned: true,
             CommandAuthorized: commandAuthorized,
             CommandSource: "native" as const,
-            SessionKey: `telegram:slash:${senderId || chatId}`,
+            SessionKey: `agent:${route.agentId}:telegram:slash:${senderId || chatId}`,
             AccountId: route.accountId,
             CommandTargetSessionKey: sessionKey,
             MessageThreadId: threadSpec.id,


### PR DESCRIPTION
## Summary

Telegram native slash commands were storing session metadata under a bare key (`telegram:slash:<id>`), which omitted the `agent:<agentId>:` namespace. This could collide with agent-scoped sessions and lead to duplicate delivery routing.

## Changes

- Prefix Telegram slash SessionKey with `agent:${route.agentId}:...` in native command context.
- Tighten the session-meta unit test to assert the exact namespaced key format.

## Testing

- `pnpm exec vitest run src/telegram/bot-native-commands.session-meta.test.ts --config vitest.channels.config.ts`

Fixes openclaw/openclaw#38648
