### PR TITLE
feat(ios): replace ElevenLabs batch STT with realtime WebSocket STT

### DIFF
--- a/apps/ios/Sources/Gateway/GatewaySettingsStore.swift
+++ b/apps/ios/Sources/Gateway/GatewaySettingsStore.swift
@@ -412,7 +412,7 @@ enum GatewayDiagnostics {
     private static let keepLogBytes: Int64 = 256 * 1024
     private static let logSizeCheckEveryWrites = 50
     private static let logWritesSinceCheck = OSAllocatedUnfairLock(initialState: 0)
-    private static let isoFormatter: ISO8601DateFormatter = {
+    private nonisolated(unsafe) static let isoFormatter: ISO8601DateFormatter = {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return f

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -339,6 +339,26 @@ struct SettingsTab: View {
                                     .font(.footnote)
                                     .foregroundStyle(.secondary)
                             }
+
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("Speech-to-Text")
+                                    .font(.footnote.weight(.semibold))
+                                    .foregroundStyle(.secondary)
+                                Picker("STT Model", selection: Bindable(self.appModel.talkMode).sttModelId) {
+                                    Text("Scribe v2 Realtime").tag("scribe_v2_realtime")
+                                }
+                                TextField(
+                                    "Language (e.g. eng, zho, auto)",
+                                    text: Bindable(self.appModel.talkMode).sttLanguageCode)
+                                    .textInputAutocapitalization(.never)
+                                    .autocorrectionDisabled()
+                                Text(
+                                    "ElevenLabs STT is enabled when an API key is configured. "
+                                        + "Leave language empty for auto-detect.")
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            }
+
                             self.featureToggle(
                                 "Show Talk Button",
                                 isOn: self.$talkButtonEnabled,

--- a/apps/ios/Sources/Voice/ElevenLabsRealtimeSTTClient.swift
+++ b/apps/ios/Sources/Voice/ElevenLabsRealtimeSTTClient.swift
@@ -1,0 +1,144 @@
+import Foundation
+import OSLog
+
+/// WebSocket client for ElevenLabs Realtime Speech-to-Text API.
+/// Streams Int16 PCM audio chunks and receives partial/committed transcripts.
+@MainActor
+final class ElevenLabsRealtimeSTTClient {
+    enum TranscriptKind { case partial, committed }
+
+    var onTranscript: ((String, TranscriptKind) -> Void)?
+    var onError: ((Error) -> Void)?
+    private(set) var isConnected: Bool = false
+
+    private let apiKey: String
+    private let modelId: String
+    private let languageCode: String
+    private let sampleRate: Int
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var receiveTask: Task<Void, Never>?
+    private let logger = Logger(subsystem: "ai.openclaw", category: "RealtimeSTT")
+
+    init(apiKey: String, modelId: String = "scribe_v2_realtime", languageCode: String = "", sampleRate: Int = 48000) {
+        self.apiKey = apiKey
+        self.modelId = modelId
+        self.languageCode = languageCode
+        self.sampleRate = sampleRate
+    }
+
+    func connect() {
+        guard self.webSocketTask == nil else { return }
+
+        var components = URLComponents(string: "wss://api.elevenlabs.io/v1/speech-to-text/realtime")!
+        components.queryItems = [
+            URLQueryItem(name: "model_id", value: self.modelId),
+            URLQueryItem(name: "audio_format", value: "pcm_\(self.sampleRate)"),
+            URLQueryItem(name: "commit_strategy", value: "manual"),
+        ]
+        if !self.languageCode.isEmpty {
+            components.queryItems?.append(URLQueryItem(name: "language_code", value: self.languageCode))
+        }
+
+        var request = URLRequest(url: components.url!)
+        request.setValue(self.apiKey, forHTTPHeaderField: "xi-api-key")
+
+        let task = URLSession.shared.webSocketTask(with: request)
+        self.webSocketTask = task
+        task.resume()
+        self.isConnected = true
+        self.logger.info("websocket connecting model=\(self.modelId, privacy: .public)")
+
+        self.receiveTask = Task { [weak self] in
+            await self?.receiveLoop()
+        }
+    }
+
+    /// Sends Int16 PCM audio data as a base64-encoded chunk.
+    func sendAudio(_ int16Data: Data) {
+        guard let task = self.webSocketTask, self.isConnected else { return }
+        let base64 = int16Data.base64EncodedString()
+        let json = "{\"message_type\":\"input_audio_chunk\",\"audio_base_64\":\"\(base64)\"}"
+        task.send(.string(json)) { [weak self] error in
+            if let error {
+                self?.logger.warning("send error: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    /// Sends a commit message to finalize the current transcript.
+    func commit() {
+        guard let task = self.webSocketTask, self.isConnected else { return }
+        let json = "{\"message_type\":\"commit\"}"
+        task.send(.string(json)) { [weak self] error in
+            if let error {
+                self?.logger.warning("commit send error: \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    func disconnect() {
+        self.receiveTask?.cancel()
+        self.receiveTask = nil
+        self.webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        self.webSocketTask = nil
+        self.isConnected = false
+        self.logger.info("websocket disconnected")
+    }
+
+    // MARK: - Private
+
+    private func receiveLoop() async {
+        guard let task = self.webSocketTask else { return }
+        while !Task.isCancelled {
+            do {
+                let message = try await task.receive()
+                switch message {
+                case .string(let text):
+                    self.handleMessage(text)
+                case .data(let data):
+                    if let text = String(data: data, encoding: .utf8) {
+                        self.handleMessage(text)
+                    }
+                @unknown default:
+                    break
+                }
+            } catch {
+                if Task.isCancelled { return }
+                await MainActor.run {
+                    self.isConnected = false
+                    self.logger.warning("websocket receive error: \(error.localizedDescription, privacy: .public)")
+                    self.onError?(error)
+                }
+                return
+            }
+        }
+    }
+
+    private struct RealtimeMessage: Decodable {
+        let message_type: String
+        let text: String?
+    }
+
+    private func handleMessage(_ text: String) {
+        guard let data = text.data(using: .utf8),
+              let msg = try? JSONDecoder().decode(RealtimeMessage.self, from: data)
+        else { return }
+
+        switch msg.message_type {
+        case "partial_transcript":
+            if let transcript = msg.text {
+                Task { @MainActor in
+                    self.onTranscript?(transcript, .partial)
+                }
+            }
+        case "committed_transcript":
+            if let transcript = msg.text {
+                Task { @MainActor in
+                    self.onTranscript?(transcript, .committed)
+                }
+            }
+        default:
+            break
+        }
+    }
+}

--- a/apps/ios/Sources/Voice/ElevenLabsSTTClient.swift
+++ b/apps/ios/Sources/Voice/ElevenLabsSTTClient.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Client for the ElevenLabs Speech-to-Text (Scribe v2) batch API.
+/// Kept as a fallback; the primary path uses ElevenLabsRealtimeSTTClient.
+struct ElevenLabsSTTClient {
+    private static let endpoint = URL(string: "https://api.elevenlabs.io/v1/speech-to-text")!
+
+    /// Transcribes WAV audio data using ElevenLabs Scribe.
+    /// - Parameters:
+    ///   - wavData: WAV-encoded audio data (16-bit PCM mono).
+    ///   - apiKey: ElevenLabs API key (same key used for TTS).
+    ///   - languageCode: Optional ISO 639-3 language code hint (e.g. "eng", "zho").
+    ///   - modelId: Scribe model to use (default "scribe_v2").
+    /// - Returns: The transcribed text.
+    static func transcribe(
+        wavData: Data, apiKey: String, languageCode: String? = nil, modelId: String = "scribe_v2"
+    ) async throws -> String {
+        let boundary = "Boundary-\(UUID().uuidString)"
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+
+        var body = Data()
+        // model_id field
+        body.appendMultipartField(name: "model_id", value: modelId, boundary: boundary)
+        // language_code field (optional)
+        if let languageCode, !languageCode.isEmpty {
+            body.appendMultipartField(name: "language_code", value: languageCode, boundary: boundary)
+        }
+        // file field
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append("Content-Disposition: form-data; name=\"file\"; filename=\"audio.wav\"\r\n".data(using: .utf8)!)
+        body.append("Content-Type: audio/wav\r\n\r\n".data(using: .utf8)!)
+        body.append(wavData)
+        body.append("\r\n".data(using: .utf8)!)
+        // closing boundary
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+        request.httpBody = body
+        request.timeoutInterval = 30
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NSError(domain: "ElevenLabsSTT", code: -1, userInfo: [
+                NSLocalizedDescriptionKey: "Invalid response",
+            ])
+        }
+        guard httpResponse.statusCode == 200 else {
+            let detail = String(data: data, encoding: .utf8) ?? "unknown error"
+            throw NSError(domain: "ElevenLabsSTT", code: httpResponse.statusCode, userInfo: [
+                NSLocalizedDescriptionKey: "STT failed (\(httpResponse.statusCode)): \(detail)",
+            ])
+        }
+
+        struct STTResponse: Decodable { let text: String }
+        let decoded = try JSONDecoder().decode(STTResponse.self, from: data)
+        return decoded.text
+    }
+}
+
+private extension Data {
+    mutating func appendMultipartField(name: String, value: String, boundary: String) {
+        self.append("--\(boundary)\r\n".data(using: .utf8)!)
+        self.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".data(using: .utf8)!)
+        self.append("\(value)\r\n".data(using: .utf8)!)
+    }
+}

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -70,6 +70,20 @@ final class TalkModeManager: NSObject {
     private var recognitionTask: SFSpeechRecognitionTask?
     private var silenceTask: Task<Void, Never>?
 
+    /// When true, use ElevenLabs realtime WebSocket STT instead of Apple Speech.
+    private var useElevenLabsSTT: Bool = false
+    /// Realtime WebSocket STT client for ElevenLabs.
+    private var realtimeSTTClient: ElevenLabsRealtimeSTTClient?
+
+    /// User-selected STT model (persisted in UserDefaults).
+    var sttModelId: String {
+        didSet { UserDefaults.standard.set(sttModelId, forKey: "talk.stt.modelId") }
+    }
+    /// User-selected STT language code (persisted in UserDefaults). Empty = auto-detect.
+    var sttLanguageCode: String {
+        didSet { UserDefaults.standard.set(sttLanguageCode, forKey: "talk.stt.languageCode") }
+    }
+
     private var lastHeard: Date?
     private var lastTranscript: String = ""
     private var loggedPartialThisCycle: Bool = false
@@ -119,6 +133,8 @@ final class TalkModeManager: NSObject {
 
     init(allowSimulatorCapture: Bool = false) {
         self.allowSimulatorCapture = allowSimulatorCapture
+        self.sttModelId = UserDefaults.standard.string(forKey: "talk.stt.modelId") ?? "scribe_v2_realtime"
+        self.sttLanguageCode = UserDefaults.standard.string(forKey: "talk.stt.languageCode") ?? ""
         super.init()
     }
 
@@ -172,23 +188,26 @@ final class TalkModeManager: NSObject {
         }
 
         self.logger.info("start")
-        self.statusText = "Requesting permissions…"
+        self.statusText = "Starting…"
         let micOk = await Self.requestMicrophonePermission()
         guard micOk else {
             self.logger.warning("start blocked: microphone permission denied")
             self.statusText = "Microphone permission denied"
             return
         }
-        let speechOk = await Self.requestSpeechPermission()
-        guard speechOk else {
-            self.logger.warning("start blocked: speech permission denied")
-            self.statusText = Self.permissionMessage(
-                kind: "Speech recognition",
-                status: SFSpeechRecognizer.authorizationStatus())
-            return
-        }
 
         await self.reloadConfig()
+
+        if !self.useElevenLabsSTT {
+            let speechOk = await Self.requestSpeechPermission()
+            guard speechOk else {
+                self.logger.warning("start blocked: speech permission denied")
+                self.statusText = Self.permissionMessage(
+                    kind: "Speech recognition",
+                    status: SFSpeechRecognizer.authorizationStatus())
+                return
+            }
+        }
         do {
             try Self.configureAudioSession()
             // Set this before starting recognition so any early speech errors are classified correctly.
@@ -323,14 +342,16 @@ final class TalkModeManager: NSObject {
                     NSLocalizedDescriptionKey: "Microphone permission denied",
                 ])
             }
-            let speechOk = await Self.requestSpeechPermission()
-            guard speechOk else {
-                self.statusText = Self.permissionMessage(
-                    kind: "Speech recognition",
-                    status: SFSpeechRecognizer.authorizationStatus())
-                throw NSError(domain: "TalkMode", code: 5, userInfo: [
-                    NSLocalizedDescriptionKey: "Speech recognition permission denied",
-                ])
+            if !self.useElevenLabsSTT {
+                let speechOk = await Self.requestSpeechPermission()
+                guard speechOk else {
+                    self.statusText = Self.permissionMessage(
+                        kind: "Speech recognition",
+                        status: SFSpeechRecognizer.authorizationStatus())
+                    throw NSError(domain: "TalkMode", code: 5, userInfo: [
+                        NSLocalizedDescriptionKey: "Speech recognition permission denied",
+                    ])
+                }
             }
         }
 
@@ -366,6 +387,13 @@ final class TalkModeManager: NSObject {
         self.isPushToTalkActive = false
         self.isListening = false
         self.captureMode = .idle
+
+        // For realtime STT, send commit before stopping so the final transcript arrives.
+        if self.useElevenLabsSTT, let client = self.realtimeSTTClient {
+            client.commit()
+            try? await Task.sleep(nanoseconds: 300_000_000)
+        }
+
         self.stopRecognition()
         self.pttTimeoutTask?.cancel()
         self.pttTimeoutTask = nil
@@ -499,17 +527,6 @@ final class TalkModeManager: NSObject {
         #endif
 
         self.stopRecognition()
-        self.speechRecognizer = SFSpeechRecognizer()
-        guard let recognizer = self.speechRecognizer else {
-            throw NSError(domain: "TalkMode", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "Speech recognizer unavailable",
-            ])
-        }
-
-        self.recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
-        self.recognitionRequest?.shouldReportPartialResults = true
-        self.recognitionRequest?.taskHint = .dictation
-        guard let request = self.recognitionRequest else { return }
 
         GatewayDiagnostics.log("talk audio: session \(Self.describeAudioSession())")
 
@@ -555,23 +572,83 @@ final class TalkModeManager: NSObject {
                 }
                 if raw >= threshold {
                     self.lastAudioActivity = Date()
+                    if self.useElevenLabsSTT {
+                        self.lastHeard = Date()
+                    }
                 }
             }
         }
         self.audioTapDiagnostics = tapDiagnostics
-        let tapBlock = Self.makeAudioTapAppendCallback(request: request, diagnostics: tapDiagnostics)
-        input.installTap(onBus: 0, bufferSize: 2048, format: format, block: tapBlock)
-        self.inputTapInstalled = true
 
-        self.audioEngine.prepare()
-        try self.audioEngine.start()
-        self.loggedPartialThisCycle = false
+        if self.useElevenLabsSTT {
+            // ElevenLabs realtime WebSocket STT path.
+            guard let apiKey = self.apiKey, !apiKey.isEmpty else {
+                throw NSError(domain: "TalkMode", code: 6, userInfo: [
+                    NSLocalizedDescriptionKey: "ElevenLabs API key not configured",
+                ])
+            }
+            let sttLang = self.sttLanguageCode.isEmpty ? "" : self.sttLanguageCode
+            let client = ElevenLabsRealtimeSTTClient(
+                apiKey: apiKey,
+                modelId: self.sttModelId,
+                languageCode: sttLang,
+                sampleRate: Int(format.sampleRate))
+            client.onTranscript = { [weak self] transcript, kind in
+                guard let self else { return }
+                let isFinal = kind == .committed
+                Task { @MainActor in
+                    await self.handleTranscript(transcript: transcript, isFinal: isFinal)
+                }
+            }
+            client.onError = { [weak self] error in
+                guard let self else { return }
+                self.logger.warning("realtime STT error: \(error.localizedDescription, privacy: .public)")
+                GatewayDiagnostics.log("talk stt: realtime error=\(error.localizedDescription)")
+                Task { @MainActor in
+                    await self.restartRecognitionAfterError()
+                }
+            }
+            self.realtimeSTTClient = client
+            client.connect()
 
-        GatewayDiagnostics.log(
-            "talk speech: recognition started mode=\(String(describing: self.captureMode)) "
-                + "engineRunning=\(self.audioEngine.isRunning)"
-        )
-        self.recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            let tapBlock = Self.makeAudioTapRealtimeCallback(client: client, diagnostics: tapDiagnostics)
+            input.installTap(onBus: 0, bufferSize: 2048, format: format, block: tapBlock)
+            self.inputTapInstalled = true
+
+            self.audioEngine.prepare()
+            try self.audioEngine.start()
+
+            GatewayDiagnostics.log(
+                "talk stt: elevenlabs realtime started mode=\(String(describing: self.captureMode)) "
+                    + "engineRunning=\(self.audioEngine.isRunning)"
+            )
+        } else {
+            // Apple Speech path: feed audio buffers into SFSpeechRecognizer.
+            self.speechRecognizer = SFSpeechRecognizer()
+            guard let recognizer = self.speechRecognizer else {
+                throw NSError(domain: "TalkMode", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "Speech recognizer unavailable",
+                ])
+            }
+
+            self.recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+            self.recognitionRequest?.shouldReportPartialResults = true
+            self.recognitionRequest?.taskHint = .dictation
+            guard let request = self.recognitionRequest else { return }
+
+            let tapBlock = Self.makeAudioTapAppendCallback(request: request, diagnostics: tapDiagnostics)
+            input.installTap(onBus: 0, bufferSize: 2048, format: format, block: tapBlock)
+            self.inputTapInstalled = true
+
+            self.audioEngine.prepare()
+            try self.audioEngine.start()
+            self.loggedPartialThisCycle = false
+
+            GatewayDiagnostics.log(
+                "talk speech: recognition started mode=\(String(describing: self.captureMode)) "
+                    + "engineRunning=\(self.audioEngine.isRunning)"
+            )
+            self.recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
             guard let self else { return }
             if let error {
                 let msg = error.localizedDescription
@@ -618,12 +695,30 @@ final class TalkModeManager: NSObject {
                 await self.handleTranscript(transcript: transcript, isFinal: result.isFinal)
             }
         }
+        }
+    }
+
+    /// Audio tap callback that streams Int16 PCM to the realtime WebSocket STT client.
+    private nonisolated static func makeAudioTapRealtimeCallback(
+        client: ElevenLabsRealtimeSTTClient,
+        diagnostics: AudioTapDiagnostics) -> AVAudioNodeTapBlock
+    {
+        { buffer, _ in
+            diagnostics.onBuffer(buffer)
+            guard let floatData = buffer.floatChannelData else { return }
+            let frameCount = Int(buffer.frameLength)
+            let int16Data = WAVEncoder.float32ToInt16(floatData[0], count: frameCount)
+            Task { @MainActor in
+                client.sendAudio(int16Data)
+            }
+        }
     }
 
     private func restartRecognitionAfterError() async {
         guard self.isEnabled, self.captureMode == .continuous else { return }
         // Avoid thrashing the audio engine if it’s already running.
-        if self.recognitionTask != nil, self.audioEngine.isRunning { return }
+        if (self.recognitionTask != nil || self.realtimeSTTClient?.isConnected == true),
+           self.audioEngine.isRunning { return }
         try? await Task.sleep(nanoseconds: 250_000_000)
         guard self.isEnabled, self.captureMode == .continuous else { return }
         do {
@@ -641,6 +736,8 @@ final class TalkModeManager: NSObject {
     }
 
     private func stopRecognition() {
+        self.realtimeSTTClient?.disconnect()
+        self.realtimeSTTClient = nil
         self.recognitionTask?.cancel()
         self.recognitionTask = nil
         self.recognitionRequest?.endAudio()
@@ -2063,6 +2160,7 @@ extension TalkModeManager {
             self.gatewayTalkDefaultVoiceId = self.defaultVoiceId
             self.gatewayTalkDefaultModelId = self.defaultModelId
             self.gatewayTalkApiKeyConfigured = (self.apiKey?.isEmpty == false)
+            self.useElevenLabsSTT = (self.apiKey?.isEmpty == false)
             self.gatewayTalkConfigLoaded = true
             if let interrupt = talk?["interruptOnSpeech"] as? Bool {
                 self.interruptOnSpeech = interrupt

--- a/apps/ios/Sources/Voice/WAVEncoder.swift
+++ b/apps/ios/Sources/Voice/WAVEncoder.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// WAV encoding utility for STT. Wraps raw Float32 mono PCM in a
+/// minimal 16-bit WAV container suitable for transcription APIs.
+struct WAVEncoder {
+    /// Converts a buffer of Float32 PCM samples to Int16 PCM data (little-endian).
+    static func float32ToInt16(_ floatPointer: UnsafePointer<Float>, count: Int) -> Data {
+        var buf = Data(capacity: count * 2)
+        for i in 0..<count {
+            let clamped = max(-1.0, min(1.0, floatPointer[i]))
+            var sample = Int16(clamped * Float(Int16.max))
+            withUnsafeBytes(of: &sample) { buf.append(contentsOf: $0) }
+        }
+        return buf
+    }
+
+    /// Wraps raw Float32 mono PCM data in a minimal WAV container (16-bit PCM).
+    static func wavFromPCM(pcmData: Data, sampleRate: UInt32) -> Data {
+        let sampleCount = pcmData.count / MemoryLayout<Float>.size
+        let int16Data = pcmData.withUnsafeBytes { raw -> Data in
+            let floats = raw.bindMemory(to: Float.self)
+            return float32ToInt16(floats.baseAddress!, count: sampleCount)
+        }
+
+        let channels: UInt16 = 1
+        let bitsPerSample: UInt16 = 16
+        let byteRate = sampleRate * UInt32(channels) * UInt32(bitsPerSample / 8)
+        let blockAlign = channels * (bitsPerSample / 8)
+        let dataSize = UInt32(int16Data.count)
+        let fileSize = 36 + dataSize
+
+        var header = Data(capacity: 44)
+        header.append(contentsOf: "RIFF".utf8)
+        header.appendLittleEndian(fileSize)
+        header.append(contentsOf: "WAVE".utf8)
+        header.append(contentsOf: "fmt ".utf8)
+        header.appendLittleEndian(UInt32(16)) // chunk size
+        header.appendLittleEndian(UInt16(1))  // PCM format
+        header.appendLittleEndian(channels)
+        header.appendLittleEndian(sampleRate)
+        header.appendLittleEndian(byteRate)
+        header.appendLittleEndian(blockAlign)
+        header.appendLittleEndian(bitsPerSample)
+        header.append(contentsOf: "data".utf8)
+        header.appendLittleEndian(dataSize)
+        header.append(int16Data)
+        return header
+    }
+}
+
+private extension Data {
+    mutating func appendLittleEndian<T: FixedWidthInteger>(_ value: T) {
+        var v = value.littleEndian
+        Swift.withUnsafeBytes(of: &v) { self.append(contentsOf: $0) }
+    }
+}

--- a/apps/ios/SwiftSources.input.xcfilelist
+++ b/apps/ios/SwiftSources.input.xcfilelist
@@ -60,8 +60,11 @@ Sources/Voice/VoiceWakePreferences.swift
 ../shared/OpenClawKit/Sources/OpenClawKit/SystemCommands.swift
 ../shared/OpenClawKit/Sources/OpenClawKit/TalkDirective.swift
 ../../Swabble/Sources/SwabbleKit/WakeWordGate.swift
+Sources/Voice/ElevenLabsRealtimeSTTClient.swift
+Sources/Voice/ElevenLabsSTTClient.swift
 Sources/Voice/TalkModeManager.swift
 Sources/Voice/TalkOrbOverlay.swift
+Sources/Voice/WAVEncoder.swift
 Sources/LiveActivity/OpenClawActivityAttributes.swift
 Sources/LiveActivity/LiveActivityManager.swift
 ActivityWidget/OpenClawActivityWidgetBundle.swift


### PR DESCRIPTION
## Summary

- Replace ElevenLabs batch REST STT (`POST /v1/speech-to-text`) with realtime WebSocket STT (`wss://api.elevenlabs.io/v1/speech-to-text/realtime`) using `scribe_v2_realtime` model
- Stream Int16 PCM audio chunks over WebSocket, receive partial/committed transcripts with ~150ms latency
- Both Apple Speech and ElevenLabs now flow through the unified `handleTranscript(transcript:, isFinal:)` method, enabling interrupt detection during TTS playback
- Add STT model and language picker to Settings > Device > Features > Advanced

## New files

- `ElevenLabsRealtimeSTTClient.swift` — WebSocket client for realtime STT API
- `WAVEncoder.swift` — Float32→Int16 PCM conversion utility
- `ElevenLabsSTTClient.swift` — Batch API client (kept as fallback)

## Test plan

- [x] Continuous mode: speak → silence detected → transcribed → response plays → cycle repeats
- [ ] PTT mode: hold → speak → release → commit sent → transcribed → response
- [ ] Interrupt: during TTS playback, speak → TTS stops
- [ ] Settings: STT model picker and language field visible under Advanced
- [ ] Apple Speech path remains functional when no ElevenLabs API key configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)