### PR TITLE
fix: re-add long dep removed in #22481 (breaks baileys rc.9 at runtime)

### DIFF
--- a/package.json
+++ b/package.json
@@ -366,6 +366,7 @@
     "json5": "^2.2.3",
     "jszip": "^3.10.1",
     "linkedom": "^0.18.12",
+    "long": "^5.3.2",
     "markdown-it": "^14.1.1",
     "node-edge-tts": "^1.2.10",
     "opusscript": "^0.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       linkedom:
         specifier: ^0.18.12
         version: 0.18.12
+      long:
+        specifier: ^5.3.2
+        version: 5.3.2
       markdown-it:
         specifier: ^14.1.1
         version: 14.1.1
@@ -3491,9 +3494,6 @@ packages:
     resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
     engines: {node: 18 || 20 || >=22}
 
-  browser-or-node@1.3.0:
-    resolution: {integrity: sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==}
-
   browser-or-node@3.0.0:
     resolution: {integrity: sha512-iczIdVJzGEYhP5DqQxYM9Hh7Ztpqqi+CXZpSmX8ALFs9ecXkQIeqRyM6TfxEfMVpwhl3dSuDvxdzzo9sUOIVBQ==}
 
@@ -3672,9 +3672,6 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
-
-  core-js@3.48.0:
-    resolution: {integrity: sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==}
 
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
@@ -9591,8 +9588,6 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  browser-or-node@1.3.0: {}
-
   browser-or-node@3.0.0: {}
 
   buffer-crc32@0.2.13: {}
@@ -9763,8 +9758,6 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
-
-  core-js@3.48.0: {}
 
   core-util-is@1.0.2: {}
 


### PR DESCRIPTION
## Summary

- **Problem:** `@whiskeysockets/baileys@7.0.0-rc.9` imports the `long` package at runtime (in `lib/Socket/messages-recv.js`) but does not declare it as a dependency in its own `package.json`. This means pnpm's strict isolation does not link `long` into baileys' virtual store node_modules.
- **Why it matters:** PR #22481 removed `long` from the root `package.json`. After that removal, the gateway crashes on startup with `ERR_MODULE_NOT_FOUND: Cannot find package 'long'`, causing a crash-restart loop.
- **What changed:** `long ^5.3.2` re-added to root `package.json` and `pnpm-lock.yaml` updated.
- **What did NOT change:** No source code changes. No behavior changes. This is a pure dependency fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #22481 (the PR that removed `long`)

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (ARM64)
- Runtime: Node.js v22.22.0
- Integration/channel: WhatsApp (Baileys)

### Steps

1. Run `pnpm install && pnpm build` on current `main`
2. Start the gateway
3. Gateway crashes immediately

### Expected

- Gateway starts successfully

### Actual

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'long' imported from
.../node_modules/@whiskeysockets/baileys/lib/Socket/messages-recv.js
```

## Evidence

- [x] Log snippet above confirms crash on startup without this fix
- Gateway starts and all channels connect healthy after re-adding `long`

## Human Verification (required)

- Verified gateway starts and WhatsApp connects with `long` present
- Verified crash reproduces after removing `long` on Node 22 with pnpm strict isolation

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert by removing `long` from `package.json` and running `pnpm install`
- This PR is a pure dep addition — no risk of regression

## Risks and Mitigations

- Risk: None beyond adding a small, stable, widely-used package
  - Mitigation: `long` is already in the lockfile as a transitive dep — this just makes it explicit