### PR TITLE
fix(message): ignore empty legacy to/channelId fields

### DIFF
--- a/src/infra/outbound/channel-target.ts
+++ b/src/infra/outbound/channel-target.ts
@@ -11,8 +11,9 @@ export function applyTargetToParams(params: {
   args: Record<string, unknown>;
 }): void {
   const target = typeof params.args.target === "string" ? params.args.target.trim() : "";
-  const hasLegacyTo = typeof params.args.to === "string";
-  const hasLegacyChannelId = typeof params.args.channelId === "string";
+  const hasLegacyTo = typeof params.args.to === "string" && params.args.to.trim().length > 0;
+  const hasLegacyChannelId =
+    typeof params.args.channelId === "string" && params.args.channelId.trim().length > 0;
   const mode =
     MESSAGE_ACTION_TARGET_MODE[params.action as keyof typeof MESSAGE_ACTION_TARGET_MODE] ?? "none";
 

--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -41,6 +41,7 @@ describe("normalizeMessageActionInput", () => {
 
     expect(normalized.target).toBe("channel:C1");
     expect(normalized.to).toBe("channel:C1");
+    expect("channelId" in normalized).toBe(false);
   });
 
   it("infers target from tool context when required", () => {

--- a/src/infra/outbound/message-action-normalization.test.ts
+++ b/src/infra/outbound/message-action-normalization.test.ts
@@ -29,6 +29,20 @@ describe("normalizeMessageActionInput", () => {
     expect(normalized.to).toBe("channel:C1");
   });
 
+  it("ignores empty legacy target fields when explicit target is present", () => {
+    const normalized = normalizeMessageActionInput({
+      action: "send",
+      args: {
+        target: "channel:C1",
+        to: "",
+        channelId: "   ",
+      },
+    });
+
+    expect(normalized.target).toBe("channel:C1");
+    expect(normalized.to).toBe("channel:C1");
+  });
+
   it("infers target from tool context when required", () => {
     const normalized = normalizeMessageActionInput({
       action: "send",

--- a/src/infra/outbound/message-action-normalization.ts
+++ b/src/infra/outbound/message-action-normalization.ts
@@ -23,9 +23,17 @@ export function normalizeMessageActionInput(params: {
     (typeof normalizedArgs.to === "string" && normalizedArgs.to.trim().length > 0) ||
     (typeof normalizedArgs.channelId === "string" && normalizedArgs.channelId.trim().length > 0);
 
-  if (explicitTarget && hasLegacyTarget) {
-    delete normalizedArgs.to;
-    delete normalizedArgs.channelId;
+  if (explicitTarget) {
+    const legacyTo = typeof normalizedArgs.to === "string" ? normalizedArgs.to.trim() : "";
+    const legacyChannelId =
+      typeof normalizedArgs.channelId === "string" ? normalizedArgs.channelId.trim() : "";
+
+    if (hasLegacyTarget || ("to" in normalizedArgs && !legacyTo)) {
+      delete normalizedArgs.to;
+    }
+    if (hasLegacyTarget || ("channelId" in normalizedArgs && !legacyChannelId)) {
+      delete normalizedArgs.channelId;
+    }
   }
 
   if (


### PR DESCRIPTION
## Summary
- treat legacy `to` and `channelId` args as legacy only when they are non-empty strings
- prevent false "Use target instead of to/channelId" errors when wrappers pass empty-string defaults
- add a normalization test that exercises explicit `target` with empty legacy fields

## Testing
- `pnpm vitest run src/infra/outbound/message-action-normalization.test.ts`

## Related
- Fixes #38830
