### PR TITLE
[AI-assisted] fix(media): bypass proxy for internal audio backends

### DIFF
--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -1,18 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const PROXY_ENV_KEYS = [
-  "HTTPS_PROXY",
-  "HTTP_PROXY",
-  "ALL_PROXY",
-  "https_proxy",
-  "http_proxy",
-  "all_proxy",
-] as const;
-
-const ORIGINAL_PROXY_ENV = Object.fromEntries(
-  PROXY_ENV_KEYS.map((key) => [key, process.env[key]]),
-) as Record<(typeof PROXY_ENV_KEYS)[number], string | undefined>;
-
 const { ProxyAgent, EnvHttpProxyAgent, undiciFetch, proxyAgentSpy, envAgentSpy, getLastAgent } =
   vi.hoisted(() => {
     const undiciFetch = vi.fn();
@@ -53,22 +40,6 @@ vi.mock("undici", () => ({
 
 import { makeProxyFetch, resolveProxyFetchFromEnv } from "./proxy-fetch.js";
 
-function clearProxyEnv(): void {
-  for (const key of PROXY_ENV_KEYS) {
-    delete process.env[key];
-  }
-}
-
-function restoreProxyEnv(): void {
-  clearProxyEnv();
-  for (const key of PROXY_ENV_KEYS) {
-    const value = ORIGINAL_PROXY_ENV[key];
-    if (typeof value === "string") {
-      process.env[key] = value;
-    }
-  }
-}
-
 describe("makeProxyFetch", () => {
   beforeEach(() => vi.clearAllMocks());
 
@@ -89,27 +60,117 @@ describe("makeProxyFetch", () => {
 });
 
 describe("resolveProxyFetchFromEnv", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.unstubAllEnvs();
-    clearProxyEnv();
-  });
-  afterEach(() => {
-    vi.unstubAllEnvs();
-    restoreProxyEnv();
-  });
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.unstubAllEnvs());
 
   it("returns undefined when no proxy env vars are set", () => {
-    expect(resolveProxyFetchFromEnv({})).toBeUndefined();
+    vi.stubEnv("HTTPS_PROXY", "");
+    vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("https_proxy", "");
+    vi.stubEnv("http_proxy", "");
+
+    expect(resolveProxyFetchFromEnv()).toBeUndefined();
+  });
+
+  it("returns undefined for explicit no_proxy host matches", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+    vi.stubEnv("NO_PROXY", "172.31.0.14,example.internal");
+
+    expect(
+      resolveProxyFetchFromEnv("http://172.31.0.14:9001/v1/audio/transcriptions"),
+    ).toBeUndefined();
+    expect(envAgentSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined for IPv6 loopback targets", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+
+    expect(resolveProxyFetchFromEnv("http://[::1]:9001/v1/models")).toBeUndefined();
+    expect(envAgentSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined for IPv4 loopback targets", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+
+    expect(resolveProxyFetchFromEnv("http://127.0.0.1:9001/v1/models")).toBeUndefined();
+    expect(envAgentSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns proxy fetch for private-network targets that are not in no_proxy", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+    vi.stubEnv("NO_PROXY", "");
+    vi.stubEnv("no_proxy", "");
+
+    expect(resolveProxyFetchFromEnv("http://192.168.3.20:8080/health")).toBeDefined();
+    expect(envAgentSpy).toHaveBeenCalled();
+  });
+
+  it("returns undefined for CIDR no_proxy matches", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+    vi.stubEnv("NO_PROXY", "203.0.113.0/24");
+
+    expect(resolveProxyFetchFromEnv("http://203.0.113.14:9001/v1/models")).toBeUndefined();
+    expect(envAgentSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined for no_proxy host:port matches", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+    vi.stubEnv("NO_PROXY", "172.31.0.14:9001,[::1]:9001");
+
+    expect(
+      resolveProxyFetchFromEnv("http://172.31.0.14:9001/v1/audio/transcriptions"),
+    ).toBeUndefined();
+    expect(resolveProxyFetchFromEnv("http://[::1]:9001/v1/models")).toBeUndefined();
+    expect(envAgentSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps proxy fetch when no_proxy host:port only matches a different port", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+    vi.stubEnv("NO_PROXY", "internal.example:8443,.example.internal:8443");
+
+    expect(resolveProxyFetchFromEnv("http://internal.example:8080/health")).toBeDefined();
+    expect(resolveProxyFetchFromEnv("http://api.example.internal:8080/health")).toBeDefined();
+    expect(envAgentSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns undefined for no_proxy suffix host:port matches", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+    vi.stubEnv("NO_PROXY", ".example.internal:8443");
+
+    expect(resolveProxyFetchFromEnv("http://api.example.internal:8443/health")).toBeUndefined();
+    expect(envAgentSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined for no_proxy host:port entries that match the default scheme port", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+    vi.stubEnv("NO_PROXY", "example.com:443");
+
+    expect(resolveProxyFetchFromEnv("https://example.com/v1/models")).toBeUndefined();
+    expect(envAgentSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps proxy fetch when wildcard no_proxy only matches a different port", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+    vi.stubEnv("NO_PROXY", "*:8080");
+
+    expect(resolveProxyFetchFromEnv("https://example.com:443/v1/models")).toBeDefined();
+    expect(envAgentSpy).toHaveBeenCalled();
+  });
+
+  it("returns undefined when wildcard no_proxy matches the target port", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+    vi.stubEnv("NO_PROXY", "*:8080");
+
+    expect(resolveProxyFetchFromEnv("http://example.com:8080/health")).toBeUndefined();
+    expect(envAgentSpy).not.toHaveBeenCalled();
   });
 
   it("returns proxy fetch using EnvHttpProxyAgent when HTTPS_PROXY is set", async () => {
+    vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
     undiciFetch.mockResolvedValue({ ok: true });
 
-    const fetchFn = resolveProxyFetchFromEnv({
-      HTTP_PROXY: "",
-      HTTPS_PROXY: "http://proxy.test:8080",
-    });
+    const fetchFn = resolveProxyFetchFromEnv();
     expect(fetchFn).toBeDefined();
     expect(envAgentSpy).toHaveBeenCalled();
 
@@ -121,47 +182,46 @@ describe("resolveProxyFetchFromEnv", () => {
   });
 
   it("returns proxy fetch when HTTP_PROXY is set", () => {
-    const fetchFn = resolveProxyFetchFromEnv({
-      HTTPS_PROXY: "",
-      HTTP_PROXY: "http://fallback.test:3128",
-    });
+    vi.stubEnv("HTTPS_PROXY", "");
+    vi.stubEnv("HTTP_PROXY", "http://fallback.test:3128");
+
+    const fetchFn = resolveProxyFetchFromEnv();
     expect(fetchFn).toBeDefined();
     expect(envAgentSpy).toHaveBeenCalled();
   });
 
   it("returns proxy fetch when lowercase https_proxy is set", () => {
-    const fetchFn = resolveProxyFetchFromEnv({
-      HTTPS_PROXY: "",
-      HTTP_PROXY: "",
-      http_proxy: "",
-      https_proxy: "http://lower.test:1080",
-    });
+    vi.stubEnv("HTTPS_PROXY", "");
+    vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("http_proxy", "");
+    vi.stubEnv("https_proxy", "http://lower.test:1080");
+
+    const fetchFn = resolveProxyFetchFromEnv();
     expect(fetchFn).toBeDefined();
     expect(envAgentSpy).toHaveBeenCalled();
   });
 
   it("returns proxy fetch when lowercase http_proxy is set", () => {
-    const fetchFn = resolveProxyFetchFromEnv({
-      HTTPS_PROXY: "",
-      HTTP_PROXY: "",
-      https_proxy: "",
-      http_proxy: "http://lower-http.test:1080",
-    });
+    vi.stubEnv("HTTPS_PROXY", "");
+    vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("https_proxy", "");
+    vi.stubEnv("http_proxy", "http://lower-http.test:1080");
+
+    const fetchFn = resolveProxyFetchFromEnv();
     expect(fetchFn).toBeDefined();
     expect(envAgentSpy).toHaveBeenCalled();
   });
 
   it("returns undefined when EnvHttpProxyAgent constructor throws", () => {
+    vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("https_proxy", "");
+    vi.stubEnv("http_proxy", "");
+    vi.stubEnv("HTTPS_PROXY", "not-a-valid-url");
     envAgentSpy.mockImplementationOnce(() => {
       throw new Error("Invalid URL");
     });
 
-    const fetchFn = resolveProxyFetchFromEnv({
-      HTTP_PROXY: "",
-      https_proxy: "",
-      http_proxy: "",
-      HTTPS_PROXY: "not-a-valid-url",
-    });
+    const fetchFn = resolveProxyFetchFromEnv();
     expect(fetchFn).toBeUndefined();
   });
 });

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -95,7 +95,6 @@ describe("resolveProxyFetchFromEnv", () => {
     expect(resolveProxyFetchFromEnv("http://127.0.0.1:9001/v1/models")).toBeUndefined();
     expect(envAgentSpy).not.toHaveBeenCalled();
   });
-
   it("returns proxy fetch for private-network targets that are not in no_proxy", () => {
     vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
     vi.stubEnv("NO_PROXY", "");

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -101,6 +101,14 @@ describe("resolveProxyFetchFromEnv", () => {
     expect(envAgentSpy).not.toHaveBeenCalled();
   });
 
+  it("returns undefined for whitespace-delimited no_proxy entries", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+    vi.stubEnv("NO_PROXY", "10.0.0.0/8 example.internal");
+
+    expect(resolveProxyFetchFromEnv("http://example.internal:9001/v1/models")).toBeUndefined();
+    expect(envAgentSpy).not.toHaveBeenCalled();
+  });
+
   it("uses lowercase no_proxy in preference to NO_PROXY", () => {
     vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
     vi.stubEnv("NO_PROXY", "example.internal");
@@ -162,6 +170,22 @@ describe("resolveProxyFetchFromEnv", () => {
   it("returns undefined for no_proxy suffix host:port matches", () => {
     vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
     vi.stubEnv("NO_PROXY", ".example.internal:8443");
+
+    expect(resolveProxyFetchFromEnv("http://api.example.internal:8443/health")).toBeUndefined();
+    expect(envAgentSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined for leading-dot no_proxy entries on the exact host", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+    vi.stubEnv("NO_PROXY", ".example.internal:8443");
+
+    expect(resolveProxyFetchFromEnv("http://example.internal:8443/health")).toBeUndefined();
+    expect(envAgentSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined for wildcard-suffix no_proxy entries", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+    vi.stubEnv("NO_PROXY", "*.example.internal:8443");
 
     expect(resolveProxyFetchFromEnv("http://api.example.internal:8443/health")).toBeUndefined();
     expect(envAgentSpy).not.toHaveBeenCalled();

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -122,7 +122,6 @@ describe("resolveProxyFetchFromEnv", () => {
     expect(resolveProxyFetchFromEnv("http://[::1]:9001/v1/models")).toBeUndefined();
     expect(envAgentSpy).not.toHaveBeenCalled();
   });
-
   it("keeps proxy fetch when no_proxy host:port only matches a different port", () => {
     vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
     vi.stubEnv("NO_PROXY", "internal.example:8443,.example.internal:8443");
@@ -163,7 +162,6 @@ describe("resolveProxyFetchFromEnv", () => {
     expect(resolveProxyFetchFromEnv("http://example.com:8080/health")).toBeUndefined();
     expect(envAgentSpy).not.toHaveBeenCalled();
   });
-
   it("returns proxy fetch using EnvHttpProxyAgent when HTTPS_PROXY is set", async () => {
     vi.stubEnv("HTTP_PROXY", "");
     vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");

--- a/src/infra/net/proxy-fetch.test.ts
+++ b/src/infra/net/proxy-fetch.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const ORIGINAL_NO_PROXY = process.env.NO_PROXY;
+const ORIGINAL_no_proxy = process.env.no_proxy;
+
 const { ProxyAgent, EnvHttpProxyAgent, undiciFetch, proxyAgentSpy, envAgentSpy, getLastAgent } =
   vi.hoisted(() => {
     const undiciFetch = vi.fn();
@@ -60,8 +63,24 @@ describe("makeProxyFetch", () => {
 });
 
 describe("resolveProxyFetchFromEnv", () => {
-  beforeEach(() => vi.clearAllMocks());
-  afterEach(() => vi.unstubAllEnvs());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    if (ORIGINAL_NO_PROXY === undefined) {
+      delete process.env.NO_PROXY;
+    } else {
+      process.env.NO_PROXY = ORIGINAL_NO_PROXY;
+    }
+    if (ORIGINAL_no_proxy === undefined) {
+      delete process.env.no_proxy;
+    } else {
+      process.env.no_proxy = ORIGINAL_no_proxy;
+    }
+  });
 
   it("returns undefined when no proxy env vars are set", () => {
     vi.stubEnv("HTTPS_PROXY", "");
@@ -80,6 +99,15 @@ describe("resolveProxyFetchFromEnv", () => {
       resolveProxyFetchFromEnv("http://172.31.0.14:9001/v1/audio/transcriptions"),
     ).toBeUndefined();
     expect(envAgentSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses lowercase no_proxy in preference to NO_PROXY", () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+    vi.stubEnv("NO_PROXY", "example.internal");
+    vi.stubEnv("no_proxy", "");
+
+    expect(resolveProxyFetchFromEnv("http://example.internal:9001/v1/models")).toBeDefined();
+    expect(envAgentSpy).toHaveBeenCalled();
   });
 
   it("returns undefined for IPv6 loopback targets", () => {

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -1,3 +1,4 @@
+import { isIP } from "node:net";
 import { EnvHttpProxyAgent, ProxyAgent, fetch as undiciFetch } from "undici";
 import { logWarn } from "../../logger.js";
 import { hasEnvHttpProxyConfigured } from "./proxy-env.js";
@@ -6,6 +7,143 @@ export const PROXY_FETCH_PROXY_URL = Symbol.for("openclaw.proxyFetch.proxyUrl");
 type ProxyFetchWithMetadata = typeof fetch & {
   [PROXY_FETCH_PROXY_URL]?: string;
 };
+type NoProxyEntry = {
+  pattern: string;
+  port?: string;
+};
+
+function normalizeNoProxyEntry(entry: string): NoProxyEntry | null {
+  const value = entry.trim().toLowerCase();
+  if (!value) {
+    return null;
+  }
+  if (value === "*" || value.includes("/")) {
+    return { pattern: value };
+  }
+  if (value.startsWith("[")) {
+    const closingBracket = value.indexOf("]");
+    if (closingBracket > 0) {
+      const pattern = value.slice(1, closingBracket);
+      const remainder = value.slice(closingBracket + 1);
+      if (!remainder) {
+        return { pattern };
+      }
+      if (/^:\d+$/.test(remainder)) {
+        return { pattern, port: remainder.slice(1) };
+      }
+      return { pattern: value };
+    }
+  }
+  const colonCount = value.split(":").length - 1;
+  if (colonCount === 1) {
+    const lastColon = value.lastIndexOf(":");
+    const pattern = value.slice(0, lastColon);
+    const port = value.slice(lastColon + 1);
+    if (pattern && /^\d+$/.test(port)) {
+      return { pattern, port };
+    }
+  }
+  return { pattern: value };
+}
+
+function getNoProxyEntries(env: NodeJS.ProcessEnv): NoProxyEntry[] {
+  return [env.NO_PROXY, env.no_proxy]
+    .flatMap((value) => String(value ?? "").split(","))
+    .map(normalizeNoProxyEntry)
+    .filter((entry): entry is NoProxyEntry => Boolean(entry));
+}
+
+function getDefaultPort(protocol: string): string {
+  if (protocol === "http:") {
+    return "80";
+  }
+  if (protocol === "https:") {
+    return "443";
+  }
+  return "";
+}
+
+function parseIpv4(value: string): number | null {
+  const parts = value.split(".");
+  if (parts.length !== 4) {
+    return null;
+  }
+  let result = 0;
+  for (const part of parts) {
+    if (!/^\d+$/.test(part)) {
+      return null;
+    }
+    const octet = Number(part);
+    if (!Number.isInteger(octet) || octet < 0 || octet > 255) {
+      return null;
+    }
+    result = (result << 8) | octet;
+  }
+  return result >>> 0;
+}
+
+function matchesIpv4Cidr(hostname: string, cidr: string): boolean {
+  const [network, prefixRaw] = cidr.split("/");
+  const hostValue = parseIpv4(hostname);
+  const networkValue = parseIpv4(network ?? "");
+  const prefix = Number(prefixRaw);
+  if (hostValue === null || networkValue === null || !Number.isInteger(prefix)) {
+    return false;
+  }
+  if (prefix < 0 || prefix > 32) {
+    return false;
+  }
+  if (prefix === 0) {
+    return true;
+  }
+  const mask = (0xffffffff << (32 - prefix)) >>> 0;
+  return (hostValue & mask) === (networkValue & mask);
+}
+
+function shouldBypassProxy(targetUrl: string, env: NodeJS.ProcessEnv): boolean {
+  let hostname: string;
+  let port: string;
+  try {
+    const target = new URL(targetUrl);
+    const rawHostname = target.hostname.trim().toLowerCase();
+    hostname =
+      rawHostname.startsWith("[") && rawHostname.endsWith("]")
+        ? rawHostname.slice(1, -1)
+        : rawHostname;
+    port = target.port || getDefaultPort(target.protocol);
+  } catch {
+    return false;
+  }
+
+  if (!hostname) {
+    return false;
+  }
+  if (hostname === "localhost" || hostname === "::1") {
+    return true;
+  }
+  if (isIP(hostname) === 4 && matchesIpv4Cidr(hostname, "127.0.0.0/8")) {
+    return true;
+  }
+
+  const entries = getNoProxyEntries(env);
+  return entries.some((entry) => {
+    if (entry.pattern === "*") {
+      return true;
+    }
+    if (entry.port && port && entry.port !== port) {
+      return false;
+    }
+    // Support the CIDR-style no_proxy values commonly used in local/self-hosted
+    // deployments even though undici's EnvHttpProxyAgent does not reliably do so.
+    if (entry.pattern.includes("/")) {
+      return isIP(hostname) === 4 && matchesIpv4Cidr(hostname, entry.pattern);
+    }
+    if (entry.pattern.startsWith(".")) {
+      return hostname.endsWith(entry.pattern);
+    }
+    return hostname === entry.pattern || hostname.endsWith(`.${entry.pattern}`);
+  });
+}
 
 /**
  * Create a fetch function that routes requests through the given HTTP proxy.
@@ -51,10 +189,15 @@ export function getProxyUrlFromFetch(fetchImpl?: typeof fetch): string | undefin
  * Returns undefined when no proxy is configured.
  * Gracefully returns undefined if the proxy URL is malformed.
  */
-export function resolveProxyFetchFromEnv(
-  env: NodeJS.ProcessEnv = process.env,
-): typeof fetch | undefined {
-  if (!hasEnvHttpProxyConfigured("https", env)) {
+export function resolveProxyFetchFromEnv(targetUrl?: string): typeof fetch | undefined {
+  if (!hasEnvHttpProxyConfigured("https")) {
+    return undefined;
+  }
+  // Use the default fetch path only for loopback targets or hosts the operator
+  // explicitly excluded through NO_PROXY. This keeps proxy behavior aligned
+  // with standard clients while still allowing self-hosted STT/media backends
+  // to opt out when multipart uploads break through proxy wrappers.
+  if (targetUrl && shouldBypassProxy(targetUrl, process.env)) {
     return undefined;
   }
   try {

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -142,11 +142,11 @@ function shouldBypassProxy(targetUrl: string, env: NodeJS.ProcessEnv): boolean {
 
   const entries = getNoProxyEntries(env);
   return entries.some((entry) => {
-    if (entry.pattern === "*") {
-      return true;
-    }
     if (entry.port && port && entry.port !== port) {
       return false;
+    }
+    if (entry.pattern === "*") {
+      return true;
     }
     // Support the CIDR-style no_proxy values commonly used in local/self-hosted
     // deployments even though undici's EnvHttpProxyAgent does not reliably do so.

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -12,6 +12,10 @@ type NoProxyEntry = {
   port?: string;
 };
 
+function normalizeNoProxyPattern(pattern: string): string {
+  return pattern.replace(/^\*?\./, "");
+}
+
 function normalizeNoProxyEntry(entry: string): NoProxyEntry | null {
   const value = entry.trim().toLowerCase();
   if (!value) {
@@ -37,13 +41,14 @@ function normalizeNoProxyEntry(entry: string): NoProxyEntry | null {
   const colonCount = value.split(":").length - 1;
   if (colonCount === 1) {
     const lastColon = value.lastIndexOf(":");
-    const pattern = value.slice(0, lastColon);
+    const pattern = normalizeNoProxyPattern(value.slice(0, lastColon));
     const port = value.slice(lastColon + 1);
     if (pattern && /^\d+$/.test(port)) {
       return { pattern, port };
     }
   }
-  return { pattern: value };
+  const pattern = normalizeNoProxyPattern(value);
+  return pattern ? { pattern } : null;
 }
 
 function resolveNoProxyValue(env: NodeJS.ProcessEnv): string {
@@ -58,7 +63,7 @@ function resolveNoProxyValue(env: NodeJS.ProcessEnv): string {
 
 function getNoProxyEntries(env: NodeJS.ProcessEnv): NoProxyEntry[] {
   return resolveNoProxyValue(env)
-    .split(",")
+    .split(/[\s,]+/)
     .map(normalizeNoProxyEntry)
     .filter((entry): entry is NoProxyEntry => Boolean(entry));
 }
@@ -147,9 +152,6 @@ function shouldBypassProxy(targetUrl: string, env: NodeJS.ProcessEnv): boolean {
     // deployments even though undici's EnvHttpProxyAgent does not reliably do so.
     if (entry.pattern.includes("/")) {
       return isIP(hostname) === 4 && matchesIpv4Cidr(hostname, entry.pattern);
-    }
-    if (entry.pattern.startsWith(".")) {
-      return hostname.endsWith(entry.pattern);
     }
     return hostname === entry.pattern || hostname.endsWith(`.${entry.pattern}`);
   });

--- a/src/infra/net/proxy-fetch.ts
+++ b/src/infra/net/proxy-fetch.ts
@@ -46,9 +46,19 @@ function normalizeNoProxyEntry(entry: string): NoProxyEntry | null {
   return { pattern: value };
 }
 
+function resolveNoProxyValue(env: NodeJS.ProcessEnv): string {
+  if (typeof env.no_proxy === "string") {
+    return env.no_proxy;
+  }
+  if (typeof env.NO_PROXY === "string") {
+    return env.NO_PROXY;
+  }
+  return "";
+}
+
 function getNoProxyEntries(env: NodeJS.ProcessEnv): NoProxyEntry[] {
-  return [env.NO_PROXY, env.no_proxy]
-    .flatMap((value) => String(value ?? "").split(","))
+  return resolveNoProxyValue(env)
+    .split(",")
     .map(normalizeNoProxyEntry)
     .filter((entry): entry is NoProxyEntry => Boolean(entry));
 }

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -480,10 +480,6 @@ export async function runProviderEntry(params: {
     throw new Error(`Media provider not available: ${providerId}`);
   }
 
-  // Resolve proxy-aware fetch from env vars (HTTPS_PROXY, HTTP_PROXY, etc.)
-  // so provider HTTP calls are routed through the proxy when configured.
-  const fetchFn = resolveProxyFetchFromEnv();
-
   if (capability === "audio") {
     if (!provider.transcribeAudio) {
       throw new Error(`Audio transcription provider "${providerId}" not available.`);
@@ -502,6 +498,9 @@ export async function runProviderEntry(params: {
       config: params.config,
       agentDir: params.agentDir,
     });
+    // Audio backends are often self-hosted on RFC1918/private addresses. Let
+    // resolveProxyFetchFromEnv decide whether the request should stay direct.
+    const fetchFn = resolveProxyFetchFromEnv(baseUrl);
     const providerQuery = resolveProviderQuery({
       providerId,
       config: params.config,
@@ -560,6 +559,7 @@ export async function runProviderEntry(params: {
     config: params.config,
     agentDir: params.agentDir,
   });
+  const fetchFn = resolveProxyFetchFromEnv(baseUrl);
   const result = await executeWithApiKeyRotation({
     provider: providerId,
     apiKeys,

--- a/src/media-understanding/runner.proxy.test.ts
+++ b/src/media-understanding/runner.proxy.test.ts
@@ -68,6 +68,57 @@ describe("runCapability proxy fetch passthrough", () => {
     expect(seenFetchFn).not.toBe(globalThis.fetch);
   });
 
+  it("does not pass fetchFn to audio providers for private-network targets", async () => {
+    vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+
+    let seenFetchFn: typeof fetch | undefined;
+    await withAudioFixture("openclaw-audio-private-no-proxy", async ({ ctx, media, cache }) => {
+      const providerRegistry = buildProviderRegistry({
+        openai: {
+          id: "openai",
+          capabilities: ["audio"],
+          transcribeAudio: async (req: AudioTranscriptionRequest) => {
+            seenFetchFn = req.fetchFn;
+            return { text: "transcribed", model: req.model };
+          },
+        },
+      });
+
+      const cfg = {
+        models: {
+          providers: {
+            openai: {
+              apiKey: "test-key", // pragma: allowlist secret
+              baseUrl: "http://172.31.0.14:9001/v1",
+              models: [],
+            },
+          },
+        },
+        tools: {
+          media: {
+            audio: {
+              enabled: true,
+              models: [{ provider: "openai", model: "whisper-1" }],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = await runCapability({
+        capability: "audio",
+        cfg,
+        ctx,
+        attachments: cache,
+        media,
+        providerRegistry,
+      });
+
+      expect(result.outputs[0]?.text).toBe("transcribed");
+    });
+
+    expect(seenFetchFn).toBeUndefined();
+  });
+
   it("passes fetchFn to video provider when HTTPS_PROXY is set", async () => {
     vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
 

--- a/src/media-understanding/runner.proxy.test.ts
+++ b/src/media-understanding/runner.proxy.test.ts
@@ -68,8 +68,9 @@ describe("runCapability proxy fetch passthrough", () => {
     expect(seenFetchFn).not.toBe(globalThis.fetch);
   });
 
-  it("does not pass fetchFn to audio providers for private-network targets", async () => {
+  it("does not pass fetchFn to audio providers when baseUrl is covered by NO_PROXY", async () => {
     vi.stubEnv("HTTPS_PROXY", "http://proxy.test:8080");
+    vi.stubEnv("NO_PROXY", "172.31.0.14");
 
     let seenFetchFn: typeof fetch | undefined;
     await withAudioFixture("openclaw-audio-private-no-proxy", async ({ ctx, media, cache }) => {

--- a/src/media-understanding/runner.proxy.test.ts
+++ b/src/media-understanding/runner.proxy.test.ts
@@ -1,4 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@mariozechner/pi-ai/oauth", () => ({
+  getOAuthApiKey: () => undefined,
+  getOAuthProviders: () => [],
+}));
+
 import type { OpenClawConfig } from "../config/config.js";
 import { buildProviderRegistry, runCapability } from "./runner.js";
 import { withAudioFixture, withVideoFixture } from "./runner.test-utils.js";


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: media-understanding audio transcription always injected a proxy-aware `fetch` whenever proxy env vars were present, even for self-hosted backends that operators had explicitly excluded with `NO_PROXY`.
- Why it matters: OpenAI-compatible STT backends can reject multipart uploads when routed through that proxy wrapper, which leaves voice messages untranslated into text before the agent turn.
- What changed: proxy resolution is now target-aware for media backends and bypasses the proxy wrapper only for loopback targets and exact/suffix/CIDR `NO_PROXY` matches derived from the configured backend `baseUrl`.
- What did NOT change (scope boundary): no model/provider selection changes, no config schema changes, and no blanket bypass for all private-network targets.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Voice-message transcription now succeeds for self-hosted audio backends when the configured backend target is covered by `NO_PROXY`, even if `HTTP_PROXY` or `HTTPS_PROXY` is set globally.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  Existing media transcription requests can now bypass the proxy wrapper only for loopback targets or hosts the operator already excluded through `NO_PROXY`. Coverage was added for exact host, suffix host, and CIDR matches to keep the bypass explicit and predictable.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js gateway process
- Model/provider: OpenAI-compatible audio transcription backend
- Integration/channel (if any): Matrix voice message
- Relevant config (redacted): `tools.media.audio.enabled=true`, audio model `baseUrl=http://10.0.0.25:9001/v1`, `HTTPS_PROXY=http://proxy.example:3128`, `NO_PROXY=localhost,127.0.0.1,10.0.0.0/8`

### Steps

1. Configure an OpenAI-compatible STT backend and enable global proxy env vars for the gateway process.
2. Ensure the configured backend host is excluded through `NO_PROXY`.
3. Send a voice message that should be transcribed during media understanding before the agent reply is generated.

### Expected

- Audio transcription requests to the configured `NO_PROXY` backend bypass the proxy wrapper, the multipart upload is accepted, and the transcript is injected into the user turn.

### Actual

- Before this patch, the configured backend still received the proxy-aware `fetch`, causing the multipart request to fail and leaving the user turn without a transcript.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran focused tests for proxy resolution and media runner behavior; exercised the media-understanding path against a self-hosted OpenAI-compatible STT backend with proxy env vars enabled; confirmed the transcript was produced after the bypass logic was applied.
- Edge cases checked: explicit host `NO_PROXY` match, private-network targets not listed in `NO_PROXY`, and IPv4 CIDR `NO_PROXY` entries.
- What you did **not** verify: public internet backends that should continue to use the proxy wrapper, or non-audio providers beyond the targeted regression coverage.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or temporarily unset proxy env vars for the gateway process when using the affected self-hosted media backend.
- Files/config to restore: `src/infra/net/proxy-fetch.ts` and `src/media-understanding/runner.entries.ts`
- Known bad symptoms reviewers should watch for: a configured `NO_PROXY` backend starts routing through a proxy again and voice-message turns lose their transcript content.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: `NO_PROXY` matching semantics could diverge from operator expectations for uncommon patterns.
  - Mitigation: matching is limited to localhost, exact/suffix host entries, and explicit IPv4 CIDRs, with regression tests covering each path.

AI assistance: This PR was prepared with GPT-5.4 support. I reviewed the code changes, ran the targeted tests locally, and verified the media transcription flow manually before opening the PR.
