### PR TITLE
feat(sglang-diffusion): add image generation tool

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1003,6 +1003,7 @@
                   "tools/lobster",
                   "tools/loop-detection",
                   "tools/reactions",
+                  "tools/sglang-diffusion",
                   "tools/thinking",
                   "tools/web"
                 ]

--- a/docs/tools/sglang-diffusion.md
+++ b/docs/tools/sglang-diffusion.md
@@ -1,0 +1,154 @@
+---
+summary: "Generate images locally with SGLang-Diffusion"
+read_when:
+  - You want to generate images using a local SGLang-Diffusion server
+  - You want local image generation with FLUX, Qwen-Image, or other diffusion models
+  - You need OpenAI-compatible /v1/images/generations with your own models
+title: "SGLang-Diffusion"
+---
+
+# SGLang-Diffusion
+
+[SGLang](https://github.com/sgl-project/sglang) is a fast serving framework for large language models and vision-language models. **SGLang-Diffusion** extends it with high-performance image (and video) generation via diffusion models, exposing an **OpenAI-compatible** HTTP API.
+
+OpenClaw integrates with SGLang-Diffusion through the `image_gen` tool, which calls the `/v1/images/generations` endpoint. When configured, agents can generate images on demand using locally served diffusion models.
+
+## Supported models
+
+SGLang-Diffusion supports a wide range of diffusion models, including:
+
+- **FLUX** — `black-forest-labs/FLUX.1-schnell`, `black-forest-labs/FLUX.1-dev`, `black-forest-labs/FLUX.2-dev`
+- **Qwen-Image** — `Qwen/Qwen-Image`, `Qwen/Qwen-Image-2512`
+- **Z-Image-Turbo** — `Tongyi-MAI/Z-Image-Turbo`
+- **GLM-Image** — `zai-org/GLM-Image`
+- Any diffusers-compatible model via `--backend diffusers`
+
+See the [SGLang compatibility matrix](https://docs.sglang.ai/) for the full list.
+
+## Quick start
+
+1. Install SGLang:
+
+```bash
+pip install --upgrade pip
+pip install sglang
+```
+
+2. Start the diffusion server:
+
+```bash
+sglang serve --model-path black-forest-labs/FLUX.1-dev --port 30000
+```
+
+3. Set the API key (any value works if your server has no auth):
+
+```bash
+export SGLANG_DIFFUSION_API_KEY="sglang-local" # pragma: allowlist secret
+```
+
+4. Verify the server is reachable:
+
+```bash
+curl http://127.0.0.1:30000/v1/models
+```
+
+OpenClaw will make the `image_gen` tool available to agents when SGLang-Diffusion is configured. Ask your agent to generate an image and it will use the local SGLang-Diffusion server.
+
+## Onboarding
+
+Run onboarding in manual mode and answer **Yes** to "Configure image generation?":
+
+```bash
+openclaw onboard
+```
+
+This will prompt for the base URL, API key, and model, then write the configuration to `tools.imageGen`.
+
+## Configuration
+
+SGLang-Diffusion is configured as a **tool integration** under `tools.imageGen`, not as a model provider:
+
+```json5
+{
+  tools: {
+    imageGen: {
+      provider: "sglang-diffusion",
+      baseUrl: "http://127.0.0.1:30000/v1",
+      apiKey: "SGLANG_DIFFUSION_API_KEY", // pragma: allowlist secret
+      model: "black-forest-labs/FLUX.1-dev",
+    },
+  },
+}
+```
+
+Alternatively, just set the `SGLANG_DIFFUSION_API_KEY` environment variable and OpenClaw will use the default base URL (`http://127.0.0.1:30000/v1`).
+
+The `apiKey` field supports three formats:
+
+- **Literal key** — `"sk-my-secret"` is sent as-is
+- **Bare env var name** — `"SGLANG_DIFFUSION_API_KEY"` (this specific name only) is resolved from the environment
+- **Interpolation syntax** — `"${MY_CUSTOM_VAR}"` resolves any env var by name
+
+## Advanced options
+
+The `image_gen` tool supports SGLang-Diffusion-specific parameters that the agent can use:
+
+| Parameter             | Description                                     |
+| --------------------- | ----------------------------------------------- |
+| `prompt`              | Text description of the image to generate       |
+| `size`                | Image dimensions (e.g. `1024x1024`, `1024x768`) |
+| `negative_prompt`     | What to avoid in the generated image            |
+| `num_inference_steps` | Number of diffusion denoising steps             |
+| `guidance_scale`      | Classifier-free guidance scale                  |
+| `seed`                | Random seed for reproducible generation         |
+
+## Multi-GPU
+
+SGLang-Diffusion supports tensor and data parallelism:
+
+```bash
+# Tensor parallelism (2 GPUs)
+sglang serve --model-path black-forest-labs/FLUX.1-dev --tp 2 --port 30000
+
+# Data parallelism (2 replicas)
+sglang_router.launch_server --model-path black-forest-labs/FLUX.1-dev --dp 2 --port 30000
+```
+
+## Docker
+
+SGLang provides official Docker images:
+
+```bash
+docker run --gpus all \
+    --shm-size 32g \
+    -p 30000:30000 \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    --env "HF_TOKEN=<your-token>" \
+    --ipc=host \
+    lmsysorg/sglang:latest \
+    python3 -m sglang.launch_server --model-path black-forest-labs/FLUX.1-dev --host 0.0.0.0 --port 30000
+```
+
+## Relationship to SGLang (text)
+
+SGLang-Diffusion is a **separate server** from SGLang text serving. You can run both simultaneously on different ports:
+
+- **SGLang (text)**: LLM chat completions on port 30000
+- **SGLang-Diffusion (images)**: Image generation on a separate port
+
+Each uses its own API key (`SGLANG_API_KEY` vs `SGLANG_DIFFUSION_API_KEY`) and configuration entry.
+
+## Troubleshooting
+
+- **Server not reachable**: Verify with `curl http://127.0.0.1:30000/v1/models`
+- **Auth errors**: Ensure `SGLANG_DIFFUSION_API_KEY` matches your server configuration
+- **No `image_gen` tool**: The tool only appears when SGLang-Diffusion is configured (via `tools.imageGen` in config or `SGLANG_DIFFUSION_API_KEY` env var)
+- **Slow generation**: Try reducing `num_inference_steps` or using a faster model variant
+- **FlashInfer issues**: Switch attention backend: `sglang serve --model-path <model> --attention-backend triton --sampling-backend pytorch --port 30000`
+
+## Resources
+
+- [SGLang Documentation](https://docs.sglang.ai/)
+- [SGLang GitHub](https://github.com/sgl-project/sglang)
+- [SGLang-Diffusion Guide](https://docs.sglang.ai/diffusion/index.html)
+- [OpenAI-Compatible Image API](https://docs.sglang.ai/diffusion/api/openai_api.html)

--- a/src/agents/model-auth-env-vars.ts
+++ b/src/agents/model-auth-env-vars.ts
@@ -34,6 +34,7 @@ export const PROVIDER_ENV_API_KEY_CANDIDATES: Record<string, string[]> = {
   qianfan: ["QIANFAN_API_KEY"],
   ollama: ["OLLAMA_API_KEY"],
   vllm: ["VLLM_API_KEY"],
+  "sglang-diffusion": ["SGLANG_DIFFUSION_API_KEY"],
   kilocode: ["KILOCODE_API_KEY"],
 };
 

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -11,6 +11,7 @@ import { createCanvasTool } from "./tools/canvas-tool.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { createCronTool } from "./tools/cron-tool.js";
 import { createGatewayTool } from "./tools/gateway-tool.js";
+import { createImageGenTool } from "./tools/image-gen-tool.js";
 import { createImageTool } from "./tools/image-tool.js";
 import { createMessageTool } from "./tools/message-tool.js";
 import { createNodesTool } from "./tools/nodes-tool.js";
@@ -192,6 +193,11 @@ export function createOpenClawTools(
     ...(imageTool ? [imageTool] : []),
     ...(pdfTool ? [pdfTool] : []),
   ];
+
+  const imageGenTool = createImageGenTool({ config: options?.config, agentDir: options?.agentDir });
+  if (imageGenTool) {
+    tools.push(imageGenTool);
+  }
 
   const pluginTools = resolvePluginTools({
     context: {

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -142,6 +142,7 @@ const TRUSTED_TOOL_RESULT_MEDIA = new Set([
   "exec",
   "gateway",
   "image",
+  "image_gen",
   "memory_get",
   "memory_search",
   "message",

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -18,6 +18,7 @@ export const DEFAULT_TOOL_ALLOW = [
   "edit",
   "apply_patch",
   "image",
+  "image_gen",
   "sessions_list",
   "sessions_history",
   "sessions_send",

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -226,6 +226,14 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     includeInOpenClawGroup: true,
   },
   {
+    id: "image_gen",
+    label: "image_gen",
+    description: "Generate images from text prompts",
+    sectionId: "media",
+    profiles: ["coding"],
+    includeInOpenClawGroup: true,
+  },
+  {
     id: "tts",
     label: "tts",
     description: "Text-to-speech conversion",

--- a/src/agents/tools/image-gen-tool.test.ts
+++ b/src/agents/tools/image-gen-tool.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({
+    tools: {
+      imageGen: {
+        provider: "sglang-diffusion",
+        baseUrl: "http://127.0.0.1:30000/v1",
+        apiKey: "test-key", // pragma: allowlist secret
+        model: "FLUX.1-dev",
+      },
+    },
+  })),
+}));
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    warn: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+  }),
+}));
+
+vi.mock("../../media/store.js", () => ({
+  ensureMediaDir: vi.fn(async () => "/tmp/openclaw-test-media"),
+}));
+
+vi.mock("../model-auth.js", () => ({
+  resolveEnvApiKey: vi.fn(() => null),
+  resolveApiKeyForProvider: vi.fn(async () => null),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: { writeFile: vi.fn() },
+  writeFile: vi.fn(),
+}));
+
+const { createImageGenTool } = await import("./image-gen-tool.js");
+
+// Small 1x1 white PNG as base64
+const TINY_PNG_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+
+describe("createImageGenTool", () => {
+  it("returns null when no provider is configured", () => {
+    // Pass an empty config explicitly — no tools.imageGen, env fallback returns null.
+    const tool = createImageGenTool({
+      config: {} as ReturnType<typeof import("../../config/config.js").loadConfig>,
+    });
+    expect(tool).toBeNull();
+  });
+
+  it("creates tool when tools.imageGen is configured", () => {
+    // Default mock returns config with tools.imageGen.
+    const tool = createImageGenTool();
+    expect(tool).not.toBeNull();
+    expect(tool!.name).toBe("image_gen");
+    expect(tool!.label).toBe("Image Generation");
+    expect(tool!.description).toContain("SGLang-Diffusion");
+  });
+
+  it("creates tool from legacy models.providers location (backward compat)", () => {
+    const tool = createImageGenTool({
+      config: {
+        models: {
+          providers: {
+            "sglang-diffusion": {
+              baseUrl: "http://127.0.0.1:30000/v1",
+              apiKey: "legacy-key", // pragma: allowlist secret
+              api: "openai-completions",
+              models: [
+                {
+                  id: "FLUX.1-dev",
+                  name: "FLUX.1-dev",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 1,
+                  maxTokens: 1,
+                },
+              ],
+            },
+          },
+        },
+      } as ReturnType<typeof import("../../config/config.js").loadConfig>,
+    });
+    expect(tool).not.toBeNull();
+    expect(tool!.name).toBe("image_gen");
+  });
+
+  it("creates tool when SGLANG_DIFFUSION_API_KEY env var is set", async () => {
+    const { resolveEnvApiKey } = await import("../model-auth.js");
+    vi.mocked(resolveEnvApiKey).mockReturnValueOnce({
+      apiKey: "env-key", // pragma: allowlist secret
+      source: "env: SGLANG_DIFFUSION_API_KEY",
+    });
+
+    // Empty config but env var resolves — should still create the tool.
+    const tool = createImageGenTool({
+      config: {} as ReturnType<typeof import("../../config/config.js").loadConfig>,
+    });
+    expect(tool).not.toBeNull();
+    expect(tool!.name).toBe("image_gen");
+  });
+});
+
+describe("image_gen tool execution", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("calls /v1/images/generations and returns image result", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ b64_json: TINY_PNG_B64 }],
+      }),
+    }) as unknown as typeof fetch;
+
+    const tool = createImageGenTool();
+    expect(tool).not.toBeNull();
+
+    const result = await tool!.execute(
+      "call-1",
+      { prompt: "a red cat" },
+      new AbortController().signal,
+    );
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [url, options] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://127.0.0.1:30000/v1/images/generations");
+    expect(options.method).toBe("POST");
+
+    const body = JSON.parse(options.body as string);
+    expect(body.prompt).toBe("a red cat");
+    expect(body.response_format).toBe("b64_json");
+    expect(body.size).toBe("1024x1024");
+
+    expect(result.content).toBeDefined();
+    expect(result.content.length).toBeGreaterThanOrEqual(1);
+    // Should include MEDIA: path in text content
+    const textContent = result.content.find((c) => c.type === "text");
+    expect(textContent).toBeDefined();
+    expect((textContent as { text: string }).text).toContain("MEDIA:");
+  });
+
+  it("passes optional parameters to the API", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ b64_json: TINY_PNG_B64 }],
+      }),
+    }) as unknown as typeof fetch;
+
+    const tool = createImageGenTool();
+    await tool!.execute(
+      "call-2",
+      {
+        prompt: "sunset",
+        size: "1024x768",
+        negative_prompt: "blurry",
+        num_inference_steps: 30,
+        guidance_scale: 7.5,
+        seed: 42,
+      },
+      new AbortController().signal,
+    );
+
+    const body = JSON.parse(
+      (vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit])[1].body as string,
+    );
+    expect(body.size).toBe("1024x768");
+    expect(body.negative_prompt).toBe("blurry");
+    expect(body.num_inference_steps).toBe(30);
+    expect(body.guidance_scale).toBe(7.5);
+    expect(body.seed).toBe(42);
+  });
+
+  it("handles API errors gracefully", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => "Internal Server Error",
+    }) as unknown as typeof fetch;
+
+    const tool = createImageGenTool();
+    const result = await tool!.execute("call-3", { prompt: "test" }, new AbortController().signal);
+
+    const textContent = result.content.find((c) => c.type === "text") as { text: string };
+    expect(textContent.text).toContain("Image generation failed");
+    expect(textContent.text).toContain("500");
+  });
+
+  it("handles empty response data", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    }) as unknown as typeof fetch;
+
+    const tool = createImageGenTool();
+    const result = await tool!.execute("call-4", { prompt: "test" }, new AbortController().signal);
+
+    const textContent = result.content.find((c) => c.type === "text") as { text: string };
+    expect(textContent.text).toContain("No image data returned");
+  });
+
+  it("handles network errors gracefully", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(
+        new Error("connect ECONNREFUSED 127.0.0.1:30000"),
+      ) as unknown as typeof fetch;
+
+    const tool = createImageGenTool();
+    const result = await tool!.execute("call-5", { prompt: "test" }, new AbortController().signal);
+
+    const textContent = result.content.find((c) => c.type === "text") as { text: string };
+    expect(textContent.text).toContain("Image generation failed");
+    expect(textContent.text).toContain("ECONNREFUSED");
+  });
+
+  it("includes Authorization header when apiKey is set", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ b64_json: TINY_PNG_B64 }] }),
+    }) as unknown as typeof fetch;
+
+    const tool = createImageGenTool();
+    await tool!.execute("call-6", { prompt: "test" }, new AbortController().signal);
+
+    const [, options] = vi.mocked(globalThis.fetch).mock.calls[0] as [string, RequestInit];
+    const headers = options.headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer test-key");
+  });
+});

--- a/src/agents/tools/image-gen-tool.ts
+++ b/src/agents/tools/image-gen-tool.ts
@@ -1,0 +1,262 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { Type } from "@sinclair/typebox";
+import { SGLANG_DIFFUSION_DEFAULT_BASE_URL } from "../../commands/sglang-diffusion-setup.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { loadConfig } from "../../config/config.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { ensureMediaDir } from "../../media/store.js";
+import { resolveApiKeyForProvider, resolveEnvApiKey } from "../model-auth.js";
+import type { AnyAgentTool } from "./common.js";
+import { imageResult, readStringParam } from "./common.js";
+
+const log = createSubsystemLogger("tools/image-gen");
+
+type ImageGenResponse = {
+  data?: Array<{
+    b64_json?: string;
+    url?: string;
+    revised_prompt?: string;
+  }>;
+};
+
+const ImageGenToolSchema = Type.Object({
+  prompt: Type.String({ description: "Text description of the image to generate." }),
+  size: Type.Optional(
+    Type.String({
+      description: "Image size (e.g. 1024x1024, 1024x768). Defaults to 1024x1024.",
+    }),
+  ),
+  negative_prompt: Type.Optional(
+    Type.String({ description: "What to avoid in the generated image." }),
+  ),
+  num_inference_steps: Type.Optional(
+    Type.Integer({ description: "Number of diffusion denoising steps.", minimum: 1 }),
+  ),
+  guidance_scale: Type.Optional(
+    Type.Number({ description: "Classifier-free guidance scale (higher = closer to prompt)." }),
+  ),
+  seed: Type.Optional(
+    Type.Integer({ description: "Random seed for reproducible generation.", minimum: 0 }),
+  ),
+});
+
+function resolveSecretInputString(input: unknown): string {
+  if (typeof input === "string") {
+    return input.trim();
+  }
+  if (input && typeof input === "object" && "source" in input && "id" in input) {
+    // SecretRef with source=env: resolve the env var
+    const ref = input as { source?: string; id?: string };
+    if (ref.source === "env" && ref.id) {
+      return process.env[ref.id]?.trim() ?? "";
+    }
+  }
+  return "";
+}
+
+// Env var names onboarding may write as bare placeholders.
+const KNOWN_ENV_VAR_NAMES = new Set(["SGLANG_DIFFUSION_API_KEY"]);
+
+function resolveApiKeyString(raw: unknown): string {
+  let apiKey = resolveSecretInputString(raw);
+  // Resolve ${ENV_VAR} interpolation syntax
+  const envWrapMatch = /^\$\{([A-Z0-9_]+)\}$/.exec(apiKey);
+  if (envWrapMatch?.[1]) {
+    apiKey = process.env[envWrapMatch[1]]?.trim() ?? "";
+  } else if (KNOWN_ENV_VAR_NAMES.has(apiKey)) {
+    // Bare env var name written by onboarding — resolve from environment
+    apiKey = process.env[apiKey]?.trim() ?? "";
+  }
+  return apiKey;
+}
+
+function resolveSglangDiffusionConfig(cfg?: OpenClawConfig): {
+  baseUrl: string;
+  apiKey: string;
+} | null {
+  // Primary: tools.imageGen config section
+  const imageGen = cfg?.tools?.imageGen;
+  if (imageGen?.provider || imageGen?.baseUrl || imageGen?.apiKey) {
+    const baseUrl = (imageGen.baseUrl?.trim() || SGLANG_DIFFUSION_DEFAULT_BASE_URL).replace(
+      /\/+$/,
+      "",
+    );
+    return { baseUrl, apiKey: resolveApiKeyString(imageGen.apiKey) };
+  }
+
+  // Backward compat: legacy models.providers["sglang-diffusion"] location
+  const provider = cfg?.models?.providers?.["sglang-diffusion"];
+  if (provider) {
+    const baseUrl = (provider.baseUrl?.trim() || SGLANG_DIFFUSION_DEFAULT_BASE_URL).replace(
+      /\/+$/,
+      "",
+    );
+    return { baseUrl, apiKey: resolveApiKeyString(provider.apiKey) };
+  }
+
+  // Fallback: resolve from env
+  const envResult = resolveEnvApiKey("sglang-diffusion");
+  if (envResult?.apiKey) {
+    return { baseUrl: SGLANG_DIFFUSION_DEFAULT_BASE_URL, apiKey: envResult.apiKey };
+  }
+
+  return null;
+}
+
+export function createImageGenTool(opts?: {
+  config?: OpenClawConfig;
+  agentDir?: string;
+}): AnyAgentTool | null {
+  const cfg = opts?.config ?? loadConfig();
+  const resolved = resolveSglangDiffusionConfig(cfg);
+  if (!resolved) {
+    return null;
+  }
+
+  const agentDir = opts?.agentDir;
+
+  return {
+    label: "Image Generation",
+    name: "image_gen",
+    description:
+      "Generate an image from a text prompt using a local SGLang-Diffusion server. " +
+      "Returns the generated image. Supports FLUX, Qwen-Image, and other diffusion models.",
+    parameters: ImageGenToolSchema,
+    execute: async (_toolCallId, args, signal) => {
+      try {
+        const params = args as Record<string, unknown>;
+        const prompt = readStringParam(params, "prompt", { required: true });
+        const size = readStringParam(params, "size") || "1024x1024";
+        const negativePrompt = readStringParam(params, "negative_prompt");
+
+        const numInferenceSteps =
+          typeof params.num_inference_steps === "number" ? params.num_inference_steps : undefined;
+        const guidanceScale =
+          typeof params.guidance_scale === "number" ? params.guidance_scale : undefined;
+        const seed = typeof params.seed === "number" ? params.seed : undefined;
+
+        // Re-resolve at execution time so hot config changes are picked up
+        const runtimeCfg = loadConfig();
+        const runtime = resolveSglangDiffusionConfig(runtimeCfg);
+        if (!runtime) {
+          return {
+            content: [{ type: "text", text: "SGLang-Diffusion provider is not configured." }],
+            details: { error: "not_configured" },
+          };
+        }
+
+        // Fallback: if config-based key is empty, try the auth profile store
+        // (onboarding stores the actual key there via upsertAuthProfileWithLock)
+        if (!runtime.apiKey) {
+          try {
+            const authResult = await resolveApiKeyForProvider({
+              provider: "sglang-diffusion",
+              cfg: runtimeCfg,
+              agentDir,
+            });
+            if (authResult?.apiKey) {
+              runtime.apiKey = authResult.apiKey;
+            }
+          } catch (err) {
+            log.warn(
+              `auth profile lookup failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
+
+        // Note: `model` is intentionally omitted from the request body. SGLang-Diffusion
+        // serves one model per server instance and ignores the `model` field entirely.
+        // The configured tools.imageGen.model is for documentation/UI purposes only.
+        const body: Record<string, unknown> = {
+          prompt,
+          size,
+          n: 1,
+          response_format: "b64_json",
+        };
+        if (negativePrompt) {
+          body.negative_prompt = negativePrompt;
+        }
+        if (numInferenceSteps !== undefined) {
+          body.num_inference_steps = numInferenceSteps;
+        }
+        if (guidanceScale !== undefined) {
+          body.guidance_scale = guidanceScale;
+        }
+        if (seed !== undefined) {
+          body.seed = seed;
+        }
+
+        const url = `${runtime.baseUrl}/images/generations`;
+        const headers: Record<string, string> = { "Content-Type": "application/json" };
+        if (runtime.apiKey) {
+          headers.Authorization = `Bearer ${runtime.apiKey}`;
+        }
+
+        const timeoutSignal = AbortSignal.timeout(120_000);
+        const abortSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+        const response = await fetch(url, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(body),
+          signal: abortSignal,
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => "");
+          log.warn(`SGLang-Diffusion request failed: ${response.status} ${errorText}`);
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Image generation failed (HTTP ${response.status}): ${errorText.slice(0, 200)}`,
+              },
+            ],
+            details: { error: "http_error", status: response.status },
+          };
+        }
+
+        const data = (await response.json()) as ImageGenResponse;
+        const imageData = data.data?.[0];
+
+        if (!imageData?.b64_json) {
+          return {
+            content: [{ type: "text", text: "No image data returned from SGLang-Diffusion." }],
+            details: { error: "empty_response" },
+          };
+        }
+
+        const imageBuffer = Buffer.from(imageData.b64_json, "base64");
+        const mediaDir = await ensureMediaDir();
+        const filename = `sglang-gen-${crypto.randomUUID()}.png`;
+        const filePath = path.join(mediaDir, filename);
+        await fs.writeFile(filePath, imageBuffer, { mode: 0o644 });
+
+        // Sanitize server-controlled text: collapse newlines and strip MEDIA: tokens
+        // to prevent injection of extra media directives in tool-result output.
+        const sanitized = imageData.revised_prompt
+          ?.replace(/[\r\n]+/g, " ")
+          .replace(/\bMEDIA:/gi, "")
+          .trim();
+        const revisedNote = sanitized ? `\nRevised prompt: ${sanitized}` : "";
+
+        return await imageResult({
+          label: "Image Generation",
+          path: filePath,
+          base64: imageData.b64_json,
+          mimeType: "image/png",
+          extraText: `MEDIA:${filePath}${revisedNote}`,
+          details: { prompt, size, provider: "sglang-diffusion" },
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        log.warn(`SGLang-Diffusion image generation error: ${message}`);
+        return {
+          content: [{ type: "text", text: `Image generation failed: ${message}` }],
+          details: { error: message },
+        };
+      }
+    },
+  };
+}

--- a/src/commands/sglang-diffusion-setup.ts
+++ b/src/commands/sglang-diffusion-setup.ts
@@ -1,0 +1,54 @@
+import { upsertAuthProfileWithLock } from "../agents/auth-profiles.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+
+export const SGLANG_DIFFUSION_DEFAULT_BASE_URL = "http://127.0.0.1:30000/v1";
+
+export async function promptAndConfigureSglangDiffusion(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+  agentDir?: string;
+}): Promise<{ config: OpenClawConfig }> {
+  const baseUrlRaw = await params.prompter.text({
+    message: "SGLang-Diffusion base URL",
+    initialValue: SGLANG_DIFFUSION_DEFAULT_BASE_URL,
+    placeholder: SGLANG_DIFFUSION_DEFAULT_BASE_URL,
+    validate: (value) => (value?.trim() ? undefined : "Required"),
+  });
+  const apiKeyRaw = await params.prompter.text({
+    message: "SGLang-Diffusion API key",
+    placeholder: "sk-... (or any non-empty string)",
+    validate: (value) => (value?.trim() ? undefined : "Required"),
+  });
+  const modelIdRaw = await params.prompter.text({
+    message: "SGLang-Diffusion model (for reference — restart server to change)",
+    placeholder: "black-forest-labs/FLUX.1-dev",
+  });
+
+  const baseUrl = String(baseUrlRaw ?? "")
+    .trim()
+    .replace(/\/+$/, "");
+  const apiKey = String(apiKeyRaw ?? "").trim();
+  const modelId = String(modelIdRaw ?? "").trim();
+
+  await upsertAuthProfileWithLock({
+    profileId: "sglang-diffusion:default",
+    credential: { type: "api_key", provider: "sglang-diffusion", key: apiKey },
+    agentDir: params.agentDir,
+  });
+
+  const nextConfig: OpenClawConfig = {
+    ...params.cfg,
+    tools: {
+      ...params.cfg.tools,
+      imageGen: {
+        provider: "sglang-diffusion",
+        baseUrl,
+        apiKey: "SGLANG_DIFFUSION_API_KEY", // pragma: allowlist secret
+        ...(modelId ? { model: modelId } : {}),
+      },
+    },
+  };
+
+  return { config: nextConfig };
+}

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -585,6 +585,17 @@ export type ToolsConfig = {
   exec?: ExecToolConfig;
   /** Filesystem tool path guards. */
   fs?: FsToolsConfig;
+  /** Image generation tool configuration (e.g. SGLang-Diffusion). */
+  imageGen?: {
+    /** Image generation provider (currently only "sglang-diffusion"). */
+    provider?: "sglang-diffusion";
+    /** Base URL for the image generation API (default: http://127.0.0.1:30000/v1). */
+    baseUrl?: string;
+    /** API key or env var name for the image generation server. */
+    apiKey?: SecretInput;
+    /** Model served by the image generation server (e.g. "black-forest-labs/FLUX.1-schnell"). */
+    model?: string;
+  };
   /** Runtime loop detection for repetitive/ stuck tool-call patterns. */
   loopDetection?: ToolLoopDetectionConfig;
   /** Sub-agent tool policy defaults (deny wins). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -806,6 +806,15 @@ export const ToolsSchema = z
       .optional(),
     exec: ToolExecSchema,
     fs: ToolFsSchema,
+    imageGen: z
+      .object({
+        provider: z.literal("sglang-diffusion").optional(),
+        baseUrl: z.string().optional(),
+        apiKey: SecretInputSchema.optional().register(sensitive),
+        model: z.string().optional(),
+      })
+      .strict()
+      .optional(),
     subagents: z
       .object({
         tools: ToolPolicySchema,

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -23,6 +23,7 @@ export const PROVIDER_ENV_VARS: Record<string, readonly string[]> = {
   kilocode: ["KILOCODE_API_KEY"],
   volcengine: ["VOLCANO_ENGINE_API_KEY"],
   byteplus: ["BYTEPLUS_API_KEY"],
+  "sglang-diffusion": ["SGLANG_DIFFUSION_API_KEY"],
 };
 
 export function listKnownSecretEnvVarNames(): string[] {

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -522,6 +522,27 @@ export async function runOnboardingWizard(
     });
   }
 
+  // Image generation (SGLang-Diffusion) — optional tool integration
+  if (flow !== "quickstart") {
+    const setupImageGen = await prompter.confirm({
+      message: "Configure image generation? (SGLang-Diffusion)",
+      initialValue: false,
+    });
+    if (setupImageGen) {
+      const { promptAndConfigureSglangDiffusion } =
+        await import("../commands/sglang-diffusion-setup.js");
+      // agentDir is intentionally omitted: undefined resolves to the default agent
+      // dir via resolveOpenClawAgentDir(), and ensureAuthProfileStore merges the
+      // main store into agent-scoped lookups. Same pattern as vLLM in promptDefaultModel.
+      const { config: updatedConfig } = await promptAndConfigureSglangDiffusion({
+        cfg: nextConfig,
+        prompter,
+      });
+      nextConfig = updatedConfig;
+      await prompter.note("SGLang-Diffusion image generation configured.", "Image Generation");
+    }
+  }
+
   if (opts.skipSkills) {
     await prompter.note("Skipping skills setup.", "Skills");
   } else {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenClaw lacks built-in support for local image generation via diffusion models. Image generation only exists as standalone Python skills (e.g. openai-image-gen), not as a first-class agent tool. A related issue:  sgl-project/sglang#20002
- Why it matters: SGLang-Diffusion is a high-performance serving framework for diffusion models (FLUX, Qwen-Image, etc.) with an OpenAI-compatible /v1/images/generations API. Built-in support enables a "local-first" image generation experience aligned with existing local providers (Ollama, vLLM).
- What changed: Introduced SGLang-Diffusion as a **tool integration** under `tools.imageGen`, with a new `image_gen` agent tool that calls `/v1/images/generations`, onboarding support as a separate "Configure image generation?" step, auth profile integration, and comprehensive documentation.
- What did NOT change (scope boundary): Existing provider logic, default model resolution, and the image (vision/understanding) tool remain untouched. This feature is strictly opt-in via `SGLANG_DIFFUSION_API_KEY` or explicit `tools.imageGen` configuration. Video and 3D mesh generation endpoints are not included (future work).

## Change Type (select all)

- [x] Feature
- [x] Docs

## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] Auth / tokens
- [x] Integrations
- [x] UI / DX

## Linked Issue/PR

- Closes #
- Related #35572 (SGLang text provider — complementary, not dependent)

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).
If none, write `None`.

- **New tool: `image_gen`** — agents can generate images from text prompts when a SGLang-Diffusion server is running locally.
- **New configuration: `tools.imageGen`** — SGLang-Diffusion is classified as a tool integration. Config lives under `tools.imageGen` with `provider`, `baseUrl`, `apiKey`, and `model` fields.
- **New environment variable: `SGLANG_DIFFUSION_API_KEY`** — when set, the `image_gen` tool auto-activates with default base URL (`http://127.0.0.1:30000/v1`).
- **Onboarding**: In manual onboarding mode, a new "Configure image generation? (SGLang-Diffusion)" prompt appears after search setup. This is separate from the model provider selection.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
1. Added handling for `SGLANG_DIFFUSION_API_KEY` — follows the same pattern as `VLLM_API_KEY` and other local provider keys. Stored via existing auth profile infrastructure; config references the env var name, runtime resolves from auth profiles as fallback.
2. Added outbound HTTP calls to local SGLang-Diffusion server (`127.0.0.1:30000` by default) for image generation. These are opt-in (only when configured) and target localhost by default.
3. Added `image_gen` tool to the agent tool surface — only registered when SGLang-Diffusion is configured (via `tools.imageGen` in config or `SGLANG_DIFFUSION_API_KEY` env var).

## Repro + Verification

### Environment

- OS: Linux/macOS
- Runtime/container: SGLang-Diffusion local instance
- Model/provider: FLUX.1-schnell / SGLang-Diffusion
- Integration/channel (if any): `SGLANG_DIFFUSION_API_KEY` set; SGLang-Diffusion running on port 30000.
- Relevant config (redacted): `export SGLANG_DIFFUSION_API_KEY="sglang-local"`

### Steps

1. Start SGLang-Diffusion server: `sglang serve --model-path black-forest-labs/FLUX.1-schnell --port 30000`
2. Set `SGLANG_DIFFUSION_API_KEY=sglang-local` in the environment.
3. Run openclaw and ask the agent to generate an image (e.g. "generate an image of a sunset over mountains").

### Expected

- The `image_gen` tool is available to the agent.
- Image generation completes and the image is delivered through the media pipeline.

### Actual

- `image_gen` tool calls `/v1/images/generations` with `response_format: "b64_json"`.
- Generated image is saved to the media store and delivered to the channel.

## Evidence

Attach at least one:

10 tests pass in `src/agents/tools/image-gen-tool.test.ts`: tool creation (with `tools.imageGen`, legacy `models.providers` backward compat, env var fallback), execution, parameter passing, HTTP errors, empty responses, network errors, auth headers.

`pnpm openclaw onboard`
<img width="415" height="194" alt="image" src="https://github.com/user-attachments/assets/d67815fa-b467-4d17-95e6-e6088fbc28df" />

`pnpm openclaw agent --agent main --message "generate an image with a dog eating a fish"`

```
🦞 OpenClaw 2026.3.8 (d7c6e9b) — I'm the assistant your terminal demanded, not the one your sleep schedule requested.

│
21:34:41 [gateway] device pairing auto-approved device=b410b066f48b7ee5a926bcc03d5c1d30f76df887fb5cc35b63a6c00040e002d5 role=operator
◓  Waiting for agent reply….21:34:42 [tools] tools.profile (coding) allowlist contains unknown entries (apply_patch, memory_search, memory_get). These entries won't match any tool unless the plugin is enabled.
◒  Waiting for agent reply…...21:35:36 Here you go — an image of a dog eating a fish (cartoon style).
◇
Here you go — an image of a dog eating a fish (cartoon style).
```
<img width="1024" height="1024" alt="001-a-playful-high-resolution-illustration-o" src="https://github.com/user-attachments/assets/a4bd4568-aa67-4be3-8a97-1f6db030942c" />


## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm check` passes (format, typecheck, lint, all custom lint rules). All 10 unit tests pass. End-to-end image generation verified on a cloud GPU instance with SGLang-Diffusion serving FLUX.1-schnell.
- Edge cases checked: Network errors and HTTP failures return graceful error messages. Tool not registered when provider is not configured. Auth profile fallback works when env var is unset. Backward compatibility with legacy `models.providers["sglang-diffusion"]` config location.
- What you did **not** verify: Multi-agent scenarios with agent-scoped auth profiles on separate agent directories.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`) — new optional `SGLANG_DIFFUSION_API_KEY` env var and optional `tools.imageGen` config entry. Legacy `models.providers.sglang-diffusion` configs are still read as a backward-compat fallback.
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Unset `SGLANG_DIFFUSION_API_KEY` or remove `tools.imageGen` from the config. The `image_gen` tool will not register.
- Files/config to restore: N/A
- Known bad symptoms reviewers should watch for: If `tools.profile` is set to `"messaging"`, the `image_gen` tool will be filtered out even when configured.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.
`None`
