### PR TITLE
fix(webchat): use agent identity name in session dropdown

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -1,16 +1,60 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const TEST_GLOBALS = vi.hoisted(() => {
+  const store = new Map<string, string>();
+  const localStorage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value));
+    },
+  } as Storage;
+  vi.stubGlobal("localStorage", localStorage);
+  vi.stubGlobal("navigator", { language: "en-US" } as Navigator);
+  return { localStorage };
+});
+
 import {
   isCronSessionKey,
   parseSessionKey,
   resolveSessionDisplayName,
 } from "./app-render.helpers.ts";
-import type { SessionsListResult } from "./types.ts";
+import type { AgentsListResult, SessionsListResult } from "./types.ts";
 
 type SessionRow = SessionsListResult["sessions"][number];
 
 function row(overrides: Partial<SessionRow> & { key: string }): SessionRow {
   return { kind: "direct", updatedAt: 0, ...overrides };
 }
+
+const AGENTS_LIST: AgentsListResult = {
+  defaultId: "main",
+  mainKey: "main",
+  scope: "per-sender",
+  agents: [
+    { id: "main", identity: { name: "Hal", emoji: "🔴" } },
+    { id: "butler", identity: { name: "Jarvis", emoji: "🎩" } },
+    { id: "sentinel", identity: { name: "Vigil", emoji: "🛡️" } },
+  ],
+};
+
+afterEach(() => {
+  TEST_GLOBALS.localStorage.clear();
+  vi.restoreAllMocks();
+});
 
 /* ================================================================
  *  parseSessionKey – low-level key → type / fallback mapping
@@ -135,6 +179,26 @@ describe("resolveSessionDisplayName", () => {
 
   it("returns raw key for unknown patterns", () => {
     expect(resolveSessionDisplayName("something-custom")).toBe("something-custom");
+  });
+
+  it("uses agent identity for canonical agent main session keys", () => {
+    expect(resolveSessionDisplayName("agent:butler:main", undefined, AGENTS_LIST)).toBe(
+      "🎩 Jarvis (butler)",
+    );
+  });
+
+  it("uses agent identity for legacy webchat main session keys", () => {
+    expect(resolveSessionDisplayName("webchat:g-agent-sentinel-main", undefined, AGENTS_LIST)).toBe(
+      "🛡️ Vigil (sentinel)",
+    );
+  });
+
+  it("omits id suffix when agent identity name already matches id", () => {
+    const agentsList: AgentsListResult = {
+      ...AGENTS_LIST,
+      agents: [{ id: "main", identity: { name: "main", emoji: "🔴" } }],
+    };
+    expect(resolveSessionDisplayName("agent:main:main", undefined, agentsList)).toBe("🔴 main");
   });
 
   // ── With row data (label / displayName) ──────────

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,5 +1,6 @@
 import { html } from "lit";
 import { repeat } from "lit/directives/repeat.js";
+import { parseAgentSessionKey } from "../../../src/routing/session-key.js";
 import { t } from "../i18n/index.ts";
 import { refreshChat } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
@@ -10,11 +11,16 @@ import { icons } from "./icons.ts";
 import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
 import type { ThemeTransitionContext } from "./theme-transition.ts";
 import type { ThemeMode } from "./theme.ts";
-import type { SessionsListResult } from "./types.ts";
+import type { AgentsListResult, SessionsListResult } from "./types.ts";
 
 type SessionDefaultsSnapshot = {
   mainSessionKey?: string;
   mainKey?: string;
+};
+
+type SessionOption = {
+  key: string;
+  displayName?: string;
 };
 
 function resolveSidebarChatSessionKey(state: AppViewState): string {
@@ -131,6 +137,7 @@ export function renderChatControls(state: AppViewState) {
   const sessionOptions = resolveSessionOptions(
     state.sessionKey,
     state.sessionsResult,
+    state.agentsList,
     mainSessionKey,
     hideCron,
   );
@@ -337,6 +344,46 @@ function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function resolveSessionAgentId(key: string, agentsList?: AgentsListResult | null): string | null {
+  const parsed = parseAgentSessionKey(key);
+  const mainKey = agentsList?.mainKey?.trim().toLowerCase() || "main";
+  if (parsed?.rest === mainKey) {
+    return parsed.agentId;
+  }
+  const normalized = key.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  const legacyMatch = normalized.match(
+    new RegExp(`(?:^|:)g-agent-(.+)-${escapeRegExp(mainKey)}$`, "i"),
+  );
+  const legacyAgentId = legacyMatch?.[1]?.trim();
+  return legacyAgentId || null;
+}
+
+function resolveAgentSessionDisplayName(
+  key: string,
+  agentsList?: AgentsListResult | null,
+): string | null {
+  const agentId = resolveSessionAgentId(key, agentsList);
+  if (!agentId || !agentsList?.agents?.length) {
+    return null;
+  }
+  const agent = agentsList.agents.find((entry) => entry.id.trim().toLowerCase() === agentId);
+  if (!agent) {
+    return null;
+  }
+  const name = agent.identity?.name?.trim() || agent.name?.trim() || agent.id;
+  const emoji = agent.identity?.emoji?.trim() || "";
+  const suffix =
+    name.trim().toLowerCase() === agent.id.trim().toLowerCase() ? "" : ` (${agent.id})`;
+  return `${emoji ? `${emoji} ` : ""}${name}${suffix}`;
+}
+
 /**
  * Parse a session key to extract type information and a human-readable
  * fallback display name.  Exported for testing.
@@ -390,6 +437,7 @@ export function parseSessionKey(key: string): SessionKeyInfo {
 export function resolveSessionDisplayName(
   key: string,
   row?: SessionsListResult["sessions"][number],
+  agentsList?: AgentsListResult | null,
 ): string {
   const label = row?.label?.trim() || "";
   const displayName = row?.displayName?.trim() || "";
@@ -399,7 +447,7 @@ export function resolveSessionDisplayName(
     if (!prefix) {
       return name;
     }
-    const prefixPattern = new RegExp(`^${prefix.replace(/[.*+?^${}()|[\\]\\]/g, "\\$&")}\\s*`, "i");
+    const prefixPattern = new RegExp(`^${escapeRegExp(prefix)}\\s*`, "i");
     return prefixPattern.test(name) ? name : `${prefix} ${name}`;
   };
 
@@ -408,6 +456,10 @@ export function resolveSessionDisplayName(
   }
   if (displayName && displayName !== key) {
     return applyTypedPrefix(displayName);
+  }
+  const agentDisplayName = resolveAgentSessionDisplayName(key, agentsList);
+  if (agentDisplayName) {
+    return applyTypedPrefix(agentDisplayName);
   }
   return fallbackName;
 }
@@ -434,11 +486,12 @@ export function isCronSessionKey(key: string): boolean {
 function resolveSessionOptions(
   sessionKey: string,
   sessions: SessionsListResult | null,
+  agentsList?: AgentsListResult | null,
   mainSessionKey?: string | null,
   hideCron = false,
 ) {
   const seen = new Set<string>();
-  const options: Array<{ key: string; displayName?: string }> = [];
+  const options: SessionOption[] = [];
 
   const resolvedMain = mainSessionKey && sessions?.sessions?.find((s) => s.key === mainSessionKey);
   const resolvedCurrent = sessions?.sessions?.find((s) => s.key === sessionKey);
@@ -448,7 +501,7 @@ function resolveSessionOptions(
     seen.add(mainSessionKey);
     options.push({
       key: mainSessionKey,
-      displayName: resolveSessionDisplayName(mainSessionKey, resolvedMain || undefined),
+      displayName: resolveSessionDisplayName(mainSessionKey, resolvedMain || undefined, agentsList),
     });
   }
 
@@ -458,7 +511,7 @@ function resolveSessionOptions(
     seen.add(sessionKey);
     options.push({
       key: sessionKey,
-      displayName: resolveSessionDisplayName(sessionKey, resolvedCurrent),
+      displayName: resolveSessionDisplayName(sessionKey, resolvedCurrent, agentsList),
     });
   }
 
@@ -469,7 +522,7 @@ function resolveSessionOptions(
         seen.add(s.key);
         options.push({
           key: s.key,
-          displayName: resolveSessionDisplayName(s.key, s),
+          displayName: resolveSessionDisplayName(s.key, s, agentsList),
         });
       }
     }


### PR DESCRIPTION
## Summary

- Problem: When multiple agents are configured, the webchat session dropdown shows raw session keys like `agent:butler:main` instead of friendly names
- Why it matters: Users cannot easily identify which agent session they are switching to, especially with multiple agents
- What changed: `resolveSessionDisplayName` now resolves agent identity (emoji + name) from the `agentsList` data already loaded on gateway connect, producing labels like "🎩 Jarvis (butler)"
- What did NOT change (scope boundary): Backend session API, session key format, existing label/displayName priority, non-agent session resolution

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38679

## User-visible / Behavior Changes

Session dropdown in webchat now displays agent-friendly labels:

| Before | After |
|--------|-------|
| `agent:butler:main` | 🎩 Jarvis (butler) |
| `agent:sentinel:main` | 🛡️ Vigil (sentinel) |
| `webchat:g-agent-butler-main` | 🎩 Jarvis (butler) |

When agent identity name already matches the agent ID (e.g. agent named "main"), the redundant suffix is omitted: `🔴 main` instead of `🔴 main (main)`.

Existing `label` and `displayName` fields from the session row still take priority — agent identity is only used as a fallback when neither is set.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Runtime: Node 22+ / Bun
- UI: OpenClaw Control UI (Lit web components)

### Steps

1. Configure multiple agents with distinct `identity.name` and `identity.emoji`
2. Open the webchat Control UI
3. Click the session dropdown

### Expected

- Each agent's main session shows its friendly name with emoji (e.g. "🎩 Jarvis (butler)")

### Actual (before fix)

- Raw session keys shown (e.g. "agent:butler:main")

## Evidence

- [x] Failing test/log before + passing after

3 new test cases added covering:

| Test | Input key | Expected output |
|------|-----------|-----------------|
| Canonical agent key | `agent:butler:main` | `🎩 Jarvis (butler)` |
| Legacy webchat key | `webchat:g-agent-sentinel-main` | `🛡️ Vigil (sentinel)` |
| Name matches ID | `agent:main:main` (name="main") | `🔴 main` |

All 39 tests pass (36 existing + 3 new).

## Human Verification (required)

- Verified scenarios: All 39 unit tests pass, format check (oxfmt), lint (oxlint), type check (tsgo) all green
- Edge cases checked: Legacy `webchat:g-agent-*` key format, agent name matching agent ID (suffix omission), missing agentsList (graceful fallback), whitespace handling
- What you did **not** verify: Live browser testing with real multi-agent gateway setup

## Compatibility / Migration

- Backward compatible? Yes — all new parameters are optional; existing callers without `agentsList` behave exactly as before
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit; the optional `agentsList` parameter means no callers are forced to use it
- Files/config to restore: `ui/src/ui/app-render.helpers.ts`
- Known bad symptoms reviewers should watch for: Session dropdown showing `undefined` or empty labels for agent sessions

## Risks and Mitigations

- Risk: Legacy key regex (`g-agent-<id>-<mainKey>`) may not cover all possible legacy formats
  - Mitigation: Falls through gracefully to existing `parseSessionKey` fallback; no worse than current behavior