### PR TITLE
fix(cron): preserve sandbox config when merging agent overrides (#38663)

### DIFF
--- a/src/cron/isolated-agent/run.sandbox-config-preserved.test.ts
+++ b/src/cron/isolated-agent/run.sandbox-config-preserved.test.ts
@@ -28,7 +28,7 @@ function makeParams(overrides?: Record<string, unknown>) {
     cfg: {
       agents: {
         defaults: {
-          sandbox: { mode: "all" },
+          sandbox: { mode: "all" as const },
         },
       },
     },

--- a/src/cron/isolated-agent/run.sandbox-config-preserved.test.ts
+++ b/src/cron/isolated-agent/run.sandbox-config-preserved.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearFastTestEnv,
+  loadRunCronIsolatedAgentTurn,
+  resolveAgentConfigMock,
+  resetRunCronIsolatedAgentTurnHarness,
+  restoreFastTestEnv,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+// ---------- helpers ----------
+
+function makeJob(overrides?: Record<string, unknown>) {
+  return {
+    id: "sandbox-test-job",
+    name: "Sandbox Test",
+    schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+    sessionTarget: "isolated",
+    payload: { kind: "agentTurn", message: "test" },
+    ...overrides,
+  } as never;
+}
+
+function makeParams(overrides?: Record<string, unknown>) {
+  return {
+    cfg: {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all" },
+        },
+      },
+    },
+    deps: {} as never,
+    job: makeJob(),
+    message: "test",
+    sessionKey: "cron:sandbox-test",
+    ...overrides,
+  };
+}
+
+// ---------- tests ----------
+
+describe("runCronIsolatedAgentTurn — sandbox config preserved (#38663)", () => {
+  let previousFastTestEnv: string | undefined;
+
+  beforeEach(() => {
+    previousFastTestEnv = clearFastTestEnv();
+    resetRunCronIsolatedAgentTurnHarness();
+  });
+
+  afterEach(() => {
+    restoreFastTestEnv(previousFastTestEnv);
+  });
+
+  it("preserves sandbox.mode from defaults when agent override has no sandbox", async () => {
+    // Agent config exists (e.g. has a name) but does NOT configure sandbox.
+    // resolveAgentConfig returns { sandbox: undefined, ... } for such entries;
+    // before the fix Object.assign would overwrite the global sandbox config.
+    resolveAgentConfigMock.mockReturnValue({
+      name: "my-agent",
+      sandbox: undefined,
+    });
+
+    await runCronIsolatedAgentTurn(makeParams({ agentId: "my-agent" }));
+
+    expect(runWithModelFallbackMock).toHaveBeenCalledTimes(1);
+    const cfg = runWithModelFallbackMock.mock.calls[0][0].cfg;
+    expect(cfg.agents.defaults.sandbox).toEqual({ mode: "all" });
+  });
+
+  it("preserves sandbox.mode when agent override has other properties", async () => {
+    resolveAgentConfigMock.mockReturnValue({
+      name: "worker",
+      workspace: "/custom/workspace",
+      sandbox: undefined,
+      heartbeat: undefined,
+      tools: undefined,
+    });
+
+    await runCronIsolatedAgentTurn(makeParams({ agentId: "worker" }));
+
+    expect(runWithModelFallbackMock).toHaveBeenCalledTimes(1);
+    const cfg = runWithModelFallbackMock.mock.calls[0][0].cfg;
+    expect(cfg.agents.defaults.sandbox).toEqual({ mode: "all" });
+  });
+
+  it("uses agent-specific sandbox config when explicitly set", async () => {
+    resolveAgentConfigMock.mockReturnValue({
+      name: "sandboxed-agent",
+      sandbox: { mode: "non-main", scope: "per-session" },
+    });
+
+    await runCronIsolatedAgentTurn(makeParams({ agentId: "sandboxed-agent" }));
+
+    expect(runWithModelFallbackMock).toHaveBeenCalledTimes(1);
+    const cfg = runWithModelFallbackMock.mock.calls[0][0].cfg;
+    expect(cfg.agents.defaults.sandbox).toEqual({
+      mode: "non-main",
+      scope: "per-session",
+    });
+  });
+
+  it("works correctly when no agent config override exists", async () => {
+    resolveAgentConfigMock.mockReturnValue(undefined);
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    expect(runWithModelFallbackMock).toHaveBeenCalledTimes(1);
+    const cfg = runWithModelFallbackMock.mock.calls[0][0].cfg;
+    expect(cfg.agents.defaults.sandbox).toEqual({ mode: "all" });
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -130,10 +130,18 @@ export async function runCronIsolatedAgentTurn(params: {
   // This ensures auth-profiles, workspace, and agentDir all resolve to the
   // correct per-agent paths (e.g. ~/.openclaw/agents/<agentId>/agent/).
   const agentId = normalizedRequested ?? defaultAgentId;
+  // Filter out undefined values from agent overrides so they don't clobber
+  // global defaults via Object.assign. resolveAgentConfig() returns undefined
+  // for properties the agent entry doesn't configure (e.g. sandbox); without
+  // filtering, Object.assign copies those undefined values over the global
+  // defaults, effectively erasing them. (#38663)
+  const definedOverrides = Object.fromEntries(
+    Object.entries(agentOverrideRest).filter(([, v]) => v !== undefined),
+  );
   const agentCfg: AgentDefaultsConfig = Object.assign(
     {},
     params.cfg.agents?.defaults,
-    agentOverrideRest as Partial<AgentDefaultsConfig>,
+    definedOverrides as Partial<AgentDefaultsConfig>,
   );
   // Merge agent model override with defaults instead of replacing, so that
   // `fallbacks` from `agents.defaults.model` are preserved when the agent


### PR DESCRIPTION
## Summary

Fixes #38663 — Cron isolated jobs don't execute in sandbox despite `sandbox.mode="all"`.

**Root cause:** `runCronIsolatedAgentTurn()` merges agent-specific config overrides into `agents.defaults` using `Object.assign`. When an agent entry exists but doesn't explicitly configure `sandbox`, `resolveAgentConfig()` returns `{ sandbox: undefined, ... }`. `Object.assign` copies the `undefined` value over the global default, effectively erasing `sandbox.mode: "all"`. The resulting `cfgWithAgentDefaults` has `agents.defaults.sandbox = undefined`, which causes `resolveSandboxConfigForAgent()` to fall back to `mode: "off"` — silently disabling sandbox for that cron job.

**Fix:** Filter out `undefined` values from the agent config override before `Object.assign`, so properties the agent doesn't configure are preserved from global defaults.

```js
// Before (bug): Object.assign copies sandbox: undefined over sandbox: { mode: "all" }
Object.assign({}, defaults, agentOverrideRest);

// After (fix): only merge properties the agent actually configures
const definedOverrides = Object.fromEntries(
  Object.entries(agentOverrideRest).filter(([, v]) => v !== undefined),
);
Object.assign({}, defaults, definedOverrides);
```

## Changes

- `src/cron/isolated-agent/run.ts` — Filter undefined values from agent config overrides before merging into defaults
- `src/cron/isolated-agent/run.sandbox-config-preserved.test.ts` — 4 new tests verifying sandbox config is preserved across merge scenarios

## Test plan

- [x] New tests pass: `npx vitest run src/cron/isolated-agent/run.sandbox-config-preserved.test.ts` (4/4)
- [x] Existing cron tests pass: `npx vitest run src/cron/isolated-agent/run.*.test.ts` (26/26)
- [x] `pnpm build` succeeds
- [ ] Manual: configure `agents.defaults.sandbox.mode: "all"` + agent entry without sandbox → cron job runs in sandbox container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
