### PR TITLE
docs(cli): improve memory command examples

### DIFF
--- a/src/cli/memory-cli.ts
+++ b/src/cli/memory-cli.ts
@@ -582,8 +582,13 @@ export function registerMemoryCli(program: Command) {
       () =>
         `\n${theme.heading("Examples:")}\n${formatHelpExamples([
           ["openclaw memory status", "Show index and provider status."],
+          ["openclaw memory status --deep", "Probe embeddings and vector readiness."],
           ["openclaw memory index --force", "Force a full reindex."],
-          ['openclaw memory search --query "deployment notes"', "Search indexed memory entries."],
+          ['openclaw memory search "meeting notes"', "Quick search using positional query."],
+          [
+            'openclaw memory search --query "deployment" --max-results 20',
+            "Limit results for focused troubleshooting.",
+          ],
           ["openclaw memory status --json", "Output machine-readable JSON."],
         ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/memory", "docs.openclaw.ai/cli/memory")}\n`,
     );


### PR DESCRIPTION
## Summary
Improve openclaw memory CLI help examples so users can discover advanced options faster.

## Changes
- Add openclaw memory status --deep example to highlight deep diagnostics.
- Add openclaw memory search --query "deployment" --max-results 20 example to show result limiting.
- Replace the older search example with a simpler positional form: openclaw memory search "meeting notes".
- Keep examples practical and aligned with actual supported flags and arguments.

## Before
- openclaw memory status
- openclaw memory index --force
- openclaw memory search --query "deployment notes"
- openclaw memory status --json

## After
- openclaw memory status
- openclaw memory status --deep
- openclaw memory index --force
- openclaw memory search "meeting notes"
- openclaw memory search --query "deployment" --max-results 20
- openclaw memory status --json

## Testing
- pnpm vitest run src/cli/memory-cli.test.ts
- pnpm check

## Notes
- Docs/help text only; no runtime behavior changes.

Fixes #31803