### PR TITLE
fix(openai-http): propagate token usage in /v1/chat/completions response

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -593,6 +593,38 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         expect(usage?.total_tokens).toBe(59);
       }
 
+      // usage includes cache tokens in total
+      {
+        agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "hi back" }],
+          meta: { agentMeta: { usage: { input: 10, output: 5, cacheRead: 20, cacheWrite: 3 } } },
+        } as never);
+        const json = await postSyncUserMessage("hi");
+        const usage = json.usage as
+          | { prompt_tokens: number; completion_tokens: number; total_tokens: number }
+          | undefined;
+        expect(usage?.prompt_tokens).toBe(10);
+        expect(usage?.completion_tokens).toBe(5);
+        expect(usage?.total_tokens).toBe(38);
+      }
+
+      // usage respects precomputed total from agentMeta
+      {
+        agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "hi back" }],
+          meta: { agentMeta: { usage: { input: 10, output: 5, total: 100 } } },
+        } as never);
+        const json = await postSyncUserMessage("hi");
+        const usage = json.usage as
+          | { prompt_tokens: number; completion_tokens: number; total_tokens: number }
+          | undefined;
+        expect(usage?.prompt_tokens).toBe(10);
+        expect(usage?.completion_tokens).toBe(5);
+        expect(usage?.total_tokens).toBe(100);
+      }
+
       // usage defaults to zeros when agentMeta has no usage
       {
         agentCommand.mockClear();

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -577,6 +577,38 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         expect(msg.content).toBe("No response from OpenClaw.");
       }
 
+      // usage should reflect agentMeta when available
+      {
+        agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "hi back" }],
+          meta: { agentMeta: { usage: { input: 42, output: 17 } } },
+        } as never);
+        const json = await postSyncUserMessage("hi");
+        const usage = json.usage as
+          | { prompt_tokens: number; completion_tokens: number; total_tokens: number }
+          | undefined;
+        expect(usage?.prompt_tokens).toBe(42);
+        expect(usage?.completion_tokens).toBe(17);
+        expect(usage?.total_tokens).toBe(59);
+      }
+
+      // usage defaults to zeros when agentMeta has no usage
+      {
+        agentCommand.mockClear();
+        agentCommand.mockResolvedValueOnce({
+          payloads: [{ text: "hi back" }],
+          meta: {},
+        } as never);
+        const json = await postSyncUserMessage("hi");
+        const usage = json.usage as
+          | { prompt_tokens: number; completion_tokens: number; total_tokens: number }
+          | undefined;
+        expect(usage?.prompt_tokens).toBe(0);
+        expect(usage?.completion_tokens).toBe(0);
+        expect(usage?.total_tokens).toBe(0);
+      }
+
       {
         const res = await postChatCompletions(port, {
           model: "openclaw",

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -591,6 +591,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         expect(usage?.prompt_tokens).toBe(42);
         expect(usage?.completion_tokens).toBe(17);
         expect(usage?.total_tokens).toBe(59);
+        expect((usage as Record<string, unknown>)?.prompt_tokens_details).toBeUndefined();
       }
 
       // usage includes cache tokens in total
@@ -607,6 +608,9 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         expect(usage?.prompt_tokens).toBe(10);
         expect(usage?.completion_tokens).toBe(5);
         expect(usage?.total_tokens).toBe(38);
+        expect((usage as Record<string, unknown>)?.prompt_tokens_details).toEqual({
+          cached_tokens: 20,
+        });
       }
 
       // usage respects precomputed total from agentMeta

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -484,10 +484,26 @@ export async function handleOpenAiHttpRequest(
 
       const content = resolveAgentResponseText(result);
       const agentUsage = (
-        result as { meta?: { agentMeta?: { usage?: { input?: number; output?: number } } } }
+        result as {
+          meta?: {
+            agentMeta?: {
+              usage?: {
+                input?: number;
+                output?: number;
+                cacheRead?: number;
+                cacheWrite?: number;
+                total?: number;
+              };
+            };
+          };
+        }
       )?.meta?.agentMeta?.usage;
       const promptTokens = agentUsage?.input ?? 0;
       const completionTokens = agentUsage?.output ?? 0;
+      const cacheRead = agentUsage?.cacheRead ?? 0;
+      const cacheWrite = agentUsage?.cacheWrite ?? 0;
+      const totalTokens =
+        agentUsage?.total ?? promptTokens + completionTokens + cacheRead + cacheWrite;
 
       sendJson(res, 200, {
         id: runId,
@@ -504,7 +520,7 @@ export async function handleOpenAiHttpRequest(
         usage: {
           prompt_tokens: promptTokens,
           completion_tokens: completionTokens,
-          total_tokens: promptTokens + completionTokens,
+          total_tokens: totalTokens,
         },
       });
     } catch (err) {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -521,6 +521,16 @@ export async function handleOpenAiHttpRequest(
           prompt_tokens: promptTokens,
           completion_tokens: completionTokens,
           total_tokens: totalTokens,
+          ...(cacheRead > 0 || cacheWrite > 0
+            ? {
+                prompt_tokens_details: {
+                  cached_tokens: cacheRead,
+                },
+                completion_tokens_details: {
+                  reasoning_tokens: 0,
+                },
+              }
+            : {}),
         },
       });
     } catch (err) {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -483,6 +483,11 @@ export async function handleOpenAiHttpRequest(
       const result = await agentCommandFromIngress(commandInput, defaultRuntime, deps);
 
       const content = resolveAgentResponseText(result);
+      const agentUsage = (
+        result as { meta?: { agentMeta?: { usage?: { input?: number; output?: number } } } }
+      )?.meta?.agentMeta?.usage;
+      const promptTokens = agentUsage?.input ?? 0;
+      const completionTokens = agentUsage?.output ?? 0;
 
       sendJson(res, 200, {
         id: runId,
@@ -496,7 +501,11 @@ export async function handleOpenAiHttpRequest(
             finish_reason: "stop",
           },
         ],
-        usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+        usage: {
+          prompt_tokens: promptTokens,
+          completion_tokens: completionTokens,
+          total_tokens: promptTokens + completionTokens,
+        },
       });
     } catch (err) {
       logWarn(`openai-compat: chat completion failed: ${String(err)}`);


### PR DESCRIPTION
## Problem

The non-streaming `/v1/chat/completions` endpoint always returns hardcoded zero token usage:

```json
"usage": { "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0 }
```

This makes it impossible for consumers of the OpenAI-compatible API to track token usage for cost monitoring.

## Root Cause

The handler discards the full `agentCommandFromIngress()` result and only extracts text via `resolveAgentResponseText()`. The usage data is available in `result.meta.agentMeta.usage` (with `.input` and `.output` fields) but was never read.

## Fix

Extract the `input` and `output` token counts from the agent run result and map them to the OpenAI-compatible `prompt_tokens` / `completion_tokens` / `total_tokens` fields. Falls back to 0 when usage data is unavailable.

## Tests

Added two test cases:
- Verifies usage is correctly propagated when `agentMeta.usage` is present
- Verifies graceful fallback to zeros when usage data is absent

All existing tests continue to pass.

Fixes #38735