### PR TITLE
feat: configurable heartbeat ack token

### DIFF
--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -45,6 +45,7 @@ export function buildSystemPrompt(params: {
   extraSystemPrompt?: string;
   ownerNumbers?: string[];
   heartbeatPrompt?: string;
+  heartbeatAckToken?: string;
   docsPath?: string;
   tools: AgentTool[];
   contextFiles?: EmbeddedContextFile[];
@@ -83,6 +84,7 @@ export function buildSystemPrompt(params: {
     ownerDisplaySecret: ownerDisplay.ownerDisplaySecret,
     reasoningTagHint: false,
     heartbeatPrompt: params.heartbeatPrompt,
+    heartbeatAckToken: params.heartbeatAckToken,
     docsPath: params.docsPath,
     acpEnabled: params.config?.acp?.enabled !== false,
     runtimeInfo,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -514,6 +514,9 @@ export async function compactEmbeddedPiSessionDirect(
       heartbeatPrompt: isDefaultAgent
         ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)
         : undefined,
+      heartbeatAckToken: isDefaultAgent
+        ? params.config?.agents?.defaults?.heartbeat?.ackToken
+        : undefined,
       skillsPrompt,
       docsPath: docsPath ?? undefined,
       ttsHint,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1001,6 +1001,9 @@ export async function runEmbeddedAttempt(
       heartbeatPrompt: isDefaultAgent
         ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)
         : undefined,
+      heartbeatAckToken: isDefaultAgent
+        ? params.config?.agents?.defaults?.heartbeat?.ackToken
+        : undefined,
       skillsPrompt,
       docsPath: docsPath ?? undefined,
       ttsHint,

--- a/src/agents/pi-embedded-runner/system-prompt.ts
+++ b/src/agents/pi-embedded-runner/system-prompt.ts
@@ -18,6 +18,7 @@ export function buildEmbeddedSystemPrompt(params: {
   ownerDisplaySecret?: string;
   reasoningTagHint: boolean;
   heartbeatPrompt?: string;
+  heartbeatAckToken?: string;
   skillsPrompt?: string;
   docsPath?: string;
   ttsHint?: string;
@@ -64,6 +65,7 @@ export function buildEmbeddedSystemPrompt(params: {
     ownerDisplaySecret: params.ownerDisplaySecret,
     reasoningTagHint: params.reasoningTagHint,
     heartbeatPrompt: params.heartbeatPrompt,
+    heartbeatAckToken: params.heartbeatAckToken,
     skillsPrompt: params.skillsPrompt,
     docsPath: params.docsPath,
     ttsHint: params.ttsHint,

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -205,6 +205,7 @@ export function buildAgentSystemPrompt(params: {
   bootstrapTruncationWarningLines?: string[];
   skillsPrompt?: string;
   heartbeatPrompt?: string;
+  heartbeatAckToken?: string;
   docsPath?: string;
   workspaceNotes?: string[];
   ttsHint?: string;
@@ -665,13 +666,14 @@ export function buildAgentSystemPrompt(params: {
 
   // Skip heartbeats for subagent/none modes
   if (!isMinimal) {
+    const ackToken = params.heartbeatAckToken?.trim() || "HEARTBEAT_OK";
     lines.push(
       "## Heartbeats",
       heartbeatPromptLine,
       "If you receive a heartbeat poll (a user message matching the heartbeat prompt above), and there is nothing that needs attention, reply exactly:",
-      "HEARTBEAT_OK",
-      'OpenClaw treats a leading/trailing "HEARTBEAT_OK" as a heartbeat ack (and may discard it).',
-      'If something needs attention, do NOT include "HEARTBEAT_OK"; reply with the alert text instead.',
+      ackToken,
+      `OpenClaw treats a leading/trailing "${ackToken}" as a heartbeat ack (and may discard it).`,
+      `If something needs attention, do NOT include "${ackToken}"; reply with the alert text instead.`,
       "",
     );
   }

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -1,5 +1,5 @@
 import { escapeRegExp } from "../utils.js";
-import { HEARTBEAT_TOKEN } from "./tokens.js";
+import { DEFAULT_HEARTBEAT_ACK_TOKEN, HEARTBEAT_TOKEN } from "./tokens.js";
 
 // Default heartbeat prompt (used when config.agents.defaults.heartbeat.prompt is unset).
 // Keep it tight and avoid encouraging the model to invent/rehash "open loops" from prior chat context.
@@ -59,13 +59,25 @@ export function resolveHeartbeatPrompt(raw?: string): string {
 
 export type StripHeartbeatMode = "heartbeat" | "message";
 
-function stripTokenAtEdges(raw: string): { text: string; didStrip: boolean } {
+/**
+ * Resolve the effective heartbeat ack token from config.
+ * Falls back to the built-in HEARTBEAT_OK constant.
+ */
+export function resolveHeartbeatAckToken(configToken?: string): string {
+  const trimmed = typeof configToken === "string" ? configToken.trim() : "";
+  return trimmed || DEFAULT_HEARTBEAT_ACK_TOKEN;
+}
+
+function stripTokenAtEdges(
+  raw: string,
+  tokenOverride?: string,
+): { text: string; didStrip: boolean } {
   let text = raw.trim();
   if (!text) {
     return { text: "", didStrip: false };
   }
 
-  const token = HEARTBEAT_TOKEN;
+  const token = tokenOverride || HEARTBEAT_TOKEN;
   const tokenAtEndWithOptionalTrailingPunctuation = new RegExp(
     `${escapeRegExp(token)}[^\\w]{0,4}$`,
   );
@@ -109,7 +121,7 @@ function stripTokenAtEdges(raw: string): { text: string; didStrip: boolean } {
 
 export function stripHeartbeatToken(
   raw?: string,
-  opts: { mode?: StripHeartbeatMode; maxAckChars?: number } = {},
+  opts: { mode?: StripHeartbeatMode; maxAckChars?: number; ackToken?: string } = {},
 ) {
   if (!raw) {
     return { shouldSkip: true, text: "", didStrip: false };
@@ -142,14 +154,26 @@ export function stripHeartbeatToken(
       .replace(/^[*`~_]+/, "")
       .replace(/[*`~_]+$/, "");
 
+  const effectiveToken = resolveHeartbeatAckToken(opts.ackToken);
   const trimmedNormalized = stripMarkup(trimmed);
-  const hasToken = trimmed.includes(HEARTBEAT_TOKEN) || trimmedNormalized.includes(HEARTBEAT_TOKEN);
+  // Check for both the configured token and the built-in HEARTBEAT_OK
+  // so agents can use either form regardless of config.
+  const hasToken =
+    trimmed.includes(effectiveToken) ||
+    trimmedNormalized.includes(effectiveToken) ||
+    trimmed.includes(HEARTBEAT_TOKEN) ||
+    trimmedNormalized.includes(HEARTBEAT_TOKEN);
   if (!hasToken) {
     return { shouldSkip: false, text: trimmed, didStrip: false };
   }
 
-  const strippedOriginal = stripTokenAtEdges(trimmed);
-  const strippedNormalized = stripTokenAtEdges(trimmedNormalized);
+  // Try stripping the configured token first, fall back to built-in
+  const strippedOriginal = trimmed.includes(effectiveToken)
+    ? stripTokenAtEdges(trimmed, effectiveToken)
+    : stripTokenAtEdges(trimmed, HEARTBEAT_TOKEN);
+  const strippedNormalized = trimmedNormalized.includes(effectiveToken)
+    ? stripTokenAtEdges(trimmedNormalized, effectiveToken)
+    : stripTokenAtEdges(trimmedNormalized, HEARTBEAT_TOKEN);
   const picked =
     strippedOriginal.didStrip && strippedOriginal.text ? strippedOriginal : strippedNormalized;
   if (!picked.didStrip) {

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -1,6 +1,7 @@
 import { escapeRegExp } from "../utils.js";
 
 export const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
+export const DEFAULT_HEARTBEAT_ACK_TOKEN = HEARTBEAT_TOKEN;
 export const SILENT_REPLY_TOKEN = "NO_REPLY";
 
 const silentExactRegexByToken = new Map<string, RegExp>();

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -244,7 +244,9 @@ export type AgentDefaultsConfig = {
     accountId?: string;
     /** Override the heartbeat prompt body (default: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK."). */
     prompt?: string;
-    /** Max chars allowed after HEARTBEAT_OK before delivery (default: 30). */
+    /** Custom heartbeat acknowledgement token (default: "HEARTBEAT_OK"). The agent replies with this token to signal "nothing to report". Can be an emoji (e.g. "💗") or any short string. */
+    ackToken?: string;
+    /** Max chars allowed after the ack token before delivery (default: 30). */
     ackMaxChars?: number;
     /** Suppress tool error warning payloads during heartbeat runs. */
     suppressToolErrorWarnings?: boolean;

--- a/src/cron/heartbeat-policy.ts
+++ b/src/cron/heartbeat-policy.ts
@@ -9,6 +9,7 @@ export type HeartbeatDeliveryPayload = {
 export function shouldSkipHeartbeatOnlyDelivery(
   payloads: HeartbeatDeliveryPayload[],
   ackMaxChars: number,
+  ackToken?: string,
 ): boolean {
   if (payloads.length === 0) {
     return true;
@@ -23,6 +24,7 @@ export function shouldSkipHeartbeatOnlyDelivery(
     const result = stripHeartbeatToken(payload.text, {
       mode: "heartbeat",
       maxAckChars: ackMaxChars,
+      ackToken,
     });
     return result.shouldSkip;
   });

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -88,11 +88,21 @@ export function pickLastDeliverablePayload(payloads: DeliveryPayload[]) {
  * Check if delivery should be skipped because the agent signaled no user-visible update.
  * Returns true when any payload is a heartbeat ack token and no payload contains media.
  */
-export function isHeartbeatOnlyResponse(payloads: DeliveryPayload[], ackMaxChars: number) {
-  return shouldSkipHeartbeatOnlyDelivery(payloads, ackMaxChars);
+export function isHeartbeatOnlyResponse(
+  payloads: DeliveryPayload[],
+  ackMaxChars: number,
+  ackToken?: string,
+) {
+  return shouldSkipHeartbeatOnlyDelivery(payloads, ackMaxChars, ackToken);
 }
 
 export function resolveHeartbeatAckMaxChars(agentCfg?: { heartbeat?: { ackMaxChars?: number } }) {
   const raw = agentCfg?.heartbeat?.ackMaxChars ?? DEFAULT_HEARTBEAT_ACK_MAX_CHARS;
   return Math.max(0, raw);
+}
+
+export function resolveHeartbeatAckToken(agentCfg?: {
+  heartbeat?: { ackToken?: string };
+}): string | undefined {
+  return agentCfg?.heartbeat?.ackToken;
 }

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -68,6 +68,7 @@ import {
   pickSummaryFromOutput,
   pickSummaryFromPayloads,
   resolveHeartbeatAckMaxChars,
+  resolveHeartbeatAckToken,
 } from "./helpers.js";
 import { resolveCronAgentSessionKey } from "./session-key.js";
 import { resolveCronSession } from "./session.js";
@@ -725,9 +726,11 @@ export async function runCronIsolatedAgentTurn(params: {
       ...telemetry,
     });
 
-  // Skip delivery for heartbeat-only responses (HEARTBEAT_OK with no real content).
+  // Skip delivery for heartbeat-only responses (HEARTBEAT_OK or custom ackToken with no real content).
   const ackMaxChars = resolveHeartbeatAckMaxChars(agentCfg);
-  const skipHeartbeatDelivery = deliveryRequested && isHeartbeatOnlyResponse(payloads, ackMaxChars);
+  const ackToken = resolveHeartbeatAckToken(agentCfg);
+  const skipHeartbeatDelivery =
+    deliveryRequested && isHeartbeatOnlyResponse(payloads, ackMaxChars, ackToken);
   const skipMessagingToolDelivery =
     deliveryRequested &&
     finalRunResult.didSendViaMessagingTool === true &&

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -447,12 +447,14 @@ function normalizeHeartbeatReply(
   payload: ReplyPayload,
   responsePrefix: string | undefined,
   ackMaxChars: number,
+  ackToken?: string,
 ) {
   const rawText = typeof payload.text === "string" ? payload.text : "";
   const textForStrip = stripLeadingHeartbeatResponsePrefix(rawText, responsePrefix);
   const stripped = stripHeartbeatToken(textForStrip, {
     mode: "heartbeat",
     maxAckChars: ackMaxChars,
+    ackToken,
   });
   const hasMedia = Boolean(payload.mediaUrl || (payload.mediaUrls?.length ?? 0) > 0);
   if (stripped.shouldSkip && !hasMedia) {
@@ -712,7 +714,10 @@ export async function runHeartbeatOnce(opts: {
     return { status: "skipped", reason: "alerts-disabled" };
   }
 
-  const heartbeatOkText = responsePrefix ? `${responsePrefix} ${HEARTBEAT_TOKEN}` : HEARTBEAT_TOKEN;
+  const effectiveAckToken = heartbeat?.ackToken?.trim() || HEARTBEAT_TOKEN;
+  const heartbeatOkText = responsePrefix
+    ? `${responsePrefix} ${effectiveAckToken}`
+    : effectiveAckToken;
   const outboundSession = buildOutboundSessionContext({
     cfg,
     agentId,
@@ -801,7 +806,8 @@ export async function runHeartbeatOnce(opts: {
     }
 
     const ackMaxChars = resolveHeartbeatAckMaxChars(cfg, heartbeat);
-    const normalized = normalizeHeartbeatReply(replyPayload, responsePrefix, ackMaxChars);
+    const ackToken = heartbeat?.ackToken;
+    const normalized = normalizeHeartbeatReply(replyPayload, responsePrefix, ackMaxChars, ackToken);
     // For exec completion events, don't skip even if the response looks like HEARTBEAT_OK.
     // The model should be responding with exec results, not ack tokens.
     // Also, if normalized.text is empty due to token stripping but we have exec completion,

--- a/src/web/auto-reply.impl.ts
+++ b/src/web/auto-reply.impl.ts
@@ -1,5 +1,13 @@
-export { HEARTBEAT_PROMPT, stripHeartbeatToken } from "../auto-reply/heartbeat.js";
-export { HEARTBEAT_TOKEN, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+export {
+  HEARTBEAT_PROMPT,
+  resolveHeartbeatAckToken,
+  stripHeartbeatToken,
+} from "../auto-reply/heartbeat.js";
+export {
+  DEFAULT_HEARTBEAT_ACK_TOKEN,
+  HEARTBEAT_TOKEN,
+  SILENT_REPLY_TOKEN,
+} from "../auto-reply/tokens.js";
 
 export { DEFAULT_WEB_MEDIA_BYTES } from "./auto-reply/constants.js";
 export { resolveHeartbeatRecipients, runWebHeartbeatOnce } from "./auto-reply/heartbeat-runner.js";

--- a/src/web/auto-reply/heartbeat-runner.ts
+++ b/src/web/auto-reply/heartbeat-runner.ts
@@ -51,7 +51,7 @@ export async function runWebHeartbeatOnce(opts: {
 
   // Resolve heartbeat visibility settings for WhatsApp
   const visibility = resolveHeartbeatVisibility({ cfg, channel: "whatsapp" });
-  const heartbeatOkText = HEARTBEAT_TOKEN;
+  const heartbeatOkText = cfg?.agents?.defaults?.heartbeat?.ackToken?.trim() || HEARTBEAT_TOKEN;
 
   const maybeSendHeartbeatOk = async (): Promise<boolean> => {
     if (!visibility.showOk) {

--- a/src/web/auto-reply/heartbeat-runner.ts
+++ b/src/web/auto-reply/heartbeat-runner.ts
@@ -6,7 +6,7 @@ import {
   stripHeartbeatToken,
 } from "../../auto-reply/heartbeat.js";
 import { getReplyFromConfig } from "../../auto-reply/reply.js";
-import { HEARTBEAT_TOKEN } from "../../auto-reply/tokens.js";
+import { DEFAULT_HEARTBEAT_ACK_TOKEN } from "../../auto-reply/tokens.js";
 import { resolveWhatsAppHeartbeatRecipients } from "../../channels/plugins/whatsapp-heartbeat.js";
 import { loadConfig } from "../../config/config.js";
 import {
@@ -51,7 +51,7 @@ export async function runWebHeartbeatOnce(opts: {
 
   // Resolve heartbeat visibility settings for WhatsApp
   const visibility = resolveHeartbeatVisibility({ cfg, channel: "whatsapp" });
-  const heartbeatOkText = cfg?.agents?.defaults?.heartbeat?.ackToken?.trim() || HEARTBEAT_TOKEN;
+  const heartbeatOkText = cfg?.agents?.defaults?.heartbeat?.ackToken?.trim() || DEFAULT_HEARTBEAT_ACK_TOKEN;
 
   const maybeSendHeartbeatOk = async (): Promise<boolean> => {
     if (!visibility.showOk) {
@@ -209,6 +209,7 @@ export async function runWebHeartbeatOnce(opts: {
     const stripped = stripHeartbeatToken(replyPayload.text, {
       mode: "heartbeat",
       maxAckChars: ackMaxChars,
+      ackToken: heartbeatOkText,
     });
     if (stripped.shouldSkip && !hasMedia) {
       // Don't let heartbeats keep sessions alive: restore previous updatedAt so idle expiry still works.


### PR DESCRIPTION
## Description

### What
Adds an `ackToken` option to the heartbeat config (`agents.defaults.heartbeat.ackToken`), allowing users to replace the default `HEARTBEAT_OK` string with a custom token — such as an emoji (e.g. `💗`).

### Why
The hardcoded `HEARTBEAT_OK` string works fine for silent/discarded heartbeats, but many users configure heartbeat delivery to Telegram/Discord so they can see the "all clear" signal. In that case, `HEARTBEAT_OK` feels robotic and wastes screen space. A short emoji like `💗` is more natural for chat surfaces.

Currently, even if the agent replies with a custom token (e.g. `💗` as instructed in HEARTBEAT.md), the gateway doesn't recognize it as a heartbeat ack and delivers it as a regular message — losing the skip/strip behavior.

### Config example
```yaml
agents:
  defaults:
    heartbeat:
      every: 30m
      ackToken: "💗"
```

### How it works
- The custom token is injected into the system prompt (replacing `HEARTBEAT_OK` in the heartbeat instructions)
- `stripHeartbeatToken()` recognizes **both** the configured token and the built-in `HEARTBEAT_OK`, so agents can use either form regardless of config
- The token flows through all heartbeat paths: cron delivery, heartbeat runner, web auto-reply, and compaction

### Files changed (14)
| File | Change |
|------|--------|
| `src/config/types.agent-defaults.ts` | Add `ackToken` to heartbeat config type |
| `src/auto-reply/tokens.ts` | Export `DEFAULT_HEARTBEAT_ACK_TOKEN` constant |
| `src/auto-reply/heartbeat.ts` | `resolveHeartbeatAckToken()` helper; `stripHeartbeatToken` accepts `ackToken` option; recognizes both custom + built-in tokens |
| `src/agents/system-prompt.ts` | Use resolved `ackToken` in heartbeat prompt section |
| `src/agents/cli-runner/helpers.ts` | Thread `heartbeatAckToken` through CLI runner |
| `src/agents/pi-embedded-runner/*.ts` | Thread `heartbeatAckToken` through embedded runner + compaction |
| `src/cron/heartbeat-policy.ts` | Accept `ackToken` in `shouldSkipHeartbeatOnlyDelivery` |
| `src/cron/isolated-agent/helpers.ts` | Add `resolveHeartbeatAckToken` helper; pass to `isHeartbeatOnlyResponse` |
| `src/cron/isolated-agent/run.ts` | Resolve and pass `ackToken` for cron delivery skip logic |
| `src/infra/heartbeat-runner.ts` | Use `ackToken` in heartbeat OK text and `normalizeHeartbeatReply` |
| `src/web/auto-reply.impl.ts` | Re-export new token utilities |
| `src/web/auto-reply/heartbeat-runner.ts` | Use `ackToken` in web heartbeat runner |

### Backward compatibility
- **Fully backward compatible.** If `ackToken` is not set, behavior is identical to current — `HEARTBEAT_OK` is used everywhere.
- Both the configured token and the built-in `HEARTBEAT_OK` are always recognized, so existing agents/prompts continue to work without changes.

⚠️ CI failure in extensions/feishu/src/monitor.test-mocks.ts is pre-existing — unrelated to this change. The TS2742 error is a missing type reference to @vitest/spy in the Feishu extension test mocks.

---

🤖 **AI-assisted:** This patch was authored by an AI agent (Claude Opus 4.6 via OpenClaw) running a 24/7 heartbeat system. The motivation came from real daily usage — wanting `💗` instead of `HEARTBEAT_OK` in Telegram. **Lightly tested** against local OpenClaw instance (config set, heartbeat recognized). Full CI not run. The author understands all changes.
