### PR TITLE
fix: skip detached spawn on Windows to prevent orphaned gateway process

### DIFF
--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -75,7 +75,9 @@ export async function runGatewayLoop(params: {
         `full process restart failed (${respawn.detail ?? "unknown error"}); falling back to in-process restart`,
       );
     } else {
-      gatewayLog.info("restart mode: in-process restart (OPENCLAW_NO_RESPAWN)");
+      gatewayLog.info(
+        `restart mode: in-process restart (${respawn.detail ?? "OPENCLAW_NO_RESPAWN"})`,
+      );
     }
     if (hadLock && !(await reacquireLockForInProcessRestart())) {
       return;

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -110,6 +110,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
   it("spawns detached child with current exec argv", () => {
     delete process.env.OPENCLAW_NO_RESPAWN;
     clearSupervisorHints();
+    setPlatform("linux");
     process.execArgv = ["--import", "tsx"];
     process.argv = ["/usr/local/bin/node", "/repo/dist/index.js", "gateway", "run"];
     spawnMock.mockReturnValue({ pid: 4242, unref: vi.fn() });
@@ -163,6 +164,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
   it("returns failed when spawn throws", () => {
     delete process.env.OPENCLAW_NO_RESPAWN;
     clearSupervisorHints();
+    setPlatform("linux");
 
     spawnMock.mockImplementation(() => {
       throw new Error("spawn failed");

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -148,6 +148,18 @@ describe("restartGatewayProcessWithFreshPid", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
+  it("returns disabled on Windows to avoid orphaned detached spawn", () => {
+    delete process.env.OPENCLAW_NO_RESPAWN;
+    clearSupervisorHints();
+    setPlatform("win32");
+
+    const result = restartGatewayProcessWithFreshPid();
+
+    expect(result.mode).toBe("disabled");
+    expect(result.detail).toContain("win32");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
   it("returns failed when spawn throws", () => {
     delete process.env.OPENCLAW_NO_RESPAWN;
     clearSupervisorHints();

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -47,6 +47,14 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
     return { mode: "supervised" };
   }
 
+  // Windows has no native process supervisor equivalent to launchd/systemd.
+  // Spawning a detached child leaves it orphaned and unmanaged — if the child
+  // dies (e.g. under a Scheduled Task), the gateway stays down permanently.
+  // Fall back to in-process restart so the original process stays alive.
+  if (process.platform === "win32") {
+    return { mode: "disabled", detail: "win32: no process supervisor" };
+  }
+
   try {
     const args = [...process.execArgv, ...process.argv.slice(1)];
     const child = spawn(process.execPath, args, {


### PR DESCRIPTION
## Summary

- **Problem:** On Windows with gateway registered as a Scheduled Task, SIGUSR1 restart spawns a detached child process. The original process exits, Scheduled Task marks the job complete, and the child runs orphaned with no supervision. If the child crashes, the gateway stays down permanently.
- **Why it matters:** Any Windows Scheduled Task user who triggers a restart (config.patch, gateway tool, internal SIGUSR1) loses automatic recovery. The gateway silently stays down until manual intervention.
- **What changed:** Added a `process.platform === "win32"` check in `restartGatewayProcessWithFreshPid()` that skips the detached spawn path and returns `disabled` mode, causing the caller to fall back to in-process restart. Updated the caller log to show the detail reason. Added a test for the Windows path.
- **What did NOT change:** macOS launchd kickstart, Linux systemd detection, the detached spawn path for non-Windows unsupervised environments, and the in-process restart logic are all untouched.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #38508

## User-visible / Behavior Changes

On Windows, gateway SIGUSR1 restart now uses in-process restart instead of spawning a detached child. The gateway process stays alive and remains under Scheduled Task supervision. Log output changes from "restart mode: full process restart (spawned pid XXXX)" to "restart mode: in-process restart (win32: no process supervisor)".

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows 10/11 with Scheduled Task (login trigger)
- Runtime/container: Node.js
- Model/provider: Any
- Integration/channel: Any

### Steps

1. Register gateway as a Windows Scheduled Task (login trigger)
2. Start gateway via Scheduled Task
3. Trigger SIGUSR1 restart (e.g. config.patch with auto-restart)
4. Before fix: original process exits, Scheduled Task marks complete, child is orphaned
5. After fix: in-process restart keeps the original process alive under Scheduled Task

### Expected

Gateway restarts in-process and remains supervised by Scheduled Task.

### Actual (before fix)

Gateway spawns detached child, original exits, Scheduled Task marks complete. Child is orphaned. If child dies, gateway stays down permanently.

## Evidence

- [x] Failing test/log before + passing after

New test `returns disabled on Windows to avoid orphaned detached spawn` verifies the win32 path returns `disabled` mode without calling `spawn`. All 11 tests in `process-respawn.test.ts` pass. All 8 tests in `run-loop.test.ts` pass.

## Human Verification (required)

- Verified scenarios: Traced the code path from `restartGatewayProcessWithFreshPid()` through the caller in `run-loop.ts:63-79`. On win32 without supervisor hints, the new check returns `{ mode: "disabled", detail: "win32: no process supervisor" }`. The caller's `handleRestartAfterServerClose` sees neither "spawned" nor "supervised", skips `exitProcess(0)`, and proceeds to in-process restart. The log message now shows the detail string instead of hardcoded "OPENCLAW_NO_RESPAWN".
- Edge cases checked: (1) Windows with `OPENCLAW_NO_RESPAWN=1` hits the earlier check first, still returns disabled. (2) Windows with supervisor env vars (e.g. `OPENCLAW_SERVICE_MARKER`) hits the supervised path first, returns supervised. (3) Non-Windows platforms are unaffected since the `win32` check only matches Windows.
- What you did **not** verify: Actual Windows Scheduled Task environment (no Windows machine available). The fix is a platform check that gates existing, tested code paths.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert `src/infra/process-respawn.ts` (remove the 6-line win32 check block)
- Files/config to restore: `src/infra/process-respawn.ts`, `src/cli/gateway-cli/run-loop.ts`
- Known bad symptoms: Gateway on Windows does not restart at all on SIGUSR1 (would indicate the in-process restart fallback path is broken, which would be a pre-existing issue)

## Risks and Mitigations

- Risk: Windows users in non-Scheduled-Task environments (e.g. manual terminal) also get in-process restart instead of detached spawn.
  - Mitigation: In-process restart is the safer default for Windows regardless of launch method, since Windows lacks a standard process supervisor. Detached spawn on Windows was always unsupervised and could leave orphaned processes.