### PR TITLE
fix(feishu): reply inside P2P threads instead of main chat

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1709,6 +1709,83 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("replies inside P2P thread when thread_id is present (#38806)", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-sender",
+        },
+      },
+      message: {
+        message_id: "msg-p2p-thread",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        root_id: "om_p2p_thread_root",
+        thread_id: "omt_p2p_thread",
+        message_type: "text",
+        content: JSON.stringify({ text: "reply in p2p thread" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_p2p_thread_root",
+        replyInThread: true,
+        threadReply: true,
+        skipReplyToInMessages: false,
+      }),
+    );
+  });
+
+  it("does not reply in thread for normal P2P messages without thread_id", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-sender",
+        },
+      },
+      message: {
+        message_id: "msg-p2p-normal",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "normal dm" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyInThread: false,
+        threadReply: false,
+        skipReplyToInMessages: true,
+      }),
+    );
+  });
+
   it("does not dispatch twice for the same image message_id (concurrent dedupe)", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1157,7 +1157,11 @@ export async function handleFeishuMessage(params: {
     const feishuTo = isGroup ? `chat:${ctx.chatId}` : `user:${ctx.senderOpenId}`;
     const peerId = isGroup ? (groupSession?.peerId ?? ctx.chatId) : ctx.senderOpenId;
     const parentPeer = isGroup ? (groupSession?.parentPeer ?? null) : null;
-    const replyInThread = isGroup ? (groupSession?.replyInThread ?? false) : false;
+    // P2P threads: when the inbound message carries a thread_id, the user is
+    // inside a thread even in a direct-message chat.  Honour that so the reply
+    // stays in the same thread instead of landing in the main chat.
+    const isP2pThread = isDirect && Boolean(ctx.threadId);
+    const replyInThread = isGroup ? (groupSession?.replyInThread ?? false) : isP2pThread;
 
     if (isGroup && groupSession) {
       log(
@@ -1354,9 +1358,15 @@ export async function handleFeishuMessage(params: {
     const configReplyInThread =
       isGroup &&
       (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
+    // For P2P threads, reply to the thread root so the response stays inside
+    // the thread.  thread_id indicates a thread message per Feishu API docs,
+    // while root_id alone indicates a quote-reply.
+    const p2pThread = isDirect && Boolean(ctx.threadId);
     const replyTargetMessageId =
-      isTopicSession || configReplyInThread ? (ctx.rootId ?? ctx.messageId) : ctx.messageId;
-    const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
+      isTopicSession || configReplyInThread || p2pThread
+        ? (ctx.rootId ?? ctx.messageId)
+        : ctx.messageId;
+    const threadReply = isGroup ? (groupSession?.threadReply ?? false) : p2pThread;
 
     if (broadcastAgents) {
       // Cross-account dedup: in multi-account setups, Feishu delivers the same
@@ -1407,7 +1417,7 @@ export async function handleFeishuMessage(params: {
             runtime: runtime as RuntimeEnv,
             chatId: ctx.chatId,
             replyToMessageId: replyTargetMessageId,
-            skipReplyToInMessages: !isGroup,
+            skipReplyToInMessages: !isGroup && !p2pThread,
             replyInThread,
             rootId: ctx.rootId,
             threadReply,
@@ -1505,7 +1515,7 @@ export async function handleFeishuMessage(params: {
         runtime: runtime as RuntimeEnv,
         chatId: ctx.chatId,
         replyToMessageId: replyTargetMessageId,
-        skipReplyToInMessages: !isGroup,
+        skipReplyToInMessages: !isGroup && !p2pThread,
         replyInThread,
         rootId: ctx.rootId,
         threadReply,


### PR DESCRIPTION
## Summary

When a user sends a message inside a thread in a P2P (direct message) chat, the bot replies outside the thread as a standalone message.

This regression was introduced by #33789, which fixed group reply targeting (#32980) but inadvertently broke P2P thread replies by gating all thread-aware logic behind `isGroup` checks.

## Changes

Three places in `extensions/feishu/src/bot.ts` now handle P2P threads:

1. **`replyInThread`** — was forced `false` for P2P; now `true` when `thread_id` is present (indicating a thread message per [Feishu API docs](https://open.feishu.cn/document/server-docs/im-v1/message/events/receive))
2. **`replyTargetMessageId`** — ignored `root_id` for P2P; now uses `root_id` for P2P threads so the reply targets the thread root
3. **`skipReplyToInMessages`** — was always `true` for P2P; now `false` for P2P threads so the send layer uses `im.message.reply` instead of `im.message.create`

The distinction between `thread_id` (thread message) and `root_id` alone (quote reply) is preserved — only messages with `thread_id` trigger thread-aware behavior in P2P.

## Testing

- All 339 existing Feishu tests pass
- No group chat behavior is affected (changes are gated behind `isDirect && Boolean(ctx.threadId)`)

Closes #38806