### PR TITLE
fix(skills): resolve `skills info` name mismatches

### DIFF
--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -63,6 +63,49 @@ function formatSkillMissingSummary(skill: SkillStatusEntry): string {
   return missing.join("; ");
 }
 
+function normalizeSkillLookupToken(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_/]+/g, "-")
+    .replace(/[^a-z0-9-]+/g, "")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function resolveSkillByName(report: SkillStatusReport, requestedName: string): SkillStatusEntry | null {
+  const raw = requestedName.trim();
+  if (!raw) {
+    return null;
+  }
+
+  const direct = report.skills.find((s) => s.name === raw || s.skillKey === raw);
+  if (direct) {
+    return direct;
+  }
+
+  const lower = raw.toLowerCase();
+  const caseInsensitive = report.skills.find(
+    (s) => s.name.toLowerCase() === lower || s.skillKey.toLowerCase() === lower,
+  );
+  if (caseInsensitive) {
+    return caseInsensitive;
+  }
+
+  const normalized = normalizeSkillLookupToken(raw);
+  if (!normalized) {
+    return null;
+  }
+
+  return (
+    report.skills.find(
+      (s) =>
+        normalizeSkillLookupToken(s.name) === normalized ||
+        normalizeSkillLookupToken(s.skillKey) === normalized,
+    ) ?? null
+  );
+}
+
 export function formatSkillsList(report: SkillStatusReport, opts: SkillsListOptions): string {
   const skills = opts.eligible ? report.skills.filter((s) => s.eligible) : report.skills;
 
@@ -137,14 +180,15 @@ export function formatSkillInfo(
   skillName: string,
   opts: SkillInfoOptions,
 ): string {
-  const skill = report.skills.find((s) => s.name === skillName || s.skillKey === skillName);
+  const requestedName = skillName.trim();
+  const skill = resolveSkillByName(report, requestedName);
 
   if (!skill) {
     if (opts.json) {
-      return JSON.stringify({ error: "not found", skill: skillName }, null, 2);
+      return JSON.stringify({ error: "not found", skill: requestedName }, null, 2);
     }
     return appendClawHubHint(
-      `Skill "${skillName}" not found. Run \`${formatCliCommand("openclaw skills list")}\` to see available skills.`,
+      `Skill "${requestedName}" not found. Run \`${formatCliCommand("openclaw skills list")}\` to see available skills.`,
       opts.json,
     );
   }

--- a/src/cli/skills-cli.test.ts
+++ b/src/cli/skills-cli.test.ts
@@ -148,6 +148,32 @@ describe("skills-cli", () => {
       expect(output).toContain("Any binaries");
       expect(output).toContain("API_KEY");
     });
+
+    it("resolves skill info case-insensitively", () => {
+      const report = createMockReport([
+        createMockSkill({
+          name: "Excel-XLSX",
+          skillKey: "excel-xlsx",
+          description: "Spreadsheet helpers",
+        }),
+      ]);
+
+      const output = formatSkillInfo(report, "excel-xlsx", {});
+      expect(output).toContain("Spreadsheet helpers");
+    });
+
+    it("resolves skill info across separator variants", () => {
+      const report = createMockReport([
+        createMockSkill({
+          name: "Excel XLSX",
+          skillKey: "excel_xlsx",
+          description: "Spreadsheet helpers",
+        }),
+      ]);
+
+      const output = formatSkillInfo(report, "excel-xlsx", {});
+      expect(output).toContain("Spreadsheet helpers");
+    });
   });
 
   describe("formatSkillsCheck", () => {


### PR DESCRIPTION
## Summary
- make `openclaw skills info <name>` resolve skills using exact, case-insensitive, and separator-normalized matching
- normalize lookup tokens across whitespace, underscores, slashes, and dashes so list-visible names and skill keys resolve consistently
- trim the requested name in not-found JSON/text responses for cleaner UX

## Why
Fixes #38546 where skills can show as ready in `skills list` but fail lookup in `skills info` (and by extension agent-facing selection paths) due strict identifier matching.

## Testing
- pnpm -C /Users/newdldewdl/.openclaw/workspace/memory/openclaw-contrib/worktrees/issue-38686 test src/cli/skills-cli.test.ts
- bash /Users/newdldewdl/.openclaw/workspace/skills/openclaw-autonomous-contributor/scripts/quality_gate.sh /Users/newdldewdl/.openclaw/workspace/memory/openclaw-contrib/worktrees/issue-38686