### PR TITLE
fix(agents): rebuild sandbox skill prompt paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/skills: rebuild non-rw sandbox attempt and compaction skill prompts from config-eligible sandbox entries, so host-only snapshot paths and disabled skill env overrides stay out of sandboxed runs. Fixes #43383; carries forward #38789 and refs #51471. Thanks @whyuds, @eggyrooch-blip, and @lanmoke.
 - NVIDIA/NIM: persist the `NVIDIA_API_KEY` provider marker and mark bundled NVIDIA Chat Completions models as string-content compatible, so NIM models load from `models.json` and OpenAI-compatible subagent calls send plain text content. Fixes #73013 and #50107; refs #73014. Thanks @bautrey, @iot2edge, @ifearghal, and @futhgar.
 - Channels/Discord: let text-only configs drop the `GuildVoiceStates` gateway intent and expose a bounded `/gateway/bot` metadata timeout with rate-limited fallback logs, reducing idle CPU and warning floods. Fixes #73709 and #73585. Thanks @sanchezm86 and @trac3r00.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Agents/skills: rebuild non-rw sandbox attempt and compaction skill prompts from config-eligible sandbox entries, so host-only snapshot paths and disabled skill env overrides stay out of sandboxed runs. Fixes #43383; carries forward #38789 and refs #51471. Thanks @whyuds, @eggyrooch-blip, and @lanmoke.
+- Agents/skills: rebuild non-rw sandbox attempt and compaction skill prompts from prompt-visible, config-eligible sandbox entries, so host-only snapshot paths and hidden or disabled skill env overrides stay out of sandboxed runs. Fixes #43383; carries forward #38789 and refs #51471. Thanks @whyuds, @eggyrooch-blip, and @lanmoke.
 - NVIDIA/NIM: persist the `NVIDIA_API_KEY` provider marker and mark bundled NVIDIA Chat Completions models as string-content compatible, so NIM models load from `models.json` and OpenAI-compatible subagent calls send plain text content. Fixes #73013 and #50107; refs #73014. Thanks @bautrey, @iot2edge, @ifearghal, and @futhgar.
 - Channels/Discord: let text-only configs drop the `GuildVoiceStates` gateway intent and expose a bounded `/gateway/bot` metadata timeout with rate-limited fallback logs, reducing idle CPU and warning floods. Fixes #73709 and #73585. Thanks @sanchezm86 and @trac3r00.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -21,6 +21,7 @@ import {
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
+import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { extractModelCompat } from "../../plugins/provider-model-compat.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
@@ -464,12 +465,17 @@ export async function compactEmbeddedPiSessionDirect(
   let checkpointSnapshot: CapturedCompactionCheckpointSnapshot | null = null;
   let checkpointSnapshotRetained = false;
   try {
+    const remoteSkillEligibility = getRemoteSkillEligibility();
+    const skillEligibility = remoteSkillEligibility
+      ? { remote: remoteSkillEligibility }
+      : undefined;
     const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries({
       workspaceDir: effectiveWorkspace,
       config: params.config,
       agentId: effectiveSkillAgentId,
       skillsSnapshot: params.skillsSnapshot,
       forceLoadEntries: preferWorkspaceSkillsPrompt,
+      ...(skillEligibility === undefined ? {} : { eligibility: skillEligibility }),
     });
     restoreSkillEnv =
       params.skillsSnapshot && !preferWorkspaceSkillsPrompt
@@ -488,6 +494,7 @@ export async function compactEmbeddedPiSessionDirect(
       workspaceDir: effectiveWorkspace,
       agentId: effectiveSkillAgentId,
       preferEntries: preferWorkspaceSkillsPrompt,
+      ...(skillEligibility === undefined ? {} : { eligibility: skillEligibility }),
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -447,6 +447,7 @@ export async function compactEmbeddedPiSessionDirect(
       ? resolvedWorkspace
       : sandbox.workspaceDir
     : resolvedWorkspace;
+  const preferWorkspaceSkillsPrompt = !!sandbox?.enabled && sandbox.workspaceAccess !== "rw";
   await fs.mkdir(effectiveWorkspace, { recursive: true });
   await ensureSessionHeader({
     sessionFile: params.sessionFile,
@@ -468,22 +469,25 @@ export async function compactEmbeddedPiSessionDirect(
       config: params.config,
       agentId: effectiveSkillAgentId,
       skillsSnapshot: params.skillsSnapshot,
+      forceLoadEntries: preferWorkspaceSkillsPrompt,
     });
-    restoreSkillEnv = params.skillsSnapshot
-      ? applySkillEnvOverridesFromSnapshot({
-          snapshot: params.skillsSnapshot,
-          config: params.config,
-        })
-      : applySkillEnvOverrides({
-          skills: skillEntries ?? [],
-          config: params.config,
-        });
+    restoreSkillEnv =
+      params.skillsSnapshot && !preferWorkspaceSkillsPrompt
+        ? applySkillEnvOverridesFromSnapshot({
+            snapshot: params.skillsSnapshot,
+            config: params.config,
+          })
+        : applySkillEnvOverrides({
+            skills: skillEntries ?? [],
+            config: params.config,
+          });
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,
       entries: shouldLoadSkillEntries ? skillEntries : undefined,
       config: params.config,
       workspaceDir: effectiveWorkspace,
       agentId: effectiveSkillAgentId,
+      preferEntries: preferWorkspaceSkillsPrompt,
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -57,6 +57,7 @@ import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { resolveOpenClawReferencePaths } from "../docs-path.js";
+import { canExecRequestNode } from "../exec-defaults.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../heartbeat-system-prompt.js";
 import {
   applyAuthHeaderOverride,
@@ -465,7 +466,14 @@ export async function compactEmbeddedPiSessionDirect(
   let checkpointSnapshot: CapturedCompactionCheckpointSnapshot | null = null;
   let checkpointSnapshotRetained = false;
   try {
-    const remoteSkillEligibility = getRemoteSkillEligibility();
+    const remoteSkillEligibility = getRemoteSkillEligibility({
+      advertiseExecNode: canExecRequestNode({
+        cfg: params.config,
+        sessionKey: sandboxSessionKey,
+        agentId: effectiveSkillAgentId,
+        sandboxAvailable: sandbox?.enabled,
+      }),
+    });
     const skillEligibility = remoteSkillEligibility
       ? { remote: remoteSkillEligibility }
       : undefined;

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -469,14 +469,16 @@ export async function compactEmbeddedPiSessionDirect(
     const skillEligibility = remoteSkillEligibility
       ? { remote: remoteSkillEligibility }
       : undefined;
-    const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries({
-      workspaceDir: effectiveWorkspace,
-      config: params.config,
-      agentId: effectiveSkillAgentId,
-      skillsSnapshot: params.skillsSnapshot,
-      forceLoadEntries: preferWorkspaceSkillsPrompt,
-      ...(skillEligibility === undefined ? {} : { eligibility: skillEligibility }),
-    });
+    const { shouldLoadSkillEntries, skillEntries, promptSkillEntries } =
+      resolveEmbeddedRunSkillEntries({
+        workspaceDir: effectiveWorkspace,
+        config: params.config,
+        agentId: effectiveSkillAgentId,
+        skillsSnapshot: params.skillsSnapshot,
+        forceLoadEntries: preferWorkspaceSkillsPrompt,
+        ...(skillEligibility === undefined ? {} : { eligibility: skillEligibility }),
+      });
+    const liveEnvSkillEntries = preferWorkspaceSkillsPrompt ? promptSkillEntries : skillEntries;
     restoreSkillEnv =
       params.skillsSnapshot && !preferWorkspaceSkillsPrompt
         ? applySkillEnvOverridesFromSnapshot({
@@ -484,12 +486,16 @@ export async function compactEmbeddedPiSessionDirect(
             config: params.config,
           })
         : applySkillEnvOverrides({
-            skills: skillEntries ?? [],
+            skills: liveEnvSkillEntries,
             config: params.config,
           });
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,
-      entries: shouldLoadSkillEntries ? skillEntries : undefined,
+      entries: shouldLoadSkillEntries
+        ? preferWorkspaceSkillsPrompt
+          ? promptSkillEntries
+          : skillEntries
+        : undefined,
       config: params.config,
       workspaceDir: effectiveWorkspace,
       agentId: effectiveSkillAgentId,

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -277,7 +277,8 @@ vi.mock("../../skills.js", () => ({
 vi.mock("../skills-runtime.js", () => ({
   resolveEmbeddedRunSkillEntries: () => ({
     shouldLoadSkillEntries: false,
-    skillEntries: undefined,
+    skillEntries: [],
+    promptSkillEntries: [],
   }),
 }));
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -77,6 +77,7 @@ import {
 } from "../../channel-tools.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { resolveOpenClawReferencePaths } from "../../docs-path.js";
+import { canExecRequestNode } from "../../exec-defaults.js";
 import { isTimeoutError } from "../../failover-error.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-prompt.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
@@ -621,7 +622,14 @@ export async function runEmbeddedAttempt(
     | ((outcome: "completed" | "aborted" | "error", err?: unknown) => void)
     | undefined;
   try {
-    const remoteSkillEligibility = getRemoteSkillEligibility();
+    const remoteSkillEligibility = getRemoteSkillEligibility({
+      advertiseExecNode: canExecRequestNode({
+        cfg: params.config,
+        sessionKey: sandboxSessionKey,
+        agentId: sessionAgentId,
+        sandboxAvailable: sandbox?.enabled,
+      }),
+    });
     const skillEligibility = remoteSkillEligibility
       ? { remote: remoteSkillEligibility }
       : undefined;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -601,6 +601,7 @@ export async function runEmbeddedAttempt(
       ? resolvedWorkspace
       : sandbox.workspaceDir
     : resolvedWorkspace;
+  const preferWorkspaceSkillsPrompt = !!sandbox?.enabled && sandbox.workspaceAccess !== "rw";
   await fs.mkdir(effectiveWorkspace, { recursive: true });
   const { sessionAgentId } = resolveSessionAgentIds({
     sessionKey: params.sessionKey,
@@ -624,16 +625,18 @@ export async function runEmbeddedAttempt(
       config: params.config,
       agentId: sessionAgentId,
       skillsSnapshot: params.skillsSnapshot,
+      forceLoadEntries: preferWorkspaceSkillsPrompt,
     });
-    restoreSkillEnv = params.skillsSnapshot
-      ? applySkillEnvOverridesFromSnapshot({
-          snapshot: params.skillsSnapshot,
-          config: params.config,
-        })
-      : applySkillEnvOverrides({
-          skills: skillEntries ?? [],
-          config: params.config,
-        });
+    restoreSkillEnv =
+      params.skillsSnapshot && !preferWorkspaceSkillsPrompt
+        ? applySkillEnvOverridesFromSnapshot({
+            snapshot: params.skillsSnapshot,
+            config: params.config,
+          })
+        : applySkillEnvOverrides({
+            skills: skillEntries ?? [],
+            config: params.config,
+          });
 
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,
@@ -641,6 +644,7 @@ export async function runEmbeddedAttempt(
       config: params.config,
       workspaceDir: effectiveWorkspace,
       agentId: sessionAgentId,
+      preferEntries: preferWorkspaceSkillsPrompt,
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -21,6 +21,7 @@ import { isEmbeddedMode } from "../../../infra/embedded-mode.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { resolveHeartbeatSummaryForAgent } from "../../../infra/heartbeat-summary.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
+import { getRemoteSkillEligibility } from "../../../infra/skills-remote.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import { listRegisteredPluginAgentPromptGuidance } from "../../../plugins/command-registry-state.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
@@ -620,12 +621,17 @@ export async function runEmbeddedAttempt(
     | ((outcome: "completed" | "aborted" | "error", err?: unknown) => void)
     | undefined;
   try {
+    const remoteSkillEligibility = getRemoteSkillEligibility();
+    const skillEligibility = remoteSkillEligibility
+      ? { remote: remoteSkillEligibility }
+      : undefined;
     const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries({
       workspaceDir: effectiveWorkspace,
       config: params.config,
       agentId: sessionAgentId,
       skillsSnapshot: params.skillsSnapshot,
       forceLoadEntries: preferWorkspaceSkillsPrompt,
+      ...(skillEligibility === undefined ? {} : { eligibility: skillEligibility }),
     });
     restoreSkillEnv =
       params.skillsSnapshot && !preferWorkspaceSkillsPrompt
@@ -645,6 +651,7 @@ export async function runEmbeddedAttempt(
       workspaceDir: effectiveWorkspace,
       agentId: sessionAgentId,
       preferEntries: preferWorkspaceSkillsPrompt,
+      ...(skillEligibility === undefined ? {} : { eligibility: skillEligibility }),
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -625,14 +625,16 @@ export async function runEmbeddedAttempt(
     const skillEligibility = remoteSkillEligibility
       ? { remote: remoteSkillEligibility }
       : undefined;
-    const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries({
-      workspaceDir: effectiveWorkspace,
-      config: params.config,
-      agentId: sessionAgentId,
-      skillsSnapshot: params.skillsSnapshot,
-      forceLoadEntries: preferWorkspaceSkillsPrompt,
-      ...(skillEligibility === undefined ? {} : { eligibility: skillEligibility }),
-    });
+    const { shouldLoadSkillEntries, skillEntries, promptSkillEntries } =
+      resolveEmbeddedRunSkillEntries({
+        workspaceDir: effectiveWorkspace,
+        config: params.config,
+        agentId: sessionAgentId,
+        skillsSnapshot: params.skillsSnapshot,
+        forceLoadEntries: preferWorkspaceSkillsPrompt,
+        ...(skillEligibility === undefined ? {} : { eligibility: skillEligibility }),
+      });
+    const liveEnvSkillEntries = preferWorkspaceSkillsPrompt ? promptSkillEntries : skillEntries;
     restoreSkillEnv =
       params.skillsSnapshot && !preferWorkspaceSkillsPrompt
         ? applySkillEnvOverridesFromSnapshot({
@@ -640,13 +642,17 @@ export async function runEmbeddedAttempt(
             config: params.config,
           })
         : applySkillEnvOverrides({
-            skills: skillEntries ?? [],
+            skills: liveEnvSkillEntries,
             config: params.config,
           });
 
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,
-      entries: shouldLoadSkillEntries ? skillEntries : undefined,
+      entries: shouldLoadSkillEntries
+        ? preferWorkspaceSkillsPrompt
+          ? promptSkillEntries
+          : skillEntries
+        : undefined,
       config: params.config,
       workspaceDir: effectiveWorkspace,
       agentId: sessionAgentId,

--- a/src/agents/pi-embedded-runner/skills-runtime.test.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.test.ts
@@ -154,6 +154,7 @@ describe("resolveEmbeddedRunSkillEntries", () => {
     expect(result).toEqual({
       shouldLoadSkillEntries: false,
       skillEntries: [],
+      promptSkillEntries: [],
     });
     expect(loadWorkspaceSkillEntriesSpy).not.toHaveBeenCalled();
   });
@@ -175,6 +176,7 @@ describe("resolveEmbeddedRunSkillEntries", () => {
     expect(result.shouldLoadSkillEntries).toBe(true);
     expect(loadWorkspaceSkillEntriesSpy).toHaveBeenCalledTimes(1);
     expect(loadWorkspaceSkillEntriesSpy).toHaveBeenCalledWith("/workspace", { config: {} });
+    expect(result.promptSkillEntries).toEqual([]);
   });
 
   it("returns the same config-eligible live entries used for prompt rebuilding", () => {
@@ -200,6 +202,27 @@ describe("resolveEmbeddedRunSkillEntries", () => {
     });
 
     expect(result.skillEntries).toEqual([enabled]);
+    expect(result.promptSkillEntries).toEqual([enabled]);
+  });
+
+  it("keeps env override entries aligned with the prompt-visible live entries", () => {
+    const visible = createSkillEntry("visible-skill");
+    const hidden = createSkillEntry("hidden-skill", { disableModelInvocation: true });
+    loadWorkspaceSkillEntriesSpy.mockReturnValue([visible, hidden]);
+
+    const result = resolveEmbeddedRunSkillEntries({
+      workspaceDir: "/workspace",
+      config: {},
+      skillsSnapshot: {
+        prompt: "host prompt",
+        skills: [{ name: "visible-skill" }, { name: "hidden-skill" }],
+        resolvedSkills: [],
+      },
+      forceLoadEntries: true,
+    });
+
+    expect(result.skillEntries).toEqual([visible, hidden]);
+    expect(result.promptSkillEntries).toEqual([visible]);
   });
 
   it("preserves snapshot skill filter when force loading entries", () => {
@@ -259,7 +282,7 @@ describe("resolveEmbeddedRunSkillEntries", () => {
   });
 });
 
-function createSkillEntry(name: string): SkillEntry {
+function createSkillEntry(name: string, opts?: { disableModelInvocation?: boolean }): SkillEntry {
   return {
     skill: createCanonicalFixtureSkill({
       name,
@@ -267,6 +290,7 @@ function createSkillEntry(name: string): SkillEntry {
       filePath: `/workspace/skills/${name}/SKILL.md`,
       baseDir: `/workspace/skills/${name}`,
       source: "openclaw-workspace",
+      disableModelInvocation: opts?.disableModelInvocation,
     }),
     frontmatter: {},
   };

--- a/src/agents/pi-embedded-runner/skills-runtime.test.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.test.ts
@@ -156,4 +156,47 @@ describe("resolveEmbeddedRunSkillEntries", () => {
     });
     expect(loadWorkspaceSkillEntriesSpy).not.toHaveBeenCalled();
   });
+
+  it("can force loading skill entries even when snapshot skills are present", () => {
+    const snapshot: SkillSnapshot = {
+      prompt: "host prompt",
+      skills: [{ name: "demo" }],
+      resolvedSkills: [],
+    };
+
+    const result = resolveEmbeddedRunSkillEntries({
+      workspaceDir: "/workspace",
+      config: {},
+      skillsSnapshot: snapshot,
+      forceLoadEntries: true,
+    });
+
+    expect(result.shouldLoadSkillEntries).toBe(true);
+    expect(loadWorkspaceSkillEntriesSpy).toHaveBeenCalledTimes(1);
+    expect(loadWorkspaceSkillEntriesSpy).toHaveBeenCalledWith("/workspace", { config: {} });
+  });
+
+  it("preserves snapshot skill filter when force loading entries", () => {
+    const snapshot: SkillSnapshot = {
+      prompt: "host prompt",
+      skills: [{ name: "github" }],
+      skillFilter: ["github"],
+      resolvedSkills: [],
+    };
+
+    const result = resolveEmbeddedRunSkillEntries({
+      workspaceDir: "/workspace",
+      config: {},
+      agentId: "writer",
+      skillsSnapshot: snapshot,
+      forceLoadEntries: true,
+    });
+
+    expect(result.shouldLoadSkillEntries).toBe(true);
+    expect(loadWorkspaceSkillEntriesSpy).toHaveBeenCalledWith("/workspace", {
+      config: {},
+      agentId: "writer",
+      skillFilter: ["github"],
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/skills-runtime.test.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.test.ts
@@ -5,7 +5,8 @@ import {
   type OpenClawConfig,
 } from "../../config/config.js";
 import * as skillsModule from "../skills.js";
-import type { SkillSnapshot } from "../skills.js";
+import type { SkillEntry, SkillSnapshot } from "../skills.js";
+import { createCanonicalFixtureSkill } from "../skills.test-helpers.js";
 
 const { resolveEmbeddedRunSkillEntries } = await import("./skills-runtime.js");
 
@@ -176,6 +177,31 @@ describe("resolveEmbeddedRunSkillEntries", () => {
     expect(loadWorkspaceSkillEntriesSpy).toHaveBeenCalledWith("/workspace", { config: {} });
   });
 
+  it("returns the same config-eligible live entries used for prompt rebuilding", () => {
+    const enabled = createSkillEntry("enabled-skill");
+    const disabled = createSkillEntry("disabled-skill");
+    loadWorkspaceSkillEntriesSpy.mockReturnValue([enabled, disabled]);
+
+    const result = resolveEmbeddedRunSkillEntries({
+      workspaceDir: "/workspace",
+      config: {
+        skills: {
+          entries: {
+            "disabled-skill": { enabled: false },
+          },
+        },
+      },
+      skillsSnapshot: {
+        prompt: "host prompt",
+        skills: [{ name: "enabled-skill" }, { name: "disabled-skill" }],
+        resolvedSkills: [],
+      },
+      forceLoadEntries: true,
+    });
+
+    expect(result.skillEntries).toEqual([enabled]);
+  });
+
   it("preserves snapshot skill filter when force loading entries", () => {
     const snapshot: SkillSnapshot = {
       prompt: "host prompt",
@@ -232,3 +258,16 @@ describe("resolveEmbeddedRunSkillEntries", () => {
     });
   });
 });
+
+function createSkillEntry(name: string): SkillEntry {
+  return {
+    skill: createCanonicalFixtureSkill({
+      name,
+      description: name,
+      filePath: `/workspace/skills/${name}/SKILL.md`,
+      baseDir: `/workspace/skills/${name}`,
+      source: "openclaw-workspace",
+    }),
+    frontmatter: {},
+  };
+}

--- a/src/agents/pi-embedded-runner/skills-runtime.test.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.test.ts
@@ -199,4 +199,36 @@ describe("resolveEmbeddedRunSkillEntries", () => {
       skillFilter: ["github"],
     });
   });
+
+  it("threads eligibility through live skill loading", () => {
+    const eligibility = {
+      remote: {
+        platforms: ["darwin"],
+        hasBin: () => true,
+        hasAnyBin: () => true,
+        note: "Remote macOS node available.",
+      },
+    };
+
+    resolveEmbeddedRunSkillEntries({
+      workspaceDir: "/workspace",
+      config: {},
+      agentId: "writer",
+      skillsSnapshot: {
+        prompt: "host prompt",
+        skills: [{ name: "remote-only" }],
+        skillFilter: ["remote-only"],
+        resolvedSkills: [],
+      },
+      forceLoadEntries: true,
+      eligibility,
+    });
+
+    expect(loadWorkspaceSkillEntriesSpy).toHaveBeenCalledWith("/workspace", {
+      config: {},
+      agentId: "writer",
+      skillFilter: ["remote-only"],
+      eligibility,
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
+  filterPromptVisibleWorkspaceSkillEntries,
   filterWorkspaceSkillEntriesWithOptions,
   loadWorkspaceSkillEntries,
   type SkillEligibilityContext,
@@ -18,6 +19,7 @@ export function resolveEmbeddedRunSkillEntries(params: {
 }): {
   shouldLoadSkillEntries: boolean;
   skillEntries: SkillEntry[];
+  promptSkillEntries: SkillEntry[];
 } {
   const shouldLoadSkillEntries =
     !!params.forceLoadEntries || !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
@@ -41,5 +43,6 @@ export function resolveEmbeddedRunSkillEntries(params: {
   return {
     shouldLoadSkillEntries,
     skillEntries,
+    promptSkillEntries: filterPromptVisibleWorkspaceSkillEntries(skillEntries),
   };
 }

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -1,5 +1,10 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { loadWorkspaceSkillEntries, type SkillEntry, type SkillSnapshot } from "../skills.js";
+import {
+  loadWorkspaceSkillEntries,
+  type SkillEligibilityContext,
+  type SkillEntry,
+  type SkillSnapshot,
+} from "../skills.js";
 import { resolveSkillRuntimeConfig } from "../skills/runtime-config.js";
 
 export function resolveEmbeddedRunSkillEntries(params: {
@@ -8,6 +13,7 @@ export function resolveEmbeddedRunSkillEntries(params: {
   agentId?: string;
   skillsSnapshot?: SkillSnapshot;
   forceLoadEntries?: boolean;
+  eligibility?: SkillEligibilityContext;
 }): {
   shouldLoadSkillEntries: boolean;
   skillEntries: SkillEntry[];
@@ -23,6 +29,7 @@ export function resolveEmbeddedRunSkillEntries(params: {
           config,
           ...(params.agentId === undefined ? {} : { agentId: params.agentId }),
           ...(skillFilter === undefined ? {} : { skillFilter }),
+          ...(params.eligibility === undefined ? {} : { eligibility: params.eligibility }),
         })
       : [],
   };

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
+  filterWorkspaceSkillEntriesWithOptions,
   loadWorkspaceSkillEntries,
   type SkillEligibilityContext,
   type SkillEntry,
@@ -22,15 +23,23 @@ export function resolveEmbeddedRunSkillEntries(params: {
     !!params.forceLoadEntries || !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
   const config = resolveSkillRuntimeConfig(params.config);
   const skillFilter = params.skillsSnapshot?.skillFilter;
-  return {
-    shouldLoadSkillEntries,
-    skillEntries: shouldLoadSkillEntries
-      ? loadWorkspaceSkillEntries(params.workspaceDir, {
+  const skillEntries = shouldLoadSkillEntries
+    ? filterWorkspaceSkillEntriesWithOptions(
+        loadWorkspaceSkillEntries(params.workspaceDir, {
           config,
           ...(params.agentId === undefined ? {} : { agentId: params.agentId }),
           ...(skillFilter === undefined ? {} : { skillFilter }),
           ...(params.eligibility === undefined ? {} : { eligibility: params.eligibility }),
-        })
-      : [],
+        }),
+        {
+          config,
+          ...(skillFilter === undefined ? {} : { skillFilter }),
+          ...(params.eligibility === undefined ? {} : { eligibility: params.eligibility }),
+        },
+      )
+    : [];
+  return {
+    shouldLoadSkillEntries,
+    skillEntries,
   };
 }

--- a/src/agents/pi-embedded-runner/skills-runtime.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.ts
@@ -7,16 +7,23 @@ export function resolveEmbeddedRunSkillEntries(params: {
   config?: OpenClawConfig;
   agentId?: string;
   skillsSnapshot?: SkillSnapshot;
+  forceLoadEntries?: boolean;
 }): {
   shouldLoadSkillEntries: boolean;
   skillEntries: SkillEntry[];
 } {
-  const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
+  const shouldLoadSkillEntries =
+    !!params.forceLoadEntries || !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
   const config = resolveSkillRuntimeConfig(params.config);
+  const skillFilter = params.skillsSnapshot?.skillFilter;
   return {
     shouldLoadSkillEntries,
     skillEntries: shouldLoadSkillEntries
-      ? loadWorkspaceSkillEntries(params.workspaceDir, { config, agentId: params.agentId })
+      ? loadWorkspaceSkillEntries(params.workspaceDir, {
+          config,
+          ...(params.agentId === undefined ? {} : { agentId: params.agentId }),
+          ...(skillFilter === undefined ? {} : { skillFilter }),
+        })
       : [],
   };
 }

--- a/src/agents/skills.resolveskillspromptforrun.test.ts
+++ b/src/agents/skills.resolveskillspromptforrun.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createCanonicalFixtureSkill } from "./skills.test-helpers.js";
-import type { SkillEntry } from "./skills/types.js";
+import type { SkillEligibilityContext, SkillEntry } from "./skills/types.js";
 import { resolveSkillsPromptForRun } from "./skills/workspace.js";
 
 describe("resolveSkillsPromptForRun", () => {
@@ -199,6 +199,37 @@ describe("resolveSkillsPromptForRun", () => {
 
     expect(prompt).toContain("/workspace/skills/github/SKILL.md");
     expect(prompt).not.toContain("/workspace/skills/weather/SKILL.md");
+  });
+
+  it("preserves remote eligibility note when preferring entries", () => {
+    const entry: SkillEntry = {
+      skill: createFixtureSkill({
+        name: "demo-skill",
+        description: "Demo",
+        filePath: "/workspace/skills/demo-skill/SKILL.md",
+        baseDir: "/workspace/skills/demo-skill",
+        source: "workspace",
+        disableModelInvocation: false,
+      }),
+      frontmatter: {},
+    };
+    const eligibility: SkillEligibilityContext = {
+      remote: {
+        platforms: ["darwin"],
+        hasBin: () => true,
+        hasAnyBin: () => true,
+        note: "Remote macOS node available. Run macOS-only skills via nodes.run.",
+      },
+    };
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: { prompt: "HOST-SNAPSHOT", skills: [] },
+      entries: [entry],
+      workspaceDir: "/workspace",
+      preferEntries: true,
+      eligibility,
+    });
+    expect(prompt).toContain("Remote macOS node available");
+    expect(prompt).toContain("/workspace/skills/demo-skill/SKILL.md");
   });
 });
 

--- a/src/agents/skills.resolveskillspromptforrun.test.ts
+++ b/src/agents/skills.resolveskillspromptforrun.test.ts
@@ -130,6 +130,76 @@ describe("resolveSkillsPromptForRun", () => {
     expect(prompt).not.toContain("/app/skills/weather/SKILL.md");
     expect(prompt).toContain("/app/skills/docs-search/SKILL.md");
   });
+
+  it("can prefer live entries over a snapshot prompt", () => {
+    const entry: SkillEntry = {
+      skill: createFixtureSkill({
+        name: "demo-skill",
+        description: "Demo",
+        filePath: "/workspace/skills/demo-skill/SKILL.md",
+        baseDir: "/workspace/skills/demo-skill",
+        source: "workspace",
+        disableModelInvocation: false,
+      }),
+      frontmatter: {},
+    };
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: { prompt: "HOST-SNAPSHOT", skills: [] },
+      entries: [entry],
+      workspaceDir: "/workspace",
+      preferEntries: true,
+    });
+    expect(prompt).not.toContain("HOST-SNAPSHOT");
+    expect(prompt).toContain("/workspace/skills/demo-skill/SKILL.md");
+  });
+
+  it("does not fall back to snapshot prompt when preferred live entries are empty", () => {
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: { prompt: "HOST-SNAPSHOT", skills: [] },
+      entries: [],
+      workspaceDir: "/workspace",
+      preferEntries: true,
+    });
+
+    expect(prompt).toBe("");
+  });
+
+  it("preserves snapshot skill filter when rebuilding a preferred live prompt", () => {
+    const visible: SkillEntry = {
+      skill: createFixtureSkill({
+        name: "github",
+        description: "GitHub",
+        filePath: "/workspace/skills/github/SKILL.md",
+        baseDir: "/workspace/skills/github",
+        source: "openclaw-workspace",
+      }),
+      frontmatter: {},
+    };
+    const hidden: SkillEntry = {
+      skill: createFixtureSkill({
+        name: "weather",
+        description: "Weather",
+        filePath: "/workspace/skills/weather/SKILL.md",
+        baseDir: "/workspace/skills/weather",
+        source: "openclaw-workspace",
+      }),
+      frontmatter: {},
+    };
+
+    const prompt = resolveSkillsPromptForRun({
+      skillsSnapshot: {
+        prompt: "HOST-SNAPSHOT",
+        skills: [],
+        skillFilter: ["github"],
+      },
+      entries: [visible, hidden],
+      workspaceDir: "/workspace",
+      preferEntries: true,
+    });
+
+    expect(prompt).toContain("/workspace/skills/github/SKILL.md");
+    expect(prompt).not.toContain("/workspace/skills/weather/SKILL.md");
+  });
 });
 
 function createFixtureSkill(params: {

--- a/src/agents/skills.resolveskillspromptforrun.test.ts
+++ b/src/agents/skills.resolveskillspromptforrun.test.ts
@@ -1,4 +1,12 @@
+import { randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
+import {
+  getRemoteSkillEligibility,
+  recordRemoteNodeBins,
+  recordRemoteNodeInfo,
+  removeRemoteNodeInfo,
+} from "../infra/skills-remote.js";
+import { canExecRequestNode } from "./exec-defaults.js";
 import { createCanonicalFixtureSkill } from "./skills.test-helpers.js";
 import type { SkillEligibilityContext, SkillEntry } from "./skills/types.js";
 import { resolveSkillsPromptForRun } from "./skills/workspace.js";
@@ -230,6 +238,54 @@ describe("resolveSkillsPromptForRun", () => {
     });
     expect(prompt).toContain("Remote macOS node available");
     expect(prompt).toContain("/workspace/skills/demo-skill/SKILL.md");
+  });
+
+  it("preserves remote eligibility without advertising exec-node routing", () => {
+    const nodeId = `node-${randomUUID()}`;
+    const bin = `bin-${randomUUID()}`;
+    try {
+      recordRemoteNodeInfo({
+        nodeId,
+        displayName: "Mac Studio",
+        platform: "darwin",
+        commands: ["system.run"],
+      });
+      recordRemoteNodeBins(nodeId, [bin]);
+      const entry: SkillEntry = {
+        skill: createFixtureSkill({
+          name: "remote-only",
+          description: "Remote only",
+          filePath: "/workspace/skills/remote-only/SKILL.md",
+          baseDir: "/workspace/skills/remote-only",
+          source: "workspace",
+        }),
+        frontmatter: {},
+        metadata: {
+          os: ["darwin"],
+          requires: { bins: [bin] },
+        },
+      };
+      const remote = getRemoteSkillEligibility({
+        advertiseExecNode: canExecRequestNode({
+          cfg: { tools: { exec: { host: "auto" } } },
+          sandboxAvailable: true,
+        }),
+      });
+
+      const prompt = resolveSkillsPromptForRun({
+        skillsSnapshot: { prompt: "HOST-SNAPSHOT", skills: [] },
+        entries: [entry],
+        workspaceDir: "/workspace",
+        preferEntries: true,
+        eligibility: remote ? { remote } : undefined,
+      });
+
+      expect(remote?.note).toBeUndefined();
+      expect(prompt).toContain("/workspace/skills/remote-only/SKILL.md");
+      expect(prompt).not.toContain("exec host=node");
+    } finally {
+      removeRemoteNodeInfo(nodeId);
+    }
   });
 });
 

--- a/src/agents/skills.ts
+++ b/src/agents/skills.ts
@@ -30,6 +30,7 @@ export type {
 export {
   buildWorkspaceSkillSnapshot,
   buildWorkspaceSkillsPrompt,
+  filterPromptVisibleWorkspaceSkillEntries,
   filterWorkspaceSkillEntries,
   filterWorkspaceSkillEntriesWithOptions,
   loadWorkspaceSkillEntries,

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -98,6 +98,10 @@ function isSkillVisibleInAvailableSkillsPrompt(entry: SkillEntry): boolean {
   return entry.skill.disableModelInvocation !== true;
 }
 
+export function filterPromptVisibleWorkspaceSkillEntries(entries: SkillEntry[]): SkillEntry[] {
+  return entries.filter((entry) => isSkillVisibleInAvailableSkillsPrompt(entry));
+}
+
 function filterSkillEntries(
   entries: SkillEntry[],
   config?: OpenClawConfig,
@@ -781,7 +785,7 @@ function resolveWorkspaceSkillPromptState(
     effectiveSkillFilter,
     opts?.eligibility,
   );
-  const promptEntries = eligible.filter((entry) => isSkillVisibleInAvailableSkillsPrompt(entry));
+  const promptEntries = filterPromptVisibleWorkspaceSkillEntries(eligible);
   const remoteNote = opts?.eligibility?.remote?.note?.trim();
   const resolvedSkills = promptEntries.map((entry) => entry.skill);
   // Derive prompt-facing skills with compacted paths (e.g. ~/...) once.

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -817,7 +817,18 @@ export function resolveSkillsPromptForRun(params: {
   config?: OpenClawConfig;
   workspaceDir: string;
   agentId?: string;
+  preferEntries?: boolean;
 }): string {
+  const skillFilter = params.skillsSnapshot?.skillFilter;
+  if (params.preferEntries) {
+    const prompt = buildWorkspaceSkillsPrompt(params.workspaceDir, {
+      entries: params.entries ?? [],
+      config: params.config,
+      agentId: params.agentId,
+      ...(skillFilter === undefined ? {} : { skillFilter }),
+    });
+    return prompt.trim() ? prompt : "";
+  }
   const snapshotPrompt = params.skillsSnapshot?.prompt?.trim();
   if (snapshotPrompt) {
     return snapshotPrompt;
@@ -827,6 +838,7 @@ export function resolveSkillsPromptForRun(params: {
       entries: params.entries,
       config: params.config,
       agentId: params.agentId,
+      ...(skillFilter === undefined ? {} : { skillFilter }),
     });
     return prompt.trim() ? prompt : "";
   }

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -818,6 +818,7 @@ export function resolveSkillsPromptForRun(params: {
   workspaceDir: string;
   agentId?: string;
   preferEntries?: boolean;
+  eligibility?: SkillEligibilityContext;
 }): string {
   const skillFilter = params.skillsSnapshot?.skillFilter;
   if (params.preferEntries) {
@@ -826,6 +827,7 @@ export function resolveSkillsPromptForRun(params: {
       config: params.config,
       agentId: params.agentId,
       ...(skillFilter === undefined ? {} : { skillFilter }),
+      ...(params.eligibility === undefined ? {} : { eligibility: params.eligibility }),
     });
     return prompt.trim() ? prompt : "";
   }
@@ -839,6 +841,7 @@ export function resolveSkillsPromptForRun(params: {
       config: params.config,
       agentId: params.agentId,
       ...(skillFilter === undefined ? {} : { skillFilter }),
+      ...(params.eligibility === undefined ? {} : { eligibility: params.eligibility }),
     });
     return prompt.trim() ? prompt : "";
   }


### PR DESCRIPTION
## Summary
- rebuild the skills prompt from live workspace entries when a run is sandboxed with a non-rw workspace so SKILL paths point at the sandbox workspace instead of the host snapshot path
- keep the existing snapshot reuse path for normal runs and scope the override to sandbox-isolated workspaces only
- add regression tests for forced skill entry loading and prompt rebuilding from /workspace entries

## Test plan
- [x] `pnpm vitest run src/agents/skills.resolveskillspromptforrun.test.ts src/agents/pi-embedded-runner/skills-runtime.test.ts`
- [x] `pnpm check`