### PR TITLE
fix: move clearBootstrapSnapshot after active run ends to prevent stale cache

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -207,14 +207,15 @@ async function ensureSessionRuntimeCleanup(params: {
     queueKeys.add(params.sessionId);
   }
   clearSessionQueues([...queueKeys]);
-  clearBootstrapSnapshot(params.target.canonicalKey);
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
   if (!params.sessionId) {
+    clearBootstrapSnapshot(params.target.canonicalKey);
     await closeTrackedBrowserTabs();
     return undefined;
   }
   abortEmbeddedPiRun(params.sessionId);
   const ended = await waitForEmbeddedPiRunEnd(params.sessionId, 15_000);
+  clearBootstrapSnapshot(params.target.canonicalKey);
   if (ended) {
     await closeTrackedBrowserTabs();
     return undefined;


### PR DESCRIPTION
## Summary

- Move `clearBootstrapSnapshot` to after `waitForEmbeddedPiRunEnd` in `ensureSessionRuntimeCleanup` to close a race window where a dying run could re-populate the bootstrap cache with stale content after the clear

## Problem

When `/new` is sent while a session is active, `clearBootstrapSnapshot` runs before `abortEmbeddedPiRun`. The dying run's next turn can call `getOrLoadBootstrapFiles`, which re-reads files from disk and repopulates the cache — after the clear already happened. The new session then gets a cache hit with stale data.

### Race window (before fix)

1. `clearBootstrapSnapshot(canonicalKey)` — cache entry deleted
2. Active run still in-flight — calls `getOrLoadBootstrapFiles` → cache miss → re-populates cache
3. `abortEmbeddedPiRun` fires — active run terminates
4. New session starts → cache hit with stale content from step 2

## Fix

Move `clearBootstrapSnapshot` to after the `await waitForEmbeddedPiRunEnd` call, ensuring the active run is fully terminated before the cache is invalidated. When there's no `sessionId` (no active run), the clear still happens immediately before returning.

## Test plan

- [x] Verify `clearBootstrapSnapshot` is called after `waitForEmbeddedPiRunEnd` in the code path where `sessionId` exists
- [x] Verify `clearBootstrapSnapshot` is still called in the early return path (no `sessionId`)
- [x] Existing `bootstrap-cache.test.ts` tests continue to pass (they test the cache module itself, not the ordering)

Fixes #38854