### PR TITLE
fix(gateway): prevent browser rate-limit self-DoS on missing credentials

### DIFF
--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -367,6 +367,58 @@ describe("gateway auth", () => {
     expect(limiter.check).toHaveBeenCalledWith(undefined, "custom-scope");
     expect(limiter.recordFailure).toHaveBeenCalledWith(undefined, "custom-scope");
   });
+
+  it("does not record rate-limit failure for missing token (misconfigured client, not brute-force)", async () => {
+    const limiter = createLimiterSpy();
+    const res = await authorizeGatewayConnect({
+      auth: { mode: "token", token: "secret", allowTailscale: false },
+      connectAuth: null,
+      rateLimiter: limiter,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("token_missing");
+    expect(limiter.recordFailure).not.toHaveBeenCalled();
+  });
+
+  it("does not record rate-limit failure for missing password (misconfigured client, not brute-force)", async () => {
+    const limiter = createLimiterSpy();
+    const res = await authorizeGatewayConnect({
+      auth: { mode: "password", password: "secret", allowTailscale: false },
+      connectAuth: null,
+      rateLimiter: limiter,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("password_missing");
+    expect(limiter.recordFailure).not.toHaveBeenCalled();
+  });
+
+  it("still records rate-limit failure for wrong token (brute-force attempt)", async () => {
+    const limiter = createLimiterSpy();
+    const res = await authorizeGatewayConnect({
+      auth: { mode: "token", token: "secret", allowTailscale: false },
+      connectAuth: { token: "wrong" },
+      rateLimiter: limiter,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("token_mismatch");
+    expect(limiter.recordFailure).toHaveBeenCalled();
+  });
+
+  it("still records rate-limit failure for wrong password (brute-force attempt)", async () => {
+    const limiter = createLimiterSpy();
+    const res = await authorizeGatewayConnect({
+      auth: { mode: "password", password: "secret", allowTailscale: false },
+      connectAuth: { password: "wrong" },
+      rateLimiter: limiter,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("password_mismatch");
+    expect(limiter.recordFailure).toHaveBeenCalled();
+  });
 });
 
 describe("trusted-proxy auth", () => {

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -439,7 +439,9 @@ export async function authorizeGatewayConnect(
       return { ok: false, reason: "token_missing_config" };
     }
     if (!connectAuth?.token) {
-      limiter?.recordFailure(ip, rateLimitScope);
+      // Don't burn rate-limit slots for missing credentials — the client
+      // simply hasn't provided a token yet (e.g. bare browser open).
+      // Only actual *wrong* credentials should count as failures.
       return { ok: false, reason: "token_missing" };
     }
     if (!safeEqualSecret(connectAuth.token, auth.token)) {
@@ -456,7 +458,7 @@ export async function authorizeGatewayConnect(
       return { ok: false, reason: "password_missing_config" };
     }
     if (!password) {
-      limiter?.recordFailure(ip, rateLimitScope);
+      // Same as token_missing — don't penalize absent credentials.
       return { ok: false, reason: "password_missing" };
     }
     if (!safeEqualSecret(password, auth.password)) {

--- a/src/gateway/reconnect-gating.test.ts
+++ b/src/gateway/reconnect-gating.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { type GatewayErrorInfo, isNonRecoverableAuthError } from "../../ui/src/ui/gateway.ts";
+import { ConnectErrorDetailCodes } from "./protocol/connect-error-details.js";
+
+function makeError(detailCode: string): GatewayErrorInfo {
+  return { code: "connect_failed", message: "auth failed", details: { code: detailCode } };
+}
+
+describe("isNonRecoverableAuthError", () => {
+  it("returns false for undefined error (normal disconnect)", () => {
+    expect(isNonRecoverableAuthError(undefined)).toBe(false);
+  });
+
+  it("returns false for errors without detail codes (network issues)", () => {
+    expect(isNonRecoverableAuthError({ code: "connect_failed", message: "timeout" })).toBe(false);
+  });
+
+  it("blocks reconnect for AUTH_TOKEN_MISSING (misconfigured client)", () => {
+    expect(isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_TOKEN_MISSING))).toBe(
+      true,
+    );
+  });
+
+  it("blocks reconnect for AUTH_PASSWORD_MISSING", () => {
+    expect(
+      isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING)),
+    ).toBe(true);
+  });
+
+  it("blocks reconnect for AUTH_PASSWORD_MISMATCH (wrong password won't self-correct)", () => {
+    expect(
+      isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_PASSWORD_MISMATCH)),
+    ).toBe(true);
+  });
+
+  it("blocks reconnect for AUTH_RATE_LIMITED (reconnecting burns more slots)", () => {
+    expect(isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_RATE_LIMITED))).toBe(
+      true,
+    );
+  });
+
+  it("allows reconnect for AUTH_TOKEN_MISMATCH (device-token fallback flow)", () => {
+    // Browser client fallback: stale device token → mismatch → sendConnect() clears it →
+    // next reconnect uses opts.token (shared gateway token). Blocking here breaks recovery.
+    expect(isNonRecoverableAuthError(makeError(ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH))).toBe(
+      false,
+    );
+  });
+
+  it("allows reconnect for unrecognized detail codes (future-proof)", () => {
+    expect(isNonRecoverableAuthError(makeError("SOME_FUTURE_CODE"))).toBe(false);
+  });
+});

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -5,7 +5,10 @@ import {
   type GatewayClientMode,
   type GatewayClientName,
 } from "../../../src/gateway/protocol/client-info.js";
-import { readConnectErrorDetailCode } from "../../../src/gateway/protocol/connect-error-details.js";
+import {
+  ConnectErrorDetailCodes,
+  readConnectErrorDetailCode,
+} from "../../../src/gateway/protocol/connect-error-details.js";
 import { clearDeviceAuthToken, loadDeviceAuthToken, storeDeviceAuthToken } from "./device-auth.ts";
 import { loadOrCreateDeviceIdentity, signDevicePayload } from "./device-identity.ts";
 import { generateUUID } from "./uuid.ts";
@@ -48,6 +51,29 @@ export function resolveGatewayErrorDetailCode(
   error: { details?: unknown } | null | undefined,
 ): string | null {
   return readConnectErrorDetailCode(error?.details);
+}
+
+/**
+ * Auth errors that won't resolve without user action — don't auto-reconnect.
+ *
+ * NOTE: AUTH_TOKEN_MISMATCH is intentionally NOT included here because the
+ * browser client has a device-token fallback flow: a stale cached device token
+ * triggers a mismatch, sendConnect() clears it, and the next reconnect retries
+ * with opts.token (the shared gateway token). Blocking reconnect on mismatch
+ * would break that fallback. The rate limiter still catches persistent wrong
+ * tokens after N failures → AUTH_RATE_LIMITED stops the loop.
+ */
+export function isNonRecoverableAuthError(error: GatewayErrorInfo | undefined): boolean {
+  if (!error) {
+    return false;
+  }
+  const code = resolveGatewayErrorDetailCode(error);
+  return (
+    code === ConnectErrorDetailCodes.AUTH_TOKEN_MISSING ||
+    code === ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING ||
+    code === ConnectErrorDetailCodes.AUTH_PASSWORD_MISMATCH ||
+    code === ConnectErrorDetailCodes.AUTH_RATE_LIMITED
+  );
 }
 
 export type GatewayHelloOk = {
@@ -135,7 +161,9 @@ export class GatewayBrowserClient {
       this.ws = null;
       this.flushPending(new Error(`gateway closed (${ev.code}): ${reason}`));
       this.opts.onClose?.({ code: ev.code, reason, error: connectError });
-      this.scheduleReconnect();
+      if (!isNonRecoverableAuthError(connectError)) {
+        this.scheduleReconnect();
+      }
     });
     this.ws.addEventListener("error", () => {
       // ignored; close handler will fire


### PR DESCRIPTION
## Summary

- **Problem:** Opening the web UI without `?token=` triggers a self-DoS: missing credentials count as rate-limit failures, and the browser auto-reconnects, exhausting the limit in ~40 seconds, leading to a 5-minute lockout for ALL browser connections from that IP.
- **What changed:** (1) `auth.ts` - stop calling `recordFailure()` for `token_missing`/`password_missing`; only actual mismatches burn rate-limit slots. (2) `gateway.ts` - stop auto-reconnecting on non-recoverable auth errors (`AUTH_TOKEN_MISSING`, `AUTH_PASSWORD_MISSING`, `AUTH_PASSWORD_MISMATCH`, `AUTH_RATE_LIMITED`).
- **What did NOT change:** `browserRateLimiter` config, rate limiter internals, device-token fallback flow (`AUTH_TOKEN_MISMATCH` deliberately NOT in the non-recoverable list, since the stale device-token to shared-token retry flow needs reconnect).

Continuation of #36138 (closed due to unrelated changes drifting into the branch). This PR contains only the gateway auth fix, the same 2 source files that received a [4/5 from Greptile](https://github.com/openclaw/openclaw/pull/36138#issuecomment-4004896260) with "No issues found."

## Changes at a glance

| File | Change |
|------|--------|
| `src/gateway/auth.ts:L45-L52` | Remove `recordFailure()` for `token_missing`/`password_missing` |
| `ui/src/ui/gateway.ts:L1-L30` | Add `isNonRecoverableAuthError()` gate before `scheduleReconnect()` |
| `src/gateway/auth.test.ts` | 4 new tests: missing creds don't burn slots, mismatches do |
| `src/gateway/reconnect-gating.test.ts` | 8 new tests: non-recoverable errors block reconnect, mismatch allows it |

## Change Type

- [x] Bug fix
- [x] Security hardening

## Linked Issue

Fixes #28997

## Verification

```bash
pnpm vitest run src/gateway/auth.test.ts        # 35 tests pass
pnpm vitest run src/gateway/reconnect-gating    # 8 tests pass
```

## Risks and Mitigations

| Risk | Mitigation |
|------|------------|
| No-token connections not rate-limited | Missing-token connections are rejected immediately with no server cost. Real brute-force uses wrong tokens (mismatch), which remain rate-limited. |
| Non-recoverable error list needs future updating | List is conservative, covering only errors that provably cannot resolve without user action. New codes default to allowing reconnect (safe default). |
