### PR TITLE
feat(github-copilot): support gpt-5.4 via openai-responses forward-compat

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -1,6 +1,11 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
+import {
+  COPILOT_GPT_54_CONTEXT_WINDOW,
+  COPILOT_GPT_54_MAX_TOKENS,
+  DEFAULT_COPILOT_API_BASE_URL,
+} from "../providers/github-copilot-constants.js";
 import { isModernModelRef } from "./live-model-filter.js";
 import { normalizeModelCompat } from "./model-compat.js";
 import { resolveForwardCompatModel } from "./model-forward-compat.js";
@@ -72,10 +77,29 @@ function createOpenAICodexTemplateModel(id: string): Model<Api> {
   } as Model<Api>;
 }
 
+function createGitHubCopilotTemplateModel(id: string): Model<Api> {
+  return {
+    id,
+    name: id,
+    provider: "github-copilot",
+    api: "openai-responses",
+    baseUrl: DEFAULT_COPILOT_API_BASE_URL,
+    input: ["text", "image"],
+    reasoning: true,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 32_768,
+  } as Model<Api>;
+}
+
 function createRegistry(models: Record<string, Model<Api>>): ModelRegistry {
+  const allModels = Object.values(models);
   return {
     find(provider: string, modelId: string) {
       return models[`${provider}/${modelId}`] ?? null;
+    },
+    getAll() {
+      return allModels;
     },
   } as ModelRegistry;
 }
@@ -353,6 +377,69 @@ describe("resolveForwardCompatModel", () => {
     expect(model?.baseUrl).toBe("https://api.openai.com/v1");
     expect(model?.contextWindow).toBe(1_050_000);
     expect(model?.maxTokens).toBe(128_000);
+  });
+
+  it("resolves github-copilot gpt-5.4 via copilot gpt-5 template", () => {
+    const registry = createRegistry({
+      "github-copilot/gpt-5": createGitHubCopilotTemplateModel("gpt-5"),
+    });
+    const model = resolveForwardCompatModel("github-copilot", "gpt-5.4", registry);
+    expectResolvedForwardCompat(model, { provider: "github-copilot", id: "gpt-5.4" });
+    expect(model?.api).toBe("openai-responses");
+    expect(model?.baseUrl).toBe(DEFAULT_COPILOT_API_BASE_URL);
+    expect(model?.reasoning).toBe(true);
+    expect(model?.contextWindow).toBe(COPILOT_GPT_54_CONTEXT_WINDOW);
+    expect(model?.maxTokens).toBe(COPILOT_GPT_54_MAX_TOKENS);
+  });
+
+  it("resolves github-copilot gpt-5.4 without templates using normalized fallback defaults", () => {
+    const registry = createRegistry({});
+
+    const model = resolveForwardCompatModel("github-copilot", "gpt-5.4", registry);
+
+    expectResolvedForwardCompat(model, { provider: "github-copilot", id: "gpt-5.4" });
+    expect(model?.api).toBe("openai-responses");
+    expect(model?.baseUrl).toBe(DEFAULT_COPILOT_API_BASE_URL);
+    expect(model?.input).toEqual(["text", "image"]);
+    expect(model?.reasoning).toBe(true);
+    expect(model?.contextWindow).toBe(COPILOT_GPT_54_CONTEXT_WINDOW);
+    expect(model?.maxTokens).toBe(COPILOT_GPT_54_MAX_TOKENS);
+    expect(model?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+  });
+
+  it("reuses an existing copilot baseUrl in the no-template fallback", () => {
+    const registry = createRegistry({
+      "github-copilot/gpt-4o": {
+        ...createGitHubCopilotTemplateModel("gpt-4o"),
+        baseUrl: "https://copilot-proxy.example.test",
+      },
+    });
+
+    const model = resolveForwardCompatModel("github-copilot", "gpt-5.4", registry);
+
+    expect(model?.baseUrl).toBe("https://copilot-proxy.example.test");
+    expect(model?.contextWindow).toBe(COPILOT_GPT_54_CONTEXT_WINDOW);
+    expect(model?.maxTokens).toBe(COPILOT_GPT_54_MAX_TOKENS);
+  });
+
+  it("reuses registry baseUrl when a copilot template exists without baseUrl", () => {
+    const { baseUrl: _ignoredBaseUrl, ...templateWithoutBaseUrl } =
+      createGitHubCopilotTemplateModel("gpt-5");
+
+    const registry = createRegistry({
+      "github-copilot/gpt-5": templateWithoutBaseUrl as Model<Api>,
+      "github-copilot/gpt-4o": {
+        ...createGitHubCopilotTemplateModel("gpt-4o"),
+        baseUrl: "https://copilot-proxy.example.test",
+      },
+    });
+
+    const model = resolveForwardCompatModel("github-copilot", "gpt-5.4", registry);
+
+    expect(model?.baseUrl).toBe("https://copilot-proxy.example.test");
+    expect(model?.reasoning).toBe(true);
+    expect(model?.contextWindow).toBe(COPILOT_GPT_54_CONTEXT_WINDOW);
+    expect(model?.maxTokens).toBe(COPILOT_GPT_54_MAX_TOKENS);
   });
 
   it("resolves openai-codex gpt-5.4 via codex template fallback", () => {

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -1,5 +1,11 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
 import type { ModelRegistry } from "@mariozechner/pi-coding-agent";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  buildCopilotModelMetadata,
+  COPILOT_GPT_54_MODEL_ID,
+  DEFAULT_COPILOT_API_BASE_URL,
+} from "../providers/github-copilot-constants.js";
 import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { normalizeModelCompat } from "./model-compat.js";
 import { normalizeProviderId } from "./model-selection.js";
@@ -33,6 +39,8 @@ const GEMINI_3_1_PRO_PREFIX = "gemini-3.1-pro";
 const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";
 const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3-pro-preview"] as const;
 const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview"] as const;
+
+const log = createSubsystemLogger("model-forward-compat");
 
 function resolveOpenAIGpt54ForwardCompatModel(
   provider: string,
@@ -89,7 +97,7 @@ function resolveOpenAIGpt54ForwardCompatModel(
 function cloneFirstTemplateModel(params: {
   normalizedProvider: string;
   trimmedModelId: string;
-  templateIds: string[];
+  templateIds: readonly string[];
   modelRegistry: ModelRegistry;
   patch?: Partial<Model<Api>>;
 }): Model<Api> | undefined {
@@ -111,6 +119,75 @@ function cloneFirstTemplateModel(params: {
 
 const CODEX_GPT54_ELIGIBLE_PROVIDERS = new Set(["openai-codex"]);
 const CODEX_GPT53_ELIGIBLE_PROVIDERS = new Set(["openai-codex", "github-copilot"]);
+const GITHUB_COPILOT_GPT54_TEMPLATE_MODEL_IDS = ["gpt-5", "gpt-5.1"] as const;
+
+function resolveCopilotBaseUrlFromRegistry(modelRegistry: ModelRegistry): string {
+  try {
+    // Best effort: preserve any token-derived / provider-specific Copilot proxy URL
+    // already present in the registry so GPT-5.4 resolves like existing Copilot models.
+    const existing = modelRegistry
+      .getAll()
+      .find(
+        (model) =>
+          normalizeProviderId(model.provider) === "github-copilot" &&
+          typeof model.baseUrl === "string" &&
+          model.baseUrl.trim().length > 0,
+      );
+    return existing?.baseUrl?.trim() ?? DEFAULT_COPILOT_API_BASE_URL;
+  } catch (err) {
+    log.debug(`resolveCopilotBaseUrlFromRegistry failed: ${String(err)}`);
+    return DEFAULT_COPILOT_API_BASE_URL;
+  }
+}
+
+function resolveGitHubCopilotGpt54ForwardCompatModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: ModelRegistry,
+): Model<Api> | undefined {
+  if (normalizeProviderId(provider) !== "github-copilot") {
+    return undefined;
+  }
+
+  const trimmedModelId = modelId.trim();
+  const lower = trimmedModelId.toLowerCase();
+  if (lower !== COPILOT_GPT_54_MODEL_ID) {
+    return undefined;
+  }
+
+  const metadata = buildCopilotModelMetadata(trimmedModelId);
+
+  const templateModel = cloneFirstTemplateModel({
+    normalizedProvider: "github-copilot",
+    trimmedModelId,
+    templateIds: GITHUB_COPILOT_GPT54_TEMPLATE_MODEL_IDS,
+    modelRegistry,
+    patch: {
+      api: "openai-responses",
+      provider: "github-copilot",
+      ...metadata,
+    },
+  });
+  if (templateModel) {
+    // Reuse the template directly when it already carries a concrete Copilot baseUrl.
+    if (typeof templateModel.baseUrl === "string" && templateModel.baseUrl.trim().length > 0) {
+      return templateModel;
+    }
+    return {
+      ...templateModel,
+      baseUrl: resolveCopilotBaseUrlFromRegistry(modelRegistry),
+    } as Model<Api>;
+  }
+
+  return normalizeModelCompat({
+    id: trimmedModelId,
+    name: trimmedModelId,
+    api: "openai-responses",
+    provider: "github-copilot",
+    baseUrl: resolveCopilotBaseUrlFromRegistry(modelRegistry),
+    ...metadata,
+  } as Model<Api>);
+}
 
 function resolveOpenAICodexForwardCompatModel(
   provider: string,
@@ -322,6 +399,7 @@ export function resolveForwardCompatModel(
 ): Model<Api> | undefined {
   return (
     resolveOpenAIGpt54ForwardCompatModel(provider, modelId, modelRegistry) ??
+    resolveGitHubCopilotGpt54ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveOpenAICodexForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -2,10 +2,8 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import {
-  DEFAULT_COPILOT_API_BASE_URL,
-  resolveCopilotApiToken,
-} from "../providers/github-copilot-token.js";
+import { DEFAULT_COPILOT_API_BASE_URL } from "../providers/github-copilot-constants.js";
+import { resolveCopilotApiToken } from "../providers/github-copilot-token.js";
 import {
   KILOCODE_BASE_URL,
   KILOCODE_DEFAULT_CONTEXT_WINDOW,

--- a/src/providers/github-copilot-constants.ts
+++ b/src/providers/github-copilot-constants.ts
@@ -1,0 +1,41 @@
+import type { ModelDefinitionConfig } from "../config/types.js";
+
+export const DEFAULT_COPILOT_API_BASE_URL = "https://api.individual.githubcopilot.com";
+export const COPILOT_GPT_54_MODEL_ID = "gpt-5.4";
+// Copilot docs advertise a 1M-token window for GPT-5.4; keep provider metadata
+// aligned with that public limit even though OpenAI's direct forward-compat path
+// uses a slightly larger experimental value.
+export const COPILOT_GPT_54_CONTEXT_WINDOW = 1_000_000;
+export const COPILOT_GPT_54_MAX_TOKENS = 128_000;
+
+const DEFAULT_COPILOT_CONTEXT_WINDOW = 128_000;
+const DEFAULT_COPILOT_MAX_TOKENS = 8192;
+const DEFAULT_COPILOT_MODEL_INPUT: ModelDefinitionConfig["input"] = ["text", "image"];
+const DEFAULT_COPILOT_MODEL_COST: ModelDefinitionConfig["cost"] = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+};
+
+export function buildCopilotModelMetadata(
+  modelId: string,
+): Pick<ModelDefinitionConfig, "reasoning" | "input" | "cost" | "contextWindow" | "maxTokens"> {
+  if (modelId.trim().toLowerCase() === COPILOT_GPT_54_MODEL_ID) {
+    return {
+      reasoning: true,
+      input: [...DEFAULT_COPILOT_MODEL_INPUT],
+      cost: { ...DEFAULT_COPILOT_MODEL_COST },
+      contextWindow: COPILOT_GPT_54_CONTEXT_WINDOW,
+      maxTokens: COPILOT_GPT_54_MAX_TOKENS,
+    };
+  }
+
+  return {
+    reasoning: false,
+    input: [...DEFAULT_COPILOT_MODEL_INPUT],
+    cost: { ...DEFAULT_COPILOT_MODEL_COST },
+    contextWindow: DEFAULT_COPILOT_CONTEXT_WINDOW,
+    maxTokens: DEFAULT_COPILOT_MAX_TOKENS,
+  };
+}

--- a/src/providers/github-copilot-models.test.ts
+++ b/src/providers/github-copilot-models.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from "vitest";
+import {
+  COPILOT_GPT_54_CONTEXT_WINDOW,
+  COPILOT_GPT_54_MAX_TOKENS,
+} from "./github-copilot-constants.js";
 import { buildCopilotModelDefinition, getDefaultCopilotModelIds } from "./github-copilot-models.js";
 
 describe("github-copilot-models", () => {
@@ -9,6 +13,10 @@ describe("github-copilot-models", () => {
 
     it("includes claude-sonnet-4.5", () => {
       expect(getDefaultCopilotModelIds()).toContain("claude-sonnet-4.5");
+    });
+
+    it("includes gpt-5.4", () => {
+      expect(getDefaultCopilotModelIds()).toContain("gpt-5.4");
     });
 
     it("returns a mutable copy", () => {
@@ -24,6 +32,13 @@ describe("github-copilot-models", () => {
       const def = buildCopilotModelDefinition("claude-sonnet-4.6");
       expect(def.id).toBe("claude-sonnet-4.6");
       expect(def.api).toBe("openai-responses");
+    });
+
+    it("applies GPT-5.4 metadata overrides", () => {
+      const def = buildCopilotModelDefinition("gpt-5.4");
+      expect(def.reasoning).toBe(true);
+      expect(def.contextWindow).toBe(COPILOT_GPT_54_CONTEXT_WINDOW);
+      expect(def.maxTokens).toBe(COPILOT_GPT_54_MAX_TOKENS);
     });
 
     it("trims whitespace from model id", () => {

--- a/src/providers/github-copilot-models.ts
+++ b/src/providers/github-copilot-models.ts
@@ -1,7 +1,5 @@
 import type { ModelDefinitionConfig } from "../config/types.js";
-
-const DEFAULT_CONTEXT_WINDOW = 128_000;
-const DEFAULT_MAX_TOKENS = 8192;
+import { buildCopilotModelMetadata } from "./github-copilot-constants.js";
 
 // Copilot model ids vary by plan/org and can change.
 // We keep this list intentionally broad; if a model isn't available Copilot will
@@ -9,6 +7,7 @@ const DEFAULT_MAX_TOKENS = 8192;
 const DEFAULT_MODEL_IDS = [
   "claude-sonnet-4.6",
   "claude-sonnet-4.5",
+  "gpt-5.4",
   "gpt-4o",
   "gpt-4.1",
   "gpt-4.1-mini",
@@ -34,10 +33,6 @@ export function buildCopilotModelDefinition(modelId: string): ModelDefinitionCon
     // We use OpenAI-compatible responses API, while keeping the provider id as
     // "github-copilot" (pi-ai uses that to attach Copilot-specific headers).
     api: "openai-responses",
-    reasoning: false,
-    input: ["text", "image"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_WINDOW,
-    maxTokens: DEFAULT_MAX_TOKENS,
+    ...buildCopilotModelMetadata(id),
   };
 }

--- a/src/providers/github-copilot-token.ts
+++ b/src/providers/github-copilot-token.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
+// Internal use; also re-exported below for backward-compat with existing importers.
+import { DEFAULT_COPILOT_API_BASE_URL } from "./github-copilot-constants.js";
+
+export { DEFAULT_COPILOT_API_BASE_URL } from "./github-copilot-constants.js";
 
 const COPILOT_TOKEN_URL = "https://api.github.com/copilot_internal/v2/token";
 
@@ -51,8 +55,6 @@ function parseCopilotTokenResponse(value: unknown): {
 
   return { token, expiresAt: expiresAtMs };
 }
-
-export const DEFAULT_COPILOT_API_BASE_URL = "https://api.individual.githubcopilot.com";
 
 export function deriveCopilotApiBaseUrlFromToken(token: string): string | null {
   const trimmed = token.trim();


### PR DESCRIPTION
## Summary
Add minimal runtime support for `github-copilot/gpt-5.4` on top of current `main`.

## Why
Upstream already supports GPT-5.4 forward-compat for OpenAI / OpenAI Codex, but `github-copilot/gpt-5.4` still lacks the corresponding runtime path.

Adding `gpt-5.4` to the default Copilot model list is not sufficient by itself. The runtime also needs a provider-specific forward-compat resolver so the model resolves to the correct API path.

GitHub Copilot tokens are machine-code style tokens, not ChatGPT Codex OAuth JWTs, so this model should stay on `openai-responses`, not `openai-codex-responses`.

## What changed
- add `gpt-5.4` to default GitHub Copilot model ids
- add a dedicated `github-copilot/gpt-5.4` forward-compat resolver
- keep Copilot GPT-5.4 on `openai-responses`
- preserve provider as `github-copilot`
- centralize Copilot GPT-5.4 metadata / default baseUrl constants
- ensure both template and fallback paths produce consistent metadata
- reuse token/provider-derived Copilot baseUrl when available, with safe fallback to defaults
- add targeted regression coverage

## Scope / overlap note
There is partial overlap with #37506, which adds `gpt-5.4` to the default GitHub Copilot model list and adds the related provider test.

This change additionally includes the missing runtime forward-compat path, consistent metadata handling, fallback behavior, and runtime-focused validation. If #37506 lands first, the overlapping list/test hunk can be dropped.

## Validation
Passed locally:
- `pnpm exec vitest run src/providers/github-copilot-models.test.ts src/agents/model-compat.test.ts`
- `pnpm build:strict-smoke`

Passed in isolated Docker validation:
- embedded local run via a temporary agent pinned to `github-copilot/gpt-5.4`
- gateway-path run via the same temporary agent

Both real runs returned:
- `provider = github-copilot`
- `model = gpt-5.4`
- reply payload = `ok`
