### PR TITLE
fix(message): ignore empty legacy target fields

### DIFF
--- a/src/infra/outbound/channel-target.ts
+++ b/src/infra/outbound/channel-target.ts
@@ -11,8 +11,7 @@ export function applyTargetToParams(params: {
   args: Record<string, unknown>;
 }): void {
   const target = typeof params.args.target === "string" ? params.args.target.trim() : "";
-  const hasLegacyTo =
-    typeof params.args.to === "string" && params.args.to.trim().length > 0;
+  const hasLegacyTo = typeof params.args.to === "string" && params.args.to.trim().length > 0;
   const hasLegacyChannelId =
     typeof params.args.channelId === "string" && params.args.channelId.trim().length > 0;
   const mode =

--- a/src/infra/outbound/channel-target.ts
+++ b/src/infra/outbound/channel-target.ts
@@ -11,8 +11,10 @@ export function applyTargetToParams(params: {
   args: Record<string, unknown>;
 }): void {
   const target = typeof params.args.target === "string" ? params.args.target.trim() : "";
-  const hasLegacyTo = typeof params.args.to === "string";
-  const hasLegacyChannelId = typeof params.args.channelId === "string";
+  const hasLegacyTo =
+    typeof params.args.to === "string" && params.args.to.trim().length > 0;
+  const hasLegacyChannelId =
+    typeof params.args.channelId === "string" && params.args.channelId.trim().length > 0;
   const mode =
     MESSAGE_ACTION_TARGET_MODE[params.action as keyof typeof MESSAGE_ACTION_TARGET_MODE] ?? "none";
 

--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -57,6 +57,21 @@ describe("normalizeMessageActionInput", () => {
     expect(normalized.channel).toBe("slack");
   });
 
+  it("accepts explicit target when legacy fields are empty strings", () => {
+    const normalized = normalizeMessageActionInput({
+      action: "send",
+      args: {
+        target: "1214056829",
+        to: "",
+        channelId: "",
+      },
+    });
+
+    expect(normalized.target).toBe("1214056829");
+    expect(normalized.to).toBe("1214056829");
+    expect(normalized.channelId).toBe("");
+  });
+
   it("throws when required target remains unresolved", () => {
     expect(() =>
       normalizeMessageActionInput({


### PR DESCRIPTION
## Summary

Fix message target normalization to ignore empty-string legacy fields (`to` / `channelId`) so valid `target`-based sends are not rejected.

## Changes

- In `channel-target.ts`, treat legacy fields as present only when non-empty after trim.
- Add regression test covering `target` + empty legacy fields.

## Testing

- `vitest run src/infra/outbound/message-action-normalization.test.ts` (6 passed)

Fixes openclaw/openclaw#38830