### PR TITLE
fix(ui): guard against undefined cron job payload in render loop

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -183,7 +183,7 @@ export function renderApp(state: AppViewState) {
         ...resolveConfiguredCronModelSuggestions(configValue),
         ...state.cronJobs
           .map((job) => {
-            if (job.payload.kind !== "agentTurn" || typeof job.payload.model !== "string") {
+            if (job.payload?.kind !== "agentTurn" || typeof job.payload.model !== "string") {
               return "";
             }
             return job.payload.model.trim();

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -449,12 +449,12 @@ function jobToForm(job: CronJob, prev: CronFormState): CronFormState {
     staggerUnit: "seconds",
     sessionTarget: job.sessionTarget,
     wakeMode: job.wakeMode,
-    payloadKind: job.payload.kind,
-    payloadText: job.payload.kind === "systemEvent" ? job.payload.text : job.payload.message,
-    payloadModel: job.payload.kind === "agentTurn" ? (job.payload.model ?? "") : "",
-    payloadThinking: job.payload.kind === "agentTurn" ? (job.payload.thinking ?? "") : "",
+    payloadKind: job.payload?.kind ?? "agentTurn",
+    payloadText: job.payload?.kind === "systemEvent" ? job.payload.text : (job.payload?.kind === "agentTurn" ? job.payload.message : ""),
+    payloadModel: job.payload?.kind === "agentTurn" ? (job.payload.model ?? "") : "",
+    payloadThinking: job.payload?.kind === "agentTurn" ? (job.payload.thinking ?? "") : "",
     payloadLightContext:
-      job.payload.kind === "agentTurn" ? job.payload.lightContext === true : false,
+      job.payload?.kind === "agentTurn" ? job.payload.lightContext === true : false,
     deliveryMode: job.delivery?.mode ?? "none",
     deliveryChannel: job.delivery?.channel ?? CRON_CHANNEL_LAST,
     deliveryTo: job.delivery?.to ?? "",
@@ -488,7 +488,7 @@ function jobToForm(job: CronJob, prev: CronFormState): CronFormState {
     failureAlertAccountId:
       failureAlert && typeof failureAlert === "object" ? (failureAlert.accountId ?? "") : "",
     timeoutSeconds:
-      job.payload.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
+      job.payload?.kind === "agentTurn" && typeof job.payload.timeoutSeconds === "number"
         ? String(job.payload.timeoutSeconds)
         : "",
   };
@@ -640,7 +640,7 @@ export async function addCronJob(state: CronState) {
       : undefined;
     if (payload.kind === "agentTurn") {
       const existingLightContext =
-        editingJob?.payload.kind === "agentTurn" ? editingJob.payload.lightContext : undefined;
+        editingJob?.payload?.kind === "agentTurn" ? editingJob.payload.lightContext : undefined;
       if (
         !form.payloadLightContext &&
         state.cronEditingJobId &&

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -1591,6 +1591,9 @@ function renderJob(job: CronJob, props: CronProps) {
 }
 
 function renderJobPayload(job: CronJob) {
+  if (!job.payload) {
+    return nothing;
+  }
   if (job.payload.kind === "systemEvent") {
     return html`<div class="cron-job-detail">
       <span class="cron-job-detail-label">${t("cron.jobDetail.system")}</span>


### PR DESCRIPTION
## Summary

- When a cron job's `payload` field is `undefined` (e.g. from incomplete API data or legacy jobs), directly accessing `job.payload.kind` in `app-render.ts` throws `TypeError: Cannot read properties of undefined (reading 'kind')`.
- Since this error occurs inside the LitElement `render()` method, it triggers on every reactive update, creating an infinite error loop that freezes the entire dashboard UI — users cannot switch tabs or interact with the page at all.
- This PR adds optional chaining (`?.`) guards to all `job.payload` access sites in `app-render.ts`, `controllers/cron.ts`, and `views/cron.ts`, with an early-return `nothing` guard in `renderJobPayload()`.

## Reproduction

1. Have a cron job where the gateway returns a job object with `payload: undefined`
2. Navigate to or through the Cron tab in the Gateway Dashboard
3. Observe the console filling with hundreds of `TypeError: Cannot read properties of undefined (reading 'kind')` errors
4. The UI becomes completely unresponsive

## Test plan

- [x] `vite build` compiles successfully with no type errors
- [x] `controllers/cron.test.ts` — all 27 tests pass
- [x] No regressions introduced (all pre-existing test failures remain unchanged)


Made with [Cursor](https://cursor.com)