### PR TITLE
fix: handle array type in extractToolText for tool result display (Issue #38223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/tool cards: join string fragments from array-shaped tool result `text` and `content` payloads while ignoring null or non-string fragments, so embedded tool results render readable output again. Fixes #38223; carries forward #38876 and #38228. Thanks @gambletan and @haroldfabla2-hue.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/ui/src/ui/chat/tool-cards.node.test.ts
+++ b/ui/src/ui/chat/tool-cards.node.test.ts
@@ -144,7 +144,13 @@ describe("tool-card extraction", () => {
           {
             type: "tool_result",
             name: "browser.open",
-            text: ["Opened A", { text: "Loaded title" }, { text: 42 }, null],
+            text: [
+              "Opened A",
+              { text: "Loaded title" },
+              { content: "Captured content" },
+              { text: 42 },
+              null,
+            ],
           },
           {
             type: "tool_result",
@@ -159,11 +165,33 @@ describe("tool-card extraction", () => {
     expect(cards).toHaveLength(2);
     expect(cards[0]).toMatchObject({
       name: "browser.open",
-      outputText: "Opened A\nLoaded title",
+      outputText: "Opened A\nLoaded title\nCaptured content",
     });
     expect(cards[1]).toMatchObject({
       name: "browser.read",
       outputText: "First paragraph\nSecond paragraph",
+    });
+  });
+
+  it("keeps array-shaped tool results empty when they contain no string fragments", () => {
+    const cards = extractToolCards(
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_result",
+            name: "browser.open",
+            text: [undefined, null, 42, { text: null }, { content: false }],
+          },
+        ],
+      },
+      "msg:array-empty",
+    );
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      name: "browser.open",
+      outputText: undefined,
     });
   });
 

--- a/ui/src/ui/chat/tool-cards.node.test.ts
+++ b/ui/src/ui/chat/tool-cards.node.test.ts
@@ -136,6 +136,37 @@ describe("tool-card extraction", () => {
     });
   });
 
+  it("joins string fragments from array-shaped tool result text and content", () => {
+    const cards = extractToolCards(
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_result",
+            name: "browser.open",
+            text: ["Opened A", { text: "Loaded title" }, { text: 42 }, null],
+          },
+          {
+            type: "tool_result",
+            name: "browser.read",
+            content: [undefined, { text: "First paragraph" }, "Second paragraph", { text: null }],
+          },
+        ],
+      },
+      "msg:array-results",
+    );
+
+    expect(cards).toHaveLength(2);
+    expect(cards[0]).toMatchObject({
+      name: "browser.open",
+      outputText: "Opened A\nLoaded title",
+    });
+    expect(cards[1]).toMatchObject({
+      name: "browser.read",
+      outputText: "First paragraph\nSecond paragraph",
+    });
+  });
+
   it("builds sidebar content with input and empty output status", () => {
     const [card] = extractToolCards(
       {

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -42,37 +42,43 @@ function coerceArgs(value: unknown): unknown {
 }
 
 function extractToolText(item: Record<string, unknown>): string | undefined {
-  // Direct text field as string
   if (typeof item.text === "string") {
     return item.text;
   }
-  // text as array: [{ text: "..." }]
   if (Array.isArray(item.text)) {
-    for (const textItem of item.text) {
-      if (typeof textItem === "object" && textItem !== null) {
-        const ti = textItem as Record<string, unknown>;
-        if (typeof ti.text === "string") {
-          return ti.text;
-        }
-      }
+    const parts = collectTextParts(item.text);
+    if (parts.length > 0) {
+      return parts.join("\n");
     }
   }
-  // content as string
   if (typeof item.content === "string") {
     return item.content;
   }
-  // content as array: [{ text: "..." }]
   if (Array.isArray(item.content)) {
-    for (const contentItem of item.content) {
-      if (typeof contentItem === "object" && contentItem !== null) {
-        const ci = contentItem as Record<string, unknown>;
-        if (typeof ci.text === "string") {
-          return ci.text;
-        }
-      }
+    const parts = collectTextParts(item.content);
+    if (parts.length > 0) {
+      return parts.join("\n");
     }
   }
   return undefined;
+}
+
+function collectTextParts(items: unknown[]): string[] {
+  const parts: string[] = [];
+  for (const entry of items) {
+    if (typeof entry === "string") {
+      parts.push(entry);
+      continue;
+    }
+    if (typeof entry !== "object" || entry === null) {
+      continue;
+    }
+    const text = (entry as Record<string, unknown>).text;
+    if (typeof text === "string") {
+      parts.push(text);
+    }
+  }
+  return parts;
 }
 
 export function extractToolPreview(

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -76,6 +76,11 @@ function collectTextParts(items: unknown[]): string[] {
     const text = (entry as Record<string, unknown>).text;
     if (typeof text === "string") {
       parts.push(text);
+      continue;
+    }
+    const content = (entry as Record<string, unknown>).content;
+    if (typeof content === "string") {
+      parts.push(content);
     }
   }
   return parts;

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -42,11 +42,35 @@ function coerceArgs(value: unknown): unknown {
 }
 
 function extractToolText(item: Record<string, unknown>): string | undefined {
+  // Direct text field as string
   if (typeof item.text === "string") {
     return item.text;
   }
+  // text as array: [{ text: "..." }]
+  if (Array.isArray(item.text)) {
+    for (const textItem of item.text) {
+      if (typeof textItem === "object" && textItem !== null) {
+        const ti = textItem as Record<string, unknown>;
+        if (typeof ti.text === "string") {
+          return ti.text;
+        }
+      }
+    }
+  }
+  // content as string
   if (typeof item.content === "string") {
     return item.content;
+  }
+  // content as array: [{ text: "..." }]
+  if (Array.isArray(item.content)) {
+    for (const contentItem of item.content) {
+      if (typeof contentItem === "object" && contentItem !== null) {
+        const ci = contentItem as Record<string, unknown>;
+        if (typeof ci.text === "string") {
+          return ci.text;
+        }
+      }
+    }
   }
   return undefined;
 }


### PR DESCRIPTION
Fix Issue #38223 - WebUI tool result shows 'No output' when WebSocket data contains content[0].text

## Changes
- Add handling for item.text as array [{ text: '...' }]
- Add handling for item.content as array [{ text: '...' }]

## Testing
This fix ensures the extractToolText function properly extracts text from array-type content in tool results.