### PR TITLE
fix(gateway): validate config before restart + run loop crash guard (#35862)

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
@@ -1,0 +1,145 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const readConfigFileSnapshotMock = vi.fn();
+const loadConfig = vi.fn(() => ({}));
+
+const runtimeLogs: string[] = [];
+const defaultRuntime = {
+  log: (message: string) => runtimeLogs.push(message),
+  error: vi.fn(),
+  exit: (code: number) => {
+    throw new Error(`__exit__:${code}`);
+  },
+};
+
+const service = {
+  label: "TestService",
+  loadedText: "loaded",
+  notLoadedText: "not loaded",
+  install: vi.fn(),
+  uninstall: vi.fn(),
+  stop: vi.fn(),
+  isLoaded: vi.fn(),
+  readCommand: vi.fn(),
+  readRuntime: vi.fn(),
+  restart: vi.fn(),
+};
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: () => loadConfig(),
+  readConfigFileSnapshot: () => readConfigFileSnapshotMock(),
+}));
+
+vi.mock("../../config/issue-format.js", () => ({
+  formatConfigIssueLines: (
+    issues: Array<{ path: string; message: string }>,
+    _prefix: string,
+    _opts?: unknown,
+  ) => issues.map((i) => `${i.path}: ${i.message}`),
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime,
+}));
+
+describe("runServiceRestart config pre-flight (#35862)", () => {
+  let runServiceRestart: typeof import("./lifecycle-core.js").runServiceRestart;
+
+  beforeAll(async () => {
+    ({ runServiceRestart } = await import("./lifecycle-core.js"));
+  });
+
+  beforeEach(() => {
+    runtimeLogs.length = 0;
+    readConfigFileSnapshotMock.mockReset();
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {},
+      issues: [],
+    });
+    loadConfig.mockReset();
+    loadConfig.mockReturnValue({});
+    service.isLoaded.mockClear();
+    service.readCommand.mockClear();
+    service.restart.mockClear();
+    service.isLoaded.mockResolvedValue(true);
+    service.readCommand.mockResolvedValue({ environment: {} });
+    service.restart.mockResolvedValue(undefined);
+    vi.unstubAllEnvs();
+    vi.stubEnv("OPENCLAW_GATEWAY_TOKEN", "");
+    vi.stubEnv("CLAWDBOT_GATEWAY_TOKEN", "");
+  });
+
+  it("aborts restart when config is invalid", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: false,
+      config: {},
+      issues: [{ path: "agents.defaults.pdfModel", message: "Unrecognized key" }],
+    });
+
+    await expect(
+      runServiceRestart({
+        serviceNoun: "Gateway",
+        service,
+        renderStartHints: () => [],
+        opts: { json: true },
+      }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(service.restart).not.toHaveBeenCalled();
+  });
+
+  it("proceeds with restart when config is valid", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {},
+      issues: [],
+    });
+
+    const result = await runServiceRestart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true },
+    });
+
+    expect(result).toBe(true);
+    expect(service.restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("proceeds with restart when config file does not exist", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: false,
+      valid: true,
+      config: {},
+      issues: [],
+    });
+
+    const result = await runServiceRestart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true },
+    });
+
+    expect(result).toBe(true);
+    expect(service.restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("proceeds with restart when snapshot read throws", async () => {
+    readConfigFileSnapshotMock.mockRejectedValue(new Error("read failed"));
+
+    const result = await runServiceRestart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true },
+    });
+
+    expect(result).toBe(true);
+    expect(service.restart).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.config-guard.test.ts
@@ -143,3 +143,64 @@ describe("runServiceRestart config pre-flight (#35862)", () => {
     expect(service.restart).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("runServiceStart config pre-flight (#35862)", () => {
+  let runServiceStart: typeof import("./lifecycle-core.js").runServiceStart;
+
+  beforeAll(async () => {
+    ({ runServiceStart } = await import("./lifecycle-core.js"));
+  });
+
+  beforeEach(() => {
+    runtimeLogs.length = 0;
+    readConfigFileSnapshotMock.mockReset();
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {},
+      issues: [],
+    });
+    service.isLoaded.mockClear();
+    service.restart.mockClear();
+    service.isLoaded.mockResolvedValue(true);
+    service.restart.mockResolvedValue(undefined);
+  });
+
+  it("aborts start when config is invalid", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: false,
+      config: {},
+      issues: [{ path: "agents.defaults.pdfModel", message: "Unrecognized key" }],
+    });
+
+    await expect(
+      runServiceStart({
+        serviceNoun: "Gateway",
+        service,
+        renderStartHints: () => [],
+        opts: { json: true },
+      }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(service.restart).not.toHaveBeenCalled();
+  });
+
+  it("proceeds with start when config is valid", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {},
+      issues: [],
+    });
+
+    await runServiceStart({
+      serviceNoun: "Gateway",
+      service,
+      renderStartHints: () => [],
+      opts: { json: true },
+    });
+
+    expect(service.restart).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -333,6 +333,19 @@ export async function runServiceRestart(params: {
   if (loaded === null) {
     return false;
   }
+
+  // Pre-flight config validation: check before any restart action (including
+  // onNotLoaded which may send SIGUSR1 to an unmanaged process). (#35862)
+  {
+    const configError = await getConfigValidationError();
+    if (configError) {
+      fail(
+        `${params.serviceNoun} aborted: config is invalid.\n${configError}\nFix the config and retry, or run "openclaw doctor" to repair.`,
+      );
+      return false;
+    }
+  }
+
   if (!loaded) {
     try {
       handledNotLoaded = (await params.onNotLoaded?.({ json, stdout, fail })) ?? null;
@@ -385,17 +398,6 @@ export async function runServiceRestart(params: {
           defaultRuntime.log(`\n⚠️  ${warning}\n`);
         }
       }
-    }
-  }
-
-  // Pre-flight config validation (#35862)
-  {
-    const configError = await getConfigValidationError();
-    if (configError) {
-      fail(
-        `${params.serviceNoun} aborted: config is invalid.\n${configError}\nFix the config and retry, or run "openclaw doctor" to repair.`,
-      );
-      return false;
     }
   }
 

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -111,7 +111,11 @@ async function resolveServiceLoadedOrFail(params: {
 /**
  * Best-effort config validation. Returns a string describing the issues if
  * config exists and is invalid, or null if config is valid/missing/unreadable.
- * (#35862)
+ *
+ * Note: This reads the config file snapshot in the current CLI environment.
+ * Configs using env vars only available in the service context (launchd/systemd)
+ * may produce false positives, but the check is intentionally best-effort —
+ * a false positive here is safer than a crash on startup. (#35862)
  */
 async function getConfigValidationError(): Promise<string | null> {
   try {
@@ -214,7 +218,7 @@ export async function runServiceStart(params: {
       fail(
         `${params.serviceNoun} aborted: config is invalid.\n${configError}\nFix the config and retry, or run "openclaw doctor" to repair.`,
       );
-      return false;
+      return;
     }
   }
 

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -1,5 +1,6 @@
 import type { Writable } from "node:stream";
-import { readBestEffortConfig } from "../../config/config.js";
+import { readBestEffortConfig, readConfigFileSnapshot } from "../../config/config.js";
+import { formatConfigIssueLines } from "../../config/issue-format.js";
 import { resolveIsNixMode } from "../../config/paths.js";
 import { checkTokenDrift } from "../../daemon/service-audit.js";
 import type { GatewayService } from "../../daemon/service.js";
@@ -107,6 +108,25 @@ async function resolveServiceLoadedOrFail(params: {
   }
 }
 
+/**
+ * Best-effort config validation. Returns a string describing the issues if
+ * config exists and is invalid, or null if config is valid/missing/unreadable.
+ * (#35862)
+ */
+async function getConfigValidationError(): Promise<string | null> {
+  try {
+    const snapshot = await readConfigFileSnapshot();
+    if (!snapshot.exists || snapshot.valid) {
+      return null;
+    }
+    return snapshot.issues.length > 0
+      ? formatConfigIssueLines(snapshot.issues, "", { normalizeRoot: true }).join("\n")
+      : "Unknown validation issue.";
+  } catch {
+    return null;
+  }
+}
+
 export async function runServiceUninstall(params: {
   serviceNoun: string;
   service: GatewayService;
@@ -187,6 +207,17 @@ export async function runServiceStart(params: {
     });
     return;
   }
+  // Pre-flight config validation (#35862)
+  {
+    const configError = await getConfigValidationError();
+    if (configError) {
+      fail(
+        `${params.serviceNoun} aborted: config is invalid.\n${configError}\nFix the config and retry, or run "openclaw doctor" to repair.`,
+      );
+      return false;
+    }
+  }
+
   try {
     await params.service.restart({ env: process.env, stdout });
   } catch (err) {
@@ -350,6 +381,17 @@ export async function runServiceRestart(params: {
           defaultRuntime.log(`\n⚠️  ${warning}\n`);
         }
       }
+    }
+  }
+
+  // Pre-flight config validation (#35862)
+  {
+    const configError = await getConfigValidationError();
+    if (configError) {
+      fail(
+        `${params.serviceNoun} aborted: config is invalid.\n${configError}\nFix the config and retry, or run "openclaw doctor" to repair.`,
+      );
+      return false;
     }
   }
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -187,20 +187,27 @@ export async function runGatewayLoop(params: {
 
     // Keep process alive; SIGUSR1 triggers an in-process restart (no supervisor required).
     // SIGTERM/SIGINT still exit after a graceful shutdown.
+    let isFirstStart = true;
     // eslint-disable-next-line no-constant-condition
     while (true) {
       onIteration();
       try {
         server = await params.start();
+        isFirstStart = false;
       } catch (err) {
-        // If startup fails (e.g., invalid config after a config-triggered
-        // restart), keep the process alive and wait for the next SIGUSR1
-        // instead of crashing. A crash here would respawn a new process that
-        // loses macOS Full Disk Access (TCC permissions are PID-bound). (#35862)
+        // On initial startup, let the error propagate so the outer handler
+        // can report "Gateway failed to start" and exit non-zero. Only
+        // swallow errors on subsequent in-process restarts to keep the
+        // process alive (a crash would lose macOS TCC permissions). (#35862)
+        if (isFirstStart) {
+          throw err;
+        }
         server = null;
+        const errMsg = err instanceof Error ? err.message : String(err);
+        const errStack = err instanceof Error && err.stack ? `\n${err.stack}` : "";
         gatewayLog.error(
-          `gateway startup failed: ${err instanceof Error ? err.message : String(err)}. ` +
-            "Process will stay alive; fix the issue and restart.",
+          `gateway startup failed: ${errMsg}. ` +
+            `Process will stay alive; fix the issue and restart.${errStack}`,
         );
       }
       await new Promise<void>((resolve) => {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -190,7 +190,19 @@ export async function runGatewayLoop(params: {
     // eslint-disable-next-line no-constant-condition
     while (true) {
       onIteration();
-      server = await params.start();
+      try {
+        server = await params.start();
+      } catch (err) {
+        // If startup fails (e.g., invalid config after a config-triggered
+        // restart), keep the process alive and wait for the next SIGUSR1
+        // instead of crashing. A crash here would respawn a new process that
+        // loses macOS Full Disk Access (TCC permissions are PID-bound). (#35862)
+        server = null;
+        gatewayLog.error(
+          `gateway startup failed: ${err instanceof Error ? err.message : String(err)}. ` +
+            "Process will stay alive; fix the issue and restart.",
+        );
+      }
       await new Promise<void>((resolve) => {
         restartResolver = resolve;
       });

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -203,6 +203,11 @@ export async function runGatewayLoop(params: {
           throw err;
         }
         server = null;
+        // Release the gateway lock so that `daemon restart/stop` (which
+        // discovers PIDs via the gateway port) can still manage the process.
+        // Without this, the process holds the lock but is not listening,
+        // forcing manual cleanup. (#35862)
+        await releaseLockIfHeld();
         const errMsg = err instanceof Error ? err.message : String(err);
         const errStack = err instanceof Error && err.stack ? `\n${err.stack}` : "";
         gatewayLog.error(


### PR DESCRIPTION
## What
Add pre-flight config validation before `gateway restart` and `gateway start`, plus crash guard in the gateway run loop.

## Why
Fixes #35862 — When `openclaw gateway restart` is run with invalid config, the new process crashes on startup. On macOS, this causes Full Disk Access (TCC) permissions to be lost because launchd respawns with a different PID.

## How
**Two layers of defense:**

1. **CLI pre-check** (`lifecycle-core.ts`): `getConfigValidationError()` validates config before `runServiceRestart()` and `runServiceStart()`. If invalid, aborts with clear error message.
2. **Run loop crash guard** (`run-loop.ts`): Wraps `params.start()` in try/catch. On failure, sets `server=null`, logs error, and waits for next SIGUSR1 instead of crashing.

The config watcher's hot-reload path already had this guard (`handleInvalidSnapshot`), but CLI commands and the run loop did not.

## Testing
- [x] `pnpm build` + `pnpm check` pass
- [x] 6 new tests (restart + start, invalid/valid/missing/error cases)
- [x] 3 existing lifecycle-core tests pass
- [x] AI-assisted (OpenClaw agent, fully tested)

_Replaces #35924 which was auto-closed by barnacle bot (PR slot limit)._