### PR TITLE
fix(telegram): add reasoning filter to slash command delivery path

### DIFF
--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -71,6 +71,7 @@ import {
   evaluateTelegramGroupPolicyAccess,
 } from "./group-access.js";
 import { resolveTelegramGroupPromptSettings } from "./group-config-helpers.js";
+import { splitTelegramReasoningText } from "./reasoning-lane-coordinator.js";
 import { buildInlineKeyboard } from "./send.js";
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
@@ -713,8 +714,27 @@ export const registerTelegramNativeCommands = ({
             dispatcherOptions: {
               ...prefixOptions,
               deliver: async (payload, _info) => {
+                // Strip reasoning text that leaks via <think> tags (e.g. Gemini Flash).
+                // bot-message-dispatch has full lane-based reasoning handling;
+                // this simpler path just drops reasoning content.
+                let filteredPayload = payload;
+                if (typeof payload.text === "string" && payload.text.length > 0) {
+                  const split = splitTelegramReasoningText(payload.text);
+                  const hasMedia =
+                    Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+                  if (split.reasoningText && !split.answerText) {
+                    if (hasMedia) {
+                      // Reasoning-only text but has media — deliver media with empty text.
+                      filteredPayload = { ...payload, text: "" };
+                    } else {
+                      return;
+                    }
+                  } else if (split.reasoningText && split.answerText) {
+                    filteredPayload = { ...payload, text: split.answerText };
+                  }
+                }
                 const result = await deliverReplies({
-                  replies: [payload],
+                  replies: [filteredPayload],
                   ...deliveryBaseOptions,
                 });
                 if (result.delivered) {


### PR DESCRIPTION
## Summary

- Problem: `bot-native-commands.ts` handles slash commands (`/reset`, `/model`, etc.) via `dispatchReplyWithBufferedBlockDispatcher`, but its `deliver` callback had no reasoning text filtering. Gemini Flash thinking content (delivered as `<think>` tags in text) leaks to Telegram users after slash commands, even when reasoning display is off.
- Why it matters: Users see raw internal reasoning text (`Reasoning:\n_thinking content_`) in Telegram after `/reset` and other slash commands.
- What changed: Added `splitTelegramReasoningText` filtering to the slash command `deliver` callback, matching the behavior already present in `bot-message-dispatch.ts` (regular messages). Reasoning-only payloads with media still deliver media with empty text.
- What did NOT change (scope boundary): `bot-message-dispatch.ts` (regular message path), `reasoning-lane-coordinator.ts` (split logic), reasoning level configuration. Slash commands always suppress reasoning text (no `/reasoning on` support in this path).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related #37890
- Related #26466

## User-visible / Behavior Changes

Slash command responses in Telegram no longer include leaked reasoning/thinking text from Gemini Flash models when reasoning display is off (the default).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22, OpenClaw gateway via launchd
- Model/provider: `google/gemini-2.5-flash` (Google AI native provider)
- Integration/channel: Telegram DM
- Relevant config: `thinkingDefault: off`, `reasoningLevel: off` (default)

### Steps

1. Configure OpenClaw with Gemini 2.5 Flash and Telegram channel
2. Send `/reset` in Telegram DM
3. Observe the greeting response

### Expected

Only the greeting text appears (e.g. "Hello! Is there anything I can help you with?")

### Actual (before fix)

A separate message with `Reasoning:\n_The user has started a new session..._` appears before the greeting

## Evidence

- [x] Trace/log snippets

Raw stream log before fix shows `<think>` content in `text_delta` events, and the text delivered to Telegram includes reasoning prefix. After fix, only answer text is delivered.

The key diagnostic: `appendRawStream` debug logging in `bot-message-dispatch.ts` showed zero `tg_` events for `/reset` responses, proving the delivery went through `bot-native-commands.ts` instead — which had no reasoning filter.

## Human Verification (required)

- Verified scenarios: `/reset` with Gemini 2.5 Flash on Telegram — reasoning text no longer appears
- Edge cases checked: reasoning-only + media payloads (deliver media with empty text, matching `bot-message-dispatch.ts` behavior)
- What I did **not** verify: Other slash commands with reasoning-capable models (expected same behavior since they share the same `deliver` callback)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit (single file, single function change)
- Files/config to restore: `src/telegram/bot-native-commands.ts`
- Known bad symptoms reviewers should watch for: Slash command responses being silently dropped (would indicate `splitTelegramReasoningText` false-positiving on non-reasoning text)

## Risks and Mitigations

- Risk: `splitTelegramReasoningText` could false-positive on legitimate text starting with "Reasoning:" prefix
  - Mitigation: Same risk exists in `bot-message-dispatch.ts` which has been running in production. The split function uses specific pattern matching (`Reasoning:\n_..._`) not a broad substring match.
- Risk: Slash commands always suppress reasoning regardless of `/reasoning on` setting
  - Mitigation: Slash commands don't have reasoning level UI/state. If reasoning display support is added to slash commands in the future, this filter should be updated to check `resolvedReasoningLevel`.