### PR TITLE
feat(agents): split E bootstrap compaction, overflow protection, and Feishu media persistence

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -8,6 +8,7 @@ const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 const resolveReceiveIdTypeMock = vi.hoisted(() => vi.fn());
 const createReplyDispatcherWithTypingMock = vi.hoisted(() => vi.fn());
+const emitMessageSentMock = vi.hoisted(() => vi.fn());
 const addTypingIndicatorMock = vi.hoisted(() => vi.fn(async () => ({ messageId: "om_msg" })));
 const removeTypingIndicatorMock = vi.hoisted(() => vi.fn(async () => {}));
 const streamingInstances = vi.hoisted(() => [] as any[]);
@@ -45,6 +46,7 @@ vi.mock("./streaming-card.js", () => ({
   },
   FeishuStreamingSession: class {
     active = false;
+    messageId = "om_stream_1";
     start = vi.fn(async () => {
       this.active = true;
     });
@@ -52,7 +54,11 @@ vi.mock("./streaming-card.js", () => ({
     close = vi.fn(async () => {
       this.active = false;
     });
+    discard = vi.fn(async () => {
+      this.active = false;
+    });
     isActive = vi.fn(() => this.active);
+    getMessageId = vi.fn(() => this.messageId);
 
     constructor() {
       streamingInstances.push(this);
@@ -62,11 +68,17 @@ vi.mock("./streaming-card.js", () => ({
 
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 
+async function flushAsyncTasks(iterations = 8): Promise<void> {
+  for (let i = 0; i < iterations; i += 1) {
+    await Promise.resolve();
+  }
+}
+
 describe("createFeishuReplyDispatcher streaming behavior", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     streamingInstances.length = 0;
-    sendMediaFeishuMock.mockResolvedValue(undefined);
+    sendMediaFeishuMock.mockResolvedValue({ messageId: "om_media_1", chatId: "oc_chat" });
 
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
@@ -102,6 +114,9 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
           createReplyDispatcherWithTyping: createReplyDispatcherWithTypingMock,
           resolveHumanDelayConfig: vi.fn(() => undefined),
         },
+      },
+      hooks: {
+        emitMessageSent: emitMessageSentMock,
       },
     });
   });
@@ -217,6 +232,57 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
     expect(sendMediaFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("does not force streaming in auto mode for reasoning/tool events without card content", async () => {
+    const dispatcher = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await dispatcher.replyOptions.onReasoningStream?.({ text: "reasoning...", isReasoning: true });
+    await flushAsyncTasks();
+    await dispatcher.replyOptions.onToolStart?.({ name: "Read", phase: "start" });
+    await flushAsyncTasks();
+
+    expect(streamingInstances).toHaveLength(0);
+
+    await options.deliver({ text: "plain text" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(0);
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("renders staged thinking status with first partial text chunk in auto mode", async () => {
+    const dispatcher = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    await dispatcher.replyOptions.onPartialReply?.({ text: "第一段答案" });
+    await flushAsyncTasks();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].update).toHaveBeenNthCalledWith(
+      1,
+      "💭 思考中...\n---\n第一段答案",
+      {
+        mode: "replace",
+      },
+    );
+    expect(streamingInstances[0].update).toHaveBeenNthCalledWith(2, "第一段答案", {
+      mode: "replace",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.onIdle?.();
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("第一段答案");
   });
 
   it("uses streaming session for auto mode markdown payloads", async () => {
@@ -374,7 +440,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
   });
 
-  it("treats block updates as delta chunks", async () => {
+  it("stages thinking prelude on assistant message start without opening a card", async () => {
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
       appId: "app_id",
@@ -386,22 +452,172 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     });
 
-    const result = createFeishuReplyDispatcher({
+    const dispatcher = createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
       runtime: { log: vi.fn(), error: vi.fn() } as never,
       chatId: "oc_chat",
     });
 
+    await dispatcher.replyOptions.onAssistantMessageStart?.();
+    await flushAsyncTasks();
+
+    expect(streamingInstances).toHaveLength(0);
+
     const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
-    await options.onReplyStart?.();
-    await result.replyOptions.onPartialReply?.({ text: "hello" });
-    await options.deliver({ text: "lo world" }, { kind: "block" });
     await options.onIdle?.();
+    expect(streamingInstances).toHaveLength(0);
+  });
+
+  it("stages thinking/tool status lines until first text chunk and keeps final close content text-only", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+
+    const dispatcher = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+
+    await dispatcher.replyOptions.onReasoningStream?.({
+      text: "Reasoning:\n_step_",
+      isReasoning: true,
+    });
+    await flushAsyncTasks();
+
+    expect(streamingInstances).toHaveLength(0);
+
+    await dispatcher.replyOptions.onToolStart?.({ name: "Read", phase: "start" });
+    await flushAsyncTasks();
+
+    expect(streamingInstances).toHaveLength(0);
+
+    await dispatcher.replyOptions.onPartialReply?.({ text: "第一段答案" });
+    await flushAsyncTasks();
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].update).toHaveBeenNthCalledWith(
+      1,
+      "🔧 正在使用Read工具...\n---\n第一段答案",
+      {
+        mode: "replace",
+      },
+    );
+    expect(streamingInstances[0].update).toHaveBeenNthCalledWith(2, "第一段答案", {
+      mode: "replace",
+    });
+
+    await dispatcher.replyOptions.onToolStart?.({ name: "Grep", phase: "start" });
+    await flushAsyncTasks();
+    expect(streamingInstances[0].update).toHaveBeenLastCalledWith(
+      "🔧 已使用 2 个工具，正在处理...\n---\n第一段答案",
+      { mode: "replace" },
+    );
+
+    await dispatcher.replyOptions.onPartialReply?.({ text: "第一段答案\n第二段答案" });
+    await flushAsyncTasks();
+    expect(streamingInstances[0].update).toHaveBeenLastCalledWith("第一段答案\n第二段答案", {
+      mode: "replace",
+    });
+
+    await options.onIdle?.();
+    expect(streamingInstances[0].close).toHaveBeenCalledWith("第一段答案\n第二段答案");
+  });
+
+  it("stages tool status when tool event is first and renders with first text", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+
+    const dispatcher = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    await dispatcher.replyOptions.onToolStart?.({ name: "Read", phase: "start" });
+    await flushAsyncTasks();
+
+    expect(streamingInstances).toHaveLength(0);
+
+    await dispatcher.replyOptions.onPartialReply?.({ text: "第一段答案" });
+    await flushAsyncTasks();
 
     expect(streamingInstances).toHaveLength(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[0].close).toHaveBeenCalledWith("hellolo world");
+    expect(streamingInstances[0].update).toHaveBeenNthCalledWith(
+      1,
+      "🔧 正在使用Read工具...\n---\n第一段答案",
+      {
+        mode: "replace",
+      },
+    );
+    expect(streamingInstances[0].update).toHaveBeenNthCalledWith(2, "第一段答案", {
+      mode: "replace",
+    });
+  });
+
+  it("replaces pre-tool status text when the first post-tool partial restarts the answer", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+
+    const dispatcher = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    await dispatcher.replyOptions.onPartialReply?.({ text: "**Checking SEO JSON-LD in PR #16**" });
+    await flushAsyncTasks();
+    await dispatcher.replyOptions.onToolStart?.({ name: "Read", phase: "start" });
+    await flushAsyncTasks();
+    await dispatcher.replyOptions.onPartialReply?.({
+      text: '<at user_id="ou_luke">Luke</at> 加了。',
+    });
+    await flushAsyncTasks();
+    await dispatcher.replyOptions.onPartialReply?.({
+      text: '<at user_id="ou_luke">Luke</at> 加了。\n我刚又确认了一遍',
+    });
+    await flushAsyncTasks();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].update).toHaveBeenLastCalledWith(
+      "<at id=ou_luke></at> 加了。\n我刚又确认了一遍",
+      {
+        mode: "replace",
+      },
+    );
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.onIdle?.();
+    expect(streamingInstances[0].close).toHaveBeenCalledWith(
+      "<at id=ou_luke></at> 加了。\n我刚又确认了一遍",
+    );
   });
 
   it("sends media-only payloads as attachments", async () => {
@@ -547,7 +763,33 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
-  it("disables streaming for thread replies and keeps reply metadata", async () => {
+  it("uses streaming for thread replies and keeps reply metadata when streamingInThread is enabled", async () => {
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+      replyToMessageId: "om_msg",
+      replyInThread: false,
+      streamingInThread: true,
+      threadReply: true,
+      rootId: "om_root_topic",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].start).toHaveBeenCalledWith("oc_chat", "chat_id", {
+      replyToMessageId: "om_msg",
+      replyInThread: true,
+      rootId: "om_root_topic",
+    });
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("disables streaming for thread replies by default", async () => {
     createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
@@ -571,6 +813,36 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     );
   });
 
+  it("does not create streaming card when final content is empty", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+
+    const dispatcher = createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    await dispatcher.replyOptions.onReasoningStream?.({ text: "thinking", isReasoning: true });
+    await flushAsyncTasks();
+    await dispatcher.replyOptions.onToolStart?.({ name: "Read", phase: "start" });
+    await flushAsyncTasks();
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(0);
+  });
+
   it("passes replyInThread to media attachments", async () => {
     createFeishuReplyDispatcher({
       cfg: {} as never,
@@ -589,6 +861,184 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
         replyToMessageId: "om_msg",
         replyInThread: true,
       }),
+    );
+  });
+
+  it("emits persistence signals for media-only final replies", async () => {
+    const onFinalTextDelivered = vi.fn(async () => {});
+    sendMediaFeishuMock.mockResolvedValueOnce({ messageId: "om_media_1", chatId: "oc_chat" });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+      onFinalTextDelivered,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver(
+      { mediaUrl: "https://example.com/path/photo.png?x=1" },
+      { kind: "final" },
+    );
+
+    expect(emitMessageSentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "oc_chat",
+        content: "photo.png",
+        success: true,
+        messageId: "om_media_1",
+        metadata: expect.objectContaining({
+          chatId: "oc_chat",
+          messageIds: ["om_media_1"],
+        }),
+      }),
+      expect.objectContaining({
+        channelId: "feishu",
+        conversationId: "oc_chat",
+      }),
+    );
+    expect(onFinalTextDelivered).toHaveBeenCalledWith({
+      text: "photo.png",
+      messageId: "om_media_1",
+      messageIds: ["om_media_1"],
+      chatId: "oc_chat",
+      accountId: "main",
+    });
+  });
+
+  it("emits onFinalTextDelivered for non-streaming final text replies", async () => {
+    const onFinalTextDelivered = vi.fn(async () => {});
+    sendMessageFeishuMock.mockResolvedValue({ messageId: "om_final_1", chatId: "oc_chat" });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+      onFinalTextDelivered,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "@Trent 请继续" }, { kind: "final" });
+
+    expect(onFinalTextDelivered).toHaveBeenCalledTimes(1);
+    expect(onFinalTextDelivered).toHaveBeenCalledWith({
+      text: "@Trent 请继续",
+      messageId: "om_final_1",
+      messageIds: ["om_final_1"],
+      chatId: "oc_chat",
+      accountId: "main",
+    });
+  });
+
+  it("emits every provider message id for chunked non-streaming final text replies", async () => {
+    const onFinalTextDelivered = vi.fn(async () => {});
+    sendMessageFeishuMock
+      .mockResolvedValueOnce({ messageId: "om_chunk_1", chatId: "oc_chat" })
+      .mockResolvedValueOnce({ messageId: "om_chunk_2", chatId: "oc_chat" });
+    getFeishuRuntimeMock.mockReturnValue({
+      channel: {
+        text: {
+          resolveTextChunkLimit: vi.fn(() => 16),
+          resolveChunkMode: vi.fn(() => "line"),
+          resolveMarkdownTableMode: vi.fn(() => "preserve"),
+          convertMarkdownTables: vi.fn((text) => text),
+          chunkTextWithMode: vi.fn(() => ["第一段", "第二段"]),
+        },
+        reply: {
+          createReplyDispatcherWithTyping: createReplyDispatcherWithTypingMock,
+          resolveHumanDelayConfig: vi.fn(() => undefined),
+        },
+      },
+      hooks: {
+        emitMessageSent: emitMessageSentMock,
+      },
+    });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+      onFinalTextDelivered,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "第一段\n第二段" }, { kind: "final" });
+
+    expect(onFinalTextDelivered).toHaveBeenCalledTimes(1);
+    expect(onFinalTextDelivered).toHaveBeenCalledWith({
+      text: "第一段\n第二段",
+      messageId: "om_chunk_2",
+      messageIds: ["om_chunk_1", "om_chunk_2"],
+      chatId: "oc_chat",
+      accountId: "main",
+    });
+  });
+
+  it("emits onFinalTextDelivered when streaming closes with final text", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+    const onFinalTextDelivered = vi.fn(async () => {});
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+      onFinalTextDelivered,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "最终回复内容" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(onFinalTextDelivered).toHaveBeenCalledTimes(1);
+    expect(onFinalTextDelivered).toHaveBeenCalledWith({
+      text: "最终回复内容",
+      messageId: "om_stream_1",
+      chatId: "oc_chat",
+      accountId: "main",
+    });
+  });
+
+  it("normalizes user_id mention tags before closing streaming card", async () => {
+    resolveFeishuAccountMock.mockReturnValue({
+      accountId: "main",
+      appId: "app_id",
+      appSecret: "app_secret",
+      domain: "feishu",
+      config: {
+        renderMode: "card",
+        streaming: true,
+      },
+    });
+
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver(
+      { text: '是 <at user_id="ou_vivi">Vivi（薇薇）</at> 的回合，不是我' },
+      { kind: "final" },
+    );
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledWith(
+      "是 <at id=ou_vivi></at> 的回合，不是我",
     );
   });
 });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -225,8 +225,67 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
   let finalTextEmitted = false;
+  /** Tracks whether any visible text was delivered during this reply cycle
+   *  (via streaming partial, block, or final text). Used to avoid emitting
+   *  a synthetic media filename as "final text" when real text was already
+   *  delivered through the streaming card. */
+  let hasVisibleTextInReply = false;
   let replaceNextPartialAfterTool = false;
   const deliveredFinalTexts = new Set<string>();
+
+  /**
+   * Deliver media files and emit persistence signals for media-only final payloads.
+   * Extracted to avoid duplicating this logic across streaming/non-streaming paths.
+   */
+  const deliverMediaAndEmitIfNeeded = async (
+    mediaList: string[],
+    text: string,
+    info: { kind?: string } | undefined,
+    hasText: boolean,
+  ): Promise<void> => {
+    const deliveredMediaMessageIds: string[] = [];
+    for (const mediaUrl of mediaList) {
+      const sent = await sendMediaFeishu({
+        cfg,
+        to: chatId,
+        mediaUrl,
+        replyToMessageId: sendReplyToMessageId,
+        replyInThread: effectiveReplyInThread,
+        accountId,
+      });
+      if (typeof sent?.messageId === "string" && sent.messageId.trim()) {
+        deliveredMediaMessageIds.push(sent.messageId);
+      }
+    }
+    // For media-only finals, wait for any pending streaming renders to settle
+    // before checking visibility. This avoids guessing whether queued text will
+    // actually be displayed — after the queue flushes, hasVisibleTextInReply
+    // definitively reflects whether text was delivered or the render failed.
+    if (info?.kind === "final" && !hasText) {
+      if (streamingStartPromise) {
+        await streamingStartPromise;
+      }
+      await partialUpdateQueue.catch(() => undefined);
+    }
+    if (
+      info?.kind === "final" &&
+      !hasText &&
+      !hasVisibleTextInReply &&
+      deliveredMediaMessageIds.length > 0
+    ) {
+      const finalContent = resolveFinalDeliveryContent(text, mediaList);
+      emitMessageSent({
+        content: finalContent,
+        success: true,
+        messageId: deliveredMediaMessageIds.at(-1),
+        metadata: { chatId, messageIds: deliveredMediaMessageIds },
+      });
+      await emitFinalTextIfNeeded(finalContent, {
+        messageId: deliveredMediaMessageIds.at(-1),
+        messageIds: deliveredMediaMessageIds,
+      });
+    }
+  };
 
   const emitFinalTextIfNeeded = async (
     text: string,
@@ -344,6 +403,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       }
       lastRenderedStreamContent = renderedForCard;
       await streaming.update(renderedForCard, { mode: "replace" });
+      // Only mark visible when real assistant text exists — status-only renders
+      // (e.g. "💭 思考中...") are discarded by closeStreaming() and should not
+      // suppress media-only final persistence.
+      if (streamText.trim()) {
+        hasVisibleTextInReply = true;
+      }
     });
   };
 
@@ -453,6 +518,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           text = buildMentionedCardContent(mentionTargets, text);
         }
         await streaming.close(normalizeMentionTagsForCard(text));
+        hasVisibleTextInReply = true;
       }
       if (options?.emitFinalText !== false) {
         emitMessageSent({ content: finalText, success: true, messageId: streamMessageId });
@@ -482,6 +548,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
       onReplyStart: () => {
         deliveredFinalTexts.clear();
+        hasVisibleTextInReply = false;
         if (streamingEnabled && renderMode === "card") {
           startStreaming();
         }
@@ -533,43 +600,20 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             if (info?.kind === "block") {
               // Some runtimes emit block payloads without onPartial/final callbacks.
               // Mirror block text into streamText so onIdle close still sends content.
+              // hasVisibleTextInReply is set by queueStreamingRender on successful update.
               queueThinkingPrelude();
               queueStreamingUpdate(text);
             }
             if (info?.kind === "final") {
               streamText = text;
               await closeStreaming({ emitFinalText: true });
+              // Mark visible only after closeStreaming succeeds — text is now delivered.
+              hasVisibleTextInReply = true;
               deliveredFinalTexts.add(text);
             }
             // Send media even when streaming handled the text
-            const deliveredMediaMessageIds: string[] = [];
             if (hasMedia) {
-              for (const mediaUrl of mediaList) {
-                const sent = await sendMediaFeishu({
-                  cfg,
-                  to: chatId,
-                  mediaUrl,
-                  replyToMessageId: sendReplyToMessageId,
-                  replyInThread: effectiveReplyInThread,
-                  accountId,
-                });
-                if (typeof sent?.messageId === "string" && sent.messageId.trim()) {
-                  deliveredMediaMessageIds.push(sent.messageId);
-                }
-              }
-            }
-            if (info?.kind === "final" && !hasText && deliveredMediaMessageIds.length > 0) {
-              const finalContent = resolveFinalDeliveryContent(text, mediaList);
-              emitMessageSent({
-                content: finalContent,
-                success: true,
-                messageId: deliveredMediaMessageIds.at(-1),
-                metadata: { chatId, messageIds: deliveredMediaMessageIds },
-              });
-              await emitFinalTextIfNeeded(finalContent, {
-                messageId: deliveredMediaMessageIds.at(-1),
-                messageIds: deliveredMediaMessageIds,
-              });
+              await deliverMediaAndEmitIfNeeded(mediaList, text, info, hasText);
             }
             return;
           }
@@ -623,6 +667,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               first = false;
             }
           }
+          if (deliveredMessageIds.length > 0) {
+            hasVisibleTextInReply = true;
+          }
           if (info?.kind === "final") {
             deliveredFinalTexts.add(text);
             emitMessageSent({ content: text, success: true, messageId: lastMessageId });
@@ -633,34 +680,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           }
         }
 
-        const deliveredMediaMessageIds: string[] = [];
         if (hasMedia) {
-          for (const mediaUrl of mediaList) {
-            const sent = await sendMediaFeishu({
-              cfg,
-              to: chatId,
-              mediaUrl,
-              replyToMessageId: sendReplyToMessageId,
-              replyInThread: effectiveReplyInThread,
-              accountId,
-            });
-            if (typeof sent?.messageId === "string" && sent.messageId.trim()) {
-              deliveredMediaMessageIds.push(sent.messageId);
-            }
-          }
-        }
-        if (info?.kind === "final" && !hasText && deliveredMediaMessageIds.length > 0) {
-          const finalContent = resolveFinalDeliveryContent(text, mediaList);
-          emitMessageSent({
-            content: finalContent,
-            success: true,
-            messageId: deliveredMediaMessageIds.at(-1),
-            metadata: { chatId, messageIds: deliveredMediaMessageIds },
-          });
-          await emitFinalTextIfNeeded(finalContent, {
-            messageId: deliveredMediaMessageIds.at(-1),
-            messageIds: deliveredMediaMessageIds,
-          });
+          await deliverMediaAndEmitIfNeeded(mediaList, text, info, hasText);
         }
       },
       onError: async (error, info) => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {
   createReplyPrefixContext,
   createTypingCallbacks,
@@ -5,15 +6,15 @@ import {
   type ClawdbotConfig,
   type ReplyPayload,
   type RuntimeEnv,
-} from "openclaw/plugin-sdk/feishu";
+} from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { sendMediaFeishu } from "./media.js";
 import type { MentionTarget } from "./mention.js";
-import { buildMentionedCardContent } from "./mention.js";
+import { buildMentionedCardContent, normalizeMentionTagsForCard } from "./mention.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMarkdownCardFeishu, sendMessageFeishu } from "./send.js";
-import { FeishuStreamingSession, mergeStreamingText } from "./streaming-card.js";
+import { FeishuStreamingSession } from "./streaming-card.js";
 import { resolveReceiveIdType } from "./targets.js";
 import { addTypingIndicator, removeTypingIndicator, type TypingIndicatorState } from "./typing.js";
 
@@ -26,6 +27,34 @@ function shouldUseCard(text: string): boolean {
  * Messages older than this are likely replays after context compaction (#30418). */
 const TYPING_INDICATOR_MAX_AGE_MS = 2 * 60_000;
 const MS_EPOCH_MIN = 1_000_000_000_000;
+
+function resolveFinalDeliveryContent(text: string, mediaUrls: string[]): string {
+  const normalized = text.trim();
+  if (normalized) {
+    return normalized;
+  }
+  if (mediaUrls.length === 0) {
+    return normalized;
+  }
+  const names = mediaUrls
+    .map((mediaUrl) => {
+      const trimmed = mediaUrl.trim();
+      if (!trimmed) {
+        return null;
+      }
+      const withoutHash = trimmed.split("#")[0] ?? trimmed;
+      const withoutQuery = withoutHash.split("?")[0] ?? withoutHash;
+      try {
+        const parsed = new URL(withoutQuery);
+        return path.basename(parsed.pathname) || null;
+      } catch {
+        const base = path.basename(withoutQuery);
+        return base && base !== "." && base !== "/" ? base : null;
+      }
+    })
+    .filter((value): value is string => Boolean(value));
+  return names.length > 0 ? names.join(", ") : "media";
+}
 
 function normalizeEpochMs(timestamp: number | undefined): number | undefined {
   if (!Number.isFinite(timestamp) || timestamp === undefined || timestamp <= 0) {
@@ -45,14 +74,26 @@ export type CreateFeishuReplyDispatcherParams = {
   /** When true, preserve typing indicator on reply target but send messages without reply metadata */
   skipReplyToInMessages?: boolean;
   replyInThread?: boolean;
+  /** Whether card streaming status is allowed in thread/topic replies (default: false). */
+  streamingInThread?: boolean;
   /** True when inbound message is already inside a thread/topic context */
   threadReply?: boolean;
   rootId?: string;
   mentionTargets?: MentionTarget[];
   accountId?: string;
+  /** Bot open_id used to identify this app's typing reaction during cleanup lookup. */
+  botOpenId?: string;
   /** Epoch ms when the inbound message was created. Used to suppress typing
    *  indicators on old/replayed messages after context compaction (#30418). */
   messageCreateTimeMs?: number;
+  /** Callback fired when a final visible text reply has been delivered. */
+  onFinalTextDelivered?: (params: {
+    text: string;
+    messageId?: string;
+    messageIds?: string[];
+    chatId: string;
+    accountId?: string;
+  }) => Promise<void> | void;
 };
 
 export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherParams) {
@@ -64,6 +105,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyToMessageId,
     skipReplyToInMessages,
     replyInThread,
+    streamingInThread,
     threadReply,
     rootId,
     mentionTargets,
@@ -73,6 +115,35 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const threadReplyMode = threadReply === true;
   const effectiveReplyInThread = threadReplyMode ? true : replyInThread;
   const account = resolveFeishuAccount({ cfg, accountId });
+
+  // Emit message_sent plugin hooks via the runtime SDK so downstream consumers
+  // (e.g. bot-company journal) can record outbound messages. The feishu reply
+  // dispatcher bypasses the core deliverOutboundPayloads pipeline, so hooks
+  // must be emitted explicitly here. Using core.hooks avoids the bundle singleton
+  // splitting issue that makes direct getGlobalHookRunner() imports fail.
+  const emitMessageSent = (event: {
+    content: string;
+    success: boolean;
+    messageId?: string;
+    error?: string;
+    metadata?: Record<string, unknown>;
+  }) => {
+    core.hooks.emitMessageSent(
+      {
+        to: chatId,
+        content: event.content,
+        success: event.success,
+        ...(event.messageId ? { messageId: event.messageId } : {}),
+        ...(event.error ? { error: event.error } : {}),
+        metadata: { chatId, ...(event.metadata ?? {}) },
+      },
+      {
+        channelId: "feishu",
+        accountId: accountId ?? account.accountId,
+        conversationId: chatId,
+      },
+    );
+  };
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
 
   let typingState: TypingIndicatorState | null = null;
@@ -104,6 +175,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         cfg,
         messageId: replyToMessageId,
         accountId,
+        botOpenId: params.botOpenId,
         runtime: params.runtime,
       });
     },
@@ -136,23 +208,162 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const chunkMode = core.channel.text.resolveChunkMode(cfg, "feishu");
   const tableMode = core.channel.text.resolveMarkdownTableMode({ cfg, channel: "feishu" });
   const renderMode = account.config?.renderMode ?? "auto";
-  // Card streaming may miss thread affinity in topic contexts; use direct replies there.
   const streamingEnabled =
-    !threadReplyMode && account.config?.streaming !== false && renderMode !== "raw";
+    account.config?.streaming !== false &&
+    renderMode !== "raw" &&
+    (!threadReplyMode || streamingInThread === true);
 
   let streaming: FeishuStreamingSession | null = null;
   let streamText = "";
   let lastPartial = "";
-  const deliveredFinalTexts = new Set<string>();
+  let lastRenderedStreamContent = "";
+  let streamPhase: "idle" | "thinking" | "tool" | "streaming" = "idle";
+  let toolUseCount = 0;
+  let lastToolName: string | undefined;
+  let hasThinkingPrelude = false;
+  let stagedStatusLine: string | undefined;
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
-  type StreamTextUpdateMode = "snapshot" | "delta";
+  let finalTextEmitted = false;
+  let replaceNextPartialAfterTool = false;
+  const deliveredFinalTexts = new Set<string>();
+
+  const emitFinalTextIfNeeded = async (
+    text: string,
+    delivery?: { messageId?: string; messageIds?: string[] },
+  ) => {
+    const normalized = text.trim();
+    if (!normalized || finalTextEmitted || typeof params.onFinalTextDelivered !== "function") {
+      return;
+    }
+    finalTextEmitted = true;
+    try {
+      await params.onFinalTextDelivered({
+        text: normalized,
+        ...(delivery?.messageId ? { messageId: delivery.messageId } : {}),
+        ...(delivery?.messageIds && delivery.messageIds.length > 0
+          ? { messageIds: delivery.messageIds }
+          : {}),
+        chatId,
+        accountId: accountId ?? account.accountId,
+      });
+    } catch (error) {
+      params.runtime.error?.(
+        `feishu[${account.accountId}] onFinalTextDelivered failed: ${String(error)}`,
+      );
+    }
+  };
+
+  const TOOL_DISPLAY_NAMES: Record<string, string> = {
+    feishu_chat_history: "聊天记录",
+    feishu_chat_info: "群信息",
+    feishu_chat_members: "群成员",
+    feishu_member_chats: "成员群列表",
+  };
+
+  const normalizeToolName = (name: string | undefined): string | undefined => {
+    const trimmed = name?.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const stripped = trimmed.replace("mcp__openclaw__", "");
+    return TOOL_DISPLAY_NAMES[stripped] ?? stripped.replace(/\s+/g, " ");
+  };
+
+  const resolveStatusLine = (): string | undefined => {
+    if (streamPhase === "thinking") {
+      return "💭 思考中...";
+    }
+    if (streamPhase === "tool") {
+      if (toolUseCount >= 2) {
+        return `🔧 已使用 ${toolUseCount} 个工具，正在处理...`;
+      }
+      const toolName = lastToolName?.trim();
+      return toolName ? `🔧 正在使用${toolName}工具...` : "🔧 正在使用工具...";
+    }
+    return undefined;
+  };
+
+  const composeStreamingContent = (mode: "live" | "final" = "live"): string => {
+    const assistantText = streamText;
+    if (mode === "final") {
+      return assistantText;
+    }
+    const statusLine = resolveStatusLine();
+    if (!statusLine) {
+      return assistantText;
+    }
+    if (!assistantText) {
+      return statusLine;
+    }
+    return `${statusLine}\n---\n${assistantText}`;
+  };
+
+  const mergeStreamingText = (nextText: string) => {
+    if (!streamText) {
+      streamText = nextText;
+      return;
+    }
+    if (nextText.startsWith(streamText)) {
+      // Handle cumulative partial payloads where nextText already includes prior text.
+      streamText = nextText;
+      return;
+    }
+    if (streamText.endsWith(nextText)) {
+      return;
+    }
+    streamText += nextText;
+  };
+
+  /** Strip trailing incomplete <at ...> tag to prevent streaming card corruption. */
+  const stripIncompleteAtTag = (text: string): string => {
+    const lastAtIdx = text.lastIndexOf("<at");
+    if (lastAtIdx === -1) {
+      return text;
+    }
+    const tail = text.substring(lastAtIdx);
+    if (/<\/at>/i.test(tail) || /\/>/i.test(tail)) {
+      return text;
+    }
+    return text.substring(0, lastAtIdx);
+  };
+
+  const queueStreamingRender = (renderedSnapshot?: string) => {
+    partialUpdateQueue = partialUpdateQueue.then(async () => {
+      if (streamingStartPromise) {
+        await streamingStartPromise;
+      }
+      if (!streaming?.isActive()) {
+        return;
+      }
+      const rendered = renderedSnapshot ?? composeStreamingContent("live");
+      const safeRendered = stripIncompleteAtTag(rendered);
+      const renderedForCard = normalizeMentionTagsForCard(safeRendered);
+      if (!renderedForCard || renderedForCard === lastRenderedStreamContent) {
+        return;
+      }
+      lastRenderedStreamContent = renderedForCard;
+      await streaming.update(renderedForCard, { mode: "replace" });
+    });
+  };
+
+  const shouldRenderStreamingStatus = (): boolean =>
+    renderMode === "card" || Boolean(streamingStartPromise) || Boolean(streaming?.isActive());
+
+  const queueThinkingPrelude = (): boolean => {
+    if (hasThinkingPrelude) {
+      return false;
+    }
+    streamPhase = "thinking";
+    stagedStatusLine = resolveStatusLine();
+    hasThinkingPrelude = true;
+    return true;
+  };
 
   const queueStreamingUpdate = (
     nextText: string,
     options?: {
       dedupeWithLastPartial?: boolean;
-      mode?: StreamTextUpdateMode;
     },
   ) => {
     if (!nextText) {
@@ -161,20 +372,40 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     if (options?.dedupeWithLastPartial && nextText === lastPartial) {
       return;
     }
+    const shouldResetAfterTool =
+      replaceNextPartialAfterTool &&
+      options?.dedupeWithLastPartial === true &&
+      Boolean(streamText) &&
+      !nextText.startsWith(streamText);
     if (options?.dedupeWithLastPartial) {
       lastPartial = nextText;
     }
-    const mode = options?.mode ?? "snapshot";
-    streamText =
-      mode === "delta" ? `${streamText}${nextText}` : mergeStreamingText(streamText, nextText);
-    partialUpdateQueue = partialUpdateQueue.then(async () => {
-      if (streamingStartPromise) {
-        await streamingStartPromise;
-      }
-      if (streaming?.isActive()) {
-        await streaming.update(streamText);
-      }
-    });
+    if (shouldResetAfterTool) {
+      streamText = nextText;
+      replaceNextPartialAfterTool = false;
+      streamPhase = "streaming";
+      queueStreamingRender();
+      return;
+    }
+    replaceNextPartialAfterTool = false;
+    const hadVisibleText = Boolean(streamText);
+    mergeStreamingText(nextText);
+    const shouldRenderStagedStatus =
+      !hadVisibleText && Boolean(streamText) && Boolean(stagedStatusLine);
+    const stagedSnapshot = shouldRenderStagedStatus
+      ? `${stagedStatusLine}\n---\n${streamText}`
+      : undefined;
+    if (shouldRenderStagedStatus) {
+      stagedStatusLine = undefined;
+    }
+    streamPhase = "streaming";
+    if (stagedSnapshot) {
+      queueStreamingRender(stagedSnapshot);
+      // Immediately follow with plain text so close(finalText) remains text-only.
+      queueStreamingRender();
+      return;
+    }
+    queueStreamingRender();
   };
 
   const startStreaming = () => {
@@ -206,22 +437,42 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     })();
   };
 
-  const closeStreaming = async () => {
+  const closeStreaming = async (options?: { emitFinalText?: boolean }) => {
     if (streamingStartPromise) {
       await streamingStartPromise;
     }
     await partialUpdateQueue;
+    const streamMessageId = streaming?.getMessageId();
     if (streaming?.isActive()) {
-      let text = streamText;
-      if (mentionTargets?.length) {
-        text = buildMentionedCardContent(mentionTargets, text);
+      const finalText = composeStreamingContent("final");
+      if (!finalText.trim()) {
+        await streaming.discard();
+      } else {
+        let text = finalText;
+        if (mentionTargets?.length) {
+          text = buildMentionedCardContent(mentionTargets, text);
+        }
+        await streaming.close(normalizeMentionTagsForCard(text));
       }
-      await streaming.close(text);
+      if (options?.emitFinalText !== false) {
+        emitMessageSent({ content: finalText, success: true, messageId: streamMessageId });
+        await emitFinalTextIfNeeded(
+          finalText,
+          streamMessageId ? { messageId: streamMessageId } : undefined,
+        );
+      }
     }
     streaming = null;
     streamingStartPromise = null;
     streamText = "";
     lastPartial = "";
+    lastRenderedStreamContent = "";
+    streamPhase = "idle";
+    toolUseCount = 0;
+    lastToolName = undefined;
+    hasThinkingPrelude = false;
+    stagedStatusLine = undefined;
+    replaceNextPartialAfterTool = false;
   };
 
   const { dispatcher, replyOptions, markDispatchIdle } =
@@ -246,6 +497,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               : [];
         const hasText = Boolean(text.trim());
         const hasMedia = mediaList.length > 0;
+        // Suppress only exact duplicate final text payloads to avoid
+        // dropping legitimate multi-part final replies.
         const skipTextForDuplicateFinal =
           info?.kind === "final" && hasText && deliveredFinalTexts.has(text);
         const shouldDeliverText = hasText && !skipTextForDuplicateFinal;
@@ -280,17 +533,19 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             if (info?.kind === "block") {
               // Some runtimes emit block payloads without onPartial/final callbacks.
               // Mirror block text into streamText so onIdle close still sends content.
-              queueStreamingUpdate(text, { mode: "delta" });
+              queueThinkingPrelude();
+              queueStreamingUpdate(text);
             }
             if (info?.kind === "final") {
-              streamText = mergeStreamingText(streamText, text);
-              await closeStreaming();
+              streamText = text;
+              await closeStreaming({ emitFinalText: true });
               deliveredFinalTexts.add(text);
             }
             // Send media even when streaming handled the text
+            const deliveredMediaMessageIds: string[] = [];
             if (hasMedia) {
               for (const mediaUrl of mediaList) {
-                await sendMediaFeishu({
+                const sent = await sendMediaFeishu({
                   cfg,
                   to: chatId,
                   mediaUrl,
@@ -298,19 +553,37 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                   replyInThread: effectiveReplyInThread,
                   accountId,
                 });
+                if (typeof sent?.messageId === "string" && sent.messageId.trim()) {
+                  deliveredMediaMessageIds.push(sent.messageId);
+                }
               }
+            }
+            if (info?.kind === "final" && !hasText && deliveredMediaMessageIds.length > 0) {
+              const finalContent = resolveFinalDeliveryContent(text, mediaList);
+              emitMessageSent({
+                content: finalContent,
+                success: true,
+                messageId: deliveredMediaMessageIds.at(-1),
+                metadata: { chatId, messageIds: deliveredMediaMessageIds },
+              });
+              await emitFinalTextIfNeeded(finalContent, {
+                messageId: deliveredMediaMessageIds.at(-1),
+                messageIds: deliveredMediaMessageIds,
+              });
             }
             return;
           }
 
           let first = true;
+          let lastMessageId: string | undefined;
+          const deliveredMessageIds: string[] = [];
           if (useCard) {
             for (const chunk of core.channel.text.chunkTextWithMode(
               text,
               textChunkLimit,
               chunkMode,
             )) {
-              await sendMarkdownCardFeishu({
+              const sent = await sendMarkdownCardFeishu({
                 cfg,
                 to: chatId,
                 text: chunk,
@@ -319,10 +592,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 mentions: first ? mentionTargets : undefined,
                 accountId,
               });
+              const sentMessageId = sent?.messageId;
+              if (typeof sentMessageId === "string" && sentMessageId.trim()) {
+                lastMessageId = sentMessageId;
+                deliveredMessageIds.push(sentMessageId);
+              }
               first = false;
-            }
-            if (info?.kind === "final") {
-              deliveredFinalTexts.add(text);
             }
           } else {
             const converted = core.channel.text.convertMarkdownTables(text, tableMode);
@@ -331,7 +606,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               textChunkLimit,
               chunkMode,
             )) {
-              await sendMessageFeishu({
+              const sent = await sendMessageFeishu({
                 cfg,
                 to: chatId,
                 text: chunk,
@@ -340,17 +615,28 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 mentions: first ? mentionTargets : undefined,
                 accountId,
               });
+              const sentMessageId = sent?.messageId;
+              if (typeof sentMessageId === "string" && sentMessageId.trim()) {
+                lastMessageId = sentMessageId;
+                deliveredMessageIds.push(sentMessageId);
+              }
               first = false;
             }
-            if (info?.kind === "final") {
-              deliveredFinalTexts.add(text);
-            }
+          }
+          if (info?.kind === "final") {
+            deliveredFinalTexts.add(text);
+            emitMessageSent({ content: text, success: true, messageId: lastMessageId });
+            await emitFinalTextIfNeeded(text, {
+              ...(lastMessageId ? { messageId: lastMessageId } : {}),
+              ...(deliveredMessageIds.length > 0 ? { messageIds: deliveredMessageIds } : {}),
+            });
           }
         }
 
+        const deliveredMediaMessageIds: string[] = [];
         if (hasMedia) {
           for (const mediaUrl of mediaList) {
-            await sendMediaFeishu({
+            const sent = await sendMediaFeishu({
               cfg,
               to: chatId,
               mediaUrl,
@@ -358,18 +644,34 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               replyInThread: effectiveReplyInThread,
               accountId,
             });
+            if (typeof sent?.messageId === "string" && sent.messageId.trim()) {
+              deliveredMediaMessageIds.push(sent.messageId);
+            }
           }
+        }
+        if (info?.kind === "final" && !hasText && deliveredMediaMessageIds.length > 0) {
+          const finalContent = resolveFinalDeliveryContent(text, mediaList);
+          emitMessageSent({
+            content: finalContent,
+            success: true,
+            messageId: deliveredMediaMessageIds.at(-1),
+            metadata: { chatId, messageIds: deliveredMediaMessageIds },
+          });
+          await emitFinalTextIfNeeded(finalContent, {
+            messageId: deliveredMediaMessageIds.at(-1),
+            messageIds: deliveredMediaMessageIds,
+          });
         }
       },
       onError: async (error, info) => {
         params.runtime.error?.(
           `feishu[${account.accountId}] ${info.kind} reply failed: ${String(error)}`,
         );
-        await closeStreaming();
+        await closeStreaming({ emitFinalText: false });
         typingCallbacks.onIdle?.();
       },
       onIdle: async () => {
-        await closeStreaming();
+        await closeStreaming({ emitFinalText: true });
         typingCallbacks.onIdle?.();
       },
       onCleanup: () => {
@@ -382,15 +684,75 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     replyOptions: {
       ...replyOptions,
       onModelSelected: prefixContext.onModelSelected,
+      onAssistantMessageStart: streamingEnabled
+        ? () => {
+            if (renderMode !== "card") {
+              return;
+            }
+            queueThinkingPrelude();
+          }
+        : undefined,
+      onReasoningStream: streamingEnabled
+        ? () => {
+            queueThinkingPrelude();
+            streamPhase = "thinking";
+            stagedStatusLine = resolveStatusLine();
+            if (!shouldRenderStreamingStatus()) {
+              return;
+            }
+            if (!streaming?.isActive()) {
+              return;
+            }
+            queueStreamingRender();
+          }
+        : undefined,
+      onReasoningEnd: streamingEnabled
+        ? () => {
+            if (streamPhase !== "thinking") {
+              return;
+            }
+            streamPhase = streamText ? "streaming" : "idle";
+            if (!shouldRenderStreamingStatus()) {
+              return;
+            }
+            queueStreamingRender();
+          }
+        : undefined,
+      onToolStart: streamingEnabled
+        ? (payload: { name?: string; phase?: string }) => {
+            const isStartPhase = !payload?.phase || payload.phase === "start";
+            if (isStartPhase) {
+              toolUseCount += 1;
+              lastToolName = normalizeToolName(payload?.name) ?? lastToolName;
+              replaceNextPartialAfterTool = Boolean(streamText);
+            }
+            queueThinkingPrelude();
+            streamPhase = "tool";
+            stagedStatusLine = resolveStatusLine();
+            if (!shouldRenderStreamingStatus()) {
+              return;
+            }
+            if (!streaming?.isActive()) {
+              return;
+            }
+            queueStreamingRender();
+          }
+        : undefined,
       onPartialReply: streamingEnabled
         ? (payload: ReplyPayload) => {
             if (!payload.text) {
               return;
             }
-            queueStreamingUpdate(payload.text, {
-              dedupeWithLastPartial: true,
-              mode: "snapshot",
-            });
+            // Ensure streaming card is started when partial text arrives.
+            // In embedded mode with block streaming, the card is started by the
+            // deliver handler on the first block reply. CLI mode has no block
+            // streaming — text arrives as complete chunks via onPartialReply —
+            // so the card must be started here. startStreaming() is idempotent
+            // (guarded by streamingStartPromise), so calling it here is safe
+            // even when the card was already started by deliver.
+            queueThinkingPrelude();
+            startStreaming();
+            queueStreamingUpdate(payload.text, { dedupeWithLastPartial: true });
           }
         : undefined,
     },

--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -2,6 +2,8 @@ import path from "node:path";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 
+export type { BootstrapProfile, BootstrapProfileConfig } from "./pi-embedded-helpers.js";
+
 export const DEFAULT_BOOTSTRAP_NEAR_LIMIT_RATIO = 0.85;
 export const DEFAULT_BOOTSTRAP_PROMPT_WARNING_MAX_FILES = 3;
 export const DEFAULT_BOOTSTRAP_PROMPT_WARNING_SIGNATURE_HISTORY_MAX = 32;

--- a/src/agents/bootstrap-compaction.test.ts
+++ b/src/agents/bootstrap-compaction.test.ts
@@ -24,6 +24,15 @@ const STRUCTURED_SUMMARY = `## Key Rules
 ## Critical References
 - /path/to/file.ts`;
 
+/**
+ * Input content that is longer than STRUCTURED_SUMMARY so the output-length
+ * guard (compacted.length < charsBefore) in compactBootstrapFile doesn't
+ * reject the compaction as counter-productive.
+ */
+const LONG_CONTENT =
+  "A".repeat(200) +
+  " — memory content that is intentionally longer than the structured summary output.";
+
 /** Creates a mock llmFn that returns the given text. */
 function makeLlmFn(response: string): CompactionLlmFn & ReturnType<typeof vi.fn> {
   return vi.fn().mockResolvedValue(response) as CompactionLlmFn & ReturnType<typeof vi.fn>;
@@ -155,7 +164,7 @@ describe("compactBootstrapFile", () => {
     const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
 
     const { compacted, result } = await compactBootstrapFile({
-      content: "Some long memory content that needs compaction.",
+      content: LONG_CONTENT,
       filePath: "/workspace/MEMORY.md",
       config: {},
       llmFn,
@@ -165,7 +174,7 @@ describe("compactBootstrapFile", () => {
     expect(compacted).toBe(STRUCTURED_SUMMARY);
     expect(result.success).toBe(true);
     expect(result.path).toBe("/workspace/MEMORY.md");
-    expect(result.charsBefore).toBe("Some long memory content that needs compaction.".length);
+    expect(result.charsBefore).toBe(LONG_CONTENT.length);
     expect(result.charsAfter).toBe(STRUCTURED_SUMMARY.length);
     expect(llmFn).toHaveBeenCalledOnce();
   });
@@ -174,14 +183,14 @@ describe("compactBootstrapFile", () => {
     const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
 
     await compactBootstrapFile({
-      content: "Memory content to compact",
+      content: LONG_CONTENT,
       filePath: "/workspace/MEMORY.md",
       config: {},
       llmFn,
       modelRef: "test/model",
     });
 
-    expect(llmFn).toHaveBeenCalledWith("Memory content to compact", undefined);
+    expect(llmFn).toHaveBeenCalledWith(LONG_CONTENT, undefined);
   });
 
   it("returns original content with success=false on llmFn error", async () => {
@@ -246,7 +255,7 @@ describe("compactBootstrapFile", () => {
     const signal = AbortSignal.abort();
 
     await compactBootstrapFile({
-      content: "Memory content",
+      content: LONG_CONTENT,
       filePath: "/workspace/MEMORY.md",
       config: {},
       llmFn,
@@ -254,7 +263,7 @@ describe("compactBootstrapFile", () => {
       signal,
     });
 
-    expect(llmFn).toHaveBeenCalledWith("Memory content", signal);
+    expect(llmFn).toHaveBeenCalledWith(LONG_CONTENT, signal);
   });
 });
 
@@ -268,7 +277,7 @@ describe("compactBootstrapFile - content-hash cache", () => {
   it("returns cached result without calling LLM on second call with same content", async () => {
     const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
 
-    const content = "Memory content for caching test";
+    const content = LONG_CONTENT;
 
     // First call — should hit the LLM
     const first = await compactBootstrapFile({
@@ -320,7 +329,7 @@ describe("compactBootstrapFile - content-hash cache", () => {
   it("cache is keyed by file path — different paths do not share cache", async () => {
     const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
 
-    const content = "Same content for both files";
+    const content = LONG_CONTENT;
 
     await compactBootstrapFile({
       content,
@@ -407,7 +416,7 @@ describe("compactBootstrapFile - content-hash cache", () => {
   it("hits cache when both content and modelRef are identical", async () => {
     const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
 
-    const content = "Content for model-aware cache test";
+    const content = LONG_CONTENT;
     const modelRef = "anthropic/claude-haiku-4-5-20251001";
 
     await compactBootstrapFile({
@@ -576,7 +585,7 @@ describe("compactBootstrapFiles", () => {
   it("returns CompactionResult with correct charsBefore and charsAfter on success", async () => {
     const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
 
-    const originalContent = "Original content";
+    const originalContent = LONG_CONTENT;
     const contextFiles = [{ path: "/workspace/MEMORY.md", content: originalContent }];
 
     const { results } = await compactBootstrapFiles({

--- a/src/agents/bootstrap-compaction.test.ts
+++ b/src/agents/bootstrap-compaction.test.ts
@@ -1,0 +1,592 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type CompactionLlmFn,
+  DEFAULT_COMPACTION_TIMEOUT_MS,
+  clearCompactionCache,
+  compactBootstrapFile,
+  compactBootstrapFiles,
+  isCompactableFile,
+  resolveCompactionConfig,
+} from "./bootstrap-compaction.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const STRUCTURED_SUMMARY = `## Key Rules
+- Rule A
+- Rule B
+
+## Recent Decisions
+- Decision X made because Y
+
+## Open Tasks / Blockers
+- Task 1: in-progress
+
+## Critical References
+- /path/to/file.ts`;
+
+/** Creates a mock llmFn that returns the given text. */
+function makeLlmFn(response: string): CompactionLlmFn & ReturnType<typeof vi.fn> {
+  return vi.fn().mockResolvedValue(response) as CompactionLlmFn & ReturnType<typeof vi.fn>;
+}
+
+/** Creates a mock llmFn that rejects with the given error. */
+function makeFailingLlmFn(error: Error): CompactionLlmFn & ReturnType<typeof vi.fn> {
+  return vi.fn().mockRejectedValue(error) as CompactionLlmFn & ReturnType<typeof vi.fn>;
+}
+
+// ── isCompactableFile ─────────────────────────────────────────────────────────
+
+describe("isCompactableFile", () => {
+  it("accepts MEMORY.md", () => {
+    expect(isCompactableFile("/workspace/MEMORY.md")).toBe(true);
+    expect(isCompactableFile("MEMORY.md")).toBe(true);
+  });
+
+  it("accepts memory/YYYY-MM-DD.md", () => {
+    expect(isCompactableFile("/workspace/memory/2026-03-07.md")).toBe(true);
+    expect(isCompactableFile("memory/2024-01-01.md")).toBe(true);
+    expect(isCompactableFile("/home/user/memory/2025-12-31.md")).toBe(true);
+  });
+
+  it("rejects AGENTS.md", () => {
+    expect(isCompactableFile("/workspace/AGENTS.md")).toBe(false);
+  });
+
+  it("rejects SOUL.md", () => {
+    expect(isCompactableFile("/workspace/SOUL.md")).toBe(false);
+  });
+
+  it("rejects IDENTITY.md", () => {
+    expect(isCompactableFile("IDENTITY.md")).toBe(false);
+  });
+
+  it("rejects CONSTITUTION.md", () => {
+    expect(isCompactableFile("/workspace/CONSTITUTION.md")).toBe(false);
+  });
+
+  it("rejects arbitrary .md files", () => {
+    expect(isCompactableFile("/workspace/README.md")).toBe(false);
+    expect(isCompactableFile("/workspace/TOOLS.md")).toBe(false);
+    expect(isCompactableFile("/workspace/memory/notes.md")).toBe(false);
+  });
+
+  it("rejects MEMORY.md in wrong directory (date-like name but wrong parent)", () => {
+    // A date-named .md that is not inside a 'memory' directory
+    expect(isCompactableFile("/workspace/logs/2026-03-07.md")).toBe(false);
+  });
+
+  it("accepts memory/YYYY-MM-DD.md only when parent dir is 'memory'", () => {
+    expect(isCompactableFile("/workspace/archive/2026-03-07.md")).toBe(false);
+    expect(isCompactableFile("/workspace/memory/2026-03-07.md")).toBe(true);
+  });
+});
+
+// ── resolveCompactionConfig ───────────────────────────────────────────────────
+
+describe("resolveCompactionConfig", () => {
+  it("returns empty config when cfg is undefined", () => {
+    const result = resolveCompactionConfig(undefined);
+    expect(result.model).toBeUndefined();
+    expect(result.timeoutMs).toBeUndefined();
+  });
+
+  it("returns empty config when agents.defaults.compaction is absent", () => {
+    const result = resolveCompactionConfig({ agents: { defaults: {} } } as never);
+    expect(result.model).toBeUndefined();
+    expect(result.timeoutMs).toBeUndefined();
+  });
+
+  it("reads model from config", () => {
+    const cfg = {
+      agents: { defaults: { compaction: { model: "claude-haiku-4-5-20251001" } } },
+    } as never;
+    const result = resolveCompactionConfig(cfg);
+    expect(result.model).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("reads timeoutMs from config", () => {
+    const cfg = {
+      agents: { defaults: { compaction: { timeoutMs: 15_000 } } },
+    } as never;
+    const result = resolveCompactionConfig(cfg);
+    expect(result.timeoutMs).toBe(15_000);
+  });
+
+  it("reads both model and timeoutMs from config", () => {
+    const cfg = {
+      agents: {
+        defaults: { compaction: { model: "claude-opus-4-6", timeoutMs: 60_000 } },
+      },
+    } as never;
+    const result = resolveCompactionConfig(cfg);
+    expect(result.model).toBe("claude-opus-4-6");
+    expect(result.timeoutMs).toBe(60_000);
+  });
+
+  it("ignores non-string model values", () => {
+    const cfg = {
+      agents: { defaults: { compaction: { model: 42 } } },
+    } as never;
+    const result = resolveCompactionConfig(cfg);
+    expect(result.model).toBeUndefined();
+  });
+
+  it("ignores non-number timeoutMs values", () => {
+    const cfg = {
+      agents: { defaults: { compaction: { timeoutMs: "30000" } } },
+    } as never;
+    const result = resolveCompactionConfig(cfg);
+    expect(result.timeoutMs).toBeUndefined();
+  });
+
+  it("DEFAULT_COMPACTION_TIMEOUT_MS is 30 seconds", () => {
+    expect(DEFAULT_COMPACTION_TIMEOUT_MS).toBe(30_000);
+  });
+});
+
+// ── compactBootstrapFile ──────────────────────────────────────────────────────
+
+describe("compactBootstrapFile", () => {
+  beforeEach(() => {
+    clearCompactionCache();
+  });
+
+  it("calls llmFn and returns compacted content", async () => {
+    const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
+
+    const { compacted, result } = await compactBootstrapFile({
+      content: "Some long memory content that needs compaction.",
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+
+    expect(compacted).toBe(STRUCTURED_SUMMARY);
+    expect(result.success).toBe(true);
+    expect(result.path).toBe("/workspace/MEMORY.md");
+    expect(result.charsBefore).toBe("Some long memory content that needs compaction.".length);
+    expect(result.charsAfter).toBe(STRUCTURED_SUMMARY.length);
+    expect(llmFn).toHaveBeenCalledOnce();
+  });
+
+  it("passes content as user prompt to llmFn", async () => {
+    const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
+
+    await compactBootstrapFile({
+      content: "Memory content to compact",
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+
+    expect(llmFn).toHaveBeenCalledWith("Memory content to compact", undefined);
+  });
+
+  it("returns original content with success=false on llmFn error", async () => {
+    const llmFn = makeFailingLlmFn(new Error("API error 500"));
+
+    const content = "Original memory content";
+    const { compacted, result } = await compactBootstrapFile({
+      content,
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+
+    expect(result.success).toBe(false);
+    expect(compacted).toBe(content);
+    expect(result.fallbackReason).toContain("API error 500");
+    expect(result.charsAfter).toBe(content.length);
+  });
+
+  it("returns original content with success=false on llmFn rejection", async () => {
+    const llmFn = makeFailingLlmFn(new Error("Network error"));
+
+    const content = "Original memory content";
+    const { compacted, result } = await compactBootstrapFile({
+      content,
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+
+    expect(result.success).toBe(false);
+    expect(compacted).toBe(content);
+    expect(result.fallbackReason).toContain("Network error");
+  });
+
+  it("truncates input to COMPACTION_MAX_INPUT_CHARS with head+tail split before sending", async () => {
+    const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
+
+    const longContent = "H".repeat(5_000) + "T".repeat(10_000); // 15K, exceeds 10K limit
+    await compactBootstrapFile({
+      content: longContent,
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+
+    const sentPrompt = llmFn.mock.calls[0][0] as string;
+    // Head 30% = 3000 chars, tail 70% = 7000 chars, plus omission marker in between
+    expect(sentPrompt).toContain("[... middle content omitted for compaction ...]");
+    expect(sentPrompt.startsWith("H")).toBe(true);
+    expect(sentPrompt.endsWith("T")).toBe(true);
+    // Total should be 10K + marker length
+    const markerLen = "\n\n[... middle content omitted for compaction ...]\n\n".length;
+    expect(sentPrompt.length).toBe(10_000 + markerLen);
+  });
+
+  it("passes signal to llmFn", async () => {
+    const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
+    const signal = AbortSignal.abort();
+
+    await compactBootstrapFile({
+      content: "Memory content",
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+      signal,
+    });
+
+    expect(llmFn).toHaveBeenCalledWith("Memory content", signal);
+  });
+});
+
+// ── Content-hash caching ──────────────────────────────────────────────────────
+
+describe("compactBootstrapFile - content-hash cache", () => {
+  beforeEach(() => {
+    clearCompactionCache();
+  });
+
+  it("returns cached result without calling LLM on second call with same content", async () => {
+    const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
+
+    const content = "Memory content for caching test";
+
+    // First call — should hit the LLM
+    const first = await compactBootstrapFile({
+      content,
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+    expect(llmFn).toHaveBeenCalledOnce();
+
+    // Second call with same content — should use cache
+    const second = await compactBootstrapFile({
+      content,
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+    expect(llmFn).toHaveBeenCalledOnce(); // still only one call
+    expect(second.compacted).toBe(first.compacted);
+  });
+
+  it("calls LLM again when content changes (cache miss)", async () => {
+    const llmFn = vi
+      .fn()
+      .mockResolvedValueOnce("Summary A")
+      .mockResolvedValueOnce("Summary B") as CompactionLlmFn & ReturnType<typeof vi.fn>;
+
+    await compactBootstrapFile({
+      content: "Content version 1",
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+    expect(llmFn).toHaveBeenCalledTimes(1);
+
+    await compactBootstrapFile({
+      content: "Content version 2 — different content",
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+    expect(llmFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("cache is keyed by file path — different paths do not share cache", async () => {
+    const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
+
+    const content = "Same content for both files";
+
+    await compactBootstrapFile({
+      content,
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+    await compactBootstrapFile({
+      content,
+      filePath: "/workspace/memory/2026-03-07.md",
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+
+    // Different file paths → two separate LLM calls
+    expect(llmFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates cache when only middle content changes (full-content hash)", async () => {
+    const llmFn = vi
+      .fn()
+      .mockResolvedValueOnce("Summary A")
+      .mockResolvedValueOnce("Summary B") as CompactionLlmFn & ReturnType<typeof vi.fn>;
+
+    // Content > 10K so it gets truncated (head 3K + tail 7K).
+    // Head and tail stay identical; only the middle (which is omitted from LLM input) changes.
+    const head = "H".repeat(3_000);
+    const tail = "T".repeat(7_000);
+    const contentV1 = head + "MIDDLE-V1".repeat(500) + tail; // well over 10K
+    const contentV2 = head + "MIDDLE-V2".repeat(500) + tail; // same head/tail, different middle
+
+    await compactBootstrapFile({
+      content: contentV1,
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+    expect(llmFn).toHaveBeenCalledTimes(1);
+
+    // Middle changed → full-content hash differs → cache miss → second LLM call
+    const { compacted } = await compactBootstrapFile({
+      content: contentV2,
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+    expect(llmFn).toHaveBeenCalledTimes(2);
+    expect(compacted).toBe("Summary B");
+  });
+
+  it("cache invalidates when modelRef changes", async () => {
+    const llmFn = vi
+      .fn()
+      .mockResolvedValueOnce("Summary model-A")
+      .mockResolvedValueOnce("Summary model-B") as CompactionLlmFn & ReturnType<typeof vi.fn>;
+
+    const content = "Same content for both calls";
+
+    await compactBootstrapFile({
+      content,
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef: "provider/model-a",
+    });
+    expect(llmFn).toHaveBeenCalledTimes(1);
+
+    // Same content, different model → cache miss
+    const { compacted } = await compactBootstrapFile({
+      content,
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef: "provider/model-b",
+    });
+    expect(llmFn).toHaveBeenCalledTimes(2);
+    expect(compacted).toBe("Summary model-B");
+  });
+
+  it("hits cache when both content and modelRef are identical", async () => {
+    const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
+
+    const content = "Content for model-aware cache test";
+    const modelRef = "anthropic/claude-haiku-4-5-20251001";
+
+    await compactBootstrapFile({
+      content,
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef,
+    });
+    await compactBootstrapFile({
+      content,
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef,
+    });
+    expect(llmFn).toHaveBeenCalledOnce();
+  });
+});
+
+// ── Timeout handling ──────────────────────────────────────────────────────────
+
+describe("compactBootstrapFile - timeout handling", () => {
+  beforeEach(() => {
+    clearCompactionCache();
+  });
+
+  it("falls back gracefully when llmFn is aborted", async () => {
+    const abortError = new DOMException("The operation was aborted.", "AbortError");
+    const llmFn = makeFailingLlmFn(abortError);
+
+    const content = "Memory content";
+    const { compacted, result } = await compactBootstrapFile({
+      content,
+      filePath: "/workspace/MEMORY.md",
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+      signal: AbortSignal.abort(), // pre-aborted
+    });
+
+    expect(result.success).toBe(false);
+    expect(compacted).toBe(content); // original content returned
+    expect(result.fallbackReason).toBeTruthy();
+  });
+});
+
+// ── compactBootstrapFiles (orchestrator) ──────────────────────────────────────
+
+describe("compactBootstrapFiles", () => {
+  beforeEach(() => {
+    clearCompactionCache();
+  });
+
+  it("returns unchanged files when no compactable files present", async () => {
+    const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
+
+    const contextFiles = [
+      { path: "/workspace/AGENTS.md", content: "Agents content" },
+      { path: "/workspace/SOUL.md", content: "Soul content" },
+    ];
+
+    const { contextFiles: result, results } = await compactBootstrapFiles({
+      contextFiles,
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+
+    expect(result).toEqual(contextFiles);
+    expect(results).toHaveLength(0);
+    expect(llmFn).not.toHaveBeenCalled();
+  });
+
+  it("compacts MEMORY.md and replaces its content", async () => {
+    const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
+
+    const contextFiles = [
+      { path: "/workspace/AGENTS.md", content: "Agents content (not compactable)" },
+      { path: "/workspace/MEMORY.md", content: "Long memory content".repeat(100) },
+    ];
+
+    const { contextFiles: result, results } = await compactBootstrapFiles({
+      contextFiles,
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+
+    expect(result).toHaveLength(2);
+    // AGENTS.md should be unchanged
+    expect(result[0].content).toBe("Agents content (not compactable)");
+    // MEMORY.md should be compacted
+    expect(result[1].content).toBe(STRUCTURED_SUMMARY);
+    expect(results).toHaveLength(1);
+    expect(results[0].success).toBe(true);
+    expect(results[0].path).toBe("/workspace/MEMORY.md");
+  });
+
+  it("compacts memory/YYYY-MM-DD.md files", async () => {
+    const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
+
+    const contextFiles = [
+      { path: "/workspace/memory/2026-03-07.md", content: "Daily log content".repeat(50) },
+    ];
+
+    const { contextFiles: result, results } = await compactBootstrapFiles({
+      contextFiles,
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+
+    expect(result[0].content).toBe(STRUCTURED_SUMMARY);
+    expect(results[0].success).toBe(true);
+  });
+
+  it("selects only the largest 3 compactable files", async () => {
+    const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
+
+    const contextFiles = [
+      { path: "/workspace/MEMORY.md", content: "A".repeat(5000) },
+      { path: "/workspace/memory/2026-03-05.md", content: "B".repeat(3000) },
+      { path: "/workspace/memory/2026-03-06.md", content: "C".repeat(4000) },
+      { path: "/workspace/memory/2026-03-07.md", content: "D".repeat(2000) },
+      // 4 compactable files → only 3 largest should be compacted
+    ];
+
+    const { results } = await compactBootstrapFiles({
+      contextFiles,
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+
+    expect(results).toHaveLength(3);
+    expect(llmFn).toHaveBeenCalledTimes(3);
+    // Verify the 3 largest were selected (MEMORY.md=5000, 2026-03-06=4000, 2026-03-05=3000)
+    const compactedPaths = results.map((r) => r.path).toSorted();
+    expect(compactedPaths).toContain("/workspace/MEMORY.md");
+    expect(compactedPaths).toContain("/workspace/memory/2026-03-06.md");
+    expect(compactedPaths).toContain("/workspace/memory/2026-03-05.md");
+    // Smallest (2026-03-07=2000) should NOT be compacted
+    expect(compactedPaths).not.toContain("/workspace/memory/2026-03-07.md");
+  });
+
+  it("preserves original content for files that fail compaction", async () => {
+    const llmFn = makeFailingLlmFn(new Error("API unavailable"));
+
+    const originalContent = "Memory content to compact";
+    const contextFiles = [{ path: "/workspace/MEMORY.md", content: originalContent }];
+
+    const { contextFiles: result, results } = await compactBootstrapFiles({
+      contextFiles,
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+
+    // Content should be unchanged on failure
+    expect(result[0].content).toBe(originalContent);
+    expect(results[0].success).toBe(false);
+    expect(results[0].fallbackReason).toContain("API unavailable");
+  });
+
+  it("returns CompactionResult with correct charsBefore and charsAfter on success", async () => {
+    const llmFn = makeLlmFn(STRUCTURED_SUMMARY);
+
+    const originalContent = "Original content";
+    const contextFiles = [{ path: "/workspace/MEMORY.md", content: originalContent }];
+
+    const { results } = await compactBootstrapFiles({
+      contextFiles,
+      config: {},
+      llmFn,
+      modelRef: "test/model",
+    });
+
+    expect(results[0].charsBefore).toBe(originalContent.length);
+    expect(results[0].charsAfter).toBe(STRUCTURED_SUMMARY.length);
+  });
+});

--- a/src/agents/bootstrap-compaction.ts
+++ b/src/agents/bootstrap-compaction.ts
@@ -1,0 +1,269 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/config.js";
+import type { EmbeddedContextFile } from "./pi-embedded-helpers/types.js";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+export const DEFAULT_COMPACTION_TIMEOUT_MS = 30_000;
+const COMPACTION_MAX_INPUT_CHARS = 10_000;
+const COMPACTION_MAX_FILES = 3;
+/** Bump this when COMPACTION_SYSTEM_PROMPT changes to invalidate caches. */
+const COMPACTION_CACHE_VERSION = 1;
+
+export const COMPACTION_SYSTEM_PROMPT = [
+  "You are a memory compaction assistant. Given the content of a memory file, produce a structured summary using EXACTLY the following template — no additional sections, no content outside the headers:",
+  "",
+  "## Key Rules",
+  "[Essential rules and constraints from the original content]",
+  "",
+  "## Recent Decisions",
+  "[Decisions made recently with rationale]",
+  "",
+  "## Open Tasks / Blockers",
+  "[Active tasks, their status, and any blockers]",
+  "",
+  "## Critical References",
+  "[Important file paths, URLs, IDs, and technical details that must be preserved exactly]",
+  "",
+  "RULES:",
+  "- Use the exact four section headers above.",
+  "- Preserve all identifiers exactly: UUIDs, IDs, file paths, URLs, IP addresses, model names, config keys.",
+  "- Prioritize recent information over older information.",
+  "- Keep output under 5000 characters total.",
+  "- If a section has no relevant content, write '[none]' for that section.",
+].join("\n");
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface BootstrapCompactionConfig {
+  /**
+   * Model to use for compaction (provider/model format, e.g. "anthropic/claude-haiku-4-5-20251001").
+   * When unset, inherits the agent's current model.
+   */
+  model?: string;
+  /** Timeout in ms. Default 30_000. */
+  timeoutMs?: number;
+}
+
+export interface CompactionResult {
+  /** Original file path */
+  path: string;
+  /** Original char count */
+  charsBefore: number;
+  /** Compacted char count */
+  charsAfter: number;
+  /** Whether compaction was attempted and succeeded */
+  success: boolean;
+  /** If failed, the reason */
+  fallbackReason?: string;
+}
+
+/**
+ * Provider-agnostic LLM call function.
+ * Takes the user prompt (with system prompt already embedded by the caller or
+ * handled internally) and returns the model's text response.
+ *
+ * The caller is responsible for wiring up model resolution, auth, and the
+ * actual API call (via completeSimple or equivalent).
+ */
+export type CompactionLlmFn = (userPrompt: string, signal?: AbortSignal) => Promise<string>;
+
+// ── Content-hash cache ────────────────────────────────────────────────────────
+
+/**
+ * In-memory cache (process lifetime). Key = file path, value = { hash, compacted }.
+ * Avoids redundant LLM calls when file content hasn't changed.
+ */
+const compactionCache = new Map<string, { hash: string; compacted: string }>();
+
+/** Exported for testing only. */
+export function clearCompactionCache(): void {
+  compactionCache.clear();
+}
+
+function getContentHash(content: string): string {
+  return createHash("sha256").update(content).digest("hex").slice(0, 16);
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve compaction config from OpenClawConfig.
+ * Config path: cfg.agents.defaults.compaction.model / .timeoutMs
+ */
+export function resolveCompactionConfig(cfg?: OpenClawConfig): BootstrapCompactionConfig {
+  // The existing AgentCompactionConfig type doesn't include bootstrap-specific fields,
+  // so we access them via a type-erased cast. They're optional runtime extensions.
+  const raw = cfg?.agents?.defaults?.compaction as unknown as
+    | { model?: unknown; timeoutMs?: unknown }
+    | undefined;
+  return {
+    model: typeof raw?.model === "string" ? raw.model : undefined,
+    timeoutMs: typeof raw?.timeoutMs === "number" ? raw.timeoutMs : undefined,
+  };
+}
+
+/**
+ * Check if a bootstrap file is eligible for compaction.
+ * Only MEMORY.md and memory/YYYY-MM-DD.md files can be compacted.
+ */
+export function isCompactableFile(filePath: string): boolean {
+  const basename = path.basename(filePath);
+  if (basename === "MEMORY.md") {
+    return true;
+  }
+  // Match memory/YYYY-MM-DD.md pattern
+  if (/^20\d{2}-\d{2}-\d{2}\.md$/.test(basename)) {
+    const dir = path.basename(path.dirname(filePath));
+    return dir === "memory";
+  }
+  return false;
+}
+
+// ── Core compaction functions ─────────────────────────────────────────────────
+
+/**
+ * Compact a single bootstrap file using LLM summarization.
+ *
+ * Uses content-hash caching: if the file content hasn't changed since last
+ * compaction, returns the cached result without calling the LLM.
+ *
+ * The actual LLM call is delegated to `llmFn`, making this function
+ * provider-agnostic. The caller wires up model resolution and auth.
+ *
+ * Always returns successfully — on LLM failure, returns the original content
+ * with success=false and fallbackReason set.
+ */
+export async function compactBootstrapFile(params: {
+  content: string;
+  filePath: string;
+  config: BootstrapCompactionConfig;
+  /** Provider-agnostic LLM call. The caller resolves model + auth. */
+  llmFn: CompactionLlmFn;
+  /** Resolved "provider/model" used for compaction. Included in cache key so switching models invalidates. */
+  modelRef: string;
+  signal?: AbortSignal;
+}): Promise<{ compacted: string; result: CompactionResult }> {
+  const { content, filePath, signal } = params;
+  const charsBefore = content.length;
+
+  // Enforce max input size — head+tail split to preserve recent content at end of file.
+  // MEMORY.md and daily memory files have latest entries at the bottom.
+  let inputContent: string;
+  if (content.length > COMPACTION_MAX_INPUT_CHARS) {
+    const headChars = Math.floor(COMPACTION_MAX_INPUT_CHARS * 0.3);
+    const tailChars = COMPACTION_MAX_INPUT_CHARS - headChars;
+    inputContent =
+      content.slice(0, headChars) +
+      "\n\n[... middle content omitted for compaction ...]\n\n" +
+      content.slice(-tailChars);
+  } else {
+    inputContent = content;
+  }
+
+  // Cache lookup — hash the FULL content (pre-truncation) so middle-of-file
+  // edits invalidate the cache. Include cache version + resolved model so
+  // prompt changes and model switches also miss.
+  const hashInput = `v${COMPACTION_CACHE_VERSION}:${params.modelRef}:${content}`;
+  const contentHash = getContentHash(hashInput);
+  const cached = compactionCache.get(filePath);
+  if (cached?.hash === contentHash) {
+    return {
+      compacted: cached.compacted,
+      result: {
+        path: filePath,
+        charsBefore,
+        charsAfter: cached.compacted.length,
+        success: true,
+      },
+    };
+  }
+
+  try {
+    const compacted = await params.llmFn(inputContent, signal);
+
+    compactionCache.set(filePath, { hash: contentHash, compacted });
+
+    return {
+      compacted,
+      result: {
+        path: filePath,
+        charsBefore,
+        charsAfter: compacted.length,
+        success: true,
+      },
+    };
+  } catch (err) {
+    const fallbackReason = err instanceof Error ? err.message : String(err);
+    return {
+      compacted: content,
+      result: {
+        path: filePath,
+        charsBefore,
+        charsAfter: charsBefore,
+        success: false,
+        fallbackReason,
+      },
+    };
+  }
+}
+
+/**
+ * Try to compact eligible files in a bootstrap context file list.
+ * Selects up to COMPACTION_MAX_FILES largest compactable files.
+ * Returns new context files with compacted content + per-file results.
+ */
+export async function compactBootstrapFiles(params: {
+  contextFiles: EmbeddedContextFile[];
+  config: BootstrapCompactionConfig;
+  /** Provider-agnostic LLM call. The caller resolves model + auth. */
+  llmFn: CompactionLlmFn;
+  /** Resolved "provider/model" used for compaction. Passed to per-file cache key. */
+  modelRef: string;
+  signal?: AbortSignal;
+}): Promise<{
+  contextFiles: EmbeddedContextFile[];
+  results: CompactionResult[];
+}> {
+  const { contextFiles, config, signal } = params;
+
+  // Select compactable files, sorted by size descending, capped at max
+  const compactable = contextFiles
+    .filter((f) => isCompactableFile(f.path))
+    .toSorted((a, b) => b.content.length - a.content.length)
+    .slice(0, COMPACTION_MAX_FILES);
+
+  if (compactable.length === 0) {
+    return { contextFiles, results: [] };
+  }
+
+  const compactableSet = new Set(compactable.map((f) => f.path));
+  const results: CompactionResult[] = [];
+  const compactedMap = new Map<string, string>();
+
+  for (const file of compactable) {
+    const { compacted, result } = await compactBootstrapFile({
+      content: file.content,
+      filePath: file.path,
+      config,
+      llmFn: params.llmFn,
+      modelRef: params.modelRef,
+      signal,
+    });
+    results.push(result);
+    if (result.success) {
+      compactedMap.set(file.path, compacted);
+    }
+  }
+
+  // Rebuild context files list with compacted content where successful
+  const updatedContextFiles = contextFiles.map((f) => {
+    if (compactableSet.has(f.path) && compactedMap.has(f.path)) {
+      return { ...f, content: compactedMap.get(f.path) as string };
+    }
+    return f;
+  });
+
+  return { contextFiles: updatedContextFiles, results };
+}

--- a/src/agents/bootstrap-compaction.ts
+++ b/src/agents/bootstrap-compaction.ts
@@ -72,10 +72,25 @@ export type CompactionLlmFn = (userPrompt: string, signal?: AbortSignal) => Prom
 // ── Content-hash cache ────────────────────────────────────────────────────────
 
 /**
- * In-memory cache (process lifetime). Key = file path, value = { hash, compacted }.
+ * In-memory LRU cache (process lifetime). Key = file path, value = { hash, compacted }.
  * Avoids redundant LLM calls when file content hasn't changed.
+ * Capped at MAX_CACHE_ENTRIES to prevent unbounded memory growth.
  */
+const MAX_CACHE_ENTRIES = 100;
 const compactionCache = new Map<string, { hash: string; compacted: string }>();
+
+function cacheSet(key: string, value: { hash: string; compacted: string }): void {
+  // Delete-then-set to refresh LRU order (Map iterates in insertion order)
+  compactionCache.delete(key);
+  compactionCache.set(key, value);
+  // Evict oldest entries when over limit
+  if (compactionCache.size > MAX_CACHE_ENTRIES) {
+    const oldest = compactionCache.keys().next().value;
+    if (oldest !== undefined) {
+      compactionCache.delete(oldest);
+    }
+  }
+}
 
 /** Exported for testing only. */
 export function clearCompactionCache(): void {
@@ -93,14 +108,14 @@ function getContentHash(content: string): string {
  * Config path: cfg.agents.defaults.compaction.model / .timeoutMs
  */
 export function resolveCompactionConfig(cfg?: OpenClawConfig): BootstrapCompactionConfig {
-  // The existing AgentCompactionConfig type doesn't include bootstrap-specific fields,
-  // so we access them via a type-erased cast. They're optional runtime extensions.
-  const raw = cfg?.agents?.defaults?.compaction as unknown as
-    | { model?: unknown; timeoutMs?: unknown }
-    | undefined;
+  const raw = cfg?.agents?.defaults?.compaction;
+  if (!raw || typeof raw !== "object") {
+    return {};
+  }
+  const obj = raw as Record<string, unknown>;
   return {
-    model: typeof raw?.model === "string" ? raw.model : undefined,
-    timeoutMs: typeof raw?.timeoutMs === "number" ? raw.timeoutMs : undefined,
+    model: typeof obj.model === "string" ? obj.model : undefined,
+    timeoutMs: typeof obj.timeoutMs === "number" ? obj.timeoutMs : undefined,
   };
 }
 
@@ -169,6 +184,8 @@ export async function compactBootstrapFile(params: {
   const contentHash = getContentHash(hashInput);
   const cached = compactionCache.get(filePath);
   if (cached?.hash === contentHash) {
+    // Refresh LRU position on cache hit
+    cacheSet(filePath, cached);
     return {
       compacted: cached.compacted,
       result: {
@@ -183,7 +200,22 @@ export async function compactBootstrapFile(params: {
   try {
     const compacted = await params.llmFn(inputContent, signal);
 
-    compactionCache.set(filePath, { hash: contentHash, compacted });
+    // Guard: if LLM output is not shorter than original, compaction is
+    // counter-productive — fall back to original content.
+    if (compacted.length >= charsBefore) {
+      return {
+        compacted: content,
+        result: {
+          path: filePath,
+          charsBefore,
+          charsAfter: charsBefore,
+          success: false,
+          fallbackReason: `compacted output (${compacted.length} chars) not shorter than original (${charsBefore} chars)`,
+        },
+      };
+    }
+
+    cacheSet(filePath, { hash: contentHash, compacted });
 
     return {
       compacted,
@@ -242,14 +274,28 @@ export async function compactBootstrapFiles(params: {
   const results: CompactionResult[] = [];
   const compactedMap = new Map<string, string>();
 
+  // Overall compaction deadline: total budget across all files.
+  // Per-file timeout prevents one slow file from starving the rest,
+  // but the overall deadline caps total compaction latency.
+  const rawTimeout = config.timeoutMs ?? DEFAULT_COMPACTION_TIMEOUT_MS;
+  const sanitizedTimeout =
+    Number.isFinite(rawTimeout) && rawTimeout > 0
+      ? Math.floor(rawTimeout)
+      : DEFAULT_COMPACTION_TIMEOUT_MS;
+  const overallDeadline = AbortSignal.timeout(sanitizedTimeout * compactable.length);
+  const overallSignal = signal ? AbortSignal.any([signal, overallDeadline]) : overallDeadline;
+
   for (const file of compactable) {
+    // Each file gets its own timeout to avoid one slow file starving the rest.
+    const perFileTimeout = AbortSignal.timeout(sanitizedTimeout);
+    const mergedSignal = AbortSignal.any([overallSignal, perFileTimeout]);
     const { compacted, result } = await compactBootstrapFile({
       content: file.content,
       filePath: file.path,
       config,
       llmFn: params.llmFn,
       modelRef: params.modelRef,
-      signal,
+      signal: mergedSignal,
     });
     results.push(result);
     if (result.success) {

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -104,6 +104,8 @@ export async function resolveBootstrapContextForRun(params: {
   warn?: (message: string) => void;
   contextMode?: BootstrapContextMode;
   runKind?: BootstrapContextRunKind;
+  /** When provided, dynamically adjusts bootstrap budget based on model context window. */
+  contextWindowTokens?: number;
 }): Promise<{
   bootstrapFiles: WorkspaceBootstrapFile[];
   contextFiles: EmbeddedContextFile[];
@@ -111,7 +113,7 @@ export async function resolveBootstrapContextForRun(params: {
   const bootstrapFiles = await resolveBootstrapFilesForRun(params);
   const contextFiles = buildBootstrapContextFiles(bootstrapFiles, {
     maxChars: resolveBootstrapMaxChars(params.config),
-    totalMaxChars: resolveBootstrapTotalMaxChars(params.config),
+    totalMaxChars: resolveBootstrapTotalMaxChars(params.config, params.contextWindowTokens),
     warn: params.warn,
   });
   return { bootstrapFiles, contextFiles };

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { ImageContent } from "@mariozechner/pi-ai";
+import { type ImageContent, completeSimple } from "@mariozechner/pi-ai";
 import { resolveHeartbeatPrompt } from "../auto-reply/heartbeat.js";
 import type { ThinkLevel } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -26,6 +26,12 @@ import {
   buildBootstrapPromptWarning,
   buildBootstrapTruncationReportMeta,
 } from "./bootstrap-budget.js";
+import {
+  COMPACTION_SYSTEM_PROMPT,
+  DEFAULT_COMPACTION_TIMEOUT_MS,
+  compactBootstrapFiles,
+  resolveCompactionConfig,
+} from "./bootstrap-compaction.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "./bootstrap-files.js";
 import { resolveCliBackendConfig } from "./cli-backends.js";
 import {
@@ -47,6 +53,12 @@ import {
 import { resolveContextWindowInfo } from "./context-window-guard.js";
 import { resolveOpenClawDocsPath } from "./docs-path.js";
 import { FailoverError, resolveFailoverStatus } from "./failover-error.js";
+import { getApiKeyForModel, requireApiKey } from "./model-auth.js";
+import {
+  isCliProvider,
+  resolveDefaultModelForAgent,
+  resolveNonCliModelRef,
+} from "./model-selection.js";
 import {
   buildBootstrapContextFiles,
   classifyFailoverReason,
@@ -59,6 +71,7 @@ import {
   type BootstrapProfile,
 } from "./pi-embedded-helpers.js";
 import type { EmbeddedPiRunResult } from "./pi-embedded-runner.js";
+import { resolveModel } from "./pi-embedded-runner/model.js";
 import {
   applySkillEnvOverrides,
   applySkillEnvOverridesFromSnapshot,
@@ -609,18 +622,150 @@ export async function runCliAgent(params: {
     // Estimate total prompt: system prompt + user task prompt (promptForRun includes prepended context)
     let estimatedTokens = estimatePromptTokens(systemPrompt) + estimatePromptTokens(promptForRun);
 
+    // Compaction observability state
+    let compactionAttempted = false;
+    let compactedFilesList: string[] = [];
+    let compactionCharsBefore = 0;
+    let compactionCharsAfter = 0;
+    let compactionModelUsed = "";
+    let compactionFallbackReason: string | undefined;
+
     if (estimatedTokens > hardLimitTokens) {
       const warnForProfile = makeBootstrapWarn({
         sessionLabel,
         warn: (message) => log.warn(message),
       });
-      for (const profile of ["reduced", "minimal"] as BootstrapProfile[]) {
+
+      // Track last-built profile context files so compaction can compact them
+      let lastProfileContextFiles = contextFiles;
+
+      for (const profile of ["reduced", "compaction", "minimal"] as (
+        | BootstrapProfile
+        | "compaction"
+      )[]) {
+        if (profile === "compaction") {
+          compactionAttempted = true;
+          const compactionCfg = resolveCompactionConfig(params.config);
+          // Resolve compaction model: config.model (may be "provider/model") or
+          // inherit the agent's current model + provider.
+          let compactionProvider: string;
+          let compactionModelRef: string;
+          if (compactionCfg.model?.includes("/")) {
+            compactionProvider = compactionCfg.model.split("/")[0];
+            compactionModelRef = compactionCfg.model.split("/").slice(1).join("/");
+          } else if (compactionCfg.model) {
+            compactionProvider = params.provider;
+            compactionModelRef = compactionCfg.model;
+          } else {
+            compactionProvider = params.provider;
+            compactionModelRef = modelId;
+          }
+
+          // CLI backends (claude-cli, codex-cli) are wrappers around real LLM
+          // providers — they don't exist in the model registry. Resolve the
+          // agent's configured default model to get the real provider + model.
+          if (isCliProvider(compactionProvider, params.config)) {
+            const agentDefault = resolveDefaultModelForAgent({
+              cfg: params.config ?? {},
+              agentId: params.agentId,
+            });
+            const resolved = resolveNonCliModelRef(agentDefault, params.config);
+            compactionProvider = resolved.provider;
+            compactionModelRef = resolved.model;
+          }
+
+          compactionModelUsed = `${compactionProvider}/${compactionModelRef}`;
+          try {
+            // Resolve model via the unified model registry (provider-agnostic).
+            const resolved = resolveModel(
+              compactionProvider,
+              compactionModelRef,
+              undefined,
+              params.config,
+            );
+            if (!resolved.model) {
+              throw new Error(
+                resolved.error ??
+                  `Unknown compaction model: ${compactionProvider}/${compactionModelRef}`,
+              );
+            }
+            const apiKey = requireApiKey(
+              await getApiKeyForModel({ model: resolved.model, cfg: params.config }),
+              compactionProvider,
+            );
+
+            const isTextBlock = (b: { type: string }): b is { type: "text"; text: string } =>
+              b.type === "text";
+            const compactionSignal = AbortSignal.timeout(
+              compactionCfg.timeoutMs ?? DEFAULT_COMPACTION_TIMEOUT_MS,
+            );
+
+            const { contextFiles: compactedContextFiles, results } = await compactBootstrapFiles({
+              contextFiles: lastProfileContextFiles,
+              config: compactionCfg,
+              modelRef: compactionModelUsed,
+              llmFn: async (userPrompt, signal) => {
+                const res = await completeSimple(
+                  resolved.model!,
+                  {
+                    systemPrompt: COMPACTION_SYSTEM_PROMPT,
+                    messages: [{ role: "user", content: userPrompt, timestamp: Date.now() }],
+                  },
+                  { apiKey, maxTokens: 4096, temperature: 0, signal },
+                );
+                const texts = res.content.filter(isTextBlock);
+                if (texts.length === 0) {
+                  throw new Error("No text content in compaction response");
+                }
+                return texts.map((b) => b.text).join("\n");
+              },
+              signal: compactionSignal,
+            });
+
+            compactedFilesList = results.filter((r) => r.success).map((r) => r.path);
+            compactionCharsBefore = results.reduce((sum, r) => sum + r.charsBefore, 0);
+            compactionCharsAfter = results.reduce((sum, r) => sum + r.charsAfter, 0);
+
+            if (compactedFilesList.length > 0) {
+              const compactedSystemPrompt = buildSystemPrompt({
+                workspaceDir,
+                config: params.config,
+                defaultThinkLevel: params.thinkLevel,
+                extraSystemPrompt,
+                skillsPrompt,
+                ownerNumbers: params.ownerNumbers,
+                heartbeatPrompt,
+                docsPath: docsPath ?? undefined,
+                tools: [],
+                contextFiles: compactedContextFiles,
+                bootstrapTruncationWarningLines: bootstrapPromptWarning.lines,
+                modelDisplay,
+                agentId: sessionAgentId,
+              });
+              const compactedTokens =
+                estimatePromptTokens(compactedSystemPrompt) + estimatePromptTokens(promptForRun);
+              if (compactedTokens <= hardLimitTokens) {
+                systemPrompt = compactedSystemPrompt;
+                estimatedTokens = compactedTokens;
+                break;
+              }
+            }
+          } catch (err) {
+            compactionFallbackReason = err instanceof Error ? err.message : String(err);
+            log.warn(
+              `cli-runner: bootstrap compaction failed, falling back to minimal profile: ${compactionFallbackReason}`,
+            );
+          }
+          continue;
+        }
+
         const profileConfig = getBootstrapProfileConfig(profile);
         const profileContextFiles = buildBootstrapContextFiles(bootstrapFiles, {
           maxChars: profileConfig.maxCharsPerFile,
           totalMaxChars: profileConfig.totalMaxChars,
           warn: warnForProfile,
         });
+        lastProfileContextFiles = profileContextFiles;
         const profileSystemPrompt = buildSystemPrompt({
           workspaceDir,
           config: params.config,
@@ -660,6 +805,14 @@ export async function runCliAgent(params: {
       files_injected: contextFiles.length,
       files_truncated: bootstrapAnalysis.truncatedFiles.length,
       files_skipped: bootstrapFiles.length - contextFiles.length,
+      compaction_attempted: compactionAttempted,
+      ...(compactionAttempted && {
+        compacted_files: compactedFilesList,
+        chars_before: compactionCharsBefore,
+        chars_after: compactionCharsAfter,
+        compaction_model: compactionModelUsed,
+        ...(compactionFallbackReason ? { fallback_reason: compactionFallbackReason } : {}),
+      }),
     });
   }
 

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -28,7 +28,6 @@ import {
 } from "./bootstrap-budget.js";
 import {
   COMPACTION_SYSTEM_PROMPT,
-  DEFAULT_COMPACTION_TIMEOUT_MS,
   compactBootstrapFiles,
   resolveCompactionConfig,
 } from "./bootstrap-compaction.js";
@@ -116,10 +115,30 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-/** Rough token estimate using chars/4 heuristic (conservative for English-heavy content). */
+/**
+ * Rough token estimate. Uses chars/1.5 for CJK-heavy content (>30% CJK chars),
+ * chars/4 for English-heavy content. CJK characters typically tokenize at 1-3
+ * tokens per character, so chars/4 severely underestimates for Chinese/Japanese
+ * text — which is common in feishu/飞书 deployments.
+ */
 function estimatePromptTokens(text: string): number {
-  return Math.ceil(text.length / 4);
+  if (!text) {
+    return 0;
+  }
+  // Count CJK Unified Ideographs, Hangul, Hiragana, Katakana, full-width forms
+  const cjkCount =
+    text.match(/[\u2e80-\u9fff\uac00-\ud7af\uf900-\ufaff\u3040-\u30ff\u31f0-\u31ff\uff00-\uffef]/g)
+      ?.length ?? 0;
+  const cjkRatio = cjkCount / text.length;
+  const charsPerToken = cjkRatio > 0.3 ? 1.5 : 4;
+  return Math.ceil(text.length / charsPerToken);
 }
+
+/**
+ * Estimate image token cost for pre-flight context window guard.
+ * Uses a rough average of ~1000 tokens per image (standard resolution).
+ */
+const ESTIMATED_TOKENS_PER_IMAGE = 1000;
 
 function resolveConfiguredPath(rawPath: string | undefined): string | undefined {
   const trimmed = rawPath?.trim();
@@ -492,13 +511,30 @@ export async function runCliAgent(params: {
   const sessionLabel = params.sessionKey ?? params.sessionId;
 
   // Resolve context window early — needed by Layer 3 (dynamic budget) and Layer 1 (pre-flight guard).
+  // For CLI backends (claude-cli, codex-cli), resolve to the real provider/model first
+  // so the context window lookup finds the actual model entry in config.
+  // Use the raw modelId (pre-backend-alias) because normalizedModel may already be
+  // aliased to a short name (e.g. "sonnet") that won't match the real model entry.
+  // If the resolved model is still an unresolved placeholder (e.g. "default"),
+  // fall back to the agent's configured default model for accurate lookup.
+  let contextWindowRef = resolveNonCliModelRef(
+    { provider: params.provider, model: modelId },
+    params.config,
+  );
+  if (isCliProvider(contextWindowRef.provider, params.config)) {
+    const agentDefault = resolveDefaultModelForAgent({
+      cfg: params.config ?? {},
+      agentId: params.agentId,
+    });
+    contextWindowRef = resolveNonCliModelRef(agentDefault, params.config);
+  }
   const contextWindowInfo = resolveContextWindowInfo({
     cfg: params.config,
-    provider: params.provider,
-    modelId: normalizedModel,
+    provider: contextWindowRef.provider,
+    modelId: contextWindowRef.model,
     defaultTokens: 200_000,
   });
-  let contextWindowTokens = contextWindowInfo.tokens;
+  const contextWindowTokens = contextWindowInfo.tokens;
 
   const { bootstrapFiles, contextFiles } = await resolveBootstrapContextForRun({
     workspaceDir,
@@ -614,13 +650,23 @@ export async function runCliAgent(params: {
   });
   let systemPrompt = hookSystemPromptOverride ?? builtSystemPrompt;
   let activeProfile: BootstrapProfile = "normal";
+  let activeContextFiles = contextFiles;
+
+  // Layer 1: Pre-flight context window guard
+  // Image token estimate is used by both Layer 1 (pre-flight) and Layer 2 (retry).
+  // Only charge multimodal token cost when the backend sends images via imageArg.
+  // When imageArg is absent, images are appended as file paths to the prompt text,
+  // which is already covered by estimatePromptTokens on the prompt string.
+  const imageTokenEstimate = backend.imageArg
+    ? (params.images?.length ?? 0) * ESTIMATED_TOKENS_PER_IMAGE
+    : 0;
 
   // Layer 1: Pre-flight context window guard
   // Estimate tokens for the TOTAL prompt (system + task + images), not just system prompt.
   if (!hookSystemPromptOverride) {
     const hardLimitTokens = Math.floor(contextWindowTokens * 0.7);
-    // Estimate total prompt: system prompt + user task prompt (promptForRun includes prepended context)
-    let estimatedTokens = estimatePromptTokens(systemPrompt) + estimatePromptTokens(promptForRun);
+    let estimatedTokens =
+      estimatePromptTokens(systemPrompt) + estimatePromptTokens(promptForRun) + imageTokenEstimate;
 
     // Compaction observability state
     let compactionAttempted = false;
@@ -662,16 +708,27 @@ export async function runCliAgent(params: {
           }
 
           // CLI backends (claude-cli, codex-cli) are wrappers around real LLM
-          // providers — they don't exist in the model registry. Resolve the
-          // agent's configured default model to get the real provider + model.
+          // providers — they don't exist in the model registry. Resolve to a real
+          // provider/model. Use the current run's model (which may come from
+          // --model override) first, falling back to agent default only if needed.
           if (isCliProvider(compactionProvider, params.config)) {
-            const agentDefault = resolveDefaultModelForAgent({
-              cfg: params.config ?? {},
-              agentId: params.agentId,
-            });
-            const resolved = resolveNonCliModelRef(agentDefault, params.config);
-            compactionProvider = resolved.provider;
-            compactionModelRef = resolved.model;
+            const currentRunRef = resolveNonCliModelRef(
+              { provider: compactionProvider, model: compactionModelRef },
+              params.config,
+            );
+            if (!isCliProvider(currentRunRef.provider, params.config)) {
+              compactionProvider = currentRunRef.provider;
+              compactionModelRef = currentRunRef.model;
+            } else {
+              // Current model alias not resolvable — fall back to agent default
+              const agentDefault = resolveDefaultModelForAgent({
+                cfg: params.config ?? {},
+                agentId: params.agentId,
+              });
+              const resolved = resolveNonCliModelRef(agentDefault, params.config);
+              compactionProvider = resolved.provider;
+              compactionModelRef = resolved.model;
+            }
           }
 
           compactionModelUsed = `${compactionProvider}/${compactionModelRef}`;
@@ -696,10 +753,8 @@ export async function runCliAgent(params: {
 
             const isTextBlock = (b: { type: string }): b is { type: "text"; text: string } =>
               b.type === "text";
-            const compactionSignal = AbortSignal.timeout(
-              compactionCfg.timeoutMs ?? DEFAULT_COMPACTION_TIMEOUT_MS,
-            );
-
+            // Per-file timeout is handled inside compactBootstrapFiles.
+            // Pass the outer abort signal so user cancellation propagates.
             const { contextFiles: compactedContextFiles, results } = await compactBootstrapFiles({
               contextFiles: lastProfileContextFiles,
               config: compactionCfg,
@@ -719,7 +774,7 @@ export async function runCliAgent(params: {
                 }
                 return texts.map((b) => b.text).join("\n");
               },
-              signal: compactionSignal,
+              signal: params.abortSignal,
             });
 
             compactedFilesList = results.filter((r) => r.success).map((r) => r.path);
@@ -727,6 +782,24 @@ export async function runCliAgent(params: {
             compactionCharsAfter = results.reduce((sum, r) => sum + r.charsAfter, 0);
 
             if (compactedFilesList.length > 0) {
+              // Compute warning lines using the active profile's budget (not normal)
+              const compactedBudget =
+                activeProfile === "normal"
+                  ? { maxCharsPerFile: bootstrapMaxChars, totalMaxChars: bootstrapTotalMaxChars }
+                  : getBootstrapProfileConfig(activeProfile);
+              const compactedWarning = buildBootstrapPromptWarning({
+                analysis: analyzeBootstrapBudget({
+                  files: buildBootstrapInjectionStats({
+                    bootstrapFiles,
+                    injectedFiles: compactedContextFiles,
+                  }),
+                  bootstrapMaxChars: compactedBudget.maxCharsPerFile,
+                  bootstrapTotalMaxChars: compactedBudget.totalMaxChars,
+                }),
+                mode: bootstrapPromptWarningMode,
+                seenSignatures: params.bootstrapPromptWarningSignaturesSeen,
+                previousSignature: params.bootstrapPromptWarningSignature,
+              });
               const compactedSystemPrompt = buildSystemPrompt({
                 workspaceDir,
                 config: params.config,
@@ -738,14 +811,17 @@ export async function runCliAgent(params: {
                 docsPath: docsPath ?? undefined,
                 tools: [],
                 contextFiles: compactedContextFiles,
-                bootstrapTruncationWarningLines: bootstrapPromptWarning.lines,
+                bootstrapTruncationWarningLines: compactedWarning.lines,
                 modelDisplay,
                 agentId: sessionAgentId,
               });
               const compactedTokens =
-                estimatePromptTokens(compactedSystemPrompt) + estimatePromptTokens(promptForRun);
+                estimatePromptTokens(compactedSystemPrompt) +
+                estimatePromptTokens(promptForRun) +
+                imageTokenEstimate;
               if (compactedTokens <= hardLimitTokens) {
                 systemPrompt = compactedSystemPrompt;
+                activeContextFiles = compactedContextFiles;
                 estimatedTokens = compactedTokens;
                 break;
               }
@@ -766,6 +842,20 @@ export async function runCliAgent(params: {
           warn: warnForProfile,
         });
         lastProfileContextFiles = profileContextFiles;
+        // Compute warning lines for this profile's context (not the original)
+        const profileWarning = buildBootstrapPromptWarning({
+          analysis: analyzeBootstrapBudget({
+            files: buildBootstrapInjectionStats({
+              bootstrapFiles,
+              injectedFiles: profileContextFiles,
+            }),
+            bootstrapMaxChars: profileConfig.maxCharsPerFile,
+            bootstrapTotalMaxChars: profileConfig.totalMaxChars,
+          }),
+          mode: bootstrapPromptWarningMode,
+          seenSignatures: params.bootstrapPromptWarningSignaturesSeen,
+          previousSignature: params.bootstrapPromptWarningSignature,
+        });
         const profileSystemPrompt = buildSystemPrompt({
           workspaceDir,
           config: params.config,
@@ -777,14 +867,17 @@ export async function runCliAgent(params: {
           docsPath: docsPath ?? undefined,
           tools: [],
           contextFiles: profileContextFiles,
-          bootstrapTruncationWarningLines: bootstrapPromptWarning.lines,
+          bootstrapTruncationWarningLines: profileWarning.lines,
           modelDisplay,
           agentId: sessionAgentId,
         });
         activeProfile = profile;
         systemPrompt = profileSystemPrompt;
+        activeContextFiles = profileContextFiles;
         estimatedTokens =
-          estimatePromptTokens(profileSystemPrompt) + estimatePromptTokens(promptForRun);
+          estimatePromptTokens(profileSystemPrompt) +
+          estimatePromptTokens(promptForRun) +
+          imageTokenEstimate;
         if (estimatedTokens <= hardLimitTokens) {
           break;
         }
@@ -796,15 +889,30 @@ export async function runCliAgent(params: {
       }
     }
 
+    const logActiveBudget =
+      activeProfile === "normal"
+        ? { maxCharsPerFile: bootstrapMaxChars, totalMaxChars: bootstrapTotalMaxChars }
+        : getBootstrapProfileConfig(activeProfile);
+    const logActiveAnalysis =
+      activeContextFiles !== contextFiles
+        ? analyzeBootstrapBudget({
+            files: buildBootstrapInjectionStats({
+              bootstrapFiles,
+              injectedFiles: activeContextFiles,
+            }),
+            bootstrapMaxChars: logActiveBudget.maxCharsPerFile,
+            bootstrapTotalMaxChars: logActiveBudget.totalMaxChars,
+          })
+        : bootstrapAnalysis;
     log.info("cli-runner prompt stats", {
       estimated_tokens: estimatedTokens,
       context_window: contextWindowTokens,
       reserve: contextWindowTokens - hardLimitTokens,
       trim_profile: activeProfile,
       retry_count: 0,
-      files_injected: contextFiles.length,
-      files_truncated: bootstrapAnalysis.truncatedFiles.length,
-      files_skipped: bootstrapFiles.length - contextFiles.length,
+      files_injected: activeContextFiles.length,
+      files_truncated: logActiveAnalysis.truncatedFiles.length,
+      files_skipped: bootstrapFiles.length - activeContextFiles.length,
       compaction_attempted: compactionAttempted,
       ...(compactionAttempted && {
         compacted_files: compactedFilesList,
@@ -816,28 +924,58 @@ export async function runCliAgent(params: {
     });
   }
 
-  const systemPromptReport = buildSystemPromptReport({
-    source: "run",
-    generatedAt: Date.now(),
-    sessionId: params.sessionId,
-    sessionKey: params.sessionKey,
-    provider: params.provider,
-    model: modelId,
-    workspaceDir,
-    bootstrapMaxChars,
-    bootstrapTotalMaxChars,
-    bootstrapTruncation: buildBootstrapTruncationReportMeta({
-      analysis: bootstrapAnalysis,
-      warningMode: bootstrapPromptWarningMode,
-      warning: bootstrapPromptWarning,
-    }),
-    sandbox: { mode: "off", sandboxed: false },
-    systemPrompt,
-    bootstrapFiles,
-    injectedFiles: contextFiles,
-    skillsPrompt: "",
-    tools: [],
-  });
+  // Rebuild analysis/report from the final active context files so metadata
+  // reflects the actual profile used (not the initial "normal" profile).
+  const buildReportForActiveContext = () => {
+    // Use the active profile's budget limits so truncation analysis is accurate
+    const activeBudget =
+      activeProfile === "normal"
+        ? { maxCharsPerFile: bootstrapMaxChars, totalMaxChars: bootstrapTotalMaxChars }
+        : getBootstrapProfileConfig(activeProfile);
+    const analysis =
+      activeContextFiles !== contextFiles
+        ? analyzeBootstrapBudget({
+            files: buildBootstrapInjectionStats({
+              bootstrapFiles,
+              injectedFiles: activeContextFiles,
+            }),
+            bootstrapMaxChars: activeBudget.maxCharsPerFile,
+            bootstrapTotalMaxChars: activeBudget.totalMaxChars,
+          })
+        : bootstrapAnalysis;
+    const warning =
+      activeContextFiles !== contextFiles
+        ? buildBootstrapPromptWarning({
+            analysis,
+            mode: bootstrapPromptWarningMode,
+            seenSignatures: params.bootstrapPromptWarningSignaturesSeen,
+            previousSignature: params.bootstrapPromptWarningSignature,
+          })
+        : bootstrapPromptWarning;
+    return buildSystemPromptReport({
+      source: "run",
+      generatedAt: Date.now(),
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      provider: params.provider,
+      model: modelId,
+      workspaceDir,
+      bootstrapMaxChars: activeBudget.maxCharsPerFile,
+      bootstrapTotalMaxChars: activeBudget.totalMaxChars,
+      bootstrapTruncation: buildBootstrapTruncationReportMeta({
+        analysis,
+        warningMode: bootstrapPromptWarningMode,
+        warning,
+      }),
+      sandbox: { mode: "off", sandboxed: false },
+      systemPrompt,
+      bootstrapFiles,
+      injectedFiles: activeContextFiles,
+      skillsPrompt: "",
+      tools: [],
+    });
+  };
+  let systemPromptReport = buildReportForActiveContext();
 
   // Helper function to execute CLI with given session ID
   const executeCliWithSession = async (
@@ -1175,7 +1313,10 @@ export async function runCliAgent(params: {
       if (err instanceof FailoverError) {
         // Layer 2: Context overflow retry with minimal bootstrap profile
         if (isContextOverflowError(err.message) && activeProfile !== "minimal") {
-          const preRetryEstimatedTokens = estimatePromptTokens(systemPrompt);
+          const preRetryEstimatedTokens =
+            estimatePromptTokens(systemPrompt) +
+            estimatePromptTokens(promptForRun) +
+            imageTokenEstimate;
           log.warn("cli-runner: context overflow detected, retrying with minimal profile", {
             retry_count: 1,
             trim_profile: "minimal",
@@ -1190,6 +1331,19 @@ export async function runCliAgent(params: {
             totalMaxChars: minimalConfig.totalMaxChars,
             warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
           });
+          const minimalWarning = buildBootstrapPromptWarning({
+            analysis: analyzeBootstrapBudget({
+              files: buildBootstrapInjectionStats({
+                bootstrapFiles,
+                injectedFiles: minimalContextFiles,
+              }),
+              bootstrapMaxChars: minimalConfig.maxCharsPerFile,
+              bootstrapTotalMaxChars: minimalConfig.totalMaxChars,
+            }),
+            mode: bootstrapPromptWarningMode,
+            seenSignatures: params.bootstrapPromptWarningSignaturesSeen,
+            previousSignature: params.bootstrapPromptWarningSignature,
+          });
           const minimalSystemPrompt = buildSystemPrompt({
             workspaceDir,
             config: params.config,
@@ -1201,13 +1355,16 @@ export async function runCliAgent(params: {
             docsPath: docsPath ?? undefined,
             tools: [],
             contextFiles: minimalContextFiles,
-            bootstrapTruncationWarningLines: [],
+            bootstrapTruncationWarningLines: minimalWarning.lines,
             modelDisplay,
             agentId: sessionAgentId,
           });
-          // Reassign the `let` binding so executeCliWithSession sees the new prompt
+          // Reassign the `let` bindings so executeCliWithSession sees the new prompt
           systemPrompt = minimalSystemPrompt;
+          activeContextFiles = minimalContextFiles;
           activeProfile = "minimal";
+          // Rebuild report to reflect the minimal profile used for retry
+          systemPromptReport = buildReportForActiveContext();
           try {
             const output = await executeCliWithSession(undefined);
             const text = output.text?.trim();
@@ -1227,7 +1384,10 @@ export async function runCliAgent(params: {
             };
           } catch (retryErr) {
             if (retryErr instanceof FailoverError && isContextOverflowError(retryErr.message)) {
-              const estimatedTks = estimatePromptTokens(minimalSystemPrompt);
+              const estimatedTks =
+                estimatePromptTokens(minimalSystemPrompt) +
+                estimatePromptTokens(promptForRun) +
+                imageTokenEstimate;
               throw new FailoverError(
                 `Current task exceeds context window for this runtime (estimated=${estimatedTks} tokens, profile=minimal). 建议改走 pi-embedded runtime 或拆任务。`,
                 {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -1,14 +1,24 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { resolveHeartbeatPrompt } from "../auto-reply/heartbeat.js";
 import type { ThinkLevel } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { appendCliTurnToSessionTranscript } from "../config/sessions.js";
+import type { CliBackendConfig } from "../config/types.js";
+import { MCP_PORT_OFFSET, ensureMcpConfigFile } from "../gateway/mcp-http.js";
 import { shouldLogVerbose } from "../globals.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import type { PluginHookAgentContext } from "../plugins/types.js";
 import { getProcessSupervisor } from "../process/supervisor/index.js";
 import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import { sliceUtf16Safe, resolveUserPath } from "../utils.js";
 import { resolveSessionAgentIds } from "./agent-scope.js";
 import {
   analyzeBootstrapBudget,
@@ -23,6 +33,7 @@ import {
   buildCliSupervisorScopeKey,
   buildCliArgs,
   buildSystemPrompt,
+  createStreamJsonProcessor,
   enqueueCliRun,
   normalizeCliModel,
   parseCliJson,
@@ -33,20 +44,351 @@ import {
   resolveSystemPromptUsage,
   writeCliImages,
 } from "./cli-runner/helpers.js";
+import { resolveContextWindowInfo } from "./context-window-guard.js";
 import { resolveOpenClawDocsPath } from "./docs-path.js";
 import { FailoverError, resolveFailoverStatus } from "./failover-error.js";
 import {
+  buildBootstrapContextFiles,
   classifyFailoverReason,
+  getBootstrapProfileConfig,
+  isContextOverflowError,
   isFailoverErrorMessage,
   resolveBootstrapMaxChars,
   resolveBootstrapPromptTruncationWarningMode,
   resolveBootstrapTotalMaxChars,
+  type BootstrapProfile,
 } from "./pi-embedded-helpers.js";
 import type { EmbeddedPiRunResult } from "./pi-embedded-runner.js";
+import {
+  applySkillEnvOverrides,
+  applySkillEnvOverridesFromSnapshot,
+  loadWorkspaceSkillEntries,
+  resolveSkillsPromptForRun,
+  type SkillSnapshot,
+} from "./skills.js";
 import { buildSystemPromptReport } from "./system-prompt-report.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "./workspace-run.js";
 
 const log = createSubsystemLogger("agent/claude-cli");
+
+type McpServers = Record<string, unknown>;
+const MERGED_MCP_CONFIG_BASENAME_RE = /^mcp\.cli-merged\.[a-f0-9]{16}\.json$/;
+const MERGED_MCP_CONFIG_MAX_FILES = 20;
+const MERGED_MCP_CONFIG_MIN_AGE_MS = 60 * 60 * 1000;
+const CLI_OUTPUT_LOG_HEAD_CHARS = 240;
+const CLI_OUTPUT_LOG_TAIL_CHARS = 160;
+const CLI_OUTPUT_LOG_PREVIEW_MAX_CHARS = CLI_OUTPUT_LOG_HEAD_CHARS + CLI_OUTPUT_LOG_TAIL_CHARS;
+
+function formatCliOutputForLog(channel: "stdout" | "stderr", text: string): string {
+  if (!text) {
+    return `cli ${channel}: <empty>`;
+  }
+  const totalChars = text.length;
+  if (totalChars <= CLI_OUTPUT_LOG_PREVIEW_MAX_CHARS) {
+    return `cli ${channel} (${totalChars} chars):\n${text}`;
+  }
+  const head = sliceUtf16Safe(text, 0, CLI_OUTPUT_LOG_HEAD_CHARS);
+  const tailStart = Math.max(0, totalChars - CLI_OUTPUT_LOG_TAIL_CHARS);
+  const tail = sliceUtf16Safe(text, tailStart);
+  const truncatedChars = Math.max(0, totalChars - head.length - tail.length);
+  return [
+    `cli ${channel} (${totalChars} chars):`,
+    head,
+    `[truncated ${truncatedChars} chars]`,
+    tail,
+  ].join("\n");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/** Rough token estimate using chars/4 heuristic (conservative for English-heavy content). */
+function estimatePromptTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function resolveConfiguredPath(rawPath: string | undefined): string | undefined {
+  const trimmed = rawPath?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return resolveUserPath(trimmed);
+}
+
+async function readMcpServers(filePath: string): Promise<McpServers | null> {
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isRecord(parsed)) {
+      return {};
+    }
+    const serversRaw = parsed.mcpServers;
+    if (!isRecord(serversRaw)) {
+      return {};
+    }
+    return { ...serversRaw };
+  } catch {
+    return null;
+  }
+}
+
+async function writeMcpConfigIfChanged(filePath: string, content: string): Promise<void> {
+  try {
+    const existing = await fs.readFile(filePath, "utf-8");
+    if (existing === content) {
+      return;
+    }
+  } catch {
+    // file may not exist yet
+  }
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, { mode: 0o600 });
+}
+
+async function cleanupMergedMcpConfigs(params: {
+  dir: string;
+  keepFilePath: string;
+}): Promise<void> {
+  const keepName = path.basename(params.keepFilePath);
+  const now = Date.now();
+  const entries = await fs.readdir(params.dir, { withFileTypes: true }).catch(() => []);
+  const candidates: Array<{ name: string; filePath: string; mtimeMs: number }> = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !MERGED_MCP_CONFIG_BASENAME_RE.test(entry.name)) {
+      continue;
+    }
+    const filePath = path.join(params.dir, entry.name);
+    const stat = await fs.stat(filePath).catch(() => null);
+    if (!stat) {
+      continue;
+    }
+    candidates.push({
+      name: entry.name,
+      filePath,
+      mtimeMs: stat.mtimeMs,
+    });
+  }
+  candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  const keepNames = new Set<string>([keepName]);
+  for (const candidate of candidates) {
+    if (keepNames.size >= MERGED_MCP_CONFIG_MAX_FILES) {
+      break;
+    }
+    keepNames.add(candidate.name);
+  }
+
+  for (const candidate of candidates) {
+    if (keepNames.has(candidate.name)) {
+      continue;
+    }
+    if (now - candidate.mtimeMs < MERGED_MCP_CONFIG_MIN_AGE_MS) {
+      continue;
+    }
+    await fs.unlink(candidate.filePath).catch(() => undefined);
+  }
+}
+
+async function resolveClaudeMcpConfigForRun(params: {
+  backend: CliBackendConfig;
+  config?: OpenClawConfig;
+}): Promise<{ mcpConfigPath?: string; useStrictMcp: boolean }> {
+  const mcpCfg = params.backend.mcp;
+  if (mcpCfg?.enabled === false) {
+    return { mcpConfigPath: undefined, useStrictMcp: false };
+  }
+
+  const useStrictMcp = mcpCfg?.strict !== false;
+  const gatewayPort = params.config?.gateway?.port ?? 18789;
+  const mcpPort = gatewayPort + MCP_PORT_OFFSET;
+  const openclawDir = path.join(os.homedir(), ".openclaw");
+  const defaultMcpConfigPath = ensureMcpConfigFile(openclawDir, mcpPort);
+
+  const configuredMcpPath = resolveConfiguredPath(mcpCfg?.configPath);
+  const mergeMcpPath = resolveConfiguredPath(mcpCfg?.mergeConfigPath);
+  const inlineServers = isRecord(mcpCfg?.servers) ? { ...mcpCfg.servers } : {};
+  const hasInlineServers = Object.keys(inlineServers).length > 0;
+  const needsMerge = Boolean(
+    mergeMcpPath ||
+    hasInlineServers ||
+    (configuredMcpPath && configuredMcpPath !== defaultMcpConfigPath),
+  );
+  if (!needsMerge) {
+    return {
+      mcpConfigPath: configuredMcpPath ?? defaultMcpConfigPath,
+      useStrictMcp,
+    };
+  }
+
+  const openclawServers = await readMcpServers(defaultMcpConfigPath);
+  if (openclawServers === null) {
+    log.warn(`MCP default config read failed, skipping merge: ${defaultMcpConfigPath}`);
+    return {
+      mcpConfigPath: defaultMcpConfigPath,
+      useStrictMcp,
+    };
+  }
+  const configuredServers = configuredMcpPath
+    ? await readMcpServers(configuredMcpPath)
+    : openclawServers;
+  if (configuredMcpPath && configuredServers === null) {
+    log.warn(`MCP primary config read failed: ${configuredMcpPath}`);
+  }
+  const mergeServers = mergeMcpPath ? await readMcpServers(mergeMcpPath) : {};
+  if (mergeMcpPath && mergeServers === null) {
+    log.warn(`MCP merge config read failed: ${mergeMcpPath}`);
+  }
+
+  const mergedServers: McpServers = {
+    ...(configuredServers ?? openclawServers),
+    ...mergeServers,
+    ...inlineServers,
+  };
+  const openclawServer = openclawServers.openclaw;
+  if (isRecord(openclawServer)) {
+    // Keep OpenClaw MCP server authoritative so tool routing cannot be shadowed.
+    mergedServers.openclaw = openclawServer;
+  }
+
+  const mergedContent = `${JSON.stringify({ mcpServers: mergedServers }, null, 2)}\n`;
+  const mergedHash = crypto.createHash("sha256").update(mergedContent).digest("hex").slice(0, 16);
+  const mergedPath = path.join(
+    path.dirname(defaultMcpConfigPath),
+    `mcp.cli-merged.${mergedHash}.json`,
+  );
+  await writeMcpConfigIfChanged(mergedPath, mergedContent);
+  await cleanupMergedMcpConfigs({
+    dir: path.dirname(defaultMcpConfigPath),
+    keepFilePath: mergedPath,
+  }).catch((err) => {
+    log.debug(`MCP merged config cleanup skipped: ${String(err)}`);
+  });
+  return { mcpConfigPath: mergedPath, useStrictMcp };
+}
+
+function createAbortError(signal?: AbortSignal): Error {
+  const reason = signal && "reason" in signal ? (signal as { reason?: unknown }).reason : undefined;
+  const err = reason ? new Error("aborted", { cause: reason }) : new Error("aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+async function readCliHookMessages(sessionFile: string): Promise<unknown[]> {
+  const trimmed = sessionFile.trim();
+  if (!trimmed) {
+    return [];
+  }
+  try {
+    const raw = await fs.readFile(path.resolve(trimmed), "utf-8");
+    const lines = raw.split(/\r?\n/g);
+    const messages: unknown[] = [];
+    for (const line of lines) {
+      const value = line.trim();
+      if (!value) {
+        continue;
+      }
+      try {
+        const parsed = JSON.parse(value) as unknown;
+        if (isRecord(parsed) && parsed.type === "message" && "message" in parsed) {
+          messages.push(parsed.message);
+        }
+      } catch {
+        // ignore malformed lines
+      }
+    }
+    return messages;
+  } catch {
+    return [];
+  }
+}
+
+async function resolveCliPromptBuildHookResult(params: {
+  hookRunner: ReturnType<typeof getGlobalHookRunner>;
+  prompt: string;
+  messages: unknown[];
+  hookCtx: PluginHookAgentContext;
+}): Promise<{ systemPrompt?: string; prependContext?: string } | undefined> {
+  const hookRunner = params.hookRunner;
+  if (!hookRunner) {
+    return undefined;
+  }
+  const promptBuildResult = hookRunner.hasHooks("before_prompt_build")
+    ? await hookRunner
+        .runBeforePromptBuild(
+          {
+            prompt: params.prompt,
+            messages: params.messages,
+          },
+          params.hookCtx,
+        )
+        .catch((hookErr: unknown) => {
+          log.warn(`before_prompt_build hook failed: ${String(hookErr)}`);
+          return undefined;
+        })
+    : undefined;
+  const legacyResult = hookRunner.hasHooks("before_agent_start")
+    ? await hookRunner
+        .runBeforeAgentStart(
+          {
+            prompt: params.prompt,
+            messages: params.messages,
+          },
+          params.hookCtx,
+        )
+        .catch((hookErr: unknown) => {
+          log.warn(`before_agent_start hook (CLI path) failed: ${String(hookErr)}`);
+          return undefined;
+        })
+    : undefined;
+  return {
+    systemPrompt: promptBuildResult?.systemPrompt ?? legacyResult?.systemPrompt,
+    prependContext: [promptBuildResult?.prependContext, legacyResult?.prependContext]
+      .filter((value): value is string => Boolean(value))
+      .join("\n\n"),
+  };
+}
+
+function emitCliLlmOutputHook(params: {
+  hookRunner: ReturnType<typeof getGlobalHookRunner>;
+  hookCtx: PluginHookAgentContext;
+  runId: string;
+  sessionId: string;
+  provider: string;
+  model: string;
+  output: {
+    text: string;
+    usage?: {
+      input?: number;
+      output?: number;
+      cacheRead?: number;
+      cacheWrite?: number;
+      total?: number;
+    };
+  };
+}) {
+  const hookRunner = params.hookRunner;
+  if (!hookRunner?.hasHooks("llm_output")) {
+    return;
+  }
+  const text = params.output.text.trim();
+  hookRunner
+    .runLlmOutput(
+      {
+        runId: params.runId,
+        sessionId: params.sessionId,
+        provider: params.provider,
+        model: params.model,
+        assistantTexts: text ? [text] : [],
+        lastAssistant: text ? { role: "assistant", content: text } : undefined,
+        usage: params.output.usage,
+      },
+      params.hookCtx,
+    )
+    .catch((hookErr) => {
+      log.warn(`llm_output hook failed (CLI path): ${String(hookErr)}`);
+    });
+}
 
 export async function runCliAgent(params: {
   sessionId: string;
@@ -62,6 +404,7 @@ export async function runCliAgent(params: {
   timeoutMs: number;
   runId: string;
   extraSystemPrompt?: string;
+  skillsSnapshot?: SkillSnapshot;
   streamParams?: import("../commands/agent/types.js").AgentStreamParams;
   ownerNumbers?: string[];
   cliSessionId?: string;
@@ -69,6 +412,18 @@ export async function runCliAgent(params: {
   /** Backward-compat fallback when only the previous signature is available. */
   bootstrapPromptWarningSignature?: string;
   images?: ImageContent[];
+  onAssistantTurn?: (text: string) => void;
+  onSystemInit?: (payload: { subtype: string; sessionId?: string }) => void;
+  onToolUse?: (toolName: string) => void;
+  onThinkingTurn?: (payload: { text: string; delta?: string }) => void;
+  onToolUseEvent?: (payload: { name: string; toolUseId?: string; input?: unknown }) => void;
+  onToolResult?: (payload: { toolUseId?: string; text?: string; isError?: boolean }) => void;
+  abortSignal?: AbortSignal;
+  trigger?: PluginHookAgentContext["trigger"];
+  messageChannel?: string;
+  messageAccountId?: string;
+  messageTo?: string;
+  messageThreadId?: string | number;
 }): Promise<EmbeddedPiRunResult> {
   const started = Date.now();
   const workspaceResolution = resolveRunWorkspaceDir({
@@ -97,23 +452,51 @@ export async function runCliAgent(params: {
   const normalizedModel = normalizeCliModel(modelId, backend);
   const modelDisplay = `${params.provider}/${modelId}`;
 
-  const extraSystemPrompt = [
-    params.extraSystemPrompt?.trim(),
-    "Tools are disabled in this session. Do not call tools.",
-  ]
-    .filter(Boolean)
-    .join("\n");
+  const isClaude = backendResolved.id === "claude-cli";
+
+  // MCP tool access only for Claude CLI; other backends get a "tools disabled" hint.
+  let mcpConfigPath: string | undefined;
+  let useStrictMcp = true;
+  if (isClaude) {
+    try {
+      const mcpResolved = await resolveClaudeMcpConfigForRun({
+        backend,
+        config: params.config,
+      });
+      mcpConfigPath = mcpResolved.mcpConfigPath;
+      useStrictMcp = mcpResolved.useStrictMcp;
+    } catch (err) {
+      log.warn(`mcp config setup failed: ${String(err)}`);
+    }
+  }
+
+  const extraSystemPrompt = isClaude
+    ? params.extraSystemPrompt?.trim() || undefined
+    : [params.extraSystemPrompt?.trim(), "Tools are disabled in this session. Do not call tools."]
+        .filter(Boolean)
+        .join("\n");
 
   const sessionLabel = params.sessionKey ?? params.sessionId;
+
+  // Resolve context window early — needed by Layer 3 (dynamic budget) and Layer 1 (pre-flight guard).
+  const contextWindowInfo = resolveContextWindowInfo({
+    cfg: params.config,
+    provider: params.provider,
+    modelId: normalizedModel,
+    defaultTokens: 200_000,
+  });
+  let contextWindowTokens = contextWindowInfo.tokens;
+
   const { bootstrapFiles, contextFiles } = await resolveBootstrapContextForRun({
     workspaceDir,
     config: params.config,
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
     warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+    contextWindowTokens,
   });
   const bootstrapMaxChars = resolveBootstrapMaxChars(params.config);
-  const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config);
+  const bootstrapTotalMaxChars = resolveBootstrapTotalMaxChars(params.config, contextWindowTokens);
   const bootstrapAnalysis = analyzeBootstrapBudget({
     files: buildBootstrapInjectionStats({
       bootstrapFiles,
@@ -134,6 +517,40 @@ export async function runCliAgent(params: {
     config: params.config,
     agentId: params.agentId,
   });
+  const hookCtx: PluginHookAgentContext = {
+    agentId: sessionAgentId,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    workspaceDir,
+    messageProvider: params.messageChannel,
+    trigger: params.trigger,
+    channelId: params.messageChannel,
+  };
+  const hookRunner = getGlobalHookRunner();
+  const hasPromptBuildHooks = Boolean(
+    hookRunner?.hasHooks("before_prompt_build") || hookRunner?.hasHooks("before_agent_start"),
+  );
+  let promptForRun = params.prompt;
+  const hookMessages = hasPromptBuildHooks ? await readCliHookMessages(params.sessionFile) : [];
+  const promptBuildHookResult = hasPromptBuildHooks
+    ? await resolveCliPromptBuildHookResult({
+        hookRunner,
+        prompt: params.prompt,
+        messages: hookMessages,
+        hookCtx,
+      })
+    : undefined;
+  const prependContext = promptBuildHookResult?.prependContext;
+  if (prependContext?.trim()) {
+    promptForRun = `${prependContext}\n\n${params.prompt}`;
+    log.debug(`hooks: prepended context to CLI prompt (${prependContext.length} chars)`);
+  }
+  const hookSystemPromptOverride = promptBuildHookResult?.systemPrompt?.trim() || undefined;
+  if (hookSystemPromptOverride) {
+    log.debug(
+      `hooks: applied CLI systemPrompt override (${hookSystemPromptOverride.length} chars)`,
+    );
+  }
   const heartbeatPrompt =
     sessionAgentId === defaultAgentId
       ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)
@@ -144,11 +561,35 @@ export async function runCliAgent(params: {
     cwd: process.cwd(),
     moduleUrl: import.meta.url,
   });
-  const systemPrompt = buildSystemPrompt({
+  let skillsPrompt: string | undefined;
+  let restoreSkillEnv: (() => void) | undefined;
+  if (isClaude) {
+    const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
+    const skillEntries = shouldLoadSkillEntries
+      ? loadWorkspaceSkillEntries(workspaceDir, { config: params.config })
+      : undefined;
+    restoreSkillEnv = params.skillsSnapshot
+      ? applySkillEnvOverridesFromSnapshot({
+          snapshot: params.skillsSnapshot,
+          config: params.config,
+        })
+      : applySkillEnvOverrides({
+          skills: skillEntries ?? [],
+          config: params.config,
+        });
+    skillsPrompt = resolveSkillsPromptForRun({
+      skillsSnapshot: params.skillsSnapshot,
+      entries: shouldLoadSkillEntries ? skillEntries : undefined,
+      config: params.config,
+      workspaceDir,
+    });
+  }
+  const builtSystemPrompt = buildSystemPrompt({
     workspaceDir,
     config: params.config,
     defaultThinkLevel: params.thinkLevel,
     extraSystemPrompt,
+    skillsPrompt,
     ownerNumbers: params.ownerNumbers,
     heartbeatPrompt,
     docsPath: docsPath ?? undefined,
@@ -158,6 +599,70 @@ export async function runCliAgent(params: {
     modelDisplay,
     agentId: sessionAgentId,
   });
+  let systemPrompt = hookSystemPromptOverride ?? builtSystemPrompt;
+  let activeProfile: BootstrapProfile = "normal";
+
+  // Layer 1: Pre-flight context window guard
+  // Estimate tokens for the TOTAL prompt (system + task + images), not just system prompt.
+  if (!hookSystemPromptOverride) {
+    const hardLimitTokens = Math.floor(contextWindowTokens * 0.7);
+    // Estimate total prompt: system prompt + user task prompt (promptForRun includes prepended context)
+    let estimatedTokens = estimatePromptTokens(systemPrompt) + estimatePromptTokens(promptForRun);
+
+    if (estimatedTokens > hardLimitTokens) {
+      const warnForProfile = makeBootstrapWarn({
+        sessionLabel,
+        warn: (message) => log.warn(message),
+      });
+      for (const profile of ["reduced", "minimal"] as BootstrapProfile[]) {
+        const profileConfig = getBootstrapProfileConfig(profile);
+        const profileContextFiles = buildBootstrapContextFiles(bootstrapFiles, {
+          maxChars: profileConfig.maxCharsPerFile,
+          totalMaxChars: profileConfig.totalMaxChars,
+          warn: warnForProfile,
+        });
+        const profileSystemPrompt = buildSystemPrompt({
+          workspaceDir,
+          config: params.config,
+          defaultThinkLevel: params.thinkLevel,
+          extraSystemPrompt,
+          skillsPrompt,
+          ownerNumbers: params.ownerNumbers,
+          heartbeatPrompt,
+          docsPath: docsPath ?? undefined,
+          tools: [],
+          contextFiles: profileContextFiles,
+          bootstrapTruncationWarningLines: bootstrapPromptWarning.lines,
+          modelDisplay,
+          agentId: sessionAgentId,
+        });
+        activeProfile = profile;
+        systemPrompt = profileSystemPrompt;
+        estimatedTokens =
+          estimatePromptTokens(profileSystemPrompt) + estimatePromptTokens(promptForRun);
+        if (estimatedTokens <= hardLimitTokens) {
+          break;
+        }
+      }
+      if (estimatedTokens > hardLimitTokens) {
+        log.error(
+          `cli-runner: system prompt exceeds context limit after minimal profile (estimated=${estimatedTokens} tokens, limit=${hardLimitTokens}); proceeding anyway`,
+        );
+      }
+    }
+
+    log.info("cli-runner prompt stats", {
+      estimated_tokens: estimatedTokens,
+      context_window: contextWindowTokens,
+      reserve: contextWindowTokens - hardLimitTokens,
+      trim_profile: activeProfile,
+      retry_count: 0,
+      files_injected: contextFiles.length,
+      files_truncated: bootstrapAnalysis.truncatedFiles.length,
+      files_skipped: bootstrapFiles.length - contextFiles.length,
+    });
+  }
+
   const systemPromptReport = buildSystemPromptReport({
     source: "run",
     generatedAt: Date.now(),
@@ -195,6 +700,9 @@ export async function runCliAgent(params: {
       total?: number;
     };
   }> => {
+    if (params.abortSignal?.aborted) {
+      throw createAbortError(params.abortSignal);
+    }
     const { sessionId: resolvedSessionId, isNew } = resolveSessionIdToSend({
       backend,
       cliSessionId: cliSessionIdToUse,
@@ -210,7 +718,7 @@ export async function runCliAgent(params: {
 
     let imagePaths: string[] | undefined;
     let cleanupImages: (() => Promise<void>) | undefined;
-    let prompt = params.prompt;
+    let prompt = promptForRun;
     if (params.images && params.images.length > 0) {
       const imagePayload = await writeCliImages(params.images);
       imagePaths = imagePayload.paths;
@@ -239,6 +747,13 @@ export async function runCliAgent(params: {
       promptArg: argsPrompt,
       useResume,
     });
+    // --mcp-config is a Claude Code specific flag.
+    if (mcpConfigPath && backendResolved.id === "claude-cli") {
+      if (useStrictMcp && !args.includes("--strict-mcp-config")) {
+        args.push("--strict-mcp-config");
+      }
+      args.push("--mcp-config", mcpConfigPath);
+    }
 
     const serialize = backend.serialize ?? true;
     const queueKey = serialize ? backendResolved.id : `${backendResolved.id}:${params.runId}`;
@@ -246,7 +761,7 @@ export async function runCliAgent(params: {
     try {
       const output = await enqueueCliRun(queueKey, async () => {
         log.info(
-          `cli exec: provider=${params.provider} model=${normalizedModel} promptChars=${params.prompt.length}`,
+          `cli exec: provider=${params.provider} model=${normalizedModel} promptChars=${promptForRun.length}`,
         );
         const logOutputText = isTruthyEnvValue(process.env.OPENCLAW_CLAUDE_CLI_LOG_OUTPUT);
         if (logOutputText) {
@@ -290,6 +805,15 @@ export async function runCliAgent(params: {
           for (const key of backend.clearEnv ?? []) {
             delete next[key];
           }
+          if (mcpConfigPath) {
+            next.OPENCLAW_MCP_AGENT_ID = sessionAgentId ?? "";
+            next.OPENCLAW_MCP_ACCOUNT_ID = params.messageAccountId ?? "";
+            next.OPENCLAW_MCP_SESSION_KEY = params.sessionKey ?? "";
+            next.OPENCLAW_MCP_MESSAGE_CHANNEL = params.messageChannel ?? "";
+            next.OPENCLAW_MCP_TO = params.messageTo ?? "";
+            next.OPENCLAW_MCP_THREAD_ID =
+              params.messageThreadId != null ? String(params.messageThreadId) : "";
+          }
           return next;
         })();
         const noOutputTimeoutMs = resolveCliNoOutputTimeoutMs({
@@ -304,6 +828,21 @@ export async function runCliAgent(params: {
           cliSessionId: useResume ? resolvedSessionId : undefined,
         });
 
+        const outputMode = useResume ? (backend.resumeOutput ?? backend.output) : backend.output;
+
+        // Stream-json mode: process NDJSON lines as they arrive via onStdout
+        const streamProcessor =
+          outputMode === "stream-json"
+            ? createStreamJsonProcessor(backend, {
+                onSystemInit: params.onSystemInit,
+                onAssistantTurn: params.onAssistantTurn,
+                onToolUse: params.onToolUse,
+                onThinkingTurn: params.onThinkingTurn,
+                onToolUseEvent: params.onToolUseEvent,
+                onToolResult: params.onToolResult,
+              })
+            : undefined;
+
         const managedRun = await supervisor.spawn({
           sessionId: params.sessionId,
           backendId: backendResolved.id,
@@ -316,25 +855,44 @@ export async function runCliAgent(params: {
           cwd: workspaceDir,
           env,
           input: stdinPayload,
+          ...(streamProcessor ? { onStdout: streamProcessor.feed } : {}),
         });
-        const result = await managedRun.wait();
+        const onAbort = () => {
+          managedRun.cancel("manual-cancel");
+        };
+        if (params.abortSignal) {
+          if (params.abortSignal.aborted) {
+            onAbort();
+          } else {
+            params.abortSignal.addEventListener("abort", onAbort, { once: true });
+          }
+        }
+        let result;
+        try {
+          result = await managedRun.wait();
+        } finally {
+          params.abortSignal?.removeEventListener("abort", onAbort);
+        }
+        if (result.reason === "manual-cancel" && params.abortSignal?.aborted) {
+          throw createAbortError(params.abortSignal);
+        }
 
         const stdout = result.stdout.trim();
         const stderr = result.stderr.trim();
         if (logOutputText) {
           if (stdout) {
-            log.info(`cli stdout:\n${stdout}`);
+            log.info(formatCliOutputForLog("stdout", stdout));
           }
           if (stderr) {
-            log.info(`cli stderr:\n${stderr}`);
+            log.info(formatCliOutputForLog("stderr", stderr));
           }
         }
         if (shouldLogVerbose()) {
           if (stdout) {
-            log.debug(`cli stdout:\n${stdout}`);
+            log.debug(formatCliOutputForLog("stdout", stdout));
           }
           if (stderr) {
-            log.debug(`cli stderr:\n${stderr}`);
+            log.debug(formatCliOutputForLog("stderr", stderr));
           }
         }
 
@@ -382,18 +940,54 @@ export async function runCliAgent(params: {
           });
         }
 
-        const outputMode = useResume ? (backend.resumeOutput ?? backend.output) : backend.output;
-
-        if (outputMode === "text") {
-          return { text: stdout, sessionId: undefined };
-        }
-        if (outputMode === "jsonl") {
+        let output: {
+          text: string;
+          sessionId?: string;
+          usage?: {
+            input?: number;
+            output?: number;
+            cacheRead?: number;
+            cacheWrite?: number;
+            total?: number;
+          };
+        };
+        if (streamProcessor) {
+          output = streamProcessor.finish();
+        } else if (outputMode === "text") {
+          output = { text: stdout, sessionId: undefined };
+        } else if (outputMode === "jsonl") {
           const parsed = parseCliJsonl(stdout, backend);
-          return parsed ?? { text: stdout };
+          output = parsed ?? { text: stdout };
+        } else {
+          const parsed = parseCliJson(stdout, backend);
+          output = parsed ?? { text: stdout };
         }
-
-        const parsed = parseCliJson(stdout, backend);
-        return parsed ?? { text: stdout };
+        try {
+          const appendResult = await appendCliTurnToSessionTranscript({
+            sessionFile: params.sessionFile,
+            sessionId: params.sessionId,
+            userText: params.prompt,
+            assistantText: output.text,
+            provider: params.provider,
+            model: normalizedModel,
+            usage: output.usage,
+          });
+          if (!appendResult.ok) {
+            log.debug(`cli transcript append skipped: ${appendResult.reason}`);
+          }
+        } catch (err) {
+          log.warn(`cli transcript append failed: ${String(err)}`);
+        }
+        emitCliLlmOutputHook({
+          hookRunner,
+          hookCtx,
+          runId: params.runId,
+          sessionId: output.sessionId ?? resolvedSessionId ?? params.sessionId,
+          provider: params.provider,
+          model: normalizedModel,
+          output,
+        });
+        return output;
       });
 
       return output;
@@ -406,68 +1000,147 @@ export async function runCliAgent(params: {
 
   // Try with the provided CLI session ID first
   try {
-    const output = await executeCliWithSession(params.cliSessionId);
-    const text = output.text?.trim();
-    const payloads = text ? [{ text }] : undefined;
+    try {
+      const output = await executeCliWithSession(params.cliSessionId);
+      const text = output.text?.trim();
+      const payloads = text ? [{ text }] : undefined;
 
-    return {
-      payloads,
-      meta: {
-        durationMs: Date.now() - started,
-        systemPromptReport,
-        agentMeta: {
-          sessionId: output.sessionId ?? params.cliSessionId ?? params.sessionId ?? "",
+      return {
+        payloads,
+        meta: {
+          durationMs: Date.now() - started,
+          systemPromptReport,
+          agentMeta: {
+            sessionId: output.sessionId ?? params.cliSessionId ?? params.sessionId ?? "",
+            provider: params.provider,
+            model: modelId,
+            usage: output.usage,
+          },
+        },
+      };
+    } catch (err) {
+      if (err instanceof FailoverError) {
+        // Layer 2: Context overflow retry with minimal bootstrap profile
+        if (isContextOverflowError(err.message) && activeProfile !== "minimal") {
+          const preRetryEstimatedTokens = estimatePromptTokens(systemPrompt);
+          log.warn("cli-runner: context overflow detected, retrying with minimal profile", {
+            retry_count: 1,
+            trim_profile: "minimal",
+            reason: "context_overflow",
+            previous_profile: activeProfile,
+            estimated_tokens: preRetryEstimatedTokens,
+            context_window: contextWindowTokens,
+          });
+          const minimalConfig = getBootstrapProfileConfig("minimal");
+          const minimalContextFiles = buildBootstrapContextFiles(bootstrapFiles, {
+            maxChars: minimalConfig.maxCharsPerFile,
+            totalMaxChars: minimalConfig.totalMaxChars,
+            warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+          });
+          const minimalSystemPrompt = buildSystemPrompt({
+            workspaceDir,
+            config: params.config,
+            defaultThinkLevel: params.thinkLevel,
+            extraSystemPrompt,
+            skillsPrompt,
+            ownerNumbers: params.ownerNumbers,
+            heartbeatPrompt,
+            docsPath: docsPath ?? undefined,
+            tools: [],
+            contextFiles: minimalContextFiles,
+            bootstrapTruncationWarningLines: [],
+            modelDisplay,
+            agentId: sessionAgentId,
+          });
+          // Reassign the `let` binding so executeCliWithSession sees the new prompt
+          systemPrompt = minimalSystemPrompt;
+          activeProfile = "minimal";
+          try {
+            const output = await executeCliWithSession(undefined);
+            const text = output.text?.trim();
+            const payloads = text ? [{ text }] : undefined;
+            return {
+              payloads,
+              meta: {
+                durationMs: Date.now() - started,
+                systemPromptReport,
+                agentMeta: {
+                  sessionId: output.sessionId ?? params.sessionId ?? "",
+                  provider: params.provider,
+                  model: modelId,
+                  usage: output.usage,
+                },
+              },
+            };
+          } catch (retryErr) {
+            if (retryErr instanceof FailoverError && isContextOverflowError(retryErr.message)) {
+              const estimatedTks = estimatePromptTokens(minimalSystemPrompt);
+              throw new FailoverError(
+                `Current task exceeds context window for this runtime (estimated=${estimatedTks} tokens, profile=minimal). 建议改走 pi-embedded runtime 或拆任务。`,
+                {
+                  reason: "unknown",
+                  provider: params.provider,
+                  model: modelId,
+                  status: resolveFailoverStatus("unknown"),
+                },
+              );
+            }
+            throw retryErr;
+          }
+        }
+
+        // Check if this is a session expired error and we have a session to clear
+        if (err.reason === "session_expired" && params.cliSessionId && params.sessionKey) {
+          log.warn(
+            `CLI session expired, clearing session ID and retrying: provider=${params.provider} session=${redactRunIdentifier(params.cliSessionId)}`,
+          );
+
+          // Clear the expired session ID from the session entry
+          // This requires access to the session store, which we don't have here
+          // We'll need to modify the caller to handle this case
+
+          // For now, retry without the session ID to create a new session
+          const output = await executeCliWithSession(undefined);
+          const text = output.text?.trim();
+          const payloads = text ? [{ text }] : undefined;
+
+          return {
+            payloads,
+            meta: {
+              durationMs: Date.now() - started,
+              systemPromptReport,
+              agentMeta: {
+                sessionId: output.sessionId ?? params.sessionId ?? "",
+                provider: params.provider,
+                model: modelId,
+                usage: output.usage,
+              },
+            },
+          };
+        }
+        throw err;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      if (isFailoverErrorMessage(message)) {
+        const reason = classifyFailoverReason(message) ?? "unknown";
+        const status = resolveFailoverStatus(reason);
+        throw new FailoverError(message, {
+          reason,
           provider: params.provider,
           model: modelId,
-          usage: output.usage,
-        },
-      },
-    };
-  } catch (err) {
-    if (err instanceof FailoverError) {
-      // Check if this is a session expired error and we have a session to clear
-      if (err.reason === "session_expired" && params.cliSessionId && params.sessionKey) {
-        log.warn(
-          `CLI session expired, clearing session ID and retrying: provider=${params.provider} session=${redactRunIdentifier(params.cliSessionId)}`,
-        );
-
-        // Clear the expired session ID from the session entry
-        // This requires access to the session store, which we don't have here
-        // We'll need to modify the caller to handle this case
-
-        // For now, retry without the session ID to create a new session
-        const output = await executeCliWithSession(undefined);
-        const text = output.text?.trim();
-        const payloads = text ? [{ text }] : undefined;
-
-        return {
-          payloads,
-          meta: {
-            durationMs: Date.now() - started,
-            systemPromptReport,
-            agentMeta: {
-              sessionId: output.sessionId ?? params.sessionId ?? "",
-              provider: params.provider,
-              model: modelId,
-              usage: output.usage,
-            },
-          },
-        };
+          status,
+        });
       }
       throw err;
     }
-    const message = err instanceof Error ? err.message : String(err);
-    if (isFailoverErrorMessage(message)) {
-      const reason = classifyFailoverReason(message) ?? "unknown";
-      const status = resolveFailoverStatus(reason);
-      throw new FailoverError(message, {
-        reason,
-        provider: params.provider,
-        model: modelId,
-        status,
-      });
+  } finally {
+    if (restoreSkillEnv) {
+      try {
+        restoreSkillEnv();
+      } catch (error) {
+        log.warn(`failed to restore skill env overrides: ${String(error)}`);
+      }
     }
-    throw err;
   }
 }
 
@@ -485,9 +1158,22 @@ export async function runClaudeCliAgent(params: {
   timeoutMs: number;
   runId: string;
   extraSystemPrompt?: string;
+  skillsSnapshot?: SkillSnapshot;
   ownerNumbers?: string[];
   claudeSessionId?: string;
   images?: ImageContent[];
+  onAssistantTurn?: (text: string) => void;
+  onSystemInit?: (payload: { subtype: string; sessionId?: string }) => void;
+  onToolUse?: (toolName: string) => void;
+  onThinkingTurn?: (payload: { text: string; delta?: string }) => void;
+  onToolUseEvent?: (payload: { name: string; toolUseId?: string; input?: unknown }) => void;
+  onToolResult?: (payload: { toolUseId?: string; text?: string; isError?: boolean }) => void;
+  abortSignal?: AbortSignal;
+  trigger?: PluginHookAgentContext["trigger"];
+  messageChannel?: string;
+  messageAccountId?: string;
+  messageTo?: string;
+  messageThreadId?: string | number;
 }): Promise<EmbeddedPiRunResult> {
   return runCliAgent({
     sessionId: params.sessionId,
@@ -503,8 +1189,21 @@ export async function runClaudeCliAgent(params: {
     timeoutMs: params.timeoutMs,
     runId: params.runId,
     extraSystemPrompt: params.extraSystemPrompt,
+    skillsSnapshot: params.skillsSnapshot,
     ownerNumbers: params.ownerNumbers,
     cliSessionId: params.claudeSessionId,
     images: params.images,
+    onAssistantTurn: params.onAssistantTurn,
+    onSystemInit: params.onSystemInit,
+    onToolUse: params.onToolUse,
+    onThinkingTurn: params.onThinkingTurn,
+    onToolUseEvent: params.onToolUseEvent,
+    onToolResult: params.onToolResult,
+    abortSignal: params.abortSignal,
+    trigger: params.trigger,
+    messageChannel: params.messageChannel,
+    messageAccountId: params.messageAccountId,
+    messageTo: params.messageTo,
+    messageThreadId: params.messageThreadId,
   });
 }

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -12,6 +12,7 @@ import {
   modelKey,
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
+  resolveNonCliModelRef,
   resolveThinkingDefault,
   resolveModelRefFromString,
 } from "./model-selection.js";
@@ -538,6 +539,71 @@ describe("model-selection", () => {
         }),
       ).toBe("adaptive");
     });
+  });
+});
+
+describe("resolveNonCliModelRef", () => {
+  it("returns non-CLI provider ref as-is", () => {
+    const ref = { provider: "anthropic", model: "claude-opus-4-6" };
+    expect(resolveNonCliModelRef(ref)).toEqual(ref);
+  });
+
+  it("returns non-CLI openai ref as-is", () => {
+    const ref = { provider: "openai", model: "gpt-4o" };
+    expect(resolveNonCliModelRef(ref)).toEqual(ref);
+  });
+
+  it("maps claude-cli to anthropic", () => {
+    const ref = { provider: "claude-cli", model: "claude-opus-4-6" };
+    const result = resolveNonCliModelRef(ref);
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-opus-4-6");
+  });
+
+  it("maps codex-cli to openai", () => {
+    const ref = { provider: "codex-cli", model: "o4-mini" };
+    const result = resolveNonCliModelRef(ref);
+    expect(result.provider).toBe("openai");
+    expect(result.model).toBe("o4-mini");
+  });
+
+  it("falls back to DEFAULT_PROVIDER (anthropic) for unknown custom CLI backend", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "my-custom-cli": {},
+          },
+        },
+      },
+    } as never;
+    const ref = { provider: "my-custom-cli", model: "some-model" };
+    const result = resolveNonCliModelRef(ref, cfg);
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("some-model");
+  });
+
+  it("resolves through alias when cfg + alias index match", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-haiku-4-5-20251001": { alias: "haiku" },
+          },
+        },
+      },
+    } as never;
+    const ref = { provider: "claude-cli", model: "haiku" };
+    const result = resolveNonCliModelRef(ref, cfg);
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-haiku-4-5-20251001");
+  });
+
+  it("returns mapped provider + original model when no alias matches", () => {
+    const ref = { provider: "claude-cli", model: "claude-opus-4-6" };
+    const result = resolveNonCliModelRef(ref, undefined);
+    expect(result.provider).toBe("anthropic");
+    expect(result.model).toBe("claude-opus-4-6");
   });
 });
 

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -320,6 +320,42 @@ export function resolveConfiguredModelRef(params: {
   return { provider: params.defaultProvider, model: params.defaultModel };
 }
 
+/**
+ * Resolve a ModelRef that may point to a CLI provider (claude-cli, codex-cli,
+ * or a custom cliBackend) to a real API provider.
+ *
+ * - Non-CLI providers are returned as-is.
+ * - `claude-cli` maps to `anthropic`; `codex-cli` maps to `openai`.
+ * - Unknown custom CLI backends fall back to DEFAULT_PROVIDER.
+ * - The model string is resolved through the alias index for the target provider.
+ */
+export function resolveNonCliModelRef(ref: ModelRef, cfg?: OpenClawConfig): ModelRef {
+  if (!isCliProvider(ref.provider, cfg)) {
+    return ref;
+  }
+
+  const normalized = normalizeProviderId(ref.provider);
+  let realProvider: string;
+  if (normalized === "claude-cli") {
+    realProvider = "anthropic";
+  } else if (normalized === "codex-cli") {
+    realProvider = "openai";
+  } else {
+    realProvider = DEFAULT_PROVIDER;
+  }
+
+  if (cfg) {
+    const aliasIndex = buildModelAliasIndex({ cfg, defaultProvider: realProvider });
+    const aliasKey = normalizeAliasKey(ref.model);
+    const aliasMatch = aliasIndex.byAlias.get(aliasKey);
+    if (aliasMatch) {
+      return aliasMatch.ref;
+    }
+  }
+
+  return { provider: realProvider, model: ref.model };
+}
+
 export function resolveDefaultModelForAgent(params: {
   cfg: OpenClawConfig;
   agentId?: string;

--- a/src/agents/pi-embedded-helpers.bootstrap-profiles.test.ts
+++ b/src/agents/pi-embedded-helpers.bootstrap-profiles.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  getBootstrapProfileConfig,
+  resolveBootstrapBudgetForModel,
+  resolveBootstrapTotalMaxChars,
+  DEFAULT_BOOTSTRAP_MAX_CHARS,
+  DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS,
+} from "./pi-embedded-helpers.js";
+
+describe("getBootstrapProfileConfig", () => {
+  it("normal profile returns default limits", () => {
+    const config = getBootstrapProfileConfig("normal");
+    expect(config.maxCharsPerFile).toBe(DEFAULT_BOOTSTRAP_MAX_CHARS);
+    expect(config.totalMaxChars).toBe(DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS);
+  });
+
+  it("reduced profile has lower limits than normal", () => {
+    const normal = getBootstrapProfileConfig("normal");
+    const reduced = getBootstrapProfileConfig("reduced");
+    expect(reduced.maxCharsPerFile).toBeLessThan(normal.maxCharsPerFile);
+    expect(reduced.totalMaxChars).toBeLessThan(normal.totalMaxChars);
+    expect(reduced.maxCharsPerFile).toBe(10_000);
+    expect(reduced.totalMaxChars).toBe(50_000);
+  });
+
+  it("minimal profile has the lowest limits", () => {
+    const reduced = getBootstrapProfileConfig("reduced");
+    const minimal = getBootstrapProfileConfig("minimal");
+    expect(minimal.maxCharsPerFile).toBeLessThan(reduced.maxCharsPerFile);
+    expect(minimal.totalMaxChars).toBeLessThan(reduced.totalMaxChars);
+    expect(minimal.maxCharsPerFile).toBe(5_000);
+    expect(minimal.totalMaxChars).toBe(20_000);
+  });
+});
+
+describe("resolveBootstrapBudgetForModel", () => {
+  it("returns capped totalMaxChars for large context windows", () => {
+    // 200K token window: reserve = max(60K, 30K) = 60K, available = 140K, chars = 560K → capped at 150K
+    const budget = resolveBootstrapBudgetForModel(200_000);
+    expect(budget.totalMaxChars).toBe(DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS);
+  });
+
+  it("returns floored totalMaxChars for tiny context windows", () => {
+    // 1K token window: reserve = max(300, 30K) = 30K, available = -29K → chars = floor(-29K*4) → floor at 20K
+    const budget = resolveBootstrapBudgetForModel(1_000);
+    expect(budget.totalMaxChars).toBe(20_000);
+  });
+
+  it("scales appropriately for mid-range context windows", () => {
+    // 50K token window: reserve = max(15K, 30K) = 30K, available = 20K, chars = 80K → below cap
+    const budget = resolveBootstrapBudgetForModel(50_000);
+    expect(budget.totalMaxChars).toBe(80_000);
+    expect(budget.totalMaxChars).toBeLessThan(DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS);
+  });
+
+  it("applies 30K minimum reserve", () => {
+    // 60K token window: reserve = max(18K, 30K) = 30K, available = 30K, chars = 120K
+    const budget = resolveBootstrapBudgetForModel(60_000);
+    expect(budget.totalMaxChars).toBe(120_000);
+  });
+
+  it("preserves default maxCharsPerFile", () => {
+    const budget = resolveBootstrapBudgetForModel(100_000);
+    expect(budget.maxCharsPerFile).toBe(DEFAULT_BOOTSTRAP_MAX_CHARS);
+  });
+
+  it("totalMaxChars is always at least 20K", () => {
+    for (const tokens of [0.001, 100, 1_000, 10_000]) {
+      const budget = resolveBootstrapBudgetForModel(tokens);
+      expect(budget.totalMaxChars).toBeGreaterThanOrEqual(20_000);
+    }
+  });
+
+  it("totalMaxChars never exceeds DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS", () => {
+    for (const tokens of [100_000, 500_000, 1_000_000]) {
+      const budget = resolveBootstrapBudgetForModel(tokens);
+      expect(budget.totalMaxChars).toBeLessThanOrEqual(DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS);
+    }
+  });
+});
+
+describe("resolveBootstrapTotalMaxChars with contextWindowTokens", () => {
+  it("returns config value when set, ignoring contextWindowTokens", () => {
+    const cfg = { agents: { defaults: { bootstrapTotalMaxChars: 75_000 } } } as Parameters<
+      typeof resolveBootstrapTotalMaxChars
+    >[0];
+    const result = resolveBootstrapTotalMaxChars(cfg, 200_000);
+    expect(result).toBe(75_000);
+  });
+
+  it("uses contextWindowTokens when config is not set", () => {
+    // 50K token window → resolveBootstrapBudgetForModel gives 80K
+    const result = resolveBootstrapTotalMaxChars(undefined, 50_000);
+    expect(result).toBe(80_000);
+  });
+
+  it("returns default when neither config nor contextWindowTokens is set", () => {
+    const result = resolveBootstrapTotalMaxChars();
+    expect(result).toBe(DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS);
+  });
+
+  it("ignores contextWindowTokens of 0", () => {
+    const result = resolveBootstrapTotalMaxChars(undefined, 0);
+    expect(result).toBe(DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS);
+  });
+});

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -4,10 +4,14 @@ export {
   DEFAULT_BOOTSTRAP_PROMPT_TRUNCATION_WARNING_MODE,
   DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS,
   ensureSessionHeader,
+  getBootstrapProfileConfig,
+  resolveBootstrapBudgetForModel,
   resolveBootstrapMaxChars,
   resolveBootstrapPromptTruncationWarningMode,
   resolveBootstrapTotalMaxChars,
   stripThoughtSignatures,
+  type BootstrapProfile,
+  type BootstrapProfileConfig,
 } from "./pi-embedded-helpers/bootstrap.js";
 export {
   BILLING_ERROR_USER_MESSAGE,

--- a/src/agents/pi-embedded-helpers/bootstrap.ts
+++ b/src/agents/pi-embedded-helpers/bootstrap.ts
@@ -104,12 +104,61 @@ export function resolveBootstrapMaxChars(cfg?: OpenClawConfig): number {
   return DEFAULT_BOOTSTRAP_MAX_CHARS;
 }
 
-export function resolveBootstrapTotalMaxChars(cfg?: OpenClawConfig): number {
+export function resolveBootstrapTotalMaxChars(
+  cfg?: OpenClawConfig,
+  contextWindowTokens?: number,
+): number {
   const raw = cfg?.agents?.defaults?.bootstrapTotalMaxChars;
   if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
     return Math.floor(raw);
   }
+  if (typeof contextWindowTokens === "number" && contextWindowTokens > 0) {
+    return resolveBootstrapBudgetForModel(contextWindowTokens).totalMaxChars;
+  }
   return DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS;
+}
+
+// ── Bootstrap profiles ────────────────────────────────────────────────────────
+
+/** Controls how aggressively bootstrap content is trimmed for context overflow prevention. */
+export type BootstrapProfile = "normal" | "reduced" | "minimal";
+
+export type BootstrapProfileConfig = {
+  maxCharsPerFile: number;
+  totalMaxChars: number;
+};
+
+const BOOTSTRAP_PROFILE_CONFIGS: Record<BootstrapProfile, BootstrapProfileConfig> = {
+  normal: {
+    maxCharsPerFile: DEFAULT_BOOTSTRAP_MAX_CHARS,
+    totalMaxChars: DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS,
+  },
+  reduced: { maxCharsPerFile: 10_000, totalMaxChars: 50_000 },
+  minimal: { maxCharsPerFile: 5_000, totalMaxChars: 20_000 },
+};
+
+/** Returns the character budget limits for a given bootstrap profile. */
+export function getBootstrapProfileConfig(profile: BootstrapProfile): BootstrapProfileConfig {
+  return BOOTSTRAP_PROFILE_CONFIGS[profile];
+}
+
+/**
+ * Layer 3: Calculates a dynamic bootstrap budget based on the model's context window.
+ * Reserves 30% (minimum 30K tokens) for output and tool calls.
+ */
+export function resolveBootstrapBudgetForModel(
+  contextWindowTokens: number,
+): BootstrapProfileConfig {
+  const reserve = Math.max(contextWindowTokens * 0.3, 30_000);
+  const available = contextWindowTokens - reserve;
+  const bootstrapTotalMaxChars = Math.min(
+    DEFAULT_BOOTSTRAP_TOTAL_MAX_CHARS,
+    Math.max(20_000, Math.floor(available * 4)),
+  );
+  return {
+    maxCharsPerFile: DEFAULT_BOOTSTRAP_MAX_CHARS,
+    totalMaxChars: bootstrapTotalMaxChars,
+  };
 }
 
 export function resolveBootstrapPromptTruncationWarningMode(

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -86,6 +86,10 @@ export const AgentDefaultsSchema = z
       .optional(),
     compaction: z
       .object({
+        /** Model for bootstrap compaction (e.g. "anthropic/claude-haiku-4-5-20251001"). Inherits agent default when unset. */
+        model: z.string().optional(),
+        /** Bootstrap compaction LLM call timeout in ms. Default 30_000. */
+        timeoutMs: z.number().int().positive().optional(),
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
         reserveTokens: z.number().int().nonnegative().optional(),
         keepRecentTokens: z.number().int().positive().optional(),


### PR DESCRIPTION
## Problem

`ai-team` also contains the bootstrap/context-overflow work plus a Feishu persistence fix. Reviewers need a clean branch for the agent bootstrap path instead of hunting through unrelated runtime commits.

## Fix

- persist bot media-only replies to DB correctly
- add 3-layer context overflow protection for the CLI runner
- add LLM-based bootstrap compaction
- harden bootstrap compaction and context window budgeting
- prevent false media-only persistence when streamed text is still pending

## Flow

```text
large bootstrap / long context
  -> overflow guard trims inputs in layers
  -> optional LLM compaction reduces bootstrap payload
  -> runtime budgets the final prompt safely
  -> Feishu media-only persistence only triggers when reply text is truly absent
```

## Why merge

This slice is the bootstrap-stability PR. It contains the safety rails that keep long prompts usable, plus the related Feishu persistence fixes that were developed alongside that path.
