### PR TITLE
fix(gateway): hide delivery-mirror transcript entries from chat history

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -367,7 +367,12 @@ function isDeliveryMirrorTranscriptMessage(message: unknown): boolean {
     return false;
   }
   const entry = message as Record<string, unknown>;
-  return entry.role === "assistant" && entry.model === "delivery-mirror";
+  return (
+    entry.role === "assistant" &&
+    entry.model === "delivery-mirror" &&
+    entry.provider === "openclaw" &&
+    entry.api === "openai-responses"
+  );
 }
 
 function sanitizeChatHistoryMessages(messages: unknown[]): unknown[] {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -362,6 +362,14 @@ function extractAssistantTextForSilentCheck(message: unknown): string | undefine
   return texts.length > 0 ? texts.join("\n") : undefined;
 }
 
+function isDeliveryMirrorTranscriptMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as Record<string, unknown>;
+  return entry.role === "assistant" && entry.model === "delivery-mirror";
+}
+
 function sanitizeChatHistoryMessages(messages: unknown[]): unknown[] {
   if (messages.length === 0) {
     return messages;
@@ -371,6 +379,14 @@ function sanitizeChatHistoryMessages(messages: unknown[]): unknown[] {
   for (const message of messages) {
     const res = sanitizeChatHistoryMessage(message);
     changed ||= res.changed;
+
+    // Delivery-mirror transcript writes are transport artifacts and should not be shown
+    // as normal assistant history entries in Webchat.
+    if (isDeliveryMirrorTranscriptMessage(res.message)) {
+      changed = true;
+      continue;
+    }
+
     // Drop assistant messages whose entire visible text is the silent reply token.
     const text = extractAssistantTextForSilentCheck(res.message);
     if (text !== undefined && isSilentReplyText(text, SILENT_REPLY_TOKEN)) {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -413,7 +413,7 @@ describe("gateway server chat", () => {
     expect(textValues).toEqual(["hello", "real reply", "real text field reply", "NO_REPLY"]);
   });
 
-  test("chat.history hides delivery-mirror assistant transcript entries", async () => {
+  test("chat.history hides only delivery-mirror transcript artifacts", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
       {
         role: "user",
@@ -430,14 +430,26 @@ describe("gateway server chat", () => {
       },
       {
         role: "assistant",
+        content: [{ type: "text", text: "real assistant uses delivery-mirror model id" }],
+        model: "delivery-mirror",
+        provider: "custom-provider",
+        api: "custom-api",
+        timestamp: 3,
+      },
+      {
+        role: "assistant",
         content: [{ type: "text", text: "real assistant reply" }],
         model: "gpt-5",
-        timestamp: 3,
+        timestamp: 4,
       },
     ]);
 
     const textValues = collectHistoryTextValues(historyMessages);
-    expect(textValues).toEqual(["hello", "real assistant reply"]);
+    expect(textValues).toEqual([
+      "hello",
+      "real assistant uses delivery-mirror model id",
+      "real assistant reply",
+    ]);
   });
 
   test("routes chat.send slash commands without agent runs", async () => {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -413,6 +413,33 @@ describe("gateway server chat", () => {
     expect(textValues).toEqual(["hello", "real reply", "real text field reply", "NO_REPLY"]);
   });
 
+  test("chat.history hides delivery-mirror assistant transcript entries", async () => {
+    const historyMessages = await loadChatHistoryWithMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "mirrored outbound delivery" }],
+        model: "delivery-mirror",
+        provider: "openclaw",
+        api: "openai-responses",
+        timestamp: 2,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "real assistant reply" }],
+        model: "gpt-5",
+        timestamp: 3,
+      },
+    ]);
+
+    const textValues = collectHistoryTextValues(historyMessages);
+    expect(textValues).toEqual(["hello", "real assistant reply"]);
+  });
+
   test("routes chat.send slash commands without agent runs", async () => {
     await withMainSessionStore(async () => {
       const spy = vi.mocked(agentCommand);


### PR DESCRIPTION
Fixes #38787

## Problem

Webchat was displaying \delivery-mirror\ assistant messages as normal conversation history entries. These are transport artifacts for outbound delivery tracking, not actual assistant replies. This caused duplicate messages in Telegram and other channels.

## Solution

- Add \isDeliveryMirrorTranscriptMessage\ helper to detect delivery-mirror entries
- Filter out these entries in \sanitizeChatHistoryMessages\
- Add test coverage for the filtering behavior

## Testing

\\\ash
pnpm test src/gateway/server.chat.gateway-server-chat.test.ts
\\\

New test verifies that:
- User messages are preserved
- Delivery-mirror entries are filtered out
- Real assistant replies are preserved