### PR TITLE
fix(agents): preserve Azure streaming usage compat in openai-completions

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -225,6 +225,18 @@ describe("normalizeModelCompat", () => {
     expect(supportsUsageInStreaming(normalized)).toBe(true);
   });
 
+  it("keeps supportsUsageInStreaming undefined for Azure OpenAI when compat is unset", () => {
+    const model = {
+      ...baseModel(),
+      provider: "azure-openai",
+      baseUrl: "https://my-deployment.openai.azure.com/openai",
+    };
+    delete (model as { compat?: unknown }).compat;
+    const normalized = normalizeModelCompat(model as Model<Api>);
+    expect(supportsDeveloperRole(normalized)).toBe(false);
+    expect(supportsUsageInStreaming(normalized)).toBeUndefined();
+  });
+
   it("preserves explicit supportsUsageInStreaming false for Azure OpenAI", () => {
     const model = {
       ...baseModel(),

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -212,6 +212,30 @@ describe("normalizeModelCompat", () => {
       baseUrl: "https://my-deployment.openai.azure.com/openai",
     });
   });
+
+  it("does not force supportsUsageInStreaming off for Azure OpenAI endpoints", () => {
+    const model = {
+      ...baseModel(),
+      provider: "azure-openai",
+      baseUrl: "https://my-deployment.openai.azure.com/openai",
+      compat: { supportsUsageInStreaming: true },
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(supportsDeveloperRole(normalized)).toBe(false);
+    expect(supportsUsageInStreaming(normalized)).toBe(true);
+  });
+
+  it("preserves explicit supportsUsageInStreaming false for Azure OpenAI", () => {
+    const model = {
+      ...baseModel(),
+      provider: "azure-openai",
+      baseUrl: "https://my-deployment.openai.azure.com/openai",
+      compat: { supportsUsageInStreaming: false },
+    };
+    const normalized = normalizeModelCompat(model);
+    expect(supportsDeveloperRole(normalized)).toBe(false);
+    expect(supportsUsageInStreaming(normalized)).toBe(false);
+  });
   it("forces supportsDeveloperRole off for generic custom openai-completions provider", () => {
     expectSupportsDeveloperRoleForcedOff({
       provider: "custom-cpa",

--- a/src/agents/model-compat.ts
+++ b/src/agents/model-compat.ts
@@ -20,6 +20,15 @@ function isOpenAINativeEndpoint(baseUrl: string): boolean {
   }
 }
 
+function isAzureOpenAIEndpoint(baseUrl: string): boolean {
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase();
+    return host.endsWith(".openai.azure.com");
+  } catch {
+    return false;
+  }
+}
+
 function isAnthropicMessagesModel(model: Model<Api>): model is Model<"anthropic-messages"> {
   return model.api === "anthropic-messages";
 }
@@ -61,10 +70,24 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
   // leave compat unchanged and let default native behavior apply.
   // Note: explicit true values are intentionally overridden for non-native
   // endpoints for safety.
+  const isAzure = baseUrl ? isAzureOpenAIEndpoint(baseUrl) : false;
   const needsForce = baseUrl ? !isOpenAINativeEndpoint(baseUrl) : false;
   if (!needsForce) {
     return model;
   }
+
+  if (isAzure) {
+    if (compat?.supportsDeveloperRole === false) {
+      return model;
+    }
+    return {
+      ...model,
+      compat: compat
+        ? { ...compat, supportsDeveloperRole: false }
+        : { supportsDeveloperRole: false },
+    } as typeof model;
+  }
+
   if (compat?.supportsDeveloperRole === false && compat?.supportsUsageInStreaming === false) {
     return model;
   }


### PR DESCRIPTION
## Summary

Azure OpenAI (`*.openai.azure.com`) was being treated as a generic non-native `openai-completions` endpoint, which forced `compat.supportsUsageInStreaming=false`. That suppresses `stream_options.include_usage`, so streaming usage chunks never arrive and `/status` can show `Context: 0/...`.

This patch keeps the existing Azure safeguard (`supportsDeveloperRole=false`) but preserves `supportsUsageInStreaming` for Azure endpoints.

## Changes

- Add `isAzureOpenAIEndpoint(baseUrl)` host check in `model-compat`.
- In `normalizeModelCompat(...)`, branch Azure handling to only force `supportsDeveloperRole=false`.
- Keep existing force-off behavior (`supportsDeveloperRole=false`, `supportsUsageInStreaming=false`) for non-native, non-Azure `openai-completions` backends.
- Add/extend unit coverage in `src/agents/model-compat.test.ts` for:
  - Azure preserves `supportsUsageInStreaming=true`
  - Azure preserves explicit `supportsUsageInStreaming=false`

## Testing

- `pnpm exec vitest run src/agents/model-compat.test.ts --config vitest.config.ts` ✅ (34 passed)

Fixes openclaw/openclaw#38784