### PR TITLE
fix(message): ignore empty strings in legacy to/channelId fields

### DIFF
--- a/src/infra/outbound/channel-target.ts
+++ b/src/infra/outbound/channel-target.ts
@@ -11,8 +11,9 @@ export function applyTargetToParams(params: {
   args: Record<string, unknown>;
 }): void {
   const target = typeof params.args.target === "string" ? params.args.target.trim() : "";
-  const hasLegacyTo = typeof params.args.to === "string";
-  const hasLegacyChannelId = typeof params.args.channelId === "string";
+  const hasLegacyTo = typeof params.args.to === "string" && params.args.to.trim().length > 0;
+  const hasLegacyChannelId =
+    typeof params.args.channelId === "string" && params.args.channelId.trim().length > 0;
   const mode =
     MESSAGE_ACTION_TARGET_MODE[params.action as keyof typeof MESSAGE_ACTION_TARGET_MODE] ?? "none";
 


### PR DESCRIPTION
## Summary

Fixes Issue #38830 - message tool misclassifies empty channelId/to fields as legacy params

## Root cause

The legacy-param detection in `src/infra/outbound/channel-target.ts` checked only whether fields existed as strings:

```ts
const hasLegacyTo = typeof params.args.to === "string";
const hasLegacyChannelId = typeof params.args.channelId === "string";
```

This incorrectly treated empty strings like `to: ""` or `channelId: ""` as legacy-param usage.

## Fix

Changed the checks to require non-empty strings:

```ts
const hasLegacyTo =
  typeof params.args.to === "string" && params.args.to.trim().length > 0;
const hasLegacyChannelId =
  typeof params.args.channelId === "string" &&
  params.args.channelId.trim().length > 0;
```

## Testing

- Build passes successfully
- The fix allows valid target-based sends with empty-string defaults to work correctly