### PR TITLE
fix: prevent API key plaintext leak into models.json state file

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -267,6 +267,39 @@ describe("models-config", () => {
     });
   });
 
+  it("does not persist resolved env var value as plaintext in models.json", async () => {
+    await withEnvVar("OPENAI_API_KEY", "sk-plaintext-should-not-appear", async () => {
+      await withTempHome(async () => {
+        const cfg: OpenClawConfig = {
+          models: {
+            providers: {
+              openai: {
+                apiKey: "sk-plaintext-should-not-appear", // already resolved by loadConfig
+                api: "openai-completions",
+                models: [
+                  {
+                    id: "gpt-4.1",
+                    name: "GPT-4.1",
+                    input: ["text"],
+                    reasoning: false,
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 128000,
+                    maxTokens: 16384,
+                  },
+                ],
+              },
+            },
+          },
+        };
+        await ensureOpenClawModelsJson(cfg);
+        const result = await readGeneratedModelsJson<{
+          providers: Record<string, { apiKey?: string }>;
+        }>();
+        expect(result.providers.openai?.apiKey).toBe("OPENAI_API_KEY");
+      });
+    });
+  });
+
   it("preserves explicit larger token limits when they exceed implicit catalog defaults", async () => {
     await withTempHome(async () => {
       await withEnvVar("MOONSHOT_API_KEY", "sk-moonshot-test", async () => {

--- a/src/agents/models-config.providers.normalize-keys.test.ts
+++ b/src/agents/models-config.providers.normalize-keys.test.ts
@@ -73,4 +73,38 @@ describe("normalizeProviders", () => {
       await fs.rm(agentDir, { recursive: true, force: true });
     }
   });
+
+  it("replaces resolved env var value with env var name to prevent plaintext persistence", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    const original = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "sk-test-secret-value-12345";
+    try {
+      const providers: NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]> = {
+        openai: {
+          apiKey: "sk-test-secret-value-12345", // simulates resolved ${OPENAI_API_KEY}
+          api: "openai-completions",
+          models: [
+            {
+              id: "gpt-4.1",
+              name: "GPT-4.1",
+              input: ["text"],
+              reasoning: false,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 128000,
+              maxTokens: 16384,
+            },
+          ],
+        },
+      };
+      const normalized = normalizeProviders({ providers, agentDir });
+      expect(normalized?.openai?.apiKey).toBe("OPENAI_API_KEY");
+    } finally {
+      if (original === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = original;
+      }
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -384,6 +384,8 @@ async function discoverVllmModels(
   }
 }
 
+const ENV_VAR_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;
+
 function normalizeApiKeyConfig(value: string): string {
   const trimmed = value.trim();
   const match = /^\$\{([A-Z0-9_]+)\}$/.exec(trimmed);
@@ -516,6 +518,23 @@ export function normalizeProviders(params: {
         ...normalizedProvider,
         apiKey: normalizeApiKeyConfig(configuredApiKey),
       };
+    }
+
+    // Reverse-lookup: if apiKey looks like a resolved secret value (not an env
+    // var name), check whether it matches the canonical env var for this provider.
+    // This prevents resolveConfigEnvVars()-resolved secrets from being persisted
+    // to models.json as plaintext. (Fixes #38757)
+    const currentApiKey = normalizedProvider.apiKey;
+    if (
+      typeof currentApiKey === "string" &&
+      currentApiKey.trim() &&
+      !ENV_VAR_NAME_RE.test(currentApiKey.trim())
+    ) {
+      const envVarName = resolveEnvApiKeyVarName(normalizedKey);
+      if (envVarName && process.env[envVarName] === currentApiKey) {
+        mutated = true;
+        normalizedProvider = { ...normalizedProvider, apiKey: envVarName };
+      }
     }
 
     // If a provider defines models, pi's ModelRegistry requires apiKey to be set.


### PR DESCRIPTION
## Summary

Fixes #38757

When users configure API keys with env var substitution (`"apiKey": "${LLM_API_KEY}"`) in `openclaw.json`, `resolveConfigEnvVars()` resolves the placeholder to the actual secret value before `ensureOpenClawModelsJson()` runs. The plaintext secret was then persisted to `agents/*/agent/models.json`.

- Add a reverse-lookup step in `normalizeProviders()` that detects when an `apiKey` value matches a known provider env var's value and replaces it with the env var **name** instead
- Uses strict equality check against `process.env[canonicalVarName]` to prevent false positives
- Skips values that already look like env var names (e.g. `OPENAI_API_KEY`)

## Test plan

- [x] Unit test: `normalizeProviders()` replaces resolved secret with env var name
- [x] E2E test: `ensureOpenClawModelsJson()` writes env var name (not plaintext) to `models.json`
- [x] All existing `models-config` tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)