### PR TITLE
fix(gateway): clear bootstrap cache after active run ends

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -207,14 +207,15 @@ async function ensureSessionRuntimeCleanup(params: {
     queueKeys.add(params.sessionId);
   }
   clearSessionQueues([...queueKeys]);
-  clearBootstrapSnapshot(params.target.canonicalKey);
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
   if (!params.sessionId) {
+    clearBootstrapSnapshot(params.target.canonicalKey);
     await closeTrackedBrowserTabs();
     return undefined;
   }
   abortEmbeddedPiRun(params.sessionId);
   const ended = await waitForEmbeddedPiRunEnd(params.sessionId, 15_000);
+  clearBootstrapSnapshot(params.target.canonicalKey);
   if (ended) {
     await closeTrackedBrowserTabs();
     return undefined;


### PR DESCRIPTION
## Summary

- Move `clearBootstrapSnapshot` call to **after** `waitForEmbeddedPiRunEnd` in `ensureSessionRuntimeCleanup`, closing a race window where a dying run could re-populate the cache with stale content after the clear.

## Problem

When `/new` is sent while a run is in-flight:

1. `clearBootstrapSnapshot(canonicalKey)` — cache cleared
2. Active run still executing — calls `getOrLoadBootstrapFiles` → cache miss → reads from disk → **re-populates cache with stale content**
3. `abortEmbeddedPiRun` fires — run terminates
4. New session starts → cache hit with stale content from step 2

## Fix

Reorder so the active run is fully terminated before the cache is cleared:

```
clearSessionQueues(...)
stopSubagentsForRequester(...)
abortEmbeddedPiRun(sessionId)
await waitForEmbeddedPiRunEnd(sessionId, 15_000)
clearBootstrapSnapshot(canonicalKey)    // ← moved here
```

When no `sessionId` exists (no active run), the cache is cleared immediately since there's no race possible.

## Test plan

- [x] TypeScript type check passes (`pnpm tsgo`)
- [x] Existing bootstrap-cache tests pass (`pnpm vitest run src/agents/bootstrap-cache.test.ts`)
- [ ] Manual: edit AGENTS.md → send `/new` while run is active → verify new session uses updated content

Closes #38854