### PR TITLE
fix(cron): default delivery mode to "announce" for isolated agentTurn jobs

### DIFF
--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -558,3 +558,47 @@ describe("cron stagger defaults", () => {
     }
   });
 });
+
+describe("createJob delivery defaults", () => {
+  const now = Date.parse("2026-02-28T12:00:00.000Z");
+
+  it('defaults delivery to { mode: "announce" } for isolated agentTurn jobs without explicit delivery', () => {
+    const state = createMockState(now);
+    const job = createJob(state, {
+      name: "isolated-no-delivery",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "hello" },
+    });
+    expect(job.delivery).toEqual({ mode: "announce" });
+  });
+
+  it("preserves explicit delivery for isolated agentTurn jobs", () => {
+    const state = createMockState(now);
+    const job = createJob(state, {
+      name: "isolated-explicit-delivery",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      payload: { kind: "agentTurn", message: "hello" },
+      delivery: { mode: "none" },
+    });
+    expect(job.delivery).toEqual({ mode: "none" });
+  });
+
+  it("does not set delivery for main systemEvent jobs without explicit delivery", () => {
+    const state = createMockState(now, { defaultAgentId: "main" });
+    const job = createJob(state, {
+      name: "main-no-delivery",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "ping" },
+    });
+    expect(job.delivery).toBeUndefined();
+  });
+});

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -544,7 +544,11 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     sessionTarget: input.sessionTarget,
     wakeMode: input.wakeMode,
     payload: input.payload,
-    delivery: input.delivery,
+    delivery:
+      input.delivery ??
+      (input.sessionTarget === "isolated" && input.payload.kind === "agentTurn"
+        ? { mode: "announce" }
+        : undefined),
     failureAlert: input.failureAlert,
     state: {
       ...input.state,


### PR DESCRIPTION
Fixes #38791

## Problem

`createJob` in `src/cron/service/jobs.ts` passes `input.delivery` directly to the new job. When a user creates an isolated agentTurn cron job without specifying delivery, the delivery field is `undefined`, which is later treated as `mode: "none"` by `mergeCronDelivery`.

However, the store migration (`src/cron/service/store.ts` line 522) and documentation both state that isolated agentTurn jobs should default to `{ mode: "announce" }`.

## Fix

In `createJob`, when `input.delivery` is `undefined` and the job is an isolated agentTurn job (`sessionTarget === "isolated"` and `payload.kind === "agentTurn"`), default delivery to `{ mode: "announce" }`.

This approach:
- Fixes the default at creation time, consistent with the store migration behavior
- Does not touch `mergeCronDelivery`, so patch/update logic is unaffected
- Preserves explicit `{ mode: "none" }` if the user explicitly sets it

## Tests

Added 3 test cases:
1. Isolated agentTurn job without delivery defaults to `{ mode: "announce" }`
2. Isolated agentTurn job with explicit delivery preserves user choice
3. Main systemEvent job without delivery stays `undefined`