### PR TITLE
feat(plugins): split D Bun embedded-plugin loading and SkillStore publishing

### DIFF
--- a/skills/skillstore-plugin-publisher/SKILL.md
+++ b/skills/skillstore-plugin-publisher/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: skillstore-plugin-publisher
+description: "Publish plugins to SkillStore marketplace. Use when: (1) publishing a new plugin, (2) updating existing plugin, (3) generating cover images, (4) approving plugins for listing."
+metadata: { "openclaw": { "emoji": "📦", "requires": { "bins": ["gh", "curl"] }, "install": [] } }
+---
+
+# SkillStore Plugin Publisher
+
+Complete workflow for publishing plugins to SkillStore marketplace.
+
+## When to Use
+
+✅ **USE this skill when:**
+
+- Publishing a new plugin to SkillStore
+- Updating an existing plugin
+- Generating cover images for plugins
+- Approving plugins for public listing
+
+## Workflow
+
+### 1. Prepare Plugin
+
+Ensure plugin has:
+
+- Unique slug (e.g., `my-awesome-plugin`)
+- Clear name and description
+- At least 3 skills bundled
+- Proper folder structure in marketplace repo
+
+### 2. Generate Cover Image
+
+**Using Gemini to generate cover image:**
+
+1. Open Gemini: https://gemini.google.com/app
+2. Request image generation with prompt describing plugin purpose
+3. Use "Save image as" to download, or find actual image URL
+4. Download to local: `curl -o cover.jpg <image_url>`
+
+**Image requirements:**
+
+- List view: 320×180 thumbnail
+- Detail view: Original size (will be resized)
+- Format: JPG or PNG
+
+### 3. Upload Cover Image
+
+```bash
+# Upload to Supabase Storage or use skillstore API
+# Update plugin record with coverImageUrl
+```
+
+### 4. Approve Plugin
+
+```bash
+# Via skillstore CLI or API
+# Set review_status from 'pending_review' to 'approved'
+```
+
+### 5. Verify Publishing
+
+```bash
+# Check plugin appears in list
+curl "https://skillstore.io/api/plugins?limit=20"
+
+# Check plugin detail
+curl "https://skillstore.io/api/plugins/<slug>"
+```
+
+## Key Commands
+
+```bash
+# Install skillstore CLI
+npx -y skillstore plugin install <slug>
+
+# Check plugin status
+curl "https://skillstore.io/api/plugins/<slug>"
+
+# List all plugins
+curl "https://skillstore.io/api/plugins?type=top&limit=50"
+```
+
+## Troubleshooting
+
+- **404 on plugin page**: Check if `review_status` is `approved`
+- **Image distorted**: Use 320×180 for list, original for detail
+- **Missing from list**: Ensure `visibility: public` and `review_status: approved`
+
+## References
+
+- SkillStore: https://skillstore.io
+- Marketplace Repo: https://github.com/aiskillstore/marketplace
+- Plugin Docs: https://docs.skillstore.io

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -551,6 +551,24 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     diagnostics: discovery.diagnostics,
   });
   pushDiagnostics(registry.diagnostics, manifestRegistry.diagnostics);
+
+  // Embedded plugins (from Bun binary): manifests are injected by manifest-registry.ts.
+  // Add matching discovery candidates so the loader loop can find them.
+  const embeddedPlugins = (globalThis as Record<string, unknown>).__OPENCLAW_EMBEDDED_PLUGINS__ as
+    | Array<{ id: string; module: unknown; manifest: Record<string, unknown> }>
+    | undefined;
+  if (Array.isArray(embeddedPlugins)) {
+    for (const ep of embeddedPlugins) {
+      const rootDir = `__embedded__:${ep.id}`;
+      discovery.candidates.unshift({
+        idHint: ep.id,
+        source: rootDir,
+        rootDir,
+        origin: "bundled",
+      });
+    }
+  }
+
   warnWhenAllowlistIsOpen({
     logger,
     pluginsEnabled: normalized.enabled,
@@ -570,6 +588,15 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   let jitiLoader: ReturnType<typeof createJiti> | null = null;
   const getJiti = () => {
     if (jitiLoader) {
+      return jitiLoader;
+    }
+    // Bun compiled binaries cannot resolve jiti's babel.cjs from the virtual
+    // filesystem.  Bypass jiti entirely and use require() which is synchronous
+    // and Bun handles ESM→CJS interop automatically for .js files.
+    if (typeof (globalThis as Record<string, unknown>).Bun !== "undefined") {
+      jitiLoader = ((specifier: string) => {
+        return require(specifier);
+      }) as unknown as ReturnType<typeof createJiti>;
       return jitiLoader;
     }
     const pluginSdkAlias = resolvePluginSdkAlias();
@@ -689,37 +716,47 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       continue;
     }
 
-    const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
-    const opened = openBoundaryFileSync({
-      absolutePath: candidate.source,
-      rootPath: pluginRoot,
-      boundaryLabel: "plugin root",
-      rejectHardlinks: candidate.origin !== "bundled",
-      skipLexicalRootCheck: true,
-    });
-    if (!opened.ok) {
-      pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
-      continue;
-    }
-    const safeSource = opened.path;
-    fs.closeSync(opened.fd);
-
     let mod: OpenClawPluginModule | null = null;
-    try {
-      mod = getJiti()(safeSource) as OpenClawPluginModule;
-    } catch (err) {
-      recordPluginError({
-        logger,
-        registry,
-        record,
-        seenIds,
-        pluginId,
-        origin: candidate.origin,
-        error: err,
-        logPrefix: `[plugins] ${record.id} failed to load from ${record.source}: `,
-        diagnosticMessagePrefix: "failed to load plugin: ",
+
+    // Embedded plugins: module is already loaded in memory, skip file I/O.
+    const embeddedEntry = candidate.source.startsWith("__embedded__:")
+      ? embeddedPlugins?.find((e) => `__embedded__:${e.id}` === candidate.source)
+      : undefined;
+
+    if (embeddedEntry) {
+      mod = embeddedEntry.module as OpenClawPluginModule;
+    } else {
+      const pluginRoot = safeRealpathOrResolve(candidate.rootDir);
+      const opened = openBoundaryFileSync({
+        absolutePath: candidate.source,
+        rootPath: pluginRoot,
+        boundaryLabel: "plugin root",
+        rejectHardlinks: candidate.origin !== "bundled",
+        skipLexicalRootCheck: true,
       });
-      continue;
+      if (!opened.ok) {
+        pushPluginLoadError("plugin entry path escapes plugin root or fails alias checks");
+        continue;
+      }
+      const safeSource = opened.path;
+      fs.closeSync(opened.fd);
+
+      try {
+        mod = getJiti()(safeSource) as OpenClawPluginModule;
+      } catch (err) {
+        recordPluginError({
+          logger,
+          registry,
+          record,
+          seenIds,
+          pluginId,
+          origin: candidate.origin,
+          error: err,
+          logPrefix: `[plugins] ${record.id} failed to load from ${record.source}: `,
+          diagnosticMessagePrefix: "failed to load plugin: ",
+        });
+        continue;
+      }
     }
 
     const resolved = resolvePluginModuleExport(mod);

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -250,6 +250,32 @@ export function loadPluginManifestRegistry(params: {
     );
   }
 
+  // Inject embedded plugins from Bun compiled binary so they are visible
+  // to both the config validator and the plugin loader.
+  const embeddedPlugins = (globalThis as Record<string, unknown>).__OPENCLAW_EMBEDDED_PLUGINS__ as
+    | Array<{ id: string; manifest: Record<string, unknown> }>
+    | undefined;
+  if (Array.isArray(embeddedPlugins)) {
+    for (const ep of embeddedPlugins) {
+      const rootDir = `__embedded__:${ep.id}`;
+      records.push({
+        id: ep.manifest.id as string,
+        rootDir,
+        source: rootDir,
+        manifestPath: `${rootDir}/openclaw.plugin.json`,
+        origin: "bundled",
+        configSchema: ep.manifest.configSchema as Record<string, unknown> | undefined,
+        kind: ep.manifest.kind as PluginKind | undefined,
+        channels: (ep.manifest.channels as string[]) ?? [],
+        providers: (ep.manifest.providers as string[]) ?? [],
+        skills: [],
+        name: ep.manifest.name as string | undefined,
+        description: ep.manifest.description as string | undefined,
+        version: ep.manifest.version as string | undefined,
+      });
+    }
+  }
+
   const registry = { plugins: records, diagnostics };
   if (cacheEnabled) {
     const ttl = resolveManifestCacheMs(env);


### PR DESCRIPTION
## Problem

Two distribution-oriented changes were buried inside `ai-team`:
- Bun compiled binaries need embedded plugin loading support
- the SkillStore publisher skill was added alongside unrelated runtime work

## Fix

- support embedded plugins from Bun compiled binaries
- add the `skillstore-plugin-publisher` skill

## Flow

```text
compiled Bun binary
  -> load embedded plugin manifests correctly
  -> expose publisher workflow as a first-class skill
```

## Why merge

These changes are isolated from the runtime/Feishu refactors and review much faster on their own.
