### PR TITLE
feat(feishu): split C message pipeline, streaming cards, and plugin dispatch

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -6,10 +6,13 @@ import { registerFeishuChatTools } from "./src/chat.js";
 import { registerFeishuDocTools } from "./src/docx.js";
 import { registerFeishuDriveTools } from "./src/drive.js";
 import { registerFeishuPermTools } from "./src/perm.js";
+import { createFeishuReplyDispatcher } from "./src/reply-dispatcher.js";
 import { setFeishuRuntime } from "./src/runtime.js";
 import { registerFeishuWikiTools } from "./src/wiki.js";
 
 export { monitorFeishuProvider } from "./src/monitor.js";
+export { getBotOpenId } from "./src/monitor.js";
+export { createFeishuReplyDispatcher } from "./src/reply-dispatcher.js";
 export {
   sendMessageFeishu,
   sendCardFeishu,
@@ -51,6 +54,15 @@ const plugin = {
   description: "Feishu/Lark channel plugin",
   configSchema: emptyPluginConfigSchema(),
   register(api: OpenClawPluginApi) {
+    // Expose Feishu-native reply dispatcher factory for other plugins
+    // (e.g. bot-company group dispatch) to reuse streaming card behavior.
+    const replyRuntime =
+      (api.runtime as unknown as { channel?: { reply?: Record<string, unknown> } })?.channel
+        ?.reply ?? null;
+    if (replyRuntime && typeof replyRuntime.createFeishuReplyDispatcher !== "function") {
+      replyRuntime.createFeishuReplyDispatcher = createFeishuReplyDispatcher as unknown;
+    }
+
     setFeishuRuntime(api.runtime);
     api.registerChannel({ plugin: feishuPlugin });
     registerFeishuDocTools(api);

--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -128,7 +128,7 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     expect(ctx.content).toBe("hello world");
   });
 
-  it("keeps raw @name text and normalizes mention placeholders to <at> tags", () => {
+  it("strips bot mention placeholder and normalizes others to <at> tags", () => {
     const event = makeEvent(
       "group",
       [
@@ -138,9 +138,9 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
       "@Bot @_bot_1 请 @Luke @_user_1 review",
     );
     const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
-    expect(ctx.content).toBe(
-      '@Bot <at user_id="ou_bot_123">Bot</at> 请 @Luke <at user_id="ou_luke">Luke</at> review',
-    );
+    // Bot mention placeholder (@_bot_1) is stripped so slash commands like @Bot /help
+    // retain the leading /. Non-bot mentions are normalized to <at> tags.
+    expect(ctx.content).toBe('@Bot  请 @Luke <at user_id="ou_luke">Luke</at> review');
   });
 
   it("returns mentionedBot=true for post message with at (no top-level mentions)", () => {

--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -128,7 +128,7 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     expect(ctx.content).toBe("hello world");
   });
 
-  it("strips only bot mention and preserves human mention text", () => {
+  it("keeps raw @name text and normalizes mention placeholders to <at> tags", () => {
     const event = makeEvent(
       "group",
       [
@@ -138,7 +138,9 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
       "@Bot @_bot_1 请 @Luke @_user_1 review",
     );
     const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
-    expect(ctx.content).toBe("请 @Luke @_user_1 review");
+    expect(ctx.content).toBe(
+      '@Bot <at user_id="ou_bot_123">Bot</at> 请 @Luke <at user_id="ou_luke">Luke</at> review',
+    );
   });
 
   it("returns mentionedBot=true for post message with at (no top-level mentions)", () => {

--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -128,6 +128,19 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     expect(ctx.content).toBe("hello world");
   });
 
+  it("strips only bot mention and preserves human mention text", () => {
+    const event = makeEvent(
+      "group",
+      [
+        { key: "@_bot_1", name: "Bot", id: { open_id: BOT_OPEN_ID } },
+        { key: "@_user_1", name: "Luke", id: { open_id: "ou_luke" } },
+      ],
+      "@Bot @_bot_1 请 @Luke @_user_1 review",
+    );
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.content).toBe("请 @Luke @_user_1 review");
+  });
+
   it("returns mentionedBot=true for post message with at (no top-level mentions)", () => {
     const BOT_OPEN_ID = "ou_bot_123";
     const event = makePostEvent({

--- a/extensions/feishu/src/bot.stripBotMention.test.ts
+++ b/extensions/feishu/src/bot.stripBotMention.test.ts
@@ -111,6 +111,23 @@ describe("normalizeMentions (via parseFeishuMessageEvent)", () => {
     );
   });
 
+  it("avoids cascading rewrite when mention keys overlap by prefix", () => {
+    const ctx = parseFeishuMessageEvent(
+      makeEvent(
+        "请 @_user_10 处理，再请 @_user_1 复核",
+        [
+          { key: "@_user_1", name: "One", id: { open_id: "ou_user_1" } },
+          { key: "@_user_10", name: "Ten", id: { open_id: "ou_user_10" } },
+        ],
+        "group",
+      ) as any,
+      BOT_OPEN_ID,
+    );
+    expect(ctx.content).toBe(
+      '请 <at user_id="ou_user_10">Ten</at> 处理，再请 <at user_id="ou_user_1">One</at> 复核',
+    );
+  });
+
   it("treats $ in display name as literal (no replacement-pattern interpolation)", () => {
     const ctx = parseFeishuMessageEvent(
       makeEvent("@_user_1 hi", [

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1,5 +1,13 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import type { ClawdbotConfig, PluginRuntime, RuntimeEnv } from "openclaw/plugin-sdk/feishu";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  registerLiveSessionTranscript,
+  resetLiveSessionTranscriptRegistryForTests,
+} from "../../../src/agents/pi-embedded-runner/live-session-registry.js";
 import { createPluginRuntimeMock } from "../../test-utils/plugin-runtime-mock.js";
 import type { FeishuMessageEvent } from "./bot.js";
 import {
@@ -77,6 +85,39 @@ async function dispatchMessage(params: { cfg: ClawdbotConfig; event: FeishuMessa
   });
 }
 
+function createSessionTranscriptFixture() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-feishu-bot-"));
+  const storePath = path.join(dir, "sessions.json");
+  const sessionId = "sess-bot-quoted-1";
+  const sessionKey = "agent:main:feishu:dm:ou-attacker";
+  const sessionFile = path.join(dir, `${sessionId}.jsonl`);
+
+  fs.writeFileSync(
+    storePath,
+    JSON.stringify({
+      [sessionKey]: {
+        sessionId,
+        updatedAt: Date.now(),
+        sessionFile,
+      },
+    }),
+    "utf-8",
+  );
+  fs.writeFileSync(
+    sessionFile,
+    `${JSON.stringify({
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: sessionId,
+      timestamp: new Date().toISOString(),
+      cwd: process.cwd(),
+    })}\n`,
+    "utf-8",
+  );
+
+  return { dir, storePath, sessionFile };
+}
+
 describe("buildFeishuAgentBody", () => {
   it("builds message id, speaker, quoted content, mentions, and permission notice in order", () => {
     const body = buildFeishuAgentBody({
@@ -139,6 +180,7 @@ describe("handleFeishuMessage command authorization", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetLiveSessionTranscriptRegistryForTests();
     mockShouldComputeCommandAuthorized.mockReset().mockReturnValue(true);
     mockResolveAgentRoute.mockReturnValue({
       agentId: "main",
@@ -184,6 +226,9 @@ describe("handleFeishuMessage command authorization", () => {
           media: {
             saveMediaBuffer:
               mockSaveMediaBuffer as unknown as PluginRuntime["channel"]["media"]["saveMediaBuffer"],
+          },
+          session: {
+            resolveStorePath: vi.fn((store?: string) => store ?? "/tmp/sessions.json"),
           },
           pairing: {
             readAllowFromStore: mockReadAllowFromStore,
@@ -385,6 +430,294 @@ describe("handleFeishuMessage command authorization", () => {
         ReplyToBody: "quoted content",
       }),
     );
+  });
+
+  it("prefers the session transcript over Feishu API for DM reply reconstruction", async () => {
+    const fixture = createSessionTranscriptFixture();
+    try {
+      const sessionManager = SessionManager.open(fixture.sessionFile);
+      sessionManager.appendMessage({
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: [
+              "Conversation info (untrusted metadata):",
+              "```json",
+              JSON.stringify({ message_id: "om_parent_session_1" }, null, 2),
+              "```",
+              "",
+              "完整 session 原文",
+            ].join("\n"),
+          },
+        ],
+        timestamp: Date.now(),
+      });
+      // SessionManager keeps user-only turns buffered until an assistant message appears.
+      // Append a noop assistant turn so the prior DM reply target is present on disk.
+      sessionManager.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "noop" }],
+        api: "openai-responses",
+        provider: "openclaw",
+        model: "test-helper",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            total: 0,
+          },
+        },
+        stopReason: "stop",
+        timestamp: Date.now(),
+      });
+
+      const cfg: ClawdbotConfig = {
+        session: {
+          store: fixture.storePath,
+        },
+        channels: {
+          feishu: {
+            enabled: true,
+            dmPolicy: "open",
+          },
+        },
+      } as ClawdbotConfig;
+
+      const event: FeishuMessageEvent = {
+        sender: {
+          sender_id: {
+            open_id: "ou-attacker",
+          },
+        },
+        message: {
+          message_id: "om_reply_session_1",
+          parent_id: "om_parent_session_1",
+          chat_id: "oc-dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "reply text" }),
+        },
+      };
+
+      await dispatchMessage({ cfg, event });
+
+      expect(mockGetMessageFeishu).not.toHaveBeenCalled();
+      expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ReplyToId: "om_parent_session_1",
+          ReplyToBody: "完整 session 原文",
+        }),
+      );
+    } finally {
+      fs.rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers the live session over Feishu API for DM reply reconstruction before transcript flush", async () => {
+    const fixture = createSessionTranscriptFixture();
+    try {
+      const sessionManager = SessionManager.open(fixture.sessionFile);
+      sessionManager.appendMessage({
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: [
+              "Conversation info (untrusted metadata):",
+              "```json",
+              JSON.stringify({ message_id: "om_parent_live_1" }, null, 2),
+              "```",
+              "",
+              "live session 里的完整原文",
+            ].join("\n"),
+          },
+        ],
+        timestamp: Date.now(),
+      });
+      const unregister = registerLiveSessionTranscript({
+        sessionKey: "agent:main:feishu:dm:ou-attacker",
+        sessionId: "sess-bot-quoted-1",
+        sessionReader: sessionManager,
+      });
+
+      try {
+        const cfg: ClawdbotConfig = {
+          session: {
+            store: fixture.storePath,
+          },
+          channels: {
+            feishu: {
+              enabled: true,
+              dmPolicy: "open",
+            },
+          },
+        } as ClawdbotConfig;
+
+        const event: FeishuMessageEvent = {
+          sender: {
+            sender_id: {
+              open_id: "ou-attacker",
+            },
+          },
+          message: {
+            message_id: "om_reply_live_1",
+            parent_id: "om_parent_live_1",
+            chat_id: "oc-dm",
+            chat_type: "p2p",
+            message_type: "text",
+            content: JSON.stringify({ text: "reply text" }),
+          },
+        };
+
+        await dispatchMessage({ cfg, event });
+
+        expect(mockGetMessageFeishu).not.toHaveBeenCalled();
+        expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+          expect.objectContaining({
+            ReplyToId: "om_parent_live_1",
+            ReplyToBody: "live session 里的完整原文",
+          }),
+        );
+      } finally {
+        unregister();
+      }
+    } finally {
+      fs.rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("mirrors DM assistant reply ids into the session transcript for quoted reply recovery", async () => {
+    const fixture = createSessionTranscriptFixture();
+    try {
+      const cfg: ClawdbotConfig = {
+        session: {
+          store: fixture.storePath,
+        },
+        channels: {
+          feishu: {
+            enabled: true,
+            dmPolicy: "open",
+          },
+        },
+      } as ClawdbotConfig;
+
+      await dispatchMessage({
+        cfg,
+        event: {
+          sender: {
+            sender_id: {
+              open_id: "ou-attacker",
+            },
+          },
+          message: {
+            message_id: "om_user_1",
+            chat_id: "oc-dm",
+            chat_type: "p2p",
+            message_type: "text",
+            content: JSON.stringify({ text: "hello" }),
+          },
+        },
+      });
+
+      const dispatcherParams = mockCreateFeishuReplyDispatcher.mock.calls.at(-1)?.[0] as
+        | {
+            onFinalTextDelivered?: (params: {
+              text: string;
+              messageId?: string;
+              messageIds?: string[];
+              chatId: string;
+              accountId?: string;
+            }) => Promise<void>;
+          }
+        | undefined;
+      expect(typeof dispatcherParams?.onFinalTextDelivered).toBe("function");
+
+      await dispatcherParams?.onFinalTextDelivered?.({
+        text: "完整 bot 回复",
+        messageId: "om_bot_2",
+        messageIds: ["om_bot_1", "om_bot_2"],
+        chatId: "oc-dm",
+        accountId: "default",
+      });
+
+      mockFinalizeInboundContext.mockClear();
+      mockGetMessageFeishu.mockClear();
+
+      await dispatchMessage({
+        cfg,
+        event: {
+          sender: {
+            sender_id: {
+              open_id: "ou-attacker",
+            },
+          },
+          message: {
+            message_id: "om_user_2",
+            parent_id: "om_bot_1",
+            chat_id: "oc-dm",
+            chat_type: "p2p",
+            message_type: "text",
+            content: JSON.stringify({ text: "reply to bot" }),
+          },
+        },
+      });
+
+      expect(mockGetMessageFeishu).not.toHaveBeenCalled();
+      expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ReplyToId: "om_bot_1",
+          ReplyToBody: "完整 bot 回复",
+        }),
+      );
+    } finally {
+      fs.rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not attach the direct-reply transcript mirror callback for group dispatches", async () => {
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          enabled: true,
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    await dispatchMessage({
+      cfg,
+      event: {
+        sender: {
+          sender_id: {
+            open_id: "ou-attacker",
+          },
+        },
+        message: {
+          message_id: "om_group_1",
+          chat_id: "oc-group",
+          chat_type: "group",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello group" }),
+        },
+      },
+    });
+
+    const dispatcherParams = mockCreateFeishuReplyDispatcher.mock.calls.at(-1)?.[0] as
+      | { onFinalTextDelivered?: unknown }
+      | undefined;
+    expect(dispatcherParams?.onFinalTextDelivered).toBeUndefined();
   });
 
   it("replies pairing challenge to DM chat_id instead of user:sender id", async () => {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -67,6 +67,17 @@ vi.mock("./client.js", () => ({
   createFeishuClient: mockCreateFeishuClient,
 }));
 
+vi.mock("openclaw/plugin-sdk", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    getSessionBindingService: () => ({
+      resolveByConversation: () => undefined,
+      touch: vi.fn(),
+    }),
+  };
+});
+
 function createRuntimeEnv(): RuntimeEnv {
   return {
     log: vi.fn(),
@@ -1524,6 +1535,110 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("backs off sender name lookup per sender when Feishu returns no user authority", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    const mockGetUser = vi.fn().mockRejectedValue({
+      response: {
+        data: {
+          code: 41050,
+          msg: "no user authority error",
+        },
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: {
+        user: {
+          get: mockGetUser,
+        },
+      },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_noauth",
+          appSecret: "sec_noauth",
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const eventA: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-noauth-a",
+        },
+      },
+      message: {
+        message_id: "msg-noauth-1",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello group A" }),
+      },
+    };
+    const eventARepeat: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-noauth-a",
+        },
+      },
+      message: {
+        message_id: "msg-noauth-2",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello group A repeat" }),
+      },
+    };
+    const eventB: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-noauth-b",
+        },
+      },
+      message: {
+        message_id: "msg-noauth-3",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello group B" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event: eventA });
+    await dispatchMessage({ cfg, event: eventARepeat });
+    await dispatchMessage({ cfg, event: eventB });
+
+    expect(mockGetUser).toHaveBeenCalledTimes(2);
+    expect(mockCreateFeishuClient).toHaveBeenCalledTimes(2);
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(3);
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining("ou-noauth-a: hello group A"),
+      }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining("ou-noauth-a: hello group A repeat"),
+      }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining("ou-noauth-b: hello group B"),
+      }),
+    );
+    for (const [arg] of mockFinalizeInboundContext.mock.calls) {
+      const body = (arg as { BodyForAgent?: string }).BodyForAgent ?? "";
+      expect(body).not.toContain("Permission grant URL");
+    }
+  });
+
   it("routes group sessions by sender when groupSessionScope=group_sender", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
@@ -1919,7 +2034,7 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
         replyToMessageId: "om_quote_reply",
-        rootId: "om_original_msg",
+        rootId: undefined,
       }),
     );
   });
@@ -1957,7 +2072,7 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
         replyToMessageId: "om_topic_root",
-        rootId: "om_topic_root",
+        rootId: undefined,
       }),
     );
   });
@@ -1995,7 +2110,7 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
         replyToMessageId: "om_topic_sender_root",
-        rootId: "om_topic_sender_root",
+        rootId: undefined,
       }),
     );
   });

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1667,7 +1667,7 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
-  it("forces thread replies when inbound message contains thread_id", async () => {
+  it("respects replyInThread=disabled even when thread_id is present", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
     const cfg: ClawdbotConfig = {
@@ -1700,8 +1700,50 @@ describe("handleFeishuMessage command authorization", () => {
 
     expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
-        replyInThread: true,
-        threadReply: true,
+        replyInThread: false,
+        streamingInThread: false,
+        threadReply: false,
+      }),
+    );
+  });
+
+  it("gates threadReply and rootId when replyInThread is disabled", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group",
+              replyInThread: "disabled",
+              streamingInThread: "disabled",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-thread-stream-off" } },
+      message: {
+        message_id: "msg-thread-stream-off",
+        chat_id: "oc-group",
+        chat_type: "group",
+        thread_id: "omt_topic_stream_off",
+        message_type: "text",
+        content: JSON.stringify({ text: "thread content" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyInThread: false,
+        streamingInThread: false,
+        threadReply: false,
       }),
     );
   });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -5,6 +5,7 @@ import {
   clearHistoryEntriesIfEnabled,
   createScopedPairingAccess,
   DEFAULT_GROUP_HISTORY_LIMIT,
+  getSessionBindingService,
   type HistoryEntry,
   normalizeAgentId,
   recordPendingHistoryEntryIfEnabled,
@@ -1006,6 +1007,7 @@ export async function handleFeishuMessage(params: {
     : null;
 
   let requireMention = false; // DMs never require mention; groups may override below
+  let boundSessionKey: string | undefined;
   if (isGroup) {
     if (groupConfig?.enabled === false) {
       log(`feishu[${account.accountId}]: group ${ctx.chatId} is disabled`);
@@ -1066,7 +1068,25 @@ export async function handleFeishuMessage(params: {
       groupConfig,
     }));
 
-    if (requireMention && !ctx.mentionedBot) {
+    // Check if message is in a topic thread bound to an ACP/subagent session
+    const inboundRootId = ctx.rootId?.trim() || ctx.threadId?.trim();
+    if (inboundRootId) {
+      const binding = getSessionBindingService().resolveByConversation({
+        channel: "feishu",
+        accountId: account.accountId,
+        conversationId: `${ctx.chatId}:${inboundRootId}`,
+      });
+      if (binding?.targetSessionKey) {
+        boundSessionKey = binding.targetSessionKey;
+        getSessionBindingService().touch(binding.bindingId);
+        requireMention = false;
+        log(
+          `feishu[${account.accountId}]: bound thread detected root=${inboundRootId}, routing to session ${boundSessionKey}`,
+        );
+      }
+    }
+
+    if (dispatchMode !== "plugin" && requireMention && !ctx.mentionedBot) {
       log(`feishu[${account.accountId}]: message in group ${ctx.chatId} did not mention bot`);
       // Record to pending history for non-broadcast groups only. For broadcast groups,
       // the mentioned handler's broadcast dispatch writes the turn directly into all
@@ -1375,7 +1395,9 @@ export async function handleFeishuMessage(params: {
       isTopicSession || configReplyInThread ? (ctx.rootId ?? ctx.messageId) : ctx.messageId;
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
 
-    if (broadcastAgents) {
+    if (broadcastAgents && !boundSessionKey) {
+      // Note: bound thread sessions (ACP/subagent) bypass broadcast dispatch —
+      // bound threads route directly to the single-agent path below.
       // Cross-account dedup: in multi-account setups, Feishu delivers the same
       // event to every bot account in the group. Only one account should handle
       // broadcast dispatch to avoid duplicate agent sessions and race conditions.
@@ -1509,10 +1531,64 @@ export async function handleFeishuMessage(params: {
       log(
         `feishu[${account.accountId}]: broadcast dispatch complete for ${broadcastAgents.length} agents`,
       );
-    } else {
-      // --- Single-agent dispatch (existing behavior) ---
+    } else if (isGroup && dispatchMode === "plugin" && !boundSessionKey) {
+      // --- Plugin dispatch mode: run hooks but suppress reply generation ---
       const ctxPayload = buildCtxPayloadForAgent(
         route.sessionKey,
+        route.accountId,
+        ctx.mentionedBot,
+      );
+      const shouldForwardControlCommands = feishuCfg?.pluginMode?.forwardControlCommands ?? true;
+      if (
+        !shouldForwardControlCommands &&
+        core.channel.commands.isControlCommandMessage(ctx.content, effectiveCfg)
+      ) {
+        log(
+          `feishu[${account.accountId}]: skipping control command relay in plugin mode (message=${ctx.messageId})`,
+        );
+        if (isGroup && historyKey && chatHistories) {
+          clearHistoryEntriesIfEnabled({
+            historyMap: chatHistories,
+            historyKey,
+            limit: historyLimit,
+          });
+        }
+        return;
+      }
+
+      const { dispatcher, replyOptions, markDispatchIdle } =
+        core.channel.reply.createReplyDispatcherWithTyping({
+          deliver: async () => {},
+          onIdle: () => {},
+          onError: () => {},
+        });
+
+      log(`feishu[${account.accountId}]: group plugin dispatch mode enabled, skipping auto reply`);
+
+      try {
+        await core.channel.reply.dispatchReplyFromConfig({
+          ctx: ctxPayload,
+          cfg: effectiveCfg,
+          dispatcher,
+          replyOptions,
+          replyResolver: async () => undefined,
+        });
+      } finally {
+        markDispatchIdle();
+      }
+
+      if (isGroup && historyKey && chatHistories) {
+        clearHistoryEntriesIfEnabled({
+          historyMap: chatHistories,
+          historyKey,
+          limit: historyLimit,
+        });
+      }
+    } else {
+      // --- Single-agent dispatch (existing behavior) ---
+      const effectiveSessionKey = boundSessionKey ?? route.sessionKey;
+      const ctxPayload = buildCtxPayloadForAgent(
+        effectiveSessionKey,
         route.accountId,
         ctx.mentionedBot,
       );
@@ -1522,18 +1598,20 @@ export async function handleFeishuMessage(params: {
         agentId: route.agentId,
         runtime: runtime as RuntimeEnv,
         chatId: ctx.chatId,
-        replyToMessageId: replyTargetMessageId,
+        replyToMessageId: boundSessionKey
+          ? (ctx.rootId ?? replyTargetMessageId)
+          : replyTargetMessageId,
         skipReplyToInMessages: !isGroup,
-        replyInThread,
-        streamingInThread,
-        rootId: ctx.rootId,
-        threadReply,
+        replyInThread: boundSessionKey ? true : replyInThread,
+        streamingInThread: boundSessionKey ? true : streamingInThread,
+        rootId: boundSessionKey ? ctx.rootId : replyInThread ? ctx.rootId : undefined,
+        threadReply: boundSessionKey ? true : replyInThread && threadReply,
         mentionTargets: ctx.mentionTargets,
         accountId: account.accountId,
         messageCreateTimeMs,
       });
 
-      log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);
+      log(`feishu[${account.accountId}]: dispatching to agent (session=${effectiveSessionKey})`);
       const { queuedFinal, counts } = await core.channel.reply.withReplyDispatcher({
         dispatcher,
         onSettled: () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -13,6 +13,7 @@ import {
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "openclaw/plugin-sdk/feishu";
+import { appendAssistantMessageToSessionTranscript } from "../../../src/config/sessions.js";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { tryRecordMessage, tryRecordMessagePersistent } from "./dedup.js";
@@ -27,9 +28,10 @@ import {
   isFeishuGroupAllowed,
 } from "./policy.js";
 import { parsePostContent } from "./post.js";
+import { resolveQuotedFeishuMessageContent } from "./quoted-message.js";
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { getMessageFeishu, sendMessageFeishu } from "./send.js";
+import { sendMessageFeishu } from "./send.js";
 import type { FeishuMessageContext, FeishuMediaInfo, ResolvedFeishuAccount } from "./types.js";
 import type { DynamicAgentCreationConfig } from "./types.js";
 
@@ -254,8 +256,7 @@ function resolveFeishuGroupSession(params: {
   const normalizedRootId = rootId?.trim();
   const threadReply = Boolean(normalizedThreadId || normalizedRootId);
   const replyInThread =
-    (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled" ||
-    threadReply;
+    (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
   const streamingInThread =
     (groupConfig?.streamingInThread ?? feishuCfg?.streamingInThread ?? "disabled") === "enabled";
 
@@ -876,6 +877,78 @@ export function buildFeishuAgentBody(params: {
   return messageBody;
 }
 
+function collectProviderMessageIds(params: {
+  messageId?: string;
+  messageIds?: string[];
+}): string[] {
+  const ids = new Set<string>();
+  if (typeof params.messageId === "string" && params.messageId.trim()) {
+    ids.add(params.messageId);
+  }
+  if (Array.isArray(params.messageIds)) {
+    for (const value of params.messageIds) {
+      if (typeof value === "string" && value.trim()) {
+        ids.add(value);
+      }
+    }
+  }
+  return [...ids];
+}
+
+function createDirectReplyMirrorHandler(params: {
+  cfg: ClawdbotConfig;
+  agentId: string;
+  sessionKey: string;
+  accountId: string;
+  log: (message: string) => void;
+}) {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  const storePath = getFeishuRuntime().channel.session.resolveStorePath(params.cfg.session?.store, {
+    agentId: params.agentId,
+  });
+  return async (delivery: {
+    text: string;
+    messageId?: string;
+    messageIds?: string[];
+    chatId: string;
+    accountId?: string;
+  }) => {
+    const providerMessageIds = collectProviderMessageIds(delivery);
+    const providerMessageId = providerMessageIds.at(-1);
+    if (!providerMessageId) {
+      return;
+    }
+    try {
+      const result = await appendAssistantMessageToSessionTranscript({
+        agentId: params.agentId,
+        sessionKey,
+        storePath,
+        text: delivery.text,
+        messageMeta: {
+          channel: "feishu",
+          accountId: delivery.accountId ?? params.accountId,
+          chatId: delivery.chatId,
+          chatType: "direct",
+          providerMessageId,
+          providerMessageIds,
+        },
+      });
+      if (!result.ok) {
+        params.log(
+          `feishu[${params.accountId}]: failed to mirror direct reply into session ${sessionKey}: ${result.reason}`,
+        );
+      }
+    } catch (err) {
+      params.log(
+        `feishu[${params.accountId}]: failed to mirror direct reply into session ${sessionKey}: ${String(err)}`,
+      );
+    }
+  };
+}
+
 export async function handleFeishuMessage(params: {
   cfg: ClawdbotConfig;
   event: FeishuMessageEvent;
@@ -983,6 +1056,7 @@ export async function handleFeishuMessage(params: {
     0,
     feishuCfg?.historyLimit ?? cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
   );
+  const dispatchMode = feishuCfg?.dispatchMode ?? "auto";
   const groupConfig = isGroup
     ? resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: ctx.chatId })
     : undefined;
@@ -1266,19 +1340,27 @@ export async function handleFeishuMessage(params: {
     });
     const mediaPayload = buildAgentMediaPayload(mediaList);
 
-    // Fetch quoted/replied message content if parentId exists
+    // Resolve quoted/replied message content if parentId exists.
+    // For Feishu DMs prefer the local session transcript first, then Bot-Company DB,
+    // and only call the provider API as the final fallback.
     let quotedContent: string | undefined;
     if (ctx.parentId) {
       try {
-        const quotedMsg = await getMessageFeishu({
+        const quotedMsg = await resolveQuotedFeishuMessageContent({
           cfg,
-          messageId: ctx.parentId,
           accountId: account.accountId,
+          agentId: route.agentId,
+          sessionKey: route.sessionKey,
+          chatId: ctx.chatId,
+          parentId: ctx.parentId,
+          isGroup,
         });
-        if (quotedMsg) {
+        if (quotedMsg.content) {
           quotedContent = quotedMsg.content;
           log(
-            `feishu[${account.accountId}]: fetched quoted message: ${quotedContent?.slice(0, 100)}`,
+            `feishu[${account.accountId}]: fetched quoted message from ${
+              quotedMsg.source ?? "unknown"
+            }: ${quotedContent.slice(0, 100)}`,
           );
         }
       } catch (err) {
@@ -1439,6 +1521,15 @@ export async function handleFeishuMessage(params: {
         );
 
         if (agentId === activeAgentId) {
+          const onFinalTextDelivered = isGroup
+            ? undefined
+            : createDirectReplyMirrorHandler({
+                cfg: effectiveCfg,
+                agentId,
+                sessionKey: agentSessionKey,
+                accountId: account.accountId,
+                log,
+              });
           // Active agent: real Feishu dispatcher (responds on Feishu)
           const { dispatcher, replyOptions, markDispatchIdle } = createFeishuReplyDispatcher({
             cfg,
@@ -1449,11 +1540,12 @@ export async function handleFeishuMessage(params: {
             skipReplyToInMessages: !isGroup,
             replyInThread,
             streamingInThread,
-            rootId: ctx.rootId,
-            threadReply,
+            rootId: replyInThread ? ctx.rootId : undefined,
+            threadReply: replyInThread && threadReply,
             mentionTargets: ctx.mentionTargets,
             accountId: account.accountId,
             messageCreateTimeMs,
+            onFinalTextDelivered,
           });
 
           log(
@@ -1592,6 +1684,15 @@ export async function handleFeishuMessage(params: {
         route.accountId,
         ctx.mentionedBot,
       );
+      const onFinalTextDelivered = isGroup
+        ? undefined
+        : createDirectReplyMirrorHandler({
+            cfg: effectiveCfg,
+            agentId: route.agentId,
+            sessionKey: effectiveSessionKey,
+            accountId: account.accountId,
+            log,
+          });
 
       const { dispatcher, replyOptions, markDispatchIdle } = createFeishuReplyDispatcher({
         cfg,
@@ -1609,6 +1710,7 @@ export async function handleFeishuMessage(params: {
         mentionTargets: ctx.mentionTargets,
         accountId: account.accountId,
         messageCreateTimeMs,
+        onFinalTextDelivered,
       });
 
       log(`feishu[${account.accountId}]: dispatching to agent (session=${effectiveSessionKey})`);

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1,3 +1,4 @@
+import { getSessionBindingService } from "openclaw/plugin-sdk";
 import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk/feishu";
 import {
   buildAgentMediaPayload,
@@ -5,7 +6,6 @@ import {
   clearHistoryEntriesIfEnabled,
   createScopedPairingAccess,
   DEFAULT_GROUP_HISTORY_LIMIT,
-  getSessionBindingService,
   type HistoryEntry,
   normalizeAgentId,
   recordPendingHistoryEntryIfEnabled,
@@ -44,6 +44,7 @@ type PermissionError = {
 };
 
 const IGNORED_PERMISSION_SCOPE_TOKENS = ["contact:contact.base:readonly"];
+const SOFT_SENDER_LOOKUP_ERROR_CODES = new Set([41050]);
 
 // Feishu API sometimes returns incorrect scope names in permission error
 // responses (e.g. "contact:contact.base:readonly" instead of the valid
@@ -99,6 +100,8 @@ function extractPermissionError(err: unknown): PermissionError | null {
 // Cache display names by sender id (open_id/user_id) to avoid an API call on every message.
 const SENDER_NAME_TTL_MS = 10 * 60 * 1000;
 const senderNameCache = new Map<string, { name: string; expireAt: number }>();
+const senderLookupBackoffUntilByAccountSender = new Map<string, number>();
+const SENDER_LOOKUP_BACKOFF_MS = 10 * 60 * 1000;
 
 // Cache permission errors to avoid spamming the user with repeated notifications.
 // Key: appId or "default", Value: timestamp of last notification
@@ -110,6 +113,11 @@ type SenderNameResult = {
   permissionError?: PermissionError;
 };
 
+type SenderLookupSoftError = {
+  code: number;
+  message: string;
+};
+
 function resolveSenderLookupIdType(senderId: string): "open_id" | "user_id" | "union_id" {
   const trimmed = senderId.trim();
   if (trimmed.startsWith("ou_")) {
@@ -119,6 +127,33 @@ function resolveSenderLookupIdType(senderId: string): "open_id" | "user_id" | "u
     return "union_id";
   }
   return "user_id";
+}
+
+function extractSenderLookupSoftError(err: unknown): SenderLookupSoftError | null {
+  if (!err || typeof err !== "object") return null;
+
+  const axiosErr = err as { response?: { data?: unknown } };
+  const data = axiosErr.response?.data;
+  if (!data || typeof data !== "object") return null;
+
+  const feishuErr = data as { code?: number; msg?: string };
+  const code = feishuErr.code;
+  const message = typeof feishuErr.msg === "string" ? feishuErr.msg : "";
+  if (typeof code === "number" && SOFT_SENDER_LOOKUP_ERROR_CODES.has(code)) {
+    return { code, message };
+  }
+  if (message.toLowerCase().includes("no user authority")) {
+    return { code: typeof code === "number" ? code : 41050, message };
+  }
+  return null;
+}
+
+function resolveSenderLookupBackoffKey(
+  account: ResolvedFeishuAccount,
+  normalizedSenderId: string,
+): string {
+  const accountKey = account.accountId?.trim() || account.appId?.trim() || "default";
+  return `${accountKey}:${normalizedSenderId}`;
 }
 
 async function resolveFeishuSenderName(params: {
@@ -135,6 +170,9 @@ async function resolveFeishuSenderName(params: {
   const cached = senderNameCache.get(normalizedSenderId);
   const now = Date.now();
   if (cached && cached.expireAt > now) return { name: cached.name };
+  const lookupBackoffKey = resolveSenderLookupBackoffKey(account, normalizedSenderId);
+  const backoffUntil = senderLookupBackoffUntilByAccountSender.get(lookupBackoffKey) ?? 0;
+  if (backoffUntil > now) return {};
 
   try {
     const client = createFeishuClient(account);
@@ -159,6 +197,19 @@ async function resolveFeishuSenderName(params: {
 
     return {};
   } catch (err) {
+    const softErr = extractSenderLookupSoftError(err);
+    if (softErr) {
+      const priorBackoffUntil = senderLookupBackoffUntilByAccountSender.get(lookupBackoffKey) ?? 0;
+      senderLookupBackoffUntilByAccountSender.set(lookupBackoffKey, now + SENDER_LOOKUP_BACKOFF_MS);
+      if (priorBackoffUntil <= now) {
+        const accountKey = account.accountId?.trim() || account.appId?.trim() || "default";
+        log(
+          `feishu: sender name lookup temporarily disabled for account=${accountKey} sender=${normalizedSenderId} code=${softErr.code}`,
+        );
+      }
+      return {};
+    }
+
     // Check if this is a permission error
     const permErr = extractPermissionError(err);
     if (permErr) {
@@ -954,6 +1005,7 @@ export async function handleFeishuMessage(params: {
   event: FeishuMessageEvent;
   botOpenId?: string;
   botName?: string;
+  botOpenIdsByAccount?: Record<string, string | undefined>;
   runtime?: RuntimeEnv;
   chatHistories?: Map<string, HistoryEntry[]>;
   accountId?: string;
@@ -1451,6 +1503,30 @@ export async function handleFeishuMessage(params: {
         OriginatingChannel: "feishu" as const,
         OriginatingTo: feishuTo,
         GroupSystemPrompt: isGroup ? groupConfig?.systemPrompt?.trim() || undefined : undefined,
+        ChannelData: {
+          messageId: ctx.messageId,
+          chatId: ctx.chatId,
+          chatType: ctx.chatType,
+          accountId: account.accountId,
+          accountBotOpenId: botOpenId,
+          botOpenIdsByAccount: params.botOpenIdsByAccount,
+          messageType: event.message.message_type,
+          rawContent: event.message.content,
+          rootId: ctx.rootId,
+          parentId: ctx.parentId,
+          mentions: event.message.mentions ?? [],
+          senderType: event.sender.sender_type,
+          senderOpenId: ctx.senderOpenId,
+          senderUnionId: event.sender.sender_id.union_id,
+          ...(mediaList.length > 0
+            ? {
+                mediaPath: mediaList[0].path,
+                mediaType: mediaList[0].contentType,
+                mediaPaths: mediaList.map((m) => m.path),
+                mediaTypes: mediaList.filter((m) => m.contentType).map((m) => m.contentType!),
+              }
+            : {}),
+        },
         ...mediaPayload,
       });
 
@@ -1544,6 +1620,7 @@ export async function handleFeishuMessage(params: {
             threadReply: replyInThread && threadReply,
             mentionTargets: ctx.mentionTargets,
             accountId: account.accountId,
+            botOpenId,
             messageCreateTimeMs,
             onFinalTextDelivered,
           });
@@ -1709,6 +1786,7 @@ export async function handleFeishuMessage(params: {
         threadReply: boundSessionKey ? true : replyInThread && threadReply,
         mentionTargets: ctx.mentionTargets,
         accountId: account.accountId,
+        botOpenId,
         messageCreateTimeMs,
         onFinalTextDelivered,
       });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -224,6 +224,7 @@ type ResolvedFeishuGroupSession = {
   parentPeer: { kind: "group"; id: string } | null;
   groupSessionScope: GroupSessionScope;
   replyInThread: boolean;
+  streamingInThread: boolean;
   threadReply: boolean;
 };
 
@@ -237,11 +238,13 @@ function resolveFeishuGroupSession(params: {
     groupSessionScope?: GroupSessionScope;
     topicSessionMode?: "enabled" | "disabled";
     replyInThread?: "enabled" | "disabled";
+    streamingInThread?: "enabled" | "disabled";
   };
   feishuCfg?: {
     groupSessionScope?: GroupSessionScope;
     topicSessionMode?: "enabled" | "disabled";
     replyInThread?: "enabled" | "disabled";
+    streamingInThread?: "enabled" | "disabled";
   };
 }): ResolvedFeishuGroupSession {
   const { chatId, senderOpenId, messageId, rootId, threadId, groupConfig, feishuCfg } = params;
@@ -250,7 +253,8 @@ function resolveFeishuGroupSession(params: {
   const normalizedRootId = rootId?.trim();
   const threadReply = Boolean(normalizedThreadId || normalizedRootId);
   const replyInThread =
-    (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
+    (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled" ||
+    threadReply;
   const streamingInThread =
     (groupConfig?.streamingInThread ?? feishuCfg?.streamingInThread ?? "disabled") === "enabled";
 
@@ -302,6 +306,7 @@ function resolveFeishuGroupSession(params: {
     parentPeer,
     groupSessionScope,
     replyInThread,
+    streamingInThread,
     threadReply,
   };
 }
@@ -1169,6 +1174,7 @@ export async function handleFeishuMessage(params: {
     const peerId = isGroup ? (groupSession?.peerId ?? ctx.chatId) : ctx.senderOpenId;
     const parentPeer = isGroup ? (groupSession?.parentPeer ?? null) : null;
     const replyInThread = isGroup ? (groupSession?.replyInThread ?? false) : false;
+    const streamingInThread = isGroup ? (groupSession?.streamingInThread ?? false) : true;
 
     if (isGroup && groupSession) {
       log(
@@ -1421,8 +1427,8 @@ export async function handleFeishuMessage(params: {
             skipReplyToInMessages: !isGroup,
             replyInThread,
             streamingInThread,
-            rootId: replyInThread ? ctx.rootId : undefined,
-            threadReply: replyInThread && threadReply,
+            rootId: ctx.rootId,
+            threadReply,
             mentionTargets: ctx.mentionTargets,
             accountId: account.accountId,
             messageCreateTimeMs,
@@ -1520,8 +1526,8 @@ export async function handleFeishuMessage(params: {
         skipReplyToInMessages: !isGroup,
         replyInThread,
         streamingInThread,
-        rootId: replyInThread ? ctx.rootId : undefined,
-        threadReply: replyInThread && threadReply,
+        rootId: ctx.rootId,
+        threadReply,
         mentionTargets: ctx.mentionTargets,
         accountId: account.accountId,
         messageCreateTimeMs,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -250,8 +250,9 @@ function resolveFeishuGroupSession(params: {
   const normalizedRootId = rootId?.trim();
   const threadReply = Boolean(normalizedThreadId || normalizedRootId);
   const replyInThread =
-    (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled" ||
-    threadReply;
+    (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
+  const streamingInThread =
+    (groupConfig?.streamingInThread ?? feishuCfg?.streamingInThread ?? "disabled") === "enabled";
 
   const legacyTopicSessionMode =
     groupConfig?.topicSessionMode ?? feishuCfg?.topicSessionMode ?? "disabled";
@@ -477,9 +478,13 @@ function normalizeMentions(
 
   const escaped = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const escapeName = (value: string) => value.replace(/</g, "&lt;").replace(/>/g, "&gt;");
-  let result = text;
+  const replacementByKey = new Map<string, string>();
 
   for (const mention of mentions) {
+    const key = mention.key?.trim();
+    if (!key || replacementByKey.has(key)) {
+      continue;
+    }
     const mentionId = mention.id.open_id;
     const replacement =
       botStripId && mentionId === botStripId
@@ -487,11 +492,18 @@ function normalizeMentions(
         : mentionId
           ? `<at user_id="${mentionId}">${escapeName(mention.name)}</at>`
           : `@${mention.name}`;
-
-    result = result.replace(new RegExp(escaped(mention.key), "g"), () => replacement).trim();
+    replacementByKey.set(key, replacement);
   }
 
-  return result;
+  if (replacementByKey.size === 0) {
+    return text;
+  }
+
+  // One-pass replacement avoids recursive/cascading rewrites when keys overlap,
+  // e.g. "@_user_1" and "@_user_10".
+  const sortedKeys = [...replacementByKey.keys()].sort((left, right) => right.length - left.length);
+  const keyPattern = new RegExp(sortedKeys.map((key) => escaped(key)).join("|"), "g");
+  return text.replace(keyPattern, (matched) => replacementByKey.get(matched) ?? matched).trim();
 }
 
 function normalizeFeishuCommandProbeBody(text: string): string {
@@ -1408,8 +1420,9 @@ export async function handleFeishuMessage(params: {
             replyToMessageId: replyTargetMessageId,
             skipReplyToInMessages: !isGroup,
             replyInThread,
-            rootId: ctx.rootId,
-            threadReply,
+            streamingInThread,
+            rootId: replyInThread ? ctx.rootId : undefined,
+            threadReply: replyInThread && threadReply,
             mentionTargets: ctx.mentionTargets,
             accountId: account.accountId,
             messageCreateTimeMs,
@@ -1506,8 +1519,9 @@ export async function handleFeishuMessage(params: {
         replyToMessageId: replyTargetMessageId,
         skipReplyToInMessages: !isGroup,
         replyInThread,
-        rootId: ctx.rootId,
-        threadReply,
+        streamingInThread,
+        rootId: replyInThread ? ctx.rootId : undefined,
+        threadReply: replyInThread && threadReply,
         mentionTargets: ctx.mentionTargets,
         accountId: account.accountId,
         messageCreateTimeMs,

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -46,3 +46,79 @@ describe("feishuPlugin.status.probeAccount", () => {
     expect(result).toMatchObject({ ok: true, appId: "cli_main" });
   });
 });
+
+describe("feishuPlugin.configSchema", () => {
+  it("exposes top-level streamingInThread in channel schema", () => {
+    const schema = feishuPlugin.configSchema?.schema as
+      | {
+          properties?: Record<string, unknown>;
+        }
+      | undefined;
+    const streamingInThread = schema?.properties?.streamingInThread as
+      | { enum?: string[] }
+      | undefined;
+    expect(streamingInThread?.enum).toEqual(["disabled", "enabled"]);
+  });
+
+  it("exposes account-level dispatchMode in channel schema", () => {
+    const schema = feishuPlugin.configSchema?.schema as
+      | {
+          properties?: {
+            accounts?: {
+              additionalProperties?: {
+                properties?: Record<string, unknown>;
+              };
+            };
+          };
+        }
+      | undefined;
+
+    const dispatchMode = schema?.properties?.accounts?.additionalProperties?.properties
+      ?.dispatchMode as { enum?: string[] } | undefined;
+
+    expect(dispatchMode?.enum).toEqual(["auto", "plugin"]);
+  });
+
+  it("exposes account-level streamingInThread in channel schema", () => {
+    const schema = feishuPlugin.configSchema?.schema as
+      | {
+          properties?: {
+            accounts?: {
+              additionalProperties?: {
+                properties?: Record<string, unknown>;
+              };
+            };
+          };
+        }
+      | undefined;
+    const streamingInThread = schema?.properties?.accounts?.additionalProperties?.properties
+      ?.streamingInThread as { enum?: string[] } | undefined;
+    expect(streamingInThread?.enum).toEqual(["disabled", "enabled"]);
+  });
+
+  it("exposes account-level pluginMode.forwardControlCommands in channel schema", () => {
+    const schema = feishuPlugin.configSchema?.schema as
+      | {
+          properties?: {
+            accounts?: {
+              additionalProperties?: {
+                properties?: Record<string, unknown>;
+              };
+            };
+          };
+        }
+      | undefined;
+
+    const pluginMode = schema?.properties?.accounts?.additionalProperties?.properties?.pluginMode as
+      | {
+          properties?: Record<string, unknown>;
+        }
+      | undefined;
+
+    const forwardControlCommands = pluginMode?.properties?.forwardControlCommands as
+      | { type?: string }
+      | undefined;
+
+    expect(forwardControlCommands?.type).toBe("boolean");
+  });
+});

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -110,6 +110,14 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
           ],
         },
         connectionMode: { type: "string", enum: ["websocket", "webhook"] },
+        dispatchMode: { type: "string", enum: ["auto", "plugin"] },
+        pluginMode: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            forwardControlCommands: { type: "boolean" },
+          },
+        },
         webhookPath: { type: "string" },
         webhookHost: { type: "string" },
         webhookPort: { type: "integer", minimum: 1 },

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -127,6 +127,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
         },
         topicSessionMode: { type: "string", enum: ["disabled", "enabled"] },
         replyInThread: { type: "string", enum: ["disabled", "enabled"] },
+        streamingInThread: { type: "string", enum: ["disabled", "enabled"] },
         historyLimit: { type: "integer", minimum: 0 },
         dmHistoryLimit: { type: "integer", minimum: 0 },
         textChunkLimit: { type: "integer", minimum: 1 },
@@ -149,6 +150,15 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
               webhookHost: { type: "string" },
               webhookPath: { type: "string" },
               webhookPort: { type: "integer", minimum: 1 },
+              dispatchMode: { type: "string", enum: ["auto", "plugin"] },
+              streamingInThread: { type: "string", enum: ["disabled", "enabled"] },
+              pluginMode: {
+                type: "object",
+                additionalProperties: false,
+                properties: {
+                  forwardControlCommands: { type: "boolean" },
+                },
+              },
             },
           },
         },

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -145,6 +145,37 @@ describe("FeishuConfigSchema replyInThread", () => {
   });
 });
 
+describe("FeishuConfigSchema streamingInThread", () => {
+  it("accepts streamingInThread at top level", () => {
+    const result = FeishuConfigSchema.parse({ streamingInThread: "disabled" });
+    expect(result.streamingInThread).toBe("disabled");
+  });
+
+  it("defaults streamingInThread to undefined when not set", () => {
+    const result = FeishuConfigSchema.parse({});
+    expect(result.streamingInThread).toBeUndefined();
+  });
+
+  it("rejects invalid streamingInThread value", () => {
+    const result = FeishuConfigSchema.safeParse({ streamingInThread: "always" });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts streamingInThread in group config", () => {
+    const result = FeishuGroupSchema.parse({ streamingInThread: "disabled" });
+    expect(result.streamingInThread).toBe("disabled");
+  });
+
+  it("accepts streamingInThread in account config", () => {
+    const result = FeishuConfigSchema.parse({
+      accounts: {
+        main: { streamingInThread: "disabled" },
+      },
+    });
+    expect(result.accounts?.main?.streamingInThread).toBe("disabled");
+  });
+});
+
 describe("FeishuConfigSchema optimization flags", () => {
   it("defaults top-level typingIndicator and resolveSenderNames to true", () => {
     const result = FeishuConfigSchema.parse({});

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -13,6 +13,7 @@ const FeishuDomainSchema = z.union([
   z.string().url().startsWith("https://"),
 ]);
 const FeishuConnectionModeSchema = z.enum(["websocket", "webhook"]);
+const DispatchModeSchema = z.enum(["auto", "plugin"]);
 
 const ToolPolicySchema = z
   .object({
@@ -58,6 +59,13 @@ const ChannelHeartbeatVisibilitySchema = z
   .object({
     visibility: z.enum(["visible", "hidden"]).optional(),
     intervalMs: z.number().int().positive().optional(),
+  })
+  .strict()
+  .optional();
+
+const PluginModeConfigSchema = z
+  .object({
+    forwardControlCommands: z.boolean().optional(),
   })
   .strict()
   .optional();
@@ -169,6 +177,7 @@ const FeishuSharedConfigShape = {
   mediaMaxMb: z.number().positive().optional(),
   httpTimeoutMs: z.number().int().positive().max(300_000).optional(),
   heartbeat: ChannelHeartbeatVisibilitySchema,
+  pluginMode: PluginModeConfigSchema,
   renderMode: RenderModeSchema,
   streaming: StreamingModeSchema,
   tools: FeishuToolsConfigSchema,
@@ -193,6 +202,7 @@ export const FeishuAccountConfigSchema = z
     verificationToken: buildSecretInputSchema().optional(),
     domain: FeishuDomainSchema.optional(),
     connectionMode: FeishuConnectionModeSchema.optional(),
+    dispatchMode: DispatchModeSchema.optional(),
     webhookPath: z.string().optional(),
     ...FeishuSharedConfigShape,
     groupSessionScope: GroupSessionScopeSchema,
@@ -211,6 +221,7 @@ export const FeishuConfigSchema = z
     verificationToken: buildSecretInputSchema().optional(),
     domain: FeishuDomainSchema.optional().default("feishu"),
     connectionMode: FeishuConnectionModeSchema.optional().default("websocket"),
+    dispatchMode: DispatchModeSchema.optional().default("auto"),
     webhookPath: z.string().optional().default("/feishu/events"),
     ...FeishuSharedConfigShape,
     dmPolicy: DmPolicySchema.optional().default("pairing"),

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -130,6 +130,7 @@ const ReactionNotificationModeSchema = z.enum(["off", "own", "all"]).optional();
  * causing the reply to appear as a topic (话题) under the original message.
  */
 const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
+const StreamingInThreadSchema = z.enum(["disabled", "enabled"]).optional();
 
 export const FeishuGroupSchema = z
   .object({
@@ -142,6 +143,7 @@ export const FeishuGroupSchema = z
     groupSessionScope: GroupSessionScopeSchema,
     topicSessionMode: TopicSessionModeSchema,
     replyInThread: ReplyInThreadSchema,
+    streamingInThread: StreamingInThreadSchema,
   })
   .strict();
 
@@ -171,6 +173,7 @@ const FeishuSharedConfigShape = {
   streaming: StreamingModeSchema,
   tools: FeishuToolsConfigSchema,
   replyInThread: ReplyInThreadSchema,
+  streamingInThread: StreamingInThreadSchema,
   reactionNotifications: ReactionNotificationModeSchema,
   typingIndicator: z.boolean().optional(),
   resolveSenderNames: z.boolean().optional(),

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -16,14 +16,13 @@ function json(data: unknown) {
 // ============ Actions ============
 
 async function getRootFolderToken(client: Lark.Client): Promise<string> {
-  // Use generic HTTP client to call the root folder meta API
-  // as it's not directly exposed in the SDK
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accessing internal SDK property
-  const domain = (client as any).domain ?? "https://open.feishu.cn";
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accessing internal SDK property
-  const res = (await (client as any).httpInstance.get(
-    `${domain}/open-apis/drive/explorer/v2/root_folder/meta`,
-  )) as { code: number; msg?: string; data?: { token?: string } };
+  // Use SDK generic request for endpoints not exposed as typed methods.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK generic request method
+  const res = (await (client as any).request({
+    method: "GET",
+    url: "/open-apis/drive/explorer/v2/root_folder/meta",
+    data: {},
+  })) as { code: number; msg?: string; data?: { token?: string } };
   if (res.code !== 0) {
     throw new Error(res.msg ?? "Failed to get root folder");
   }

--- a/extensions/feishu/src/exports.test.ts
+++ b/extensions/feishu/src/exports.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("feishu extension exports", () => {
+  it("exports createFeishuReplyDispatcher and getBotOpenId", async () => {
+    const mod = await import("../index.js");
+
+    expect(typeof mod.createFeishuReplyDispatcher).toBe("function");
+    expect(typeof mod.getBotOpenId).toBe("function");
+  });
+
+  it("register() exposes native feishu dispatcher on runtime.channel.reply", async () => {
+    const mod = await import("../index.js");
+    const register = mod.default.register as (api: unknown) => void;
+    const runtime = {
+      channel: {
+        reply: {},
+      },
+    };
+    register({
+      config: {},
+      logger: {},
+      runtime,
+      registerChannel: vi.fn(),
+      registerTool: vi.fn(),
+    });
+    expect(
+      typeof (runtime as { channel: { reply: { createFeishuReplyDispatcher?: unknown } } }).channel
+        .reply.createFeishuReplyDispatcher,
+    ).toBe("function");
+  });
+});

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -190,9 +190,10 @@ describe("sendMediaFeishu msg_type routing", () => {
       fileName: "photo.png",
     });
 
-    expect(imageCreateMock).toHaveBeenCalledWith(
+    // Timeout is now set on the client via httpTimeoutMs, not per-call
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        timeout: 120_000,
+        httpTimeoutMs: 120_000,
       }),
     );
     expect(messageCreateMock).toHaveBeenCalledWith(
@@ -213,7 +214,7 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ msg_type: "file" }),
+        data: expect.objectContaining({ msg_type: "media" }),
       }),
     );
 
@@ -253,7 +254,7 @@ describe("sendMediaFeishu msg_type routing", () => {
 
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ msg_type: "file" }),
+        data: expect.objectContaining({ msg_type: "media" }),
       }),
     );
     expect(messageReplyMock).not.toHaveBeenCalled();
@@ -323,7 +324,12 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(imageGetMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { image_key: imageKey },
-        timeout: 120_000,
+      }),
+    );
+    // Timeout is now set on the client via httpTimeoutMs, not per-call
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpTimeoutMs: 120_000,
       }),
     );
     expect(result.buffer).toEqual(Buffer.from("image-data"));
@@ -515,7 +521,11 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_audio_msg", file_key: "file_key_audio" },
         params: { type: "file" },
-        timeout: 120_000,
+      }),
+    );
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpTimeoutMs: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);
@@ -535,7 +545,11 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_img_msg", file_key: "img_key_1" },
         params: { type: "image" },
-        timeout: 120_000,
+      }),
+    );
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpTimeoutMs: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -202,7 +202,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("uses msg_type=media when replying with mp4", async () => {
+  it("uses message.create when replying with mp4 without replyInThread", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -211,14 +211,13 @@ describe("sendMediaFeishu msg_type routing", () => {
       replyToMessageId: "om_parent",
     });
 
-    expect(messageReplyMock).toHaveBeenCalledWith(
+    expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        path: { message_id: "om_parent" },
-        data: expect.objectContaining({ msg_type: "media" }),
+        data: expect.objectContaining({ msg_type: "file" }),
       }),
     );
 
-    expect(messageCreateMock).not.toHaveBeenCalled();
+    expect(messageReplyMock).not.toHaveBeenCalled();
   });
 
   it("passes reply_in_thread when replyInThread is true", async () => {
@@ -242,7 +241,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("omits reply_in_thread when replyInThread is false", async () => {
+  it("uses message.create when replyInThread is false", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -252,8 +251,12 @@ describe("sendMediaFeishu msg_type routing", () => {
       replyInThread: false,
     });
 
-    const callData = messageReplyMock.mock.calls[0][0].data;
-    expect(callData).not.toHaveProperty("reply_in_thread");
+    expect(messageCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ msg_type: "file" }),
+      }),
+    );
+    expect(messageReplyMock).not.toHaveBeenCalled();
   });
 
   it("passes mediaLocalRoots as localRoots to loadWebMedia for local paths (#27884)", async () => {

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -310,7 +310,7 @@ export async function sendImageFeishu(params: {
   });
   const content = JSON.stringify({ image_key: imageKey });
 
-  if (replyToMessageId) {
+  if (replyToMessageId && replyInThread) {
     const response = await client.im.message.reply({
       path: { message_id: replyToMessageId },
       data: {
@@ -357,7 +357,7 @@ export async function sendFileFeishu(params: {
   });
   const content = JSON.stringify({ file_key: fileKey });
 
-  if (replyToMessageId) {
+  if (replyToMessageId && replyInThread) {
     const response = await client.im.message.reply({
       path: { message_id: replyToMessageId },
       data: {

--- a/extensions/feishu/src/mention.test.ts
+++ b/extensions/feishu/src/mention.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { normalizeMentionTagsForCard, normalizeMentionTagsForText } from "./mention.js";
+
+describe("mention tag normalization", () => {
+  it("converts text-style mentions to card-style mentions", () => {
+    const input = `<at user_id="ou_123">Emma</at> hello <at user_id='all'>Everyone</at>`;
+    const output = normalizeMentionTagsForCard(input);
+    expect(output).toBe("<at id=ou_123></at> hello <at id=all></at>");
+  });
+
+  it("converts card-style mentions to text-style mentions with display names", () => {
+    const input = "<at id=ou_123></at> hi";
+    const output = normalizeMentionTagsForText(input, { ou_123: "Emma" });
+    expect(output).toBe('<at user_id="ou_123">Emma</at> hi');
+  });
+
+  it("falls back to id when card mention has no mapped display name", () => {
+    const input = "<at id=ou_999></at>";
+    const output = normalizeMentionTagsForText(input);
+    expect(output).toBe('<at user_id="ou_999">ou_999</at>');
+  });
+
+  it("keeps non-mention text unchanged", () => {
+    const input = "plain text";
+    expect(normalizeMentionTagsForCard(input)).toBe(input);
+    expect(normalizeMentionTagsForText(input)).toBe(input);
+  });
+});

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -1,6 +1,7 @@
 import * as crypto from "crypto";
 import * as Lark from "@larksuiteoapi/node-sdk";
 import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "openclaw/plugin-sdk/feishu";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { raceWithTimeoutAndAbort } from "./async.js";
 import {
@@ -505,6 +506,14 @@ function registerEventHandlers(
       try {
         const event = data as unknown as FeishuBotAddedEvent;
         log(`feishu[${accountId}]: bot added to chat ${event.chat_id}`);
+        if (!event.chat_id) return;
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_bot_added")) {
+          void hookRunner.runChatMemberBotAdded(
+            { chatId: event.chat_id },
+            { channelId: "feishu", accountId },
+          );
+        }
       } catch (err) {
         error(`feishu[${accountId}]: error handling bot added event: ${String(err)}`);
       }
@@ -513,8 +522,103 @@ function registerEventHandlers(
       try {
         const event = data as unknown as { chat_id: string };
         log(`feishu[${accountId}]: bot removed from chat ${event.chat_id}`);
+        if (!event.chat_id) return;
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_bot_deleted")) {
+          void hookRunner.runChatMemberBotDeleted(
+            { chatId: event.chat_id },
+            { channelId: "feishu", accountId },
+          );
+        }
       } catch (err) {
         error(`feishu[${accountId}]: error handling bot removed event: ${String(err)}`);
+      }
+    },
+    "im.chat.member.user.added_v1": async (data) => {
+      try {
+        const event = data as unknown as {
+          chat_id?: string;
+          users?: Array<{
+            name?: string;
+            user_id?: { open_id?: string; union_id?: string };
+          }>;
+        };
+        log(`feishu[${accountId}]: users added to chat ${event.chat_id}`);
+        if (!event.chat_id) return;
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_user_added")) {
+          const users = (event.users ?? [])
+            .filter((u) => !!u.user_id?.open_id)
+            .map((u) => ({
+              openId: u.user_id!.open_id!,
+              unionId: u.user_id?.union_id,
+              name: u.name,
+            }));
+          void hookRunner.runChatMemberUserAdded(
+            { chatId: event.chat_id, users },
+            { channelId: "feishu", accountId },
+          );
+        }
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling user added event: ${String(err)}`);
+      }
+    },
+    "im.chat.member.user.deleted_v1": async (data) => {
+      try {
+        const event = data as unknown as {
+          chat_id?: string;
+          users?: Array<{
+            name?: string;
+            user_id?: { open_id?: string; union_id?: string };
+          }>;
+        };
+        log(`feishu[${accountId}]: users deleted from chat ${event.chat_id}`);
+        if (!event.chat_id) return;
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_user_deleted")) {
+          const users = (event.users ?? [])
+            .filter((u) => !!u.user_id?.open_id)
+            .map((u) => ({
+              openId: u.user_id!.open_id!,
+              unionId: u.user_id?.union_id,
+              name: u.name,
+            }));
+          void hookRunner.runChatMemberUserDeleted(
+            { chatId: event.chat_id, users },
+            { channelId: "feishu", accountId },
+          );
+        }
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling user deleted event: ${String(err)}`);
+      }
+    },
+    "im.chat.member.user.withdrawn_v1": async (data) => {
+      try {
+        const event = data as unknown as {
+          chat_id?: string;
+          users?: Array<{
+            name?: string;
+            user_id?: { open_id?: string; union_id?: string };
+          }>;
+        };
+        log(`feishu[${accountId}]: users withdrawn from chat ${event.chat_id}`);
+        if (!event.chat_id) return;
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_user_withdrawn")) {
+          const users = (event.users ?? [])
+            .filter((u) => !!u.user_id?.open_id)
+            .map((u) => ({
+              openId: u.user_id!.open_id!,
+              unionId: u.user_id?.union_id,
+              name: u.name,
+            }));
+          void hookRunner.runChatMemberUserWithdrawn(
+            { chatId: event.chat_id, users },
+            { channelId: "feishu", accountId },
+          );
+        }
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling user withdrawn event: ${String(err)}`);
       }
     },
     "im.message.reaction.created_v1": async (data) => {

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -24,6 +24,7 @@ import { botNames, botOpenIds } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu } from "./send.js";
+import { createFeishuThreadBindingManager } from "./thread-bindings.manager.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 const FEISHU_REACTION_VERIFY_TIMEOUT_MS = 1_500;
@@ -628,6 +629,25 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
   const warmupCount = await warmupDedupFromDisk(accountId, log);
   if (warmupCount > 0) {
     log(`feishu[${accountId}]: dedup warmup loaded ${warmupCount} entries from disk`);
+  }
+
+  const threadBindingManager = createFeishuThreadBindingManager({
+    accountId,
+    cfg,
+    persist: true,
+    enableSweeper: true,
+  });
+  log(`feishu[${accountId}]: thread binding adapter registered`);
+
+  if (abortSignal) {
+    abortSignal.addEventListener(
+      "abort",
+      () => {
+        threadBindingManager.stop();
+        log(`feishu[${accountId}]: thread binding adapter stopped`);
+      },
+      { once: true },
+    );
   }
 
   const eventDispatcher = createEventDispatcher(account);

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -38,6 +38,17 @@ export type FeishuReactionCreatedEvent = {
   action_time?: string;
 };
 
+type FeishuMessageRecalledEvent = {
+  message_id?: string;
+  chat_id?: string;
+  recall_time?: string;
+  action_time?: string;
+  operator_id?: unknown;
+  user_id?: unknown;
+  deleter_id?: unknown;
+  message?: unknown;
+};
+
 type ResolveReactionSyntheticEventParams = {
   cfg: ClawdbotConfig;
   accountId: string;
@@ -123,6 +134,86 @@ export async function resolveReactionSyntheticEvent(
         text: `[reacted with ${emoji} to message ${messageId}]`,
       }),
     },
+  };
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value && typeof value === "object") {
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+function pickFirstString(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function resolveOpenIdLike(value: unknown): string | undefined {
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+  return pickFirstString(
+    asNonEmptyString(record.open_id),
+    asNonEmptyString(record.user_id),
+    asNonEmptyString(record.union_id),
+    resolveOpenIdLike(record.sender_id),
+    resolveOpenIdLike(record.id),
+    resolveOpenIdLike(record.user),
+  );
+}
+
+function buildRecalledEventSummary(eventData: unknown): {
+  messageId: string;
+  chatId: string;
+  operatorOpenId: string;
+  senderOpenId: string;
+  rootId: string;
+  threadId: string;
+  recallTime: string;
+} {
+  const event = (eventData as FeishuMessageRecalledEvent | undefined) ?? {};
+  const message = asRecord(event.message);
+  const messageSender = asRecord(message?.sender);
+  return {
+    messageId:
+      pickFirstString(asNonEmptyString(event.message_id), asNonEmptyString(message?.message_id)) ??
+      "unknown",
+    chatId:
+      pickFirstString(asNonEmptyString(event.chat_id), asNonEmptyString(message?.chat_id)) ??
+      "unknown",
+    operatorOpenId:
+      pickFirstString(
+        resolveOpenIdLike(event.operator_id),
+        resolveOpenIdLike(event.deleter_id),
+        resolveOpenIdLike(event.user_id),
+        resolveOpenIdLike(message?.recalled_by),
+        resolveOpenIdLike(message?.deleted_by),
+      ) ?? "unknown",
+    senderOpenId:
+      pickFirstString(resolveOpenIdLike(message?.sender_id), resolveOpenIdLike(messageSender)) ??
+      "unknown",
+    rootId: asNonEmptyString(message?.root_id) ?? "unknown",
+    threadId: asNonEmptyString(message?.thread_id) ?? "unknown",
+    recallTime:
+      pickFirstString(
+        asNonEmptyString(event.recall_time),
+        asNonEmptyString(event.action_time),
+        asNonEmptyString(message?.update_time),
+      ) ?? "unknown",
   };
 }
 
@@ -396,6 +487,18 @@ function registerEventHandlers(
     },
     "im.message.message_read_v1": async () => {
       // Ignore read receipts
+    },
+    "im.message.recalled_v1": async (data) => {
+      try {
+        const summary = buildRecalledEventSummary(data);
+        log(
+          `feishu[${accountId}]: message recalled chat=${summary.chatId} message=${summary.messageId} ` +
+            `operator=${summary.operatorOpenId} sender=${summary.senderOpenId} ` +
+            `root=${summary.rootId} thread=${summary.threadId} recall_time=${summary.recallTime}`,
+        );
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling message recalled event: ${String(err)}`);
+      }
     },
     "im.chat.member.bot.added_v1": async (data) => {
       try {

--- a/extensions/feishu/src/monitor.events.test.ts
+++ b/extensions/feishu/src/monitor.events.test.ts
@@ -1,0 +1,246 @@
+import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const probeFeishuMock = vi.hoisted(() => vi.fn());
+const createFeishuWSClientMock = vi.hoisted(() => vi.fn());
+const createEventDispatcherMock = vi.hoisted(() => vi.fn());
+const hookRunnerMocks = vi.hoisted(() => ({
+  hasHooks: vi.fn(() => true),
+  runChatMemberBotAdded: vi.fn(),
+  runChatMemberBotDeleted: vi.fn(),
+  runChatMemberUserAdded: vi.fn(),
+  runChatMemberUserDeleted: vi.fn(),
+  runChatMemberUserWithdrawn: vi.fn(),
+}));
+
+vi.mock("./probe.js", () => ({
+  probeFeishu: probeFeishuMock,
+}));
+
+vi.mock("./client.js", () => ({
+  createFeishuWSClient: createFeishuWSClientMock,
+  createEventDispatcher: createEventDispatcherMock,
+}));
+
+vi.mock("openclaw/plugin-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk")>();
+  return {
+    ...actual,
+    getGlobalHookRunner: () => hookRunnerMocks,
+  };
+});
+
+import { monitorFeishuProvider, stopFeishuMonitor } from "./monitor.js";
+
+type RegisteredHandlers = Record<string, (data: unknown) => Promise<void>>;
+
+function buildWebSocketConfig(accountId = "default"): ClawdbotConfig {
+  return {
+    channels: {
+      feishu: {
+        enabled: true,
+        accounts: {
+          [accountId]: {
+            enabled: true,
+            appId: "cli_test",
+            appSecret: "secret_test",
+            connectionMode: "websocket",
+          },
+        },
+      },
+    },
+  } as ClawdbotConfig;
+}
+
+async function waitForRegisterCall(registerMock: ReturnType<typeof vi.fn>): Promise<void> {
+  for (let i = 0; i < 30; i += 1) {
+    if (registerMock.mock.calls.length > 0) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error("event dispatcher handlers were not registered");
+}
+
+async function startMonitorAndGetHandlers(): Promise<{
+  handlers: RegisteredHandlers;
+  logMock: ReturnType<typeof vi.fn>;
+  errorMock: ReturnType<typeof vi.fn>;
+  stop: () => Promise<void>;
+}> {
+  const registerMock = vi.fn();
+  createEventDispatcherMock.mockReturnValue({ register: registerMock });
+  createFeishuWSClientMock.mockReturnValue({ start: vi.fn() });
+  probeFeishuMock.mockResolvedValue({ ok: true, botOpenId: "ou_bot_default" });
+  const logMock = vi.fn();
+  const errorMock = vi.fn();
+
+  const abortController = new AbortController();
+  const monitorPromise = monitorFeishuProvider({
+    config: buildWebSocketConfig(),
+    runtime: {
+      log: logMock,
+      error: errorMock,
+      exit: vi.fn(),
+    },
+    abortSignal: abortController.signal,
+  });
+
+  await waitForRegisterCall(registerMock);
+  const handlers = registerMock.mock.calls[0]?.[0] as RegisteredHandlers;
+  if (!handlers) {
+    throw new Error("missing registered handlers");
+  }
+
+  return {
+    handlers,
+    logMock,
+    errorMock,
+    stop: async () => {
+      abortController.abort();
+      await monitorPromise;
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hookRunnerMocks.hasHooks.mockReturnValue(true);
+});
+
+afterEach(() => {
+  stopFeishuMonitor();
+});
+
+describe("monitorFeishuProvider chat member relay", () => {
+  it("forwards Feishu member events to hook runner with normalized payload", async () => {
+    const { handlers, stop } = await startMonitorAndGetHandlers();
+    try {
+      await handlers["im.chat.member.bot.added_v1"]({
+        chat_id: "oc_group_1",
+        operator_id: { open_id: "ou_operator" },
+        external: false,
+      });
+      await handlers["im.chat.member.bot.deleted_v1"]({
+        chat_id: "oc_group_1",
+      });
+      await handlers["im.chat.member.user.added_v1"]({
+        chat_id: "oc_group_1",
+        users: [
+          { name: "Alice", user_id: { open_id: "ou_alice", union_id: "on_alice" } },
+          { name: "Ghost", user_id: { union_id: "on_ghost" } },
+          { name: "Bob", user_id: { open_id: "ou_bob" } },
+        ],
+      });
+      await handlers["im.chat.member.user.deleted_v1"]({
+        chat_id: "oc_group_1",
+        users: [
+          { name: "Alice", user_id: { open_id: "ou_alice", union_id: "on_alice" } },
+          { name: "NoOpen", user_id: { union_id: "on_none" } },
+        ],
+      });
+      await handlers["im.chat.member.user.withdrawn_v1"]({
+        chat_id: "oc_group_1",
+        users: [
+          { name: "Bob", user_id: { open_id: "ou_bob", union_id: "on_bob" } },
+          { name: "NoOpen", user_id: {} },
+        ],
+      });
+
+      expect(hookRunnerMocks.runChatMemberBotAdded).toHaveBeenCalledWith(
+        { chatId: "oc_group_1" },
+        { channelId: "feishu", accountId: "default" },
+      );
+      expect(hookRunnerMocks.runChatMemberBotDeleted).toHaveBeenCalledWith(
+        { chatId: "oc_group_1" },
+        { channelId: "feishu", accountId: "default" },
+      );
+      expect(hookRunnerMocks.runChatMemberUserAdded).toHaveBeenCalledWith(
+        {
+          chatId: "oc_group_1",
+          users: [
+            { openId: "ou_alice", unionId: "on_alice", name: "Alice" },
+            { openId: "ou_bob", unionId: undefined, name: "Bob" },
+          ],
+        },
+        { channelId: "feishu", accountId: "default" },
+      );
+      expect(hookRunnerMocks.runChatMemberUserDeleted).toHaveBeenCalledWith(
+        {
+          chatId: "oc_group_1",
+          users: [{ openId: "ou_alice", unionId: "on_alice", name: "Alice" }],
+        },
+        { channelId: "feishu", accountId: "default" },
+      );
+      expect(hookRunnerMocks.runChatMemberUserWithdrawn).toHaveBeenCalledWith(
+        {
+          chatId: "oc_group_1",
+          users: [{ openId: "ou_bob", unionId: "on_bob", name: "Bob" }],
+        },
+        { channelId: "feishu", accountId: "default" },
+      );
+    } finally {
+      await stop();
+    }
+  });
+
+  it("skips member relay when hook is not registered or chat_id is empty", async () => {
+    const { handlers, stop } = await startMonitorAndGetHandlers();
+    try {
+      hookRunnerMocks.hasHooks.mockReturnValue(false);
+      await handlers["im.chat.member.bot.added_v1"]({ chat_id: "oc_group_1" });
+      await handlers["im.chat.member.user.added_v1"]({
+        chat_id: "oc_group_1",
+        users: [{ name: "Alice", user_id: { open_id: "ou_alice" } }],
+      });
+      expect(hookRunnerMocks.runChatMemberBotAdded).not.toHaveBeenCalled();
+      expect(hookRunnerMocks.runChatMemberUserAdded).not.toHaveBeenCalled();
+
+      hookRunnerMocks.hasHooks.mockReturnValue(true);
+      await handlers["im.chat.member.bot.deleted_v1"]({ chat_id: "" });
+      await handlers["im.chat.member.user.deleted_v1"]({
+        chat_id: "",
+        users: [{ name: "Alice", user_id: { open_id: "ou_alice" } }],
+      });
+      await handlers["im.chat.member.user.withdrawn_v1"]({
+        users: [{ name: "Alice", user_id: { open_id: "ou_alice" } }],
+      });
+      expect(hookRunnerMocks.runChatMemberBotDeleted).not.toHaveBeenCalled();
+      expect(hookRunnerMocks.runChatMemberUserDeleted).not.toHaveBeenCalled();
+      expect(hookRunnerMocks.runChatMemberUserWithdrawn).not.toHaveBeenCalled();
+    } finally {
+      await stop();
+    }
+  });
+
+  it("logs recalled events with account attribution and recall metadata", async () => {
+    const { handlers, logMock, errorMock, stop } = await startMonitorAndGetHandlers();
+    try {
+      await handlers["im.message.recalled_v1"]({
+        message_id: "om_recalled_1",
+        chat_id: "oc_group_1",
+        recall_time: "1741175699887",
+        operator_id: { open_id: "ou_operator" },
+        message: {
+          sender_id: { open_id: "ou_sender" },
+          root_id: "om_root_1",
+          thread_id: "omt_thread_1",
+        },
+      });
+
+      const recalledLogLine = logMock.mock.calls
+        .map((call) => call[0])
+        .find((value) => typeof value === "string" && value.includes("message recalled"));
+      expect(recalledLogLine).toBe(
+        "feishu[default]: message recalled chat=oc_group_1 message=om_recalled_1 " +
+          "operator=ou_operator sender=ou_sender root=om_root_1 " +
+          "thread=omt_thread_1 recall_time=1741175699887",
+      );
+      expect(errorMock).not.toHaveBeenCalledWith(
+        expect.stringContaining("error handling message recalled event"),
+      );
+    } finally {
+      await stop();
+    }
+  });
+});

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -370,6 +370,74 @@ describe("resolveReactionSyntheticEvent", () => {
   });
 });
 
+describe("monitorSingleAccount recalled event logging", () => {
+  it("logs recalled event metadata for per-account attribution", async () => {
+    handlers = {};
+    vi.clearAllMocks();
+    setFeishuRuntime(
+      createPluginRuntimeMock({
+        channel: {
+          debounce: {
+            createInboundDebouncer,
+            resolveInboundDebounceMs,
+          },
+          text: {
+            hasControlCommand,
+          },
+        },
+      }),
+    );
+    const register = vi.fn((registered: Record<string, (data: unknown) => Promise<void>>) => {
+      handlers = registered;
+    });
+    createEventDispatcherMock.mockReturnValue({ register });
+    const log = vi.fn();
+    const error = vi.fn();
+
+    await monitorSingleAccount({
+      cfg,
+      account: buildDebounceAccount(),
+      runtime: {
+        log,
+        error,
+        exit: vi.fn(),
+      } as RuntimeEnv,
+      botOpenIdSource: { kind: "prefetched", botOpenId: "ou_bot" },
+    });
+
+    const onRecalled = handlers["im.message.recalled_v1"];
+    if (!onRecalled) {
+      throw new Error("missing im.message.recalled_v1 handler");
+    }
+
+    await onRecalled({
+      message: {
+        message_id: "om_recalled_nested",
+        chat_id: "oc_group_nested",
+        sender: {
+          id: { open_id: "ou_sender_nested" },
+        },
+        root_id: "om_root_nested",
+        thread_id: "omt_thread_nested",
+      },
+      action_time: "1741175699887",
+      user_id: { open_id: "ou_operator_nested" },
+    });
+
+    const recalledLogLine = log.mock.calls
+      .map((call) => call[0])
+      .find((value) => typeof value === "string" && value.includes("message recalled"));
+    expect(recalledLogLine).toBe(
+      "feishu[default]: message recalled chat=oc_group_nested message=om_recalled_nested " +
+        "operator=ou_operator_nested sender=ou_sender_nested root=om_root_nested " +
+        "thread=omt_thread_nested recall_time=1741175699887",
+    );
+    expect(error).not.toHaveBeenCalledWith(
+      expect.stringContaining("error handling message recalled event"),
+    );
+  });
+});
+
 describe("Feishu inbound debounce regressions", () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -14,6 +14,7 @@ import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-actio
 import { createFeishuWSClient, createEventDispatcher } from "./client.js";
 import { fetchBotOpenIdForMonitor } from "./monitor.startup.js";
 import { getMessageFeishu } from "./send.js";
+import { createFeishuThreadBindingManager } from "./thread-bindings.manager.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 export type MonitorFeishuOpts = {
@@ -620,6 +621,26 @@ async function monitorSingleAccount(params: MonitorAccountParams): Promise<void>
   if (connectionMode === "webhook" && !account.verificationToken?.trim()) {
     throw new Error(`Feishu account "${accountId}" webhook mode requires verificationToken`);
   }
+
+  const threadBindingManager = createFeishuThreadBindingManager({
+    accountId,
+    cfg,
+    persist: true,
+    enableSweeper: true,
+  });
+  log(`feishu[${accountId}]: thread binding adapter registered`);
+
+  if (abortSignal) {
+    abortSignal.addEventListener(
+      "abort",
+      () => {
+        threadBindingManager.stop();
+        log(`feishu[${accountId}]: thread binding adapter stopped`);
+      },
+      { once: true },
+    );
+  }
+
   const eventDispatcher = createEventDispatcher(account);
   const chatHistories = new Map<string, HistoryEntry[]>();
 

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -12,7 +12,7 @@ import { resolveFeishuAccount, listEnabledFeishuAccounts } from "./accounts.js";
 import { handleFeishuMessage, type FeishuMessageEvent, type FeishuBotAddedEvent } from "./bot.js";
 import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-action.js";
 import { createFeishuWSClient, createEventDispatcher } from "./client.js";
-import { probeFeishu } from "./probe.js";
+import { fetchBotOpenIdForMonitor } from "./monitor.startup.js";
 import { getMessageFeishu } from "./send.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
@@ -43,6 +43,17 @@ export type FeishuReactionCreatedEvent = {
   operator_type?: string;
   user_id?: { open_id?: string };
   action_time?: string;
+};
+
+type FeishuMessageRecalledEvent = {
+  message_id?: string;
+  chat_id?: string;
+  recall_time?: string;
+  action_time?: string;
+  operator_id?: unknown;
+  user_id?: unknown;
+  deleter_id?: unknown;
+  message?: unknown;
 };
 
 type ResolveReactionSyntheticEventParams = {
@@ -235,15 +246,97 @@ export async function resolveReactionSyntheticEvent(
   };
 }
 
+function asNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value && typeof value === "object") {
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+function pickFirstString(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function resolveOpenIdLike(value: unknown): string | undefined {
+  const record = asRecord(value);
+  if (!record) {
+    return undefined;
+  }
+  return pickFirstString(
+    asNonEmptyString(record.open_id),
+    asNonEmptyString(record.user_id),
+    asNonEmptyString(record.union_id),
+    resolveOpenIdLike(record.sender_id),
+    resolveOpenIdLike(record.id),
+    resolveOpenIdLike(record.user),
+  );
+}
+
+function buildRecalledEventSummary(eventData: unknown): {
+  messageId: string;
+  chatId: string;
+  operatorOpenId: string;
+  senderOpenId: string;
+  rootId: string;
+  threadId: string;
+  recallTime: string;
+} {
+  const event = (eventData as FeishuMessageRecalledEvent | undefined) ?? {};
+  const message = asRecord(event.message);
+  const messageSender = asRecord(message?.sender);
+  return {
+    messageId:
+      pickFirstString(asNonEmptyString(event.message_id), asNonEmptyString(message?.message_id)) ??
+      "unknown",
+    chatId:
+      pickFirstString(asNonEmptyString(event.chat_id), asNonEmptyString(message?.chat_id)) ??
+      "unknown",
+    operatorOpenId:
+      pickFirstString(
+        resolveOpenIdLike(event.operator_id),
+        resolveOpenIdLike(event.deleter_id),
+        resolveOpenIdLike(event.user_id),
+        resolveOpenIdLike(message?.recalled_by),
+        resolveOpenIdLike(message?.deleted_by),
+      ) ?? "unknown",
+    senderOpenId:
+      pickFirstString(resolveOpenIdLike(message?.sender_id), resolveOpenIdLike(messageSender)) ??
+      "unknown",
+    rootId: asNonEmptyString(message?.root_id) ?? "unknown",
+    threadId: asNonEmptyString(message?.thread_id) ?? "unknown",
+    recallTime:
+      pickFirstString(
+        asNonEmptyString(event.recall_time),
+        asNonEmptyString(event.action_time),
+        asNonEmptyString(message?.update_time),
+      ) ?? "unknown",
+  };
+}
+
 export function getBotOpenId(accountId: string): string | undefined {
   const value = botOpenIds.get(accountId)?.trim();
   return value ? value : undefined;
 }
 
-async function fetchBotOpenId(account: ResolvedFeishuAccount): Promise<string | undefined> {
+async function fetchBotOpenId(
+  account: ResolvedFeishuAccount,
+  options: { runtime?: RuntimeEnv; abortSignal?: AbortSignal } = {},
+): Promise<string | undefined> {
   try {
-    const result = await probeFeishu(account);
-    return result.ok ? result.botOpenId : undefined;
+    return await fetchBotOpenIdForMonitor(account, options);
   } catch {
     return undefined;
   }
@@ -296,6 +389,18 @@ function registerEventHandlers(
     },
     "im.message.message_read_v1": async () => {
       // Ignore read receipts
+    },
+    "im.message.recalled_v1": async (data) => {
+      try {
+        const summary = buildRecalledEventSummary(data);
+        log(
+          `feishu[${accountId}]: message recalled chat=${summary.chatId} message=${summary.messageId} ` +
+            `operator=${summary.operatorOpenId} sender=${summary.senderOpenId} ` +
+            `root=${summary.rootId} thread=${summary.threadId} recall_time=${summary.recallTime}`,
+        );
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling message recalled event: ${String(err)}`);
+      }
     },
     "im.chat.member.bot.added_v1": async (data) => {
       try {
@@ -492,6 +597,7 @@ type MonitorAccountParams = {
   account: ResolvedFeishuAccount;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
+  botOpenIdSource?: { kind: "prefetched"; botOpenId?: string } | { kind: "fetch" };
 };
 
 /**
@@ -502,8 +608,11 @@ async function monitorSingleAccount(params: MonitorAccountParams): Promise<void>
   const { accountId } = account;
   const log = runtime?.log ?? console.log;
 
-  // Fetch bot open_id
-  const botOpenId = await fetchBotOpenId(account);
+  const botOpenIdSource = params.botOpenIdSource ?? { kind: "fetch" as const };
+  const botOpenId =
+    botOpenIdSource.kind === "prefetched"
+      ? botOpenIdSource.botOpenId
+      : await fetchBotOpenIdForMonitor(account, { runtime, abortSignal });
   botOpenIds.set(accountId, botOpenId ?? "");
   log(`feishu[${accountId}]: bot open_id resolved: ${botOpenId ?? "unknown"}`);
 
@@ -703,7 +812,23 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
     `feishu: starting ${accounts.length} account(s): ${accounts.map((a) => a.accountId).join(", ")}`,
   );
 
-  // Start all accounts in parallel
+  // Probe bot info sequentially so startup does not burst requests across accounts.
+  const prefetchedBotOpenIds = new Map<string, string | undefined>();
+  for (const account of accounts) {
+    if (opts.abortSignal?.aborted) {
+      break;
+    }
+    prefetchedBotOpenIds.set(
+      account.accountId,
+      await fetchBotOpenId(account, { runtime: opts.runtime, abortSignal: opts.abortSignal }),
+    );
+  }
+
+  if (opts.abortSignal?.aborted) {
+    return;
+  }
+
+  // Start account monitors in parallel after preflight completes.
   await Promise.all(
     accounts.map((account) =>
       monitorSingleAccount({
@@ -711,6 +836,10 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
         account,
         runtime: opts.runtime,
         abortSignal: opts.abortSignal,
+        botOpenIdSource: {
+          kind: "prefetched",
+          botOpenId: prefetchedBotOpenIds.get(account.accountId),
+        },
       }),
     ),
   );

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -1,17 +1,20 @@
-import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk/feishu";
-import { listEnabledFeishuAccounts, resolveFeishuAccount } from "./accounts.js";
+import * as crypto from "crypto";
+import * as http from "http";
+import * as Lark from "@larksuiteoapi/node-sdk";
 import {
-  monitorSingleAccount,
-  resolveReactionSyntheticEvent,
-  type FeishuReactionCreatedEvent,
-} from "./monitor.account.js";
-import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
-import {
-  clearFeishuWebhookRateLimitStateForTest,
-  getFeishuWebhookRateLimitStateSizeForTest,
-  isWebhookRateLimitedForTest,
-  stopFeishuMonitorState,
-} from "./monitor.state.js";
+  type ClawdbotConfig,
+  type RuntimeEnv,
+  type HistoryEntry,
+  getGlobalHookRunner,
+  installRequestBodyLimitGuard,
+} from "openclaw/plugin-sdk";
+import { resolveFeishuAccount, listEnabledFeishuAccounts } from "./accounts.js";
+import { handleFeishuMessage, type FeishuMessageEvent, type FeishuBotAddedEvent } from "./bot.js";
+import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-action.js";
+import { createFeishuWSClient, createEventDispatcher } from "./client.js";
+import { probeFeishu } from "./probe.js";
+import { getMessageFeishu } from "./send.js";
+import type { ResolvedFeishuAccount } from "./types.js";
 
 export type MonitorFeishuOpts = {
   config?: ClawdbotConfig;
@@ -20,14 +23,654 @@ export type MonitorFeishuOpts = {
   accountId?: string;
 };
 
-export {
-  clearFeishuWebhookRateLimitStateForTest,
-  getFeishuWebhookRateLimitStateSizeForTest,
-  isWebhookRateLimitedForTest,
-  resolveReactionSyntheticEvent,
-};
-export type { FeishuReactionCreatedEvent };
+// Per-account WebSocket clients, HTTP servers, and bot info
+const wsClients = new Map<string, Lark.WSClient>();
+const httpServers = new Map<string, http.Server>();
+const botOpenIds = new Map<string, string>();
+const FEISHU_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
+const FEISHU_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
+const FEISHU_WEBHOOK_RATE_LIMIT_WINDOW_MS = 60_000;
+const FEISHU_WEBHOOK_RATE_LIMIT_MAX_REQUESTS = 120;
+const FEISHU_WEBHOOK_RATE_LIMIT_MAX_TRACKED_KEYS = 4_096;
+const FEISHU_WEBHOOK_COUNTER_LOG_EVERY = 25;
+const FEISHU_REACTION_VERIFY_TIMEOUT_MS = 1_500;
 
+export type FeishuReactionCreatedEvent = {
+  message_id: string;
+  chat_id?: string;
+  chat_type?: "p2p" | "group";
+  reaction_type?: { emoji_type?: string };
+  operator_type?: string;
+  user_id?: { open_id?: string };
+  action_time?: string;
+};
+
+type ResolveReactionSyntheticEventParams = {
+  cfg: ClawdbotConfig;
+  accountId: string;
+  event: FeishuReactionCreatedEvent;
+  botOpenId?: string;
+  fetchMessage?: typeof getMessageFeishu;
+  verificationTimeoutMs?: number;
+  logger?: (message: string) => void;
+  uuid?: () => string;
+};
+
+const feishuWebhookRateLimits = new Map<string, { count: number; windowStartMs: number }>();
+const feishuWebhookStatusCounters = new Map<string, number>();
+let lastWebhookRateLimitCleanupMs = 0;
+
+function isJsonContentType(value: string | string[] | undefined): boolean {
+  const first = Array.isArray(value) ? value[0] : value;
+  if (!first) {
+    return false;
+  }
+  const mediaType = first.split(";", 1)[0]?.trim().toLowerCase();
+  return mediaType === "application/json" || Boolean(mediaType?.endsWith("+json"));
+}
+
+function trimWebhookRateLimitState(): void {
+  while (feishuWebhookRateLimits.size > FEISHU_WEBHOOK_RATE_LIMIT_MAX_TRACKED_KEYS) {
+    const oldestKey = feishuWebhookRateLimits.keys().next().value;
+    if (typeof oldestKey !== "string") {
+      break;
+    }
+    feishuWebhookRateLimits.delete(oldestKey);
+  }
+}
+
+function maybePruneWebhookRateLimitState(nowMs: number): void {
+  if (
+    feishuWebhookRateLimits.size === 0 ||
+    nowMs - lastWebhookRateLimitCleanupMs < FEISHU_WEBHOOK_RATE_LIMIT_WINDOW_MS
+  ) {
+    return;
+  }
+  lastWebhookRateLimitCleanupMs = nowMs;
+  for (const [key, state] of feishuWebhookRateLimits) {
+    if (nowMs - state.windowStartMs >= FEISHU_WEBHOOK_RATE_LIMIT_WINDOW_MS) {
+      feishuWebhookRateLimits.delete(key);
+    }
+  }
+}
+
+export function clearFeishuWebhookRateLimitStateForTest(): void {
+  feishuWebhookRateLimits.clear();
+  lastWebhookRateLimitCleanupMs = 0;
+}
+
+export function getFeishuWebhookRateLimitStateSizeForTest(): number {
+  return feishuWebhookRateLimits.size;
+}
+
+export function isWebhookRateLimitedForTest(key: string, nowMs: number): boolean {
+  maybePruneWebhookRateLimitState(nowMs);
+
+  const state = feishuWebhookRateLimits.get(key);
+  if (!state || nowMs - state.windowStartMs >= FEISHU_WEBHOOK_RATE_LIMIT_WINDOW_MS) {
+    feishuWebhookRateLimits.set(key, { count: 1, windowStartMs: nowMs });
+    trimWebhookRateLimitState();
+    return false;
+  }
+
+  state.count += 1;
+  if (state.count > FEISHU_WEBHOOK_RATE_LIMIT_MAX_REQUESTS) {
+    return true;
+  }
+  return false;
+}
+
+function isWebhookRateLimited(key: string, nowMs: number): boolean {
+  return isWebhookRateLimitedForTest(key, nowMs);
+}
+
+function recordWebhookStatus(
+  runtime: RuntimeEnv | undefined,
+  accountId: string,
+  path: string,
+  statusCode: number,
+): void {
+  if (![400, 401, 408, 413, 415, 429].includes(statusCode)) {
+    return;
+  }
+  const key = `${accountId}:${path}:${statusCode}`;
+  const next = (feishuWebhookStatusCounters.get(key) ?? 0) + 1;
+  feishuWebhookStatusCounters.set(key, next);
+  if (next === 1 || next % FEISHU_WEBHOOK_COUNTER_LOG_EVERY === 0) {
+    const log = runtime?.log ?? console.log;
+    log(`feishu[${accountId}]: webhook anomaly path=${path} status=${statusCode} count=${next}`);
+  }
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | null> {
+  let timeoutId: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race<T | null>([
+      promise,
+      new Promise<null>((resolve) => {
+        timeoutId = setTimeout(() => resolve(null), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+export async function resolveReactionSyntheticEvent(
+  params: ResolveReactionSyntheticEventParams,
+): Promise<FeishuMessageEvent | null> {
+  const {
+    cfg,
+    accountId,
+    event,
+    botOpenId,
+    fetchMessage = getMessageFeishu,
+    verificationTimeoutMs = FEISHU_REACTION_VERIFY_TIMEOUT_MS,
+    logger,
+    uuid = () => crypto.randomUUID(),
+  } = params;
+
+  const emoji = event.reaction_type?.emoji_type;
+  const messageId = event.message_id;
+  const senderId = event.user_id?.open_id;
+  if (!emoji || !messageId || !senderId) {
+    return null;
+  }
+
+  const account = resolveFeishuAccount({ cfg, accountId });
+  const reactionNotifications = account.config.reactionNotifications ?? "own";
+  if (reactionNotifications === "off") {
+    return null;
+  }
+
+  // Skip bot self-reactions
+  if (event.operator_type === "app" || senderId === botOpenId) {
+    return null;
+  }
+
+  // Skip typing indicator emoji
+  if (emoji === "Typing") {
+    return null;
+  }
+
+  if (reactionNotifications === "own" && !botOpenId) {
+    logger?.(
+      `feishu[${accountId}]: bot open_id unavailable, skipping reaction ${emoji} on ${messageId}`,
+    );
+    return null;
+  }
+
+  const reactedMsg = await withTimeout(
+    fetchMessage({ cfg, messageId, accountId }),
+    verificationTimeoutMs,
+  ).catch(() => null);
+  const isBotMessage = reactedMsg?.senderType === "app" || reactedMsg?.senderOpenId === botOpenId;
+  if (!reactedMsg || (reactionNotifications === "own" && !isBotMessage)) {
+    logger?.(
+      `feishu[${accountId}]: ignoring reaction on non-bot/unverified message ${messageId} ` +
+        `(sender: ${reactedMsg?.senderOpenId ?? "unknown"})`,
+    );
+    return null;
+  }
+
+  const syntheticChatIdRaw = event.chat_id ?? reactedMsg.chatId;
+  const syntheticChatId = syntheticChatIdRaw?.trim() ? syntheticChatIdRaw : `p2p:${senderId}`;
+  const syntheticChatType: "p2p" | "group" = event.chat_type ?? "p2p";
+  return {
+    sender: {
+      sender_id: { open_id: senderId },
+      sender_type: "user",
+    },
+    message: {
+      message_id: `${messageId}:reaction:${emoji}:${uuid()}`,
+      chat_id: syntheticChatId,
+      chat_type: syntheticChatType,
+      message_type: "text",
+      content: JSON.stringify({
+        text: `[reacted with ${emoji} to message ${messageId}]`,
+      }),
+    },
+  };
+}
+
+export function getBotOpenId(accountId: string): string | undefined {
+  const value = botOpenIds.get(accountId)?.trim();
+  return value ? value : undefined;
+}
+
+async function fetchBotOpenId(account: ResolvedFeishuAccount): Promise<string | undefined> {
+  try {
+    const result = await probeFeishu(account);
+    return result.ok ? result.botOpenId : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Register common event handlers on an EventDispatcher.
+ * When fireAndForget is true (webhook mode), message handling is not awaited
+ * to avoid blocking the HTTP response (Lark requires <3s response).
+ */
+function registerEventHandlers(
+  eventDispatcher: Lark.EventDispatcher,
+  context: {
+    cfg: ClawdbotConfig;
+    accountId: string;
+    runtime?: RuntimeEnv;
+    chatHistories: Map<string, HistoryEntry[]>;
+    fireAndForget?: boolean;
+  },
+) {
+  const { cfg, accountId, runtime, chatHistories, fireAndForget } = context;
+  const log = runtime?.log ?? console.log;
+  const error = runtime?.error ?? console.error;
+
+  eventDispatcher.register({
+    "im.message.receive_v1": async (data) => {
+      try {
+        const event = data as unknown as FeishuMessageEvent;
+        const promise = handleFeishuMessage({
+          cfg,
+          event,
+          botOpenId: botOpenIds.get(accountId),
+          botOpenIdsByAccount: Object.fromEntries(
+            Array.from(botOpenIds.entries()).map(([id, openId]) => [id, openId || undefined]),
+          ),
+          runtime,
+          chatHistories,
+          accountId,
+        });
+        if (fireAndForget) {
+          promise.catch((err) => {
+            error(`feishu[${accountId}]: error handling message: ${String(err)}`);
+          });
+        } else {
+          await promise;
+        }
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling message: ${String(err)}`);
+      }
+    },
+    "im.message.message_read_v1": async () => {
+      // Ignore read receipts
+    },
+    "im.chat.member.bot.added_v1": async (data) => {
+      try {
+        const event = data as unknown as FeishuBotAddedEvent;
+        log(`feishu[${accountId}]: bot added to chat ${event.chat_id}`);
+        if (!event.chat_id) return;
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_bot_added")) {
+          void hookRunner.runChatMemberBotAdded(
+            { chatId: event.chat_id },
+            { channelId: "feishu", accountId },
+          );
+        }
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling bot added event: ${String(err)}`);
+      }
+    },
+    "im.chat.member.bot.deleted_v1": async (data) => {
+      try {
+        const event = data as unknown as { chat_id: string };
+        log(`feishu[${accountId}]: bot removed from chat ${event.chat_id}`);
+        if (!event.chat_id) return;
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_bot_deleted")) {
+          void hookRunner.runChatMemberBotDeleted(
+            { chatId: event.chat_id },
+            { channelId: "feishu", accountId },
+          );
+        }
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling bot removed event: ${String(err)}`);
+      }
+    },
+    "im.chat.member.user.added_v1": async (data) => {
+      try {
+        const event = data as unknown as {
+          chat_id?: string;
+          users?: Array<{
+            name?: string;
+            user_id?: { open_id?: string; union_id?: string };
+          }>;
+        };
+        log(`feishu[${accountId}]: users added to chat ${event.chat_id}`);
+        if (!event.chat_id) return;
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_user_added")) {
+          const users = (event.users ?? [])
+            .filter((u) => !!u.user_id?.open_id)
+            .map((u) => ({
+              openId: u.user_id!.open_id!,
+              unionId: u.user_id?.union_id,
+              name: u.name,
+            }));
+          void hookRunner.runChatMemberUserAdded(
+            { chatId: event.chat_id, users },
+            { channelId: "feishu", accountId },
+          );
+        }
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling user added event: ${String(err)}`);
+      }
+    },
+    "im.chat.member.user.deleted_v1": async (data) => {
+      try {
+        const event = data as unknown as {
+          chat_id?: string;
+          users?: Array<{
+            name?: string;
+            user_id?: { open_id?: string; union_id?: string };
+          }>;
+        };
+        log(`feishu[${accountId}]: users deleted from chat ${event.chat_id}`);
+        if (!event.chat_id) return;
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_user_deleted")) {
+          const users = (event.users ?? [])
+            .filter((u) => !!u.user_id?.open_id)
+            .map((u) => ({
+              openId: u.user_id!.open_id!,
+              unionId: u.user_id?.union_id,
+              name: u.name,
+            }));
+          void hookRunner.runChatMemberUserDeleted(
+            { chatId: event.chat_id, users },
+            { channelId: "feishu", accountId },
+          );
+        }
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling user deleted event: ${String(err)}`);
+      }
+    },
+    "im.chat.member.user.withdrawn_v1": async (data) => {
+      try {
+        const event = data as unknown as {
+          chat_id?: string;
+          users?: Array<{
+            name?: string;
+            user_id?: { open_id?: string; union_id?: string };
+          }>;
+        };
+        log(`feishu[${accountId}]: users withdrawn from chat ${event.chat_id}`);
+        if (!event.chat_id) return;
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("chat_member_user_withdrawn")) {
+          const users = (event.users ?? [])
+            .filter((u) => !!u.user_id?.open_id)
+            .map((u) => ({
+              openId: u.user_id!.open_id!,
+              unionId: u.user_id?.union_id,
+              name: u.name,
+            }));
+          void hookRunner.runChatMemberUserWithdrawn(
+            { chatId: event.chat_id, users },
+            { channelId: "feishu", accountId },
+          );
+        }
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling user withdrawn event: ${String(err)}`);
+      }
+    },
+    "im.message.reaction.created_v1": async (data) => {
+      const processReaction = async () => {
+        const event = data as FeishuReactionCreatedEvent;
+        const myBotId = botOpenIds.get(accountId);
+        const syntheticEvent = await resolveReactionSyntheticEvent({
+          cfg,
+          accountId,
+          event,
+          botOpenId: myBotId,
+          logger: log,
+        });
+        if (!syntheticEvent) {
+          return;
+        }
+        const promise = handleFeishuMessage({
+          cfg,
+          event: syntheticEvent,
+          botOpenId: myBotId,
+          runtime,
+          chatHistories,
+          accountId,
+        });
+        if (fireAndForget) {
+          promise.catch((err) => {
+            error(`feishu[${accountId}]: error handling reaction: ${String(err)}`);
+          });
+          return;
+        }
+        await promise;
+      };
+
+      if (fireAndForget) {
+        void processReaction().catch((err) => {
+          error(`feishu[${accountId}]: error handling reaction event: ${String(err)}`);
+        });
+        return;
+      }
+
+      try {
+        await processReaction();
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling reaction event: ${String(err)}`);
+      }
+    },
+    "im.message.reaction.deleted_v1": async () => {
+      // Ignore reaction removals
+    },
+    "card.action.trigger": async (data: unknown) => {
+      try {
+        const event = data as unknown as FeishuCardActionEvent;
+        const promise = handleFeishuCardAction({
+          cfg,
+          event,
+          botOpenId: botOpenIds.get(accountId),
+          runtime,
+          accountId,
+        });
+        if (fireAndForget) {
+          promise.catch((err) => {
+            error(`feishu[${accountId}]: error handling card action: ${String(err)}`);
+          });
+        } else {
+          await promise;
+        }
+      } catch (err) {
+        error(`feishu[${accountId}]: error handling card action: ${String(err)}`);
+      }
+    },
+  });
+}
+
+type MonitorAccountParams = {
+  cfg: ClawdbotConfig;
+  account: ResolvedFeishuAccount;
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+};
+
+/**
+ * Monitor a single Feishu account.
+ */
+async function monitorSingleAccount(params: MonitorAccountParams): Promise<void> {
+  const { cfg, account, runtime, abortSignal } = params;
+  const { accountId } = account;
+  const log = runtime?.log ?? console.log;
+
+  // Fetch bot open_id
+  const botOpenId = await fetchBotOpenId(account);
+  botOpenIds.set(accountId, botOpenId ?? "");
+  log(`feishu[${accountId}]: bot open_id resolved: ${botOpenId ?? "unknown"}`);
+
+  const connectionMode = account.config.connectionMode ?? "websocket";
+  if (connectionMode === "webhook" && !account.verificationToken?.trim()) {
+    throw new Error(`Feishu account "${accountId}" webhook mode requires verificationToken`);
+  }
+  const eventDispatcher = createEventDispatcher(account);
+  const chatHistories = new Map<string, HistoryEntry[]>();
+
+  registerEventHandlers(eventDispatcher, {
+    cfg,
+    accountId,
+    runtime,
+    chatHistories,
+    fireAndForget: connectionMode === "webhook",
+  });
+
+  if (connectionMode === "webhook") {
+    return monitorWebhook({ params, accountId, eventDispatcher });
+  }
+
+  return monitorWebSocket({ params, accountId, eventDispatcher });
+}
+
+type ConnectionParams = {
+  params: MonitorAccountParams;
+  accountId: string;
+  eventDispatcher: Lark.EventDispatcher;
+};
+
+async function monitorWebSocket({
+  params,
+  accountId,
+  eventDispatcher,
+}: ConnectionParams): Promise<void> {
+  const { account, runtime, abortSignal } = params;
+  const log = runtime?.log ?? console.log;
+  const error = runtime?.error ?? console.error;
+
+  log(`feishu[${accountId}]: starting WebSocket connection...`);
+
+  const wsClient = createFeishuWSClient(account);
+  wsClients.set(accountId, wsClient);
+
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      wsClients.delete(accountId);
+      botOpenIds.delete(accountId);
+    };
+
+    const handleAbort = () => {
+      log(`feishu[${accountId}]: abort signal received, stopping`);
+      cleanup();
+      resolve();
+    };
+
+    if (abortSignal?.aborted) {
+      cleanup();
+      resolve();
+      return;
+    }
+
+    abortSignal?.addEventListener("abort", handleAbort, { once: true });
+
+    try {
+      wsClient.start({ eventDispatcher });
+      log(`feishu[${accountId}]: WebSocket client started`);
+    } catch (err) {
+      cleanup();
+      abortSignal?.removeEventListener("abort", handleAbort);
+      reject(err);
+    }
+  });
+}
+
+async function monitorWebhook({
+  params,
+  accountId,
+  eventDispatcher,
+}: ConnectionParams): Promise<void> {
+  const { account, runtime, abortSignal } = params;
+  const log = runtime?.log ?? console.log;
+  const error = runtime?.error ?? console.error;
+
+  const port = account.config.webhookPort ?? 3000;
+  const path = account.config.webhookPath ?? "/feishu/events";
+  const host = account.config.webhookHost ?? "127.0.0.1";
+
+  log(`feishu[${accountId}]: starting Webhook server on ${host}:${port}, path ${path}...`);
+
+  const server = http.createServer();
+  const webhookHandler = Lark.adaptDefault(path, eventDispatcher, { autoChallenge: true });
+  server.on("request", (req, res) => {
+    res.on("finish", () => {
+      recordWebhookStatus(runtime, accountId, path, res.statusCode);
+    });
+
+    const rateLimitKey = `${accountId}:${path}:${req.socket.remoteAddress ?? "unknown"}`;
+    if (isWebhookRateLimited(rateLimitKey, Date.now())) {
+      res.statusCode = 429;
+      res.end("Too Many Requests");
+      return;
+    }
+
+    if (req.method === "POST" && !isJsonContentType(req.headers["content-type"])) {
+      res.statusCode = 415;
+      res.end("Unsupported Media Type");
+      return;
+    }
+
+    const guard = installRequestBodyLimitGuard(req, res, {
+      maxBytes: FEISHU_WEBHOOK_MAX_BODY_BYTES,
+      timeoutMs: FEISHU_WEBHOOK_BODY_TIMEOUT_MS,
+      responseFormat: "text",
+    });
+    if (guard.isTripped()) {
+      return;
+    }
+    void Promise.resolve(webhookHandler(req, res))
+      .catch((err) => {
+        if (!guard.isTripped()) {
+          error(`feishu[${accountId}]: webhook handler error: ${String(err)}`);
+        }
+      })
+      .finally(() => {
+        guard.dispose();
+      });
+  });
+  httpServers.set(accountId, server);
+
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      server.close();
+      httpServers.delete(accountId);
+      botOpenIds.delete(accountId);
+    };
+
+    const handleAbort = () => {
+      log(`feishu[${accountId}]: abort signal received, stopping Webhook server`);
+      cleanup();
+      resolve();
+    };
+
+    if (abortSignal?.aborted) {
+      cleanup();
+      resolve();
+      return;
+    }
+
+    abortSignal?.addEventListener("abort", handleAbort, { once: true });
+
+    server.listen(port, host, () => {
+      log(`feishu[${accountId}]: Webhook server listening on ${host}:${port}`);
+    });
+
+    server.on("error", (err) => {
+      error(`feishu[${accountId}]: Webhook server error: ${err}`);
+      abortSignal?.removeEventListener("abort", handleAbort);
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Main entry: start monitoring for all enabled accounts.
+ */
 export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promise<void> {
   const cfg = opts.config;
   if (!cfg) {
@@ -36,6 +679,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
 
   const log = opts.runtime?.log ?? console.log;
 
+  // If accountId is specified, only monitor that account
   if (opts.accountId) {
     const account = resolveFeishuAccount({ cfg, accountId: opts.accountId });
     if (!account.enabled || !account.configured) {
@@ -49,6 +693,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
     });
   }
 
+  // Otherwise, start all enabled accounts
   const accounts = listEnabledFeishuAccounts(cfg);
   if (accounts.length === 0) {
     throw new Error("No enabled Feishu accounts configured");
@@ -58,38 +703,37 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
     `feishu: starting ${accounts.length} account(s): ${accounts.map((a) => a.accountId).join(", ")}`,
   );
 
-  const monitorPromises: Promise<void>[] = [];
-  for (const account of accounts) {
-    if (opts.abortSignal?.aborted) {
-      log("feishu: abort signal received during startup preflight; stopping startup");
-      break;
-    }
-
-    // Probe sequentially so large multi-account startups do not burst Feishu's bot-info endpoint.
-    const { botOpenId, botName } = await fetchBotIdentityForMonitor(account, {
-      runtime: opts.runtime,
-      abortSignal: opts.abortSignal,
-    });
-
-    if (opts.abortSignal?.aborted) {
-      log("feishu: abort signal received during startup preflight; stopping startup");
-      break;
-    }
-
-    monitorPromises.push(
+  // Start all accounts in parallel
+  await Promise.all(
+    accounts.map((account) =>
       monitorSingleAccount({
         cfg,
         account,
         runtime: opts.runtime,
         abortSignal: opts.abortSignal,
-        botOpenIdSource: { kind: "prefetched", botOpenId, botName },
       }),
-    );
-  }
-
-  await Promise.all(monitorPromises);
+    ),
+  );
 }
 
+/**
+ * Stop monitoring for a specific account or all accounts.
+ */
 export function stopFeishuMonitor(accountId?: string): void {
-  stopFeishuMonitorState(accountId);
+  if (accountId) {
+    wsClients.delete(accountId);
+    const server = httpServers.get(accountId);
+    if (server) {
+      server.close();
+      httpServers.delete(accountId);
+    }
+    botOpenIds.delete(accountId);
+  } else {
+    wsClients.clear();
+    for (const server of httpServers.values()) {
+      server.close();
+    }
+    httpServers.clear();
+    botOpenIds.clear();
+  }
 }

--- a/extensions/feishu/src/quoted-message.test.ts
+++ b/extensions/feishu/src/quoted-message.test.ts
@@ -1,0 +1,459 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
+import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  registerLiveSessionTranscript,
+  resetLiveSessionTranscriptRegistryForTests,
+} from "../../../src/agents/pi-embedded-runner/live-session-registry.js";
+import { appendAssistantMessageToSessionTranscript } from "../../../src/config/sessions.js";
+import { resolveQuotedFeishuMessageContent } from "./quoted-message.js";
+
+function createSessionFixture() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-feishu-quoted-"));
+  const storePath = path.join(dir, "sessions.json");
+  const sessionId = "sess-quoted-1";
+  const sessionKey = "agent:main:feishu:dm:ou-attacker";
+  const sessionFile = path.join(dir, `${sessionId}.jsonl`);
+
+  fs.writeFileSync(
+    storePath,
+    JSON.stringify({
+      [sessionKey]: {
+        sessionId,
+        updatedAt: Date.now(),
+        sessionFile,
+      },
+    }),
+    "utf-8",
+  );
+
+  return { dir, storePath, sessionId, sessionKey, sessionFile };
+}
+
+function ensureSessionHeader(sessionFile: string, sessionId: string) {
+  fs.writeFileSync(
+    sessionFile,
+    `${JSON.stringify({
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: sessionId,
+      timestamp: new Date().toISOString(),
+      cwd: process.cwd(),
+    })}\n`,
+    "utf-8",
+  );
+}
+
+function appendUserTurn(params: {
+  sessionFile: string;
+  messageId: string;
+  body: string;
+  contentType?: "text" | "input_text";
+}) {
+  const sessionManager = SessionManager.open(params.sessionFile);
+  sessionManager.appendMessage({
+    role: "user",
+    content: [
+      {
+        type: params.contentType ?? "text",
+        text: [
+          "Conversation info (untrusted metadata):",
+          "```json",
+          JSON.stringify({ message_id: params.messageId }, null, 2),
+          "```",
+          "",
+          params.body,
+        ].join("\n"),
+      },
+    ],
+    timestamp: Date.now(),
+  });
+  // SessionManager only flushes buffered turns after an assistant message exists.
+  // Append a noop assistant turn so the quoted user message is actually persisted.
+  sessionManager.appendMessage({
+    role: "assistant",
+    content: [{ type: "text", text: "noop" }],
+    api: "openai-responses",
+    provider: "openclaw",
+    model: "test-helper",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+  });
+}
+
+function appendAssistantTurn(params: {
+  sessionFile: string;
+  body: string;
+  contentType?: "text" | "output_text";
+  messageMeta?: Record<string, unknown>;
+}) {
+  const sessionManager = SessionManager.open(params.sessionFile);
+  sessionManager.appendMessage({
+    role: "assistant",
+    content: [{ type: params.contentType ?? "text", text: params.body }],
+    api: "openai-responses",
+    provider: "openclaw",
+    model: "test-helper",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        total: 0,
+      },
+    },
+    stopReason: "stop",
+    timestamp: Date.now(),
+    ...(params.messageMeta ? { openclawMessageMeta: params.messageMeta } : {}),
+  });
+}
+
+function createBotCompanyDb(
+  dbPath: string,
+  rows: Array<{ chatId: string; messageId: string; content: string }>,
+) {
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+CREATE TABLE chat_messages (
+  chat_id TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  content TEXT NOT NULL,
+  PRIMARY KEY (chat_id, message_id)
+);
+`);
+  const insert = db.prepare(
+    `INSERT INTO chat_messages (chat_id, message_id, content) VALUES (?, ?, ?)`,
+  );
+  for (const row of rows) {
+    insert.run(row.chatId, row.messageId, row.content);
+  }
+  db.close();
+}
+
+describe("resolveQuotedFeishuMessageContent", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(() => {
+    resetLiveSessionTranscriptRegistryForTests();
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (dir) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("prefers the session transcript for user reply targets in DMs", async () => {
+    const fixture = createSessionFixture();
+    cleanupDirs.push(fixture.dir);
+    ensureSessionHeader(fixture.sessionFile, fixture.sessionId);
+    appendUserTurn({
+      sessionFile: fixture.sessionFile,
+      messageId: "om_parent_ctx",
+      body: "完整用户原文",
+    });
+
+    const fetchMessage = vi.fn(async () => null);
+    const result = await resolveQuotedFeishuMessageContent({
+      cfg: { session: { store: fixture.storePath } } as ClawdbotConfig,
+      accountId: "default",
+      agentId: "main",
+      sessionKey: fixture.sessionKey,
+      chatId: "oc_dm_1",
+      parentId: "om_parent_ctx",
+      isGroup: false,
+      storePath: fixture.storePath,
+      fetchMessage,
+    });
+
+    expect(result).toEqual({ content: "完整用户原文", source: "session" });
+    expect(fetchMessage).not.toHaveBeenCalled();
+  });
+
+  it("reads DM quoted user content from input_text transcript blocks", async () => {
+    const fixture = createSessionFixture();
+    cleanupDirs.push(fixture.dir);
+    ensureSessionHeader(fixture.sessionFile, fixture.sessionId);
+    appendUserTurn({
+      sessionFile: fixture.sessionFile,
+      messageId: "om_parent_input_text",
+      body: "input_text 里的完整原文",
+      contentType: "input_text",
+    });
+
+    const fetchMessage = vi.fn(async () => null);
+    const result = await resolveQuotedFeishuMessageContent({
+      cfg: { session: { store: fixture.storePath } } as ClawdbotConfig,
+      accountId: "default",
+      agentId: "main",
+      sessionKey: fixture.sessionKey,
+      chatId: "oc_dm_1",
+      parentId: "om_parent_input_text",
+      isGroup: false,
+      storePath: fixture.storePath,
+      fetchMessage,
+    });
+
+    expect(result).toEqual({ content: "input_text 里的完整原文", source: "session" });
+    expect(fetchMessage).not.toHaveBeenCalled();
+  });
+
+  it("prefers the live session transcript before the jsonl transcript in DMs", async () => {
+    const fixture = createSessionFixture();
+    cleanupDirs.push(fixture.dir);
+    ensureSessionHeader(fixture.sessionFile, fixture.sessionId);
+
+    const sessionManager = SessionManager.open(fixture.sessionFile);
+    sessionManager.appendMessage({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: [
+            "Conversation info (untrusted metadata):",
+            "```json",
+            JSON.stringify({ message_id: "om_parent_live" }, null, 2),
+            "```",
+            "",
+            "来自 live session 的完整原文",
+          ].join("\n"),
+        },
+      ],
+      timestamp: Date.now(),
+    });
+    const unregister = registerLiveSessionTranscript({
+      sessionKey: fixture.sessionKey,
+      sessionId: fixture.sessionId,
+      sessionReader: sessionManager,
+    });
+
+    try {
+      const fetchMessage = vi.fn(async () => null);
+      const result = await resolveQuotedFeishuMessageContent({
+        cfg: { session: { store: fixture.storePath } } as ClawdbotConfig,
+        accountId: "default",
+        agentId: "main",
+        sessionKey: fixture.sessionKey,
+        chatId: "oc_dm_1",
+        parentId: "om_parent_live",
+        isGroup: false,
+        storePath: fixture.storePath,
+        fetchMessage,
+      });
+
+      expect(result).toEqual({ content: "来自 live session 的完整原文", source: "session" });
+      expect(fetchMessage).not.toHaveBeenCalled();
+    } finally {
+      unregister();
+    }
+  });
+
+  it("matches mirrored assistant replies in the session transcript by provider message id", async () => {
+    const fixture = createSessionFixture();
+    cleanupDirs.push(fixture.dir);
+
+    await appendAssistantMessageToSessionTranscript({
+      storePath: fixture.storePath,
+      sessionKey: fixture.sessionKey,
+      text: "完整 bot 回复",
+      messageMeta: {
+        channel: "feishu",
+        accountId: "default",
+        chatId: "oc_dm_1",
+        chatType: "direct",
+        providerMessageId: "om_bot_2",
+        providerMessageIds: ["om_bot_1", "om_bot_2"],
+      },
+    });
+
+    const fetchMessage = vi.fn(async () => null);
+    const result = await resolveQuotedFeishuMessageContent({
+      cfg: { session: { store: fixture.storePath } } as ClawdbotConfig,
+      accountId: "default",
+      agentId: "main",
+      sessionKey: fixture.sessionKey,
+      chatId: "oc_dm_1",
+      parentId: "om_bot_1",
+      isGroup: false,
+      storePath: fixture.storePath,
+      fetchMessage,
+    });
+
+    expect(result).toEqual({ content: "完整 bot 回复", source: "session" });
+    expect(fetchMessage).not.toHaveBeenCalled();
+  });
+
+  it("reads mirrored assistant replies from output_text transcript blocks", async () => {
+    const fixture = createSessionFixture();
+    cleanupDirs.push(fixture.dir);
+    ensureSessionHeader(fixture.sessionFile, fixture.sessionId);
+    appendAssistantTurn({
+      sessionFile: fixture.sessionFile,
+      body: "output_text 里的完整 bot 回复",
+      contentType: "output_text",
+      messageMeta: {
+        channel: "feishu",
+        accountId: "default",
+        chatId: "oc_dm_1",
+        chatType: "direct",
+        providerMessageId: "om_bot_output_2",
+        providerMessageIds: ["om_bot_output_1", "om_bot_output_2"],
+      },
+    });
+
+    const fetchMessage = vi.fn(async () => null);
+    const result = await resolveQuotedFeishuMessageContent({
+      cfg: { session: { store: fixture.storePath } } as ClawdbotConfig,
+      accountId: "default",
+      agentId: "main",
+      sessionKey: fixture.sessionKey,
+      chatId: "oc_dm_1",
+      parentId: "om_bot_output_1",
+      isGroup: false,
+      storePath: fixture.storePath,
+      fetchMessage,
+    });
+
+    expect(result).toEqual({ content: "output_text 里的完整 bot 回复", source: "session" });
+    expect(fetchMessage).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the bot-company DB when the session transcript misses", async () => {
+    const fixture = createSessionFixture();
+    cleanupDirs.push(fixture.dir);
+    ensureSessionHeader(fixture.sessionFile, fixture.sessionId);
+
+    const dbPath = path.join(fixture.dir, "bot-company.db");
+    createBotCompanyDb(dbPath, [
+      { chatId: "oc_dm_1", messageId: "om_parent_db", content: "来自 DB 的完整内容" },
+    ]);
+
+    const fetchMessage = vi.fn(async () => null);
+    const result = await resolveQuotedFeishuMessageContent({
+      cfg: {
+        session: { store: fixture.storePath },
+        plugins: {
+          entries: {
+            "bot-company": {
+              config: {
+                dbPath,
+              },
+            },
+          },
+        },
+      } as ClawdbotConfig,
+      accountId: "default",
+      agentId: "main",
+      sessionKey: fixture.sessionKey,
+      chatId: "oc_dm_1",
+      parentId: "om_parent_db",
+      isGroup: false,
+      storePath: fixture.storePath,
+      fetchMessage,
+    });
+
+    expect(result).toEqual({ content: "来自 DB 的完整内容", source: "db" });
+    expect(fetchMessage).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Feishu API when session transcript and DB both miss", async () => {
+    const fixture = createSessionFixture();
+    cleanupDirs.push(fixture.dir);
+    ensureSessionHeader(fixture.sessionFile, fixture.sessionId);
+
+    const fetchMessage = vi.fn(async () => ({
+      messageId: "om_parent_api",
+      chatId: "oc_dm_1",
+      content: "来自 API 的降级内容",
+      contentType: "text",
+    }));
+
+    const result = await resolveQuotedFeishuMessageContent({
+      cfg: { session: { store: fixture.storePath } } as ClawdbotConfig,
+      accountId: "default",
+      agentId: "main",
+      sessionKey: fixture.sessionKey,
+      chatId: "oc_dm_1",
+      parentId: "om_parent_api",
+      isGroup: false,
+      storePath: fixture.storePath,
+      fetchMessage,
+    });
+
+    expect(result).toEqual({ content: "来自 API 的降级内容", source: "api" });
+    expect(fetchMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips session and DB lookup for group replies", async () => {
+    const fixture = createSessionFixture();
+    cleanupDirs.push(fixture.dir);
+    ensureSessionHeader(fixture.sessionFile, fixture.sessionId);
+    appendUserTurn({
+      sessionFile: fixture.sessionFile,
+      messageId: "om_parent_group",
+      body: "群聊 session 命中内容",
+    });
+
+    const dbPath = path.join(fixture.dir, "bot-company.db");
+    createBotCompanyDb(dbPath, [
+      { chatId: "oc_group_1", messageId: "om_parent_group", content: "群聊 DB 内容" },
+    ]);
+
+    const fetchMessage = vi.fn(async () => ({
+      messageId: "om_parent_group",
+      chatId: "oc_group_1",
+      content: "群聊 API 内容",
+      contentType: "text",
+    }));
+
+    const result = await resolveQuotedFeishuMessageContent({
+      cfg: {
+        session: { store: fixture.storePath },
+        plugins: {
+          entries: {
+            "bot-company": {
+              config: {
+                dbPath,
+              },
+            },
+          },
+        },
+      } as ClawdbotConfig,
+      accountId: "default",
+      agentId: "main",
+      sessionKey: fixture.sessionKey,
+      chatId: "oc_group_1",
+      parentId: "om_parent_group",
+      isGroup: true,
+      storePath: fixture.storePath,
+      fetchMessage,
+    });
+
+    expect(result).toEqual({ content: "群聊 API 内容", source: "api" });
+    expect(fetchMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/feishu/src/quoted-message.ts
+++ b/extensions/feishu/src/quoted-message.ts
@@ -1,0 +1,409 @@
+import fs from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import { getLiveSessionTranscriptEntries } from "../../../src/agents/pi-embedded-runner/live-session-registry.js";
+import {
+  loadSessionStore,
+  resolveSessionFilePath,
+  resolveSessionFilePathOptions,
+  type SessionEntry,
+  type SessionTranscriptMessageMeta,
+} from "../../../src/config/sessions.js";
+import { stripEnvelopeFromMessage } from "../../../src/gateway/chat-sanitize.js";
+import { resolveUserPath } from "../../../src/utils.js";
+import { getFeishuRuntime } from "./runtime.js";
+import { getMessageFeishu, type FeishuMessageInfo } from "./send.js";
+
+type QuotedMessageSource = "session" | "db" | "api";
+
+export type ResolvedQuotedFeishuMessage = {
+  content?: string;
+  source?: QuotedMessageSource;
+};
+
+type FetchQuotedMessage = (params: {
+  cfg: ClawdbotConfig;
+  messageId: string;
+  accountId?: string;
+}) => Promise<FeishuMessageInfo | null>;
+
+function toNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function extractMessageText(message: Record<string, unknown>): string | undefined {
+  const directContent = toNonEmptyString(message.content);
+  if (directContent) {
+    return directContent;
+  }
+  if (Array.isArray(message.content)) {
+    const parts = message.content
+      .map((item) => {
+        if (!item || typeof item !== "object") {
+          return undefined;
+        }
+        const record = item as Record<string, unknown>;
+        if (
+          record.type !== "text" &&
+          record.type !== "input_text" &&
+          record.type !== "output_text"
+        ) {
+          return undefined;
+        }
+        return toNonEmptyString(record.text);
+      })
+      .filter((value): value is string => Boolean(value));
+    if (parts.length > 0) {
+      return parts.join("\n");
+    }
+  }
+  return toNonEmptyString(message.text);
+}
+
+function extractSanitizedMessageText(message: Record<string, unknown>): string | undefined {
+  const sanitized = stripEnvelopeFromMessage(message);
+  if (!sanitized || typeof sanitized !== "object") {
+    return undefined;
+  }
+  return extractMessageText(sanitized as Record<string, unknown>);
+}
+
+function extractConversationInfo(text: string): Record<string, unknown> | null {
+  const match = text.match(
+    /(?:^|\n)Conversation info \(untrusted metadata\):\n```json\n([\s\S]*?)\n```/,
+  );
+  if (!match?.[1]) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(match[1]);
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveTranscriptPath(params: {
+  storePath: string;
+  agentId?: string;
+  sessionKey: string;
+}): string | undefined {
+  const store = loadSessionStore(params.storePath, { skipCache: true });
+  const entry = store[params.sessionKey] as SessionEntry | undefined;
+  if (!entry?.sessionId) {
+    return undefined;
+  }
+  return resolveSessionFilePath(
+    entry.sessionId,
+    entry,
+    resolveSessionFilePathOptions({
+      agentId: params.agentId,
+      storePath: params.storePath,
+    }),
+  );
+}
+
+function resolveSessionEntry(params: {
+  storePath: string;
+  sessionKey: string;
+}): SessionEntry | undefined {
+  const store = loadSessionStore(params.storePath, { skipCache: true });
+  return store[params.sessionKey] as SessionEntry | undefined;
+}
+
+function resolveMirroredProviderMessageIds(meta: SessionTranscriptMessageMeta): string[] {
+  const ids = new Set<string>();
+  const providerMessageId = toNonEmptyString(meta.providerMessageId);
+  if (providerMessageId) {
+    ids.add(providerMessageId);
+  }
+  if (Array.isArray(meta.providerMessageIds)) {
+    for (const value of meta.providerMessageIds) {
+      const id = toNonEmptyString(value);
+      if (id) {
+        ids.add(id);
+      }
+    }
+  }
+  return [...ids];
+}
+
+function matchesMirroredAssistantMessage(params: {
+  meta: SessionTranscriptMessageMeta;
+  parentId: string;
+  accountId?: string;
+  chatId: string;
+}): boolean {
+  const channel = toNonEmptyString(params.meta.channel)?.toLowerCase();
+  if (channel && channel !== "feishu") {
+    return false;
+  }
+  const accountId = toNonEmptyString(params.meta.accountId);
+  if (accountId && params.accountId && accountId !== params.accountId) {
+    return false;
+  }
+  const chatId = toNonEmptyString(params.meta.chatId);
+  if (chatId && chatId !== params.chatId) {
+    return false;
+  }
+  return resolveMirroredProviderMessageIds(params.meta).includes(params.parentId);
+}
+
+function findQuotedContentInEntries(
+  entries: unknown[],
+  params: {
+    parentId: string;
+    accountId?: string;
+    chatId: string;
+  },
+): string | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const parsed = entries[index];
+    if (!parsed || typeof parsed !== "object") {
+      continue;
+    }
+    const entry = parsed as Record<string, unknown>;
+    if (entry.type !== "message") {
+      continue;
+    }
+    const message =
+      entry.message && typeof entry.message === "object"
+        ? (entry.message as Record<string, unknown>)
+        : null;
+    if (!message) {
+      continue;
+    }
+
+    const role = toNonEmptyString(message.role)?.toLowerCase();
+    if (role === "user") {
+      const rawText = extractMessageText(message);
+      const conversationInfo = rawText ? extractConversationInfo(rawText) : null;
+      if (toNonEmptyString(conversationInfo?.message_id) !== params.parentId) {
+        continue;
+      }
+      return extractSanitizedMessageText(message);
+    }
+
+    if (role === "assistant") {
+      const meta =
+        message.openclawMessageMeta && typeof message.openclawMessageMeta === "object"
+          ? (message.openclawMessageMeta as SessionTranscriptMessageMeta)
+          : undefined;
+      if (
+        !meta ||
+        !matchesMirroredAssistantMessage({
+          meta,
+          parentId: params.parentId,
+          accountId: params.accountId,
+          chatId: params.chatId,
+        })
+      ) {
+        continue;
+      }
+      return extractSanitizedMessageText(message);
+    }
+  }
+
+  return undefined;
+}
+
+function readQuotedContentFromLiveSession(params: {
+  storePath: string;
+  sessionKey: string;
+  parentId: string;
+  accountId?: string;
+  chatId: string;
+}): string | undefined {
+  const sessionEntry = resolveSessionEntry({
+    storePath: params.storePath,
+    sessionKey: params.sessionKey,
+  });
+  const entries = getLiveSessionTranscriptEntries({
+    sessionKey: params.sessionKey,
+    sessionId: sessionEntry?.sessionId,
+  });
+  if (!entries || entries.length === 0) {
+    return undefined;
+  }
+  return findQuotedContentInEntries(entries, {
+    parentId: params.parentId,
+    accountId: params.accountId,
+    chatId: params.chatId,
+  });
+}
+
+function readQuotedContentFromSession(params: {
+  storePath: string;
+  agentId?: string;
+  sessionKey: string;
+  parentId: string;
+  accountId?: string;
+  chatId: string;
+}): string | undefined {
+  const sessionFile = resolveTranscriptPath({
+    storePath: params.storePath,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+  });
+  if (!sessionFile || !fs.existsSync(sessionFile)) {
+    return undefined;
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(sessionFile, "utf-8");
+  } catch {
+    return undefined;
+  }
+  if (!raw.trim()) {
+    return undefined;
+  }
+
+  const entries = raw
+    .split("\n")
+    .filter((line) => line.trim())
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+
+  return findQuotedContentInEntries(entries, {
+    parentId: params.parentId,
+    accountId: params.accountId,
+    chatId: params.chatId,
+  });
+}
+
+function resolveBotCompanyDbPath(cfg: ClawdbotConfig, override?: string): string | undefined {
+  const explicit = toNonEmptyString(override);
+  if (explicit) {
+    return explicit;
+  }
+  const entry = cfg.plugins?.entries?.["bot-company"];
+  const pluginConfig =
+    entry?.config && typeof entry.config === "object"
+      ? (entry.config as Record<string, unknown>)
+      : undefined;
+  const nestedDb =
+    pluginConfig?.db && typeof pluginConfig.db === "object"
+      ? (pluginConfig.db as Record<string, unknown>)
+      : undefined;
+  return toNonEmptyString(pluginConfig?.dbPath) ?? toNonEmptyString(nestedDb?.path);
+}
+
+function readQuotedContentFromBotCompanyDb(params: {
+  cfg: ClawdbotConfig;
+  chatId: string;
+  parentId: string;
+  dbPath?: string;
+}): string | undefined {
+  const rawDbPath = resolveBotCompanyDbPath(params.cfg, params.dbPath);
+  if (!rawDbPath || rawDbPath === ":memory:") {
+    return undefined;
+  }
+
+  const dbPath = resolveUserPath(rawDbPath);
+  if (!dbPath || !fs.existsSync(dbPath)) {
+    return undefined;
+  }
+
+  let db: DatabaseSync | undefined;
+  try {
+    db = new DatabaseSync(dbPath, { readOnly: true });
+    const row = db
+      .prepare(
+        `SELECT content
+         FROM chat_messages
+         WHERE chat_id = ? AND message_id = ?
+         LIMIT 1`,
+      )
+      .get(params.chatId, params.parentId) as { content?: unknown } | undefined;
+    return toNonEmptyString(row?.content);
+  } catch {
+    return undefined;
+  } finally {
+    db?.close();
+  }
+}
+
+export async function resolveQuotedFeishuMessageContent(params: {
+  cfg: ClawdbotConfig;
+  accountId?: string;
+  agentId?: string;
+  sessionKey?: string;
+  chatId: string;
+  parentId: string;
+  isGroup: boolean;
+  storePath?: string;
+  dbPath?: string;
+  fetchMessage?: FetchQuotedMessage;
+}): Promise<ResolvedQuotedFeishuMessage> {
+  const parentId = toNonEmptyString(params.parentId);
+  if (!parentId) {
+    return {};
+  }
+
+  const fetchMessage = params.fetchMessage ?? getMessageFeishu;
+
+  if (!params.isGroup) {
+    const sessionKey = toNonEmptyString(params.sessionKey);
+    const storePath =
+      toNonEmptyString(params.storePath) ??
+      (sessionKey
+        ? getFeishuRuntime().channel.session.resolveStorePath(params.cfg.session?.store, {
+            agentId: params.agentId,
+          })
+        : undefined);
+
+    if (storePath && sessionKey) {
+      const liveSessionContent = readQuotedContentFromLiveSession({
+        storePath,
+        sessionKey,
+        parentId,
+        accountId: params.accountId,
+        chatId: params.chatId,
+      });
+      if (liveSessionContent) {
+        return { content: liveSessionContent, source: "session" };
+      }
+
+      const sessionContent = readQuotedContentFromSession({
+        storePath,
+        agentId: params.agentId,
+        sessionKey,
+        parentId,
+        accountId: params.accountId,
+        chatId: params.chatId,
+      });
+      if (sessionContent) {
+        return { content: sessionContent, source: "session" };
+      }
+    }
+
+    const dbContent = readQuotedContentFromBotCompanyDb({
+      cfg: params.cfg,
+      chatId: params.chatId,
+      parentId,
+      dbPath: params.dbPath,
+    });
+    if (dbContent) {
+      return { content: dbContent, source: "db" };
+    }
+  }
+
+  const apiResult = await fetchMessage({
+    cfg: params.cfg,
+    messageId: parentId,
+    accountId: params.accountId,
+  });
+  const apiContent = toNonEmptyString(apiResult?.content);
+  return apiContent ? { content: apiContent, source: "api" } : {};
+}

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -67,10 +67,10 @@ vi.mock("./streaming-card.js", () => ({
 
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 
-async function flushAsyncTasks(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
+async function flushAsyncTasks(iterations = 8): Promise<void> {
+  for (let i = 0; i < iterations; i += 1) {
+    await Promise.resolve();
+  }
 }
 
 describe("createFeishuReplyDispatcher streaming behavior", () => {
@@ -113,6 +113,9 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
           createReplyDispatcherWithTyping: createReplyDispatcherWithTypingMock,
           resolveHumanDelayConfig: vi.fn(() => undefined),
         },
+      },
+      hooks: {
+        emitMessageSent: vi.fn(),
       },
     });
   });
@@ -516,11 +519,14 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     await flushAsyncTasks();
     expect(streamingInstances[0].update).toHaveBeenLastCalledWith(
       "🔧 已使用 2 个工具，正在处理...\n---\n第一段答案",
+      { mode: "replace" },
     );
 
     await dispatcher.replyOptions.onPartialReply?.({ text: "第一段答案\n第二段答案" });
     await flushAsyncTasks();
-    expect(streamingInstances[0].update).toHaveBeenLastCalledWith("第一段答案\n第二段答案");
+    expect(streamingInstances[0].update).toHaveBeenLastCalledWith("第一段答案\n第二段答案", {
+      mode: "replace",
+    });
 
     await options.onIdle?.();
     expect(streamingInstances[0].close).toHaveBeenCalledWith("第一段答案\n第二段答案");
@@ -876,6 +882,52 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(onFinalTextDelivered).toHaveBeenCalledWith({
       text: "@Trent 请继续",
       messageId: "om_final_1",
+      messageIds: ["om_final_1"],
+      chatId: "oc_chat",
+      accountId: "main",
+    });
+  });
+
+  it("emits every provider message id for chunked non-streaming final text replies", async () => {
+    const onFinalTextDelivered = vi.fn(async () => {});
+    sendMessageFeishuMock
+      .mockResolvedValueOnce({ messageId: "om_chunk_1", chatId: "oc_chat" })
+      .mockResolvedValueOnce({ messageId: "om_chunk_2", chatId: "oc_chat" });
+    getFeishuRuntimeMock.mockReturnValue({
+      channel: {
+        text: {
+          resolveTextChunkLimit: vi.fn(() => 16),
+          resolveChunkMode: vi.fn(() => "line"),
+          resolveMarkdownTableMode: vi.fn(() => "preserve"),
+          convertMarkdownTables: vi.fn((text) => text),
+          chunkTextWithMode: vi.fn(() => ["第一段", "第二段"]),
+        },
+        reply: {
+          createReplyDispatcherWithTyping: createReplyDispatcherWithTypingMock,
+          resolveHumanDelayConfig: vi.fn(() => undefined),
+        },
+      },
+      hooks: {
+        emitMessageSent: vi.fn(),
+      },
+    });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+      onFinalTextDelivered,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "第一段\n第二段" }, { kind: "final" });
+
+    expect(onFinalTextDelivered).toHaveBeenCalledTimes(1);
+    expect(onFinalTextDelivered).toHaveBeenCalledWith({
+      text: "第一段\n第二段",
+      messageId: "om_chunk_2",
+      messageIds: ["om_chunk_1", "om_chunk_2"],
       chatId: "oc_chat",
       accountId: "main",
     });

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -45,6 +45,7 @@ vi.mock("./streaming-card.js", () => ({
   },
   FeishuStreamingSession: class {
     active = false;
+    messageId = "om_stream_1";
     start = vi.fn(async () => {
       this.active = true;
     });
@@ -52,7 +53,11 @@ vi.mock("./streaming-card.js", () => ({
     close = vi.fn(async () => {
       this.active = false;
     });
+    discard = vi.fn(async () => {
+      this.active = false;
+    });
     isActive = vi.fn(() => this.active);
+    getMessageId = vi.fn(() => this.messageId);
 
     constructor() {
       streamingInstances.push(this);
@@ -61,6 +66,12 @@ vi.mock("./streaming-card.js", () => ({
 }));
 
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
+
+async function flushAsyncTasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 describe("createFeishuReplyDispatcher streaming behavior", () => {
   beforeEach(() => {
@@ -219,6 +230,57 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMediaFeishuMock).not.toHaveBeenCalled();
   });
 
+  it("does not force streaming in auto mode for reasoning/tool events without card content", async () => {
+    const dispatcher = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await dispatcher.replyOptions.onReasoningStream?.({ text: "reasoning...", isReasoning: true });
+    await flushAsyncTasks();
+    await dispatcher.replyOptions.onToolStart?.({ name: "Read", phase: "start" });
+    await flushAsyncTasks();
+
+    expect(streamingInstances).toHaveLength(0);
+
+    await options.deliver({ text: "plain text" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(0);
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("renders staged thinking status with first partial text chunk in auto mode", async () => {
+    const dispatcher = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    await dispatcher.replyOptions.onPartialReply?.({ text: "第一段答案" });
+    await flushAsyncTasks();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].update).toHaveBeenNthCalledWith(
+      1,
+      "💭 思考中...\n---\n第一段答案",
+      {
+        mode: "replace",
+      },
+    );
+    expect(streamingInstances[0].update).toHaveBeenNthCalledWith(2, "第一段答案", {
+      mode: "replace",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.onIdle?.();
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("第一段答案");
+  });
+
   it("uses streaming session for auto mode markdown payloads", async () => {
     createFeishuReplyDispatcher({
       cfg: {} as never,
@@ -374,7 +436,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
   });
 
-  it("treats block updates as delta chunks", async () => {
+  it("stages thinking prelude on assistant message start without opening a card", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
       appId: "app_id",
@@ -386,22 +448,169 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const result = createFeishuReplyDispatcher({
+    const dispatcher = createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
       runtime: { log: vi.fn(), error: vi.fn() } as never,
       chatId: "oc_chat",
     });
 
+    await dispatcher.replyOptions.onAssistantMessageStart?.();
+    await flushAsyncTasks();
+
+    expect(streamingInstances).toHaveLength(0);
+
     const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
-    await options.onReplyStart?.();
-    await result.replyOptions.onPartialReply?.({ text: "hello" });
-    await options.deliver({ text: "lo world" }, { kind: "block" });
     await options.onIdle?.();
+    expect(streamingInstances).toHaveLength(0);
+  });
+
+  it("stages thinking/tool status lines until first text chunk and keeps final close content text-only", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+
+    const dispatcher = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+
+    await dispatcher.replyOptions.onReasoningStream?.({
+      text: "Reasoning:\n_step_",
+      isReasoning: true,
+    });
+    await flushAsyncTasks();
+
+    expect(streamingInstances).toHaveLength(0);
+
+    await dispatcher.replyOptions.onToolStart?.({ name: "Read", phase: "start" });
+    await flushAsyncTasks();
+
+    expect(streamingInstances).toHaveLength(0);
+
+    await dispatcher.replyOptions.onPartialReply?.({ text: "第一段答案" });
+    await flushAsyncTasks();
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].update).toHaveBeenNthCalledWith(
+      1,
+      "🔧 正在使用Read工具...\n---\n第一段答案",
+      {
+        mode: "replace",
+      },
+    );
+    expect(streamingInstances[0].update).toHaveBeenNthCalledWith(2, "第一段答案", {
+      mode: "replace",
+    });
+
+    await dispatcher.replyOptions.onToolStart?.({ name: "Grep", phase: "start" });
+    await flushAsyncTasks();
+    expect(streamingInstances[0].update).toHaveBeenLastCalledWith(
+      "🔧 已使用 2 个工具，正在处理...\n---\n第一段答案",
+    );
+
+    await dispatcher.replyOptions.onPartialReply?.({ text: "第一段答案\n第二段答案" });
+    await flushAsyncTasks();
+    expect(streamingInstances[0].update).toHaveBeenLastCalledWith("第一段答案\n第二段答案");
+
+    await options.onIdle?.();
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("第一段答案\n第二段答案");
+  });
+
+  it("stages tool status when tool event is first and renders with first text", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+
+    const dispatcher = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    await dispatcher.replyOptions.onToolStart?.({ name: "Read", phase: "start" });
+    await flushAsyncTasks();
+
+    expect(streamingInstances).toHaveLength(0);
+
+    await dispatcher.replyOptions.onPartialReply?.({ text: "第一段答案" });
+    await flushAsyncTasks();
 
     expect(streamingInstances).toHaveLength(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledWith("hellolo world");
+    expect(streamingInstances[0].update).toHaveBeenNthCalledWith(
+      1,
+      "🔧 正在使用Read工具...\n---\n第一段答案",
+      {
+        mode: "replace",
+      },
+    );
+    expect(streamingInstances[0].update).toHaveBeenNthCalledWith(2, "第一段答案", {
+      mode: "replace",
+    });
+  });
+
+  it("replaces pre-tool status text when the first post-tool partial restarts the answer", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+
+    const dispatcher = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    await dispatcher.replyOptions.onPartialReply?.({ text: "**Checking SEO JSON-LD in PR #16**" });
+    await flushAsyncTasks();
+    await dispatcher.replyOptions.onToolStart?.({ name: "Read", phase: "start" });
+    await flushAsyncTasks();
+    await dispatcher.replyOptions.onPartialReply?.({
+      text: '<at user_id="ou_luke">Luke</at> 加了。',
+    });
+    await flushAsyncTasks();
+    await dispatcher.replyOptions.onPartialReply?.({
+      text: '<at user_id="ou_luke">Luke</at> 加了。\n我刚又确认了一遍',
+    });
+    await flushAsyncTasks();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].update).toHaveBeenLastCalledWith(
+      "<at id=ou_luke></at> 加了。\n我刚又确认了一遍",
+      {
+        mode: "replace",
+      },
+    );
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.onIdle?.();
+    expect(streamingInstances[0].close).toHaveBeenCalledWith(
+      "<at id=ou_luke></at> 加了。\n我刚又确认了一遍",
+    );
   });
 
   it("sends media-only payloads as attachments", async () => {
@@ -547,7 +756,33 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
-  it("disables streaming for thread replies and keeps reply metadata", async () => {
+  it("uses streaming for thread replies and keeps reply metadata when streamingInThread is enabled", async () => {
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+      replyToMessageId: "om_msg",
+      replyInThread: false,
+      streamingInThread: true,
+      threadReply: true,
+      rootId: "om_root_topic",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].start).toHaveBeenCalledWith("oc_chat", "chat_id", {
+      replyToMessageId: "om_msg",
+      replyInThread: true,
+      rootId: "om_root_topic",
+    });
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("disables streaming for thread replies by default", async () => {
     createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
@@ -571,6 +806,36 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
   });
 
+  it("does not create streaming card when final content is empty", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+
+    const dispatcher = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    await dispatcher.replyOptions.onReasoningStream?.({ text: "thinking", isReasoning: true });
+    await flushAsyncTasks();
+    await dispatcher.replyOptions.onToolStart?.({ name: "Read", phase: "start" });
+    await flushAsyncTasks();
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(0);
+  });
+
   it("passes replyInThread to media attachments", async () => {
     createFeishuReplyDispatcher({
       cfg: {} as never,
@@ -589,6 +854,95 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
         replyToMessageId: "om_msg",
         replyInThread: true,
       }),
+    );
+  });
+
+  it("emits onFinalTextDelivered for non-streaming final text replies", async () => {
+    const onFinalTextDelivered = vi.fn(async () => {});
+    sendMessageFeishuMock.mockResolvedValue({ messageId: "om_final_1", chatId: "oc_chat" });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+      onFinalTextDelivered,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "@Trent 请继续" }, { kind: "final" });
+
+    expect(onFinalTextDelivered).toHaveBeenCalledTimes(1);
+    expect(onFinalTextDelivered).toHaveBeenCalledWith({
+      text: "@Trent 请继续",
+      messageId: "om_final_1",
+      chatId: "oc_chat",
+      accountId: "main",
+    });
+  });
+
+  it("emits onFinalTextDelivered when streaming closes with final text", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+    const onFinalTextDelivered = vi.fn(async () => {});
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+      onFinalTextDelivered,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "最终回复内容" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(onFinalTextDelivered).toHaveBeenCalledTimes(1);
+    expect(onFinalTextDelivered).toHaveBeenCalledWith({
+      text: "最终回复内容",
+      messageId: "om_stream_1",
+      chatId: "oc_chat",
+      accountId: "main",
+    });
+  });
+
+  it("normalizes user_id mention tags before closing streaming card", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver(
+      { text: '是 <at user_id="ou_vivi">Vivi（薇薇）</at> 的回合，不是我' },
+      { kind: "final" },
+    );
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledWith(
+      "是 <at id=ou_vivi></at> 的回合，不是我",
     );
   });
 });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -52,6 +52,8 @@ export type CreateFeishuReplyDispatcherParams = {
   rootId?: string;
   mentionTargets?: MentionTarget[];
   accountId?: string;
+  /** Bot open_id used to identify this app's typing reaction during cleanup lookup. */
+  botOpenId?: string;
   /** Epoch ms when the inbound message was created. Used to suppress typing
    *  indicators on old/replayed messages after context compaction (#30418). */
   messageCreateTimeMs?: number;
@@ -143,6 +145,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         cfg,
         messageId: replyToMessageId,
         accountId,
+        botOpenId: params.botOpenId,
         runtime: params.runtime,
       });
     },
@@ -193,6 +196,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streamingStartPromise: Promise<void> | null = null;
   let finalTextEmitted = false;
   let replaceNextPartialAfterTool = false;
+  const deliveredFinalTexts = new Set<string>();
 
   const emitFinalTextIfNeeded = async (
     text: string,
@@ -447,6 +451,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
       onReplyStart: () => {
+        deliveredFinalTexts.clear();
         if (streamingEnabled && renderMode === "card") {
           startStreaming();
         }
@@ -462,12 +467,17 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               : [];
         const hasText = Boolean(text.trim());
         const hasMedia = mediaList.length > 0;
+        // Suppress only exact duplicate final text payloads to avoid
+        // dropping legitimate multi-part final replies.
+        const skipTextForDuplicateFinal =
+          info?.kind === "final" && hasText && deliveredFinalTexts.has(text);
+        const shouldDeliverText = hasText && !skipTextForDuplicateFinal;
 
-        if (!hasText && !hasMedia) {
+        if (!shouldDeliverText && !hasMedia) {
           return;
         }
 
-        if (hasText) {
+        if (shouldDeliverText) {
           const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
 
           if (info?.kind === "block") {
@@ -499,6 +509,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             if (info?.kind === "final") {
               streamText = text;
               await closeStreaming({ emitFinalText: true });
+              deliveredFinalTexts.add(text);
             }
             // Send media even when streaming handled the text
             if (hasMedia) {
@@ -566,6 +577,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             }
           }
           if (info?.kind === "final") {
+            deliveredFinalTexts.add(text);
             emitMessageSent({ content: text, success: true, messageId: lastMessageId });
             await emitFinalTextIfNeeded(text, {
               ...(lastMessageId ? { messageId: lastMessageId } : {}),

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -208,12 +208,20 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     return `${statusLine}\n---\n${assistantText}`;
   };
 
+  const TOOL_DISPLAY_NAMES: Record<string, string> = {
+    feishu_chat_history: "聊天记录",
+    feishu_chat_info: "群信息",
+    feishu_chat_members: "群成员",
+    feishu_member_chats: "成员群列表",
+  };
+
   const normalizeToolName = (name: string | undefined): string | undefined => {
     const trimmed = name?.trim();
     if (!trimmed) {
       return undefined;
     }
-    return trimmed.replace(/\s+/g, " ");
+    const stripped = trimmed.replace("mcp__openclaw__", "");
+    return TOOL_DISPLAY_NAMES[stripped] ?? stripped.replace(/\s+/g, " ");
   };
 
   const resolveStatusLine = (): string | undefined => {
@@ -631,8 +639,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             // streaming — text arrives as complete chunks via onPartialReply —
             // so the card must be started here. startStreaming() is idempotent
             // (guarded by streamingStartPromise), so calling it here is safe
-            // even when the card was already started by deliver.
-            queueThinkingPrelude();
+            // even when the card was already started by onReplyStart or deliver.
             startStreaming();
             queueStreamingUpdate(payload.text, { dedupeWithLastPartial: true });
           }

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -59,6 +59,7 @@ export type CreateFeishuReplyDispatcherParams = {
   onFinalTextDelivered?: (params: {
     text: string;
     messageId?: string;
+    messageIds?: string[];
     chatId: string;
     accountId?: string;
   }) => Promise<void> | void;
@@ -83,6 +84,34 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const threadReplyMode = threadReply === true;
   const effectiveReplyInThread = threadReplyMode ? true : replyInThread;
   const account = resolveFeishuAccount({ cfg, accountId });
+
+  // Emit message_sent plugin hooks via the runtime SDK so downstream consumers
+  // (e.g. bot-company journal) can record outbound messages. The feishu reply
+  // dispatcher bypasses the core deliverOutboundPayloads pipeline, so hooks
+  // must be emitted explicitly here. Using core.hooks avoids the bundle singleton
+  // splitting issue that makes direct getGlobalHookRunner() imports fail.
+  const emitMessageSent = (event: {
+    content: string;
+    success: boolean;
+    messageId?: string;
+    error?: string;
+  }) => {
+    core.hooks.emitMessageSent(
+      {
+        to: chatId,
+        content: event.content,
+        success: event.success,
+        ...(event.messageId ? { messageId: event.messageId } : {}),
+        ...(event.error ? { error: event.error } : {}),
+        metadata: { chatId },
+      },
+      {
+        channelId: "feishu",
+        accountId: accountId ?? account.accountId,
+        conversationId: chatId,
+      },
+    );
+  };
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
 
   let typingState: TypingIndicatorState | null = null;
@@ -165,7 +194,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let finalTextEmitted = false;
   let replaceNextPartialAfterTool = false;
 
-  const emitFinalTextIfNeeded = async (text: string, messageId?: string) => {
+  const emitFinalTextIfNeeded = async (
+    text: string,
+    delivery?: { messageId?: string; messageIds?: string[] },
+  ) => {
     const normalized = text.trim();
     if (!normalized || finalTextEmitted || typeof params.onFinalTextDelivered !== "function") {
       return;
@@ -174,7 +206,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     try {
       await params.onFinalTextDelivered({
         text: normalized,
-        messageId,
+        ...(delivery?.messageId ? { messageId: delivery.messageId } : {}),
+        ...(delivery?.messageIds && delivery.messageIds.length > 0
+          ? { messageIds: delivery.messageIds }
+          : {}),
         chatId,
         accountId: accountId ?? account.accountId,
       });
@@ -183,29 +218,6 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         `feishu[${account.accountId}] onFinalTextDelivered failed: ${String(error)}`,
       );
     }
-    if (streamPhase === "tool") {
-      if (toolUseCount >= 2) {
-        return `🔧 已使用 ${toolUseCount} 个工具，正在处理...`;
-      }
-      const toolName = lastToolName?.trim();
-      return toolName ? `🔧 正在使用${toolName}工具...` : "🔧 正在使用工具...";
-    }
-    return undefined;
-  };
-
-  const composeStreamingContent = (mode: "live" | "final" = "live"): string => {
-    const assistantText = streamText;
-    if (mode === "final") {
-      return assistantText;
-    }
-    const statusLine = resolveStatusLine();
-    if (!statusLine) {
-      return assistantText;
-    }
-    if (!assistantText) {
-      return statusLine;
-    }
-    return `${statusLine}\n---\n${assistantText}`;
   };
 
   const TOOL_DISPLAY_NAMES: Record<string, string> = {
@@ -232,7 +244,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (toolUseCount >= 2) {
         return `🔧 已使用 ${toolUseCount} 个工具，正在处理...`;
       }
-      return `🔧 正在使用 ${lastToolName ?? "工具"}...`;
+      const toolName = lastToolName?.trim();
+      return toolName ? `🔧 正在使用${toolName}工具...` : "🔧 正在使用工具...";
     }
     return undefined;
   };
@@ -295,8 +308,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (!renderedForCard || renderedForCard === lastRenderedStreamContent) {
         return;
       }
-      lastRenderedStreamContent = rendered;
-      await streaming.update(rendered);
+      lastRenderedStreamContent = renderedForCard;
+      await streaming.update(renderedForCard, { mode: "replace" });
     });
   };
 
@@ -397,9 +410,22 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     await partialUpdateQueue;
     const streamMessageId = streaming?.getMessageId();
     if (streaming?.isActive()) {
-      let text = composeStreamingContent("final");
-      if (mentionTargets?.length) {
-        text = buildMentionedCardContent(mentionTargets, text);
+      const finalText = composeStreamingContent("final");
+      if (!finalText.trim()) {
+        await streaming.discard();
+      } else {
+        let text = finalText;
+        if (mentionTargets?.length) {
+          text = buildMentionedCardContent(mentionTargets, text);
+        }
+        await streaming.close(normalizeMentionTagsForCard(text));
+      }
+      if (options?.emitFinalText !== false) {
+        emitMessageSent({ content: finalText, success: true, messageId: streamMessageId });
+        await emitFinalTextIfNeeded(
+          finalText,
+          streamMessageId ? { messageId: streamMessageId } : undefined,
+        );
       }
     }
     streaming = null;
@@ -491,7 +517,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           }
 
           let first = true;
-          let firstMessageId: string | undefined;
+          let lastMessageId: string | undefined;
+          const deliveredMessageIds: string[] = [];
           if (useCard) {
             for (const chunk of core.channel.text.chunkTextWithMode(
               text,
@@ -508,8 +535,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 accountId,
               });
               const sentMessageId = sent?.messageId;
-              if (!firstMessageId && typeof sentMessageId === "string" && sentMessageId.trim()) {
-                firstMessageId = sentMessageId;
+              if (typeof sentMessageId === "string" && sentMessageId.trim()) {
+                lastMessageId = sentMessageId;
+                deliveredMessageIds.push(sentMessageId);
               }
               first = false;
             }
@@ -530,14 +558,19 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 accountId,
               });
               const sentMessageId = sent?.messageId;
-              if (!firstMessageId && typeof sentMessageId === "string" && sentMessageId.trim()) {
-                firstMessageId = sentMessageId;
+              if (typeof sentMessageId === "string" && sentMessageId.trim()) {
+                lastMessageId = sentMessageId;
+                deliveredMessageIds.push(sentMessageId);
               }
               first = false;
             }
           }
           if (info?.kind === "final") {
-            await emitFinalTextIfNeeded(text, firstMessageId);
+            emitMessageSent({ content: text, success: true, messageId: lastMessageId });
+            await emitFinalTextIfNeeded(text, {
+              ...(lastMessageId ? { messageId: lastMessageId } : {}),
+              ...(deliveredMessageIds.length > 0 ? { messageIds: deliveredMessageIds } : {}),
+            });
           }
         }
 
@@ -617,6 +650,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               lastToolName = normalizeToolName(payload?.name) ?? lastToolName;
               replaceNextPartialAfterTool = Boolean(streamText);
             }
+            queueThinkingPrelude();
             streamPhase = "tool";
             stagedStatusLine = resolveStatusLine();
             if (!shouldRenderStreamingStatus()) {
@@ -639,7 +673,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             // streaming — text arrives as complete chunks via onPartialReply —
             // so the card must be started here. startStreaming() is idempotent
             // (guarded by streamingStartPromise), so calling it here is safe
-            // even when the card was already started by onReplyStart or deliver.
+            // even when the card was already started by deliver.
+            queueThinkingPrelude();
             startStreaming();
             queueStreamingUpdate(payload.text, { dedupeWithLastPartial: true });
           }

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -5,15 +5,15 @@ import {
   type ClawdbotConfig,
   type ReplyPayload,
   type RuntimeEnv,
-} from "openclaw/plugin-sdk/feishu";
+} from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { sendMediaFeishu } from "./media.js";
 import type { MentionTarget } from "./mention.js";
-import { buildMentionedCardContent } from "./mention.js";
+import { buildMentionedCardContent, normalizeMentionTagsForCard } from "./mention.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMarkdownCardFeishu, sendMessageFeishu } from "./send.js";
-import { FeishuStreamingSession, mergeStreamingText } from "./streaming-card.js";
+import { FeishuStreamingSession } from "./streaming-card.js";
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
 
@@ -45,6 +45,8 @@ export type CreateFeishuReplyDispatcherParams = {
   /** When true, preserve typing indicator on reply target but send messages without reply metadata */
   skipReplyToInMessages?: boolean;
   replyInThread?: boolean;
+  /** Whether card streaming status is allowed in thread/topic replies (default: false). */
+  streamingInThread?: boolean;
   /** True when inbound message is already inside a thread/topic context */
   threadReply?: boolean;
   rootId?: string;
@@ -53,6 +55,13 @@ export type CreateFeishuReplyDispatcherParams = {
   /** Epoch ms when the inbound message was created. Used to suppress typing
    *  indicators on old/replayed messages after context compaction (#30418). */
   messageCreateTimeMs?: number;
+  /** Callback fired when a final visible text reply has been delivered. */
+  onFinalTextDelivered?: (params: {
+    text: string;
+    messageId?: string;
+    chatId: string;
+    accountId?: string;
+  }) => Promise<void> | void;
 };
 
 export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherParams) {
@@ -64,6 +73,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyToMessageId,
     skipReplyToInMessages,
     replyInThread,
+    streamingInThread,
     threadReply,
     rootId,
     mentionTargets,
@@ -136,23 +146,169 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const chunkMode = core.channel.text.resolveChunkMode(cfg, "feishu");
   const tableMode = core.channel.text.resolveMarkdownTableMode({ cfg, channel: "feishu" });
   const renderMode = account.config?.renderMode ?? "auto";
-  // Card streaming may miss thread affinity in topic contexts; use direct replies there.
   const streamingEnabled =
-    !threadReplyMode && account.config?.streaming !== false && renderMode !== "raw";
+    account.config?.streaming !== false &&
+    renderMode !== "raw" &&
+    (!threadReplyMode || streamingInThread === true);
 
   let streaming: FeishuStreamingSession | null = null;
   let streamText = "";
   let lastPartial = "";
-  const deliveredFinalTexts = new Set<string>();
+  let lastRenderedStreamContent = "";
+  let streamPhase: "idle" | "thinking" | "tool" | "streaming" = "idle";
+  let toolUseCount = 0;
+  let lastToolName: string | undefined;
+  let hasThinkingPrelude = false;
+  let stagedStatusLine: string | undefined;
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
-  type StreamTextUpdateMode = "snapshot" | "delta";
+  let finalTextEmitted = false;
+  let replaceNextPartialAfterTool = false;
+
+  const emitFinalTextIfNeeded = async (text: string, messageId?: string) => {
+    const normalized = text.trim();
+    if (!normalized || finalTextEmitted || typeof params.onFinalTextDelivered !== "function") {
+      return;
+    }
+    finalTextEmitted = true;
+    try {
+      await params.onFinalTextDelivered({
+        text: normalized,
+        messageId,
+        chatId,
+        accountId: accountId ?? account.accountId,
+      });
+    } catch (error) {
+      params.runtime.error?.(
+        `feishu[${account.accountId}] onFinalTextDelivered failed: ${String(error)}`,
+      );
+    }
+    if (streamPhase === "tool") {
+      if (toolUseCount >= 2) {
+        return `🔧 已使用 ${toolUseCount} 个工具，正在处理...`;
+      }
+      const toolName = lastToolName?.trim();
+      return toolName ? `🔧 正在使用${toolName}工具...` : "🔧 正在使用工具...";
+    }
+    return undefined;
+  };
+
+  const composeStreamingContent = (mode: "live" | "final" = "live"): string => {
+    const assistantText = streamText;
+    if (mode === "final") {
+      return assistantText;
+    }
+    const statusLine = resolveStatusLine();
+    if (!statusLine) {
+      return assistantText;
+    }
+    if (!assistantText) {
+      return statusLine;
+    }
+    return `${statusLine}\n---\n${assistantText}`;
+  };
+
+  const normalizeToolName = (name: string | undefined): string | undefined => {
+    const trimmed = name?.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    return trimmed.replace(/\s+/g, " ");
+  };
+
+  const resolveStatusLine = (): string | undefined => {
+    if (streamPhase === "thinking") {
+      return "💭 思考中...";
+    }
+    if (streamPhase === "tool") {
+      if (toolUseCount >= 2) {
+        return `🔧 已使用 ${toolUseCount} 个工具，正在处理...`;
+      }
+      return `🔧 正在使用 ${lastToolName ?? "工具"}...`;
+    }
+    return undefined;
+  };
+
+  const composeStreamingContent = (mode: "live" | "final" = "live"): string => {
+    const assistantText = streamText;
+    if (mode === "final") {
+      return assistantText;
+    }
+    const statusLine = resolveStatusLine();
+    if (!statusLine) {
+      return assistantText;
+    }
+    if (!assistantText) {
+      return statusLine;
+    }
+    return `${statusLine}\n---\n${assistantText}`;
+  };
+
+  const mergeStreamingText = (nextText: string) => {
+    if (!streamText) {
+      streamText = nextText;
+      return;
+    }
+    if (nextText.startsWith(streamText)) {
+      // Handle cumulative partial payloads where nextText already includes prior text.
+      streamText = nextText;
+      return;
+    }
+    if (streamText.endsWith(nextText)) {
+      return;
+    }
+    streamText += nextText;
+  };
+
+  /** Strip trailing incomplete <at ...> tag to prevent streaming card corruption. */
+  const stripIncompleteAtTag = (text: string): string => {
+    const lastAtIdx = text.lastIndexOf("<at");
+    if (lastAtIdx === -1) {
+      return text;
+    }
+    const tail = text.substring(lastAtIdx);
+    if (/<\/at>/i.test(tail) || /\/>/i.test(tail)) {
+      return text;
+    }
+    return text.substring(0, lastAtIdx);
+  };
+
+  const queueStreamingRender = (renderedSnapshot?: string) => {
+    partialUpdateQueue = partialUpdateQueue.then(async () => {
+      if (streamingStartPromise) {
+        await streamingStartPromise;
+      }
+      if (!streaming?.isActive()) {
+        return;
+      }
+      const rendered = renderedSnapshot ?? composeStreamingContent("live");
+      const safeRendered = stripIncompleteAtTag(rendered);
+      const renderedForCard = normalizeMentionTagsForCard(safeRendered);
+      if (!renderedForCard || renderedForCard === lastRenderedStreamContent) {
+        return;
+      }
+      lastRenderedStreamContent = rendered;
+      await streaming.update(rendered);
+    });
+  };
+
+  const shouldRenderStreamingStatus = (): boolean =>
+    renderMode === "card" || Boolean(streamingStartPromise) || Boolean(streaming?.isActive());
+
+  const queueThinkingPrelude = (): boolean => {
+    if (hasThinkingPrelude) {
+      return false;
+    }
+    streamPhase = "thinking";
+    stagedStatusLine = resolveStatusLine();
+    hasThinkingPrelude = true;
+    return true;
+  };
 
   const queueStreamingUpdate = (
     nextText: string,
     options?: {
       dedupeWithLastPartial?: boolean;
-      mode?: StreamTextUpdateMode;
     },
   ) => {
     if (!nextText) {
@@ -161,20 +317,40 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     if (options?.dedupeWithLastPartial && nextText === lastPartial) {
       return;
     }
+    const shouldResetAfterTool =
+      replaceNextPartialAfterTool &&
+      options?.dedupeWithLastPartial === true &&
+      Boolean(streamText) &&
+      !nextText.startsWith(streamText);
     if (options?.dedupeWithLastPartial) {
       lastPartial = nextText;
     }
-    const mode = options?.mode ?? "snapshot";
-    streamText =
-      mode === "delta" ? `${streamText}${nextText}` : mergeStreamingText(streamText, nextText);
-    partialUpdateQueue = partialUpdateQueue.then(async () => {
-      if (streamingStartPromise) {
-        await streamingStartPromise;
-      }
-      if (streaming?.isActive()) {
-        await streaming.update(streamText);
-      }
-    });
+    if (shouldResetAfterTool) {
+      streamText = nextText;
+      replaceNextPartialAfterTool = false;
+      streamPhase = "streaming";
+      queueStreamingRender();
+      return;
+    }
+    replaceNextPartialAfterTool = false;
+    const hadVisibleText = Boolean(streamText);
+    mergeStreamingText(nextText);
+    const shouldRenderStagedStatus =
+      !hadVisibleText && Boolean(streamText) && Boolean(stagedStatusLine);
+    const stagedSnapshot = shouldRenderStagedStatus
+      ? `${stagedStatusLine}\n---\n${streamText}`
+      : undefined;
+    if (shouldRenderStagedStatus) {
+      stagedStatusLine = undefined;
+    }
+    streamPhase = "streaming";
+    if (stagedSnapshot) {
+      queueStreamingRender(stagedSnapshot);
+      // Immediately follow with plain text so close(finalText) remains text-only.
+      queueStreamingRender();
+      return;
+    }
+    queueStreamingRender();
   };
 
   const startStreaming = () => {
@@ -206,22 +382,29 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     })();
   };
 
-  const closeStreaming = async () => {
+  const closeStreaming = async (options?: { emitFinalText?: boolean }) => {
     if (streamingStartPromise) {
       await streamingStartPromise;
     }
     await partialUpdateQueue;
+    const streamMessageId = streaming?.getMessageId();
     if (streaming?.isActive()) {
-      let text = streamText;
+      let text = composeStreamingContent("final");
       if (mentionTargets?.length) {
         text = buildMentionedCardContent(mentionTargets, text);
       }
-      await streaming.close(text);
     }
     streaming = null;
     streamingStartPromise = null;
     streamText = "";
     lastPartial = "";
+    lastRenderedStreamContent = "";
+    streamPhase = "idle";
+    toolUseCount = 0;
+    lastToolName = undefined;
+    hasThinkingPrelude = false;
+    stagedStatusLine = undefined;
+    replaceNextPartialAfterTool = false;
   };
 
   const { dispatcher, replyOptions, markDispatchIdle } =
@@ -230,7 +413,6 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       responsePrefixContextProvider: prefixContext.responsePrefixContextProvider,
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
       onReplyStart: () => {
-        deliveredFinalTexts.clear();
         if (streamingEnabled && renderMode === "card") {
           startStreaming();
         }
@@ -246,15 +428,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               : [];
         const hasText = Boolean(text.trim());
         const hasMedia = mediaList.length > 0;
-        const skipTextForDuplicateFinal =
-          info?.kind === "final" && hasText && deliveredFinalTexts.has(text);
-        const shouldDeliverText = hasText && !skipTextForDuplicateFinal;
 
-        if (!shouldDeliverText && !hasMedia) {
+        if (!hasText && !hasMedia) {
           return;
         }
 
-        if (shouldDeliverText) {
+        if (hasText) {
           const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
 
           if (info?.kind === "block") {
@@ -280,12 +459,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             if (info?.kind === "block") {
               // Some runtimes emit block payloads without onPartial/final callbacks.
               // Mirror block text into streamText so onIdle close still sends content.
-              queueStreamingUpdate(text, { mode: "delta" });
+              queueThinkingPrelude();
+              queueStreamingUpdate(text);
             }
             if (info?.kind === "final") {
-              streamText = mergeStreamingText(streamText, text);
-              await closeStreaming();
-              deliveredFinalTexts.add(text);
+              streamText = text;
+              await closeStreaming({ emitFinalText: true });
             }
             // Send media even when streaming handled the text
             if (hasMedia) {
@@ -304,13 +483,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           }
 
           let first = true;
+          let firstMessageId: string | undefined;
           if (useCard) {
             for (const chunk of core.channel.text.chunkTextWithMode(
               text,
               textChunkLimit,
               chunkMode,
             )) {
-              await sendMarkdownCardFeishu({
+              const sent = await sendMarkdownCardFeishu({
                 cfg,
                 to: chatId,
                 text: chunk,
@@ -319,10 +499,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 mentions: first ? mentionTargets : undefined,
                 accountId,
               });
+              const sentMessageId = sent?.messageId;
+              if (!firstMessageId && typeof sentMessageId === "string" && sentMessageId.trim()) {
+                firstMessageId = sentMessageId;
+              }
               first = false;
-            }
-            if (info?.kind === "final") {
-              deliveredFinalTexts.add(text);
             }
           } else {
             const converted = core.channel.text.convertMarkdownTables(text, tableMode);
@@ -331,7 +512,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               textChunkLimit,
               chunkMode,
             )) {
-              await sendMessageFeishu({
+              const sent = await sendMessageFeishu({
                 cfg,
                 to: chatId,
                 text: chunk,
@@ -340,11 +521,15 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 mentions: first ? mentionTargets : undefined,
                 accountId,
               });
+              const sentMessageId = sent?.messageId;
+              if (!firstMessageId && typeof sentMessageId === "string" && sentMessageId.trim()) {
+                firstMessageId = sentMessageId;
+              }
               first = false;
             }
-            if (info?.kind === "final") {
-              deliveredFinalTexts.add(text);
-            }
+          }
+          if (info?.kind === "final") {
+            await emitFinalTextIfNeeded(text, firstMessageId);
           }
         }
 
@@ -365,11 +550,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         params.runtime.error?.(
           `feishu[${account.accountId}] ${info.kind} reply failed: ${String(error)}`,
         );
-        await closeStreaming();
+        await closeStreaming({ emitFinalText: false });
         typingCallbacks.onIdle?.();
       },
       onIdle: async () => {
-        await closeStreaming();
+        await closeStreaming({ emitFinalText: true });
         typingCallbacks.onIdle?.();
       },
       onCleanup: () => {
@@ -382,15 +567,74 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
+      onAssistantMessageStart: streamingEnabled
+        ? () => {
+            if (renderMode !== "card") {
+              return;
+            }
+            queueThinkingPrelude();
+          }
+        : undefined,
+      onReasoningStream: streamingEnabled
+        ? () => {
+            queueThinkingPrelude();
+            streamPhase = "thinking";
+            stagedStatusLine = resolveStatusLine();
+            if (!shouldRenderStreamingStatus()) {
+              return;
+            }
+            if (!streaming?.isActive()) {
+              return;
+            }
+            queueStreamingRender();
+          }
+        : undefined,
+      onReasoningEnd: streamingEnabled
+        ? () => {
+            if (streamPhase !== "thinking") {
+              return;
+            }
+            streamPhase = streamText ? "streaming" : "idle";
+            if (!shouldRenderStreamingStatus()) {
+              return;
+            }
+            queueStreamingRender();
+          }
+        : undefined,
+      onToolStart: streamingEnabled
+        ? (payload: { name?: string; phase?: string }) => {
+            const isStartPhase = !payload?.phase || payload.phase === "start";
+            if (isStartPhase) {
+              toolUseCount += 1;
+              lastToolName = normalizeToolName(payload?.name) ?? lastToolName;
+              replaceNextPartialAfterTool = Boolean(streamText);
+            }
+            streamPhase = "tool";
+            stagedStatusLine = resolveStatusLine();
+            if (!shouldRenderStreamingStatus()) {
+              return;
+            }
+            if (!streaming?.isActive()) {
+              return;
+            }
+            queueStreamingRender();
+          }
+        : undefined,
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
             if (!payload.text) {
               return;
             }
-            queueStreamingUpdate(payload.text, {
-              dedupeWithLastPartial: true,
-              mode: "snapshot",
-            });
+            // Ensure streaming card is started when partial text arrives.
+            // In embedded mode with block streaming, the card is started by the
+            // deliver handler on the first block reply. CLI mode has no block
+            // streaming — text arrives as complete chunks via onPartialReply —
+            // so the card must be started here. startStreaming() is idempotent
+            // (guarded by streamingStartPromise), so calling it here is safe
+            // even when the card was already started by deliver.
+            queueThinkingPrelude();
+            startStreaming();
+            queueStreamingUpdate(payload.text, { dedupeWithLastPartial: true });
           }
         : undefined,
     },

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -15,6 +15,14 @@ export function assertFeishuMessageApiSuccess(
   }
 }
 
+export function rethrowWithFeishuErrorDetail(err: unknown, prefix: string): never {
+  const data = (err as any)?.response?.data;
+  if (data && typeof data.msg === "string") {
+    throw new Error(`${prefix}: ${data.msg}`, { cause: err });
+  }
+  throw err;
+}
+
 export function toFeishuSendResult(
   response: FeishuMessageApiResponse,
   chatId: string,

--- a/extensions/feishu/src/send-result.ts
+++ b/extensions/feishu/src/send-result.ts
@@ -3,6 +3,7 @@ export type FeishuMessageApiResponse = {
   msg?: string;
   data?: {
     message_id?: string;
+    chat_id?: string;
   };
 };
 
@@ -32,6 +33,9 @@ export function toFeishuSendResult(
 } {
   return {
     messageId: response.data?.message_id ?? "unknown",
-    chatId,
+    // Prefer API-returned chat_id over the caller-provided fallback.
+    // For DMs sent via open_id, the caller passes the user's open_id as chatId,
+    // but the API response contains the actual oc_* conversation chat_id.
+    chatId: response.data?.chat_id ?? chatId,
   };
 }

--- a/extensions/feishu/src/send.reply-fallback.test.ts
+++ b/extensions/feishu/src/send.reply-fallback.test.ts
@@ -56,6 +56,7 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
       to: "user:ou_target",
       text: "hello",
       replyToMessageId: "om_parent",
+      replyInThread: true,
     });
 
     expect(replyMock).toHaveBeenCalledTimes(1);
@@ -78,6 +79,7 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
       to: "user:ou_target",
       card: { schema: "2.0" },
       replyToMessageId: "om_parent",
+      replyInThread: true,
     });
 
     expect(replyMock).toHaveBeenCalledTimes(1);
@@ -97,6 +99,7 @@ describe("Feishu reply fallback for withdrawn/deleted targets", () => {
         to: "user:ou_target",
         text: "hello",
         replyToMessageId: "om_parent",
+        replyInThread: true,
       }),
     ).rejects.toThrow("Feishu reply failed");
 

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -1,6 +1,6 @@
 import type { ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getMessageFeishu } from "./send.js";
+import { enrichMentionPlaceholders, getMessageFeishu } from "./send.js";
 
 const { mockClientGet, mockCreateFeishuClient, mockResolveFeishuAccount } = vi.hoisted(() => ({
   mockClientGet: vi.fn(),
@@ -164,5 +164,49 @@ describe("getMessageFeishu", () => {
         content: "single payload",
       }),
     );
+  });
+});
+
+describe("enrichMentionPlaceholders", () => {
+  it("replaces @_user_N placeholders with @name", () => {
+    const content = "@_user_1 登陆了，@_user_2 也来了";
+    const mentions = [
+      { key: "@_user_1", name: "张三" },
+      { key: "@_user_2", name: "李四" },
+    ];
+    expect(enrichMentionPlaceholders(content, mentions)).toBe("@张三 登陆了，@李四 也来了");
+  });
+
+  it("handles prefix collision: @_user_1 vs @_user_10", () => {
+    const content = "@_user_1 和 @_user_10 都在";
+    const mentions = [
+      { key: "@_user_1", name: "Alice" },
+      { key: "@_user_10", name: "Bob" },
+    ];
+    expect(enrichMentionPlaceholders(content, mentions)).toBe("@Alice 和 @Bob 都在");
+  });
+
+  it("returns content unchanged when mentions is empty or undefined", () => {
+    expect(enrichMentionPlaceholders("hello @_user_1", undefined)).toBe("hello @_user_1");
+    expect(enrichMentionPlaceholders("hello @_user_1", [])).toBe("hello @_user_1");
+  });
+
+  it("skips entries with missing key or name", () => {
+    const content = "@_user_1 和 @_user_2 在";
+    const mentions = [
+      { key: "@_user_1", name: "Alice" },
+      { key: "@_user_2", name: undefined },
+      { key: undefined, name: "Ghost" },
+    ] as Array<{ key?: string; name?: string }>;
+    expect(enrichMentionPlaceholders(content, mentions)).toBe("@Alice 和 @_user_2 在");
+  });
+
+  it("trims whitespace-only keys and names", () => {
+    const content = "@_user_1 hi";
+    const mentions = [
+      { key: "  ", name: "Alice" },
+      { key: "@_user_1", name: "  " },
+    ];
+    expect(enrichMentionPlaceholders(content, mentions)).toBe("@_user_1 hi");
   });
 });

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -66,6 +66,7 @@ async function sendFallbackDirect(
     msgType: string;
   },
   errorPrefix: string,
+  mentionMeta?: Record<string, unknown>,
 ): Promise<FeishuSendResult> {
   const response = await client.im.message.create({
     params: { receive_id_type: params.receiveIdType },
@@ -76,7 +77,10 @@ async function sendFallbackDirect(
     },
   });
   assertFeishuMessageApiSuccess(response, errorPrefix);
-  return toFeishuSendResult(response, params.receiveId);
+  return {
+    ...toFeishuSendResult(response, params.receiveId),
+    ...(mentionMeta ? { meta: mentionMeta } : {}),
+  };
 }
 
 export type FeishuMessageInfo = {
@@ -259,9 +263,9 @@ export async function getMessageFeishu(params: {
 
     const msgType = item.msg_type ?? "text";
     const rawContent = item.body?.content ?? "";
-    const content = parseQuotedMessageContent(rawContent, msgType);
+    const parsedContent = parseQuotedMessageContent(rawContent, msgType);
 
-    content = enrichMentionPlaceholders(content, item.mentions);
+    const content = enrichMentionPlaceholders(parsedContent, item.mentions);
 
     return {
       messageId: item.message_id ?? messageId,
@@ -402,10 +406,10 @@ export async function sendMessageFeishu(
       if (!isWithdrawnReplyError(err)) {
         throw err;
       }
-      return sendFallbackDirect(client, directParams, "Feishu send failed");
+      return sendFallbackDirect(client, directParams, "Feishu send failed", mentionMeta);
     }
     if (shouldFallbackFromReplyTarget(response)) {
-      return sendFallbackDirect(client, directParams, "Feishu send failed");
+      return sendFallbackDirect(client, directParams, "Feishu send failed", mentionMeta);
     }
     assertFeishuMessageApiSuccess(response, "Feishu reply failed");
     return {
@@ -414,7 +418,7 @@ export async function sendMessageFeishu(
     };
   }
 
-  return sendFallbackDirect(client, directParams, "Feishu send failed");
+  return sendFallbackDirect(client, directParams, "Feishu send failed", mentionMeta);
 }
 
 export type SendFeishuCardParams = {
@@ -451,10 +455,10 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
       if (!isWithdrawnReplyError(err)) {
         throw err;
       }
-      return sendFallbackDirect(client, directParams, "Feishu card send failed");
+      return sendFallbackDirect(client, directParams, "Feishu card send failed", mentionMeta);
     }
     if (shouldFallbackFromReplyTarget(response)) {
-      return sendFallbackDirect(client, directParams, "Feishu card send failed");
+      return sendFallbackDirect(client, directParams, "Feishu card send failed", mentionMeta);
     }
     assertFeishuMessageApiSuccess(response, "Feishu card reply failed");
     return {
@@ -463,7 +467,7 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
     };
   }
 
-  return sendFallbackDirect(client, directParams, "Feishu card send failed");
+  return sendFallbackDirect(client, directParams, "Feishu card send failed", mentionMeta);
 }
 
 export async function updateCardFeishu(params: {

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -2,7 +2,12 @@ import type { ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import type { MentionTarget } from "./mention.js";
-import { buildMentionedMessage, buildMentionedCardContent } from "./mention.js";
+import {
+  buildMentionedMessage,
+  buildMentionedCardContent,
+  normalizeMentionTagsForCard,
+  normalizeMentionTagsForText,
+} from "./mention.js";
 import { parsePostContent } from "./post.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
@@ -158,6 +163,32 @@ function parseQuotedMessageContent(rawContent: string, msgType: string): string 
 }
 
 /**
+ * Replace `@_user_N` placeholders with `@name` using the mentions array
+ * returned by the Feishu message API.
+ */
+export function enrichMentionPlaceholders(
+  content: string,
+  mentions?: Array<{ key?: string; name?: string }>,
+): string {
+  if (!mentions || mentions.length === 0) return content;
+
+  const entries: Array<[string, string]> = [];
+  for (const m of mentions) {
+    const key = m.key?.trim();
+    const name = m.name?.trim();
+    if (key && name) entries.push([key, `@${name}`]);
+  }
+  if (entries.length === 0) return content;
+
+  // Sort by key length descending to prevent @_user_1 matching @_user_10
+  entries.sort((a, b) => b[0].length - a[0].length);
+
+  const pattern = entries.map(([k]) => k.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|");
+  const map = new Map(entries);
+  return content.replace(new RegExp(pattern, "g"), (match) => map.get(match) ?? match);
+}
+
+/**
  * Get a message by its ID.
  * Useful for fetching quoted/replied message content.
  */
@@ -191,6 +222,11 @@ export async function getMessageFeishu(params: {
             id_type?: string;
             sender_type?: string;
           };
+          mentions?: Array<{
+            key?: string;
+            name?: string;
+            id?: { open_id?: string; user_id?: string; union_id?: string };
+          }>;
           create_time?: string;
         }>;
         message_id?: string;
@@ -225,6 +261,8 @@ export async function getMessageFeishu(params: {
     const rawContent = item.body?.content ?? "";
     const content = parseQuotedMessageContent(rawContent, msgType);
 
+    content = enrichMentionPlaceholders(content, item.mentions);
+
     return {
       messageId: item.message_id ?? messageId,
       chatId: item.chat_id ?? "",
@@ -253,6 +291,57 @@ export type SendFeishuMessageParams = {
   accountId?: string;
 };
 
+function buildMentionMeta(
+  mentions?: MentionTarget[],
+): { mentions: Array<{ id: string; name?: string }> } | undefined {
+  if (!mentions || mentions.length === 0) {
+    return undefined;
+  }
+  return {
+    mentions: mentions.map((mention) => ({
+      id: mention.openId,
+      name: mention.name,
+    })),
+  };
+}
+
+function buildMentionDisplayNameMap(
+  mentions?: MentionTarget[],
+): Record<string, string> | undefined {
+  if (!mentions || mentions.length === 0) {
+    return undefined;
+  }
+  const map: Record<string, string> = {};
+  for (const mention of mentions) {
+    const openId = mention.openId?.trim();
+    if (!openId) {
+      continue;
+    }
+    const name = mention.name?.trim();
+    if (name) {
+      map[openId] = name;
+    }
+  }
+  return Object.keys(map).length > 0 ? map : undefined;
+}
+
+function normalizeCardMentionTags(value: unknown): unknown {
+  if (typeof value === "string") {
+    return normalizeMentionTagsForCard(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeCardMentionTags(item));
+  }
+  if (value && typeof value === "object") {
+    const normalized: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+      normalized[key] = normalizeCardMentionTags(item);
+    }
+    return normalized;
+  }
+  return value;
+}
+
 function buildFeishuPostMessagePayload(params: { messageText: string }): {
   content: string;
   msgType: string;
@@ -279,6 +368,7 @@ export async function sendMessageFeishu(
   params: SendFeishuMessageParams,
 ): Promise<FeishuSendResult> {
   const { cfg, to, text, replyToMessageId, replyInThread, mentions, accountId } = params;
+  const mentionMeta = buildMentionMeta(mentions);
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
   const tableMode = getFeishuRuntime().channel.text.resolveMarkdownTableMode({
     cfg,
@@ -290,6 +380,7 @@ export async function sendMessageFeishu(
   if (mentions && mentions.length > 0) {
     rawText = buildMentionedMessage(mentions, rawText);
   }
+  rawText = normalizeMentionTagsForText(rawText, buildMentionDisplayNameMap(mentions));
   const messageText = getFeishuRuntime().channel.text.convertMarkdownTables(rawText, tableMode);
 
   const { content, msgType } = buildFeishuPostMessagePayload({ messageText });
@@ -317,7 +408,10 @@ export async function sendMessageFeishu(
       return sendFallbackDirect(client, directParams, "Feishu send failed");
     }
     assertFeishuMessageApiSuccess(response, "Feishu reply failed");
-    return toFeishuSendResult(response, receiveId);
+    return {
+      ...toFeishuSendResult(response, receiveId),
+      ...(mentionMeta ? { meta: mentionMeta } : {}),
+    };
   }
 
   return sendFallbackDirect(client, directParams, "Feishu send failed");
@@ -330,11 +424,13 @@ export type SendFeishuCardParams = {
   replyToMessageId?: string;
   /** When true, reply creates a Feishu topic thread instead of an inline reply */
   replyInThread?: boolean;
+  mentions?: MentionTarget[];
   accountId?: string;
 };
 
 export async function sendCardFeishu(params: SendFeishuCardParams): Promise<FeishuSendResult> {
-  const { cfg, to, card, replyToMessageId, replyInThread, accountId } = params;
+  const { cfg, to, card, replyToMessageId, replyInThread, mentions, accountId } = params;
+  const mentionMeta = buildMentionMeta(mentions);
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
   const content = JSON.stringify(card);
 
@@ -361,7 +457,10 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
       return sendFallbackDirect(client, directParams, "Feishu card send failed");
     }
     assertFeishuMessageApiSuccess(response, "Feishu card reply failed");
-    return toFeishuSendResult(response, receiveId);
+    return {
+      ...toFeishuSendResult(response, receiveId),
+      ...(mentionMeta ? { meta: mentionMeta } : {}),
+    };
   }
 
   return sendFallbackDirect(client, directParams, "Feishu card send failed");
@@ -380,7 +479,7 @@ export async function updateCardFeishu(params: {
   }
 
   const client = createFeishuClient(account);
-  const content = JSON.stringify(card);
+  const content = JSON.stringify(normalizeCardMentionTags(card));
 
   const response = await client.im.message.patch({
     path: { message_id: messageId },
@@ -434,8 +533,9 @@ export async function sendMarkdownCardFeishu(params: {
   if (mentions && mentions.length > 0) {
     cardText = buildMentionedCardContent(mentions, text);
   }
+  cardText = normalizeMentionTagsForCard(cardText);
   const card = buildMarkdownCard(cardText);
-  return sendCardFeishu({ cfg, to, card, replyToMessageId, replyInThread, accountId });
+  return sendCardFeishu({ cfg, to, card, replyToMessageId, replyInThread, mentions, accountId });
 }
 
 /**
@@ -459,7 +559,11 @@ export async function editMessageFeishu(params: {
     cfg,
     channel: "feishu",
   });
-  const messageText = getFeishuRuntime().channel.text.convertMarkdownTables(text ?? "", tableMode);
+  const normalizedText = normalizeMentionTagsForText(text ?? "");
+  const messageText = getFeishuRuntime().channel.text.convertMarkdownTables(
+    normalizedText,
+    tableMode,
+  );
 
   const { content, msgType } = buildFeishuPostMessagePayload({ messageText });
 

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
 
-vi.mock("openclaw/plugin-sdk", () => ({
+vi.mock("openclaw/plugin-sdk/feishu", () => ({
   fetchWithSsrFGuard: fetchWithSsrFGuardMock,
 }));
 

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -12,23 +12,52 @@ import {
   resolveStreamingCardSendMode,
 } from "./streaming-card.js";
 
-function installFetchMock(): void {
-  fetchWithSsrFGuardMock.mockImplementation(async ({ url }: { url: string }) => {
-    if (url.includes("/auth/v3/tenant_access_token/internal")) {
-      return {
-        response: {
-          json: async () => ({ code: 0, tenant_access_token: "token", expire: 7200 }),
-        },
-        release: async () => {},
-      };
-    }
-    return {
-      response: {
-        json: async () => ({ code: 0, msg: "ok", data: {} }),
+function createClientMock() {
+  const messageDelete = vi.fn(async () => ({ code: 0, msg: "ok" }));
+  const messageCreate = vi.fn(async () => ({
+    code: 0,
+    msg: "ok",
+    data: { message_id: "message-id" },
+  }));
+  const messageReply = vi.fn(async () => ({
+    code: 0,
+    msg: "ok",
+    data: { message_id: "message-id" },
+  }));
+  const cardCreate = vi.fn(async () => ({ code: 0, msg: "ok", data: { card_id: "card-id" } }));
+  const cardSettings = vi.fn(async () => ({ code: 0, msg: "ok" }));
+  const cardElementContent = vi.fn(async () => ({ code: 0, msg: "ok" }));
+
+  const client = {
+    im: {
+      message: {
+        delete: messageDelete,
+        create: messageCreate,
+        reply: messageReply,
       },
-      release: async () => {},
-    };
-  });
+    },
+    cardkit: {
+      v1: {
+        card: {
+          create: cardCreate,
+          settings: cardSettings,
+        },
+        cardElement: {
+          content: cardElementContent,
+        },
+      },
+    },
+  };
+
+  return {
+    client: client as never,
+    messageDelete,
+    messageCreate,
+    messageReply,
+    cardCreate,
+    cardSettings,
+    cardElementContent,
+  };
 }
 
 describe("mergeStreamingText", () => {
@@ -83,14 +112,14 @@ describe("resolveStreamingCardSendMode", () => {
   });
 });
 
-describe("FeishuStreamingSession.close", () => {
+describe("FeishuStreamingSession.update", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    installFetchMock();
   });
 
-  it("treats explicit empty final text as authoritative", async () => {
-    const session = new FeishuStreamingSession({} as never, {
+  it("supports replace mode to overwrite transient status text", async () => {
+    const { client } = createClientMock();
+    const session = new FeishuStreamingSession(client, {
       appId: "app",
       appSecret: "secret",
     });
@@ -100,7 +129,64 @@ describe("FeishuStreamingSession.close", () => {
       sequence: 1,
       currentText: "💭 思考中...",
     };
-    (session as any).pendingText = "💭 思考中...";
+    const updateCardContentSpy = vi
+      .spyOn(session as any, "updateCardContent")
+      .mockResolvedValue(undefined);
+
+    await session.update("🔧 正在使用Read工具...", { mode: "replace" });
+
+    expect(updateCardContentSpy).toHaveBeenCalledWith(
+      "🔧 正在使用Read工具...",
+      expect.any(Function),
+    );
+    expect((session as any).state.currentText).toBe("🔧 正在使用Read工具...");
+  });
+});
+
+describe("FeishuStreamingSession.discard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes the interactive message instead of leaving an empty card", async () => {
+    const { client, messageDelete } = createClientMock();
+    const session = new FeishuStreamingSession(client, {
+      appId: "app",
+      appSecret: "secret",
+    });
+    (session as any).state = {
+      cardId: "card-id",
+      messageId: "message-id",
+      sequence: 1,
+      currentText: "💭 思考中...",
+    };
+
+    await session.discard();
+
+    expect(messageDelete).toHaveBeenCalledWith({
+      path: { message_id: "message-id" },
+    });
+  });
+});
+
+describe("FeishuStreamingSession.close", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("treats explicit empty final text as authoritative", async () => {
+    const { client } = createClientMock();
+    const session = new FeishuStreamingSession(client, {
+      appId: "app",
+      appSecret: "secret",
+    });
+    (session as any).state = {
+      cardId: "card-id",
+      messageId: "message-id",
+      sequence: 1,
+      currentText: "💭 思考中...",
+    };
+    (session as any).pendingUpdate = { text: "💭 思考中...", mode: "replace" };
     const updateCardContentSpy = vi
       .spyOn(session as any, "updateCardContent")
       .mockResolvedValue(undefined);
@@ -142,7 +228,8 @@ describe("FeishuStreamingSession.close", () => {
   });
 
   it("keeps pending merge behavior when final text is omitted", async () => {
-    const session = new FeishuStreamingSession({} as never, {
+    const { client } = createClientMock();
+    const session = new FeishuStreamingSession(client, {
       appId: "app",
       appSecret: "secret",
     });
@@ -152,7 +239,7 @@ describe("FeishuStreamingSession.close", () => {
       sequence: 1,
       currentText: "第一段",
     };
-    (session as any).pendingText = "第一段\n第二段";
+    (session as any).pendingUpdate = { text: "第一段\n第二段", mode: "merge" };
     const updateCardContentSpy = vi
       .spyOn(session as any, "updateCardContent")
       .mockResolvedValue(undefined);

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -162,4 +162,54 @@ describe("FeishuStreamingSession.close", () => {
     expect(updateCardContentSpy).toHaveBeenCalledWith("第一段\n第二段");
     expect((session as any).state.currentText).toBe("第一段\n第二段");
   });
+
+  it("respects pending replace updates when final text is omitted", async () => {
+    const { client } = createClientMock();
+    const session = new FeishuStreamingSession(client, {
+      appId: "app",
+      appSecret: "secret",
+    });
+    (session as any).state = {
+      cardId: "card-id",
+      messageId: "message-id",
+      sequence: 1,
+      currentText: "💭 思考中...",
+    };
+    (session as any).pendingUpdate = { text: "🔧 正在使用Read工具...", mode: "replace" };
+    const updateCardContentSpy = vi
+      .spyOn(session as any, "updateCardContent")
+      .mockResolvedValue(undefined);
+
+    await session.close();
+
+    expect(updateCardContentSpy).toHaveBeenCalledWith("🔧 正在使用Read工具...");
+    expect((session as any).state.currentText).toBe("🔧 正在使用Read工具...");
+  });
+
+  it("strips html tags when writing summary content on close", async () => {
+    const { client, cardSettings } = createClientMock();
+    const session = new FeishuStreamingSession(client, {
+      appId: "app",
+      appSecret: "secret",
+    });
+    (session as any).state = {
+      cardId: "card-id",
+      messageId: "message-id",
+      sequence: 1,
+      currentText: "",
+    };
+
+    await session.close(
+      '<at user_id="ou_user_1">Lukin</at> 已完成 <b>发布</b><br/>请查看 <a href="https://example.com">链接</a>',
+    );
+
+    expect(cardSettings).toHaveBeenCalled();
+    const cardSettingsArg = cardSettings.mock.calls[0]?.[0] as {
+      data?: { settings?: string };
+    };
+    const settingsPayload = JSON.parse(cardSettingsArg.data?.settings ?? "{}") as {
+      config?: { summary?: { content?: string } };
+    };
+    expect(settingsPayload.config?.summary?.content).toBe("Lukin 已完成 发布 请查看 链接");
+  });
 });

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -1,5 +1,35 @@
-import { describe, expect, it } from "vitest";
-import { mergeStreamingText, resolveStreamingCardSendMode } from "./streaming-card.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk", () => ({
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+import {
+  FeishuStreamingSession,
+  mergeStreamingText,
+  resolveStreamingCardSendMode,
+} from "./streaming-card.js";
+
+function installFetchMock(): void {
+  fetchWithSsrFGuardMock.mockImplementation(async ({ url }: { url: string }) => {
+    if (url.includes("/auth/v3/tenant_access_token/internal")) {
+      return {
+        response: {
+          json: async () => ({ code: 0, tenant_access_token: "token", expire: 7200 }),
+        },
+        release: async () => {},
+      };
+    }
+    return {
+      response: {
+        json: async () => ({ code: 0, msg: "ok", data: {} }),
+      },
+      release: async () => {},
+    };
+  });
+}
 
 describe("mergeStreamingText", () => {
   it("prefers the latest full text when it already includes prior text", () => {
@@ -50,5 +80,86 @@ describe("resolveStreamingCardSendMode", () => {
         replyInThread: true,
       }),
     ).toBe("create");
+  });
+});
+
+describe("FeishuStreamingSession.close", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    installFetchMock();
+  });
+
+  it("treats explicit empty final text as authoritative", async () => {
+    const session = new FeishuStreamingSession({} as never, {
+      appId: "app",
+      appSecret: "secret",
+    });
+    (session as any).state = {
+      cardId: "card-id",
+      messageId: "message-id",
+      sequence: 1,
+      currentText: "💭 思考中...",
+    };
+    (session as any).pendingText = "💭 思考中...";
+    const updateCardContentSpy = vi
+      .spyOn(session as any, "updateCardContent")
+      .mockResolvedValue(undefined);
+
+    await session.close("");
+
+    expect(updateCardContentSpy).toHaveBeenCalledWith("");
+    expect((session as any).state.currentText).toBe("");
+  });
+
+  it("treats explicit non-empty final text as authoritative", async () => {
+    const { client } = createClientMock();
+    const session = new FeishuStreamingSession(client, {
+      appId: "app",
+      appSecret: "secret",
+    });
+    (session as any).state = {
+      cardId: "card-id",
+      messageId: "message-id",
+      sequence: 1,
+      currentText: "**Checking SEO JSON-LD in PR #16**<at id=ou_luke></at> 加了。",
+    };
+    (session as any).pendingUpdate = {
+      text: "**Checking SEO JSON-LD in PR #16**<at id=ou_luke></at> 加了。\n我刚",
+      mode: "replace",
+    };
+    const updateCardContentSpy = vi
+      .spyOn(session as any, "updateCardContent")
+      .mockResolvedValue(undefined);
+
+    await session.close("<at id=ou_luke></at> 加了。\n我刚又确认了一遍");
+
+    expect(updateCardContentSpy).toHaveBeenCalledWith(
+      "<at id=ou_luke></at> 加了。\n我刚又确认了一遍",
+    );
+    expect((session as any).state.currentText).toBe(
+      "<at id=ou_luke></at> 加了。\n我刚又确认了一遍",
+    );
+  });
+
+  it("keeps pending merge behavior when final text is omitted", async () => {
+    const session = new FeishuStreamingSession({} as never, {
+      appId: "app",
+      appSecret: "secret",
+    });
+    (session as any).state = {
+      cardId: "card-id",
+      messageId: "message-id",
+      sequence: 1,
+      currentText: "第一段",
+    };
+    (session as any).pendingText = "第一段\n第二段";
+    const updateCardContentSpy = vi
+      .spyOn(session as any, "updateCardContent")
+      .mockResolvedValue(undefined);
+
+    await session.close();
+
+    expect(updateCardContentSpy).toHaveBeenCalledWith("第一段\n第二段");
+    expect((session as any).state.currentText).toBe("第一段\n第二段");
   });
 });

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -285,6 +285,19 @@ export class FeishuStreamingSession {
       .catch((error) => onError?.(error));
   }
 
+  private async deleteMessage(messageId: string): Promise<void> {
+    try {
+      const response = await this.client.im.message.delete({
+        path: { message_id: messageId },
+      });
+      if (response.code !== 0) {
+        throw new Error(response.msg || `code ${response.code}`);
+      }
+    } catch (e) {
+      this.log?.(`Delete failed: ${String(e)}`);
+    }
+  }
+
   async update(
     text: string,
     options?: {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -95,8 +95,24 @@ function truncateSummary(text: string, max = 50): string {
   if (!text) {
     return "";
   }
-  const clean = text.replace(/\n/g, " ").trim();
+  const clean = stripHtmlTagsToText(text).replace(/\s+/g, " ").trim();
   return clean.length <= max ? clean : clean.slice(0, max - 3) + "...";
+}
+
+function stripHtmlTagsToText(text: string): string {
+  if (!text) {
+    return "";
+  }
+  return text
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/(p|div|li|h[1-6])>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'");
 }
 
 export function mergeStreamingText(

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -6,8 +6,10 @@ import type { Client } from "@larksuiteoapi/node-sdk";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/feishu";
 import type { FeishuDomain } from "./types.js";
 
-type Credentials = { appId: string; appSecret: string; domain?: FeishuDomain };
+type Credentials = { appId: string; appSecret: string; domain?: string };
 type CardState = { cardId: string; messageId: string; sequence: number; currentText: string };
+type UpdateMode = "merge" | "replace";
+type PendingUpdate = { text: string; mode: UpdateMode };
 
 /** Optional header for streaming cards (title bar with color template) */
 export type StreamingCardHeader = {
@@ -88,6 +90,7 @@ async function getToken(creds: Credentials): Promise<string> {
   return data.tenant_access_token;
 }
 
+
 function truncateSummary(text: string, max = 50): string {
   if (!text) {
     return "";
@@ -145,18 +148,16 @@ export function resolveStreamingCardSendMode(options?: StreamingStartOptions) {
 /** Streaming card session manager */
 export class FeishuStreamingSession {
   private client: Client;
-  private creds: Credentials;
   private state: CardState | null = null;
   private queue: Promise<void> = Promise.resolve();
   private closed = false;
   private log?: (msg: string) => void;
   private lastUpdateTime = 0;
-  private pendingText: string | null = null;
+  private pendingUpdate: PendingUpdate | null = null;
   private updateThrottleMs = 100; // Throttle updates to max 10/sec
 
-  constructor(client: Client, creds: Credentials, log?: (msg: string) => void) {
+  constructor(client: Client, _creds: Credentials, log?: (msg: string) => void) {
     this.client = client;
-    this.creds = creds;
     this.log = log;
   }
 
@@ -169,7 +170,6 @@ export class FeishuStreamingSession {
       return;
     }
 
-    const apiBase = resolveApiBase(this.creds.domain);
     const cardJson: Record<string, unknown> = {
       schema: "2.0",
       config: {
@@ -188,31 +188,14 @@ export class FeishuStreamingSession {
       };
     }
 
-    // Create card entity
-    const { response: createRes, release: releaseCreate } = await fetchWithSsrFGuard({
-      url: `${apiBase}/cardkit/v1/cards`,
-      init: {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${await getToken(this.creds)}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ type: "card_json", data: JSON.stringify(cardJson) }),
+    // Create card entity via SDK
+    const createData = await this.client.cardkit.v1.card.create({
+      data: {
+        type: "card_json",
+        data: JSON.stringify(cardJson),
       },
-      policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
-      auditContext: "feishu.streaming-card.create",
     });
-    if (!createRes.ok) {
-      await releaseCreate();
-      throw new Error(`Create card request failed with HTTP ${createRes.status}`);
-    }
-    const createData = (await createRes.json()) as {
-      code: number;
-      msg: string;
-      data?: { card_id: string };
-    };
-    await releaseCreate();
-    if (createData.code !== 0 || !createData.data?.card_id) {
+    if ((createData.code ?? 0) !== 0 || !createData.data?.card_id) {
       throw new Error(`Create card failed: ${createData.msg}`);
     }
     const cardId = createData.data.card_id;
@@ -265,36 +248,39 @@ export class FeishuStreamingSession {
     if (!this.state) {
       return;
     }
-    const apiBase = resolveApiBase(this.creds.domain);
     this.state.sequence += 1;
-    await fetchWithSsrFGuard({
-      url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/content/content`,
-      init: {
-        method: "PUT",
-        headers: {
-          Authorization: `Bearer ${await getToken(this.creds)}`,
-          "Content-Type": "application/json",
+    await this.client.cardkit.v1.cardElement
+      .content({
+        path: {
+          card_id: this.state.cardId,
+          element_id: "content",
         },
-        body: JSON.stringify({
+        data: {
           content: text,
           sequence: this.state.sequence,
           uuid: `s_${this.state.cardId}_${this.state.sequence}`,
-        }),
-      },
-      policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
-      auditContext: "feishu.streaming-card.update",
-    })
-      .then(async ({ release }) => {
-        await release();
+        },
+      })
+      .then((response) => {
+        if ((response.code ?? 0) !== 0) {
+          throw new Error(response.msg || `code ${response.code}`);
+        }
       })
       .catch((error) => onError?.(error));
   }
 
-  async update(text: string): Promise<void> {
+  async update(
+    text: string,
+    options?: {
+      mode?: UpdateMode;
+    },
+  ): Promise<void> {
     if (!this.state || this.closed) {
       return;
     }
-    const mergedInput = mergeStreamingText(this.pendingText ?? this.state.currentText, text);
+    const mode = options?.mode ?? "merge";
+    const pendingBase = this.pendingUpdate?.text ?? this.state.currentText;
+    const mergedInput = mode === "replace" ? text : mergeStreamingText(pendingBase, text);
     if (!mergedInput || mergedInput === this.state.currentText) {
       return;
     }
@@ -302,17 +288,18 @@ export class FeishuStreamingSession {
     // Throttle: skip if updated recently, but remember pending text
     const now = Date.now();
     if (now - this.lastUpdateTime < this.updateThrottleMs) {
-      this.pendingText = mergedInput;
+      this.pendingUpdate = { text: mergedInput, mode: "replace" };
       return;
     }
-    this.pendingText = null;
+    this.pendingUpdate = null;
     this.lastUpdateTime = now;
 
     this.queue = this.queue.then(async () => {
       if (!this.state || this.closed) {
         return;
       }
-      const mergedText = mergeStreamingText(this.state.currentText, mergedInput);
+      const mergedText =
+        mode === "replace" ? mergedInput : mergeStreamingText(this.state.currentText, mergedInput);
       if (!mergedText || mergedText === this.state.currentText) {
         return;
       }
@@ -329,46 +316,66 @@ export class FeishuStreamingSession {
     this.closed = true;
     await this.queue;
 
-    const pendingMerged = mergeStreamingText(this.state.currentText, this.pendingText ?? undefined);
-    const text = finalText ? mergeStreamingText(pendingMerged, finalText) : pendingMerged;
-    const apiBase = resolveApiBase(this.creds.domain);
+    const hasExplicitFinalText = finalText !== undefined;
+    const pendingMerged = this.pendingUpdate
+      ? this.pendingUpdate.mode === "replace"
+        ? this.pendingUpdate.text
+        : mergeStreamingText(this.state.currentText, this.pendingUpdate.text)
+      : this.state.currentText;
+    this.pendingUpdate = null;
+    const text = hasExplicitFinalText ? finalText : pendingMerged;
 
-    // Only send final update if content differs from what's already displayed
-    if (text && text !== this.state.currentText) {
+    // Explicit finalText (even empty) must win over transient status lines.
+    if (
+      hasExplicitFinalText
+        ? text !== this.state.currentText
+        : Boolean(text && text !== this.state.currentText)
+    ) {
       await this.updateCardContent(text);
       this.state.currentText = text;
     }
 
     // Close streaming mode
     this.state.sequence += 1;
-    await fetchWithSsrFGuard({
-      url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/settings`,
-      init: {
-        method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${await getToken(this.creds)}`,
-          "Content-Type": "application/json; charset=utf-8",
-        },
-        body: JSON.stringify({
+    await this.client.cardkit.v1.card
+      .settings({
+        path: { card_id: this.state.cardId },
+        data: {
           settings: JSON.stringify({
             config: { streaming_mode: false, summary: { content: truncateSummary(text) } },
           }),
           sequence: this.state.sequence,
           uuid: `c_${this.state.cardId}_${this.state.sequence}`,
-        }),
-      },
-      policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
-      auditContext: "feishu.streaming-card.close",
-    })
-      .then(async ({ release }) => {
-        await release();
+        },
+      })
+      .then((response) => {
+        if ((response.code ?? 0) !== 0) {
+          throw new Error(response.msg || `code ${response.code}`);
+        }
       })
       .catch((e) => this.log?.(`Close failed: ${String(e)}`));
 
     this.log?.(`Closed streaming: cardId=${this.state.cardId}`);
   }
 
+  async discard(): Promise<void> {
+    if (!this.state || this.closed) {
+      return;
+    }
+    this.closed = true;
+    await this.queue;
+    const messageId = this.state.messageId;
+    const cardId = this.state.cardId;
+    this.pendingUpdate = null;
+    await this.deleteMessage(messageId);
+    this.log?.(`Discarded streaming card: cardId=${cardId}, messageId=${messageId}`);
+  }
+
   isActive(): boolean {
     return this.state !== null && !this.closed;
+  }
+
+  getMessageId(): string | undefined {
+    return this.state?.messageId;
   }
 }

--- a/extensions/feishu/src/thread-bindings.manager.test.ts
+++ b/extensions/feishu/src/thread-bindings.manager.test.ts
@@ -1,0 +1,393 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock sendMessageFeishu before importing the manager
+vi.mock("./send.js", () => ({
+  sendMessageFeishu: vi.fn().mockResolvedValue({ messageId: "om_intro_msg_1", chatId: "oc_chat1" }),
+}));
+
+// Mock plugin-sdk session binding registration
+const registeredAdapters = new Map<string, any>();
+vi.mock("openclaw/plugin-sdk", async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...original,
+    registerSessionBindingAdapter: vi.fn((adapter: any) => {
+      registeredAdapters.set(`${adapter.channel}:${adapter.accountId}`, adapter);
+    }),
+    unregisterSessionBindingAdapter: vi.fn((params: any) => {
+      registeredAdapters.delete(`${params.channel}:${params.accountId}`);
+    }),
+    normalizeAccountId: (id?: string) => (id?.trim() || "default").toLowerCase(),
+  };
+});
+
+import type { ClawdbotConfig } from "openclaw/plugin-sdk";
+import { sendMessageFeishu } from "./send.js";
+import {
+  createFeishuThreadBindingManager,
+  resetManagersForTests,
+} from "./thread-bindings.manager.js";
+import { resetForTests } from "./thread-bindings.state.js";
+
+const mockSend = vi.mocked(sendMessageFeishu);
+
+function makeCfg(): ClawdbotConfig {
+  return {} as ClawdbotConfig;
+}
+
+beforeEach(() => {
+  resetManagersForTests();
+  resetForTests();
+  registeredAdapters.clear();
+  mockSend.mockReset();
+  mockSend.mockResolvedValue({ messageId: "om_intro_msg_1", chatId: "oc_chat1" });
+});
+
+afterEach(() => {
+  resetManagersForTests();
+  resetForTests();
+  registeredAdapters.clear();
+});
+
+describe("createFeishuThreadBindingManager", () => {
+  it("registers a session binding adapter on creation", () => {
+    const manager = createFeishuThreadBindingManager({
+      accountId: "test-acc",
+      cfg: makeCfg(),
+      persist: false,
+      enableSweeper: false,
+    });
+
+    expect(registeredAdapters.has("feishu:test-acc")).toBe(true);
+    manager.stop();
+    expect(registeredAdapters.has("feishu:test-acc")).toBe(false);
+  });
+
+  it("binds a target by sending intro + reply messages", async () => {
+    const manager = createFeishuThreadBindingManager({
+      accountId: "acc1",
+      cfg: makeCfg(),
+      persist: false,
+      enableSweeper: false,
+    });
+
+    const record = await manager.bind({
+      chatId: "oc_chat1",
+      targetKind: "acp",
+      targetSessionKey: "agent:default:feishu:group:oc_chat1",
+      introText: "Hello thread!",
+    });
+
+    expect(record).not.toBeNull();
+    expect(record!.chatId).toBe("oc_chat1");
+    expect(record!.rootId).toBe("om_intro_msg_1");
+    expect(record!.targetSessionKey).toBe("agent:default:feishu:group:oc_chat1");
+
+    // Two messages: intro + thread activation reply
+    expect(mockSend).toHaveBeenCalledTimes(2);
+    // First call: intro message
+    expect(mockSend.mock.calls[0][0]).toMatchObject({
+      to: "chat:oc_chat1",
+      text: "Hello thread!",
+    });
+    // Second call: thread activation reply
+    expect(mockSend.mock.calls[1][0]).toMatchObject({
+      to: "chat:oc_chat1",
+      replyToMessageId: "om_intro_msg_1",
+      replyInThread: true,
+    });
+
+    manager.stop();
+  });
+
+  it("retrieves binding by key after bind", async () => {
+    const manager = createFeishuThreadBindingManager({
+      accountId: "acc1",
+      cfg: makeCfg(),
+      persist: false,
+      enableSweeper: false,
+    });
+
+    await manager.bind({
+      chatId: "oc_chat1",
+      targetKind: "acp",
+      targetSessionKey: "agent:default:feishu:group:oc_chat1",
+    });
+
+    const found = manager.getByKey("oc_chat1", "om_intro_msg_1");
+    expect(found).not.toBeUndefined();
+    expect(found!.targetSessionKey).toBe("agent:default:feishu:group:oc_chat1");
+
+    manager.stop();
+  });
+
+  it("lists bindings by session key", async () => {
+    const manager = createFeishuThreadBindingManager({
+      accountId: "acc1",
+      cfg: makeCfg(),
+      persist: false,
+      enableSweeper: false,
+    });
+
+    let callCount = 0;
+    mockSend.mockImplementation(async () => {
+      callCount++;
+      return { messageId: `om_msg_${callCount}`, chatId: "oc_chat1" };
+    });
+
+    const sessionKey = "agent:default:feishu:group:oc_chat1";
+    await manager.bind({ chatId: "oc_chat1", targetKind: "acp", targetSessionKey: sessionKey });
+    await manager.bind({ chatId: "oc_chat1", targetKind: "acp", targetSessionKey: sessionKey });
+
+    const list = manager.listBySessionKey(sessionKey);
+    expect(list).toHaveLength(2);
+
+    manager.stop();
+  });
+
+  it("unbinds a binding and sends farewell", async () => {
+    const manager = createFeishuThreadBindingManager({
+      accountId: "acc1",
+      cfg: makeCfg(),
+      persist: false,
+      enableSweeper: false,
+    });
+
+    await manager.bind({
+      chatId: "oc_chat1",
+      targetKind: "acp",
+      targetSessionKey: "sess1",
+    });
+
+    mockSend.mockClear();
+    const removed = manager.unbind("oc_chat1", "om_intro_msg_1", {
+      reason: "test-done",
+      sendFarewell: true,
+    });
+
+    expect(removed).not.toBeNull();
+    expect(removed!.rootId).toBe("om_intro_msg_1");
+    expect(manager.getByKey("oc_chat1", "om_intro_msg_1")).toBeUndefined();
+    // Farewell message sent
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat:oc_chat1",
+        replyToMessageId: "om_intro_msg_1",
+        replyInThread: true,
+      }),
+    );
+
+    manager.stop();
+  });
+
+  it("unbinds by session key", async () => {
+    const manager = createFeishuThreadBindingManager({
+      accountId: "acc1",
+      cfg: makeCfg(),
+      persist: false,
+      enableSweeper: false,
+    });
+
+    await manager.bind({
+      chatId: "oc_chat1",
+      targetKind: "acp",
+      targetSessionKey: "sess1",
+    });
+
+    const removed = manager.unbindBySessionKey("sess1");
+    expect(removed).toHaveLength(1);
+    expect(manager.listBindings()).toHaveLength(0);
+
+    manager.stop();
+  });
+
+  it("touches a binding and updates lastActivityAt", async () => {
+    const manager = createFeishuThreadBindingManager({
+      accountId: "acc1",
+      cfg: makeCfg(),
+      persist: false,
+      enableSweeper: false,
+    });
+
+    await manager.bind({
+      chatId: "oc_chat1",
+      targetKind: "acp",
+      targetSessionKey: "sess1",
+    });
+
+    const before = manager.getByKey("oc_chat1", "om_intro_msg_1")!.lastActivityAt;
+    const futureTime = Date.now() + 60_000;
+    const updated = manager.touch("oc_chat1", "om_intro_msg_1", futureTime);
+    expect(updated!.lastActivityAt).toBeGreaterThanOrEqual(futureTime);
+    expect(updated!.lastActivityAt).toBeGreaterThan(before);
+
+    manager.stop();
+  });
+
+  it("returns null for bind with empty chatId", async () => {
+    const manager = createFeishuThreadBindingManager({
+      accountId: "acc1",
+      cfg: makeCfg(),
+      persist: false,
+      enableSweeper: false,
+    });
+
+    const result = await manager.bind({
+      chatId: "",
+      targetKind: "acp",
+      targetSessionKey: "sess1",
+    });
+    expect(result).toBeNull();
+
+    manager.stop();
+  });
+
+  it("returns null for bind when send fails", async () => {
+    mockSend.mockRejectedValue(new Error("API error"));
+
+    const manager = createFeishuThreadBindingManager({
+      accountId: "acc1",
+      cfg: makeCfg(),
+      persist: false,
+      enableSweeper: false,
+    });
+
+    const result = await manager.bind({
+      chatId: "oc_chat1",
+      targetKind: "acp",
+      targetSessionKey: "sess1",
+    });
+    expect(result).toBeNull();
+
+    manager.stop();
+  });
+});
+
+describe("session binding adapter", () => {
+  it("adapter bind with child placement creates thread", async () => {
+    const manager = createFeishuThreadBindingManager({
+      accountId: "acc1",
+      cfg: makeCfg(),
+      persist: false,
+      enableSweeper: false,
+    });
+
+    const adapter = registeredAdapters.get("feishu:acc1");
+    expect(adapter).toBeDefined();
+    expect(adapter.capabilities.placements).toContain("child");
+
+    const result = await adapter.bind({
+      targetSessionKey: "sess1",
+      targetKind: "session",
+      conversation: {
+        channel: "feishu",
+        accountId: "acc1",
+        conversationId: "oc_chat1",
+        parentConversationId: "oc_chat1",
+      },
+      placement: "child",
+      metadata: { introText: "Hello from ACP" },
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.conversation.channel).toBe("feishu");
+    expect(result!.targetSessionKey).toBe("sess1");
+
+    manager.stop();
+  });
+
+  it("adapter bind with current placement binds existing thread", async () => {
+    const manager = createFeishuThreadBindingManager({
+      accountId: "acc1",
+      cfg: makeCfg(),
+      persist: false,
+      enableSweeper: false,
+    });
+
+    const adapter = registeredAdapters.get("feishu:acc1");
+    const result = await adapter.bind({
+      targetSessionKey: "sess1",
+      targetKind: "session",
+      conversation: {
+        channel: "feishu",
+        accountId: "acc1",
+        conversationId: "oc_chat1:om_existing_root",
+      },
+      placement: "current",
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.conversation.conversationId).toBe("oc_chat1:om_existing_root");
+
+    manager.stop();
+  });
+
+  it("adapter resolveByConversation finds bound thread", async () => {
+    const manager = createFeishuThreadBindingManager({
+      accountId: "acc1",
+      cfg: makeCfg(),
+      persist: false,
+      enableSweeper: false,
+    });
+
+    await manager.bind({
+      chatId: "oc_chat1",
+      targetKind: "acp",
+      targetSessionKey: "sess1",
+    });
+
+    const adapter = registeredAdapters.get("feishu:acc1");
+    const resolved = adapter.resolveByConversation({
+      channel: "feishu",
+      accountId: "acc1",
+      conversationId: "oc_chat1:om_intro_msg_1",
+    });
+
+    expect(resolved).not.toBeNull();
+    expect(resolved!.targetSessionKey).toBe("sess1");
+
+    manager.stop();
+  });
+
+  it("adapter resolveByConversation returns null for unknown thread", () => {
+    const manager = createFeishuThreadBindingManager({
+      accountId: "acc1",
+      cfg: makeCfg(),
+      persist: false,
+      enableSweeper: false,
+    });
+
+    const adapter = registeredAdapters.get("feishu:acc1");
+    const resolved = adapter.resolveByConversation({
+      channel: "feishu",
+      accountId: "acc1",
+      conversationId: "oc_chat1:om_nonexistent",
+    });
+
+    expect(resolved).toBeNull();
+
+    manager.stop();
+  });
+
+  it("adapter listBySession returns bound sessions", async () => {
+    const manager = createFeishuThreadBindingManager({
+      accountId: "acc1",
+      cfg: makeCfg(),
+      persist: false,
+      enableSweeper: false,
+    });
+
+    await manager.bind({
+      chatId: "oc_chat1",
+      targetKind: "acp",
+      targetSessionKey: "sess1",
+    });
+
+    const adapter = registeredAdapters.get("feishu:acc1");
+    const list = adapter.listBySession("sess1");
+    expect(list).toHaveLength(1);
+    expect(list[0].targetSessionKey).toBe("sess1");
+
+    manager.stop();
+  });
+});

--- a/extensions/feishu/src/thread-bindings.manager.ts
+++ b/extensions/feishu/src/thread-bindings.manager.ts
@@ -1,0 +1,512 @@
+import {
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
+  normalizeAccountId,
+  type BindingTargetKind,
+  type ClawdbotConfig,
+  type SessionBindingRecord,
+} from "openclaw/plugin-sdk";
+import { sendMessageFeishu } from "./send.js";
+import {
+  BINDINGS_BY_KEY,
+  ensureBindingsLoaded,
+  parseConversationId,
+  removeBindingRecord,
+  resolveBindingKeysForSession,
+  saveBindingsToDisk,
+  setBindingRecord,
+  setPersistEnabled,
+  shouldDefaultPersist,
+  toBindingKey,
+  toConversationId,
+} from "./thread-bindings.state.js";
+import {
+  DEFAULT_FEISHU_THREAD_BINDING_IDLE_TIMEOUT_MS,
+  DEFAULT_FEISHU_THREAD_BINDING_MAX_AGE_MS,
+  FEISHU_THREAD_BINDINGS_SWEEP_INTERVAL_MS,
+  FEISHU_THREAD_BINDING_TOUCH_PERSIST_MIN_INTERVAL_MS,
+  type FeishuThreadBindingRecord,
+  type FeishuThreadBindingTargetKind,
+} from "./thread-bindings.types.js";
+
+// ---------------------------------------------------------------------------
+// Conversion helpers
+// ---------------------------------------------------------------------------
+
+function resolveAgentIdFromSessionKey(sessionKey: string): string {
+  // agent:<agentId>:<channel>:<peerKind>:<peerId>
+  const parts = sessionKey.split(":");
+  return parts.length >= 2 ? parts[1] : "default";
+}
+
+function normalizeTargetKind(
+  raw: unknown,
+  targetSessionKey: string,
+): FeishuThreadBindingTargetKind {
+  if (raw === "subagent" || raw === "acp") return raw;
+  return targetSessionKey.includes(":subagent:") ? "subagent" : "acp";
+}
+
+function toSessionBindingTargetKind(raw: string): BindingTargetKind {
+  return raw === "subagent" ? "subagent" : "session";
+}
+
+function toFeishuTargetKind(raw: BindingTargetKind): FeishuThreadBindingTargetKind {
+  return raw === "subagent" ? "subagent" : "acp";
+}
+
+function normalizeDurationMs(raw: unknown, fallback: number): number {
+  if (typeof raw === "number" && Number.isFinite(raw) && raw >= 0) {
+    return Math.floor(raw);
+  }
+  return fallback;
+}
+
+function resolveIdleTimeoutMs(record: FeishuThreadBindingRecord, defaultMs: number): number {
+  return normalizeDurationMs(record.idleTimeoutMs, defaultMs);
+}
+
+function resolveMaxAgeMs(record: FeishuThreadBindingRecord, defaultMs: number): number {
+  return normalizeDurationMs(record.maxAgeMs, defaultMs);
+}
+
+function resolveInactivityExpiresAt(
+  record: FeishuThreadBindingRecord,
+  defaultMs: number,
+): number | undefined {
+  const idle = resolveIdleTimeoutMs(record, defaultMs);
+  if (idle <= 0) return undefined;
+  return record.lastActivityAt + idle;
+}
+
+function resolveMaxAgeExpiresAt(
+  record: FeishuThreadBindingRecord,
+  defaultMs: number,
+): number | undefined {
+  const maxAge = resolveMaxAgeMs(record, defaultMs);
+  if (maxAge <= 0) return undefined;
+  return record.boundAt + maxAge;
+}
+
+function resolveEffectiveExpiresAt(
+  record: FeishuThreadBindingRecord,
+  defaults: { idleTimeoutMs: number; maxAgeMs: number },
+): number | undefined {
+  const inactivity = resolveInactivityExpiresAt(record, defaults.idleTimeoutMs);
+  const maxAge = resolveMaxAgeExpiresAt(record, defaults.maxAgeMs);
+  if (inactivity != null && maxAge != null) return Math.min(inactivity, maxAge);
+  return inactivity ?? maxAge;
+}
+
+function toSessionBindingRecord(
+  record: FeishuThreadBindingRecord,
+  defaults: { idleTimeoutMs: number; maxAgeMs: number },
+): SessionBindingRecord {
+  const bindingId = toBindingKey(record.accountId, record.chatId, record.rootId);
+  return {
+    bindingId,
+    targetSessionKey: record.targetSessionKey,
+    targetKind: toSessionBindingTargetKind(record.targetKind),
+    conversation: {
+      channel: "feishu",
+      accountId: record.accountId,
+      conversationId: toConversationId(record.chatId, record.rootId),
+      parentConversationId: record.chatId,
+    },
+    status: "active",
+    boundAt: record.boundAt,
+    expiresAt: resolveEffectiveExpiresAt(record, defaults),
+    metadata: {
+      agentId: record.agentId,
+      label: record.label,
+      boundBy: record.boundBy,
+      lastActivityAt: record.lastActivityAt,
+      idleTimeoutMs: resolveIdleTimeoutMs(record, defaults.idleTimeoutMs),
+      maxAgeMs: resolveMaxAgeMs(record, defaults.maxAgeMs),
+    },
+  };
+}
+
+function parseBindingIdParts(
+  accountId: string,
+  bindingId: string,
+): { chatId: string; rootId: string } | null {
+  const prefix = `${accountId}:`;
+  if (!bindingId.startsWith(prefix)) return null;
+  const rest = bindingId.slice(prefix.length);
+  return parseConversationId(rest);
+}
+
+// ---------------------------------------------------------------------------
+// Manager registry (prevents duplicate managers for the same account)
+// Stored on globalThis so ESM and jiti loader paths share one registry.
+// ---------------------------------------------------------------------------
+
+const MANAGERS_KEY = "__openclawFeishuThreadBindingManagers";
+
+function resolveManagersMap(): Map<string, FeishuThreadBindingManager> {
+  const g = globalThis as typeof globalThis & {
+    [MANAGERS_KEY]?: Map<string, FeishuThreadBindingManager>;
+  };
+  if (!g[MANAGERS_KEY]) {
+    g[MANAGERS_KEY] = new Map();
+  }
+  return g[MANAGERS_KEY];
+}
+
+const MANAGERS_BY_ACCOUNT = resolveManagersMap();
+
+// ---------------------------------------------------------------------------
+// Manager
+// ---------------------------------------------------------------------------
+
+export type FeishuThreadBindingManager = {
+  accountId: string;
+  getByKey: (chatId: string, rootId: string) => FeishuThreadBindingRecord | undefined;
+  listBySessionKey: (sessionKey: string) => FeishuThreadBindingRecord[];
+  listBindings: () => FeishuThreadBindingRecord[];
+  touch: (chatId: string, rootId: string, at?: number) => FeishuThreadBindingRecord | null;
+  bind: (params: FeishuBindParams) => Promise<FeishuThreadBindingRecord | null>;
+  unbind: (
+    chatId: string,
+    rootId: string,
+    opts?: { reason?: string; sendFarewell?: boolean; farewellText?: string },
+  ) => FeishuThreadBindingRecord | null;
+  unbindBySessionKey: (
+    sessionKey: string,
+    opts?: { reason?: string; sendFarewell?: boolean },
+  ) => FeishuThreadBindingRecord[];
+  stop: () => void;
+};
+
+type FeishuBindParams = {
+  chatId: string;
+  targetKind: FeishuThreadBindingTargetKind;
+  targetSessionKey: string;
+  agentId?: string;
+  label?: string;
+  boundBy?: string;
+  introText?: string;
+};
+
+type CreateManagerParams = {
+  accountId?: string;
+  cfg: ClawdbotConfig;
+  persist?: boolean;
+  enableSweeper?: boolean;
+  idleTimeoutMs?: number;
+  maxAgeMs?: number;
+};
+
+export function createFeishuThreadBindingManager(
+  params: CreateManagerParams,
+): FeishuThreadBindingManager {
+  ensureBindingsLoaded();
+
+  const accountId = normalizeAccountId(params.accountId);
+  const existing = MANAGERS_BY_ACCOUNT.get(accountId);
+  if (existing) return existing;
+
+  const { cfg } = params;
+  const persist = params.persist ?? shouldDefaultPersist();
+  setPersistEnabled(accountId, persist);
+
+  const idleTimeoutMs = normalizeDurationMs(
+    params.idleTimeoutMs,
+    DEFAULT_FEISHU_THREAD_BINDING_IDLE_TIMEOUT_MS,
+  );
+  const maxAgeMs = normalizeDurationMs(params.maxAgeMs, DEFAULT_FEISHU_THREAD_BINDING_MAX_AGE_MS);
+  const defaults = { idleTimeoutMs, maxAgeMs };
+
+  let sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+  // -- farewell helper --
+  const sendFarewellInThread = (record: FeishuThreadBindingRecord, text: string) => {
+    void sendMessageFeishu({
+      cfg,
+      to: `chat:${record.chatId}`,
+      text,
+      replyToMessageId: record.rootId,
+      replyInThread: true,
+      accountId,
+    }).catch(() => {});
+  };
+
+  const manager: FeishuThreadBindingManager = {
+    accountId,
+
+    getByKey: (chatId, rootId) => {
+      const key = toBindingKey(accountId, chatId, rootId);
+      const entry = BINDINGS_BY_KEY.get(key);
+      return entry?.accountId === accountId ? entry : undefined;
+    },
+
+    listBySessionKey: (sessionKey) => {
+      const keys = resolveBindingKeysForSession({ targetSessionKey: sessionKey, accountId });
+      return keys
+        .map((k) => BINDINGS_BY_KEY.get(k))
+        .filter((e): e is FeishuThreadBindingRecord => Boolean(e));
+    },
+
+    listBindings: () => [...BINDINGS_BY_KEY.values()].filter((e) => e.accountId === accountId),
+
+    touch: (chatId, rootId, at) => {
+      const key = toBindingKey(accountId, chatId, rootId);
+      const existing = BINDINGS_BY_KEY.get(key);
+      if (!existing || existing.accountId !== accountId) return null;
+      const now = Date.now();
+      const touchAt =
+        typeof at === "number" && Number.isFinite(at) ? Math.max(0, Math.floor(at)) : now;
+      const updated: FeishuThreadBindingRecord = {
+        ...existing,
+        lastActivityAt: Math.max(existing.lastActivityAt || 0, touchAt),
+      };
+      setBindingRecord(updated);
+      if (persist) {
+        saveBindingsToDisk({ minIntervalMs: FEISHU_THREAD_BINDING_TOUCH_PERSIST_MIN_INTERVAL_MS });
+      }
+      return updated;
+    },
+
+    bind: async (bindParams) => {
+      const chatId = bindParams.chatId?.trim();
+      if (!chatId) return null;
+      const targetSessionKey = bindParams.targetSessionKey.trim();
+      if (!targetSessionKey) return null;
+
+      const introText = bindParams.introText?.trim();
+
+      // Send intro message to create the thread anchor
+      let rootId: string | undefined;
+      try {
+        const result = await sendMessageFeishu({
+          cfg,
+          to: `chat:${chatId}`,
+          text: introText || "Thread created.",
+          accountId,
+        });
+        rootId = result.messageId;
+      } catch {
+        return null;
+      }
+      if (!rootId || rootId === "unknown") return null;
+
+      // Reply in-thread to activate topic thread in Feishu UI
+      try {
+        await sendMessageFeishu({
+          cfg,
+          to: `chat:${chatId}`,
+          text: "Listening in this thread.",
+          replyToMessageId: rootId,
+          replyInThread: true,
+          accountId,
+        });
+      } catch {
+        // Thread activation is best-effort; binding still works
+      }
+
+      const now = Date.now();
+      const targetKind = normalizeTargetKind(bindParams.targetKind, targetSessionKey);
+      const record: FeishuThreadBindingRecord = {
+        accountId,
+        chatId,
+        rootId,
+        targetKind,
+        targetSessionKey,
+        agentId: bindParams.agentId?.trim() || resolveAgentIdFromSessionKey(targetSessionKey),
+        label: bindParams.label?.trim() || undefined,
+        boundBy: bindParams.boundBy?.trim() || "system",
+        boundAt: now,
+        lastActivityAt: now,
+        idleTimeoutMs,
+        maxAgeMs,
+      };
+      setBindingRecord(record);
+      if (persist) saveBindingsToDisk();
+      return record;
+    },
+
+    unbind: (chatId, rootId, opts) => {
+      const key = toBindingKey(accountId, chatId, rootId);
+      const removed = removeBindingRecord(key);
+      if (!removed) return null;
+      if (persist) saveBindingsToDisk();
+      if (opts?.sendFarewell !== false) {
+        const text = opts?.farewellText || opts?.reason || "Thread binding ended.";
+        sendFarewellInThread(removed, text);
+      }
+      return removed;
+    },
+
+    unbindBySessionKey: (sessionKey, opts) => {
+      const keys = resolveBindingKeysForSession({ targetSessionKey: sessionKey, accountId });
+      const removed: FeishuThreadBindingRecord[] = [];
+      for (const key of keys) {
+        const binding = BINDINGS_BY_KEY.get(key);
+        if (!binding) continue;
+        const entry = manager.unbind(binding.chatId, binding.rootId, {
+          reason: opts?.reason,
+          sendFarewell: opts?.sendFarewell,
+        });
+        if (entry) removed.push(entry);
+      }
+      return removed;
+    },
+
+    stop: () => {
+      if (sweepTimer) {
+        clearInterval(sweepTimer);
+        sweepTimer = null;
+      }
+      const current = MANAGERS_BY_ACCOUNT.get(accountId);
+      if (current === manager) MANAGERS_BY_ACCOUNT.delete(accountId);
+      unregisterSessionBindingAdapter({ channel: "feishu", accountId });
+    },
+  };
+
+  // -- sweeper --
+  if (params.enableSweeper !== false) {
+    sweepTimer = setInterval(() => {
+      const bindings = manager.listBindings();
+      for (const snapshot of bindings) {
+        const binding = manager.getByKey(snapshot.chatId, snapshot.rootId);
+        if (!binding) continue;
+        const now = Date.now();
+        const inactivityAt = resolveInactivityExpiresAt(binding, idleTimeoutMs);
+        const maxAgeAt = resolveMaxAgeExpiresAt(binding, maxAgeMs);
+        const candidates: Array<{ reason: string; at: number }> = [];
+        if (inactivityAt != null && now >= inactivityAt) {
+          candidates.push({ reason: "idle-expired", at: inactivityAt });
+        }
+        if (maxAgeAt != null && now >= maxAgeAt) {
+          candidates.push({ reason: "max-age-expired", at: maxAgeAt });
+        }
+        if (candidates.length > 0) {
+          candidates.sort((a, b) => a.at - b.at);
+          manager.unbind(binding.chatId, binding.rootId, {
+            reason: candidates[0].reason,
+            sendFarewell: true,
+            farewellText: `Thread binding ended: ${candidates[0].reason}.`,
+          });
+        }
+      }
+    }, FEISHU_THREAD_BINDINGS_SWEEP_INTERVAL_MS);
+    sweepTimer.unref?.();
+  }
+
+  MANAGERS_BY_ACCOUNT.set(accountId, manager);
+
+  // -- register session binding adapter --
+  registerSessionBindingAdapter({
+    channel: "feishu",
+    accountId,
+    capabilities: { placements: ["current", "child"] },
+
+    bind: async (input) => {
+      if (input.conversation.channel !== "feishu") return null;
+      const targetSessionKey = input.targetSessionKey.trim();
+      if (!targetSessionKey) return null;
+
+      const metadata = input.metadata ?? {};
+      const label =
+        typeof metadata.label === "string" ? metadata.label.trim() || undefined : undefined;
+      const introText =
+        typeof metadata.introText === "string" ? metadata.introText.trim() || undefined : undefined;
+      const boundBy =
+        typeof metadata.boundBy === "string" ? metadata.boundBy.trim() || undefined : undefined;
+      const agentId =
+        typeof metadata.agentId === "string" ? metadata.agentId.trim() || undefined : undefined;
+      const placement = input.placement === "child" ? "child" : "current";
+
+      if (placement === "child") {
+        // Create a new thread in the specified chat.
+        // parentConversationId is the preferred source for the chat ID.
+        // If only conversationId is provided and it's a composite "chatId:rootId",
+        // extract just the chatId portion.
+        let chatId = input.conversation.parentConversationId?.trim();
+        if (!chatId) {
+          const raw = input.conversation.conversationId?.trim();
+          const parsed = raw ? parseConversationId(raw) : null;
+          chatId = parsed ? parsed.chatId : raw;
+        }
+        if (!chatId) return null;
+        const bound = await manager.bind({
+          chatId,
+          targetKind: toFeishuTargetKind(input.targetKind),
+          targetSessionKey,
+          agentId,
+          label,
+          boundBy,
+          introText,
+        });
+        return bound ? toSessionBindingRecord(bound, defaults) : null;
+      }
+
+      // placement === "current": bind to existing thread
+      const parsed = parseConversationId(input.conversation.conversationId);
+      if (!parsed) return null;
+      const { chatId, rootId } = parsed;
+
+      const now = Date.now();
+      const record: FeishuThreadBindingRecord = {
+        accountId,
+        chatId,
+        rootId,
+        targetKind: toFeishuTargetKind(input.targetKind),
+        targetSessionKey,
+        agentId: agentId || resolveAgentIdFromSessionKey(targetSessionKey),
+        label,
+        boundBy: boundBy || "system",
+        boundAt: now,
+        lastActivityAt: now,
+        idleTimeoutMs,
+        maxAgeMs,
+      };
+      setBindingRecord(record);
+      if (persist) saveBindingsToDisk();
+      return toSessionBindingRecord(record, defaults);
+    },
+
+    listBySession: (targetSessionKey) =>
+      manager.listBySessionKey(targetSessionKey).map((e) => toSessionBindingRecord(e, defaults)),
+
+    resolveByConversation: (ref) => {
+      if (ref.channel !== "feishu") return null;
+      const parsed = parseConversationId(ref.conversationId);
+      if (!parsed) return null;
+      const binding = manager.getByKey(parsed.chatId, parsed.rootId);
+      return binding ? toSessionBindingRecord(binding, defaults) : null;
+    },
+
+    touch: (bindingId, at) => {
+      const parts = parseBindingIdParts(accountId, bindingId);
+      if (!parts) return;
+      manager.touch(parts.chatId, parts.rootId, at);
+    },
+
+    unbind: async (input) => {
+      if (input.targetSessionKey?.trim()) {
+        const removed = manager.unbindBySessionKey(input.targetSessionKey, {
+          reason: input.reason,
+        });
+        return removed.map((e) => toSessionBindingRecord(e, defaults));
+      }
+      if (input.bindingId) {
+        const parts = parseBindingIdParts(accountId, input.bindingId);
+        if (!parts) return [];
+        const removed = manager.unbind(parts.chatId, parts.rootId, { reason: input.reason });
+        return removed ? [toSessionBindingRecord(removed, defaults)] : [];
+      }
+      return [];
+    },
+  });
+
+  return manager;
+}
+
+export function resetManagersForTests(): void {
+  for (const m of MANAGERS_BY_ACCOUNT.values()) {
+    m.stop();
+  }
+  MANAGERS_BY_ACCOUNT.clear();
+}

--- a/extensions/feishu/src/thread-bindings.state.test.ts
+++ b/extensions/feishu/src/thread-bindings.state.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  BINDINGS_BY_KEY,
+  BINDINGS_BY_SESSION,
+  ensureBindingsLoaded,
+  parseConversationId,
+  removeBindingRecord,
+  resetForTests,
+  resolveBindingKeysForSession,
+  setBindingRecord,
+  toBindingKey,
+  toConversationId,
+} from "./thread-bindings.state.js";
+import type { FeishuThreadBindingRecord } from "./thread-bindings.types.js";
+
+function makeRecord(overrides: Partial<FeishuThreadBindingRecord> = {}): FeishuThreadBindingRecord {
+  return {
+    accountId: "default",
+    chatId: "oc_chat1",
+    rootId: "om_root1",
+    targetKind: "acp",
+    targetSessionKey: "agent:default:feishu:group:oc_chat1",
+    agentId: "default",
+    boundBy: "system",
+    boundAt: Date.now(),
+    lastActivityAt: Date.now(),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  resetForTests();
+});
+
+describe("toBindingKey", () => {
+  it("concatenates accountId:chatId:rootId", () => {
+    expect(toBindingKey("acc1", "oc_chat", "om_msg")).toBe("acc1:oc_chat:om_msg");
+  });
+});
+
+describe("toConversationId / parseConversationId", () => {
+  it("round-trips chatId:rootId", () => {
+    const convId = toConversationId("oc_chat1", "om_root1");
+    expect(convId).toBe("oc_chat1:om_root1");
+    const parsed = parseConversationId(convId);
+    expect(parsed).toEqual({ chatId: "oc_chat1", rootId: "om_root1" });
+  });
+
+  it("returns null for invalid conversationId", () => {
+    expect(parseConversationId("nocolon")).toBeNull();
+    expect(parseConversationId(":trailing")).toBeNull();
+    expect(parseConversationId("leading:")).toBeNull();
+  });
+});
+
+describe("setBindingRecord / removeBindingRecord", () => {
+  it("stores and retrieves a binding record", () => {
+    const record = makeRecord();
+    setBindingRecord(record);
+
+    const key = toBindingKey(record.accountId, record.chatId, record.rootId);
+    expect(BINDINGS_BY_KEY.get(key)).toEqual(record);
+    expect(BINDINGS_BY_SESSION.get(record.targetSessionKey)?.has(key)).toBe(true);
+  });
+
+  it("removes a binding record and unlinks session", () => {
+    const record = makeRecord();
+    setBindingRecord(record);
+    const key = toBindingKey(record.accountId, record.chatId, record.rootId);
+
+    const removed = removeBindingRecord(key);
+    expect(removed).toEqual(record);
+    expect(BINDINGS_BY_KEY.has(key)).toBe(false);
+    expect(BINDINGS_BY_SESSION.has(record.targetSessionKey)).toBe(false);
+  });
+
+  it("returns null when removing non-existent key", () => {
+    expect(removeBindingRecord("nonexistent")).toBeNull();
+  });
+
+  it("updates session index when record is replaced", () => {
+    const record1 = makeRecord({ targetSessionKey: "session-a" });
+    setBindingRecord(record1);
+    const key = toBindingKey(record1.accountId, record1.chatId, record1.rootId);
+
+    const record2 = makeRecord({ targetSessionKey: "session-b" });
+    setBindingRecord(record2);
+
+    expect(BINDINGS_BY_SESSION.has("session-a")).toBe(false);
+    expect(BINDINGS_BY_SESSION.get("session-b")?.has(key)).toBe(true);
+  });
+});
+
+describe("resolveBindingKeysForSession", () => {
+  it("returns all keys for a session", () => {
+    const sessionKey = "agent:default:feishu:group:oc_chat1";
+    setBindingRecord(makeRecord({ rootId: "om_r1", targetSessionKey: sessionKey }));
+    setBindingRecord(makeRecord({ rootId: "om_r2", targetSessionKey: sessionKey }));
+    setBindingRecord(makeRecord({ rootId: "om_r3", targetSessionKey: "other-session" }));
+
+    const keys = resolveBindingKeysForSession({ targetSessionKey: sessionKey });
+    expect(keys).toHaveLength(2);
+  });
+
+  it("filters by accountId when provided", () => {
+    const sessionKey = "agent:default:feishu:group:oc_chat1";
+    setBindingRecord(
+      makeRecord({ accountId: "acc1", rootId: "om_r1", targetSessionKey: sessionKey }),
+    );
+    setBindingRecord(
+      makeRecord({ accountId: "acc2", rootId: "om_r2", targetSessionKey: sessionKey }),
+    );
+
+    const keys = resolveBindingKeysForSession({ targetSessionKey: sessionKey, accountId: "acc1" });
+    expect(keys).toHaveLength(1);
+    expect(keys[0]).toContain("acc1:");
+  });
+});
+
+describe("ensureBindingsLoaded", () => {
+  it("is idempotent", () => {
+    ensureBindingsLoaded();
+    setBindingRecord(makeRecord());
+    ensureBindingsLoaded(); // should not clear the record
+    expect(BINDINGS_BY_KEY.size).toBe(1);
+  });
+});

--- a/extensions/feishu/src/thread-bindings.state.ts
+++ b/extensions/feishu/src/thread-bindings.state.ts
@@ -1,0 +1,218 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  FEISHU_THREAD_BINDINGS_VERSION,
+  FEISHU_THREAD_BINDING_TOUCH_PERSIST_MIN_INTERVAL_MS,
+  type FeishuThreadBindingRecord,
+  type PersistedFeishuThreadBindingsPayload,
+} from "./thread-bindings.types.js";
+
+// ---------------------------------------------------------------------------
+// globalThis state (shared across ESM / jiti loader paths)
+// ---------------------------------------------------------------------------
+
+type FeishuThreadBindingsGlobalState = {
+  bindingsByKey: Map<string, FeishuThreadBindingRecord>;
+  bindingsBySession: Map<string, Set<string>>;
+  persistByAccountId: Map<string, boolean>;
+  loadedBindings: boolean;
+  lastPersistedAtMs: number;
+};
+
+const STATE_KEY = "__openclawFeishuThreadBindingsState";
+
+function createGlobalState(): FeishuThreadBindingsGlobalState {
+  return {
+    bindingsByKey: new Map(),
+    bindingsBySession: new Map(),
+    persistByAccountId: new Map(),
+    loadedBindings: false,
+    lastPersistedAtMs: 0,
+  };
+}
+
+function resolveGlobalState(): FeishuThreadBindingsGlobalState {
+  const g = globalThis as typeof globalThis & { [STATE_KEY]?: FeishuThreadBindingsGlobalState };
+  if (!g[STATE_KEY]) {
+    g[STATE_KEY] = createGlobalState();
+  }
+  return g[STATE_KEY];
+}
+
+const STATE = resolveGlobalState();
+
+export const BINDINGS_BY_KEY = STATE.bindingsByKey;
+export const BINDINGS_BY_SESSION = STATE.bindingsBySession;
+
+// ---------------------------------------------------------------------------
+// Binding key helpers
+// ---------------------------------------------------------------------------
+
+export function toBindingKey(accountId: string, chatId: string, rootId: string): string {
+  return `${accountId}:${chatId}:${rootId}`;
+}
+
+export function toConversationId(chatId: string, rootId: string): string {
+  return `${chatId}:${rootId}`;
+}
+
+export function parseConversationId(
+  conversationId: string,
+): { chatId: string; rootId: string } | null {
+  const idx = conversationId.indexOf(":");
+  if (idx < 1 || idx === conversationId.length - 1) return null;
+  return { chatId: conversationId.slice(0, idx), rootId: conversationId.slice(idx + 1) };
+}
+
+// ---------------------------------------------------------------------------
+// Session key indexing
+// ---------------------------------------------------------------------------
+
+function linkSession(targetSessionKey: string, bindingKey: string): void {
+  const key = targetSessionKey.trim();
+  if (!key) return;
+  const set = BINDINGS_BY_SESSION.get(key) ?? new Set<string>();
+  set.add(bindingKey);
+  BINDINGS_BY_SESSION.set(key, set);
+}
+
+function unlinkSession(targetSessionKey: string, bindingKey: string): void {
+  const key = targetSessionKey.trim();
+  if (!key) return;
+  const set = BINDINGS_BY_SESSION.get(key);
+  if (!set) return;
+  set.delete(bindingKey);
+  if (set.size === 0) BINDINGS_BY_SESSION.delete(key);
+}
+
+// ---------------------------------------------------------------------------
+// Record CRUD
+// ---------------------------------------------------------------------------
+
+export function setBindingRecord(record: FeishuThreadBindingRecord): void {
+  const key = toBindingKey(record.accountId, record.chatId, record.rootId);
+  const previous = BINDINGS_BY_KEY.get(key);
+  if (previous) {
+    unlinkSession(previous.targetSessionKey, key);
+  }
+  BINDINGS_BY_KEY.set(key, record);
+  linkSession(record.targetSessionKey, key);
+}
+
+export function removeBindingRecord(bindingKey: string): FeishuThreadBindingRecord | null {
+  const existing = BINDINGS_BY_KEY.get(bindingKey);
+  if (!existing) return null;
+  BINDINGS_BY_KEY.delete(bindingKey);
+  unlinkSession(existing.targetSessionKey, bindingKey);
+  return existing;
+}
+
+export function resolveBindingKeysForSession(params: {
+  targetSessionKey: string;
+  accountId?: string;
+}): string[] {
+  const set = BINDINGS_BY_SESSION.get(params.targetSessionKey.trim());
+  if (!set) return [];
+  if (!params.accountId) return [...set];
+  return [...set].filter((key) => key.startsWith(`${params.accountId}:`));
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+function resolveStateDirFromEnv(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.OPENCLAW_STATE_DIR?.trim() || env.CLAWDBOT_STATE_DIR?.trim();
+  if (override) return override;
+  if (env.VITEST || env.NODE_ENV === "test") {
+    return path.join(os.tmpdir(), ["openclaw-vitest", String(process.pid)].join("-"));
+  }
+  return path.join(os.homedir(), ".openclaw");
+}
+
+export function resolveThreadBindingsPath(): string {
+  return path.join(resolveStateDirFromEnv(), "feishu", "thread-bindings.json");
+}
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+export function shouldDefaultPersist(): boolean {
+  return !(process.env.VITEST || process.env.NODE_ENV === "test");
+}
+
+function shouldPersistAnyAccount(): boolean {
+  for (const enabled of STATE.persistByAccountId.values()) {
+    if (enabled) return true;
+  }
+  return false;
+}
+
+export function saveBindingsToDisk(params: { force?: boolean; minIntervalMs?: number } = {}): void {
+  if (!params.force && !shouldPersistAnyAccount()) return;
+  const minIntervalMs = params.minIntervalMs ?? FEISHU_THREAD_BINDING_TOUCH_PERSIST_MIN_INTERVAL_MS;
+  const now = Date.now();
+  if (
+    !params.force &&
+    minIntervalMs > 0 &&
+    STATE.lastPersistedAtMs > 0 &&
+    now - STATE.lastPersistedAtMs < minIntervalMs
+  ) {
+    return;
+  }
+  const bindings: Record<string, FeishuThreadBindingRecord> = {};
+  for (const [key, record] of BINDINGS_BY_KEY.entries()) {
+    bindings[key] = { ...record };
+  }
+  const payload: PersistedFeishuThreadBindingsPayload = {
+    version: FEISHU_THREAD_BINDINGS_VERSION,
+    bindings,
+  };
+  const filePath = resolveThreadBindingsPath();
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp.${process.pid}`;
+  fs.writeFileSync(tmpPath, JSON.stringify(payload, null, 2) + "\n", "utf-8");
+  fs.renameSync(tmpPath, filePath);
+  STATE.lastPersistedAtMs = now;
+}
+
+export function ensureBindingsLoaded(): void {
+  if (STATE.loadedBindings) return;
+  STATE.loadedBindings = true;
+  BINDINGS_BY_KEY.clear();
+  BINDINGS_BY_SESSION.clear();
+
+  const filePath = resolveThreadBindingsPath();
+  let raw: PersistedFeishuThreadBindingsPayload | null = null;
+  try {
+    const content = fs.readFileSync(filePath, "utf-8");
+    raw = JSON.parse(content) as PersistedFeishuThreadBindingsPayload;
+  } catch {
+    // File missing or malformed — start fresh
+  }
+  if (!raw || typeof raw !== "object" || raw.version !== FEISHU_THREAD_BINDINGS_VERSION) {
+    return;
+  }
+  if (!raw.bindings || typeof raw.bindings !== "object") {
+    return;
+  }
+  for (const [key, entry] of Object.entries(raw.bindings)) {
+    if (!entry || typeof entry !== "object") continue;
+    if (!entry.accountId || !entry.chatId || !entry.rootId || !entry.targetSessionKey) continue;
+    setBindingRecord(entry as FeishuThreadBindingRecord);
+  }
+}
+
+export function setPersistEnabled(accountId: string, enabled: boolean): void {
+  STATE.persistByAccountId.set(accountId, enabled);
+}
+
+export function resetForTests(): void {
+  BINDINGS_BY_KEY.clear();
+  BINDINGS_BY_SESSION.clear();
+  STATE.persistByAccountId.clear();
+  STATE.loadedBindings = false;
+  STATE.lastPersistedAtMs = 0;
+}

--- a/extensions/feishu/src/thread-bindings.types.ts
+++ b/extensions/feishu/src/thread-bindings.types.ts
@@ -1,0 +1,27 @@
+export type FeishuThreadBindingTargetKind = "subagent" | "acp";
+
+export type FeishuThreadBindingRecord = {
+  accountId: string;
+  chatId: string; // group chat ID (oc_xxx)
+  rootId: string; // message ID anchoring the topic thread
+  targetKind: FeishuThreadBindingTargetKind;
+  targetSessionKey: string;
+  agentId: string;
+  label?: string;
+  boundBy: string;
+  boundAt: number;
+  lastActivityAt: number;
+  idleTimeoutMs?: number;
+  maxAgeMs?: number;
+};
+
+export type PersistedFeishuThreadBindingsPayload = {
+  version: number;
+  bindings: Record<string, FeishuThreadBindingRecord>;
+};
+
+export const FEISHU_THREAD_BINDINGS_VERSION = 1 as const;
+export const FEISHU_THREAD_BINDINGS_SWEEP_INTERVAL_MS = 120_000;
+export const DEFAULT_FEISHU_THREAD_BINDING_IDLE_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24h
+export const DEFAULT_FEISHU_THREAD_BINDING_MAX_AGE_MS = 0; // disabled
+export const FEISHU_THREAD_BINDING_TOUCH_PERSIST_MIN_INTERVAL_MS = 15_000;

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -58,6 +58,7 @@ export type FeishuMessageContext = {
 export type FeishuSendResult = {
   messageId: string;
   chatId: string;
+  meta?: Record<string, unknown>;
 };
 
 export type FeishuProbeResult = BaseProbeResult<string> & {

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -13,6 +13,7 @@ export type FeishuAccountConfig = z.infer<typeof FeishuAccountConfigSchema>;
 
 export type FeishuDomain = "feishu" | "lark" | (string & {});
 export type FeishuConnectionMode = "websocket" | "webhook";
+export type FeishuDispatchMode = "auto" | "plugin";
 
 export type FeishuDefaultAccountSelectionSource =
   | "explicit-default"

--- a/extensions/test-utils/plugin-runtime-mock.ts
+++ b/extensions/test-utils/plugin-runtime-mock.ts
@@ -35,6 +35,9 @@ function mergeDeep<T>(base: T, overrides: DeepPartial<T>): T {
 export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = {}): PluginRuntime {
   const base: PluginRuntime = {
     version: "1.0.0-test",
+    agents: {
+      runEmbeddedPiAgent: vi.fn() as unknown as PluginRuntime["agents"]["runEmbeddedPiAgent"],
+    },
     config: {
       loadConfig: vi.fn(() => ({})) as unknown as PluginRuntime["config"]["loadConfig"],
       writeConfigFile: vi.fn() as unknown as PluginRuntime["config"]["writeConfigFile"],

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -39,17 +39,18 @@ const CLAUDE_BYPASS_PERMISSIONS_MODE = "bypassPermissions";
 
 const DEFAULT_CLAUDE_BACKEND: CliBackendConfig = {
   command: "claude",
-  args: ["-p", "--output-format", "json", "--permission-mode", "bypassPermissions"],
+  args: ["-p", "--verbose", "--output-format", "stream-json", "--permission-mode", "bypassPermissions"],
   resumeArgs: [
     "-p",
+    "--verbose",
     "--output-format",
-    "json",
+    "stream-json",
     "--permission-mode",
     "bypassPermissions",
     "--resume",
     "{sessionId}",
   ],
-  output: "json",
+  output: "stream-json",
   input: "arg",
   modelArg: "--model",
   modelAliases: CLAUDE_MODEL_ALIASES,

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -58,7 +58,7 @@ const DEFAULT_CLAUDE_BACKEND: CliBackendConfig = {
   sessionIdFields: ["session_id", "sessionId", "conversation_id", "conversationId"],
   systemPromptArg: "--append-system-prompt",
   systemPromptMode: "append",
-  systemPromptWhen: "first",
+  systemPromptWhen: "always",
   clearEnv: ["ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY_OLD"],
   reliability: {
     watchdog: {

--- a/src/agents/cli-runner.test.ts
+++ b/src/agents/cli-runner.test.ts
@@ -9,6 +9,17 @@ import { resolveCliNoOutputTimeoutMs } from "./cli-runner/helpers.js";
 const supervisorSpawnMock = vi.fn();
 const enqueueSystemEventMock = vi.fn();
 const requestHeartbeatNowMock = vi.fn();
+const ensureMcpConfigFileMock = vi.hoisted(() => vi.fn(() => "/tmp/openclaw-mcp.json"));
+const getGlobalHookRunnerMock = vi.hoisted(() => vi.fn(() => null));
+
+vi.mock("../gateway/mcp-http.js", () => ({
+  MCP_PORT_OFFSET: 1,
+  ensureMcpConfigFile: (...args: unknown[]) => ensureMcpConfigFileMock(...args),
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: (...args: unknown[]) => getGlobalHookRunnerMock(...args),
+}));
 
 vi.mock("../process/supervisor/index.js", () => ({
   getProcessSupervisor: () => ({
@@ -57,10 +68,15 @@ function createManagedRun(exit: MockRunExit, pid = 1234) {
 }
 
 describe("runCliAgent with process supervisor", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     supervisorSpawnMock.mockClear();
     enqueueSystemEventMock.mockClear();
     requestHeartbeatNowMock.mockClear();
+    ensureMcpConfigFileMock.mockClear();
+    ensureMcpConfigFileMock.mockReturnValue("/tmp/openclaw-mcp.json");
+    getGlobalHookRunnerMock.mockReset();
+    getGlobalHookRunnerMock.mockReturnValue(null);
+    await fs.rm("/tmp/session.jsonl", { force: true }).catch(() => undefined);
   });
 
   it("runs CLI through supervisor and returns payload", async () => {
@@ -105,6 +121,158 @@ describe("runCliAgent with process supervisor", () => {
     expect(input.noOutputTimeoutMs).toBeGreaterThanOrEqual(1_000);
     expect(input.replaceExistingScope).toBe(true);
     expect(input.scopeKey).toContain("thread-123");
+    expect(ensureMcpConfigFileMock).not.toHaveBeenCalled();
+  });
+
+  it("writes prompt and assistant reply into the OpenClaw session transcript", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-runner-transcript-"));
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "CLI answer",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    try {
+      await runCliAgent({
+        sessionId: "s-transcript",
+        sessionFile,
+        workspaceDir: tempDir,
+        prompt: "What changed today?",
+        provider: "codex-cli",
+        model: "gpt-5.2-codex",
+        timeoutMs: 1_000,
+        runId: "run-cli-transcript",
+      });
+      const lines = (await fs.readFile(sessionFile, "utf-8")).trim().split("\n");
+      const entries = lines.map((line) => JSON.parse(line));
+      const messages = entries.filter((entry) => entry.type === "message");
+      expect(messages.length).toBe(2);
+      const userLine = messages[0];
+      const assistantLine = messages[1];
+      expect(userLine.message.role).toBe("user");
+      expect(userLine.message.content[0].text).toBe("What changed today?");
+      expect(assistantLine.message.role).toBe("assistant");
+      expect(assistantLine.message.content[0].text).toBe("CLI answer");
+      expect(assistantLine.message.provider).toBe("codex-cli");
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not apply skill env overrides for non-claude CLI backends", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-runner-codex-env-"));
+    const skillDir = path.join(tempDir, "skills", "demo-skill");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      ["---", "name: demo-skill", "description: demo", "---", ""].join("\n"),
+      "utf-8",
+    );
+    const envKey = "OPENCLAW_TEST_SKILL_ENV_OVERRIDE";
+    const previous = process.env[envKey];
+    delete process.env[envKey];
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "ok",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    try {
+      await runCliAgent({
+        sessionId: "s1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: tempDir,
+        config: {
+          skills: {
+            entries: {
+              "demo-skill": {
+                env: {
+                  [envKey]: "should-not-be-injected-for-codex",
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        prompt: "hi",
+        provider: "codex-cli",
+        model: "gpt-5.2-codex",
+        timeoutMs: 1_000,
+        runId: "run-codex-skill-env",
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      if (previous === undefined) {
+        delete process.env[envKey];
+      } else {
+        process.env[envKey] = previous;
+      }
+    }
+
+    const input = supervisorSpawnMock.mock.calls[0]?.[0] as {
+      env?: Record<string, string | undefined>;
+    };
+    expect(input.env?.[envKey]).toBeUndefined();
+    expect(process.env[envKey]).toBeUndefined();
+  });
+
+  it("adds strict MCP config flags for claude-cli", async () => {
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: '{"content":[{"type":"text","text":"ok"}]}',
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    await runCliAgent({
+      sessionId: "s1",
+      sessionKey: "agent:main:main",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {
+        gateway: {
+          port: 19000,
+        },
+      } as OpenClawConfig,
+      prompt: "hi",
+      provider: "claude-cli",
+      model: "sonnet",
+      timeoutMs: 1_000,
+      runId: "run-claude-mcp",
+    });
+
+    expect(ensureMcpConfigFileMock).toHaveBeenCalledTimes(1);
+    expect(ensureMcpConfigFileMock).toHaveBeenCalledWith(
+      path.join(os.homedir(), ".openclaw"),
+      19001,
+    );
+    const input = supervisorSpawnMock.mock.calls[0]?.[0] as { argv?: string[] };
+    expect(input.argv).toContain("--strict-mcp-config");
+    expect(input.argv).toContain("--mcp-config");
+    const mcpConfigIndex = input.argv?.indexOf("--mcp-config") ?? -1;
+    expect(mcpConfigIndex).toBeGreaterThanOrEqual(0);
+    expect(input.argv?.[mcpConfigIndex + 1]).toBe("/tmp/openclaw-mcp.json");
   });
 
   it("omits strict MCP flag when claude-cli backend mcp.strict is false", async () => {
@@ -1160,6 +1328,50 @@ describe("runCliAgent with process supervisor", () => {
 
     const input = supervisorSpawnMock.mock.calls[0]?.[0] as { cwd?: string };
     expect(input.cwd).toBe(path.resolve(fallbackWorkspace));
+  });
+
+  it("cancels running CLI process on abort signal", async () => {
+    const managedRun = createManagedRun({
+      reason: "manual-cancel",
+      exitCode: null,
+      exitSignal: "SIGTERM",
+      durationMs: 25,
+      stdout: "",
+      stderr: "",
+      timedOut: false,
+      noOutputTimedOut: false,
+    });
+    managedRun.wait = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      return {
+        reason: "manual-cancel",
+        exitCode: null,
+        exitSignal: "SIGTERM",
+        durationMs: 25,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      };
+    });
+    supervisorSpawnMock.mockResolvedValueOnce(managedRun);
+    const abortController = new AbortController();
+    const runPromise = runCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hi",
+      provider: "codex-cli",
+      model: "gpt-5.2-codex",
+      timeoutMs: 1_000,
+      runId: "run-abort",
+      abortSignal: abortController.signal,
+    });
+
+    await vi.waitFor(() => expect(supervisorSpawnMock).toHaveBeenCalledTimes(1));
+    abortController.abort("stop");
+    await expect(runPromise).rejects.toMatchObject({ name: "AbortError" });
+    expect(managedRun.cancel).toHaveBeenCalledWith("manual-cancel");
   });
 });
 

--- a/src/agents/cli-runner.test.ts
+++ b/src/agents/cli-runner.test.ts
@@ -107,6 +107,873 @@ describe("runCliAgent with process supervisor", () => {
     expect(input.scopeKey).toContain("thread-123");
   });
 
+  it("omits strict MCP flag when claude-cli backend mcp.strict is false", async () => {
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: '{"content":[{"type":"text","text":"ok"}]}',
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    await runCliAgent({
+      sessionId: "s1",
+      sessionKey: "agent:main:main",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "claude-cli": {
+                command: "claude",
+                mcp: {
+                  strict: false,
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "hi",
+      provider: "claude-cli",
+      model: "sonnet",
+      timeoutMs: 1_000,
+      runId: "run-claude-mcp-no-strict",
+    });
+
+    const input = supervisorSpawnMock.mock.calls[0]?.[0] as { argv?: string[] };
+    expect(input.argv).not.toContain("--strict-mcp-config");
+    expect(input.argv).toContain("--mcp-config");
+  });
+
+  it("disables MCP flags when claude-cli backend mcp.enabled is false", async () => {
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: '{"content":[{"type":"text","text":"ok"}]}',
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    await runCliAgent({
+      sessionId: "s1",
+      sessionKey: "agent:main:main",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      config: {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "claude-cli": {
+                command: "claude",
+                mcp: {
+                  enabled: false,
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      prompt: "hi",
+      provider: "claude-cli",
+      model: "sonnet",
+      timeoutMs: 1_000,
+      runId: "run-claude-mcp-disabled",
+    });
+
+    expect(ensureMcpConfigFileMock).not.toHaveBeenCalled();
+    const input = supervisorSpawnMock.mock.calls[0]?.[0] as { argv?: string[] };
+    expect(input.argv).not.toContain("--mcp-config");
+    expect(input.argv).not.toContain("--strict-mcp-config");
+  });
+
+  it("falls back to default MCP config when default file cannot be read", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-runner-mcp-fallback-"));
+    const missingDefaultPath = path.join(tempDir, "missing-default-mcp.json");
+    const extraMcpPath = path.join(tempDir, "mcp-extra.json");
+    await fs.writeFile(
+      extraMcpPath,
+      `${JSON.stringify(
+        {
+          mcpServers: {
+            remote: {
+              type: "stdio",
+              command: "node",
+              args: ["remote-mcp.js"],
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+    ensureMcpConfigFileMock.mockReturnValue(missingDefaultPath);
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: '{"content":[{"type":"text","text":"ok"}]}',
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    try {
+      await runCliAgent({
+        sessionId: "s1",
+        sessionKey: "agent:main:main",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {
+          agents: {
+            defaults: {
+              cliBackends: {
+                "claude-cli": {
+                  command: "claude",
+                  mcp: {
+                    mergeConfigPath: extraMcpPath,
+                  },
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        prompt: "hi",
+        provider: "claude-cli",
+        model: "sonnet",
+        timeoutMs: 1_000,
+        runId: "run-claude-mcp-default-read-fallback",
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+
+    const input = supervisorSpawnMock.mock.calls[0]?.[0] as { argv?: string[] };
+    const mcpConfigIndex = input.argv?.indexOf("--mcp-config") ?? -1;
+    expect(mcpConfigIndex).toBeGreaterThanOrEqual(0);
+    expect(input.argv?.[mcpConfigIndex + 1]).toBe(missingDefaultPath);
+  });
+
+  it("falls back to openclaw MCP servers when primary config file cannot be read", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-runner-mcp-primary-"));
+    const baseMcpPath = path.join(tempDir, "mcp-base.json");
+    const missingPrimaryPath = path.join(tempDir, "mcp-primary-missing.json");
+    await fs.writeFile(
+      baseMcpPath,
+      `${JSON.stringify(
+        {
+          mcpServers: {
+            openclaw: {
+              type: "http",
+              url: "http://127.0.0.1:19001/mcp",
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+    ensureMcpConfigFileMock.mockReturnValue(baseMcpPath);
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: '{"content":[{"type":"text","text":"ok"}]}',
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    try {
+      await runCliAgent({
+        sessionId: "s1",
+        sessionKey: "agent:main:main",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {
+          agents: {
+            defaults: {
+              cliBackends: {
+                "claude-cli": {
+                  command: "claude",
+                  mcp: {
+                    configPath: missingPrimaryPath,
+                  },
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        prompt: "hi",
+        provider: "claude-cli",
+        model: "sonnet",
+        timeoutMs: 1_000,
+        runId: "run-claude-mcp-primary-read-fallback",
+      });
+
+      const input = supervisorSpawnMock.mock.calls[0]?.[0] as { argv?: string[] };
+      const mcpConfigIndex = input.argv?.indexOf("--mcp-config") ?? -1;
+      expect(mcpConfigIndex).toBeGreaterThanOrEqual(0);
+      const mergedPath = input.argv?.[mcpConfigIndex + 1];
+      expect(mergedPath).not.toBe(missingPrimaryPath);
+      const mergedRaw = await fs.readFile(String(mergedPath), "utf-8");
+      const merged = JSON.parse(mergedRaw) as { mcpServers?: Record<string, unknown> };
+      expect(merged.mcpServers?.openclaw).toBeTruthy();
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("merges configured MCP servers into claude-cli MCP config", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-runner-mcp-merge-"));
+    const baseMcpPath = path.join(tempDir, "mcp-base.json");
+    const extraMcpPath = path.join(tempDir, "mcp-extra.json");
+    await fs.writeFile(
+      baseMcpPath,
+      `${JSON.stringify(
+        {
+          mcpServers: {
+            openclaw: {
+              type: "http",
+              url: "http://127.0.0.1:19001/mcp",
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+    await fs.writeFile(
+      extraMcpPath,
+      `${JSON.stringify(
+        {
+          mcpServers: {
+            remote: {
+              type: "stdio",
+              command: "node",
+              args: ["remote-mcp.js"],
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+    ensureMcpConfigFileMock.mockReturnValue(baseMcpPath);
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: '{"content":[{"type":"text","text":"ok"}]}',
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    try {
+      await runCliAgent({
+        sessionId: "s1",
+        sessionKey: "agent:main:main",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {
+          agents: {
+            defaults: {
+              cliBackends: {
+                "claude-cli": {
+                  command: "claude",
+                  mcp: {
+                    mergeConfigPath: extraMcpPath,
+                  },
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        prompt: "hi",
+        provider: "claude-cli",
+        model: "sonnet",
+        timeoutMs: 1_000,
+        runId: "run-claude-mcp-merged",
+      });
+
+      const input = supervisorSpawnMock.mock.calls[0]?.[0] as { argv?: string[] };
+      const mcpConfigIndex = input.argv?.indexOf("--mcp-config") ?? -1;
+      expect(mcpConfigIndex).toBeGreaterThanOrEqual(0);
+      const mergedPath = input.argv?.[mcpConfigIndex + 1];
+      expect(typeof mergedPath).toBe("string");
+      const mergedRaw = await fs.readFile(String(mergedPath), "utf-8");
+      const merged = JSON.parse(mergedRaw) as { mcpServers?: Record<string, unknown> };
+      expect(merged.mcpServers?.openclaw).toBeTruthy();
+      expect(merged.mcpServers?.remote).toBeTruthy();
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("cleans up stale merged MCP config files while keeping recent snapshots", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-runner-mcp-prune-"));
+    const baseMcpPath = path.join(tempDir, "mcp-base.json");
+    const extraMcpPath = path.join(tempDir, "mcp-extra.json");
+    await fs.writeFile(
+      baseMcpPath,
+      `${JSON.stringify(
+        {
+          mcpServers: {
+            openclaw: {
+              type: "http",
+              url: "http://127.0.0.1:19001/mcp",
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+    await fs.writeFile(
+      extraMcpPath,
+      `${JSON.stringify(
+        {
+          mcpServers: {
+            remote: {
+              type: "stdio",
+              command: "node",
+              args: ["remote-mcp.js"],
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+    const oldTime = Date.now() - 2 * 60 * 60 * 1000;
+    for (let index = 0; index < 30; index += 1) {
+      const hash = index.toString(16).padStart(16, "0");
+      const filePath = path.join(tempDir, `mcp.cli-merged.${hash}.json`);
+      await fs.writeFile(filePath, '{"mcpServers":{}}\n', "utf-8");
+      const oldDate = new Date(oldTime);
+      await fs.utimes(filePath, oldDate, oldDate);
+    }
+    ensureMcpConfigFileMock.mockReturnValue(baseMcpPath);
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: '{"content":[{"type":"text","text":"ok"}]}',
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    try {
+      await runCliAgent({
+        sessionId: "s1",
+        sessionKey: "agent:main:main",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {
+          agents: {
+            defaults: {
+              cliBackends: {
+                "claude-cli": {
+                  command: "claude",
+                  mcp: {
+                    mergeConfigPath: extraMcpPath,
+                  },
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        prompt: "hi",
+        provider: "claude-cli",
+        model: "sonnet",
+        timeoutMs: 1_000,
+        runId: "run-claude-mcp-merged-prune",
+      });
+
+      const files = await fs.readdir(tempDir);
+      const mergedFiles = files.filter((file) =>
+        /^mcp\.cli-merged\.[a-f0-9]{16}\.json$/.test(file),
+      );
+      expect(mergedFiles.length).toBeLessThanOrEqual(20);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("injects workspace skills into claude system prompt", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-runner-skills-"));
+    const skillDir = path.join(tempDir, "skills", "demo-skill");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      [
+        "---",
+        "name: demo-skill",
+        "description: Demo skill for CLI prompt injection",
+        "---",
+        "",
+        "Run demo steps from {baseDir}.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: '{"content":[{"type":"text","text":"ok"}]}',
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    try {
+      await runCliAgent({
+        sessionId: "s1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: tempDir,
+        prompt: "hi",
+        provider: "claude-cli",
+        model: "sonnet",
+        timeoutMs: 1_000,
+        runId: "run-claude-plugin-dir",
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+
+    const input = supervisorSpawnMock.mock.calls[0]?.[0] as { argv?: string[] };
+    expect(input.argv).toContain("--append-system-prompt");
+    const systemPromptIndex = input.argv?.indexOf("--append-system-prompt") ?? -1;
+    expect(systemPromptIndex).toBeGreaterThanOrEqual(0);
+    const systemPrompt = input.argv?.[systemPromptIndex + 1] ?? "";
+    expect(systemPrompt).toContain("<available_skills>");
+    expect(systemPrompt).toContain("demo-skill");
+  });
+
+  it("uses provided skillsSnapshot prompt for claude runs", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-runner-noskills-"));
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: '{"content":[{"type":"text","text":"ok"}]}',
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    try {
+      await runCliAgent({
+        sessionId: "s1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: tempDir,
+        prompt: "hi",
+        provider: "claude-cli",
+        model: "sonnet",
+        timeoutMs: 1_000,
+        runId: "run-claude-no-plugin-dir",
+        skillsSnapshot: {
+          prompt:
+            "<available_skills><skill><name>snapshot-skill</name><description>from snapshot</description><location>/tmp/snapshot-skill/SKILL.md</location></skill></available_skills>",
+          skills: [{ name: "snapshot-skill" }],
+        },
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+
+    const input = supervisorSpawnMock.mock.calls[0]?.[0] as { argv?: string[] };
+    expect(input.argv).toContain("--append-system-prompt");
+    const systemPromptIndex = input.argv?.indexOf("--append-system-prompt") ?? -1;
+    expect(systemPromptIndex).toBeGreaterThanOrEqual(0);
+    const systemPrompt = input.argv?.[systemPromptIndex + 1] ?? "";
+    expect(systemPrompt).toContain("snapshot-skill");
+  });
+
+  it("applies before_prompt_build hooks in CLI mode", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "before_prompt_build"),
+      runBeforePromptBuild: vi.fn(async () => ({
+        prependContext: "HOOK_CONTEXT",
+        systemPrompt: "HOOK_SYSTEM",
+      })),
+      runBeforeAgentStart: vi.fn(async () => undefined),
+      runLlmOutput: vi.fn(async () => undefined),
+    };
+    getGlobalHookRunnerMock.mockReturnValue(hookRunner as unknown);
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: '{"type":"result","result":"ok"}',
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    await runCliAgent({
+      sessionId: "s1",
+      sessionKey: "agent:main:main",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hi",
+      provider: "claude-cli",
+      model: "sonnet",
+      timeoutMs: 1_000,
+      runId: "run-cli-hook-before-prompt-build",
+      trigger: "user",
+      messageChannel: "whatsapp",
+    });
+
+    const input = supervisorSpawnMock.mock.calls[0]?.[0] as { argv?: string[] };
+    expect(input.argv).toContain("HOOK_CONTEXT\n\nhi");
+    const systemPromptIndex = input.argv?.indexOf("--append-system-prompt") ?? -1;
+    expect(systemPromptIndex).toBeGreaterThanOrEqual(0);
+    expect(input.argv?.[systemPromptIndex + 1]).toBe("HOOK_SYSTEM");
+    expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledWith(
+      {
+        prompt: "hi",
+        messages: [],
+      },
+      expect.objectContaining({
+        sessionId: "s1",
+        sessionKey: "agent:main:main",
+        workspaceDir: "/tmp",
+        trigger: "user",
+        messageProvider: "whatsapp",
+        channelId: "whatsapp",
+      }),
+    );
+  });
+
+  it("passes transcript messages to before_prompt_build hooks in CLI mode", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-hook-messages-"));
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({ type: "meta", foo: "bar" }),
+        JSON.stringify({ type: "tool", message: { role: "tool", content: "should-ignore" } }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "hello" } }),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "world" } }),
+        "not-json",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "before_prompt_build"),
+      runBeforePromptBuild: vi.fn(async () => undefined),
+      runBeforeAgentStart: vi.fn(async () => undefined),
+      runLlmOutput: vi.fn(async () => undefined),
+    };
+    getGlobalHookRunnerMock.mockReturnValue(hookRunner as unknown);
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: '{"type":"result","result":"ok"}',
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    try {
+      await runCliAgent({
+        sessionId: "s1",
+        sessionFile,
+        workspaceDir: tempDir,
+        prompt: "hi",
+        provider: "claude-cli",
+        model: "sonnet",
+        timeoutMs: 1_000,
+        runId: "run-cli-hook-message-history",
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+
+    expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledWith(
+      {
+        prompt: "hi",
+        messages: [
+          { role: "user", content: "hello" },
+          { role: "assistant", content: "world" },
+        ],
+      },
+      expect.any(Object),
+    );
+  });
+
+  it("emits llm_output hooks in CLI mode", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "llm_output"),
+      runBeforePromptBuild: vi.fn(async () => undefined),
+      runBeforeAgentStart: vi.fn(async () => undefined),
+      runLlmOutput: vi.fn(async () => undefined),
+    };
+    getGlobalHookRunnerMock.mockReturnValue(hookRunner as unknown);
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "ok",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    await runCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hi",
+      provider: "codex-cli",
+      model: "gpt-5.2-codex",
+      timeoutMs: 1_000,
+      runId: "run-cli-hook-llm-output",
+      trigger: "user",
+      messageChannel: "telegram",
+    });
+
+    expect(hookRunner.runLlmOutput).toHaveBeenCalledTimes(1);
+    expect(hookRunner.runLlmOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-cli-hook-llm-output",
+        sessionId: "s1",
+        provider: "codex-cli",
+        model: "gpt-5.2-codex",
+        assistantTexts: ["ok"],
+      }),
+      expect.objectContaining({
+        sessionId: "s1",
+        workspaceDir: "/tmp",
+        messageProvider: "telegram",
+        channelId: "telegram",
+      }),
+    );
+  });
+
+  it("reports normalized model id in llm_output hooks", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) => hookName === "llm_output"),
+      runBeforePromptBuild: vi.fn(async () => undefined),
+      runBeforeAgentStart: vi.fn(async () => undefined),
+      runLlmOutput: vi.fn(async () => undefined),
+    };
+    getGlobalHookRunnerMock.mockReturnValue(hookRunner as unknown);
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "ok",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    await runCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hi",
+      provider: "claude-cli",
+      model: "claude-sonnet-4-6",
+      timeoutMs: 1_000,
+      runId: "run-cli-hook-normalized-model",
+    });
+
+    expect(hookRunner.runLlmOutput).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "sonnet",
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("resends system prompt on resumed claude sessions by default", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-runner-resume-"));
+    const skillDir = path.join(tempDir, "skills", "resume-skill");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      [
+        "---",
+        "name: resume-skill",
+        "description: Resume-skill description",
+        "---",
+        "",
+        "Use this skill after resume.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: '{"content":[{"type":"text","text":"ok"}]}',
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    try {
+      await runCliAgent({
+        sessionId: "s1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: tempDir,
+        prompt: "hi",
+        provider: "claude-cli",
+        model: "sonnet",
+        timeoutMs: 1_000,
+        runId: "run-claude-resume-plugin-dir",
+        cliSessionId: "existing-claude-session",
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+
+    const input = supervisorSpawnMock.mock.calls[0]?.[0] as { argv?: string[] };
+    expect(input.argv).toContain("--resume");
+    expect(input.argv).toContain("existing-claude-session");
+    expect(input.argv).toContain("--append-system-prompt");
+    const systemPromptIndex = input.argv?.indexOf("--append-system-prompt") ?? -1;
+    expect(systemPromptIndex).toBeGreaterThanOrEqual(0);
+    const systemPrompt = input.argv?.[systemPromptIndex + 1] ?? "";
+    expect(systemPrompt).toContain("<available_skills>");
+    expect(systemPrompt).toContain("resume-skill");
+  });
+
+  it("skips system prompt on resumed claude sessions when configured with first", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-runner-resume-first-"));
+    const skillDir = path.join(tempDir, "skills", "resume-skill-first");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      [
+        "---",
+        "name: resume-skill-first",
+        "description: Resume-skill description for first mode",
+        "---",
+        "",
+        "Use this skill only on first run.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: '{"content":[{"type":"text","text":"ok"}]}',
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": {
+              command: "claude",
+              systemPromptWhen: "first",
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    try {
+      await runCliAgent({
+        sessionId: "s1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: tempDir,
+        prompt: "hi",
+        provider: "claude-cli",
+        model: "sonnet",
+        timeoutMs: 1_000,
+        runId: "run-claude-resume-first",
+        cliSessionId: "existing-claude-session",
+        config: cfg,
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+
+    const input = supervisorSpawnMock.mock.calls[0]?.[0] as { argv?: string[] };
+    expect(input.argv).toContain("--resume");
+    expect(input.argv).toContain("existing-claude-session");
+    expect(input.argv).not.toContain("--append-system-prompt");
+  });
+
   it("fails with timeout when no-output watchdog trips", async () => {
     supervisorSpawnMock.mockResolvedValueOnce(
       createManagedRun({

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -29,6 +29,7 @@ import {
   buildCliSupervisorScopeKey,
   buildCliArgs,
   buildSystemPrompt,
+  createStreamJsonProcessor,
   enqueueCliRun,
   normalizeCliModel,
   parseCliJson,
@@ -398,17 +399,7 @@ export async function runCliAgent(params: {
   bootstrapPromptWarningSignature?: string;
   images?: ImageContent[];
   onAssistantTurn?: (text: string) => void;
-  onSystemInit?: (payload: { subtype: string; sessionId?: string }) => void;
   onToolUse?: (toolName: string) => void;
-  onThinkingTurn?: (payload: { text: string; delta?: string }) => void;
-  onToolUseEvent?: (payload: { name: string; toolUseId?: string; input?: unknown }) => void;
-  onToolResult?: (payload: { toolUseId?: string; text?: string; isError?: boolean }) => void;
-  abortSignal?: AbortSignal;
-  trigger?: PluginHookAgentContext["trigger"];
-  messageChannel?: string;
-  messageAccountId?: string;
-  messageTo?: string;
-  messageThreadId?: string | number;
 }): Promise<EmbeddedPiRunResult> {
   const started = Date.now();
   const workspaceResolution = resolveRunWorkspaceDir({
@@ -742,12 +733,8 @@ export async function runCliAgent(params: {
         const streamProcessor =
           outputMode === "stream-json"
             ? createStreamJsonProcessor(backend, {
-                onSystemInit: params.onSystemInit,
                 onAssistantTurn: params.onAssistantTurn,
                 onToolUse: params.onToolUse,
-                onThinkingTurn: params.onThinkingTurn,
-                onToolUseEvent: params.onToolUseEvent,
-                onToolResult: params.onToolResult,
               })
             : undefined;
 
@@ -763,6 +750,7 @@ export async function runCliAgent(params: {
           cwd: workspaceDir,
           env,
           input: stdinPayload,
+          ...(streamProcessor ? { onStdout: streamProcessor.feed } : {}),
         });
         const onAbort = () => {
           managedRun.cancel("manual-cancel");
@@ -847,22 +835,14 @@ export async function runCliAgent(params: {
           });
         }
 
-        let output: {
-          text: string;
-          sessionId?: string;
-          usage?: {
-            input?: number;
-            output?: number;
-            cacheRead?: number;
-            cacheWrite?: number;
-            total?: number;
-          };
-        };
         if (streamProcessor) {
-          output = streamProcessor.finish();
-        } else if (outputMode === "text") {
-          output = { text: stdout, sessionId: undefined };
-        } else if (outputMode === "jsonl") {
+          return streamProcessor.finish();
+        }
+
+        if (outputMode === "text") {
+          return { text: stdout, sessionId: undefined };
+        }
+        if (outputMode === "jsonl") {
           const parsed = parseCliJsonl(stdout, backend);
           output = parsed ?? { text: stdout };
         } else {
@@ -1001,17 +981,7 @@ export async function runClaudeCliAgent(params: {
   claudeSessionId?: string;
   images?: ImageContent[];
   onAssistantTurn?: (text: string) => void;
-  onSystemInit?: (payload: { subtype: string; sessionId?: string }) => void;
   onToolUse?: (toolName: string) => void;
-  onThinkingTurn?: (payload: { text: string; delta?: string }) => void;
-  onToolUseEvent?: (payload: { name: string; toolUseId?: string; input?: unknown }) => void;
-  onToolResult?: (payload: { toolUseId?: string; text?: string; isError?: boolean }) => void;
-  abortSignal?: AbortSignal;
-  trigger?: PluginHookAgentContext["trigger"];
-  messageChannel?: string;
-  messageAccountId?: string;
-  messageTo?: string;
-  messageThreadId?: string | number;
 }): Promise<EmbeddedPiRunResult> {
   return runCliAgent({
     sessionId: params.sessionId,
@@ -1032,16 +1002,6 @@ export async function runClaudeCliAgent(params: {
     cliSessionId: params.claudeSessionId,
     images: params.images,
     onAssistantTurn: params.onAssistantTurn,
-    onSystemInit: params.onSystemInit,
     onToolUse: params.onToolUse,
-    onThinkingTurn: params.onThinkingTurn,
-    onToolUseEvent: params.onToolUseEvent,
-    onToolResult: params.onToolResult,
-    abortSignal: params.abortSignal,
-    trigger: params.trigger,
-    messageChannel: params.messageChannel,
-    messageAccountId: params.messageAccountId,
-    messageTo: params.messageTo,
-    messageThreadId: params.messageThreadId,
   });
 }

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -1,9 +1,13 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { resolveHeartbeatPrompt } from "../auto-reply/heartbeat.js";
 import type { ThinkLevel } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { appendCliTurnToSessionTranscript } from "../config/sessions.js";
+import type { CliBackendConfig } from "../config/types.js";
 import { MCP_PORT_OFFSET, ensureMcpConfigFile } from "../gateway/mcp-http.js";
 import { shouldLogVerbose } from "../globals.js";
 import { isTruthyEnvValue } from "../infra/env.js";
@@ -399,7 +403,17 @@ export async function runCliAgent(params: {
   bootstrapPromptWarningSignature?: string;
   images?: ImageContent[];
   onAssistantTurn?: (text: string) => void;
+  onSystemInit?: (payload: { subtype: string; sessionId?: string }) => void;
   onToolUse?: (toolName: string) => void;
+  onThinkingTurn?: (payload: { text: string; delta?: string }) => void;
+  onToolUseEvent?: (payload: { name: string; toolUseId?: string; input?: unknown }) => void;
+  onToolResult?: (payload: { toolUseId?: string; text?: string; isError?: boolean }) => void;
+  abortSignal?: AbortSignal;
+  trigger?: PluginHookAgentContext["trigger"];
+  messageChannel?: string;
+  messageAccountId?: string;
+  messageTo?: string;
+  messageThreadId?: string | number;
 }): Promise<EmbeddedPiRunResult> {
   const started = Date.now();
   const workspaceResolution = resolveRunWorkspaceDir({
@@ -432,12 +446,15 @@ export async function runCliAgent(params: {
 
   // MCP tool access only for Claude CLI; other backends get a "tools disabled" hint.
   let mcpConfigPath: string | undefined;
+  let useStrictMcp = true;
   if (isClaude) {
     try {
-      const gatewayPort = params.config?.gateway?.port ?? 18789;
-      const mcpPort = gatewayPort + MCP_PORT_OFFSET;
-      const openclawDir = path.join(os.homedir(), ".openclaw");
-      mcpConfigPath = ensureMcpConfigFile(openclawDir, mcpPort);
+      const mcpResolved = await resolveClaudeMcpConfigForRun({
+        backend,
+        config: params.config,
+      });
+      mcpConfigPath = mcpResolved.mcpConfigPath;
+      useStrictMcp = mcpResolved.useStrictMcp;
     } catch (err) {
       log.warn(`mcp config setup failed: ${String(err)}`);
     }
@@ -648,7 +665,7 @@ export async function runCliAgent(params: {
     });
     // --mcp-config is a Claude Code specific flag.
     if (mcpConfigPath && backendResolved.id === "claude-cli") {
-      if (!args.includes("--strict-mcp-config")) {
+      if (useStrictMcp && !args.includes("--strict-mcp-config")) {
         args.push("--strict-mcp-config");
       }
       args.push("--mcp-config", mcpConfigPath);
@@ -733,8 +750,12 @@ export async function runCliAgent(params: {
         const streamProcessor =
           outputMode === "stream-json"
             ? createStreamJsonProcessor(backend, {
+                onSystemInit: params.onSystemInit,
                 onAssistantTurn: params.onAssistantTurn,
                 onToolUse: params.onToolUse,
+                onThinkingTurn: params.onThinkingTurn,
+                onToolUseEvent: params.onToolUseEvent,
+                onToolResult: params.onToolResult,
               })
             : undefined;
 
@@ -835,14 +856,22 @@ export async function runCliAgent(params: {
           });
         }
 
+        let output: {
+          text: string;
+          sessionId?: string;
+          usage?: {
+            input?: number;
+            output?: number;
+            cacheRead?: number;
+            cacheWrite?: number;
+            total?: number;
+          };
+        };
         if (streamProcessor) {
-          return streamProcessor.finish();
-        }
-
-        if (outputMode === "text") {
-          return { text: stdout, sessionId: undefined };
-        }
-        if (outputMode === "jsonl") {
+          output = streamProcessor.finish();
+        } else if (outputMode === "text") {
+          output = { text: stdout, sessionId: undefined };
+        } else if (outputMode === "jsonl") {
           const parsed = parseCliJsonl(stdout, backend);
           output = parsed ?? { text: stdout };
         } else {
@@ -981,7 +1010,17 @@ export async function runClaudeCliAgent(params: {
   claudeSessionId?: string;
   images?: ImageContent[];
   onAssistantTurn?: (text: string) => void;
+  onSystemInit?: (payload: { subtype: string; sessionId?: string }) => void;
   onToolUse?: (toolName: string) => void;
+  onThinkingTurn?: (payload: { text: string; delta?: string }) => void;
+  onToolUseEvent?: (payload: { name: string; toolUseId?: string; input?: unknown }) => void;
+  onToolResult?: (payload: { toolUseId?: string; text?: string; isError?: boolean }) => void;
+  abortSignal?: AbortSignal;
+  trigger?: PluginHookAgentContext["trigger"];
+  messageChannel?: string;
+  messageAccountId?: string;
+  messageTo?: string;
+  messageThreadId?: string | number;
 }): Promise<EmbeddedPiRunResult> {
   return runCliAgent({
     sessionId: params.sessionId,
@@ -1002,6 +1041,16 @@ export async function runClaudeCliAgent(params: {
     cliSessionId: params.claudeSessionId,
     images: params.images,
     onAssistantTurn: params.onAssistantTurn,
+    onSystemInit: params.onSystemInit,
     onToolUse: params.onToolUse,
+    onThinkingTurn: params.onThinkingTurn,
+    onToolUseEvent: params.onToolUseEvent,
+    onToolResult: params.onToolResult,
+    abortSignal: params.abortSignal,
+    trigger: params.trigger,
+    messageChannel: params.messageChannel,
+    messageAccountId: params.messageAccountId,
+    messageTo: params.messageTo,
+    messageThreadId: params.messageThreadId,
   });
 }

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -1,14 +1,20 @@
+import os from "node:os";
+import path from "node:path";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { resolveHeartbeatPrompt } from "../auto-reply/heartbeat.js";
 import type { ThinkLevel } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { MCP_PORT_OFFSET, ensureMcpConfigFile } from "../gateway/mcp-http.js";
 import { shouldLogVerbose } from "../globals.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import type { PluginHookAgentContext } from "../plugins/types.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import { sliceUtf16Safe, resolveUserPath } from "../utils.js";
 import { resolveSessionAgentIds } from "./agent-scope.js";
 import {
   analyzeBootstrapBudget,
@@ -43,10 +49,331 @@ import {
   resolveBootstrapTotalMaxChars,
 } from "./pi-embedded-helpers.js";
 import type { EmbeddedPiRunResult } from "./pi-embedded-runner.js";
+import {
+  applySkillEnvOverrides,
+  applySkillEnvOverridesFromSnapshot,
+  loadWorkspaceSkillEntries,
+  resolveSkillsPromptForRun,
+  type SkillSnapshot,
+} from "./skills.js";
 import { buildSystemPromptReport } from "./system-prompt-report.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "./workspace-run.js";
 
 const log = createSubsystemLogger("agent/claude-cli");
+
+type McpServers = Record<string, unknown>;
+const MERGED_MCP_CONFIG_BASENAME_RE = /^mcp\.cli-merged\.[a-f0-9]{16}\.json$/;
+const MERGED_MCP_CONFIG_MAX_FILES = 20;
+const MERGED_MCP_CONFIG_MIN_AGE_MS = 60 * 60 * 1000;
+const CLI_OUTPUT_LOG_HEAD_CHARS = 240;
+const CLI_OUTPUT_LOG_TAIL_CHARS = 160;
+const CLI_OUTPUT_LOG_PREVIEW_MAX_CHARS = CLI_OUTPUT_LOG_HEAD_CHARS + CLI_OUTPUT_LOG_TAIL_CHARS;
+
+function formatCliOutputForLog(channel: "stdout" | "stderr", text: string): string {
+  if (!text) {
+    return `cli ${channel}: <empty>`;
+  }
+  const totalChars = text.length;
+  if (totalChars <= CLI_OUTPUT_LOG_PREVIEW_MAX_CHARS) {
+    return `cli ${channel} (${totalChars} chars):\n${text}`;
+  }
+  const head = sliceUtf16Safe(text, 0, CLI_OUTPUT_LOG_HEAD_CHARS);
+  const tailStart = Math.max(0, totalChars - CLI_OUTPUT_LOG_TAIL_CHARS);
+  const tail = sliceUtf16Safe(text, tailStart);
+  const truncatedChars = Math.max(0, totalChars - head.length - tail.length);
+  return [
+    `cli ${channel} (${totalChars} chars):`,
+    head,
+    `[truncated ${truncatedChars} chars]`,
+    tail,
+  ].join("\n");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function resolveConfiguredPath(rawPath: string | undefined): string | undefined {
+  const trimmed = rawPath?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return resolveUserPath(trimmed);
+}
+
+async function readMcpServers(filePath: string): Promise<McpServers | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed)) {
+      return {};
+    }
+    const serversRaw = parsed.mcpServers;
+    if (!isRecord(serversRaw)) {
+      return {};
+    }
+    return { ...serversRaw };
+  } catch {
+    return null;
+  }
+}
+
+async function writeMcpConfigIfChanged(filePath: string, content: string): Promise<void> {
+  try {
+    const existing = await fs.readFile(filePath, "utf-8");
+    if (existing === content) {
+      return;
+    }
+  } catch {
+    // file may not exist yet
+  }
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, { mode: 0o600 });
+}
+
+async function cleanupMergedMcpConfigs(params: {
+  dir: string;
+  keepFilePath: string;
+}): Promise<void> {
+  const keepName = path.basename(params.keepFilePath);
+  const now = Date.now();
+  const entries = await fs.readdir(params.dir, { withFileTypes: true }).catch(() => []);
+  const candidates: Array<{ name: string; filePath: string; mtimeMs: number }> = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !MERGED_MCP_CONFIG_BASENAME_RE.test(entry.name)) {
+      continue;
+    }
+    const filePath = path.join(params.dir, entry.name);
+    const stat = await fs.stat(filePath).catch(() => null);
+    if (!stat) {
+      continue;
+    }
+    candidates.push({
+      name: entry.name,
+      filePath,
+      mtimeMs: stat.mtimeMs,
+    });
+  }
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  const keepNames = new Set<string>([keepName]);
+  for (const candidate of candidates) {
+    if (keepNames.size >= MERGED_MCP_CONFIG_MAX_FILES) {
+      break;
+    }
+    keepNames.add(candidate.name);
+  }
+
+  for (const candidate of candidates) {
+    if (keepNames.has(candidate.name)) {
+      continue;
+    }
+    if (now - candidate.mtimeMs < MERGED_MCP_CONFIG_MIN_AGE_MS) {
+      continue;
+    }
+    await fs.unlink(candidate.filePath).catch(() => undefined);
+  }
+}
+
+async function resolveClaudeMcpConfigForRun(params: {
+  backend: CliBackendConfig;
+  config?: OpenClawConfig;
+}): Promise<{ mcpConfigPath?: string; useStrictMcp: boolean }> {
+  const mcpCfg = params.backend.mcp;
+  if (mcpCfg?.enabled === false) {
+    return { mcpConfigPath: undefined, useStrictMcp: false };
+  }
+
+  const useStrictMcp = mcpCfg?.strict !== false;
+  const gatewayPort = params.config?.gateway?.port ?? 18789;
+  const mcpPort = gatewayPort + MCP_PORT_OFFSET;
+  const openclawDir = path.join(os.homedir(), ".openclaw");
+  const defaultMcpConfigPath = ensureMcpConfigFile(openclawDir, mcpPort);
+
+  const configuredMcpPath = resolveConfiguredPath(mcpCfg?.configPath);
+  const mergeMcpPath = resolveConfiguredPath(mcpCfg?.mergeConfigPath);
+  const inlineServers = isRecord(mcpCfg?.servers) ? { ...mcpCfg.servers } : {};
+  const hasInlineServers = Object.keys(inlineServers).length > 0;
+  const needsMerge = Boolean(
+    mergeMcpPath ||
+    hasInlineServers ||
+    (configuredMcpPath && configuredMcpPath !== defaultMcpConfigPath),
+  );
+  if (!needsMerge) {
+    return {
+      mcpConfigPath: configuredMcpPath ?? defaultMcpConfigPath,
+      useStrictMcp,
+    };
+  }
+
+  const openclawServers = await readMcpServers(defaultMcpConfigPath);
+  if (openclawServers === null) {
+    log.warn(`MCP default config read failed, skipping merge: ${defaultMcpConfigPath}`);
+    return {
+      mcpConfigPath: defaultMcpConfigPath,
+      useStrictMcp,
+    };
+  }
+  const configuredServers = configuredMcpPath
+    ? await readMcpServers(configuredMcpPath)
+    : openclawServers;
+  if (configuredMcpPath && configuredServers === null) {
+    log.warn(`MCP primary config read failed: ${configuredMcpPath}`);
+  }
+  const mergeServers = mergeMcpPath ? await readMcpServers(mergeMcpPath) : {};
+  if (mergeMcpPath && mergeServers === null) {
+    log.warn(`MCP merge config read failed: ${mergeMcpPath}`);
+  }
+
+  const mergedServers: McpServers = {
+    ...(configuredServers ?? openclawServers),
+    ...mergeServers,
+    ...inlineServers,
+  };
+  const openclawServer = openclawServers.openclaw;
+  if (isRecord(openclawServer)) {
+    // Keep OpenClaw MCP server authoritative so tool routing cannot be shadowed.
+    mergedServers.openclaw = openclawServer;
+  }
+
+  const mergedContent = `${JSON.stringify({ mcpServers: mergedServers }, null, 2)}\n`;
+  const mergedHash = crypto.createHash("sha256").update(mergedContent).digest("hex").slice(0, 16);
+  const mergedPath = path.join(
+    path.dirname(defaultMcpConfigPath),
+    `mcp.cli-merged.${mergedHash}.json`,
+  );
+  await writeMcpConfigIfChanged(mergedPath, mergedContent);
+  await cleanupMergedMcpConfigs({
+    dir: path.dirname(defaultMcpConfigPath),
+    keepFilePath: mergedPath,
+  }).catch((err) => {
+    log.debug(`MCP merged config cleanup skipped: ${String(err)}`);
+  });
+  return { mcpConfigPath: mergedPath, useStrictMcp };
+}
+
+function createAbortError(signal?: AbortSignal): Error {
+  const reason = signal && "reason" in signal ? (signal as { reason?: unknown }).reason : undefined;
+  const err = reason ? new Error("aborted", { cause: reason }) : new Error("aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+async function readCliHookMessages(sessionFile: string): Promise<unknown[]> {
+  const trimmed = sessionFile.trim();
+  if (!trimmed) {
+    return [];
+  }
+  try {
+    const raw = await fs.readFile(path.resolve(trimmed), "utf-8");
+    const lines = raw.split(/\r?\n/g);
+    const messages: unknown[] = [];
+    for (const line of lines) {
+      const value = line.trim();
+      if (!value) {
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(value) as unknown;
+        if (isRecord(parsed) && parsed.type === "message" && "message" in parsed) {
+          messages.push(parsed.message);
+        }
+      } catch {
+        // ignore malformed lines
+      }
+    }
+    return messages;
+  } catch {
+    return [];
+  }
+}
+
+async function resolveCliPromptBuildHookResult(params: {
+  hookRunner: ReturnType<typeof getGlobalHookRunner>;
+  prompt: string;
+  messages: unknown[];
+  hookCtx: PluginHookAgentContext;
+}): Promise<{ systemPrompt?: string; prependContext?: string } | undefined> {
+  const hookRunner = params.hookRunner;
+  if (!hookRunner) {
+    return undefined;
+  }
+  const promptBuildResult = hookRunner.hasHooks("before_prompt_build")
+    ? await hookRunner
+        .runBeforePromptBuild(
+          {
+            prompt: params.prompt,
+            messages: params.messages,
+          },
+          params.hookCtx,
+        )
+        .catch((hookErr: unknown) => {
+          log.warn(`before_prompt_build hook failed: ${String(hookErr)}`);
+          return undefined;
+        })
+    : undefined;
+  const legacyResult = hookRunner.hasHooks("before_agent_start")
+    ? await hookRunner
+        .runBeforeAgentStart(
+          {
+            prompt: params.prompt,
+            messages: params.messages,
+          },
+          params.hookCtx,
+        )
+        .catch((hookErr: unknown) => {
+          log.warn(`before_agent_start hook (CLI path) failed: ${String(hookErr)}`);
+          return undefined;
+        })
+    : undefined;
+  return {
+    systemPrompt: promptBuildResult?.systemPrompt ?? legacyResult?.systemPrompt,
+    prependContext: [promptBuildResult?.prependContext, legacyResult?.prependContext]
+      .filter((value): value is string => Boolean(value))
+      .join("\n\n"),
+  };
+}
+
+function emitCliLlmOutputHook(params: {
+  hookRunner: ReturnType<typeof getGlobalHookRunner>;
+  hookCtx: PluginHookAgentContext;
+  runId: string;
+  sessionId: string;
+  provider: string;
+  model: string;
+  output: {
+    text: string;
+    usage?: {
+      input?: number;
+      output?: number;
+      cacheRead?: number;
+      cacheWrite?: number;
+      total?: number;
+    };
+  };
+}) {
+  const hookRunner = params.hookRunner;
+  if (!hookRunner?.hasHooks("llm_output")) {
+    return;
+  }
+  const text = params.output.text.trim();
+  hookRunner
+    .runLlmOutput(
+      {
+        runId: params.runId,
+        sessionId: params.sessionId,
+        provider: params.provider,
+        model: params.model,
+        assistantTexts: text ? [text] : [],
+        lastAssistant: text ? { role: "assistant", content: text } : undefined,
+        usage: params.output.usage,
+      },
+      params.hookCtx,
+    )
+    .catch((hookErr) => {
+      log.warn(`llm_output hook failed (CLI path): ${String(hookErr)}`);
+    });
+}
 
 export async function runCliAgent(params: {
   sessionId: string;
@@ -62,6 +389,7 @@ export async function runCliAgent(params: {
   timeoutMs: number;
   runId: string;
   extraSystemPrompt?: string;
+  skillsSnapshot?: SkillSnapshot;
   streamParams?: import("../commands/agent/types.js").AgentStreamParams;
   ownerNumbers?: string[];
   cliSessionId?: string;
@@ -69,6 +397,18 @@ export async function runCliAgent(params: {
   /** Backward-compat fallback when only the previous signature is available. */
   bootstrapPromptWarningSignature?: string;
   images?: ImageContent[];
+  onAssistantTurn?: (text: string) => void;
+  onSystemInit?: (payload: { subtype: string; sessionId?: string }) => void;
+  onToolUse?: (toolName: string) => void;
+  onThinkingTurn?: (payload: { text: string; delta?: string }) => void;
+  onToolUseEvent?: (payload: { name: string; toolUseId?: string; input?: unknown }) => void;
+  onToolResult?: (payload: { toolUseId?: string; text?: string; isError?: boolean }) => void;
+  abortSignal?: AbortSignal;
+  trigger?: PluginHookAgentContext["trigger"];
+  messageChannel?: string;
+  messageAccountId?: string;
+  messageTo?: string;
+  messageThreadId?: string | number;
 }): Promise<EmbeddedPiRunResult> {
   const started = Date.now();
   const workspaceResolution = resolveRunWorkspaceDir({
@@ -97,12 +437,26 @@ export async function runCliAgent(params: {
   const normalizedModel = normalizeCliModel(modelId, backend);
   const modelDisplay = `${params.provider}/${modelId}`;
 
-  const extraSystemPrompt = [
-    params.extraSystemPrompt?.trim(),
-    "Tools are disabled in this session. Do not call tools.",
-  ]
-    .filter(Boolean)
-    .join("\n");
+  const isClaude = backendResolved.id === "claude-cli";
+
+  // MCP tool access only for Claude CLI; other backends get a "tools disabled" hint.
+  let mcpConfigPath: string | undefined;
+  if (isClaude) {
+    try {
+      const gatewayPort = params.config?.gateway?.port ?? 18789;
+      const mcpPort = gatewayPort + MCP_PORT_OFFSET;
+      const openclawDir = path.join(os.homedir(), ".openclaw");
+      mcpConfigPath = ensureMcpConfigFile(openclawDir, mcpPort);
+    } catch (err) {
+      log.warn(`mcp config setup failed: ${String(err)}`);
+    }
+  }
+
+  const extraSystemPrompt = isClaude
+    ? params.extraSystemPrompt?.trim() || undefined
+    : [params.extraSystemPrompt?.trim(), "Tools are disabled in this session. Do not call tools."]
+        .filter(Boolean)
+        .join("\n");
 
   const sessionLabel = params.sessionKey ?? params.sessionId;
   const { bootstrapFiles, contextFiles } = await resolveBootstrapContextForRun({
@@ -134,6 +488,40 @@ export async function runCliAgent(params: {
     config: params.config,
     agentId: params.agentId,
   });
+  const hookCtx: PluginHookAgentContext = {
+    agentId: sessionAgentId,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    workspaceDir,
+    messageProvider: params.messageChannel,
+    trigger: params.trigger,
+    channelId: params.messageChannel,
+  };
+  const hookRunner = getGlobalHookRunner();
+  const hasPromptBuildHooks = Boolean(
+    hookRunner?.hasHooks("before_prompt_build") || hookRunner?.hasHooks("before_agent_start"),
+  );
+  let promptForRun = params.prompt;
+  const hookMessages = hasPromptBuildHooks ? await readCliHookMessages(params.sessionFile) : [];
+  const promptBuildHookResult = hasPromptBuildHooks
+    ? await resolveCliPromptBuildHookResult({
+        hookRunner,
+        prompt: params.prompt,
+        messages: hookMessages,
+        hookCtx,
+      })
+    : undefined;
+  const prependContext = promptBuildHookResult?.prependContext;
+  if (prependContext?.trim()) {
+    promptForRun = `${prependContext}\n\n${params.prompt}`;
+    log.debug(`hooks: prepended context to CLI prompt (${prependContext.length} chars)`);
+  }
+  const hookSystemPromptOverride = promptBuildHookResult?.systemPrompt?.trim() || undefined;
+  if (hookSystemPromptOverride) {
+    log.debug(
+      `hooks: applied CLI systemPrompt override (${hookSystemPromptOverride.length} chars)`,
+    );
+  }
   const heartbeatPrompt =
     sessionAgentId === defaultAgentId
       ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)
@@ -144,11 +532,35 @@ export async function runCliAgent(params: {
     cwd: process.cwd(),
     moduleUrl: import.meta.url,
   });
-  const systemPrompt = buildSystemPrompt({
+  let skillsPrompt: string | undefined;
+  let restoreSkillEnv: (() => void) | undefined;
+  if (isClaude) {
+    const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
+    const skillEntries = shouldLoadSkillEntries
+      ? loadWorkspaceSkillEntries(workspaceDir, { config: params.config })
+      : undefined;
+    restoreSkillEnv = params.skillsSnapshot
+      ? applySkillEnvOverridesFromSnapshot({
+          snapshot: params.skillsSnapshot,
+          config: params.config,
+        })
+      : applySkillEnvOverrides({
+          skills: skillEntries ?? [],
+          config: params.config,
+        });
+    skillsPrompt = resolveSkillsPromptForRun({
+      skillsSnapshot: params.skillsSnapshot,
+      entries: shouldLoadSkillEntries ? skillEntries : undefined,
+      config: params.config,
+      workspaceDir,
+    });
+  }
+  const builtSystemPrompt = buildSystemPrompt({
     workspaceDir,
     config: params.config,
     defaultThinkLevel: params.thinkLevel,
     extraSystemPrompt,
+    skillsPrompt,
     ownerNumbers: params.ownerNumbers,
     heartbeatPrompt,
     docsPath: docsPath ?? undefined,
@@ -158,6 +570,7 @@ export async function runCliAgent(params: {
     modelDisplay,
     agentId: sessionAgentId,
   });
+  const systemPrompt = hookSystemPromptOverride ?? builtSystemPrompt;
   const systemPromptReport = buildSystemPromptReport({
     source: "run",
     generatedAt: Date.now(),
@@ -195,6 +608,9 @@ export async function runCliAgent(params: {
       total?: number;
     };
   }> => {
+    if (params.abortSignal?.aborted) {
+      throw createAbortError(params.abortSignal);
+    }
     const { sessionId: resolvedSessionId, isNew } = resolveSessionIdToSend({
       backend,
       cliSessionId: cliSessionIdToUse,
@@ -210,7 +626,7 @@ export async function runCliAgent(params: {
 
     let imagePaths: string[] | undefined;
     let cleanupImages: (() => Promise<void>) | undefined;
-    let prompt = params.prompt;
+    let prompt = promptForRun;
     if (params.images && params.images.length > 0) {
       const imagePayload = await writeCliImages(params.images);
       imagePaths = imagePayload.paths;
@@ -239,6 +655,13 @@ export async function runCliAgent(params: {
       promptArg: argsPrompt,
       useResume,
     });
+    // --mcp-config is a Claude Code specific flag.
+    if (mcpConfigPath && backendResolved.id === "claude-cli") {
+      if (!args.includes("--strict-mcp-config")) {
+        args.push("--strict-mcp-config");
+      }
+      args.push("--mcp-config", mcpConfigPath);
+    }
 
     const serialize = backend.serialize ?? true;
     const queueKey = serialize ? backendResolved.id : `${backendResolved.id}:${params.runId}`;
@@ -246,7 +669,7 @@ export async function runCliAgent(params: {
     try {
       const output = await enqueueCliRun(queueKey, async () => {
         log.info(
-          `cli exec: provider=${params.provider} model=${normalizedModel} promptChars=${params.prompt.length}`,
+          `cli exec: provider=${params.provider} model=${normalizedModel} promptChars=${promptForRun.length}`,
         );
         const logOutputText = isTruthyEnvValue(process.env.OPENCLAW_CLAUDE_CLI_LOG_OUTPUT);
         if (logOutputText) {
@@ -290,6 +713,15 @@ export async function runCliAgent(params: {
           for (const key of backend.clearEnv ?? []) {
             delete next[key];
           }
+          if (mcpConfigPath) {
+            next.OPENCLAW_MCP_AGENT_ID = sessionAgentId ?? "";
+            next.OPENCLAW_MCP_ACCOUNT_ID = params.messageAccountId ?? "";
+            next.OPENCLAW_MCP_SESSION_KEY = params.sessionKey ?? "";
+            next.OPENCLAW_MCP_MESSAGE_CHANNEL = params.messageChannel ?? "";
+            next.OPENCLAW_MCP_TO = params.messageTo ?? "";
+            next.OPENCLAW_MCP_THREAD_ID =
+              params.messageThreadId != null ? String(params.messageThreadId) : "";
+          }
           return next;
         })();
         const noOutputTimeoutMs = resolveCliNoOutputTimeoutMs({
@@ -304,6 +736,21 @@ export async function runCliAgent(params: {
           cliSessionId: useResume ? resolvedSessionId : undefined,
         });
 
+        const outputMode = useResume ? (backend.resumeOutput ?? backend.output) : backend.output;
+
+        // Stream-json mode: process NDJSON lines as they arrive via onStdout
+        const streamProcessor =
+          outputMode === "stream-json"
+            ? createStreamJsonProcessor(backend, {
+                onSystemInit: params.onSystemInit,
+                onAssistantTurn: params.onAssistantTurn,
+                onToolUse: params.onToolUse,
+                onThinkingTurn: params.onThinkingTurn,
+                onToolUseEvent: params.onToolUseEvent,
+                onToolResult: params.onToolResult,
+              })
+            : undefined;
+
         const managedRun = await supervisor.spawn({
           sessionId: params.sessionId,
           backendId: backendResolved.id,
@@ -317,24 +764,42 @@ export async function runCliAgent(params: {
           env,
           input: stdinPayload,
         });
-        const result = await managedRun.wait();
+        const onAbort = () => {
+          managedRun.cancel("manual-cancel");
+        };
+        if (params.abortSignal) {
+          if (params.abortSignal.aborted) {
+            onAbort();
+          } else {
+            params.abortSignal.addEventListener("abort", onAbort, { once: true });
+          }
+        }
+        let result;
+        try {
+          result = await managedRun.wait();
+        } finally {
+          params.abortSignal?.removeEventListener("abort", onAbort);
+        }
+        if (result.reason === "manual-cancel" && params.abortSignal?.aborted) {
+          throw createAbortError(params.abortSignal);
+        }
 
         const stdout = result.stdout.trim();
         const stderr = result.stderr.trim();
         if (logOutputText) {
           if (stdout) {
-            log.info(`cli stdout:\n${stdout}`);
+            log.info(formatCliOutputForLog("stdout", stdout));
           }
           if (stderr) {
-            log.info(`cli stderr:\n${stderr}`);
+            log.info(formatCliOutputForLog("stderr", stderr));
           }
         }
         if (shouldLogVerbose()) {
           if (stdout) {
-            log.debug(`cli stdout:\n${stdout}`);
+            log.debug(formatCliOutputForLog("stdout", stdout));
           }
           if (stderr) {
-            log.debug(`cli stderr:\n${stderr}`);
+            log.debug(formatCliOutputForLog("stderr", stderr));
           }
         }
 
@@ -382,18 +847,54 @@ export async function runCliAgent(params: {
           });
         }
 
-        const outputMode = useResume ? (backend.resumeOutput ?? backend.output) : backend.output;
-
-        if (outputMode === "text") {
-          return { text: stdout, sessionId: undefined };
-        }
-        if (outputMode === "jsonl") {
+        let output: {
+          text: string;
+          sessionId?: string;
+          usage?: {
+            input?: number;
+            output?: number;
+            cacheRead?: number;
+            cacheWrite?: number;
+            total?: number;
+          };
+        };
+        if (streamProcessor) {
+          output = streamProcessor.finish();
+        } else if (outputMode === "text") {
+          output = { text: stdout, sessionId: undefined };
+        } else if (outputMode === "jsonl") {
           const parsed = parseCliJsonl(stdout, backend);
-          return parsed ?? { text: stdout };
+          output = parsed ?? { text: stdout };
+        } else {
+          const parsed = parseCliJson(stdout, backend);
+          output = parsed ?? { text: stdout };
         }
-
-        const parsed = parseCliJson(stdout, backend);
-        return parsed ?? { text: stdout };
+        try {
+          const appendResult = await appendCliTurnToSessionTranscript({
+            sessionFile: params.sessionFile,
+            sessionId: params.sessionId,
+            userText: params.prompt,
+            assistantText: output.text,
+            provider: params.provider,
+            model: normalizedModel,
+            usage: output.usage,
+          });
+          if (!appendResult.ok) {
+            log.debug(`cli transcript append skipped: ${appendResult.reason}`);
+          }
+        } catch (err) {
+          log.warn(`cli transcript append failed: ${String(err)}`);
+        }
+        emitCliLlmOutputHook({
+          hookRunner,
+          hookCtx,
+          runId: params.runId,
+          sessionId: output.sessionId ?? resolvedSessionId ?? params.sessionId,
+          provider: params.provider,
+          model: normalizedModel,
+          output,
+        });
+        return output;
       });
 
       return output;
@@ -406,68 +907,78 @@ export async function runCliAgent(params: {
 
   // Try with the provided CLI session ID first
   try {
-    const output = await executeCliWithSession(params.cliSessionId);
-    const text = output.text?.trim();
-    const payloads = text ? [{ text }] : undefined;
+    try {
+      const output = await executeCliWithSession(params.cliSessionId);
+      const text = output.text?.trim();
+      const payloads = text ? [{ text }] : undefined;
 
-    return {
-      payloads,
-      meta: {
-        durationMs: Date.now() - started,
-        systemPromptReport,
-        agentMeta: {
-          sessionId: output.sessionId ?? params.cliSessionId ?? params.sessionId ?? "",
+      return {
+        payloads,
+        meta: {
+          durationMs: Date.now() - started,
+          systemPromptReport,
+          agentMeta: {
+            sessionId: output.sessionId ?? params.cliSessionId ?? params.sessionId ?? "",
+            provider: params.provider,
+            model: modelId,
+            usage: output.usage,
+          },
+        },
+      };
+    } catch (err) {
+      if (err instanceof FailoverError) {
+        // Check if this is a session expired error and we have a session to clear
+        if (err.reason === "session_expired" && params.cliSessionId && params.sessionKey) {
+          log.warn(
+            `CLI session expired, clearing session ID and retrying: provider=${params.provider} session=${redactRunIdentifier(params.cliSessionId)}`,
+          );
+
+          // Clear the expired session ID from the session entry
+          // This requires access to the session store, which we don't have here
+          // We'll need to modify the caller to handle this case
+
+          // For now, retry without the session ID to create a new session
+          const output = await executeCliWithSession(undefined);
+          const text = output.text?.trim();
+          const payloads = text ? [{ text }] : undefined;
+
+          return {
+            payloads,
+            meta: {
+              durationMs: Date.now() - started,
+              systemPromptReport,
+              agentMeta: {
+                sessionId: output.sessionId ?? params.sessionId ?? "",
+                provider: params.provider,
+                model: modelId,
+                usage: output.usage,
+              },
+            },
+          };
+        }
+        throw err;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      if (isFailoverErrorMessage(message)) {
+        const reason = classifyFailoverReason(message) ?? "unknown";
+        const status = resolveFailoverStatus(reason);
+        throw new FailoverError(message, {
+          reason,
           provider: params.provider,
           model: modelId,
-          usage: output.usage,
-        },
-      },
-    };
-  } catch (err) {
-    if (err instanceof FailoverError) {
-      // Check if this is a session expired error and we have a session to clear
-      if (err.reason === "session_expired" && params.cliSessionId && params.sessionKey) {
-        log.warn(
-          `CLI session expired, clearing session ID and retrying: provider=${params.provider} session=${redactRunIdentifier(params.cliSessionId)}`,
-        );
-
-        // Clear the expired session ID from the session entry
-        // This requires access to the session store, which we don't have here
-        // We'll need to modify the caller to handle this case
-
-        // For now, retry without the session ID to create a new session
-        const output = await executeCliWithSession(undefined);
-        const text = output.text?.trim();
-        const payloads = text ? [{ text }] : undefined;
-
-        return {
-          payloads,
-          meta: {
-            durationMs: Date.now() - started,
-            systemPromptReport,
-            agentMeta: {
-              sessionId: output.sessionId ?? params.sessionId ?? "",
-              provider: params.provider,
-              model: modelId,
-              usage: output.usage,
-            },
-          },
-        };
+          status,
+        });
       }
       throw err;
     }
-    const message = err instanceof Error ? err.message : String(err);
-    if (isFailoverErrorMessage(message)) {
-      const reason = classifyFailoverReason(message) ?? "unknown";
-      const status = resolveFailoverStatus(reason);
-      throw new FailoverError(message, {
-        reason,
-        provider: params.provider,
-        model: modelId,
-        status,
-      });
+  } finally {
+    if (restoreSkillEnv) {
+      try {
+        restoreSkillEnv();
+      } catch (error) {
+        log.warn(`failed to restore skill env overrides: ${String(error)}`);
+      }
     }
-    throw err;
   }
 }
 
@@ -485,9 +996,22 @@ export async function runClaudeCliAgent(params: {
   timeoutMs: number;
   runId: string;
   extraSystemPrompt?: string;
+  skillsSnapshot?: SkillSnapshot;
   ownerNumbers?: string[];
   claudeSessionId?: string;
   images?: ImageContent[];
+  onAssistantTurn?: (text: string) => void;
+  onSystemInit?: (payload: { subtype: string; sessionId?: string }) => void;
+  onToolUse?: (toolName: string) => void;
+  onThinkingTurn?: (payload: { text: string; delta?: string }) => void;
+  onToolUseEvent?: (payload: { name: string; toolUseId?: string; input?: unknown }) => void;
+  onToolResult?: (payload: { toolUseId?: string; text?: string; isError?: boolean }) => void;
+  abortSignal?: AbortSignal;
+  trigger?: PluginHookAgentContext["trigger"];
+  messageChannel?: string;
+  messageAccountId?: string;
+  messageTo?: string;
+  messageThreadId?: string | number;
 }): Promise<EmbeddedPiRunResult> {
   return runCliAgent({
     sessionId: params.sessionId,
@@ -503,8 +1027,21 @@ export async function runClaudeCliAgent(params: {
     timeoutMs: params.timeoutMs,
     runId: params.runId,
     extraSystemPrompt: params.extraSystemPrompt,
+    skillsSnapshot: params.skillsSnapshot,
     ownerNumbers: params.ownerNumbers,
     cliSessionId: params.claudeSessionId,
     images: params.images,
+    onAssistantTurn: params.onAssistantTurn,
+    onSystemInit: params.onSystemInit,
+    onToolUse: params.onToolUse,
+    onThinkingTurn: params.onThinkingTurn,
+    onToolUseEvent: params.onToolUseEvent,
+    onToolResult: params.onToolResult,
+    abortSignal: params.abortSignal,
+    trigger: params.trigger,
+    messageChannel: params.messageChannel,
+    messageAccountId: params.messageAccountId,
+    messageTo: params.messageTo,
+    messageThreadId: params.messageThreadId,
   });
 }

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -7,9 +7,12 @@ import type { ImageContent } from "@mariozechner/pi-ai";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { CliBackendConfig } from "../../config/types.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
 import { isRecord } from "../../utils.js";
+
+const log = createSubsystemLogger("agent/claude-cli/stream");
 import { buildModelAliasLines } from "../model-alias-lines.js";
 import { resolveDefaultModelForAgent } from "../model-selection.js";
 import { resolveOwnerDisplaySetting } from "../owner-display.js";
@@ -249,280 +252,25 @@ export function parseCliJsonl(raw: string, backend: CliBackendConfig): CliOutput
 }
 
 export type StreamJsonCallbacks = {
-  onSystemInit?: (payload: { subtype: string; sessionId?: string }) => void;
   onAssistantTurn?: (text: string) => void;
   onToolUse?: (toolName: string) => void;
-  onThinkingTurn?: (payload: { text: string; delta?: string }) => void;
-  onToolUseEvent?: (payload: { name: string; toolUseId?: string; input?: unknown }) => void;
-  onToolResult?: (payload: { toolUseId?: string; text?: string; isError?: boolean }) => void;
 };
 
-const MAX_STREAM_EVENT_DEDUPE_KEYS = 2_048;
-const KNOWN_STREAM_TOP_LEVEL_TYPES = new Set([
-  "assistant",
-  "user",
-  "system",
-  "result",
-  "rate_limit_event",
-]);
-const KNOWN_STREAM_CONTENT_BLOCK_TYPES = new Set([
-  "text",
-  "thinking",
-  "tool_use",
-  "tool_result",
-  "tool_result_error",
-]);
-
-type StreamContentBlock = Record<string, unknown>;
-
-function extractContentBlocks(message: unknown): StreamContentBlock[] {
-  if (!isRecord(message) || !Array.isArray(message.content)) {
+function extractToolUseNames(message: unknown): string[] {
+  if (!isRecord(message)) {
     return [];
   }
-  return message.content.filter((entry): entry is StreamContentBlock => isRecord(entry));
-}
-
-function extractToolUseNames(contentBlocks: StreamContentBlock[]): string[] {
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return [];
+  }
   const names: string[] = [];
-  for (const block of contentBlocks) {
-    if (block.type === "tool_use" && typeof block.name === "string") {
+  for (const block of content) {
+    if (isRecord(block) && block.type === "tool_use" && typeof block.name === "string") {
       names.push(block.name);
     }
   }
   return names;
-}
-
-function extractAssistantTextFromBlocks(contentBlocks: StreamContentBlock[]): string {
-  const parts: string[] = [];
-  for (const block of contentBlocks) {
-    if (block.type !== "text") {
-      continue;
-    }
-    if (typeof block.text === "string" && block.text) {
-      parts.push(block.text);
-    }
-  }
-  return parts.join("");
-}
-
-function extractThinkingTextFromBlocks(contentBlocks: StreamContentBlock[]): string {
-  const parts: string[] = [];
-  for (const block of contentBlocks) {
-    if (block.type !== "thinking") {
-      continue;
-    }
-    if (typeof block.thinking === "string" && block.thinking) {
-      parts.push(block.thinking);
-    }
-  }
-  return parts.join("");
-}
-
-type ToolUseBlockEvent = {
-  name: string;
-  toolUseId?: string;
-  input?: unknown;
-};
-
-function extractToolUseEvents(contentBlocks: StreamContentBlock[]): ToolUseBlockEvent[] {
-  const events: ToolUseBlockEvent[] = [];
-  for (const block of contentBlocks) {
-    if (block.type !== "tool_use" || typeof block.name !== "string") {
-      continue;
-    }
-    const toolUseId = typeof block.id === "string" ? block.id : undefined;
-    events.push({
-      name: block.name,
-      toolUseId,
-      input: block.input,
-    });
-  }
-  return events;
-}
-
-type ToolResultBlockEvent = {
-  toolUseId?: string;
-  text?: string;
-  isError?: boolean;
-};
-
-function extractToolResultEvents(contentBlocks: StreamContentBlock[]): ToolResultBlockEvent[] {
-  const events: ToolResultBlockEvent[] = [];
-  for (const block of contentBlocks) {
-    const type = typeof block.type === "string" ? block.type : "";
-    if (type !== "tool_result" && type !== "tool_result_error") {
-      continue;
-    }
-    const text = collectText(block.content ?? block.result ?? block.text).trim();
-    const toolUseId =
-      typeof block.tool_use_id === "string"
-        ? block.tool_use_id
-        : typeof block.toolUseId === "string"
-          ? block.toolUseId
-          : undefined;
-    const isError = block.is_error === true || type === "tool_result_error";
-    events.push({
-      toolUseId,
-      text: text || undefined,
-      isError,
-    });
-  }
-  return events;
-}
-
-function resolveDelta(nextText: string, previousText: string): string | undefined {
-  if (!nextText) {
-    return undefined;
-  }
-  if (!previousText) {
-    return nextText;
-  }
-  if (nextText.startsWith(previousText)) {
-    const delta = nextText.slice(previousText.length);
-    return delta || undefined;
-  }
-  // Non-append rewrites should not be treated as deltas.
-  return undefined;
-}
-
-function addDedupeKey(bucket: Set<string>, order: string[], key: string): boolean {
-  if (bucket.has(key)) {
-    return false;
-  }
-  bucket.add(key);
-  order.push(key);
-  if (order.length > MAX_STREAM_EVENT_DEDUPE_KEYS) {
-    const oldest = order.shift();
-    if (oldest) {
-      bucket.delete(oldest);
-    }
-  }
-  return true;
-}
-
-function stringifyForDedupe(value: unknown): string {
-  if (value === undefined) {
-    return "";
-  }
-  try {
-    return JSON.stringify(value) ?? "";
-  } catch {
-    return "[unserializable]";
-  }
-}
-
-function buildAnonymousToolUseKey(event: ToolUseBlockEvent): string {
-  return `${event.name}:${stringifyForDedupe(event.input)}`;
-}
-
-function buildToolResultDedupeKey(event: ToolResultBlockEvent): string | undefined {
-  if (!event.toolUseId) {
-    return undefined;
-  }
-  return `${event.toolUseId}:${event.isError === true ? "1" : "0"}:${event.text ?? ""}`;
-}
-
-function shouldEmitAnonymousToolUse(
-  event: ToolUseBlockEvent,
-  lastKey: string | undefined,
-): { emit: boolean; key: string } {
-  const key = buildAnonymousToolUseKey(event);
-  return { emit: key !== lastKey, key };
-}
-
-function formatToolResultDedupeKey(event: ToolResultBlockEvent): string | undefined {
-  return buildToolResultDedupeKey(event);
-}
-
-function trackToolResultDedupeKey(
-  emittedToolResultKeys: Set<string>,
-  emittedToolResultOrder: string[],
-  event: ToolResultBlockEvent,
-): boolean {
-  const dedupeKey = formatToolResultDedupeKey(event);
-  if (!dedupeKey) {
-    return true;
-  }
-  return addDedupeKey(emittedToolResultKeys, emittedToolResultOrder, dedupeKey);
-}
-
-function trackToolUseDedupeKey(
-  emittedToolUseKeys: Set<string>,
-  emittedToolUseOrder: string[],
-  event: ToolUseBlockEvent,
-): boolean {
-  if (!event.toolUseId) {
-    return true;
-  }
-  return addDedupeKey(emittedToolUseKeys, emittedToolUseOrder, event.toolUseId);
-}
-
-function shouldEmitToolUse(
-  emittedToolUseKeys: Set<string>,
-  emittedToolUseOrder: string[],
-  event: ToolUseBlockEvent,
-  lastAnonymousToolUseKey: string | undefined,
-): { emit: boolean; nextAnonymousToolUseKey?: string } {
-  if (event.toolUseId) {
-    return {
-      emit: trackToolUseDedupeKey(emittedToolUseKeys, emittedToolUseOrder, event),
-      nextAnonymousToolUseKey: undefined,
-    };
-  }
-  const anonymous = shouldEmitAnonymousToolUse(event, lastAnonymousToolUseKey);
-  return {
-    emit: anonymous.emit,
-    nextAnonymousToolUseKey: anonymous.key,
-  };
-}
-
-function shouldEmitToolResult(
-  emittedToolResultKeys: Set<string>,
-  emittedToolResultOrder: string[],
-  event: ToolResultBlockEvent,
-): boolean {
-  return trackToolResultDedupeKey(emittedToolResultKeys, emittedToolResultOrder, event);
-}
-
-function isToolResultAllowedEnvelope(params: {
-  isAssistantEnvelope: boolean;
-  type: string;
-  messageRole: string;
-}): boolean {
-  if (params.isAssistantEnvelope) {
-    return true;
-  }
-  return (
-    params.type === "user" ||
-    params.type === "tool" ||
-    params.messageRole === "user" ||
-    params.messageRole === "tool"
-  );
-}
-
-function buildFallbackAssistantText(params: {
-  isAssistantEnvelope: boolean;
-  extractedText: string;
-  rawMessage: unknown;
-  message: Record<string, unknown>;
-}): string {
-  if (!params.isAssistantEnvelope || params.extractedText) {
-    return params.extractedText;
-  }
-  return collectText(params.rawMessage) || collectText(params.message);
-}
-
-function logUnknownStreamTypeOnce(params: {
-  seen: Set<string>;
-  value: string;
-  kind: "top-level" | "content-block";
-}): void {
-  const normalized = params.value.trim();
-  if (!normalized || params.seen.has(normalized)) {
-    return;
-  }
-  params.seen.add(normalized);
-  log.debug(`stream-json unknown ${params.kind} type observed: ${normalized}`);
 }
 
 export function createStreamJsonProcessor(
@@ -534,17 +282,9 @@ export function createStreamJsonProcessor(
 } {
   let buffer = "";
   let lastAssistantText = "";
-  let lastThinkingText = "";
   let resultText: string | undefined;
   let sessionId: string | undefined;
   let usage: CliUsage | undefined;
-  const emittedToolUseKeys = new Set<string>();
-  const emittedToolUseOrder: string[] = [];
-  const emittedToolResultKeys = new Set<string>();
-  const emittedToolResultOrder: string[] = [];
-  let lastAnonymousToolUseKey: string | undefined;
-  const seenUnknownTopLevelTypes = new Set<string>();
-  const seenUnknownContentBlockTypes = new Set<string>();
 
   const processLine = (line: string) => {
     const trimmed = line.trim();
@@ -562,19 +302,37 @@ export function createStreamJsonProcessor(
     }
 
     const type = typeof parsed.type === "string" ? parsed.type : "";
-    if (type && !KNOWN_STREAM_TOP_LEVEL_TYPES.has(type)) {
-      logUnknownStreamTypeOnce({
-        seen: seenUnknownTopLevelTypes,
-        value: type,
-        kind: "top-level",
-      });
-    }
 
     if (!sessionId) {
       sessionId = pickSessionId(parsed, backend);
     }
 
-    if (type === "result") {
+    if (type === "assistant") {
+      const msg = isRecord(parsed.message) ? parsed.message : parsed;
+      const contentBlocks = Array.isArray(isRecord(msg) ? msg.content : undefined)
+        ? (msg.content as unknown[])
+        : [];
+      const blockTypes = contentBlocks
+        .map((b) => (isRecord(b) && typeof b.type === "string" ? b.type : "?"))
+        .join(",");
+
+      const text = collectText(parsed.message);
+      const toolNames = extractToolUseNames(msg);
+
+      log.debug(
+        `stream-json assistant: blocks=[${blockTypes}] text=${text.length} chars tools=[${toolNames.join(",")}]${text ? ` content=${text.slice(0, 200)}` : ""}`,
+      );
+
+      if (text) {
+        lastAssistantText = text;
+        callbacks?.onAssistantTurn?.(lastAssistantText);
+      }
+      if (callbacks?.onToolUse) {
+        for (const name of toolNames) {
+          callbacks.onToolUse(name);
+        }
+      }
+    } else if (type === "result") {
       resultText =
         (typeof parsed.result === "string" ? parsed.result : undefined) ?? collectText(parsed);
       if (isRecord(parsed.usage)) {
@@ -583,113 +341,9 @@ export function createStreamJsonProcessor(
       log.debug(
         `stream-json result: ${resultText?.length ?? 0} chars, sessionId=${sessionId ?? "none"}`,
       );
-      return;
-    }
-
-    if (type === "system") {
+    } else if (type === "system") {
       const subtype = typeof parsed.subtype === "string" ? parsed.subtype : "";
       log.debug(`stream-json system: subtype=${subtype} sessionId=${sessionId ?? "none"}`);
-      if (subtype === "init") {
-        callbacks?.onSystemInit?.({ subtype, sessionId });
-      }
-      return;
-    }
-    if (type === "rate_limit_event") {
-      return;
-    }
-
-    const rawMessage = parsed.message;
-    const message = isRecord(rawMessage) ? rawMessage : parsed;
-    const messageRole = typeof message.role === "string" ? message.role : "";
-    const isAssistantEnvelope = type === "assistant" || messageRole === "assistant";
-    const contentBlocks = extractContentBlocks(message);
-    if (contentBlocks.length > 0) {
-      for (const block of contentBlocks) {
-        const blockType = typeof block.type === "string" ? block.type : "";
-        if (!blockType || KNOWN_STREAM_CONTENT_BLOCK_TYPES.has(blockType)) {
-          continue;
-        }
-        logUnknownStreamTypeOnce({
-          seen: seenUnknownContentBlockTypes,
-          value: blockType,
-          kind: "content-block",
-        });
-      }
-      const blockTypes = contentBlocks
-        .map((block) => (typeof block.type === "string" ? block.type : "?"))
-        .join(",");
-      const extractedText = isAssistantEnvelope
-        ? extractAssistantTextFromBlocks(contentBlocks)
-        : "";
-      const text = buildFallbackAssistantText({
-        isAssistantEnvelope,
-        extractedText,
-        rawMessage,
-        message,
-      });
-      const thinkingText = isAssistantEnvelope ? extractThinkingTextFromBlocks(contentBlocks) : "";
-      const toolUseEvents = isAssistantEnvelope ? extractToolUseEvents(contentBlocks) : [];
-      const allowToolResultEvents = isToolResultAllowedEnvelope({
-        isAssistantEnvelope,
-        type,
-        messageRole,
-      });
-      const toolResultEvents = allowToolResultEvents ? extractToolResultEvents(contentBlocks) : [];
-      const toolNames = extractToolUseNames(contentBlocks);
-
-      if (isAssistantEnvelope) {
-        log.debug(
-          `stream-json assistant: blocks=[${blockTypes}] text=${text.length} chars thinking=${thinkingText.length} chars tools=[${toolNames.join(",")}]${text ? ` content=${text.slice(0, 200)}` : ""}`,
-        );
-      }
-
-      if (text && text !== lastAssistantText) {
-        lastAssistantText = text;
-        callbacks?.onAssistantTurn?.(lastAssistantText);
-      }
-
-      if (thinkingText && thinkingText !== lastThinkingText) {
-        const delta = resolveDelta(thinkingText, lastThinkingText);
-        lastThinkingText = thinkingText;
-        callbacks?.onThinkingTurn?.({
-          text: thinkingText,
-          ...(delta ? { delta } : {}),
-        });
-      }
-
-      for (const event of toolUseEvents) {
-        const dedupe = shouldEmitToolUse(
-          emittedToolUseKeys,
-          emittedToolUseOrder,
-          event,
-          lastAnonymousToolUseKey,
-        );
-        if (!dedupe.emit) {
-          continue;
-        }
-        if (!event.toolUseId) {
-          lastAnonymousToolUseKey = dedupe.nextAnonymousToolUseKey;
-        } else {
-          lastAnonymousToolUseKey = undefined;
-        }
-        callbacks?.onToolUse?.(event.name);
-        callbacks?.onToolUseEvent?.(event);
-      }
-
-      for (const event of toolResultEvents) {
-        if (!shouldEmitToolResult(emittedToolResultKeys, emittedToolResultOrder, event)) {
-          continue;
-        }
-        callbacks?.onToolResult?.(event);
-      }
-    } else if (isAssistantEnvelope) {
-      // Backward compatibility for custom stream-json backends that emit
-      // assistant content as a string/object instead of typed content blocks.
-      const fallbackText = collectText(rawMessage) || collectText(message);
-      if (fallbackText && fallbackText !== lastAssistantText) {
-        lastAssistantText = fallbackText;
-        callbacks?.onAssistantTurn?.(lastAssistantText);
-      }
     }
   };
 

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -252,25 +252,280 @@ export function parseCliJsonl(raw: string, backend: CliBackendConfig): CliOutput
 }
 
 export type StreamJsonCallbacks = {
+  onSystemInit?: (payload: { subtype: string; sessionId?: string }) => void;
   onAssistantTurn?: (text: string) => void;
   onToolUse?: (toolName: string) => void;
+  onThinkingTurn?: (payload: { text: string; delta?: string }) => void;
+  onToolUseEvent?: (payload: { name: string; toolUseId?: string; input?: unknown }) => void;
+  onToolResult?: (payload: { toolUseId?: string; text?: string; isError?: boolean }) => void;
 };
 
-function extractToolUseNames(message: unknown): string[] {
-  if (!isRecord(message)) {
+const MAX_STREAM_EVENT_DEDUPE_KEYS = 2_048;
+const KNOWN_STREAM_TOP_LEVEL_TYPES = new Set([
+  "assistant",
+  "user",
+  "system",
+  "result",
+  "rate_limit_event",
+]);
+const KNOWN_STREAM_CONTENT_BLOCK_TYPES = new Set([
+  "text",
+  "thinking",
+  "tool_use",
+  "tool_result",
+  "tool_result_error",
+]);
+
+type StreamContentBlock = Record<string, unknown>;
+
+function extractContentBlocks(message: unknown): StreamContentBlock[] {
+  if (!isRecord(message) || !Array.isArray(message.content)) {
     return [];
   }
-  const content = message.content;
-  if (!Array.isArray(content)) {
-    return [];
-  }
+  return message.content.filter((entry): entry is StreamContentBlock => isRecord(entry));
+}
+
+function extractToolUseNames(contentBlocks: StreamContentBlock[]): string[] {
   const names: string[] = [];
-  for (const block of content) {
-    if (isRecord(block) && block.type === "tool_use" && typeof block.name === "string") {
+  for (const block of contentBlocks) {
+    if (block.type === "tool_use" && typeof block.name === "string") {
       names.push(block.name);
     }
   }
   return names;
+}
+
+function extractAssistantTextFromBlocks(contentBlocks: StreamContentBlock[]): string {
+  const parts: string[] = [];
+  for (const block of contentBlocks) {
+    if (block.type !== "text") {
+      continue;
+    }
+    if (typeof block.text === "string" && block.text) {
+      parts.push(block.text);
+    }
+  }
+  return parts.join("");
+}
+
+function extractThinkingTextFromBlocks(contentBlocks: StreamContentBlock[]): string {
+  const parts: string[] = [];
+  for (const block of contentBlocks) {
+    if (block.type !== "thinking") {
+      continue;
+    }
+    if (typeof block.thinking === "string" && block.thinking) {
+      parts.push(block.thinking);
+    }
+  }
+  return parts.join("");
+}
+
+type ToolUseBlockEvent = {
+  name: string;
+  toolUseId?: string;
+  input?: unknown;
+};
+
+function extractToolUseEvents(contentBlocks: StreamContentBlock[]): ToolUseBlockEvent[] {
+  const events: ToolUseBlockEvent[] = [];
+  for (const block of contentBlocks) {
+    if (block.type !== "tool_use" || typeof block.name !== "string") {
+      continue;
+    }
+    const toolUseId = typeof block.id === "string" ? block.id : undefined;
+    events.push({
+      name: block.name,
+      toolUseId,
+      input: block.input,
+    });
+  }
+  return events;
+}
+
+type ToolResultBlockEvent = {
+  toolUseId?: string;
+  text?: string;
+  isError?: boolean;
+};
+
+function extractToolResultEvents(contentBlocks: StreamContentBlock[]): ToolResultBlockEvent[] {
+  const events: ToolResultBlockEvent[] = [];
+  for (const block of contentBlocks) {
+    const type = typeof block.type === "string" ? block.type : "";
+    if (type !== "tool_result" && type !== "tool_result_error") {
+      continue;
+    }
+    const text = collectText(block.content ?? block.result ?? block.text).trim();
+    const toolUseId =
+      typeof block.tool_use_id === "string"
+        ? block.tool_use_id
+        : typeof block.toolUseId === "string"
+          ? block.toolUseId
+          : undefined;
+    const isError = block.is_error === true || type === "tool_result_error";
+    events.push({
+      toolUseId,
+      text: text || undefined,
+      isError,
+    });
+  }
+  return events;
+}
+
+function resolveDelta(nextText: string, previousText: string): string | undefined {
+  if (!nextText) {
+    return undefined;
+  }
+  if (!previousText) {
+    return nextText;
+  }
+  if (nextText.startsWith(previousText)) {
+    const delta = nextText.slice(previousText.length);
+    return delta || undefined;
+  }
+  // Non-append rewrites should not be treated as deltas.
+  return undefined;
+}
+
+function addDedupeKey(bucket: Set<string>, order: string[], key: string): boolean {
+  if (bucket.has(key)) {
+    return false;
+  }
+  bucket.add(key);
+  order.push(key);
+  if (order.length > MAX_STREAM_EVENT_DEDUPE_KEYS) {
+    const oldest = order.shift();
+    if (oldest) {
+      bucket.delete(oldest);
+    }
+  }
+  return true;
+}
+
+function stringifyForDedupe(value: unknown): string {
+  if (value === undefined) {
+    return "";
+  }
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+function buildAnonymousToolUseKey(event: ToolUseBlockEvent): string {
+  return `${event.name}:${stringifyForDedupe(event.input)}`;
+}
+
+function buildToolResultDedupeKey(event: ToolResultBlockEvent): string | undefined {
+  if (!event.toolUseId) {
+    return undefined;
+  }
+  return `${event.toolUseId}:${event.isError === true ? "1" : "0"}:${event.text ?? ""}`;
+}
+
+function shouldEmitAnonymousToolUse(
+  event: ToolUseBlockEvent,
+  lastKey: string | undefined,
+): { emit: boolean; key: string } {
+  const key = buildAnonymousToolUseKey(event);
+  return { emit: key !== lastKey, key };
+}
+
+function formatToolResultDedupeKey(event: ToolResultBlockEvent): string | undefined {
+  return buildToolResultDedupeKey(event);
+}
+
+function trackToolResultDedupeKey(
+  emittedToolResultKeys: Set<string>,
+  emittedToolResultOrder: string[],
+  event: ToolResultBlockEvent,
+): boolean {
+  const dedupeKey = formatToolResultDedupeKey(event);
+  if (!dedupeKey) {
+    return true;
+  }
+  return addDedupeKey(emittedToolResultKeys, emittedToolResultOrder, dedupeKey);
+}
+
+function trackToolUseDedupeKey(
+  emittedToolUseKeys: Set<string>,
+  emittedToolUseOrder: string[],
+  event: ToolUseBlockEvent,
+): boolean {
+  if (!event.toolUseId) {
+    return true;
+  }
+  return addDedupeKey(emittedToolUseKeys, emittedToolUseOrder, event.toolUseId);
+}
+
+function shouldEmitToolUse(
+  emittedToolUseKeys: Set<string>,
+  emittedToolUseOrder: string[],
+  event: ToolUseBlockEvent,
+  lastAnonymousToolUseKey: string | undefined,
+): { emit: boolean; nextAnonymousToolUseKey?: string } {
+  if (event.toolUseId) {
+    return {
+      emit: trackToolUseDedupeKey(emittedToolUseKeys, emittedToolUseOrder, event),
+      nextAnonymousToolUseKey: undefined,
+    };
+  }
+  const anonymous = shouldEmitAnonymousToolUse(event, lastAnonymousToolUseKey);
+  return {
+    emit: anonymous.emit,
+    nextAnonymousToolUseKey: anonymous.key,
+  };
+}
+
+function shouldEmitToolResult(
+  emittedToolResultKeys: Set<string>,
+  emittedToolResultOrder: string[],
+  event: ToolResultBlockEvent,
+): boolean {
+  return trackToolResultDedupeKey(emittedToolResultKeys, emittedToolResultOrder, event);
+}
+
+function isToolResultAllowedEnvelope(params: {
+  isAssistantEnvelope: boolean;
+  type: string;
+  messageRole: string;
+}): boolean {
+  if (params.isAssistantEnvelope) {
+    return true;
+  }
+  return (
+    params.type === "user" ||
+    params.type === "tool" ||
+    params.messageRole === "user" ||
+    params.messageRole === "tool"
+  );
+}
+
+function buildFallbackAssistantText(params: {
+  isAssistantEnvelope: boolean;
+  extractedText: string;
+  rawMessage: unknown;
+  message: Record<string, unknown>;
+}): string {
+  if (!params.isAssistantEnvelope || params.extractedText) {
+    return params.extractedText;
+  }
+  return collectText(params.rawMessage) || collectText(params.message);
+}
+
+function logUnknownStreamTypeOnce(params: {
+  seen: Set<string>;
+  value: string;
+  kind: "top-level" | "content-block";
+}): void {
+  const normalized = params.value.trim();
+  if (!normalized || params.seen.has(normalized)) {
+    return;
+  }
+  params.seen.add(normalized);
+  log.debug(`stream-json unknown ${params.kind} type observed: ${normalized}`);
 }
 
 export function createStreamJsonProcessor(
@@ -282,9 +537,17 @@ export function createStreamJsonProcessor(
 } {
   let buffer = "";
   let lastAssistantText = "";
+  let lastThinkingText = "";
   let resultText: string | undefined;
   let sessionId: string | undefined;
   let usage: CliUsage | undefined;
+  const emittedToolUseKeys = new Set<string>();
+  const emittedToolUseOrder: string[] = [];
+  const emittedToolResultKeys = new Set<string>();
+  const emittedToolResultOrder: string[] = [];
+  let lastAnonymousToolUseKey: string | undefined;
+  const seenUnknownTopLevelTypes = new Set<string>();
+  const seenUnknownContentBlockTypes = new Set<string>();
 
   const processLine = (line: string) => {
     const trimmed = line.trim();
@@ -302,37 +565,19 @@ export function createStreamJsonProcessor(
     }
 
     const type = typeof parsed.type === "string" ? parsed.type : "";
+    if (type && !KNOWN_STREAM_TOP_LEVEL_TYPES.has(type)) {
+      logUnknownStreamTypeOnce({
+        seen: seenUnknownTopLevelTypes,
+        value: type,
+        kind: "top-level",
+      });
+    }
 
     if (!sessionId) {
       sessionId = pickSessionId(parsed, backend);
     }
 
-    if (type === "assistant") {
-      const msg = isRecord(parsed.message) ? parsed.message : parsed;
-      const contentBlocks = Array.isArray(isRecord(msg) ? msg.content : undefined)
-        ? (msg.content as unknown[])
-        : [];
-      const blockTypes = contentBlocks
-        .map((b) => (isRecord(b) && typeof b.type === "string" ? b.type : "?"))
-        .join(",");
-
-      const text = collectText(parsed.message);
-      const toolNames = extractToolUseNames(msg);
-
-      log.debug(
-        `stream-json assistant: blocks=[${blockTypes}] text=${text.length} chars tools=[${toolNames.join(",")}]${text ? ` content=${text.slice(0, 200)}` : ""}`,
-      );
-
-      if (text) {
-        lastAssistantText = text;
-        callbacks?.onAssistantTurn?.(lastAssistantText);
-      }
-      if (callbacks?.onToolUse) {
-        for (const name of toolNames) {
-          callbacks.onToolUse(name);
-        }
-      }
-    } else if (type === "result") {
+    if (type === "result") {
       resultText =
         (typeof parsed.result === "string" ? parsed.result : undefined) ?? collectText(parsed);
       if (isRecord(parsed.usage)) {
@@ -341,9 +586,113 @@ export function createStreamJsonProcessor(
       log.debug(
         `stream-json result: ${resultText?.length ?? 0} chars, sessionId=${sessionId ?? "none"}`,
       );
-    } else if (type === "system") {
+      return;
+    }
+
+    if (type === "system") {
       const subtype = typeof parsed.subtype === "string" ? parsed.subtype : "";
       log.debug(`stream-json system: subtype=${subtype} sessionId=${sessionId ?? "none"}`);
+      if (subtype === "init") {
+        callbacks?.onSystemInit?.({ subtype, sessionId });
+      }
+      return;
+    }
+    if (type === "rate_limit_event") {
+      return;
+    }
+
+    const rawMessage = parsed.message;
+    const message = isRecord(rawMessage) ? rawMessage : parsed;
+    const messageRole = typeof message.role === "string" ? message.role : "";
+    const isAssistantEnvelope = type === "assistant" || messageRole === "assistant";
+    const contentBlocks = extractContentBlocks(message);
+    if (contentBlocks.length > 0) {
+      for (const block of contentBlocks) {
+        const blockType = typeof block.type === "string" ? block.type : "";
+        if (!blockType || KNOWN_STREAM_CONTENT_BLOCK_TYPES.has(blockType)) {
+          continue;
+        }
+        logUnknownStreamTypeOnce({
+          seen: seenUnknownContentBlockTypes,
+          value: blockType,
+          kind: "content-block",
+        });
+      }
+      const blockTypes = contentBlocks
+        .map((block) => (typeof block.type === "string" ? block.type : "?"))
+        .join(",");
+      const extractedText = isAssistantEnvelope
+        ? extractAssistantTextFromBlocks(contentBlocks)
+        : "";
+      const text = buildFallbackAssistantText({
+        isAssistantEnvelope,
+        extractedText,
+        rawMessage,
+        message,
+      });
+      const thinkingText = isAssistantEnvelope ? extractThinkingTextFromBlocks(contentBlocks) : "";
+      const toolUseEvents = isAssistantEnvelope ? extractToolUseEvents(contentBlocks) : [];
+      const allowToolResultEvents = isToolResultAllowedEnvelope({
+        isAssistantEnvelope,
+        type,
+        messageRole,
+      });
+      const toolResultEvents = allowToolResultEvents ? extractToolResultEvents(contentBlocks) : [];
+      const toolNames = extractToolUseNames(contentBlocks);
+
+      if (isAssistantEnvelope) {
+        log.debug(
+          `stream-json assistant: blocks=[${blockTypes}] text=${text.length} chars thinking=${thinkingText.length} chars tools=[${toolNames.join(",")}]${text ? ` content=${text.slice(0, 200)}` : ""}`,
+        );
+      }
+
+      if (text && text !== lastAssistantText) {
+        lastAssistantText = text;
+        callbacks?.onAssistantTurn?.(lastAssistantText);
+      }
+
+      if (thinkingText && thinkingText !== lastThinkingText) {
+        const delta = resolveDelta(thinkingText, lastThinkingText);
+        lastThinkingText = thinkingText;
+        callbacks?.onThinkingTurn?.({
+          text: thinkingText,
+          ...(delta ? { delta } : {}),
+        });
+      }
+
+      for (const event of toolUseEvents) {
+        const dedupe = shouldEmitToolUse(
+          emittedToolUseKeys,
+          emittedToolUseOrder,
+          event,
+          lastAnonymousToolUseKey,
+        );
+        if (!dedupe.emit) {
+          continue;
+        }
+        if (!event.toolUseId) {
+          lastAnonymousToolUseKey = dedupe.nextAnonymousToolUseKey;
+        } else {
+          lastAnonymousToolUseKey = undefined;
+        }
+        callbacks?.onToolUse?.(event.name);
+        callbacks?.onToolUseEvent?.(event);
+      }
+
+      for (const event of toolResultEvents) {
+        if (!shouldEmitToolResult(emittedToolResultKeys, emittedToolResultOrder, event)) {
+          continue;
+        }
+        callbacks?.onToolResult?.(event);
+      }
+    } else if (isAssistantEnvelope) {
+      // Backward compatibility for custom stream-json backends that emit
+      // assistant content as a string/object instead of typed content blocks.
+      const fallbackText = collectText(rawMessage) || collectText(message);
+      if (fallbackText && fallbackText !== lastAssistantText) {
+        lastAssistantText = fallbackText;
+        callbacks?.onAssistantTurn?.(lastAssistantText);
+      }
     }
   };
 

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -43,6 +43,7 @@ export function buildSystemPrompt(params: {
   config?: OpenClawConfig;
   defaultThinkLevel?: ThinkLevel;
   extraSystemPrompt?: string;
+  skillsPrompt?: string;
   ownerNumbers?: string[];
   heartbeatPrompt?: string;
   docsPath?: string;
@@ -78,6 +79,7 @@ export function buildSystemPrompt(params: {
     workspaceDir: params.workspaceDir,
     defaultThinkLevel: params.defaultThinkLevel,
     extraSystemPrompt: params.extraSystemPrompt,
+    skillsPrompt: params.skillsPrompt,
     ownerNumbers: params.ownerNumbers,
     ownerDisplay: ownerDisplay.ownerDisplay,
     ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,
@@ -246,6 +248,478 @@ export function parseCliJsonl(raw: string, backend: CliBackendConfig): CliOutput
   return { text, sessionId, usage };
 }
 
+export type StreamJsonCallbacks = {
+  onSystemInit?: (payload: { subtype: string; sessionId?: string }) => void;
+  onAssistantTurn?: (text: string) => void;
+  onToolUse?: (toolName: string) => void;
+  onThinkingTurn?: (payload: { text: string; delta?: string }) => void;
+  onToolUseEvent?: (payload: { name: string; toolUseId?: string; input?: unknown }) => void;
+  onToolResult?: (payload: { toolUseId?: string; text?: string; isError?: boolean }) => void;
+};
+
+const MAX_STREAM_EVENT_DEDUPE_KEYS = 2_048;
+const KNOWN_STREAM_TOP_LEVEL_TYPES = new Set([
+  "assistant",
+  "user",
+  "system",
+  "result",
+  "rate_limit_event",
+]);
+const KNOWN_STREAM_CONTENT_BLOCK_TYPES = new Set([
+  "text",
+  "thinking",
+  "tool_use",
+  "tool_result",
+  "tool_result_error",
+]);
+
+type StreamContentBlock = Record<string, unknown>;
+
+function extractContentBlocks(message: unknown): StreamContentBlock[] {
+  if (!isRecord(message) || !Array.isArray(message.content)) {
+    return [];
+  }
+  return message.content.filter((entry): entry is StreamContentBlock => isRecord(entry));
+}
+
+function extractToolUseNames(contentBlocks: StreamContentBlock[]): string[] {
+  const names: string[] = [];
+  for (const block of contentBlocks) {
+    if (block.type === "tool_use" && typeof block.name === "string") {
+      names.push(block.name);
+    }
+  }
+  return names;
+}
+
+function extractAssistantTextFromBlocks(contentBlocks: StreamContentBlock[]): string {
+  const parts: string[] = [];
+  for (const block of contentBlocks) {
+    if (block.type !== "text") {
+      continue;
+    }
+    if (typeof block.text === "string" && block.text) {
+      parts.push(block.text);
+    }
+  }
+  return parts.join("");
+}
+
+function extractThinkingTextFromBlocks(contentBlocks: StreamContentBlock[]): string {
+  const parts: string[] = [];
+  for (const block of contentBlocks) {
+    if (block.type !== "thinking") {
+      continue;
+    }
+    if (typeof block.thinking === "string" && block.thinking) {
+      parts.push(block.thinking);
+    }
+  }
+  return parts.join("");
+}
+
+type ToolUseBlockEvent = {
+  name: string;
+  toolUseId?: string;
+  input?: unknown;
+};
+
+function extractToolUseEvents(contentBlocks: StreamContentBlock[]): ToolUseBlockEvent[] {
+  const events: ToolUseBlockEvent[] = [];
+  for (const block of contentBlocks) {
+    if (block.type !== "tool_use" || typeof block.name !== "string") {
+      continue;
+    }
+    const toolUseId = typeof block.id === "string" ? block.id : undefined;
+    events.push({
+      name: block.name,
+      toolUseId,
+      input: block.input,
+    });
+  }
+  return events;
+}
+
+type ToolResultBlockEvent = {
+  toolUseId?: string;
+  text?: string;
+  isError?: boolean;
+};
+
+function extractToolResultEvents(contentBlocks: StreamContentBlock[]): ToolResultBlockEvent[] {
+  const events: ToolResultBlockEvent[] = [];
+  for (const block of contentBlocks) {
+    const type = typeof block.type === "string" ? block.type : "";
+    if (type !== "tool_result" && type !== "tool_result_error") {
+      continue;
+    }
+    const text = collectText(block.content ?? block.result ?? block.text).trim();
+    const toolUseId =
+      typeof block.tool_use_id === "string"
+        ? block.tool_use_id
+        : typeof block.toolUseId === "string"
+          ? block.toolUseId
+          : undefined;
+    const isError = block.is_error === true || type === "tool_result_error";
+    events.push({
+      toolUseId,
+      text: text || undefined,
+      isError,
+    });
+  }
+  return events;
+}
+
+function resolveDelta(nextText: string, previousText: string): string | undefined {
+  if (!nextText) {
+    return undefined;
+  }
+  if (!previousText) {
+    return nextText;
+  }
+  if (nextText.startsWith(previousText)) {
+    const delta = nextText.slice(previousText.length);
+    return delta || undefined;
+  }
+  // Non-append rewrites should not be treated as deltas.
+  return undefined;
+}
+
+function addDedupeKey(bucket: Set<string>, order: string[], key: string): boolean {
+  if (bucket.has(key)) {
+    return false;
+  }
+  bucket.add(key);
+  order.push(key);
+  if (order.length > MAX_STREAM_EVENT_DEDUPE_KEYS) {
+    const oldest = order.shift();
+    if (oldest) {
+      bucket.delete(oldest);
+    }
+  }
+  return true;
+}
+
+function stringifyForDedupe(value: unknown): string {
+  if (value === undefined) {
+    return "";
+  }
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+function buildAnonymousToolUseKey(event: ToolUseBlockEvent): string {
+  return `${event.name}:${stringifyForDedupe(event.input)}`;
+}
+
+function buildToolResultDedupeKey(event: ToolResultBlockEvent): string | undefined {
+  if (!event.toolUseId) {
+    return undefined;
+  }
+  return `${event.toolUseId}:${event.isError === true ? "1" : "0"}:${event.text ?? ""}`;
+}
+
+function shouldEmitAnonymousToolUse(
+  event: ToolUseBlockEvent,
+  lastKey: string | undefined,
+): { emit: boolean; key: string } {
+  const key = buildAnonymousToolUseKey(event);
+  return { emit: key !== lastKey, key };
+}
+
+function formatToolResultDedupeKey(event: ToolResultBlockEvent): string | undefined {
+  return buildToolResultDedupeKey(event);
+}
+
+function trackToolResultDedupeKey(
+  emittedToolResultKeys: Set<string>,
+  emittedToolResultOrder: string[],
+  event: ToolResultBlockEvent,
+): boolean {
+  const dedupeKey = formatToolResultDedupeKey(event);
+  if (!dedupeKey) {
+    return true;
+  }
+  return addDedupeKey(emittedToolResultKeys, emittedToolResultOrder, dedupeKey);
+}
+
+function trackToolUseDedupeKey(
+  emittedToolUseKeys: Set<string>,
+  emittedToolUseOrder: string[],
+  event: ToolUseBlockEvent,
+): boolean {
+  if (!event.toolUseId) {
+    return true;
+  }
+  return addDedupeKey(emittedToolUseKeys, emittedToolUseOrder, event.toolUseId);
+}
+
+function shouldEmitToolUse(
+  emittedToolUseKeys: Set<string>,
+  emittedToolUseOrder: string[],
+  event: ToolUseBlockEvent,
+  lastAnonymousToolUseKey: string | undefined,
+): { emit: boolean; nextAnonymousToolUseKey?: string } {
+  if (event.toolUseId) {
+    return {
+      emit: trackToolUseDedupeKey(emittedToolUseKeys, emittedToolUseOrder, event),
+      nextAnonymousToolUseKey: undefined,
+    };
+  }
+  const anonymous = shouldEmitAnonymousToolUse(event, lastAnonymousToolUseKey);
+  return {
+    emit: anonymous.emit,
+    nextAnonymousToolUseKey: anonymous.key,
+  };
+}
+
+function shouldEmitToolResult(
+  emittedToolResultKeys: Set<string>,
+  emittedToolResultOrder: string[],
+  event: ToolResultBlockEvent,
+): boolean {
+  return trackToolResultDedupeKey(emittedToolResultKeys, emittedToolResultOrder, event);
+}
+
+function isToolResultAllowedEnvelope(params: {
+  isAssistantEnvelope: boolean;
+  type: string;
+  messageRole: string;
+}): boolean {
+  if (params.isAssistantEnvelope) {
+    return true;
+  }
+  return (
+    params.type === "user" ||
+    params.type === "tool" ||
+    params.messageRole === "user" ||
+    params.messageRole === "tool"
+  );
+}
+
+function buildFallbackAssistantText(params: {
+  isAssistantEnvelope: boolean;
+  extractedText: string;
+  rawMessage: unknown;
+  message: Record<string, unknown>;
+}): string {
+  if (!params.isAssistantEnvelope || params.extractedText) {
+    return params.extractedText;
+  }
+  return collectText(params.rawMessage) || collectText(params.message);
+}
+
+function logUnknownStreamTypeOnce(params: {
+  seen: Set<string>;
+  value: string;
+  kind: "top-level" | "content-block";
+}): void {
+  const normalized = params.value.trim();
+  if (!normalized || params.seen.has(normalized)) {
+    return;
+  }
+  params.seen.add(normalized);
+  log.debug(`stream-json unknown ${params.kind} type observed: ${normalized}`);
+}
+
+export function createStreamJsonProcessor(
+  backend: CliBackendConfig,
+  callbacks?: StreamJsonCallbacks,
+): {
+  feed: (chunk: string) => void;
+  finish: () => CliOutput;
+} {
+  let buffer = "";
+  let lastAssistantText = "";
+  let lastThinkingText = "";
+  let resultText: string | undefined;
+  let sessionId: string | undefined;
+  let usage: CliUsage | undefined;
+  const emittedToolUseKeys = new Set<string>();
+  const emittedToolUseOrder: string[] = [];
+  const emittedToolResultKeys = new Set<string>();
+  const emittedToolResultOrder: string[] = [];
+  let lastAnonymousToolUseKey: string | undefined;
+  const seenUnknownTopLevelTypes = new Set<string>();
+  const seenUnknownContentBlockTypes = new Set<string>();
+
+  const processLine = (line: string) => {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      return;
+    }
+    if (!isRecord(parsed)) {
+      return;
+    }
+
+    const type = typeof parsed.type === "string" ? parsed.type : "";
+    if (type && !KNOWN_STREAM_TOP_LEVEL_TYPES.has(type)) {
+      logUnknownStreamTypeOnce({
+        seen: seenUnknownTopLevelTypes,
+        value: type,
+        kind: "top-level",
+      });
+    }
+
+    if (!sessionId) {
+      sessionId = pickSessionId(parsed, backend);
+    }
+
+    if (type === "result") {
+      resultText =
+        (typeof parsed.result === "string" ? parsed.result : undefined) ?? collectText(parsed);
+      if (isRecord(parsed.usage)) {
+        usage = toUsage(parsed.usage);
+      }
+      log.debug(
+        `stream-json result: ${resultText?.length ?? 0} chars, sessionId=${sessionId ?? "none"}`,
+      );
+      return;
+    }
+
+    if (type === "system") {
+      const subtype = typeof parsed.subtype === "string" ? parsed.subtype : "";
+      log.debug(`stream-json system: subtype=${subtype} sessionId=${sessionId ?? "none"}`);
+      if (subtype === "init") {
+        callbacks?.onSystemInit?.({ subtype, sessionId });
+      }
+      return;
+    }
+    if (type === "rate_limit_event") {
+      return;
+    }
+
+    const rawMessage = parsed.message;
+    const message = isRecord(rawMessage) ? rawMessage : parsed;
+    const messageRole = typeof message.role === "string" ? message.role : "";
+    const isAssistantEnvelope = type === "assistant" || messageRole === "assistant";
+    const contentBlocks = extractContentBlocks(message);
+    if (contentBlocks.length > 0) {
+      for (const block of contentBlocks) {
+        const blockType = typeof block.type === "string" ? block.type : "";
+        if (!blockType || KNOWN_STREAM_CONTENT_BLOCK_TYPES.has(blockType)) {
+          continue;
+        }
+        logUnknownStreamTypeOnce({
+          seen: seenUnknownContentBlockTypes,
+          value: blockType,
+          kind: "content-block",
+        });
+      }
+      const blockTypes = contentBlocks
+        .map((block) => (typeof block.type === "string" ? block.type : "?"))
+        .join(",");
+      const extractedText = isAssistantEnvelope
+        ? extractAssistantTextFromBlocks(contentBlocks)
+        : "";
+      const text = buildFallbackAssistantText({
+        isAssistantEnvelope,
+        extractedText,
+        rawMessage,
+        message,
+      });
+      const thinkingText = isAssistantEnvelope ? extractThinkingTextFromBlocks(contentBlocks) : "";
+      const toolUseEvents = isAssistantEnvelope ? extractToolUseEvents(contentBlocks) : [];
+      const allowToolResultEvents = isToolResultAllowedEnvelope({
+        isAssistantEnvelope,
+        type,
+        messageRole,
+      });
+      const toolResultEvents = allowToolResultEvents ? extractToolResultEvents(contentBlocks) : [];
+      const toolNames = extractToolUseNames(contentBlocks);
+
+      if (isAssistantEnvelope) {
+        log.debug(
+          `stream-json assistant: blocks=[${blockTypes}] text=${text.length} chars thinking=${thinkingText.length} chars tools=[${toolNames.join(",")}]${text ? ` content=${text.slice(0, 200)}` : ""}`,
+        );
+      }
+
+      if (text && text !== lastAssistantText) {
+        lastAssistantText = text;
+        callbacks?.onAssistantTurn?.(lastAssistantText);
+      }
+
+      if (thinkingText && thinkingText !== lastThinkingText) {
+        const delta = resolveDelta(thinkingText, lastThinkingText);
+        lastThinkingText = thinkingText;
+        callbacks?.onThinkingTurn?.({
+          text: thinkingText,
+          ...(delta ? { delta } : {}),
+        });
+      }
+
+      for (const event of toolUseEvents) {
+        const dedupe = shouldEmitToolUse(
+          emittedToolUseKeys,
+          emittedToolUseOrder,
+          event,
+          lastAnonymousToolUseKey,
+        );
+        if (!dedupe.emit) {
+          continue;
+        }
+        if (!event.toolUseId) {
+          lastAnonymousToolUseKey = dedupe.nextAnonymousToolUseKey;
+        } else {
+          lastAnonymousToolUseKey = undefined;
+        }
+        callbacks?.onToolUse?.(event.name);
+        callbacks?.onToolUseEvent?.(event);
+      }
+
+      for (const event of toolResultEvents) {
+        if (!shouldEmitToolResult(emittedToolResultKeys, emittedToolResultOrder, event)) {
+          continue;
+        }
+        callbacks?.onToolResult?.(event);
+      }
+    } else if (isAssistantEnvelope) {
+      // Backward compatibility for custom stream-json backends that emit
+      // assistant content as a string/object instead of typed content blocks.
+      const fallbackText = collectText(rawMessage) || collectText(message);
+      if (fallbackText && fallbackText !== lastAssistantText) {
+        lastAssistantText = fallbackText;
+        callbacks?.onAssistantTurn?.(lastAssistantText);
+      }
+    }
+  };
+
+  const feed = (chunk: string) => {
+    buffer += chunk;
+    const lines = buffer.split("\n");
+    // Keep the last (possibly incomplete) segment in buffer
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      try {
+        processLine(line);
+      } catch (err) {
+        log.warn(`stream-json processLine error: ${String(err)}`);
+      }
+    }
+  };
+
+  const finish = (): CliOutput => {
+    // Process any remaining data in buffer
+    if (buffer.trim()) {
+      processLine(buffer);
+      buffer = "";
+    }
+    const text = resultText ?? lastAssistantText;
+    return { text: text.trim(), sessionId, usage };
+  };
+
+  return { feed, finish };
+}
+
 export function resolveSystemPromptUsage(params: {
   backend: CliBackendConfig;
   isNewSession: boolean;
@@ -255,7 +729,7 @@ export function resolveSystemPromptUsage(params: {
   if (!systemPrompt) {
     return null;
   }
-  const when = params.backend.systemPromptWhen ?? "first";
+  const when = params.backend.systemPromptWhen ?? "always";
   if (when === "never") {
     return null;
   }
@@ -356,10 +830,10 @@ export function buildCliArgs(params: {
   useResume: boolean;
 }): string[] {
   const args: string[] = [...params.baseArgs];
-  if (!params.useResume && params.backend.modelArg && params.modelId) {
+  if (params.backend.modelArg && params.modelId) {
     args.push(params.backend.modelArg, params.modelId);
   }
-  if (!params.useResume && params.systemPrompt && params.backend.systemPromptArg) {
+  if (params.systemPrompt && params.backend.systemPromptArg) {
     args.push(params.backend.systemPromptArg, params.systemPrompt);
   }
   if (!params.useResume && params.sessionId) {

--- a/src/agents/pi-embedded-runner/live-session-registry.ts
+++ b/src/agents/pi-embedded-runner/live-session-registry.ts
@@ -1,0 +1,81 @@
+type SessionEntryReader = {
+  getEntries?: () => unknown[];
+};
+
+type LiveSessionRegistration = {
+  token: symbol;
+  readEntries: () => unknown[] | undefined;
+};
+
+const LIVE_SESSION_BY_KEY = new Map<string, LiveSessionRegistration>();
+const LIVE_SESSION_BY_ID = new Map<string, LiveSessionRegistration>();
+
+function normalizeLookupKey(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed.toLowerCase() : undefined;
+}
+
+function normalizeSessionId(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function registerLiveSessionTranscript(params: {
+  sessionKey?: string;
+  sessionId?: string;
+  sessionReader: SessionEntryReader;
+}): () => void {
+  const sessionKey = normalizeLookupKey(params.sessionKey);
+  const sessionId = normalizeSessionId(params.sessionId);
+  const token = Symbol("live-session-transcript");
+  const registration: LiveSessionRegistration = {
+    token,
+    readEntries: () => {
+      try {
+        const entries = params.sessionReader.getEntries?.();
+        return Array.isArray(entries) ? entries.slice() : undefined;
+      } catch {
+        return undefined;
+      }
+    },
+  };
+
+  if (sessionKey) {
+    LIVE_SESSION_BY_KEY.set(sessionKey, registration);
+  }
+  if (sessionId) {
+    LIVE_SESSION_BY_ID.set(sessionId, registration);
+  }
+
+  return () => {
+    if (sessionKey && LIVE_SESSION_BY_KEY.get(sessionKey)?.token === token) {
+      LIVE_SESSION_BY_KEY.delete(sessionKey);
+    }
+    if (sessionId && LIVE_SESSION_BY_ID.get(sessionId)?.token === token) {
+      LIVE_SESSION_BY_ID.delete(sessionId);
+    }
+  };
+}
+
+export function getLiveSessionTranscriptEntries(params: {
+  sessionKey?: string;
+  sessionId?: string;
+}): unknown[] | undefined {
+  const sessionKey = normalizeLookupKey(params.sessionKey);
+  const sessionId = normalizeSessionId(params.sessionId);
+  const registration =
+    (sessionKey ? LIVE_SESSION_BY_KEY.get(sessionKey) : undefined) ??
+    (sessionId ? LIVE_SESSION_BY_ID.get(sessionId) : undefined);
+  return registration?.readEntries();
+}
+
+export function resetLiveSessionTranscriptRegistryForTests(): void {
+  LIVE_SESSION_BY_KEY.clear();
+  LIVE_SESSION_BY_ID.clear();
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -98,6 +98,7 @@ import {
   sanitizeToolsForGoogle,
 } from "../google.js";
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
+import { registerLiveSessionTranscript } from "../live-session-registry.js";
 import { log } from "../logger.js";
 import { buildModelAliasLines } from "../model.js";
 import {
@@ -999,6 +1000,7 @@ export async function runEmbeddedAttempt(
     let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
     let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
     let removeToolResultContextGuard: (() => void) | undefined;
+    let unregisterLiveSessionTranscript: (() => void) | undefined;
     try {
       await repairSessionFileIfNeeded({
         sessionFile: params.sessionFile,
@@ -1111,6 +1113,11 @@ export async function runEmbeddedAttempt(
         throw new Error("Embedded agent session missing");
       }
       const activeSession = session;
+      unregisterLiveSessionTranscript = registerLiveSessionTranscript({
+        sessionKey: sandboxSessionKey,
+        sessionId: activeSession.sessionId,
+        sessionReader: sessionManager,
+      });
       removeToolResultContextGuard = installToolResultContextGuard({
         agent: activeSession.agent,
         contextWindowTokens: Math.max(
@@ -1826,6 +1833,7 @@ export async function runEmbeddedAttempt(
             `CRITICAL: unsubscribe failed, possible resource leak: runId=${params.runId} ${String(err)}`,
           );
         }
+        unregisterLiveSessionTranscript?.();
         clearActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
         params.abortSignal?.removeEventListener?.("abort", onAbort);
       }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -237,48 +237,6 @@ export async function runAgentTurnWithFallback(params: {
               // forward to onPartialReply.  Awaiting this chain after the CLI run
               // ensures markRunComplete() isn't called before streaming initialises.
               let streamingChain: Promise<void> = Promise.resolve();
-              const streamingDirectiveAccumulator = createStreamingDirectiveAccumulator();
-              let cliReasoningOpen = false;
-              let assistantMessageStartQueued = false;
-              const queueStreamingStep = (step: () => Promise<void>) => {
-                streamingChain = streamingChain.then(step).catch((err) => {
-                  defaultRuntime.error(
-                    `cli streaming chain error: ${err instanceof Error ? err.message : String(err)}`,
-                  );
-                });
-              };
-              const queueAssistantMessageStart = () => {
-                if (assistantMessageStartQueued) {
-                  return;
-                }
-                assistantMessageStartQueued = true;
-                queueStreamingStep(async () => {
-                  await params.typingSignals.signalMessageStart();
-                  await params.opts?.onAssistantMessageStart?.();
-                });
-              };
-              const escapeMarkdownItalic = (value: string): string =>
-                value.replaceAll("\\", "\\\\").replaceAll("_", "\\_").replaceAll("*", "\\*");
-              const formatReasoningPayload = (text: string): string => {
-                const trimmed = text.trim();
-                if (!trimmed) {
-                  return "";
-                }
-                const lines = escapeMarkdownItalic(trimmed)
-                  .split("\n")
-                  .map((line) => line.trim());
-                const italicized = lines.map((line) => (line ? `_${line}_` : "")).join("\n");
-                return `Reasoning:\n${italicized}`;
-              };
-              const queueReasoningEndIfNeeded = () => {
-                if (!cliReasoningOpen) {
-                  return;
-                }
-                cliReasoningOpen = false;
-                queueStreamingStep(async () => {
-                  await params.opts?.onReasoningEnd?.();
-                });
-              };
               try {
                 const result = await runCliAgent({
                   sessionId: params.followupRun.run.sessionId,
@@ -303,17 +261,7 @@ export async function runAgentTurnWithFallback(params: {
                       bootstrapPromptWarningSignaturesSeen.length - 1
                     ],
                   images: params.opts?.images,
-                  abortSignal: params.opts?.abortSignal,
-                  trigger: params.isHeartbeat ? "heartbeat" : "user",
-                  messageChannel: params.followupRun.run.messageProvider,
-                  onSystemInit: ({ subtype }) => {
-                    if (subtype === "init") {
-                      queueAssistantMessageStart();
-                    }
-                  },
                   onAssistantTurn: (text) => {
-                    queueAssistantMessageStart();
-                    queueReasoningEndIfNeeded();
                     emitAgentEvent({
                       runId,
                       stream: "assistant",
@@ -325,83 +273,24 @@ export async function runAgentTurnWithFallback(params: {
                     // 2. then onPartialReply queues the card content update
                     // Chained (not fire-and-forget) so signalTextDelta completes
                     // before onPartialReply, and markRunComplete waits for all.
-                    queueStreamingStep(async () => {
-                      const parsedChunk = streamingDirectiveAccumulator.consume(text, {
-                        silentToken: SILENT_REPLY_TOKEN,
+                    streamingChain = streamingChain
+                      .then(async () => {
+                        const normalizedText = await handlePartialForTyping({ text });
+                        if (normalizedText !== undefined && params.opts?.onPartialReply) {
+                          await params.opts.onPartialReply({ text: normalizedText });
+                        }
+                      })
+                      .catch((err) => {
+                        defaultRuntime.error(
+                          `cli streaming chain error: ${err instanceof Error ? err.message : String(err)}`,
+                        );
                       });
-                      const normalizedText = await handlePartialForTyping({
-                        text: parsedChunk?.text,
-                        mediaUrl: parsedChunk?.mediaUrl,
-                        mediaUrls: parsedChunk?.mediaUrls,
-                        audioAsVoice: parsedChunk?.audioAsVoice,
-                      });
-                      if (normalizedText !== undefined && params.opts?.onPartialReply) {
-                        await params.opts.onPartialReply({ text: normalizedText });
-                      }
-                    });
                   },
-                  onThinkingTurn: ({ text, delta }) => {
-                    if (!text.trim()) {
-                      return;
-                    }
-                    queueAssistantMessageStart();
-                    cliReasoningOpen = true;
-                    emitAgentEvent({
-                      runId,
-                      stream: "thinking",
-                      data: {
-                        text,
-                        ...(delta ? { delta } : {}),
-                      },
-                    });
-                    queueStreamingStep(async () => {
-                      await params.typingSignals.signalReasoningDelta();
-                      const rendered = formatReasoningPayload(text);
-                      if (!rendered) {
-                        return;
-                      }
-                      await params.opts?.onReasoningStream?.({
-                        text: rendered,
-                        isReasoning: true,
-                      });
-                    });
-                  },
-                  onToolUseEvent: (payload) => {
-                    queueAssistantMessageStart();
-                    queueReasoningEndIfNeeded();
+                  onToolUse: (toolName) => {
                     emitAgentEvent({
                       runId,
                       stream: "tool",
-                      data: {
-                        phase: "start",
-                        name: payload.name,
-                        ...(payload.toolUseId ? { toolUseId: payload.toolUseId } : {}),
-                        ...(payload.input !== undefined ? { input: payload.input } : {}),
-                      },
-                    });
-                    queueStreamingStep(async () => {
-                      await params.typingSignals.signalToolStart();
-                      await params.opts?.onToolStart?.({
-                        name: payload.name,
-                        phase: "start",
-                      });
-                    });
-                  },
-                  onToolResult: (payload) => {
-                    queueReasoningEndIfNeeded();
-                    const preview =
-                      typeof payload.text === "string" && payload.text.trim()
-                        ? payload.text.trim().slice(0, 1_200)
-                        : undefined;
-                    emitAgentEvent({
-                      runId,
-                      stream: "tool",
-                      data: {
-                        phase: "result",
-                        ...(payload.toolUseId ? { toolUseId: payload.toolUseId } : {}),
-                        ...(preview ? { partialResult: preview, result: preview } : {}),
-                        ...(payload.isError ? { isError: true } : {}),
-                      },
+                      data: { phase: "start", name: toolName },
                     });
                   },
                 });
@@ -410,9 +299,14 @@ export async function runAgentTurnWithFallback(params: {
                 );
                 queueReasoningEndIfNeeded();
 
-                // CLI backends don't emit streaming assistant events, so we need to
-                // emit one with the final text so server-chat can populate its buffer
-                // and send the response to TUI/WebSocket clients.
+                // Drain all pending streaming card updates before returning.
+                // This must happen before the caller's markRunComplete() so the
+                // typing controller's startGuard doesn't block startStreaming().
+                await streamingChain;
+
+                // Emit the final/authoritative assistant text so server-chat can
+                // populate its buffer. For stream-json backends this supplements
+                // the intermediate onAssistantTurn events with the definitive result.
                 const cliText = result.payloads?.[0]?.text?.trim();
                 if (cliText) {
                   emitAgentEvent({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -237,6 +237,48 @@ export async function runAgentTurnWithFallback(params: {
               // forward to onPartialReply.  Awaiting this chain after the CLI run
               // ensures markRunComplete() isn't called before streaming initialises.
               let streamingChain: Promise<void> = Promise.resolve();
+              const streamingDirectiveAccumulator = createStreamingDirectiveAccumulator();
+              let cliReasoningOpen = false;
+              let assistantMessageStartQueued = false;
+              const queueStreamingStep = (step: () => Promise<void>) => {
+                streamingChain = streamingChain.then(step).catch((err) => {
+                  defaultRuntime.error(
+                    `cli streaming chain error: ${err instanceof Error ? err.message : String(err)}`,
+                  );
+                });
+              };
+              const queueAssistantMessageStart = () => {
+                if (assistantMessageStartQueued) {
+                  return;
+                }
+                assistantMessageStartQueued = true;
+                queueStreamingStep(async () => {
+                  await params.typingSignals.signalMessageStart();
+                  await params.opts?.onAssistantMessageStart?.();
+                });
+              };
+              const escapeMarkdownItalic = (value: string): string =>
+                value.replaceAll("\\", "\\\\").replaceAll("_", "\\_").replaceAll("*", "\\*");
+              const formatReasoningPayload = (text: string): string => {
+                const trimmed = text.trim();
+                if (!trimmed) {
+                  return "";
+                }
+                const lines = escapeMarkdownItalic(trimmed)
+                  .split("\n")
+                  .map((line) => line.trim());
+                const italicized = lines.map((line) => (line ? `_${line}_` : "")).join("\n");
+                return `Reasoning:\n${italicized}`;
+              };
+              const queueReasoningEndIfNeeded = () => {
+                if (!cliReasoningOpen) {
+                  return;
+                }
+                cliReasoningOpen = false;
+                queueStreamingStep(async () => {
+                  await params.opts?.onReasoningEnd?.();
+                });
+              };
               try {
                 const result = await runCliAgent({
                   sessionId: params.followupRun.run.sessionId,
@@ -261,7 +303,21 @@ export async function runAgentTurnWithFallback(params: {
                       bootstrapPromptWarningSignaturesSeen.length - 1
                     ],
                   images: params.opts?.images,
+                  abortSignal: params.opts?.abortSignal,
+                  trigger: params.isHeartbeat ? "heartbeat" : "user",
+                  messageChannel: params.followupRun.run.messageProvider,
+                  messageAccountId:
+                    (params.sessionCtx as { AccountId?: string }).AccountId ?? undefined,
+                  messageTo: params.sessionCtx.OriginatingTo ?? params.sessionCtx.To ?? undefined,
+                  messageThreadId: params.sessionCtx.MessageThreadId ?? undefined,
+                  onSystemInit: ({ subtype }) => {
+                    if (subtype === "init") {
+                      queueAssistantMessageStart();
+                    }
+                  },
                   onAssistantTurn: (text) => {
+                    queueAssistantMessageStart();
+                    queueReasoningEndIfNeeded();
                     emitAgentEvent({
                       runId,
                       stream: "assistant",
@@ -273,24 +329,83 @@ export async function runAgentTurnWithFallback(params: {
                     // 2. then onPartialReply queues the card content update
                     // Chained (not fire-and-forget) so signalTextDelta completes
                     // before onPartialReply, and markRunComplete waits for all.
-                    streamingChain = streamingChain
-                      .then(async () => {
-                        const normalizedText = await handlePartialForTyping({ text });
-                        if (normalizedText !== undefined && params.opts?.onPartialReply) {
-                          await params.opts.onPartialReply({ text: normalizedText });
-                        }
-                      })
-                      .catch((err) => {
-                        defaultRuntime.error(
-                          `cli streaming chain error: ${err instanceof Error ? err.message : String(err)}`,
-                        );
+                    queueStreamingStep(async () => {
+                      const parsedChunk = streamingDirectiveAccumulator.consume(text, {
+                        silentToken: SILENT_REPLY_TOKEN,
                       });
+                      const normalizedText = await handlePartialForTyping({
+                        text: parsedChunk?.text,
+                        mediaUrl: parsedChunk?.mediaUrl,
+                        mediaUrls: parsedChunk?.mediaUrls,
+                        audioAsVoice: parsedChunk?.audioAsVoice,
+                      });
+                      if (normalizedText !== undefined && params.opts?.onPartialReply) {
+                        await params.opts.onPartialReply({ text: normalizedText });
+                      }
+                    });
                   },
-                  onToolUse: (toolName) => {
+                  onThinkingTurn: ({ text, delta }) => {
+                    if (!text.trim()) {
+                      return;
+                    }
+                    queueAssistantMessageStart();
+                    cliReasoningOpen = true;
+                    emitAgentEvent({
+                      runId,
+                      stream: "thinking",
+                      data: {
+                        text,
+                        ...(delta ? { delta } : {}),
+                      },
+                    });
+                    queueStreamingStep(async () => {
+                      await params.typingSignals.signalReasoningDelta();
+                      const rendered = formatReasoningPayload(text);
+                      if (!rendered) {
+                        return;
+                      }
+                      await params.opts?.onReasoningStream?.({
+                        text: rendered,
+                        isReasoning: true,
+                      });
+                    });
+                  },
+                  onToolUseEvent: (payload) => {
+                    queueAssistantMessageStart();
+                    queueReasoningEndIfNeeded();
                     emitAgentEvent({
                       runId,
                       stream: "tool",
-                      data: { phase: "start", name: toolName },
+                      data: {
+                        phase: "start",
+                        name: payload.name,
+                        ...(payload.toolUseId ? { toolUseId: payload.toolUseId } : {}),
+                        ...(payload.input !== undefined ? { input: payload.input } : {}),
+                      },
+                    });
+                    queueStreamingStep(async () => {
+                      await params.typingSignals.signalToolStart();
+                      await params.opts?.onToolStart?.({
+                        name: payload.name,
+                        phase: "start",
+                      });
+                    });
+                  },
+                  onToolResult: (payload) => {
+                    queueReasoningEndIfNeeded();
+                    const preview =
+                      typeof payload.text === "string" && payload.text.trim()
+                        ? payload.text.trim().slice(0, 1_200)
+                        : undefined;
+                    emitAgentEvent({
+                      runId,
+                      stream: "tool",
+                      data: {
+                        phase: "result",
+                        ...(payload.toolUseId ? { toolUseId: payload.toolUseId } : {}),
+                        ...(preview ? { partialResult: preview, result: preview } : {}),
+                        ...(payload.isError ? { isError: true } : {}),
+                      },
                     });
                   },
                 });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -31,6 +31,7 @@ import { stripHeartbeatToken } from "../heartbeat.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
 import {
+  couldBeSilentTokenStart,
   HEARTBEAT_TOKEN,
   isSilentReplyPrefixText,
   isSilentReplyText,
@@ -45,6 +46,7 @@ import {
 import { type BlockReplyPipeline } from "./block-reply-pipeline.js";
 import type { FollowupRun } from "./queue.js";
 import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
+import { createStreamingDirectiveAccumulator } from "./streaming-directives.js";
 import type { TypingSignaler } from "./typing-mode.js";
 
 export type RuntimeFallbackAttempt = {
@@ -178,11 +180,24 @@ export async function runAgentTurnWithFallback(params: {
         }
         return { text: sanitized, skip: false };
       };
+      // Buffer potential silent-token prefix from BPE-split streaming chunks (e.g. "NO" + "_REPLY").
+      // Only buffers SILENT_REPLY_TOKEN; HEARTBEAT_TOKEN is handled by normalizeStreamingText
+      // via string includes() which works on partial text without prefix-buffering.
+      let silentPrefixBuf = "";
       const handlePartialForTyping = async (payload: ReplyPayload): Promise<string | undefined> => {
-        if (isSilentReplyPrefixText(payload.text, SILENT_REPLY_TOKEN)) {
+        const combinedText = silentPrefixBuf + (payload.text ?? "");
+        silentPrefixBuf = "";
+        if (isSilentReplyText(combinedText, SILENT_REPLY_TOKEN)) {
           return undefined;
         }
-        const { text, skip } = normalizeStreamingText(payload);
+        if (isSilentReplyPrefixText(combinedText, SILENT_REPLY_TOKEN)) {
+          return undefined;
+        }
+        if (couldBeSilentTokenStart(combinedText, SILENT_REPLY_TOKEN)) {
+          silentPrefixBuf = combinedText;
+          return undefined;
+        }
+        const { text, skip } = normalizeStreamingText({ ...payload, text: combinedText });
         if (skip || !text) {
           return undefined;
         }
@@ -216,6 +231,54 @@ export async function runAgentTurnWithFallback(params: {
             const cliSessionId = getCliSessionId(params.getActiveSessionEntry(), provider);
             return (async () => {
               let lifecycleTerminalEmitted = false;
+              // Serialized chain for streaming card updates.  Each onAssistantTurn
+              // appends an async step that mirrors the embedded path: first await
+              // signalTextDelta (which triggers startStreaming on first call), then
+              // forward to onPartialReply.  Awaiting this chain after the CLI run
+              // ensures markRunComplete() isn't called before streaming initialises.
+              let streamingChain: Promise<void> = Promise.resolve();
+              const streamingDirectiveAccumulator = createStreamingDirectiveAccumulator();
+              let cliReasoningOpen = false;
+              let assistantMessageStartQueued = false;
+              const queueStreamingStep = (step: () => Promise<void>) => {
+                streamingChain = streamingChain.then(step).catch((err) => {
+                  defaultRuntime.error(
+                    `cli streaming chain error: ${err instanceof Error ? err.message : String(err)}`,
+                  );
+                });
+              };
+              const queueAssistantMessageStart = () => {
+                if (assistantMessageStartQueued) {
+                  return;
+                }
+                assistantMessageStartQueued = true;
+                queueStreamingStep(async () => {
+                  await params.typingSignals.signalMessageStart();
+                  await params.opts?.onAssistantMessageStart?.();
+                });
+              };
+              const escapeMarkdownItalic = (value: string): string =>
+                value.replaceAll("\\", "\\\\").replaceAll("_", "\\_").replaceAll("*", "\\*");
+              const formatReasoningPayload = (text: string): string => {
+                const trimmed = text.trim();
+                if (!trimmed) {
+                  return "";
+                }
+                const lines = escapeMarkdownItalic(trimmed)
+                  .split("\n")
+                  .map((line) => line.trim());
+                const italicized = lines.map((line) => (line ? `_${line}_` : "")).join("\n");
+                return `Reasoning:\n${italicized}`;
+              };
+              const queueReasoningEndIfNeeded = () => {
+                if (!cliReasoningOpen) {
+                  return;
+                }
+                cliReasoningOpen = false;
+                queueStreamingStep(async () => {
+                  await params.opts?.onReasoningEnd?.();
+                });
+              };
               try {
                 const result = await runCliAgent({
                   sessionId: params.followupRun.run.sessionId,
@@ -231,6 +294,7 @@ export async function runAgentTurnWithFallback(params: {
                   timeoutMs: params.followupRun.run.timeoutMs,
                   runId,
                   extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+                  skillsSnapshot: params.followupRun.run.skillsSnapshot,
                   ownerNumbers: params.followupRun.run.ownerNumbers,
                   cliSessionId,
                   bootstrapPromptWarningSignaturesSeen,
@@ -239,10 +303,112 @@ export async function runAgentTurnWithFallback(params: {
                       bootstrapPromptWarningSignaturesSeen.length - 1
                     ],
                   images: params.opts?.images,
+                  abortSignal: params.opts?.abortSignal,
+                  trigger: params.isHeartbeat ? "heartbeat" : "user",
+                  messageChannel: params.followupRun.run.messageProvider,
+                  onSystemInit: ({ subtype }) => {
+                    if (subtype === "init") {
+                      queueAssistantMessageStart();
+                    }
+                  },
+                  onAssistantTurn: (text) => {
+                    queueAssistantMessageStart();
+                    queueReasoningEndIfNeeded();
+                    emitAgentEvent({
+                      runId,
+                      stream: "assistant",
+                      data: { text },
+                    });
+                    // Mirror the embedded path's onPartialReply flow:
+                    // 1. handlePartialForTyping awaits signalTextDelta (starts
+                    //    streaming card on first call via typing → onReplyStart)
+                    // 2. then onPartialReply queues the card content update
+                    // Chained (not fire-and-forget) so signalTextDelta completes
+                    // before onPartialReply, and markRunComplete waits for all.
+                    queueStreamingStep(async () => {
+                      const parsedChunk = streamingDirectiveAccumulator.consume(text, {
+                        silentToken: SILENT_REPLY_TOKEN,
+                      });
+                      const normalizedText = await handlePartialForTyping({
+                        text: parsedChunk?.text,
+                        mediaUrl: parsedChunk?.mediaUrl,
+                        mediaUrls: parsedChunk?.mediaUrls,
+                        audioAsVoice: parsedChunk?.audioAsVoice,
+                      });
+                      if (normalizedText !== undefined && params.opts?.onPartialReply) {
+                        await params.opts.onPartialReply({ text: normalizedText });
+                      }
+                    });
+                  },
+                  onThinkingTurn: ({ text, delta }) => {
+                    if (!text.trim()) {
+                      return;
+                    }
+                    queueAssistantMessageStart();
+                    cliReasoningOpen = true;
+                    emitAgentEvent({
+                      runId,
+                      stream: "thinking",
+                      data: {
+                        text,
+                        ...(delta ? { delta } : {}),
+                      },
+                    });
+                    queueStreamingStep(async () => {
+                      await params.typingSignals.signalReasoningDelta();
+                      const rendered = formatReasoningPayload(text);
+                      if (!rendered) {
+                        return;
+                      }
+                      await params.opts?.onReasoningStream?.({
+                        text: rendered,
+                        isReasoning: true,
+                      });
+                    });
+                  },
+                  onToolUseEvent: (payload) => {
+                    queueAssistantMessageStart();
+                    queueReasoningEndIfNeeded();
+                    emitAgentEvent({
+                      runId,
+                      stream: "tool",
+                      data: {
+                        phase: "start",
+                        name: payload.name,
+                        ...(payload.toolUseId ? { toolUseId: payload.toolUseId } : {}),
+                        ...(payload.input !== undefined ? { input: payload.input } : {}),
+                      },
+                    });
+                    queueStreamingStep(async () => {
+                      await params.typingSignals.signalToolStart();
+                      await params.opts?.onToolStart?.({
+                        name: payload.name,
+                        phase: "start",
+                      });
+                    });
+                  },
+                  onToolResult: (payload) => {
+                    queueReasoningEndIfNeeded();
+                    const preview =
+                      typeof payload.text === "string" && payload.text.trim()
+                        ? payload.text.trim().slice(0, 1_200)
+                        : undefined;
+                    emitAgentEvent({
+                      runId,
+                      stream: "tool",
+                      data: {
+                        phase: "result",
+                        ...(payload.toolUseId ? { toolUseId: payload.toolUseId } : {}),
+                        ...(preview ? { partialResult: preview, result: preview } : {}),
+                        ...(payload.isError ? { isError: true } : {}),
+                      },
+                    });
+                  },
                 });
                 bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
                   result.meta?.systemPromptReport,
                 );
+                queueReasoningEndIfNeeded();
 
                 // CLI backends don't emit streaming assistant events, so we need to
                 // emit one with the final text so server-chat can populate its buffer
@@ -269,6 +435,8 @@ export async function runAgentTurnWithFallback(params: {
 
                 return result;
               } catch (err) {
+                queueReasoningEndIfNeeded();
+                await streamingChain;
                 emitAgentEvent({
                   runId,
                   stream: "lifecycle",

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -787,7 +787,18 @@ describe("runReplyAgent block streaming", () => {
 });
 
 describe("runReplyAgent claude-cli routing", () => {
-  function createRun() {
+  function createRun(params?: {
+    typingMode?: "instant" | "thinking";
+    opts?: {
+      onAssistantMessageStart?: () => Promise<void> | void;
+      onReasoningStream?: (payload: {
+        text?: string;
+        isReasoning?: boolean;
+      }) => Promise<void> | void;
+      onToolStart?: (payload: { name?: string; phase?: string }) => Promise<void> | void;
+      onReasoningEnd?: () => Promise<void> | void;
+    };
+  }) {
     const typing = createMockTypingController();
     const sessionCtx = {
       Provider: "webchat",
@@ -840,7 +851,8 @@ describe("runReplyAgent claude-cli routing", () => {
       blockStreamingEnabled: false,
       resolvedBlockStreamingBreak: "message_end",
       shouldInjectGroupIntro: false,
-      typingMode: "instant",
+      typingMode: params?.typingMode ?? "instant",
+      opts: params?.opts,
     });
   }
 
@@ -878,6 +890,179 @@ describe("runReplyAgent claude-cli routing", () => {
     expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
     expect(lifecyclePhases).toEqual(["start", "end"]);
     expect(result).toMatchObject({ text: "ok" });
+  });
+
+  it("forwards cli thinking/tool stream events to reply callbacks", async () => {
+    const runId = "00000000-0000-0000-0000-000000000002";
+    const randomSpy = vi.spyOn(crypto, "randomUUID").mockReturnValue(runId);
+    const onReasoningStream = vi.fn();
+    const onToolStart = vi.fn();
+    const toolPhases: string[] = [];
+    const thinkingEvents: string[] = [];
+    const unsubscribe = onAgentEvent((evt) => {
+      if (evt.runId !== runId) {
+        return;
+      }
+      if (evt.stream === "tool" && typeof evt.data?.phase === "string") {
+        toolPhases.push(evt.data.phase);
+      }
+      if (evt.stream === "thinking" && typeof evt.data?.text === "string") {
+        thinkingEvents.push(evt.data.text);
+      }
+    });
+    runCliAgentMock.mockImplementationOnce(
+      async (params: {
+        onThinkingTurn?: (payload: { text: string; delta?: string }) => void;
+        onToolUseEvent?: (payload: { name: string; toolUseId?: string; input?: unknown }) => void;
+        onToolResult?: (payload: { toolUseId?: string; text?: string; isError?: boolean }) => void;
+        onAssistantTurn?: (text: string) => void;
+      }) => {
+        params.onThinkingTurn?.({
+          text: "Check_*files*\n\nThen_more",
+          delta: "Check_*files*\n\nThen_more",
+        });
+        params.onToolUseEvent?.({ name: "Read", toolUseId: "toolu_1" });
+        params.onToolResult?.({ toolUseId: "toolu_1", text: "README contents" });
+        params.onAssistantTurn?.("Final answer");
+        return {
+          payloads: [{ text: "Final answer" }],
+          meta: {
+            agentMeta: {
+              provider: "claude-cli",
+              model: "opus-4.5",
+            },
+          },
+        };
+      },
+    );
+
+    const result = await createRun({
+      typingMode: "thinking",
+      opts: {
+        onReasoningStream,
+        onToolStart,
+      },
+    });
+    unsubscribe();
+    randomSpy.mockRestore();
+
+    expect(onReasoningStream).toHaveBeenCalledWith({
+      text: "Reasoning:\n_Check\\_\\*files\\*_\n\n_Then\\_more_",
+      isReasoning: true,
+    });
+    expect(onToolStart).toHaveBeenCalledWith({
+      name: "Read",
+      phase: "start",
+    });
+    expect(thinkingEvents).toEqual(["Check_*files*\n\nThen_more"]);
+    expect(toolPhases).toEqual(expect.arrayContaining(["start", "result"]));
+    expect(result).toMatchObject({ text: "Final answer" });
+  });
+
+  it("bridges cli system init to assistant message start once", async () => {
+    const callbackOrder: string[] = [];
+    const onAssistantMessageStart = vi.fn(() => {
+      callbackOrder.push("start");
+    });
+    const onReasoningStream = vi.fn(() => {
+      callbackOrder.push("reasoning");
+    });
+    const onToolStart = vi.fn(() => {
+      callbackOrder.push("tool");
+    });
+
+    runCliAgentMock.mockImplementationOnce(
+      async (params: {
+        onSystemInit?: (payload: { subtype: string; sessionId?: string }) => void;
+        onThinkingTurn?: (payload: { text: string; delta?: string }) => void;
+        onToolUseEvent?: (payload: { name: string; toolUseId?: string; input?: unknown }) => void;
+        onAssistantTurn?: (text: string) => void;
+      }) => {
+        params.onSystemInit?.({ subtype: "init", sessionId: "cli-session-1" });
+        params.onThinkingTurn?.({ text: "step", delta: "step" });
+        params.onToolUseEvent?.({ name: "Read", toolUseId: "toolu_1" });
+        params.onAssistantTurn?.("Answer");
+        return {
+          payloads: [{ text: "Answer" }],
+          meta: {
+            agentMeta: {
+              provider: "claude-cli",
+              model: "opus-4.5",
+            },
+          },
+        };
+      },
+    );
+
+    const result = await createRun({
+      typingMode: "thinking",
+      opts: {
+        onAssistantMessageStart,
+        onReasoningStream,
+        onToolStart,
+      },
+    });
+
+    expect(onAssistantMessageStart).toHaveBeenCalledTimes(1);
+    expect(callbackOrder[0]).toBe("start");
+    expect(callbackOrder).toEqual(expect.arrayContaining(["reasoning", "tool"]));
+    expect(result).toMatchObject({ text: "Answer" });
+  });
+
+  it("strips reply directive tags from cli partial replies (including split tags)", async () => {
+    const onPartialReply = vi.fn();
+    runCliAgentMock.mockImplementationOnce(
+      async (params: { onAssistantTurn?: (text: string) => void }) => {
+        params.onAssistantTurn?.("[[reply_to_cur");
+        params.onAssistantTurn?.("rent]]7452136093975117843 请确认一下");
+        return {
+          payloads: [{ text: "[[reply_to_current]]7452136093975117843 请确认一下" }],
+          meta: {
+            agentMeta: {
+              provider: "claude-cli",
+              model: "opus-4.5",
+            },
+          },
+        };
+      },
+    );
+
+    const result = await createRun({
+      opts: {
+        onPartialReply,
+      },
+    });
+
+    const partialTexts = onPartialReply.mock.calls
+      .map((call) => call[0]?.text)
+      .filter((value): value is string => typeof value === "string");
+    expect(partialTexts).toEqual(["7452136093975117843 请确认一下"]);
+    expect(partialTexts.some((value) => value.includes("[[reply_to"))).toBe(false);
+    expect(result).toMatchObject({
+      text: "7452136093975117843 请确认一下",
+    });
+  });
+
+  it("closes reasoning stream when cli runner throws after thinking", async () => {
+    const onReasoningEnd = vi.fn();
+    runCliAgentMock.mockImplementationOnce(
+      async (params: { onThinkingTurn?: (payload: { text: string; delta?: string }) => void }) => {
+        params.onThinkingTurn?.({ text: "debug path", delta: "debug path" });
+        throw new Error("cli boom");
+      },
+    );
+
+    const result = await createRun({
+      typingMode: "thinking",
+      opts: {
+        onReasoningEnd,
+      },
+    });
+
+    expect(result).toMatchObject({
+      text: expect.stringContaining("cli boom"),
+    });
+    expect(onReasoningEnd).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/auto-reply/reply/message-received-hooks.ts
+++ b/src/auto-reply/reply/message-received-hooks.ts
@@ -1,0 +1,94 @@
+import { logVerbose } from "../../globals.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import type { FinalizedMsgContext } from "../templating.js";
+
+function resolveInboundContent(ctx: FinalizedMsgContext): string {
+  if (typeof ctx.BodyForCommands === "string") {
+    return ctx.BodyForCommands;
+  }
+  if (typeof ctx.RawBody === "string") {
+    return ctx.RawBody;
+  }
+  if (typeof ctx.Body === "string") {
+    return ctx.Body;
+  }
+  return "";
+}
+
+export function emitMessageReceivedHooks(params: { ctx: FinalizedMsgContext }): void {
+  const { ctx } = params;
+
+  const timestamp =
+    typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp) ? ctx.Timestamp : undefined;
+  const messageIdForHook =
+    ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
+  const content = resolveInboundContent(ctx);
+  const channelId = (ctx.OriginatingChannel ?? ctx.Surface ?? ctx.Provider ?? "").toLowerCase();
+  const conversationId = ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? undefined;
+
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner?.hasHooks("message_received")) {
+    void hookRunner
+      .runMessageReceived(
+        {
+          from: ctx.From ?? "",
+          content,
+          timestamp,
+          metadata: {
+            to: ctx.To,
+            provider: ctx.Provider,
+            surface: ctx.Surface,
+            threadId: ctx.MessageThreadId,
+            originatingChannel: ctx.OriginatingChannel,
+            originatingTo: ctx.OriginatingTo,
+            messageId: messageIdForHook,
+            channelData: ctx.ChannelData,
+            senderId: ctx.SenderId,
+            senderName: ctx.SenderName,
+            senderUsername: ctx.SenderUsername,
+            senderE164: ctx.SenderE164,
+            guildId: ctx.GroupSpace,
+            channelName: ctx.GroupChannel,
+          },
+        },
+        {
+          channelId,
+          accountId: ctx.AccountId,
+          conversationId,
+        },
+      )
+      .catch((err) => {
+        logVerbose(`dispatch-from-config: message_received plugin hook failed: ${String(err)}`);
+      });
+  }
+
+  const sessionKey = ctx.SessionKey;
+  if (sessionKey) {
+    void triggerInternalHook(
+      createInternalHookEvent("message", "received", sessionKey, {
+        from: ctx.From ?? "",
+        content,
+        timestamp,
+        channelId,
+        accountId: ctx.AccountId,
+        conversationId,
+        messageId: messageIdForHook,
+        metadata: {
+          to: ctx.To,
+          provider: ctx.Provider,
+          surface: ctx.Surface,
+          threadId: ctx.MessageThreadId,
+          senderId: ctx.SenderId,
+          senderName: ctx.SenderName,
+          senderUsername: ctx.SenderUsername,
+          senderE164: ctx.SenderE164,
+          guildId: ctx.GroupSpace,
+          channelName: ctx.GroupChannel,
+        },
+      }),
+    ).catch((err) => {
+      logVerbose(`dispatch-from-config: message_received internal hook failed: ${String(err)}`);
+    });
+  }
+}

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -299,6 +299,14 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     const result = await appendAssistantMessageToSessionTranscript({
       sessionKey,
       text: "Hello from delivery mirror!",
+      messageMeta: {
+        channel: "feishu",
+        accountId: "default",
+        chatId: "oc_dm_1",
+        chatType: "direct",
+        providerMessageId: "om_reply_1",
+        providerMessageIds: ["om_reply_1"],
+      },
       storePath: fixture.storePath(),
     });
 
@@ -322,6 +330,14 @@ describe("appendAssistantMessageToSessionTranscript", () => {
       expect(messageLine.message.role).toBe("assistant");
       expect(messageLine.message.content[0].type).toBe("text");
       expect(messageLine.message.content[0].text).toBe("Hello from delivery mirror!");
+      expect(messageLine.message.openclawMessageMeta).toEqual({
+        channel: "feishu",
+        accountId: "default",
+        chatId: "oc_dm_1",
+        chatType: "direct",
+        providerMessageId: "om_reply_1",
+        providerMessageIds: ["om_reply_1"],
+      });
     }
   });
 });

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -79,11 +79,147 @@ async function ensureSessionHeader(params: {
   });
 }
 
+type CliTurnUsage = {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  total?: number;
+};
+
+const ZERO_USAGE = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    total: 0,
+  },
+};
+
+export type SessionTranscriptMessageMeta = {
+  channel?: string;
+  accountId?: string;
+  chatId?: string;
+  chatType?: "direct" | "group";
+  providerMessageId?: string;
+  providerMessageIds?: string[];
+  parentId?: string;
+  threadId?: string | number;
+};
+
+function normalizeNonNegativeNumber(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  const normalized = Math.max(0, Math.floor(value));
+  return normalized;
+}
+
+function buildCliUsage(usage?: CliTurnUsage): {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  cost: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    total: number;
+  };
+} | null {
+  if (!usage) {
+    return null;
+  }
+  const input = normalizeNonNegativeNumber(usage.input) ?? 0;
+  const output = normalizeNonNegativeNumber(usage.output) ?? 0;
+  const cacheRead = normalizeNonNegativeNumber(usage.cacheRead) ?? 0;
+  const cacheWrite = normalizeNonNegativeNumber(usage.cacheWrite) ?? 0;
+  const totalTokens =
+    normalizeNonNegativeNumber(usage.total) ?? input + output + cacheRead + cacheWrite;
+  const hasUsage = totalTokens > 0 || input > 0 || output > 0 || cacheRead > 0 || cacheWrite > 0;
+  if (!hasUsage) {
+    return null;
+  }
+  return {
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    totalTokens,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    },
+  };
+}
+
+export async function appendCliTurnToSessionTranscript(params: {
+  sessionFile: string;
+  sessionId: string;
+  userText?: string;
+  assistantText?: string;
+  provider: string;
+  model: string;
+  usage?: CliTurnUsage;
+}): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const sessionFile = params.sessionFile.trim();
+  if (!sessionFile) {
+    return { ok: false, reason: "missing sessionFile" };
+  }
+  const sessionId = params.sessionId.trim();
+  if (!sessionId) {
+    return { ok: false, reason: "missing sessionId" };
+  }
+  const userText = params.userText?.trim() ?? "";
+  const assistantText = params.assistantText?.trim() ?? "";
+  if (!userText && !assistantText) {
+    return { ok: false, reason: "empty turn" };
+  }
+
+  await ensureSessionHeader({ sessionFile, sessionId });
+
+  const sessionManager = SessionManager.open(sessionFile);
+  if (userText) {
+    sessionManager.appendMessage({
+      role: "user",
+      content: [{ type: "text", text: userText }],
+      timestamp: Date.now(),
+    });
+  }
+  if (assistantText) {
+    const usage = buildCliUsage(params.usage) ?? ZERO_USAGE;
+    sessionManager.appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: assistantText }],
+      api: "cli",
+      provider: params.provider,
+      model: params.model,
+      usage,
+      stopReason: "stop",
+      timestamp: Date.now(),
+    });
+  }
+  emitSessionTranscriptUpdate(sessionFile);
+  return { ok: true };
+}
+
 export async function appendAssistantMessageToSessionTranscript(params: {
   agentId?: string;
   sessionKey: string;
   text?: string;
   mediaUrls?: string[];
+  messageMeta?: SessionTranscriptMessageMeta;
   /** Optional override for store path (mostly for tests). */
   storePath?: string;
 }): Promise<{ ok: true; sessionFile: string } | { ok: false; reason: string }> {
@@ -129,6 +265,9 @@ export async function appendAssistantMessageToSessionTranscript(params: {
   await ensureSessionHeader({ sessionFile, sessionId: entry.sessionId });
 
   const sessionManager = SessionManager.open(sessionFile);
+  // Save current leafId before appending delivery-mirror
+  // This prevents delivery-mirror from affecting the main chain (leafId)
+  const savedLeafId = sessionManager.getLeafId();
   sessionManager.appendMessage({
     role: "assistant",
     content: [{ type: "text", text: mirrorText }],
@@ -151,7 +290,17 @@ export async function appendAssistantMessageToSessionTranscript(params: {
     },
     stopReason: "stop",
     timestamp: Date.now(),
+    ...(params.messageMeta ? { openclawMessageMeta: params.messageMeta } : {}),
   });
+  // Restore leafId so delivery-mirror doesn't affect the main chain.
+  // branch() only updates in-memory leafId; on next SessionManager.open(),
+  // _buildIndex() would set leafId to the delivery-mirror entry (last in JSONL).
+  // branchWithSummary() persists a branch_summary entry to JSONL, so _buildIndex()
+  // picks it up as leafId. buildSessionContext() walks from its parentId (savedLeafId),
+  // skipping delivery-mirror. Empty summary is filtered by the "entry.summary" guard.
+  if (savedLeafId !== null) {
+    sessionManager.branchWithSummary(savedLeafId, "", undefined, false);
+  }
 
   emitSessionTranscriptUpdate(sessionFile);
   return { ok: true, sessionFile };

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -50,9 +50,9 @@ export type CliBackendConfig = {
   /** Base args applied to every invocation. */
   args?: string[];
   /** Output parsing mode (default: json). */
-  output?: "json" | "text" | "jsonl";
+  output?: "json" | "text" | "jsonl" | "stream-json";
   /** Output parsing mode when resuming a CLI session. */
-  resumeOutput?: "json" | "text" | "jsonl";
+  resumeOutput?: "json" | "text" | "jsonl" | "stream-json";
   /** Prompt input mode (default: arg). */
   input?: "arg" | "stdin";
   /** Max prompt length for arg mode (if exceeded, stdin is used). */

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -76,6 +76,10 @@ if (
   }
 
   function ensureExperimentalWarningSuppressed(): boolean {
+    // Bun-compiled binaries cannot respawn through the Node-only warning flag.
+    if (typeof Bun !== "undefined") {
+      return false;
+    }
     if (shouldSkipRespawnForArgv(process.argv)) {
       return false;
     }

--- a/src/gateway/chat-sanitize.test.ts
+++ b/src/gateway/chat-sanitize.test.ts
@@ -22,6 +22,22 @@ describe("stripEnvelopeFromMessage", () => {
     expect(result.content?.[0]?.text).toBe("hi");
   });
 
+  test("removes inbound metadata from input_text content arrays", () => {
+    const input = {
+      role: "user",
+      content: [
+        {
+          type: "input_text",
+          text: 'Conversation info (untrusted metadata):\n```json\n{"message_id":"123"}\n```\n\nHello there',
+        },
+      ],
+    };
+    const result = stripEnvelopeFromMessage(input) as {
+      content?: Array<{ type: string; text?: string }>;
+    };
+    expect(result.content?.[0]?.text).toBe("Hello there");
+  });
+
   test("does not strip inline message_id text that is part of a line", () => {
     const input = {
       role: "user",
@@ -48,6 +64,22 @@ describe("stripEnvelopeFromMessage", () => {
     };
     const result = stripEnvelopeFromMessage(input) as { content?: string };
     expect(result.content).toBe("Assistant body");
+  });
+
+  test("defensively strips inbound metadata blocks from output_text content arrays", () => {
+    const input = {
+      role: "assistant",
+      content: [
+        {
+          type: "output_text",
+          text: 'Conversation info (untrusted metadata):\n```json\n{"message_id":"123"}\n```\n\nAssistant body',
+        },
+      ],
+    };
+    const result = stripEnvelopeFromMessage(input) as {
+      content?: Array<{ type: string; text?: string }>;
+    };
+    expect(result.content?.[0]?.text).toBe("Assistant body");
   });
 
   test("removes inbound un-bracketed conversation info blocks from user messages", () => {

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -13,7 +13,10 @@ function stripEnvelopeFromContentWithRole(
       return item;
     }
     const entry = item as Record<string, unknown>;
-    if (entry.type !== "text" || typeof entry.text !== "string") {
+    if (
+      (entry.type !== "text" && entry.type !== "input_text" && entry.type !== "output_text") ||
+      typeof entry.text !== "string"
+    ) {
       return item;
     }
     const inboundStripped = stripInboundMetadata(entry.text);

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -76,15 +76,45 @@ ${params.sessionContent.slice(0, 2000)}
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
     const aliasIndex = buildModelAliasIndex({ cfg: params.cfg, defaultProvider: DEFAULT_PROVIDER });
-    const resolved = modelRef
-      ? resolveModelRefFromString({ raw: modelRef, defaultProvider: DEFAULT_PROVIDER, aliasIndex })
-      : null;
-    const rawProvider = resolved?.ref.provider ?? DEFAULT_PROVIDER;
-    const rawModel = resolved?.ref.model ?? DEFAULT_MODEL;
-    // Slug generation is a lightweight embedded LLM call — CLI backends are not supported.
-    // Fall back to default embedded provider when the agent's primary model is a CLI backend.
-    const provider = isCliProvider(rawProvider, params.cfg) ? DEFAULT_PROVIDER : rawProvider;
-    const model = isCliProvider(rawProvider, params.cfg) ? DEFAULT_MODEL : rawModel;
+
+    // Hook-level model override: hooks.internal.entries.session-memory.model
+    const hookEntry = params.cfg.hooks?.internal?.entries?.["session-memory"];
+    const hookModelRaw =
+      hookEntry && typeof hookEntry === "object"
+        ? (hookEntry as Record<string, unknown>).model
+        : undefined;
+    const hookResolved =
+      typeof hookModelRaw === "string" && hookModelRaw
+        ? resolveModelRefFromString({
+            raw: hookModelRaw,
+            defaultProvider: DEFAULT_PROVIDER,
+            aliasIndex,
+          })
+        : null;
+
+    let provider: string;
+    let model: string;
+
+    if (hookResolved && !isCliProvider(hookResolved.ref.provider, params.cfg)) {
+      // Use explicitly configured hook model
+      provider = hookResolved.ref.provider;
+      model = hookResolved.ref.model;
+    } else {
+      // Fall back to agent's effective model
+      const modelRef = resolveAgentEffectiveModelPrimary(params.cfg, agentId);
+      const resolved = modelRef
+        ? resolveModelRefFromString({
+            raw: modelRef,
+            defaultProvider: DEFAULT_PROVIDER,
+            aliasIndex,
+          })
+        : null;
+      const rawProvider = resolved?.ref.provider ?? DEFAULT_PROVIDER;
+      const rawModel = resolved?.ref.model ?? DEFAULT_MODEL;
+      // Slug generation is a lightweight embedded LLM call — CLI backends are not supported.
+      provider = isCliProvider(rawProvider, params.cfg) ? DEFAULT_PROVIDER : rawProvider;
+      model = isCliProvider(rawProvider, params.cfg) ? DEFAULT_MODEL : rawModel;
+    }
     const timeoutMs = resolveSlugTimeoutMs(params.cfg);
 
     const result = await runEmbeddedPiAgent({

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -12,12 +12,43 @@ import {
   resolveAgentEffectiveModelPrimary,
 } from "../agents/agent-scope.js";
 import { DEFAULT_PROVIDER, DEFAULT_MODEL } from "../agents/defaults.js";
-import { parseModelRef } from "../agents/model-selection.js";
+import {
+  buildModelAliasIndex,
+  isCliProvider,
+  resolveModelRefFromString,
+} from "../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 const log = createSubsystemLogger("llm-slug-generator");
+const DEFAULT_LLM_SLUG_TIMEOUT_MS = 45_000;
+const MIN_LLM_SLUG_TIMEOUT_MS = 5_000;
+const MAX_LLM_SLUG_TIMEOUT_MS = 300_000;
+
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function resolveSlugTimeoutMs(cfg: OpenClawConfig): number {
+  const hookEntry = cfg.hooks?.internal?.entries?.["session-memory"];
+  const raw =
+    hookEntry && typeof hookEntry === "object"
+      ? (hookEntry as Record<string, unknown>).llmSlugTimeoutMs
+      : undefined;
+  const parsed =
+    typeof raw === "number"
+      ? Number.isFinite(raw)
+        ? Math.floor(raw)
+        : undefined
+      : typeof raw === "string"
+        ? Number.parseInt(raw, 10)
+        : undefined;
+  if (typeof parsed !== "number" || Number.isNaN(parsed) || parsed <= 0) {
+    return DEFAULT_LLM_SLUG_TIMEOUT_MS;
+  }
+  return clampNumber(parsed, MIN_LLM_SLUG_TIMEOUT_MS, MAX_LLM_SLUG_TIMEOUT_MS);
+}
 
 /**
  * Generate a short 1-2 word filename slug from session content using LLM
@@ -44,11 +75,17 @@ ${params.sessionContent.slice(0, 2000)}
 
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
-    // Resolve model from agent config instead of using hardcoded defaults
-    const modelRef = resolveAgentEffectiveModelPrimary(params.cfg, agentId);
-    const parsed = modelRef ? parseModelRef(modelRef, DEFAULT_PROVIDER) : null;
-    const provider = parsed?.provider ?? DEFAULT_PROVIDER;
-    const model = parsed?.model ?? DEFAULT_MODEL;
+    const aliasIndex = buildModelAliasIndex({ cfg: params.cfg, defaultProvider: DEFAULT_PROVIDER });
+    const resolved = modelRef
+      ? resolveModelRefFromString({ raw: modelRef, defaultProvider: DEFAULT_PROVIDER, aliasIndex })
+      : null;
+    const rawProvider = resolved?.ref.provider ?? DEFAULT_PROVIDER;
+    const rawModel = resolved?.ref.model ?? DEFAULT_MODEL;
+    // Slug generation is a lightweight embedded LLM call — CLI backends are not supported.
+    // Fall back to default embedded provider when the agent's primary model is a CLI backend.
+    const provider = isCliProvider(rawProvider, params.cfg) ? DEFAULT_PROVIDER : rawProvider;
+    const model = isCliProvider(rawProvider, params.cfg) ? DEFAULT_MODEL : rawModel;
+    const timeoutMs = resolveSlugTimeoutMs(params.cfg);
 
     const result = await runEmbeddedPiAgent({
       sessionId: `slug-generator-${Date.now()}`,
@@ -61,7 +98,10 @@ Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", 
       prompt,
       provider,
       model,
-      timeoutMs: 15_000, // 15 second timeout
+      trigger: "memory",
+      thinkLevel: "minimal",
+      disableTools: true,
+      timeoutMs,
       runId: `slug-gen-${Date.now()}`,
     });
 

--- a/src/infra/outbound/conversation-id.test.ts
+++ b/src/infra/outbound/conversation-id.test.ts
@@ -31,6 +31,13 @@ describe("resolveConversationIdFromTargets", () => {
     expect(resolved).toBe("1475250310120214812");
   });
 
+  it("extracts chat ids from chat: targets (Feishu format)", () => {
+    const resolved = resolveConversationIdFromTargets({
+      targets: ["chat:oc_abc123def456"],
+    });
+    expect(resolved).toBe("oc_abc123def456");
+  });
+
   it("returns undefined for non-channel targets", () => {
     const resolved = resolveConversationIdFromTargets({
       targets: ["user:alice", "general"],

--- a/src/infra/outbound/conversation-id.ts
+++ b/src/infra/outbound/conversation-id.ts
@@ -28,6 +28,13 @@ export function resolveConversationIdFromTargets(params: {
       }
       continue;
     }
+    if (target.startsWith("chat:")) {
+      const chatId = normalizeConversationId(target.slice("chat:".length));
+      if (chatId) {
+        return chatId;
+      }
+      continue;
+    }
     const mentionMatch = target.match(/^<#(\d+)>$/);
     if (mentionMatch?.[1]) {
       return mentionMatch[1];

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -804,7 +804,40 @@ describe("deliverOutboundPayloads", () => {
     });
 
     expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith(
-      expect.objectContaining({ text: "report.pdf" }),
+      expect.objectContaining({
+        text: "report.pdf",
+        messageMeta: {
+          channel: "telegram",
+          accountId: undefined,
+          chatId: "c1",
+          chatType: "direct",
+          providerMessageId: "m1",
+          providerMessageIds: ["m1"],
+        },
+      }),
+    );
+  });
+
+  it("stores every provider message id in transcript mirror metadata for chunked replies", async () => {
+    mocks.appendAssistantMessageToSessionTranscript.mockClear();
+
+    await runChunkedWhatsAppDelivery({
+      mirror: {
+        sessionKey: "agent:main:main",
+      },
+    });
+
+    expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageMeta: {
+          channel: "whatsapp",
+          accountId: undefined,
+          chatId: undefined,
+          chatType: "direct",
+          providerMessageId: "w2",
+          providerMessageIds: ["w1", "w2"],
+        },
+      }),
     );
   });
 

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -16,6 +16,7 @@ import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
 import {
   appendAssistantMessageToSessionTranscript,
   resolveMirroredTranscriptText,
+  type SessionTranscriptMessageMeta,
 } from "../../config/sessions.js";
 import type { sendMessageDiscord } from "../../discord/send.js";
 import { fireAndForgetHook } from "../../hooks/fire-and-forget.js";
@@ -260,7 +261,82 @@ type MessageSentEvent = {
   content: string;
   error?: string;
   messageId?: string;
+  metadata?: Record<string, unknown>;
 };
+
+function buildMirrorMessageMeta(params: {
+  channel: Exclude<OutboundChannel, "none">;
+  accountId?: string;
+  replyToId?: string | null;
+  threadId?: string | number | null;
+  mirror?: DeliverOutboundPayloadsCoreParams["mirror"];
+  results: OutboundDeliveryResult[];
+}): SessionTranscriptMessageMeta | undefined {
+  const providerMessageIds = [
+    ...new Set(
+      params.results
+        .map((result) => result.messageId)
+        .filter((value): value is string => typeof value === "string" && value.trim().length > 0),
+    ),
+  ];
+  const chatIds = [
+    ...new Set(
+      params.results
+        .map((result) => result.chatId)
+        .filter((value): value is string => typeof value === "string" && value.trim().length > 0),
+    ),
+  ];
+  const providerMessageId = providerMessageIds.at(-1);
+  const chatId = chatIds.length === 1 ? chatIds[0] : undefined;
+
+  if (
+    !providerMessageId &&
+    providerMessageIds.length === 0 &&
+    !chatId &&
+    !params.accountId &&
+    !params.replyToId &&
+    params.threadId == null
+  ) {
+    return undefined;
+  }
+
+  return {
+    channel: params.channel,
+    accountId: params.accountId,
+    chatId,
+    chatType: params.mirror?.isGroup ? "group" : "direct",
+    providerMessageId,
+    ...(providerMessageIds.length > 0 ? { providerMessageIds } : {}),
+    ...(params.replyToId ? { parentId: params.replyToId } : {}),
+    ...(params.threadId != null ? { threadId: params.threadId } : {}),
+  };
+}
+
+/**
+ * Extract channel-specific fields from a delivery result into hook metadata.
+ * This ensures fields like chatId (returned by the channel API but not in `to`)
+ * are available to message_sent hook consumers — critical for channels where the
+ * outbound `to` address differs from the resolved chat identifier (e.g. feishu DMs
+ * addressed by open_id but resolved to a chat_id by the API).
+ */
+function buildDeliveryResultMetadata(
+  result: OutboundDeliveryResult | undefined,
+): Record<string, unknown> | undefined {
+  if (!result) {
+    return undefined;
+  }
+  const meta: Record<string, unknown> = {};
+  if (result.chatId) {
+    meta.chatId = result.chatId;
+  }
+  if (result.channelId) {
+    meta.channelId = result.channelId;
+  }
+  if (result.meta) {
+    Object.assign(meta, result.meta);
+  }
+  return Object.keys(meta).length > 0 ? meta : undefined;
+}
 
 function hasMediaPayload(payload: ReplyPayload): boolean {
   return Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
@@ -329,6 +405,25 @@ function buildPayloadSummary(payload: ReplyPayload): NormalizedOutboundPayload {
   };
 }
 
+function resolveMirrorFallbackContent(payloads: ReplyPayload[]): {
+  text?: string;
+  mediaUrls?: string[];
+} {
+  if (payloads.length === 0) {
+    return {};
+  }
+  const summaries = payloads.map((payload) => buildPayloadSummary(payload));
+  const text = summaries
+    .map((summary) => summary.text)
+    .filter((value) => value.trim().length > 0)
+    .join("\n");
+  const mediaUrls = summaries.flatMap((summary) => summary.mediaUrls);
+  return {
+    ...(text ? { text } : {}),
+    ...(mediaUrls.length > 0 ? { mediaUrls } : {}),
+  };
+}
+
 function createMessageSentEmitter(params: {
   hookRunner: ReturnType<typeof getGlobalHookRunner>;
   channel: Exclude<OutboundChannel, "none">;
@@ -353,6 +448,7 @@ function createMessageSentEmitter(params: {
       accountId: params.accountId ?? undefined,
       conversationId: params.to,
       messageId: event.messageId,
+      metadata: event.metadata,
       isGroup: params.mirrorIsGroup,
       groupId: params.mirrorGroupId,
     });
@@ -663,6 +759,7 @@ async function deliverOutboundPayloadsCore(
     };
   };
   const normalizedPayloads = normalizePayloadsForChannelDelivery(payloads, channel);
+  const mirrorFallback = resolveMirrorFallbackContent(normalizedPayloads);
   const hookRunner = getGlobalHookRunner();
   const sessionKeyForInternalHooks = params.mirror?.sessionKey ?? params.session?.key;
   const mirrorIsGroup = params.mirror?.isGroup;
@@ -720,6 +817,7 @@ async function deliverOutboundPayloadsCore(
           success: true,
           content: payloadSummary.text,
           messageId: delivery.messageId,
+          metadata: buildDeliveryResultMetadata(delivery),
         });
         continue;
       }
@@ -730,11 +828,12 @@ async function deliverOutboundPayloadsCore(
         } else {
           await sendTextChunks(payloadSummary.text, sendOverrides);
         }
-        const messageId = results.at(-1)?.messageId;
+        const lastResult = results.at(-1);
         emitMessageSent({
           success: results.length > beforeCount,
           content: payloadSummary.text,
-          messageId,
+          messageId: lastResult?.messageId,
+          metadata: buildDeliveryResultMetadata(lastResult),
         });
         continue;
       }
@@ -785,6 +884,7 @@ async function deliverOutboundPayloadsCore(
         success: true,
         content: payloadSummary.text,
         messageId: lastMessageId,
+        metadata: buildDeliveryResultMetadata(results.at(-1)),
       });
     } catch (err) {
       emitMessageSent({
@@ -800,14 +900,22 @@ async function deliverOutboundPayloadsCore(
   }
   if (params.mirror && results.length > 0) {
     const mirrorText = resolveMirroredTranscriptText({
-      text: params.mirror.text,
-      mediaUrls: params.mirror.mediaUrls,
+      text: params.mirror.text ?? mirrorFallback.text,
+      mediaUrls: params.mirror.mediaUrls ?? mirrorFallback.mediaUrls,
     });
     if (mirrorText) {
       await appendAssistantMessageToSessionTranscript({
         agentId: params.mirror.agentId,
         sessionKey: params.mirror.sessionKey,
         text: mirrorText,
+        messageMeta: buildMirrorMessageMeta({
+          channel,
+          accountId,
+          replyToId: params.replyToId,
+          threadId: params.threadId,
+          mirror: params.mirror,
+          results,
+        }),
       });
     }
   }

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -387,6 +387,7 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
+  /invalid receive_id/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -166,6 +166,7 @@ describe("delivery-queue", () => {
       "Forbidden: bot was kicked from the group chat",
       "chat_id is empty",
       "Outbound not configured for channel: msteams",
+      "Feishu send failed: invalid receive_id",
     ])("returns true for permanent error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(true);
     });

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -718,3 +718,8 @@ export { loadWebMedia, type WebMediaResult } from "../web/media.js";
 
 // Security utilities
 export { redactSensitiveText } from "../logging/redact.js";
+
+// Plugin hooks
+export type { HookRunner } from "../plugins/hooks.js";
+export { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+export { emitMessageReceivedHooks } from "../auto-reply/reply/message-received-hooks.js";

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -518,6 +518,27 @@ export type { HookEntry } from "../hooks/types.js";
 export { clamp, escapeRegExp, normalizeE164, safeParseJson, sleep } from "../utils.js";
 export { stripAnsi } from "../terminal/ansi.js";
 export { missingTargetError } from "../infra/outbound/target-errors.js";
+export {
+  getSessionBindingService,
+  registerSessionBindingAdapter,
+  unregisterSessionBindingAdapter,
+  SessionBindingError,
+  isSessionBindingError,
+} from "../infra/outbound/session-binding-service.js";
+export type {
+  BindingTargetKind,
+  BindingStatus,
+  ConversationRef,
+  SessionBindingAdapter,
+  SessionBindingAdapterCapabilities,
+  SessionBindingBindInput,
+  SessionBindingCapabilities,
+  SessionBindingErrorCode,
+  SessionBindingPlacement,
+  SessionBindingRecord,
+  SessionBindingService,
+  SessionBindingUnbindInput,
+} from "../infra/outbound/session-binding-service.js";
 export { registerLogTransport } from "../logging/logger.js";
 export type { LogTransport, LogTransportRecord } from "../logging/logger.js";
 export {

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -2,6 +2,7 @@ import { createRequire } from "node:module";
 import { resolveStateDir } from "../../config/paths.js";
 import { transcribeAudioFile } from "../../media-understanding/transcribe-audio.js";
 import { textToSpeechTelephony } from "../../tts/tts.js";
+import { getGlobalHookRunner } from "../hook-runner-global.js";
 import { createRuntimeChannel } from "./runtime-channel.js";
 import { createRuntimeConfig } from "./runtime-config.js";
 import { createRuntimeEvents } from "./runtime-events.js";
@@ -39,6 +40,15 @@ export function createPluginRuntime(): PluginRuntime {
     tools: createRuntimeTools(),
     channel: createRuntimeChannel(),
     events: createRuntimeEvents(),
+    hooks: {
+      emitMessageSent: (event, context) => {
+        const hookRunner = getGlobalHookRunner();
+        if (!hookRunner?.hasHooks("message_sent")) {
+          return;
+        }
+        void hookRunner.runMessageSent(event, context);
+      },
+    },
     logging: createRuntimeLogging(),
     state: { resolveStateDir },
   } satisfies PluginRuntime;

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -49,6 +49,29 @@ export type PluginRuntimeCore = {
       opts?: { level?: LogLevel },
     ) => RuntimeLogger;
   };
+  hooks: {
+    /**
+     * Emit a message_sent plugin hook event.
+     * Use this from extensions that bypass the core deliverOutboundPayloads pipeline
+     * (e.g. channel-specific reply dispatchers) so downstream plugins (bot-company
+     * journal, analytics, etc.) can still observe outbound messages.
+     */
+    emitMessageSent: (
+      event: {
+        to: string;
+        content: string;
+        success: boolean;
+        messageId?: string;
+        error?: string;
+        metadata?: Record<string, unknown>;
+      },
+      context: {
+        channelId: string;
+        accountId?: string;
+        conversationId?: string;
+      },
+    ) => void;
+  };
   state: {
     resolveStateDir: typeof import("../../config/paths.js").resolveStateDir;
   };

--- a/src/plugins/schema-validator.ts
+++ b/src/plugins/schema-validator.ts
@@ -1,9 +1,8 @@
-import { createRequire } from "node:module";
+import Ajv from "ajv";
 import type { ErrorObject, ValidateFunction } from "ajv";
 import { appendAllowedValuesHint, summarizeAllowedValues } from "../config/allowed-values.js";
 import { sanitizeTerminalText } from "../terminal/safe-text.js";
 
-const require = createRequire(import.meta.url);
 type AjvLike = {
   compile: (schema: Record<string, unknown>) => ValidateFunction;
 };
@@ -13,17 +12,14 @@ function getAjv(): AjvLike {
   if (ajvSingleton) {
     return ajvSingleton;
   }
-  const ajvModule = require("ajv") as { default?: new (opts?: object) => AjvLike };
-  const AjvCtor =
-    typeof ajvModule.default === "function"
-      ? ajvModule.default
-      : (ajvModule as unknown as new (opts?: object) => AjvLike);
-  ajvSingleton = new AjvCtor({
+  const AjvCtor = Ajv as unknown as new (opts?: object) => AjvLike;
+  const ajv = new AjvCtor({
     allErrors: true,
     strict: false,
     removeAdditional: false,
   });
-  return ajvSingleton;
+  ajvSingleton = ajv;
+  return ajv;
 }
 
 type CachedValidator = {


### PR DESCRIPTION
## Problem

The Feishu work in `ai-team` is the largest review hotspot. It mixes mention normalization, quoted-message cleanup, streaming cards, reply dispatching, recall handling, delivery recovery, and plugin-dispatch behavior in one place.

## Fix

- normalize Feishu mention tags for text/card sends
- enrich quoted-message placeholders and sender lookup behavior
- add the native reply dispatcher with streaming card updates
- handle recall events and improve delivery error recovery
- integrate CLI stream-json mode with streaming cards
- emit `message_sent` hooks from the dispatcher and support group plugin dispatch mode
- absorb the Feishu-side `0a2f38310` follow-ups (mention meta fallback, reply dedupe, test fixes)

## Flow

```text
Feishu message/event
  -> normalize mentions / quoted text
  -> dispatch through native reply pipeline
  -> stream card updates safely
  -> recover from recall + reply fallback edge cases
  -> emit message_sent hooks / plugin dispatch metadata
```

## Why merge

This is the user-visible Feishu slice. Splitting it out makes the review boundary obvious: everything here is about Feishu message fidelity, delivery behavior, and plugin-facing Feishu metadata.
