### PR TITLE
fix(failover): classify "too many tokens" as rate_limit (AWS Bedrock)

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -32,6 +32,8 @@ const BEDROCK_THROTTLING_EXCEPTION_MESSAGE =
   "ThrottlingException: Your request was denied due to exceeding the account quotas for Amazon Bedrock.";
 const BEDROCK_SERVICE_UNAVAILABLE_MESSAGE =
   "ServiceUnavailable: The service is temporarily unable to handle the request.";
+// AWS Bedrock daily token limit error (#38822):
+const BEDROCK_TOKEN_LIMIT_MESSAGE = "Too many tokens per day";
 // Groq error codes examples: https://console.groq.com/docs/errors
 const GROQ_TOO_MANY_REQUESTS_MESSAGE =
   "429 Too Many Requests: Too many requests were sent in a given timeframe.";
@@ -111,6 +113,12 @@ describe("failover-error", () => {
     ).toBe("rate_limit");
     expect(
       resolveFailoverReasonFromError({
+        status: 429,
+        message: BEDROCK_TOKEN_LIMIT_MESSAGE,
+      }),
+    ).toBe("rate_limit");
+    expect(
+      resolveFailoverReasonFromError({
         status: 503,
         message: BEDROCK_SERVICE_UNAVAILABLE_MESSAGE,
       }),
@@ -162,6 +170,14 @@ describe("failover-error", () => {
     expect(
       resolveFailoverReasonFromError({
         message: "LLM error: monthly limit reached",
+      }),
+    ).toBe("rate_limit");
+  });
+
+  it("treats bedrock daily token limit as rate_limit (#38822)", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        message: BEDROCK_TOKEN_LIMIT_MESSAGE,
       }),
     ).toBe("rate_limit");
   });

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -14,6 +14,7 @@ const ERROR_PATTERNS = {
     "usage limit",
     /\btpm\b/i,
     "tokens per minute",
+    "too many tokens",
   ],
   overloaded: [
     /overloaded_error|"type"\s*:\s*"overloaded_error"/i,


### PR DESCRIPTION
## Summary

- Problem: AWS Bedrock returns `Too many tokens per day` when daily token limits are exceeded, but OpenClaw does not recognize this as a rate-limit condition
- Why it matters: The primary model keeps failing without triggering fallback, making the system appear stuck
- What changed: Added `"too many tokens"` pattern to the `rateLimit` error patterns in `failover-matches.ts`
- What did NOT change (scope boundary): No other error categories modified; existing rate-limit patterns untouched

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #38822

## User-visible / Behavior Changes

When AWS Bedrock returns "Too many tokens per day", OpenClaw now correctly classifies it as a rate-limit error and triggers the fallback chain instead of repeatedly failing on the same model.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Model/provider: AWS Bedrock
- Integration/channel: Any

### Steps

1. Configure a primary model on AWS Bedrock with a daily token limit
2. Exceed the daily token limit so Bedrock returns "Too many tokens per day"
3. Observe that OpenClaw now classifies this as `rate_limit` and triggers fallback

### Expected

- Error classified as `rate_limit`, fallback chain activates

### Actual (before fix)

- Error not recognized, primary model keeps failing without fallback

## Evidence

- [x] Failing test/log before + passing after

| Pattern | Matched before | Matched after |
|---------|---------------|---------------|
| `Too many tokens per day` | No | Yes (`rate_limit`) |
| `Too many tokens` | No | Yes (`rate_limit`) |
| `rate limit reached` | Yes | Yes (unchanged) |
| `tokens per minute` | Yes | Yes (unchanged) |

All 25 tests in `failover-error.test.ts` pass, including the new Bedrock daily token limit test case.

## Human Verification (required)

- Verified scenarios: `npx vitest run src/agents/failover-error.test.ts` — 25/25 tests pass
- Edge cases checked: Pattern is case-insensitive via `matchesErrorPatterns` (lowercases input before matching); verified "Too many tokens per day", "too many tokens", and "Too Many Tokens" all match
- What you did **not** verify: Live AWS Bedrock environment (no access); verified via unit tests only

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single-line addition in `failover-matches.ts`
- Files/config to restore: `src/agents/pi-embedded-helpers/failover-matches.ts`
- Known bad symptoms reviewers should watch for: False positive rate-limit classification for messages containing "too many tokens" in a non-rate-limit context (unlikely — this phrase is specific to usage limits)

## Risks and Mitigations

- Risk: False positive if a non-rate-limit error message happens to contain "too many tokens"
  - Mitigation: The phrase "too many tokens" is highly specific to usage/quota limits across providers; no known false-positive scenarios exist