### PR TITLE
fix(browser): keep local action timeouts specific instead of service outage

### DIFF
--- a/src/browser/client-fetch.timeout-errors.test.ts
+++ b/src/browser/client-fetch.timeout-errors.test.ts
@@ -20,5 +20,8 @@ describe("fetchBrowserJson timeout error mapping", () => {
     await expect(fetchBrowserJson("/act", { method: "POST", timeoutMs: 1234 })).rejects.toThrow(
       "Browser action timed out after 1234ms while the local browser control service remained reachable",
     );
+    await expect(fetchBrowserJson("/act", { method: "POST", timeoutMs: 1234 })).rejects.toThrow(
+      "Retry only after changing something concrete",
+    );
   });
 });

--- a/src/browser/client-fetch.timeout-errors.test.ts
+++ b/src/browser/client-fetch.timeout-errors.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./control-service.js", () => ({
+  createBrowserControlContext: vi.fn(() => ({})),
+  startBrowserControlServiceFromConfig: vi.fn(async () => true),
+}));
+
+vi.mock("./routes/dispatcher.js", () => ({
+  createBrowserRouteDispatcher: vi.fn(() => ({
+    dispatch: vi.fn(async () => {
+      throw new Error("timed out");
+    }),
+  })),
+}));
+
+import { fetchBrowserJson } from "./client-fetch.js";
+
+describe("fetchBrowserJson timeout error mapping", () => {
+  it("keeps local action timeout errors specific instead of reporting service outage", async () => {
+    await expect(fetchBrowserJson("/act", { method: "POST", timeoutMs: 1234 })).rejects.toThrow(
+      "Browser action timed out after 1234ms while the local browser control service remained reachable",
+    );
+  });
+});

--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -118,21 +118,22 @@ function looksLikeTimeoutError(err: unknown): boolean {
 
 function enhanceBrowserFetchError(url: string, err: unknown, timeoutMs: number): Error {
   const isLocal = !isAbsoluteHttp(url);
-  // Model-facing suffix: explicitly tell the LLM NOT to retry.
-  // Without this, models see "try again" and enter an infinite tool-call loop.
-  const modelHint =
-    "Do NOT retry the browser tool — it will keep failing. " +
-    "Use an alternative approach or inform the user that the browser is currently unavailable.";
+  const localTimeoutModelHint =
+    "Retry only after changing something concrete (for example: refresh snapshot refs or increase timeoutMs). " +
+    "Do not repeat the exact same browser action call unchanged.";
+  const serviceOutageModelHint =
+    "Do NOT retry the browser tool unchanged — it will likely keep failing while the service is unavailable. " +
+    "Use an alternative approach or inform the user that the browser service is currently unavailable.";
 
   if (looksLikeTimeoutError(err)) {
     if (isLocal) {
       return new Error(
-        `Browser action timed out after ${timeoutMs}ms while the local browser control service remained reachable. Try a fresh snapshot and retry with a stable ref, or increase timeoutMs if the action is expected to take longer. ${modelHint}`,
+        `Browser action timed out after ${timeoutMs}ms while the local browser control service remained reachable. Try a fresh snapshot and retry with a stable ref, or increase timeoutMs if the action is expected to take longer. ${localTimeoutModelHint}`,
       );
     }
 
     return new Error(
-      `Can't reach the OpenClaw browser control service (timed out after ${timeoutMs}ms). If this is a sandboxed session, ensure the sandbox browser is running. ${modelHint}`,
+      `Can't reach the OpenClaw browser control service (timed out after ${timeoutMs}ms). If this is a sandboxed session, ensure the sandbox browser is running. ${serviceOutageModelHint}`,
     );
   }
 
@@ -142,7 +143,7 @@ function enhanceBrowserFetchError(url: string, err: unknown, timeoutMs: number):
     : "If this is a sandboxed session, ensure the sandbox browser is running.";
 
   return new Error(
-    `Can't reach the OpenClaw browser control service. ${operatorHint} ${modelHint} (${errorMessage(err)})`,
+    `Can't reach the OpenClaw browser control service. ${operatorHint} ${serviceOutageModelHint} (${errorMessage(err)})`,
   );
 }
 

--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -98,32 +98,51 @@ function withLoopbackBrowserAuth(
   });
 }
 
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return `${err.name}: ${err.message}`;
+  }
+  return String(err);
+}
+
+function looksLikeTimeoutError(err: unknown): boolean {
+  const msgLower = errorMessage(err).toLowerCase();
+  return (
+    msgLower.includes("timed out") ||
+    msgLower.includes("timeout") ||
+    msgLower.includes("aborted") ||
+    msgLower.includes("abort") ||
+    msgLower.includes("aborterror")
+  );
+}
+
 function enhanceBrowserFetchError(url: string, err: unknown, timeoutMs: number): Error {
   const isLocal = !isAbsoluteHttp(url);
-  // Human-facing hint for logs/diagnostics.
-  const operatorHint = isLocal
-    ? `Restart the OpenClaw gateway (OpenClaw.app menubar, or \`${formatCliCommand("openclaw gateway")}\`).`
-    : "If this is a sandboxed session, ensure the sandbox browser is running.";
   // Model-facing suffix: explicitly tell the LLM NOT to retry.
   // Without this, models see "try again" and enter an infinite tool-call loop.
   const modelHint =
     "Do NOT retry the browser tool — it will keep failing. " +
     "Use an alternative approach or inform the user that the browser is currently unavailable.";
-  const msg = String(err);
-  const msgLower = msg.toLowerCase();
-  const looksLikeTimeout =
-    msgLower.includes("timed out") ||
-    msgLower.includes("timeout") ||
-    msgLower.includes("aborted") ||
-    msgLower.includes("abort") ||
-    msgLower.includes("aborterror");
-  if (looksLikeTimeout) {
+
+  if (looksLikeTimeoutError(err)) {
+    if (isLocal) {
+      return new Error(
+        `Browser action timed out after ${timeoutMs}ms while the local browser control service remained reachable. Try a fresh snapshot and retry with a stable ref, or increase timeoutMs if the action is expected to take longer. ${modelHint}`,
+      );
+    }
+
     return new Error(
-      `Can't reach the OpenClaw browser control service (timed out after ${timeoutMs}ms). ${operatorHint} ${modelHint}`,
+      `Can't reach the OpenClaw browser control service (timed out after ${timeoutMs}ms). If this is a sandboxed session, ensure the sandbox browser is running. ${modelHint}`,
     );
   }
+
+  // Human-facing hint for logs/diagnostics.
+  const operatorHint = isLocal
+    ? `Restart the OpenClaw gateway (OpenClaw.app menubar, or \`${formatCliCommand("openclaw gateway")}\`).`
+    : "If this is a sandboxed session, ensure the sandbox browser is running.";
+
   return new Error(
-    `Can't reach the OpenClaw browser control service. ${operatorHint} ${modelHint} (${msg})`,
+    `Can't reach the OpenClaw browser control service. ${operatorHint} ${modelHint} (${errorMessage(err)})`,
   );
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `fetchBrowserJson` mapped local browser action timeouts to a transport outage error (`Can't reach the OpenClaw browser control service`), which is misleading when the local dispatcher is alive but the action itself timed out.
- Why it matters: stale refs / long-running file chooser actions can look like gateway failures, pushing users and agents toward incorrect remediation (restart gateway) and retry loops.
- What changed: split timeout detection from generic fetch errors and return a local-action-specific timeout message for relative/local browser control routes.
- What changed: added `client-fetch.timeout-errors.test.ts` to lock in this behavior.
- What did NOT change (scope boundary): no change to route dispatch semantics, no change to timeout defaults, and no automatic retry behavior added.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38844
- Related #

## User-visible / Behavior Changes

Local browser action timeouts (relative routes) now report as action timeouts while the control service is reachable, instead of incorrectly reporting browser-control-service outage.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (WSL2)
- Runtime/container: local Node + pnpm
- Model/provider: n/a
- Integration/channel (if any): browser control local dispatcher path
- Relevant config (redacted): default local browser control path

### Steps

1. Trigger `fetchBrowserJson` on a local/relative browser route where dispatcher throws a timeout-like error.
2. Observe returned error text.
3. Run targeted test: `pnpm exec vitest run src/browser/client-fetch.timeout-errors.test.ts`.

### Expected

- Error stays action-specific for local dispatch timeout and does not claim browser control service outage.

### Actual

- Test passes and confirms message contains: `Browser action timed out after ... while the local browser control service remained reachable`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: local dispatch timeout now maps to local-action timeout message.
- Edge cases checked: absolute HTTP URL timeout path still uses service-unreachable timeout messaging (unchanged by test scope, code path retained).
- What you did **not** verify: full end-to-end browser chooser flow in live UI.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `f01ae55`.
- Files/config to restore: `src/browser/client-fetch.ts`, remove `src/browser/client-fetch.timeout-errors.test.ts`.
- Known bad symptoms reviewers should watch for: timeout errors reverting to transport-outage wording for local routes.

## Risks and Mitigations

- Risk: wording change may affect any tests or tooling that match old timeout text.
  - Mitigation: change is scoped to local timeout branch only; added dedicated test for new intended wording.
