### PR TITLE
feat(thinking): register supportsXHighThinking for Anthropic provider

### DIFF
--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -477,6 +477,17 @@ export function registerAnthropicPlugin(api: OpenClawPluginApi): void {
     isModernModelRef: ({ modelId }) => matchesAnthropicModernModel(modelId),
     resolveReasoningOutputMode: () => "native",
     wrapStreamFn: wrapAnthropicProviderStream,
+    supportsXHighThinking: ({ modelId }) => {
+      // Only Opus 4.6 truly supports xhigh (mapped to "max" effort).
+      // Sonnet 4.6 gets downgraded to "high" by the transport, so
+      // advertising xhigh for it would be misleading.
+      const lower = normalizeLowercaseStringOrEmpty(modelId);
+      return (
+        (lower.startsWith(ANTHROPIC_OPUS_46_MODEL_ID) ||
+          lower.startsWith(ANTHROPIC_OPUS_46_DOT_MODEL_ID)) ||
+        undefined
+      );
+    },
     resolveDefaultThinkingLevel: ({ modelId }) =>
       matchesAnthropicModernModel(modelId) && shouldUseAnthropicAdaptiveThinkingDefault(modelId)
         ? "adaptive"


### PR DESCRIPTION
Add `supportsXHighThinking` to the Anthropic provider plugin registration, enabling xhigh/max thinking effort for Opus 4-6 and Sonnet 4-6.

Uses the existing `shouldUseAnthropicAdaptiveThinkingDefault` helper for model matching, keeping it consistent with how `resolveDefaultThinkingLevel` already identifies these models.

The plugin system for xhigh support was introduced in recent refactors (OpenAI, GitHub Copilot, and Codex providers all register it) but the Anthropic extension was never wired up, leaving xhigh unavailable for Claude models despite the infrastructure being in place.

**Files changed:** `extensions/anthropic/register.runtime.ts` (+2 lines)

Related: #62950 (preserves think levels through directive clearing — the other half of making xhigh work end-to-end in webchat)