### PR TITLE
fix(feishu): persist bot media-only messages to DB

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -8,6 +8,7 @@ const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 const resolveReceiveIdTypeMock = vi.hoisted(() => vi.fn());
 const createReplyDispatcherWithTypingMock = vi.hoisted(() => vi.fn());
+const emitMessageSentMock = vi.hoisted(() => vi.fn());
 const addTypingIndicatorMock = vi.hoisted(() => vi.fn(async () => ({ messageId: "om_msg" })));
 const removeTypingIndicatorMock = vi.hoisted(() => vi.fn(async () => {}));
 const streamingInstances = vi.hoisted(() => [] as any[]);
@@ -66,7 +67,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     streamingInstances.length = 0;
-    sendMediaFeishuMock.mockResolvedValue(undefined);
+    sendMediaFeishuMock.mockResolvedValue({ messageId: "om_media_1", chatId: "oc_chat" });
 
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
@@ -102,6 +103,9 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
           createReplyDispatcherWithTyping: createReplyDispatcherWithTypingMock,
           resolveHumanDelayConfig: vi.fn(() => undefined),
         },
+      },
+      hooks: {
+        emitMessageSent: emitMessageSentMock,
       },
     });
   });
@@ -589,6 +593,184 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
         replyToMessageId: "om_msg",
         replyInThread: true,
       }),
+    );
+  });
+
+  it("emits persistence signals for media-only final replies", async () => {
+    const onFinalTextDelivered = vi.fn(async () => {});
+    sendMediaFeishuMock.mockResolvedValueOnce({ messageId: "om_media_1", chatId: "oc_chat" });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+      onFinalTextDelivered,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver(
+      { mediaUrl: "https://example.com/path/photo.png?x=1" },
+      { kind: "final" },
+    );
+
+    expect(emitMessageSentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "oc_chat",
+        content: "photo.png",
+        success: true,
+        messageId: "om_media_1",
+        metadata: expect.objectContaining({
+          chatId: "oc_chat",
+          messageIds: ["om_media_1"],
+        }),
+      }),
+      expect.objectContaining({
+        channelId: "feishu",
+        conversationId: "oc_chat",
+      }),
+    );
+    expect(onFinalTextDelivered).toHaveBeenCalledWith({
+      text: "photo.png",
+      messageId: "om_media_1",
+      messageIds: ["om_media_1"],
+      chatId: "oc_chat",
+      accountId: "main",
+    });
+  });
+
+  it("emits onFinalTextDelivered for non-streaming final text replies", async () => {
+    const onFinalTextDelivered = vi.fn(async () => {});
+    sendMessageFeishuMock.mockResolvedValue({ messageId: "om_final_1", chatId: "oc_chat" });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+      onFinalTextDelivered,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "@Trent 请继续" }, { kind: "final" });
+
+    expect(onFinalTextDelivered).toHaveBeenCalledTimes(1);
+    expect(onFinalTextDelivered).toHaveBeenCalledWith({
+      text: "@Trent 请继续",
+      messageId: "om_final_1",
+      messageIds: ["om_final_1"],
+      chatId: "oc_chat",
+      accountId: "main",
+    });
+  });
+
+  it("emits every provider message id for chunked non-streaming final text replies", async () => {
+    const onFinalTextDelivered = vi.fn(async () => {});
+    sendMessageFeishuMock
+      .mockResolvedValueOnce({ messageId: "om_chunk_1", chatId: "oc_chat" })
+      .mockResolvedValueOnce({ messageId: "om_chunk_2", chatId: "oc_chat" });
+    getFeishuRuntimeMock.mockReturnValue({
+      channel: {
+        text: {
+          resolveTextChunkLimit: vi.fn(() => 16),
+          resolveChunkMode: vi.fn(() => "line"),
+          resolveMarkdownTableMode: vi.fn(() => "preserve"),
+          convertMarkdownTables: vi.fn((text) => text),
+          chunkTextWithMode: vi.fn(() => ["第一段", "第二段"]),
+        },
+        reply: {
+          createReplyDispatcherWithTyping: createReplyDispatcherWithTypingMock,
+          resolveHumanDelayConfig: vi.fn(() => undefined),
+        },
+      },
+      hooks: {
+        emitMessageSent: emitMessageSentMock,
+      },
+    });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+      onFinalTextDelivered,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "第一段\n第二段" }, { kind: "final" });
+
+    expect(onFinalTextDelivered).toHaveBeenCalledTimes(1);
+    expect(onFinalTextDelivered).toHaveBeenCalledWith({
+      text: "第一段\n第二段",
+      messageId: "om_chunk_2",
+      messageIds: ["om_chunk_1", "om_chunk_2"],
+      chatId: "oc_chat",
+      accountId: "main",
+    });
+  });
+
+  it("emits onFinalTextDelivered when streaming closes with final text", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+    const onFinalTextDelivered = vi.fn(async () => {});
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+      onFinalTextDelivered,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "最终回复内容" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(onFinalTextDelivered).toHaveBeenCalledTimes(1);
+    expect(onFinalTextDelivered).toHaveBeenCalledWith({
+      text: "最终回复内容",
+      messageId: "om_stream_1",
+      chatId: "oc_chat",
+      accountId: "main",
+    });
+  });
+
+  it("normalizes user_id mention tags before closing streaming card", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver(
+      { text: '是 <at user_id="ou_vivi">Vivi（薇薇）</at> 的回合，不是我' },
+      { kind: "final" },
+    );
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledWith(
+      "是 <at id=ou_vivi></at> 的回合，不是我",
     );
   });
 });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {
   createReplyPrefixContext,
   createTypingCallbacks,
@@ -26,6 +27,34 @@ function shouldUseCard(text: string): boolean {
  * Messages older than this are likely replays after context compaction (#30418). */
 const TYPING_INDICATOR_MAX_AGE_MS = 2 * 60_000;
 const MS_EPOCH_MIN = 1_000_000_000_000;
+
+function resolveFinalDeliveryContent(text: string, mediaUrls: string[]): string {
+  const normalized = text.trim();
+  if (normalized) {
+    return normalized;
+  }
+  if (mediaUrls.length === 0) {
+    return normalized;
+  }
+  const names = mediaUrls
+    .map((mediaUrl) => {
+      const trimmed = mediaUrl.trim();
+      if (!trimmed) {
+        return null;
+      }
+      const withoutHash = trimmed.split("#")[0] ?? trimmed;
+      const withoutQuery = withoutHash.split("?")[0] ?? withoutHash;
+      try {
+        const parsed = new URL(withoutQuery);
+        return path.basename(parsed.pathname) || null;
+      } catch {
+        const base = path.basename(withoutQuery);
+        return base && base !== "." && base !== "/" ? base : null;
+      }
+    })
+    .filter((value): value is string => Boolean(value));
+  return names.length > 0 ? names.join(", ") : "media";
+}
 
 function normalizeEpochMs(timestamp: number | undefined): number | undefined {
   if (!Number.isFinite(timestamp) || timestamp === undefined || timestamp <= 0) {
@@ -73,6 +102,35 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const threadReplyMode = threadReply === true;
   const effectiveReplyInThread = threadReplyMode ? true : replyInThread;
   const account = resolveFeishuAccount({ cfg, accountId });
+
+  // Emit message_sent plugin hooks via the runtime SDK so downstream consumers
+  // (e.g. bot-company journal) can record outbound messages. The feishu reply
+  // dispatcher bypasses the core deliverOutboundPayloads pipeline, so hooks
+  // must be emitted explicitly here. Using core.hooks avoids the bundle singleton
+  // splitting issue that makes direct getGlobalHookRunner() imports fail.
+  const emitMessageSent = (event: {
+    content: string;
+    success: boolean;
+    messageId?: string;
+    error?: string;
+    metadata?: Record<string, unknown>;
+  }) => {
+    core.hooks.emitMessageSent(
+      {
+        to: chatId,
+        content: event.content,
+        success: event.success,
+        ...(event.messageId ? { messageId: event.messageId } : {}),
+        ...(event.error ? { error: event.error } : {}),
+        metadata: { chatId, ...(event.metadata ?? {}) },
+      },
+      {
+        channelId: "feishu",
+        accountId: accountId ?? account.accountId,
+        conversationId: chatId,
+      },
+    );
+  };
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
 
   let typingState: TypingIndicatorState | null = null;
@@ -288,9 +346,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               deliveredFinalTexts.add(text);
             }
             // Send media even when streaming handled the text
+            const deliveredMediaMessageIds: string[] = [];
             if (hasMedia) {
               for (const mediaUrl of mediaList) {
-                await sendMediaFeishu({
+                const sent = await sendMediaFeishu({
                   cfg,
                   to: chatId,
                   mediaUrl,
@@ -298,7 +357,23 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                   replyInThread: effectiveReplyInThread,
                   accountId,
                 });
+                if (typeof sent?.messageId === "string" && sent.messageId.trim()) {
+                  deliveredMediaMessageIds.push(sent.messageId);
+                }
               }
+            }
+            if (info?.kind === "final" && !hasText && deliveredMediaMessageIds.length > 0) {
+              const finalContent = resolveFinalDeliveryContent(text, mediaList);
+              emitMessageSent({
+                content: finalContent,
+                success: true,
+                messageId: deliveredMediaMessageIds.at(-1),
+                metadata: { chatId, messageIds: deliveredMediaMessageIds },
+              });
+              await emitFinalTextIfNeeded(finalContent, {
+                messageId: deliveredMediaMessageIds.at(-1),
+                messageIds: deliveredMediaMessageIds,
+              });
             }
             return;
           }
@@ -348,9 +423,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           }
         }
 
+        const deliveredMediaMessageIds: string[] = [];
         if (hasMedia) {
           for (const mediaUrl of mediaList) {
-            await sendMediaFeishu({
+            const sent = await sendMediaFeishu({
               cfg,
               to: chatId,
               mediaUrl,
@@ -358,7 +434,23 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               replyInThread: effectiveReplyInThread,
               accountId,
             });
+            if (typeof sent?.messageId === "string" && sent.messageId.trim()) {
+              deliveredMediaMessageIds.push(sent.messageId);
+            }
           }
+        }
+        if (info?.kind === "final" && !hasText && deliveredMediaMessageIds.length > 0) {
+          const finalContent = resolveFinalDeliveryContent(text, mediaList);
+          emitMessageSent({
+            content: finalContent,
+            success: true,
+            messageId: deliveredMediaMessageIds.at(-1),
+            metadata: { chatId, messageIds: deliveredMediaMessageIds },
+          });
+          await emitFinalTextIfNeeded(finalContent, {
+            messageId: deliveredMediaMessageIds.at(-1),
+            messageIds: deliveredMediaMessageIds,
+          });
         }
       },
       onError: async (error, info) => {


### PR DESCRIPTION
## Problem

When a bot sends media-only messages (images, files), the Feishu reply
dispatcher calls `sendMediaFeishu()` directly and returns — it never
reaches the `message_sent` hook or `onFinalTextDelivered`. As a result,
downstream consumers (e.g. bot-company journal DB) never record these
outbound messages.

**Impact:** Bot-sent media messages are invisible in conversation history,
breaking continuity and auditability.

## Root Cause

The `deliver` callback in `createFeishuReplyDispatcher` had an early-exit
branch for media payloads that skipped the persistence signal path used by
text finals.

## Flow: Before vs After

```
BEFORE
──────
deliver({ mediaUrl, kind: "final" })
  └─► sendMediaFeishu()   ← returns here, no persistence signal
        ✗ message_sent hook NOT emitted
        ✗ onFinalTextDelivered NOT called

AFTER
─────
deliver({ mediaUrl, kind: "final" })
  └─► sendMediaFeishu()   ← sends media, collects messageId
  └─► emitMessageSent()   ← ✓ fires message_sent hook
        content  = filename extracted from mediaUrl (e.g. "photo.png")
        metadata = { chatId, messageIds: ["om_media_1"] }
  └─► onFinalTextDelivered()  ← ✓ called with text + messageIds
```

## Fix

Three targeted changes in `reply-dispatcher.ts`:

1. **Emit persistence signal for media-only finals** — after
   `sendMediaFeishu()` resolves, call `emitMessageSent` so the
   `message_sent` hook fires.

2. **Generate fallback content from filename** — `resolveFinalDeliveryContent()`
   extracts the basename from the media URL (strips query/hash) so the DB
   record has a human-readable content field instead of an empty string.

3. **Pass `mediaIds` in metadata** — the collected `messageId` from the
   media send result is forwarded in `metadata.messageIds` so downstream
   consumers can correlate provider IDs.

## Files Changed

| File | Change |
|------|--------|
| `extensions/feishu/src/reply-dispatcher.ts` | Add `emitMessageSent` helper; emit signal for media-only finals; use `resolveFinalDeliveryContent` for fallback text |
| `extensions/feishu/src/reply-dispatcher.test.ts` | New test: `emits persistence signals for media-only final replies` |

## Tests

New test case added:

```
✓ emits persistence signals for media-only final replies
```

Covers:
- `emitMessageSent` called with correct `content` (extracted filename),
  `messageId`, and `metadata.messageIds`
- `onFinalTextDelivered` called with matching payload

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>