### PR TITLE
fix(voice-call): add missing fields to plugin config JSON Schema

### DIFF
--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -249,6 +249,10 @@
         "type": "integer",
         "minimum": 1
       },
+      "staleCallReaperSeconds": {
+        "type": "integer",
+        "minimum": 0
+      },
       "silenceTimeoutMs": {
         "type": "integer",
         "minimum": 1
@@ -313,6 +317,27 @@
           }
         }
       },
+      "webhookSecurity": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "allowedHosts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "trustForwardingHeaders": {
+            "type": "boolean"
+          },
+          "trustedProxyIPs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "streaming": {
         "type": "object",
         "additionalProperties": false,
@@ -341,6 +366,22 @@
           },
           "streamPath": {
             "type": "string"
+          },
+          "preStartTimeoutMs": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "maxPendingConnections": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "maxPendingConnectionsPerIp": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "maxConnections": {
+            "type": "integer",
+            "minimum": 1
           }
         }
       },


### PR DESCRIPTION
The plugin manifest configSchema (openclaw.plugin.json) was missing several fields that the Zod schema and runtime code support, causing the gateway to reject valid config with additionalProperties errors.

Add:
- webhookSecurity object (allowedHosts, trustForwardingHeaders, trustedProxyIPs)
- streaming sub-fields (preStartTimeoutMs, maxPendingConnections, maxPendingConnectionsPerIp, maxConnections)
- staleCallReaperSeconds

## Summary

- **Problem:** The voice-call plugin manifest (`openclaw.plugin.json`) declares `"additionalProperties": false` but is missing several config fields that the Zod schema, runtime code, and [official docs](https://docs.openclaw.ai/plugins/voice-call) all support. The gateway's AJV validation rejects these fields before the plugin ever loads, making documented config like `webhookSecurity` and `streaming` security limits unusable.
- **Why it matters:** Users following the docs (e.g. the [Webhook Security](https://docs.openclaw.ai/plugins/voice-call#webhook-security) and [Streaming](https://docs.openclaw.ai/plugins/voice-call#config) sections) get a gateway startup failure with no clear indication that the config is actually valid but the schema is incomplete.
- **What changed:** Added the missing properties to `configSchema` in `extensions/voice-call/openclaw.plugin.json` so AJV accepts them, and the existing Zod validation + runtime code can use them as designed.
- **What did NOT change (scope boundary):** No runtime logic, no Zod schemas, no docs, no tests modified. This is a pure JSON Schema alignment fix in the plugin manifest.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: The docs at https://docs.openclaw.ai/plugins/voice-call reference all of these config fields.

## User-visible / Behavior Changes

Users can now set these config fields without the gateway rejecting them on startup:

| Field | Location in config | What it controls |
|---|---|---|
| `webhookSecurity.allowedHosts` | top-level | Allowlisted hosts for forwarded header trust |
| `webhookSecurity.trustForwardingHeaders` | top-level | Trust forwarded headers without allowlist |
| `webhookSecurity.trustedProxyIPs` | top-level | Only trust forwarded headers from specific proxy IPs |
| `streaming.preStartTimeoutMs` | `streaming` | Close sockets that never send a valid `start` frame |
| `streaming.maxPendingConnections` | `streaming` | Cap total unauthenticated pre-start sockets |
| `streaming.maxPendingConnectionsPerIp` | `streaming` | Cap pre-start sockets per source IP |
| `streaming.maxConnections` | `streaming` | Hard cap for all open media stream sockets |
| `staleCallReaperSeconds` | top-level | Auto-reap calls stuck in non-terminal states |

No defaults change. Users who don't set these fields are unaffected.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

Note: This fix *unblocks* security-hardening config (`webhookSecurity`, streaming rate limits) that was already implemented in runtime code but unreachable due to the schema gap.

## Repro + Verification

### Environment

- OS: macOS (also reproducible on Linux)
- Runtime/container: Node 22+
- Integration/channel: voice-call plugin (Twilio/Plivo/Telnyx)
- Relevant config (redacted):

```json5
{
  plugins: {
    entries: {
      "voice-call": {
        enabled: true,
        config: {
          provider: "twilio",
          webhookSecurity: {
            allowedHosts: ["voice.example.com"],
          },
          streaming: {
            enabled: true,
            maxPendingConnections: 16,
          },
          staleCallReaperSeconds: 180,
        },
      },
    },
  },
}
```

### Steps to reproduce (before fix)

1. Add any of the missing fields (`webhookSecurity`, `streaming.maxPendingConnections`, `staleCallReaperSeconds`, etc.) to voice-call plugin config
2. Start the gateway (`openclaw gateway run`)
3. Observe gateway fails to start with config validation error

### Expected

- Gateway starts and the plugin loads with the documented config

### Actual (before fix)

- Gateway rejects config: AJV reports `additionalProperties` violation for the undeclared fields

### After fix

- Tested on a live OpenClaw installation with the patched `openclaw.plugin.json`. Gateway starts successfully and the plugin loads with all documented fields accepted.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

Root cause trace:
1. `src/plugins/loader.ts:778-787` calls `validatePluginConfig` with the manifest's `configSchema`
2. `src/plugins/schema-validator.ts:21-25` initializes AJV with `removeAdditional: false`
3. The manifest's top-level `"additionalProperties": false` (line 164) rejects `webhookSecurity` and `staleCallReaperSeconds`
4. The manifest's `streaming` sub-object `"additionalProperties": false` (line 318) rejects `preStartTimeoutMs`, `maxPendingConnections`, `maxPendingConnectionsPerIp`, `maxConnections`
5. The plugin is skipped entirely (`continue` at line 787)

Meanwhile, the Zod schema (`extensions/voice-call/src/config.ts:253-350`) and all runtime consumers (`runtime.ts:112,125`, `webhook.ts:87-90`, `media-stream.ts:97-101`) fully support these fields.

## Human Verification (required)

- Verified scenarios: Tested on a live OpenClaw installation -- gateway starts successfully with `webhookSecurity`, `streaming` security limits, and `staleCallReaperSeconds` all present in config. Before the fix, the same config caused a gateway startup failure. Also ran `extensions/voice-call/src/config.test.ts` (7 tests), `src/config/config.plugin-validation.test.ts` (8 tests), `src/plugins/voice-call.plugin.test.ts` (7 tests), `src/plugins/schema-validator.test.ts` (7 tests) -- all pass.
- Edge cases checked: Verified JSON is valid after edit. Confirmed no other fields are missing by diffing every property in `VoiceCallConfigSchema` (Zod) against the `configSchema` (JSON Schema).
- What I did **not** verify: End-to-end voice call with these specific fields actively exercised (e.g. an actual proxied webhook hitting `allowedHosts`), but the runtime code paths are already covered by existing unit tests.

## Compatibility / Migration

- Backward compatible? `Yes` -- only adds new accepted properties; existing configs are unaffected
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit (one file changed)
- Files/config to restore: `extensions/voice-call/openclaw.plugin.json`
- Known bad symptoms reviewers should watch for: If a typo were introduced in the JSON, the manifest would fail to parse and the plugin wouldn't load at all -- but CI JSON validation and the existing plugin tests catch this.

## Risks and Mitigations

- Risk: A typo in the JSON Schema could silently accept invalid config values.
  - Mitigation: The new schema entries mirror the exact types and constraints from the Zod schema. The Zod layer (`config.ts`) remains the authoritative runtime validator and will still reject truly invalid values (wrong types, out-of-range numbers, etc.) even if AJV passes them through.
