### PR TITLE
fix(podman): evaluate GATEWAY_BIND after sourcing .env

### DIFF
--- a/scripts/run-openclaw-podman.sh
+++ b/scripts/run-openclaw-podman.sh
@@ -75,9 +75,6 @@ OPENCLAW_IMAGE="${OPENCLAW_PODMAN_IMAGE:-openclaw:local}"
 PODMAN_PULL="${OPENCLAW_PODMAN_PULL:-never}"
 HOST_GATEWAY_PORT="${OPENCLAW_PODMAN_GATEWAY_HOST_PORT:-${OPENCLAW_GATEWAY_PORT:-18789}}"
 HOST_BRIDGE_PORT="${OPENCLAW_PODMAN_BRIDGE_HOST_PORT:-${OPENCLAW_BRIDGE_PORT:-18790}}"
-# Keep Podman default local-only unless explicitly overridden.
-# Non-loopback binds require gateway.controlUi.allowedOrigins (security hardening).
-GATEWAY_BIND="${OPENCLAW_GATEWAY_BIND:-loopback}"
 
 # Safe cwd for podman (openclaw is nologin; avoid inherited cwd from sudo)
 cd "$EFFECTIVE_HOME" 2>/dev/null || cd /tmp 2>/dev/null || true
@@ -99,6 +96,11 @@ if [[ -f "$ENV_FILE" ]]; then
   source "$ENV_FILE" 2>/dev/null || true
   set +a
 fi
+
+# Keep Podman default local-only unless explicitly overridden.
+# Non-loopback binds require gateway.controlUi.allowedOrigins (security hardening).
+# NOTE: must be evaluated after sourcing ENV_FILE so OPENCLAW_GATEWAY_BIND set in .env takes effect.
+GATEWAY_BIND="${OPENCLAW_GATEWAY_BIND:-loopback}"
 
 upsert_env_var() {
   local file="$1"


### PR DESCRIPTION
## Summary

- **Problem:** In `scripts/run-openclaw-podman.sh`, `GATEWAY_BIND` was assigned from `OPENCLAW_GATEWAY_BIND` (line 80) *before* the `.env` file was sourced (lines 96–101). As a result, setting `OPENCLAW_GATEWAY_BIND=lan` (or any non-default value) in the user's `.env` file had no effect — `GATEWAY_BIND` always resolved to the default `loopback`.
- **Why it matters:** Users who configure `bind: lan` via the onboarding wizard have `OPENCLAW_GATEWAY_BIND=lan` written to their `.env`, but the gateway still starts with `--bind loopback`, making the dashboard unreachable from any non-loopback address (e.g. WSL, LAN, remote browser).
- **What changed:** Moved the `GATEWAY_BIND` assignment and its comment to after the `.env` source block, so the env file value is respected.
- **What did NOT change:** Default behavior (`loopback`) is unchanged when no `.env` or env var is present. No other variables affected.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #38810

## User-visible / Behavior Changes

`OPENCLAW_GATEWAY_BIND` set in `.env` now takes effect as expected. Default remains `loopback` when unset.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (WSL2 on Windows 10)
- Runtime/container: rootless Podman

### Steps

1. Run onboarding wizard and choose `lan` bind
2. Confirm `OPENCLAW_GATEWAY_BIND=lan` is written to `~/.openclaw/.env`
3. Start gateway with `./scripts/run-openclaw-podman.sh launch`
4. Check running process: `ps aux | grep gateway`

### Expected

- Process shows `--bind lan`

### Actual (before fix)

- Process shows `--bind loopback` — `.env` value ignored

## Evidence

- Root cause confirmed by inspecting script execution order: `GATEWAY_BIND="${OPENCLAW_GATEWAY_BIND:-loopback}"` evaluated at line 80, `.env` sourced at line 96.

## Human Verification

- Verified by tracing script execution in WSL2 + rootless Podman environment
- Confirmed gateway process changed from `--bind loopback` to `--bind lan` after fix

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- Revert: restore the `GATEWAY_BIND` line to its original position (before the `.env` source block)

## Risks and Mitigations

- Risk: Users who relied on env-var override via command-line prefix will see no behavior change (fix aligns `.env` with that already-working path).
  - Mitigation: Default `loopback` is preserved; no change for users without `.env` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)