### PR TITLE
fix(docker): remove outdated node:22-bookworm digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # This stage extracts only the package.json files we need from extensions/,
 # so the main build layer is not invalidated by unrelated extension source changes.
 ARG OPENCLAW_EXTENSIONS=""
-FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935 AS ext-deps
+FROM node:22-bookworm AS ext-deps
 ARG OPENCLAW_EXTENSIONS
 COPY extensions /tmp/extensions
 RUN mkdir -p /out && \
@@ -17,14 +17,13 @@ RUN mkdir -p /out && \
       fi; \
     done
 
-FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935
+FROM node:22-bookworm
 
 # OCI base-image metadata for downstream image consumers.
 # If you change these annotations, also update:
 # - docs/install/docker.md ("Base image metadata" section)
 # - https://docs.openclaw.ai/install/docker
 LABEL org.opencontainers.image.base.name="docker.io/library/node:22-bookworm" \
-  org.opencontainers.image.base.digest="sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935" \
   org.opencontainers.image.source="https://github.com/openclaw/openclaw" \
   org.opencontainers.image.url="https://openclaw.ai" \
   org.opencontainers.image.documentation="https://docs.openclaw.ai/install/docker" \

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -167,10 +167,9 @@ The main Docker image currently uses:
 
 - `node:22-bookworm`
 
-The docker image now publishes OCI base-image annotations (sha256 is an example):
+The docker image now publishes OCI base-image annotations:
 
 - `org.opencontainers.image.base.name=docker.io/library/node:22-bookworm`
-- `org.opencontainers.image.base.digest=sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935`
 - `org.opencontainers.image.source=https://github.com/openclaw/openclaw`
 - `org.opencontainers.image.url=https://openclaw.ai`
 - `org.opencontainers.image.documentation=https://docs.openclaw.ai/install/docker`


### PR DESCRIPTION
Fixes #38771

## Problem

The Dockerfile pins `node:22-bookworm` to a specific digest (`sha256:cd7bcd2e7a1e6...`) that is no longer available on Docker Hub, causing all Docker builds to fail with:

```
ERROR: failed to resolve source metadata for docker.io/library/node:22-bookworm@sha256:cd7bcd2e...: 
failed to read expected number of bytes: unexpected EOF
```

This blocks all users trying to build OpenClaw with Docker.

## Solution

Remove the digest pin from:
1. Line 9: `FROM node:22-bookworm AS ext-deps` (multi-stage build)
2. Line 20: `FROM node:22-bookworm` (main stage)
3. LABEL `org.opencontainers.image.base.digest` (OCI metadata)

This allows Docker to automatically use the latest `node:22-bookworm` image, preventing future digest expiration issues.

## Changes

```diff
-FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935
+FROM node:22-bookworm
```

## Testing

- ✅ Code review: All 3 occurrences updated
- ⏳ Docker build test: Awaiting maintainer verification
- 🟢 Risk: Very low (static config change, no code logic)

## Trade-offs

**Pros:**
- ✅ Fixes immediate build failure
- ✅ Prevents future digest expiration issues
- ✅ Follows standard Docker practices for base images

**Cons:**
- ⚠️ Builds are no longer 100% reproducible (image may change over time)
- ⚠️ Potential for Node.js version drift within the 22.x line

**Recommendation**: If reproducibility is critical, consider using a CI job to periodically update the digest to the latest available image.

---

**Reporter**: Issue #38771
**Environment**: macOS 26.2, OpenClaw 2026.3.2, Docker
**Tested on**: Linux (code inspection, no Docker available for build test)